### PR TITLE
feat(compute): enable Windows SSH password authentication

### DIFF
--- a/resources/compute-askpass-win.cjs
+++ b/resources/compute-askpass-win.cjs
@@ -1,0 +1,56 @@
+'use strict'
+
+// Windows OpenSSH starts SSH_ASKPASS as an executable and passes the prompt as argv[1]. Running the
+// app executable in Electron Node mode makes Node interpret that prompt as its script path, so this
+// preload completes the one-shot named-pipe exchange synchronously and exits before script loading.
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require('node:fs')
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('node:path')
+
+let descriptor
+let response = ''
+let password
+const buffer = Buffer.allocUnsafe(4096)
+
+try {
+  const socketPath = process.env.OPEN_SCIENCE_ASKPASS_SOCKET
+  const capability = process.env.OPEN_SCIENCE_ASKPASS_CAPABILITY
+  const promptArgument = process.argv[1] || ''
+  const prompt = path.isAbsolute(promptArgument)
+    ? path.relative(process.cwd(), promptArgument)
+    : promptArgument
+
+  if (!socketPath || !capability || !prompt) throw new Error('Missing askpass capability.')
+
+  descriptor = fs.openSync(socketPath, 'r+')
+  const request = Buffer.from(JSON.stringify({ capability, prompt }), 'utf8')
+  let written = 0
+  while (written < request.length) {
+    written += fs.writeSync(descriptor, request, written, request.length - written)
+  }
+  request.fill(0)
+
+  for (;;) {
+    const size = fs.readSync(descriptor, buffer, 0, buffer.length, null)
+    if (size === 0) break
+    response += buffer.subarray(0, size).toString('utf8')
+    buffer.fill(0, 0, size)
+  }
+
+  const parsed = JSON.parse(response)
+  if (typeof parsed.password !== 'string') throw new Error('Password unavailable.')
+  password = parsed.password
+} catch {
+  password = undefined
+} finally {
+  buffer.fill(0)
+  response = ''
+  if (descriptor !== undefined) fs.closeSync(descriptor)
+}
+
+if (password === undefined) process.exit(1)
+fs.writeSync(process.stdout.fd, password)
+password = ''
+process.exit(0)

--- a/resources/compute-askpass-win.cjs
+++ b/resources/compute-askpass-win.cjs
@@ -8,11 +8,14 @@
 const fs = require('node:fs')
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require('node:path')
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { StringDecoder } = require('node:string_decoder')
 
 let descriptor
 let response = ''
 let password
 const buffer = Buffer.allocUnsafe(4096)
+const decoder = new StringDecoder('utf8')
 
 try {
   const socketPath = process.env.OPEN_SCIENCE_ASKPASS_SOCKET
@@ -35,9 +38,10 @@ try {
   for (;;) {
     const size = fs.readSync(descriptor, buffer, 0, buffer.length, null)
     if (size === 0) break
-    response += buffer.subarray(0, size).toString('utf8')
+    response += decoder.write(buffer.subarray(0, size))
     buffer.fill(0, 0, size)
   }
+  response += decoder.end()
 
   const parsed = JSON.parse(response)
   if (typeof parsed.password !== 'string') throw new Error('Password unavailable.')

--- a/src/main/compute/compute-password-auth.architecture.test.ts
+++ b/src/main/compute/compute-password-auth.architecture.test.ts
@@ -70,11 +70,13 @@ describe('Compute password authentication release guards', () => {
     }
     expect(adapter).not.toContain('PASSWORD: password')
     expect(read('resources/compute-askpass.sh')).not.toMatch(/\$PASSWORD|%PASSWORD%/)
+    expect(read('resources/compute-askpass-win.cjs')).not.toMatch(/\$PASSWORD|%PASSWORD%/)
   })
 
   it('ships the constrained askpass helper outside the archive', () => {
     expect(read('electron-builder.yml')).toContain('- resources/**')
     expect(read('resources/compute-askpass.cjs')).toContain('OPEN_SCIENCE_ASKPASS_CAPABILITY')
+    expect(read('resources/compute-askpass-win.cjs')).toContain('OPEN_SCIENCE_ASKPASS_CAPABILITY')
   })
 
   it('routes the complete Compute Job lifecycle through the connection Broker', () => {

--- a/src/main/compute/connection-adapters.ts
+++ b/src/main/compute/connection-adapters.ts
@@ -193,7 +193,14 @@ const askpassBaseEnvironment = (): NodeJS.ProcessEnv => {
     'TMPDIR',
     'TMP',
     'TEMP',
-    'XDG_CONFIG_HOME'
+    'XDG_CONFIG_HOME',
+    'SystemRoot',
+    'WINDIR',
+    'USERPROFILE',
+    'HOMEDRIVE',
+    'HOMEPATH',
+    'APPDATA',
+    'LOCALAPPDATA'
   ]) {
     const value = process.env[name]
     if (value !== undefined) result[name] = value
@@ -205,20 +212,23 @@ const createAskpassEnvironment = async (
   password: string,
   expectedAccounts: readonly string[] = []
 ): Promise<AskpassEnvironment> => {
-  if (platform() === 'win32') throw new ComputeConnectionError('unsupported_auth_configuration')
+  const currentPlatform = platform()
   const capability = randomUUID()
-  const socketPath = join(tmpdir(), `os-askpass-${randomUUID()}.sock`)
+  const socketPath =
+    currentPlatform === 'win32'
+      ? `\\\\.\\pipe\\open-science-askpass-${randomUUID()}`
+      : join(tmpdir(), `os-askpass-${randomUUID()}.sock`)
   let answered = false
   let unsupportedPromptRejected = false
   const server = createServer((socket) => {
     let request = ''
+    let responded = false
     socket.setEncoding('utf8')
     socket.on('data', (chunk) => {
       request += chunk
-    })
-    socket.on('end', () => {
       try {
         const payload = JSON.parse(request) as { capability?: string; prompt?: string }
+        responded = true
         const prompt = payload.prompt ?? ''
         const rejected = /passphrase|keyboard|interactive|verification|one[- ]?time|otp|mfa|proxy/i
         const targetPasswordPrompt = expectedAccounts.some((account) =>
@@ -236,40 +246,57 @@ const createAskpassEnvironment = async (
         answered = true
         socket.end(JSON.stringify({ password }))
       } catch {
-        socket.end('{}')
+        // A request may arrive in multiple chunks. Wait for the complete JSON payload.
       }
+    })
+    socket.on('end', () => {
+      if (!responded) socket.end('{}')
     })
   })
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject)
     server.listen(socketPath, resolve)
   })
-  try {
-    await chmod(socketPath, 0o600)
-  } catch {
-    await new Promise<void>((resolve) => server.close(() => resolve()))
-    await rm(socketPath, { force: true })
-    throw new ComputeConnectionError('credential_unavailable')
+  if (currentPlatform !== 'win32') {
+    try {
+      await chmod(socketPath, 0o600)
+    } catch {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(socketPath, { force: true })
+      throw new ComputeConnectionError('credential_unavailable')
+    }
+  }
+  const sharedEnvironment = {
+    ...askpassBaseEnvironment(),
+    LANG: 'C',
+    LC_ALL: 'C',
+    SSH_ASKPASS_REQUIRE: 'force',
+    OPEN_SCIENCE_ASKPASS_SOCKET: socketPath,
+    OPEN_SCIENCE_ASKPASS_CAPABILITY: capability,
+    ELECTRON_RUN_AS_NODE: '1'
   }
   return {
-    env: {
-      ...askpassBaseEnvironment(),
-      LANG: 'C',
-      LC_ALL: 'C',
-      DISPLAY: process.env.DISPLAY || 'open-science-askpass',
-      SSH_ASKPASS_REQUIRE: 'force',
-      SSH_ASKPASS: askpassResourcePath('compute-askpass.sh'),
-      OPEN_SCIENCE_ASKPASS_RUNTIME: process.execPath,
-      OPEN_SCIENCE_ASKPASS_MODULE: askpassResourcePath('compute-askpass.cjs'),
-      OPEN_SCIENCE_ASKPASS_SOCKET: socketPath,
-      OPEN_SCIENCE_ASKPASS_CAPABILITY: capability,
-      ELECTRON_RUN_AS_NODE: '1'
-    },
+    env:
+      currentPlatform === 'win32'
+        ? {
+            ...sharedEnvironment,
+            SSH_ASKPASS: process.execPath,
+            NODE_OPTIONS: `--require=${JSON.stringify(
+              askpassResourcePath('compute-askpass-win.cjs')
+            )}`
+          }
+        : {
+            ...sharedEnvironment,
+            DISPLAY: process.env.DISPLAY || 'open-science-askpass',
+            SSH_ASKPASS: askpassResourcePath('compute-askpass.sh'),
+            OPEN_SCIENCE_ASKPASS_RUNTIME: process.execPath,
+            OPEN_SCIENCE_ASKPASS_MODULE: askpassResourcePath('compute-askpass.cjs')
+          },
     wasAnswered: () => answered,
     wasUnsupportedPromptRejected: () => unsupportedPromptRejected,
     dispose: async () => {
       await new Promise<void>((resolve) => server.close(() => resolve()))
-      await rm(socketPath, { force: true })
+      if (currentPlatform !== 'win32') await rm(socketPath, { force: true })
     }
   }
 }

--- a/src/main/compute/connection-broker.test.ts
+++ b/src/main/compute/connection-broker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { spawn } from 'node:child_process'
 import { createConnection } from 'node:net'
 import { platform } from 'node:os'
 
@@ -31,7 +32,7 @@ const target: ResolvedSshTarget = {
   extraArgs: ['-o', 'BatchMode=yes']
 }
 
-const unixSocketAskpass = it.skipIf(platform() === 'win32')
+const socketAskpass = it
 
 const answeredAskpass = (): {
   env: NodeJS.ProcessEnv
@@ -67,17 +68,57 @@ const askAskpass = (env: NodeJS.ProcessEnv, prompt: string): Promise<Record<stri
 
 describe('ComputeConnectionBroker SSH configuration compatibility', () => {
   it.runIf(platform() === 'win32')(
-    'rejects Unix-socket askpass construction on Windows',
+    'returns one matching password through the constrained Windows askpass helper',
     async () => {
-      await expect(
-        createAskpassEnvironment('must-not-open-a-socket', ['researcher@cluster'])
-      ).rejects.toMatchObject({
-        code: 'unsupported_auth_configuration'
-      })
+      const secret = 'Windows askpass secret "quoted" Unicode 密码'
+      vi.stubEnv('OPEN_SCIENCE_RELEASE_GATE_SECRET', secret)
+      const askpass = await createAskpassEnvironment(secret, ['researcher@cluster'])
+      const invoke = (
+        prompt: string
+      ): Promise<{ code: number | null; stdout: string; stderr: string }> =>
+        new Promise((resolve, reject) => {
+          const child = spawn(askpass.env['SSH_ASKPASS'] as string, [prompt], {
+            env: askpass.env,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            windowsHide: true
+          })
+          let stdout = ''
+          let stderr = ''
+          child.stdout.setEncoding('utf8')
+          child.stderr.setEncoding('utf8')
+          child.stdout.on('data', (chunk) => {
+            stdout += chunk
+          })
+          child.stderr.on('data', (chunk) => {
+            stderr += chunk
+          })
+          child.once('error', reject)
+          child.once('close', (code) => resolve({ code, stdout, stderr }))
+        })
+
+      try {
+        expect(askpass.env['OPEN_SCIENCE_RELEASE_GATE_SECRET']).toBeUndefined()
+        expect(JSON.stringify(askpass.env)).not.toContain(secret)
+        expect(askpass.env['OPEN_SCIENCE_ASKPASS_SOCKET']).toMatch(/^\\\\\.\\pipe\\/)
+        expect(askpass.env['SSH_ASKPASS']).toBe(process.execPath)
+        expect(askpass.env['NODE_OPTIONS']).toContain('compute-askpass-win.cjs')
+
+        await expect(invoke("researcher@cluster's password:")).resolves.toEqual({
+          code: 0,
+          stdout: secret,
+          stderr: ''
+        })
+        expect(askpass.wasAnswered()).toBe(true)
+
+        await expect(invoke("researcher@cluster's password:")).resolves.toMatchObject({ code: 1 })
+        expect(askpass.wasUnsupportedPromptRejected?.()).toBe(true)
+      } finally {
+        await askpass.dispose()
+      }
     }
   )
 
-  unixSocketAskpass(
+  socketAskpass(
     'does not inherit unrelated process environment values into the askpass child',
     async () => {
       const distinctiveSecret = 'release gate secret "quoted"\nUnicode 密码'
@@ -1268,7 +1309,7 @@ describe('ComputeConnectionBroker SSH configuration compatibility', () => {
     )
   })
 
-  unixSocketAskpass(
+  socketAskpass(
     'fails closed after rejecting any interactive variant or repeated target prompt',
     async () => {
       const secret = 'distinctive target-only secret'
@@ -1327,7 +1368,7 @@ describe('ComputeConnectionBroker SSH configuration compatibility', () => {
     }
   )
 
-  unixSocketAskpass.each([
+  socketAskpass.each([
     ['passphrase', ["Enter passphrase for key '/tmp/id_ed25519':"]],
     ['other-account password', ["proxy@bastion's password:"]],
     ['keyboard-interactive', ['Keyboard-interactive authentication:']],
@@ -1526,7 +1567,7 @@ describe('ComputeConnectionBroker SSH configuration compatibility', () => {
     await expect(lease.redactSensitiveOutputs?.(['tail 1'])).resolves.toEqual(['tail [redacted]'])
   })
 
-  unixSocketAskpass(
+  socketAskpass(
     'keeps an answered target-password failure classified and persisted as authentication_failed',
     async () => {
       const passwordHost = {
@@ -1587,7 +1628,7 @@ describe('ComputeConnectionBroker SSH configuration compatibility', () => {
     }
   )
 
-  unixSocketAskpass(
+  socketAskpass(
     'does not persist a rejected proxy prompt as an authentication failure',
     async () => {
       const passwordHost = {

--- a/src/main/compute/connection-broker.test.ts
+++ b/src/main/compute/connection-broker.test.ts
@@ -70,7 +70,9 @@ describe('ComputeConnectionBroker SSH configuration compatibility', () => {
   it.runIf(platform() === 'win32')(
     'returns one matching password through the constrained Windows askpass helper',
     async () => {
-      const secret = 'Windows askpass secret "quoted" Unicode 密码'
+      // The JSON prefix places the first byte of this character at the end of the helper's
+      // 4096-byte read buffer, exercising UTF-8 decoding across pipe read boundaries.
+      const secret = `${'a'.repeat(4082)}密码`
       vi.stubEnv('OPEN_SCIENCE_RELEASE_GATE_SECRET', secret)
       const askpass = await createAskpassEnvironment(secret, ['researcher@cluster'])
       const invoke = (

--- a/src/main/compute/credential-vault.test.ts
+++ b/src/main/compute/credential-vault.test.ts
@@ -10,19 +10,16 @@ const cipher = (backend: string): ComputeCredentialCipher => ({
 })
 
 describe('Compute password secure-storage capability', () => {
-  it('fails closed on Windows regardless of the OS cipher backend', () => {
+  it('uses the available OS cipher backend on Windows', () => {
     const vault = new CredentialVault(
       { getCredential: vi.fn(async () => null) },
       cipher('os_crypt'),
       'win32'
     )
 
-    expect(vault.capability()).toEqual({
-      available: false,
-      reason: 'unsupported_platform'
-    })
-    expect(() => vault.encrypt('must not persist')).toThrowError(
-      expect.objectContaining({ code: 'secure_storage_unavailable' })
+    expect(vault.capability()).toEqual({ available: true })
+    expect(vault.encrypt('windows protected secret').toString()).toBe(
+      'encrypted:windows protected secret'
     )
   })
 

--- a/src/main/compute/credential-vault.ts
+++ b/src/main/compute/credential-vault.ts
@@ -46,7 +46,6 @@ class CredentialVault {
 
   isAvailable(): boolean {
     try {
-      if (this.suppliedPlatform === 'win32') return false
       if (!this.cipher.isEncryptionAvailable()) return false
       return !(
         this.suppliedPlatform === 'linux' &&
@@ -62,10 +61,7 @@ class CredentialVault {
       ? { available: true }
       : {
           available: false,
-          reason:
-            this.suppliedPlatform === 'win32'
-              ? 'unsupported_platform'
-              : 'secure_storage_unavailable'
+          reason: 'secure_storage_unavailable'
         }
   }
 


### PR DESCRIPTION
## Problem

Compute SSH password authentication was hard-disabled on Windows in two places even though Windows OpenSSH supports `SSH_ASKPASS` and Electron `safeStorage` provides the existing DPAPI-backed credential boundary. As a result, a Windows user could save neither a Compute password nor use it for SSH connections.

## Proposed change

- Allow the Compute credential vault to use an available Windows `safeStorage` backend.
- Add a Windows `SSH_ASKPASS` bridge that runs the app executable in Electron Node mode and exchanges one password through a random named pipe.
- Preserve the existing one-shot capability, expected-account prompt matching, and fail-closed handling for passphrases, proxy prompts, repeated prompts, keyboard-interactive, OTP, and MFA flows.
- Keep unrelated environment variables and the password itself out of the askpass child environment and argv.

## Scope and non-goals

- Scope: Windows Compute SSH account-password authentication.
- Unix socket-based askpass behavior remains unchanged.
- No keyboard-interactive, OTP/MFA, proxy-password, key-passphrase, or arbitrary-prompt support is added.
- This intentionally uses the same Windows-account trust boundary as existing provider credentials stored with Electron `safeStorage`; it does not attempt to isolate secrets from arbitrary code already running as the same Windows user.

## Compatibility, state, and persistence

- **Historical compatibility:** no migration is required. Existing Windows records remain readable where DPAPI can decrypt them. Ciphertext copied from macOS/Linux, another Windows user, or another machine remains unavailable and must be reset, matching current `safeStorage` behavior.
- **State/enums:** no enum values or persisted states are added.
- **Persistence:** no schema or serialized-format changes. `ComputeCredential.ciphertext` continues to hold the bytes returned by Electron `safeStorage`; Windows now uses its DPAPI backend instead of rejecting the platform.

## Acceptance criteria

- Windows reports password storage available when Electron `safeStorage` encryption is available.
- A matching target-password prompt receives the password once through the named pipe.
- The password does not appear in child argv or environment variables.
- Unsupported or repeated interactive prompts fail closed.
- Existing non-Windows behavior remains covered by the same tests.

## Validation

- `npx vitest run` over the Compute module test plan's 32 files: **31 files passed, 1 skipped; 797 tests passed, 15 skipped**.
- Password-auth architecture/release guards: **1 passed, 1 skipped** (real-host SSH gate skipped because its opt-in environment was not configured).
- Focused Windows credential-vault, connection-broker, and architecture tests: **3 files / 63 tests passed**.
- Windows helper executed successfully through the repository Electron 39 binary in Node mode: **exit 0**.
- `npm run lint`: **passed**.
- `node --check resources/compute-askpass-win.cjs`: **passed**.
- `npm run typecheck:node`: blocked by the shared checkout dependency state (stale Prisma client and an unrelated `@zed-industries/claude-agent-acp` export mismatch); all reported diagnostics are outside this diff. PR CI is the authoritative clean-environment check.
- Full `npm test` was intentionally not run; PR CI covers the complete suite.

## Review focus

- Windows OpenSSH/Electron `SSH_ASKPASS` process behavior.
- Named-pipe request framing and one-shot capability enforcement.
- Preservation of the existing credential-storage trust boundary and Unix behavior.
