### PR TITLE
test(workspace): honor OpenAI Responses protocol in picker tests

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -88,19 +88,20 @@ const provider = (overrides: Partial<ProviderView>): ProviderView => ({
 })
 
 // Official OpenAI models are documented as Responses-only. Tests that pick those catalog ids must
-// run under a Responses-capable framework; the store's initial Claude Code state only speaks
-// Anthropic, so the picker would otherwise hide the trigger as "No compatible model".
-// Include Anthropic as well so mixed-catalog cases (OpenAI + a custom Gateway) stay selectable.
-const responsesCapableFramework: {
-  agentFrameworkId: 'opencode'
+// run under Codex, the framework that actually speaks Responses. The store's initial Claude Code
+// state only speaks Anthropic, so the picker would otherwise hide the trigger as
+// "No compatible model". OpenCode is not used here: its adapter only drives Anthropic and Chat
+// Completions, even if a fixture claimed otherwise.
+const codexFramework: {
+  agentFrameworkId: 'codex'
   agentFrameworks: AgentFrameworkView[]
 } = {
-  agentFrameworkId: 'opencode',
+  agentFrameworkId: 'codex',
   agentFrameworks: [
     {
-      id: 'opencode',
-      displayName: 'OpenCode',
-      supportedApiTypes: ['anthropic', 'openai', 'responses'],
+      id: 'codex',
+      displayName: 'Codex',
+      supportedApiTypes: ['responses'],
       supportsSkills: true
     }
   ]
@@ -550,7 +551,7 @@ describe('ComposerModelPicker', () => {
     // gpt-5.2 is not in the bundled OpenAI catalog, so it resolves to the vendor-level profile
     // (low-medium-high-xhigh) — supported, with the stored 'high' intent mapping to the High rung.
     useSettingsStore.setState({
-      ...responsesCapableFramework,
+      ...codexFramework,
       providers: [
         provider({
           id: 'off',
@@ -578,7 +579,7 @@ describe('ComposerModelPicker', () => {
     // Long model names must not swallow the effort suffix: the model span truncates, the suffix
     // span is shrink-protected and never wraps.
     useSettingsStore.setState({
-      ...responsesCapableFramework,
+      ...codexFramework,
       providers: [
         provider({
           id: 'off',
@@ -614,7 +615,7 @@ describe('ComposerModelPicker', () => {
 
   it('shows no effort suffix on the trigger when the effort intent is default', () => {
     useSettingsStore.setState({
-      ...responsesCapableFramework,
+      ...codexFramework,
       providers: [
         provider({
           id: 'off',
@@ -726,7 +727,7 @@ describe('ComposerModelPicker', () => {
 
   it('summarizes the current pick in the Model row as provider line over model name', async () => {
     useSettingsStore.setState({
-      ...responsesCapableFramework,
+      ...codexFramework,
       providers: [
         provider({
           id: 'off',
@@ -804,7 +805,7 @@ describe('ComposerModelPicker', () => {
 
   it('keeps the grouped provider catalog in the Model submenu and switches on pick', async () => {
     useSettingsStore.setState({
-      ...responsesCapableFramework,
+      ...codexFramework,
       providers: [
         provider({
           id: 'off',
@@ -813,7 +814,7 @@ describe('ComposerModelPicker', () => {
           name: 'OpenAI',
           models: ['gpt-5.2', 'gpt-5.5']
         }),
-        provider({ id: 'gw', name: 'Gateway', models: ['gm'] })
+        provider({ id: 'gw', name: 'Gateway', apiEndpoints: ['openai'], models: ['gm'] })
       ],
       activeProviderId: 'off',
       activeModel: 'gpt-5.2'

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -9,6 +9,7 @@ import {
   CLAUDE_ISOLATED_PROVIDER_ID,
   CLAUDE_SHARED_PROVIDER_ID,
   CODEX_SHARED_PROVIDER_ID,
+  type AgentFrameworkView,
   type ProviderView,
   type SessionAgentConfiguration
 } from '../../../../shared/settings'
@@ -85,6 +86,25 @@ const provider = (overrides: Partial<ProviderView>): ProviderView => ({
   needsKey: false,
   ...overrides
 })
+
+// Official OpenAI models are documented as Responses-only. Tests that pick those catalog ids must
+// run under a Responses-capable framework; the store's initial Claude Code state only speaks
+// Anthropic, so the picker would otherwise hide the trigger as "No compatible model".
+// Include Anthropic as well so mixed-catalog cases (OpenAI + a custom Gateway) stay selectable.
+const responsesCapableFramework: {
+  agentFrameworkId: 'opencode'
+  agentFrameworks: AgentFrameworkView[]
+} = {
+  agentFrameworkId: 'opencode',
+  agentFrameworks: [
+    {
+      id: 'opencode',
+      displayName: 'OpenCode',
+      supportedApiTypes: ['anthropic', 'openai', 'responses'],
+      supportsSkills: true
+    }
+  ]
+}
 
 const render = (
   unavailable = false,
@@ -281,6 +301,30 @@ describe('ComposerModelPicker', () => {
     const trigger = container.querySelector('[aria-label="No compatible model"]')
     expect(trigger).not.toBeNull()
     expect(trigger?.textContent).toContain('No compatible model')
+  })
+
+  it('treats official OpenAI Responses models as incompatible with Claude Code', () => {
+    // Official OpenAI catalog entries resolve to Responses regardless of the mock provider's omitted
+    // apiEndpoints. Claude Code remains Anthropic-only, so the picker must warn instead of treating
+    // those models as selectable.
+    useSettingsStore.setState({
+      agentFrameworkId: 'claude-code',
+      providers: [
+        provider({
+          id: 'off',
+          type: 'official',
+          vendorId: 'openai',
+          name: 'OpenAI',
+          models: ['gpt-5.2', 'gpt-5.5']
+        })
+      ],
+      activeProviderId: 'off',
+      activeModel: 'gpt-5.2'
+    })
+    render()
+
+    expect(container.querySelector('[aria-label="Select model"]')).toBeNull()
+    expect(container.querySelector('[aria-label="No compatible model"]')).not.toBeNull()
   })
 
   it('treats a Chat provider as bridge-compatible under Codex without a per-model probe', async () => {
@@ -506,6 +550,7 @@ describe('ComposerModelPicker', () => {
     // gpt-5.2 is not in the bundled OpenAI catalog, so it resolves to the vendor-level profile
     // (low-medium-high-xhigh) — supported, with the stored 'high' intent mapping to the High rung.
     useSettingsStore.setState({
+      ...responsesCapableFramework,
       providers: [
         provider({
           id: 'off',
@@ -533,6 +578,7 @@ describe('ComposerModelPicker', () => {
     // Long model names must not swallow the effort suffix: the model span truncates, the suffix
     // span is shrink-protected and never wraps.
     useSettingsStore.setState({
+      ...responsesCapableFramework,
       providers: [
         provider({
           id: 'off',
@@ -568,6 +614,7 @@ describe('ComposerModelPicker', () => {
 
   it('shows no effort suffix on the trigger when the effort intent is default', () => {
     useSettingsStore.setState({
+      ...responsesCapableFramework,
       providers: [
         provider({
           id: 'off',
@@ -679,6 +726,7 @@ describe('ComposerModelPicker', () => {
 
   it('summarizes the current pick in the Model row as provider line over model name', async () => {
     useSettingsStore.setState({
+      ...responsesCapableFramework,
       providers: [
         provider({
           id: 'off',
@@ -756,6 +804,7 @@ describe('ComposerModelPicker', () => {
 
   it('keeps the grouped provider catalog in the Model submenu and switches on pick', async () => {
     useSettingsStore.setState({
+      ...responsesCapableFramework,
       providers: [
         provider({
           id: 'off',


### PR DESCRIPTION
## Problem

Recently merged PRs that ran the full macOS Vitest suite (`#1807`, `#1810`) failed CI on `ComposerModelPicker.render.test.tsx`. Targeted PRs that skipped the full suite (`#1811`) looked green, so the breakage landed on `main`.

`#1807` started resolving official vendor models against their documented protocols. Official OpenAI catalog entries are Responses-only. The picker tests still used those ids under the store's initial Claude Code fixture, which only speaks Anthropic, so the trigger rendered as "No compatible model" instead of the selectable catalog those tests assert.

## Proposed change

- Drive the OpenAI catalog UI tests under a Responses-capable OpenCode fixture (Anthropic remains included so mixed OpenAI + custom Gateway cases stay selectable).
- Add a regression that official OpenAI Responses models warn under Claude Code instead of appearing selectable.

## Scope and non-goals

- Tests only. No product, persistence, or catalog changes.
- Windows E2E failures on recent PRs are a separate pattern (see review notes) and are not addressed here.

## Acceptance criteria and validation

- Full-suite classification no longer fails these five picker tests for the `#1807` protocol change.
- Claude Code + official OpenAI remains a warning, matching the documented protocol.

### Evidence (after last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Picker OpenAI protocol fixtures | `npm test -- src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx` | 22 passed |
| Catalog protocol contract | `npm test -- src/shared/configured-model-catalog.test.ts` | 6 passed |
| Web types | `npm run typecheck:web` | passed |
| Lint of the changed test | `npx eslint src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx` | no issues |

Excluded: full `npm test` (PR Gate remains authoritative), Windows/macOS E2E (no product/UI change), `typecheck:node` (renderer test only).

## Review focus

- Confirm the Claude Code incompatibility warning is the intended `#1807` product behavior, not a test-only workaround.
- Historical compatibility of stored official OpenAI `apiEndpoints` is unchanged here and called out in the discussion for a product decision if needed.