### PR TITLE
fix(delegation): preserve artifact runtime segment on settlement

### DIFF
--- a/src/main/delegation/delegation-settlement-wake-owner.test.ts
+++ b/src/main/delegation/delegation-settlement-wake-owner.test.ts
@@ -15,7 +15,15 @@ const snapshot = (
   rootFrameId: 'root-frame',
   activeRootPromptIds: ['root-prompt'],
   attempts,
-  ...overrides
+  ...overrides,
+  rootPromptRuntimeSegments:
+    overrides.rootPromptRuntimeSegments ??
+    Object.fromEntries(
+      (overrides.activeRootPromptIds ?? ['root-prompt']).map((promptId) => [
+        promptId,
+        'root-runtime'
+      ])
+    )
 })
 
 const child = (

--- a/src/main/delegation/delegation-settlement-wake-owner.ts
+++ b/src/main/delegation/delegation-settlement-wake-owner.ts
@@ -23,6 +23,7 @@ type DelegationSettlementSnapshot = Readonly<{
   rootFrameId: string
   rootBranchId?: string
   activeRootPromptIds: readonly string[]
+  rootPromptRuntimeSegments: Readonly<Record<string, string>>
   attempts: readonly DelegationSettlementAttempt[]
 }>
 
@@ -32,6 +33,7 @@ type DelegationSettlementDispatch = Readonly<{
   originatingPromptId: string
   rootFrameId: string
   rootBranchId?: string
+  runtimeSegmentId: string
   promptId: string
   text: string
 }>
@@ -56,6 +58,7 @@ type Watch = {
   originatingPromptId: string
   rootFrameId: string
   rootBranchId?: string
+  runtimeSegmentId: string
   remaining: Map<string, WatchedAttempt>
   pending: Map<string, SettlementItem>
 }
@@ -215,6 +218,11 @@ class DelegationSettlementWakeOwner {
         this.deleteIfIdle(input.sessionId, state)
         return
       }
+      const runtimeSegmentId = snapshot.rootPromptRuntimeSegments[input.originatingPromptId]
+      if (!runtimeSegmentId) {
+        this.deleteIfIdle(input.sessionId, state)
+        return
+      }
       const remaining = new Map<string, WatchedAttempt>()
       const pending = new Map<string, SettlementItem>()
       for (const attempt of snapshot.attempts) {
@@ -245,7 +253,8 @@ class DelegationSettlementWakeOwner {
       if (
         existing &&
         existing.projectId === snapshot.projectId &&
-        existing.rootFrameId === snapshot.rootFrameId
+        existing.rootFrameId === snapshot.rootFrameId &&
+        existing.runtimeSegmentId === runtimeSegmentId
       ) {
         existing.rootBranchId = snapshot.rootBranchId
         for (const [key, watched] of remaining) {
@@ -261,6 +270,7 @@ class DelegationSettlementWakeOwner {
           originatingPromptId: input.originatingPromptId,
           rootFrameId: snapshot.rootFrameId,
           ...(snapshot.rootBranchId ? { rootBranchId: snapshot.rootBranchId } : {}),
+          runtimeSegmentId,
           remaining,
           pending
         })
@@ -418,6 +428,7 @@ class DelegationSettlementWakeOwner {
           originatingPromptId: selected.originatingPromptId,
           rootFrameId: selected.rootFrameId,
           ...(selected.rootBranchId ? { rootBranchId: selected.rootBranchId } : {}),
+          runtimeSegmentId: selected.runtimeSegmentId,
           promptId,
           text: settlementText(items, selected.remaining.size)
         }

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -606,7 +606,8 @@ describe('production delegated-work composition', () => {
     expect(request).toMatchObject({
       projectId: harness.session.projectId,
       sessionId: harness.session.id,
-      originatingPromptId: harness.caller.originMessageId
+      originatingPromptId: harness.caller.originMessageId,
+      runtimeSegmentId: 'runtime-segment-session-codex'
     })
     expect(request?.text).toContain(delegated.children[0].frameId)
     expect(request?.text).toContain(delegated.children[0].attemptId)
@@ -958,7 +959,7 @@ describe('production delegated-work composition', () => {
         rootFrameId: harness.caller.frameId,
         agentFrameId: harness.caller.frameId,
         messageAncestry: [harness.caller.originMessageId],
-        runtimeSegmentId: expect.stringMatching(/^delegation-settlement-/u)
+        runtimeSegmentId: 'runtime-segment-session-codex'
       }
     })
     harness.execution.control(staggered.children[2].attemptId).complete('gamma')
@@ -978,7 +979,7 @@ describe('production delegated-work composition', () => {
       .poll(() => promptEnded)
       .toContainEqual({
         sessionId: harness.session.id,
-        promptId: first.request.provenanceContext!.runtimeSegmentId!
+        promptId: expect.stringMatching(/^delegation-settlement-/u)
       })
     await vi.advanceTimersByTimeAsync(100)
     await expect.poll(() => pendingContinuations).toHaveLength(2)

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -156,17 +156,29 @@ const settlementSnapshot = (
   if (!rootFrame) return undefined
   const rootBranch = graph.branches.find(({ id }) => id === rootFrame.activeBranchId)
   if (!rootBranch) return undefined
-  const activeRootPromptIds = resolveActiveConversationMessages({
+  const activeRootMessages = resolveActiveConversationMessages({
     ...graph,
     activeFrameId: graph.rootFrameId
-  }).map(({ id }) => id)
+  })
+  const durableRootRuntimeSegmentIds = new Set(
+    graph.runtimeSegments
+      .filter(({ agentFrameId }) => agentFrameId === graph.rootFrameId)
+      .map(({ id }) => id)
+  )
   const records = session.runtimeContext?.delegatedWork?.records ?? []
   return {
     projectId: session.projectId,
     sessionId: session.id,
     rootFrameId: graph.rootFrameId,
     rootBranchId: rootBranch.id,
-    activeRootPromptIds,
+    activeRootPromptIds: activeRootMessages.map(({ id }) => id),
+    rootPromptRuntimeSegments: Object.fromEntries(
+      activeRootMessages.flatMap(({ id, runtimeSegmentId }) =>
+        runtimeSegmentId && durableRootRuntimeSegmentIds.has(runtimeSegmentId)
+          ? [[id, runtimeSegmentId]]
+          : []
+      )
+    ),
     attempts: records.flatMap((record) => {
       const frame = graph.frames.find(({ id }) => id === record.agentFrameId)
       if (!frame) return []

--- a/src/main/delegation/settlement-continuation-dispatch.test.ts
+++ b/src/main/delegation/settlement-continuation-dispatch.test.ts
@@ -13,6 +13,7 @@ const request: DelegationSettlementDispatch = {
   originatingPromptId: 'root-prompt',
   rootFrameId: 'root-frame',
   rootBranchId: 'root-branch',
+  runtimeSegmentId: 'root-runtime',
   promptId: 'wake-1',
   text: 'settlement update'
 }

--- a/src/main/delegation/settlement-continuation-dispatch.ts
+++ b/src/main/delegation/settlement-continuation-dispatch.ts
@@ -33,7 +33,7 @@ const createDelegationSettlementContinuationDispatch =
               }
             : {}),
           messageAncestry: [request.originatingPromptId],
-          runtimeSegmentId: request.promptId
+          runtimeSegmentId: request.runtimeSegmentId
         }
       },
       () => {


### PR DESCRIPTION
## Problem

Delegation settlement wake continuations used their generated flight prompt ID as the Artifact provenance Runtime Segment. That synthetic ID is not present in the durable Session conversation graph, so any Artifact Version produced during the continuation failed Artifact Finalization with runtime-segment-missing.

## Proposed change

- Resolve the originating root Message to its durable Runtime Segment when building the settlement snapshot.
- Carry that Runtime Segment through the settlement watch and dispatch boundary.
- Keep the generated settlement prompt ID only as the flight lifecycle identity.
- Fail closed by not dispatching a settlement continuation when durable Runtime Segment ownership is unavailable.

## Scope and non-goals

This changes only delegation settlement provenance routing and its tests. It does not change persisted schemas, renderer behavior, Artifact storage, or repair previously pending Artifact Versions.

## Acceptance criteria and validation

All listed checks ran after the final material edit. The exact-head classifier selected the full fallback because the delegation test files currently have no module-impact owner.

- Settlement owner, adapter, and ACP consumer behavior -> npm test -- src/main/delegation/delegation-settlement-wake-owner.test.ts src/main/delegation/settlement-continuation-dispatch.test.ts src/main/delegation/production-composition.test.ts -> 76 passed.
- Artifact Finalization durable ownership boundaries -> npm test -- src/main/artifacts/provenance-repository.test.ts with the valid and invalid ownership cases -> 2 passed.
- Node and renderer type safety -> npm run typecheck -> passed.
- Repository lint -> npm run lint -> passed.
- Exact-head portable regression plan -> npm run test:affected -- --base origin/main --head HEAD -> 1,211 files passed, 15 skipped; 19,768 tests passed, 232 skipped.

An earlier full fallback run encountered two unrelated renderer bootstrap timing failures; the file passed 21/21 in isolation, and the final exact-head full run passed completely.

No platform, packaging, migration, or UI E2E lane was included because the change does not affect those surfaces. Existing pending claims created with the synthetic Runtime Segment are intentionally not repaired by this PR.

## Review focus

Please focus on whether the originating Message is the correct durable Runtime Segment authority and whether suppressing a wake when that proof is unavailable is the appropriate fail-closed behavior.