### PR TITLE
fix(compute): defer completion during remote jobs

### DIFF
--- a/src/main/compute/electron-ipc-adapter.ts
+++ b/src/main/compute/electron-ipc-adapter.ts
@@ -1,6 +1,7 @@
 import type {
   ChangeComputeHostAuthenticationRequest,
   ComputeApprovalDecision,
+  ComputeJobsListFilter,
   CreateComputeHostRequest,
   CreatePasswordComputeHostRequest,
   ResetPasswordComputeHostRequest,
@@ -122,10 +123,9 @@ const registerComputeIpcHandlerSet = ({ handlers, enabledHosts }: ComputeIpcAdap
     typeof id === 'string' ? handlers.approvalReplay(id) : null
   )
   ipcMainHandle('compute:approval-replay-pending', () => handlers.approvalReplayPending())
-  // Returns all jobs for a session as JobSummary[], optionally filtered by status (Phase 3d).
-  ipcMainHandle(
-    COMPUTE_JOBS_LIST_CHANNEL,
-    (_event, filter: { sessionId: string; status?: string[] }) => handlers.jobsList(filter)
+  // Returns a Session job feed or the global non-terminal activity projection.
+  ipcMainHandle(COMPUTE_JOBS_LIST_CHANNEL, (_event, filter: ComputeJobsListFilter) =>
+    handlers.jobsList(filter)
   )
   // Returns jobs pending analysis turn (notifiedAt set, notificationConsumedAt null — issue 05).
   ipcMainHandle('compute:jobs:pending-notification', (_event, sessionId: string) =>

--- a/src/main/compute/electron-ipc-adapter.ts
+++ b/src/main/compute/electron-ipc-adapter.ts
@@ -2,6 +2,7 @@ import type {
   ChangeComputeHostAuthenticationRequest,
   ComputeApprovalDecision,
   ComputeJobsListFilter,
+  ComputeJobsPendingNotificationFilter,
   CreateComputeHostRequest,
   CreatePasswordComputeHostRequest,
   ResetPasswordComputeHostRequest,
@@ -128,8 +129,10 @@ const registerComputeIpcHandlerSet = ({ handlers, enabledHosts }: ComputeIpcAdap
     handlers.jobsList(filter)
   )
   // Returns jobs pending analysis turn (notifiedAt set, notificationConsumedAt null — issue 05).
-  ipcMainHandle('compute:jobs:pending-notification', (_event, sessionId: string) =>
-    handlers.jobsPendingNotification(sessionId)
+  ipcMainHandle(
+    'compute:jobs:pending-notification',
+    (_event, filter: ComputeJobsPendingNotificationFilter) =>
+      handlers.jobsPendingNotification(filter)
   )
   // Marks job ids as notification-consumed (analysis turn done — issue 05).
   ipcMainHandle('compute:jobs:mark-consumed', (_event, sessionId: string, jobIds: string[]) =>

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -826,6 +826,36 @@ describe('compute handlers — jobsList', () => {
     expect(findBySession).toHaveBeenCalledWith('sess-1', undefined)
   })
 
+  it('returns all persisted non-terminal jobs for the renderer activity projection', async () => {
+    const host = sampleHost({ providerId: 'ssh:biowulf', displayName: 'Biowulf HPC' })
+    const list = vi.fn().mockResolvedValue([host])
+    const jobs = [
+      makeJob({ job_id: 'job-1', session_id: 'sess-1', status: 'queued' }),
+      makeJob({ job_id: 'job-2', session_id: 'sess-2', status: 'running' })
+    ]
+    const findNonTerminal = vi.fn().mockResolvedValue(jobs)
+
+    const handlers = createComputeHandlers(
+      mockRepository({ list }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      mockJobRepository({ findNonTerminal }),
+      undefined,
+      undefined,
+      '/tmp/test-storage'
+    )
+
+    const result = await handlers.jobsList({ nonTerminal: true })
+
+    expect(result.map((job) => [job.job_id, job.session_id])).toEqual([
+      ['job-1', 'sess-1'],
+      ['job-2', 'sess-2']
+    ])
+    expect(findNonTerminal).toHaveBeenCalledOnce()
+  })
+
   it('returns empty array when no jobRepository is injected', async () => {
     const handlers = createComputeHandlers(mockRepository({}))
     const result = await handlers.jobsList({ sessionId: 'sess-1' })

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -1928,6 +1928,29 @@ describe('compute handlers — jobsPendingNotification', () => {
     expect(result[0]!.notification_consumed_at).toBeUndefined()
   })
 
+  it('returns pending notifications across all Sessions for App-level recovery', async () => {
+    const list = vi.fn().mockResolvedValue([])
+    const findPendingNotifications = vi
+      .fn()
+      .mockResolvedValue([makeJob({ job_id: 'job-a', session_id: 'sess-a' })])
+    const handlers = createComputeHandlers(
+      mockRepository({ list }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      mockJobRepo({ findPendingNotifications }),
+      undefined,
+      undefined,
+      storageRoot
+    )
+
+    const result = await handlers.jobsPendingNotification({ allSessions: true })
+
+    expect(findPendingNotifications).toHaveBeenCalledWith()
+    expect(result[0]).toMatchObject({ job_id: 'job-a', session_id: 'sess-a' })
+  })
+
   it('returns an empty array when no jobRepository is injected', async () => {
     const handlers = createComputeHandlers(mockRepository({}))
     const result = await handlers.jobsPendingNotification('sess-1')

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -13,6 +13,7 @@ import type {
   ComputePasswordCapability,
   ComputeHostDeletionStatus,
   ComputeJob,
+  ComputeJobsListFilter,
   JobSummary,
   CreateComputeHostRequest,
   CreatePasswordComputeHostRequest,
@@ -196,8 +197,8 @@ type ComputeHandlers = {
   approvalCompleteSessionCancellation: (sessionId: string) => void
   approvalBeginSessionDeletion: (sessionId: string) => void
   approvalFinishSessionDeletion: (sessionId: string, retained: boolean) => void
-  // Returns JobSummary[] for a session, optionally filtered by status (renderer feed, issue 05).
-  jobsList: (filter: { sessionId: string; status?: string[] }) => Promise<JobSummary[]>
+  // Returns either a Session feed or the bounded global non-terminal activity projection.
+  jobsList: (filter: ComputeJobsListFilter) => Promise<JobSummary[]>
   // Returns jobs with notifiedAt set and notificationConsumedAt null (issue 05 restart recovery).
   jobsPendingNotification: (sessionId: string) => Promise<JobSummary[]>
   // Marks the given job ids as notification-consumed. Idempotent (issue 05).
@@ -454,7 +455,10 @@ const createComputeHandlers = (
       if (!jobRepository || !storageRoot) return []
       const hosts = await repository.list()
       const hostNameMap = new Map(hosts.map((h) => [h.providerId, h.displayName]))
-      const jobs = await jobRepository.findBySession(filter.sessionId, filter.status)
+      const jobs =
+        'nonTerminal' in filter
+          ? await jobRepository.findNonTerminal()
+          : await jobRepository.findBySession(filter.sessionId, filter.status)
       return Promise.all(
         jobs.map((j) =>
           toJobSummary(j, hostNameMap.get(j.provider_id) ?? j.provider_id, storageRoot)

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -14,6 +14,7 @@ import type {
   ComputeHostDeletionStatus,
   ComputeJob,
   ComputeJobsListFilter,
+  ComputeJobsPendingNotificationFilter,
   JobSummary,
   CreateComputeHostRequest,
   CreatePasswordComputeHostRequest,
@@ -200,7 +201,7 @@ type ComputeHandlers = {
   // Returns either a Session feed or the bounded global non-terminal activity projection.
   jobsList: (filter: ComputeJobsListFilter) => Promise<JobSummary[]>
   // Returns jobs with notifiedAt set and notificationConsumedAt null (issue 05 restart recovery).
-  jobsPendingNotification: (sessionId: string) => Promise<JobSummary[]>
+  jobsPendingNotification: (filter: ComputeJobsPendingNotificationFilter) => Promise<JobSummary[]>
   // Marks the given job ids as notification-consumed. Idempotent (issue 05).
   jobsMarkConsumed: (sessionId: string, jobIds: string[]) => Promise<void>
 }
@@ -465,11 +466,14 @@ const createComputeHandlers = (
         )
       )
     },
-    jobsPendingNotification: async (sessionId) => {
+    jobsPendingNotification: async (filter) => {
       if (!jobRepository || !storageRoot) return []
       const hosts = await repository.list()
       const hostNameMap = new Map(hosts.map((h) => [h.providerId, h.displayName]))
-      const jobs = await jobRepository.findPendingNotifications(sessionId)
+      const jobs =
+        typeof filter === 'string'
+          ? await jobRepository.findPendingNotifications(filter)
+          : await jobRepository.findPendingNotifications()
       return Promise.all(
         jobs.map((j) =>
           toJobSummary(j, hostNameMap.get(j.provider_id) ?? j.provider_id, storageRoot)

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -361,6 +361,12 @@ describe('ComputeJob repository (SQLite integration)', () => {
     const pending = await repo.findPendingNotifications('sess-1')
     expect(pending).toHaveLength(1)
     expect(pending[0]!.job_id).toBe('job-notified-unconsumed')
+
+    const allPending = await repo.findPendingNotifications()
+    expect(allPending.map((job) => job.job_id)).toEqual([
+      'job-notified-unconsumed',
+      'job-other-session'
+    ])
   })
 
   it('markNotificationsConsumed sets notificationConsumedAt and is idempotent', async () => {

--- a/src/main/compute/job-repository.ts
+++ b/src/main/compute/job-repository.ts
@@ -373,14 +373,13 @@ export class ComputeJobRepository {
     })
   }
 
-  // Returns jobs for a session that have been notified (notifiedAt set) but not yet consumed
-  // (notificationConsumedAt null). Used by the renderer at session load time to find jobs that
-  // need an analysis turn (issue 05: restart recovery path).
-  async findPendingNotifications(sessionId: string): Promise<ComputeJob[]> {
+  // Returns notified jobs that have not yet been consumed, optionally scoped to one Session.
+  // The App-level analysis owner uses the global form for restart recovery.
+  async findPendingNotifications(sessionId?: string): Promise<ComputeJob[]> {
     const client = await this.getClient()
     const rows = await client.computeJob.findMany({
       where: {
-        sessionId,
+        ...(sessionId === undefined ? {} : { sessionId }),
         notifiedAt: { not: null },
         notificationConsumedAt: null
       },

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -681,6 +681,7 @@ const createApplicationModules = async (
   const computeJobActivityRef: {
     current?: {
       findNonTerminal(): Promise<Array<{ project_id: string }>>
+      countNonTerminalBySession(sessionId: string): Promise<number>
     }
   } = {}
   const projectRuntimeQuiescenceRef: { current?: ProjectRuntimeQuiescenceOwner } = {}
@@ -1363,6 +1364,11 @@ const createApplicationModules = async (
       notificationsLog.warn('task notification delivery failed', errorLogFields(error)),
     onAttentionError: (error) =>
       notificationsLog.warn('desktop attention handler failed', errorLogFields(error)),
+    hasNonTerminalComputeJobs: async (sessionId) => {
+      const computeJobs = computeJobActivityRef.current
+      if (!computeJobs) throw new Error('Compute Job activity is not initialized.')
+      return (await computeJobs.countNonTerminalBySession(sessionId)) > 0
+    },
     inbox: notificationInbox,
     onInboxError: (error) =>
       notificationsLog.warn('message center recording failed', errorLogFields(error))

--- a/src/main/notifications/task-notifications.test.ts
+++ b/src/main/notifications/task-notifications.test.ts
@@ -267,6 +267,7 @@ const createService = (overrides: {
   onAttentionError?: (error: unknown) => void
   inbox?: TaskNotificationServiceDeps['inbox']
   onInboxError?: (error: unknown) => void
+  hasNonTerminalComputeJobs?: (sessionId: string) => Promise<boolean>
 }): {
   service: TaskNotificationService
   shown: TaskNotificationRequest[]
@@ -287,7 +288,8 @@ const createService = (overrides: {
     onDeliveryError: overrides.onDeliveryError ?? ((error) => deliveryErrors.push(error)),
     onAttentionError: overrides.onAttentionError ?? ((error) => attentionErrors.push(error)),
     inbox: overrides.inbox,
-    onInboxError: overrides.onInboxError ?? ((error) => inboxErrors.push(error))
+    onInboxError: overrides.onInboxError ?? ((error) => inboxErrors.push(error)),
+    hasNonTerminalComputeJobs: overrides.hasNonTerminalComputeJobs
   })
   service.setAttentionHandlers({
     request: overrides.requestAttention ?? (() => attentionRequests.push(1)),
@@ -316,6 +318,25 @@ describe('TaskNotificationService', () => {
       body: 'The agent finished responding to "Plot the curve".'
     })
     expect(attentionRequests).toEqual([])
+  })
+
+  it('defers completion while the Session owns non-terminal remote compute', async () => {
+    const inbox = {
+      record: vi.fn(async () => undefined),
+      settleAction: vi.fn(async () => undefined),
+      settleAuthorization: vi.fn(async () => undefined)
+    }
+    const hasNonTerminalComputeJobs = vi.fn(async () => true)
+    const { service, shown } = createService({ inbox, hasNonTerminalComputeJobs })
+
+    service.trackPrompt({ sessionId: 'session-1', text: 'Run the remote analysis' })
+    await service.handleRuntimeEvent(stopEvent('end_turn'))
+
+    expect(shown).toHaveLength(0)
+    expect(inbox.record).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'task.completed' })
+    )
+    expect(hasNonTerminalComputeJobs).toHaveBeenCalledWith('session-1')
   })
 
   it('collapses multiline prompts to their first line', async () => {

--- a/src/main/notifications/task-notifications.test.ts
+++ b/src/main/notifications/task-notifications.test.ts
@@ -339,6 +339,26 @@ describe('TaskNotificationService', () => {
     expect(hasNonTerminalComputeJobs).toHaveBeenCalledWith('session-1')
   })
 
+  it('still records and delivers completion when the compute activity query fails', async () => {
+    const queryError = new Error('compute database unavailable')
+    const inbox = {
+      record: vi.fn(async () => undefined),
+      settleAction: vi.fn(async () => undefined),
+      settleAuthorization: vi.fn(async () => undefined)
+    }
+    const { service, shown, deliveryErrors } = createService({
+      inbox,
+      hasNonTerminalComputeJobs: vi.fn(async () => Promise.reject(queryError))
+    })
+
+    service.trackPrompt({ sessionId: 'session-1', text: 'Run the remote analysis' })
+    await service.handleRuntimeEvent(stopEvent('end_turn'))
+
+    expect(deliveryErrors).toEqual([queryError])
+    expect(inbox.record).toHaveBeenCalledWith(expect.objectContaining({ kind: 'task.completed' }))
+    expect(shown).toHaveLength(1)
+  })
+
   it('collapses multiline prompts to their first line', async () => {
     const { service, shown } = createService({})
 

--- a/src/main/notifications/task-notifications.ts
+++ b/src/main/notifications/task-notifications.ts
@@ -44,6 +44,9 @@ export type TaskNotificationServiceDeps = {
   // without changing the underlying task or approval lifecycle.
   inbox?: Pick<NotificationInboxController, 'record' | 'settleAction' | 'settleAuthorization'>
   onInboxError?: (error: unknown) => void
+  // A clean foreground turn is not a completed workflow while its remote Compute Jobs can still
+  // trigger an automatic analysis turn.
+  hasNonTerminalComputeJobs?: (sessionId: string) => Promise<boolean>
 }
 
 export type TaskNotificationAttentionHandlers = {
@@ -309,6 +312,17 @@ export class TaskNotificationService {
     }
   }
 
+  private async hasNonTerminalComputeJobs(sessionId: string): Promise<boolean> {
+    if (!this.deps.hasNonTerminalComputeJobs) return false
+    try {
+      return await this.deps.hasNonTerminalComputeJobs(sessionId)
+    } catch (error) {
+      // If workflow activity cannot be established, fail closed instead of announcing completion.
+      reportTaskNotificationError(this.deps.onDeliveryError, error)
+      return true
+    }
+  }
+
   // Bound once the window lifecycle exists (index.ts, after installAppLifecycle): clicking a
   // notification surfaces the main window (always) and opens the conversation when the notification
   // belonged to a known session.
@@ -421,6 +435,15 @@ export class TaskNotificationService {
     // injected via runtime.sendPrompt directly) never pass through trackPrompt, so their terminal
     // events stay silent — the background reviewer must never notify.
     if (!tracked) return
+
+    if (
+      event.kind === 'stop' &&
+      event.text === 'end_turn' &&
+      this.deps.hasNonTerminalComputeJobs &&
+      (await this.hasNonTerminalComputeJobs(sessionId))
+    ) {
+      return
+    }
 
     const notification = describeTaskNotification(event, snippet)
 

--- a/src/main/notifications/task-notifications.ts
+++ b/src/main/notifications/task-notifications.ts
@@ -317,9 +317,9 @@ export class TaskNotificationService {
     try {
       return await this.deps.hasNonTerminalComputeJobs(sessionId)
     } catch (error) {
-      // If workflow activity cannot be established, fail closed instead of announcing completion.
+      // Preserve notification delivery when the activity projection is temporarily unavailable.
       reportTaskNotificationError(this.deps.onDeliveryError, error)
-      return true
+      return false
     }
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,7 +4,12 @@ import { unwrapApplicationCommandOutcome } from '../shared/application-command-c
 import { createElectronRendererContractAdapter } from './electron-renderer-contract-adapter'
 import type { OpenScienceAPI } from './renderer-api'
 
-import type { ComputeApprovalDecision, ComputeApprovalRequest, JobSummary } from '../shared/compute'
+import type {
+  ComputeApprovalDecision,
+  ComputeApprovalRequest,
+  ComputeJobsListFilter,
+  JobSummary
+} from '../shared/compute'
 import type {
   InitializeLocalePreferenceRequest,
   SetLocalePreferenceRequest
@@ -617,8 +622,8 @@ const api: OpenScienceAPI = {
       electronRendererContracts.invoke('compute.bookmarksGet', providerId),
     bookmarksSet: (providerId, folders) =>
       electronRendererContracts.invoke('compute.bookmarksSet', providerId, folders),
-    // Returns all jobs for a session as JobSummary[], optionally filtered by status (Phase 3d).
-    jobsList: (filter: { sessionId: string; status?: string[] }) =>
+    // Returns a Session job feed or the global non-terminal activity projection.
+    jobsList: (filter: ComputeJobsListFilter) =>
       electronRendererContracts.invoke('compute.jobsList', filter),
     // Returns jobs pending analysis turn (notifiedAt set, notificationConsumedAt null).
     jobsPendingNotification: (sessionId) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,7 @@ import type {
   ComputeApprovalDecision,
   ComputeApprovalRequest,
   ComputeJobsListFilter,
+  ComputeJobsPendingNotificationFilter,
   JobSummary
 } from '../shared/compute'
 import type {
@@ -626,8 +627,8 @@ const api: OpenScienceAPI = {
     jobsList: (filter: ComputeJobsListFilter) =>
       electronRendererContracts.invoke('compute.jobsList', filter),
     // Returns jobs pending analysis turn (notifiedAt set, notificationConsumedAt null).
-    jobsPendingNotification: (sessionId) =>
-      electronRendererContracts.invoke('compute.jobsPendingNotification', sessionId),
+    jobsPendingNotification: (filter: ComputeJobsPendingNotificationFilter) =>
+      electronRendererContracts.invoke('compute.jobsPendingNotification', filter),
     // Marks job ids as notification-consumed after a successful analysis turn (issue 05).
     jobsMarkConsumed: (sessionId, jobIds) =>
       electronRendererContracts.invoke('compute.jobsMarkConsumed', sessionId, jobIds),

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -78,6 +78,7 @@ import type {
 import type {
   ComputeApprovalDecision,
   ComputeApprovalRequest,
+  ComputeJobsListFilter,
   ComputeHost,
   ComputeHostDeletionStatus,
   ComputePasswordCapability,
@@ -805,8 +806,8 @@ export interface OpenScienceAPI {
     // Bookmark folders for the file browser Go-to/Pin feature, persisted in settings JSON.
     bookmarksGet(providerId: string): Promise<string[]>
     bookmarksSet(providerId: string, folders: string[]): Promise<void>
-    // Returns all jobs for a session as JobSummary[], optionally filtered by status (Phase 3d).
-    jobsList(filter: { sessionId: string; status?: string[] }): Promise<JobSummary[]>
+    // Returns a Session job feed or the global non-terminal activity projection.
+    jobsList(filter: ComputeJobsListFilter): Promise<JobSummary[]>
     // Returns jobs with notifiedAt set and notificationConsumedAt null (issue 05 restart recovery).
     jobsPendingNotification(sessionId: string): Promise<JobSummary[]>
     // Marks job ids as notification-consumed after a successful analysis turn (issue 05).

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -79,6 +79,7 @@ import type {
   ComputeApprovalDecision,
   ComputeApprovalRequest,
   ComputeJobsListFilter,
+  ComputeJobsPendingNotificationFilter,
   ComputeHost,
   ComputeHostDeletionStatus,
   ComputePasswordCapability,
@@ -809,7 +810,7 @@ export interface OpenScienceAPI {
     // Returns a Session job feed or the global non-terminal activity projection.
     jobsList(filter: ComputeJobsListFilter): Promise<JobSummary[]>
     // Returns jobs with notifiedAt set and notificationConsumedAt null (issue 05 restart recovery).
-    jobsPendingNotification(sessionId: string): Promise<JobSummary[]>
+    jobsPendingNotification(filter: ComputeJobsPendingNotificationFilter): Promise<JobSummary[]>
     // Marks job ids as notification-consumed after a successful analysis turn (issue 05).
     jobsMarkConsumed(sessionId: string, jobIds: string[]): Promise<void>
     // Fires when a job's status or tail changes (broadcast from the main-process poller).

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -34,7 +34,8 @@ const mocks = vi.hoisted(() => {
     compute: {
       enqueueApproval: vi.fn(),
       dismissApproval: vi.fn(),
-      pendingApprovals: [] as unknown[]
+      pendingApprovals: [] as unknown[],
+      jobsList: vi.fn().mockResolvedValue([])
     },
     navigation: { view: 'home' as 'home' | 'workspace', userNavigationRevision: 0 },
     sessions: [] as Array<{ id: string }>,
@@ -391,6 +392,7 @@ describe('App startup routing', () => {
     mocks.skillImport.dismiss.mockClear()
     mocks.compute.enqueueApproval.mockClear()
     mocks.compute.dismissApproval.mockClear()
+    mocks.compute.jobsList.mockClear()
     mocks.navigation.view = 'home'
     mocks.startupView = 'app'
     mocks.sessionPersistence.isReady = true
@@ -452,6 +454,7 @@ describe('App startup routing', () => {
         onApprovalSettled: vi.fn(() => vi.fn()),
         replayPendingApprovals: vi.fn().mockResolvedValue(undefined),
         onJobUpdated: vi.fn(() => vi.fn()),
+        jobsList: mocks.compute.jobsList,
         enabledHostsSet: vi.fn(() => Promise.resolve())
       },
       permissions: { onChanged: vi.fn(() => vi.fn()) },
@@ -494,6 +497,13 @@ describe('App startup routing', () => {
     root = createRoot(container)
     await act(async () => root.render(<App />))
   }
+
+  it('hydrates the persisted non-terminal Compute Job projection at app startup', async () => {
+    mocks.settings.isLoaded = true
+    await render()
+
+    expect(mocks.compute.jobsList).toHaveBeenCalledWith({ nonTerminal: true })
+  })
 
   it('opens Settings with Cmd/Ctrl+, after startup is interactive', async () => {
     await render()

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -35,8 +35,13 @@ const mocks = vi.hoisted(() => {
       enqueueApproval: vi.fn(),
       dismissApproval: vi.fn(),
       pendingApprovals: [] as unknown[],
-      jobsList: vi.fn().mockResolvedValue([])
+      jobsList: vi.fn().mockResolvedValue([]),
+      jobsPendingNotification: vi.fn().mockResolvedValue([]),
+      jobsMarkConsumed: vi.fn().mockResolvedValue(undefined)
     },
+    runtimeSendMessage: vi
+      .fn()
+      .mockResolvedValue({ sessionId: 'session-1', messageId: 'analysis-message' }),
     navigation: { view: 'home' as 'home' | 'workspace', userNavigationRevision: 0 },
     sessions: [] as Array<{ id: string }>,
     appendRoutedUserMessage: vi.fn(),
@@ -172,7 +177,8 @@ vi.mock('@/stores/session-store', () => ({
     getState: () => ({
       sessions: mocks.sessions,
       appendRoutedUserMessage: mocks.appendRoutedUserMessage
-    })
+    }),
+    subscribe: vi.fn(() => vi.fn())
   }
 }))
 vi.mock('@/stores/notebook-env-store', () => ({
@@ -258,7 +264,8 @@ vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
     pendingPermissions: [],
     promptInFlightSessionIds: [],
     sendPreparationInFlightSessionIds: [],
-    saveAsSkillInFlightSessionIds: []
+    saveAsSkillInFlightSessionIds: [],
+    sendMessage: mocks.runtimeSendMessage
   })
 }))
 vi.mock('@/pages/home/HomePage', () => ({
@@ -393,6 +400,9 @@ describe('App startup routing', () => {
     mocks.compute.enqueueApproval.mockClear()
     mocks.compute.dismissApproval.mockClear()
     mocks.compute.jobsList.mockClear()
+    mocks.compute.jobsPendingNotification.mockClear()
+    mocks.compute.jobsMarkConsumed.mockClear()
+    mocks.runtimeSendMessage.mockClear()
     mocks.navigation.view = 'home'
     mocks.startupView = 'app'
     mocks.sessionPersistence.isReady = true
@@ -455,6 +465,8 @@ describe('App startup routing', () => {
         replayPendingApprovals: vi.fn().mockResolvedValue(undefined),
         onJobUpdated: vi.fn(() => vi.fn()),
         jobsList: mocks.compute.jobsList,
+        jobsPendingNotification: mocks.compute.jobsPendingNotification,
+        jobsMarkConsumed: mocks.compute.jobsMarkConsumed,
         enabledHostsSet: vi.fn(() => Promise.resolve())
       },
       permissions: { onChanged: vi.fn(() => vi.fn()) },
@@ -503,6 +515,40 @@ describe('App startup routing', () => {
     await render()
 
     expect(mocks.compute.jobsList).toHaveBeenCalledWith({ nonTerminal: true })
+  })
+
+  it('keeps the remote-job analysis owner active while Home is presented', async () => {
+    mocks.settings.isLoaded = true
+    mocks.compute.jobsPendingNotification.mockResolvedValueOnce([
+      {
+        job_id: 'job-1',
+        provider_id: 'ssh:cluster',
+        display_name: 'Cluster',
+        shape: 'direct_ssh',
+        session_id: 'session-1',
+        status: 'success',
+        intent: 'Analyze results',
+        created_at: 1,
+        started_at: 2,
+        finished_at: 3,
+        exit_code: 0,
+        error_code: undefined,
+        remote_workdir: undefined,
+        stdout_tail: undefined,
+        stderr_tail: undefined,
+        notified_at: 4,
+        notification_consumed_at: undefined
+      }
+    ])
+
+    await render()
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
+
+    expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
+    expect(mocks.compute.jobsPendingNotification).toHaveBeenCalledWith({ allSessions: true })
+    expect(mocks.runtimeSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-1' })
+    )
   })
 
   it('opens Settings with Cmd/Ctrl+, after startup is interactive', async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -43,7 +43,7 @@ const mocks = vi.hoisted(() => {
       .fn()
       .mockResolvedValue({ sessionId: 'session-1', messageId: 'analysis-message' }),
     navigation: { view: 'home' as 'home' | 'workspace', userNavigationRevision: 0 },
-    sessions: [] as Array<{ id: string }>,
+    sessions: [] as Array<{ id: string } & Record<string, unknown>>,
     appendRoutedUserMessage: vi.fn(),
     sideChatRelayBox,
     environment: {
@@ -519,6 +519,18 @@ describe('App startup routing', () => {
 
   it('keeps the remote-job analysis owner active while Home is presented', async () => {
     mocks.settings.isLoaded = true
+    mocks.sessions = [
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Background Session',
+        cwd: '/workspace/project-1',
+        status: 'idle',
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
     mocks.compute.jobsPendingNotification.mockResolvedValueOnce([
       {
         job_id: 'job-1',
@@ -547,7 +559,7 @@ describe('App startup routing', () => {
     expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
     expect(mocks.compute.jobsPendingNotification).toHaveBeenCalledWith({ allSessions: true })
     expect(mocks.runtimeSendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: 'session-1' })
+      expect.objectContaining({ sessionId: 'session-1', preserveSelection: true })
     )
   })
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -500,6 +500,7 @@ describe('App startup routing', () => {
   })
 
   afterEach(async () => {
+    vi.useRealTimers()
     await act(async () => root?.unmount())
     canvasContextSpy.mockRestore()
     container.remove()
@@ -515,6 +516,21 @@ describe('App startup routing', () => {
     await render()
 
     expect(mocks.compute.jobsList).toHaveBeenCalledWith({ nonTerminal: true })
+  })
+
+  it('retries global Compute Job activity hydration after a transient startup failure', async () => {
+    vi.useFakeTimers()
+    mocks.settings.isLoaded = true
+    mocks.compute.jobsList
+      .mockRejectedValueOnce(new Error('main process unavailable'))
+      .mockResolvedValueOnce([])
+
+    await render()
+    await act(async () => Promise.resolve())
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+
+    expect(mocks.compute.jobsList).toHaveBeenCalledTimes(2)
+    expect(mocks.compute.jobsList).toHaveBeenLastCalledWith({ nonTerminal: true })
   })
 
   it('keeps the remote-job analysis owner active while Home is presented', async () => {

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -18,6 +18,7 @@ import { WebEventRecoveryDialog } from '@/components/WebEventRecoveryDialog'
 import { useApplicationEventBindings } from '@/hooks/useApplicationEventBindings'
 import { useApplicationStartup } from '@/hooks/useApplicationStartup'
 import { WorkspaceAgentRuntimeProvider } from '@/lib/acp/useWorkspaceAgentRuntime'
+import { JobAnalysisRuntimeBridge } from '@/lib/compute/useJobAnalysisEffect'
 import { HomePage } from '@/pages/home/HomePage'
 import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
 import { ComputeApprovalDialog } from '@/pages/settings/ComputeApprovalDialog'
@@ -179,6 +180,7 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
         ) : null}
         {sessions.catalogRecovery.kind !== 'ready' ? writeErrorAlert : null}
         <WorkspaceAgentRuntimeProvider>
+          <JobAnalysisRuntimeBridge enabled={sessions.isReady} />
           <WorkspaceMessageQueueProvider>
             <WorkspaceMessageQueueRuntimeBridge />
             {events.navigation.view === 'home' ? (

--- a/src/renderer/src/hooks/useApplicationEventBindings.ts
+++ b/src/renderer/src/hooks/useApplicationEventBindings.ts
@@ -101,6 +101,7 @@ const useApplicationEventBindings = ({
     state.pending.some((candidate) => !openSideChatParentSessionIds.has(candidate.sessionId))
   )
   const applyJobUpdate = useSessionJobStore((state) => state.applyUpdate)
+  const hydrateNonTerminalJobs = useSessionJobStore((state) => state.hydrateNonTerminal)
   const isUpdateDialogOpen = useUpdateStore((state) => state.isDialogOpen)
   const isFilePreviewOpen = usePreviewWorkbenchStore((state) => state.fileDialogItem !== undefined)
   const isExpandedPreviewOpen = usePreviewWorkbenchStore(
@@ -387,6 +388,10 @@ const useApplicationEventBindings = ({
     }
   }, [dismissComputeApproval, enqueueComputeApproval])
   useEffect(() => window.api.compute.onJobUpdated(applyJobUpdate), [applyJobUpdate])
+  useEffect(() => {
+    if (startupView !== 'app' || !sessionPersistence.isHydrated) return
+    void hydrateNonTerminalJobs().catch(() => undefined)
+  }, [hydrateNonTerminalJobs, sessionPersistence.isHydrated, startupView])
 
   return {
     presentation,

--- a/src/renderer/src/hooks/useApplicationEventBindings.ts
+++ b/src/renderer/src/hooks/useApplicationEventBindings.ts
@@ -390,7 +390,19 @@ const useApplicationEventBindings = ({
   useEffect(() => window.api.compute.onJobUpdated(applyJobUpdate), [applyJobUpdate])
   useEffect(() => {
     if (startupView !== 'app' || !sessionPersistence.isHydrated) return
-    void hydrateNonTerminalJobs().catch(() => undefined)
+    let isActive = true
+    let retryTimer: ReturnType<typeof setTimeout> | undefined
+    const hydrate = (attempt = 0): void => {
+      void hydrateNonTerminalJobs().catch(() => {
+        if (!isActive || attempt >= 2) return
+        retryTimer = setTimeout(() => hydrate(attempt + 1), 1_000 * 2 ** attempt)
+      })
+    }
+    hydrate()
+    return () => {
+      isActive = false
+      clearTimeout(retryTimer)
+    }
   }, [hydrateNonTerminalJobs, sessionPersistence.isHydrated, startupView])
 
   return {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -656,6 +656,7 @@ describe('workspace runtime architecture', () => {
     }
     expect(unsupportedFacadeImports).toEqual([])
     expect(hookConsumers).toEqual([
+      'lib/compute/useJobAnalysisEffect.ts',
       'pages/workspace/WorkspacePage.tsx',
       'pages/workspace/workspace-message-queue-controller.ts'
     ])

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -494,7 +494,8 @@ const sendIntentKeys = [
   'specialistId',
   'enabledComputeHosts',
   'selectedComputeHosts',
-  'agentConfiguration'
+  'agentConfiguration',
+  'preserveSelection'
 ] as const
 const ownerDependencyNames = (path: string): string[] => {
   const targets = new Set(importsFrom(path).map((reference) => reference.target))

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -509,6 +509,73 @@ describe('workspace Agent Runtime hook contract', () => {
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
 
+  it('sends a background turn without changing the visible Session', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'session-provider',
+      activeModel: 'session-model',
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: [
+        {
+          id: 'claude-code',
+          displayName: 'Claude Code',
+          supportsSkills: true,
+          supportedApiTypes: ['anthropic']
+        }
+      ],
+      providers: [
+        {
+          id: 'session-provider',
+          type: 'custom',
+          name: 'Session',
+          apiEndpoints: ['anthropic'],
+          baseUrl: 'https://example.test/v1',
+          model: 'session-model',
+          models: ['session-model'],
+          supportsImageInput: false,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+    const configuration = {
+      providerId: 'session-provider',
+      model: 'session-model',
+      reasoningEffort: 'low' as const
+    }
+    for (const sessionId of ['visible-session', 'background-session']) {
+      useSessionStore.getState().appendUserMessage({
+        sessionId,
+        content: 'Earlier turn',
+        cwd: workspacePath,
+        projectId: 'project-1',
+        agentFrameworkId: 'claude-code',
+        agentConfiguration: configuration
+      })
+      useSessionStore.getState().finishRun(sessionId)
+    }
+    useSessionStore.setState({ selectedSessionId: 'visible-session' })
+    const runtime = createRuntime(createSnapshot({ sessionIds: ['background-session'] }))
+    runtimeMock.current = runtime
+    await render()
+
+    await act(async () => {
+      await latest.sendMessage({
+        sessionId: 'background-session',
+        text: 'Analyze the completed Compute Job.',
+        preserveSelection: true
+      })
+    })
+
+    expect(useSessionStore.getState().selectedSessionId).toBe('visible-session')
+    expect(
+      useSessionStore
+        .getState()
+        .sessions.find((session) => session.id === 'background-session')
+        ?.messages.at(-1)?.content
+    ).toBe('Analyze the completed Compute Job.')
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+  })
+
   it('routes live events into Workspace before snapshot reconciliation', async () => {
     const pending = useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -58,6 +58,7 @@ type SendWorkspaceMessageIntent = {
   enabledComputeHosts?: string[]
   selectedComputeHosts?: string[]
   agentConfiguration?: SessionAgentConfiguration
+  preserveSelection?: boolean
 }
 type SendWorkspaceMessageCommand = SendWorkspaceMessageIntent & {
   agentFrameworkId?: AgentFrameworkId
@@ -495,7 +496,8 @@ const sendWorkspaceMessage = async (
         agentFrameworkId: input.agentFrameworkId,
         agentBackendId: input.agentBackendId,
         agentModel: input.agentModel,
-        agentConfiguration: input.agentConfiguration
+        agentConfiguration: input.agentConfiguration,
+        preserveSelection: input.preserveSelection
       })
       if (!appended) return undefined
       startPendingPrompt(
@@ -575,7 +577,8 @@ const sendWorkspaceMessage = async (
       agentFrameworkId: prepared.appendOwnership.agentFrameworkId,
       agentBackendId: prepared.appendOwnership.agentBackendId,
       agentModel: input.agentModel,
-      agentConfiguration: input.agentConfiguration
+      agentConfiguration: input.agentConfiguration,
+      preserveSelection: input.preserveSelection
     })
     if (!appended) return undefined
     const replay = prepared.replay()

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { JobSummary } from '../../../../shared/compute'
+import type { PersistedChatSession } from '../../../../shared/session-persistence'
 import { createInitialSessionJobState, useSessionJobStore } from '../../stores/session-job-store'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
 import { useJobAnalysisEffect } from './useJobAnalysisEffect'
@@ -40,6 +41,7 @@ describe('useJobAnalysisEffect persistence readiness', () => {
   const jobsPendingNotification = vi.fn().mockResolvedValue([makeCompletedJob()])
   const jobsMarkConsumed = vi.fn().mockResolvedValue(undefined)
   const jobsList = vi.fn().mockResolvedValue([])
+  const loadOne = vi.fn().mockResolvedValue(undefined)
 
   type AnalysisSendMessage = Parameters<typeof useJobAnalysisEffect>[0]['sendMessage']
 
@@ -62,18 +64,34 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     jobsPendingNotification.mockClear()
     jobsMarkConsumed.mockClear()
     jobsList.mockClear()
+    loadOne.mockReset().mockResolvedValue(undefined)
     useSessionJobStore.setState({
       ...createInitialSessionJobState(),
       hydratedSessionId: 'session-1',
       isLoaded: true
     })
-    useSessionStore.setState(createInitialSessionState())
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-a',
+          title: 'Ready',
+          cwd: '/workspace/project-a',
+          status: 'idle',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
     window.api = {
       compute: {
         jobsPendingNotification,
         jobsMarkConsumed,
         jobsList
-      }
+      },
+      sessions: { loadOne }
     } as unknown as Window['api']
   })
 
@@ -231,20 +249,58 @@ describe('useJobAnalysisEffect persistence readiness', () => {
   })
 
   it('recovers pending analysis across all Sessions from the App-level owner', async () => {
+    const persistedBackground: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-a',
+      title: 'Background Session',
+      cwd: '/workspace/project-a',
+      status: 'idle',
+      agentFrameworkId: 'claude-code',
+      agentConfiguration: {
+        providerId: 'session-provider',
+        model: 'session-model',
+        reasoningEffort: 'high'
+      },
+      messages: [
+        {
+          id: 'earlier-message',
+          role: 'user',
+          content: 'Earlier question',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 2
+    }
+    loadOne.mockResolvedValueOnce(persistedBackground)
     useSessionStore.setState({
-      ...createInitialSessionState(),
       sessions: [
+        {
+          id: 'visible-session',
+          projectId: 'project-a',
+          title: 'Visible Session',
+          cwd: '/workspace/visible',
+          status: 'idle',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 3
+        },
         {
           id: 'session-1',
           projectId: 'project-a',
           title: 'Background Session',
-          cwd: '/workspace/project-a',
+          cwd: '',
           status: 'idle',
           messages: [],
           createdAt: 1,
-          updatedAt: 1
+          updatedAt: 2,
+          contentLoaded: false
         }
-      ]
+      ],
+      selectedSessionId: 'visible-session'
     })
 
     await act(async () => {
@@ -253,13 +309,25 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     })
 
     expect(jobsPendingNotification).toHaveBeenCalledWith({ allSessions: true })
+    expect(loadOne).toHaveBeenCalledWith({ projectId: 'project-a', sessionId: 'session-1' })
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'session-1',
         cwd: '/workspace/project-a',
-        projectId: 'project-a'
+        projectId: 'project-a',
+        preserveSelection: true
       })
     )
+    expect(useSessionStore.getState().selectedSessionId).toBe('visible-session')
+    const hydratedBackground = useSessionStore
+      .getState()
+      .sessions.find((session) => session.id === 'session-1')
+    expect(hydratedBackground?.contentLoaded).not.toBe(false)
+    expect(hydratedBackground).toMatchObject({
+      cwd: '/workspace/project-a',
+      agentConfiguration: persistedBackground.agentConfiguration,
+      messages: [{ id: 'earlier-message', content: 'Earlier question' }]
+    })
   })
 
   it('adds pending-scan jobs to the local store before dispatching analysis', async () => {

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
@@ -106,7 +106,7 @@ describe('useJobAnalysisEffect persistence readiness', () => {
       root.render(<Probe enabled />)
       await Promise.resolve()
     })
-    expect(jobsPendingNotification).toHaveBeenCalledWith('session-1')
+    expect(jobsPendingNotification).toHaveBeenCalledWith({ allSessions: true })
 
     await act(async () => root.render(<Probe enabled={false} />))
     await act(async () => {
@@ -226,8 +226,40 @@ describe('useJobAnalysisEffect persistence readiness', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    expect(jobsPendingNotification).toHaveBeenCalledWith('session-1')
+    expect(jobsPendingNotification).toHaveBeenCalledWith({ allSessions: true })
     expect(sendMessage).toHaveBeenCalledOnce()
+  })
+
+  it('recovers pending analysis across all Sessions from the App-level owner', async () => {
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-a',
+          title: 'Background Session',
+          cwd: '/workspace/project-a',
+          status: 'idle',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<Probe enabled />)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(jobsPendingNotification).toHaveBeenCalledWith({ allSessions: true })
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        cwd: '/workspace/project-a',
+        projectId: 'project-a'
+      })
+    )
   })
 
   it('adds pending-scan jobs to the local store before dispatching analysis', async () => {

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
@@ -1,17 +1,18 @@
 // useJobAnalysisEffect — wires the job-analysis-trigger into the React component tree.
 //
-// Called from WorkspacePage (which owns `sendMessage` from useWorkspaceAgentRuntime).
-// On every `compute:job-updated` broadcast AND once at session hydration time,
+// Owned by the App-level runtime bridge so analysis survives navigation away from Workspace.
+// On every `compute:job-updated` broadcast AND once after App persistence recovery,
 // the trigger is fed the job summary and decides whether to fire / queue an analysis turn.
 //
 // Design decisions:
 // - One readiness-scoped effect owns the trigger and every subscription so delayed work cannot cross
 //   a persistence recovery boundary.
 // - `isSessionInFlight` reads from useSessionStore.getState() synchronously — no subscription needed.
-// - The restart-recovery scan fires whenever the active session id changes (session navigation).
+// - The restart-recovery scan covers every persisted Session from the App-lifetime owner.
 
 import { useEffect, useEffectEvent } from 'react'
 
+import { useWorkspaceAgentRuntime } from '../acp/useWorkspaceAgentRuntime'
 import { useSessionJobStore } from '../../stores/session-job-store'
 import { useSessionStore } from '../../stores/session-store'
 import { createJobAnalysisTrigger } from '../compute/job-analysis-trigger'
@@ -20,6 +21,8 @@ import { createJobAnalysisTrigger } from '../compute/job-analysis-trigger'
 type SendMessageFn = (input: {
   sessionId?: string
   text: string
+  cwd?: string
+  projectId?: string
 }) => Promise<{ sessionId: string; messageId: string } | undefined>
 
 type UseJobAnalysisEffectOptions = {
@@ -28,7 +31,7 @@ type UseJobAnalysisEffectOptions = {
 }
 
 // Subscribes to all done-state compute:job-updated broadcasts and runs the analysis turn trigger.
-// Also scans for pending notifications on session load (restart recovery path).
+// Also scans every Session for pending notifications on startup (restart recovery path).
 export const useJobAnalysisEffect = ({
   enabled,
   sendMessage
@@ -54,7 +57,15 @@ export const useJobAnalysisEffect = ({
       },
       sendPrompt: async (sessionId, text) => {
         if (!isActive) return undefined
-        return sendLatestMessage({ sessionId, text })
+        const session = useSessionStore
+          .getState()
+          .sessions.find((candidate) => candidate.id === sessionId)
+        return sendLatestMessage({
+          sessionId,
+          text,
+          cwd: session?.cwd,
+          projectId: session?.projectId
+        })
       },
       markConsumed: async (sessionId, jobIds) => {
         if (!isActive) return
@@ -100,39 +111,34 @@ export const useJobAnalysisEffect = ({
       }
     }
 
-    const scanPendingJobs = (sessionId: string | undefined, retryDelay = 1_000): void => {
-      if (!sessionId) return
+    const scanPendingJobs = (retryDelay = 1_000): void => {
       if (typeof window.api?.compute?.jobsPendingNotification !== 'function') return
-      if (useSessionJobStore.getState().hydratedSessionId !== sessionId) return
       clearTimeout(pendingScanRetry)
       pendingScanRetry = undefined
 
       void window.api.compute
-        .jobsPendingNotification(sessionId)
+        .jobsPendingNotification({ allSessions: true })
         .then((jobs) => {
           if (!isActive) return
           const jobStore = useSessionJobStore.getState()
           for (const job of jobs) jobStore.applyUpdate(job)
         })
         .catch((error) => {
-          if (!isActive || useSessionJobStore.getState().hydratedSessionId !== sessionId) return
+          if (!isActive) return
           console.warn('[compute] analysis-turn:pending-scan-failed', error)
           pendingScanRetry = setTimeout(() => {
             pendingScanRetry = undefined
-            scanPendingJobs(sessionId, Math.min(retryDelay * 2, 30_000))
+            scanPendingJobs(Math.min(retryDelay * 2, 30_000))
           }, retryDelay)
         })
     }
 
     const initialState = useSessionJobStore.getState()
     feedNotifiedJobs(initialState)
-    scanPendingJobs(initialState.hydratedSessionId)
+    scanPendingJobs()
 
-    const unsubscribeJobs = useSessionJobStore.subscribe((state, previousState) => {
+    const unsubscribeJobs = useSessionJobStore.subscribe((state) => {
       feedNotifiedJobs(state)
-      if (state.hydratedSessionId !== previousState.hydratedSessionId) {
-        scanPendingJobs(state.hydratedSessionId)
-      }
     })
 
     return () => {
@@ -144,3 +150,11 @@ export const useJobAnalysisEffect = ({
     }
   }, [enabled])
 }
+
+const JobAnalysisRuntimeBridge = ({ enabled }: { enabled: boolean }): null => {
+  const runtime = useWorkspaceAgentRuntime()
+  useJobAnalysisEffect({ enabled, sendMessage: runtime.sendMessage })
+  return null
+}
+
+export { JobAnalysisRuntimeBridge }

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
@@ -13,6 +13,10 @@
 import { useEffect, useEffectEvent } from 'react'
 
 import { useWorkspaceAgentRuntime } from '../acp/useWorkspaceAgentRuntime'
+import {
+  hydratePersistedSessionIfPresent,
+  loadPersistedSession
+} from '../session-persistence/session-persistence'
 import { useSessionJobStore } from '../../stores/session-job-store'
 import { useSessionStore } from '../../stores/session-store'
 import { createJobAnalysisTrigger } from '../compute/job-analysis-trigger'
@@ -23,6 +27,7 @@ type SendMessageFn = (input: {
   text: string
   cwd?: string
   projectId?: string
+  preserveSelection?: boolean
 }) => Promise<{ sessionId: string; messageId: string } | undefined>
 
 type UseJobAnalysisEffectOptions = {
@@ -57,14 +62,25 @@ export const useJobAnalysisEffect = ({
       },
       sendPrompt: async (sessionId, text) => {
         if (!isActive) return undefined
-        const session = useSessionStore
+        let session = useSessionStore
           .getState()
           .sessions.find((candidate) => candidate.id === sessionId)
+        if (!session) return undefined
+        if (session.contentLoaded === false) {
+          const persisted = await loadPersistedSession({
+            projectId: session.projectId,
+            sessionId
+          })
+          if (!isActive || !persisted) return undefined
+          session = hydratePersistedSessionIfPresent(persisted)
+          if (!session) return undefined
+        }
         return sendLatestMessage({
           sessionId,
           text,
-          cwd: session?.cwd,
-          projectId: session?.projectId
+          cwd: session.cwd,
+          projectId: session.projectId,
+          preserveSelection: true
         })
       },
       markConsumed: async (sessionId, jobIds) => {

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { JobSummary } from '../../../../shared/compute'
 import type { ProjectFilesChangedEvent } from '../../../../shared/project-files'
 import type { Project } from '../../../../shared/projects'
 import type { EnvironmentCheckResult } from '../../../../shared/settings'
@@ -10,6 +11,7 @@ import type { ActivePlanProjection } from '../../../../shared/session-plan/contr
 import { EMPTY_SNAPSHOT, useNotificationInboxStore } from '@/stores/notification-inbox-store'
 import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
 import { useNavigationStore } from '@/stores/navigation-store'
+import { createInitialSessionJobState, useSessionJobStore } from '@/stores/session-job-store'
 import {
   createInitialSessionState,
   type ChatSession,
@@ -60,6 +62,29 @@ const session = (
     : {}),
   createdAt: updatedAt,
   updatedAt
+})
+
+const computeJob = (
+  sessionId: string,
+  status: Extract<JobSummary['status'], 'queued' | 'submitted' | 'running'>
+): JobSummary => ({
+  job_id: `job-${status}`,
+  provider_id: 'ssh:cluster',
+  display_name: 'Cluster',
+  shape: 'direct_ssh',
+  session_id: sessionId,
+  status,
+  intent: 'Run remote analysis',
+  created_at: 500_000,
+  started_at: status === 'running' ? 510_000 : undefined,
+  finished_at: undefined,
+  exit_code: undefined,
+  error_code: undefined,
+  remote_workdir: undefined,
+  stdout_tail: undefined,
+  stderr_tail: undefined,
+  notified_at: undefined,
+  notification_consumed_at: undefined
 })
 
 const pendingPlan: ActivePlanProjection = {
@@ -342,6 +367,7 @@ beforeEach(() => {
   })
   useProjectStore.setState(createInitialProjectState())
   useNavigationStore.setState({ pendingProjectCreation: false })
+  useSessionJobStore.setState(createInitialSessionJobState())
   useSessionStore.setState(createInitialSessionState())
   useSettingsStore.setState(createInitialSettingsState())
   useNotificationInboxStore.setState({
@@ -1111,6 +1137,53 @@ describe('HomePage activity overview', () => {
       container.querySelector('[aria-label="Open session Delegated runs, completed"]')
     ).toBeNull()
   })
+
+  it.each(['queued', 'submitted', 'running'] as const)(
+    'shows Running instead of an unread completion while remote compute is %s',
+    async (status) => {
+      const candidate = session('remote-compute', 'Remote analysis', 'idle', 590_000)
+      useProjectStore.setState({
+        ...createInitialProjectState(),
+        projects: [project],
+        isLoaded: true
+      })
+      useSessionStore.setState({ ...createInitialSessionState(), sessions: [candidate] })
+      useSessionJobStore.getState().applyUpdate(computeJob(candidate.id, status))
+      useNotificationInboxStore.setState({
+        revision: 1,
+        unreadCount: 1,
+        latestSequence: 1,
+        status: 'ready',
+        items: [
+          {
+            id: 'completed-while-compute-active',
+            sequence: 1,
+            dedupeKey: 'task:completed:remote-compute',
+            kind: 'task.completed',
+            projectId: project.id,
+            sessionId: candidate.id,
+            originId: 'root-run',
+            title: candidate.title,
+            summary: 'The foreground turn completed.',
+            createdAt: 590_000
+          }
+        ]
+      })
+
+      await act(async () =>
+        root.render(
+          <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+        )
+      )
+
+      expect(
+        container.querySelector('[aria-label="Open session Remote analysis, completed"]')
+      ).toBeNull()
+      expect(
+        container.querySelector('[aria-label="Open session Remote analysis, running"]')
+      ).not.toBeNull()
+    }
+  )
 
   it('keeps inactive-branch delegated work Running until its current Attempt becomes terminal', async () => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(600_000)

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useNotificationInboxStore } from '@/stores/notification-inbox-store'
+import { useSessionJobStore } from '@/stores/session-job-store'
 import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 import { useProjectStore } from '@/stores/project-store'
@@ -114,17 +115,21 @@ const getRequiredEnvironmentFailures = (
   environment: EnvironmentCheckResult | undefined
 ): EnvironmentCheckItem[] => environment?.checks.filter((check) => check.status === 'failed') ?? []
 
-const getHomeSessionActivity = (session: ChatSession): HomeSessionActivity | undefined => {
+const getHomeSessionActivity = (
+  session: ChatSession,
+  hasNonTerminalCompute: boolean
+): HomeSessionActivity | undefined => {
   const actionability = projectPresentedSessionActionability(session)
   if (actionability.waitReason) return actionability.waitReason
-  if (actionability.activity === 'running') return 'running'
+  if (actionability.activity === 'running' || hasNonTerminalCompute) return 'running'
   return undefined
 }
 
-const getRunningActivityTimestamp = (session: ChatSession): number => {
+const getRunningActivityTimestamp = (session: ChatSession, computeStartedAt?: number): number => {
   const candidates = [
     session.status === 'running' ? session.activeRun?.startedAt : undefined,
-    earliestCurrentDelegatedAttemptStartedAt(session)
+    earliestCurrentDelegatedAttemptStartedAt(session),
+    computeStartedAt
   ].filter((value): value is number => value !== undefined)
   return candidates.length > 0
     ? Math.min(...candidates)
@@ -176,6 +181,7 @@ const HomePage = ({
   const updateProjectArchive = useProjectStore((state) => state.updateProjectArchive)
   const deleteProject = useProjectStore((state) => state.deleteProject)
   const sessions = useSessionStore((state) => state.sessions)
+  const computeJobsById = useSessionJobStore((state) => state.jobsById)
   const notificationItems = useNotificationInboxStore((state) => state.items)
   const markSessionCompletionsRead = useNotificationInboxStore(
     (state) => state.markSessionCompletionsRead
@@ -248,9 +254,26 @@ const HomePage = ({
     return completedBySession
   }, [notificationItems])
 
+  const activeComputeStartedAtBySession = useMemo(() => {
+    const startedAtBySession = new Map<string, number>()
+
+    for (const job of computeJobsById.values()) {
+      if (job.status !== 'queued' && job.status !== 'submitted' && job.status !== 'running')
+        continue
+      const startedAt = job.started_at ?? job.created_at
+      startedAtBySession.set(
+        job.session_id,
+        Math.min(startedAtBySession.get(job.session_id) ?? startedAt, startedAt)
+      )
+    }
+
+    return startedAtBySession
+  }, [computeJobsById])
+
   const sessionUpdates = useMemo<HomeSessionUpdate[]>(() => {
     const updates = persistedSessions.flatMap<HomeSessionUpdate>((session) => {
-      const activity = getHomeSessionActivity(session)
+      const computeStartedAt = activeComputeStartedAtBySession.get(session.id)
+      const activity = getHomeSessionActivity(session, computeStartedAt !== undefined)
 
       if (activity) {
         return [
@@ -259,7 +282,7 @@ const HomePage = ({
             activity,
             activityTimestamp: isSessionWaitReason(activity)
               ? session.updatedAt
-              : getRunningActivityTimestamp(session)
+              : getRunningActivityTimestamp(session, computeStartedAt)
           }
         ]
       }
@@ -282,7 +305,7 @@ const HomePage = ({
           (isSessionWaitReason(right.activity) ? 0 : right.activity === 'running' ? 1 : 2) ||
         right.activityTimestamp - left.activityTimestamp
     )
-  }, [persistedSessions, unreadCompletedBySession])
+  }, [activeComputeStartedAtBySession, persistedSessions, unreadCompletedBySession])
 
   const activeSessionCounts = useMemo(
     () => ({
@@ -311,10 +334,15 @@ const HomePage = ({
         project,
         sessionCount: projectSessions.length,
         runningCount: projectSessions.filter(
-          (session) => getHomeSessionActivity(session) === 'running'
+          (session) =>
+            getHomeSessionActivity(session, activeComputeStartedAtBySession.has(session.id)) ===
+            'running'
         ).length,
         waitingCount: projectSessions.filter((session) => {
-          const activity = getHomeSessionActivity(session)
+          const activity = getHomeSessionActivity(
+            session,
+            activeComputeStartedAtBySession.has(session.id)
+          )
           return activity !== undefined && isSessionWaitReason(activity)
         }).length,
         lastActivityAt
@@ -326,7 +354,7 @@ const HomePage = ({
         Number(Boolean(right.project.pinned)) - Number(Boolean(left.project.pinned)) ||
         right.lastActivityAt - left.lastActivityAt
     )
-  }, [activeProjects, persistedSessions])
+  }, [activeComputeStartedAtBySession, activeProjects, persistedSessions])
 
   const recentSessions = useMemo(
     () =>
@@ -422,7 +450,8 @@ const HomePage = ({
     !sessions.some(
       (session) =>
         session.projectId === project.id &&
-        projectPresentedSessionActionability(session).activity !== 'inactive'
+        getHomeSessionActivity(session, activeComputeStartedAtBySession.has(session.id)) !==
+          undefined
     )
 
   const archiveUnavailableReason = (project: Project): string | undefined => {

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -181,7 +181,7 @@ const HomePage = ({
   const updateProjectArchive = useProjectStore((state) => state.updateProjectArchive)
   const deleteProject = useProjectStore((state) => state.deleteProject)
   const sessions = useSessionStore((state) => state.sessions)
-  const computeJobsById = useSessionJobStore((state) => state.jobsById)
+  const computeJobsById = useSessionJobStore((state) => state.nonTerminalJobsById)
   const notificationItems = useNotificationInboxStore((state) => state.items)
   const markSessionCompletionsRead = useNotificationInboxStore(
     (state) => state.markSessionCompletionsRead

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -60,7 +60,6 @@ import { useProjectFormDialog } from '@/hooks/useProjectFormDialog'
 import { ProjectFormDialog } from '../home/ProjectFormDialog'
 import { getVisiblePermissionRequests } from './session-permissions'
 import { WorkspaceSidebarContainer } from './WorkspaceSidebarContainer'
-import { useJobAnalysisEffect } from '@/lib/compute/useJobAnalysisEffect'
 import { WorkspacePanelLayout } from './workspace-panel-layout'
 import { useWorkspaceComposerController } from './workspace-composer-controller'
 import { useWorkspaceConversationController } from './workspace-conversation-controller'
@@ -216,8 +215,6 @@ const WorkspacePage = ({
   } = runtime
   const { respondToElicitation } = useWorkspaceElicitation(runtime.resolveSessionRuntimeSelection)
 
-  // Auto-trigger an analysis turn when a remote job finishes (design §11).
-  useJobAnalysisEffect({ enabled: isSessionPersistenceReady, sendMessage: runtime.sendMessage })
   const [newConversationPermissionProfile, setNewConversationPermissionProfile] =
     useState<PermissionProfileId>(defaultPermissionProfile)
   // Draft auto-review state for a not-yet-created conversation. Auto-review defaults off, so a new

--- a/src/renderer/src/stores/session-job-store.test.ts
+++ b/src/renderer/src/stores/session-job-store.test.ts
@@ -110,6 +110,50 @@ describe('session job store — hydrate', () => {
   })
 })
 
+describe('session job store — global activity projection', () => {
+  it('hydrates persisted non-terminal jobs across Sessions', async () => {
+    const jobs = [
+      makeJob({ job_id: 'job-a', session_id: 'session-a', status: 'queued' }),
+      makeJob({ job_id: 'job-b', session_id: 'session-b', status: 'running' })
+    ]
+    const jobsList = vi.fn().mockResolvedValue(jobs)
+    setJobsApi({ jobsList })
+
+    await useSessionJobStore.getState().hydrateNonTerminal()
+
+    const projection = useSessionJobStore.getState().nonTerminalJobsById
+    expect(jobsList).toHaveBeenCalledWith({ nonTerminal: true })
+    expect(Array.from(projection.values())).toEqual(jobs)
+  })
+
+  it('does not resurrect a job that becomes terminal while global hydration is pending', async () => {
+    let resolveHydration: ((jobs: JobSummary[]) => void) | undefined
+    setJobsApi({
+      jobsList: vi.fn(() => new Promise<JobSummary[]>((resolve) => (resolveHydration = resolve)))
+    })
+    const running = makeJob({ job_id: 'job-race', status: 'running' })
+
+    const hydration = useSessionJobStore.getState().hydrateNonTerminal()
+    useSessionJobStore.getState().applyUpdate({ ...running, status: 'success' })
+    resolveHydration?.([running])
+    await hydration
+
+    expect(useSessionJobStore.getState().nonTerminalJobsById.has('job-race')).toBe(false)
+  })
+
+  it('keeps global activity when a Workspace hydrates one Session history', async () => {
+    const active = makeJob({ job_id: 'global-job', session_id: 'other-session' })
+    setJobsApi({
+      jobsList: vi.fn().mockResolvedValueOnce([active]).mockResolvedValueOnce([])
+    })
+
+    await useSessionJobStore.getState().hydrateNonTerminal()
+    await useSessionJobStore.getState().hydrate('workspace-session')
+
+    expect(useSessionJobStore.getState().nonTerminalJobsById.get(active.job_id)).toEqual(active)
+  })
+})
+
 describe('session job store — applyUpdate', () => {
   it('inserts a new job into the map', () => {
     const job = makeJob({ job_id: 'job-x', status: 'running' })

--- a/src/renderer/src/stores/session-job-store.ts
+++ b/src/renderer/src/stores/session-job-store.ts
@@ -2,12 +2,16 @@ import { create } from 'zustand'
 
 import type { JobSummary } from '../../../shared/compute'
 
-// Session-scoped job feed store (renderer-only, never persisted).
-// Hydrates from compute:jobs:list once per session and stays fresh via compute:job-updated broadcasts.
-// The store is global so the App can subscribe to the broadcast once at startup.
+const isNonTerminal = (job: JobSummary): boolean =>
+  job.status === 'queued' || job.status === 'submitted' || job.status === 'running'
+
+// Renderer-only job projections, never persisted here: Workspace hydrates a Session history while
+// the App hydrates bounded cross-Session activity. Broadcasts keep both projections current.
 type SessionJobStoreData = {
   // All known jobs indexed by job_id for O(1) incremental updates.
   jobsById: Map<string, JobSummary>
+  // Persisted activity for every Session, hydrated once per renderer recovery cycle.
+  nonTerminalJobsById: Map<string, JobSummary>
   // Session id for which the initial list was last fetched.
   hydratedSessionId: string | undefined
   isLoaded: boolean
@@ -16,6 +20,8 @@ type SessionJobStoreData = {
 type SessionJobStore = SessionJobStoreData & {
   // Loads all jobs for a session from the main process (initial hydration).
   hydrate: (sessionId: string) => Promise<void>
+  // Loads the bounded cross-Session activity projection after app startup or recovery.
+  hydrateNonTerminal: () => Promise<void>
   // Applies an incremental update from the compute:job-updated broadcast.
   // Stored regardless of session match so cross-session jobs in the broadcast window aren't lost.
   applyUpdate: (job: JobSummary) => void
@@ -27,12 +33,14 @@ type SessionJobStore = SessionJobStoreData & {
 
 export const createInitialSessionJobState = (): SessionJobStoreData => ({
   jobsById: new Map(),
+  nonTerminalJobsById: new Map(),
   hydratedSessionId: undefined,
   isLoaded: false
 })
 
 export const useSessionJobStore = create<SessionJobStore>((set, get) => {
   let latestHydrationRequest = 0
+  let latestNonTerminalHydrationRequest = 0
   let latestUpdateRevision = 0
   const updateRevisionByJobId = new Map<string, number>()
 
@@ -72,14 +80,43 @@ export const useSessionJobStore = create<SessionJobStore>((set, get) => {
       })
     },
 
-    // Upserts a single job received via broadcast. Works even if the store has not been hydrated yet
-    // (the job simply lands in the map for when selectors query it).
+    hydrateNonTerminal: async () => {
+      const requestId = ++latestNonTerminalHydrationRequest
+      const startedAtUpdateRevision = latestUpdateRevision
+      const jobs = await window.api.compute.jobsList({ nonTerminal: true })
+      if (requestId !== latestNonTerminalHydrationRequest) return
+
+      set((state) => {
+        const next = new Map<string, JobSummary>()
+
+        for (const job of jobs) {
+          const updateRevision = updateRevisionByJobId.get(job.job_id)
+          if (updateRevision !== undefined && updateRevision > startedAtUpdateRevision) continue
+          next.set(job.job_id, job)
+        }
+
+        for (const [jobId, job] of state.nonTerminalJobsById) {
+          const updateRevision = updateRevisionByJobId.get(jobId)
+          if (updateRevision !== undefined && updateRevision > startedAtUpdateRevision) {
+            next.set(jobId, job)
+          }
+        }
+
+        return { nonTerminalJobsById: next }
+      })
+    },
+
+    // Upserts Session history and adds/removes the job from the global activity projection. Works
+    // before either hydration so a startup broadcast cannot be lost to a later snapshot.
     applyUpdate: (job) => {
       updateRevisionByJobId.set(job.job_id, ++latestUpdateRevision)
       set((state) => {
         const next = new Map(state.jobsById)
+        const nextNonTerminal = new Map(state.nonTerminalJobsById)
         next.set(job.job_id, job)
-        return { jobsById: next }
+        if (isNonTerminal(job)) nextNonTerminal.set(job.job_id, job)
+        else nextNonTerminal.delete(job.job_id)
+        return { jobsById: next, nonTerminalJobsById: nextNonTerminal }
       })
     },
 

--- a/src/renderer/src/stores/session-store-message-graph-helpers.ts
+++ b/src/renderer/src/stores/session-store-message-graph-helpers.ts
@@ -44,6 +44,7 @@ export type AppendUserMessageInput = {
   specialistId?: string
   enabledComputeHosts?: string[]
   selectedComputeHosts?: string[]
+  preserveSelection?: boolean
 }
 
 export type AppendPendingUserMessageInput = Omit<AppendUserMessageInput, 'sessionId' | 'isPending'>

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -46,7 +46,6 @@ const createPendingSessionId = (): string => {
   pendingSessionSequence += 1
   return `pending-session-${Date.now()}-${pendingSessionSequence}`
 }
-
 const createSessionBranchSource = (
   source: ChatSession,
   headMessageId?: string
@@ -226,7 +225,8 @@ export const createSessionMessageGraphOwner = <
     isPending,
     specialistId,
     enabledComputeHosts,
-    selectedComputeHosts
+    selectedComputeHosts,
+    preserveSelection
   }) => {
     const trimmedContent = content.trim()
     const normalizedAgentBackendId = agentBackendId?.trim() || undefined
@@ -265,7 +265,7 @@ export const createSessionMessageGraphOwner = <
             )
           : [...existingSession.messages, userMessage]
       set({
-        selectedSessionId: sessionId,
+        selectedSessionId: preserveSelection ? state.selectedSessionId : sessionId,
         sessions: state.sessions.map((session) =>
           session.id === sessionId
             ? {
@@ -343,7 +343,7 @@ export const createSessionMessageGraphOwner = <
       )
 
       set({
-        selectedSessionId: sessionId,
+        selectedSessionId: preserveSelection ? state.selectedSessionId : sessionId,
         sessions: [newSession, ...state.sessions]
       } as Partial<State>)
     }

--- a/src/shared/compute.ts
+++ b/src/shared/compute.ts
@@ -438,3 +438,5 @@ export type JobSummary = {
 // cross-Session query used to hydrate renderer-lifetime activity after startup or recovery.
 export type ComputeJobsListFilter =
   Readonly<{ sessionId: string; status?: string[] }> | Readonly<{ nonTerminal: true }>
+
+export type ComputeJobsPendingNotificationFilter = string | Readonly<{ allSessions: true }>

--- a/src/shared/compute.ts
+++ b/src/shared/compute.ts
@@ -433,3 +433,8 @@ export type JobSummary = {
   left_on_remote?: Array<{ uri: string; size_mb: number; reason: string }>
   harvest_error?: string
 }
+
+// The existing per-Session feed supports workspace history. The non-terminal variant is a bounded
+// cross-Session query used to hydrate renderer-lifetime activity after startup or recovery.
+export type ComputeJobsListFilter =
+  Readonly<{ sessionId: string; status?: string[] }> | Readonly<{ nonTerminal: true }>


### PR DESCRIPTION
## Problem

An Agent turn can end while a Session-owned remote Compute Job is still queued, submitted, or running. The foreground `end_turn` was immediately recorded as `task.completed`, so Home presented the idle Session as Completed even though the remote workflow was still active and would later start an automatic result-analysis turn.

Closes #1801.

## Proposed change

- project non-terminal Compute Jobs as Running in the existing Home Session activity view;
- prefer that live activity over an unread historical completion notification;
- defer `task.completed` inbox and desktop notifications while the Session owns a non-terminal Compute Job;
- use the existing `ComputeJob` repository and renderer job feed without adding persisted state.

## Scope and non-goals

- no Prisma schema or migration changes;
- no new Session status or Compute Job status values;
- no new renderer-facing command/event contract;
- no change to Session archive or application-quit behavior;
- no framework-, provider-, model-, or operating-system-specific ACP behavior.

## Acceptance criteria and validation

The regression tests were added before the implementation. On the unfixed code, the Home test failed consistently for queued, submitted, and running jobs because the Completed card remained visible, and the notification test failed because one Task completed notification was delivered.

Final evidence after the last material edit:

- Home activity and job-feed projection -> `node ../../node_modules/vitest/vitest.mjs run src/renderer/src/pages/home/HomePage.render.test.tsx src/renderer/src/stores/session-job-store.test.ts` -> 51 tests passed.
- completion notification gating -> `node ../../node_modules/vitest/vitest.mjs run src/main/notifications/task-notifications.test.ts` -> 72 tests passed.
- persisted non-terminal status query -> `node ../../node_modules/vitest/vitest.mjs run src/main/compute/job-repository.test.ts -t 'countNonTerminalBySession'` -> 1 test passed.
- Node process types -> `npm run typecheck:node` -> passed.
- renderer types -> `npm run typecheck:web` -> passed.
- lint -> `npm run lint` -> passed.
- changed-file formatting -> Prettier check -> passed.

The complete portable and platform suites are delegated to PR CI as requested. A live remote Compute Host E2E was not run locally; the deterministic public Home and notification boundaries reproduce the reported application-level behavior without depending on a provider, model, or operating system.

## Review focus

- the ordering of prompt-track settlement versus the asynchronous Compute Job activity query;
- fail-closed behavior when Compute Job activity cannot be read;
- Home precedence between waiting interactions, non-terminal remote compute, and unread completion outcomes.
