### PR TITLE
perf(markdown): lazy-load rendering plugins

### DIFF
--- a/src/renderer/src/components/streamdown/AgentMarkdown.lazy-failure.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.lazy-failure.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { act, type PropsWithChildren } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const harness = vi.hoisted(() => ({
+  plugins: undefined as Record<string, unknown> | undefined
+}))
+
+vi.mock('./code-highlighter-runtime', () => ({ code: { name: 'shiki' } }))
+vi.mock('@streamdown/cjk', () => ({ cjk: {} }))
+vi.mock('@streamdown/math', () => ({ createMathPlugin: () => ({}) }))
+vi.mock('./mermaid-runtime', () => {
+  throw new Error('Mermaid chunk unavailable')
+})
+vi.mock('streamdown', () => ({
+  Streamdown: ({
+    children,
+    plugins
+  }: PropsWithChildren<{ plugins?: Record<string, unknown> }>): React.JSX.Element => {
+    harness.plugins = plugins
+    return <div data-testid="markdown-source">{children}</div>
+  }
+}))
+
+const { PresentedAgentMarkdown } = await import('./AgentMarkdown')
+
+describe('AgentMarkdown optional plugin failures', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps Mermaid source readable when the Mermaid chunk fails to load', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const content = '```mermaid\ngraph TD\n  A --> B\n```'
+
+    await act(async () => {
+      root.render(<PresentedAgentMarkdown content={content} />)
+    })
+
+    expect(container.querySelector('[data-testid="markdown-source"]')?.textContent).toBe(content)
+    expect(harness.plugins?.mermaid).toBeUndefined()
+    expect(
+      consoleError.mock.calls.some(([message]) => message === 'Failed to load Mermaid rendering.')
+    ).toBe(true)
+
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
@@ -178,7 +178,8 @@ describe('AgentMarkdown renderer recovery', () => {
     })
     expect(streamdownHarness.plugins?.code).toEqual({ name: 'shiki' })
 
-    const listMermaid = '1. Diagram:\n\n    ```mermaid\n    graph TD\n      A --> B\n    ```'
+    const listMermaid =
+      '- Outer item\n    - Inner item\n      ```mermaid\n      graph TD\n        A --> B\n      ```'
     await act(async () => {
       root.render(<AgentMarkdown content={listMermaid} />)
     })

--- a/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
@@ -5,17 +5,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const streamdownHarness = vi.hoisted(() => ({
   shouldThrow: true,
+  codeImports: 0,
+  mermaidImports: 0,
   disallowedElements: undefined as readonly string[] | undefined,
   components: undefined as Record<string, unknown> | undefined,
+  plugins: undefined as Record<string, unknown> | undefined,
+  shikiTheme: undefined as unknown,
+  mermaidOptions: undefined as unknown,
   animated: undefined as unknown,
   caret: undefined as string | undefined,
   blockComponent: undefined as unknown
 }))
 
-vi.mock('@streamdown/code', () => ({ code: {} }))
+vi.mock('./code-highlighter-runtime', () => {
+  streamdownHarness.codeImports += 1
+  return { code: { name: 'shiki' } }
+})
 vi.mock('@streamdown/cjk', () => ({ cjk: {} }))
 vi.mock('@streamdown/math', () => ({ createMathPlugin: () => ({}) }))
-vi.mock('@streamdown/mermaid', () => ({ mermaid: {} }))
+vi.mock('./mermaid-runtime', () => {
+  streamdownHarness.mermaidImports += 1
+  return { mermaid: { name: 'mermaid' } }
+})
 vi.mock('streamdown', () => ({
   Streamdown: ({
     children,
@@ -23,13 +34,19 @@ vi.mock('streamdown', () => ({
     caret,
     components,
     disallowedElements,
-    BlockComponent
+    BlockComponent,
+    plugins,
+    shikiTheme,
+    mermaid
   }: PropsWithChildren<{
     animated?: unknown
     caret?: string
     components?: Record<string, unknown>
     disallowedElements?: readonly string[]
     BlockComponent?: unknown
+    plugins?: Record<string, unknown>
+    shikiTheme?: unknown
+    mermaid?: unknown
   }>): React.JSX.Element => {
     if (streamdownHarness.shouldThrow) throw new Error('optimized Markdown chunk failed to load')
     streamdownHarness.components = components
@@ -37,12 +54,15 @@ vi.mock('streamdown', () => ({
     streamdownHarness.animated = animated
     streamdownHarness.caret = caret
     streamdownHarness.blockComponent = BlockComponent
+    streamdownHarness.plugins = plugins
+    streamdownHarness.shikiTheme = shikiTheme
+    streamdownHarness.mermaidOptions = mermaid
 
     return <div data-testid="rich-markdown">{children}</div>
   }
 }))
 
-const { AgentMarkdown } = await import('./AgentMarkdown')
+const { AgentMarkdown, PresentedAgentMarkdown } = await import('./AgentMarkdown')
 const { SessionMessageLink } = await import('./SessionMessageLink')
 const { StreamingBlock } = await import('./StreamingBlock')
 
@@ -54,6 +74,9 @@ describe('AgentMarkdown renderer recovery', () => {
     streamdownHarness.shouldThrow = true
     streamdownHarness.disallowedElements = undefined
     streamdownHarness.components = undefined
+    streamdownHarness.plugins = undefined
+    streamdownHarness.shikiTheme = undefined
+    streamdownHarness.mermaidOptions = undefined
     streamdownHarness.animated = undefined
     streamdownHarness.caret = undefined
     streamdownHarness.blockComponent = undefined
@@ -69,6 +92,62 @@ describe('AgentMarkdown renderer recovery', () => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
     container.remove()
+  })
+
+  it('does not request Mermaid or code highlighting for prose, lists, and tables', async () => {
+    streamdownHarness.shouldThrow = false
+
+    await act(async () => {
+      root.render(
+        <AgentMarkdown
+          content={'Plain text\n\n- list item\n\n| Name | Value |\n| --- | --- |\n| A | 1 |'}
+        />
+      )
+    })
+
+    expect(streamdownHarness.codeImports).toBe(0)
+    expect(streamdownHarness.mermaidImports).toBe(0)
+    expect(streamdownHarness.plugins?.code).toBeUndefined()
+    expect(streamdownHarness.plugins?.mermaid).toBeUndefined()
+    expect(streamdownHarness.shikiTheme).toBeUndefined()
+    expect(streamdownHarness.mermaidOptions).toBeUndefined()
+  })
+
+  it('loads code highlighting and its themes only after a fence appears', async () => {
+    streamdownHarness.shouldThrow = false
+    const content = '```ts\nconst value = 1\n```'
+
+    await act(async () => {
+      root.render(<AgentMarkdown content={content} />)
+    })
+
+    expect(streamdownHarness.codeImports).toBe(1)
+    expect(streamdownHarness.mermaidImports).toBe(0)
+    expect(streamdownHarness.plugins?.code).toEqual({ name: 'shiki' })
+    expect(streamdownHarness.shikiTheme).toEqual(['github-light', 'github-light'])
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe(content)
+  })
+
+  it('upgrades a streaming fence to Mermaid without dropping its readable source', async () => {
+    streamdownHarness.shouldThrow = false
+
+    await act(async () => {
+      root.render(<PresentedAgentMarkdown content={'```mer'} isAnimating />)
+    })
+
+    expect(streamdownHarness.mermaidImports).toBe(0)
+    expect(streamdownHarness.plugins?.mermaid).toBeUndefined()
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('```mer')
+
+    const content = '```mermaid\ngraph TD\n  A --> B'
+    await act(async () => {
+      root.render(<PresentedAgentMarkdown content={content} isAnimating />)
+    })
+
+    expect(streamdownHarness.mermaidImports).toBe(1)
+    expect(streamdownHarness.plugins?.mermaid).toEqual({ name: 'mermaid' })
+    expect(streamdownHarness.mermaidOptions).toBeDefined()
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe(content)
   })
 
   it('keeps the original message and sibling UI visible when rich Markdown rendering fails', async () => {

--- a/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
@@ -150,6 +150,25 @@ describe('AgentMarkdown renderer recovery', () => {
     expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe(content)
   })
 
+  it('loads plugins for code and Mermaid fences nested in Markdown containers', async () => {
+    streamdownHarness.shouldThrow = false
+
+    const listCode = '- ```ts\n  const value = 1\n  ```'
+    await act(async () => {
+      root.render(<AgentMarkdown content={listCode} />)
+    })
+    expect(streamdownHarness.plugins?.code).toEqual({ name: 'shiki' })
+
+    const quotedMermaid = '> ```mermaid\n> graph TD\n>   A --> B\n> ```'
+    await act(async () => {
+      root.render(<AgentMarkdown content={quotedMermaid} />)
+    })
+    expect(streamdownHarness.plugins?.mermaid).toEqual({ name: 'mermaid' })
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe(
+      quotedMermaid
+    )
+  })
+
   it('keeps the original message and sibling UI visible when rich Markdown rendering fails', async () => {
     await act(async () => {
       root.render(

--- a/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
@@ -169,6 +169,23 @@ describe('AgentMarkdown renderer recovery', () => {
     )
   })
 
+  it('loads plugins for fences on indented list continuations', async () => {
+    streamdownHarness.shouldThrow = false
+
+    const listCode = '- Code sample:\n\n    ```ts\n    const value = 1\n    ```'
+    await act(async () => {
+      root.render(<AgentMarkdown content={listCode} />)
+    })
+    expect(streamdownHarness.plugins?.code).toEqual({ name: 'shiki' })
+
+    const listMermaid = '1. Diagram:\n\n    ```mermaid\n    graph TD\n      A --> B\n    ```'
+    await act(async () => {
+      root.render(<AgentMarkdown content={listMermaid} />)
+    })
+    expect(streamdownHarness.plugins?.mermaid).toEqual({ name: 'mermaid' })
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe(listMermaid)
+  })
+
   it('keeps the original message and sibling UI visible when rich Markdown rendering fails', async () => {
     await act(async () => {
       root.render(

--- a/src/renderer/src/components/streamdown/AgentMarkdown.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.tsx
@@ -1,18 +1,32 @@
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
-import { Component, memo, useMemo, useState, type ErrorInfo, type ReactNode } from 'react'
+import {
+  Component,
+  memo,
+  useEffect,
+  useMemo,
+  useState,
+  type ErrorInfo,
+  type ReactNode
+} from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { code } from '@streamdown/code'
 import { cjk } from '@streamdown/cjk'
 import { createMathPlugin } from '@streamdown/math'
-import { mermaid } from '@streamdown/mermaid'
-import { Streamdown, type Components, type LinkSafetyConfig } from 'streamdown'
+import {
+  Streamdown,
+  type Components,
+  type LinkSafetyConfig,
+  type PluginConfig,
+  type ThemeInput
+} from 'streamdown'
 import 'katex/dist/katex.min.css'
 
+import { getMarkdownPluginNeeds } from './code-fence'
 import { AGENT_ALLOWED_TAGS, AGENT_CONTROLS } from './streamdown-config'
 import { LinkSafetyModal } from './LinkSafetyModal'
 import { SessionMessageLink } from './SessionMessageLink'
 import { StreamingBlock } from './StreamingBlock'
 import { createAgentMarkdownNormalizer } from './normalize-agent-markdown'
+import { useCodeHighlighter } from './use-code-highlighter'
 import { useSmoothStreamingContent } from './use-smooth-streaming-content'
 import { cn } from '@/lib/utils'
 
@@ -98,10 +112,37 @@ const MermaidErrorPanel = ({ chart, error, retry }: MermaidErrorPanelProps): Rea
 }
 
 const math = createMathPlugin({ singleDollarTextMath: true })
-const plugins = { code, math, mermaid, cjk } as const
+const basePlugins = { math, cjk } as const
+const shikiThemes: [ThemeInput, ThemeInput] = ['github-light', 'github-light']
 const mermaidOptions = {
   config: { theme: 'default' as const },
   errorComponent: MermaidErrorPanel
+}
+
+const useMarkdownPlugins = (content: string): PluginConfig => {
+  const needs = useMemo(() => getMarkdownPluginNeeds(content), [content])
+  const [optionalPlugins, setOptionalPlugins] = useState<PluginConfig>({})
+  const code = useCodeHighlighter(needs.code)
+
+  useEffect(() => {
+    if (!needs.mermaid || optionalPlugins.mermaid) return
+
+    let active = true
+    void import('./mermaid-runtime').then(
+      ({ mermaid }) => {
+        if (active) setOptionalPlugins((current) => ({ ...current, mermaid }))
+      },
+      (error: unknown) => console.error('Failed to load Mermaid rendering.', error)
+    )
+    return () => {
+      active = false
+    }
+  }, [needs.mermaid, optionalPlugins.mermaid])
+
+  return useMemo(
+    () => ({ ...basePlugins, ...(code ? { code } : {}), ...optionalPlugins }),
+    [code, optionalPlugins]
+  )
 }
 
 const agentLinkSafety: LinkSafetyConfig = {
@@ -169,6 +210,7 @@ const RichAgentMarkdown = memo(
     // Append-only streaming re-normalizes just the trailing block instead of the full message.
     const [normalizer] = useState(() => createAgentMarkdownNormalizer())
     const renderedContent = useMemo(() => normalizer(content), [normalizer, content])
+    const plugins = useMarkdownPlugins(renderedContent)
     const renderedComponents = useMemo(
       () => (sessionLinks ? { ...sessionLinkComponents, ...components } : components),
       [components, sessionLinks]
@@ -196,8 +238,8 @@ const RichAgentMarkdown = memo(
           normalizeHtmlIndentation={!isAnimating}
           allowedTags={AGENT_ALLOWED_TAGS}
           disallowedElements={allowMedia ? undefined : NETWORK_FETCHING_MEDIA_ELEMENTS}
-          shikiTheme={['github-light', 'github-light']}
-          mermaid={mermaidOptions}
+          shikiTheme={plugins.code ? shikiThemes : undefined}
+          mermaid={plugins.mermaid ? mermaidOptions : undefined}
         >
           {renderedContent}
         </Streamdown>

--- a/src/renderer/src/components/streamdown/code-fence.ts
+++ b/src/renderer/src/components/streamdown/code-fence.ts
@@ -45,7 +45,7 @@ const getMarkdownPluginNeeds = (markdown: string): MarkdownPluginNeeds => {
   let fenceBlockquoteDepth = 0
   let fenceListIndent = 0
   let listBlockquoteDepth = 0
-  let listContentIndent = 0
+  const listContentIndents: number[] = []
 
   for (const rawLine of markdown.split('\n')) {
     const wasOpen = tracker.isOpen()
@@ -61,26 +61,29 @@ const getMarkdownPluginNeeds = (markdown: string): MarkdownPluginNeeds => {
     if (wasOpen && fenceListIndent > 0) {
       const indentation = line.match(LEADING_WHITESPACE)?.[0].length ?? 0
       if (indentation >= fenceListIndent) line = line.slice(fenceListIndent)
-    } else if (!wasOpen) {
-      const listMarker = line.match(LIST_MARKER)?.[0]
-      if (listMarker) {
-        listContentIndent = listMarker.length
-        listBlockquoteDepth = blockquoteDepth
-        line = line.slice(listContentIndent)
-      } else if (line.trim() && listContentIndent > 0) {
+    } else if (!wasOpen && line.trim()) {
+      if (blockquoteDepth !== listBlockquoteDepth) listContentIndents.length = 0
+
+      if (listContentIndents.length > 0) {
         const indentation = line.match(LEADING_WHITESPACE)?.[0].length ?? 0
-        if (blockquoteDepth === listBlockquoteDepth && indentation >= listContentIndent) {
-          line = line.slice(listContentIndent)
-        } else {
-          listContentIndent = 0
-        }
+        while ((listContentIndents.at(-1) ?? 0) > indentation) listContentIndents.pop()
+        line = line.slice(listContentIndents.at(-1) ?? 0)
+      }
+
+      let listIndent = listContentIndents.at(-1) ?? 0
+      for (let listMarker = line.match(LIST_MARKER)?.[0]; listMarker;) {
+        listIndent += listMarker.length
+        listContentIndents.push(listIndent)
+        listBlockquoteDepth = blockquoteDepth
+        line = line.slice(listMarker.length)
+        listMarker = line.match(LIST_MARKER)?.[0]
       }
     }
 
     const isOpen = tracker.feed(line)
     if (!wasOpen && isOpen) {
       fenceBlockquoteDepth = blockquoteDepth
-      fenceListIndent = listContentIndent
+      fenceListIndent = listContentIndents.at(-1) ?? 0
     } else if (wasOpen && !isOpen) {
       fenceListIndent = 0
     }

--- a/src/renderer/src/components/streamdown/code-fence.ts
+++ b/src/renderer/src/components/streamdown/code-fence.ts
@@ -1,6 +1,8 @@
 // Shared markdown code-fence tracking used by the streaming renderers (normalization boundary
 // and the deferred-highlight block) so fence open/close rules live in exactly one place.
 const FENCE_LINE = /^[ \t]{0,3}(`{3,}|~{3,})/
+const BLOCKQUOTE_PREFIX = /^\s{0,3}>\s?/u
+const LIST_MARKER = /^\s{0,3}(?:[-+*]|\d+[.)])\s+/u
 
 type MarkdownPluginNeeds = {
   code: boolean
@@ -39,10 +41,22 @@ const createCodeFenceTracker = (): {
 const getMarkdownPluginNeeds = (markdown: string): MarkdownPluginNeeds => {
   const tracker = createCodeFenceTracker()
   let code = false
+  let fenceBlockquoteDepth = 0
 
-  for (const line of markdown.split('\n')) {
+  for (const rawLine of markdown.split('\n')) {
     const wasOpen = tracker.isOpen()
+    let line = rawLine
+    let blockquoteDepth = 0
+    while (blockquoteDepth < (wasOpen ? fenceBlockquoteDepth : Number.POSITIVE_INFINITY)) {
+      const prefix = line.match(BLOCKQUOTE_PREFIX)?.[0]
+      if (!prefix) break
+      line = line.slice(prefix.length)
+      blockquoteDepth += 1
+    }
+    if (!wasOpen) line = line.replace(LIST_MARKER, '')
+
     const isOpen = tracker.feed(line)
+    if (!wasOpen && isOpen) fenceBlockquoteDepth = blockquoteDepth
     if (wasOpen || !isOpen) continue
 
     code = true

--- a/src/renderer/src/components/streamdown/code-fence.ts
+++ b/src/renderer/src/components/streamdown/code-fence.ts
@@ -2,6 +2,11 @@
 // and the deferred-highlight block) so fence open/close rules live in exactly one place.
 const FENCE_LINE = /^[ \t]{0,3}(`{3,}|~{3,})/
 
+type MarkdownPluginNeeds = {
+  code: boolean
+  mermaid: boolean
+}
+
 // Tracks one fence's open/close state while lines stream through `feed`. A fence opens on the
 // first marker line and closes on a marker with the same character at equal or greater length.
 const createCodeFenceTracker = (): {
@@ -31,4 +36,22 @@ const createCodeFenceTracker = (): {
   }
 }
 
-export { FENCE_LINE, createCodeFenceTracker }
+const getMarkdownPluginNeeds = (markdown: string): MarkdownPluginNeeds => {
+  const tracker = createCodeFenceTracker()
+  let code = false
+
+  for (const line of markdown.split('\n')) {
+    const wasOpen = tracker.isOpen()
+    const isOpen = tracker.feed(line)
+    if (wasOpen || !isOpen) continue
+
+    code = true
+    const language = line.replace(FENCE_LINE, '').trim().split(/\s+/, 1)[0]
+    if (language === 'mermaid') return { code: true, mermaid: true }
+  }
+
+  return { code, mermaid: false }
+}
+
+export { FENCE_LINE, createCodeFenceTracker, getMarkdownPluginNeeds }
+export type { MarkdownPluginNeeds }

--- a/src/renderer/src/components/streamdown/code-fence.ts
+++ b/src/renderer/src/components/streamdown/code-fence.ts
@@ -3,6 +3,7 @@
 const FENCE_LINE = /^[ \t]{0,3}(`{3,}|~{3,})/
 const BLOCKQUOTE_PREFIX = /^\s{0,3}>\s?/u
 const LIST_MARKER = /^\s{0,3}(?:[-+*]|\d+[.)])\s+/u
+const LEADING_WHITESPACE = /^\s*/u
 
 type MarkdownPluginNeeds = {
   code: boolean
@@ -42,6 +43,9 @@ const getMarkdownPluginNeeds = (markdown: string): MarkdownPluginNeeds => {
   const tracker = createCodeFenceTracker()
   let code = false
   let fenceBlockquoteDepth = 0
+  let fenceListIndent = 0
+  let listBlockquoteDepth = 0
+  let listContentIndent = 0
 
   for (const rawLine of markdown.split('\n')) {
     const wasOpen = tracker.isOpen()
@@ -53,10 +57,33 @@ const getMarkdownPluginNeeds = (markdown: string): MarkdownPluginNeeds => {
       line = line.slice(prefix.length)
       blockquoteDepth += 1
     }
-    if (!wasOpen) line = line.replace(LIST_MARKER, '')
+
+    if (wasOpen && fenceListIndent > 0) {
+      const indentation = line.match(LEADING_WHITESPACE)?.[0].length ?? 0
+      if (indentation >= fenceListIndent) line = line.slice(fenceListIndent)
+    } else if (!wasOpen) {
+      const listMarker = line.match(LIST_MARKER)?.[0]
+      if (listMarker) {
+        listContentIndent = listMarker.length
+        listBlockquoteDepth = blockquoteDepth
+        line = line.slice(listContentIndent)
+      } else if (line.trim() && listContentIndent > 0) {
+        const indentation = line.match(LEADING_WHITESPACE)?.[0].length ?? 0
+        if (blockquoteDepth === listBlockquoteDepth && indentation >= listContentIndent) {
+          line = line.slice(listContentIndent)
+        } else {
+          listContentIndent = 0
+        }
+      }
+    }
 
     const isOpen = tracker.feed(line)
-    if (!wasOpen && isOpen) fenceBlockquoteDepth = blockquoteDepth
+    if (!wasOpen && isOpen) {
+      fenceBlockquoteDepth = blockquoteDepth
+      fenceListIndent = listContentIndent
+    } else if (wasOpen && !isOpen) {
+      fenceListIndent = 0
+    }
     if (wasOpen || !isOpen) continue
 
     code = true

--- a/src/renderer/src/components/streamdown/code-highlighter-runtime.ts
+++ b/src/renderer/src/components/streamdown/code-highlighter-runtime.ts
@@ -1,0 +1,1 @@
+export { code } from '@streamdown/code'

--- a/src/renderer/src/components/streamdown/mermaid-runtime.ts
+++ b/src/renderer/src/components/streamdown/mermaid-runtime.ts
@@ -1,0 +1,1 @@
+export { mermaid } from '@streamdown/mermaid'

--- a/src/renderer/src/components/streamdown/use-code-highlighter.ts
+++ b/src/renderer/src/components/streamdown/use-code-highlighter.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import type { CodeHighlighterPlugin } from '@streamdown/code'
+
+let loadedPlugin: CodeHighlighterPlugin | undefined
+let loadingPlugin: Promise<CodeHighlighterPlugin | undefined> | undefined
+
+const loadCodeHighlighter = (): Promise<CodeHighlighterPlugin | undefined> => {
+  if (loadedPlugin) return Promise.resolve(loadedPlugin)
+
+  loadingPlugin ??= import('./code-highlighter-runtime').then(
+    ({ code }) => (loadedPlugin = code),
+    (error: unknown) => {
+      loadingPlugin = undefined
+      console.error('Failed to load Markdown code highlighting.', error)
+      return undefined
+    }
+  )
+  return loadingPlugin
+}
+
+const useCodeHighlighter = (enabled: boolean): CodeHighlighterPlugin | undefined => {
+  const [plugin, setPlugin] = useState(loadedPlugin)
+
+  useEffect(() => {
+    if (!enabled || plugin) return
+
+    let active = true
+    void loadCodeHighlighter().then((loaded) => {
+      if (active && loaded) setPlugin(loaded)
+    })
+    return () => {
+      active = false
+    }
+  }, [enabled, plugin])
+
+  return plugin
+}
+
+export { useCodeHighlighter }

--- a/src/renderer/src/pages/workspace/HighlightedCodeLines.tsx
+++ b/src/renderer/src/pages/workspace/HighlightedCodeLines.tsx
@@ -1,9 +1,9 @@
-import { code as streamdownCode } from '@streamdown/code'
 import type { HighlightResult } from '@streamdown/code'
 import type { BundledLanguage } from 'shiki'
 import { useEffect, useState } from 'react'
 
 import { cn } from '@/lib/utils'
+import { useCodeHighlighter } from '@/components/streamdown/use-code-highlighter'
 
 const MAX_HIGHLIGHT_BYTES = 256 * 1024
 
@@ -47,10 +47,13 @@ const HighlightedCodeLines = ({
   const source = code.replace(/\0/g, '').replace(/\r\n/g, '\n')
   const highlightKey = language ? `${language}\0${source}` : ''
   const lines = source.length > 0 ? source.split(/\r?\n/) : ['']
-  const shouldHighlight =
-    Boolean(language) &&
-    streamdownCode.supportsLanguage(language as BundledLanguage) &&
-    new TextEncoder().encode(source).byteLength <= MAX_HIGHLIGHT_BYTES
+  const isWithinHighlightLimit = language
+    ? new TextEncoder().encode(source).byteLength <= MAX_HIGHLIGHT_BYTES
+    : false
+  const highlighter = useCodeHighlighter(Boolean(language) && isWithinHighlightLimit)
+  const shouldHighlight = Boolean(
+    isWithinHighlightLimit && language && highlighter?.supportsLanguage(language as BundledLanguage)
+  )
 
   useEffect(() => {
     if (!shouldHighlight) return
@@ -59,11 +62,11 @@ const HighlightedCodeLines = ({
     const apply = (result: HighlightResult): void => {
       if (active) setHighlighted({ key: highlightKey, result })
     }
-    const immediate = streamdownCode.highlight(
+    const immediate = highlighter?.highlight(
       {
         code: source,
         language: language as BundledLanguage,
-        themes: streamdownCode.getThemes()
+        themes: highlighter.getThemes()
       },
       apply
     )
@@ -73,7 +76,7 @@ const HighlightedCodeLines = ({
     return () => {
       active = false
     }
-  }, [highlightKey, language, shouldHighlight, source])
+  }, [highlightKey, language, shouldHighlight, source, highlighter])
 
   const tokens =
     highlighted?.key === highlightKey &&

--- a/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx
@@ -4,7 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mimic dual-theme Shiki output: colors live in htmlStyle, not token.color.
-vi.mock('@streamdown/code', () => ({
+vi.mock('@/components/streamdown/code-highlighter-runtime', () => ({
   code: {
     supportsLanguage: () => true,
     getThemes: () => ['github-light', 'github-dark'],

--- a/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.tsx
@@ -1,10 +1,11 @@
-import { code } from '@streamdown/code'
 import type { HighlightResult } from '@streamdown/code'
 import { cn } from '@/lib/utils'
 import { Copy } from 'lucide-react'
 import { Fragment, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { BundledLanguage } from 'shiki'
+
+import { useCodeHighlighter } from '@/components/streamdown/use-code-highlighter'
 
 type WorkspaceToolCodeBlockProps = {
   code: string
@@ -48,6 +49,7 @@ const WorkspaceToolCodeBlock = ({
   const [highlighted, setHighlighted] = useState<HighlightState | null>(null)
   const [copied, setCopied] = useState(false)
   const highlightKey = createHighlightKey(source, language)
+  const highlighter = useCodeHighlighter(Boolean(language))
 
   const copyCode = useCallback(async () => {
     if (!navigator.clipboard) return
@@ -62,15 +64,15 @@ const WorkspaceToolCodeBlock = ({
   }, [source])
 
   useEffect(() => {
-    if (!language || !code.supportsLanguage(language as BundledLanguage)) return
+    if (!language || !highlighter?.supportsLanguage(language as BundledLanguage)) return
 
     let active = true
     const apply = (result: HighlightResult): void => {
       if (active) setHighlighted({ key: highlightKey, result })
     }
     // The highlighter loads languages/themes asynchronously; cached hits return immediately instead.
-    const immediate = code.highlight(
-      { code: source, language: language as BundledLanguage, themes: code.getThemes() },
+    const immediate = highlighter.highlight(
+      { code: source, language: language as BundledLanguage, themes: highlighter.getThemes() },
       apply
     )
 
@@ -79,7 +81,7 @@ const WorkspaceToolCodeBlock = ({
     return () => {
       active = false
     }
-  }, [source, language, highlightKey])
+  }, [source, language, highlightKey, highlighter])
 
   // Only paint tokens that were produced for the currently rendered code and language.
   const tokens = highlighted?.key === highlightKey ? highlighted.result.tokens : undefined

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -35,7 +35,7 @@ vi.mock('3dmol', () => ({
   }
 }))
 
-vi.mock('@streamdown/code', () => ({
+vi.mock('@/components/streamdown/code-highlighter-runtime', () => ({
   code: {
     supportsLanguage: (language: string) =>
       ['bash', 'css', 'javascript', 'jsx', 'python', 'r', 'typescript', 'tsx'].includes(language),

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -609,9 +609,11 @@ describe('conversation message scroller integration', () => {
     expect(workspaceToolRowButtonSource).toContain('const WorkspaceToolActivityRowButton')
     expect(workspaceToolRowButtonSource).toContain('data-testid="tool-chip"')
     expect(workspaceToolRowButtonSource).toContain('aria-controls={canExpand ? detailsDomId')
-    // Code blocks reuse the shared Shiki highlighter for consistent syntax colors.
-    expect(workspaceToolCodeBlockSource).toContain("from '@streamdown/code'")
-    expect(workspaceToolCodeBlockSource).toContain('code.highlight(')
+    // Code blocks reuse the shared lazy Shiki highlighter for consistent syntax colors.
+    expect(workspaceToolCodeBlockSource).toContain(
+      "from '@/components/streamdown/use-code-highlighter'"
+    )
+    expect(workspaceToolCodeBlockSource).toContain('highlighter.highlight(')
   })
 
   it('keeps generated artifact cards the same size when expanded inline', () => {


### PR DESCRIPTION
## Problem

`AgentMarkdown` and workspace code surfaces statically imported the Streamdown Mermaid and code plugins. As a result, ordinary prose conversations pulled Mermaid, Shiki, and theme runtimes into the eagerly loaded renderer graph.

## Proposed change

- Detect fenced code and Mermaid fences before requesting optional rendering plugins.
- Dynamically load Mermaid only when a Mermaid fence is present.
- Dynamically load the code highlighter and themes only when fenced code is present.
- Keep Streamdown mounted while plugins load so Markdown and code source remain readable.
- Reuse the same lazy code-highlighter hook in workspace code surfaces to remove their static imports.
- Preserve the existing Mermaid error panel and source-code fallback on load or render failure.
- Keep Mermaid and code highlighting in separate optional runtime chunks.

## Scope and non-goals

- No additional Markdown rendering system.
- Math and CJK plugin behavior is unchanged.
- No user-visible copy or translation changes.
- No historical-data compatibility handling is required.
- No enum or durable state is added.
- No persistence or data migration is involved.

## Acceptance criteria and validation

- `npm test -- src/renderer/src/components/streamdown src/renderer/src/pages/workspace/WorkspaceToolCodeBlock.test.tsx src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx` — 15 files / 160 tests passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed.
- `npm run build:web` — passed.
- The production build entry has no static Mermaid dependency and dynamically imports distinct code-highlighter and Mermaid runtime entries.

The full cross-platform suite is left to PR CI as requested.

## Review focus

- Fence detection during streaming transitions.
- Source fallback while plugins load or fail.
- Production chunk boundaries for Mermaid versus Shiki/themes.
