### PR TITLE
fix(archive): quiesce project activity before archiving

### DIFF
--- a/src/main/archive/coordinator.test.ts
+++ b/src/main/archive/coordinator.test.ts
@@ -237,6 +237,30 @@ describe('ArchiveCoordinator', () => {
     expect(projects.updateArchive).not.toHaveBeenCalled()
   })
 
+  it('waits for asynchronous Project activity before archiving', async () => {
+    const projects = {
+      get: vi.fn().mockResolvedValue(project),
+      updateArchive: vi.fn().mockResolvedValue({ ...project, archivedAt: 40 })
+    }
+    const sessions = {
+      assertProjectArchivable: vi.fn().mockResolvedValue([]),
+      assertSessionAvailable: vi.fn(),
+      updateArchive: vi.fn(),
+      sessionProjectId: vi.fn()
+    }
+    const coordinator = new ArchiveCoordinator(projects, sessions, {
+      isSessionBusy: vi.fn(),
+      isProjectBusy: vi.fn().mockResolvedValue(false),
+      liveSessionProjectId: vi.fn()
+    })
+
+    await expect(
+      coordinator.updateProjectArchive({ id: project.id, archived: true, expectedArchivedAt: null })
+    ).resolves.toMatchObject({ archivedAt: 40 })
+
+    expect(projects.updateArchive).toHaveBeenCalledOnce()
+  })
+
   it('resolves a fresh live session owner before archive admission', async () => {
     const projects = {
       get: vi.fn().mockResolvedValue({ ...project, archivedAt: 40 }),

--- a/src/main/archive/coordinator.ts
+++ b/src/main/archive/coordinator.ts
@@ -24,7 +24,7 @@ type SessionArchivePersistence = {
 
 type SessionRuntimeActivity = {
   isSessionBusy(projectId: string, sessionId: string): boolean
-  isProjectBusy(projectId: string): boolean
+  isProjectBusy(projectId: string): boolean | Promise<boolean>
   liveSessionProjectId(sessionId: string): string | undefined
 }
 
@@ -73,7 +73,7 @@ class ArchiveCoordinator {
       }
       if (request.archived === (currentArchivedAt !== null)) return project
 
-      if (request.archived && this.runtime.isProjectBusy(request.id)) {
+      if (request.archived && (await this.runtime.isProjectBusy(request.id))) {
         throw new Error('Finish or stop active sessions before archiving this project.')
       }
       const sessionIds = request.archived

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -678,6 +678,11 @@ const createApplicationModules = async (
       ): Promise<void>
     }
   } = {}
+  const computeJobActivityRef: {
+    current?: {
+      findNonTerminal(): Promise<Array<{ project_id: string }>>
+    }
+  } = {}
   const projectRuntimeQuiescenceRef: { current?: ProjectRuntimeQuiescenceOwner } = {}
   const computeJobDeletionPort = {
     restoreProjectJobDeletion: (projectId: string): Promise<void> => {
@@ -855,8 +860,17 @@ const createApplicationModules = async (
         detectArchiveBlockingSessions().some(
           (session) => session.projectId === projectId && session.sessionId === sessionId
         ),
-      isProjectBusy: (projectId) =>
-        detectArchiveBlockingSessions().some((session) => session.projectId === projectId),
+      isProjectBusy: async (projectId) => {
+        if (
+          reviewerProjectRuntime.isProjectBusy(projectId) ||
+          detectArchiveBlockingSessions().some((session) => session.projectId === projectId)
+        ) {
+          return true
+        }
+        const computeJobs = computeJobActivityRef.current
+        if (!computeJobs) throw new Error('Compute Job activity is not initialized.')
+        return (await computeJobs.findNonTerminal()).some((job) => job.project_id === projectId)
+      },
       liveSessionProjectId: (sessionId) => runtimeRef.current?.liveSessionProjectId(sessionId)
     }
   )
@@ -1473,6 +1487,7 @@ const createApplicationModules = async (
     hostRepository,
     enabledComputeHostsRegistry: hostsRegistry
   } = computeIpcModule
+  computeJobActivityRef.current = jobRepository
   const sessionEnabledComputeHostsOwner = new SessionEnabledComputeHostsOwner({
     registry: hostsRegistry,
     hostExists: async (providerId) => (await hostRepository.get(providerId)) !== null,
@@ -3187,6 +3202,8 @@ const createApplicationModules = async (
     acpRuntime: runtime,
     modelRuntime: reviewerModelRuntime,
     projectRuntime: reviewerProjectRuntime,
+    withProjectAvailable: <Result>(projectId: string, operation: () => Promise<Result>) =>
+      archiveCoordinator.withProjectAvailable(projectId, operation),
     mcpEntryPath: mainEntryPath,
     artifactProvenanceRepository,
     resolveSessionAgentTarget,

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -229,6 +229,22 @@ describe('reviewer IPC handlers', () => {
     expect(quiesced).toBe(true)
   })
 
+  it('checks Project archive availability before admitting a Review', async () => {
+    const projectRuntime = new ReviewerProjectRuntimeOwner()
+    const admit = vi.spyOn(projectRuntime, 'admit')
+    const withProjectAvailable = vi.fn(async () => {
+      throw new Error('Restore this archived Project before continuing.')
+    })
+    const options = { acpRuntime, projectRuntime, withProjectAvailable }
+    const owner = createReviewerCommandOwner(options)
+
+    await expect(owner.run(createRequest())).rejects.toThrow('archived Project')
+
+    expect(withProjectAvailable).toHaveBeenCalledWith('project-1', expect.any(Function))
+    expect(admit).not.toHaveBeenCalled()
+    expect(runReview).not.toHaveBeenCalled()
+  })
+
   it('runs reviews with artifacts rooted at the data root, not the config root', async () => {
     registerReviewerIpcHandlers({ acpRuntime })
 

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -106,6 +106,10 @@ type ReviewerIpcOptions = {
     >
   }>
   projectRuntime?: Pick<ReviewerProjectRuntimeOwner, 'admit'>
+  withProjectAvailable?: <Result>(
+    projectId: string,
+    operation: () => Promise<Result>
+  ) => Promise<Result>
   resolveSessionAgentTarget?: SessionAgentTargetResolver
   saveSessionAgentConfiguration?: (
     session: PersistedChatSession,
@@ -492,18 +496,23 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
   }
 
   const triggerReview = (request: ReviewRunRequest): Promise<ReviewRunResult> => {
-    let projectAdmission: ReviewerProjectAdmission
-    try {
-      // Admission is acquired synchronously before session/repository/model work begins. Once
-      // Project deletion closes it, no new Reviewer operation can slip into the quiescence snapshot.
-      projectAdmission = projectRuntime.admit(request.projectId)
-    } catch (error) {
-      return Promise.reject(error)
+    const admitReview = (): Promise<ReviewRunResult> => {
+      let projectAdmission: ReviewerProjectAdmission
+      try {
+        // Admission is acquired synchronously before session/repository/model work begins. Once
+        // Project deletion closes it, no new Reviewer operation can slip into the quiescence snapshot.
+        projectAdmission = projectRuntime.admit(request.projectId)
+      } catch (error) {
+        return Promise.reject(error)
+      }
+      return triggerAdmittedReview(request, projectAdmission).catch((error: unknown) => {
+        projectAdmission.release()
+        throw error
+      })
     }
-    return triggerAdmittedReview(request, projectAdmission).catch((error: unknown) => {
-      projectAdmission.release()
-      throw error
-    })
+    return options.withProjectAvailable
+      ? options.withProjectAvailable(request.projectId, admitReview)
+      : admitReview()
   }
 
   return { run: triggerReview, triggerReview, getForSession, abort, abortFixLoop }

--- a/src/main/reviewer/project-runtime-owner.test.ts
+++ b/src/main/reviewer/project-runtime-owner.test.ts
@@ -8,6 +8,9 @@ describe('ReviewerProjectRuntimeOwner', () => {
     const target = owner.admit('project-1')
     const other = owner.admit('project-2')
 
+    expect(owner.isProjectBusy('project-1')).toBe(true)
+    expect(owner.isProjectBusy('project-2')).toBe(true)
+
     let quiesced = false
     const quiescing = owner.quiesceProject('project-1').then(() => {
       quiesced = true
@@ -22,6 +25,7 @@ describe('ReviewerProjectRuntimeOwner', () => {
     target.release()
     await quiescing
     expect(quiesced).toBe(true)
+    expect(owner.isProjectBusy('project-1')).toBe(false)
 
     const stillAvailable = owner.admit('project-2')
     stillAvailable.release()

--- a/src/main/reviewer/project-runtime-owner.ts
+++ b/src/main/reviewer/project-runtime-owner.ts
@@ -47,6 +47,10 @@ class ReviewerProjectRuntimeOwner {
     })
   }
 
+  isProjectBusy(projectId: string): boolean {
+    return (this.activeByProject.get(projectId)?.size ?? 0) > 0
+  }
+
   async quiesceProject(projectId: string): Promise<void> {
     this.restoreProjectDeletion(projectId)
     for (;;) {

--- a/src/renderer/src/pages/workspace/workspace-message-queue-admission.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-admission.ts
@@ -69,6 +69,7 @@ const queueSessionIsSendable = (
   session: ChatSession
 ): boolean =>
   session.archivedAt === undefined &&
+  (options.isProjectActive?.(session.projectId) ?? true) &&
   (session.status === 'idle' || session.status === 'error') &&
   // Errored turns have no live reveal to wait for; let the queue proceed immediately.
   (session.status === 'error' || !options.isPresentationRevealing(session.id)) &&

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatSession } from '@/stores/session-store'
+import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
 
 import { type ComposerDoc } from './composer/composer-doc'
 import {
@@ -125,6 +126,7 @@ const options = (
   isPresentationRevealing: vi.fn(() => false),
   isSpecialistReady: vi.fn(() => true),
   hasPendingPermissionRequest: vi.fn(() => false),
+  isProjectActive: vi.fn(() => true),
   abortFixLoop: vi.fn(async () => undefined),
   getSession: () => activeSession,
   subscribeSessionChanges: () => () => undefined,
@@ -181,6 +183,7 @@ const mounted: Hook[] = []
 
 afterEach(() => {
   for (const hook of mounted.splice(0)) hook.unmount()
+  useProjectStore.setState(createInitialProjectState())
   setWorkspaceSpecialistBarrier('session-a', false)
   setWorkspacePresentationRevealing('session-a', false)
   vi.restoreAllMocks()
@@ -244,6 +247,59 @@ describe('workspace message queue controller', () => {
     workspace.returnToWorkspace()
     await vi.waitFor(() => expect(workspace.result.current.items).toEqual([]))
     expect(workspace.result.current.lifecycle.blocksImmediateSend(currentSession.id)).toBe(false)
+  })
+
+  it('does not drain a queued message after its Project is archived', async () => {
+    let currentSession = session()
+    let notifySessionChanged: (() => void) | undefined
+    const input = options(currentSession, {
+      promptInFlightSessionIds: [],
+      isProjectActive: (projectId) =>
+        useProjectStore
+          .getState()
+          .projects.some((project) => project.id === projectId && project.archivedAt === undefined),
+      getSession: () => currentSession,
+      subscribeSessionChanges: (listener) => {
+        notifySessionChanged = listener
+        return () => {
+          notifySessionChanged = undefined
+        }
+      }
+    })
+    const workspace = renderController(input)
+    mounted.push(workspace)
+    useProjectStore.setState({
+      projects: [
+        {
+          id: 'project-a',
+          name: 'Project A',
+          description: '',
+          isExample: false,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      isLoaded: true
+    })
+
+    act(() => workspace.result.current.lifecycle.enqueue(admission('do not send after archive')))
+    workspace.leaveWorkspace()
+    useProjectStore.setState((state) => ({
+      projects: state.projects.map((project) => ({ ...project, archivedAt: 2 }))
+    }))
+
+    currentSession = session('idle')
+    act(() => notifySessionChanged?.())
+    await Promise.resolve()
+
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+
+    useProjectStore.setState((state) => ({
+      projects: state.projects.map((project) => ({ ...project, archivedAt: undefined }))
+    }))
+    act(() => notifySessionChanged?.())
+
+    await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
   })
 
   it('dispatches queued messages with the agentConfiguration captured at enqueue', async () => {

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -13,6 +13,7 @@ import {
 } from 'react'
 
 import { useSessionStore } from '@/stores/session-store'
+import { useProjectStore } from '@/stores/project-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { useWorkspaceAgentRuntime } from '@/lib/acp/useWorkspaceAgentRuntime'
 
@@ -94,6 +95,7 @@ const WorkspaceMessageQueueRuntimeBridge = (): null => {
   const specialistItems = useSpecialistStore((state) => state.items)
   const loadSpecialists = useSpecialistStore((state) => state.load)
   const openSideChatParentSessionIds = useOpenSideChatParentSessionIds()
+  const projects = useProjectStore((state) => state.projects)
   useLayoutEffect(() => {
     owner.updateRuntime({
       promptInFlightSessionIds: runtime.promptInFlightSessionIds,
@@ -119,6 +121,8 @@ const WorkspaceMessageQueueRuntimeBridge = (): null => {
       isSideChatOpen: (sessionId) => openSideChatParentSessionIds.has(sessionId),
       hasPendingPermissionRequest: (sessionId) =>
         runtime.pendingPermissions.some((request) => request.sessionId === sessionId),
+      isProjectActive: (projectId) =>
+        projects.some((project) => project.id === projectId && project.archivedAt === undefined),
       abortFixLoop: (request) => window.api.reviewer.abortFixLoop(request),
       getSession: (sessionId) =>
         useSessionStore.getState().sessions.find((candidate) => candidate.id === sessionId),
@@ -128,6 +132,7 @@ const WorkspaceMessageQueueRuntimeBridge = (): null => {
     loadSpecialists,
     openSideChatParentSessionIds,
     owner,
+    projects,
     runtime,
     specialistCatalogLoaded,
     specialistItems

--- a/src/renderer/src/pages/workspace/workspace-message-queue-owner.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-owner.ts
@@ -63,6 +63,7 @@ type WorkspaceMessageQueueControllerOptions = {
   isPresentationRevealing: (sessionId: string) => boolean
   isSpecialistReady: (sessionId: string) => boolean
   hasPendingPermissionRequest: (sessionId: string) => boolean
+  isProjectActive?: (projectId: string) => boolean
   abortFixLoop: (request: { projectId: string; appSessionId: string }) => Promise<unknown>
   getSession: (sessionId: string) => ChatSession | undefined
   subscribeSessionChanges: (listener: () => void) => () => void
@@ -83,6 +84,7 @@ type WorkspaceMessageQueueRuntimeOptions = Pick<
   | 'isSpecialistReady'
   | 'isSideChatOpen'
   | 'hasPendingPermissionRequest'
+  | 'isProjectActive'
   | 'abortFixLoop'
   | 'getSession'
   | 'subscribeSessionChanges'


### PR DESCRIPTION
## Problem

Project archive persisted only `Project.archivedAt`. The application-level renderer message queue survived Workspace navigation and checked only Session actionability, so a queued message could attempt to drain after its Project disappeared from active UI. Main already fenced ordinary Prompt and Side chat admission, but active Reviewer work and non-terminal remote Compute Jobs were not part of Project archive quiescence.

## Proposed change

- Make Project activity checks await asynchronous owners and include active Reviewer operations plus persisted non-terminal Compute Jobs.
- Serialize Reviewer admission with Project archive availability, then retain the existing Reviewer runtime admission until the background review settles.
- Feed live Project archive state into the global message queue owner. Pause dispatch while the Project is archived and resume the retained in-memory queue after restore.

## Scope and non-goals

- Archive still changes only `Project.archivedAt`.
- No new database columns, persisted fields, migrations, enum values, or durable state formats.
- No historical-data compatibility path is required.
- Active Reviewer or Compute work is not cancelled or deleted; archive remains rejected until Project activity is quiescent.
- No new UI surface or copy. The only interaction change is queue pause on archive and automatic resume on restore.

## Acceptance criteria and validation

Regression evidence on the unfixed code:

- `does not drain a queued message after its Project is archived` failed stably 3 of 3 runs because `runtime.sendMessage` was called once after navigation and archive.
- `waits for asynchronous Project activity before archiving` failed because the unresolved Promise was treated as a truthy busy result.
- `checks Project archive availability before admitting a Review` failed because Review admission still ran.

Final evidence mapping after the last material edit:

- Archived Project queue pause and restore resume -> `npm run test:module -- workspace_page` -> 25 files, 545 tests passed.
- Reviewer admission and active-operation quiescence -> `npm run test:module -- reviewer_orchestrator` -> 27 files, 496 tests passed.
- Non-terminal remote Compute Job archive blocking and compute consumers -> `npm run test:module -- compute_service` -> 31 files passed, 1 skipped; 806 tests passed, 6 skipped.
- Main and renderer interfaces -> `npm run typecheck:node` and `npm run typecheck:web` -> passed.
- Source quality -> `npm run lint`, Prettier check, and `git diff --check` -> passed.

The complete portable suite was not run locally. Exact-head PR Gate and platform lanes remain authoritative.

## Review focus

Please focus on the short archive/admission serialization boundaries, the late Compute repository activity wiring during application composition, and the decision to retain queued messages for automatic restore-time resume rather than discarding them.