### PR TITLE
feat(providers): expand OpenCode model catalogs

### DIFF
--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -240,7 +240,7 @@ describe('AgentRuntimeManager', () => {
       id: 'provider-a',
       type: 'custom',
       name: 'Provider A',
-      model: 'model-a',
+      model: 'stored-model',
       apiEndpoints: ['openai'],
       keyRef: 'encrypted-key',
       lastValidatedAt: 10

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -373,19 +373,18 @@ export class AgentRuntimeManager {
     const activeProvider = settings.activeProviderId
       ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
       : undefined
+    const activeModel = activeProvider
+      ? providers.resolveActiveModel(activeProvider, settings.activeModel)
+      : undefined
     const activeEndpoints = activeProvider
-      ? providers.resolveProviderApiEndpoints(activeProvider, activeProvider.model)
+      ? providers.resolveProviderApiEndpoints(activeProvider, activeModel)
       : undefined
     const activeProviderCompatible = activeProvider
       ? isProviderUsableByFramework(
           { apiEndpoints: activeEndpoints, type: activeProvider.type },
           framework
         ) &&
-        (framework.id !== 'codex' ||
-          isModelBridgeSupported(
-            activeProvider,
-            providers.resolveActiveModel(activeProvider, settings.activeModel)
-          ))
+        (framework.id !== 'codex' || isModelBridgeSupported(activeProvider, activeModel))
       : false
     const activeProviderKeyUsable =
       activeProvider && activeProvider.lastValidatedAt !== undefined

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -57,7 +57,7 @@ import type { XaiOAuthControllerPort } from './xai-oauth'
 import { XaiProviderAccountOwner } from './xai-provider-account-owner'
 import { ProviderModelCatalogOwner } from './provider-model-catalog-owner'
 import { assertProviderCapacity, assertProviderDraftLimits } from './provider-resource-limits'
-
+import { assertProviderModelLimit } from './provider-resource-limits'
 type ProviderAccountsModuleOptions = {
   repository: SettingsRepository
   storageRoot: string
@@ -78,7 +78,6 @@ type ProviderAccountsModuleOptions = {
   claudeSharedAuth?: ClaudeSharedAuthControllerPort
   xaiOAuth?: XaiOAuthControllerPort
 }
-
 // Owns durable provider records and every provider-specific validation/authentication lifecycle;
 // executable installation, runtime spawn, live ACP reconnect, and transports remain outside.
 class ProviderAccountsModule {
@@ -354,6 +353,7 @@ class ProviderAccountsModule {
   }
   async validateProvider(request: ValidateProviderRequest): Promise<ValidateProviderResult> {
     if (request.draft) assertProviderDraftLimits(request.draft)
+    assertProviderModelLimit(request.model)
     const settings = await this.repository.getSettings()
     const resolved = this.resolveValidationTarget(request, settings)
     if (!resolved) {
@@ -419,10 +419,10 @@ class ProviderAccountsModule {
     const latestSettings = await this.repository.getSettings()
     const stored = latestSettings.providers.find((provider) => provider.id === resolved.storedId)
     if (!stored) return { ...result, applied: false }
-    const latestResolved = this.resolveProvider(
-      stored,
-      latestSettings.activeProviderId === stored.id ? latestSettings.activeModel : undefined
-    )
+    const model =
+      request.model ??
+      (latestSettings.activeProviderId === stored.id ? latestSettings.activeModel : undefined)
+    const latestResolved = this.resolveProvider(stored, model)
     if (!this.sameValidationTarget(resolved.provider, latestResolved)) {
       return { ...result, applied: false }
     }
@@ -553,12 +553,12 @@ class ProviderAccountsModule {
   ): { provider: ResolvedProvider; storedId?: string } | undefined {
     if (request.providerId) {
       const stored = settings.providers.find((provider) => provider.id === request.providerId)
+      const model =
+        request.model ??
+        (settings.activeProviderId === stored?.id ? settings.activeModel : undefined)
       return stored
         ? {
-            provider: this.resolveProvider(
-              stored,
-              settings.activeProviderId === stored.id ? settings.activeModel : undefined
-            ),
+            provider: this.resolveProvider(stored, model),
             storedId: stored.id
           }
         : undefined

--- a/src/main/settings/provider-draft-projection.ts
+++ b/src/main/settings/provider-draft-projection.ts
@@ -1,11 +1,10 @@
-import type { ChatApiEndpoint, ProviderDraft } from '../../shared/settings'
+import type { ProviderDraft } from '../../shared/settings'
 import {
   defaultVendorModel,
   isOfficialVendorId,
-  isVendorModelResponsesSupported,
   resolveCustomModelContextWindow,
-  resolveVendorApiEndpoints,
   resolveVendorBaseUrl,
+  resolveVendorModelApiEndpoints,
   resolveVendorOpenAiBaseUrl
 } from '../../shared/provider-registry'
 import type { ResolvedProvider } from './provider-env'
@@ -14,12 +13,6 @@ import { resolveCustomTokenLimits } from './provider-token-limits'
 export const resolveProviderDraft = (draft: ProviderDraft): ResolvedProvider => {
   if (draft.type === 'official' && isOfficialVendorId(draft.vendorId)) {
     const draftModel = draft.model ?? defaultVendorModel(draft.vendorId)
-    const vendorEndpoints = resolveVendorApiEndpoints(draft.vendorId)
-    const draftEndpoints: ChatApiEndpoint[] =
-      !vendorEndpoints.includes('responses') &&
-      isVendorModelResponsesSupported(draft.vendorId, draftModel)
-        ? [...vendorEndpoints, 'responses']
-        : vendorEndpoints
     return {
       type: 'custom',
       vendorId: draft.vendorId,
@@ -27,7 +20,7 @@ export const resolveProviderDraft = (draft: ProviderDraft): ResolvedProvider => 
       openaiBaseUrl: resolveVendorOpenAiBaseUrl(draft.vendorId, draft.region),
       model: draftModel,
       key: draft.key,
-      apiEndpoints: draftEndpoints
+      apiEndpoints: resolveVendorModelApiEndpoints(draft.vendorId, draftModel)
     }
   }
   const tokenLimits = draft.type === 'custom' ? resolveCustomTokenLimits(draft) : undefined

--- a/src/main/settings/provider-resource-limits.ts
+++ b/src/main/settings/provider-resource-limits.ts
@@ -32,10 +32,19 @@ const assertProviderDraftLimits = (draft: ProviderDraft): void => {
   }
 }
 
+const assertProviderModelLimit = (model: string | undefined): void => {
+  assertCharacterLimit(model, PROVIDER_RESOURCE_LIMITS.modelIdCharacters, 'Model ID')
+}
+
 const assertProviderCapacity = (providerCount: number, editingExisting: boolean): void => {
   if (!editingExisting && providerCount >= PROVIDER_RESOURCE_LIMITS.providers) {
     throw new Error(`Provider limit of ${PROVIDER_RESOURCE_LIMITS.providers} reached.`)
   }
 }
 
-export { PROVIDER_RESOURCE_LIMITS, assertProviderCapacity, assertProviderDraftLimits }
+export {
+  PROVIDER_RESOURCE_LIMITS,
+  assertProviderCapacity,
+  assertProviderDraftLimits,
+  assertProviderModelLimit
+}

--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -127,6 +127,49 @@ describe('ProviderRuntimeProjectionOwner', () => {
     expect(owner.toProviderView(provider).supportsImageInput).toBe(false)
   })
 
+  it('routes mixed OpenCode Zen models only through their documented protocol', () => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: 'opencode-zen',
+      type: 'official',
+      vendorId: 'opencode',
+      name: 'OpenCode Zen'
+    }
+
+    const responsesTarget = owner.resolveRuntimeTarget(
+      provider,
+      { kind: 'required', model: 'gpt-5.6-sol' },
+      getAgentFramework('codex')
+    )
+    const incompatibleResponsesTarget = owner.resolveRuntimeTarget(
+      provider,
+      { kind: 'required', model: 'gpt-5.6-sol' },
+      getAgentFramework('opencode')
+    )
+    const messagesTarget = owner.resolveRuntimeTarget(
+      provider,
+      { kind: 'required', model: 'claude-opus-5' },
+      getAgentFramework('claude-code')
+    )
+
+    expect(responsesTarget).toMatchObject({
+      apiEndpoints: ['responses'],
+      frameworkCompatible: true,
+      needsChatResponsesBridge: false,
+      needsNativeResponsesCompatibility: true
+    })
+    expect(incompatibleResponsesTarget).toMatchObject({
+      apiEndpoints: ['responses'],
+      frameworkCompatible: false
+    })
+    expect(messagesTarget).toMatchObject({
+      apiEndpoints: ['anthropic'],
+      frameworkCompatible: true,
+      needsChatResponsesBridge: false,
+      needsNativeResponsesCompatibility: false
+    })
+  })
+
   it('keeps an exact required model when a subscription catalog is unknown', () => {
     const owner = new ProviderRuntimeProjectionOwner()
     const provider: StoredProvider = {

--- a/src/main/settings/provider-runtime-projection.ts
+++ b/src/main/settings/provider-runtime-projection.ts
@@ -12,11 +12,10 @@ import {
   getOfficialVendorModelIds,
   isModelBridgeSupported,
   isVendorModelMultimodal,
-  isVendorModelResponsesSupported,
   resolveCustomModelContextWindow,
   resolveModelContextWindow,
-  resolveVendorApiEndpoints,
   resolveVendorBaseUrl,
+  resolveVendorModelApiEndpoints,
   resolveVendorOpenAiBaseUrl
 } from '../../shared/provider-registry'
 import {
@@ -68,15 +67,10 @@ class ProviderRuntimeProjectionOwner {
   resolveProviderApiEndpoints(provider: StoredProvider, activeModel?: string): ChatApiEndpoint[] {
     if (isXaiSubscriptionProvider(provider.type)) return ['anthropic', 'openai', 'responses']
     if (provider.type === 'official' && provider.vendorId) {
-      const vendorEndpoints = resolveVendorApiEndpoints(provider.vendorId)
-      const modelToCheck = activeModel ?? defaultVendorModel(provider.vendorId)
-      if (
-        !vendorEndpoints.includes('responses') &&
-        isVendorModelResponsesSupported(provider.vendorId, modelToCheck)
-      ) {
-        return [...vendorEndpoints, 'responses']
-      }
-      return vendorEndpoints
+      return resolveVendorModelApiEndpoints(
+        provider.vendorId,
+        activeModel ?? defaultVendorModel(provider.vendorId)
+      )
     }
 
     return provider.apiEndpoints && provider.apiEndpoints.length > 0

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1448,6 +1448,36 @@ describe('SettingsService: validation', () => {
     expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeGreaterThan(0)
   })
 
+  it('validates a saved official provider with its pending model before activation', async () => {
+    const service = createService()
+    const fetchMock = vi.fn().mockResolvedValue(validAnthropicResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const created = (
+      await service.upsertProvider({
+        type: 'official',
+        name: 'OpenCode Zen',
+        vendorId: 'opencode',
+        key: 'k'
+      })
+    ).providers[0]
+
+    const result = await service.validateProvider({
+      providerId: created.id,
+      model: 'claude-fable-5'
+    })
+
+    expect(result).toMatchObject({ ok: true, category: 'ok', applied: true })
+    expect(fetchMock.mock.calls[0][0]).toBe('https://opencode.ai/zen/v1/messages')
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      model: 'claude-fable-5'
+    })
+
+    const settings = await repository.getSettings()
+    expect(settings.activeModel).toBeUndefined()
+    expect(settings.providers[0].lastValidatedAt).toBeGreaterThan(0)
+  })
+
   it('probes over the proxy-aware net.fetch, not Node global fetch directly', async () => {
     const service = createService()
     // A direct undici fetch ignores the system proxy, so an official vendor reachable only through a

--- a/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
@@ -614,7 +614,9 @@ describe('ProviderStep', () => {
     await clickButton(/test & continue/i)
 
     expect(container.textContent).not.toContain("isn't compatible with Claude Code")
-    expect(saveAndActivateProvider).toHaveBeenCalledOnce()
+    expect(saveAndActivateProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ vendorId: 'opencode', model: 'claude-fable-5' })
+    )
   })
 
   // Switches the auth picker to the isolated "Sign in with Open Science" mode — the only path that

--- a/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
@@ -588,6 +588,35 @@ describe('ProviderStep', () => {
     expect(saveAndActivateProvider).toHaveBeenCalledOnce()
   })
 
+  it('lets Claude Code add a mixed-protocol Zen provider before choosing an active model', async () => {
+    readyClaudeEnvironment()
+    useSettingsStore.setState({
+      agentFrameworks: [
+        {
+          id: 'claude-code',
+          displayName: 'Claude Code',
+          supportedApiTypes: ['anthropic'],
+          supportsSkills: true
+        }
+      ]
+    })
+    const saveAndActivateProvider = vi
+      .fn()
+      .mockResolvedValue({ providerId: 'zen', validation: { ok: true, category: 'ok' } })
+    useSettingsStore.setState({ saveAndActivateProvider })
+
+    await renderStep({
+      initialValue: createEmptyProviderFormValue({
+        ...providerKindPatch('official:opencode'),
+        key: 'sk-test'
+      })
+    })
+    await clickButton(/test & continue/i)
+
+    expect(container.textContent).not.toContain("isn't compatible with Claude Code")
+    expect(saveAndActivateProvider).toHaveBeenCalledOnce()
+  })
+
   // Switches the auth picker to the isolated "Sign in with Open Science" mode — the only path that
   // runs the browser login (loginIsolatedCodex).
   const switchToIsolatedSignIn = async (): Promise<void> => {

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -26,6 +26,7 @@ import {
   getProviderFormErrors,
   hasProviderFormErrors,
   providerFormApiEndpoints,
+  providerFormModelForFramework,
   providerFormTokenLimits,
   providerKindPatch,
   type ProviderFormValue
@@ -198,12 +199,20 @@ const ProviderStep = ({
       return
     }
 
+    const providerValue =
+      formValue.type === 'official'
+        ? {
+            ...formValue,
+            model: providerFormModelForFramework(formValue, frameworkEndpoints) ?? formValue.model
+          }
+        : formValue
+
     // A provider that validates can still be unusable by the selected framework (e.g. Claude + an
     // OpenAI-only gateway). Block that before it becomes the active provider, so onboarding can't
     // finish with a pair the agent can't actually spawn.
     if (
       !isProviderUsableByFramework(
-        { apiEndpoints: providerFormApiEndpoints(formValue), type: formValue.type },
+        { apiEndpoints: providerFormApiEndpoints(providerValue), type: providerValue.type },
         { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
       )
     ) {
@@ -352,7 +361,7 @@ const ProviderStep = ({
         return
       }
 
-      const { validation } = await saveAndActivateProvider(toUpsertRequest(formValue))
+      const { validation } = await saveAndActivateProvider(toUpsertRequest(providerValue))
 
       // A validation superseded by a newer test (or a provider removed/edited mid-test) reports its
       // outcome but was not recorded; do not finish onboarding on a result the stored provider never

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -8,6 +8,7 @@ import {
   getProviderFormErrors,
   hasProviderFormErrors,
   providerFormApiEndpoints,
+  providerFormModelForFramework,
   providerKindPatch,
   selectedKindKey
 } from './provider-form-value'
@@ -139,7 +140,7 @@ describe('provider-kind helpers', () => {
       providerFormApiEndpoints(
         createEmptyProviderFormValue({ type: 'official', vendorId: 'opencode' })
       )
-    ).toEqual(['openai', 'responses', 'anthropic'])
+    ).toEqual(['openai'])
     expect(
       providerFormApiEndpoints(
         createEmptyProviderFormValue({
@@ -149,6 +150,14 @@ describe('provider-kind helpers', () => {
         })
       )
     ).toEqual(['anthropic'])
+  })
+
+  it('chooses a directly compatible official model before onboarding validation', () => {
+    const zen = createEmptyProviderFormValue({ type: 'official', vendorId: 'opencode' })
+
+    expect(providerFormModelForFramework(zen, ['anthropic'])).toBe('claude-fable-5')
+    expect(providerFormModelForFramework(zen, ['responses'])).toBe('gpt-5.6-sol')
+    expect(providerFormModelForFramework(zen, ['anthropic', 'openai'])).toBe('kimi-k2.7-code')
   })
 
   it('groups each subscription on its own, official vendors under API, and custom under Other', () => {

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -135,6 +135,20 @@ describe('provider-kind helpers', () => {
     expect(
       providerFormApiEndpoints(createEmptyProviderFormValue({ type: 'xai-subscription' }))
     ).toEqual(['anthropic', 'openai', 'responses'])
+    expect(
+      providerFormApiEndpoints(
+        createEmptyProviderFormValue({ type: 'official', vendorId: 'opencode' })
+      )
+    ).toEqual(['openai', 'responses', 'anthropic'])
+    expect(
+      providerFormApiEndpoints(
+        createEmptyProviderFormValue({
+          type: 'official',
+          vendorId: 'opencode',
+          model: 'claude-opus-5'
+        })
+      )
+    ).toEqual(['anthropic'])
   })
 
   it('groups each subscription on its own, official vendors under API, and custom under Other', () => {

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -11,7 +11,7 @@ import {
 import {
   OFFICIAL_VENDORS,
   getOfficialVendor,
-  resolveVendorApiEndpoints,
+  resolveVendorModelApiEndpoints,
   type OfficialVendorId
 } from '../../../../shared/provider-registry'
 import type {
@@ -93,10 +93,25 @@ export const defaultCustomApiEndpoint = (
   frameworkEndpoints: readonly ChatApiEndpoint[]
 ): ChatApiEndpoint => preferredEndpoint(frameworkEndpoints, frameworkEndpoints) ?? 'anthropic'
 
-// Built-in providers expose their complete protocol set; `apiEndpoint` only represents the single
-// format selected for a custom gateway and may be stale after switching provider kinds.
+// Built-in providers expose their complete catalog protocol set until a model is chosen;
+// `apiEndpoint` only represents the single format selected for a custom gateway and may be stale
+// after switching provider kinds.
 export const providerFormApiEndpoints = (value: ProviderFormValue): ChatApiEndpoint[] => {
-  if (value.type === 'official' && value.vendorId) return resolveVendorApiEndpoints(value.vendorId)
+  if (value.type === 'official' && value.vendorId) {
+    const vendorId = value.vendorId
+    const selectedModel = value.model.trim()
+    const models = selectedModel
+      ? [selectedModel]
+      : (getOfficialVendor(vendorId)?.models.map(({ id }) => id) ?? [])
+
+    return [
+      ...new Set(
+        (models.length > 0 ? models : [undefined]).flatMap((model) =>
+          resolveVendorModelApiEndpoints(vendorId, model)
+        )
+      )
+    ]
+  }
   if (value.type === 'xai-subscription') return ['anthropic', 'openai', 'responses']
   return [value.apiEndpoint]
 }

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../shared/settings'
 import {
   OFFICIAL_VENDORS,
+  defaultVendorModel,
   getOfficialVendor,
   resolveVendorModelApiEndpoints,
   type OfficialVendorId
@@ -93,27 +94,40 @@ export const defaultCustomApiEndpoint = (
   frameworkEndpoints: readonly ChatApiEndpoint[]
 ): ChatApiEndpoint => preferredEndpoint(frameworkEndpoints, frameworkEndpoints) ?? 'anthropic'
 
-// Built-in providers expose their complete catalog protocol set until a model is chosen;
-// `apiEndpoint` only represents the single format selected for a custom gateway and may be stale
-// after switching provider kinds.
+// Built-in providers resolve the exact protocol for the selected/default model. `apiEndpoint` only
+// represents the single format selected for a custom gateway and may be stale after switching
+// provider kinds.
 export const providerFormApiEndpoints = (value: ProviderFormValue): ChatApiEndpoint[] => {
   if (value.type === 'official' && value.vendorId) {
-    const vendorId = value.vendorId
-    const selectedModel = value.model.trim()
-    const models = selectedModel
-      ? [selectedModel]
-      : (getOfficialVendor(vendorId)?.models.map(({ id }) => id) ?? [])
-
-    return [
-      ...new Set(
-        (models.length > 0 ? models : [undefined]).flatMap((model) =>
-          resolveVendorModelApiEndpoints(vendorId, model)
-        )
-      )
-    ]
+    return resolveVendorModelApiEndpoints(
+      value.vendorId,
+      value.model.trim() || defaultVendorModel(value.vendorId)
+    )
   }
   if (value.type === 'xai-subscription') return ['anthropic', 'openai', 'responses']
   return [value.apiEndpoint]
+}
+
+// Before an official provider is saved, select the first model that speaks a protocol the active
+// framework consumes directly. If none does, keep the vendor default so the normal compatibility
+// gate can reject the pair (or allow Codex's Chat bridge).
+export const providerFormModelForFramework = (
+  value: ProviderFormValue,
+  frameworkEndpoints: readonly ChatApiEndpoint[]
+): string | undefined => {
+  const selectedModel = value.model.trim()
+  if (selectedModel || value.type !== 'official' || !value.vendorId) {
+    return selectedModel || undefined
+  }
+
+  const vendorId = value.vendorId
+  return (
+    getOfficialVendor(vendorId)?.models.find(({ id }) =>
+      resolveVendorModelApiEndpoints(vendorId, id).some((endpoint) =>
+        frameworkEndpoints.includes(endpoint)
+      )
+    )?.id ?? defaultVendorModel(vendorId)
+  )
 }
 
 // The provider kind pre-selected when the Add provider form opens, matched to the active agent

--- a/src/renderer/src/stores/settings-provider-auth-slice.test.ts
+++ b/src/renderer/src/stores/settings-provider-auth-slice.test.ts
@@ -232,9 +232,9 @@ describe('provider auth slice: persistence and validation', () => {
     store.setState({ saveProvider, setActiveProvider })
 
     await expect(
-      store.getState().saveAndActivateProvider({ type: 'custom', name: 'new' })
+      store.getState().saveAndActivateProvider({ type: 'custom', name: 'new', model: 'model-a' })
     ).resolves.toEqual({ providerId: 'new', validation })
-    expect(setActiveProvider).toHaveBeenCalledWith('new')
+    expect(setActiveProvider).toHaveBeenCalledWith('new', 'model-a')
   })
 
   it('refreshes saved validation outcomes but leaves draft validation projection untouched', async () => {

--- a/src/renderer/src/stores/settings-provider-auth-slice.test.ts
+++ b/src/renderer/src/stores/settings-provider-auth-slice.test.ts
@@ -214,7 +214,7 @@ describe('provider auth slice: persistence and validation', () => {
     commands.upsertProvider.mockResolvedValue(snapshot([provider('new')]))
     commands.getSettings.mockResolvedValue(snapshot([provider('new')]))
 
-    await store.getState().saveProvider({ type: 'custom', name: 'new', model: 'model-a' })
+    await store.getState().saveProvider({ type: 'custom', name: 'new', model: ' model-a ' })
 
     expect(commands.validateProvider).toHaveBeenCalledWith({
       providerId: 'new',
@@ -244,7 +244,7 @@ describe('provider auth slice: persistence and validation', () => {
     store.setState({ saveProvider, setActiveProvider })
 
     await expect(
-      store.getState().saveAndActivateProvider({ type: 'custom', name: 'new', model: 'model-a' })
+      store.getState().saveAndActivateProvider({ type: 'custom', name: 'new', model: ' model-a ' })
     ).resolves.toEqual({ providerId: 'new', validation })
     expect(setActiveProvider).toHaveBeenCalledWith('new', 'model-a')
   })

--- a/src/renderer/src/stores/settings-provider-auth-slice.test.ts
+++ b/src/renderer/src/stores/settings-provider-auth-slice.test.ts
@@ -210,6 +210,18 @@ describe('provider auth slice: persistence and validation', () => {
     expect(refreshPreflight).toHaveBeenCalledOnce()
   })
 
+  it('validates a saved provider with the model selected for activation', async () => {
+    commands.upsertProvider.mockResolvedValue(snapshot([provider('new')]))
+    commands.getSettings.mockResolvedValue(snapshot([provider('new')]))
+
+    await store.getState().saveProvider({ type: 'custom', name: 'new', model: 'model-a' })
+
+    expect(commands.validateProvider).toHaveBeenCalledWith({
+      providerId: 'new',
+      model: 'model-a'
+    })
+  })
+
   it('returns unknown without validating or refreshing when an upsert has no affected id', async () => {
     commands.upsertProvider.mockResolvedValue(snapshot([]))
 

--- a/src/renderer/src/stores/settings-provider-auth-slice.ts
+++ b/src/renderer/src/stores/settings-provider-auth-slice.ts
@@ -142,7 +142,7 @@ export const createProviderAuthSlice = <Store extends ProviderAuthHost>({
 
   saveAndActivateProvider: async (request) => {
     const result = await get().saveProvider(request)
-    if (result.providerId) await get().setActiveProvider(result.providerId)
+    if (result.providerId) await get().setActiveProvider(result.providerId, request.model)
     return result
   },
 

--- a/src/renderer/src/stores/settings-provider-auth-slice.ts
+++ b/src/renderer/src/stores/settings-provider-auth-slice.ts
@@ -105,6 +105,9 @@ const resolveUpsertedProviderId = (
   return after.find((provider) => !beforeIds.has(provider.id))?.id
 }
 
+const normalizeProviderModel = (model: string | undefined): string | undefined =>
+  model?.trim() || undefined
+
 export const createProviderAuthSlice = <Store extends ProviderAuthHost>({
   get,
   getCommands,
@@ -134,9 +137,10 @@ export const createProviderAuthSlice = <Store extends ProviderAuthHost>({
       return { providerId: '', validation: { ok: false, category: 'unknown' } }
     }
 
+    const model = normalizeProviderModel(request.model)
     const validation = await commands.validateProvider({
       providerId,
-      ...(request.model ? { model: request.model } : {})
+      ...(model ? { model } : {})
     })
     reconcileSnapshot(await commands.getSettings())
     await refreshPreflight()
@@ -145,7 +149,9 @@ export const createProviderAuthSlice = <Store extends ProviderAuthHost>({
 
   saveAndActivateProvider: async (request) => {
     const result = await get().saveProvider(request)
-    if (result.providerId) await get().setActiveProvider(result.providerId, request.model)
+    if (result.providerId) {
+      await get().setActiveProvider(result.providerId, normalizeProviderModel(request.model))
+    }
     return result
   },
 

--- a/src/renderer/src/stores/settings-provider-auth-slice.ts
+++ b/src/renderer/src/stores/settings-provider-auth-slice.ts
@@ -134,7 +134,10 @@ export const createProviderAuthSlice = <Store extends ProviderAuthHost>({
       return { providerId: '', validation: { ok: false, category: 'unknown' } }
     }
 
-    const validation = await commands.validateProvider({ providerId })
+    const validation = await commands.validateProvider({
+      providerId,
+      ...(request.model ? { model: request.model } : {})
+    })
     reconcileSnapshot(await commands.getSettings())
     await refreshPreflight()
     return { providerId, validation }

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -311,7 +311,7 @@ describe('settings store: saveAndActivateProvider', () => {
     })
 
     expect(result).toEqual({ providerId: 'p_new', validation: { ok: true, category: 'ok' } })
-    expect(api.validateProvider).toHaveBeenCalledWith({ providerId: 'p_new' })
+    expect(api.validateProvider).toHaveBeenCalledWith({ providerId: 'p_new', model: 'model-a' })
     expect(api.setActiveProvider).toHaveBeenCalledWith({ id: 'p_new', model: 'model-a' })
     expect(useSettingsStore.getState().activeProviderId).toBe('p_new')
   })

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -306,12 +306,13 @@ describe('settings store: saveAndActivateProvider', () => {
       type: 'custom',
       name: 'Gateway',
       baseUrl: 'https://g/v1',
+      model: 'model-a',
       key: 'k'
     })
 
     expect(result).toEqual({ providerId: 'p_new', validation: { ok: true, category: 'ok' } })
     expect(api.validateProvider).toHaveBeenCalledWith({ providerId: 'p_new' })
-    expect(api.setActiveProvider).toHaveBeenCalledWith({ id: 'p_new' })
+    expect(api.setActiveProvider).toHaveBeenCalledWith({ id: 'p_new', model: 'model-a' })
     expect(useSettingsStore.getState().activeProviderId).toBe('p_new')
   })
 
@@ -332,7 +333,7 @@ describe('settings store: saveAndActivateProvider', () => {
     expect(result.validation.ok).toBe(false)
     // A failed probe no longer blocks activation — the provider is configured in and can be tested
     // live; it is still kept (flagged as unverified), not rolled back.
-    expect(api.setActiveProvider).toHaveBeenCalledWith({ id: 'p_new' })
+    expect(api.setActiveProvider).toHaveBeenCalledWith({ id: 'p_new', model: undefined })
     expect(api.deleteProvider).not.toHaveBeenCalled()
   })
 

--- a/src/shared/configured-model-catalog.test.ts
+++ b/src/shared/configured-model-catalog.test.ts
@@ -67,6 +67,31 @@ describe('configured model catalog', () => {
     ])
   })
 
+  it('checks each official model against its documented protocol', () => {
+    const entries = buildConfiguredModelCatalog({
+      providers: [
+        provider('opencode-zen', ['kimi-k2.7-code', 'gpt-5.6-sol', 'claude-opus-5'], {
+          type: 'official',
+          vendorId: 'opencode'
+        })
+      ],
+      frameworkId: 'opencode',
+      frameworkEndpoints: ['anthropic', 'openai']
+    })
+
+    expect(
+      entries.map(({ model, selectable, unavailableReason }) => [
+        model,
+        selectable,
+        unavailableReason
+      ])
+    ).toEqual([
+      ['kimi-k2.7-code', true, undefined],
+      ['gpt-5.6-sol', false, 'framework-incompatible'],
+      ['claude-opus-5', true, undefined]
+    ])
+  })
+
   it('projects xAI subscription models as image-capable', () => {
     const [entry] = buildConfiguredModelCatalog({
       providers: [

--- a/src/shared/configured-model-catalog.ts
+++ b/src/shared/configured-model-catalog.ts
@@ -1,4 +1,8 @@
-import { isModelBridgeSupported, isVendorModelMultimodal } from './provider-registry'
+import {
+  isModelBridgeSupported,
+  isVendorModelMultimodal,
+  resolveVendorModelApiEndpoints
+} from './provider-registry'
 import type { OfficialVendorId } from './provider-registry'
 import {
   isClaudeSubscriptionProvider,
@@ -110,8 +114,12 @@ export const buildConfiguredModelCatalog = (
   return buildConfiguredModelInventory(input).map((entry) => {
     const provider = input.providers.find((candidate) => candidate.id === entry.providerId)!
     const model = entry.model
+    const apiEndpoints =
+      provider.type === 'official' && provider.vendorId
+        ? resolveVendorModelApiEndpoints(provider.vendorId, model)
+        : provider.apiEndpoints
     const frameworkCompatible = isProviderUsableByFramework(
-      { apiEndpoints: provider.apiEndpoints, type: provider.type },
+      { apiEndpoints, type: provider.type },
       { id: input.frameworkId, supportedApiTypes: input.frameworkEndpoints }
     )
     const bridgeSupported = input.frameworkId !== 'codex' || isModelBridgeSupported(provider, model)

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -12,6 +12,7 @@ import {
   resolveVendorApiEndpoints,
   resolveVendorApiKeyUrl,
   resolveVendorBaseUrl,
+  resolveVendorModelApiEndpoints,
   resolveVendorModelsUrl,
   resolveVendorModelReasoningEffort,
   resolveVendorOpenAiBaseUrl,
@@ -46,8 +47,10 @@ describe('provider registry', () => {
     expect(OFFICIAL_VENDORS[anthropicIndex + 1]?.id).toBe('xai')
   })
 
-  it('places OpenCode Go and Zen immediately before OpenRouter with curated Chat catalogs', () => {
+  it('places OpenCode Go and Zen before OpenRouter with curated mixed-protocol catalogs', () => {
     const openRouterIndex = OFFICIAL_VENDORS.findIndex((vendor) => vendor.id === 'openrouter')
+    const goModels = getOfficialVendor('opencode-go')?.models.map(({ id }) => id)
+    const zenModels = getOfficialVendor('opencode')?.models.map(({ id }) => id)
 
     expect(
       OFFICIAL_VENDORS.slice(openRouterIndex - 2, openRouterIndex + 1).map(({ id }) => id)
@@ -60,6 +63,83 @@ describe('provider registry', () => {
     expect(resolveVendorModelsUrl('opencode')).toBeUndefined()
     expect(defaultVendorModel('opencode-go')).toBe('kimi-k2.7-code')
     expect(defaultVendorModel('opencode')).toBe('kimi-k2.7-code')
+    expect(goModels).toEqual([
+      'kimi-k2.7-code',
+      'grok-4.6',
+      'gpt-5.6-luna',
+      'glm-5.3-flash',
+      'glm-5.3',
+      'glm-5.2',
+      'glm-5.1',
+      'kimi-k3',
+      'kimi-k2.6',
+      'longcat-2.0',
+      'deepseek-v4-pro',
+      'deepseek-v4-flash',
+      'deepseek-v4-flash-vision-exp',
+      'mimo-v2.5',
+      'mimo-v2.5-pro',
+      'minimax-m3',
+      'muse-spark-1.2-contributor',
+      'qwen3.8-max',
+      'qwen3.7-max',
+      'qwen3.7-plus',
+      'hy3'
+    ])
+    expect(zenModels).toEqual([
+      'kimi-k2.7-code',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'claude-fable-5',
+      'claude-opus-5',
+      'claude-sonnet-5',
+      'grok-4.6',
+      'gpt-5.5',
+      'gpt-5.5-pro',
+      'gpt-5.4',
+      'gpt-5.4-pro',
+      'gpt-5.4-mini',
+      'gpt-5.4-nano',
+      'gpt-5.3-codex',
+      'gpt-5.3-codex-spark',
+      'gpt-5.2',
+      'gpt-5.1',
+      'gpt-5',
+      'gpt-5-nano',
+      'claude-opus-4-8',
+      'claude-opus-4-7',
+      'claude-opus-4-6',
+      'claude-opus-4-5',
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-5',
+      'claude-haiku-4-5',
+      'grok-4.5',
+      'grok-build-0.1',
+      'muse-spark-1.2',
+      'qwen3.7-max',
+      'qwen3.7-plus',
+      'qwen3.5-plus',
+      'kimi-k3',
+      'kimi-k2.6',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'minimax-m3',
+      'glm-5.2',
+      'glm-5.1'
+    ])
+    for (const excluded of ['minimax-m2.7', 'minimax-m2.5', 'qwen3.6-plus']) {
+      expect(goModels).not.toContain(excluded)
+      expect(zenModels).not.toContain(excluded)
+    }
+    expect(resolveVendorModelApiEndpoints('opencode-go', 'kimi-k2.7-code')).toEqual(['openai'])
+    expect(resolveVendorModelApiEndpoints('opencode-go', 'grok-4.6')).toEqual(['responses'])
+    expect(resolveVendorModelApiEndpoints('opencode-go', 'minimax-m3')).toEqual(['anthropic'])
+    expect(resolveVendorModelApiEndpoints('opencode', 'gpt-5.6-sol')).toEqual(['responses'])
+    expect(resolveVendorModelApiEndpoints('opencode', 'claude-opus-5')).toEqual(['anthropic'])
+    expect(resolveVendorModelApiEndpoints('opencode', 'minimax-m3')).toEqual(['openai'])
+    expect(isVendorModelMultimodal('opencode-go', 'glm-5.3-flash')).toBe(true)
+    expect(isVendorModelMultimodal('opencode', 'gpt-5.3-codex-spark')).toBe(false)
   })
 
   it('resolves a single-endpoint vendor base URL', () => {
@@ -694,6 +774,11 @@ describe('provider registry', () => {
       expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro[1m]')).toBe(true)
       expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-flash')).toBe(true)
       expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-flash-vision-exp')).toBe(true)
+      expect(resolveVendorModelApiEndpoints('deepseek', 'deepseek-v4-pro')).toEqual([
+        'anthropic',
+        'openai',
+        'responses'
+      ])
     })
 
     it('returns false for unknown DeepSeek models', () => {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -55,6 +55,9 @@ export type OfficialModel = {
   id: string
   // Advertised context-window size for this exact model, in tokens.
   contextWindow: number
+  // Optional exact protocol override for mixed-protocol vendor catalogs. Absent means the model uses
+  // the vendor-level endpoint set.
+  apiEndpoint?: ChatApiEndpoint
   // Optional override for a model whose effort levels differ from the vendor default.
   reasoningEffort?: ReasoningEffortPresetSetting
 }
@@ -622,15 +625,94 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     apiEndpoints: ['openai'],
     baseUrl: 'https://opencode.ai/zen/go/v1',
     apiKeyUrl: 'https://opencode.ai/zen',
-    // The public catalog mixes Chat Completions, Responses, and Messages models but does not expose
-    // protocol metadata. Keep this list to models that use the provider's default OpenAI-compatible
-    // package instead of offering a refresh that could surface models this transport cannot drive.
+    // OpenCode documents one protocol per model. Keep the catalog bundled so deprecated and temporary
+    // free entries do not appear through the broader live model endpoint.
     models: [
       { id: 'kimi-k2.7-code', contextWindow: 262_144 },
+      {
+        id: 'grok-4.6',
+        contextWindow: 500_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.6-luna',
+        contextWindow: 1_050_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-max'
+      },
+      {
+        id: 'glm-5.3-flash',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'low-high-max'
+      },
+      { id: 'glm-5.3', contextWindow: 1_000_000, reasoningEffort: 'low-high-max' },
+      { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'high-max' },
+      { id: 'glm-5.1', contextWindow: 202_752 },
       { id: 'kimi-k3', contextWindow: 1_048_576 },
-      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 },
-      { id: 'glm-5.3', contextWindow: 1_000_000 }
-    ]
+      { id: 'kimi-k2.6', contextWindow: 262_144 },
+      { id: 'longcat-2.0', contextWindow: 1_000_000, reasoningEffort: 'none-high' },
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000, reasoningEffort: 'high-max' },
+      {
+        id: 'deepseek-v4-flash',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'low-high-max'
+      },
+      {
+        id: 'deepseek-v4-flash-vision-exp',
+        contextWindow: 1_000_000,
+        reasoningEffort: 'none-high-max'
+      },
+      { id: 'mimo-v2.5', contextWindow: 1_000_000 },
+      { id: 'mimo-v2.5-pro', contextWindow: 1_048_576 },
+      {
+        id: 'minimax-m3',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'none-high'
+      },
+      {
+        id: 'muse-spark-1.2-contributor',
+        contextWindow: 1_048_576,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'minimal-low-medium-high'
+      },
+      {
+        id: 'qwen3.8-max',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'none-high'
+      },
+      {
+        id: 'qwen3.7-max',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'none-high'
+      },
+      {
+        id: 'qwen3.7-plus',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'none-high'
+      },
+      { id: 'hy3', contextWindow: 256_000, reasoningEffort: 'none-high' }
+    ],
+    multimodal: {
+      multimodalModels: [
+        'kimi-k2.7-code',
+        'grok-4.6',
+        'gpt-5.6-luna',
+        'glm-5.3-flash',
+        'kimi-k3',
+        'kimi-k2.6',
+        'deepseek-v4-flash-vision-exp',
+        'mimo-v2.5',
+        'mimo-v2.5-pro',
+        'muse-spark-1.2-contributor',
+        'qwen3.8-max',
+        'qwen3.7-plus'
+      ]
+    }
   },
   {
     id: 'opencode',
@@ -639,15 +721,232 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     apiEndpoints: ['openai'],
     baseUrl: 'https://opencode.ai/zen/v1',
     apiKeyUrl: 'https://opencode.ai/zen',
-    // Zen's public list has the same mixed-protocol limitation as Go, so this catalog is deliberately
-    // curated to default OpenAI-compatible models.
+    // Zen also mixes protocols. Exclude Google-native, temporary free, deprecated, and explicitly
+    // product-excluded models while preserving the existing Kimi default.
     models: [
       { id: 'kimi-k2.7-code', contextWindow: 262_144 },
+      {
+        id: 'gpt-5.6-sol',
+        contextWindow: 1_050_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-max'
+      },
+      {
+        id: 'gpt-5.6-terra',
+        contextWindow: 1_050_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-max'
+      },
+      {
+        id: 'gpt-5.6-luna',
+        contextWindow: 1_050_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-max'
+      },
+      {
+        id: 'claude-fable-5',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'claude-opus-5',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'claude-sonnet-5',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'grok-4.6',
+        contextWindow: 500_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.5',
+        contextWindow: 1_050_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.5-pro',
+        contextWindow: 1_050_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.4',
+        contextWindow: 1_050_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.4-pro',
+        contextWindow: 1_050_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.4-mini',
+        contextWindow: 400_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.4-nano',
+        contextWindow: 400_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.3-codex',
+        contextWindow: 400_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.3-codex-spark',
+        contextWindow: 128_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.2',
+        contextWindow: 400_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'none-low-medium-high-xhigh'
+      },
+      {
+        id: 'gpt-5.1',
+        contextWindow: 400_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'low-medium-high'
+      },
+      {
+        id: 'gpt-5',
+        contextWindow: 400_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'minimal-low-medium-high'
+      },
+      {
+        id: 'gpt-5-nano',
+        contextWindow: 400_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'minimal-low-medium-high'
+      },
+      {
+        id: 'claude-opus-4-8',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'claude-opus-4-7',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'standard-5'
+      },
+      {
+        id: 'claude-opus-4-6',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'low-medium-high-max'
+      },
+      {
+        id: 'claude-opus-4-5',
+        contextWindow: 200_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'low-medium-high'
+      },
+      {
+        id: 'claude-sonnet-4-6',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'low-medium-high-max'
+      },
+      { id: 'claude-sonnet-4-5', contextWindow: 1_000_000, apiEndpoint: 'anthropic' },
+      { id: 'claude-haiku-4-5', contextWindow: 200_000, apiEndpoint: 'anthropic' },
+      {
+        id: 'grok-4.5',
+        contextWindow: 500_000,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'low-medium-high'
+      },
+      { id: 'grok-build-0.1', contextWindow: 256_000, apiEndpoint: 'responses' },
+      {
+        id: 'muse-spark-1.2',
+        contextWindow: 1_048_576,
+        apiEndpoint: 'responses',
+        reasoningEffort: 'minimal-low-medium-high'
+      },
+      {
+        id: 'qwen3.7-max',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'none-high'
+      },
+      {
+        id: 'qwen3.7-plus',
+        contextWindow: 1_000_000,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'none-high'
+      },
+      {
+        id: 'qwen3.5-plus',
+        contextWindow: 262_144,
+        apiEndpoint: 'anthropic',
+        reasoningEffort: 'none-high'
+      },
       { id: 'kimi-k3', contextWindow: 1_048_576 },
+      { id: 'kimi-k2.6', contextWindow: 262_144, reasoningEffort: 'none-high' },
       { id: 'deepseek-v4-flash', contextWindow: 1_000_000 },
       { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
-      { id: 'glm-5.2', contextWindow: 1_000_000 }
-    ]
+      { id: 'minimax-m3', contextWindow: 512_000 },
+      { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'high-max' },
+      { id: 'glm-5.1', contextWindow: 204_800, reasoningEffort: 'none-high' }
+    ],
+    multimodal: {
+      multimodalModels: [
+        'kimi-k2.7-code',
+        'gpt-5.6-sol',
+        'gpt-5.6-terra',
+        'gpt-5.6-luna',
+        'claude-fable-5',
+        'claude-opus-5',
+        'claude-sonnet-5',
+        'grok-4.6',
+        'gpt-5.5',
+        'gpt-5.5-pro',
+        'gpt-5.4',
+        'gpt-5.4-pro',
+        'gpt-5.4-mini',
+        'gpt-5.4-nano',
+        'gpt-5.3-codex',
+        'gpt-5.2',
+        'gpt-5.1',
+        'gpt-5',
+        'gpt-5-nano',
+        'claude-opus-4-8',
+        'claude-opus-4-7',
+        'claude-opus-4-6',
+        'claude-opus-4-5',
+        'claude-sonnet-4-6',
+        'claude-sonnet-4-5',
+        'claude-haiku-4-5',
+        'grok-4.5',
+        'grok-build-0.1',
+        'muse-spark-1.2',
+        'qwen3.5-plus',
+        'kimi-k3',
+        'kimi-k2.6',
+        'minimax-m3'
+      ]
+    }
   },
   // OpenRouter is an aggregation gateway (many vendors behind one key), so it sits last in the picker.
   {
@@ -969,8 +1268,29 @@ export const isVendorModelResponsesSupported = (
   const vendor = VENDORS_BY_ID.get(vendorId)
   if (!vendor) return false
 
+  const modelEndpoint = vendor.models.find(({ id }) => id === modelId)?.apiEndpoint
+  if (modelEndpoint) return modelEndpoint === 'responses'
   if (vendor.apiEndpoints?.includes('responses')) return true
   return vendor.responsesModels?.includes(modelId) ?? false
+}
+
+// Resolves the exact protocol set for one bundled model. Mixed-protocol gateways can override the
+// vendor default with one documented endpoint; legacy `responsesModels` catalogs keep their additive
+// Responses behavior.
+export const resolveVendorModelApiEndpoints = (
+  vendorId: OfficialVendorId,
+  modelId: string | undefined
+): ChatApiEndpoint[] => {
+  const modelEndpoint = VENDORS_BY_ID.get(vendorId)?.models.find(
+    ({ id }) => id === modelId
+  )?.apiEndpoint
+  if (modelEndpoint) return [modelEndpoint]
+
+  const vendorEndpoints = resolveVendorApiEndpoints(vendorId)
+  return !vendorEndpoints.includes('responses') &&
+    isVendorModelResponsesSupported(vendorId, modelId)
+    ? [...vendorEndpoints, 'responses']
+    : vendorEndpoints
 }
 
 // Custom model ids are opaque: guessing from their name is less reliable than a stable documented

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -649,6 +649,8 @@ export type SetActiveProviderRequest = {
 export type ValidateProviderRequest = {
   providerId?: string
   draft?: ProviderDraft
+  // Optional model override for validating a saved provider before that model becomes active.
+  model?: string
 }
 
 // Structured validation outcome so the renderer can render an actionable message per category.


### PR DESCRIPTION
## Problem

OpenCode Go and Zen now advertise substantially larger model catalogs, with model-specific Chat Completions, Responses, and Anthropic Messages endpoints. The app currently exposes only a small Chat-only subset, so newer models are unavailable and a provider-wide endpoint cannot represent the documented mixed protocols.

Official references:

- https://opencode.ai/docs/go/
- https://opencode.ai/docs/zen/

## Proposed change

- Expand the bundled OpenCode Go catalog to 21 supported models.
- Expand the bundled OpenCode Zen catalog to 40 supported models.
- Add an optional model-level endpoint override and use it in provider drafts, runtime routing, and configured-model compatibility.
- Make preflight use the effective active model and make fresh official-provider setup select one framework-compatible catalog model for gating, main validation, and activation. Saved-provider validation receives the normalized pending model without activating it early.
- Include official context-window, reasoning-effort, and multimodal metadata.
- Keep `kimi-k2.7-code` as the existing default for both plans.

### OpenCode Go

`kimi-k2.7-code`, `grok-4.6`, `gpt-5.6-luna`, `glm-5.3-flash`, `glm-5.3`, `glm-5.2`, `glm-5.1`, `kimi-k3`, `kimi-k2.6`, `longcat-2.0`, `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`, `mimo-v2.5`, `mimo-v2.5-pro`, `minimax-m3`, `muse-spark-1.2-contributor`, `qwen3.8-max`, `qwen3.7-max`, `qwen3.7-plus`, `hy3`.

### OpenCode Zen

`kimi-k2.7-code`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `grok-4.6`, `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`, `gpt-5.1`, `gpt-5`, `gpt-5-nano`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5`, `claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `grok-4.5`, `grok-build-0.1`, `muse-spark-1.2`, `qwen3.7-max`, `qwen3.7-plus`, `qwen3.5-plus`, `kimi-k3`, `kimi-k2.6`, `deepseek-v4-flash`, `deepseek-v4-pro`, `minimax-m3`, `glm-5.2`, `glm-5.1`.

## Scope and non-goals

- Explicitly excludes `minimax-m2.7`, `minimax-m2.5`, and `qwen3.6-plus` from both plans.
- Excludes Google-native Gemini entries because the app has no Google endpoint enum/transport.
- Excludes temporary free and officially deprecated entries.
- Does not enable live model refresh or add dependencies.

## Compatibility and data impact

- Historical compatibility: no migration is required; existing provider records derive exact endpoints from their selected model at runtime.
- Enum impact: no enum value is added. The existing `anthropic`, `openai`, and `responses` values are reused.
- Persistence impact: onboarding writes the selected compatible model to the existing `activeModel` field. No field/schema is added, and bundled model-level endpoint metadata is not written to settings.

## Acceptance evidence

- Exact Go/Zen catalogs, exclusions, protocol metadata, multimodal metadata, and legacy additive Responses behavior: `src/shared/provider-registry.test.ts`.
- Runtime routing and framework compatibility for Responses and Anthropic models: `src/main/settings/provider-runtime-projection.test.ts`.
- Per-model compatibility in mixed-protocol model selectors: `src/shared/configured-model-catalog.test.ts`.
- Effective-model preflight routing: `src/main/settings/agent-runtime-manager.test.ts`.
- Mixed-protocol fresh setup under Claude Code and preservation of its pending model through saved-provider validation and activation: `src/renderer/src/pages/settings/provider-form-value.test.ts`, `src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx`, `src/main/settings/service.test.ts`, and provider store tests.

## Local verification

- `npm run test:module -- settings_provider_accounts` — 21 files, 399 tests passed.
- Targeted regression set — 8 files, 275 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `git diff --check` — passed.

The affected-test planner falls back to the complete Vitest suite because `src/shared/configured-model-catalog.test.ts` has no module owner. Per project guidance, the complete suite is left to PR CI.
