### PR TITLE
fix(annotations): hide annotate trigger outside scroll viewport

### DIFF
--- a/src/renderer/src/pages/workspace/annotations/AnnotationTrigger.tsx
+++ b/src/renderer/src/pages/workspace/annotations/AnnotationTrigger.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { Pencil } from 'lucide-react'
 
 import { PopoverAnchor } from '@/components/ui/popover'
-import { anchorRangeTrigger } from './annotation-trigger-anchor'
+import { anchorRangeTrigger, isRangeTriggerVisible } from './annotation-trigger-anchor'
 
 const FALLBACK_TRIGGER_WIDTH = 82
 const FALLBACK_TRIGGER_HEIGHT = 24
@@ -22,7 +22,7 @@ const AnnotationTrigger = ({
   onActivate: () => void
 }): React.ReactPortal => {
   const triggerRef = useRef<HTMLButtonElement | null>(null)
-  const [position, setPosition] = useState({ left: 0, top: 0, ready: false })
+  const [position, setPosition] = useState({ left: 0, top: 0, ready: false, visible: true })
 
   const updatePosition = useCallback((): void => {
     const trigger = triggerRef.current
@@ -32,10 +32,17 @@ const AnnotationTrigger = ({
       triggerWidth: trigger?.offsetWidth || FALLBACK_TRIGGER_WIDTH,
       triggerHeight: trigger?.offsetHeight || FALLBACK_TRIGGER_HEIGHT
     })
+    const visible = isRangeTriggerVisible(range, backward, {
+      width: window.innerWidth,
+      height: window.innerHeight
+    })
     setPosition((current) =>
-      current.ready && current.left === next.left && current.top === next.top
+      current.ready &&
+      current.left === next.left &&
+      current.top === next.top &&
+      current.visible === visible
         ? current
-        : { ...next, ready: true }
+        : { ...next, ready: true, visible }
     )
   }, [backward, range])
 
@@ -58,7 +65,7 @@ const AnnotationTrigger = ({
           aria-hidden="true"
         />
       </PopoverAnchor>
-      {hidden ? null : (
+      {hidden || !position.visible ? null : (
         <button
           ref={triggerRef}
           type="button"

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
@@ -666,6 +666,77 @@ describe('TextAnnotationSurface annotate trigger', () => {
     expect(document.querySelector('textarea')).toBeNull()
   })
 
+  it('hides the trigger when the selection scrolls outside its clipping container', async () => {
+    await act(async () =>
+      root.render(
+        <div data-testid="annotation-scroll-viewport" style={{ maxHeight: 100, overflow: 'auto' }}>
+          <TextAnnotationSurface
+            source={{ kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }}
+            activeAnnotations={[]}
+            onAdd={vi.fn()}
+            onError={vi.fn()}
+          >
+            <p>selectable agent reply</p>
+          </TextAnnotationSurface>
+        </div>
+      )
+    )
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-testid="annotation-scroll-viewport"]'
+    )!
+    const paragraph = container.querySelector('p')!
+    const rect = (top: number, bottom: number): DOMRect =>
+      ({
+        left: 10,
+        right: 120,
+        top,
+        bottom,
+        width: 110,
+        height: bottom - top,
+        x: 10,
+        y: top,
+        toJSON: () => ({})
+      }) as DOMRect
+    Object.defineProperty(viewport, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect(0, 100)
+    })
+
+    let selectionRect = rect(20, 40)
+    const originalRangeRect = Object.getOwnPropertyDescriptor(
+      Range.prototype,
+      'getBoundingClientRect'
+    )
+    Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => selectionRect
+    })
+
+    try {
+      const range = document.createRange()
+      range.selectNodeContents(paragraph.firstChild!)
+      const selection = window.getSelection()!
+      selection.removeAllRanges()
+      selection.addRange(range)
+      await act(async () => paragraph.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })))
+      expect(annotateTrigger()).toBeDefined()
+
+      selectionRect = rect(120, 140)
+      await act(async () => viewport.dispatchEvent(new Event('scroll')))
+      expect(annotateTrigger()).toBeUndefined()
+
+      selectionRect = rect(20, 40)
+      await act(async () => viewport.dispatchEvent(new Event('scroll')))
+      expect(annotateTrigger()).toBeDefined()
+    } finally {
+      if (originalRangeRect) {
+        Object.defineProperty(Range.prototype, 'getBoundingClientRect', originalRangeRect)
+      } else {
+        delete (Range.prototype as { getBoundingClientRect?: unknown }).getBoundingClientRect
+      }
+    }
+  })
+
   it('places the trigger beside the last line of a multi-line selection', async () => {
     const paragraph = await renderSurface()
     const range = document.createRange()

--- a/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts
@@ -21,6 +21,52 @@ type SelectionTriggerViewport = Readonly<{
 const TRIGGER_ANCHOR_OFFSET = 6
 const TRIGGER_VIEWPORT_MARGIN = 8
 
+const rangeAnchorRect = (range: Range, backward: boolean): DOMRect | undefined => {
+  const rects = typeof range.getClientRects === 'function' ? Array.from(range.getClientRects()) : []
+  const bounding =
+    typeof range.getBoundingClientRect === 'function' ? range.getBoundingClientRect() : undefined
+  return rects.length > 0 ? (backward ? rects[0] : rects[rects.length - 1]) : bounding
+}
+
+const rectsIntersect = (
+  left: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom'>,
+  right: Pick<DOMRect, 'left' | 'right' | 'top' | 'bottom'>
+): boolean =>
+  left.right > right.left &&
+  left.left < right.right &&
+  left.bottom > right.top &&
+  left.top < right.bottom
+
+const isRangeTriggerVisible = (
+  range: Range,
+  backward: boolean,
+  viewport: Pick<SelectionTriggerViewport, 'width' | 'height'>
+): boolean => {
+  const anchorRect = rangeAnchorRect(range, backward)
+  // Geometry is unavailable for detached and jsdom ranges. Placement keeps its
+  // existing fallback there; live browser ranges always provide a rectangle.
+  if (!anchorRect) return true
+  if (
+    !rectsIntersect(anchorRect, { left: 0, right: viewport.width, top: 0, bottom: viewport.height })
+  ) {
+    return false
+  }
+
+  let ancestor =
+    range.commonAncestorContainer instanceof Element
+      ? range.commonAncestorContainer
+      : range.commonAncestorContainer.parentElement
+  while (ancestor && ancestor !== document.body) {
+    const style = window.getComputedStyle(ancestor)
+    const clips = [style.overflow, style.overflowX, style.overflowY].some((overflow) =>
+      /^(auto|clip|hidden|scroll)$/.test(overflow)
+    )
+    if (clips && !rectsIntersect(anchorRect, ancestor.getBoundingClientRect())) return false
+    ancestor = ancestor.parentElement
+  }
+  return true
+}
+
 const isBackwardSelection = (selected: Selection): boolean => {
   const { anchorNode, anchorOffset, focusNode, focusOffset } = selected
   if (!anchorNode || !focusNode) return false
@@ -35,10 +81,7 @@ const anchorRangeTrigger = (
   viewport: SelectionTriggerViewport
 ): { left: number; top: number } => {
   // jsdom and detached ranges expose neither geometry method.
-  const rects = typeof range.getClientRects === 'function' ? Array.from(range.getClientRects()) : []
-  const bounding =
-    typeof range.getBoundingClientRect === 'function' ? range.getBoundingClientRect() : undefined
-  const anchorRect = rects.length > 0 ? (backward ? rects[0] : rects[rects.length - 1]) : bounding
+  const anchorRect = rangeAnchorRect(range, backward)
   const desiredLeft = (anchorRect?.right ?? 0) + TRIGGER_ANCHOR_OFFSET
   const below = (anchorRect?.bottom ?? 0) + TRIGGER_ANCHOR_OFFSET
   const above = (anchorRect?.top ?? 0) - viewport.triggerHeight - TRIGGER_ANCHOR_OFFSET
@@ -56,4 +99,4 @@ const anchorRangeTrigger = (
   }
 }
 
-export { anchorRangeTrigger, isBackwardSelection }
+export { anchorRangeTrigger, isBackwardSelection, isRangeTriggerVisible }


### PR DESCRIPTION
## Problem

After selecting annotatable text, scrolling the selection outside the conversation viewport left the portalled `Annotate` trigger visible over the Notebook/composer area. The trigger recomputed its position on scroll, but it only clamped against the browser window and did not account for overflow-clipping ancestors.

## Proposed change

- Determine trigger visibility from the selected Range's active edge.
- Hide the trigger when that edge leaves the window or any `auto`, `scroll`, `hidden`, or `clip` overflow ancestor.
- Restore the trigger if the selection scrolls back into view.
- Add a component regression test covering hide and restore across a clipping scroll container.

## Scope and non-goals

- No z-index or composer/Notebook layout changes.
- No annotation data-format, persistence, migration, historical-compatibility, or new enum/state-value changes.
- No dependency or user-visible copy changes.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- Annotation trigger placement and direct workspace/preview consumers -> `../../node_modules/.bin/vitest run --config vitest.worktree.config.ts src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.annotations.test.tsx src/renderer/src/pages/workspace/WorkspaceActivityGroup.annotations.test.tsx` -> 5 files, 51 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Production Web bundle used for browser verification -> `npm run build:web` -> passed (existing CSS highlight and bundle-size warnings only).
- Real Web interaction -> selected visible Agent text, scrolled its conversation viewport by 900 px, and observed trigger count `1 -> 0 -> 1` as the Range left and re-entered the clipping rectangle.
- Exact diff impact explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> fail-closed full plan because the annotation path has no declared module owner; PR Gate is the final full-suite authority.

Uncovered local risk: browser geometry can vary slightly by platform, so exact-head cross-platform CI remains authoritative. Per maintainer request, the complete local `npm test` suite was not run.

## Review focus

- Whether overflow ancestor traversal matches all annotation surfaces.
- Whether using the selection's active edge gives the expected behavior for multiline and backward selections.
