### PR TITLE
fix(acp): enforce project agent context consistency

### DIFF
--- a/src/main/acp/provider-session-adopter.test.ts
+++ b/src/main/acp/provider-session-adopter.test.ts
@@ -74,6 +74,7 @@ const createHarness = (
     initialBackend?: AcpBackendGenerationView
     capabilityPolicy?: SessionCapabilityPolicy
     projectAgentContext?: string
+    projectAgentContextError?: Error
     specialistIdentity?: { append: string; prefix: string }
     specialistSkills?: EffectiveSpecialistSkills
   } = {}
@@ -169,9 +170,13 @@ const createHarness = (
     resolveSpecialistSkills: options.specialistSkills
       ? vi.fn(async () => options.specialistSkills as EffectiveSpecialistSkills)
       : undefined,
-    resolveProjectAgentContext: options.projectAgentContext
-      ? vi.fn(async () => options.projectAgentContext)
-      : undefined,
+    resolveProjectAgentContext: options.projectAgentContextError
+      ? vi.fn(async () => {
+          throw options.projectAgentContextError
+        })
+      : options.projectAgentContext
+        ? vi.fn(async () => options.projectAgentContext)
+        : undefined,
     peekClaudeReplay: () => options.handoffAppend,
     commitClaudeReplay,
     updateCwd: () => order.push('cwd callback'),
@@ -475,6 +480,17 @@ describe('AcpProviderSessionAdopter', () => {
     expect(
       harness.registry.lookup('stable-app-session')?.aggregate.snapshot().sessionSetupPromptPrefix
     ).toContain('Always cite DOIs.')
+  })
+
+  it('does not adopt a provider Session when Project Agent Context resolution fails', async () => {
+    const failure = new Error('database is locked')
+    const harness = createHarness({ projectAgentContextError: failure })
+
+    await expect(harness.adopt()).rejects.toBe(failure)
+
+    expect(harness.connection.agent.buildSession).not.toHaveBeenCalled()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
   })
 
   it('does not roll back publication when the state observer fails', async () => {

--- a/src/main/acp/provider-session-adopter.ts
+++ b/src/main/acp/provider-session-adopter.ts
@@ -239,13 +239,8 @@ export class AcpProviderSessionAdopter {
 
   private async resolveProjectAgentContext(projectId: string): Promise<string | undefined> {
     if (!this.deps.resolveProjectAgentContext) return undefined
-    try {
-      const context = await this.deps.resolveProjectAgentContext(projectId)
-      return this.presentation.projectAgentContext(context)
-    } catch (error) {
-      log.warn('project Agent Context resolution failed', diagnosticErrorFields(error))
-      return undefined
-    }
+    const context = await this.deps.resolveProjectAgentContext(projectId)
+    return this.presentation.projectAgentContext(context)
   }
 
   private async resolveSpecialistIdentity(

--- a/src/main/acp/provider-session-creator.test.ts
+++ b/src/main/acp/provider-session-creator.test.ts
@@ -54,6 +54,7 @@ const createHarness = (options: {
   bridgeMcpAliasesEnabled?: boolean
   backendId?: string
   projectAgentContext?: string
+  projectAgentContextError?: Error
   specialistIdentity?: { append: string; prefix: string }
 }): CreatorHarness => {
   const order = options.order ?? []
@@ -138,9 +139,13 @@ const createHarness = (options: {
     },
     capabilities: { provision },
     capabilityPolicy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-    resolveProjectAgentContext: options.projectAgentContext
-      ? vi.fn(async () => options.projectAgentContext)
-      : undefined,
+    resolveProjectAgentContext: options.projectAgentContextError
+      ? vi.fn(async () => {
+          throw options.projectAgentContextError
+        })
+      : options.projectAgentContext
+        ? vi.fn(async () => options.projectAgentContext)
+        : undefined,
     resolveSpecialistIdentity: options.specialistIdentity
       ? vi.fn(async () => options.specialistIdentity)
       : undefined,
@@ -317,5 +322,15 @@ describe('AcpProviderSessionCreator', () => {
 
     expect(harness.sessionSetupAppends.length).toBeGreaterThan(0)
     expect(harness.sessionSetupAppends.flat()).not.toContain('Always cite DOIs.')
+  })
+
+  it('does not start a provider Session when Project Agent Context resolution fails', async () => {
+    const failure = new Error('database is locked')
+    const harness = createHarness({ projectAgentContextError: failure })
+
+    await expect(harness.creator.create({ projectId: 'project-1' })).rejects.toBe(failure)
+
+    expect(harness.provision).not.toHaveBeenCalled()
+    expect(harness.buildSession).not.toHaveBeenCalled()
   })
 })

--- a/src/main/acp/provider-session-creator.ts
+++ b/src/main/acp/provider-session-creator.ts
@@ -204,13 +204,8 @@ export class AcpProviderSessionCreator {
 
   private async resolveProjectAgentContext(projectId: string): Promise<string | undefined> {
     if (!this.deps.resolveProjectAgentContext) return undefined
-    try {
-      const context = await this.deps.resolveProjectAgentContext(projectId)
-      return this.presentation.projectAgentContext(context)
-    } catch (error) {
-      this.safeLogError('project Agent Context resolution failed', error, undefined, false)
-      return undefined
-    }
+    const context = await this.deps.resolveProjectAgentContext(projectId)
+    return this.presentation.projectAgentContext(context)
   }
 
   private async resolveSpecialist(

--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -71,6 +71,7 @@ type HarnessOptions = {
   invalidateDuringResume?: boolean
   observerError?: Error
   projectAgentContext?: string
+  projectAgentContextError?: Error
   providerSessionId?: string
   resumeError?: unknown
   specialistIdentity?:
@@ -298,9 +299,13 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     ...(options.specialistSkills
       ? { resolveSpecialistSkills: vi.fn(async () => options.specialistSkills!) }
       : {}),
-    resolveProjectAgentContext: options.projectAgentContext
-      ? vi.fn(async () => options.projectAgentContext)
-      : undefined,
+    resolveProjectAgentContext: options.projectAgentContextError
+      ? vi.fn(async () => {
+          throw options.projectAgentContextError
+        })
+      : options.projectAgentContext
+        ? vi.fn(async () => options.projectAgentContext)
+        : undefined,
     updateCwd: () => order.push('cwd callback'),
     pushEvent: () => {
       order.push('event callback')
@@ -877,6 +882,17 @@ describe('AcpProviderSessionResumer', () => {
     expect(
       harness.registry.lookup('stable-app-session')?.aggregate.snapshot().sessionSetupPromptPrefix
     ).toContain('Always cite DOIs.')
+  })
+
+  it('does not resume a provider Session when Project Agent Context resolution fails', async () => {
+    const failure = new Error('database is locked')
+    const harness = createHarness({ projectAgentContextError: failure })
+
+    await expect(harness.resume()).rejects.toBe(failure)
+
+    expect(harness.request).not.toHaveBeenCalled()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
   })
 
   it.each([

--- a/src/main/acp/provider-session-resumer.ts
+++ b/src/main/acp/provider-session-resumer.ts
@@ -489,13 +489,8 @@ export class AcpProviderSessionResumer {
 
   private async resolveProjectAgentContext(projectId: string): Promise<string | undefined> {
     if (!this.deps.resolveProjectAgentContext) return undefined
-    try {
-      const context = await this.deps.resolveProjectAgentContext(projectId)
-      return this.presentation.projectAgentContext(context)
-    } catch (error) {
-      log.warn('project Agent Context resolution failed', errorLogFields(error))
-      return undefined
-    }
+    const context = await this.deps.resolveProjectAgentContext(projectId)
+    return this.presentation.projectAgentContext(context)
   }
 
   private async resolveSpecialistSkills(

--- a/src/main/acp/runtime-composition.test.ts
+++ b/src/main/acp/runtime-composition.test.ts
@@ -1,6 +1,5 @@
 // Pins the production Agent Context resolver: createAcpRuntime is Electron-coupled, so the lookup
-// policy (trim, blank/missing ⇒ undefined, failure ⇒ undefined instead of throwing) is extracted as
-// createProjectAgentContextResolver and covered here against a fake repository.
+// policy is extracted as createProjectAgentContextResolver and covered here against a fake repository.
 
 import { describe, expect, it, vi } from 'vitest'
 
@@ -56,14 +55,14 @@ describe('createProjectAgentContextResolver', () => {
     await expect(absent('project-1')).resolves.toBeUndefined()
   })
 
-  it('returns undefined instead of throwing when the lookup fails', async () => {
+  it('fails closed when the Project lookup fails', async () => {
     const resolver = createProjectAgentContextResolver({
       get: vi.fn(async () => {
         throw new Error('database is locked')
       })
     })
 
-    await expect(resolver('project-1')).resolves.toBeUndefined()
+    await expect(resolver('project-1')).rejects.toThrow('Project Agent Context')
   })
 })
 

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -56,8 +56,8 @@ const log = createLogger('acp')
 
 // Builds the session-setup resolver for a project's Agent Context system-prompt append. The ACP
 // projectId carries the Project id; unknown ids (e.g. the DEFAULT_ARTIFACT_PROJECT_ID fallback
-// namespace), blank contexts, and lookup failures all yield undefined so session setup proceeds
-// without an append.
+// namespace) and blank contexts yield undefined. Lookup failures stay fatal so a Session cannot
+// silently start without a configured policy boundary.
 const createProjectAgentContextResolver = (repository: {
   get: (id: string) => Promise<{ agentContext?: string } | null>
 }): ((projectId: string) => Promise<string | undefined>) => {
@@ -68,7 +68,9 @@ const createProjectAgentContextResolver = (repository: {
       return context ? context : undefined
     } catch (error) {
       log.warn('project Agent Context lookup failed', errorLogFields(error))
-      return undefined
+      throw new Error(
+        'Project Agent Context could not be loaded. Retry after Project storage recovers.'
+      )
     }
   }
 }

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -13,6 +13,7 @@ import type { ConversationPermissionGrantStore } from './permission-broker'
 import type { AgentModelChangeTarget } from '../agent-framework'
 import { DelegateMessageParkedError } from '../delegation/execution-port'
 import type { RootDelegatedWorkControl } from '../delegation/production-composition'
+import { createProjectHandlers } from '../projects/ipc'
 
 const createDeferred = <Value = void>(): {
   promise: Promise<Value>
@@ -2849,6 +2850,78 @@ describe('AcpRuntimeCoordinator', () => {
 
     retirement.resolve()
     await reloadRequest
+  })
+
+  it('uses a fresh runtime generation on the next prompt after Project Agent Context changes', async () => {
+    let storedAgentContext = 'Always cite DOIs.'
+    const promptContexts: string[] = []
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const generationAgentContext = storedAgentContext
+      const fake = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: created.length === 0 ? ['agent-session'] : ['fresh-session'],
+        callbacks,
+        prompt: async () => {
+          promptContexts.push(generationAgentContext)
+          return { stopReason: 'end_turn' }
+        }
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+    const project = {
+      id: 'project-1',
+      name: 'Research',
+      description: '',
+      agentContext: storedAgentContext,
+      isExample: false,
+      createdAt: 1,
+      updatedAt: 2
+    }
+    const repository = {
+      list: vi.fn(),
+      get: vi.fn(async () => ({ ...project, agentContext: storedAgentContext })),
+      create: vi.fn(),
+      update: vi.fn(async (request) => {
+        storedAgentContext = request.agentContext ?? storedAgentContext
+        return { ...project, agentContext: storedAgentContext, updatedAt: 3 }
+      })
+    }
+    const handlers = createProjectHandlers(
+      repository,
+      {
+        deleteProject: vi.fn(),
+        waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
+      },
+      {
+        updateArchive: vi.fn(),
+        onAgentContextChanged: () => {
+          void coordinator.requestProjectAgentContextReload()
+        }
+      }
+    )
+    const session = await coordinator.createSession({ projectId: project.id })
+
+    await handlers.update({
+      id: project.id,
+      agentContext: 'Prefer Python.',
+      expectedUpdatedAt: project.updatedAt
+    })
+
+    expect(coordinator.getSnapshot().sessionIds).not.toContain(session.sessionId)
+    await coordinator.resumeSession({
+      sessionId: session.sessionId,
+      cwd: '/workspace',
+      projectId: project.id,
+      previousFrameworkId: 'claude-code'
+    })
+    await coordinator.sendPrompt({ sessionId: session.sessionId, text: 'Use the current policy' })
+
+    expect(promptContexts).toEqual(['Prefer Python.'])
+    expect(created[0].sendPrompt).not.toHaveBeenCalled()
+    expect(created[1].resumeSession).toHaveBeenCalledOnce()
+    expect(created[1].sendPrompt).toHaveBeenCalledOnce()
   })
 
   it('publishes prompt ownership only from the runtime that currently owns the session', async () => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1327,6 +1327,12 @@ class AcpRuntimeCoordinator {
     await this.retireRuntimeGenerations(this.runtimes)
   }
 
+  async requestProjectAgentContextReload(): Promise<void> {
+    // Project Agent Context is captured during Session setup. Retire every generation so its idle
+    // Sessions resume with the current Project value before their next prompt.
+    await this.retireRuntimeGenerations(this.runtimes)
+  }
+
   async requestSkillsReloadForFramework(frameworkId: AgentFrameworkId): Promise<void> {
     // A framework-scoped derived asset must not rotate an unrelated backend generation. An empty
     // generation has no session holding stale assets; its first Session will provision from the

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -897,7 +897,12 @@ const createApplicationModules = async (
     onSessionsReconciled: (sessionIds) => visionEvidenceRepository.reconcileSessions(sessionIds)
   })
   const projectHandlers = createProjectHandlers(projectRepository, projectDeletionCoordinator, {
-    updateArchive: (request) => archiveCoordinator.updateProjectArchive(request)
+    updateArchive: (request) => archiveCoordinator.updateProjectArchive(request),
+    onAgentContextChanged: () => {
+      // Runtime generations capture Project Agent Context during Session setup. Retiring them marks
+      // idle Sessions for resume immediately; an in-flight turn drains before its next prompt.
+      void runtimeRef.current?.requestProjectAgentContextReload()
+    }
   })
   const projectFilesHandlers = createProjectFilesHandlers(
     projectFilesRepository,

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -152,6 +152,46 @@ describe('createProjectHandlers', () => {
     })
   })
 
+  it('invalidates Agent Sessions only when an update changes Agent Context', async () => {
+    const oldProject = { ...project, agentContext: 'Always cite DOIs.' }
+    const updatedProject = { ...project, agentContext: 'Prefer Python.', updatedAt: 3 }
+    const repository = {
+      list: vi.fn(),
+      get: vi.fn().mockResolvedValueOnce(oldProject).mockResolvedValueOnce(updatedProject),
+      create: vi.fn(),
+      update: vi.fn().mockResolvedValue(updatedProject)
+    }
+    const deletionCoordinator = {
+      deleteProject: vi.fn(),
+      waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
+    }
+    const onAgentContextChanged = vi.fn()
+    const handlers = createProjectHandlers(repository, deletionCoordinator, {
+      updateArchive: vi.fn(),
+      onAgentContextChanged
+    })
+
+    await handlers.update({
+      id: 'project-1',
+      agentContext: 'Prefer Python.',
+      expectedUpdatedAt: 2
+    })
+    await handlers.update({
+      id: 'project-1',
+      agentContext: 'Prefer Python.',
+      expectedUpdatedAt: 3
+    })
+    await handlers.update({
+      id: 'project-1',
+      name: 'Renamed project',
+      expectedUpdatedAt: 4
+    })
+
+    expect(onAgentContextChanged).toHaveBeenCalledOnce()
+    expect(onAgentContextChanged).toHaveBeenCalledWith('project-1')
+    expect(repository.get).toHaveBeenCalledTimes(2)
+  })
+
   it('leaves only preview state on the capability-specific Electron adapter', async () => {
     const previewRepository = {
       get: vi.fn().mockResolvedValue(null),

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -42,14 +42,16 @@ type ProjectDeleteHandler = Pick<
 >
 type ProjectCrudRepository = Pick<ProjectRepository, 'list' | 'get' | 'create' | 'update'> &
   Partial<Pick<ProjectRepository, 'updateArchive'>>
-type ProjectArchiveHandler = Pick<ProjectHandlers, 'updateArchive'>
+type ProjectHandlerEffects = Pick<ProjectHandlers, 'updateArchive'> & {
+  onAgentContextChanged?: (projectId: string) => void
+}
 
 // Adapts repository operations into thin handlers while enforcing Project-scoped recovery admission.
 // A failed durable deletion intent remains closed without denying unrelated Project operations.
 const createProjectHandlers = (
   repository: ProjectCrudRepository,
   deletionCoordinator: ProjectDeleteHandler,
-  archiveHandler: ProjectArchiveHandler = {
+  effects: ProjectHandlerEffects = {
     updateArchive: (request) => {
       if (!repository.updateArchive) throw new Error('Project archive is unavailable.')
       return repository.updateArchive(request, Date.now())
@@ -70,11 +72,19 @@ const createProjectHandlers = (
   },
   update: async (request) => {
     await deletionCoordinator.waitForProjectOperations([request.id])
-    return repository.update(request)
+    const previousAgentContext =
+      request.agentContext === undefined
+        ? undefined
+        : (await repository.get(request.id))?.agentContext
+    const project = await repository.update(request)
+    if (request.agentContext !== undefined && previousAgentContext !== project.agentContext) {
+      effects.onAgentContextChanged?.(request.id)
+    }
+    return project
   },
   updateArchive: async (request) => {
     await deletionCoordinator.waitForProjectOperations([request.id])
-    return archiveHandler.updateArchive(request)
+    return effects.updateArchive(request)
   },
   delete: async (id) => {
     await deletionCoordinator.waitForProjectOperations([id])


### PR DESCRIPTION
## Summary

- fail closed when Project Agent Context lookup fails during provider Session create, adopt, or resume
- retire runtime generations after an actual Agent Context change so an idle Session resumes with the new Context before its next prompt
- keep missing Projects and blank Agent Context values as the existing intentional no-context behavior

## Problem

Project Agent Context is a user-configured system-prompt policy boundary. Previously, database, migration, or transient repository errors were logged and converted to `undefined`, allowing a Session to start without the configured instructions. Separately, editing Agent Context did not invalidate an already connected Session, so later prompts could continue using the old provider setup until an unrelated reset or resume occurred.

## Implementation

- preserve the original Project lookup diagnostic, then throw a stable Agent Context load error instead of returning `undefined`
- remove the three provider lifecycle catches that converted resolver failures into an absent Context
- compare the persisted Context before and after Project updates and emit an invalidation effect only for a real Context change
- add `requestProjectAgentContextReload()` as the semantic coordinator boundary and reuse established runtime-generation retirement/resume behavior

This intentionally avoids a persisted Context revision or per-Session version field. Runtime retirement already supplies the required consistency boundary across `claude-code`, `opencode`, `codex-response`, and `codex-bridge`.

## Compatibility and data impact

- historical data compatibility: unchanged; absent legacy wire values still mean no Agent Context
- persistence/schema: no new fields, migrations, or stored Session metadata
- state model: no new enum values or lifecycle states
- interaction: no new UI or copy; saving a changed Agent Context makes the next prompt resume on a fresh runtime generation

## Tests

Red baseline was run twice on the unfixed parent. It failed because create/adopt/resume still proceeded after lookup errors and because the old `agent-session` remained attached after a Context update. The same regressions pass after the fix.

- focused main-process suite: 6 files, 195 tests passed
- renderer retiring-runtime resume behavior: 1 passed, 182 skipped by test filter
- `npm run typecheck:node` equivalent: passed
- ESLint on changed files: passed
- Prettier check on changed files: passed
- `git diff --check`: passed

The affected-test planner conservatively selects the full suite because one changed test file has no registered module owner. Per the requested local-test scope, the complete suite is deferred to this PR's CI gate.
