### PR TITLE
fix(compute): validate Electron IPC arguments

### DIFF
--- a/src/main/compute/electron-ipc-adapter.ts
+++ b/src/main/compute/electron-ipc-adapter.ts
@@ -1,3 +1,6 @@
+import type { IpcMainInvokeEvent } from 'electron'
+import { z } from 'zod'
+
 import type {
   ChangeComputeHostAuthenticationRequest,
   ComputeApprovalDecision,
@@ -5,9 +8,9 @@ import type {
   ComputeJobsPendingNotificationFilter,
   CreateComputeHostRequest,
   CreatePasswordComputeHostRequest,
-  ResetPasswordComputeHostRequest,
   DeleteComputeHostRequest,
-  DetailsAuthor
+  DetailsAuthor,
+  ResetPasswordComputeHostRequest
 } from '../../shared/compute'
 import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
 import type { DownloadDest, SerializableRemoteFsError } from '../../shared/remote-fs'
@@ -24,6 +27,142 @@ import type { SessionEnabledComputeHostsOwner } from './session-enabled-hosts-ow
 // IPC channel name for the renderer job feed (Phase 3d, issue 05).
 const COMPUTE_JOBS_LIST_CHANNEL = 'compute:jobs:list'
 
+const finiteNumberSchema = z.number().finite()
+const integerSchema = finiteNumberSchema.int()
+const stringArraySchema = z.array(z.string())
+const detailsAuthorSchema = z.enum(['user', 'agent']) satisfies z.ZodType<DetailsAuthor>
+
+const createComputeHostRequestSchema = z
+  .object({
+    sshAlias: z.string(),
+    displayName: z.string().optional(),
+    detailsDoc: z.string().optional(),
+    sshOverrides: z
+      .object({
+        user: z.string().optional(),
+        port: finiteNumberSchema.optional(),
+        identityFile: z.string().optional()
+      })
+      .strict()
+      .optional()
+  })
+  .strict() satisfies z.ZodType<CreateComputeHostRequest>
+
+const createPasswordComputeHostRequestSchema = z
+  .object({
+    sshAlias: z.string(),
+    displayName: z.string().optional(),
+    detailsDoc: z.string().optional(),
+    authenticationMode: z.literal('password'),
+    username: z.string(),
+    port: finiteNumberSchema,
+    password: z.string(),
+    operationId: z.string()
+  })
+  .strict() satisfies z.ZodType<CreatePasswordComputeHostRequest>
+
+const resetPasswordComputeHostRequestSchema = z
+  .object({
+    providerId: z.string(),
+    password: z.string(),
+    operationId: z.string(),
+    expectedAuthenticationRevision: integerSchema
+  })
+  .strict() satisfies z.ZodType<ResetPasswordComputeHostRequest>
+
+const changeComputeHostAuthenticationRequestSchema = z
+  .object({
+    providerId: z.string(),
+    expectedRevision: integerSchema,
+    operationId: z.string(),
+    authenticationMode: z.enum(['ssh_config', 'password']),
+    username: z.string().optional(),
+    port: finiteNumberSchema,
+    identityFile: z.string().optional(),
+    password: z.string().optional()
+  })
+  .strict() satisfies z.ZodType<ChangeComputeHostAuthenticationRequest>
+
+const deleteComputeHostRequestSchema = z
+  .object({ providerId: z.string() })
+  .strict() satisfies z.ZodType<DeleteComputeHostRequest>
+
+const downloadDestSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('artifact'), projectId: z.string() }).strict(),
+  z.object({ kind: z.literal('os-downloads') }).strict(),
+  z.object({ kind: z.literal('session-cache') }).strict()
+]) satisfies z.ZodType<DownloadDest>
+
+const computeApprovalResponseSchema = z
+  .object({
+    id: z.string(),
+    decision: z.enum(['once', 'conversation', 'project', 'global', 'deny'])
+  })
+  .strict() satisfies z.ZodType<{ id: string; decision: ComputeApprovalDecision }>
+
+const computeJobsListFilterSchema = z.union([
+  z.object({ sessionId: z.string(), status: stringArraySchema.optional() }).strict(),
+  z.object({ nonTerminal: z.literal(true) }).strict()
+]) satisfies z.ZodType<ComputeJobsListFilter>
+
+const computeJobsPendingNotificationFilterSchema = z.union([
+  z.string(),
+  z.object({ allSessions: z.literal(true) }).strict()
+]) satisfies z.ZodType<ComputeJobsPendingNotificationFilter>
+
+const computeIpcArgumentSchemas = Object.freeze({
+  'compute:list': z.tuple([]),
+  'compute:get': z.tuple([z.string()]),
+  'compute:create': z.tuple([createComputeHostRequestSchema]),
+  'compute:create-password': z.tuple([createPasswordComputeHostRequestSchema]),
+  'compute:reset-password': z.tuple([resetPasswordComputeHostRequestSchema]),
+  'compute:change-authentication': z.tuple([changeComputeHostAuthenticationRequestSchema]),
+  'compute:password-capability': z.tuple([]),
+  'compute:deletion-status': z.tuple([deleteComputeHostRequestSchema]),
+  'compute:delete': z.tuple([deleteComputeHostRequestSchema]),
+  'compute:ssh-config-aliases': z.tuple([]),
+  'compute:probe': z.tuple([z.string()]),
+  'compute:details:get': z.tuple([z.string()]),
+  'compute:details:save': z.tuple([z.string(), z.string(), z.string(), detailsAuthorSchema]),
+  'compute:scratch:set': z.tuple([z.string(), z.string()]),
+  'compute:concurrency:set': z.tuple([z.string(), finiteNumberSchema]),
+  'compute:session:set-concurrency-limit': z.tuple([z.string(), finiteNumberSchema]),
+  'compute:session:status': z.tuple([z.string()]),
+  'compute:list-dir': z.tuple([z.string(), z.string()]),
+  'compute:download': z.tuple([z.string(), z.string(), downloadDestSchema]),
+  'compute:reveal-in-folder': z.tuple([z.string()]),
+  'compute:approval-respond': z.tuple([computeApprovalResponseSchema]),
+  'compute:approval-replay': z.tuple([z.string()]),
+  'compute:approval-replay-pending': z.tuple([]),
+  'compute:jobs:list': z.tuple([computeJobsListFilterSchema]),
+  'compute:jobs:pending-notification': z.tuple([computeJobsPendingNotificationFilterSchema]),
+  'compute:jobs:mark-consumed': z.tuple([z.string(), stringArraySchema]),
+  'compute:enabled-hosts:get': z.tuple([z.string()]),
+  'compute:enabled-hosts:set': z.tuple([z.string(), stringArraySchema]),
+  'compute:host-enabled:set': z.tuple([z.string(), z.string(), z.boolean()]),
+  'compute:host-selected:set': z.tuple([z.string(), z.string(), z.boolean()])
+})
+
+type ComputeIpcChannel = keyof typeof computeIpcArgumentSchemas
+type ComputeIpcArguments<Channel extends ComputeIpcChannel> = z.output<
+  (typeof computeIpcArgumentSchemas)[Channel]
+>
+
+const COMPUTE_IPC_CHANNELS: readonly ComputeIpcChannel[] = Object.freeze(
+  (Object.keys(computeIpcArgumentSchemas) as ComputeIpcChannel[]).sort()
+)
+
+const decodeComputeIpcArguments = <Channel extends ComputeIpcChannel>(
+  channel: Channel,
+  input: readonly unknown[]
+): ComputeIpcArguments<Channel> => {
+  const result = computeIpcArgumentSchemas[channel].safeParse(input)
+  if (!result.success) {
+    throw new Error(`Invalid arguments for Electron IPC channel: ${channel}`)
+  }
+  return result.data as ComputeIpcArguments<Channel>
+}
+
 type ComputeIpcAdapter = {
   handlers: ComputeHandlers
   enabledHosts: Pick<
@@ -32,57 +171,52 @@ type ComputeIpcAdapter = {
   >
 }
 
+const handleComputeIpc = <Channel extends ComputeIpcChannel>(
+  channel: Channel,
+  listener: (event: IpcMainInvokeEvent, ...args: ComputeIpcArguments<Channel>) => unknown
+): void => {
+  ipcMainHandle(channel, (event, ...input) =>
+    listener(event, ...decodeComputeIpcArguments(channel, input))
+  )
+}
+
 const registerComputeIpcHandlerSet = ({ handlers, enabledHosts }: ComputeIpcAdapter): void => {
-  ipcMainHandle('compute:list', () => handlers.list())
-  ipcMainHandle('compute:get', (_event, providerId: string) => handlers.get(providerId))
-  ipcMainHandle('compute:create', (_event, request: CreateComputeHostRequest) =>
-    handlers.create(request)
+  handleComputeIpc('compute:list', () => handlers.list())
+  handleComputeIpc('compute:get', (_event, providerId) => handlers.get(providerId))
+  handleComputeIpc('compute:create', (_event, request) => handlers.create(request))
+  handleComputeIpc('compute:create-password', (_event, request) => handlers.createPassword(request))
+  handleComputeIpc('compute:reset-password', (_event, request) => handlers.resetPassword(request))
+  handleComputeIpc('compute:change-authentication', (_event, request) =>
+    handlers.changeAuthentication(request)
   )
-  ipcMainHandle('compute:create-password', (_event, request: CreatePasswordComputeHostRequest) =>
-    handlers.createPassword(request)
-  )
-  ipcMainHandle('compute:reset-password', (_event, request: ResetPasswordComputeHostRequest) =>
-    handlers.resetPassword(request)
-  )
-  ipcMainHandle(
-    'compute:change-authentication',
-    (_event, request: ChangeComputeHostAuthenticationRequest) =>
-      handlers.changeAuthentication(request)
-  )
-  ipcMainHandle('compute:password-capability', () => handlers.passwordCapability())
-  ipcMainHandle('compute:deletion-status', (_event, request: DeleteComputeHostRequest) =>
+  handleComputeIpc('compute:password-capability', () => handlers.passwordCapability())
+  handleComputeIpc('compute:deletion-status', (_event, request) =>
     handlers.deletionStatus(request.providerId)
   )
-  ipcMainHandle('compute:delete', async (_event, request: DeleteComputeHostRequest) => {
+  handleComputeIpc('compute:delete', async (_event, request) => {
     await handlers.delete(request.providerId)
   })
-  ipcMainHandle('compute:ssh-config-aliases', () => handlers.sshConfigAliases())
-  ipcMainHandle('compute:probe', (_event, providerId: string) => handlers.probe(providerId))
-  ipcMainHandle('compute:details:get', (_event, providerId: string) =>
-    handlers.detailsGet(providerId)
+  handleComputeIpc('compute:ssh-config-aliases', () => handlers.sshConfigAliases())
+  handleComputeIpc('compute:probe', (_event, providerId) => handlers.probe(providerId))
+  handleComputeIpc('compute:details:get', (_event, providerId) => handlers.detailsGet(providerId))
+  handleComputeIpc('compute:details:save', (_event, providerId, text, oldText, author) =>
+    handlers.detailsSave(providerId, text, oldText, author)
   )
-  ipcMainHandle(
-    'compute:details:save',
-    (_event, providerId: string, text: string, oldText: string, author: DetailsAuthor) =>
-      handlers.detailsSave(providerId, text, oldText, author)
-  )
-  ipcMainHandle('compute:scratch:set', (_event, providerId: string, path: string) =>
+  handleComputeIpc('compute:scratch:set', (_event, providerId, path) =>
     handlers.scratchSet(providerId, path)
   )
-  ipcMainHandle('compute:concurrency:set', (_event, providerId: string, limit: number) =>
+  handleComputeIpc('compute:concurrency:set', (_event, providerId, limit) =>
     handlers.concurrencySet(providerId, limit)
   )
   // Session-level concurrency control (Phase 3c, issue 04).
-  ipcMainHandle(
-    'compute:session:set-concurrency-limit',
-    (_event, sessionId: string, limit: number) =>
-      handlers.setSessionConcurrencyLimit(sessionId, limit)
+  handleComputeIpc('compute:session:set-concurrency-limit', (_event, sessionId, limit) =>
+    handlers.setSessionConcurrencyLimit(sessionId, limit)
   )
-  ipcMainHandle('compute:session:status', (_event, sessionId: string) =>
+  handleComputeIpc('compute:session:status', (_event, sessionId) =>
     handlers.getSessionConcurrencyStatus(sessionId)
   )
   // Lists a remote directory (browse experience, issue 05).
-  ipcMainHandle('compute:list-dir', async (_event, providerId: string, path: string) => {
+  handleComputeIpc('compute:list-dir', async (_event, providerId, path) => {
     try {
       return await handlers.listDir(providerId, path)
     } catch (err) {
@@ -94,95 +228,74 @@ const registerComputeIpcHandlerSet = ({ handlers, enabledHosts }: ComputeIpcAdap
     }
   })
   // Downloads a remote file to OS Downloads or project artifact. No approval gate (issue 03).
-  ipcMainHandle(
-    'compute:download',
-    async (_event, providerId: string, remotePath: string, dest: DownloadDest) => {
-      try {
-        return await handlers.download(providerId, remotePath, dest)
-      } catch (err) {
-        const e = err as Error & { remoteFsError?: SerializableRemoteFsError }
-        if (e.remoteFsError) {
-          throw new Error(encodeRemoteFsError(e.message, e.remoteFsError))
-        }
-        throw err
+  handleComputeIpc('compute:download', async (_event, providerId, remotePath, dest) => {
+    try {
+      return await handlers.download(providerId, remotePath, dest)
+    } catch (err) {
+      const e = err as Error & { remoteFsError?: SerializableRemoteFsError }
+      if (e.remoteFsError) {
+        throw new Error(encodeRemoteFsError(e.message, e.remoteFsError))
       }
+      throw err
     }
-  )
+  })
   // Reveals a local file path in the OS file manager (Finder / Explorer).
-  ipcMainHandle('compute:reveal-in-folder', (_event, filePath: string) => {
+  handleComputeIpc('compute:reveal-in-folder', (_event, filePath) => {
     handlers.revealInFolder(filePath)
   })
   // Renderer responds to an in-flight approval card (issue 04/05). Decision now carries the
-  // chosen scope: 'once' | 'conversation' | 'project' | 'deny'.
-  ipcMainHandle(
-    'compute:approval-respond',
-    (_event, request: { id: string; decision: ComputeApprovalDecision }) => {
-      handlers.approvalRespond(request.id, request.decision)
-    }
-  )
-  ipcMainHandle('compute:approval-replay', (_event, id: unknown) =>
-    typeof id === 'string' ? handlers.approvalReplay(id) : null
-  )
-  ipcMainHandle('compute:approval-replay-pending', () => handlers.approvalReplayPending())
+  // chosen scope: 'once' | 'conversation' | 'project' | 'global' | 'deny'.
+  handleComputeIpc('compute:approval-respond', (_event, request) => {
+    handlers.approvalRespond(request.id, request.decision)
+  })
+  handleComputeIpc('compute:approval-replay', (_event, id) => handlers.approvalReplay(id))
+  handleComputeIpc('compute:approval-replay-pending', () => handlers.approvalReplayPending())
   // Returns a Session job feed or the global non-terminal activity projection.
-  ipcMainHandle(COMPUTE_JOBS_LIST_CHANNEL, (_event, filter: ComputeJobsListFilter) =>
-    handlers.jobsList(filter)
-  )
+  handleComputeIpc(COMPUTE_JOBS_LIST_CHANNEL, (_event, filter) => handlers.jobsList(filter))
   // Returns jobs pending analysis turn (notifiedAt set, notificationConsumedAt null — issue 05).
-  ipcMainHandle(
-    'compute:jobs:pending-notification',
-    (_event, filter: ComputeJobsPendingNotificationFilter) =>
-      handlers.jobsPendingNotification(filter)
+  handleComputeIpc('compute:jobs:pending-notification', (_event, filter) =>
+    handlers.jobsPendingNotification(filter)
   )
   // Marks job ids as notification-consumed (analysis turn done — issue 05).
-  ipcMainHandle('compute:jobs:mark-consumed', (_event, sessionId: string, jobIds: string[]) =>
+  handleComputeIpc('compute:jobs:mark-consumed', (_event, sessionId, jobIds) =>
     handlers.jobsMarkConsumed(sessionId, jobIds)
   )
 
   // Per-session enabled Compute Hosts. Main commits Session authority before updating the runtime
   // projection consulted by legacy list_compute and canonical list_preferred.
-  ipcMainHandle('compute:enabled-hosts:get', (_event, sessionId: string): string[] =>
+  handleComputeIpc('compute:enabled-hosts:get', (_event, sessionId): string[] =>
     enabledHosts.get(sessionId)
   )
-  ipcMainHandle(
-    'compute:enabled-hosts:set',
-    async (event, sessionId: string, providerIds: string[]) => {
-      const originClientId = getLifecycleClientId(event)
-      const session = await enabledHosts.set(sessionId, providerIds)
-      try {
-        broadcastLifecycleEvent(LIFECYCLE_CHANNELS.sessionUpdated, { session, originClientId })
-      } catch {
-        // Lifecycle delivery cannot roll back committed Session authority.
-      }
-      return session
+  handleComputeIpc('compute:enabled-hosts:set', async (event, sessionId, providerIds) => {
+    const originClientId = getLifecycleClientId(event)
+    const session = await enabledHosts.set(sessionId, providerIds)
+    try {
+      broadcastLifecycleEvent(LIFECYCLE_CHANNELS.sessionUpdated, { session, originClientId })
+    } catch {
+      // Lifecycle delivery cannot roll back committed Session authority.
     }
-  )
-  ipcMainHandle(
-    'compute:host-enabled:set',
-    async (event, sessionId: string, providerId: string, enabled: boolean) => {
-      const originClientId = getLifecycleClientId(event)
-      const session = await enabledHosts.setHostEnabled(sessionId, providerId, enabled)
-      try {
-        broadcastLifecycleEvent(LIFECYCLE_CHANNELS.sessionUpdated, { session, originClientId })
-      } catch {
-        // Lifecycle delivery cannot roll back committed Session authority.
-      }
-      return session
+    return session
+  })
+  handleComputeIpc('compute:host-enabled:set', async (event, sessionId, providerId, enabled) => {
+    const originClientId = getLifecycleClientId(event)
+    const session = await enabledHosts.setHostEnabled(sessionId, providerId, enabled)
+    try {
+      broadcastLifecycleEvent(LIFECYCLE_CHANNELS.sessionUpdated, { session, originClientId })
+    } catch {
+      // Lifecycle delivery cannot roll back committed Session authority.
     }
-  )
-  ipcMainHandle(
-    'compute:host-selected:set',
-    async (event, sessionId: string, providerId: string, selected: boolean) => {
-      const originClientId = getLifecycleClientId(event)
-      const session = await enabledHosts.setHostSelected(sessionId, providerId, selected)
-      try {
-        broadcastLifecycleEvent(LIFECYCLE_CHANNELS.sessionUpdated, { session, originClientId })
-      } catch {
-        // Lifecycle delivery cannot roll back committed Session authority.
-      }
-      return session
+    return session
+  })
+  handleComputeIpc('compute:host-selected:set', async (event, sessionId, providerId, selected) => {
+    const originClientId = getLifecycleClientId(event)
+    const session = await enabledHosts.setHostSelected(sessionId, providerId, selected)
+    try {
+      broadcastLifecycleEvent(LIFECYCLE_CHANNELS.sessionUpdated, { session, originClientId })
+    } catch {
+      // Lifecycle delivery cannot roll back committed Session authority.
     }
-  )
+    return session
+  })
 }
 
 // Installs only the renderer-callable Electron adapter over an already-constructed Compute module.
@@ -197,5 +310,5 @@ const installComputeIpcHandlers = (adapter: ComputeIpcAdapter): IpcHandlerInstal
   }
 }
 
-export { COMPUTE_JOBS_LIST_CHANNEL, installComputeIpcHandlers }
+export { COMPUTE_IPC_CHANNELS, COMPUTE_JOBS_LIST_CHANNEL, installComputeIpcHandlers }
 export type { ComputeIpcAdapter }

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -18,6 +18,7 @@ import type { PasswordSshAdapter } from './connection-adapters'
 import { ComputeConnectionError, SshConfigComputeConnectionBroker } from './connection-broker'
 import type { CredentialVault } from './credential-vault'
 import { ComputeApprovalBroker } from './compute-approval-broker'
+import { COMPUTE_IPC_CHANNELS } from './electron-ipc-adapter'
 import {
   COMPUTE_JOB_UPDATED_CHANNEL,
   COMPUTE_JOBS_LIST_CHANNEL,
@@ -2096,6 +2097,10 @@ describe('installComputeIpcHandlers', () => {
       'compute:list',
       'compute:get',
       'compute:create',
+      'compute:create-password',
+      'compute:reset-password',
+      'compute:change-authentication',
+      'compute:password-capability',
       'compute:delete',
       'compute:deletion-status',
       'compute:ssh-config-aliases',
@@ -2110,6 +2115,8 @@ describe('installComputeIpcHandlers', () => {
       'compute:download',
       'compute:reveal-in-folder',
       'compute:approval-respond',
+      'compute:approval-replay',
+      'compute:approval-replay-pending',
       COMPUTE_JOBS_LIST_CHANNEL,
       'compute:jobs:pending-notification',
       'compute:jobs:mark-consumed',
@@ -2117,10 +2124,10 @@ describe('installComputeIpcHandlers', () => {
       'compute:enabled-hosts:set',
       'compute:host-enabled:set',
       'compute:host-selected:set'
-    ]
-    for (const channel of expected) {
-      expect(handlers.has(channel)).toBe(true)
-    }
+    ].sort()
+
+    expect([...handlers.keys()].sort()).toEqual(expected)
+    expect(COMPUTE_IPC_CHANNELS).toEqual(expected)
   })
 
   it('starts defensive orphan Credential recovery when the Compute module is created', async () => {
@@ -2190,6 +2197,52 @@ describe('installComputeIpcHandlers', () => {
 
     expect(handlers.has('compute:list')).toBe(true)
     expect(module.computeService).toBeDefined()
+  })
+
+  it('rejects an invalid approval decision without settling the pending operation', async () => {
+    const broker = new ComputeApprovalBroker({
+      broadcast: vi.fn(),
+      generateId: () => 'approval-1',
+      setTimer: vi.fn(() => 1 as never),
+      clearTimer: vi.fn()
+    })
+    const computeHandlers = createComputeHandlers(
+      mockRepository({}),
+      undefined,
+      mockService({}),
+      broker
+    )
+    installComputeIpcHandlers({
+      handlers: computeHandlers,
+      enabledHosts: {
+        get: vi.fn(() => []),
+        set: vi.fn(),
+        setHostEnabled: vi.fn(),
+        setHostSelected: vi.fn()
+      }
+    })
+    const decision = broker.request({
+      provider_id: 'ssh:biowulf',
+      provider_name: 'biowulf',
+      shape: 'direct_ssh',
+      intent: 'Inspect the environment',
+      command_preview: 'env',
+      command_full: 'env'
+    })
+    const settled = vi.fn()
+    void decision.then(settled)
+
+    await expect(
+      invokeHandler('compute:approval-respond', {
+        id: 'approval-1',
+        decision: 'unexpected-allow-value'
+      })
+    ).rejects.toThrow(/invalid.*compute:approval-respond/i)
+    await Promise.resolve()
+    expect(settled).not.toHaveBeenCalled()
+
+    await invokeHandler('compute:approval-respond', { id: 'approval-1', decision: 'deny' })
+    await expect(decision).resolves.toBe('deny')
   })
 
   it('routes enabled-hosts IPC through the authoritative owner and publishes its result', async () => {


### PR DESCRIPTION
## Problem

Legacy Compute Electron IPC handlers relied on erased TypeScript parameter types. A malformed `compute:approval-respond` decision reached `ComputeApprovalBroker`, where every value other than `deny` settled the pending operation as approved.

The regression was reproduced through the installed Electron invoke handler: before the fix, an unexpected decision resolved successfully instead of rejecting and released the held approval.

## Proposed change

- Define strict Zod tuple schemas for all 30 channels installed by the Compute Electron adapter.
- Decode argument tuples before invoking Compute owners while retaining existing remote-filesystem error projection.
- Return a stable channel-specific error without embedding credential or payload values.
- Pin the registered-handler inventory and schema inventory to the same exact channel set.
- Add a regression proving an invalid approval decision cannot settle a pending operation and that a later valid deny still works.

## Scope and non-goals

- No renderer interaction or valid-call behavior changes.
- No database, persisted-format, historical-data, domain-model, relationship, or migration changes.
- No new lifecycle state or enum value.
- Business validation such as path rules, port ranges, concurrency limits, and optimistic-write conflicts remains with existing owners.
- Migrating Compute to the application-command Electron adapter and adding Compute Web/Application Command contracts are out of scope.

## Acceptance criteria and validation

All listed checks ran after the last material edit and rebase onto current `main`.

- Malformed approval fail-open -> targeted `src/main/compute/ipc.test.ts` regression -> passed (2 focused tests; the same test failed twice before the fix with "promise resolved undefined instead of rejecting").
- Compute Electron adapter behavior, current `global` approval scope, cross-session job filters, and error projection -> full `src/main/compute/ipc.test.ts` -> 72 passed.
- Compute owner, contract, and representative consumer impact set -> `compute_service` files from `scripts/ci/module-impact.json` -> 802 passed, 15 skipped across 32 files.
- Main-process and renderer type safety -> fresh-install PR Static checks (format, lint, Node/Web typecheck, interface contracts, CLI/SDK, and i18n) -> passed.
- Source quality -> Prettier, ESLint, and `git diff --check` -> passed.

Full `npm test` was intentionally not run; PR Gate/CI remains authoritative for the complete portable and platform suites.

## Review focus

- Confirm the schemas enforce transport shape only and do not absorb owner business rules.
- Confirm every installed Compute IPC channel is registered through the decoder helper.
- Confirm malformed approval values fail closed without exposing credential payloads in errors.
- Note the remaining risk: Compute Web/Application Commands still lack per-command runtime contracts and should be handled as a separate architecture change.