### PR TITLE
fix(compute): persist unexpected dispatch failures

### DIFF
--- a/src/main/compute/compute-job-workflow-owner.test.ts
+++ b/src/main/compute/compute-job-workflow-owner.test.ts
@@ -12,6 +12,7 @@ import type { ResolvedSshTarget, SshRunner } from './ssh-runner'
 import type { ComputeConnectionBrokerAcquirer } from './connection-broker'
 import type { ConcurrencyManager } from './concurrency-manager'
 import { sharedDispatchTracker } from './dispatch-tracker'
+import { JobPoller } from './job-poller'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -117,7 +118,8 @@ const makeOwner = (
   publishJobUpdated?: (job: import('../../shared/compute').ComputeJob) => void,
   artifactResolver?: { resolveArtifactPath(uri: string): Promise<string> },
   storageRoot?: string,
-  concurrencyManager?: ConcurrencyManager
+  concurrencyManager?: ConcurrencyManager,
+  observeBackgroundDispatch?: (dispatch: Promise<void>) => void
 ): ComputeJobWorkflowOwner =>
   new ComputeJobWorkflowOwner(
     brokerFromRunner(runner),
@@ -127,7 +129,8 @@ const makeOwner = (
     publishJobUpdated,
     artifactResolver,
     storageRoot,
-    concurrencyManager
+    concurrencyManager,
+    observeBackgroundDispatch
   )
 
 const makeJobRepo = (
@@ -220,6 +223,65 @@ const makeJobRepo = (
 }
 
 describe('ComputeJobWorkflowOwner.submitJob', () => {
+  it('does not misclassify an unexpected live dispatch failure as restart recovery', async () => {
+    const jobs = new Map<string, import('../../shared/compute').ComputeJob>()
+    const runner: SshRunner = { run: vi.fn(() => Promise.reject(new Error('transport crashed'))) }
+    const { repo: jobRepo } = makeJobRepo(jobs)
+    const { repo: hostRepo } = makeRepo()
+    const broker = {
+      request: vi.fn(),
+      requestWithContext: vi.fn(() => Promise.resolve('once' as const)),
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+    let backgroundDispatch: Promise<void> | undefined
+    const service = makeOwner(
+      runner,
+      hostRepo,
+      broker,
+      jobRepo,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      (dispatch) => {
+        backgroundDispatch = dispatch.catch(() => undefined)
+      }
+    )
+
+    const submitted = await service.submitJob(
+      'ssh:biowulf',
+      'test unexpected dispatch failure',
+      'echo hi',
+      {},
+      { sessionId: 's1', projectId: 'p1' }
+    )
+    expect(backgroundDispatch).toBeDefined()
+    await backgroundDispatch
+
+    const pollerRepository = {
+      ...jobRepo,
+      findNonTerminal: vi.fn(async () =>
+        [...jobs.values()].filter((job) => ['queued', 'submitted', 'running'].includes(job.status))
+      )
+    } as unknown as import('./job-repository').ComputeJobRepository
+    const poller = new JobPoller({
+      connectionBroker: brokerFromRunner(runner),
+      hostRepository: hostRepo,
+      jobRepository: pollerRepository,
+      dispatchTracker: sharedDispatchTracker
+    })
+
+    await poller.tick()
+
+    expect(jobs.get(submitted.job_id)).toMatchObject({
+      status: 'error',
+      error_code: 'dispatch_failed',
+      stderr_tail: 'The remote Compute Job dispatch failed unexpectedly.',
+      started_at: undefined,
+      remote_handle: undefined
+    })
+  })
+
   it('tracks a committed submitted row through dispatcher registration', async () => {
     const runner = makeFakeRunner({
       exitCode: 1,

--- a/src/main/compute/compute-job-workflow-owner.ts
+++ b/src/main/compute/compute-job-workflow-owner.ts
@@ -146,7 +146,8 @@ export class ComputeJobWorkflowOwner {
     private readonly publishJobUpdated: ((job: ComputeJob) => void) | undefined,
     private readonly artifactResolver: ArtifactResolver | undefined,
     private readonly storageRoot: string | undefined,
-    private readonly concurrencyManager: ConcurrencyManager | undefined
+    private readonly concurrencyManager: ConcurrencyManager | undefined,
+    private readonly observeBackgroundDispatch?: (dispatch: Promise<void>) => void
   ) {}
 
   async submitJob(
@@ -328,12 +329,14 @@ export class ComputeJobWorkflowOwner {
       }
 
       if (initialStatus === 'submitted') {
-        void dispatchJob(jobId, {
+        const dispatch = dispatchJob(jobId, {
           connectionBroker: this.connectionBroker,
           hostRepository: this.hostRepository,
           jobRepository: this.jobRepository,
           onJobUpdated: this.handleJobUpdated
         })
+        this.observeBackgroundDispatch?.(dispatch)
+        void dispatch
       }
     } finally {
       if (dispatchHandoffHeld) sharedDispatchTracker.end(jobId)

--- a/src/main/compute/job-dispatcher.test.ts
+++ b/src/main/compute/job-dispatcher.test.ts
@@ -464,12 +464,12 @@ describe('dispatchJob', () => {
     expect(tracker.has('job-1')).toBe(false) // cleared in finally
   })
 
-  it('clears the in-flight tracker even when dispatch throws', async () => {
+  it('terminalizes unexpected dispatch errors before clearing the in-flight tracker', async () => {
     const job = makeJob()
     const tracker = new DispatchTracker()
     // A runner that throws simulates an unexpected error mid-dispatch.
     const runner: SshRunner = { run: vi.fn(() => Promise.reject(new Error('boom'))) }
-    const { repo } = makeJobRepo(job)
+    const { repo, transition } = makeJobRepo(job)
 
     await expect(
       dispatchJob(job.job_id, {
@@ -478,8 +478,14 @@ describe('dispatchJob', () => {
         jobRepository: repo as unknown as ComputeJobRepository,
         dispatchTracker: tracker
       })
-    ).rejects.toThrow('boom')
+    ).resolves.toBeUndefined()
 
+    expect(transition).toHaveBeenCalledWith('job-1', ['submitted'], {
+      status: 'error',
+      errorCode: 'dispatch_failed',
+      stderrTail: 'The remote Compute Job dispatch failed unexpectedly.',
+      finishedAt: expect.any(Date)
+    })
     expect(tracker.has('job-1')).toBe(false)
   })
 

--- a/src/main/compute/job-dispatcher.ts
+++ b/src/main/compute/job-dispatcher.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 
 import type { ComputeJob } from '../../shared/compute'
+import { createLogger, errorLogFields } from '../logger'
 import {
   classifyConnectionFailure,
   ComputeConnectionError,
@@ -20,6 +21,7 @@ const DISPATCH_MAX_OUTPUT_BYTES = 4 * 1024
 // Timeout for the dispatch SSH connection (mkdir + write files + launch). Generous to accommodate
 // slow cluster file systems; the job itself runs detached so the connection can close after.
 const DISPATCH_TIMEOUT_MS = 120_000
+const log = createLogger('compute')
 
 // Remote handle stored in the DB once the job is launched.
 export type RemoteHandle = {
@@ -140,12 +142,22 @@ export async function dispatchJob(jobId: string, deps: DispatcherDeps): Promise<
     try {
       await dispatchJobInner(jobId, deps)
     } catch (error) {
-      if (!(error instanceof ComputeConnectionError)) throw error
       const lifecycle = new ComputeJobLifecycle(deps.jobRepository, deps.onJobUpdated)
-      await lifecycle.dispatchError(jobId, {
-        errorCode: error.code,
-        stderrTail: error.message
-      })
+      if (error instanceof ComputeConnectionError) {
+        await lifecycle.dispatchError(jobId, {
+          errorCode: error.code,
+          stderrTail: error.message
+        })
+      } else {
+        log.warn('remote Compute Job dispatch failed unexpectedly', {
+          jobId,
+          ...errorLogFields(error)
+        })
+        await lifecycle.dispatchError(jobId, {
+          errorCode: 'dispatch_failed',
+          stderrTail: 'The remote Compute Job dispatch failed unexpectedly.'
+        })
+      }
     }
   } finally {
     tracker.end(jobId)


### PR DESCRIPTION
## Problem

An unexpected non-`ComputeConnectionError` failure during remote dispatch escaped the fire-and-forget task. The dispatch tracker was then released while the durable Compute Job remained `submitted` without a remote handle. The next poller tick treated that live-process failure as restart recovery and overwrote the real cause with `dispatch interrupted by restart`.

## Proposed change

- Persist the existing `error` / `dispatch_failed` terminal transition for unexpected dispatch failures before releasing the tracker.
- Keep the underlying exception in the existing redacted structured log while storing a safe user-facing failure message.
- Add a minimal observer seam for the background dispatch Promise so regression coverage deterministically exercises `submitJob -> dispatchJob -> tracker release -> JobPoller.tick -> persisted Job`.

## Scope and non-goals

- No database field, schema, migration, data-model, status, or error-code additions.
- No interaction-flow changes.
- Genuine restart-orphan recovery remains unchanged.
- Existing misclassified historical Jobs are not rewritten because their original dispatch cause cannot be proven safely.

## Acceptance criteria and validation

The regression test was first run with the production fix removed and failed with the reported symptom:

```text
Expected stderr_tail:
The remote Compute Job dispatch failed unexpectedly.

Received stderr_tail:
dispatch interrupted by restart
```

The same test passes with the fix restored.

Final checks ran after the last material edit:

- unexpected live dispatch failure is not misclassified as restart recovery -> `npm test -- src/main/compute/compute-job-workflow-owner.test.ts -t 'does not misclassify an unexpected live dispatch failure as restart recovery'` -> passed
- dispatcher and submit workflow contracts -> `npm test -- src/main/compute/compute-job-workflow-owner.test.ts src/main/compute/job-dispatcher.test.ts` -> 73 passed
- compute owner, contract, and representative consumer coverage -> `npm run test:module -- compute_service` -> 810 passed, 6 skipped
- affected main-process types -> `npm run typecheck:node` -> passed
- linted source and tests -> `npm run lint` -> passed

The module plan selects the `windows_sensitive` capability overlay. Local verification covered the shared main-process behavior on macOS; Windows certification and remaining platform risk are delegated to required PR CI. Per request, the complete local `npm test` suite was not run.

## Review focus

- The unknown-error path terminalizes the Job before tracker release.
- The observer seam only makes the existing fire-and-forget boundary deterministic in tests and does not replace the production dispatcher.
- Persisted diagnostics remain safe while the structured log retains the redacted underlying error.

Fixes #1809
