### PR TITLE
fix(session-delete): make empty Claude sessions deletable

### DIFF
--- a/patches/@agentclientprotocol+claude-agent-acp+0.70.0.patch
+++ b/patches/@agentclientprotocol+claude-agent-acp+0.70.0.patch
@@ -95,6 +95,24 @@ index f11169b..cca061f 100644
                              lastAssistantWasUsageLimit = isSyntheticUsageLimitMessage(message.message);
                              if (message.error || lastAssistantWasUsageLimit) {
                                  lastAssistantFailureTitle = assistantMessageText(message.message);
+@@ -3715,7 +3771,16 @@ export class ClaudeAcpAgent {
+         if (this.sessions[params.sessionId]) {
+             await this.teardownSession(params.sessionId);
+         }
+-        await deleteSession(params.sessionId);
++        try {
++            await deleteSession(params.sessionId);
++        }
++        catch (error) {
++            // A new Session is not written to disk until its first prompt. Deleting that
++            // in-memory-only Session is already complete after teardown, so keep deletion idempotent.
++            if (!(error instanceof Error && error.message.startsWith(`Session ${params.sessionId} not found`))) {
++                throw error;
++            }
++        }
+         return {};
+     }
+     async setSessionMode(params) {
 @@ -4995,6 +5051,7 @@ export class ClaudeAcpAgent {
          let initializationResult;
          try {

--- a/src/main/acp/claude-agent-acp-patch.test.ts
+++ b/src/main/acp/claude-agent-acp-patch.test.ts
@@ -1,7 +1,13 @@
 import type { McpServerStatus, Query } from '@anthropic-ai/claude-agent-sdk'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
-import { waitForMcpServers } from '@agentclientprotocol/claude-agent-acp/dist/acp-agent.js'
+import {
+  ClaudeAcpAgent,
+  waitForMcpServers
+} from '@agentclientprotocol/claude-agent-acp/dist/acp-agent.js'
 
 type McpStatusQuery = Pick<Query, 'mcpServerStatus' | 'close'>
 
@@ -86,5 +92,21 @@ describe('claude-agent-acp MCP readiness patch', () => {
       '[mcp-readiness] Timed out waiting for MCP servers: open-science-notebook'
     )
     expect(query.close).toHaveBeenCalledOnce()
+  })
+})
+
+describe('claude-agent-acp Session deletion patch', () => {
+  it('treats a never-materialized Session as already deleted', async () => {
+    const sessionId = '11111111-1111-4111-8111-111111111111'
+    const configDir = mkdtempSync(join(tmpdir(), 'open-science-claude-session-delete-'))
+    vi.stubEnv('CLAUDE_CONFIG_DIR', configDir)
+
+    try {
+      const agent = new ClaudeAcpAgent({} as never)
+      await expect(agent.deleteSession({ sessionId })).resolves.toEqual({})
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(configDir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Problem

Branching from a completed Agent message creates and persists an idle Claude Session without sending a prompt. The Claude SDK does not materialize that Session transcript until the first prompt. Deleting the Session tears down the in-memory runtime, then the SDK reports that the Session cannot be found on disk. Open Science treats that as a runtime deletion failure, retains the durable Session, and repeated Retry attempts fail the same way.

## Proposed change

- Extend the existing `claude-agent-acp` patch so the exact same-Session not-found result after teardown is treated as idempotent success.
- Add a regression test at the public `ClaudeAcpAgent.deleteSession()` boundary using an isolated temporary Claude config directory and the real SDK absent-session behavior.
- Preserve failures for permission, I/O, connection, and all other provider errors.

## Scope and non-goals

- This affects only the Claude Code ACP adapter. OpenCode, Codex Responses, and Codex Bridge protocols are unchanged.
- No schema, data-field, data-model, enum/state, architecture, or UI-flow changes.
- Materialized provider transcript deletion remains unchanged.
- Artifacts continue to remain in the project under the existing deletion behavior.

## Historical compatibility and persistence

Historical, empty, or failed Sessions whose provider transcript is already absent can now be deleted without migration. Existing provider transcripts are still deleted normally, and the application Session persistence sequence is unchanged.

## Acceptance criteria

- An idle branched Claude Session can be deleted before its first prompt.
- Deleting an already-absent same-ID provider Session is idempotent.
- Non-not-found provider errors still fail deletion.

## Validation

All checks below were run after the last material edit:

- `vitest run src/main/acp/claude-agent-acp-patch.test.ts src/main/acp/session-deletion-workflow.test.ts src/main/session-deletion/owner.test.ts` — 3 files, 21 tests passed.
- `vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t "creates and persists an idle branched Session without sending a prompt"` — selected test passed.
- `npm run typecheck:node` — passed.
- `npm run lint` — passed.
- `npm run check:claude-acp-patch` — passed.
- `git diff --check` — passed.
- Reverse dry-run verified the tracked dependency patch matches the installed patched package.

The regression test was also run twice against the unfixed code and failed consistently with `Session <id> not found in any project directory`, matching the reported deletion failure. Full local `npm test` was intentionally not run; the exact-head affected-test classifier selects the full CI plan because this change touches a tracked dependency patch, so PR CI is the final authority.

## Review focus

- Exact discrimination of the SDK not-found error.
- Replayability of the tracked `claude-agent-acp` patch.
