### PR TITLE
fix(context-window): disclose incomplete call history

### DIFF
--- a/src/renderer/src/pages/workspace/ContextWindowDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ContextWindowDialog.render.test.tsx
@@ -317,6 +317,105 @@ describe('ContextWindowDialog', () => {
     return withCalls
   }
 
+  const sessionWithCallsAfterRuntimeSwitch = (): ChatSession => {
+    const switched = session()
+    switched.messages.push(
+      {
+        id: 'answer-claude',
+        role: 'agent',
+        responseToMessageId: 'prompt-1',
+        content: 'Claude result',
+        eventIds: [],
+        status: 'complete',
+        turnUsage: { inputTokens: 30, cacheTokens: 6, outputTokens: 8, turnCount: 2 },
+        createdAt: 2,
+        updatedAt: 3,
+        completedAt: 3
+      },
+      {
+        id: 'prompt-2',
+        role: 'user',
+        content: 'Continue with Codex',
+        eventIds: [],
+        status: 'complete',
+        createdAt: 4,
+        updatedAt: 4
+      },
+      {
+        id: 'answer-codex',
+        role: 'agent',
+        responseToMessageId: 'prompt-2',
+        content: 'Codex result',
+        eventIds: [],
+        status: 'complete',
+        turnUsage: { inputTokens: 20, cacheTokens: 4, outputTokens: 5, turnCount: 1 },
+        modelCallUsage: [
+          {
+            id: 'answer-codex:model-call:0',
+            index: 0,
+            inputTokens: 20,
+            cacheTokens: 4,
+            outputTokens: 5,
+            contextUsedTokens: 24,
+            contextWindowSize: 25
+          }
+        ],
+        createdAt: 5,
+        updatedAt: 6,
+        completedAt: 6
+      }
+    )
+    switched.conversationGraph?.messages.push(
+      {
+        id: 'answer-claude',
+        role: 'agent',
+        responseToMessageId: 'prompt-1',
+        content: 'Claude result',
+        eventIds: [],
+        status: 'complete',
+        agentFrameId: 'root',
+        introducedOnBranchId: 'branch-1',
+        revisionRootMessageId: 'answer-claude',
+        runtimeSegmentId: 'runtime-1',
+        createdAt: 2,
+        updatedAt: 3
+      },
+      {
+        id: 'prompt-2',
+        role: 'user',
+        content: 'Continue with Codex',
+        eventIds: [],
+        status: 'complete',
+        agentFrameId: 'root',
+        introducedOnBranchId: 'branch-1',
+        revisionRootMessageId: 'prompt-2',
+        runtimeSegmentId: 'runtime-2',
+        createdAt: 4,
+        updatedAt: 4
+      },
+      {
+        id: 'answer-codex',
+        role: 'agent',
+        responseToMessageId: 'prompt-2',
+        content: 'Codex result',
+        eventIds: [],
+        status: 'complete',
+        agentFrameId: 'root',
+        introducedOnBranchId: 'branch-1',
+        revisionRootMessageId: 'answer-codex',
+        runtimeSegmentId: 'runtime-2',
+        createdAt: 5,
+        updatedAt: 6
+      }
+    )
+    const branch = switched.conversationGraph?.branches[0]
+    if (branch) {
+      branch.headMessageId = 'answer-codex'
+      branch.updatedAt = 6
+    }
+    return switched
+  }
+
   const switchToCalls = (): void => {
     const callsToggle = [
       ...document.body.querySelectorAll<HTMLButtonElement>('[role="radio"]')
@@ -383,6 +482,27 @@ describe('ContextWindowDialog', () => {
     expect(mix?.textContent).toContain('Input20 69%')
     expect(mix?.textContent).toContain('Cache4 14%')
     expect(mix?.textContent).toContain('Output5 17%')
+  })
+
+  it('discloses earlier calls without exact details after switching ACP or model', () => {
+    act(() => {
+      root.render(
+        <ContextWindowDialog
+          open
+          session={sessionWithCallsAfterRuntimeSwitch()}
+          onOpenChange={vi.fn()}
+        />
+      )
+    })
+    switchToCalls()
+
+    expect(document.body.querySelectorAll('[data-slot="context-call-point"]')).toHaveLength(1)
+    expect(document.body.querySelector('[data-slot="context-call-band"]')?.textContent).toContain(
+      'T2'
+    )
+    expect(document.body.textContent).toContain(
+      'Showing 1 of 3 reported calls because some turns have no exact call details.'
+    )
   })
 
   it('previews on hover and pins a selected call on activation', () => {

--- a/src/renderer/src/pages/workspace/ContextWindowDialog.tsx
+++ b/src/renderer/src/pages/workspace/ContextWindowDialog.tsx
@@ -1165,6 +1165,17 @@ const ContextWindowDialogData = ({
     [activities, conversationGraph, granularity, messages]
   )
   const callSummary = useMemo(() => summarizeContextWindowCallPoints(callPoints), [callPoints])
+  const reportedCallCount = useMemo(
+    () =>
+      granularity !== 'call' || messages === undefined
+        ? 0
+        : messages.reduce(
+            (total, message) =>
+              message.role === 'agent' ? total + (message.turnUsage?.turnCount ?? 0) : total,
+            0
+          ),
+    [granularity, messages]
+  )
 
   return (
     <div className="space-y-6">
@@ -1197,6 +1208,17 @@ const ContextWindowDialogData = ({
       ) : (
         <>
           <ContextCallSummary summary={callSummary} />
+          {reportedCallCount > callPoints.length ? (
+            <p
+              className="rounded-md border border-status-warning-foreground/30 bg-status-warning-surface/40 px-3 py-2 text-xs leading-5 text-status-warning-foreground dark:border-status-warning-dark-foreground/30 dark:bg-status-warning-dark-surface/20 dark:text-status-warning-dark-foreground"
+              data-slot="context-call-coverage-notice"
+            >
+              {t(
+                'Showing {{detailed}} of {{reported}} reported calls because some turns have no exact call details.',
+                { detailed: callPoints.length, reported: reportedCallCount }
+              )}
+            </p>
+          ) : null}
           {callPoints.length ? (
             <ContextCallHistory points={callPoints} />
           ) : (

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1991,6 +1991,7 @@
     "Show rendered HTML": "Mostrar HTML renderizado",
     "Show repositories": "Mostrar repositorios",
     "Showing data from {{time}}": "Mostrando datos de {{time}}",
+    "Showing {{detailed}} of {{reported}} reported calls because some turns have no exact call details.": "Se muestran {{detailed}} de {{reported}} llamadas notificadas porque algunos turnos no tienen detalles exactos de las llamadas.",
     "Showing first 5,000 entries. Navigate into a subdirectory to see more.": "Mostrando las primeras 5000 entradas. Navegue a un subdirectorio para ver más.",
     "Showing the first entries only — this directory is very large.": "Mostrando solo las primeras entradas; este directorio es muy grande.",
     "Showing {{rows}} rows · {{columns}} columns": "Mostrando {{rows}} filas · {{columns}} columnas",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1991,6 +1991,7 @@
     "Show rendered HTML": "Afficher le HTML rendu",
     "Show repositories": "Afficher les référentiels",
     "Showing data from {{time}}": "Affichage des données de {{time}}",
+    "Showing {{detailed}} of {{reported}} reported calls because some turns have no exact call details.": "{{detailed}} appels affichés sur {{reported}} signalés, car certains tours ne disposent pas de détails exacts sur les appels.",
     "Showing first 5,000 entries. Navigate into a subdirectory to see more.": "Affichage des 5 000 premières entrées. Accédez à un sous-répertoire pour en voir plus.",
     "Showing the first entries only — this directory is very large.": "Afficher uniquement les premières entrées — ce répertoire est très volumineux.",
     "Showing {{rows}} rows · {{columns}} columns": "Affichage des lignes {{rows}} · Colonnes {{columns}}",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1904,6 +1904,7 @@
     "Show rendered HTML": "レンダリングされた HTML を表示する",
     "Show repositories": "リポジトリを表示する",
     "Showing data from {{time}}": "{{time}} のデータを表示しています",
+    "Showing {{detailed}} of {{reported}} reported calls because some turns have no exact call details.": "報告された {{reported}} 件の呼び出しのうち {{detailed}} 件を表示しています。一部のターンには正確な呼び出し詳細がありません。",
     "Showing first 5,000 entries. Navigate into a subdirectory to see more.": "最初の 5,000 件のエントリを表示しています。詳細を表示するには、サブディレクトリに移動します。",
     "Showing the first entries only — this directory is very large.": "最初のエントリのみを表示します — このディレクトリは非常に大きいです。",
     "Showing {{rows}} rows · {{columns}} columns": "{{rows}} 行 · {{columns}} 列を表示しています",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1912,6 +1912,7 @@
     "Show rendered HTML": "렌더링된 HTML 표시",
     "Show repositories": "저장소 표시",
     "Showing data from {{time}}": "{{time}} 데이터를 표시하는 중",
+    "Showing {{detailed}} of {{reported}} reported calls because some turns have no exact call details.": "보고된 호출 {{reported}}개 중 {{detailed}}개를 표시합니다. 일부 턴에는 정확한 호출 세부 정보가 없습니다.",
     "Showing first 5,000 entries. Navigate into a subdirectory to see more.": "처음 5,000개의 항목을 표시합니다. 자세한 내용을 보려면 하위 디렉터리로 이동하세요.",
     "Showing the first entries only — this directory is very large.": "이 디렉터리는 매우 커서 처음 몇 개 항목만 표시합니다.",
     "Showing {{rows}} rows · {{columns}} columns": "{{rows}} 행 · {{columns}} 열 표시 중",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -2005,6 +2005,7 @@
     "Show rendered HTML": "Показать отрисованный HTML",
     "Show repositories": "Показать репозитории",
     "Showing data from {{time}}": "Данные на {{time}}",
+    "Showing {{detailed}} of {{reported}} reported calls because some turns have no exact call details.": "Показано {{detailed}} из {{reported}} зарегистрированных вызовов, поскольку для некоторых ходов нет точных сведений о вызовах.",
     "Showing first 5,000 entries. Navigate into a subdirectory to see more.": "Показаны первые 5 000 записей. Перейдите в подкаталог, чтобы увидеть больше.",
     "Showing the first entries only — this directory is very large.": "Показаны только первые записи — этот каталог очень большой.",
     "Showing {{rows}} rows · {{columns}} columns": "Показано {{rows}} строк · {{columns}} столбцов",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1975,6 +1975,7 @@
     "Show rendered HTML": "显示渲染后的 HTML",
     "Show repositories": "显示仓库",
     "Showing data from {{time}}": "显示的是 {{time}} 的数据",
+    "Showing {{detailed}} of {{reported}} reported calls because some turns have no exact call details.": "显示了 {{reported}} 次已报告调用中的 {{detailed}} 次，因为部分轮次没有精确的调用详情。",
     "Showing first 5,000 entries. Navigate into a subdirectory to see more.": "仅显示前 5,000 个条目。进入子目录可查看更多。",
     "Showing the first entries only — this directory is very large.": "仅显示前若干条目 — 该目录非常大。",
     "Showing {{rows}} rows · {{columns}} columns": "显示 {{rows}} 行 · {{columns}} 列",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1972,6 +1972,7 @@
     "Show rendered HTML": "顯示算繪後的 HTML",
     "Show repositories": "顯示儲存庫",
     "Showing data from {{time}}": "顯示的是 {{time}} 的資料",
+    "Showing {{detailed}} of {{reported}} reported calls because some turns have no exact call details.": "顯示了 {{reported}} 次已回報呼叫中的 {{detailed}} 次，因為部分輪次沒有精確的呼叫詳細資料。",
     "Showing first 5,000 entries. Navigate into a subdirectory to see more.": "僅顯示前 5,000 個項目。進入子目錄可查看更多。",
     "Showing the first entries only — this directory is very large.": "僅顯示前若干項目 — 該目錄非常大。",
     "Showing {{rows}} rows · {{columns}} columns": "顯示 {{rows}} 列 · {{columns}} 欄",


### PR DESCRIPTION
## Problem

After a user sends a prompt, switches ACP or model, and sends another prompt, the Context Window dialog can retain every aggregate Turn while the Calls view shows only the latest Turn. This happens when an earlier adapter reports a reliable aggregate model-call count but cannot provide trustworthy per-call details, while the later adapter does provide exact details. The current UI silently filters the earlier Turn out, which looks like switching runtimes overwrote call history.

## Proposed change

Derive reported call coverage from the existing Turn usage and compare it with the exact call points already selected for the Calls view. When exact details cover only part of the reported calls, show an inline localized notice with both counts.

The chart and token totals continue to include only trustworthy per-call records. The change does not synthesize missing calls.

## Scope and non-goals

- Renderer-only interaction change.
- No persisted field, database or JSON schema change, migration, new enum value, or state-model change.
- No historical backfill. Existing sessions with aggregate counts but no exact call details become transparently partial; unavailable historical details remain unavailable.
- No adapter behavior change and no attempt to infer per-call token breakdowns from aggregate Turn usage.

## Acceptance criteria and validation

- Cross-runtime session with 3 reported calls and 1 exact call shows the exact T2 call plus: "Showing 1 of 3 reported calls because some turns have no exact call details."
- Sessions whose exact call details cover all reported calls do not show the partial-coverage notice.

The regression test ran twice against the unfixed implementation and failed both times with the reported behavior: only one T2 call was rendered and no coverage explanation was present.

Final checks below ran after the last material edit and after rebasing onto the latest origin/main:

- Calls dialog behavior -> ContextWindowDialog.render.test.tsx -> 15 passed.
- Renderer translation contract -> resources.test.ts -> 743 passed.
- Renderer types -> TypeScript with tsconfig.web.json -> passed.
- Changed renderer sources -> ESLint on ContextWindowDialog.tsx and its render test -> passed.
- Changed files -> Prettier check and git diff --check -> passed.

The full npm test suite was not run locally; exact-head PR Gate and platform CI remain authoritative. No persistence, migration, adapter, or platform lane is required by this renderer-only change. The only uncovered behavior is provider-side availability of exact call details, which this change intentionally reports rather than reconstructs.

## Review focus

- Whether comparing aggregate Turn call counts with trusted per-call points is the correct boundary for partial coverage.
- Whether the notice makes the distinction between reported calls and available exact details clear without implying data recovery.
