### PR TITLE
fix(workspace): dismiss Session hover previews immediately

### DIFF
--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -31,9 +31,7 @@ type SessionPreviewRequest = (sessionId: string) => Promise<void> | void
 type SessionHoverPreviewContextValue = {
   activeSessionId: string | null
   closeNow: (sessionId: string) => void
-  keepOpen: () => void
   requestOpen: (sessionId: string) => void
-  scheduleClose: (sessionId: string) => void
 }
 
 const SessionHoverPreviewContext = createContext<SessionHoverPreviewContextValue | null>(null)
@@ -41,52 +39,22 @@ const SessionHoverPreviewContext = createContext<SessionHoverPreviewContextValue
 const SessionHoverPreviewProvider = ({ children }: { children: ReactNode }): React.JSX.Element => {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const activeSessionIdRef = useRef<string | null>(null)
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
-  const keepOpen = useCallback((): void => {
-    clearTimeout(closeTimerRef.current)
-    closeTimerRef.current = undefined
+  const requestOpen = useCallback((sessionId: string): void => {
+    activeSessionIdRef.current = sessionId
+    setActiveSessionId(sessionId)
   }, [])
 
-  const requestOpen = useCallback(
-    (sessionId: string): void => {
-      keepOpen()
-      activeSessionIdRef.current = sessionId
-      setActiveSessionId(sessionId)
-    },
-    [keepOpen]
-  )
+  const closeNow = useCallback((sessionId: string): void => {
+    if (activeSessionIdRef.current !== sessionId) return
 
-  const scheduleClose = useCallback(
-    (sessionId: string): void => {
-      if (activeSessionIdRef.current !== sessionId) return
-
-      keepOpen()
-      closeTimerRef.current = setTimeout(() => {
-        if (activeSessionIdRef.current !== sessionId) return
-        activeSessionIdRef.current = null
-        setActiveSessionId(null)
-      }, SESSION_HOVER_PREVIEW_SKIP_DELAY_MS)
-    },
-    [keepOpen]
-  )
-
-  const closeNow = useCallback(
-    (sessionId: string): void => {
-      if (activeSessionIdRef.current !== sessionId) return
-
-      keepOpen()
-      activeSessionIdRef.current = null
-      setActiveSessionId(null)
-    },
-    [keepOpen]
-  )
-
-  useEffect(() => () => keepOpen(), [keepOpen])
+    activeSessionIdRef.current = null
+    setActiveSessionId(null)
+  }, [])
 
   const value = useMemo(
-    () => ({ activeSessionId, closeNow, keepOpen, requestOpen, scheduleClose }),
-    [activeSessionId, closeNow, keepOpen, requestOpen, scheduleClose]
+    () => ({ activeSessionId, closeNow, requestOpen }),
+    [activeSessionId, closeNow, requestOpen]
   )
 
   return (
@@ -217,7 +185,7 @@ const SessionHoverPreview = ({
   const context = useContext(SessionHoverPreviewContext)
   if (!context) throw new Error('SessionHoverPreview must be inside SessionHoverPreviewProvider')
 
-  const { activeSessionId, closeNow, keepOpen, requestOpen, scheduleClose } = context
+  const { activeSessionId, closeNow, requestOpen } = context
   const open = activeSessionId === session.id
   const onPreviewRequestRef = useRef(onPreviewRequest)
   const [descriptionLoading, setDescriptionLoading] = useState(false)
@@ -249,12 +217,12 @@ const SessionHoverPreview = ({
         onPointerEnter={() => requestOpen(session.id)}
         onPointerLeave={(event) => {
           if (event.currentTarget.matches(':focus-visible')) return
-          scheduleClose(session.id)
+          closeNow(session.id)
         }}
         onFocus={() => requestOpen(session.id)}
         onBlur={(event) => {
           if (event.currentTarget.matches(':hover')) return
-          scheduleClose(session.id)
+          closeNow(session.id)
         }}
       >
         {children}
@@ -264,8 +232,7 @@ const SessionHoverPreview = ({
         align="start"
         sideOffset={10}
         collisionPadding={8}
-        onPointerEnter={keepOpen}
-        onPointerLeave={() => scheduleClose(session.id)}
+        onPointerLeave={() => closeNow(session.id)}
         onEscapeKeyDown={() => closeNow(session.id)}
         className="max-w-none overflow-visible bg-transparent p-0 text-inherit shadow-none motion-reduce:animate-none"
       >

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -305,6 +305,45 @@ describe('WorkspaceSidebar accessible render', () => {
     }
   })
 
+  it('closes a Session preview immediately after the pointer leaves its hover region', async () => {
+    const { SessionHoverPreview, SessionHoverPreviewProvider } =
+      await import('./SessionHoverPreview')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(
+          <SessionHoverPreviewProvider>
+            <SessionHoverPreview session={{ id: 'hovered', title: 'Hovered Session' }}>
+              <button type="button">Hovered trigger</button>
+            </SessionHoverPreview>
+          </SessionHoverPreviewProvider>
+        )
+      })
+      const trigger = container.querySelector('button')
+      if (!trigger) throw new Error('Session preview trigger did not render')
+      const pointerOver = new MouseEvent('pointerover', { bubbles: true })
+      Object.defineProperty(pointerOver, 'pointerType', { value: 'mouse' })
+
+      await act(async () => trigger.dispatchEvent(pointerOver))
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).not.toBeNull()
+
+      const pointerOut = new MouseEvent('pointerout', {
+        bubbles: true,
+        relatedTarget: document.body
+      })
+      Object.defineProperty(pointerOut, 'pointerType', { value: 'mouse' })
+      await act(async () => trigger.dispatchEvent(pointerOut))
+
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+    }
+  })
+
   it('closes an active Session preview when its row is removed', async () => {
     vi.useFakeTimers()
     const { SessionHoverPreview, SessionHoverPreviewProvider } =


### PR DESCRIPTION
## Problem

The desktop Session Details hover preview kept a close timer after the pointer left the hover region, so the card lingered instead of disappearing immediately.

## Proposed change

- Remove the Session hover preview close timer and its timer-management state.
- Close the preview synchronously when the pointer leaves the trigger or preview card.
- Preserve immediate pointer opening, keyboard focus behavior, Escape dismissal, and direct switching between Session rows.
- Add a regression test that verifies the preview is removed without advancing timers.

## Scope and non-goals

- Scope is limited to the desktop workspace Session list; mobile continues to use its existing title behavior.
- Historical-data compatibility: not applicable; no data format changes.
- New states or enum values: none.
- Data persistence: none.
- No user-visible copy, dependency, main-process, preload, or renderer contract changes.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- Immediate hover dismissal -> `npm test -- src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx` -> 1 file passed, 38 tests passed.
- Workspace Session-list behavior and consumers -> `npm run test:module -- workspace_page` -> 25 files passed, 553 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source linting -> `npm run lint` -> passed.

The changed component has one production consumer, `WorkspaceSidebar`, covered by the targeted and module tests above. Main-process, preload, persistence, migration, and platform-specific lanes are excluded because the final diff is renderer-only interaction code with no cross-process or platform API. Full local `npm test` was intentionally not run; exact-head PR CI remains the final validation authority.

## Review focus

- Pointer leave closes immediately with no timer.
- Keyboard-focus accessibility and direct switching between Session rows remain intact.
