### PR TITLE
test(architecture): relax implementation-detail assertions

### DIFF
--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -2,21 +2,15 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { basename, dirname, extname, relative, resolve } from 'node:path'
 
 import {
-  canHaveModifiers,
   createSourceFile,
   forEachChild,
-  getModifiers,
-  isArrowFunction,
   isCallExpression,
-  isClassDeclaration,
   isExportDeclaration,
   isIdentifier,
   isImportDeclaration,
   isImportTypeNode,
   isLiteralTypeNode,
-  isMethodDeclaration,
   isPropertyAccessExpression,
-  isPropertyDeclaration,
   isStringLiteralLike,
   ScriptKind,
   ScriptTarget,
@@ -44,9 +38,7 @@ const computePaths = {
   concurrencyManager: resolve(mainRoot, 'compute/concurrency-manager.ts'),
   jobDispatcher: resolve(mainRoot, 'compute/job-dispatcher.ts'),
   jobPoller: resolve(mainRoot, 'compute/job-poller.ts'),
-  sessionEnabledHostsOwner: resolve(mainRoot, 'compute/session-enabled-hosts-owner.ts'),
   ipc: resolve(mainRoot, 'compute/ipc.ts'),
-  electronIpcAdapter: resolve(mainRoot, 'compute/electron-ipc-adapter.ts'),
   mainIpc: resolve(mainRoot, 'ipc.ts'),
   applicationCommands: resolve(mainRoot, 'compute/application-commands.ts'),
   jobRuntime: resolve(mainRoot, 'compute/job-runtime.ts'),
@@ -54,7 +46,6 @@ const computePaths = {
 } as const
 
 const readSource = (path: string): string => readFileSync(path, 'utf8')
-const rawLineCount = (source: string): number => source.trimEnd().split(/\r?\n/).length
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
 const portableProjectPath = (path: string): string =>
   relative(projectRoot, path).replaceAll('\\', '/')
@@ -197,39 +188,11 @@ const privateOwnerPaths = [
   computePaths.remoteOwner,
   computePaths.jobOwner
 ] as const
-const lifecyclePaths = [
-  computePaths.deletionOwner,
-  computePaths.jobLifecycle,
-  computePaths.jobRepository,
-  computePaths.concurrencyManager,
-  computePaths.jobDispatcher,
-  computePaths.jobPoller
-] as const
 const productionSourcePaths = productionSources()
 
 describe('Compute service architecture', () => {
-  it('keeps the facade and private owners within their completion gates', () => {
-    expect(rawLineCount(readSource(computePaths.facade))).toBeLessThanOrEqual(600)
-    for (const ownerPath of privateOwnerPaths) {
-      expect(
-        rawLineCount(readSource(ownerPath)),
-        portableProjectPath(ownerPath)
-      ).toBeLessThanOrEqual(660)
-    }
-    expect(rawLineCount(readSource(computePaths.sessionEnabledHostsOwner))).toBeLessThanOrEqual(660)
-    for (const lifecyclePath of lifecyclePaths) {
-      expect(
-        rawLineCount(readSource(lifecyclePath)),
-        portableProjectPath(lifecyclePath)
-      ).toBeLessThanOrEqual(660)
-    }
-    expect(rawLineCount(readSource(computePaths.ipc))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(computePaths.electronIpcAdapter))).toBeLessThanOrEqual(660)
-  })
-
   it('wires facade collaborators by name instead of positional optional arguments', () => {
     const facade = readSource(computePaths.facade)
-    expect(facade).toContain('constructor(dependencies: ComputeServiceDependencies)')
     expect(facade).not.toMatch(/constructor\(\s*runner:/)
 
     const ipc = readSource(computePaths.ipc)
@@ -237,42 +200,9 @@ describe('Compute service architecture', () => {
     expect(ipc).not.toMatch(/new ComputeService\(\s*sshRunner,/)
   })
 
-  it('keeps lifecycle state ownership behind the narrow intent interface', () => {
-    const lifecycle = sourceFileFor(computePaths.jobLifecycle).statements.find(
-      (statement) => isClassDeclaration(statement) && statement.name?.text === 'ComputeJobLifecycle'
-    )
-    expect(lifecycle && isClassDeclaration(lifecycle)).toBe(true)
-    if (!lifecycle || !isClassDeclaration(lifecycle)) return
-
-    const publicMethods = lifecycle.members
-      .flatMap((member) => {
-        if (
-          !isMethodDeclaration(member) ||
-          !isIdentifier(member.name) ||
-          getModifiers(member)?.some((modifier) => modifier.kind === SyntaxKind.PrivateKeyword) ===
-            true
-        ) {
-          return []
-        }
-        return [member.name.text]
-      })
-      .sort()
-    expect(publicMethods).toEqual(
-      [
-        'abortOwnerDeletion',
-        'beginOwnerDeletion',
-        'deleteOwnerRows',
-        'dispatchError',
-        'dispatchRunning',
-        'finishPolled',
-        'observeRunning',
-        'promoteQueued',
-        'recordPollError',
-        'recoverInterruptedDispatch'
-      ].sort()
-    )
+  it('keeps lifecycle writes behind the narrow intent interface', () => {
     expect(calledMembersOn(computePaths.jobLifecycle, ['this', 'repository'])).toEqual(
-      ['abortOwnerDeletion', 'beginOwnerDeletion', 'deleteByOwner', 'updateIfStatus'].sort()
+      expect.arrayContaining(['abortOwnerDeletion', 'beginOwnerDeletion', 'updateIfStatus'])
     )
 
     const lifecycleTarget = modulePath(computePaths.jobLifecycle)
@@ -399,61 +329,6 @@ describe('Compute service architecture', () => {
         portableProjectPath(ownerPath)
       ).toEqual(['src/main/compute/compute-service.ts'])
     }
-  })
-
-  it('locks the stable facade operation inventory and bound update sink', () => {
-    const facade = sourceFileFor(computePaths.facade).statements.find(
-      (statement) => isClassDeclaration(statement) && statement.name?.text === 'ComputeService'
-    )
-    expect(facade && isClassDeclaration(facade)).toBe(true)
-    if (!facade || !isClassDeclaration(facade)) return
-
-    const isPrivate = (member: (typeof facade.members)[number]): boolean =>
-      canHaveModifiers(member) &&
-      getModifiers(member)?.some((modifier) => modifier.kind === SyntaxKind.PrivateKeyword) === true
-    const publicOperations = facade.members
-      .flatMap((member) => {
-        if (
-          isPrivate(member) ||
-          (!isMethodDeclaration(member) && !isPropertyDeclaration(member)) ||
-          !isIdentifier(member.name)
-        ) {
-          return []
-        }
-        return [member.name.text]
-      })
-      .sort()
-
-    expect(publicOperations).toEqual(
-      [
-        'appendDetails',
-        'callCommand',
-        'download',
-        'getDetails',
-        'getJobResult',
-        'getJobStatus',
-        'getSessionConcurrencyStatus',
-        'handleJobUpdated',
-        'list',
-        'listDir',
-        'probe',
-        'replaceDetails',
-        'setConcurrencyLimit',
-        'setScratchRoot',
-        'setSessionConcurrencyLimit',
-        'submitJob'
-      ].sort()
-    )
-
-    const updateSink = facade.members.find(
-      (member) => isPropertyDeclaration(member) && member.name.getText() === 'handleJobUpdated'
-    )
-    const isBoundUpdateSink =
-      updateSink !== undefined &&
-      isPropertyDeclaration(updateSink) &&
-      updateSink.initializer !== undefined &&
-      isArrowFunction(updateSink.initializer)
-    expect(isBoundUpdateSink).toBe(true)
   })
 
   it('keeps Electron, application commands and job updates on the facade seam', () => {

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -202,7 +202,7 @@ describe('Compute service architecture', () => {
 
   it('keeps lifecycle writes behind the narrow intent interface', () => {
     expect(calledMembersOn(computePaths.jobLifecycle, ['this', 'repository'])).toEqual(
-      expect.arrayContaining(['abortOwnerDeletion', 'beginOwnerDeletion', 'updateIfStatus'])
+      ['abortOwnerDeletion', 'beginOwnerDeletion', 'deleteByOwner', 'updateIfStatus'].sort()
     )
 
     const lifecycleTarget = modulePath(computePaths.jobLifecycle)

--- a/src/main/compute/compute-service.test.ts
+++ b/src/main/compute/compute-service.test.ts
@@ -348,7 +348,8 @@ describe('ComputeService job workflow facade', () => {
     const result = await service.getJobResult(submitted.job_id)
     await service.setSessionConcurrencyLimit('session-1', 7)
     const concurrency = await service.getSessionConcurrencyStatus('session-1')
-    service.handleJobUpdated(storedJob!)
+    const publishJobUpdate = service.handleJobUpdated
+    publishJobUpdate(storedJob!)
 
     expect(submitted.status).toBe('queued')
     expect(status).toMatchObject({ job_id: submitted.job_id, status: 'queued' })

--- a/src/main/notebook/runtime-service.architecture.test.ts
+++ b/src/main/notebook/runtime-service.architecture.test.ts
@@ -4,8 +4,17 @@ import { resolve } from 'node:path'
 import {
   createSourceFile,
   forEachChild,
+  isArrayLiteralExpression,
+  isArrowFunction,
+  isConstructorDeclaration,
+  isFunctionDeclaration,
+  isFunctionExpression,
   isIdentifier,
+  isMethodDeclaration,
   isNewExpression,
+  isObjectLiteralExpression,
+  isPropertyAssignment,
+  isPropertyDeclaration,
   isVariableStatement,
   NodeFlags,
   ScriptKind,
@@ -21,6 +30,15 @@ const sourceFileFor = (source: string): SourceFile =>
   createSourceFile(facadePath, source, ScriptTarget.Latest, true, ScriptKind.TS)
 const facadeFile = sourceFileFor(facadeSource)
 const statefulConstructors = new Set(['Map', 'Set', 'WeakMap', 'WeakSet'])
+const isStatelessPolicyObject = (node: Node): boolean =>
+  isObjectLiteralExpression(node) &&
+  node.properties.length > 0 &&
+  node.properties.every(
+    (property) =>
+      isMethodDeclaration(property) ||
+      (isPropertyAssignment(property) &&
+        (isArrowFunction(property.initializer) || isFunctionExpression(property.initializer)))
+  )
 const moduleStateNames = (sourceFile: SourceFile = facadeFile): readonly string[] =>
   sourceFile.statements
     .filter(isVariableStatement)
@@ -35,18 +53,44 @@ const moduleStateNames = (sourceFile: SourceFile = facadeFile): readonly string[
             isNewExpression(initializer) &&
             isIdentifier(initializer.expression) &&
             statefulConstructors.has(initializer.expression.text)
-          return mutableDeclaration || mutableCollection
+          const mutableLiteral =
+            initializer !== undefined &&
+            (isArrayLiteralExpression(initializer) ||
+              (isObjectLiteralExpression(initializer) && !isStatelessPolicyObject(initializer)))
+          return mutableDeclaration || mutableCollection || mutableLiteral
         })
         .map((declaration) => declaration.name.getText(sourceFile))
     )
     .sort()
 
+const hasClassLifetime = (expression: Node): boolean => {
+  let current: Node | undefined = expression.parent
+  while (current) {
+    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) return true
+    if (
+      isMethodDeclaration(current) ||
+      isFunctionDeclaration(current) ||
+      isFunctionExpression(current) ||
+      isArrowFunction(current)
+    ) {
+      return false
+    }
+    current = current.parent
+  }
+  return false
+}
+
 const ownerConstructionCounts = (
-  sourceFile: SourceFile = facadeFile
+  sourceFile: SourceFile = facadeFile,
+  lifetime: 'class' | 'transient' = 'class'
 ): ReadonlyMap<string, number> => {
   const counts = new Map<string, number>()
   const visit = (node: Node): void => {
-    if (isNewExpression(node) && isIdentifier(node.expression)) {
+    if (
+      isNewExpression(node) &&
+      isIdentifier(node.expression) &&
+      (hasClassLifetime(node) ? 'class' : 'transient') === lifetime
+    ) {
       counts.set(node.expression.text, (counts.get(node.expression.text) ?? 0) + 1)
     }
     forEachChild(node, visit)
@@ -61,7 +105,8 @@ describe('Notebook runtime facade architecture', () => {
   })
 
   it('composes each state owner exactly once', () => {
-    const counts = ownerConstructionCounts()
+    const classLifetimeCounts = ownerConstructionCounts()
+    const transientCounts = ownerConstructionCounts(facadeFile, 'transient')
     const owners = [
       'NotebookDataExecutionAdmissionOwner',
       'NotebookEnvironmentManagementOwner',
@@ -79,17 +124,29 @@ describe('Notebook runtime facade architecture', () => {
       'NotebookSessionRegistry'
     ]
 
-    for (const owner of owners) expect(counts.get(owner), owner).toBe(1)
+    for (const owner of owners) {
+      expect(classLifetimeCounts.get(owner), owner).toBe(1)
+      expect(transientCounts.get(owner) ?? 0, owner).toBe(0)
+    }
   })
 
   it('detects module state and duplicate owners without fixing their construction syntax', () => {
     const moduleStateFile = sourceFileFor(`${facadeSource}\nconst leakedSessions = new Map()\n`)
     expect(moduleStateNames(moduleStateFile)).toContain('leakedSessions')
 
+    const arrayStateFile = sourceFileFor(`${facadeSource}\nconst leakedSessions = []\n`)
+    expect(moduleStateNames(arrayStateFile)).toContain('leakedSessions')
+
+    const objectStateFile = sourceFileFor(`${facadeSource}\nconst leakedSessions = {}\n`)
+    expect(moduleStateNames(objectStateFile)).toContain('leakedSessions')
+
     const duplicateOwnerFile = sourceFileFor(
       `${facadeSource}\nnew NotebookSessionLifecycleOwner({} as never)\n`
     )
-    expect(ownerConstructionCounts(duplicateOwnerFile).get('NotebookSessionLifecycleOwner')).toBe(2)
+    expect(ownerConstructionCounts(duplicateOwnerFile).get('NotebookSessionLifecycleOwner')).toBe(1)
+    expect(
+      ownerConstructionCounts(duplicateOwnerFile, 'transient').get('NotebookSessionLifecycleOwner')
+    ).toBe(1)
 
     const fieldInitializerFile = sourceFileFor(`
       class NotebookRuntimeService {
@@ -99,5 +156,16 @@ describe('Notebook runtime facade architecture', () => {
     expect(ownerConstructionCounts(fieldInitializerFile).get('NotebookSessionLifecycleOwner')).toBe(
       1
     )
+
+    const methodConstructionFile = sourceFileFor(`
+      class NotebookRuntimeService {
+        createSessionLifecycle() {
+          return new NotebookSessionLifecycleOwner({} as never)
+        }
+      }
+    `)
+    expect(
+      ownerConstructionCounts(methodConstructionFile).get('NotebookSessionLifecycleOwner')
+    ).toBeUndefined()
   })
 })

--- a/src/main/notebook/runtime-service.architecture.test.ts
+++ b/src/main/notebook/runtime-service.architecture.test.ts
@@ -2,26 +2,14 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import {
-  canHaveModifiers,
   createSourceFile,
   forEachChild,
-  getModifiers,
-  isArrowFunction,
-  isClassDeclaration,
-  isConstructorDeclaration,
-  isFunctionDeclaration,
-  isFunctionExpression,
   isIdentifier,
-  isMethodDeclaration,
   isNewExpression,
-  isParameter,
-  isPropertyDeclaration,
   isVariableStatement,
+  NodeFlags,
   ScriptKind,
   ScriptTarget,
-  SyntaxKind,
-  type ClassDeclaration,
-  type NewExpression,
   type SourceFile,
   type Node
 } from 'typescript'
@@ -31,172 +19,49 @@ const facadePath = resolve(__dirname, 'runtime-service.ts')
 const facadeSource = readFileSync(facadePath, 'utf8')
 const sourceFileFor = (source: string): SourceFile =>
   createSourceFile(facadePath, source, ScriptTarget.Latest, true, ScriptKind.TS)
-const facadeClassFrom = (sourceFile: SourceFile): ClassDeclaration => {
-  const candidate = sourceFile.statements.find(
-    (statement) =>
-      isClassDeclaration(statement) && statement.name?.text === 'NotebookRuntimeService'
-  )
-  if (!candidate || !isClassDeclaration(candidate)) {
-    throw new Error('NotebookRuntimeService class not found')
-  }
-  return candidate
-}
 const facadeFile = sourceFileFor(facadeSource)
-const facadeClass = facadeClassFrom(facadeFile)
-
-const hasModifier = (node: Node, kind: SyntaxKind): boolean =>
-  canHaveModifiers(node) &&
-  (getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false)
-
-const identifierName = (node: Node | undefined): string | undefined =>
-  node && isIdentifier(node) ? node.text : undefined
-
-const facadeFields = (): readonly string[] => {
-  const fields = facadeClass.members
-    .filter(isPropertyDeclaration)
-    .map((member) => identifierName(member.name))
-    .filter((name): name is string => name !== undefined)
-
-  for (const constructor of facadeClass.members.filter(isConstructorDeclaration)) {
-    fields.push(
-      ...constructor.parameters
-        .filter(
-          (parameter) =>
-            isParameter(parameter) &&
-            (hasModifier(parameter, SyntaxKind.PrivateKeyword) ||
-              hasModifier(parameter, SyntaxKind.PublicKeyword) ||
-              hasModifier(parameter, SyntaxKind.ProtectedKeyword))
-        )
-        .map((parameter) => identifierName(parameter.name))
-        .filter((name): name is string => name !== undefined)
-    )
-  }
-
-  return fields.sort()
-}
-
-const mutableFacadeFields = (): readonly string[] =>
-  facadeClass.members
-    .filter(isPropertyDeclaration)
-    .filter((member) => !hasModifier(member, SyntaxKind.ReadonlyKeyword))
-    .map((member) => identifierName(member.name))
-    .filter((name): name is string => name !== undefined)
-    .sort()
-
-const facadeMethods = (
-  visibility: 'public' | 'private',
-  target: ClassDeclaration = facadeClass
-): readonly string[] =>
-  target.members
-    .filter(isMethodDeclaration)
-    .filter((member) =>
-      visibility === 'private'
-        ? hasModifier(member, SyntaxKind.PrivateKeyword)
-        : !hasModifier(member, SyntaxKind.PrivateKeyword) &&
-          !hasModifier(member, SyntaxKind.ProtectedKeyword)
-    )
-    .map((member) => identifierName(member.name))
-    .filter((name): name is string => name !== undefined)
-    .sort()
-
-const topLevelValueNames = (sourceFile: SourceFile = facadeFile): readonly string[] =>
+const statefulConstructors = new Set(['Map', 'Set', 'WeakMap', 'WeakSet'])
+const moduleStateNames = (sourceFile: SourceFile = facadeFile): readonly string[] =>
   sourceFile.statements
-    .flatMap((statement) => {
-      if (isVariableStatement(statement)) {
-        return statement.declarationList.declarations.map((declaration) =>
-          declaration.name.getText(sourceFile)
-        )
-      }
-      if (isFunctionDeclaration(statement)) return [statement.name?.text ?? '<anonymous>']
-      return []
-    })
+    .filter(isVariableStatement)
+    .flatMap((statement) =>
+      statement.declarationList.declarations
+        .filter((declaration) => {
+          const mutableDeclaration =
+            (statement.declarationList.flags & NodeFlags.Const) !== NodeFlags.Const
+          const initializer = declaration.initializer
+          const mutableCollection =
+            initializer !== undefined &&
+            isNewExpression(initializer) &&
+            isIdentifier(initializer.expression) &&
+            statefulConstructors.has(initializer.expression.text)
+          return mutableDeclaration || mutableCollection
+        })
+        .map((declaration) => declaration.name.getText(sourceFile))
+    )
     .sort()
 
-const constructionSite = (expression: NewExpression): string => {
-  let current: Node | undefined = expression.parent
-  while (current) {
-    if (isConstructorDeclaration(current)) return 'constructor'
-    if (isMethodDeclaration(current)) {
-      return `method:${identifierName(current.name) ?? '<computed>'}`
-    }
-    if (
-      isArrowFunction(current) ||
-      isFunctionExpression(current) ||
-      isFunctionDeclaration(current)
-    ) {
-      return 'nested-function'
-    }
-    current = current.parent
-  }
-  return 'module'
-}
-
-const ownerConstructionSites = (
+const ownerConstructionCounts = (
   sourceFile: SourceFile = facadeFile
-): ReadonlyMap<string, readonly string[]> => {
-  const sites = new Map<string, string[]>()
+): ReadonlyMap<string, number> => {
+  const counts = new Map<string, number>()
   const visit = (node: Node): void => {
     if (isNewExpression(node) && isIdentifier(node.expression)) {
-      const ownerSites = sites.get(node.expression.text) ?? []
-      ownerSites.push(constructionSite(node))
-      sites.set(node.expression.text, ownerSites)
+      counts.set(node.expression.text, (counts.get(node.expression.text) ?? 0) + 1)
     }
     forEachChild(node, visit)
   }
   visit(sourceFile)
-  return sites
+  return counts
 }
 
 describe('Notebook runtime facade architecture', () => {
-  it('keeps the compatibility facade within its completion gate', () => {
-    const physicalLines = facadeSource.split(/\r?\n/).length - Number(facadeSource.endsWith('\n'))
-
-    expect(physicalLines).toBeLessThanOrEqual(1250)
-  })
-
-  it('keeps package, repair, and Session lifecycle state behind owners', () => {
-    expect(topLevelValueNames()).toEqual(
-      [
-        'DEFAULT_LOCALE',
-        'EMPTY_NOTEBOOK_RUNTIME_SETTINGS',
-        'dataProcessKey',
-        'resolveDefaultExecutorOptions',
-        'resolveLoopScript',
-        'resolveLoopScriptPaths',
-        'saveIpynbWithDialog'
-      ].sort()
-    )
-    expect(facadeFields()).toEqual(
-      [
-        'dataExecutionAdmission',
-        'dependencyAnalyzer',
-        'disposalPromise',
-        'environmentManagement',
-        'environmentOperations',
-        'environmentStateTracker',
-        'executionOwner',
-        'exportReader',
-        'mcpRpcConnectionResolver',
-        'options',
-        'packageOperations',
-        'recoveryCoordinator',
-        'repairPolicy',
-        'repository',
-        'runTerminalization',
-        'runtimeBindingOwner',
-        'runtimeEnablementResolver',
-        'runtimeLogger',
-        'runtimeRepair',
-        'sessionLifecycle',
-        'sessionReadModel',
-        'sessions'
-      ].sort()
-    )
-    expect(mutableFacadeFields()).toEqual(['disposalPromise', 'mcpRpcConnectionResolver'])
+  it('keeps mutable module state behind owners', () => {
+    expect(moduleStateNames()).toEqual([])
   })
 
   it('composes each state owner exactly once', () => {
-    const sites = ownerConstructionSites()
+    const counts = ownerConstructionCounts()
     const owners = [
       'NotebookDataExecutionAdmissionOwner',
       'NotebookEnvironmentManagementOwner',
@@ -214,103 +79,25 @@ describe('Notebook runtime facade architecture', () => {
       'NotebookSessionRegistry'
     ]
 
-    for (const owner of owners) expect(sites.get(owner), owner).toEqual(['constructor'])
+    for (const owner of owners) expect(counts.get(owner), owner).toBe(1)
   })
 
-  it('keeps the established public facade surface', () => {
-    expect(facadeMethods('public')).toEqual(
-      [
-        'appendCodeCell',
-        'beginCodeCell',
-        'beginProjectDeletion',
-        'bindRuntime',
-        'blockPrefixRecovery',
-        'clearCorruptRecoveryBlock',
-        'clearRecoveryBlock',
-        'clearRuntimeRecoveryBlock',
-        'completeRuntimeRepair',
-        'describeRuntimeUsage',
-        'dispose',
-        'ensureRecovered',
-        'execute',
-        'executeControl',
-        'executeShell',
-        'exportIpynb',
-        'exportIpynbAll',
-        'finishCodeCell',
-        'getActiveNotebookSessions',
-        'getSessionReference',
-        'inspectNamespace',
-        'inspectPackages',
-        'isDefaultEnvRecoveryBlocked',
-        'isPrefixLiveUnconfirmed',
-        'isPrefixRecoveryBlocked',
-        'listRuntimes',
-        'manageEnvironments',
-        'managePackages',
-        'peekHandoffContext',
-        'recoverInterruptedOperations',
-        'releaseProjectDeletion',
-        'restart',
-        'revokeRuntime',
-        'runCell',
-        'setControlCompletionInterceptor',
-        'setDefaultEnvProvisioner',
-        'setEnvironmentManager',
-        'setMcpRpcConnectionResolver',
-        'shutdown',
-        'shutdownAll',
-        'shutdownProject',
-        'shutdownSession',
-        'state',
-        'switchRuntime',
-        'withEnvLock'
-      ].sort()
-    )
-  })
-
-  it('keeps only stateless policy helpers in the facade', () => {
-    expect(facadeMethods('private')).toEqual(
-      [
-        'assertPrefixRecoverable',
-        'defaultEnvNameFor',
-        'environmentCaptureTarget',
-        'isDefaultEnvDisabled',
-        'resolveRunEnv',
-        'resolveRuntimeEnablement',
-        'tearDownLanguageBinding'
-      ].sort()
-    )
-  })
-
-  it('rejects module state, duplicate or lazy owners, and protected public methods', () => {
+  it('detects module state and duplicate owners without fixing their construction syntax', () => {
     const moduleStateFile = sourceFileFor(`${facadeSource}\nconst leakedSessions = new Map()\n`)
-    expect(topLevelValueNames(moduleStateFile)).toContain('leakedSessions')
+    expect(moduleStateNames(moduleStateFile)).toContain('leakedSessions')
 
     const duplicateOwnerFile = sourceFileFor(
       `${facadeSource}\nnew NotebookSessionLifecycleOwner({} as never)\n`
     )
-    expect(ownerConstructionSites(duplicateOwnerFile).get('NotebookSessionLifecycleOwner')).toEqual(
-      ['constructor', 'module']
-    )
+    expect(ownerConstructionCounts(duplicateOwnerFile).get('NotebookSessionLifecycleOwner')).toBe(2)
 
-    const lazyOwnerFile = sourceFileFor(`
+    const fieldInitializerFile = sourceFileFor(`
       class NotebookRuntimeService {
-        constructor() {
-          const createOwner = () => new NotebookSessionLifecycleOwner({} as never)
-          void createOwner
-        }
+        private readonly sessionLifecycle = new NotebookSessionLifecycleOwner({} as never)
       }
     `)
-    expect(ownerConstructionSites(lazyOwnerFile).get('NotebookSessionLifecycleOwner')).toEqual([
-      'nested-function'
-    ])
-
-    const protectedMethodFile = sourceFileFor(
-      facadeSource.replace('  async listRuntimes(', '  protected async listRuntimes(')
-    )
-    expect(facadeMethods('public', facadeClassFrom(protectedMethodFile))).not.toContain(
-      'listRuntimes'
+    expect(ownerConstructionCounts(fieldInitializerFile).get('NotebookSessionLifecycleOwner')).toBe(
+      1
     )
   })
 })

--- a/src/main/notebook/runtime-service.architecture.test.ts
+++ b/src/main/notebook/runtime-service.architecture.test.ts
@@ -39,6 +39,25 @@ const isStatelessPolicyObject = (node: Node): boolean =>
       (isPropertyAssignment(property) &&
         (isArrowFunction(property.initializer) || isFunctionExpression(property.initializer)))
   )
+const hasMutableStateInitializer = (node: Node): boolean => {
+  if (isArrowFunction(node) || isFunctionExpression(node) || isStatelessPolicyObject(node)) {
+    return false
+  }
+  if (
+    isCallExpression(node) ||
+    isNewExpression(node) ||
+    isArrayLiteralExpression(node) ||
+    isObjectLiteralExpression(node)
+  ) {
+    return true
+  }
+
+  let hasMutableState = false
+  forEachChild(node, (child) => {
+    if (hasMutableStateInitializer(child)) hasMutableState = true
+  })
+  return hasMutableState
+}
 const moduleStateNames = (sourceFile: SourceFile = facadeFile): readonly string[] =>
   sourceFile.statements
     .filter(isVariableStatement)
@@ -49,11 +68,7 @@ const moduleStateNames = (sourceFile: SourceFile = facadeFile): readonly string[
             (statement.declarationList.flags & NodeFlags.Const) !== NodeFlags.Const
           const initializer = declaration.initializer
           const mutableInitializer =
-            initializer !== undefined &&
-            (isCallExpression(initializer) ||
-              isNewExpression(initializer) ||
-              isArrayLiteralExpression(initializer) ||
-              (isObjectLiteralExpression(initializer) && !isStatelessPolicyObject(initializer)))
+            initializer !== undefined && hasMutableStateInitializer(initializer)
           return mutableDeclaration || mutableInitializer
         })
         .map((declaration) => declaration.name.getText(sourceFile))
@@ -146,6 +161,11 @@ describe('Notebook runtime facade architecture', () => {
       `${facadeSource}\nconst leakedSessions = new SessionCache()\n`
     )
     expect(moduleStateNames(constructedStateFile)).toContain('leakedSessions')
+
+    const wrappedStateFile = sourceFileFor(
+      `${facadeSource}\nconst leakedSessions = enabled ? new Map() : undefined\n`
+    )
+    expect(moduleStateNames(wrappedStateFile)).toContain('leakedSessions')
 
     const duplicateOwnerFile = sourceFileFor(
       `${facadeSource}\nnew NotebookSessionLifecycleOwner({} as never)\n`

--- a/src/main/notebook/runtime-service.architecture.test.ts
+++ b/src/main/notebook/runtime-service.architecture.test.ts
@@ -6,6 +6,7 @@ import {
   forEachChild,
   isArrayLiteralExpression,
   isArrowFunction,
+  isCallExpression,
   isConstructorDeclaration,
   isFunctionDeclaration,
   isFunctionExpression,
@@ -29,7 +30,6 @@ const facadeSource = readFileSync(facadePath, 'utf8')
 const sourceFileFor = (source: string): SourceFile =>
   createSourceFile(facadePath, source, ScriptTarget.Latest, true, ScriptKind.TS)
 const facadeFile = sourceFileFor(facadeSource)
-const statefulConstructors = new Set(['Map', 'Set', 'WeakMap', 'WeakSet'])
 const isStatelessPolicyObject = (node: Node): boolean =>
   isObjectLiteralExpression(node) &&
   node.properties.length > 0 &&
@@ -48,16 +48,13 @@ const moduleStateNames = (sourceFile: SourceFile = facadeFile): readonly string[
           const mutableDeclaration =
             (statement.declarationList.flags & NodeFlags.Const) !== NodeFlags.Const
           const initializer = declaration.initializer
-          const mutableCollection =
+          const mutableInitializer =
             initializer !== undefined &&
-            isNewExpression(initializer) &&
-            isIdentifier(initializer.expression) &&
-            statefulConstructors.has(initializer.expression.text)
-          const mutableLiteral =
-            initializer !== undefined &&
-            (isArrayLiteralExpression(initializer) ||
+            (isCallExpression(initializer) ||
+              isNewExpression(initializer) ||
+              isArrayLiteralExpression(initializer) ||
               (isObjectLiteralExpression(initializer) && !isStatelessPolicyObject(initializer)))
-          return mutableDeclaration || mutableCollection || mutableLiteral
+          return mutableDeclaration || mutableInitializer
         })
         .map((declaration) => declaration.name.getText(sourceFile))
     )
@@ -139,6 +136,16 @@ describe('Notebook runtime facade architecture', () => {
 
     const objectStateFile = sourceFileFor(`${facadeSource}\nconst leakedSessions = {}\n`)
     expect(moduleStateNames(objectStateFile)).toContain('leakedSessions')
+
+    const factoryStateFile = sourceFileFor(
+      `${facadeSource}\nconst leakedSessions = createSessionCache()\n`
+    )
+    expect(moduleStateNames(factoryStateFile)).toContain('leakedSessions')
+
+    const constructedStateFile = sourceFileFor(
+      `${facadeSource}\nconst leakedSessions = new SessionCache()\n`
+    )
+    expect(moduleStateNames(constructedStateFile)).toContain('leakedSessions')
 
     const duplicateOwnerFile = sourceFileFor(
       `${facadeSource}\nnew NotebookSessionLifecycleOwner({} as never)\n`

--- a/src/main/notebook/runtime-service.architecture.test.ts
+++ b/src/main/notebook/runtime-service.architecture.test.ts
@@ -7,6 +7,7 @@ import {
   isArrayLiteralExpression,
   isArrowFunction,
   isCallExpression,
+  isClassDeclaration,
   isConstructorDeclaration,
   isFunctionDeclaration,
   isFunctionExpression,
@@ -16,10 +17,12 @@ import {
   isObjectLiteralExpression,
   isPropertyAssignment,
   isPropertyDeclaration,
+  isSourceFile,
   isVariableStatement,
   NodeFlags,
   ScriptKind,
   ScriptTarget,
+  SyntaxKind,
   type SourceFile,
   type Node
 } from 'typescript'
@@ -75,10 +78,20 @@ const moduleStateNames = (sourceFile: SourceFile = facadeFile): readonly string[
     )
     .sort()
 
-const hasClassLifetime = (expression: Node): boolean => {
+const hasFacadeLifetime = (expression: Node): boolean => {
   let current: Node | undefined = expression.parent
   while (current) {
-    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) return true
+    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) {
+      const facade = current.parent
+      const isTargetFacade =
+        isClassDeclaration(facade) &&
+        facade.name?.text === 'NotebookRuntimeService' &&
+        isSourceFile(facade.parent)
+      const isStaticField =
+        isPropertyDeclaration(current) &&
+        current.modifiers?.some((modifier) => modifier.kind === SyntaxKind.StaticKeyword)
+      return isTargetFacade && !isStaticField
+    }
     if (
       isMethodDeclaration(current) ||
       isFunctionDeclaration(current) ||
@@ -101,7 +114,7 @@ const ownerConstructionCounts = (
     if (
       isNewExpression(node) &&
       isIdentifier(node.expression) &&
-      (hasClassLifetime(node) ? 'class' : 'transient') === lifetime
+      (hasFacadeLifetime(node) ? 'class' : 'transient') === lifetime
     ) {
       counts.set(node.expression.text, (counts.get(node.expression.text) ?? 0) + 1)
     }
@@ -193,6 +206,29 @@ describe('Notebook runtime facade architecture', () => {
     `)
     expect(
       ownerConstructionCounts(methodConstructionFile).get('NotebookSessionLifecycleOwner')
+    ).toBeUndefined()
+
+    const staticFieldFile = sourceFileFor(`
+      class NotebookRuntimeService {
+        private static readonly sessionLifecycle = new NotebookSessionLifecycleOwner({} as never)
+      }
+    `)
+    expect(
+      ownerConstructionCounts(staticFieldFile).get('NotebookSessionLifecycleOwner')
+    ).toBeUndefined()
+
+    const nestedClassFile = sourceFileFor(`
+      class NotebookRuntimeService {
+        createSessionLifecycle() {
+          class SessionLifecycleHolder {
+            readonly owner = new NotebookSessionLifecycleOwner({} as never)
+          }
+          return SessionLifecycleHolder
+        }
+      }
+    `)
+    expect(
+      ownerConstructionCounts(nestedClassFile).get('NotebookSessionLifecycleOwner')
     ).toBeUndefined()
   })
 })

--- a/src/main/project-files/repository.architecture.test.ts
+++ b/src/main/project-files/repository.architecture.test.ts
@@ -2,23 +2,14 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import {
-  canHaveModifiers,
   createSourceFile,
   forEachChild,
-  getModifiers,
-  isClassDeclaration,
-  isConstructorDeclaration,
   isExportDeclaration,
   isIdentifier,
-  isMethodDeclaration,
   isNamedExports,
   isNewExpression,
-  isParameter,
-  isPropertyDeclaration,
   ScriptKind,
   ScriptTarget,
-  SyntaxKind,
-  type ClassDeclaration,
   type Node,
   type SourceFile
 } from 'typescript'
@@ -37,72 +28,20 @@ const sources = new Map(
 const sourceFileFor = (file: (typeof productionFiles)[number]): SourceFile =>
   createSourceFile(file, sources.get(file)!, ScriptTarget.Latest, true, ScriptKind.TS)
 
-const classFrom = (file: (typeof productionFiles)[number], name: string): ClassDeclaration => {
-  const candidate = sourceFileFor(file).statements.find(
-    (statement) => isClassDeclaration(statement) && statement.name?.text === name
-  )
-  if (!candidate || !isClassDeclaration(candidate)) throw new Error(`${name} class not found`)
-  return candidate
-}
-
-const hasModifier = (node: Node, kind: SyntaxKind): boolean =>
-  canHaveModifiers(node) &&
-  (getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false)
-
-const memberName = (node: Node | undefined): string | undefined =>
-  node && isIdentifier(node) ? node.text : undefined
-
-const publicMethods = (declaration: ClassDeclaration): string[] =>
-  declaration.members
-    .filter(isMethodDeclaration)
-    .filter(
-      (member) =>
-        !hasModifier(member, SyntaxKind.PrivateKeyword) &&
-        !hasModifier(member, SyntaxKind.ProtectedKeyword)
-    )
-    .map((member) => memberName(member.name))
-    .filter((name): name is string => name !== undefined)
-    .sort()
-
-const fields = (declaration: ClassDeclaration): string[] => {
-  const result = declaration.members
-    .filter(isPropertyDeclaration)
-    .map((member) => memberName(member.name))
-    .filter((name): name is string => name !== undefined)
-
-  for (const constructor of declaration.members.filter(isConstructorDeclaration)) {
-    result.push(
-      ...constructor.parameters
-        .filter(
-          (parameter) =>
-            isParameter(parameter) &&
-            (hasModifier(parameter, SyntaxKind.PrivateKeyword) ||
-              hasModifier(parameter, SyntaxKind.PublicKeyword) ||
-              hasModifier(parameter, SyntaxKind.ProtectedKeyword))
-        )
-        .map((parameter) => memberName(parameter.name))
-        .filter((name): name is string => name !== undefined)
-    )
-  }
-  return result.sort()
-}
-
-const newExpressionSites = (sourceFile: SourceFile, className: string): string[] => {
-  const sites: string[] = []
+const newExpressionCount = (sourceFile: SourceFile, className: string): number => {
+  let count = 0
   const visit = (node: Node): void => {
     if (
       isNewExpression(node) &&
       isIdentifier(node.expression) &&
       node.expression.text === className
     ) {
-      let current: Node | undefined = node.parent
-      while (current && !isConstructorDeclaration(current)) current = current.parent
-      sites.push(current ? 'constructor' : 'outside-constructor')
+      count += 1
     }
     forEachChild(node, visit)
   }
   visit(sourceFile)
-  return sites
+  return count
 }
 
 const namedExports = (sourceFile: SourceFile): string[] =>
@@ -119,46 +58,8 @@ const namedExports = (sourceFile: SourceFile): string[] =>
 
 describe('Project Files repository architecture', () => {
   const facadeFile = sourceFileFor('repository.ts')
-  const facade = classFrom('repository.ts', 'ManagedFileIndexRepository')
-  const mutationOwner = classFrom('mutation-owner.ts', 'ProjectFilesMutationOwner')
-  const queryOwner = classFrom('query-owner.ts', 'ProjectFilesQueryOwner')
 
-  it('keeps every production module within the completion gate', () => {
-    for (const [file, source] of sources) {
-      const physicalLines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      expect(physicalLines, file).toBeLessThanOrEqual(660)
-    }
-  })
-
-  it('keeps the established public repository interface', () => {
-    expect(publicMethods(facade)).toEqual(
-      [
-        'getOverview',
-        'listArtifactGroups',
-        'listFiles',
-        'markReconciliationIncomplete',
-        'readHostArtifactCatalog',
-        'reconcileActiveSessions',
-        'restoreProject',
-        'restoreSession',
-        'searchArtifacts',
-        'softDeleteProject',
-        'softDeleteSession',
-        'syncSession'
-      ].sort()
-    )
-  })
-
-  it('keeps the established facade constructor, factory and export inventory', () => {
-    const constructors = facade.members.filter(isConstructorDeclaration)
-    expect(constructors).toHaveLength(1)
-    expect(constructors[0].parameters.map((parameter) => memberName(parameter.name))).toEqual([
-      'getClient',
-      'dataRoot'
-    ])
-    expect(newExpressionSites(facadeFile, 'ManagedFileIndexRepository')).toEqual([
-      'outside-constructor'
-    ])
+  it('keeps the public repository exports stable', () => {
     expect(namedExports(facadeFile)).toEqual(
       [
         'value:createManagedFileIndexRepository',
@@ -171,26 +72,18 @@ describe('Project Files repository architecture', () => {
     )
   })
 
-  it('composes one mutation owner and one query owner without shadow lifecycle state', () => {
-    expect(newExpressionSites(facadeFile, 'ProjectFilesMutationOwner')).toEqual(['constructor'])
-    expect(newExpressionSites(facadeFile, 'ProjectFilesQueryOwner')).toEqual(['constructor'])
-    expect(fields(facade)).toEqual(['mutationOwner', 'queryOwner'])
-    expect(fields(mutationOwner)).toEqual([
-      'dataRoot',
-      'getClient',
-      'incompleteSessions',
-      'isReconciliationIncomplete'
-    ])
-    expect(fields(queryOwner)).toEqual(['dataRoot', 'getClient', 'readIndexComplete'])
-    expect(publicMethods(queryOwner)).toEqual(
-      [
-        'getOverview',
-        'listArtifactGroups',
-        'listFiles',
-        'readHostArtifactCatalog',
-        'searchArtifacts'
-      ].sort()
+  it('composes one mutation owner and one query owner regardless of construction syntax', () => {
+    expect(newExpressionCount(facadeFile, 'ProjectFilesMutationOwner')).toBe(1)
+    expect(newExpressionCount(facadeFile, 'ProjectFilesQueryOwner')).toBe(1)
+
+    const fieldInitializerFile = createSourceFile(
+      'field-initializer.ts',
+      'class Repository { private readonly owner = new ProjectFilesMutationOwner() }',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
     )
+    expect(newExpressionCount(fieldInitializerFile, 'ProjectFilesMutationOwner')).toBe(1)
   })
 
   it('keeps Prisma writes and mutation state out of stateless support modules', () => {

--- a/src/main/project-files/repository.architecture.test.ts
+++ b/src/main/project-files/repository.architecture.test.ts
@@ -4,10 +4,16 @@ import { resolve } from 'node:path'
 import {
   createSourceFile,
   forEachChild,
+  isArrowFunction,
+  isConstructorDeclaration,
   isExportDeclaration,
+  isFunctionDeclaration,
+  isFunctionExpression,
   isIdentifier,
+  isMethodDeclaration,
   isNamedExports,
   isNewExpression,
+  isPropertyDeclaration,
   ScriptKind,
   ScriptTarget,
   type Node,
@@ -28,13 +34,35 @@ const sources = new Map(
 const sourceFileFor = (file: (typeof productionFiles)[number]): SourceFile =>
   createSourceFile(file, sources.get(file)!, ScriptTarget.Latest, true, ScriptKind.TS)
 
-const newExpressionCount = (sourceFile: SourceFile, className: string): number => {
+const hasClassLifetime = (expression: Node): boolean => {
+  let current: Node | undefined = expression.parent
+  while (current) {
+    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) return true
+    if (
+      isMethodDeclaration(current) ||
+      isFunctionDeclaration(current) ||
+      isFunctionExpression(current) ||
+      isArrowFunction(current)
+    ) {
+      return false
+    }
+    current = current.parent
+  }
+  return false
+}
+
+const newExpressionCount = (
+  sourceFile: SourceFile,
+  className: string,
+  lifetime: 'class' | 'transient' = 'class'
+): number => {
   let count = 0
   const visit = (node: Node): void => {
     if (
       isNewExpression(node) &&
       isIdentifier(node.expression) &&
-      node.expression.text === className
+      node.expression.text === className &&
+      (hasClassLifetime(node) ? 'class' : 'transient') === lifetime
     ) {
       count += 1
     }
@@ -75,6 +103,8 @@ describe('Project Files repository architecture', () => {
   it('composes one mutation owner and one query owner regardless of construction syntax', () => {
     expect(newExpressionCount(facadeFile, 'ProjectFilesMutationOwner')).toBe(1)
     expect(newExpressionCount(facadeFile, 'ProjectFilesQueryOwner')).toBe(1)
+    expect(newExpressionCount(facadeFile, 'ProjectFilesMutationOwner', 'transient')).toBe(0)
+    expect(newExpressionCount(facadeFile, 'ProjectFilesQueryOwner', 'transient')).toBe(0)
 
     const fieldInitializerFile = createSourceFile(
       'field-initializer.ts',
@@ -84,6 +114,18 @@ describe('Project Files repository architecture', () => {
       ScriptKind.TS
     )
     expect(newExpressionCount(fieldInitializerFile, 'ProjectFilesMutationOwner')).toBe(1)
+
+    const methodConstructionFile = createSourceFile(
+      'method-construction.ts',
+      'class Repository { createOwner() { return new ProjectFilesMutationOwner() } }',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+    expect(newExpressionCount(methodConstructionFile, 'ProjectFilesMutationOwner')).toBe(0)
+    expect(
+      newExpressionCount(methodConstructionFile, 'ProjectFilesMutationOwner', 'transient')
+    ).toBe(1)
   })
 
   it('keeps Prisma writes and mutation state out of stateless support modules', () => {

--- a/src/main/project-files/repository.architecture.test.ts
+++ b/src/main/project-files/repository.architecture.test.ts
@@ -5,6 +5,7 @@ import {
   createSourceFile,
   forEachChild,
   isArrowFunction,
+  isClassDeclaration,
   isConstructorDeclaration,
   isExportDeclaration,
   isFunctionDeclaration,
@@ -14,8 +15,10 @@ import {
   isNamedExports,
   isNewExpression,
   isPropertyDeclaration,
+  isSourceFile,
   ScriptKind,
   ScriptTarget,
+  SyntaxKind,
   type Node,
   type SourceFile
 } from 'typescript'
@@ -34,10 +37,20 @@ const sources = new Map(
 const sourceFileFor = (file: (typeof productionFiles)[number]): SourceFile =>
   createSourceFile(file, sources.get(file)!, ScriptTarget.Latest, true, ScriptKind.TS)
 
-const hasClassLifetime = (expression: Node): boolean => {
+const hasFacadeLifetime = (expression: Node): boolean => {
   let current: Node | undefined = expression.parent
   while (current) {
-    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) return true
+    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) {
+      const facade = current.parent
+      const isTargetFacade =
+        isClassDeclaration(facade) &&
+        facade.name?.text === 'ManagedFileIndexRepository' &&
+        isSourceFile(facade.parent)
+      const isStaticField =
+        isPropertyDeclaration(current) &&
+        current.modifiers?.some((modifier) => modifier.kind === SyntaxKind.StaticKeyword)
+      return isTargetFacade && !isStaticField
+    }
     if (
       isMethodDeclaration(current) ||
       isFunctionDeclaration(current) ||
@@ -62,7 +75,7 @@ const newExpressionCount = (
       isNewExpression(node) &&
       isIdentifier(node.expression) &&
       node.expression.text === className &&
-      (hasClassLifetime(node) ? 'class' : 'transient') === lifetime
+      (hasFacadeLifetime(node) ? 'class' : 'transient') === lifetime
     ) {
       count += 1
     }
@@ -108,7 +121,7 @@ describe('Project Files repository architecture', () => {
 
     const fieldInitializerFile = createSourceFile(
       'field-initializer.ts',
-      'class Repository { private readonly owner = new ProjectFilesMutationOwner() }',
+      'class ManagedFileIndexRepository { private readonly owner = new ProjectFilesMutationOwner() }',
       ScriptTarget.Latest,
       true,
       ScriptKind.TS
@@ -117,7 +130,7 @@ describe('Project Files repository architecture', () => {
 
     const methodConstructionFile = createSourceFile(
       'method-construction.ts',
-      'class Repository { createOwner() { return new ProjectFilesMutationOwner() } }',
+      'class ManagedFileIndexRepository { createOwner() { return new ProjectFilesMutationOwner() } }',
       ScriptTarget.Latest,
       true,
       ScriptKind.TS
@@ -126,6 +139,24 @@ describe('Project Files repository architecture', () => {
     expect(
       newExpressionCount(methodConstructionFile, 'ProjectFilesMutationOwner', 'transient')
     ).toBe(1)
+
+    const staticFieldFile = createSourceFile(
+      'static-field.ts',
+      'class ManagedFileIndexRepository { static owner = new ProjectFilesMutationOwner() }',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+    expect(newExpressionCount(staticFieldFile, 'ProjectFilesMutationOwner')).toBe(0)
+
+    const nestedClassFile = createSourceFile(
+      'nested-class.ts',
+      'class ManagedFileIndexRepository { createOwner() { class Holder { owner = new ProjectFilesMutationOwner() } return Holder } }',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+    expect(newExpressionCount(nestedClassFile, 'ProjectFilesMutationOwner')).toBe(0)
   })
 
   it('keeps Prisma writes and mutation state out of stateless support modules', () => {

--- a/src/main/uploads/repository.architecture.test.ts
+++ b/src/main/uploads/repository.architecture.test.ts
@@ -8,23 +8,18 @@ import {
   getModifiers,
   isCallExpression,
   isClassDeclaration,
-  isConstructorDeclaration,
   isEnumDeclaration,
   isExportAssignment,
   isExportDeclaration,
   isFunctionDeclaration,
   isIdentifier,
-  isMethodDeclaration,
   isNamedExports,
   isNewExpression,
-  isPropertyDeclaration,
   isPropertyAccessExpression,
-  isReturnStatement,
   isVariableStatement,
   ScriptKind,
   ScriptTarget,
   SyntaxKind,
-  type ClassDeclaration,
   type Node,
   type SourceFile
 } from 'typescript'
@@ -46,46 +41,11 @@ const sources = new Map(
 const sourceFileFor = (file: string): SourceFile =>
   createSourceFile(file, sources.get(file)!, ScriptTarget.Latest, true, ScriptKind.TS)
 
-const classFrom = (file: string, name: string): ClassDeclaration => {
-  const candidate = sourceFileFor(file).statements.find(
-    (statement) => isClassDeclaration(statement) && statement.name?.text === name
-  )
-  if (!candidate || !isClassDeclaration(candidate)) throw new Error(`${name} class not found`)
-  return candidate
-}
-
 const hasModifier = (node: Node, kind: SyntaxKind): boolean =>
   canHaveModifiers(node) &&
   (getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false)
 
-const publicMethods = (declaration: ClassDeclaration): string[] =>
-  declaration.members
-    .filter(isMethodDeclaration)
-    .filter(
-      (member) =>
-        !hasModifier(member, SyntaxKind.PrivateKeyword) &&
-        !hasModifier(member, SyntaxKind.ProtectedKeyword)
-    )
-    .map((member) => (isIdentifier(member.name) ? member.name.text : undefined))
-    .filter((name): name is string => name !== undefined)
-    .sort()
-
-const asyncMethods = (declaration: ClassDeclaration): string[] =>
-  declaration.members
-    .filter(isMethodDeclaration)
-    .filter((member) => hasModifier(member, SyntaxKind.AsyncKeyword))
-    .map((member) => (isIdentifier(member.name) ? member.name.text : undefined))
-    .filter((name): name is string => name !== undefined)
-    .sort()
-
-const fields = (declaration: ClassDeclaration): string[] =>
-  declaration.members
-    .filter(isPropertyDeclaration)
-    .map((member) => (isIdentifier(member.name) ? member.name.text : undefined))
-    .filter((name): name is string => name !== undefined)
-    .sort()
-
-const newExpressionSites = (className: string): string[] => {
+const newExpressionFiles = (className: string): string[] => {
   const sites: string[] = []
   for (const file of productionFiles) {
     const sourceFile = sourceFileFor(file)
@@ -95,47 +55,13 @@ const newExpressionSites = (className: string): string[] => {
         isIdentifier(node.expression) &&
         node.expression.text === className
       ) {
-        let current: Node | undefined = node.parent
-        while (current && !isConstructorDeclaration(current)) current = current.parent
-        sites.push(`${file}:${current ? 'constructor' : 'outside-constructor'}`)
+        sites.push(file)
       }
       forEachChild(node, visit)
     }
     visit(sourceFile)
   }
   return sites
-}
-
-const constructorParameters = (declaration: ClassDeclaration): string[] => {
-  const constructors = declaration.members.filter(isConstructorDeclaration)
-  expect(constructors).toHaveLength(1)
-  return constructors[0].parameters.map((parameter) =>
-    [
-      parameter.name.getText(),
-      parameter.type?.getText() ?? '<untyped>',
-      parameter.initializer ? 'defaulted' : 'required'
-    ].join(':')
-  )
-}
-
-const methodDeclarationSites = (methodName: string): string[] => {
-  const sites: string[] = []
-  for (const file of productionFiles) {
-    const sourceFile = sourceFileFor(file)
-    for (const statement of sourceFile.statements) {
-      if (!isClassDeclaration(statement) || !statement.name) continue
-      for (const member of statement.members) {
-        if (
-          isMethodDeclaration(member) &&
-          isIdentifier(member.name) &&
-          member.name.text === methodName
-        ) {
-          sites.push(`${file}:${statement.name.text}`)
-        }
-      }
-    }
-  }
-  return sites.sort()
 }
 
 const interactiveTransactionOptions = (): string[] => {
@@ -184,28 +110,6 @@ const variableInitializer = (file: string, variableName: string): string | undef
   return undefined
 }
 
-const facadeDelegations = (
-  facade: ClassDeclaration,
-  facadeFile: SourceFile
-): Readonly<Record<string, string>> =>
-  Object.fromEntries(
-    facade.members.filter(isMethodDeclaration).map((method) => {
-      if (!isIdentifier(method.name) || !method.body || method.body.statements.length !== 1) {
-        throw new Error('UploadRepository methods must be single-return delegations')
-      }
-      const [statement] = method.body.statements
-      if (
-        !isReturnStatement(statement) ||
-        !statement.expression ||
-        !isCallExpression(statement.expression) ||
-        !isPropertyAccessExpression(statement.expression.expression)
-      ) {
-        throw new Error(`${method.name.text} is not a direct owner delegation`)
-      }
-      return [method.name.text, statement.expression.expression.getText(facadeFile)]
-    })
-  )
-
 const exportedValues = (sourceFile: SourceFile): string[] => {
   const names: string[] = []
   for (const statement of sourceFile.statements) {
@@ -249,39 +153,8 @@ const exportedValues = (sourceFile: SourceFile): string[] => {
 
 describe('Upload repository architecture', () => {
   const facadeFile = sourceFileFor('repository.ts')
-  const facade = classFrom('repository.ts', 'UploadRepository')
 
-  it('keeps every production module within the completion gate', () => {
-    for (const [file, source] of sources) {
-      const physicalLines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      expect(physicalLines, file).toBeLessThanOrEqual(660)
-    }
-  })
-
-  it('keeps the established 15-method public facade and three value exports', () => {
-    const establishedMethods = [
-      'abortTransfer',
-      'appendTransfer',
-      'beginTransfer',
-      'deleteUpload',
-      'finalizePendingSessionUploads',
-      'finishTransfer',
-      'getTransferStatus',
-      'readManagedUploadPreview',
-      'recoverStagingUploads',
-      'resolveManagedUpload',
-      'resolveManagedUploadPath',
-      'resolveSessionUpload',
-      'resolveSessionUploadPath',
-      'stageLocalFile',
-      'upgradeLegacySessionUploads'
-    ].sort()
-    expect(publicMethods(facade)).toEqual(establishedMethods)
-    expect(asyncMethods(facade)).toEqual(establishedMethods)
-    expect(constructorParameters(facade)).toEqual([
-      'storageRoot:string:required',
-      'options:UploadRepositoryOptions:defaulted'
-    ])
+  it('keeps the public value exports stable', () => {
     expect(exportedValues(facadeFile)).toEqual(
       [
         'OrphanLegacyUploadAuthorityMissingError',
@@ -318,7 +191,7 @@ describe('Upload repository architecture', () => {
     expect(exportedValues(assignmentExport)).toEqual(['default:assigned'])
   })
 
-  it('composes each owner exactly once without facade lifecycle state', () => {
+  it('composes each owner exactly once behind the facade', () => {
     for (const owner of [
       'ActiveTransferOwner',
       'LegacyRecoveryOwner',
@@ -326,89 +199,32 @@ describe('Upload repository architecture', () => {
       'StagedPublicationOwner',
       'VerifiedLegacyCleanupOwner'
     ]) {
-      expect(newExpressionSites(owner), owner).toEqual(['repository.ts:constructor'])
+      expect(newExpressionFiles(owner), owner).toEqual(['repository.ts'])
     }
-    expect(fields(facade)).toEqual([
-      'legacyRecoveryOwner',
-      'managedUploadResolver',
-      'stagedPublicationOwner',
-      'transferOwner'
-    ])
-  })
-
-  it('keeps every facade method as a direct delegation to its established owner', () => {
-    expect(facadeDelegations(facade, facadeFile)).toEqual({
-      abortTransfer: 'this.transferOwner.abortTransfer',
-      appendTransfer: 'this.transferOwner.appendTransfer',
-      beginTransfer: 'this.transferOwner.beginTransfer',
-      deleteUpload: 'this.managedUploadResolver.deleteUpload',
-      finalizePendingSessionUploads: 'this.stagedPublicationOwner.finalizePendingSessionUploads',
-      finishTransfer: 'this.transferOwner.finishTransfer',
-      getTransferStatus: 'this.transferOwner.getTransferStatus',
-      readManagedUploadPreview: 'this.managedUploadResolver.readManagedUploadPreview',
-      recoverStagingUploads: 'this.legacyRecoveryOwner.recoverStagingUploads',
-      resolveManagedUpload: 'this.managedUploadResolver.resolveManagedUpload',
-      resolveManagedUploadPath: 'this.managedUploadResolver.resolveManagedUploadPath',
-      resolveSessionUpload: 'this.managedUploadResolver.resolveSessionUpload',
-      resolveSessionUploadPath: 'this.managedUploadResolver.resolveSessionUploadPath',
-      stageLocalFile: 'this.transferOwner.stageLocalFile',
-      upgradeLegacySessionUploads: 'this.legacyRecoveryOwner.upgradeLegacySessionUploads'
-    })
   })
 
   it('keeps recovery and verified cleanup decisions behind their owners', () => {
     const facadeSource = sources.get('repository.ts')!
-    const cleanupSource = sources.get('verified-legacy-cleanup-owner.ts')!
-    const recoverySource = sources.get('legacy-recovery-owner.ts')!
 
     expect(facadeSource).not.toMatch(/from ['"]node:fs\/promises['"]/)
     expect(facadeSource).not.toContain('LEGACY_CLEANUP_PRIVATE_SUFFIX')
     expect(facadeSource).not.toContain('settleSiblingOperations')
-    expect(publicMethods(classFrom('legacy-recovery-owner.ts', 'LegacyRecoveryOwner'))).toEqual(
-      [
-        'completeStagingUpload',
-        'hasOrphanLegacyCandidate',
-        'recoverStagingUploads',
-        'removeVerifiedLegacyCopy',
-        'upgradeLegacySessionUploads'
-      ].sort()
-    )
-    expect(
-      publicMethods(classFrom('verified-legacy-cleanup-owner.ts', 'VerifiedLegacyCleanupOwner'))
-    ).toEqual(['assertLegacySourceAbsent', 'hasPrivateClaim', 'removeVerifiedLegacyCopy'].sort())
-    expect(methodDeclarationSites('assertConsistentSessionUploadReferences')).toEqual([
-      'legacy-recovery-owner.ts:LegacyRecoveryOwner'
-    ])
-    expect(methodDeclarationSites('hasOrphanLegacyCandidate')).toEqual([
-      'legacy-recovery-owner.ts:LegacyRecoveryOwner'
-    ])
-    expect(methodDeclarationSites('completeStagingUpload')).toEqual([
-      'legacy-recovery-owner.ts:LegacyRecoveryOwner'
-    ])
-    expect(methodDeclarationSites('restoreLegacyCleanupPrivate')).toEqual([
-      'verified-legacy-cleanup-owner.ts:VerifiedLegacyCleanupOwner'
-    ])
-    expect(methodDeclarationSites('assertLegacySourceAbsent')).toEqual([
-      'verified-legacy-cleanup-owner.ts:VerifiedLegacyCleanupOwner'
-    ])
-    expect(cleanupSource.match(/LEGACY_CLEANUP_PRIVATE_SUFFIX/g)).toHaveLength(4)
     for (const [file, source] of sources) {
       if (file !== 'verified-legacy-cleanup-owner.ts') {
         expect(source, file).not.toContain('LEGACY_CLEANUP_PRIVATE_SUFFIX')
       }
     }
-    expect(recoverySource).toContain('cleanup: Pick<')
   })
 
   it('routes every interactive Upload transaction through the shared connection wait policy', () => {
     expect(variableInitializer('staged-publication-owner.ts', 'UPLOAD_TRANSACTION_OPTIONS')).toBe(
       '{ maxWait: 10_000 } as const'
     )
-    expect(interactiveTransactionOptions()).toEqual([
-      'staged-publication-owner.ts:UPLOAD_TRANSACTION_OPTIONS'
-    ])
-    expect(functionCallSites('runUploadTransaction')).toEqual([
-      'legacy-recovery-owner.ts',
+    const transactionOptions = interactiveTransactionOptions()
+    expect(transactionOptions.length).toBeGreaterThan(0)
+    for (const site of transactionOptions) expect(site).toMatch(/:UPLOAD_TRANSACTION_OPTIONS$/)
+
+    expect([...new Set(functionCallSites('runUploadTransaction'))]).toEqual([
       'legacy-recovery-owner.ts',
       'staged-publication-owner.ts'
     ])

--- a/src/main/uploads/repository.architecture.test.ts
+++ b/src/main/uploads/repository.architecture.test.ts
@@ -7,8 +7,10 @@ import {
   forEachChild,
   getModifiers,
   isArrowFunction,
+  isBindingElement,
   isCallExpression,
   isClassDeclaration,
+  isClassExpression,
   isConstructorDeclaration,
   isEnumDeclaration,
   isExportAssignment,
@@ -19,9 +21,11 @@ import {
   isMethodDeclaration,
   isNamedExports,
   isNewExpression,
+  isParameter,
   isPropertyDeclaration,
   isPropertyAccessExpression,
   isSourceFile,
+  isVariableDeclaration,
   isVariableStatement,
   ScriptKind,
   ScriptTarget,
@@ -131,9 +135,49 @@ const interactiveTransactionOptions = (
   return sites.sort()
 }
 
+const valueBindingsNamed = (sourceFile: SourceFile, name: string): Node[] => {
+  const bindings: Node[] = []
+  const visit = (node: Node): void => {
+    if (isIdentifier(node) && node.text === name) {
+      const declaration = node.parent
+      const isNamedValueDeclaration =
+        isVariableDeclaration(declaration) ||
+        isParameter(declaration) ||
+        isBindingElement(declaration) ||
+        isFunctionDeclaration(declaration) ||
+        isFunctionExpression(declaration) ||
+        isClassDeclaration(declaration) ||
+        isClassExpression(declaration) ||
+        isEnumDeclaration(declaration)
+      const isValueBinding = isNamedValueDeclaration && declaration.name === node
+      if (isValueBinding) bindings.push(node)
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return bindings
+}
+
 const expectSharedUploadTransactionPolicy = (
   sourceMap: ReadonlyMap<string, string> = sources
 ): void => {
+  const policyFile = 'staged-publication-owner.ts'
+  const policySource = createSourceFile(
+    policyFile,
+    sourceMap.get(policyFile)!,
+    ScriptTarget.Latest,
+    true,
+    ScriptKind.TS
+  )
+  const policyBindings = valueBindingsNamed(policySource, 'UPLOAD_TRANSACTION_OPTIONS')
+  expect(policyBindings).toHaveLength(1)
+  const declaration = policyBindings[0]?.parent
+  expect(
+    declaration !== undefined &&
+      isVariableDeclaration(declaration) &&
+      isVariableStatement(declaration.parent.parent) &&
+      isSourceFile(declaration.parent.parent.parent)
+  ).toBe(true)
   expect(interactiveTransactionOptions(sourceMap)).toEqual([
     'staged-publication-owner.ts:UPLOAD_TRANSACTION_OPTIONS'
   ])
@@ -326,6 +370,19 @@ describe('Upload repository architecture', () => {
       `
     )
     expect(() => expectSharedUploadTransactionPolicy(shadowedPolicySources)).toThrow()
+
+    const sameFileShadowSources = new Map(sources)
+    sameFileShadowSources.set(
+      'staged-publication-owner.ts',
+      sources.get('staged-publication-owner.ts')!.replace(
+        '): Promise<Result> => client.$transaction(operation, UPLOAD_TRANSACTION_OPTIONS)',
+        `): Promise<Result> => {
+            const UPLOAD_TRANSACTION_OPTIONS = { maxWait: 1 }
+            return client.$transaction(operation, UPLOAD_TRANSACTION_OPTIONS)
+          }`
+      )
+    )
+    expect(() => expectSharedUploadTransactionPolicy(sameFileShadowSources)).toThrow()
 
     expect([...new Set(functionCallSites('runUploadTransaction'))]).toEqual([
       'legacy-recovery-owner.ts',

--- a/src/main/uploads/repository.architecture.test.ts
+++ b/src/main/uploads/repository.architecture.test.ts
@@ -110,10 +110,12 @@ const newExpressionFiles = (
   return sites
 }
 
-const interactiveTransactionOptions = (): string[] => {
+const interactiveTransactionOptions = (
+  sourceMap: ReadonlyMap<string, string> = sources
+): string[] => {
   const sites: string[] = []
-  for (const file of productionFiles) {
-    const sourceFile = sourceFileFor(file)
+  for (const [file, source] of sourceMap) {
+    const sourceFile = createSourceFile(file, source, ScriptTarget.Latest, true, ScriptKind.TS)
     const visit = (node: Node): void => {
       if (
         isCallExpression(node) &&
@@ -127,6 +129,14 @@ const interactiveTransactionOptions = (): string[] => {
     visit(sourceFile)
   }
   return sites.sort()
+}
+
+const expectSharedUploadTransactionPolicy = (
+  sourceMap: ReadonlyMap<string, string> = sources
+): void => {
+  expect(interactiveTransactionOptions(sourceMap)).toEqual([
+    'staged-publication-owner.ts:UPLOAD_TRANSACTION_OPTIONS'
+  ])
 }
 
 const functionCallSites = (functionName: string): string[] => {
@@ -305,9 +315,17 @@ describe('Upload repository architecture', () => {
     expect(variableInitializer('staged-publication-owner.ts', 'UPLOAD_TRANSACTION_OPTIONS')).toBe(
       '{ maxWait: 10_000 } as const'
     )
-    const transactionOptions = interactiveTransactionOptions()
-    expect(transactionOptions.length).toBeGreaterThan(0)
-    for (const site of transactionOptions) expect(site).toMatch(/:UPLOAD_TRANSACTION_OPTIONS$/)
+    expectSharedUploadTransactionPolicy()
+
+    const shadowedPolicySources = new Map(sources)
+    shadowedPolicySources.set(
+      'rogue-owner.ts',
+      `
+        const UPLOAD_TRANSACTION_OPTIONS = { maxWait: 1 }
+        client.$transaction(operation, UPLOAD_TRANSACTION_OPTIONS)
+      `
+    )
+    expect(() => expectSharedUploadTransactionPolicy(shadowedPolicySources)).toThrow()
 
     expect([...new Set(functionCallSites('runUploadTransaction'))]).toEqual([
       'legacy-recovery-owner.ts',

--- a/src/main/uploads/repository.architecture.test.ts
+++ b/src/main/uploads/repository.architecture.test.ts
@@ -21,6 +21,7 @@ import {
   isNewExpression,
   isPropertyDeclaration,
   isPropertyAccessExpression,
+  isSourceFile,
   isVariableStatement,
   ScriptKind,
   ScriptTarget,
@@ -50,10 +51,19 @@ const hasModifier = (node: Node, kind: SyntaxKind): boolean =>
   canHaveModifiers(node) &&
   (getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false)
 
-const hasClassLifetime = (expression: Node): boolean => {
+const hasFacadeLifetime = (expression: Node): boolean => {
   let current: Node | undefined = expression.parent
   while (current) {
-    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) return true
+    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) {
+      const facade = current.parent
+      const isTargetFacade =
+        isClassDeclaration(facade) &&
+        facade.name?.text === 'UploadRepository' &&
+        isSourceFile(facade.parent)
+      const isStaticField =
+        isPropertyDeclaration(current) && hasModifier(current, SyntaxKind.StaticKeyword)
+      return isTargetFacade && !isStaticField
+    }
     if (
       isMethodDeclaration(current) ||
       isFunctionDeclaration(current) ||
@@ -78,7 +88,7 @@ const newExpressionLifetimes = (
       isIdentifier(node.expression) &&
       node.expression.text === className
     ) {
-      lifetimes.push(hasClassLifetime(node) ? 'class' : 'transient')
+      lifetimes.push(hasFacadeLifetime(node) ? 'class' : 'transient')
     }
     forEachChild(node, visit)
   }
@@ -241,7 +251,7 @@ describe('Upload repository architecture', () => {
 
     const fieldInitializerFile = createSourceFile(
       'field-initializer.ts',
-      'class Repository { private readonly owner = new ActiveTransferOwner() }',
+      'class UploadRepository { private readonly owner = new ActiveTransferOwner() }',
       ScriptTarget.Latest,
       true,
       ScriptKind.TS
@@ -250,7 +260,7 @@ describe('Upload repository architecture', () => {
 
     const methodConstructionFile = createSourceFile(
       'method-construction.ts',
-      'class Repository { createOwner() { return new ActiveTransferOwner() } }',
+      'class UploadRepository { createOwner() { return new ActiveTransferOwner() } }',
       ScriptTarget.Latest,
       true,
       ScriptKind.TS
@@ -258,6 +268,24 @@ describe('Upload repository architecture', () => {
     expect(newExpressionLifetimes(methodConstructionFile, 'ActiveTransferOwner')).toEqual([
       'transient'
     ])
+
+    const staticFieldFile = createSourceFile(
+      'static-field.ts',
+      'class UploadRepository { static owner = new ActiveTransferOwner() }',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+    expect(newExpressionLifetimes(staticFieldFile, 'ActiveTransferOwner')).toEqual(['transient'])
+
+    const nestedClassFile = createSourceFile(
+      'nested-class.ts',
+      'class UploadRepository { createOwner() { class Holder { owner = new ActiveTransferOwner() } return Holder } }',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+    expect(newExpressionLifetimes(nestedClassFile, 'ActiveTransferOwner')).toEqual(['transient'])
   })
 
   it('keeps recovery and verified cleanup decisions behind their owners', () => {

--- a/src/main/uploads/repository.architecture.test.ts
+++ b/src/main/uploads/repository.architecture.test.ts
@@ -6,15 +6,20 @@ import {
   createSourceFile,
   forEachChild,
   getModifiers,
+  isArrowFunction,
   isCallExpression,
   isClassDeclaration,
+  isConstructorDeclaration,
   isEnumDeclaration,
   isExportAssignment,
   isExportDeclaration,
   isFunctionDeclaration,
+  isFunctionExpression,
   isIdentifier,
+  isMethodDeclaration,
   isNamedExports,
   isNewExpression,
+  isPropertyDeclaration,
   isPropertyAccessExpression,
   isVariableStatement,
   ScriptKind,
@@ -45,21 +50,52 @@ const hasModifier = (node: Node, kind: SyntaxKind): boolean =>
   canHaveModifiers(node) &&
   (getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false)
 
-const newExpressionFiles = (className: string): string[] => {
+const hasClassLifetime = (expression: Node): boolean => {
+  let current: Node | undefined = expression.parent
+  while (current) {
+    if (isConstructorDeclaration(current) || isPropertyDeclaration(current)) return true
+    if (
+      isMethodDeclaration(current) ||
+      isFunctionDeclaration(current) ||
+      isFunctionExpression(current) ||
+      isArrowFunction(current)
+    ) {
+      return false
+    }
+    current = current.parent
+  }
+  return false
+}
+
+const newExpressionLifetimes = (
+  sourceFile: SourceFile,
+  className: string
+): Array<'class' | 'transient'> => {
+  const lifetimes: Array<'class' | 'transient'> = []
+  const visit = (node: Node): void => {
+    if (
+      isNewExpression(node) &&
+      isIdentifier(node.expression) &&
+      node.expression.text === className
+    ) {
+      lifetimes.push(hasClassLifetime(node) ? 'class' : 'transient')
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return lifetimes
+}
+
+const newExpressionFiles = (
+  className: string,
+  lifetime: 'class' | 'transient' = 'class'
+): string[] => {
   const sites: string[] = []
   for (const file of productionFiles) {
     const sourceFile = sourceFileFor(file)
-    const visit = (node: Node): void => {
-      if (
-        isNewExpression(node) &&
-        isIdentifier(node.expression) &&
-        node.expression.text === className
-      ) {
-        sites.push(file)
-      }
-      forEachChild(node, visit)
+    for (const siteLifetime of newExpressionLifetimes(sourceFile, className)) {
+      if (siteLifetime === lifetime) sites.push(file)
     }
-    visit(sourceFile)
   }
   return sites
 }
@@ -200,7 +236,28 @@ describe('Upload repository architecture', () => {
       'VerifiedLegacyCleanupOwner'
     ]) {
       expect(newExpressionFiles(owner), owner).toEqual(['repository.ts'])
+      expect(newExpressionFiles(owner, 'transient'), owner).toEqual([])
     }
+
+    const fieldInitializerFile = createSourceFile(
+      'field-initializer.ts',
+      'class Repository { private readonly owner = new ActiveTransferOwner() }',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+    expect(newExpressionLifetimes(fieldInitializerFile, 'ActiveTransferOwner')).toEqual(['class'])
+
+    const methodConstructionFile = createSourceFile(
+      'method-construction.ts',
+      'class Repository { createOwner() { return new ActiveTransferOwner() } }',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+    expect(newExpressionLifetimes(methodConstructionFile, 'ActiveTransferOwner')).toEqual([
+      'transient'
+    ])
   })
 
   it('keeps recovery and verified cleanup decisions behind their owners', () => {


### PR DESCRIPTION
## Problem

Architecture tests rejected behavior-preserving internal refactors by fixing physical line counts, private field and method inventories, constructor locations, complete public method inventories, and single-return facade bodies. A one-line formatting-only change reproduced the failure deterministically: the Notebook completion gate failed with `expected 1251 to be <= 1250`.

## Proposed change

- Remove fixed line-count gates and exact private implementation inventories.
- Replace constructor-location assertions with one-owner-construction-site boundaries.
- Remove single-return facade delegation requirements.
- Preserve public export contracts, write/read separation, forbidden reverse dependencies, private-owner import boundaries, shared transaction policy, and cross-surface capability contracts.
- Replace the arrow-property shape check for `handleJobUpdated` with an observable detached-callback behavior test.
- Add fixture coverage proving field-initializer owner composition remains valid while duplicate owners and mutable module state remain detectable.

## Scope and non-goals

Only architecture and public-behavior tests change. Production code, user-visible behavior, persisted formats, historical compatibility, data relationships, and state/enum inventories are unchanged.

## Acceptance criteria and validation

Checks below ran against the final committed state:

- Architecture/refactor tolerance -> targeted five-file Vitest run -> 5 files, 30 tests passed.
- Compute owner/contract/consumer set -> module-impact manifest file set -> 31 files passed, 1 skipped; 799 tests passed, 15 skipped.
- Project Files owner/contract/consumer set -> module-impact manifest file set -> 6 files passed; 233 tests passed, 1 skipped.
- Uploads owner/contract/consumer set -> module-impact manifest file set -> 8 files and 129 tests passed; two existing Windows symlink fixtures were blocked during setup by `EPERM` before entering product logic.
- Module-impact manifest -> `scripts/ci/validate-module-impact.test.ts` -> 9 tests passed.
- Changed files -> ESLint -> passed.
- Full repository ESLint -> passed.

`npm test` was intentionally not run locally; exact-head PR Gate is authoritative for the complete portable and platform suites. Local Node typecheck was blocked by the installed shared dependency tree: the available `@agentclientprotocol/claude-agent-acp` package does not export `waitForMcpServers`, which is imported by an unchanged ACP test.

## Review focus

- Confirm the remaining assertions describe ownership, dependency, export, persistence-safety, or observable capability boundaries.
- Confirm removed assertions constrained implementation shape without protecting external behavior.
- Confirm the detached callback test protects the runtime reason `handleJobUpdated` remains bound without prescribing arrow-field syntax.