### PR TITLE
fix(reviewer): bound captured session logs

### DIFF
--- a/src/main/reviewer/log-capture.test.ts
+++ b/src/main/reviewer/log-capture.test.ts
@@ -89,6 +89,36 @@ describe('driveReviewerToStop — log capture via onUpdate', () => {
     }
   })
 
+  it('caps a streaming text entry by serialized UTF-8 bytes', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'ééé' }
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+    const options = {
+      timeoutMs: 1000,
+      maxUpdates: 100,
+      logLimits: {
+        maxTextEntryBytes: 5,
+        maxToolInputBytes: 64,
+        maxToolOutputBytes: 64,
+        maxLogBytes: 256
+      }
+    }
+
+    const log: ReviewerLogEntry[] = []
+    await driveReviewerToStop(session, options, { onUpdate: (entry) => log.push(entry) })
+
+    expect(log).toEqual([{ kind: 'message', text: 'éé', textTruncated: true }])
+  })
+
   it('flushes interleaved content before tools and lets terminal output override raw output', async () => {
     const updates: FakeUpdate[] = [
       {
@@ -150,6 +180,196 @@ describe('driveReviewerToStop — log capture via onUpdate', () => {
         exitCode: 0
       }
     ])
+  })
+
+  it('caps tool input and output by serialized UTF-8 bytes', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-bounded',
+          toolName: 'Bash',
+          rawInput: 'ééé'
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-bounded',
+          rawOutput: 'ééé',
+          status: 'completed'
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+    const options = {
+      timeoutMs: 1000,
+      maxUpdates: 100,
+      logLimits: {
+        maxTextEntryBytes: 64,
+        maxToolInputBytes: 5,
+        maxToolOutputBytes: 5,
+        maxLogBytes: 256
+      }
+    }
+    const log: ReviewerLogEntry[] = []
+
+    await driveReviewerToStop(session, options, { onUpdate: (entry) => log.push(entry) })
+
+    expect(log).toEqual([
+      {
+        kind: 'tool',
+        toolName: 'Bash',
+        title: undefined,
+        rawInput: 'éé',
+        rawInputTruncated: true,
+        rawOutput: 'éé',
+        rawOutputTruncated: true,
+        status: 'ok'
+      }
+    ])
+  })
+
+  it('caps the complete serialized reviewer log across individually valid entries', async () => {
+    const chunkKinds = [
+      'agent_message_chunk',
+      'agent_thought_chunk',
+      'agent_message_chunk',
+      'agent_thought_chunk',
+      'agent_message_chunk'
+    ]
+    const updates: FakeUpdate[] = [
+      ...chunkKinds.map((sessionUpdate, index) => ({
+        kind: 'session_update',
+        update: {
+          sessionUpdate,
+          content: { type: 'text', text: String(index).repeat(40) }
+        }
+      })),
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+    const options = {
+      timeoutMs: 1000,
+      maxUpdates: 100,
+      logLimits: {
+        maxTextEntryBytes: 64,
+        maxToolInputBytes: 64,
+        maxToolOutputBytes: 64,
+        maxLogBytes: 256
+      }
+    }
+    const log: ReviewerLogEntry[] = []
+
+    await driveReviewerToStop(session, options, { onUpdate: (entry) => log.push(entry) })
+
+    expect(Buffer.byteLength(JSON.stringify(log), 'utf8')).toBeLessThanOrEqual(256)
+    expect(log.at(-1)).toMatchObject({ reviewLogTruncated: true })
+  })
+
+  it('keeps later tool updates within the complete serialized log budget', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'context' }
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-total-budget',
+          toolName: 'Bash'
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-total-budget',
+          rawOutput: 'x'.repeat(120),
+          status: 'completed'
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+    const options = {
+      timeoutMs: 1000,
+      maxUpdates: 100,
+      logLimits: {
+        maxTextEntryBytes: 64,
+        maxToolInputBytes: 128,
+        maxToolOutputBytes: 128,
+        maxLogBytes: 180
+      }
+    }
+    const log: ReviewerLogEntry[] = []
+
+    await driveReviewerToStop(session, options, { onUpdate: (entry) => log.push(entry) })
+
+    expect(Buffer.byteLength(JSON.stringify(log), 'utf8')).toBeLessThanOrEqual(180)
+    expect(log.at(-1)).toMatchObject({
+      kind: 'tool',
+      rawOutputTruncated: true,
+      reviewLogTruncated: true,
+      status: 'ok'
+    })
+  })
+
+  it('shares the complete log budget across a recovery drive', async () => {
+    const makeSession = (): { nextUpdate: () => Promise<FakeUpdate> } => {
+      const updates: FakeUpdate[] = [
+        {
+          kind: 'session_update',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'm'.repeat(40) }
+          }
+        },
+        {
+          kind: 'session_update',
+          update: {
+            sessionUpdate: 'agent_thought_chunk',
+            content: { type: 'text', text: 't'.repeat(40) }
+          }
+        },
+        { kind: 'stop', stopReason: 'end_turn' }
+      ]
+      let i = 0
+      return { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+    }
+    const options = {
+      timeoutMs: 1000,
+      maxUpdates: 100,
+      logLimits: {
+        maxTextEntryBytes: 64,
+        maxToolInputBytes: 64,
+        maxToolOutputBytes: 64,
+        maxLogBytes: 256
+      }
+    }
+    const log: ReviewerLogEntry[] = []
+    const callbacks = {
+      onUpdate: (entry: ReviewerLogEntry): void => {
+        log.push(entry)
+      },
+      logState: {}
+    }
+
+    await driveReviewerToStop(makeSession(), options, callbacks)
+    await driveReviewerToStop(makeSession(), options, callbacks)
+
+    expect(Buffer.byteLength(JSON.stringify(log), 'utf8')).toBeLessThanOrEqual(256)
+    expect(log.at(-1)).toMatchObject({ reviewLogTruncated: true })
   })
 
   it('produces ONE unified tool entry from tool_call + tool_call_update (not split tool_call/tool_result)', async () => {
@@ -292,6 +512,153 @@ describe('driveReviewerToStop — log capture via onUpdate', () => {
       expect(tool.rawOutput).not.toContain('[object Object]')
     }
   })
+
+  it('bounds structured tool output before serializing the display string', async () => {
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-structured-budget',
+          toolName: 'query_execution_log'
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-structured-budget',
+          rawOutput: { rows: Array.from({ length: 201 }, (_, index) => index) },
+          status: 'completed'
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+    const options = {
+      timeoutMs: 1000,
+      maxUpdates: 100,
+      logLimits: {
+        maxTextEntryBytes: 64,
+        maxToolInputBytes: 4096,
+        maxToolOutputBytes: 4096,
+        maxLogBytes: 8192
+      }
+    }
+    const log: ReviewerLogEntry[] = []
+
+    await driveReviewerToStop(session, options, { onUpdate: (entry) => log.push(entry) })
+
+    const tool = log[0]
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind !== 'tool') return
+    const output = JSON.parse(tool.rawOutput ?? '{}') as { rows?: unknown[] }
+    expect(output.rows).toHaveLength(201)
+    expect(output.rows?.at(-1)).toBe('[omitted: 1 array entries]')
+    expect(tool.rawOutputTruncated).toBe(true)
+  })
+
+  it('stops traversing structured tool output after its shared byte budget is exhausted', async () => {
+    const rawOutput: Record<string, unknown> = { first: 'x'.repeat(1024) }
+    Object.defineProperty(rawOutput, 'unvisited', {
+      enumerable: true,
+      get: () => {
+        throw new Error('structured serializer traversed beyond its byte budget')
+      }
+    })
+    const updates: FakeUpdate[] = [
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-structured-shared-budget',
+          toolName: 'query_execution_log'
+        }
+      },
+      {
+        kind: 'session_update',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-structured-shared-budget',
+          rawOutput,
+          status: 'completed'
+        }
+      },
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+    const log: ReviewerLogEntry[] = []
+
+    await driveReviewerToStop(
+      session,
+      {
+        timeoutMs: 1000,
+        maxUpdates: 100,
+        logLimits: {
+          maxTextEntryBytes: 64,
+          maxToolInputBytes: 64,
+          maxToolOutputBytes: 64,
+          maxLogBytes: 512
+        }
+      },
+      { onUpdate: (entry) => log.push(entry) }
+    )
+
+    const tool = log[0]
+    expect(tool?.kind).toBe('tool')
+    if (tool?.kind !== 'tool') return
+    expect(Buffer.byteLength(tool.rawOutput ?? '', 'utf8')).toBeLessThanOrEqual(64)
+    expect(tool.rawOutputTruncated).toBe(true)
+  })
+
+  it.each(['completed', 'failed', 'error', 'ok'])(
+    'forgets a tool after terminal status %s',
+    async (status) => {
+      const updates: FakeUpdate[] = [
+        {
+          kind: 'session_update',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'tc-reused',
+            toolName: 'Bash'
+          }
+        },
+        {
+          kind: 'session_update',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'tc-reused',
+            rawOutput: 'first',
+            status
+          }
+        },
+        {
+          kind: 'session_update',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'tc-reused',
+            toolName: 'Bash',
+            rawOutput: 'late duplicate',
+            status: 'completed'
+          }
+        },
+        { kind: 'stop', stopReason: 'end_turn' }
+      ]
+      let i = 0
+      const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+      const log: ReviewerLogEntry[] = []
+
+      await driveReviewerToStop(
+        session,
+        { timeoutMs: 1000, maxUpdates: 100 },
+        { onUpdate: (entry) => log.push(entry) }
+      )
+
+      expect(log.filter((entry) => entry.kind === 'tool')).toHaveLength(2)
+    }
+  )
 
   it('merges terminal stdout and exit code from _meta.terminal_output / _meta.terminal_exit', async () => {
     const updates: FakeUpdate[] = [
@@ -484,6 +851,8 @@ describe('ReviewRepository — reviewerLog round-trip', () => {
         title: 'python3 host.read_turn()',
         rawInput: 'python3 host.read_turn()',
         rawOutput: '[block-0]',
+        rawOutputTruncated: true,
+        reviewLogTruncated: true,
         status: 'ok',
         exitCode: 0
       },
@@ -515,6 +884,8 @@ describe('ReviewRepository — reviewerLog round-trip', () => {
       title: 'python3 host.read_turn()',
       rawInput: 'python3 host.read_turn()',
       rawOutput: '[block-0]',
+      rawOutputTruncated: true,
+      reviewLogTruncated: true,
       status: 'ok',
       exitCode: 0
     })

--- a/src/main/reviewer/orchestrator-drive.test.ts
+++ b/src/main/reviewer/orchestrator-drive.test.ts
@@ -56,6 +56,22 @@ describe('driveReviewerToStop', () => {
     )
   })
 
+  it('accepts exactly maxUpdates discrete updates before stopping', async () => {
+    const updates: FakeUpdate[] = [
+      ...Array.from({ length: 5 }, () => ({
+        kind: 'session_update',
+        update: { sessionUpdate: 'tool_call' }
+      })),
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let i = 0
+    const session = { nextUpdate: async (): Promise<FakeUpdate> => updates[i++]! }
+
+    await expect(driveReviewerToStop(session, { timeoutMs: 5000, maxUpdates: 5 })).resolves.toBe(
+      'end_turn'
+    )
+  })
+
   it('does not count streaming content chunks toward the update cap', async () => {
     // A verbose reviewer streams many message/thought chunks before it stops. These are proportional
     // to output length, not work, so they must not trip the (much smaller) discrete-update cap.

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -25,7 +25,13 @@ const harness = vi.hoisted(() => ({
   submissionAttempted: false,
   submit: undefined as ((checks: NewCheck[]) => Promise<void>) | undefined,
   promptError: undefined as Error | undefined,
-  nextUpdate: undefined as (() => Promise<{ kind: string; stopReason?: string }>) | undefined,
+  nextUpdate: undefined as
+    | (() => Promise<{
+        kind: string
+        stopReason?: string
+        update?: { sessionUpdate?: string; [key: string]: unknown }
+      }>)
+    | undefined,
   disposeError: undefined as Error | undefined,
   stopError: undefined as Error | undefined,
   bridgeScoped: undefined as boolean | undefined
@@ -433,6 +439,53 @@ describe('review assessment owner', () => {
 
     expect(result.review.lifecycle).toBe('error')
     expect(harness.events.filter((event) => event === 'acp:prompt')).toHaveLength(1)
+  })
+
+  it('shares the reviewer log budget with the protocol recovery turn', async () => {
+    harness.submission = undefined
+    const contentUpdates = (
+      prefix: string
+    ): Array<{
+      kind: string
+      update: { sessionUpdate: string; content: { type: string; text: string } }
+    }> =>
+      Array.from({ length: 10 }, (_, index) => ({
+        kind: 'session_update',
+        update: {
+          sessionUpdate: index % 2 === 0 ? 'agent_message_chunk' : 'agent_thought_chunk',
+          content: {
+            type: 'text',
+            text: `${prefix}${String(index).padStart(2, '0')}${'x'.repeat(65_536)}`
+          }
+        }
+      }))
+    const updates = [
+      ...contentUpdates('initial-'),
+      { kind: 'stop', stopReason: 'end_turn' },
+      ...contentUpdates('recovery-'),
+      { kind: 'stop', stopReason: 'end_turn' }
+    ]
+    let index = 0
+    harness.nextUpdate = async () => {
+      const update = updates[index++]!
+      if (index === updates.length) await harness.submit?.([])
+      return update
+    }
+    const reviewRepository = makeRepository()
+
+    const result = await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      mode: 'initial'
+    })
+
+    expect(result.review.lifecycle).toBe('complete')
+    const commit = vi.mocked(reviewRepository.commitScopedSubmission).mock.calls[0]?.[0]
+    expect(commit?.reviewerLog).toBeDefined()
+    const persistedLog = commit?.reviewerLog ?? []
+    expect(Buffer.byteLength(JSON.stringify(persistedLog), 'utf8')).toBeLessThanOrEqual(
+      1_024 * 1_024
+    )
+    expect(persistedLog.at(-1)).toMatchObject({ reviewLogTruncated: true })
   })
 
   it('does not retry a cancelled reviewer turn', async () => {

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -197,6 +197,12 @@ export const runReviewAssessment = async (
   let reviewerSessionFailed = false
   let reviewerSessionError: unknown
   const capturedLog: ReviewerLogEntry[] = []
+  const reviewerLogDriveCallbacks = {
+    onUpdate: (entry: ReviewerLogEntry): void => {
+      capturedLog.push(entry)
+    },
+    logState: {}
+  }
 
   try {
     const evidence = new ReviewerHostServer(
@@ -248,7 +254,7 @@ export const runReviewAssessment = async (
     const stopReason = await driveReviewerToStop(
       reviewerSession,
       { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates, signal: abortSignal },
-      { onUpdate: (entry) => capturedLog.push(entry) }
+      reviewerLogDriveCallbacks
     )
     if (options.mode === 'initial') {
       log.info('reviewer session stopped', { reviewId: review.id, stopReason })
@@ -262,7 +268,7 @@ export const runReviewAssessment = async (
       const recoveryStopReason = await driveReviewerToStop(
         reviewerSession,
         { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates, signal: abortSignal },
-        { onUpdate: (entry) => capturedLog.push(entry) }
+        reviewerLogDriveCallbacks
       )
       log.info('reviewer recovery session stopped', {
         reviewId: review.id,

--- a/src/main/reviewer/reviewer-session-driver.ts
+++ b/src/main/reviewer/reviewer-session-driver.ts
@@ -3,6 +3,22 @@
 import { extractProviderToolName, extractTerminalMeta } from '../acp/runtime-events'
 import type { ReviewerLogEntry } from '../../shared/reviewer'
 
+type ReviewerLogLimits = {
+  maxTextEntryBytes: number
+  maxToolInputBytes: number
+  maxToolOutputBytes: number
+  maxLogBytes: number
+}
+
+const DEFAULT_REVIEWER_LOG_LIMITS: ReviewerLogLimits = {
+  maxTextEntryBytes: 64 * 1_024,
+  maxToolInputBytes: 64 * 1_024,
+  maxToolOutputBytes: 256 * 1_024,
+  maxLogBytes: 1_024 * 1_024
+}
+
+const REVIEW_LOG_TRUNCATION_RESERVE_BYTES = 96
+
 // Streaming content deltas are emitted one-per-chunk as the reviewer writes its message/thinking, so
 // their count tracks how much it *says*, not how much it *does*. Counting them toward the loop cap
 // made a normally-verbose review trip the guard mid-stream before it could call submit_findings. Only
@@ -29,21 +45,133 @@ type DriveOptions = {
   timeoutMs: number
   maxUpdates: number
   signal?: AbortSignal
+  logLimits?: Partial<ReviewerLogLimits>
 }
 
 type DriveCallbacks = {
   // Called for each update that should be captured into the reviewer log.
   // The caller assembles streaming chunks into whole entries and appends them.
   onUpdate?: (entry: ReviewerLogEntry) => void
+  // Reuse one state object when multiple drives append to the same persisted Review log.
+  logState?: { budget?: ReviewerLogBudget }
 }
 
 // In-flight accumulator for streaming content (thought/message chunks are assembled into whole entries).
 // Also tracks in-progress tool entries by toolCallId so tool_call_update can merge into the same entry.
 type ChunkAccumulator = {
   thoughtText: string | null
+  thoughtTextTruncated: boolean
   messageText: string | null
+  messageTextTruncated: boolean
   // Map from toolCallId to the mutable tool log entry (shared reference allows update-in-place).
   pendingTools: Map<string, ReviewerLogEntry & { kind: 'tool' }>
+}
+
+const appendWithinUtf8Limit = (
+  current: string,
+  chunk: string,
+  maxBytes: number
+): { text: string; truncated: boolean } => {
+  let remaining = Math.max(0, maxBytes - Buffer.byteLength(current, 'utf8'))
+  let end = 0
+  for (const character of chunk) {
+    const characterBytes = Buffer.byteLength(character, 'utf8')
+    if (characterBytes > remaining) return { text: current + chunk.slice(0, end), truncated: true }
+    remaining -= characterBytes
+    end += character.length
+  }
+  return { text: current + chunk, truncated: false }
+}
+
+const serializedEntryBytes = (entry: ReviewerLogEntry): number =>
+  Buffer.byteLength(JSON.stringify(entry), 'utf8')
+
+class ReviewerLogBudget {
+  private readonly entries: ReviewerLogEntry[] = []
+  private readonly entryBytes = new Map<ReviewerLogEntry, number>()
+  private readonly contentLimit: number
+  private totalBytes = 2
+  private truncated = false
+
+  constructor(
+    private readonly maxBytes: number,
+    private readonly onUpdate: (entry: ReviewerLogEntry) => void
+  ) {
+    this.contentLimit = Math.max(2, maxBytes - REVIEW_LOG_TRUNCATION_RESERVE_BYTES)
+  }
+
+  emit(entry: ReviewerLogEntry): void {
+    if (this.truncated) return
+    const bytes = serializedEntryBytes(entry)
+    const separatorBytes = this.entries.length > 0 ? 1 : 0
+    if (this.totalBytes + separatorBytes + bytes > this.contentLimit) {
+      this.markTruncated()
+      return
+    }
+
+    this.entries.push(entry)
+    this.entryBytes.set(entry, bytes)
+    this.totalBytes += separatorBytes + bytes
+    this.onUpdate(entry)
+  }
+
+  reconcileTool(
+    entry: ReviewerLogEntry & { kind: 'tool' },
+    changedFields: readonly ('rawInput' | 'rawOutput')[]
+  ): void {
+    const previousBytes = this.entryBytes.get(entry)
+    if (previousBytes === undefined) return
+
+    let nextBytes = serializedEntryBytes(entry)
+    const limit = this.truncated ? this.maxBytes : this.contentLimit
+    if (this.totalBytes - previousBytes + nextBytes <= limit) {
+      this.entryBytes.set(entry, nextBytes)
+      this.totalBytes += nextBytes - previousBytes
+      return
+    }
+
+    for (const field of changedFields) {
+      if (field === 'rawInput') {
+        delete entry.rawInput
+        entry.rawInputTruncated = true
+      } else {
+        delete entry.rawOutput
+        entry.rawOutputTruncated = true
+      }
+    }
+    nextBytes = serializedEntryBytes(entry)
+    this.entryBytes.set(entry, nextBytes)
+    this.totalBytes += nextBytes - previousBytes
+    this.markTruncated(entry)
+  }
+
+  private markTruncated(preferredEntry?: ReviewerLogEntry): void {
+    if (this.truncated) return
+    this.truncated = true
+    const lastEntry =
+      preferredEntry && this.entryBytes.has(preferredEntry) ? preferredEntry : this.entries.at(-1)
+    if (lastEntry) {
+      const previousBytes = this.entryBytes.get(lastEntry) ?? serializedEntryBytes(lastEntry)
+      lastEntry.reviewLogTruncated = true
+      const nextBytes = serializedEntryBytes(lastEntry)
+      this.entryBytes.set(lastEntry, nextBytes)
+      this.totalBytes += nextBytes - previousBytes
+      return
+    }
+
+    const marker: ReviewerLogEntry = {
+      kind: 'message',
+      text: '',
+      reviewLogTruncated: true
+    }
+    const markerBytes = serializedEntryBytes(marker)
+    if (2 + markerBytes <= this.maxBytes) {
+      this.entries.push(marker)
+      this.entryBytes.set(marker, markerBytes)
+      this.totalBytes = 2 + markerBytes
+      this.onUpdate(marker)
+    }
+  }
 }
 
 // Extracts a text chunk from an ACP update's content field (may be a { type:'text', text:string } block).
@@ -61,31 +189,237 @@ const extractTextContent = (update: { content?: unknown }): string => {
   return ''
 }
 
-// Serializes an ACP raw tool input/output value to a display string. Strings pass through unchanged;
-// objects are JSON-encoded (never String()'d, which would produce "[object Object]"). Falls back to
-// String() only when the value cannot be serialized (e.g. a circular reference).
-const stringifyRaw = (value: unknown): string => {
-  if (typeof value === 'string') return value
-  try {
-    return JSON.stringify(value)
-  } catch {
-    return String(value)
+const MAX_STRUCTURED_ARRAY_ENTRIES = 200
+const MAX_STRUCTURED_OBJECT_ENTRIES = 200
+const MAX_STRUCTURED_DEPTH = 12
+
+const OMITTED_RAW_VALUE = Symbol('omitted-raw-value')
+
+type StructuredValueBudget = { remainingBytes: number }
+type SanitizedRawValue = {
+  value: unknown | typeof OMITTED_RAW_VALUE
+  truncated: boolean
+}
+
+const boundedJsonString = (
+  value: string,
+  maxBytes: number
+): { value: string; serializedBytes: number; truncated: boolean } | undefined => {
+  if (maxBytes < 2) return undefined
+
+  let remainingBytes = maxBytes - 2
+  const characters: string[] = []
+  for (const character of value) {
+    const encodedCharacter = JSON.stringify(character).slice(1, -1)
+    const characterBytes = Buffer.byteLength(encodedCharacter, 'utf8')
+    if (characterBytes > remainingBytes) {
+      return {
+        value: characters.join(''),
+        serializedBytes: maxBytes - remainingBytes,
+        truncated: true
+      }
+    }
+    characters.push(character)
+    remainingBytes -= characterBytes
+  }
+
+  return {
+    value: characters.join(''),
+    serializedBytes: maxBytes - remainingBytes,
+    truncated: false
   }
 }
 
-// Flushes any in-flight thought/message accumulator and returns the emitted entry (or null if nothing to flush).
-const flushAccumulator = (
+const consumeBudget = (budget: StructuredValueBudget, bytes: number): boolean => {
+  if (bytes > budget.remainingBytes) return false
+  budget.remainingBytes -= bytes
+  return true
+}
+
+const sanitizeRawValue = (
+  value: unknown,
+  budget: StructuredValueBudget,
+  depth = 0,
+  ancestors = new WeakSet<object>()
+): SanitizedRawValue => {
+  if (typeof value === 'string') {
+    const bounded = boundedJsonString(value, budget.remainingBytes)
+    if (!bounded) return { value: OMITTED_RAW_VALUE, truncated: true }
+    consumeBudget(budget, bounded.serializedBytes)
+    return { value: bounded.value, truncated: bounded.truncated }
+  }
+  if (typeof value !== 'object' || value === null) {
+    let serialized: string | undefined
+    try {
+      serialized = JSON.stringify(value)
+    } catch {
+      serialized = JSON.stringify(String(value))
+    }
+    if (serialized === undefined) serialized = 'null'
+    const bytes = Buffer.byteLength(serialized, 'utf8')
+    if (!consumeBudget(budget, bytes)) {
+      return { value: OMITTED_RAW_VALUE, truncated: true }
+    }
+    return { value: JSON.parse(serialized) as unknown, truncated: false }
+  }
+  if (depth > MAX_STRUCTURED_DEPTH) {
+    const omitted = sanitizeRawValue('[omitted: nesting limit]', budget, depth, ancestors)
+    return { value: omitted.value, truncated: true }
+  }
+  if (ancestors.has(value)) {
+    const omitted = sanitizeRawValue('[omitted: circular reference]', budget, depth, ancestors)
+    return { value: omitted.value, truncated: true }
+  }
+  if (!consumeBudget(budget, 2)) return { value: OMITTED_RAW_VALUE, truncated: true }
+
+  ancestors.add(value)
+  let truncated = false
+  if (Array.isArray(value)) {
+    const bounded: unknown[] = []
+    let index = 0
+    for (; index < Math.min(value.length, MAX_STRUCTURED_ARRAY_ENTRIES); index++) {
+      const snapshot = budget.remainingBytes
+      if (!consumeBudget(budget, bounded.length > 0 ? 1 : 0) || budget.remainingBytes < 1) {
+        budget.remainingBytes = snapshot
+        truncated = true
+        break
+      }
+      const sanitized = sanitizeRawValue(value[index], budget, depth + 1, ancestors)
+      if (sanitized.value === OMITTED_RAW_VALUE) {
+        budget.remainingBytes = snapshot
+        truncated = true
+        break
+      }
+      bounded.push(sanitized.value)
+      truncated ||= sanitized.truncated
+    }
+    if (index < value.length) {
+      const omittedEntries = value.length - index
+      const snapshot = budget.remainingBytes
+      if (consumeBudget(budget, bounded.length > 0 ? 1 : 0)) {
+        const marker = sanitizeRawValue(
+          `[omitted: ${omittedEntries} array entries]`,
+          budget,
+          depth + 1,
+          ancestors
+        )
+        if (marker.value !== OMITTED_RAW_VALUE && !marker.truncated) bounded.push(marker.value)
+        else budget.remainingBytes = snapshot
+      }
+      truncated = true
+    }
+    ancestors.delete(value)
+    return { value: bounded, truncated }
+  }
+
+  const bounded: Record<string, unknown> = {}
+  let entries = 0
+  let entryLimitReached = false
+  for (const key in value as Record<string, unknown>) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) continue
+    if (entries >= MAX_STRUCTURED_OBJECT_ENTRIES) {
+      truncated = true
+      entryLimitReached = true
+      break
+    }
+
+    const snapshot = budget.remainingBytes
+    const separatorBytes = entries > 0 ? 1 : 0
+    const boundedKey = boundedJsonString(key, budget.remainingBytes - separatorBytes - 2)
+    if (
+      !boundedKey ||
+      boundedKey.truncated ||
+      !consumeBudget(budget, separatorBytes + boundedKey.serializedBytes + 1)
+    ) {
+      budget.remainingBytes = snapshot
+      truncated = true
+      break
+    }
+    const sanitized = sanitizeRawValue(
+      (value as Record<string, unknown>)[key],
+      budget,
+      depth + 1,
+      ancestors
+    )
+    if (sanitized.value === OMITTED_RAW_VALUE) {
+      budget.remainingBytes = snapshot
+      truncated = true
+      break
+    }
+    bounded[key] = sanitized.value
+    truncated ||= sanitized.truncated
+    entries++
+  }
+  if (entryLimitReached) {
+    const snapshot = budget.remainingBytes
+    const key = '__omitted_entries__'
+    const keyBytes = Buffer.byteLength(JSON.stringify(key), 'utf8')
+    if (consumeBudget(budget, 1 + keyBytes + 1)) {
+      const marker = sanitizeRawValue('additional object entries', budget, depth + 1, ancestors)
+      if (marker.value !== OMITTED_RAW_VALUE && !marker.truncated) bounded[key] = marker.value
+      else budget.remainingBytes = snapshot
+    }
+    truncated = true
+  }
+  ancestors.delete(value)
+  return { value: bounded, truncated }
+}
+
+const stringifyRawWithinLimit = (
+  value: unknown,
+  maxBytes: number
+): { text: string; truncated: boolean } => {
+  if (typeof value === 'string') return appendWithinUtf8Limit('', value, maxBytes)
+  const sanitized = sanitizeRawValue(value, { remainingBytes: Math.max(0, maxBytes) })
+  if (sanitized.value === OMITTED_RAW_VALUE) return { text: '', truncated: true }
+  let serialized: string
+  try {
+    serialized = JSON.stringify(sanitized.value) ?? String(sanitized.value)
+  } catch {
+    serialized = String(sanitized.value)
+    sanitized.truncated = true
+  }
+  const bounded = appendWithinUtf8Limit('', serialized, maxBytes)
+  return { text: bounded.text, truncated: sanitized.truncated || bounded.truncated }
+}
+
+const flushThought = (
   acc: ChunkAccumulator,
   onUpdate: ((entry: ReviewerLogEntry) => void) | undefined
 ): void => {
   if (acc.thoughtText !== null && acc.thoughtText.length > 0) {
-    onUpdate?.({ kind: 'thought', text: acc.thoughtText })
+    onUpdate?.({
+      kind: 'thought',
+      text: acc.thoughtText,
+      ...(acc.thoughtTextTruncated ? { textTruncated: true } : {})
+    })
     acc.thoughtText = null
+    acc.thoughtTextTruncated = false
   }
+}
+
+const flushMessage = (
+  acc: ChunkAccumulator,
+  onUpdate: ((entry: ReviewerLogEntry) => void) | undefined
+): void => {
   if (acc.messageText !== null && acc.messageText.length > 0) {
-    onUpdate?.({ kind: 'message', text: acc.messageText })
+    onUpdate?.({
+      kind: 'message',
+      text: acc.messageText,
+      ...(acc.messageTextTruncated ? { textTruncated: true } : {})
+    })
     acc.messageText = null
+    acc.messageTextTruncated = false
   }
+}
+
+// Flushes any in-flight thought/message accumulators.
+const flushAccumulator = (
+  acc: ChunkAccumulator,
+  onUpdate: ((entry: ReviewerLogEntry) => void) | undefined
+): void => {
+  flushThought(acc, onUpdate)
+  flushMessage(acc, onUpdate)
 }
 
 // Sentinel used to distinguish the timeout branch from a real reviewer update in Promise.race.
@@ -107,12 +441,27 @@ export const driveReviewerToStop = async (
   callbacks?: DriveCallbacks
 ): Promise<string | undefined> => {
   const { timeoutMs, maxUpdates, signal } = options
-  const { onUpdate } = callbacks ?? {}
+  const logLimits = { ...DEFAULT_REVIEWER_LOG_LIMITS, ...options.logLimits }
+  const { onUpdate, logState } = callbacks ?? {}
+  let logBudget = logState?.budget
+  if (!logBudget && onUpdate) {
+    logBudget = new ReviewerLogBudget(logLimits.maxLogBytes, onUpdate)
+    if (logState) logState.budget = logBudget
+  }
+  const emitUpdate = logBudget
+    ? (entry: ReviewerLogEntry): void => logBudget.emit(entry)
+    : undefined
   const deadline = Date.now() + timeoutMs
   let updates = 0
 
   // In-flight accumulator for streaming text chunks (assembled into whole entries on transition).
-  const acc: ChunkAccumulator = { thoughtText: null, messageText: null, pendingTools: new Map() }
+  const acc: ChunkAccumulator = {
+    thoughtText: null,
+    thoughtTextTruncated: false,
+    messageText: null,
+    messageTextTruncated: false,
+    pendingTools: new Map()
+  }
 
   for (;;) {
     if (signal?.aborted) throw new Error('reviewer session was aborted before stopping')
@@ -141,7 +490,7 @@ export const driveReviewerToStop = async (
 
       if (result.kind === 'stop') {
         // Flush any in-flight streaming chunks before returning.
-        flushAccumulator(acc, onUpdate)
+        flushAccumulator(acc, emitUpdate)
         return result.stopReason
       }
 
@@ -151,34 +500,40 @@ export const driveReviewerToStop = async (
       // with output length, not work, and would trip the guard on a normal verbose review).
       if (!STREAMING_CHUNK_UPDATES.has(sessionUpdate)) {
         updates++
-        if (updates >= maxUpdates) {
+        if (updates > maxUpdates) {
           throw new Error(`reviewer session exceeded max updates (${maxUpdates})`)
         }
       }
 
       // --- Log capture: assemble chunks into entries and emit discrete events ---
-      if (onUpdate && result.update) {
+      if (emitUpdate && result.update) {
         const u = result.update
 
         if (sessionUpdate === 'agent_thought_chunk') {
           // Flush any in-progress message accumulator first (content type switched).
-          if (acc.messageText !== null && acc.messageText.length > 0) {
-            onUpdate({ kind: 'message', text: acc.messageText })
-            acc.messageText = null
-          }
+          flushMessage(acc, emitUpdate)
           // Accumulate into thought buffer.
-          acc.thoughtText = (acc.thoughtText ?? '') + extractTextContent(u as { content?: unknown })
+          const appended = appendWithinUtf8Limit(
+            acc.thoughtText ?? '',
+            extractTextContent(u as { content?: unknown }),
+            logLimits.maxTextEntryBytes
+          )
+          acc.thoughtText = appended.text
+          acc.thoughtTextTruncated ||= appended.truncated
         } else if (sessionUpdate === 'agent_message_chunk') {
           // Flush any in-progress thought accumulator first (content type switched).
-          if (acc.thoughtText !== null && acc.thoughtText.length > 0) {
-            onUpdate({ kind: 'thought', text: acc.thoughtText })
-            acc.thoughtText = null
-          }
+          flushThought(acc, emitUpdate)
           // Accumulate into message buffer.
-          acc.messageText = (acc.messageText ?? '') + extractTextContent(u as { content?: unknown })
+          const appended = appendWithinUtf8Limit(
+            acc.messageText ?? '',
+            extractTextContent(u as { content?: unknown }),
+            logLimits.maxTextEntryBytes
+          )
+          acc.messageText = appended.text
+          acc.messageTextTruncated ||= appended.truncated
         } else if (sessionUpdate === 'tool_call') {
           // Flush any in-flight streaming content before a discrete tool call.
-          flushAccumulator(acc, onUpdate)
+          flushAccumulator(acc, emitUpdate)
           // Extract the real tool name from ACP provider metadata (_meta.claudeCode.toolName etc.).
           // The top-level `toolName` field is absent in ACP; only the _meta path carries the name.
           const realToolName =
@@ -186,22 +541,28 @@ export const driveReviewerToStop = async (
             (u.toolName as string | undefined) ??
             ''
           const toolCallId = (u.toolCallId as string | undefined) ?? ''
+          const rawInput =
+            u.rawInput !== undefined
+              ? stringifyRawWithinLimit(u.rawInput, logLimits.maxToolInputBytes)
+              : undefined
           const entry: ReviewerLogEntry & { kind: 'tool' } = {
             kind: 'tool',
             toolName: realToolName,
             title: u.title as string | undefined,
-            rawInput: u.rawInput !== undefined ? stringifyRaw(u.rawInput) : undefined
+            rawInput: rawInput?.text,
+            ...(rawInput?.truncated ? { rawInputTruncated: true } : {})
           }
           // Remember by toolCallId so tool_call_update can mutate the same object in-place.
           if (toolCallId) {
             acc.pendingTools.set(toolCallId, entry)
           }
-          onUpdate(entry)
+          emitUpdate(entry)
         } else if (sessionUpdate === 'tool_call_update') {
           // ACP never emits tool_result — updates arrive as tool_call_update carrying rawOutput,
           // terminal stdout, exit code, and the final status. Mutate the in-flight entry in-place
           // so the already-appended log entry (shared reference) is updated without re-emit.
           const toolCallId = (u.toolCallId as string | undefined) ?? ''
+          const changedFields: ('rawInput' | 'rawOutput')[] = []
           let entry = toolCallId ? acc.pendingTools.get(toolCallId) : undefined
           if (!entry) {
             // Defensive: no prior tool_call seen — create a fresh tool entry now.
@@ -215,23 +576,39 @@ export const driveReviewerToStop = async (
               title: u.title as string | undefined
             }
             if (toolCallId) acc.pendingTools.set(toolCallId, entry)
-            onUpdate(entry)
+            emitUpdate(entry)
           }
           // Merge input/output fields into the existing entry. Claude Code seeds the initial
           // tool_call with an empty {} input and supplies the real arguments here, so a defined
           // rawInput on the update overrides the seed (mirrors the main-agent `rawInput ?? old` merge).
           if (u.rawInput !== undefined) {
-            entry.rawInput = stringifyRaw(u.rawInput)
+            const rawInput = stringifyRawWithinLimit(u.rawInput, logLimits.maxToolInputBytes)
+            entry.rawInput = rawInput.text
+            if (rawInput.truncated) entry.rawInputTruncated = true
+            else delete entry.rawInputTruncated
+            changedFields.push('rawInput')
           }
           if (u.rawOutput !== undefined) {
-            entry.rawOutput = stringifyRaw(u.rawOutput)
+            const rawOutput = stringifyRawWithinLimit(u.rawOutput, logLimits.maxToolOutputBytes)
+            entry.rawOutput = rawOutput.text
+            if (rawOutput.truncated) entry.rawOutputTruncated = true
+            else delete entry.rawOutputTruncated
+            changedFields.push('rawOutput')
           }
           const { terminalOutput, terminalExitCode } = extractTerminalMeta(
             u as Parameters<typeof extractTerminalMeta>[0]
           )
           if (terminalOutput !== undefined) {
             // Terminal stdout/stderr replaces rawOutput if it arrives via _meta.terminal_output.data
-            entry.rawOutput = terminalOutput
+            const rawOutput = appendWithinUtf8Limit(
+              '',
+              terminalOutput,
+              logLimits.maxToolOutputBytes
+            )
+            entry.rawOutput = rawOutput.text
+            if (rawOutput.truncated) entry.rawOutputTruncated = true
+            else delete entry.rawOutputTruncated
+            if (!changedFields.includes('rawOutput')) changedFields.push('rawOutput')
           }
           if (terminalExitCode !== undefined) {
             entry.exitCode = terminalExitCode
@@ -244,6 +621,16 @@ export const driveReviewerToStop = async (
             entry.status = 'error'
           } else if (statusRaw === 'ok' || statusRaw === 'error') {
             entry.status = statusRaw
+          }
+          logBudget?.reconcileTool(entry, changedFields)
+          if (
+            toolCallId &&
+            (statusRaw === 'completed' ||
+              statusRaw === 'failed' ||
+              statusRaw === 'error' ||
+              statusRaw === 'ok')
+          ) {
+            acc.pendingTools.delete(toolCallId)
           }
         }
       }

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.log.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.log.render.test.tsx
@@ -126,6 +126,29 @@ describe('SessionReviewerPanel — Reviewer log section (issue 13/15)', () => {
     expect(container.textContent).toContain('Review complete, submitting findings.')
   })
 
+  it('shows a size-limit notice when captured log content was truncated', async () => {
+    const truncatedLog: ReviewerLogEntry[] = [
+      { kind: 'message', text: 'Partial reviewer output', textTruncated: true }
+    ]
+    act(() => {
+      root.render(
+        <SessionReviewerPanel
+          review={makeReview({ reviewerLog: truncatedLog })}
+          activeFindingId={undefined}
+        />
+      )
+    })
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="reviewer-log-toggle"]')
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(container.textContent).toContain(
+      'Reviewer log content was truncated to fit the size limit.'
+    )
+  })
+
   it('renders tool entry as collapsible row with real name visible after log expansion', async () => {
     act(() => {
       root.render(

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.tsx
@@ -251,6 +251,11 @@ const ReviewerLogRow = ({ entry }: { entry: ReviewerLogEntry }): React.JSX.Eleme
 const ReviewerLogSection = ({ log }: { log: ReviewerLogEntry[] }): React.JSX.Element | null => {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
+  const wasTruncated = log.some((entry) =>
+    entry.kind === 'tool'
+      ? Boolean(entry.rawInputTruncated || entry.rawOutputTruncated || entry.reviewLogTruncated)
+      : Boolean(entry.textTruncated || entry.reviewLogTruncated)
+  )
 
   // If the log is empty, show nothing (graceful empty state per acceptance criterion).
   if (log.length === 0) return null
@@ -280,6 +285,11 @@ const ReviewerLogSection = ({ log }: { log: ReviewerLogEntry[] }): React.JSX.Ele
           className="mt-2 border-l-2 border-border-200 pl-2.5 opacity-75 space-y-0.5"
           data-testid="reviewer-log-body"
         >
+          {wasTruncated && (
+            <p className="pb-1 text-[10px] text-text-400" data-testid="reviewer-log-truncated">
+              {t('Reviewer log content was truncated to fit the size limit.')}
+            </p>
+          )}
           {log.map((entry, i) => (
             <ReviewerLogRow key={i} entry={entry} />
           ))}

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1811,6 +1811,7 @@
     "Review unavailable": "Revisión no disponible",
     "Reviewer": "Revisor",
     "Reviewer log": "Registro del revisor",
+    "Reviewer log content was truncated to fit the size limit.": "El contenido del registro del revisor se truncó para ajustarse al límite de tamaño.",
     "Reviewer model Model": "Modelo del revisor",
     "Reviewer model Reasoning effort": "Esfuerzo de razonamiento del modelo del revisor",
     "Reviewing...": "Revisando…",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1811,6 +1811,7 @@
     "Review unavailable": "Avis indisponible",
     "Reviewer": "Réviseur",
     "Reviewer log": "Journal des évaluateurs",
+    "Reviewer log content was truncated to fit the size limit.": "Le contenu du journal du réviseur a été tronqué pour respecter la limite de taille.",
     "Reviewer model Model": "Modèle de réviseur Modèle",
     "Reviewer model Reasoning effort": "Modèle de réviseur Effort de raisonnement",
     "Reviewing...": "Révision...",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1746,6 +1746,7 @@
     "Review unavailable": "レビューは利用できません",
     "Reviewer": "レビュアー",
     "Reviewer log": "レビュアーログ",
+    "Reviewer log content was truncated to fit the size limit.": "レビュアーログの内容はサイズ制限に収まるよう切り詰められました。",
     "Reviewer model Model": "レビュアーモデル",
     "Reviewer model Reasoning effort": "レビュアーモデルの推論強度",
     "Reviewing...": "レビュー中…",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1753,6 +1753,7 @@
     "Review unavailable": "검토할 수 없음",
     "Reviewer": "리뷰어",
     "Reviewer log": "리뷰어 로그",
+    "Reviewer log content was truncated to fit the size limit.": "리뷰어 로그 내용은 크기 제한에 맞게 잘렸습니다.",
     "Reviewer model Model": "리뷰어 모델",
     "Reviewer model Reasoning effort": "리뷰어 모델 추론 강도",
     "Reviewing...": "검토 중...",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1814,6 +1814,7 @@
     "Review unavailable": "Проверка недоступна",
     "Reviewer": "Рецензент",
     "Reviewer log": "Журнал проверки",
+    "Reviewer log content was truncated to fit the size limit.": "Содержимое журнала проверки обрезано в соответствии с ограничением размера.",
     "Reviewer model Model": "Модель рецензента",
     "Reviewer model Reasoning effort": "Глубина рассуждений модели рецензента",
     "Reviewing...": "Проверка...",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1817,6 +1817,7 @@
     "Review unavailable": "审查不可用",
     "Reviewer": "审查",
     "Reviewer log": "审阅器日志",
+    "Reviewer log content was truncated to fit the size limit.": "审阅器日志内容已截断，以符合大小限制。",
     "Reviewer model Model": "审查模型",
     "Reviewer model Reasoning effort": "审查模型 推理强度",
     "Reviewing...": "正在审查…",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1814,6 +1814,7 @@
     "Review unavailable": "審查無法使用",
     "Reviewer": "審查",
     "Reviewer log": "審閱器記錄",
+    "Reviewer log content was truncated to fit the size limit.": "審閱器記錄內容已截斷，以符合大小限制。",
     "Reviewer model Model": "審查模型",
     "Reviewer model Reasoning effort": "審查模型 推理強度",
     "Reviewing...": "正在審查…",

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -17,14 +17,17 @@
 // The old split tool_call / tool_result pair is collapsed into ONE unified tool entry per call:
 // tool_call seeds the entry, tool_call_update(s) mutate it in place via shared object reference.
 export type ReviewerLogEntry =
-  | { kind: 'thought'; text: string }
-  | { kind: 'message'; text: string }
+  | { kind: 'thought'; text: string; textTruncated?: boolean; reviewLogTruncated?: boolean }
+  | { kind: 'message'; text: string; textTruncated?: boolean; reviewLogTruncated?: boolean }
   | {
       kind: 'tool'
       toolName: string
       title?: string
       rawInput?: string
       rawOutput?: string
+      rawInputTruncated?: boolean
+      rawOutputTruncated?: boolean
+      reviewLogTruncated?: boolean
       status?: 'ok' | 'error'
       exitCode?: number | null
     }


### PR DESCRIPTION
## Problem

Reviewer sessions cap wall-clock time and discrete update count, but streamed text, tool input/output, terminal output, and the final reviewerLog JSON were not byte-bounded. An anomalous provider or oversized tool result could therefore grow main-process memory, trigger repeated string copies, persist an unusually large SQLite row, and stall the renderer when the log is expanded. The discrete-update guard also rejected the maxUpdates-th event even though its comment described rejecting only updates beyond the cap.

## Proposed change

- Bound each streamed thought/message entry to 64 KiB UTF-8.
- Bound tool input to 64 KiB and tool/terminal output to 256 KiB.
- Bound the complete serialized reviewerLog to 1 MiB across both the initial and protocol-recovery turns.
- Serialize structured tool values with one shared byte budget so traversal stops before building an oversized intermediate representation.
- Add optional structured truncation flags and show a localized notice in the expanded Reviewer log.
- Delete pendingTools entries on completed, failed, error, and ok terminal statuses.
- Admit exactly maxUpdates discrete events and reject maxUpdates + 1.

All supported Reviewer ACP backends (claude-code, opencode, codex-response, and codex-bridge) enter this common post-ACP session driver, so no provider-specific adapter change is required.

## Scope and non-goals

- No Prisma schema or SQLite migration. reviewerLog remains JSON in the existing TEXT column.
- No new lifecycle, status, or entry-kind enum values. The data model only gains optional truncation booleans.
- Existing rows remain readable and are not rewritten. Older app versions ignore the additive JSON fields.
- Truncated source content is intentionally not retained in a sidecar or exposed through a retrieval flow; adding storage and retention policy for raw payloads would be disproportionate to this guardrail.
- No interaction change unless a user expands a truncated Reviewer log, where a notice explains the omission.

## Acceptance criteria and validation

Regression tests were written against the public drive/session behavior first. Before the fix they failed consistently with the reported symptoms: oversized UTF-8 text/tool fields and total logs were retained, recovery turns received a fresh total budget, structured traversal continued after the byte budget, and exactly maxUpdates events were rejected. The renderer test also failed because no truncation notice existed.

Final checks after the last material edit:

- npm test -- src/main/reviewer/log-capture.test.ts src/main/reviewer/orchestrator-drive.test.ts src/main/reviewer/review-assessment-owner.test.ts src/renderer/src/pages/workspace/SessionReviewerPanel.log.render.test.tsx src/renderer/src/i18n/resources.test.ts — 5 files, 801 passed.
- npm run test:module -- reviewer_orchestrator — 27 files passed; 507 passed, 4 skipped.
- npm run typecheck:node — passed.
- npm run typecheck:web — passed.
- npm run lint — passed.
- git diff --check — passed.

The affected-test classifier selects full mode because SessionReviewerPanel.log.render.test.tsx has no module owner. Per project guidance, the complete npm test suite is left to PR CI.

## Review focus

Please focus on UTF-8 accounting and serialized-log accounting in reviewer-session-driver.ts, shared budget ownership across the recovery turn, additive reviewerLog compatibility, and whether the renderer notice is sufficient without adding raw-content retrieval.

Independent Standards and Spec reviews were run in parallel. Their initial findings (shared structured byte traversal, owner-level recovery coverage, pendingTools cleanup coverage, and duplicated flush logic) were addressed; both re-reviews reported no remaining findings.