### PR TITLE
fix(project-files): surface folder access failures

### DIFF
--- a/src/renderer/src/lib/error-detail.ts
+++ b/src/renderer/src/lib/error-detail.ts
@@ -1,4 +1,15 @@
-const errorDetail = (error: unknown): string | undefined =>
-  error instanceof Error ? error.message : typeof error === 'string' ? error : undefined
+const errorDetail = (error: unknown): string | undefined => {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message
+  }
+  return undefined
+}
 
 export { errorDetail }

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -4383,6 +4383,74 @@ describe('ProjectFilesView — granted local folders', () => {
     expect(useGrantedFoldersStore.getState().roots).toEqual([])
   })
 
+  it('shows the failed access change and retries it from the toast', async () => {
+    setGrantedRootAccess.mockRejectedValueOnce(new Error('database unavailable'))
+    await renderFilesView()
+    await openFilterMenu()
+    await hoverElement(document.body.querySelector('[data-testid="granted-root-root-1"]'))
+
+    await waitFor(() => {
+      expect(
+        document.body.querySelector('[data-testid="granted-root-allow-writes-root-1"]')
+      ).not.toBeNull()
+    })
+    await clickElement(
+      document.body.querySelector('[data-testid="granted-root-allow-writes-root-1"]')
+    )
+    expect(setGrantedRootAccess).toHaveBeenCalledWith({ id: 'root-1', access: 'rw' })
+
+    await waitFor(() => {
+      expect(document.body.querySelector('[data-testid="granted-root-error-toast"]')).not.toBeNull()
+    })
+    const toast = document.body.querySelector('[data-testid="granted-root-error-toast"]')
+    expect(toast?.textContent).toContain('Could not change folder access.')
+    expect(toast?.textContent).toContain('database unavailable')
+    expect(useGrantedFoldersStore.getState().roots[0]?.access).toBe('ro')
+
+    await clickElement(
+      Array.from(toast?.querySelectorAll('button') ?? []).find(
+        (button) => button.textContent === 'Retry'
+      )
+    )
+
+    expect(setGrantedRootAccess).toHaveBeenCalledTimes(2)
+    expect(useGrantedFoldersStore.getState().roots[0]?.access).toBe('rw')
+    expect(document.body.querySelector('[data-testid="granted-root-error-toast"]')).toBeNull()
+  })
+
+  it('shows the failed access removal and retries it from the toast', async () => {
+    removeGrantedRoot.mockRejectedValueOnce(new Error('database unavailable'))
+    await renderFilesView()
+    await openFilterMenu()
+    await hoverElement(document.body.querySelector('[data-testid="granted-root-root-1"]'))
+
+    await waitFor(() => {
+      expect(
+        document.body.querySelector('[data-testid="granted-root-remove-root-1"]')
+      ).not.toBeNull()
+    })
+    await clickElement(document.body.querySelector('[data-testid="granted-root-remove-root-1"]'))
+    expect(removeGrantedRoot).toHaveBeenCalledWith({ id: 'root-1' })
+
+    await waitFor(() => {
+      expect(document.body.querySelector('[data-testid="granted-root-error-toast"]')).not.toBeNull()
+    })
+    const toast = document.body.querySelector('[data-testid="granted-root-error-toast"]')
+    expect(toast?.textContent).toContain('Could not remove folder access.')
+    expect(toast?.textContent).toContain('database unavailable')
+    expect(useGrantedFoldersStore.getState().roots).toEqual([grantedRoot])
+
+    await clickElement(
+      Array.from(toast?.querySelectorAll('button') ?? []).find(
+        (button) => button.textContent === 'Retry'
+      )
+    )
+
+    expect(removeGrantedRoot).toHaveBeenCalledTimes(2)
+    expect(useGrantedFoldersStore.getState().roots).toEqual([])
+    expect(document.body.querySelector('[data-testid="granted-root-error-toast"]')).toBeNull()
+  })
+
   it('opens the manage submenu when the row itself is hovered', async () => {
     await renderFilesView()
     await openFilterMenu()

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -4384,7 +4384,7 @@ describe('ProjectFilesView — granted local folders', () => {
   })
 
   it('shows the failed access change and retries it from the toast', async () => {
-    setGrantedRootAccess.mockRejectedValueOnce(new Error('database unavailable'))
+    setGrantedRootAccess.mockRejectedValueOnce({ message: 'database unavailable' })
     await renderFilesView()
     await openFilterMenu()
     await hoverElement(document.body.querySelector('[data-testid="granted-root-root-1"]'))

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -9,6 +9,7 @@ import { ActionToast } from '@/components/ActionToast'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { errorDetail } from '@/lib/error-detail'
 import { relativeTimeParts, type RelativeTimeUnit } from '@/lib/format-relative-time'
 import { cn } from '@/lib/utils'
 import { useGrantedFoldersStore } from '@/stores/granted-folders-store'
@@ -355,7 +356,7 @@ const ProjectFilesViewContent = ({
     void mutation().catch((error: unknown) => {
       setGrantedRootMutationError({
         kind,
-        detail: error instanceof Error ? error.message : undefined,
+        detail: errorDetail(error),
         retry: mutation
       })
     })

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -5,6 +5,7 @@ import { ToggleGroup } from 'radix-ui'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ActionToast } from '@/components/ActionToast'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -44,6 +45,13 @@ import {
 import { FILE_PAGE_SIZE, type PageState } from './use-project-files-index'
 
 type FilePageLoadMode = 'manual' | 'scroll'
+type GrantedRootMutationKind = 'change' | 'remove'
+
+type GrantedRootMutationError = {
+  kind: GrantedRootMutationKind
+  detail?: string
+  retry: () => Promise<unknown>
+}
 
 // Keeps manual pagination recognizable without the outline competing with the surrounding file tiles.
 const loadMoreButtonClassName = 'bg-bg-200 text-text-100 hover:bg-bg-300 hover:text-text-000'
@@ -336,6 +344,22 @@ const ProjectFilesViewContent = ({
   // Granted folder the local browser is scoped to; undefined means the machine itself.
   const [selectedLocalRootId, setSelectedLocalRootId] = useState<string | undefined>(undefined)
   const [grantDialogOpen, setGrantDialogOpen] = useState(false)
+  const [grantedRootMutationError, setGrantedRootMutationError] =
+    useState<GrantedRootMutationError>()
+
+  const runGrantedRootMutation = (
+    kind: GrantedRootMutationKind,
+    mutation: () => Promise<unknown>
+  ): void => {
+    setGrantedRootMutationError(undefined)
+    void mutation().catch((error: unknown) => {
+      setGrantedRootMutationError({
+        kind,
+        detail: error instanceof Error ? error.message : undefined,
+        retry: mutation
+      })
+    })
+  }
 
   // Load the granted folders once so the filter menu can list them; localFs is absent outside
   // Electron, where the section just shows the machine entry and "Add folder…" stays inert. A
@@ -485,6 +509,11 @@ const ProjectFilesViewContent = ({
     ? grantedRoots.find((root) => root.id === selectedLocalRootId)
     : undefined
   const filesExpansionLabel = isFilesExpanded ? t('Exit full screen files') : t('Expand files')
+  const grantedRootMutationErrorTitle = grantedRootMutationError
+    ? grantedRootMutationError.kind === 'change'
+      ? t('Could not change folder access.')
+      : t('Could not remove folder access.')
+    : undefined
 
   return (
     <div data-testid="files-view" className="flex h-full min-h-0 w-full flex-col bg-bg-10">
@@ -520,6 +549,7 @@ const ProjectFilesViewContent = ({
           onBrowseLocal={handleBrowseLocal}
           onAddFolder={() => setGrantDialogOpen(true)}
           onSelectGrantedRoot={handleSelectGrantedRoot}
+          onGrantedRootMutation={runGrantedRootMutation}
           localMachineName={localMachineName}
           isLocalSelected={isLocalMode}
           selectedLocalRootId={selectedLocalRoot?.id}
@@ -811,6 +841,19 @@ const ProjectFilesViewContent = ({
         onOpenChange={setGrantDialogOpen}
         onGranted={handleSelectGrantedRoot}
       />
+      {grantedRootMutationError ? (
+        <ActionToast
+          title={grantedRootMutationErrorTitle!}
+          detail={grantedRootMutationError.detail}
+          actionLabel={t('Retry')}
+          dismissLabel={t('Close')}
+          onAction={() =>
+            runGrantedRootMutation(grantedRootMutationError.kind, grantedRootMutationError.retry)
+          }
+          onDismiss={() => setGrantedRootMutationError(undefined)}
+          testId="granted-root-error-toast"
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/pages/workspace/project-files-presentation-owner.tsx
+++ b/src/renderer/src/pages/workspace/project-files-presentation-owner.tsx
@@ -443,20 +443,20 @@ const GrantedRootMenuRow = ({
   root,
   isSelected,
   onSelect,
-  onCloseMenu
+  onCloseMenu,
+  onMutation
 }: {
   root: GrantedLocalRoot
   isSelected: boolean
   onSelect: (root: GrantedLocalRoot) => void
   onCloseMenu: () => void
+  onMutation: (kind: 'change' | 'remove', mutation: () => Promise<unknown>) => void
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const setAccess = useGrantedFoldersStore((state) => state.setAccess)
   const remove = useGrantedFoldersStore((state) => state.remove)
 
-  // The whole row is the submenu trigger: hovering it opens the manage submenu (Radix hover
-  // intent), while clicking still selects the folder. Clicking a sub-trigger would normally open
-  // the submenu instead, so the click is default-prevented and the menu closed manually.
+  // Hover opens the submenu; click selects the folder and closes the parent menu explicitly.
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger asChild>
@@ -508,7 +508,7 @@ const GrantedRootMenuRow = ({
           <DropdownMenuItem
             className="gap-2"
             data-testid={`granted-root-allow-writes-${root.id}`}
-            onSelect={() => void setAccess(root.id, 'rw').catch(() => undefined)}
+            onSelect={() => onMutation('change', () => setAccess(root.id, 'rw'))}
           >
             <LockOpen
               className="size-4 shrink-0 text-text-300"
@@ -521,7 +521,7 @@ const GrantedRootMenuRow = ({
           <DropdownMenuItem
             className="gap-2"
             data-testid={`granted-root-make-read-only-${root.id}`}
-            onSelect={() => void setAccess(root.id, 'ro').catch(() => undefined)}
+            onSelect={() => onMutation('change', () => setAccess(root.id, 'ro'))}
           >
             <Lock className="size-4 shrink-0 text-text-300" strokeWidth={1.8} aria-hidden="true" />
             <span>{t('Make read-only')}</span>
@@ -530,7 +530,7 @@ const GrantedRootMenuRow = ({
         <DropdownMenuItem
           className="gap-2 text-danger-000 data-[highlighted]:text-danger-000"
           data-testid={`granted-root-remove-${root.id}`}
-          onSelect={() => void remove(root.id).catch(() => undefined)}
+          onSelect={() => onMutation('remove', () => remove(root.id))}
         >
           <Trash2 className="size-4 shrink-0" strokeWidth={1.8} aria-hidden="true" />
           <span>{t('Remove access')}</span>
@@ -540,8 +540,7 @@ const GrantedRootMenuRow = ({
   )
 }
 
-// Keeps all/uploads filters fixed while session choices expand through their own group-header cursor,
-// preventing menu exploration from advancing any file collection shown in the content area.
+// Session choices paginate independently so menu exploration never advances the visible files.
 const ProjectFilesFilterMenu = ({
   label,
   options,
@@ -557,6 +556,7 @@ const ProjectFilesFilterMenu = ({
   onBrowseLocal,
   onAddFolder,
   onSelectGrantedRoot,
+  onGrantedRootMutation,
   localMachineName,
   isLocalSelected,
   selectedLocalRootId
@@ -575,9 +575,9 @@ const ProjectFilesFilterMenu = ({
   onBrowseLocal: () => void
   onAddFolder: () => void
   onSelectGrantedRoot: (root: GrantedLocalRoot) => void
+  onGrantedRootMutation: (kind: 'change' | 'remove', mutation: () => Promise<unknown>) => void
   localMachineName: string | undefined
   isLocalSelected: boolean
-  // Id of the granted folder the local browser is scoped to; undefined means the machine itself.
   selectedLocalRootId: string | undefined
 }): React.JSX.Element => {
   const { t } = useTranslation()
@@ -595,7 +595,6 @@ const ProjectFilesFilterMenu = ({
   const selectedLocalRoot = selectedLocalRootId
     ? grantedRoots.find((root) => root.id === selectedLocalRootId)
     : undefined
-  // The machine row is checked only when the local browser is not scoped to a granted folder.
   const isMachineSelected = isLocalSelected && selectedLocalRoot === undefined
 
   useEffect(() => {
@@ -725,6 +724,7 @@ const ProjectFilesFilterMenu = ({
               isSelected={root.id === selectedLocalRootId}
               onSelect={onSelectGrantedRoot}
               onCloseMenu={() => setMenuOpen(false)}
+              onMutation={onGrantedRootMutation}
             />
           ))}
           <DropdownMenuItem

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -598,6 +598,8 @@
     "Could not add that interpreter.": "No se pudo agregar ese intérprete.",
     "Could not archive project.": "No se pudo archivar el proyecto.",
     "Could not cancel the setup.": "No se pudo cancelar la configuración.",
+    "Could not change folder access.": "No se pudo cambiar el acceso a la carpeta.",
+    "Could not remove folder access.": "No se pudo eliminar el acceso a la carpeta.",
     "Could not change package-install authorization.": "No se pudo cambiar la autorización de instalación del paquete.",
     "Could not change that runtime.": "No se pudo cambiar ese entorno de ejecución.",
     "Could not check the data folder. Try again.": "No se pudo comprobar la carpeta de datos. Inténtelo de nuevo.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -598,6 +598,8 @@
     "Could not add that interpreter.": "Impossible d'ajouter cet interprète.",
     "Could not archive project.": "Impossible d'archiver le projet.",
     "Could not cancel the setup.": "Impossible d'annuler la configuration.",
+    "Could not change folder access.": "Impossible de modifier l’accès au dossier.",
+    "Could not remove folder access.": "Impossible de supprimer l’accès au dossier.",
     "Could not change package-install authorization.": "Impossible de modifier l'autorisation d'installation des paquets.",
     "Could not change that runtime.": "Impossible de changer cet environnement d'exécution.",
     "Could not check the data folder. Try again.": "Impossible de vérifier le dossier de données. Essayer à nouveau.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -559,6 +559,8 @@
     "Could not add that interpreter.": "そのインタープリターを追加できませんでした。",
     "Could not archive project.": "プロジェクトをアーカイブできませんでした。",
     "Could not cancel the setup.": "セットアップをキャンセルできませんでした。",
+    "Could not change folder access.": "フォルダーのアクセス権を変更できませんでした。",
+    "Could not remove folder access.": "フォルダーへのアクセス権を削除できませんでした。",
     "Could not change package-install authorization.": "パッケージのインストール権限を変更できませんでした。",
     "Could not change that runtime.": "そのランタイムを変更できませんでした。",
     "Could not check the data folder. Try again.": "データフォルダーを確認できませんでした。もう一度やり直してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -578,6 +578,8 @@
     "Could not add that interpreter.": "해당 인터프리터를 추가할 수 없습니다.",
     "Could not archive project.": "프로젝트를 보관하지 못했습니다.",
     "Could not cancel the setup.": "설정을 취소할 수 없습니다.",
+    "Could not change folder access.": "폴더 접근 권한을 변경할 수 없습니다.",
+    "Could not remove folder access.": "폴더 접근 권한을 제거할 수 없습니다.",
     "Could not change package-install authorization.": "패키지 설치 권한을 변경할 수 없습니다.",
     "Could not change that runtime.": "런타임을 변경할 수 없습니다.",
     "Could not check the data folder. Try again.": "데이터 폴더를 확인할 수 없습니다. 다시 시도해 보세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -589,6 +589,8 @@
     "Could not add that interpreter.": "Не удалось добавить интерпретатор.",
     "Could not archive project.": "Не удалось архивировать проект.",
     "Could not cancel the setup.": "Не удалось отменить настройку.",
+    "Could not change folder access.": "Не удалось изменить доступ к папке.",
+    "Could not remove folder access.": "Не удалось удалить доступ к папке.",
     "Could not change package-install authorization.": "Не удалось изменить разрешение на установку пакетов.",
     "Could not change that runtime.": "Не удалось изменить эту среду выполнения.",
     "Could not check the data folder. Try again.": "Не удалось проверить папку с данными. Попробуйте снова.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -630,6 +630,8 @@
     "Could not add that interpreter.": "无法添加该解释器。",
     "Could not archive project.": "无法归档项目。",
     "Could not cancel the setup.": "无法取消该设置流程。",
+    "Could not change folder access.": "无法更改文件夹访问权限。",
+    "Could not remove folder access.": "无法移除文件夹访问权限。",
     "Could not change package-install authorization.": "无法更改软件包安装授权。",
     "Could not change that runtime.": "无法更改该运行时。",
     "Could not check the data folder. Try again.": "无法检查数据文件夹。请重试。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -629,6 +629,8 @@
     "Could not add that interpreter.": "無法新增該解譯器。",
     "Could not archive project.": "無法封存專案。",
     "Could not cancel the setup.": "無法取消該設定流程。",
+    "Could not change folder access.": "無法變更資料夾存取權限。",
+    "Could not remove folder access.": "無法移除資料夾存取權限。",
     "Could not change package-install authorization.": "無法變更套件安裝授權。",
     "Could not change that runtime.": "無法變更該執行環境。",
     "Could not check the data folder. Try again.": "無法檢查資料夾。請再試一次。",


### PR DESCRIPTION
## Problem

Changing a granted folder between read-only and read/write access, or removing the grant, closed the menu even when the renderer-to-main mutation rejected. Each user-initiated handler ended with `.catch(() => undefined)`, so the previous grant state remained in effect without any visible explanation or retry path.

This can occur when a granted-root id is stale, the SQLite-backed grant repository fails, or the renderer command transport rejects. The store already preserves the previous root list on rejection; the missing behavior was user feedback.

## Proposed change

- Route the three granted-folder mutations through the `ProjectFilesView` state owner.
- Reuse the existing `ActionToast` to show an operation-specific title, the user-presentable rejection detail when available, and Retry/Close actions.
- Retry the exact failed mutation and clear the toast when a new attempt starts or the user dismisses it.
- Add renderer translations for both error titles in all seven shipped locales.
- Add public-boundary regression coverage for access changes and grant removal.

## Scope and non-goals

- No renderer API, IPC, database schema, data field, data relationship, or persisted-format changes.
- No new enum or durable state; `change | remove` is component-local transient presentation state.
- No historical-data compatibility or migration work is required.
- No new notification framework or dependency; this reuses the existing action toast.

## Acceptance criteria and validation

The regression tests first ran against the original swallowing handlers after confirming the Radix submenu action and IPC mock were actually invoked. Both failed at the reported symptom (`expected null not to be null` for the missing error toast). Restoring the fix made both pass.

All commands below ran after the last material edit:

- Folder access/change rejection, preserved prior state, visible error detail, Retry success -> `npm run test:module -- project_files_view` -> 6 files, 172 tests passed.
- Renderer copy, locale completeness, script purity, and translation call sites -> `npx vitest run src/renderer/src/i18n/resources.test.ts` -> 743 tests passed.
- Exact base-to-head owner, consumer, and i18n adapter impact set -> `npm run test:affected -- --base origin/main --head HEAD` -> 32 files, 1,445 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Main/shared locale adapter types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed.

The full portable `npm test` suite was intentionally left to PR CI. No platform-specific path, database, or transport behavior changed. The remaining local coverage limitation is that a live Electron database/IPC failure was not injected manually; the component test controls the existing public renderer API boundary and verifies the same rejected-Promise behavior deterministically.

## Review focus

- The failed mutation remains retryable after the Radix menu closes.
- Retry replays only the captured access mutation and does not alter grant persistence semantics.
- `project-files-presentation-owner.tsx` remains within its existing 790-line architecture limit.
