### PR TITLE
feat(providers): add GLM-5.3-Flash

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -128,6 +128,17 @@ describe('provider registry', () => {
     })
   })
 
+  it('offers GLM-5.3-Flash through both Zhipu provider types', () => {
+    const expected = {
+      id: 'glm-5.3-flash',
+      contextWindow: 1_000_000,
+      reasoningEffort: 'low-high-max'
+    }
+
+    expect(getOfficialVendor('zhipu')?.models).toContainEqual(expected)
+    expect(getOfficialVendor('glmcodingplan')?.models).toContainEqual(expected)
+  })
+
   it('routes the GLM Coding Plan through the /api/coding OpenAI path, per region', () => {
     expect(vendorHasRegions('glmcodingplan')).toBe(true)
     expect(resolveVendorApiEndpoints('glmcodingplan')).toEqual(['anthropic', 'openai'])
@@ -146,8 +157,9 @@ describe('provider registry', () => {
     // Quota-based plan: fixed catalog, no live model-list refresh.
     expect(resolveVendorModelsUrl('glmcodingplan')).toBeUndefined()
     expect(defaultVendorModel('glmcodingplan')).toBe('glm-5.3')
-    // The coding plan drops GLM's vision variant, so it serves no multimodal model.
+    // The coding plan omits the older vision variant but serves the natively multimodal Flash model.
     expect(isVendorModelMultimodal('glmcodingplan', 'glm-5v-turbo')).toBe(false)
+    expect(isVendorModelMultimodal('glmcodingplan', 'glm-5.3-flash')).toBe(true)
     expect(isVendorModelMultimodal('glmcodingplan', 'glm-5.3')).toBe(false)
     expect(isVendorModelMultimodal('glmcodingplan', 'glm-5.2')).toBe(false)
     // Each region points at its own subscription console.
@@ -171,6 +183,14 @@ describe('provider registry', () => {
       slots: ['none', 'high', 'max', 'max', 'max']
     })
     expect(resolveVendorModelReasoningEffort('glmcodingplan', 'glm-5.3')).toEqual({
+      supported: true,
+      slots: ['low', 'high', 'max', 'max', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('zhipu', 'glm-5.3-flash')).toEqual({
+      supported: true,
+      slots: ['low', 'high', 'max', 'max', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('glmcodingplan', 'glm-5.3-flash')).toEqual({
       supported: true,
       slots: ['low', 'high', 'max', 'max', 'max']
     })
@@ -574,8 +594,9 @@ describe('provider registry', () => {
       expect(isVendorModelMultimodal(planId, 'deepseek-v4-pro')).toBe(false)
     })
 
-    it('matches Zhipu vision variants by pattern, including future `Nv` ids', () => {
+    it('matches Zhipu vision variants by pattern plus GLM-5.3-Flash explicitly', () => {
       expect(isVendorModelMultimodal('zhipu', 'glm-5v-turbo')).toBe(true)
+      expect(isVendorModelMultimodal('zhipu', 'glm-5.3-flash')).toBe(true)
       // The pattern generalizes to future vision variants the live refresh may surface.
       expect(isVendorModelMultimodal('zhipu', 'glm-6v')).toBe(true)
       expect(isVendorModelMultimodal('zhipu', 'glm-5.2')).toBe(false)
@@ -719,6 +740,8 @@ describe('provider registry', () => {
       expect(resolveModelContextWindow('deepseek', 'deepseek-v4-flash')).toBe(1_000_000)
       expect(resolveModelContextWindow('deepseek', 'deepseek-v4-flash-vision-exp')).toBe(1_000_000)
       expect(resolveModelContextWindow('glmcodingplan', 'glm-5.3')).toBe(1_000_000)
+      expect(resolveModelContextWindow('zhipu', 'glm-5.3-flash')).toBe(1_000_000)
+      expect(resolveModelContextWindow('glmcodingplan', 'glm-5.3-flash')).toBe(1_000_000)
       expect(resolveModelContextWindow('zhipu', 'glm-5.2')).toBe(1_000_000)
       expect(resolveModelContextWindow('zhipu', 'glm-5.1')).toBe(200_000)
       expect(resolveModelContextWindow('kimi', 'kimi-k3')).toBe(1_000_000)

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -358,6 +358,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     ],
     models: [
       { id: 'glm-5.3', contextWindow: 1_000_000, reasoningEffort: 'low-high-max' },
+      { id: 'glm-5.3-flash', contextWindow: 1_000_000, reasoningEffort: 'low-high-max' },
       { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'none-high-max' },
       { id: 'glm-5.1', contextWindow: 200_000 },
       { id: 'glm-5', contextWindow: 200_000 },
@@ -365,9 +366,12 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       { id: 'glm-5-turbo', contextWindow: 200_000 },
       { id: 'glm-4.5-air', contextWindow: 128_000 }
     ],
-    // GLM marks vision variants with a `v` after the major version (e.g. glm-5v-turbo); the pattern
-    // also covers future `Nv` ids the live refresh may surface.
-    multimodal: { multimodalModelPattern: /glm-\d+v/i }
+    // GLM usually marks vision variants with a `v` after the major version (e.g. glm-5v-turbo), but
+    // GLM-5.3-Flash is also natively multimodal without that marker.
+    multimodal: {
+      multimodalModelPattern: /glm-\d+v/i,
+      multimodalModels: ['glm-5.3-flash']
+    }
   },
   {
     id: 'glmcodingplan',
@@ -394,15 +398,16 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         apiKeyUrl: 'https://bigmodel.cn/glm-coding'
       }
     ],
-    // The coding plan does not serve GLM's vision variant, so glm-5v-turbo is omitted and there is no
-    // `multimodal` rule (image input stays disabled for this endpoint).
+    // The coding plan omits glm-5v-turbo, but serves the natively multimodal GLM-5.3-Flash.
     models: [
       { id: 'glm-5.3', contextWindow: 1_000_000, reasoningEffort: 'low-high-max' },
+      { id: 'glm-5.3-flash', contextWindow: 1_000_000, reasoningEffort: 'low-high-max' },
       { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'none-high-max' },
       { id: 'glm-5.1', contextWindow: 200_000 },
       { id: 'glm-5', contextWindow: 200_000 },
       { id: 'glm-5-turbo', contextWindow: 200_000 }
-    ]
+    ],
+    multimodal: { multimodalModels: ['glm-5.3-flash'] }
   },
   {
     id: 'kimi',


### PR DESCRIPTION
## Problem

GLM-5.3-Flash is available through the Zhipu Model API and GLM Coding Plan, but is absent from the built-in provider catalogs.

## Proposed change

- Add glm-5.3-flash to the Zhipu pay-as-you-go and GLM Coding Plan catalogs without replacing glm-5.3 as the default.
- Register the documented 1M context window and low/high/max reasoning profile.
- Mark the model as multimodal for both provider types.
- Add provider-registry contract coverage for catalog membership, defaults, reasoning, context, and image input.

## Scope and non-goals

- qwen3.8-flash is intentionally excluded: no reviewed Alibaba Cloud first-party source lists that exact ID for Bailian pay-as-you-go, Token Plan, Coding Plan, Anthropic Messages, or Responses.
- No provider enum or application state is added.
- No database schema, migration, persisted format, or historical-data compatibility path changes.
- Existing provider selections and stored model IDs remain unchanged.

## Acceptance criteria and validation

Checks ran after the last material edit.

- GLM provider catalog and capability contract -> npm test -- src/shared/provider-registry.test.ts -> 62 passed.
- Settings provider owner, contract, and representative consumers -> npm run test:module -- settings_provider_accounts -> 21 files, 397 tests passed.
- Shared main-process types -> npm run typecheck:node -> passed.
- Shared renderer types -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed.
- Dependency-aware explain -> npm run test:affected:explain -- --base origin/main --head HEAD -> full CI plan because src/shared/provider-registry.ts has no declared module owner.

Per maintainer direction, the complete local npm test suite was not run; PR CI is the authority for the full plan and platform lanes.

Uncovered risk: no live credentialed smoke call was made against either GLM endpoint.

## Review focus

Confirm that glm-5.3 remains the default while glm-5.3-flash is selectable and image-capable for both Zhipu provider types.