### PR TITLE
fix(workspace): preserve Session preview hover bridge

### DIFF
--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -188,6 +188,8 @@ const SessionHoverPreview = ({
   const { activeSessionId, closeNow, requestOpen } = context
   const open = activeSessionId === session.id
   const onPreviewRequestRef = useRef(onPreviewRequest)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
   const [descriptionLoading, setDescriptionLoading] = useState(false)
 
   useEffect(() => {
@@ -213,10 +215,17 @@ const SessionHoverPreview = ({
   return (
     <Tooltip open={open}>
       <TooltipTrigger
+        ref={triggerRef}
         asChild
         onPointerEnter={() => requestOpen(session.id)}
         onPointerLeave={(event) => {
           if (event.currentTarget.matches(':focus-visible')) return
+          if (
+            event.relatedTarget instanceof Node &&
+            contentRef.current?.contains(event.relatedTarget)
+          ) {
+            return
+          }
           closeNow(session.id)
         }}
         onFocus={() => requestOpen(session.id)}
@@ -228,13 +237,22 @@ const SessionHoverPreview = ({
         {children}
       </TooltipTrigger>
       <TooltipContent
+        ref={contentRef}
         side="right"
         align="start"
-        sideOffset={10}
+        sideOffset={0}
         collisionPadding={8}
-        onPointerLeave={() => closeNow(session.id)}
+        onPointerLeave={(event) => {
+          if (
+            event.relatedTarget instanceof Node &&
+            triggerRef.current?.contains(event.relatedTarget)
+          ) {
+            return
+          }
+          closeNow(session.id)
+        }}
         onEscapeKeyDown={() => closeNow(session.id)}
-        className="max-w-none overflow-visible bg-transparent p-0 text-inherit shadow-none motion-reduce:animate-none"
+        className="max-w-none overflow-visible bg-transparent py-0 pr-0 pl-2.5 text-inherit shadow-none motion-reduce:animate-none"
       >
         <SessionHoverPreviewCard
           session={session}

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -330,12 +330,23 @@ describe('WorkspaceSidebar accessible render', () => {
       await act(async () => trigger.dispatchEvent(pointerOver))
       expect(document.body.querySelector('[data-slot="session-hover-preview"]')).not.toBeNull()
 
-      const pointerOut = new MouseEvent('pointerout', {
+      const hoverRegion = document.body.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
+      if (!hoverRegion) throw new Error('Session preview hover region did not render')
+      const leaveTrigger = new MouseEvent('pointerout', {
+        bubbles: true,
+        relatedTarget: hoverRegion
+      })
+      Object.defineProperty(leaveTrigger, 'pointerType', { value: 'mouse' })
+      await act(async () => trigger.dispatchEvent(leaveTrigger))
+
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).not.toBeNull()
+
+      const leaveHoverRegion = new MouseEvent('pointerout', {
         bubbles: true,
         relatedTarget: document.body
       })
-      Object.defineProperty(pointerOut, 'pointerType', { value: 'mouse' })
-      await act(async () => trigger.dispatchEvent(pointerOut))
+      Object.defineProperty(leaveHoverRegion, 'pointerType', { value: 'mouse' })
+      await act(async () => hoverRegion.dispatchEvent(leaveHoverRegion))
 
       expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
     } finally {


### PR DESCRIPTION
## Problem

Follow-up to #1796. Closing the Session preview synchronously on trigger leave removes the portaled card before the pointer can cross its 10px visual gap, so the card itself is no longer reachable by hover.

## Proposed change

- Keep the 10px visual spacing as transparent padding inside the hover region instead of an uncovered pointer gap.
- Track the trigger and portaled content so transitions between them stay open without reintroducing a close timer.
- Continue closing synchronously as soon as the pointer leaves the combined trigger, bridge, and card region.
- Extend the regression test to cover both trigger-to-card traversal and immediate dismissal from the combined region.

## Scope and non-goals

- Scope is limited to the desktop workspace Session hover preview.
- Historical-data compatibility: not applicable; no data format changes.
- New states or enum values: none.
- Data persistence: none.
- No user-visible copy, dependency, main-process, preload, or renderer contract changes.

## Acceptance criteria and validation

The checks below ran after the final material edit:

- Trigger-to-card traversal and immediate region dismissal -> `npm test -- src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx` -> 1 file passed, 38 tests passed.
- Workspace Session-list behavior and consumers -> `npm run test:module -- workspace_page` -> 25 files passed, 553 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source linting -> `npm run lint` -> passed.

The changed component has one production consumer, `WorkspaceSidebar`, covered by the targeted and module tests above. Main-process, preload, persistence, migration, and platform-specific lanes are excluded because the final diff is renderer-only pointer interaction code with no cross-process or platform API. Full local `npm test` was intentionally not run; exact-head PR CI remains the final validation authority.

## Review focus

- The visual 10px spacing remains unchanged while becoming part of the hit-tested hover region.
- No close timer is reintroduced: leaving the combined region still dismisses immediately.
