### PR TITLE
feat(workspace): mark session agent configuration changes in the timeline

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -534,7 +534,7 @@ describe('workspace runtime architecture', () => {
   it('keeps the facade, deep owners, and presentation adapter within their completion gates', () => {
     expect(physicalLines(facadePath), 'workspace runtime facade').toBeLessThanOrEqual(605)
     for (const name of ownerNames) {
-      expect(physicalLines(ownerFilePath(name)), name).toBeLessThanOrEqual(723)
+      expect(physicalLines(ownerFilePath(name)), name).toBeLessThanOrEqual(756)
     }
     expect(
       physicalLines(`${subagentPresentationTarget}.ts`),

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -5,6 +5,7 @@ import type { ActivePlanProjection } from '../../../../shared/session-plan/contr
 import {
   collectSessionReferences,
   type MessagePart,
+  type PersistedMessageAgentTarget,
   type SessionReference
 } from '../../../../shared/session-persistence'
 import type { AgentFrameworkId, SessionAgentConfiguration } from '../../../../shared/settings'
@@ -109,6 +110,29 @@ type HistoryReplayContext = {
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
+
+// Snapshots the target a send actually runs with. Only a complete identity (framework + admitted
+// provider configuration) is stamped; a partial snapshot would mark false config changes.
+const resolveSendAgentTarget = (
+  input: Readonly<{
+    agentFrameworkId?: AgentFrameworkId
+    agentBackendId?: string
+    agentModel?: string
+    agentConfiguration?: SessionAgentConfiguration
+  }>
+): PersistedMessageAgentTarget | undefined => {
+  const configuration = input.agentConfiguration
+  if (!input.agentFrameworkId || !configuration) return undefined
+  const backendId = input.agentBackendId?.trim()
+  const model = configuration.model ?? (input.agentModel?.trim() || undefined)
+  return {
+    frameworkId: input.agentFrameworkId,
+    ...(backendId ? { backendId } : {}),
+    providerId: configuration.providerId,
+    ...(model ? { model } : {}),
+    reasoningEffort: configuration.reasoningEffort
+  }
+}
 const createSessionFailureMessage = (error: unknown): string =>
   errorMessage(error)
     .replace(/^Error invoking remote method '[^']*':\s*/i, '')
@@ -418,6 +442,7 @@ const sendWorkspaceMessage = async (
       agentBackendId: input.agentBackendId,
       agentModel: input.agentModel,
       agentConfiguration: input.agentConfiguration,
+      agentTarget: resolveSendAgentTarget(input),
       specialistId: input.specialistId
     })
     if (!pending?.messageId) return undefined
@@ -506,6 +531,7 @@ const sendWorkspaceMessage = async (
         agentBackendId: input.agentBackendId,
         agentModel: input.agentModel,
         agentConfiguration: input.agentConfiguration,
+        agentTarget: resolveSendAgentTarget(input),
         preserveSelection: input.preserveSelection
       })
       if (!appended) return undefined
@@ -588,6 +614,12 @@ const sendWorkspaceMessage = async (
       agentBackendId: prepared.appendOwnership.agentBackendId,
       agentModel: input.agentModel,
       agentConfiguration: input.agentConfiguration,
+      agentTarget: resolveSendAgentTarget({
+        agentFrameworkId: prepared.appendOwnership.agentFrameworkId ?? input.agentFrameworkId,
+        agentBackendId: prepared.appendOwnership.agentBackendId ?? input.agentBackendId,
+        agentModel: input.agentModel,
+        agentConfiguration: input.agentConfiguration
+      }),
       preserveSelection: input.preserveSelection
     })
     if (!appended) return undefined
@@ -643,6 +675,7 @@ const sendWorkspaceMessage = async (
     agentBackendId: input.agentBackendId,
     agentModel: input.agentModel,
     agentConfiguration: input.agentConfiguration,
+    agentTarget: resolveSendAgentTarget(input),
     specialistId: input.specialistId ?? undefined,
     enabledComputeHosts: input.enabledComputeHosts,
     selectedComputeHosts: input.selectedComputeHosts

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -413,10 +413,12 @@ const ProvenanceMessagesTimeline = ({
 
                 // Artifact provenance builds its immutable transcript from persisted messages and
                 // activities only, so no coordinator lifecycle or durable Subagent command rows
-                // are supplied here.
+                // are supplied here. Derived config-change dividers are render-time annotations,
+                // not provenance records, and are skipped as well.
                 if (
                   conversationItem.type === 'handoff' ||
-                  conversationItem.type === 'subagent-message'
+                  conversationItem.type === 'subagent-message' ||
+                  conversationItem.type === 'session-config-change'
                 )
                   return null
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -55,6 +55,7 @@ import { Button } from '@/components/ui/button'
 import { ReviewerCard } from '@/components/ReviewerCard'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
 import { WorkspaceContextCompactionActivityRow } from './WorkspaceContextCompactionActivityRow'
+import { WorkspaceSessionConfigChangeRow } from './WorkspaceSessionConfigChangeRow'
 import { WorkspacePlanActivityRecord } from './WorkspacePlanActivityRecord'
 import { parseGeneratePlanDocument } from './generate-plan-activity-projection'
 import { WorkspaceAgentLoadingRow } from './WorkspaceAgentLoadingRow'
@@ -1597,6 +1598,16 @@ const WorkspaceMessageScrollerImpl = ({
                 if (item.type === 'compaction-activity') {
                   return (
                     <WorkspaceContextCompactionActivityRow key={item.id} activity={item.activity} />
+                  )
+                }
+
+                if (item.type === 'session-config-change') {
+                  return (
+                    <WorkspaceSessionConfigChangeRow
+                      key={item.id}
+                      id={item.id}
+                      agentTarget={item.agentTarget}
+                    />
                   )
                 }
 

--- a/src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.render.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n'
+import type { PersistedMessageAgentTarget } from '../../../../shared/session-persistence'
+import type { AgentFrameworkView, ProviderView } from '../../../../shared/settings'
+import { WorkspaceSessionConfigChangeRow } from './WorkspaceSessionConfigChangeRow'
+
+vi.mock('@/components/ui/message-scroller', () => ({
+  MessageScrollerItem: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+// renderToStaticMarkup reads zustand's server snapshot (the initial state), so the store hook is
+// stubbed with plain fixture state instead of seeding the real store.
+const settingsFixture: { agentFrameworks: AgentFrameworkView[]; providers: ProviderView[] } = {
+  agentFrameworks: [],
+  providers: []
+}
+
+vi.mock('@/stores/settings-store', () => ({
+  useSettingsStore: <Selection,>(
+    selector: (state: typeof settingsFixture) => Selection
+  ): Selection => selector(settingsFixture)
+}))
+
+const agentTarget = (
+  overrides: Partial<PersistedMessageAgentTarget> = {}
+): PersistedMessageAgentTarget => ({
+  frameworkId: 'claude-code',
+  providerId: 'provider-a',
+  model: 'model-a',
+  reasoningEffort: 'high',
+  ...overrides
+})
+
+beforeEach(() => {
+  settingsFixture.agentFrameworks = [
+    { id: 'claude-code', displayName: 'Claude Code', supportsSkills: true },
+    { id: 'codex', displayName: 'Codex', supportsSkills: true }
+  ]
+  settingsFixture.providers = [
+    {
+      id: 'provider-a',
+      type: 'custom',
+      name: 'Gateway',
+      models: ['model-a'],
+      supportsImageInput: false,
+      hasKey: true,
+      needsKey: false
+    }
+  ]
+})
+
+const renderRow = (overrides?: Partial<PersistedMessageAgentTarget>): string =>
+  renderToStaticMarkup(
+    <WorkspaceSessionConfigChangeRow
+      id="session-config-change-message-2"
+      agentTarget={agentTarget(overrides)}
+    />
+  )
+
+describe('WorkspaceSessionConfigChangeRow', () => {
+  it('renders the current framework, model, and effort as a quiet non-interactive divider', () => {
+    const html = renderRow()
+
+    expect(html).toContain('Claude Code · model-a · High')
+    expect(html).toContain(
+      'aria-label="Session configuration changed to Claude Code · model-a · High"'
+    )
+    expect(html).toContain('lucide-sliders-horizontal')
+    expect(html).toContain('bg-border-200')
+    expect(html).not.toContain('role="status"')
+    expect(html).not.toContain('<button')
+  })
+
+  it('labels an omitted model with the provider name like the Composer model picker', () => {
+    const html = renderRow({ model: undefined })
+
+    expect(html).toContain('Claude Code · Gateway · High')
+  })
+
+  it('labels the default effort like the Composer model picker', () => {
+    const html = renderRow({ reasoningEffort: 'default' })
+
+    expect(html).toContain('Claude Code · model-a · Default')
+  })
+
+  it('falls back to the raw framework id when the framework is unknown', () => {
+    settingsFixture.agentFrameworks = []
+    const html = renderRow()
+
+    expect(html).toContain('claude-code · model-a · High')
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.render.test.tsx
@@ -8,8 +8,13 @@ import type { PersistedMessageAgentTarget } from '../../../../shared/session-per
 import type { AgentFrameworkView, ProviderView } from '../../../../shared/settings'
 import { WorkspaceSessionConfigChangeRow } from './WorkspaceSessionConfigChangeRow'
 
+const scrollerItemProps: Array<Record<string, unknown>> = []
+
 vi.mock('@/components/ui/message-scroller', () => ({
-  MessageScrollerItem: ({ children }: { children: ReactNode }) => <div>{children}</div>
+  MessageScrollerItem: (props: { children: ReactNode }) => {
+    scrollerItemProps.push({ ...props, children: undefined })
+    return <div>{props.children}</div>
+  }
 }))
 
 // renderToStaticMarkup reads zustand's server snapshot (the initial state), so the store hook is
@@ -36,6 +41,7 @@ const agentTarget = (
 })
 
 beforeEach(() => {
+  scrollerItemProps.length = 0
   settingsFixture.agentFrameworks = [
     { id: 'claude-code', displayName: 'Claude Code', supportsSkills: true },
     { id: 'codex', displayName: 'Codex', supportsSkills: true }
@@ -69,10 +75,28 @@ describe('WorkspaceSessionConfigChangeRow', () => {
     expect(html).toContain(
       'aria-label="Session configuration changed to Claude Code · model-a · High"'
     )
-    expect(html).toContain('lucide-sliders-horizontal')
     expect(html).toContain('bg-border-200')
     expect(html).not.toContain('role="status"')
     expect(html).not.toContain('<button')
+  })
+
+  it('renders the framework and provider brand icons inline without a badge circle', () => {
+    const html = renderRow()
+
+    // ClaudeCode brand mark (lobehub ClaudeColor) plus the custom-provider kind icon.
+    expect(html).toContain('<title>Claude</title>')
+    expect(html).toContain('lucide-circle-plus')
+    expect(html).not.toContain('lucide-sliders-horizontal')
+    expect(html).not.toContain('rounded-full border')
+  })
+
+  it('omits the provider icon when the provider no longer resolves', () => {
+    settingsFixture.providers = []
+    const html = renderRow()
+
+    expect(html).toContain('Claude Code · model-a · High')
+    expect(html).toContain('<title>Claude</title>')
+    expect(html).not.toContain('lucide-circle-plus')
   })
 
   it('labels an omitted model with the provider name like the Composer model picker', () => {
@@ -85,6 +109,16 @@ describe('WorkspaceSessionConfigChangeRow', () => {
     const html = renderRow({ reasoningEffort: 'default' })
 
     expect(html).toContain('Claude Code · model-a · Default')
+  })
+
+  it('opts out of content-visibility containment so the short row never renders as a placeholder', () => {
+    renderRow()
+
+    expect(scrollerItemProps).toHaveLength(1)
+    expect(scrollerItemProps[0]).toMatchObject({
+      messageId: 'session-config-change-message-2',
+      disableContainment: true
+    })
   })
 
   it('falls back to the raw framework id when the framework is unknown', () => {

--- a/src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.tsx
@@ -1,0 +1,83 @@
+import { MessageScrollerItem } from '@/components/ui/message-scroller'
+import { cn } from '@/lib/utils'
+import { useSettingsStore } from '@/stores/settings-store'
+import { SlidersHorizontal } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import type { PersistedMessageAgentTarget } from '../../../../shared/session-persistence'
+import {
+  resolveProviderEffectiveModel,
+  resolveProviderReasoningEffortProfile
+} from '../../../../shared/provider-reasoning-effort'
+import { resolveReasoningEffortControl } from '../../../../shared/reasoning-effort'
+
+type WorkspaceSessionConfigChangeRowProps = {
+  id: string
+  agentTarget: PersistedMessageAgentTarget
+  contentPaddingClassName?: string
+}
+
+// Marks the transcript boundary where the Session's resolved framework · model · effort changed.
+const WorkspaceSessionConfigChangeRow = ({
+  id,
+  agentTarget,
+  contentPaddingClassName
+}: WorkspaceSessionConfigChangeRowProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
+  const providers = useSettingsStore((state) => state.providers)
+
+  const framework =
+    agentFrameworks.find((candidate) => candidate.id === agentTarget.frameworkId)?.displayName ??
+    agentTarget.frameworkId
+  const provider = providers.find((candidate) => candidate.id === agentTarget.providerId)
+  // An omitted model is the provider default; the Composer model picker labels that entry with
+  // the provider name rather than pinning a concrete catalog model.
+  const model = agentTarget.model ?? provider?.name ?? t('Default')
+  // The effort line reuses the Composer picker's resolution chain so both surfaces always agree.
+  const effortControl = resolveReasoningEffortControl(
+    agentTarget.reasoningEffort,
+    resolveProviderReasoningEffortProfile(
+      provider,
+      resolveProviderEffectiveModel(provider, agentTarget.model)
+    )
+  )
+  const effort =
+    agentTarget.reasoningEffort === 'default'
+      ? t('Default')
+      : (effortControl.options.find((option) => option.value === effortControl.selectedValue)
+          ?.label ?? agentTarget.reasoningEffort)
+
+  return (
+    <MessageScrollerItem messageId={id} className="min-w-0">
+      <div className={cn('px-4 pb-0.5 pt-2.5 md:px-6', contentPaddingClassName)}>
+        <div
+          className="flex min-w-0 items-center gap-3 py-1.5"
+          data-testid="session-config-change"
+          aria-label={t('Session configuration changed to {{framework}} · {{model}} · {{effort}}', {
+            framework,
+            model,
+            effort
+          })}
+        >
+          <span className="hidden h-px min-w-4 flex-1 bg-border-200 sm:block" aria-hidden="true" />
+          <span className="flex min-w-0 max-w-[44rem] items-center gap-2">
+            <span className="grid size-7 shrink-0 place-items-center rounded-full border border-border-200 bg-bg-000">
+              <SlidersHorizontal
+                className="size-3.5 shrink-0 text-muted-foreground"
+                strokeWidth={2.2}
+                aria-hidden={true}
+              />
+            </span>
+            <span className="min-w-0 truncate text-[12px] leading-4 text-muted-foreground">
+              {t('{{framework}} · {{model}} · {{effort}}', { framework, model, effort })}
+            </span>
+          </span>
+          <span className="hidden h-px min-w-4 flex-1 bg-border-200 sm:block" aria-hidden="true" />
+        </div>
+      </div>
+    </MessageScrollerItem>
+  )
+}
+
+export { WorkspaceSessionConfigChangeRow }

--- a/src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.tsx
@@ -1,7 +1,6 @@
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
-import { SlidersHorizontal } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import type { PersistedMessageAgentTarget } from '../../../../shared/session-persistence'
@@ -10,6 +9,8 @@ import {
   resolveProviderReasoningEffortProfile
 } from '../../../../shared/provider-reasoning-effort'
 import { resolveReasoningEffortControl } from '../../../../shared/reasoning-effort'
+import { providerKindKey } from '../settings/provider-form-value'
+import { AgentFrameworkIcon, ProviderKindIcon } from '../settings/provider-icons'
 
 type WorkspaceSessionConfigChangeRowProps = {
   id: string
@@ -31,6 +32,7 @@ const WorkspaceSessionConfigChangeRow = ({
     agentFrameworks.find((candidate) => candidate.id === agentTarget.frameworkId)?.displayName ??
     agentTarget.frameworkId
   const provider = providers.find((candidate) => candidate.id === agentTarget.providerId)
+  const kindKey = provider ? providerKindKey(provider.type, provider.vendorId) : undefined
   // An omitted model is the provider default; the Composer model picker labels that entry with
   // the provider name rather than pinning a concrete catalog model.
   const model = agentTarget.model ?? provider?.name ?? t('Default')
@@ -49,7 +51,10 @@ const WorkspaceSessionConfigChangeRow = ({
           ?.label ?? agentTarget.reasoningEffort)
 
   return (
-    <MessageScrollerItem messageId={id} className="min-w-0">
+    // A 40px divider must never render as the 10rem content-visibility placeholder: mounting
+    // off-screen mid-send would substitute the estimate for a frame and the scroll anchor would
+    // snap against the inflated height — the visible flash this row exists to avoid.
+    <MessageScrollerItem messageId={id} className="min-w-0" disableContainment>
       <div className={cn('px-4 pb-0.5 pt-2.5 md:px-6', contentPaddingClassName)}>
         <div
           className="flex min-w-0 items-center gap-3 py-1.5"
@@ -62,12 +67,14 @@ const WorkspaceSessionConfigChangeRow = ({
         >
           <span className="hidden h-px min-w-4 flex-1 bg-border-200 sm:block" aria-hidden="true" />
           <span className="flex min-w-0 max-w-[44rem] items-center gap-2">
-            <span className="grid size-7 shrink-0 place-items-center rounded-full border border-border-200 bg-bg-000">
-              <SlidersHorizontal
-                className="size-3.5 shrink-0 text-muted-foreground"
-                strokeWidth={2.2}
-                aria-hidden={true}
+            {/* Brand marks stay decorative; the row's aria-label already names the change. */}
+            <span className="flex shrink-0 items-center gap-1.5" aria-hidden="true">
+              <AgentFrameworkIcon
+                frameworkId={agentTarget.frameworkId}
+                size={14}
+                className="shrink-0"
               />
+              {kindKey ? <ProviderKindIcon kindKey={kindKey} className="size-3.5" /> : null}
             </span>
             <span className="min-w-0 truncate text-[12px] leading-4 text-muted-foreground">
               {t('{{framework}} · {{model}} · {{effort}}', { framework, model, effort })}

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import type { ChatSession, ToolActivity } from '@/stores/session-store'
+import type { ChatMessage, ChatSession, ToolActivity } from '@/stores/session-store'
 import { ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME } from '../../../../shared/acp'
 import type { HandoffLifecycleEvent } from '../../../../shared/handoff-lifecycle'
 import { createLinearConversationGraph } from '../../../../shared/conversation-graph'
@@ -509,6 +509,190 @@ describe('workspace conversation items', () => {
       'activity-tool-web-1',
       'message-2'
     ])
+  })
+
+  describe('session config-change markers', () => {
+    const targetA = {
+      frameworkId: 'claude-code' as const,
+      providerId: 'provider-a',
+      model: 'model-a',
+      reasoningEffort: 'default' as const
+    }
+    const targetB = {
+      frameworkId: 'claude-code' as const,
+      providerId: 'provider-a',
+      model: 'model-b',
+      reasoningEffort: 'default' as const
+    }
+
+    const stampedUserMessage = (
+      id: string,
+      sortIndex: number,
+      agentTarget?: ChatMessage['agentTarget']
+    ): ChatMessage => ({
+      id,
+      role: 'user',
+      content: `Turn ${id}`,
+      status: 'complete',
+      eventIds: [],
+      sortIndex,
+      createdAt: 1710000000000 + sortIndex,
+      updatedAt: 1710000000000 + sortIndex,
+      ...(agentTarget ? { agentTarget } : {})
+    })
+
+    const configChangeItems = (session: ChatSession): ReturnType<typeof createConversationItems> =>
+      createConversationItems(session).filter((item) => item.type === 'session-config-change')
+
+    it('marks a model change above the new user message', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, targetA),
+          stampedUserMessage('message-2', 2, targetB)
+        ]
+      }
+
+      const items = createConversationItems(session)
+      const divider = items.find((item) => item.type === 'session-config-change')
+      expect(divider).toEqual({
+        id: 'session-config-change-message-2',
+        type: 'session-config-change',
+        createdAt: 1710000000002,
+        sortIndex: 1.5,
+        agentTarget: targetB
+      })
+      expect(items.map((item) => item.id)).toEqual([
+        'message-1',
+        'session-config-change-message-2',
+        'message-2'
+      ])
+    })
+
+    it('marks an effort-only change', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, targetA),
+          stampedUserMessage('message-2', 2, { ...targetA, reasoningEffort: 'high' })
+        ]
+      }
+
+      expect(configChangeItems(session)).toHaveLength(1)
+    })
+
+    it('marks a framework change', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, targetA),
+          stampedUserMessage('message-2', 2, { ...targetA, frameworkId: 'codex' })
+        ]
+      }
+
+      expect(configChangeItems(session)).toHaveLength(1)
+    })
+
+    it('marks a backend-only change', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, targetA),
+          stampedUserMessage('message-2', 2, { ...targetA, backendId: 'codex-bridge' })
+        ]
+      }
+
+      expect(configChangeItems(session)).toHaveLength(1)
+    })
+
+    it('stays quiet when the target is unchanged', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, targetA),
+          stampedUserMessage('message-2', 2, targetA)
+        ]
+      }
+
+      expect(configChangeItems(session)).toEqual([])
+    })
+
+    it('stays quiet on the first stamped message of a session', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [stampedUserMessage('message-1', 1, targetA)]
+      }
+
+      expect(configChangeItems(session)).toEqual([])
+    })
+
+    it('stays quiet when the previous turn predates snapshots', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [stampedUserMessage('message-1', 1), stampedUserMessage('message-2', 2, targetA)]
+      }
+
+      expect(configChangeItems(session)).toEqual([])
+    })
+
+    it('ignores unstamped gaps between stamped turns when comparing', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, targetA),
+          stampedUserMessage('message-2', 2),
+          stampedUserMessage('message-3', 3, targetB)
+        ]
+      }
+
+      expect(configChangeItems(session).map((item) => item.id)).toEqual([
+        'session-config-change-message-3'
+      ])
+    })
+
+    it('stays quiet when picker churn nets out between sent turns', () => {
+      // A → B → A in the picker records only the two applied sends, both with target A.
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, targetA),
+          stampedUserMessage('message-2', 2, targetA)
+        ]
+      }
+
+      expect(configChangeItems(session)).toEqual([])
+    })
+
+    it('marks a branched session first send whose config differs from the copied history', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        branchSource: { sessionId: 'source-session' },
+        messages: [
+          stampedUserMessage('copied-1', 1, targetA),
+          stampedUserMessage('message-2', 2, targetB)
+        ]
+      }
+
+      expect(configChangeItems(session).map((item) => item.id)).toEqual([
+        'session-config-change-message-2'
+      ])
+    })
+
+    it('ignores relayed side-chat messages when tracking the baseline', () => {
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, targetA),
+          {
+            ...stampedUserMessage('relay-1', 2, targetB),
+            relayedFrom: { kind: 'side-chat', direction: 'to-main' }
+          },
+          stampedUserMessage('message-3', 3, targetA)
+        ]
+      }
+
+      expect(configChangeItems(session)).toEqual([])
+    })
   })
 
   it('projects every generate_plan status as a standalone item and hides step status updates', () => {

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.ts
@@ -1,7 +1,10 @@
 import type { ChatMessage, ChatSession, ToolActivity } from '@/stores/session-store'
 import { ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME } from '../../../../shared/acp'
 import type { HandoffLifecycleEvent } from '../../../../shared/handoff-lifecycle'
-import { isHiddenControlMessage } from '../../../../shared/session-persistence'
+import {
+  isHiddenControlMessage,
+  type PersistedMessageAgentTarget
+} from '../../../../shared/session-persistence'
 
 import {
   projectHandoffLifecycle,
@@ -52,6 +55,16 @@ type ConversationSubagentMessageItem = {
   message: InlineParentMessageProjection
 }
 
+// A quiet divider derived (never persisted) above a user Message whose resolved send target
+// differs from the previous stamped turn.
+type ConversationSessionConfigChangeItem = {
+  id: string
+  type: 'session-config-change'
+  createdAt: number
+  sortIndex: number
+  agentTarget: PersistedMessageAgentTarget
+}
+
 type ConversationItem =
   | ConversationMessageItem
   | ConversationActivityItem
@@ -59,6 +72,7 @@ type ConversationItem =
   | ConversationCompactionActivityItem
   | ConversationHandoffItem
   | ConversationSubagentMessageItem
+  | ConversationSessionConfigChangeItem
 
 const KNOWN_TITLE_TOOL_NAMES = new Set(['ToolSearch'])
 
@@ -208,13 +222,60 @@ const formatActivityTitle = (
   return t('Using tool: {{name}}', { name: toolName })
 }
 
+// Two send targets describe the same turn configuration only when every routed field matches.
+const agentTargetsMatch = (
+  left: PersistedMessageAgentTarget,
+  right: PersistedMessageAgentTarget
+): boolean =>
+  left.frameworkId === right.frameworkId &&
+  left.backendId === right.backendId &&
+  left.providerId === right.providerId &&
+  left.model === right.model &&
+  left.reasoningEffort === right.reasoningEffort
+
+// Derives divider rows above user Messages whose resolved send target changed from the previous
+// stamped turn. Messages without a snapshot (legacy turns, relayed side-chat messages) neither
+// emit a divider nor move the baseline, so upgraded sessions show no false markers.
+const createSessionConfigChangeItems = (
+  messages: readonly ConversationMessageItem[]
+): ConversationSessionConfigChangeItem[] => {
+  const ordered = [...messages].sort(
+    (left, right) =>
+      left.createdAt - right.createdAt ||
+      left.sortIndex - right.sortIndex ||
+      left.id.localeCompare(right.id)
+  )
+  const items: ConversationSessionConfigChangeItem[] = []
+  let baseline: PersistedMessageAgentTarget | undefined
+  for (const item of ordered) {
+    const target =
+      item.message.role === 'user' && !item.message.relayedFrom
+        ? item.message.agentTarget
+        : undefined
+    if (!target) continue
+    if (baseline && !agentTargetsMatch(baseline, target)) {
+      items.push({
+        id: `session-config-change-${item.id}`,
+        type: 'session-config-change',
+        createdAt: item.createdAt,
+        // Half a step below the owning Message keeps the divider directly above it under the
+        // shared (createdAt, sortIndex) transcript sort.
+        sortIndex: item.sortIndex - 0.5,
+        agentTarget: target
+      })
+    }
+    baseline = target
+  }
+  return items
+}
+
 // Projects persisted chat messages and transient tool activities into one sortable transcript list.
 const createConversationItems = (
   session: ChatSession | undefined,
   handoffEvents: readonly HandoffLifecycleEvent[] = []
 ): ConversationItem[] => {
-  const messages: ConversationItem[] =
-    session?.messages.flatMap((message, index): ConversationItem[] =>
+  const messages: ConversationMessageItem[] =
+    session?.messages.flatMap((message, index): ConversationMessageItem[] =>
       isHiddenControlMessage(message)
         ? []
         : [
@@ -271,7 +332,13 @@ const createConversationItems = (
   )
 
   // Runtime events and chat chunks use separate sequences, so sorting uses timestamps first.
-  return [...messages, ...activities, ...handoffs, ...subagentMessages].sort((left, right) => {
+  return [
+    ...messages,
+    ...activities,
+    ...handoffs,
+    ...subagentMessages,
+    ...createSessionConfigChangeItems(messages)
+  ].sort((left, right) => {
     if (left.createdAt !== right.createdAt) return left.createdAt - right.createdAt
     if (left.sortIndex !== right.sortIndex) return left.sortIndex - right.sortIndex
     return left.id.localeCompare(right.id)

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -46,6 +46,7 @@ const groupConversationItems = (
       item.type === 'handoff' ||
       item.type === 'plan-activity' ||
       item.type === 'compaction-activity' ||
+      item.type === 'session-config-change' ||
       (item.type === 'activity' && item.activity.elicitation)
     ) {
       groupedItems.push(item)

--- a/src/renderer/src/stores/session-store-message-graph-helpers.ts
+++ b/src/renderer/src/stores/session-store-message-graph-helpers.ts
@@ -42,6 +42,8 @@ export type AppendUserMessageInput = {
   agentBackendId?: PersistedChatSession['agentBackendId']
   agentModel?: string
   agentConfiguration?: PersistedChatSession['agentConfiguration']
+  // Resolved send target stamped onto the user Message; drives config-change timeline markers.
+  agentTarget?: PersistedChatMessage['agentTarget']
   isPending?: boolean
   specialistId?: string
   enabledComputeHosts?: string[]
@@ -64,6 +66,7 @@ export type BranchInNewSessionInput = {
   agentBackendId?: PersistedChatSession['agentBackendId']
   agentModel?: string
   agentConfiguration?: PersistedChatSession['agentConfiguration']
+  agentTarget?: PersistedChatMessage['agentTarget']
   specialistId?: string | null
 }
 

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -166,7 +166,16 @@ export const createSessionMessageGraphOwner = <
     const messages = matchingFeedback
       ? session.messages.map((existing, index) =>
           index === matchingFeedbackIndex
-            ? { ...message, sortIndex: matchingFeedback.sortIndex }
+            ? {
+                ...message,
+                sortIndex: matchingFeedback.sortIndex,
+                // The provider echo cannot know renderer-stamped send markers; keep the local
+                // copy's target snapshot and turn intent when it replaces the local Message.
+                ...(matchingFeedback.agentTarget
+                  ? { agentTarget: matchingFeedback.agentTarget }
+                  : {}),
+                ...(matchingFeedback.turnIntent ? { turnIntent: matchingFeedback.turnIntent } : {})
+              }
             : existing
         )
       : [...session.messages, message]

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -203,7 +203,8 @@ export const createSessionMessageGraphOwner = <
     specialistId,
     enabledComputeHosts,
     selectedComputeHosts,
-    preserveSelection
+    preserveSelection,
+    agentTarget
   }) => {
     const trimmedContent = content.trim()
     const normalizedAgentBackendId = agentBackendId?.trim() || undefined
@@ -217,15 +218,18 @@ export const createSessionMessageGraphOwner = <
     const state = get()
     const existingSession = state.sessions.find((session) => session.id === sessionId)
     const now = Date.now()
-    const userMessage = buildUserMessage({
-      id: createMessageId(),
-      content: trimmedContent,
-      uploads,
-      parts,
-      annotations,
-      turnIntent,
-      sortIndex: createSortIndex()
-    })
+    const userMessage: ChatMessage = {
+      ...buildUserMessage({
+        id: createMessageId(),
+        content: trimmedContent,
+        uploads,
+        parts,
+        annotations,
+        turnIntent,
+        sortIndex: createSortIndex()
+      }),
+      ...(agentTarget ? { agentTarget } : {})
+    }
     const activeRun: ActiveRun = {
       promptMessageId: userMessage.id,
       startedAt: now
@@ -347,7 +351,8 @@ export const createSessionMessageGraphOwner = <
     agentBackendId,
     agentModel,
     agentConfiguration,
-    specialistId
+    specialistId,
+    agentTarget
   }) => {
     const trimmedContent = content?.trim() ?? ''
     const uploads = attachments.map(createPersistedUpload)
@@ -375,15 +380,18 @@ export const createSessionMessageGraphOwner = <
     const sessionId = createPendingSessionId()
     const userMessage = sourceMessage
       ? undefined
-      : buildUserMessage({
-          id: createMessageId(),
-          content: trimmedContent,
-          uploads,
-          parts,
-          annotations,
-          turnIntent,
-          sortIndex: createSortIndex()
-        })
+      : {
+          ...buildUserMessage({
+            id: createMessageId(),
+            content: trimmedContent,
+            uploads,
+            parts,
+            annotations,
+            turnIntent,
+            sortIndex: createSortIndex()
+          }),
+          ...(agentTarget ? { agentTarget } : {})
+        }
     const messages = [
       ...sourceMessages.map(({ message, sortIndex }) => copySnapshotMessage(message, sortIndex)),
       ...(userMessage ? [userMessage] : [])

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -893,7 +893,7 @@ describe('Session Store architecture', () => {
     for (const file of actualModules) {
       const source = readSource(resolve(__dirname, file))
       const lines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      const completionGate = file === 'session-store-persistence-owner.ts' ? 785 : 710
+      const completionGate = file === 'session-store-persistence-owner.ts' ? 785 : 719
       expect(lines, file).toBeLessThanOrEqual(completionGate)
     }
   })

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2717,6 +2717,53 @@ describe('session store', () => {
     expect(toPersistedSession(session).agentModel).toBe('model-b')
   })
 
+  it('stamps the resolved agent target onto each sent user message', () => {
+    const firstTarget = {
+      frameworkId: 'claude-code' as const,
+      providerId: 'provider-a',
+      model: 'model-a',
+      reasoningEffort: 'default' as const
+    }
+    const secondTarget = {
+      frameworkId: 'codex' as const,
+      backendId: 'codex-responses',
+      providerId: 'provider-b',
+      reasoningEffort: 'high' as const
+    }
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'First run',
+      agentTarget: firstTarget
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Second run',
+      agentTarget: secondTarget
+    })
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.messages.map((message) => message.agentTarget)).toEqual([
+      firstTarget,
+      secondTarget
+    ])
+    expect(toPersistedSession(session).messages.map((message) => message.agentTarget)).toEqual([
+      firstTarget,
+      secondTarget
+    ])
+  })
+
+  it('leaves the agent target unset when no snapshot is supplied', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'First run'
+    })
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.messages[0]).not.toHaveProperty('agentTarget')
+  })
+
   it('keeps an existing Session agentConfiguration when a later send snapshot differs', () => {
     const snapshot = {
       providerId: 'provider-a',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -298,6 +298,61 @@ describe('session store', () => {
     ])
   })
 
+  it('keeps the local send markers when a provider echo replaces the provisional user Message', () => {
+    const agentTarget = {
+      frameworkId: 'claude-code' as const,
+      providerId: 'provider-a',
+      model: 'model-a',
+      reasoningEffort: 'high' as const
+    }
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'transport-session-1',
+          projectId: 'default-project',
+          title: 'Session',
+          cwd: '/workspace/project',
+          status: 'running',
+          messages: [
+            {
+              id: 'local-user-message-1',
+              role: 'user',
+              content: 'Run the analysis',
+              status: 'complete',
+              eventIds: [],
+              sortIndex: 1,
+              agentTarget,
+              turnIntent: 'plan-first',
+              createdAt: 1,
+              updatedAt: 1
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        } as ChatSession
+      ],
+      selectedSessionId: 'transport-session-1'
+    })
+
+    const routed = useSessionStore.getState().appendRoutedUserMessage({
+      sessionId: 'transport-session-1',
+      messageId: 'provider-message-1',
+      eventId: 'provider-event-1',
+      content: 'Run the analysis',
+      createdAt: 2
+    })
+
+    expect(routed).toEqual({ sessionId: 'transport-session-1', messageId: 'provider-message-1' })
+    expect(useSessionStore.getState().sessions[0].messages).toEqual([
+      expect.objectContaining({
+        id: 'provider-message-1',
+        sortIndex: 1,
+        agentTarget,
+        turnIntent: 'plan-first'
+      })
+    ])
+  })
+
   it('persists a routed user Message with uploads when the text is empty', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -3724,6 +3724,8 @@
     "Provider validation response exceeded {{limit}} bytes.": "La respuesta de validación del proveedor superó los {{limit}} bytes.",
     "The vendor returned more than {{limit}} models.": "El proveedor devolvió más de {{limit}} modelos.",
     "The vendor returned a model ID longer than {{limit}} characters.": "El proveedor devolvió un ID de modelo de más de {{limit}} caracteres.",
-    "Claude token must not exceed {{limit}} bytes.": "El token de Claude no debe superar {{limit}} bytes."
+    "Claude token must not exceed {{limit}} bytes.": "El token de Claude no debe superar {{limit}} bytes.",
+    "{{framework}} · {{model}} · {{effort}}": "{{framework}} · {{model}} · {{effort}}",
+    "Session configuration changed to {{framework}} · {{model}} · {{effort}}": "La configuración de la sesión cambió a {{framework}} · {{model}} · {{effort}}"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -3724,6 +3724,8 @@
     "Provider validation response exceeded {{limit}} bytes.": "La réponse de validation du fournisseur a dépassé {{limit}} octets.",
     "The vendor returned more than {{limit}} models.": "Le fournisseur a renvoyé plus de {{limit}} modèles.",
     "The vendor returned a model ID longer than {{limit}} characters.": "Le fournisseur a renvoyé un identifiant de modèle de plus de {{limit}} caractères.",
-    "Claude token must not exceed {{limit}} bytes.": "Le jeton Claude ne doit pas dépasser {{limit}} octets."
+    "Claude token must not exceed {{limit}} bytes.": "Le jeton Claude ne doit pas dépasser {{limit}} octets.",
+    "{{framework}} · {{model}} · {{effort}}": "{{framework}} · {{model}} · {{effort}}",
+    "Session configuration changed to {{framework}} · {{model}} · {{effort}}": "La configuration de la session est passée à {{framework}} · {{model}} · {{effort}}"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3434,6 +3434,8 @@
     "Provider validation response exceeded {{limit}} bytes.": "プロバイダー検証レスポンスが {{limit}} バイトを超えました。",
     "The vendor returned more than {{limit}} models.": "ベンダーから {{limit}} 件を超えるモデルが返されました。",
     "The vendor returned a model ID longer than {{limit}} characters.": "ベンダーから {{limit}} 文字を超えるモデル ID が返されました。",
-    "Claude token must not exceed {{limit}} bytes.": "Claude トークンは {{limit}} バイト以内である必要があります。"
+    "Claude token must not exceed {{limit}} bytes.": "Claude トークンは {{limit}} バイト以内である必要があります。",
+    "{{framework}} · {{model}} · {{effort}}": "{{framework}} · {{model}} · {{effort}}",
+    "Session configuration changed to {{framework}} · {{model}} · {{effort}}": "セッション構成が {{framework}} · {{model}} · {{effort}} に変更されました"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3432,6 +3432,8 @@
     "Provider validation response exceeded {{limit}} bytes.": "모델 제공업체 검증 응답이 {{limit}}바이트를 초과했습니다.",
     "The vendor returned more than {{limit}} models.": "공급업체에서 {{limit}}개보다 많은 모델을 반환했습니다.",
     "The vendor returned a model ID longer than {{limit}} characters.": "공급업체에서 {{limit}}자보다 긴 모델 ID를 반환했습니다.",
-    "Claude token must not exceed {{limit}} bytes.": "Claude 토큰은 {{limit}}바이트를 초과할 수 없습니다."
+    "Claude token must not exceed {{limit}} bytes.": "Claude 토큰은 {{limit}}바이트를 초과할 수 없습니다.",
+    "{{framework}} · {{model}} · {{effort}}": "{{framework}} · {{model}} · {{effort}}",
+    "Session configuration changed to {{framework}} · {{model}} · {{effort}}": "세션 구성이 변경되었습니다: {{framework}} · {{model}} · {{effort}}"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -3844,6 +3844,8 @@
     "Provider validation response exceeded {{limit}} bytes.": "Размер ответа при проверке поставщика превысил {{limit}} байт.",
     "The vendor returned more than {{limit}} models.": "Поставщик вернул более {{limit}} моделей.",
     "The vendor returned a model ID longer than {{limit}} characters.": "Поставщик вернул идентификатор модели длиннее {{limit}} символов.",
-    "Claude token must not exceed {{limit}} bytes.": "Токен Claude не должен превышать {{limit}} байт."
+    "Claude token must not exceed {{limit}} bytes.": "Токен Claude не должен превышать {{limit}} байт.",
+    "{{framework}} · {{model}} · {{effort}}": "{{framework}} · {{model}} · {{effort}}",
+    "Session configuration changed to {{framework}} · {{model}} · {{effort}}": "Конфигурация сессии изменена на {{framework}} · {{model}} · {{effort}}"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -3434,6 +3434,8 @@
     "Provider validation response exceeded {{limit}} bytes.": "服务商校验响应超过 {{limit}} 字节。",
     "The vendor returned more than {{limit}} models.": "服务商返回了超过 {{limit}} 个模型。",
     "The vendor returned a model ID longer than {{limit}} characters.": "服务商返回了长度超过 {{limit}} 个字符的模型 ID。",
-    "Claude token must not exceed {{limit}} bytes.": "Claude 令牌不得超过 {{limit}} 字节。"
+    "Claude token must not exceed {{limit}} bytes.": "Claude 令牌不得超过 {{limit}} 字节。",
+    "{{framework}} · {{model}} · {{effort}}": "{{framework}} · {{model}} · {{effort}}",
+    "Session configuration changed to {{framework}} · {{model}} · {{effort}}": "会话配置已更改为 {{framework}} · {{model}} · {{effort}}"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -3434,6 +3434,8 @@
     "Provider validation response exceeded {{limit}} bytes.": "服務商驗證回應超過 {{limit}} 位元組。",
     "The vendor returned more than {{limit}} models.": "服務商傳回了超過 {{limit}} 個模型。",
     "The vendor returned a model ID longer than {{limit}} characters.": "服務商傳回了長度超過 {{limit}} 個字元的模型 ID。",
-    "Claude token must not exceed {{limit}} bytes.": "Claude 權杖不得超過 {{limit}} 位元組。"
+    "Claude token must not exceed {{limit}} bytes.": "Claude 權杖不得超過 {{limit}} 位元組。",
+    "{{framework}} · {{model}} · {{effort}}": "{{framework}} · {{model}} · {{effort}}",
+    "Session configuration changed to {{framework}} · {{model}} · {{effort}}": "會話設定已變更為 {{framework}} · {{model}} · {{effort}}"
   }
 }

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -554,6 +554,108 @@ describe('message attribution persistence', () => {
   })
 })
 
+describe('message agent target persistence', () => {
+  const agentTarget = {
+    frameworkId: 'claude-code',
+    backendId: 'claude-anthropic',
+    providerId: 'provider-a',
+    model: 'model-a',
+    reasoningEffort: 'high'
+  }
+
+  const normalizeWithMessages = (messages: unknown[]): ReturnType<typeof normalizeSessionFile> =>
+    normalizeSessionFile({
+      ...createSessionWithActivity(undefined),
+      messages
+    })
+
+  it('preserves a valid send-target snapshot on a user Message', () => {
+    const session = normalizeWithMessages([
+      {
+        id: 'message-1',
+        role: 'user',
+        content: 'Run the analysis',
+        status: 'complete',
+        eventIds: [],
+        agentTarget,
+        createdAt: 2,
+        updatedAt: 2
+      }
+    ])
+
+    expect(session?.messages[0]?.agentTarget).toEqual(agentTarget)
+    expect(
+      session &&
+        materializeSessionConversationGraph(session).conversationGraph?.messages[0]?.agentTarget
+    ).toEqual(agentTarget)
+  })
+
+  it('omits optional backend and model fields when absent', () => {
+    const session = normalizeWithMessages([
+      {
+        id: 'message-1',
+        role: 'user',
+        content: 'Run the analysis',
+        status: 'complete',
+        eventIds: [],
+        agentTarget: {
+          frameworkId: 'opencode',
+          providerId: 'provider-a',
+          reasoningEffort: 'default'
+        },
+        createdAt: 2,
+        updatedAt: 2
+      }
+    ])
+
+    expect(session?.messages[0]?.agentTarget).toEqual({
+      frameworkId: 'opencode',
+      providerId: 'provider-a',
+      reasoningEffort: 'default'
+    })
+  })
+
+  it.each([
+    ['an unknown framework', { ...agentTarget, frameworkId: 'not-a-framework' }],
+    ['a missing provider', { ...agentTarget, providerId: '' }],
+    ['an unknown effort', { ...agentTarget, reasoningEffort: 'extreme' }],
+    ['a non-object value', 'claude-code']
+  ])('drops %s without dropping the Message', (_label, candidate) => {
+    const session = normalizeWithMessages([
+      {
+        id: 'message-1',
+        role: 'user',
+        content: 'Run the analysis',
+        status: 'complete',
+        eventIds: [],
+        agentTarget: candidate,
+        createdAt: 2,
+        updatedAt: 2
+      }
+    ])
+
+    expect(session?.messages[0]).toMatchObject({ id: 'message-1', role: 'user' })
+    expect(session?.messages[0]).not.toHaveProperty('agentTarget')
+  })
+
+  it('drops snapshots from agent Messages', () => {
+    const session = normalizeWithMessages([
+      {
+        id: 'message-1',
+        role: 'agent',
+        content: 'Done',
+        status: 'complete',
+        eventIds: [],
+        agentTarget,
+        createdAt: 2,
+        updatedAt: 2
+      }
+    ])
+
+    expect(session?.messages[0]).not.toHaveProperty('agentTarget')
+  })
+})
+
 describe('message part persistence', () => {
   it('preserves valid structured annotations on annotation-only user Messages', () => {
     const restored = normalizeSessionFile({

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -376,11 +376,23 @@ export const collectSessionReferences = (
   return references
 }
 
+// The resolved Agent target a user Message was sent with. Consecutive snapshots let the renderer
+// derive session config-change timeline markers without a synthetic activity. Absent on messages
+// persisted before the field existed; unknown values are discarded by the persistence sanitizer.
+export type PersistedMessageAgentTarget = {
+  frameworkId: AgentFrameworkId
+  backendId?: string
+  providerId: string
+  model?: string
+  reasoningEffort: ReasoningEffort
+}
+
 export type PersistedChatMessage = {
   id: string
   role: PersistedMessageRole
   content: string
   attribution?: MessageAttribution
+  agentTarget?: PersistedMessageAgentTarget
   status: PersistedMessageStatus
   streamId?: string
   responseToMessageId?: string
@@ -825,6 +837,31 @@ export const sanitizeMessageAttribution = (value: unknown): MessageAttribution |
     feature: value.feature,
     purpose: value.purpose,
     causeReviewId: value.causeReviewId
+  }
+}
+
+// Keeps only fully-valid send-target snapshots; a partial or unknown target would mark false
+// config changes, so the whole field drops instead of degrading to a torn snapshot.
+const sanitizeMessageAgentTarget = (value: unknown): PersistedMessageAgentTarget | undefined => {
+  if (!isRecord(value)) return undefined
+  const frameworkId = asString(value.frameworkId)
+  const providerId = asString(value.providerId)
+  if (
+    !frameworkId ||
+    !AGENT_FRAMEWORK_IDS.has(frameworkId as AgentFrameworkId) ||
+    !providerId ||
+    !isReasoningEffort(value.reasoningEffort)
+  ) {
+    return undefined
+  }
+  const backendId = asString(value.backendId)
+  const model = asString(value.model)
+  return {
+    frameworkId: frameworkId as AgentFrameworkId,
+    ...(backendId ? { backendId } : {}),
+    providerId,
+    ...(model ? { model } : {}),
+    reasoningEffort: value.reasoningEffort
   }
 }
 
@@ -3295,6 +3332,10 @@ const sanitizeMessage = (
     sanitized.structuredOutputEvidenceInvalid = true
   }
   if (role === 'user' && message.interrupted === true) sanitized.interrupted = true
+  if (role === 'user') {
+    const agentTarget = sanitizeMessageAgentTarget(message.agentTarget)
+    if (agentTarget) sanitized.agentTarget = agentTarget
+  }
   if (role === 'agent' && sanitized.status === 'complete') {
     sanitized.completedAt = completedAt ?? sanitized.updatedAt
   }


### PR DESCRIPTION
## Problem

Changing the ACP framework (global Settings), the session model, or the model reasoning effort leaves no trace in the conversation. When a later answer reads differently, there is no in-transcript evidence that the agent configuration changed between turns. The context-compaction divider already establishes a timeline-marker pattern, but nothing equivalent exists for configuration changes.

## Proposed change

When an existing Session's next send runs with a different resolved framework/backend, model, or reasoning effort than the previous turn, the transcript shows a quiet divider directly above the new user Message, labeled with the now-current `framework · model · effort` (icon + hairlines, same visual family as the compaction divider; muted tokens only).

Mechanism, per turn:

- `appendUserMessage` stamps the **resolved** send target (`frameworkId`, `backendId?`, `providerId`, `model?`, `reasoningEffort`) onto the user Message as an optional persisted `agentTarget` field. Existing-session sends use the post-resume/adoption framework and backend from `prepared.appendOwnership`, so the label reflects what the turn actually runs with.
- `createConversationItems` derives divider items at render time by comparing consecutive stamped user Messages in timeline order. The divider is never persisted and never synthesizes a tool activity, so branch scoping, activity groups, and the provenance panel are unaffected (the new item type is skipped there).
- Rules: the first stamped turn sets the baseline with no divider; messages without a snapshot (legacy turns, relayed side-chat messages) neither emit a divider nor move the baseline; comparison is against the previous **applied** target, so picker churn without a send (or A→B→A) shows nothing.
- Copy is i18n'd across all seven locales; the effort label reuses the Composer model picker's resolution chain so both surfaces always agree.

## Scope and non-goals

- Renderer + shared persistence only. No new ACP event kinds, no IPC or contract-catalog changes, no Prisma/schema changes, no migrations, no new enums.
- Framework-agnostic by construction: every send path (`claude-code`, `opencode`, `codex-response`, `codex-bridge`) flows through the same `sendWorkspaceMessage`/`appendUserMessage`, and the divider derives from persisted messages; no protocol-facing behavior changes, so no per-framework contract fixtures were added.
- No historical backfill: turns sent before this change carry no snapshot and produce no retroactive dividers (runtime segments lack reasoning effort, so backfill would be partial and could mis-mark).
- Not included: showing *which* fields changed (the label always shows the full current triple); banners or composer-side notices.

### Historical data compatibility

- Pre-upgrade turns get no dividers; the baseline starts at the first send after upgrade. No migration.
- Downgrade note: an older build's message sanitizer drops the unknown `agentTarget` field when re-persisting a Session file, so dividers for those turns disappear after a downgrade re-save. Cosmetic only — no crash, no schema break.
- Branch-in-new-session: copied messages keep their snapshots, so a branch's first send shows a divider when its configuration differs from the copied history (intended).

### New state / persisted data

- New optional persisted field `PersistedChatMessage.agentTarget` (additive; sanitizer-gated — partial or unknown targets are dropped whole so torn snapshots cannot mark false changes). Stored in the per-Session JSON (`messages` and `conversationGraph.messages`).
- New renderer-internal timeline item type `'session-config-change'` (derived, not persisted).
- No `schemaVersion` bump; graph schema untouched (`PersistedMessageNode` inherits the field structurally).

## Acceptance criteria and validation

Acceptance: model-only change → divider; effort-only change → divider; framework/backend change → divider; unchanged target → none; first turn → none; legacy predecessor → none; edit/resend with changed config → divider above the resent message; branch first send with different config → divider.

Evidence (all checks ran after the last material edit):

| Behavior | Command | Result |
| --- | --- | --- |
| Sanitizer round-trip + invalid-shape drops | `npx vitest run src/shared/session-persistence.test.ts` | pass (included in 1103 targeted tests) |
| Snapshot stamping + persistence | `npx vitest run src/renderer/src/stores/session-store.test.ts` | pass |
| Divider derivation rules (11 cases) | `npx vitest run src/renderer/src/pages/workspace/workspace-conversation-items.test.ts` | pass |
| Row rendering (label, fallbacks, aria) | `npx vitest run src/renderer/src/pages/workspace/WorkspaceSessionConfigChangeRow.render.test.tsx` | pass |
| i18n guard suite | `npx vitest run src/renderer/src/i18n/resources.test.ts` | 743 pass |
| Module suites | `npm run test:module -- session_renderer` / `session_persistence` / `workspace_page` / `i18n_catalog` | 521 / 360 / 577 / 743 pass |
| Module suite | `npm run test:module -- workspace_runtime` | 352 pass; 2 pre-existing 15s filesystem-scan timeouts in `useWorkspaceAgentRuntime.architecture.test.ts`, reproduced identically on clean `main` |
| Typecheck | `npm run typecheck:web` / `npm run typecheck:node` | clean |
| Lint | `npm run lint` | clean |

Excluded and why: no full local `npm test` (per-module suites + exact-head PR CI as authority); no Electron-launch verification (renderer-only change reachable via the Web capability profile).

Uncovered risks: no scripted visual/screenshot pass of the divider in a live conversation (covered by render tests); the `workspace_runtime` architecture-gate line-count bump (723→756, same mechanism as #1815) is assertion-covered but the two flaky filesystem-scan tests should be watched in CI.

## Review focus

- Snapshot records the *resolved* framework/backend (post-adoption), not merely the picker input (`resolveSendAgentTarget` in `workspace-runtime-command-owner.ts`).
- Derivation baseline semantics: unstamped messages neither emit nor move the baseline (`createSessionConfigChangeItems` in `workspace-conversation-items.ts`).
- Divider ordering: same `createdAt` as the owning Message, `sortIndex − 0.5` under the shared transcript sort.
- Sanitizer drops torn/unknown targets whole rather than degrading (`sanitizeMessageAgentTarget` in `session-persistence.ts`).

---

## Follow-up (commit a8c60eab): icons + send-time flash fix

Live review feedback, addressed in a second commit:

- The divider now renders the ACP framework and model provider brand marks inline (reusing `AgentFrameworkIcon` / `ProviderKindIcon`) instead of the generic badge.
- **Flash root cause (reproduced empirically with a Playwright probe against `dev:headless`):** on the send frame, the newly mounted 40px divider rendered as the scroller's 10rem `contain-intrinsic-size` placeholder for one frame; scroll anchoring acted on the inflated height, then snapped back — the visible flash. Fixed by passing the existing `disableContainment` prop on the divider's `MessageScrollerItem`; post-fix the divider mounts at its true height and scroll position never moves. (User-message/thinking rows still use the placeholder on mount — pre-existing generic scroller behavior, unchanged; fixing it would mean touching shared scroll machinery.)
- **Echo-replacement robustness:** `appendRoutedUserMessage` replacing a provisional `local-user-message-*` with a provider echo dropped the stamped `agentTarget` (divider would vanish after appearing) and `turnIntent`; both are now preserved from the local message. Store test added.

Validation for the follow-up (after last material edit): row render + session-store + conversation-items vitest **405 pass**; i18n guard 743 pass (no catalog changes); `typecheck:web`/`typecheck:node` clean; modules `session_renderer` 522 / `session_persistence` 360 / `workspace_page` 578 / `workspace_runtime` 354 pass; `npm run lint` clean.

## Known CI blocker (pre-existing on main, not from this PR)

`Full Module tests (macOS, shard 2/2)` fails on `WorkspaceMessageItem.actions.test.tsx > creates a text annotation only after the two-step confirmation` ("Annotate entry not found"). Reproduced identically on clean `origin/main` (4d9dc402) — the regression arrived with #1815 and affects other open PRs' gates as well. This PR's diff does not touch annotation actions. Local full shard 2/2 on this branch: 10119 passed, 1 failed (only that pre-existing test).
