### PR TITLE
fix(github): reduce star prompt frequency

### DIFF
--- a/src/renderer/src/components/GitHubStarBadge.render.test.tsx
+++ b/src/renderer/src/components/GitHubStarBadge.render.test.tsx
@@ -30,7 +30,7 @@ const flush = async (): Promise<void> => {
 }
 
 beforeEach(() => {
-  window.localStorage.clear()
+  window.localStorage.removeItem(STAR_NUDGE_LAST_SHOWN_STORAGE_KEY)
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -40,7 +40,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   document.body.innerHTML = ''
-  window.localStorage.clear()
+  window.localStorage.removeItem(STAR_NUDGE_LAST_SHOWN_STORAGE_KEY)
   delete (window as unknown as { api?: unknown }).api
   vi.useRealTimers()
   vi.restoreAllMocks()

--- a/src/renderer/src/components/GitHubStarBadge.render.test.tsx
+++ b/src/renderer/src/components/GitHubStarBadge.render.test.tsx
@@ -16,6 +16,8 @@ import { APP } from '../../../shared/app-config'
 
 let container: HTMLDivElement
 let root: Root
+const STAR_NUDGE_LAST_SHOWN_STORAGE_KEY = 'open-science:github-star-nudge-last-shown-at'
+const STAR_NUDGE_COOLDOWN_MS = 2 * 24 * 60 * 60 * 1_000
 
 const installApi = (getStars: () => Promise<number | null>): void => {
   ;(window as unknown as { api: unknown }).api = { github: { getStars } }
@@ -28,6 +30,7 @@ const flush = async (): Promise<void> => {
 }
 
 beforeEach(() => {
+  window.localStorage.clear()
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -37,6 +40,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   document.body.innerHTML = ''
+  window.localStorage.clear()
   delete (window as unknown as { api?: unknown }).api
   vi.useRealTimers()
   vi.restoreAllMocks()
@@ -100,6 +104,7 @@ describe('GitHubStarBadge', () => {
 
     act(() => vi.advanceTimersByTime(1))
     expect(popover()?.getAttribute('data-popover-open')).toBe('true')
+    expect(Number(window.localStorage.getItem(STAR_NUDGE_LAST_SHOWN_STORAGE_KEY))).toBe(Date.now())
     expect(container.textContent).toContain('A star helps more researchers find it.')
     expect(container.querySelector('svg[class*="_infinite"]')).not.toBeNull()
 
@@ -110,6 +115,38 @@ describe('GitHubStarBadge', () => {
     expect(popover()?.getAttribute('data-popover-open')).toBe('false')
 
     getClientRects.mockRestore()
+  })
+
+  it('shows the workspace nudge at most once every two days across projects', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-27T00:00:00.000Z'))
+    vi.spyOn(Element.prototype, 'getClientRects').mockReturnValue({ length: 1 } as DOMRectList)
+    installApi(() => Promise.resolve(2600))
+
+    const popover = (): Element | null => container.querySelector('[data-popover-open]')
+    await act(async () => {
+      root.render(<GitHubStarBadge key="project-1" variant="workspace" nudgeKey="project-1" />)
+    })
+    act(() => vi.advanceTimersByTime(5_000))
+    expect(popover()?.getAttribute('data-popover-open')).toBe('true')
+    const lastShownAt = Number(window.localStorage.getItem(STAR_NUDGE_LAST_SHOWN_STORAGE_KEY))
+
+    await act(async () => {
+      root.render(<GitHubStarBadge key="project-2" variant="workspace" nudgeKey="project-2" />)
+    })
+    vi.setSystemTime(lastShownAt + STAR_NUDGE_COOLDOWN_MS - 1)
+    act(() => vi.advanceTimersByTime(10_000))
+    expect(popover()?.getAttribute('data-popover-open')).toBe('false')
+
+    vi.setSystemTime(lastShownAt + STAR_NUDGE_COOLDOWN_MS)
+    await act(async () => {
+      root.render(<GitHubStarBadge key="project-3" variant="workspace" nudgeKey="project-3" />)
+    })
+    act(() => vi.advanceTimersByTime(4_999))
+    expect(popover()?.getAttribute('data-popover-open')).toBe('false')
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(popover()?.getAttribute('data-popover-open')).toBe('true')
   })
 
   it('starts the workspace delay after the sidebar becomes visible and closes when hidden', async () => {

--- a/src/renderer/src/components/GitHubStarBadge.tsx
+++ b/src/renderer/src/components/GitHubStarBadge.tsx
@@ -17,9 +17,29 @@ import { APP } from '../../../shared/app-config'
 const STAR_NUDGE_DELAY_MS = 5_000
 const STAR_NUDGE_VISIBILITY_POLL_MS = 500
 const STAR_NUDGE_VISIBLE_MS = 30_000
+const STAR_NUDGE_COOLDOWN_MS = 2 * 24 * 60 * 60 * 1_000
+const STAR_NUDGE_LAST_SHOWN_STORAGE_KEY = 'open-science:github-star-nudge-last-shown-at'
 
 const isVisibleStarNudgeAnchor = (anchor: HTMLElement | null): anchor is HTMLElement =>
   Boolean(anchor && !anchor.closest('[inert]') && anchor.getClientRects().length > 0)
+
+const wasStarNudgeRecentlyShown = (): boolean => {
+  try {
+    const lastShownAt = Number(window.localStorage.getItem(STAR_NUDGE_LAST_SHOWN_STORAGE_KEY))
+    const elapsed = Date.now() - lastShownAt
+    return lastShownAt > 0 && elapsed >= 0 && elapsed < STAR_NUDGE_COOLDOWN_MS
+  } catch {
+    return false
+  }
+}
+
+const recordStarNudgeShown = (): void => {
+  try {
+    window.localStorage.setItem(STAR_NUDGE_LAST_SHOWN_STORAGE_KEY, String(Date.now()))
+  } catch {
+    // The nudge remains best-effort when renderer storage is unavailable.
+  }
+}
 
 // GitHub's octocat is a brand asset that lucide-react dropped in v1, so we inline the official mark
 // here. currentColor lets it inherit the link's text color like the other icons.
@@ -78,7 +98,7 @@ const GitHubStarBadge = ({
   }, [])
 
   useEffect(() => {
-    if (variant !== 'workspace' || !nudgeKey) return
+    if (variant !== 'workspace' || !nudgeKey || wasStarNudgeRecentlyShown()) return
 
     let timeoutId: number
     const scheduleWhenVisible = (): void => {
@@ -94,6 +114,7 @@ const GitHubStarBadge = ({
           scheduleWhenVisible()
           return
         }
+        recordStarNudgeShown()
         setStarNudgeOpen(true)
       }, STAR_NUDGE_DELAY_MS)
     }


### PR DESCRIPTION
## Problem

The Workspace GitHub star prompt is keyed by project ID, so entering another project remounts the component and schedules the prompt again. There is no cross-project cooldown, which makes the prompt too frequent.

## Proposed change

- Record the time when the Workspace prompt is actually shown.
- Skip automatic prompts across all projects for the next two days.
- Treat renderer storage as best-effort so an unavailable storage backend never breaks the GitHub entry point.

## Scope and non-goals

- The persistent GitHub badge, tooltip, five-second initial delay, and thirty-second visible duration are unchanged.
- No renderer API, IPC, database schema, shared enum, dependency, or user-visible copy changes.
- The cooldown is local to each renderer storage origin; Electron and a separately hosted Web surface do not share the timestamp.

## Compatibility and persisted data

- Historical compatibility: no migration is required. Existing users have no cooldown key and remain eligible for the first prompt; missing or invalid values are treated as no prior prompt.
- Persistence: adds one renderer `localStorage` timestamp at `open-science:github-star-nudge-last-shown-at`.
- New enum/state values: none.

## Acceptance criteria and validation

The listed checks ran after the last material edit.

- Prompt persistence and exact two-day boundary -> `npm test -- src/renderer/src/components/GitHubStarBadge.render.test.tsx` -> 6 tests passed.
- Workspace consumer behavior -> `npm run test:module -- workspace_page` -> 25 files / 553 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source and formatting rules -> `npm run lint` -> passed with no warnings.
- Final impact classification -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> full PR plan because `GitHubStarBadge.render.test.tsx` has no module owner; the full local suite was intentionally not run per maintainer direction, and PR CI is the final validation authority.

Platform-specific lanes are excluded from the local set because this changes renderer-local timestamp gating only, with no path, native, IPC, or packaging behavior. Remaining risk is covered by the PR Gate full plan.

## Review focus

- Whether recording at actual display time matches the intended low-interruption policy.
- Whether a two-day, cross-project cooldown is applied at the correct boundary.
