### PR TITLE
test(performance): add scheduled runtime resource soak

### DIFF
--- a/.github/workflows/runtime-resource-soak.yml
+++ b/.github/workflows/runtime-resource-soak.yml
@@ -1,0 +1,93 @@
+name: Runtime Resource Soak
+
+on:
+  schedule:
+    - cron: '23 3 * * *'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Runtime profile duration
+        required: true
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - soak
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: runtime-resource-soak-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    name: Check for unprofiled main changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ steps.decide.outputs.should_test }}
+    steps:
+      - name: Check for unprofiled main changes
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch always profiles the selected ref."
+            exit 0
+          fi
+
+          last_successful_sha="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/runtime-resource-soak.yml/runs?branch=main&event=schedule&status=success&per_page=1" --jq '.workflow_runs[0].head_sha // ""' 2>/dev/null || true)"
+          if [[ "$last_successful_sha" == "$GITHUB_SHA" ]]; then
+            echo "should_test=false" >> "$GITHUB_OUTPUT"
+            echo "Runtime resource coverage already passed for $GITHUB_SHA."
+          else
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "Latest successful runtime resource coverage is ${last_successful_sha:-unavailable}; profiling $GITHUB_SHA."
+          fi
+
+  runtime_resource_soak:
+    name: Windows runtime resource ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'soak' }}
+    needs: plan
+    if: needs.plan.outputs.should_test == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      CI: 'true'
+      PROFILE_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'soak' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: node scripts/ci/npm-ci.mjs
+
+      - name: Record runtime resource profile
+        shell: pwsh
+        run: |
+          if ($env:PROFILE_MODE -eq 'smoke') {
+            $profileArgs = @('--repeat=1', '--phase-ms=2000', '--interval-ms=500', '--stress-cycles=1')
+          } else {
+            $profileArgs = @('--repeat=3', '--phase-ms=10000', '--interval-ms=1000', '--stress-cycles=6')
+          }
+          npm run perf:runtime -- @profileArgs '--output=test-results/performance'
+
+      - name: Upload runtime resource evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: runtime-resource-${{ env.PROFILE_MODE }}-windows
+          path: test-results
+          retention-days: 14
+          if-no-files-found: error

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -320,7 +320,25 @@ class ElectronAppHarness implements ElectronApp {
 
   async beginResourceProfile(options: RuntimeResourceProfilerOptions = {}): Promise<void> {
     if (this.resourceProfiler) throw new Error('Runtime resource profiling is already active.')
-    const profiler = new RuntimeResourceProfiler(options)
+    const profileDataRoot = join(this.testRoot, 'profile-data')
+    await mkdir(profileDataRoot, { recursive: true })
+    await this.close()
+    const settingsPath = join(this.roots.storageRoot, 'settings.json')
+    const settings = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<string, unknown>
+    settings.dataRoot = profileDataRoot
+    await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
+    await this.launch()
+    const dataRoot = await this.page.evaluate(
+      async () => (await window.api.storage.getInfo()).dataRoot
+    )
+    if (dataRoot !== profileDataRoot) {
+      throw new Error('Runtime resource profile did not activate its isolated data root.')
+    }
+    const profiler = new RuntimeResourceProfiler({
+      ...options,
+      dataRoot,
+      storageRoot: this.roots.storageRoot
+    })
     this.resourceProfiler = profiler
     await profiler.attach(this.runningApplication)
   }

--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -30,6 +30,7 @@ const RELIABLE_FAILURE_PROMPT = 'Start the reliable messaging post-fence failure
 const RELIABLE_FAILURE_OBSERVE_PROMPT = 'Observe the reliable messaging post-fence failure.'
 const RELIABLE_FAIRNESS_PROMPT = 'Start the reliable messaging fairness journey.'
 const LONG_STREAM_PROMPT = 'Stream the long scroll journey.'
+const RUNTIME_RESOURCE_STRESS_PROMPT = 'Run the runtime resource stress journey.'
 const QUEUE_GATE_PROMPT = 'Hold the queue until the reveal finishes.'
 const TOOL_ORDER_PROMPT = 'Run the ordered slow tool journey.'
 const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
@@ -630,6 +631,24 @@ if (process.argv.includes('--version')) {
             }
           })
           reply = ''
+        } else if (prompt.includes(RUNTIME_RESOURCE_STRESS_PROMPT)) {
+          const stressMessageId = `e2e-message-${nextMessageId++}`
+          const payload = 'x'.repeat(2_048)
+          for (let chunk = 0; chunk < 90; chunk += 1) {
+            await context.client.notify(acp.methods.client.session.update, {
+              sessionId: context.params.sessionId,
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                messageId: stressMessageId,
+                content: {
+                  type: 'text',
+                  text: `Resource stress chunk ${chunk}: ${payload}\n`
+                }
+              }
+            })
+            await delay(30)
+          }
+          reply = 'Runtime resource stress journey complete.'
         } else if (prompt.includes(LONG_STREAM_PROMPT)) {
           // Mirror a real agent turn: text segment -> tool call -> second text segment ->
           // tool completion -> trailing segment, with separate message ids per segment.

--- a/e2e/runtime-performance.spec.ts
+++ b/e2e/runtime-performance.spec.ts
@@ -1,5 +1,5 @@
-import { test as playwrightTest } from '@playwright/test'
-import { createProject, sendPrompt } from './certification/helpers'
+import { expect, test as playwrightTest } from '@playwright/test'
+import { createProject, openProjectSession, sendPrompt } from './certification/helpers'
 import { test } from './fixtures/electron-app'
 
 const PROFILE_PROJECT_NAME = 'Runtime performance fixture'
@@ -7,6 +7,8 @@ const ACP_PROMPT = 'Summarize the deterministic fixture.'
 const ACP_REPLY = `Deterministic reply: ${ACP_PROMPT}`
 const NOTEBOOK_PROMPT = 'Profile the notebook lifecycle.'
 const NOTEBOOK_REPLY = 'Notebook lifecycle verified for'
+const STRESS_PROMPT = 'Run the runtime resource stress journey.'
+const STRESS_REPLY = 'Runtime resource stress journey complete.'
 
 const positiveIntegerEnvironment = (name: string, fallback: number): number => {
   const raw = process.env[name]?.trim()
@@ -20,11 +22,12 @@ const positiveIntegerEnvironment = (name: string, fallback: number): number => {
 
 const phaseDurationMs = positiveIntegerEnvironment('OPEN_SCIENCE_PERF_PHASE_MS', 10_000)
 const sampleIntervalMs = positiveIntegerEnvironment('OPEN_SCIENCE_PERF_INTERVAL_MS', 1_000)
+const stressCycles = positiveIntegerEnvironment('OPEN_SCIENCE_PERF_STRESS_CYCLES', 1)
 
 test('records isolated startup, ACP, Notebook, and recovery resource trends', async ({
   app
 }, testInfo) => {
-  playwrightTest.setTimeout(180_000)
+  playwrightTest.setTimeout(180_000 + stressCycles * 15_000)
   await app.completeOnboarding()
   await app.configureFakeAgent()
   await app.beginResourceProfile({
@@ -50,12 +53,22 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
     await sendPrompt(page, ACP_PROMPT, ACP_REPLY, 60_000)
     await app.sampleResourceProfileNow()
 
-    await app.markResourceProfilePhase('notebook-tool')
-    await sendPrompt(page, NOTEBOOK_PROMPT, NOTEBOOK_REPLY, 60_000)
-    await app.sampleResourceProfileNow()
+    for (let cycle = 0; cycle < stressCycles; cycle += 1) {
+      await app.markResourceProfilePhase('session-stress')
+      await sendPrompt(page, `${STRESS_PROMPT} Cycle ${cycle + 1}.`, STRESS_REPLY, 60_000)
+      await app.sampleResourceProfileNow()
+
+      await app.markResourceProfilePhase('notebook-tool')
+      await sendPrompt(page, NOTEBOOK_PROMPT, NOTEBOOK_REPLY, 60_000)
+      await app.sampleResourceProfileNow()
+    }
 
     page = await app.restart({ resourceProfilePhase: 'recovery' })
     await page.waitForTimeout(phaseDurationMs)
+    await openProjectSession(page, PROFILE_PROJECT_NAME, ACP_PROMPT)
+    await expect(page.getByText(STRESS_REPLY, { exact: false }).last()).toBeVisible({
+      timeout: 60_000
+    })
     await app.sampleResourceProfileNow()
   } finally {
     result = await app.finishResourceProfile()
@@ -65,5 +78,10 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
     path: result.summaryMarkdownPath,
     contentType: 'text/markdown'
   })
+  const recoveryStorage = result.summary.phases.recovery?.storage
+  expect(recoveryStorage?.sessionFileCount.last).toBeGreaterThan(0)
+  expect(recoveryStorage?.sessionBytes.last).toBeGreaterThan(0)
+  expect(recoveryStorage?.notebookRunFileCount.last).toBeGreaterThan(0)
+  expect(recoveryStorage?.notebookRunBytes.last).toBeGreaterThan(0)
   console.log(`Runtime performance summary: ${result.summaryMarkdownPath}`)
 })

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -23,6 +23,7 @@ type Job = {
   'runs-on'?: string
   steps?: Step[]
   strategy?: { matrix?: { shard?: number[] } }
+  'timeout-minutes'?: number
   uses?: string
   with?: Record<string, unknown>
 }
@@ -68,6 +69,47 @@ describe('release and scheduled workflow topology', () => {
     expect(job).toMatchObject({
       needs: 'plan',
       if: "needs.plan.outputs.should_test == 'true'"
+    })
+  })
+
+  it('runs a separate daily Windows resource soak with a focused manual smoke path', () => {
+    const resource = workflow('runtime-resource-soak.yml')
+    const schedule = resource.on?.schedule as Array<{ cron: string }>
+    const dispatch = resource.on?.workflow_dispatch as {
+      inputs?: { mode?: { default?: string; options?: string[] } }
+    }
+    const plan = resource.jobs.plan
+    const soak = resource.jobs.runtime_resource_soak
+    const profile = step(soak, 'Record runtime resource profile')
+    const upload = step(soak, 'Upload runtime resource evidence')
+
+    expect(schedule).toEqual([{ cron: '23 3 * * *' }])
+    expect(dispatch.inputs?.mode).toMatchObject({
+      default: 'smoke',
+      options: ['smoke', 'soak']
+    })
+    expect(resource.permissions).toEqual({ actions: 'read', contents: 'read' })
+    expect(resource.concurrency).toEqual({
+      group: 'runtime-resource-soak-${{ github.ref }}',
+      'cancel-in-progress': true
+    })
+    expect(step(plan, 'Check for unprofiled main changes').run).toContain(
+      'event=schedule&status=success&per_page=1'
+    )
+    expect(soak).toMatchObject({
+      needs: 'plan',
+      if: "needs.plan.outputs.should_test == 'true'",
+      'runs-on': 'windows-latest',
+      'timeout-minutes': 40
+    })
+    expect(profile.run).toContain("'--stress-cycles=1'")
+    expect(profile.run).toContain("'--stress-cycles=6'")
+    expect(profile.run).toContain("'--output=test-results/performance'")
+    expect(upload).toMatchObject({ if: 'always()' })
+    expect(upload.with).toMatchObject({
+      path: 'test-results',
+      'retention-days': 14,
+      'if-no-files-found': 'error'
     })
   })
 

--- a/scripts/performance/run-runtime-profile.mjs
+++ b/scripts/performance/run-runtime-profile.mjs
@@ -8,6 +8,7 @@ Options:
   --repeat=<count>       Comparable runs to record (default: 3)
   --phase-ms=<ms>        Idle and recovery phase duration (default: 10000)
   --interval-ms=<ms>     Sampling interval from 250 to 10000 (default: 1000)
+  --stress-cycles=<n>    Sustained Session + Notebook cycles per run (default: 1)
   --output=<directory>   Local output root (default: test-results/performance)
   --skip-build           Reuse the existing Electron E2E build
   --help                 Show this help
@@ -29,6 +30,7 @@ const options = {
   repeat: 3,
   phaseMs: 10_000,
   intervalMs: 1_000,
+  stressCycles: 1,
   output: undefined,
   skipBuild: false
 }
@@ -57,6 +59,13 @@ for (const argument of process.argv.slice(2)) {
       1_000,
       { min: 250, max: 10_000 }
     )
+  } else if (argument.startsWith('--stress-cycles=')) {
+    options.stressCycles = parsePositiveInteger(
+      '--stress-cycles',
+      argument.slice('--stress-cycles='.length),
+      1,
+      { max: 20 }
+    )
   } else if (argument.startsWith('--output=')) {
     const value = argument.slice('--output='.length).trim()
     if (!value) throw new Error('--output must not be empty.')
@@ -83,6 +92,7 @@ const environment = {
   ...process.env,
   OPEN_SCIENCE_PERF_PHASE_MS: String(options.phaseMs),
   OPEN_SCIENCE_PERF_INTERVAL_MS: String(options.intervalMs),
+  OPEN_SCIENCE_PERF_STRESS_CYCLES: String(options.stressCycles),
   ...(options.output ? { OPEN_SCIENCE_PERF_OUTPUT_ROOT: options.output } : {})
 }
 

--- a/scripts/performance/runtime-resource-profiler.test.ts
+++ b/scripts/performance/runtime-resource-profiler.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { ElectronApplication } from 'playwright'
@@ -9,6 +9,7 @@ import {
   RuntimeResourceProfiler,
   mergeResourceSample,
   parseSessionHydrationDiagnostic,
+  readRuntimeStorageSnapshot,
   renderSummaryMarkdown,
   summarizeSamples,
   validatePhase,
@@ -107,6 +108,14 @@ describe('runtime resource profiler', () => {
         processTreeComplete: true,
         electronMetricsComplete: true,
         processes: [],
+        storage: {
+          notebookRunBytes: 1_024,
+          notebookRunFileCount: 1,
+          sessionBytes: 2_048,
+          sessionFileCount: 1,
+          temporaryBytes: 0,
+          temporaryFileCount: 0
+        },
         totals: {
           processCount: 4,
           totalCpuPercent: 1,
@@ -122,6 +131,14 @@ describe('runtime resource profiler', () => {
         processTreeComplete: false,
         electronMetricsComplete: true,
         processes: [],
+        storage: {
+          notebookRunBytes: 2_048,
+          notebookRunFileCount: 1,
+          sessionBytes: 4_096,
+          sessionFileCount: 1,
+          temporaryBytes: 0,
+          temporaryFileCount: 0
+        },
         totals: {
           processCount: 5,
           totalCpuPercent: 3,
@@ -142,8 +159,45 @@ describe('runtime resource profiler', () => {
     expect(summary.phases.idle.summedRssKb).toMatchObject({ first: 1_024, last: 1_024 })
     expect(summary.phases.idle).toMatchObject({ sampleCount: 2, includedSampleCount: 1 })
     expect(summary.phases.idle.roles).toEqual({})
+    expect(summary.phases.idle.storage?.sessionBytes).toMatchObject({
+      first: 2_048,
+      last: 4_096,
+      delta: 2_048
+    })
     expect(summary.incompleteSampleCount).toBe(1)
     expect(renderSummaryMarkdown(summary)).toContain('records no\nprompts, responses')
+    expect(renderSummaryMarkdown(summary)).toContain('## Durable storage snapshots')
+  })
+
+  it('records only aggregate Session, Notebook, and atomic temporary file sizes', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'open-science-runtime-storage-'))
+    const dataRoot = join(storageRoot, 'relocated-data')
+    try {
+      const sessions = join(storageRoot, 'sessions', 'project-1')
+      const notebooks = join(dataRoot, 'notebooks', 'project-1', 'session-1')
+      await Promise.all([
+        mkdir(sessions, { recursive: true }),
+        mkdir(notebooks, { recursive: true })
+      ])
+      await Promise.all([
+        writeFile(join(sessions, 'session-1.json'), '12345'),
+        writeFile(join(sessions, 'manifest.json'), 'ignored'),
+        writeFile(join(sessions, 'session-1.json.1700000000000-1.tmp'), '12'),
+        writeFile(join(notebooks, 'run.json'), '1234567'),
+        writeFile(join(notebooks, 'run.json.1700000000000-1.tmp'), '123')
+      ])
+
+      await expect(readRuntimeStorageSnapshot(storageRoot, dataRoot)).resolves.toEqual({
+        sessionFileCount: 1,
+        sessionBytes: 5,
+        notebookRunFileCount: 1,
+        notebookRunBytes: 7,
+        temporaryFileCount: 2,
+        temporaryBytes: 5
+      })
+    } finally {
+      await rm(storageRoot, { force: true, recursive: true })
+    }
   })
 
   it('excludes a sample when Electron metrics are unavailable', () => {

--- a/scripts/performance/runtime-resource-profiler.ts
+++ b/scripts/performance/runtime-resource-profiler.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, stat, writeFile } from 'node:fs/promises'
 import { arch, platform } from 'node:os'
 import { join, resolve } from 'node:path'
 import { randomUUID } from 'node:crypto'
@@ -10,7 +10,7 @@ import {
   type ProcessTreeSnapshot
 } from './process-snapshot'
 
-const PROFILE_SCHEMA_VERSION = 2
+const PROFILE_SCHEMA_VERSION = 3
 const DEFAULT_SAMPLE_INTERVAL_MS = 1_000
 const MIN_SAMPLE_INTERVAL_MS = 250
 const MAX_SAMPLE_INTERVAL_MS = 10_000
@@ -56,7 +56,26 @@ type RuntimeResourceSample = {
   processTreeComplete: boolean
   processes: RuntimeProcessSample[]
   rootPid: number
+  storage?: RuntimeStorageTotals
   totals: RuntimeResourceTotals
+}
+
+type RuntimeStorageTotals = {
+  notebookRunBytes: number
+  notebookRunFileCount: number
+  sessionBytes: number
+  sessionFileCount: number
+  temporaryBytes: number
+  temporaryFileCount: number
+}
+
+type RuntimeStorageSummary = {
+  notebookRunBytes: NumberStats
+  notebookRunFileCount: NumberStats
+  sessionBytes: NumberStats
+  sessionFileCount: NumberStats
+  temporaryBytes: NumberStats
+  temporaryFileCount: NumberStats
 }
 
 type NumberStats = {
@@ -82,6 +101,7 @@ type RuntimePhaseSummary = {
   >
   includedSampleCount: number
   sampleCount: number
+  storage?: RuntimeStorageSummary
   summedRssKb: NumberStats
   totalCpuPercent: NumberStats
 }
@@ -141,11 +161,86 @@ type RuntimeProfileResult = {
 }
 
 type RuntimeResourceProfilerOptions = {
+  dataRoot?: string
   now?: () => number
   outputRoot?: string
   readTree?: (rootPid: number) => Promise<ProcessTreeSnapshot>
   runId?: string
   sampleIntervalMs?: number
+  storageRoot?: string
+}
+
+type StorageFileKind = 'notebook-run' | 'session' | 'temporary'
+
+const emptyStorageTotals = (): RuntimeStorageTotals => ({
+  notebookRunBytes: 0,
+  notebookRunFileCount: 0,
+  sessionBytes: 0,
+  sessionFileCount: 0,
+  temporaryBytes: 0,
+  temporaryFileCount: 0
+})
+
+const scanStorageFiles = async (
+  root: string,
+  classify: (name: string) => StorageFileKind | undefined,
+  totals: RuntimeStorageTotals
+): Promise<void> => {
+  const entries = await readdir(root, { withFileTypes: true }).catch(
+    (error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return []
+      throw error
+    }
+  )
+  await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(root, entry.name)
+      if (entry.isDirectory()) {
+        await scanStorageFiles(path, classify, totals)
+        return
+      }
+      if (!entry.isFile()) return
+      const kind = classify(entry.name)
+      if (!kind) return
+      const bytes = (await stat(path)).size
+      if (kind === 'session') {
+        totals.sessionFileCount += 1
+        totals.sessionBytes += bytes
+      } else if (kind === 'notebook-run') {
+        totals.notebookRunFileCount += 1
+        totals.notebookRunBytes += bytes
+      } else {
+        totals.temporaryFileCount += 1
+        totals.temporaryBytes += bytes
+      }
+    })
+  )
+}
+
+const readRuntimeStorageSnapshot = async (
+  storageRoot: string,
+  dataRoot = storageRoot
+): Promise<RuntimeStorageTotals> => {
+  const totals = emptyStorageTotals()
+  await Promise.all([
+    scanStorageFiles(
+      join(storageRoot, 'sessions'),
+      (name) =>
+        name.endsWith('.tmp')
+          ? 'temporary'
+          : name !== 'manifest.json' && name.endsWith('.json')
+            ? 'session'
+            : undefined,
+      totals
+    ),
+    scanStorageFiles(
+      join(dataRoot, 'notebooks'),
+      (name) =>
+        name.endsWith('.tmp') ? 'temporary' : name === 'run.json' ? 'notebook-run' : undefined,
+      totals
+    )
+  ])
+  return totals
 }
 
 const SESSION_TRACE_NUMBER_FIELDS = [
@@ -323,6 +418,9 @@ const summarizeSamples = (
     const privateValues = includedSamples
       .map((sample) => sample.totals.electronPrivateKb)
       .filter((value): value is number => value !== undefined)
+    const storageSamples = phaseSamples
+      .map((sample) => sample.storage)
+      .filter((value): value is RuntimeStorageTotals => value !== undefined)
     const roleNames = new Set(
       includedSamples.flatMap((sample) => sample.processes.map((process) => processRole(process)))
     )
@@ -355,6 +453,26 @@ const summarizeSamples = (
         includedSamples.map((sample) => sample.totals.electronWorkingSetKb)
       ),
       processCount: numberStats(includedSamples.map((sample) => sample.totals.processCount)),
+      ...(storageSamples.length === 0
+        ? {}
+        : {
+            storage: {
+              notebookRunBytes: numberStats(
+                storageSamples.map((sample) => sample.notebookRunBytes)
+              ),
+              notebookRunFileCount: numberStats(
+                storageSamples.map((sample) => sample.notebookRunFileCount)
+              ),
+              sessionBytes: numberStats(storageSamples.map((sample) => sample.sessionBytes)),
+              sessionFileCount: numberStats(
+                storageSamples.map((sample) => sample.sessionFileCount)
+              ),
+              temporaryBytes: numberStats(storageSamples.map((sample) => sample.temporaryBytes)),
+              temporaryFileCount: numberStats(
+                storageSamples.map((sample) => sample.temporaryFileCount)
+              )
+            }
+          }),
       ...(privateValues.length === 0 ? {} : { electronPrivateKb: numberStats(privateValues) })
     }
   }
@@ -379,6 +497,7 @@ const summarizeSamples = (
 
 const formatNumber = (value: number): string => value.toFixed(1)
 const formatMb = (valueKb: number): string => formatNumber(valueKb / 1024)
+const formatBytesMb = (valueBytes: number): string => formatNumber(valueBytes / (1024 * 1024))
 
 const renderSummaryMarkdown = (summary: RuntimeProfileSummary): string => {
   const rows = Object.entries(summary.phases).map(([phase, stats]) => {
@@ -433,6 +552,34 @@ Operation | CPU interval | Boundary/outcome | Wall ms | CPU user ms | CPU system
 ---: | --- | --- | ---: | ---: | ---: | ---:
 ${numberedSessionTraceRows.join('\n')}
 `
+  const storageRows = Object.entries(summary.phases).flatMap(([phase, stats]) => {
+    if (!stats.storage) return []
+    return [
+      [
+        phase,
+        formatNumber(stats.storage.sessionFileCount.last),
+        formatBytesMb(stats.storage.sessionBytes.first),
+        formatBytesMb(stats.storage.sessionBytes.last),
+        formatBytesMb(stats.storage.sessionBytes.delta),
+        formatNumber(stats.storage.notebookRunFileCount.last),
+        formatBytesMb(stats.storage.notebookRunBytes.first),
+        formatBytesMb(stats.storage.notebookRunBytes.last),
+        formatBytesMb(stats.storage.notebookRunBytes.delta),
+        formatNumber(stats.storage.temporaryFileCount.max),
+        formatNumber(stats.storage.temporaryFileCount.last)
+      ].join(' | ')
+    ]
+  })
+  const storageSection =
+    storageRows.length === 0
+      ? ''
+      : `
+## Durable storage snapshots
+
+Phase | Session files end | Session start MB | Session end MB | Session delta MB | Notebook run files end | Notebook start MB | Notebook end MB | Notebook delta MB | Temp files peak | Temp files end
+--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---:
+${storageRows.join('\n')}
+`
   return `# Runtime resource profile
 
 - Platform: ${summary.platform}/${summary.architecture}
@@ -445,6 +592,7 @@ Phase | Included/total | CPU mean % | CPU p95 % | CPU peak % | CPU end % | RSS s
 --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---
 ${rows.join('\n')}
 ${sessionTraceSection}
+${storageSection}
 
 RSS is the sum of per-process resident sets and can double-count shared pages. It is intended for
 same-machine trend comparison, not as a portable absolute memory value. The profile records no
@@ -459,7 +607,8 @@ const mergeResourceSample = (
   tree: ProcessTreeSnapshot,
   electronMetrics: readonly ElectronProcessMetric[],
   cpuTracker: ProcessCpuTracker,
-  electronMetricsComplete = true
+  electronMetricsComplete = true,
+  storage?: RuntimeStorageTotals
 ): RuntimeResourceSample => {
   const electronByPid = new Map(electronMetrics.map((metric) => [metric.pid, metric]))
   const processes: RuntimeProcessSample[] = tree.processes.map((process) => {
@@ -507,6 +656,7 @@ const mergeResourceSample = (
     processTreeComplete: tree.complete,
     electronMetricsComplete,
     processes,
+    ...(storage ? { storage } : {}),
     totals: {
       processCount: processes.length,
       totalCpuPercent: processes.reduce((sum, process) => sum + (process.cpuPercent ?? 0), 0),
@@ -527,11 +677,13 @@ class RuntimeResourceProfiler {
   >()
   private electronVersion: string | undefined
   private readonly cpuTracker = new ProcessCpuTracker()
+  private readonly dataRoot: string | undefined
   private readonly now: () => number
   private readonly outputRoot: string
   private readonly readTree: (rootPid: number) => Promise<ProcessTreeSnapshot>
   private readonly runId: string
   private readonly sampleIntervalMs: number
+  private readonly storageRoot: string | undefined
   private readonly samples: RuntimeResourceSample[] = []
   private readonly sessionHydrationTrace: SessionHydrationTraceEvent[] = []
   private phase = 'startup'
@@ -542,6 +694,7 @@ class RuntimeResourceProfiler {
 
   constructor(options: RuntimeResourceProfilerOptions = {}) {
     this.now = options.now ?? Date.now
+    this.dataRoot = options.dataRoot ? resolve(options.dataRoot) : undefined
     this.outputRoot = resolve(
       options.outputRoot ?? join(process.cwd(), 'test-results', 'performance')
     )
@@ -552,6 +705,7 @@ class RuntimeResourceProfiler {
     this.sampleIntervalMs = validateSampleInterval(
       options.sampleIntervalMs ?? DEFAULT_SAMPLE_INTERVAL_MS
     )
+    this.storageRoot = options.storageRoot ? resolve(options.storageRoot) : undefined
     this.startedAt = this.now()
   }
 
@@ -660,8 +814,8 @@ class RuntimeResourceProfiler {
     const previousSample = this.sampleInFlight
     const sampling = (
       previousSample
-        ? previousSample.then(() => this.captureSample(phase))
-        : this.captureSample(phase)
+        ? previousSample.then(() => this.captureSample(phase, force))
+        : this.captureSample(phase, force)
     ).finally(() => {
       if (this.sampleInFlight === sampling) this.sampleInFlight = undefined
     })
@@ -669,12 +823,12 @@ class RuntimeResourceProfiler {
     return sampling
   }
 
-  private async captureSample(phase: string): Promise<void> {
+  private async captureSample(phase: string, includeStorage: boolean): Promise<void> {
     const application = this.application
     const rootPid = application?.process().pid
     if (!application || rootPid === undefined) return
     const capturedAt = this.now()
-    const [tree, electronSnapshot] = await Promise.all([
+    const [tree, electronSnapshot, storage] = await Promise.all([
       this.readTree(rootPid),
       application
         .evaluate(({ app }) =>
@@ -693,7 +847,10 @@ class RuntimeResourceProfiler {
         .then(
           (metrics) => ({ complete: true, metrics }),
           () => ({ complete: false, metrics: [] as ElectronProcessMetric[] })
-        )
+        ),
+      includeStorage && this.storageRoot
+        ? readRuntimeStorageSnapshot(this.storageRoot, this.dataRoot)
+        : Promise.resolve(undefined)
     ])
     this.samples.push(
       mergeResourceSample(
@@ -703,7 +860,8 @@ class RuntimeResourceProfiler {
         tree,
         electronSnapshot.metrics,
         this.cpuTracker,
-        electronSnapshot.complete
+        electronSnapshot.complete,
+        storage
       )
     )
   }
@@ -718,6 +876,7 @@ export {
   RuntimeResourceProfiler,
   mergeResourceSample,
   parseSessionHydrationDiagnostic,
+  readRuntimeStorageSnapshot,
   renderSummaryMarkdown,
   summarizeSamples,
   validatePhase,
@@ -733,5 +892,7 @@ export type {
   RuntimeResourceProfilerOptions,
   RuntimeResourceSample,
   RuntimeResourceTotals,
+  RuntimeStorageSummary,
+  RuntimeStorageTotals,
   SessionHydrationTraceEvent
 }


### PR DESCRIPTION
## Problem

The existing runtime profiler covers CPU and RSS for one short deterministic journey, but it does not exercise sustained whole-Session writes, report durable Session/Notebook IO growth, or run periodically on Windows. Regressions such as #1779 can therefore reach a long-running Session before resource behavior is visible in CI.

## Proposed change

- add a separate daily Windows `Runtime Resource Soak` workflow with manual `smoke` and `soak` modes;
- extend the deterministic fake-agent journey with configurable repeated Session stress and Notebook cycles;
- isolate the profiled app data root, restart it, and assert the stressed Session plus Notebook run survive recovery;
- add path-free aggregate Session, Notebook, and atomic-temp file counts/bytes to schema-v3 JSON/Markdown evidence;
- upload the complete profile evidence for 14 days.

Scheduled runs skip only a `main` SHA that already has successful resource coverage. A failed run is retried by the next schedule. CPU/RSS/temp-file values remain diagnostic during burn-in; deterministic recovery and non-empty durable output are the blocking assertions.

## Scope and non-goals

- This PR adds CI/performance instrumentation and deterministic load coverage; it does not change production persistence behavior.
- It does not add absolute hosted-runner CPU/RSS/OOM thresholds yet because those require a stable baseline across multiple Windows runs.
- #1779 is not modified here. Its final merged commit already added per-Session latest-save coalescing and a multi-Session flush regression test; that exact merged test also passes on this branch.
- No application data migration, persisted user-data format, enum value, or runtime state is added.
- Historical profile artifacts remain standalone JSON/Markdown. New artifacts use schema version 3; old schema-v2 artifacts are not rewritten and there is no in-repo artifact reader requiring migration.

## Acceptance criteria and validation

All listed checks ran against the final rebased head after the last material edit.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| resource/storage aggregation and Markdown evidence | `npm exec -- vitest run scripts/performance/runtime-resource-profiler.test.ts scripts/ci/release-workflows.test.ts scripts/ci/npm-ci.test.ts` | 21 passed |
| Node/E2E fixture types | `npm run typecheck:node` | passed |
| changed-file lint | `npm exec -- eslint e2e/fixtures/electron-app.ts e2e/fixtures/fake-opencode.mjs e2e/runtime-performance.spec.ts scripts/ci/release-workflows.test.ts scripts/performance/run-runtime-profile.mjs scripts/performance/runtime-resource-profiler.test.ts scripts/performance/runtime-resource-profiler.ts` | passed |
| changed-file formatting | `npm exec -- prettier --check .github/workflows/runtime-resource-soak.yml e2e/fixtures/electron-app.ts e2e/fixtures/fake-opencode.mjs e2e/runtime-performance.spec.ts scripts/ci/release-workflows.test.ts scripts/performance/run-runtime-profile.mjs scripts/performance/runtime-resource-profiler.test.ts scripts/performance/runtime-resource-profiler.ts` | passed |
| real Electron stress, Notebook persistence, restart recovery, and evidence generation | `npm run perf:runtime -- --repeat=1 --phase-ms=2000 --interval-ms=500 --stress-cycles=1 --output=test-results/performance-final-smoke --skip-build` | 1 passed; isolated recovery ended with 1 Session (~0.4 MiB), 1 Notebook run, 0 temp files |
| merged #1779 multi-Session cadence regression | `npm exec -- vitest run src/renderer/src/lib/session-persistence/session-persistence.test.ts -t "flushes a fast alternating multi-Session stream without draining cadence timers"` | 1 passed |

The full portable suite was intentionally not run locally; PR Gate remains authoritative for full module and platform coverage. The uncovered local risk is the new workflow's Windows runner execution, which should be reviewed through PR CI and its first manual/scheduled workflow run.

## Review focus

- whether the daily/manual scheduling and successful-SHA deduplication are appropriate for runner cost;
- whether six stress cycles across three soak repetitions are sufficient for initial burn-in;
- whether the aggregate storage evidence is useful without leaking paths or content;
- whether recovery assertions are strict enough while CPU/RSS thresholds remain report-only.
