### PR TITLE
fix(notebook): validate local RPC request schemas

### DIFF
--- a/src/main/notebook/local-rpc-notebook-adapter.test.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.test.ts
@@ -22,10 +22,48 @@ const createCapability = (): NotebookLocalRpcCapability =>
 const request = {
   sessionId: 'session-1',
   workspaceCwd: '/workspace',
-  provenanceContext: { promptMessageId: 'message-user-1' },
-  registeredInputFiles: [{ inputFileVersionId: 'input-1' }],
+  provenanceContext: {
+    rootFrameId: 'frame-root',
+    agentFrameId: 'frame-agent',
+    messageBranchId: 'branch-1',
+    runtimeSegmentId: 'runtime-1',
+    promptMessageId: 'message-user-1'
+  },
+  registeredInputFiles: [
+    {
+      inputFileVersionId: 'input-1',
+      sourceKind: 'upload-version',
+      sourceFileId: 'upload-1',
+      sourceProjectId: 'project-1',
+      sourceSessionId: 'session-1',
+      filename: 'input.csv',
+      sizeBytes: 10,
+      checksum: 'checksum-1',
+      storageKey: 'uploads/input-1',
+      association: 'turn-attached'
+    }
+  ],
   inputRunLeaseId: 'input-run-1'
 }
+
+const requestByMethod = {
+  beginCodeCell: request,
+  appendCodeCell: { ...request, writeId: 'write-1', cellId: 'cell-1', delta: 'print(1)' },
+  finishCodeCell: { ...request, writeId: 'write-1', cellId: 'cell-1' },
+  runCell: { ...request, cellId: 'cell-1' },
+  execute: { ...request, code: 'print(1)', language: 'python' },
+  executeControl: { ...request, code: 'return 1' },
+  executeShell: { ...request, command: 'echo hi' },
+  state: request,
+  restart: request,
+  shutdown: request,
+  inspectPackages: { ...request, language: 'python', packages: ['numpy'] },
+  managePackages: { ...request, language: 'python', packages: ['numpy'] },
+  manageEnvironments: { ...request, action: 'list' },
+  listRuntimes: request,
+  bindRuntime: { ...request, language: 'python', runtimeId: 'analysis' },
+  switchRuntime: { ...request, language: 'python', runtimeId: 'analysis' }
+} satisfies Record<NotebookLocalRpcMethod, Record<string, unknown>>
 
 describe('notebook local RPC adapter', () => {
   it('owns exactly the notebook capability method surface', () => {
@@ -74,16 +112,17 @@ describe('notebook local RPC adapter', () => {
     'preserves request, result and error identity for %s',
     async (method) => {
       const capability = createCapability()
-      const handler = resolveNotebookLocalRpcHandler(capability, method, request)
+      const methodRequest = requestByMethod[method]
+      const handler = resolveNotebookLocalRpcHandler(capability, method, methodRequest)
       const methodMock = (
         capability as unknown as Record<NotebookLocalRpcMethod, ReturnType<typeof vi.fn>>
       )[method]
       const result = { method }
       methodMock.mockResolvedValueOnce(result)
 
-      await expect(handler(request)).resolves.toBe(result)
+      await expect(handler(methodRequest)).resolves.toBe(result)
       expect(methodMock).toHaveBeenCalledTimes(1)
-      expect(methodMock.mock.calls[0]?.[0]).toBe(request)
+      expect(methodMock.mock.calls[0]?.[0]).toBe(methodRequest)
       for (const otherMethod of NOTEBOOK_LOCAL_RPC_METHODS) {
         if (otherMethod === method) continue
         expect(
@@ -96,7 +135,7 @@ describe('notebook local RPC adapter', () => {
       if (method === 'bindRuntime' || method === 'switchRuntime') return
       const failure = new Error(`${method} failed`)
       methodMock.mockRejectedValueOnce(failure)
-      await expect(handler(request)).rejects.toBe(failure)
+      await expect(handler(methodRequest)).rejects.toBe(failure)
     }
   )
 
@@ -111,11 +150,10 @@ describe('notebook local RPC adapter', () => {
         target: { language: 'python', selection: 'unresolved' }
       }
       vi.mocked(capability[method]).mockResolvedValueOnce(failure)
-      const handler = resolveNotebookLocalRpcHandler(capability, method, request)
+      const methodRequest = requestByMethod[method]
+      const handler = resolveNotebookLocalRpcHandler(capability, method, methodRequest)
 
-      await expect(
-        handler({ ...request, language: 'python', runtimeId: 'analysis' })
-      ).resolves.toBe(failure)
+      await expect(handler(methodRequest)).resolves.toBe(failure)
       expect(capability.listRuntimes).not.toHaveBeenCalled()
     }
   )
@@ -124,7 +162,8 @@ describe('notebook local RPC adapter', () => {
     'forwards request cancellation to data execution method %s',
     async (method) => {
       const capability = createCapability()
-      const handler = resolveNotebookLocalRpcHandler(capability, method, request)
+      const methodRequest = requestByMethod[method]
+      const handler = resolveNotebookLocalRpcHandler(capability, method, methodRequest)
       const cancellation = new AbortController()
 
       await (
@@ -132,9 +171,9 @@ describe('notebook local RPC adapter', () => {
           request: Record<string, unknown>,
           signal: AbortSignal
         ) => Promise<unknown>
-      )(request, cancellation.signal)
+      )(methodRequest, cancellation.signal)
 
-      expect(capability[method]).toHaveBeenCalledWith(request, cancellation.signal)
+      expect(capability[method]).toHaveBeenCalledWith(methodRequest, cancellation.signal)
     }
   )
 
@@ -156,7 +195,8 @@ describe('notebook local RPC adapter', () => {
       resolveNotebookLocalRpcHandler(capability, 'execute', {
         ...request,
         sessionId: '',
-        workspaceCwd: ''
+        workspaceCwd: '',
+        code: 'print(1)'
       })
     ).not.toThrow()
   })

--- a/src/main/notebook/local-rpc-notebook-adapter.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.ts
@@ -1,16 +1,170 @@
-import type {
-  AppendNotebookCodeCellRequest,
-  BeginNotebookCodeCellRequest,
-  ExecuteNotebookCodeRequest,
-  ExecuteNotebookControlRequest,
-  ExecuteShellRequest,
-  FinishNotebookCodeCellRequest,
-  NotebookLanguage,
-  NotebookSessionRequest,
-  RunNotebookCellRequest
+import { z } from 'zod'
+
+import {
+  notebookLanguageSchema,
+  type AppendNotebookCodeCellRequest,
+  type BeginNotebookCodeCellRequest,
+  type ExecuteNotebookCodeRequest,
+  type ExecuteNotebookControlRequest,
+  type ExecuteShellRequest,
+  type FinishNotebookCodeCellRequest,
+  type NotebookLanguage,
+  type NotebookSessionRequest,
+  type RunNotebookCellRequest
 } from '../../shared/notebook'
 import type { ManageEnvironmentsRequest, ManageEnvironmentsResult } from '../../shared/notebook-env'
 import type { InstallRequest, InstallResult } from './package-manager'
+
+const provenanceContextSchema = z
+  .object({
+    rootFrameId: z.string(),
+    agentFrameId: z.string(),
+    messageBranchId: z.string(),
+    runtimeSegmentId: z.string(),
+    promptMessageId: z.string(),
+    originMessageId: z.string().optional()
+  })
+  .strict()
+
+const registeredInputFileSchema = z
+  .object({
+    inputFileVersionId: z.string(),
+    sourceKind: z.enum(['upload-version', 'artifact-version']),
+    sourceFileId: z.string(),
+    sourceVersionNumber: z.number().optional(),
+    sourceCreatedAt: z.string().optional(),
+    sourceProjectId: z.string(),
+    sourceSessionId: z.string(),
+    filename: z.string(),
+    contentType: z.string().optional(),
+    sizeBytes: z.number(),
+    checksum: z.string(),
+    storageKey: z.string(),
+    association: z.enum(['turn-attached', 'resolver-accessed'])
+  })
+  .strict()
+
+const notebookSessionRequestSchema = z
+  .object({
+    projectId: z.string().optional(),
+    sessionId: z.string(),
+    workspaceCwd: z.string(),
+    provenanceContext: provenanceContextSchema.optional(),
+    executionInvocationId: z.string().optional(),
+    registeredInputFiles: z.array(registeredInputFileSchema).optional(),
+    inputRunLeaseId: z.string().optional(),
+    delegatedWorkAttemptId: z.string().optional()
+  })
+  .strict()
+
+const positiveTimeoutSchema = z.number().int().positive()
+const runSourceSchema = z.enum(['agent', 'user'])
+const runInputKindSchema = z.enum(['cell', 'terminal'])
+const paginationSchema = {
+  offset: z.number().int().nonnegative().optional(),
+  limit: z.number().int().positive().optional()
+}
+
+const notebookLocalRpcRequestSchemas = {
+  beginCodeCell: notebookSessionRequestSchema.extend({
+    cellId: z.string().optional(),
+    source: runSourceSchema.optional(),
+    language: notebookLanguageSchema.optional(),
+    environment: z.string().optional()
+  }),
+  appendCodeCell: notebookSessionRequestSchema.extend({
+    writeId: z.string(),
+    cellId: z.string(),
+    delta: z.string()
+  }),
+  finishCodeCell: notebookSessionRequestSchema.extend({
+    writeId: z.string(),
+    cellId: z.string()
+  }),
+  runCell: notebookSessionRequestSchema.extend({
+    cellId: z.string(),
+    timeoutMs: positiveTimeoutSchema.optional(),
+    source: runSourceSchema.optional(),
+    inputKind: runInputKindSchema.optional(),
+    environment: z.string().optional()
+  }),
+  execute: notebookSessionRequestSchema.extend({
+    code: z.string(),
+    timeoutMs: positiveTimeoutSchema.optional(),
+    cellId: z.string().optional(),
+    source: runSourceSchema.optional(),
+    inputKind: runInputKindSchema.optional(),
+    language: notebookLanguageSchema.optional(),
+    environment: z.string().optional()
+  }),
+  executeControl: notebookSessionRequestSchema.extend({
+    code: z.string(),
+    timeoutMs: positiveTimeoutSchema.optional()
+  }),
+  executeShell: notebookSessionRequestSchema.extend({
+    command: z.string(),
+    timeoutMs: positiveTimeoutSchema.optional()
+  }),
+  state: notebookSessionRequestSchema,
+  restart: notebookSessionRequestSchema,
+  shutdown: notebookSessionRequestSchema,
+  inspectPackages: notebookSessionRequestSchema.extend({
+    language: notebookLanguageSchema,
+    packages: z.array(z.string().min(1)).min(1)
+  }),
+  managePackages: notebookSessionRequestSchema.extend({
+    language: notebookLanguageSchema,
+    packages: z.array(z.string().min(1)).min(1),
+    usePip: z.boolean().optional(),
+    installer: z.enum(['biocmanager', 'github']).optional(),
+    channels: z.array(z.string().min(1)).optional(),
+    environment: z.string().optional(),
+    operation: z.enum(['install', 'uninstall']).optional()
+  }),
+  manageEnvironments: z.discriminatedUnion('action', [
+    notebookSessionRequestSchema.extend({
+      action: z.literal('create'),
+      language: notebookLanguageSchema,
+      name: z.string(),
+      packages: z.array(z.string().min(1)).optional(),
+      ...paginationSchema
+    }),
+    notebookSessionRequestSchema.extend({ action: z.literal('list'), ...paginationSchema }),
+    notebookSessionRequestSchema.extend({
+      action: z.literal('remove'),
+      name: z.string(),
+      ...paginationSchema
+    })
+  ]),
+  listRuntimes: notebookSessionRequestSchema.extend(paginationSchema),
+  bindRuntime: notebookSessionRequestSchema.extend({
+    language: notebookLanguageSchema,
+    runtimeId: z.string().min(1)
+  }),
+  switchRuntime: notebookSessionRequestSchema.extend({
+    language: notebookLanguageSchema,
+    runtimeId: z.string().min(1)
+  })
+} as const
+
+type NotebookLocalRpcRequestSchemas = typeof notebookLocalRpcRequestSchemas
+
+const parseNotebookLocalRpcRequest = <Method extends keyof NotebookLocalRpcRequestSchemas>(
+  method: Method,
+  request: Record<string, unknown>
+): z.output<NotebookLocalRpcRequestSchemas[Method]> => {
+  const parsed = notebookLocalRpcRequestSchemas[method].safeParse(request)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const path = issue?.path.join('.') || 'params'
+    throw new Error(
+      `Invalid notebook RPC params for ${method}: ${path}: ${issue?.message ?? 'invalid value'}`
+    )
+  }
+  // These schemas validate without coercion or defaults. Keep the established request identity so
+  // runtime consumers and tests observe the same object the authenticated bridge enriched.
+  return request as z.output<NotebookLocalRpcRequestSchemas[Method]>
+}
 
 type InspectPackagesRequest = NotebookSessionRequest & {
   language: NotebookLanguage
@@ -96,41 +250,54 @@ const resolveNotebookLocalRpcHandler = (
   if (!isNotebookLocalRpcMethod(method)) {
     throw new Error(`Unknown notebook RPC method: ${method}`)
   }
+  parseNotebookLocalRpcRequest(method, params)
 
   switch (method) {
     case 'beginCodeCell':
-      return (request) => capability.beginCodeCell(request as BeginNotebookCodeCellRequest)
+      return (request) =>
+        capability.beginCodeCell(parseNotebookLocalRpcRequest('beginCodeCell', request))
     case 'appendCodeCell':
-      return (request) => capability.appendCodeCell(request as AppendNotebookCodeCellRequest)
+      return (request) =>
+        capability.appendCodeCell(parseNotebookLocalRpcRequest('appendCodeCell', request))
     case 'finishCodeCell':
-      return (request) => capability.finishCodeCell(request as FinishNotebookCodeCellRequest)
+      return (request) =>
+        capability.finishCodeCell(parseNotebookLocalRpcRequest('finishCodeCell', request))
     case 'runCell':
-      return (request, signal) => capability.runCell(request as RunNotebookCellRequest, signal)
+      return (request, signal) =>
+        capability.runCell(parseNotebookLocalRpcRequest('runCell', request), signal)
     case 'execute':
-      return (request, signal) => capability.execute(request as ExecuteNotebookCodeRequest, signal)
+      return (request, signal) =>
+        capability.execute(parseNotebookLocalRpcRequest('execute', request), signal)
     case 'executeControl':
-      return (request) => capability.executeControl(request as ExecuteNotebookControlRequest)
+      return (request) =>
+        capability.executeControl(parseNotebookLocalRpcRequest('executeControl', request))
     case 'executeShell':
-      return (request) => capability.executeShell(request as ExecuteShellRequest)
+      return (request) =>
+        capability.executeShell(parseNotebookLocalRpcRequest('executeShell', request))
     case 'state':
-      return (request) => capability.state(request as NotebookSessionRequest)
+      return (request) => capability.state(parseNotebookLocalRpcRequest('state', request))
     case 'restart':
-      return (request) => capability.restart(request as NotebookSessionRequest)
+      return (request) => capability.restart(parseNotebookLocalRpcRequest('restart', request))
     case 'shutdown':
-      return (request) => capability.shutdown(request as NotebookSessionRequest)
+      return (request) => capability.shutdown(parseNotebookLocalRpcRequest('shutdown', request))
     case 'inspectPackages':
-      return (request) => capability.inspectPackages(request as InspectPackagesRequest)
+      return (request) =>
+        capability.inspectPackages(parseNotebookLocalRpcRequest('inspectPackages', request))
     case 'managePackages':
-      return (request) => capability.managePackages(request as unknown as InstallRequest)
+      return (request) =>
+        capability.managePackages(parseNotebookLocalRpcRequest('managePackages', request))
     case 'manageEnvironments':
       return (request) =>
-        capability.manageEnvironments(request as unknown as ManageEnvironmentsRequest)
+        capability.manageEnvironments(parseNotebookLocalRpcRequest('manageEnvironments', request))
     case 'listRuntimes':
-      return (request) => capability.listRuntimes(request as NotebookSessionRequest)
+      return (request) =>
+        capability.listRuntimes(parseNotebookLocalRpcRequest('listRuntimes', request))
     case 'bindRuntime':
-      return (request) => capability.bindRuntime(request as NotebookRuntimeBindingRequest)
+      return (request) =>
+        capability.bindRuntime(parseNotebookLocalRpcRequest('bindRuntime', request))
     case 'switchRuntime':
-      return (request) => capability.switchRuntime(request as NotebookRuntimeBindingRequest)
+      return (request) =>
+        capability.switchRuntime(parseNotebookLocalRpcRequest('switchRuntime', request))
   }
 }
 

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -318,6 +318,48 @@ describe('notebook local RPC server', () => {
     }
   })
 
+  it('rejects malformed notebook method params before calling the runtime capability', async () => {
+    const execute = vi.fn(async () => ({ status: 'completed' }))
+    const server = new NotebookLocalRpcServer({ execute } as never, { transport: 'tcp' })
+    const connection = await server.issueSessionConnection(
+      'session-1',
+      'project-1',
+      'root-frame-session-1'
+    )
+
+    try {
+      const response = await fetchLocalRpc(
+        connection,
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${connection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({
+            method: 'execute',
+            params: {
+              sessionId: 'session-1',
+              workspaceCwd: '/workspace',
+              code: 'print(1)',
+              language: 'julia'
+            }
+          })
+        },
+        'Notebook RPC request validation test'
+      )
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({
+        error: expect.stringContaining('Invalid notebook RPC params for execute')
+      })
+      expect(execute).not.toHaveBeenCalled()
+    } finally {
+      connection.release?.()
+      await server.close()
+    }
+  })
+
   it('injects only a fresh unambiguous app-owned execution authorization', async () => {
     const server = new NotebookLocalRpcServer({
       execute: vi.fn(async (request: unknown) => request),


### PR DESCRIPTION
## Problem

The authenticated Notebook local RPC adapter validated only `sessionId` and `workspaceCwd`. Method-specific JSON fields were asserted as TypeScript request types and could reach runtime capabilities with invalid values, such as `language: "julia"`.

## Proposed change

- Add a strict Zod request schema for each of the 16 Notebook local RPC methods.
- Parse requests before request-lifecycle setup and again immediately before the runtime capability call, covering server-enriched trusted fields without changing request identity.
- Add an authenticated HTTP regression test proving malformed method params are rejected before `execute` is called.
- Update the adapter contract test with one valid request fixture per method.

## Scope and non-goals

- No request or response fields are added.
- No renderer interaction, architecture boundary, persisted format, database schema, or data model changes.
- No new lifecycle states or enum values.
- No historical-data migration or compatibility handling is required; valid existing wire shapes remain accepted.
- Invalid requests continue to use the existing RPC error envelope and status behavior.

## Acceptance criteria and validation

- Red reproduction on the unmodified adapter: the focused HTTP test received status 200 instead of the expected 500, proving invalid `language` reached the runtime capability.
- `npx vitest run src/main/notebook/local-rpc-notebook-adapter.test.ts src/main/notebook/local-rpc-server.test.ts src/main/notebook/mcp-server.test.ts src/main/notebook/application.test.ts` — 167 tests passed after the final material edit.
- `npm run typecheck:node` — passed after the final material edit.
- `npm run lint` — passed after the final material edit.
- Prettier check and `git diff --check` — passed.
- Local full `npm test` was intentionally not run. The standard targeted wrapper was blocked before Vitest because this worktree does not have a generated Prisma Client; direct targeted Vitest passed. The dependency impact planner classifies the adapter as an unknown module owner, so PR Gate will fail closed to the complete CI plan.

## Review focus

- Confirm each method schema matches its current runtime request contract.
- Confirm strict unknown-field rejection includes every app-injected trusted field and preserves valid current callers.
- Confirm the regression test exercises the authenticated HTTP boundary rather than a test-only seam.
