### PR TITLE
fix(security): restrict Chromium renderer permissions

### DIFF
--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -73,7 +73,7 @@ type PermissionCheckHandler = (
   webContents: unknown,
   permission: string,
   requestingOrigin: string,
-  details: { isMainFrame: boolean }
+  details: { isMainFrame: boolean; requestingUrl?: string }
 ) => boolean
 type HeadersReceivedDetails = {
   webContentsId?: number
@@ -907,8 +907,9 @@ describe('window navigation policy', () => {
     }
   )
 
-  it('denies every subframe permission request while preserving trusted main-frame checks', () => {
+  it('denies sensitive Chromium permissions regardless of frame', () => {
     createMainWindow()
+    const window = lastWindow!
 
     expect(permissionRequestHandler).toBeDefined()
     expect(permissionCheckHandler).toBeDefined()
@@ -925,14 +926,67 @@ describe('window navigation policy', () => {
     ).toBe(false)
 
     const mainFrameDecision = vi.fn()
-    permissionRequestHandler?.({}, 'notifications', mainFrameDecision, {
+    permissionRequestHandler?.(window.webContents, 'media', mainFrameDecision, {
       isMainFrame: true,
       requestingUrl: 'file:///app/index.html'
     })
-    expect(mainFrameDecision).toHaveBeenCalledWith(true)
-    expect(permissionCheckHandler?.({}, 'notifications', 'file://', { isMainFrame: true })).toBe(
-      true
-    )
+    expect(mainFrameDecision).toHaveBeenCalledWith(false)
+    expect(
+      permissionCheckHandler?.(window.webContents, 'geolocation', 'file://', {
+        isMainFrame: true,
+        requestingUrl: 'file:///app/index.html'
+      })
+    ).toBe(false)
+  })
+
+  it('allows sanitized clipboard writes only from the trusted main renderer document', () => {
+    createMainWindow()
+    const window = lastWindow!
+
+    const trustedDecision = vi.fn()
+    permissionRequestHandler?.(window.webContents, 'clipboard-sanitized-write', trustedDecision, {
+      isMainFrame: true,
+      requestingUrl: 'file:///app/index.html'
+    })
+    expect(trustedDecision).toHaveBeenCalledWith(true)
+    expect(
+      permissionCheckHandler?.(window.webContents, 'clipboard-sanitized-write', 'file://', {
+        isMainFrame: true,
+        requestingUrl: 'file:///app/index.html'
+      })
+    ).toBe(true)
+
+    const untrustedDecision = vi.fn()
+    permissionRequestHandler?.(window.webContents, 'clipboard-sanitized-write', untrustedDecision, {
+      isMainFrame: true,
+      requestingUrl: 'https://example.com/'
+    })
+    expect(untrustedDecision).toHaveBeenCalledWith(false)
+    expect(
+      permissionCheckHandler?.(
+        window.webContents,
+        'clipboard-sanitized-write',
+        'https://example.com',
+        {
+          isMainFrame: true,
+          requestingUrl: 'https://example.com/'
+        }
+      )
+    ).toBe(false)
+
+    const otherWindowDecision = vi.fn()
+    permissionRequestHandler?.({}, 'clipboard-sanitized-write', otherWindowDecision, {
+      isMainFrame: true,
+      requestingUrl: 'file:///app/index.html'
+    })
+    expect(otherWindowDecision).toHaveBeenCalledWith(false)
+
+    const subframeDecision = vi.fn()
+    permissionRequestHandler?.(window.webContents, 'clipboard-sanitized-write', subframeDecision, {
+      isMainFrame: false,
+      requestingUrl: 'file:///app/index.html'
+    })
+    expect(subframeDecision).toHaveBeenCalledWith(false)
   })
 })
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -8,6 +8,7 @@ import {
   WebContentsView,
   type BrowserWindowConstructorOptions,
   type IpcMainEvent,
+  type WebContents,
   type WebFrameMain
 } from 'electron'
 import { join } from 'path'
@@ -56,6 +57,7 @@ const log = createLogger('window')
 const E2E_WINDOW_MODE_ENV = 'OPEN_SCIENCE_E2E_WINDOW_MODE'
 const RENDERER_RECOVERY_WINDOW_MS = 60_000
 const MAX_AUTOMATIC_RENDERER_RECOVERIES = 2
+const ALLOWED_RENDERER_PERMISSIONS = new Set(['clipboard-sanitized-write'])
 const RECOVERABLE_RENDERER_EXIT_REASONS = new Set([
   'abnormal-exit',
   'crashed',
@@ -113,13 +115,29 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
     }
     return { action: 'deny' }
   })
-  // Remote source pages share the main window Session but never need device, media, location, or
-  // storage permissions. Keep trusted main-frame behavior intact and fail every subframe closed.
+  const isAllowedRendererPermission = (
+    requestingWebContents: WebContents | null,
+    permission: string,
+    details: { isMainFrame: boolean; requestingUrl?: string }
+  ): boolean => {
+    const rendererUrl = window.webContents.getURL()
+    return (
+      rendererUrl !== '' &&
+      requestingWebContents === window.webContents &&
+      details.isMainFrame &&
+      details.requestingUrl === rendererUrl &&
+      ALLOWED_RENDERER_PERMISSIONS.has(permission)
+    )
+  }
+  // Remote source pages share the main window Session but never need Chromium permissions. The
+  // trusted renderer only needs sanitized clipboard writes; fail every other capability closed.
   window.webContents.session.setPermissionRequestHandler(
-    (_webContents, _permission, callback, details) => callback(details.isMainFrame)
+    (webContents, permission, callback, details) =>
+      callback(isAllowedRendererPermission(webContents, permission, details))
   )
   window.webContents.session.setPermissionCheckHandler(
-    (_webContents, _permission, _requestingOrigin, details) => details.isMainFrame
+    (webContents, permission, _requestingOrigin, details) =>
+      isAllowedRendererPermission(webContents, permission, details)
   )
   const sourcePreviewLoadMonitor = createSourcePreviewLoadMonitor((state) => {
     window.webContents.send(SOURCE_PREVIEW_LOAD_STATE_CHANNEL, state)


### PR DESCRIPTION
## Problem

The main-window Session handlers used `details.isMainFrame` as the complete authorization decision. Any Chromium permission requested or checked by the main renderer document was therefore granted, including media, geolocation, and notifications. If renderer script execution is compromised, this unnecessarily expands the capabilities available to that code.

## Proposed change

- Default both Chromium permission request and permission check paths to deny.
- Explicitly allow only `clipboard-sanitized-write`, which the renderer currently uses for copy actions.
- Require the request to come from the main frame and the currently loaded trusted renderer document URL.
- Add regression coverage through the existing `createMainWindow()` Session-handler boundary.

## Scope and non-goals

- No architecture or public interface changes.
- No data fields, data model, data relationship, persistence, migration, or historical-compatibility changes.
- No new states or enum values.
- No user-interaction changes; existing sanitized clipboard writes remain allowed.
- No new Chromium device capabilities are introduced.

## Acceptance criteria and validation

The regression test was first run against the old implementation twice and failed deterministically because a trusted main-frame `media` request received `true` instead of the expected `false`.

Final evidence after the last material edit:

- Sensitive permissions and trusted clipboard policy -> `../../node_modules/.bin/vitest.cmd run src/main/windows.test.ts` -> 64/64 passed.
- Changed-file lint -> `../../node_modules/.bin/eslint.cmd src/main/windows.ts src/main/windows.test.ts` -> passed.
- Patch hygiene -> `git diff --check` -> passed.
- Main-process typecheck -> attempted with `../../node_modules/.bin/tsc.cmd --noEmit -p tsconfig.node.json --composite false`; blocked by the shared main-checkout dependency tree being out of sync with this worktree (`waitForMcpServers` export mismatch and generated Prisma Client missing `sessionModelCallUsage`). No diagnostics referenced the changed files. Clean-install PR CI is authoritative.

The focused unit boundary does not launch a real Electron renderer to perform a clipboard write; CI and review should confirm the permission details contract remains consistent with Electron 39.

## Review focus

- Confirm `clipboard-sanitized-write` is the only Chromium permission the renderer requires.
- Confirm matching the requesting document URL to `webContents.getURL()` is appropriately fail-closed for packaged and development renderer loads.
- Confirm both request and check paths enforce the same policy.