### PR TITLE
fix(tasks): preserve artifact runtime provenance

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16,6 +16,7 @@ import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime.test-utils'
+import { createAcpTaskAgentPort } from './task-agent-port'
 import type { AcpAgentConnectionAdapter } from './agent-connection-adapter'
 import type { AcpConnectionCloseWorkflow } from './connection-close-workflow'
 import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
@@ -61,6 +62,7 @@ import type { UploadedAttachment } from '../../shared/uploads'
 import {
   createLinearConversationGraph,
   forkConversationAfterActivity,
+  getActiveConversationContext,
   projectConversationMessage,
   synchronizeActiveConversationActivities,
   synchronizeActiveConversationMessages
@@ -20918,6 +20920,147 @@ describe('ACP runtime session management', () => {
         invocation_id: 'connector-call-restored'
       }
     })
+  })
+
+  it('finalizes a Task-runner Artifact against its durable Runtime Segment', async () => {
+    const storageRoot = await createTemporaryRoot()
+    const client = createProjectDbClient(storageRoot)
+    temporaryDisconnections.push(() => client.$disconnect())
+    await migrateApplicationDatabase(client)
+    const repository = new ArtifactRepository(storageRoot)
+    const durableSessionAuthority: { current?: PersistedChatSession } = {}
+    const provenance = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository: repository,
+      loadSession: async () => durableSessionAuthority.current
+    })
+    const process = new FakeAgentProcess()
+    let artifactClaimId: string | undefined
+    startFakeAgent(process, ['task-session-1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onPrompt: async ({ sessionId }) => {
+        await runtime.writeArtifactForCurrentRun(sessionId, {
+          filename: 'plan.json',
+          content: '{"title":"Session Plan"}',
+          mimeType: 'application/json'
+        })
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: codexFramework,
+      artifacts: {
+        configRoot: storageRoot,
+        dataRoot: storageRoot,
+        projectId: 'project-1',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository,
+        provenance
+      },
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'artifact') artifactClaimId = event.artifactClaimId
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', projectId: 'project-1' })
+    const taskAgent = createAcpTaskAgentPort(
+      {
+        getSnapshot: () => runtime.getSnapshot(),
+        resumeSession: (request) => runtime.resumeSession(request),
+        setPermissionProfile: (request) => runtime.setPermissionProfile(request),
+        sendPrompt: (request) => runtime.sendPrompt(request),
+        sendPromptObserved: async (request, onProviderPromptAccepted) => {
+          onProviderPromptAccepted()
+          await runtime.sendPrompt(request)
+        },
+        cancelPrompt: (request) => runtime.cancelPrompt(request)
+      },
+      { create: vi.fn() }
+    )
+    const promptMessage: PersistedChatSession['messages'][number] = {
+      id: 'task-prompt-1',
+      role: 'user',
+      content: 'Generate a Session Plan.',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const assistantMessage: PersistedChatSession['messages'][number] = {
+      id: 'task-assistant-1',
+      role: 'agent',
+      content: 'Saved plan.json.',
+      status: 'complete',
+      responseToMessageId: promptMessage.id,
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const promptGraph = createLinearConversationGraph({
+      sessionId: session.sessionId,
+      messages: [promptMessage],
+      frameworkId: codexFramework.id,
+      createdAt: 1,
+      updatedAt: 1
+    })
+    const conversationGraph = synchronizeActiveConversationMessages(
+      promptGraph,
+      [promptMessage, assistantMessage],
+      2
+    )
+    durableSessionAuthority.current = {
+      id: session.sessionId,
+      projectId: 'project-1',
+      title: 'Task runner Plan First',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: conversationGraph.messages.map(projectConversationMessage),
+      conversationGraph,
+      createdAt: 1,
+      updatedAt: 2
+    }
+
+    const taskPrompt = {
+      sessionId: session.sessionId,
+      promptMessageId: promptMessage.id,
+      text: promptMessage.content,
+      turnIntent: 'plan-first' as const,
+      provenanceContext: getActiveConversationContext(promptGraph, promptMessage.id)
+    }
+    await taskAgent.prompt(taskPrompt)
+
+    expect(artifactClaimId).toBeTruthy()
+    const claim = resolveArtifactRunClaim(runtime, artifactClaimId!)
+    let finalized: Awaited<ReturnType<ArtifactProvenanceRepository['finalizeRun']>>
+    try {
+      finalized = await provenance.finalizeRun({
+        projectId: claim.projectId,
+        appSessionId: claim.sessionId,
+        artifactRunId: claim.runId,
+        artifactVersionIds: claim.artifactVersionIds!,
+        rootFrameId: claim.rootFrameId!,
+        agentFrameId: claim.agentFrameId!,
+        messageBranchId: claim.messageBranchId!,
+        messageBranchAncestry: claim.messageBranchAncestry,
+        messageAncestry: [...(claim.messageAncestry ?? []), assistantMessage.id],
+        runtimeSegmentId: claim.runtimeSegmentId!,
+        promptMessageId: claim.promptMessageId!,
+        messageId: assistantMessage.id
+      })
+    } catch (error) {
+      await expect(
+        client.artifactVersion.findFirstOrThrow({ where: { artifactRunId: claim.runId } })
+      ).resolves.toMatchObject({ state: 'pending', messageId: null })
+      throw error
+    }
+    expect(finalized).toEqual([expect.objectContaining({ name: 'plan.json' })])
+    await expect(
+      client.artifactVersion.findFirstOrThrow({ where: { artifactRunId: claim.runId } })
+    ).resolves.toMatchObject({ state: 'finalized', messageId: assistantMessage.id })
   })
 
   it('emits an artifact event for pending files even when the prompt fails', async () => {

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 
+import type { AgentTurnProvenanceContext } from '../../shared/acp'
 import type { TaskAgentPort } from '../tasks/task-runner'
 import {
   materializeSessionAgentConfiguration,
@@ -7,6 +8,16 @@ import {
   type SessionAgentTargetSource
 } from './session-agent-target'
 import { createAcpTaskAgentPort } from './task-agent-port'
+
+const taskProvenanceContext = (promptMessageId: string): AgentTurnProvenanceContext => ({
+  rootFrameId: 'root-frame-1',
+  agentFrameId: 'root-frame-1',
+  messageBranchId: 'message-branch-1',
+  messageBranchAncestry: ['message-branch-1'],
+  messageAncestry: [promptMessageId],
+  runtimeSegmentId: 'runtime-segment-1',
+  promptMessageId
+})
 
 describe('ACP Task Agent port', () => {
   it('exposes only the Task execution capabilities', () => {
@@ -116,6 +127,7 @@ describe('ACP Task Agent port', () => {
     await port.prompt({
       sessionId: 'session-stable',
       promptMessageId: 'persisted-prompt',
+      provenanceContext: taskProvenanceContext('persisted-prompt'),
       text: 'Continue the research.',
       turnIntent: 'plan-first',
       skillIds: ['literature-review'],
@@ -165,7 +177,7 @@ describe('ACP Task Agent port', () => {
     expect(runtime.sendPrompt).toHaveBeenCalledWith({
       sessionId: 'session-stable',
       text: 'Continue the research.',
-      provenanceContext: { promptMessageId: 'persisted-prompt' },
+      provenanceContext: taskProvenanceContext('persisted-prompt'),
       forcedSkillIds: ['literature-review'],
       turnIntent: 'plan-first',
       historyPreamble: 'Previous conversation.',
@@ -228,6 +240,7 @@ describe('ACP Task Agent port', () => {
     const prompt = {
       sessionId: 'session-1',
       promptMessageId: 'persisted-prompt',
+      provenanceContext: taskProvenanceContext('persisted-prompt'),
       text: 'Research this.',
       skillIds: ['literature-review']
     }
@@ -253,7 +266,7 @@ describe('ACP Task Agent port', () => {
     expect(trackPrompt).toHaveBeenCalledWith({
       sessionId: 'session-1',
       text: 'Research this.',
-      provenanceContext: { promptMessageId: 'persisted-prompt' },
+      provenanceContext: taskProvenanceContext('persisted-prompt'),
       forcedSkillIds: ['literature-review']
     })
     expect(untrackPrompt).not.toHaveBeenCalled()
@@ -285,6 +298,7 @@ describe('ACP Task Agent port', () => {
       {
         sessionId: 'session-1',
         promptMessageId: 'prompt-1',
+        provenanceContext: taskProvenanceContext('prompt-1'),
         text: 'Research this.'
       },
       { onProviderPromptAccepted }

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -38,7 +38,7 @@ type SessionArchiveAvailability = {
 const toAcpPromptRequest = (request: TaskAgentPromptRequest): AcpPromptRequest => ({
   sessionId: request.sessionId,
   text: request.text,
-  provenanceContext: { promptMessageId: request.promptMessageId },
+  provenanceContext: request.provenanceContext,
   ...(request.turnIntent ? { turnIntent: request.turnIntent } : {}),
   ...(request.skillIds?.length ? { forcedSkillIds: request.skillIds } : {}),
   ...(request.historyPreamble ? { historyPreamble: request.historyPreamble } : {}),

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1681,14 +1681,16 @@ describe('TaskRunner', () => {
     }
     let admissionActive = false
     let saveCount = 0
+    const savedSessions: PersistedChatSession[] = []
     const resumeRequests: Parameters<TaskRunnerDependencies['agent']['resumeSession']>[0][] = []
     const prompts: Parameters<TaskRunnerDependencies['agent']['prompt']>[0][] = []
     const ids = ['new-user', 'run-2', 'new-agent']
     const runner = createRunner({
       sessions: {
         list: async () => [existing],
-        save: async () => {
+        save: async (value) => {
           saveCount += 1
+          savedSessions.push(structuredClone(value))
           if (saveCount === 1) expect(admissionActive).toBe(true)
         }
       },
@@ -1744,7 +1746,7 @@ describe('TaskRunner', () => {
           messageBranchId: 'message-branch-session-1',
           messageBranchAncestry: ['message-branch-session-1'],
           messageAncestry: ['old-user', 'old-agent', 'new-user'],
-          runtimeSegmentId: 'runtime-segment-session-1',
+          runtimeSegmentId: expect.not.stringMatching('runtime-segment-session-1'),
           promptMessageId: 'new-user'
         },
         text: 'Follow-up question',
@@ -1753,6 +1755,12 @@ describe('TaskRunner', () => {
           'Previous conversation:\n\nUser: Initial question\n\nAssistant: Initial answer'
       }
     ])
+    const promptRuntimeSegmentId = prompts[0]?.provenanceContext.runtimeSegmentId
+    expect(
+      savedSessions[0]?.conversationGraph?.runtimeSegments.some(
+        ({ id }) => id === promptRuntimeSegmentId
+      )
+    ).toBe(true)
   })
 
   it('adopts a persisted agent configuration for an attached session', async () => {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -906,7 +906,16 @@ describe('TaskRunner', () => {
     expect(prompt).toHaveBeenCalledWith(
       expect.objectContaining({
         turnIntent: 'plan-first',
-        promptMessageId: 'user-controlled'
+        promptMessageId: 'user-controlled',
+        provenanceContext: {
+          rootFrameId: 'root-frame-session-controlled',
+          agentFrameId: 'root-frame-session-controlled',
+          messageBranchId: 'message-branch-session-controlled',
+          messageBranchAncestry: ['message-branch-session-controlled'],
+          messageAncestry: ['user-controlled'],
+          runtimeSegmentId: 'runtime-segment-session-controlled',
+          promptMessageId: 'user-controlled'
+        }
       }),
       expect.any(Object)
     )
@@ -1729,6 +1738,15 @@ describe('TaskRunner', () => {
       {
         sessionId: existing.id,
         promptMessageId: 'new-user',
+        provenanceContext: {
+          rootFrameId: 'root-frame-session-1',
+          agentFrameId: 'root-frame-session-1',
+          messageBranchId: 'message-branch-session-1',
+          messageBranchAncestry: ['message-branch-session-1'],
+          messageAncestry: ['old-user', 'old-agent', 'new-user'],
+          runtimeSegmentId: 'runtime-segment-session-1',
+          promptMessageId: 'new-user'
+        },
         text: 'Follow-up question',
         contextReset: true,
         historyPreamble:
@@ -2113,6 +2131,15 @@ describe('TaskRunner', () => {
       {
         sessionId: existing.id,
         promptMessageId: 'skill-user',
+        provenanceContext: {
+          rootFrameId: 'root-frame-session-1',
+          agentFrameId: 'root-frame-session-1',
+          messageBranchId: 'message-branch-session-1',
+          messageBranchAncestry: ['message-branch-session-1'],
+          messageAncestry: ['prior-user', 'prior-agent', 'skill-user'],
+          runtimeSegmentId: 'runtime-segment-session-1',
+          promptMessageId: 'skill-user'
+        },
         text: 'Use the selected skill.',
         skillIds: ['literature-review'],
         resumeFallback: {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -17,7 +17,10 @@ import type {
 import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE, artifactCreatedAtMs } from '../../shared/artifacts'
 import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
-import { getActiveConversationContext } from '../../shared/conversation-graph'
+import {
+  ensureConversationRuntimeSegment,
+  getActiveConversationContext
+} from '../../shared/conversation-graph'
 import {
   PROJECT_DESCRIPTION_MAX_LENGTH,
   PROJECT_NAME_MAX_LENGTH,
@@ -966,11 +969,30 @@ class TaskRunner {
       delete session.resumeRecovery
     }
 
-    const committedSession = await this.dependencies.sessions.save(session)
+    const contextReset = Boolean(sessionInfo.contextReset || existing?.pendingHistoryReplay)
+    let sessionToCommit = session
+    if (existing) {
+      const currentGraph = materializeSessionConversationGraph(existing).conversationGraph
+      const graphWithRuntime = ensureConversationRuntimeSegment(currentGraph, {
+        id: `runtime-segment-${userMessageId}`,
+        frameworkId: session.agentFrameworkId ?? 'claude-code',
+        backendId: session.agentBackendId,
+        model: session.agentModel,
+        startedAt: now,
+        forceNew: contextReset
+      })
+      if (graphWithRuntime.runtimeSegments.length !== currentGraph.runtimeSegments.length) {
+        sessionToCommit = materializeSessionConversationGraph({
+          ...session,
+          conversationGraph: graphWithRuntime
+        })
+      }
+    }
+
+    const committedSession = await this.dependencies.sessions.save(sessionToCommit)
     const previousHistoryPreamble = existing
       ? createHistoryPreamble(selectTaskHistoryMessages(existing))
       : undefined
-    const contextReset = Boolean(sessionInfo.contextReset || existing?.pendingHistoryReplay)
     return {
       session: committedSession,
       historyPreamble: contextReset ? previousHistoryPreamble : undefined,

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -2,7 +2,7 @@ import { constants } from 'node:fs'
 import { access, realpath, stat } from 'node:fs/promises'
 import { isAbsolute } from 'node:path'
 
-import type { AcpRuntimeEvent } from '../../shared/acp'
+import type { AcpRuntimeEvent, AgentTurnProvenanceContext } from '../../shared/acp'
 import { ComputeHostPreferenceValidationError } from '../../shared/compute'
 import {
   getAcpRuntimeEventImage,
@@ -17,6 +17,7 @@ import type {
 import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE, artifactCreatedAtMs } from '../../shared/artifacts'
 import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
+import { getActiveConversationContext } from '../../shared/conversation-graph'
 import {
   PROJECT_DESCRIPTION_MAX_LENGTH,
   PROJECT_NAME_MAX_LENGTH,
@@ -24,13 +25,14 @@ import {
   type UpdateProjectRequest
 } from '../../shared/projects'
 import type { AgentFrameworkId, SessionAgentConfiguration } from '../../shared/settings'
-import type {
-  DelegationPolicy,
-  PersistedArtifact,
-  PersistedChatMessage,
-  PersistedChatSession,
-  PersistedMessageImage,
-  PersistedToolActivity
+import {
+  materializeSessionConversationGraph,
+  type DelegationPolicy,
+  type PersistedArtifact,
+  type PersistedChatMessage,
+  type PersistedChatSession,
+  type PersistedMessageImage,
+  type PersistedToolActivity
 } from '../../shared/session-persistence'
 import type {
   AcquiredTaskArtifact,
@@ -111,6 +113,7 @@ type TaskAgentResumeSessionRequest = {
 type TaskAgentPromptRequest = {
   sessionId: string
   promptMessageId: string
+  provenanceContext: AgentTurnProvenanceContext
   text: string
   turnIntent?: 'plan-first'
   skillIds?: string[]
@@ -992,10 +995,16 @@ class TaskRunner {
     let cancellationAtPromptFailure: MutableTaskRun['cancellation'] = undefined
     try {
       this.publishProgress(run, 'prompt-dispatched')
+      const promptMessageId = session.activeRun!.promptMessageId
+      const provenanceContext = getActiveConversationContext(
+        materializeSessionConversationGraph(session).conversationGraph,
+        promptMessageId
+      )
       await this.dependencies.agent.prompt(
         {
           sessionId: session.id,
-          promptMessageId: session.activeRun!.promptMessageId,
+          promptMessageId,
+          provenanceContext,
           text: prompt,
           ...(request.turnIntent ? { turnIntent: request.turnIntent } : {}),
           ...(request.skillIds?.length ? { skillIds: request.skillIds } : {}),

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -736,6 +736,15 @@ describe('HeadlessTaskApi adapter', () => {
       {
         sessionId: existing.id,
         promptMessageId: 'attached-user',
+        provenanceContext: {
+          rootFrameId: 'root-frame-session-attached',
+          agentFrameId: 'root-frame-session-attached',
+          messageBranchId: 'message-branch-session-attached',
+          messageBranchAncestry: ['message-branch-session-attached'],
+          messageAncestry: ['attached-user'],
+          runtimeSegmentId: 'runtime-segment-session-attached',
+          promptMessageId: 'attached-user'
+        },
         text: 'Continue research.'
       },
       { onProviderPromptAccepted: expect.any(Function) }
@@ -839,6 +848,15 @@ describe('HeadlessTaskApi adapter', () => {
       {
         sessionId: 'session-context',
         promptMessageId: expect.any(String),
+        provenanceContext: {
+          rootFrameId: 'root-frame-session-context',
+          agentFrameId: 'root-frame-session-context',
+          messageBranchId: 'message-branch-session-context',
+          messageBranchAncestry: ['message-branch-session-context'],
+          messageAncestry: [expect.any(String)],
+          runtimeSegmentId: 'runtime-segment-session-context',
+          promptMessageId: expect.any(String)
+        },
         text: 'Research with remote context.'
       },
       { onProviderPromptAccepted: expect.any(Function) }


### PR DESCRIPTION
## Problem

Task/CLI and Web Task-runner prompts forwarded only the durable Prompt Message ID into ACP. Artifact turns therefore synthesized a process-local Runtime Segment ID. Generated-file finalization then rejected that claim because the ID was absent from the persisted Session graph, leaving the Artifact Version pending and the Run failed with runtime-segment-missing.

Fixes #1798.

## Proposed change

- Derive the existing full turn provenance from the just-saved Session conversation graph before Task prompt dispatch.
- Require that provenance on the internal Task Agent prompt contract and forward it unchanged into ACP.
- Open and persist a fresh existing-format Runtime Segment before a Task prompt when provider context resets or the runtime identity changes.
- Add an integration regression that generates a Plan-first Task Artifact and finalizes it against the durable Session graph, plus a focused fresh-context regression.

## Scope and non-goals

- No database table or persisted-format change; no migration and no new data field. A fresh-context continuation appends the normal existing Runtime Segment object to the Session JSON conversationGraph.runtimeSegments array.
- No new enum/state value.
- No user-interaction or renderer change.
- No provider ACP wire-protocol or subscription change. The Task Agent adapter is shared by claude-code, opencode, codex-response, and codex-bridge paths; the regression uses the reported Codex path. Electron/renderer prompting already supplies complete provenance and is unchanged.
- Historical flat-message Sessions continue through the existing conversation-graph materialization path; no special compatibility branch is added.

## Acceptance criteria and validation

- Reported failure feedback loop: npm test -- src/main/acp/runtime.test.ts -t "finalizes a Task-runner Artifact against its durable Runtime Segment"
  - Before fix: stable ArtifactFinalizationProofError, reasonCode runtime-segment-missing; version remained pending with messageId null.
  - After fix: passed; version finalized and linked to the terminal assistant Message.
- Fresh-context feedback loop: npm test -- src/main/tasks/task-runner.test.ts -t "resumes a detached session without duplicating the new prompt in history replay"
  - Before follow-up: the new prompt remained bound to runtime-segment-session-1 from the old provider context.
  - After follow-up: the prompt receives a fresh Runtime Segment that is present in the saved Session graph.
- Task provenance construction and direct Web/CLI consumers -> npm test -- src/main/tasks/task-runner.test.ts src/main/acp/task-agent-port.test.ts src/main/web-service/task-api.test.ts -> 85 passed.
- Artifact lifecycle and downstream consumers -> npm run test:module -- artifact_provenance -> 26 files, 1376 tests passed.
- Main-process TypeScript contract -> npm run typecheck:node -> passed.
- Source/test lint -> npm run lint -> passed.

All listed checks ran after the last material edit. Full npm test was intentionally not run locally; exact-head PR CI remains authoritative for complete portable and platform coverage, including Windows.

## Review focus

- TaskRunner derives provenance from the durable Session-owned graph rather than inventing identity.
- Fresh provider contexts receive a distinct durable Runtime Segment before prompt dispatch.
- The Task Agent adapter preserves that context without weakening finalization proof validation.
- No fallback, retry, schema, or interaction complexity was added.
