### PR TITLE
fix(workspace): close file preview with one shortcut

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -753,6 +753,20 @@ describe('App startup routing', () => {
     expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
   })
 
+  it('routes the close shortcut directly to the owned file preview modal', async () => {
+    mocks.settings.isLoaded = true
+    mocks.navigation.view = 'workspace'
+    mocks.preview.fileDialogItem = { id: 'previewed-file' }
+    const previewDialog = document.createElement('div')
+    previewDialog.setAttribute('role', 'dialog')
+    previewDialog.dataset.slot = 'file-preview-dialog'
+    document.body.appendChild(previewDialog)
+    await render()
+
+    expect(mocks.closeActiveModal.handler?.()).toBe('close-preview')
+    previewDialog.remove()
+  })
+
   it('does not open Settings under the active expanded preview modal', async () => {
     mocks.settings.isLoaded = true
     mocks.navigation.view = 'workspace'

--- a/src/renderer/src/app-shell-presentation-owner.test.ts
+++ b/src/renderer/src/app-shell-presentation-owner.test.ts
@@ -172,4 +172,16 @@ describe('App Shell presentation owner', () => {
     )
     nestedPresentation.remove()
   })
+
+  it('closes the preview directly when its owned file dialog is the only DOM presentation', () => {
+    const previewDialog = document.createElement('div')
+    previewDialog.setAttribute('role', 'dialog')
+    previewDialog.dataset.slot = 'file-preview-dialog'
+    document.body.appendChild(previewDialog)
+
+    expect(resolveAppShellPresentation(input({ preview: true })).resolveCloseAction().kind).toBe(
+      'close-preview'
+    )
+    previewDialog.remove()
+  })
 })

--- a/src/renderer/src/app-shell-presentation-owner.ts
+++ b/src/renderer/src/app-shell-presentation-owner.ts
@@ -57,15 +57,21 @@ const PRESENTATION_PRIORITY: ReadonlyArray<keyof AppShellPresentationState> = [
 ]
 
 const BLOCKING_DOM_PRESENTATION_SELECTOR = `[role="dialog"], [role="alertdialog"], [data-slot="context-window-dialog"], ${STREAMDOWN_FULLSCREEN_SELECTOR}`
+const FILE_PREVIEW_DIALOG_SELECTOR = '[data-slot="file-preview-dialog"]'
 
 const isEffectivelyOpen = (element: HTMLElement): boolean =>
   element.dataset.state !== 'closed' && element.closest('[aria-hidden="true"], [hidden]') === null
 
 const findTopmostDomPresentation = (
   root: ParentNode,
-  selector = BLOCKING_DOM_PRESENTATION_SELECTOR
+  ignoredSelector?: string
 ): HTMLElement | undefined =>
-  Array.from(root.querySelectorAll<HTMLElement>(selector)).filter(isEffectivelyOpen).at(-1)
+  Array.from(root.querySelectorAll<HTMLElement>(BLOCKING_DOM_PRESENTATION_SELECTOR))
+    .filter(
+      (element) =>
+        isEffectivelyOpen(element) && (!ignoredSelector || !element.matches(ignoredSelector))
+    )
+    .at(-1)
 
 const resolveActivePresentation = (input: AppShellPresentationInput): AppShellPresentation => {
   if (input.startupView !== 'app' || !input.isSessionPersistenceHydrated) return 'startup'
@@ -84,7 +90,7 @@ const closeActionFor = (active: AppShellPresentation, root: ParentNode): AppShel
   // Workspace dialogs and fullscreen viewers can be nested inside a preview modal. They own the
   // first close command; the preview state remains intact until the next command.
   if (active === 'preview') {
-    const nestedPresentation = findTopmostDomPresentation(root)
+    const nestedPresentation = findTopmostDomPresentation(root, FILE_PREVIEW_DIALOG_SELECTOR)
     return nestedPresentation
       ? { kind: 'dismiss-dom-presentation', target: nestedPresentation }
       : { kind: 'close-preview' }

--- a/src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx
+++ b/src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx
@@ -103,6 +103,9 @@ describe('FilePreviewDialog closing lifecycle', () => {
 
     expect(rootSpy).toHaveBeenCalledWith(expect.objectContaining({ modal: false }))
     expect(focusScopeSpy).toHaveBeenCalledWith({ trapped: true })
+    expect(contentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ 'data-slot': 'file-preview-dialog' })
+    )
 
     const onInteractOutside = contentSpy.mock.calls[0]?.[0].onInteractOutside as
       ((event: { preventDefault: () => void }) => void) | undefined

--- a/src/renderer/src/pages/workspace/FilePreviewDialog.tsx
+++ b/src/renderer/src/pages/workspace/FilePreviewDialog.tsx
@@ -95,6 +95,7 @@ const FilePreviewDialog = ({ item, onClose }: FilePreviewDialogProps): React.JSX
           className={`${dialogOverlayClassName} z-[60]`}
         />
         <Dialog.Content
+          data-slot="file-preview-dialog"
           aria-describedby={undefined}
           aria-modal="true"
           onInteractOutside={(event) => event.preventDefault()}


### PR DESCRIPTION
## Problem

When a file preview opened from message content automatically focused the Provenance action, its Tooltip could consume the synthetic Escape used by the Electron `Cmd/Ctrl+W` close routing. The file preview Dialog was classified as a nested presentation, so the first shortcut dismissed the Tooltip layer and a second shortcut was needed to close the preview.

## Proposed change

- Mark `FilePreviewDialog` as the preview-owned Dialog surface.
- Exclude that owned surface when the App Shell searches for presentations nested above an active preview.
- Continue to prioritize genuine nested dialogs, alert dialogs, Context windows, and Streamdown fullscreen surfaces.
- Add App Shell and Dialog lifecycle regression coverage for the ownership marker and close routing.

## Scope and non-goals

- No change to Tooltip keyboard accessibility or focus behavior.
- No change to Electron/preload shortcut contracts.
- No persisted-data, historical-compatibility, migration, or enum/state impact.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- File preview ownership and one-command close routing -> `../../node_modules/.bin/vitest run src/renderer/src/App.test.tsx src/renderer/src/app-shell-presentation-owner.test.ts src/renderer/src/app-shell-presentation-owner.architecture.test.ts src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts src/renderer/src/pages/workspace/FilePreviewDialog.escape.test.tsx src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx` -> 6 files, 102 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Impact explanation -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> full fallback because the App-level regression test is not assigned to a module owner; the complete local suite was intentionally not run, and exact-head PR Gate CI remains the final authority.

Uncovered local risk: the Electron UI journey was not run locally. The main-process shortcut forwarding path is unchanged; PR CI will provide the complete and platform-selected verification.

## Review focus

Please verify that `file-preview-dialog` is ignored only as the active preview's owned root while truly nested presentations retain first-close priority.
