### PR TITLE
fix(responses): promote artifact guidance for compatibility

### DIFF
--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -387,46 +387,56 @@ describe('native Responses compatibility', () => {
     })
   })
 
-  it('diagnoses a completed stream that stops after a Notebook file without saving an Artifact', async () => {
+  it('promotes Artifact guidance when a Notebook run returns a generated file', async () => {
     const privateAssistantText = 'I will export the private result as an artifact:'
-    const upstream = [
-      {
-        type: 'response.output_item.done',
-        output_index: 0,
-        item: {
-          id: 'message-1',
-          type: 'message',
-          role: 'assistant',
-          content: [{ type: 'output_text', text: privateAssistantText }]
-        }
-      },
-      {
-        type: 'response.completed',
-        response: {
-          id: 'response-1',
-          status: 'completed',
-          output: [
-            {
-              type: 'message',
-              role: 'assistant',
-              content: [{ type: 'output_text', text: privateAssistantText }]
-            }
-          ]
-        }
-      },
-      '[DONE]'
-    ]
-      .map((event) => `data: ${typeof event === 'string' ? event : JSON.stringify(event)}\n\n`)
-      .join('')
+    let upstreamRequest: Record<string, unknown> | undefined
+    const fetchImpl = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      upstreamRequest = body
+      const artifactRequired =
+        typeof body.instructions === 'string' &&
+        body.instructions.includes('<open_science_artifact_instructions>')
+      const output = artifactRequired
+        ? {
+            id: 'artifact-call-item-1',
+            type: 'function_call',
+            name: 'mcp__open_science_artifacts__write_artifact_file',
+            call_id: 'artifact-call-1',
+            arguments: JSON.stringify({
+              filename: 'private.png',
+              mimeType: 'image/png',
+              source: { kind: 'localPath', path: 'data/private.png' },
+              producerRunId: 'notebook-run-1'
+            })
+          }
+        : {
+            id: 'message-1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: privateAssistantText }]
+          }
+      const upstream = [
+        { type: 'response.output_item.done', output_index: 0, item: output },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'response-1',
+            status: 'completed',
+            output: [output]
+          }
+        },
+        '[DONE]'
+      ]
+        .map((event) => `data: ${typeof event === 'string' ? event : JSON.stringify(event)}\n\n`)
+        .join('')
+      return new Response(upstream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' }
+      })
+    })
     const proxy = new NativeResponsesCompatibilityProxy(
       { baseUrl: 'https://api.example/v1', model: 'model-a' },
-      vi.fn(
-        async () =>
-          new Response(upstream, {
-            status: 200,
-            headers: { 'content-type': 'text/event-stream' }
-          })
-      )
+      fetchImpl
     )
     const connection = await proxy.start()
 
@@ -445,7 +455,8 @@ describe('native Responses compatibility', () => {
             {
               type: 'message',
               role: 'developer',
-              content: '<open_science_artifact_instructions>private guidance'
+              content:
+                '<open_science_artifact_instructions>private guidance</open_science_artifact_instructions>'
             },
             {
               type: 'function_call',
@@ -457,7 +468,8 @@ describe('native Responses compatibility', () => {
             {
               type: 'function_call_output',
               call_id: 'notebook-call-1',
-              output: '{"workingFiles":[{"relativePath":"data/private.png"}]}'
+              output:
+                '{"runId":"notebook-run-1","workingFiles":[{"relativePath":"data/private.png"}]}'
             }
           ],
           tools: [
@@ -490,8 +502,15 @@ describe('native Responses compatibility', () => {
       const responseBody = await response.text()
       expect(response.ok, responseBody).toBe(true)
       expect(responseBody).toContain('response.completed')
-      expect(responseBody).toContain(privateAssistantText)
-      expect(responseBody).not.toContain('write_artifact_file')
+      expect(responseBody).not.toContain(privateAssistantText)
+      expect(responseBody).toContain('write_artifact_file')
+      expect(upstreamRequest?.instructions).toContain('base provider instructions')
+      expect(upstreamRequest?.instructions).toContain(
+        '<open_science_artifact_instructions>private guidance</open_science_artifact_instructions>'
+      )
+      expect(JSON.stringify(upstreamRequest?.input)).not.toContain(
+        '<open_science_artifact_instructions>'
+      )
       const requestLog = logSpies.info.mock.calls.find(
         ([message]) => message === 'native Responses compatibility request'
       )
@@ -499,8 +518,8 @@ describe('native Responses compatibility', () => {
         ([message]) => message === 'native Responses compatibility stream completed'
       )
       expect(requestLog?.[1]).toMatchObject({
-        topLevelArtifactInstructionPresent: false,
-        developerArtifactInstructionPresent: true,
+        topLevelArtifactInstructionPresent: true,
+        developerArtifactInstructionPresent: false,
         artifactInstructionPresent: true,
         artifactToolPresent: true,
         functionCallOutputHistoryCount: 1
@@ -510,9 +529,9 @@ describe('native Responses compatibility', () => {
         terminalEventType: 'response.completed',
         terminalStatus: 'completed',
         terminalOutputItemCount: 1,
-        terminalMessageCount: 1,
-        observedFunctionCallCount: 0,
-        observedArtifactFunctionCallCount: 0
+        terminalMessageCount: 0,
+        observedFunctionCallCount: 1,
+        observedArtifactFunctionCallCount: 1
       })
       expect(
         JSON.stringify(Object.values(logSpies).flatMap((spy) => spy.mock.calls))

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -135,6 +135,50 @@ const containsText = (value: unknown, marker: string): boolean => {
   return isObject(value) && Object.values(value).some((item) => containsText(item, marker))
 }
 
+const ARTIFACT_INSTRUCTIONS_START = '<open_science_artifact_instructions>'
+const ARTIFACT_INSTRUCTIONS_END = '</open_science_artifact_instructions>'
+
+const promoteArtifactDeveloperInstructions = (body: JsonObject): JsonObject => {
+  if (
+    containsText(body.instructions, ARTIFACT_INSTRUCTIONS_START) ||
+    (body.instructions != null && typeof body.instructions !== 'string') ||
+    !Array.isArray(body.input)
+  ) {
+    return body
+  }
+
+  const index = body.input.findIndex(
+    (item) =>
+      isObject(item) &&
+      item.type === 'message' &&
+      item.role === 'developer' &&
+      typeof item.content === 'string' &&
+      item.content.includes(ARTIFACT_INSTRUCTIONS_START)
+  )
+  if (index < 0) return body
+
+  const item = body.input[index] as JsonObject
+  const content = item.content as string
+  const start = content.indexOf(ARTIFACT_INSTRUCTIONS_START)
+  const end = content.indexOf(ARTIFACT_INSTRUCTIONS_END, start)
+  if (end < 0) return body
+
+  const blockEnd = end + ARTIFACT_INSTRUCTIONS_END.length
+  const artifactInstructions = content.slice(start, blockEnd)
+  const remaining = `${content.slice(0, start)}${content.slice(blockEnd)}`.trim()
+  const input = body.input.flatMap((value, itemIndex) =>
+    itemIndex !== index ? [value] : remaining ? [{ ...item, content: remaining }] : []
+  )
+
+  return {
+    ...body,
+    instructions: [body.instructions, artifactInstructions]
+      .filter((value): value is string => typeof value === 'string' && value.length > 0)
+      .join('\n\n'),
+    input
+  }
+}
+
 const isArtifactTool = (value: unknown, aliases: NativeResponsesToolAliases): boolean => {
   if (!isObject(value) || typeof value.name !== 'string') return false
   const identity =
@@ -743,9 +787,14 @@ export class NativeResponsesCompatibilityProxy {
         ? { ...scopedBody, model: this.target.model }
         : scopedBody
       const { request: flattenedRequest, aliases } = flattenNativeResponsesRequest(routedBody)
+      const compatibilityRequest =
+        Array.isArray(flattenedRequest.tools) &&
+        flattenedRequest.tools.some((tool: unknown) => isArtifactTool(tool, aliases))
+          ? promoteArtifactDeveloperInstructions(flattenedRequest)
+          : flattenedRequest
       const upstreamRequest = this.target.sanitizeRequest
-        ? this.target.sanitizeRequest(flattenedRequest)
-        : flattenedRequest
+        ? this.target.sanitizeRequest(compatibilityRequest)
+        : compatibilityRequest
       const upstreamRequestBody = JSON.stringify(upstreamRequest)
       const resolvedKey = this.target.resolveKey ? await this.target.resolveKey() : this.target.key
       const headersToForward = upstreamHeaders(request, resolvedKey)


### PR DESCRIPTION
## Problem

A Codex native Responses compatibility turn can finish normally after `notebook_execute` creates a user-facing file without ever calling `write_artifact_file`. The captured MiniMax-M3 request had all of the expected structure:

- the canonical Artifact instructions were present, but only in a `developer` input item;
- the Artifact tool was declared and available;
- Notebook function-call output reported a generated working file; and
- the upstream stream completed with an assistant message and zero Artifact function calls.

Sending “continue” does not repair the contract reliably because the next compatibility request preserves the same instruction placement and still allows the provider to end with text.

Without an Artifact save, the file remains only a Notebook working file. It is not exposed as a downloadable Generated Artifact, does not receive an immutable Artifact Version and provenance, and may disappear with Notebook/session cleanup even if the assistant says it is available.

## Root cause and change

The compatibility provider observed in the report did not reliably honor the Artifact block when Codex encoded the app-owned `developer_instructions` as an input message. The Responses API defines the top-level `instructions` string as equivalent developer-level context, so the compatibility proxy now moves the existing closed Artifact block there when:

- the block is not already top-level; and
- `write_artifact_file` is actually declared for the request.

The block is removed from its original developer item instead of duplicated. This keeps the instruction content and token cost stable while giving native Responses compatibility providers the request shape they handle reliably.

The change deliberately does **not** force `tool_choice`, retry completed model responses, infer which Notebook files are final, or auto-publish working files. Those approaches require heuristic state and can publish intermediate files; they would be over-design for the observed failure.

## Regression evidence

The existing public HTTP/SSE compatibility fixture was converted from a diagnostic assertion into a red-capable regression. Its simulated provider returns the reported promise-only assistant message when the Artifact block is absent from top-level `instructions`, and a valid `write_artifact_file` call when it is present.

Before the production change, the targeted test was run three times and failed deterministically because the response contained the promise text and no Artifact call. After the change, the same boundary produces the restored namespaced Artifact call and the structural diagnostics report one Artifact function call.

## Scope and compatibility

| Framework/path | Coverage | Reason |
| --- | --- | --- |
| Codex native Responses compatibility (`codex-responses-compatibility`) | Included | Owns the request rewrite and matches the reported MiniMax-M3 path. |
| Reviewer/tool-less native compatibility scopes | Protected | Promotion runs only when the Artifact tool is actually declared. |
| Codex direct official Responses (`codex-responses`) | Excluded | Does not traverse this compatibility proxy. |
| Codex Chat bridge (`codex-bridge`) | Excluded | Uses a separate bridge and prompt path. |
| Claude Code | Excluded | Anthropic transport is unchanged. |
| OpenCode | Excluded | OpenCode transports are unchanged. |
| macOS / Windows / Linux | Included structurally | The same provider-loopback request transform runs on every platform; CI remains authoritative. |

## Data, state, persistence, and interaction impact

- **Historical compatibility:** none required; no stored request or historical Artifact data is rewritten, and prior missing Artifacts cannot be backfilled safely.
- **New state / enum values:** none.
- **Persistence / schema / data model:** none; no database, migration, file format, Session, Notebook, or Artifact model changes.
- **Data fields:** no application or persisted fields are added. Only an existing request instruction block changes location on the wire.
- **Interaction:** no UI flow changes. The intended existing interaction becomes more reliable: providers see the save requirement before claiming a generated file is available.

## Validation

All checks below ran after the final material edit:

- `npm run test:module -- settings_backend_resolution` — 37 files passed, 1 skipped; 618 tests passed, 4 skipped.
- `npm run typecheck:node` — passed.
- `npm run lint` — passed.
- `git diff --check` — passed.
- `npm run test:affected -- --base origin/main --head HEAD --explain` — selective plan inspected; PR Gate owns the larger transitive consumer set.

Per request, the full local `npm test` suite was not run. PR CI is the final validation authority.

## Review focus

- Confirm the promotion is limited to trusted developer content and only when the Artifact tool is available.
- Confirm the closed instruction block is moved, not duplicated or rewritten.
- Confirm no retry, forced tool selection, automatic file publication, or persistent state was introduced.
