### PR TITLE
perf(workspace): remove panel width animation

### DIFF
--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { act, StrictMode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import type { PanelSize } from 'react-resizable-panels'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -14,10 +15,31 @@ import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore, type ChatSession } from '@/stores/session-store'
 
+const resizablePanelHarness = vi.hoisted(() => ({
+  onResize: undefined as
+    | ((
+        panelSize: PanelSize,
+        panelId: string | number | undefined,
+        previousPanelSize: PanelSize | undefined
+      ) => void)
+    | undefined
+}))
+
 vi.mock('@/components/ui/resizable', () => ({
-  ResizablePanel: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
-    <div>{children}</div>
-  )
+  ResizablePanel: ({
+    children,
+    onResize
+  }: {
+    children: React.ReactNode
+    onResize: (
+      panelSize: PanelSize,
+      panelId: string | number | undefined,
+      previousPanelSize: PanelSize | undefined
+    ) => void
+  }): React.JSX.Element => {
+    resizablePanelHarness.onResize = onResize
+    return <div>{children}</div>
+  }
 }))
 
 vi.mock('./previews/PreviewFileContent', () => ({
@@ -73,6 +95,7 @@ describe('PreviewPanel', () => {
 
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+    resizablePanelHarness.onResize = undefined
     releaseSourcePreview = vi.fn()
     window.api = {
       saveManagedFile: vi.fn().mockResolvedValue({ saved: true }),
@@ -134,6 +157,16 @@ describe('PreviewPanel', () => {
       })
     )
     await renderPanel()
+  }
+
+  const resizePanel = async (asPercentage: number): Promise<void> => {
+    await act(async () => {
+      resizablePanelHarness.onResize?.(
+        { asPercentage, inPixels: asPercentage * 10 },
+        'right-panel-resizable',
+        undefined
+      )
+    })
   }
 
   const openTabContextMenu = async (tabIndex: number): Promise<void> => {
@@ -338,15 +371,43 @@ describe('PreviewPanel', () => {
 
     const iframe = container.querySelector<HTMLIFrameElement>('[data-source-preview-frame]')
     await act(async () => usePreviewWorkbenchStore.getState().collapsePanel())
+    await resizePanel(0)
 
     expect(container.querySelector('[data-source-preview-frame]')).toBe(iframe)
     expect(iframe?.closest<HTMLElement>('[role="tabpanel"]')?.hidden).toBe(true)
     expect(releaseSourcePreview).not.toHaveBeenCalled()
 
     await act(async () => usePreviewWorkbenchStore.getState().togglePanel())
+    await resizePanel(40)
 
     expect(container.querySelector('[data-source-preview-frame]')).toBe(iframe)
     expect(iframe?.closest<HTMLElement>('[role="tabpanel"]')?.hidden).toBe(false)
+  })
+
+  it('keeps active file content mounted until the panel physically collapses', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+
+    await renderPanel()
+
+    const content = container.querySelector('[data-testid="file-content"]')
+    const surface = container.querySelector<HTMLElement>('#right-panel')
+
+    await act(async () => usePreviewWorkbenchStore.getState().collapsePanel())
+
+    expect(container.querySelector('[data-testid="file-content"]')).toBe(content)
+    expect(surface?.getAttribute('aria-hidden')).toBeNull()
+
+    await resizePanel(0)
+
+    expect(container.querySelector('[data-testid="file-content"]')).toBeNull()
+    expect(surface?.getAttribute('aria-hidden')).toBe('true')
+    expect(surface?.hasAttribute('inert')).toBe(true)
+
+    await act(async () => usePreviewWorkbenchStore.getState().openPanel())
+    await resizePanel(40)
+
+    expect(container.querySelector('[data-testid="file-content"]')).not.toBeNull()
+    expect(surface?.getAttribute('aria-hidden')).toBeNull()
   })
 
   it('shows a two-pixel simulated loading bar until the source frame loads', async () => {
@@ -1030,19 +1091,6 @@ describe('PreviewPanel', () => {
 
     expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual(['item-2'])
     expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-2')
-  })
-
-  it('unmounts active preview content while the panel is collapsed', async () => {
-    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
-
-    await renderPanel()
-    expect(container.querySelector('[data-testid="file-content"]')).not.toBeNull()
-
-    await act(async () => usePreviewWorkbenchStore.getState().collapsePanel())
-    expect(container.querySelector('[data-testid="file-content"]')).toBeNull()
-
-    await act(async () => usePreviewWorkbenchStore.getState().togglePanel())
-    expect(container.querySelector('[data-testid="file-content"]')).not.toBeNull()
   })
 
   it('collapses the panel full-screen preview after View in context navigates', async () => {

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -130,7 +130,7 @@ describe('PreviewPanel', () => {
     container.remove()
   })
 
-  const renderPanel = async (strict = false): Promise<void> => {
+  const renderPanel = async (strict = false, contentClassName?: string): Promise<void> => {
     root = createRoot(container)
     await act(async () => {
       const panel = (
@@ -139,6 +139,7 @@ describe('PreviewPanel', () => {
           defaultSize="40%"
           minSize="30%"
           onResize={vi.fn()}
+          contentClassName={contentClassName}
         />
       )
       root.render(strict ? <StrictMode>{panel}</StrictMode> : panel)
@@ -651,8 +652,15 @@ describe('PreviewPanel', () => {
       })
     )
 
-    await renderPanel()
+    await renderPanel(false, 'test-panel-content-transition translate-x-2 opacity-0')
     const compactContent = container.querySelector('[data-testid="file-content"]')
+    const compactPanel = compactContent?.closest<HTMLElement>('[role="tabpanel"]')
+    const surface = container.querySelector<HTMLElement>('#right-panel')
+    const topBar = container.querySelector<HTMLElement>('[data-testid="preview-panel-top-bar"]')
+
+    expect(surface?.className).not.toContain('test-panel-content-transition')
+    expect(topBar?.className).toContain('test-panel-content-transition')
+    expect(compactPanel?.className).toContain('test-panel-content-transition')
 
     await act(async () => {
       container
@@ -674,6 +682,8 @@ describe('PreviewPanel', () => {
     expect(dialog?.className).toContain('bg-card')
     expect(dialog?.className).toContain('shadow-dialog')
     expect(dialog?.className).toContain('data-[state=open]:zoom-in-95')
+    expect(dialog?.className).not.toContain('test-panel-content-transition')
+    expect(dialog?.parentElement?.closest('.test-panel-content-transition')).toBeNull()
     expect(dialog?.querySelector('[data-testid="file-content"]')?.textContent).toContain(name)
     expect(dialog?.querySelector('[data-testid="file-content"]')).toBe(compactContent)
     expect(dialog?.querySelector(`[aria-label="Open full screen preview of ${name}"]`)).toBeNull()

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -47,6 +47,7 @@ type PreviewPanelProps = {
 
 type PreviewPanelSurfaceProps = {
   className?: string
+  contentClassName?: string
   hidden?: boolean
   restoredPlanResponder?: RestoredPlanResponder
 }
@@ -460,10 +461,12 @@ const usePreviewModalSurface = ({
 const PreviewFilePanel = ({
   item,
   contentKey,
+  contentClassName,
   onClose
 }: {
   item: PreviewFileItem
   contentKey: string
+  contentClassName?: string
   onClose: (id: string) => void
 }): React.JSX.Element => {
   const { t } = useTranslation()
@@ -511,7 +514,8 @@ const PreviewFilePanel = ({
                 'z-[61] flex h-[90vh] w-[90vw] max-w-none min-h-0 flex-col overflow-hidden overscroll-contain p-0'
               )
             : cn(
-                'flex h-full min-h-0 w-full flex-col overflow-hidden rounded-md bg-bg-000 shadow-card'
+                'flex h-full min-h-0 w-full flex-col overflow-hidden rounded-md bg-bg-000 shadow-card',
+                contentClassName
               )
         }
       >
@@ -543,10 +547,12 @@ const PreviewFilePanel = ({
 const PreviewToolPanel = ({
   item,
   isActive,
+  contentClassName,
   restoredPlanResponder
 }: {
   item: PreviewToolItem
   isActive: boolean
+  contentClassName?: string
   restoredPlanResponder?: RestoredPlanResponder
 }): React.JSX.Element => {
   const isExpanded = usePreviewWorkbenchStore(
@@ -591,7 +597,7 @@ const PreviewToolPanel = ({
             ? dialogPanelClassName(
                 'z-[56] flex h-[90vh] w-[90vw] max-w-none min-h-0 flex-col overflow-hidden overscroll-contain p-0'
               )
-            : 'h-full min-h-0 w-full overflow-y-auto'
+            : cn('h-full min-h-0 w-full overflow-y-auto', contentClassName)
         }
       >
         <PreviewActiveContent item={item} restoredPlanResponder={restoredPlanResponder} />
@@ -603,10 +609,12 @@ const PreviewToolPanel = ({
 const PreviewSourcePanel = ({
   item,
   isActive,
+  contentClassName,
   onClose
 }: {
   item: PreviewSourceItem
   isActive: boolean
+  contentClassName?: string
   onClose: (id: string) => void
 }): React.JSX.Element => (
   <section
@@ -615,7 +623,10 @@ const PreviewSourcePanel = ({
     aria-labelledby={getPreviewTabId(item.id)}
     tabIndex={0}
     hidden={!isActive}
-    className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-md bg-bg-000 shadow-card"
+    className={cn(
+      'flex h-full min-h-0 w-full flex-col overflow-hidden rounded-md bg-bg-000 shadow-card',
+      contentClassName
+    )}
   >
     <SourceWebPreview item={item} onClose={() => onClose(item.id)} />
   </section>
@@ -625,6 +636,7 @@ const PreviewSourcePanel = ({
 // tabs and active content inside a bottom sheet.
 const PreviewPanelSurface = ({
   className,
+  contentClassName,
   hidden = false,
   restoredPlanResponder
 }: PreviewPanelSurfaceProps): React.JSX.Element => {
@@ -701,7 +713,7 @@ const PreviewPanelSurface = ({
       {items.length > 0 ? (
         <div
           data-testid="preview-panel-top-bar"
-          className="flex min-w-0 w-full shrink-0 items-start pl-2 pr-14"
+          className={cn('flex min-w-0 w-full shrink-0 items-start pl-2 pr-14', contentClassName)}
         >
           <PreviewTabBar
             tabs={items}
@@ -719,11 +731,13 @@ const PreviewPanelSurface = ({
         )}
       >
         {!activeItem ? (
-          <PreviewActiveContent
-            key={activeContentKey}
-            item={activeItem}
-            restoredPlanResponder={restoredPlanResponder}
-          />
+          <div className={cn('size-full', contentClassName)}>
+            <PreviewActiveContent
+              key={activeContentKey}
+              item={activeItem}
+              restoredPlanResponder={restoredPlanResponder}
+            />
+          </div>
         ) : null}
         {items.map((item) => {
           const isActivePanel = item.id === activeItemId && !hidden
@@ -736,6 +750,7 @@ const PreviewPanelSurface = ({
                 key={item.id}
                 item={item}
                 isActive={isActivePanel}
+                contentClassName={contentClassName}
                 restoredPlanResponder={restoredPlanResponder}
               />
             )
@@ -749,6 +764,7 @@ const PreviewPanelSurface = ({
                 key={item.id}
                 item={item}
                 isActive={isActivePanel}
+                contentClassName={contentClassName}
                 onClose={removeItem}
               />
             )
@@ -759,6 +775,7 @@ const PreviewPanelSurface = ({
               key={item.id}
               item={item}
               contentKey={activeContentKey}
+              contentClassName={contentClassName}
               onClose={removeItem}
             />
           ) : (
@@ -816,7 +833,7 @@ const PreviewPanel = ({
       onResize={handleResize}
     >
       <PreviewPanelSurface
-        className={contentClassName}
+        contentClassName={contentClassName}
         hidden={contentHidden}
         restoredPlanResponder={restoredPlanResponder}
       />

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -42,7 +42,6 @@ type PreviewPanelProps = {
   minSize: string
   onResize: (panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void
   contentClassName?: string
-  contentHidden?: boolean
   restoredPlanResponder?: RestoredPlanResponder
 }
 
@@ -631,7 +630,6 @@ const PreviewPanelSurface = ({
 }: PreviewPanelSurfaceProps): React.JSX.Element => {
   const items = usePreviewWorkbenchStore((state) => state.items)
   const activeItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
-  const panelState = usePreviewWorkbenchStore((state) => state.panelState)
   const activateItem = usePreviewWorkbenchStore((state) => state.activateItem)
   const removeItem = usePreviewWorkbenchStore((state) => state.removeItem)
   const removeOtherItems = usePreviewWorkbenchStore((state) => state.removeOtherItems)
@@ -728,7 +726,7 @@ const PreviewPanelSurface = ({
           />
         ) : null}
         {items.map((item) => {
-          const isActivePanel = item.id === activeItemId && panelState === 'open'
+          const isActivePanel = item.id === activeItemId && !hidden
           // Tool panels render at this map position whether active or not, so React keeps the
           // subtree mounted across tab switches. File panels re-create on activation anyway
           // (contentKey encodes path+mtime), so an inactive one collapses to an empty region.
@@ -794,14 +792,15 @@ const PreviewPanel = ({
   minSize,
   onResize,
   contentClassName,
-  contentHidden,
   restoredPlanResponder
 }: PreviewPanelProps): React.JSX.Element => {
+  const [contentHidden, setContentHidden] = useState(() => Number.parseFloat(defaultSize) <= 0)
   const handleResize = (
     panelSize: PanelSize,
     _panelId: string | number | undefined,
     previousPanelSize: PanelSize | undefined
   ): void => {
+    setContentHidden(panelSize.asPercentage <= 0)
     onResize(panelSize, previousPanelSize)
   }
 

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -41,11 +41,14 @@ type PreviewPanelProps = {
   defaultSize: string
   minSize: string
   onResize: (panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void
+  contentClassName?: string
+  contentHidden?: boolean
   restoredPlanResponder?: RestoredPlanResponder
 }
 
 type PreviewPanelSurfaceProps = {
   className?: string
+  hidden?: boolean
   restoredPlanResponder?: RestoredPlanResponder
 }
 
@@ -623,6 +626,7 @@ const PreviewSourcePanel = ({
 // tabs and active content inside a bottom sheet.
 const PreviewPanelSurface = ({
   className,
+  hidden = false,
   restoredPlanResponder
 }: PreviewPanelSurfaceProps): React.JSX.Element => {
   const items = usePreviewWorkbenchStore((state) => state.items)
@@ -689,6 +693,8 @@ const PreviewPanelSurface = ({
   return (
     <aside
       id="right-panel"
+      aria-hidden={hidden ? true : undefined}
+      inert={hidden ? true : undefined}
       className={cn(
         'relative flex h-full w-full flex-col overflow-hidden bg-bg-10 py-[0.7px]',
         className
@@ -787,6 +793,8 @@ const PreviewPanel = ({
   defaultSize,
   minSize,
   onResize,
+  contentClassName,
+  contentHidden,
   restoredPlanResponder
 }: PreviewPanelProps): React.JSX.Element => {
   const handleResize = (
@@ -808,7 +816,11 @@ const PreviewPanel = ({
       collapsedSize="0%"
       onResize={handleResize}
     >
-      <PreviewPanelSurface restoredPlanResponder={restoredPlanResponder} />
+      <PreviewPanelSurface
+        className={contentClassName}
+        hidden={contentHidden}
+        restoredPlanResponder={restoredPlanResponder}
+      />
     </ResizablePanel>
   )
 }

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -47,7 +47,6 @@ const workspacePageHarness = vi.hoisted(() => ({
   previewPanelDefaultSize: undefined as string | undefined,
   previewPanelMinSize: undefined as string | undefined,
   previewContentClassName: undefined as string | undefined,
-  previewContentHidden: undefined as boolean | undefined,
   previewOnResize: undefined as
     undefined | ((panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void),
   previewPanelRef: undefined as undefined | { current: PanelImperativeHandle | null },
@@ -227,21 +226,18 @@ vi.mock('./PreviewPanel', () => ({
     defaultSize,
     minSize,
     onResize,
-    contentClassName,
-    contentHidden
+    contentClassName
   }: {
     panelRef: React.Ref<PanelImperativeHandle>
     defaultSize: string
     minSize: string
     onResize: (panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void
     contentClassName?: string
-    contentHidden?: boolean
   }): React.JSX.Element => {
     workspacePageHarness.previewPanelDefaultSize = defaultSize
     workspacePageHarness.previewPanelMinSize = minSize
     workspacePageHarness.previewOnResize = onResize
     workspacePageHarness.previewContentClassName = contentClassName
-    workspacePageHarness.previewContentHidden = contentHidden
 
     if (typeof panelRef === 'function') {
       panelRef(workspacePageHarness.previewPanelHandle)
@@ -252,13 +248,7 @@ vi.mock('./PreviewPanel', () => ({
       workspacePageHarness.previewPanelRef.current = workspacePageHarness.previewPanelHandle
     }
 
-    return (
-      <div
-        data-testid="preview-panel"
-        aria-hidden={contentHidden ? true : undefined}
-        className={contentClassName}
-      />
-    )
+    return <div data-testid="preview-panel" className={contentClassName} />
   }
 }))
 
@@ -291,7 +281,6 @@ describe('WorkspacePage preview panel resize sync', () => {
     workspacePageHarness.previewPanelDefaultSize = undefined
     workspacePageHarness.previewPanelMinSize = undefined
     workspacePageHarness.previewContentClassName = undefined
-    workspacePageHarness.previewContentHidden = undefined
     workspacePageHarness.previewOnResize = undefined
     workspacePageHarness.previewPanelRef = undefined
     workspacePageHarness.previewPanelHandle.resize = vi.fn((size: number | string) => {
@@ -846,7 +835,6 @@ describe('WorkspacePage preview panel resize sync', () => {
 
     expect(workspacePageHarness.previewPanelDefaultSize).toBe('0%')
     expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenCalledWith('0%')
-    expect(workspacePageHarness.previewContentHidden).toBe(true)
   })
 
   it('retries once when the desktop panel layout is still registering', async () => {
@@ -1026,7 +1014,6 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(workspacePageHarness.previewContentClassName).toContain('duration-150')
     expect(workspacePageHarness.previewContentClassName).toContain('translate-x-0')
     expect(workspacePageHarness.previewContentClassName).toContain('opacity-100')
-    expect(workspacePageHarness.previewContentHidden).toBe(false)
   })
 
   it('does not collapse a detached preview panel after its content fade', async () => {
@@ -1224,7 +1211,6 @@ describe('WorkspacePage preview panel resize sync', () => {
 
     expect(getPreviewToggle().getAttribute('aria-expanded')).toBe('false')
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
-    expect(workspacePageHarness.previewContentHidden).toBe(true)
     expect(workspacePageHarness.previewPanelHandle.resize).not.toHaveBeenCalledWith('0%')
 
     await act(async () => vi.advanceTimersByTime(150))

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -571,6 +571,8 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(content?.className).toContain('-translate-x-2')
     expect(content?.className).toContain('opacity-0')
     expect(content?.className).toContain('duration-150')
+    expect(content?.className).toContain('size-full')
+    expect(content?.className).toContain('min-w-0')
     expect(content?.hasAttribute('inert')).toBe(true)
     expect(workspacePageHarness.sidebarPanelHandle.resize).not.toHaveBeenCalled()
 
@@ -1012,6 +1014,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenCalledWith('40%')
     expect(workspacePageHarness.previewContentClassName).toContain('transition-[opacity,transform]')
     expect(workspacePageHarness.previewContentClassName).toContain('duration-150')
+    expect(workspacePageHarness.previewContentClassName).not.toContain('size-full')
     expect(workspacePageHarness.previewContentClassName).toContain('translate-x-0')
     expect(workspacePageHarness.previewContentClassName).toContain('opacity-100')
   })

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -46,6 +46,8 @@ const workspacePageHarness = vi.hoisted(() => ({
   previewSize: 0,
   previewPanelDefaultSize: undefined as string | undefined,
   previewPanelMinSize: undefined as string | undefined,
+  previewContentClassName: undefined as string | undefined,
+  previewContentHidden: undefined as boolean | undefined,
   previewOnResize: undefined as
     undefined | ((panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void),
   previewPanelRef: undefined as undefined | { current: PanelImperativeHandle | null },
@@ -63,27 +65,8 @@ const workspacePageHarness = vi.hoisted(() => ({
   } as PanelImperativeHandle
 }))
 
-const motionHarness = vi.hoisted(() => ({
-  animate: vi.fn(
-    (
-      from: number,
-      to: number,
-      options: { onUpdate?: (value: number) => void; onComplete?: () => void }
-    ) => ({
-      from,
-      to,
-      options,
-      stop: vi.fn()
-    })
-  )
-}))
-
 const filePreviewDialogHarness = vi.hoisted(() => ({
   item: undefined as PreviewFileItem | undefined
-}))
-
-vi.mock('motion', () => ({
-  animate: motionHarness.animate
 }))
 
 vi.mock('@/components/ui/resizable', () => ({
@@ -243,16 +226,22 @@ vi.mock('./PreviewPanel', () => ({
     panelRef,
     defaultSize,
     minSize,
-    onResize
+    onResize,
+    contentClassName,
+    contentHidden
   }: {
     panelRef: React.Ref<PanelImperativeHandle>
     defaultSize: string
     minSize: string
     onResize: (panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void
+    contentClassName?: string
+    contentHidden?: boolean
   }): React.JSX.Element => {
     workspacePageHarness.previewPanelDefaultSize = defaultSize
     workspacePageHarness.previewPanelMinSize = minSize
     workspacePageHarness.previewOnResize = onResize
+    workspacePageHarness.previewContentClassName = contentClassName
+    workspacePageHarness.previewContentHidden = contentHidden
 
     if (typeof panelRef === 'function') {
       panelRef(workspacePageHarness.previewPanelHandle)
@@ -263,7 +252,13 @@ vi.mock('./PreviewPanel', () => ({
       workspacePageHarness.previewPanelRef.current = workspacePageHarness.previewPanelHandle
     }
 
-    return <div data-testid="preview-panel" />
+    return (
+      <div
+        data-testid="preview-panel"
+        aria-hidden={contentHidden ? true : undefined}
+        className={contentClassName}
+      />
+    )
   }
 }))
 
@@ -295,16 +290,27 @@ describe('WorkspacePage preview panel resize sync', () => {
     workspacePageHarness.isMobile = false
     workspacePageHarness.previewPanelDefaultSize = undefined
     workspacePageHarness.previewPanelMinSize = undefined
+    workspacePageHarness.previewContentClassName = undefined
+    workspacePageHarness.previewContentHidden = undefined
     workspacePageHarness.previewOnResize = undefined
     workspacePageHarness.previewPanelRef = undefined
+    workspacePageHarness.previewPanelHandle.resize = vi.fn((size: number | string) => {
+      workspacePageHarness.previewSize = Number.parseFloat(String(size))
+    })
     filePreviewDialogHarness.item = undefined
     notebookAvailableListener = undefined
     vi.clearAllMocks()
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
-      callback(0)
-      return 1
-    })
-    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    vi.stubGlobal(
+      'cancelAnimationFrame',
+      vi.fn(() => undefined)
+    )
     window.matchMedia = vi.fn((query: string) => ({
       matches: query === '(max-width: 767px)' ? workspacePageHarness.isMobile : false,
       media: query,
@@ -343,6 +349,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     })
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    vi.useRealTimers()
     container.remove()
   })
 
@@ -558,8 +565,10 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(leftHandle?.className).toContain('before:left-auto')
   })
 
-  it('animates the sidebar to zero and restores its last open size', async () => {
+  it('fades the sidebar content before one-shot collapse and restores its last open size', async () => {
+    vi.useFakeTimers()
     await renderPage()
+    vi.mocked(workspacePageHarness.sidebarPanelHandle.resize).mockClear()
 
     await act(async () => {
       getSidebarToggle().dispatchEvent(new MouseEvent('click', { bubbles: true }))
@@ -569,18 +578,13 @@ describe('WorkspacePage preview panel resize sync', () => {
     const toggleButton = getSidebarToggle()
     expect(toggleButton.getAttribute('aria-expanded')).toBe('false')
     expect(toggleButton.style.left).toBe('calc(16% - 38px)')
-    expect(motionHarness.animate).toHaveBeenCalledWith(
-      16,
-      0,
-      expect.objectContaining({
-        duration: 0.22,
-        ease: [0.22, 1, 0.36, 1],
-        onUpdate: expect.any(Function)
-      })
-    )
+    const content = container.querySelector('[data-testid="workspace-sidebar-content"]')
+    expect(content?.className).toContain('-translate-x-2')
+    expect(content?.className).toContain('opacity-0')
+    expect(content?.className).toContain('duration-150')
+    expect(content?.hasAttribute('inert')).toBe(true)
+    expect(workspacePageHarness.sidebarPanelHandle.resize).not.toHaveBeenCalled()
 
-    const closeAnimationOptions = motionHarness.animate.mock.calls.at(-1)?.[2] as
-      { onComplete?: () => void } | undefined
     await act(async () => {
       workspacePageHarness.sidebarOnResize?.({ asPercentage: 8, inPixels: 80 }, 'left-panel', {
         asPercentage: 16,
@@ -598,7 +602,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(toggleButton.style.left).toBe('0px')
 
     await act(async () => {
-      closeAnimationOptions?.onComplete?.()
+      vi.advanceTimersByTime(150)
     })
     expect(workspacePageHarness.sidebarPanelHandle.resize).toHaveBeenCalledWith('0%')
 
@@ -607,15 +611,9 @@ describe('WorkspacePage preview panel resize sync', () => {
     })
 
     expect(getSidebarToggle().getAttribute('aria-expanded')).toBe('true')
-    expect(motionHarness.animate).toHaveBeenLastCalledWith(
-      0,
-      16,
-      expect.objectContaining({
-        duration: 0.22,
-        ease: [0.22, 1, 0.36, 1],
-        onUpdate: expect.any(Function)
-      })
-    )
+    expect(workspacePageHarness.sidebarPanelHandle.resize).toHaveBeenLastCalledWith('16%')
+    expect(content?.className).toContain('translate-x-0')
+    expect(content?.className).toContain('opacity-100')
   })
 
   it('keeps the preview toggle floating outside the sidebar, expanded or collapsed', async () => {
@@ -841,31 +839,29 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('open')
   })
 
-  it('syncs the initial collapsed preview size without running a close animation', async () => {
+  it('syncs the initial collapsed preview size without delaying layout', async () => {
     workspacePageHarness.previewSize = 40
 
     await renderPage()
 
     expect(workspacePageHarness.previewPanelDefaultSize).toBe('0%')
     expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenCalledWith('0%')
-    expect(motionHarness.animate).not.toHaveBeenCalled()
+    expect(workspacePageHarness.previewContentHidden).toBe(true)
   })
 
   it('retries once when the desktop panel layout is still registering', async () => {
     workspacePageHarness.previewSize = 40
-    workspacePageHarness.previewPanelHandle.getSize = vi
-      .fn()
+    workspacePageHarness.previewPanelHandle.resize = vi
+      .fn((size: number | string) => {
+        workspacePageHarness.previewSize = Number.parseFloat(String(size))
+      })
       .mockImplementationOnce(() => {
         throw new Error('Layout not found for Panel right-panel-resizable')
       })
-      .mockImplementation(() => ({
-        asPercentage: workspacePageHarness.previewSize,
-        inPixels: workspacePageHarness.previewSize * 10
-      }))
 
     await renderPage()
 
-    expect(workspacePageHarness.previewPanelHandle.getSize).toHaveBeenCalledTimes(2)
+    expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenCalledTimes(2)
     expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenCalledWith('0%')
   })
 
@@ -964,7 +960,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(container.querySelector('aside')?.getAttribute('data-mobile-open')).toBe('false')
   })
 
-  it('keeps an explicit open request when expand animation emits a near-zero resize', async () => {
+  it('keeps an explicit open request when layout reports a stale near-zero resize', async () => {
     await renderPage()
 
     const toggleButton = getPreviewToggle()
@@ -993,7 +989,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
   })
 
-  it('keeps an explicit collapse request when animation resize lacks a previous size', async () => {
+  it('keeps an explicit collapse request while the content fade is pending', async () => {
     await renderPage()
 
     const toggleButton = getPreviewToggle()
@@ -1001,11 +997,6 @@ describe('WorkspacePage preview panel resize sync', () => {
       toggleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    const openAnimationOptions = motionHarness.animate.mock.calls.at(-1)?.[2] as
-      { onUpdate?: (value: number) => void; onComplete?: () => void } | undefined
-    await act(async () => {
-      openAnimationOptions?.onComplete?.()
-    })
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('open')
 
     await act(async () => {
@@ -1020,35 +1011,26 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
   })
 
-  it('animates explicit preview open requests through panel percentage resize', async () => {
+  it('opens the preview with one target resize and a content-only transition', async () => {
     await renderPage()
+    vi.mocked(workspacePageHarness.previewPanelHandle.resize).mockClear()
 
     const toggleButton = getPreviewToggle()
     await act(async () => {
       toggleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(motionHarness.animate).toHaveBeenCalledWith(
-      0,
-      40,
-      expect.objectContaining({
-        duration: 0.22,
-        ease: [0.22, 1, 0.36, 1],
-        onUpdate: expect.any(Function)
-      })
-    )
-
-    const animationOptions = motionHarness.animate.mock.calls.at(-1)?.[2] as
-      { onUpdate?: (value: number) => void; onComplete?: () => void } | undefined
-
-    await act(async () => {
-      animationOptions?.onUpdate?.(24)
-    })
-
-    expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenCalledWith('24%')
+    expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenCalledTimes(1)
+    expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenCalledWith('40%')
+    expect(workspacePageHarness.previewContentClassName).toContain('transition-[opacity,transform]')
+    expect(workspacePageHarness.previewContentClassName).toContain('duration-150')
+    expect(workspacePageHarness.previewContentClassName).toContain('translate-x-0')
+    expect(workspacePageHarness.previewContentClassName).toContain('opacity-100')
+    expect(workspacePageHarness.previewContentHidden).toBe(false)
   })
 
-  it('does not resize a detached preview panel during an in-flight animation', async () => {
+  it('does not collapse a detached preview panel after its content fade', async () => {
+    vi.useFakeTimers()
     await renderPage()
 
     const toggleButton = getPreviewToggle()
@@ -1056,41 +1038,39 @@ describe('WorkspacePage preview panel resize sync', () => {
       toggleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    const animationOptions = motionHarness.animate.mock.calls.at(-1)?.[2] as
-      { onUpdate?: (value: number) => void; onComplete?: () => void } | undefined
     vi.mocked(workspacePageHarness.previewPanelHandle.resize).mockClear()
+
+    await act(async () => {
+      toggleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
     if (workspacePageHarness.previewPanelRef) {
       workspacePageHarness.previewPanelRef.current = null
     }
 
     await act(async () => {
-      animationOptions?.onUpdate?.(24)
-      animationOptions?.onComplete?.()
+      vi.advanceTimersByTime(150)
     })
 
     expect(workspacePageHarness.previewPanelHandle.resize).not.toHaveBeenCalled()
   })
 
-  it('temporarily relaxes the preview min size while programmatic animation runs', async () => {
+  it('uses the collapsed and open preview minimums for one-shot resizing', async () => {
     await renderPage()
 
-    expect(workspacePageHarness.previewPanelMinSize).toBe('30%')
+    expect(workspacePageHarness.previewPanelMinSize).toBe('0%')
 
     const toggleButton = getPreviewToggle()
     await act(async () => {
       toggleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(workspacePageHarness.previewPanelMinSize).toBe('0%')
-
-    const animationOptions = motionHarness.animate.mock.calls.at(-1)?.[2] as
-      { onUpdate?: (value: number) => void; onComplete?: () => void } | undefined
+    expect(workspacePageHarness.previewPanelMinSize).toBe('30%')
 
     await act(async () => {
-      animationOptions?.onComplete?.()
+      toggleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(workspacePageHarness.previewPanelMinSize).toBe('30%')
+    expect(workspacePageHarness.previewPanelMinSize).toBe('0%')
   })
 
   // Open sidebar keeps enough room for its navigation content while remaining collapsible.
@@ -1107,25 +1087,21 @@ describe('WorkspacePage preview panel resize sync', () => {
 
     expect(workspacePageHarness.sidebarPanelMinSize).toBe('0%')
 
-    const animationOptions = motionHarness.animate.mock.calls.at(-1)?.[2] as
-      { onUpdate?: (value: number) => void; onComplete?: () => void } | undefined
-
     await act(async () => {
-      animationOptions?.onComplete?.()
+      getSidebarToggle().dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
     expect(workspacePageHarness.sidebarPanelMinSize).toBe('16%')
   })
 
-  it('keeps the sidebar open when an expand animation reports a near-zero resize', async () => {
+  it('keeps the sidebar open when layout reports a stale near-zero resize', async () => {
+    vi.useFakeTimers()
     await renderPage()
 
     await act(async () => {
       getSidebarToggle().dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
-    const closeAnimationOptions = motionHarness.animate.mock.calls.at(-1)?.[2] as
-      { onComplete?: () => void } | undefined
-    await act(async () => closeAnimationOptions?.onComplete?.())
+    await act(async () => vi.advanceTimersByTime(150))
 
     await act(async () => {
       getSidebarToggle().dispatchEvent(new MouseEvent('click', { bubbles: true }))
@@ -1177,7 +1153,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(document.activeElement).toBe(toggleButton)
   })
 
-  it('lets an opposite sidebar drag interrupt a closing animation', async () => {
+  it('lets an opposite sidebar drag interrupt a pending collapse', async () => {
     await renderPage()
 
     await act(async () => {
@@ -1195,7 +1171,8 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(getSidebarToggle().getAttribute('aria-expanded')).toBe('true')
   })
 
-  it('does not resize a detached sidebar panel during an in-flight animation', async () => {
+  it('does not collapse a detached sidebar panel after its content fade', async () => {
+    vi.useFakeTimers()
     await renderPage()
 
     const toggleButton = getSidebarToggle()
@@ -1203,25 +1180,22 @@ describe('WorkspacePage preview panel resize sync', () => {
       toggleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    const animationOptions = motionHarness.animate.mock.calls.at(-1)?.[2] as
-      { onUpdate?: (value: number) => void; onComplete?: () => void } | undefined
     vi.mocked(workspacePageHarness.sidebarPanelHandle.resize).mockClear()
     if (workspacePageHarness.sidebarPanelRef) {
       workspacePageHarness.sidebarPanelRef.current = null
     }
 
     await act(async () => {
-      animationOptions?.onUpdate?.(8)
-      animationOptions?.onComplete?.()
+      vi.advanceTimersByTime(150)
     })
 
     expect(workspacePageHarness.sidebarPanelHandle.resize).not.toHaveBeenCalled()
   })
 
-  it('skips sidebar animation when reduced motion is enabled', async () => {
+  it('collapses the sidebar immediately when reduced motion is enabled', async () => {
     vi.stubGlobal(
       'matchMedia',
-      vi.fn(() => ({ matches: true }))
+      vi.fn((query: string) => ({ matches: query === '(prefers-reduced-motion: reduce)' }))
     )
 
     await renderPage()
@@ -1231,7 +1205,32 @@ describe('WorkspacePage preview panel resize sync', () => {
       toggleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(motionHarness.animate).not.toHaveBeenCalled()
     expect(workspacePageHarness.sidebarPanelHandle.resize).toHaveBeenCalledWith('0%')
+    expect(
+      container.querySelector('[data-testid="workspace-sidebar-content"]')?.className
+    ).toContain('motion-reduce:transition-none')
+  })
+
+  it('settles ten rapid preview toggles in the final collapsed state', async () => {
+    vi.useFakeTimers()
+    await renderPage()
+    vi.mocked(workspacePageHarness.previewPanelHandle.resize).mockClear()
+
+    for (let click = 0; click < 10; click += 1) {
+      await act(async () => {
+        getPreviewToggle().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      })
+    }
+
+    expect(getPreviewToggle().getAttribute('aria-expanded')).toBe('false')
+    expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
+    expect(workspacePageHarness.previewContentHidden).toBe(true)
+    expect(workspacePageHarness.previewPanelHandle.resize).not.toHaveBeenCalledWith('0%')
+
+    await act(async () => vi.advanceTimersByTime(150))
+
+    expect(workspacePageHarness.previewPanelHandle.resize).toHaveBeenLastCalledWith('0%')
+    expect(workspacePageHarness.previewContentClassName).toContain('translate-x-2')
+    expect(workspacePageHarness.previewContentClassName).toContain('opacity-0')
   })
 })

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -27,7 +27,7 @@ const OPEN_DIALOG_SELECTOR =
   '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
 const PANEL_CONTENT_TRANSITION_MS = 150
 const PANEL_CONTENT_TRANSITION_CLASS_NAME =
-  'size-full min-w-0 transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none motion-reduce:transform-none'
+  'transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none motion-reduce:transform-none'
 
 const prefersReducedMotion = (): boolean =>
   window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
@@ -530,7 +530,7 @@ const WorkspacePanelLayout = ({
                   data-testid="workspace-sidebar-content"
                   aria-hidden={sidebar.state === 'collapsed' ? true : undefined}
                   inert={sidebar.state === 'collapsed' ? true : undefined}
-                  className={`${PANEL_CONTENT_TRANSITION_CLASS_NAME} ${
+                  className={`size-full min-w-0 ${PANEL_CONTENT_TRANSITION_CLASS_NAME} ${
                     sidebar.state === 'collapsed'
                       ? 'pointer-events-none -translate-x-2 opacity-0'
                       : 'translate-x-0 opacity-100'

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -1,4 +1,3 @@
-import { animate } from 'motion'
 import { PanelLeft, PanelRight } from 'lucide-react'
 import { FocusScope } from '@radix-ui/react-focus-scope'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
@@ -26,19 +25,16 @@ const PREVIEW_PANEL_DEFAULT_SIZE_CSS = `${PREVIEW_PANEL_DEFAULT_SIZE}%`
 const PREVIEW_PANEL_MIN_OPEN_SIZE = 30
 const OPEN_DIALOG_SELECTOR =
   '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
-
-const panelAnimation = {
-  duration: 0.22,
-  ease: [0.22, 1, 0.36, 1] as [number, number, number, number]
-}
+const PANEL_CONTENT_TRANSITION_MS = 150
+const PANEL_CONTENT_TRANSITION_CLASS_NAME =
+  'size-full min-w-0 transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none motion-reduce:transform-none'
 
 const prefersReducedMotion = (): boolean =>
   window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
 
 type ResizablePanelState = 'open' | 'collapsed'
-type PanelAnimationDirection = 'opening' | 'closing'
 
-type AnimatedResizablePanelOptions = {
+type TransitionedResizablePanelOptions = {
   panelState: ResizablePanelState
   defaultOpenSize: number
   minOpenSize: number
@@ -48,15 +44,15 @@ type AnimatedResizablePanelOptions = {
   collapseFocusTargetRef: React.RefObject<HTMLButtonElement | null>
 }
 
-type AnimatedResizablePanel = {
+type TransitionedResizablePanel = {
   panelRef: React.RefObject<PanelImperativeHandle | null>
   separatorRef: React.RefObject<HTMLDivElement | null>
   minSize: string
   onResize: (panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void
 }
 
-// Owns the imperative animation lifecycle shared by the two workspace side panels.
-const useAnimatedResizablePanel = ({
+// Owns the one-shot resize and content-transition lifecycle shared by the desktop side panels.
+const useTransitionedResizablePanel = ({
   panelState,
   defaultOpenSize,
   minOpenSize,
@@ -64,118 +60,57 @@ const useAnimatedResizablePanel = ({
   onPanelStateChange,
   onPixelWidthChange,
   collapseFocusTargetRef
-}: AnimatedResizablePanelOptions): AnimatedResizablePanel => {
+}: TransitionedResizablePanelOptions): TransitionedResizablePanel => {
   const panelRef = useRef<PanelImperativeHandle | null>(null)
   const separatorRef = useRef<HTMLDivElement | null>(null)
-  const animationRef = useRef<{ stop: () => void } | null>(null)
-  const animationFrameRef = useRef<number | null>(null)
-  const animationDirectionRef = useRef<PanelAnimationDirection | null>(null)
+  const collapseTimerRef = useRef<number | null>(null)
+  const resizeFrameRef = useRef<number | null>(null)
+  const transitionTargetRef = useRef<ResizablePanelState | null>(null)
   const lastOpenSizeRef = useRef(defaultOpenSize)
   const hasSyncedInitialSizeRef = useRef(false)
-  const [isMinSizeRelaxed, setIsMinSizeRelaxed] = useState(false)
 
-  const animatePanelSize = useCallback(
-    (
-      targetSize: number,
-      direction: PanelAnimationDirection,
-      options?: { animate?: boolean }
-    ): void => {
-      const panel = panelRef.current
-      if (!panel) return
+  const resizePanel = useCallback((targetSize: number): void => {
+    const panel = panelRef.current
+    if (!panel) return
 
-      animationRef.current?.stop()
-      if (animationFrameRef.current !== null) {
-        window.cancelAnimationFrame(animationFrameRef.current)
-        animationFrameRef.current = null
-      }
+    try {
+      panel.resize(`${targetSize}%`)
+    } catch {
+      // react-resizable-panels can expose the handle before its layout is registered.
+      resizeFrameRef.current = window.requestAnimationFrame(() => {
+        resizeFrameRef.current = null
+        const nextPanel = panelRef.current
+        if (nextPanel !== panel) return
 
-      const resizePanel = (size: number): boolean => {
-        const currentPanel = panelRef.current
-
-        // Ignore motion callbacks that outlive the panel handle they were created for.
-        if (currentPanel !== panel) return false
-
-        currentPanel.resize(`${Number(size.toFixed(3))}%`)
-        return true
-      }
-
-      const startFromSize = (currentSize: number): void => {
-        if (
-          options?.animate === false ||
-          Math.abs(currentSize - targetSize) <= PANEL_COLLAPSED_THRESHOLD ||
-          prefersReducedMotion()
-        ) {
-          resizePanel(targetSize)
-          if (direction === 'opening') lastOpenSizeRef.current = targetSize
-          animationDirectionRef.current = null
-          animationRef.current = null
-          setIsMinSizeRelaxed(false)
-          return
+        try {
+          nextPanel.resize(`${targetSize}%`)
+        } catch {
+          // A detached panel will be synchronized by the next state/layout pass.
         }
-
-        animationDirectionRef.current = direction
-        setIsMinSizeRelaxed(true)
-        animationFrameRef.current = window.requestAnimationFrame(() => {
-          animationFrameRef.current = null
-          const nextPanel = panelRef.current
-          if (!nextPanel) return
-
-          const nextCurrentSize = nextPanel.getSize().asPercentage
-          animationRef.current = animate(nextCurrentSize, targetSize, {
-            ...panelAnimation,
-            onUpdate: resizePanel,
-            onComplete: () => {
-              const didResize = resizePanel(targetSize)
-              if (didResize && direction === 'opening') lastOpenSizeRef.current = targetSize
-              animationDirectionRef.current = null
-              animationRef.current = null
-              setIsMinSizeRelaxed(false)
-            }
-          })
-        })
-      }
-
-      try {
-        startFromSize(panel.getSize().asPercentage)
-      } catch {
-        // react-resizable-panels can expose the handle before its layout is registered.
-        animationFrameRef.current = window.requestAnimationFrame(() => {
-          animationFrameRef.current = null
-          const nextPanel = panelRef.current
-          if (nextPanel !== panel) return
-
-          try {
-            startFromSize(nextPanel.getSize().asPercentage)
-          } catch {
-            // A detached panel will be synchronized by the next state/layout pass.
-          }
-        })
-      }
-    },
-    []
-  )
+      })
+    }
+  }, [])
 
   const onResize = useCallback(
     (panelSize: PanelSize, previousPanelSize: PanelSize | undefined): void => {
       onPixelWidthChange?.(panelSize.inPixels)
 
       const isNearCollapsedSize = panelSize.asPercentage <= PANEL_COLLAPSED_THRESHOLD
-      const animationDirection = animationDirectionRef.current
-      const isOpeningAnimationResize =
-        animationDirection === 'opening' &&
+      const transitionTarget = transitionTargetRef.current
+      const isOpeningTransitionResize =
+        transitionTarget === 'open' &&
         (previousPanelSize === undefined ||
           panelSize.asPercentage >= previousPanelSize.asPercentage)
-      const isClosingAnimationResize =
-        animationDirection === 'closing' &&
+      const isClosingTransitionResize =
+        transitionTarget === 'collapsed' &&
         (previousPanelSize === undefined ||
           panelSize.asPercentage <= previousPanelSize.asPercentage)
 
-      if (isNearCollapsedSize && isOpeningAnimationResize) return
-      if (!isNearCollapsedSize && isClosingAnimationResize) return
+      if (isNearCollapsedSize && isOpeningTransitionResize) return
+      if (!isNearCollapsedSize && isClosingTransitionResize) return
 
-      if (!isNearCollapsedSize && animationDirection === null) {
-        lastOpenSizeRef.current = panelSize.asPercentage
-      }
+      transitionTargetRef.current = null
+      if (!isNearCollapsedSize) lastOpenSizeRef.current = panelSize.asPercentage
 
       if (isNearCollapsedSize && document.activeElement === separatorRef.current) {
         collapseFocusTargetRef.current?.focus()
@@ -186,35 +121,43 @@ const useAnimatedResizablePanel = ({
     [collapseFocusTargetRef, onPanelStateChange, onPixelWidthChange]
   )
 
-  // Synchronize restored state on first layout without introducing an entrance animation.
+  // Open layout is interactive immediately. Closing keeps layout stable only long enough for the
+  // content fade, then collapses with one resize. A new request cancels the pending collapse.
   useLayoutEffect(() => {
-    const shouldAnimate = hasSyncedInitialSizeRef.current
+    if (collapseTimerRef.current !== null) window.clearTimeout(collapseTimerRef.current)
+    if (resizeFrameRef.current !== null) window.cancelAnimationFrame(resizeFrameRef.current)
+    collapseTimerRef.current = null
+    resizeFrameRef.current = null
+    transitionTargetRef.current = panelState
+
+    const hasSyncedInitialSize = hasSyncedInitialSizeRef.current
     hasSyncedInitialSizeRef.current = true
 
     if (panelState === 'collapsed') {
-      animatePanelSize(PANEL_COLLAPSED_SIZE, 'closing', { animate: shouldAnimate })
-      return
+      const collapse = (): void => {
+        collapseTimerRef.current = null
+        resizePanel(PANEL_COLLAPSED_SIZE)
+      }
+
+      if (hasSyncedInitialSize && !prefersReducedMotion()) {
+        collapseTimerRef.current = window.setTimeout(collapse, PANEL_CONTENT_TRANSITION_MS)
+      } else {
+        collapse()
+      }
+    } else {
+      resizePanel(Math.max(lastOpenSizeRef.current, minOpenSize))
     }
 
-    animatePanelSize(Math.max(lastOpenSizeRef.current, minOpenSize), 'opening', {
-      animate: shouldAnimate
-    })
-  }, [animatePanelSize, minOpenSize, panelState, requestVersion])
-
-  useEffect(
-    () => () => {
-      animationRef.current?.stop()
-      if (animationFrameRef.current !== null) {
-        window.cancelAnimationFrame(animationFrameRef.current)
-      }
-    },
-    []
-  )
+    return () => {
+      if (collapseTimerRef.current !== null) window.clearTimeout(collapseTimerRef.current)
+      if (resizeFrameRef.current !== null) window.cancelAnimationFrame(resizeFrameRef.current)
+    }
+  }, [minOpenSize, panelState, requestVersion, resizePanel])
 
   return {
     panelRef,
     separatorRef,
-    minSize: isMinSizeRelaxed ? PANEL_COLLAPSED_SIZE_CSS : `${minOpenSize}%`,
+    minSize: panelState === 'collapsed' ? PANEL_COLLAPSED_SIZE_CSS : `${minOpenSize}%`,
     onResize
   }
 }
@@ -226,7 +169,7 @@ type WorkspacePanelLayout = {
     open: () => void
     close: () => void
   }
-  sidebar: AnimatedResizablePanel & {
+  sidebar: TransitionedResizablePanel & {
     state: ResizablePanelState
     defaultSize: string
     toggle: () => void
@@ -235,7 +178,7 @@ type WorkspacePanelLayout = {
     toggleRef: React.RefObject<HTMLButtonElement | null>
     toggleButton: React.ReactNode
   }
-  preview: AnimatedResizablePanel & {
+  preview: TransitionedResizablePanel & {
     state: ResizablePanelState
     defaultSize: string
     toggle: () => void
@@ -296,7 +239,7 @@ const useWorkspacePanelLayout = (
     if (toggle) toggle.style.left = `${Math.max(0, panelWidth - SIDEBAR_TOGGLE_RIGHT_INSET)}px`
   }, [])
 
-  const sidebar = useAnimatedResizablePanel({
+  const sidebar = useTransitionedResizablePanel({
     panelState: sidebarState,
     defaultOpenSize: SIDEBAR_PANEL_DEFAULT_SIZE,
     minOpenSize: SIDEBAR_PANEL_MIN_OPEN_SIZE,
@@ -308,7 +251,7 @@ const useWorkspacePanelLayout = (
   const [initialPreviewDefaultSize] = useState(() =>
     previewPort.state === 'collapsed' ? PANEL_COLLAPSED_SIZE_CSS : PREVIEW_PANEL_DEFAULT_SIZE_CSS
   )
-  const preview = useAnimatedResizablePanel({
+  const preview = useTransitionedResizablePanel({
     panelState: previewPort.state,
     defaultOpenSize: PREVIEW_PANEL_DEFAULT_SIZE,
     minOpenSize: PREVIEW_PANEL_MIN_OPEN_SIZE,
@@ -583,10 +526,21 @@ const WorkspacePanelLayout = ({
                   sidebar.onResize(panelSize, previousPanelSize)
                 }
               >
-                {renderDesktopSidebar({
-                  sidebarToggle: { state: sidebar.state, onToggle: sidebar.toggle },
-                  sidebarToggleRef: sidebar.toggleRef
-                })}
+                <div
+                  data-testid="workspace-sidebar-content"
+                  aria-hidden={sidebar.state === 'collapsed' ? true : undefined}
+                  inert={sidebar.state === 'collapsed' ? true : undefined}
+                  className={`${PANEL_CONTENT_TRANSITION_CLASS_NAME} ${
+                    sidebar.state === 'collapsed'
+                      ? 'pointer-events-none -translate-x-2 opacity-0'
+                      : 'translate-x-0 opacity-100'
+                  }`}
+                >
+                  {renderDesktopSidebar({
+                    sidebarToggle: { state: sidebar.state, onToggle: sidebar.toggle },
+                    sidebarToggleRef: sidebar.toggleRef
+                  })}
+                </div>
               </ResizablePanel>
 
               <ResizableHandle
@@ -594,7 +548,7 @@ const WorkspacePanelLayout = ({
                 aria-label={t('Resize left panel')}
                 disabled={sidebar.state === 'collapsed'}
                 aria-hidden={sidebar.state === 'collapsed'}
-                className={`before:left-auto before:right-full before:mr-[3px] before:translate-x-0 transition-opacity duration-200 ease-out ${
+                className={`before:left-auto before:right-full before:mr-[3px] before:translate-x-0 transition-opacity duration-150 ease-out ${
                   sidebar.state === 'collapsed' ? 'opacity-0' : 'opacity-100'
                 }`}
               />
@@ -614,7 +568,7 @@ const WorkspacePanelLayout = ({
                 aria-label={t('Resize right panel')}
                 disabled={preview.state === 'collapsed'}
                 aria-hidden={preview.state === 'collapsed'}
-                className={`bg-border shadow-[1px_0_3px_rgba(30,28,24,0.08)] before:left-auto before:right-full before:mr-0.5 before:w-1 before:translate-x-0 transition-opacity duration-200 ease-out ${
+                className={`bg-border shadow-[1px_0_3px_rgba(30,28,24,0.08)] before:left-auto before:right-full before:mr-0.5 before:w-1 before:translate-x-0 transition-opacity duration-150 ease-out ${
                   preview.state === 'collapsed' ? 'opacity-0' : 'opacity-100'
                 }`}
               />
@@ -624,6 +578,12 @@ const WorkspacePanelLayout = ({
                 defaultSize={preview.defaultSize}
                 minSize={preview.minSize}
                 onResize={preview.onResize}
+                contentClassName={`${PANEL_CONTENT_TRANSITION_CLASS_NAME} ${
+                  preview.state === 'collapsed'
+                    ? 'pointer-events-none translate-x-2 opacity-0'
+                    : 'translate-x-0 opacity-100'
+                }`}
+                contentHidden={preview.state === 'collapsed'}
                 restoredPlanResponder={restoredPlanResponder}
               />
             </>

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -583,7 +583,6 @@ const WorkspacePanelLayout = ({
                     ? 'pointer-events-none translate-x-2 opacity-0'
                     : 'translate-x-0 opacity-100'
                 }`}
-                contentHidden={preview.state === 'collapsed'}
                 restoredPlanResponder={restoredPlanResponder}
               />
             </>


### PR DESCRIPTION
## Problem

Workspace sidebar and preview open/close transitions animated panel percentages through `motion.animate(... onUpdate: panel.resize)`. That forced the resizable layout to recalculate on every animation frame.

## Proposed change

- Resize an opening panel directly to its remembered target size.
- Fade and translate closing content for 150 ms, then collapse the panel with one resize.
- Cancel a pending collapse when a newer open request arrives.
- Keep drag resizing, focus return, desktop left/right panels, mobile surfaces, and reduced-motion behavior.

## Scope and non-goals

- No data model, persistence, migration, historical compatibility, dependency, or enum changes.
- No changes to mobile Sheet presentation.

## Acceptance criteria and validation

- No frame-by-frame `panel.resize()` animation remains.
- Open layout becomes interactive in the same layout pass; content settles within 150 ms.
- Closing collapses once after the 150 ms content transition, or immediately for reduced motion.
- Ten rapid preview toggles settle to the button/store state.

Final evidence after the last material edit:

- Panel sizing, transitions, rapid toggles, focus, drag, mobile, reduced motion -> `npm run test:module -- workspace_page` -> 25 files / 553 tests passed.
- Preview surface contract -> `npm test -- src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx src/renderer/src/pages/workspace/PreviewPanel.test.tsx` -> 2 files / 73 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint` -> passed.

## Release-build performance baseline

Use packaged releases at the same viewport for performance comparisons; development-server timings are not a valid baseline.

| Packaged release | Interaction | First visual change | Settled |
| --- | --- | ---: | ---: |
| Open Science 0.20.1 | Collapse left sidebar | 49.1 ms | 314.4 ms |
| Open Science 0.20.1 | Expand left sidebar | 48.0 ms | 313.8 ms |
| Open Science 0.20.1 | Open Plan right panel | 43.3 ms | 351.6 ms |
| Claude Science release | Collapse left sidebar | 18.2 ms | 119.1 ms |
| Claude Science release | Expand left sidebar | 7.1 ms | 110.5 ms |

These measurements are comparison baselines, not measurements of this PR build. The patched packaged build should confirm that layout no longer resizes frame-by-frame, sidebar and preview transitions settle near or below 180-200 ms, and drag resizing, focus return, and reduced-motion behavior do not regress.

Uncovered local risk: no manual frame-profile capture has been run against a packaged build containing this PR; PR CI remains the automated validation authority.

## Review focus

- Confirm the 150 ms close delay and immediate open resize match the intended interaction.
- Confirm stale resize callbacks and rapid request cancellation cannot overturn the latest panel state.
- Confirm the packaged build has no frame-by-frame panel resize and settles near or below 180-200 ms.
