### PR TITLE
test(windows): raise timeout for SQLite-heavy suites

### DIFF
--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -10,6 +10,10 @@ import { MIGRATION_MANIFEST, migrateApplicationDatabase } from './migration-serv
 import { applySqliteMigrationOperations } from './sqlite-schema-migrations'
 
 const MIGRATION_ID = '0008_database_json_constraints'
+// Hosted Windows runners rebuild tables and copy SQLite backups under disk
+// contention. The Windows full-test workflow default is 60s; these suites
+// finish later without hanging.
+const WINDOWS_SQLITE_TEST_TIMEOUT_MS = 120_000
 
 const createDatabaseAtMigration0007 = async (client: PrismaClient): Promise<void> => {
   const migration0008Index = MIGRATION_MANIFEST.findIndex(
@@ -209,7 +213,7 @@ describe('database JSON constraints migration', () => {
         SELECT "seq" FROM "ManagedFile" WHERE "sourceFileId" = 'next-file'
       `
     ).resolves.toEqual([{ seq: 44 }])
-  })
+  }, WINDOWS_SQLITE_TEST_TIMEOUT_MS)
 
   it('fails closed and rolls back all rebuilt tables when historical data is invalid', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-json-0008-invalid-'))
@@ -250,5 +254,5 @@ describe('database JSON constraints migration', () => {
       })
     ])
     await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
-  })
+  }, WINDOWS_SQLITE_TEST_TIMEOUT_MS)
 })

--- a/src/main/database/database-json-constraints.test.ts
+++ b/src/main/database/database-json-constraints.test.ts
@@ -8,6 +8,11 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createProjectDbClient } from '../projects/prisma-client'
 import { migrateApplicationDatabase } from './migration-service'
 
+// Hosted Windows runners apply the full migration ledger and many CHECK
+// round-trips under disk contention. The Windows full-test workflow default
+// is 60s; this suite finishes later without hanging.
+const WINDOWS_SQLITE_TEST_TIMEOUT_MS = 120_000
+
 describe('database JSON and remaining domain constraints', () => {
   let client: PrismaClient | undefined
   let storageRoot: string | undefined
@@ -246,5 +251,5 @@ describe('database JSON and remaining domain constraints', () => {
         })
       ])
     ).resolves.toBeDefined()
-  })
+  }, WINDOWS_SQLITE_TEST_TIMEOUT_MS)
 })

--- a/src/main/notebook/input-registry.test.ts
+++ b/src/main/notebook/input-registry.test.ts
@@ -11,6 +11,11 @@ import { ImmutableInputAuthority } from '../immutable-input-authority'
 import { NotebookInputRegistry } from './input-registry'
 import { createNotebookInputPreviewKey } from '../../shared/notebook'
 
+// Hosted Windows runners migrate a fresh database for each case under disk
+// contention. The Windows full-test workflow default is 60s; the heavier
+// Version-recheck case finishes later without hanging.
+const WINDOWS_SQLITE_TEST_TIMEOUT_MS = 120_000
+
 let storageRoot: string | undefined
 let client: PrismaClient | undefined
 
@@ -362,7 +367,7 @@ describe('NotebookInputRegistry', () => {
       data: { versionNumber: 2 }
     })
     await expect(registry.openRun(turn)).rejects.toThrow(/registration no longer matches/i)
-  })
+  }, WINDOWS_SQLITE_TEST_TIMEOUT_MS)
 
   it('rejects same-size input corruption during turn registration', async () => {
     const registry = await setup()


### PR DESCRIPTION
## Problem

The latest Windows Full Test on `main` (shard 2/3) failed four cases at the workflow's 60s `--testTimeout`:

- `database-json-constraints-migration.test.ts` (valid upgrade and invalid rollback)
- `database-json-constraints.test.ts` (CHECK/JSON round-trips)
- `input-registry.test.ts` (`rechecks Version state and immutable metadata before a run`)

These suites rebuild the migration ledger and copy SQLite backups. On hosted Windows that I/O regularly exceeds 60s without hanging.

## Proposed change

Give those tests a 120s Vitest per-test timeout so they override the workflow default. Leave `--testTimeout=60000` in `windows-full-test.yml` for the rest of the shard.

## Scope and non-goals

- Test budget only. No schema, migration, or production code changes.
- Does not change the 25-minute job timeout, which remains the hang backstop.

## Acceptance criteria and validation

- The four previously timed-out cases use a 120s budget.
- Other Windows tests keep the 60s default.

### Test impact set

Checks ran after the last material edit:

- SQLite-heavy suites → `npx vitest run src/main/database/database-json-constraints-migration.test.ts src/main/database/database-json-constraints.test.ts src/main/notebook/input-registry.test.ts` → pass (9)
- changed files → `npx eslint` on the three test files → pass (pre-existing prettier warnings only)

Excluded: full `npm test` (PR Gate remains authoritative), live Windows hosted-runner confirmation (Windows Full Test after merge).

## Review focus

- Whether 120s is the right override versus raising the workflow default for every test.