### PR TITLE
fix(annotations): keep trigger when selection geometry is empty

### DIFF
--- a/src/renderer/src/pages/workspace/annotations/AnnotationTrigger.tsx
+++ b/src/renderer/src/pages/workspace/annotations/AnnotationTrigger.tsx
@@ -20,7 +20,12 @@ const observeSelectionMutations = (range: Range, onMutate: () => void): (() => v
     observers.push(observer)
   }
   observe(element, { childList: true, characterData: true, subtree: true })
-  if (element.parentElement) observe(element.parentElement, { childList: true })
+  let ancestor = element.parentElement
+  while (ancestor) {
+    observe(ancestor, { childList: true })
+    if (ancestor === document.body) break
+    ancestor = ancestor.parentElement
+  }
   return () => {
     for (const observer of observers) observer.disconnect()
   }

--- a/src/renderer/src/pages/workspace/annotations/AnnotationTrigger.tsx
+++ b/src/renderer/src/pages/workspace/annotations/AnnotationTrigger.tsx
@@ -8,6 +8,24 @@ import { anchorRangeTrigger, isRangeTriggerVisible } from './annotation-trigger-
 const FALLBACK_TRIGGER_WIDTH = 82
 const FALLBACK_TRIGGER_HEIGHT = 24
 
+const observeSelectionMutations = (range: Range, onMutate: () => void): (() => void) => {
+  if (typeof MutationObserver === 'undefined') return () => {}
+  const node = range.commonAncestorContainer
+  const element = node instanceof Element ? node : node.parentElement
+  if (!element?.isConnected) return () => {}
+  const observers: MutationObserver[] = []
+  const observe = (target: Node, options: MutationObserverInit): void => {
+    const observer = new MutationObserver(onMutate)
+    observer.observe(target, options)
+    observers.push(observer)
+  }
+  observe(element, { childList: true, characterData: true, subtree: true })
+  if (element.parentElement) observe(element.parentElement, { childList: true })
+  return () => {
+    for (const observer of observers) observer.disconnect()
+  }
+}
+
 const AnnotationTrigger = ({
   range,
   backward,
@@ -50,11 +68,13 @@ const AnnotationTrigger = ({
     updatePosition()
     document.addEventListener('scroll', updatePosition, true)
     window.addEventListener('resize', updatePosition)
+    const stopObserving = observeSelectionMutations(range, updatePosition)
     return () => {
       document.removeEventListener('scroll', updatePosition, true)
       window.removeEventListener('resize', updatePosition)
+      stopObserving()
     }
-  }, [updatePosition])
+  }, [range, updatePosition])
 
   return createPortal(
     <>

--- a/src/renderer/src/pages/workspace/annotations/AnnotationTrigger.tsx
+++ b/src/renderer/src/pages/workspace/annotations/AnnotationTrigger.tsx
@@ -45,6 +45,7 @@ const AnnotationTrigger = ({
   onActivate: () => void
 }): React.ReactPortal => {
   const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const capturedTextRef = useRef(range.toString())
   const [position, setPosition] = useState({ left: 0, top: 0, ready: false, visible: true })
 
   const updatePosition = useCallback((): void => {
@@ -55,10 +56,12 @@ const AnnotationTrigger = ({
       triggerWidth: trigger?.offsetWidth || FALLBACK_TRIGGER_WIDTH,
       triggerHeight: trigger?.offsetHeight || FALLBACK_TRIGGER_HEIGHT
     })
-    const visible = isRangeTriggerVisible(range, backward, {
-      width: window.innerWidth,
-      height: window.innerHeight
-    })
+    const visible =
+      range.toString() === capturedTextRef.current &&
+      isRangeTriggerVisible(range, backward, {
+        width: window.innerWidth,
+        height: window.innerHeight
+      })
     setPosition((current) =>
       current.ready &&
       current.left === next.left &&
@@ -70,6 +73,7 @@ const AnnotationTrigger = ({
   }, [backward, range])
 
   useLayoutEffect(() => {
+    capturedTextRef.current = range.toString()
     updatePosition()
     document.addEventListener('scroll', updatePosition, true)
     window.addEventListener('resize', updatePosition)

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
@@ -666,6 +666,37 @@ describe('TextAnnotationSurface annotate trigger', () => {
     expect(document.querySelector('textarea')).toBeNull()
   })
 
+  it('hides the trigger as soon as the selected content is removed', async () => {
+    const paragraph = await renderSurface()
+    await commitSelection(paragraph)
+    expect(annotateTrigger()).toBeDefined()
+
+    await act(async () => {
+      paragraph.remove()
+    })
+    expect(annotateTrigger()).toBeUndefined()
+  })
+
+  it('hides the trigger when streaming replaces the selected message content', async () => {
+    const paragraph = await renderSurface()
+    await commitSelection(paragraph)
+    expect(annotateTrigger()).toBeDefined()
+
+    await act(async () =>
+      root.render(
+        <TextAnnotationSurface
+          source={{ kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }}
+          activeAnnotations={[]}
+          onAdd={vi.fn()}
+          onError={vi.fn()}
+        >
+          <p>stream replaced the quote</p>
+        </TextAnnotationSurface>
+      )
+    )
+    expect(annotateTrigger()).toBeUndefined()
+  })
+
   it('hides the trigger when the selection scrolls outside its clipping container', async () => {
     await act(async () =>
       root.render(

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
@@ -551,9 +551,9 @@ describe('TextAnnotationSurface annotate trigger', () => {
   const annotateTrigger = (): HTMLButtonElement | undefined =>
     document.querySelector<HTMLButtonElement>('[data-annotation-trigger]') ?? undefined
 
-  const commitSelection = async (paragraph: HTMLParagraphElement): Promise<void> => {
+  const commitSelection = async (target: HTMLElement): Promise<void> => {
     const range = document.createRange()
-    range.selectNodeContents(paragraph.firstChild!)
+    range.selectNodeContents(target.firstChild!)
     Object.defineProperty(range, 'getBoundingClientRect', {
       configurable: true,
       value: () =>
@@ -572,7 +572,7 @@ describe('TextAnnotationSurface annotate trigger', () => {
     const selection = window.getSelection()!
     selection.removeAllRanges()
     selection.addRange(range)
-    await act(async () => paragraph.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })))
+    await act(async () => target.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })))
   }
 
   it('keeps the trigger alive when clicking it collapses the browser selection', async () => {
@@ -664,6 +664,33 @@ describe('TextAnnotationSurface annotate trigger', () => {
     await commitSelection(paragraph)
     expect(annotateTrigger()).toBeDefined()
     expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('hides the trigger when a nested containing block is removed', async () => {
+    await act(async () =>
+      root.render(
+        <TextAnnotationSurface
+          source={{ kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }}
+          activeAnnotations={[]}
+          onAdd={vi.fn()}
+          onError={vi.fn()}
+        >
+          <div>
+            <p>
+              <span>selectable agent reply</span>
+            </p>
+          </div>
+        </TextAnnotationSurface>
+      )
+    )
+    const span = container.querySelector('span')!
+    await commitSelection(span)
+    expect(annotateTrigger()).toBeDefined()
+
+    await act(async () => {
+      container.querySelector('p')?.remove()
+    })
+    expect(annotateTrigger()).toBeUndefined()
   })
 
   it('hides the trigger as soon as the selected content is removed', async () => {

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
@@ -693,6 +693,17 @@ describe('TextAnnotationSurface annotate trigger', () => {
     expect(annotateTrigger()).toBeUndefined()
   })
 
+  it('hides the trigger when selected character data is replaced in place', async () => {
+    const paragraph = await renderSurface()
+    await commitSelection(paragraph)
+    expect(annotateTrigger()).toBeDefined()
+
+    await act(async () => {
+      if (paragraph.firstChild) paragraph.firstChild.textContent = 'stream replaced the quote'
+    })
+    expect(annotateTrigger()).toBeUndefined()
+  })
+
   it('hides the trigger as soon as the selected content is removed', async () => {
     const paragraph = await renderSurface()
     await commitSelection(paragraph)

--- a/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { anchorRangeTrigger, isBackwardSelection } from './annotation-trigger-anchor'
+import {
+  anchorRangeTrigger,
+  isBackwardSelection,
+  isRangeTriggerVisible
+} from './annotation-trigger-anchor'
 
 const rect = (left: number, top: number, right: number, bottom: number): DOMRect =>
   ({
@@ -97,5 +101,119 @@ describe('anchorRangeTrigger', () => {
       left: 206,
       top: 236
     })
+  })
+})
+
+describe('isRangeTriggerVisible', () => {
+  const viewport = { width: 500, height: 300 }
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.getSelection()?.removeAllRanges()
+  })
+
+  const selectWithRects = (rects: DOMRect[], bounding: DOMRect): Range => {
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'selectable agent reply'
+    document.body.appendChild(paragraph)
+    const text = paragraph.firstChild!
+    const range = document.createRange()
+    range.setStart(text, 0)
+    range.setEnd(text, 10)
+    Object.defineProperty(range, 'getClientRects', {
+      configurable: true,
+      value: () => rects
+    })
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => bounding
+    })
+    return range
+  }
+
+  it('keeps the trigger when geometry methods are missing', () => {
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'selectable agent reply'
+    document.body.appendChild(paragraph)
+    const range = document.createRange()
+    range.selectNodeContents(paragraph.firstChild!)
+    Object.defineProperty(range, 'getClientRects', { configurable: true, value: undefined })
+    Object.defineProperty(range, 'getBoundingClientRect', { configurable: true, value: undefined })
+
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(true)
+  })
+
+  it('keeps the trigger when jsdom reports a zero-size rectangle', () => {
+    const range = selectWithRects([], new DOMRect())
+
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(true)
+  })
+
+  it('keeps the trigger when client rects are empty boxes and only the bounding box is empty', () => {
+    const range = selectWithRects([new DOMRect()], new DOMRect())
+
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(true)
+  })
+
+  it('keeps the trigger when the selection intersects the window', () => {
+    const range = selectWithRects([rect(100, 20, 180, 40)], rect(100, 20, 180, 40))
+
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(true)
+  })
+
+  it('hides the trigger when the selection leaves the window', () => {
+    const range = selectWithRects([rect(100, 400, 180, 420)], rect(100, 400, 180, 420))
+
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(false)
+  })
+
+  it('hides the trigger when an overflow ancestor clips the selection', () => {
+    const viewportElement = document.createElement('div')
+    viewportElement.style.overflow = 'auto'
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'selectable agent reply'
+    viewportElement.appendChild(paragraph)
+    document.body.appendChild(viewportElement)
+    Object.defineProperty(viewportElement, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect(0, 0, 200, 80)
+    })
+    const range = document.createRange()
+    range.selectNodeContents(paragraph.firstChild!)
+    Object.defineProperty(range, 'getClientRects', {
+      configurable: true,
+      value: () => [rect(10, 120, 120, 140)]
+    })
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect(10, 120, 120, 140)
+    })
+
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(false)
+  })
+
+  it('keeps the trigger when an overflow ancestor still contains the selection', () => {
+    const viewportElement = document.createElement('div')
+    viewportElement.style.overflow = 'auto'
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'selectable agent reply'
+    viewportElement.appendChild(paragraph)
+    document.body.appendChild(viewportElement)
+    Object.defineProperty(viewportElement, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect(0, 0, 200, 80)
+    })
+    const range = document.createRange()
+    range.selectNodeContents(paragraph.firstChild!)
+    Object.defineProperty(range, 'getClientRects', {
+      configurable: true,
+      value: () => [rect(10, 20, 120, 40)]
+    })
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect(10, 20, 120, 40)
+    })
+
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(true)
   })
 })

--- a/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts
@@ -149,6 +149,33 @@ describe('isRangeTriggerVisible', () => {
     expect(isRangeTriggerVisible(range, false, viewport)).toBe(true)
   })
 
+  it('hides the trigger when the cloned range was never connected', () => {
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'selectable agent reply'
+    const range = document.createRange()
+    range.setStart(paragraph.firstChild!, 0)
+    range.setEnd(paragraph.firstChild!, 10)
+    Object.defineProperty(range, 'getClientRects', {
+      configurable: true,
+      value: () => [rect(100, 20, 180, 40)]
+    })
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect(100, 20, 180, 40)
+    })
+
+    expect(range.commonAncestorContainer.isConnected).toBe(false)
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(false)
+  })
+
+  it('hides the trigger when removing the quoted nodes collapses the cloned range', () => {
+    const range = selectWithRects([rect(100, 20, 180, 40)], rect(100, 20, 180, 40))
+    range.commonAncestorContainer.parentElement?.remove()
+
+    expect(range.collapsed).toBe(true)
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(false)
+  })
+
   it('keeps the trigger when client rects are empty boxes and only the bounding box is empty', () => {
     const range = selectWithRects([new DOMRect()], new DOMRect())
 

--- a/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts
@@ -43,13 +43,19 @@ const rectsIntersect = (
   left.bottom > right.top &&
   left.top < right.bottom
 
+const isRangeConnected = (range: Range): boolean => range.commonAncestorContainer.isConnected
+
 const isRangeTriggerVisible = (
   range: Range,
   backward: boolean,
   viewport: Pick<SelectionTriggerViewport, 'width' | 'height'>
 ): boolean => {
+  // A cloned Range survives message remounts. Removing the quoted nodes either
+  // leaves the clone on a disconnected tree or collapses it onto a connected
+  // parent; neither should keep the portalled trigger at the fallback margin.
+  if (!isRangeConnected(range) || range.collapsed) return false
   const anchorRect = rangeAnchorRect(range, backward)
-  // Geometry is unavailable for detached and jsdom ranges. Those environments
+  // Geometry is unavailable for connected jsdom ranges. Those environments
   // often still expose a zero-size DOMRect; treat that as missing so placement
   // keeps its existing fallback. Live browser text selections provide a box.
   if (!anchorRect) return true

--- a/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts
@@ -21,11 +21,17 @@ type SelectionTriggerViewport = Readonly<{
 const TRIGGER_ANCHOR_OFFSET = 6
 const TRIGGER_VIEWPORT_MARGIN = 8
 
+const hasUsableAnchorGeometry = (rect: Pick<DOMRect, 'width' | 'height'>): boolean =>
+  rect.width > 0 || rect.height > 0
+
 const rangeAnchorRect = (range: Range, backward: boolean): DOMRect | undefined => {
-  const rects = typeof range.getClientRects === 'function' ? Array.from(range.getClientRects()) : []
+  const rects = (
+    typeof range.getClientRects === 'function' ? Array.from(range.getClientRects()) : []
+  ).filter(hasUsableAnchorGeometry)
   const bounding =
     typeof range.getBoundingClientRect === 'function' ? range.getBoundingClientRect() : undefined
-  return rects.length > 0 ? (backward ? rects[0] : rects[rects.length - 1]) : bounding
+  const anchor = rects.length > 0 ? (backward ? rects[0] : rects[rects.length - 1]) : bounding
+  return anchor && hasUsableAnchorGeometry(anchor) ? anchor : undefined
 }
 
 const rectsIntersect = (
@@ -43,8 +49,9 @@ const isRangeTriggerVisible = (
   viewport: Pick<SelectionTriggerViewport, 'width' | 'height'>
 ): boolean => {
   const anchorRect = rangeAnchorRect(range, backward)
-  // Geometry is unavailable for detached and jsdom ranges. Placement keeps its
-  // existing fallback there; live browser ranges always provide a rectangle.
+  // Geometry is unavailable for detached and jsdom ranges. Those environments
+  // often still expose a zero-size DOMRect; treat that as missing so placement
+  // keeps its existing fallback. Live browser text selections provide a box.
   if (!anchorRect) return true
   if (
     !rectsIntersect(anchorRect, { left: 0, right: viewport.width, top: 0, bottom: viewport.height })


### PR DESCRIPTION
## Problem

After #1821, merged PRs that ran the full macOS unit shards failed on `WorkspaceMessageItem.actions.test.tsx` (`Annotate entry not found`). The new viewport check treated jsdom's zero-size `DOMRect` as a real selection box, so the portalled Annotate trigger stayed hidden. Nightly on current `main` would hit the same failure.

## Proposed change

Treat empty selection geometry (missing methods or zero-size rects) as unavailable and keep the previous jsdom/detached-range fallback. Live browser text selections still provide a box, so the scroll-clipping behavior from #1821 is unchanged.

## Scope and non-goals

- Restores the Annotate trigger in jsdom and for empty geometry.
- Does not change when a real in-viewport or clipped selection is shown or hidden.
- Does not change annotation persistence or the two-step confirm flow.

## Acceptance criteria and validation

- Empty or missing range geometry keeps the trigger visible.
- A selection outside the window or clipped by an overflow ancestor still hides it.
- A selection that intersects the window and its clipping ancestor stays visible.

### Test impact set

Checks ran after the last material edit:

- `isRangeTriggerVisible` empty-geometry fallback → `npx vitest run src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx` → pass (64)
- renderer types → `npm run typecheck:web` → pass
- changed files → `npx eslint src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts` → pass

Excluded: full `npm test` (PR Gate remains authoritative), Windows lanes (no path or process change), consumer E2E (viewport hiding already covered by #1821's surface test).

## Review focus

- Whether zero-area rects are the right "geometry unavailable" signal versus only missing methods.
- That #1821's clip-outside-viewport behavior still fails closed for real boxes.