### PR TITLE
fix(connectors): stop retrying request timeouts

### DIFF
--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -74,7 +74,7 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
-  it('retries a network/timeout error then succeeds', async () => {
+  it('retries an immediate network error then succeeds', async () => {
     const fetchImpl = vi
       .fn()
       .mockRejectedValueOnce(new Error('ECONNRESET'))
@@ -92,7 +92,7 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
-  it('reports the request and retry budget when every attempt times out', async () => {
+  it('stops after the first request timeout and distinguishes it from the REPL deadline', async () => {
     const fetchImpl = vi.fn(
       async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
         new Promise((_, reject) => {
@@ -119,9 +119,10 @@ describe('ParserEngine declarative path', () => {
 
     await expect(engine.call(desc, {}, {})).rejects.toMatchObject({
       name: 'ConnectorRequestTimeoutError',
-      message: 'Connector request timed out after 3 attempts of 5ms for https://x.test/data'
+      message:
+        "Connector request timed out after 1 attempt of 5ms for https://x.test/data. This is the Connector's own deadline; increasing an outer execution timeout will not extend it. Do not retry solely with a longer timeout."
     })
-    expect(fetchImpl).toHaveBeenCalledTimes(3)
+    expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
   it('resets the timeout while response body chunks keep arriving', async () => {
@@ -193,7 +194,7 @@ describe('ParserEngine declarative path', () => {
     await expect(engine.call(desc, {}, {})).rejects.toMatchObject({
       name: 'ConnectorRequestTimeoutError',
       message:
-        'Connector request exceeded the 25ms total deadline after 1 attempt for https://x.test/data'
+        "Connector request exceeded the 25ms total deadline after 1 attempt for https://x.test/data. This is the Connector's own deadline; increasing an outer execution timeout will not extend it. Do not retry solely with a longer timeout."
     })
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
@@ -265,7 +266,7 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
-  it('times out and retries when a response body stops producing chunks', async () => {
+  it('times out without retrying when a response body stops producing chunks', async () => {
     const encoder = new TextEncoder()
     const fetchImpl = vi.fn(
       async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
@@ -303,9 +304,10 @@ describe('ParserEngine declarative path', () => {
       ])
     ).resolves.toMatchObject({
       name: 'ConnectorRequestTimeoutError',
-      message: 'Connector request timed out after 3 attempts of 5ms for https://x.test/data'
+      message:
+        "Connector request timed out after 1 attempt of 5ms for https://x.test/data. This is the Connector's own deadline; increasing an outer execution timeout will not extend it. Do not retry solely with a longer timeout."
     })
-    expect(fetchImpl).toHaveBeenCalledTimes(3)
+    expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
   it('aborts an active request without retrying it', async () => {

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -6,8 +6,8 @@ const DEFAULT_TOTAL_TIMEOUT_MS = 120_000
 const DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024 * 1024
 
 // Transient-failure retry policy shared by every connector call. Public bio APIs (PubChem PUG-REST,
-// GTEx, NCBI) routinely return 429/5xx or a brief timeout under load; a couple of backed-off retries
-// turn those blips into successes instead of surfacing them to the notebook.
+// GTEx, NCBI) routinely return 429/5xx or a brief connection failure under load; a couple of
+// backed-off retries turn those blips into successes instead of surfacing them to the notebook.
 const DEFAULT_RETRIES = 2
 const DEFAULT_BACKOFF_MS = 400
 const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504])
@@ -42,9 +42,11 @@ class ConnectorRequestTimeoutError extends Error {
 
   constructor(url: string, timeoutMs: number, attempts: number, kind: 'idle' | 'total' = 'idle') {
     super(
-      kind === 'total'
-        ? `Connector request exceeded the ${timeoutMs}ms total deadline after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} for ${redactUrl(url)}`
-        : `Connector request timed out after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} of ${timeoutMs}ms for ${redactUrl(url)}`
+      `${
+        kind === 'total'
+          ? `Connector request exceeded the ${timeoutMs}ms total deadline after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} for ${redactUrl(url)}`
+          : `Connector request timed out after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} of ${timeoutMs}ms for ${redactUrl(url)}`
+      }. This is the Connector's own deadline; increasing an outer execution timeout will not extend it. Do not retry solely with a longer timeout.`
     )
   }
 }
@@ -193,11 +195,6 @@ export class ParserEngine {
         if (caught) {
           if (signal?.aborted) throw failure
           if (failure instanceof ConnectorResponseTooLargeError) throw failure
-          // Network failure or timeout abort — retry a bounded number of times, then give up.
-          if (attempt < this.retries) {
-            await abortableDelay(nextDelay(attempt, null), signal)
-            continue
-          }
           if (timedOut) {
             throw new ConnectorRequestTimeoutError(
               url,
@@ -205,6 +202,11 @@ export class ParserEngine {
               attempt + 1,
               timedOut
             )
+          }
+          // Immediate network failures may be transient, so retry them within the bounded budget.
+          if (attempt < this.retries) {
+            await abortableDelay(nextDelay(attempt, null), signal)
+            continue
           }
           throw failure
         }


### PR DESCRIPTION
## Problem

Electron's Chromium network stack can emit SSL/socket diagnostics while `net.fetch` remains pending. The Connector engine cannot observe that native diagnostic directly; it sees its own idle deadline when the request is aborted.

The timeout then entered the same retry branch as an immediate transport rejection. With the default policy, one stalled request became three 30-second attempts. The final error also did not explain that increasing an outer Notebook execution timeout cannot change the Connector-owned deadline, which encouraged Agents to retry with 60- or 90-second outer timeouts.

The reported GTEx endpoint currently returns HTTP 200 through both curl and Electron `net.fetch`, so the transient upstream TLS failure is no longer live-reproducible. A deterministic regression at the existing public `ParserEngine.call` boundary models the observed fetch behavior by remaining pending until the Connector's AbortSignal fires. Before the fix, that test failed consistently in 3/3 runs because the engine made three attempts instead of one and returned the retry-budget message.

## Proposed change

- Treat Connector-owned idle and total deadlines as terminal before evaluating the retry budget.
- Keep bounded retries for immediate transport rejections and transient HTTP 429/5xx responses.
- Explain in the timeout error that increasing an outer execution timeout does not extend the Connector deadline and should not be the sole retry strategy.

## Scope and non-goals

- Keep the existing 30-second idle deadline and response resource limits.
- Do not add Chromium `webRequest` correlation or replace the network transport. A native SSL diagnostic that does not settle `net.fetch` can therefore still take up to the first 30-second Connector deadline; this change removes the automatic multiplication to roughly 90 seconds.
- Do not change Connector descriptors, Notebook RPC, ACP adapters, or UI behavior.
- No new data fields, architecture boundary, data-model relationship, persisted format, state/enum value, migration, or historical-data compatibility behavior.
- `claude-code`, `opencode`, `codex-response`, and `codex-bridge` reach this behavior through the same Notebook `host.mcp` -> Connector engine path; no framework-specific wire behavior or subscription lifecycle changes.

## Acceptance criteria and validation

All final checks below ran after the last material edit.

- A Connector-owned idle timeout stops after the first attempt, while immediate network errors and transient HTTP statuses retain their retry behavior -> `/Users/eweno/projects/aipoch/open-science/node_modules/.bin/vitest run src/main/connectors` -> 56 files passed; 800 tests passed, 39 skipped.
- Timeout errors distinguish the Connector deadline from outer execution deadlines -> covered by `src/main/connectors/engine.test.ts` in the Connector module run.
- Main-process consumers remain type-safe -> `/Users/eweno/projects/aipoch/open-science/node_modules/.bin/tsc --noEmit -p tsconfig.node.json --composite false` -> passed.
- Changed files satisfy lint, formatting, and whitespace checks -> targeted ESLint, targeted Prettier check, and `git diff --check` -> passed.

Per the requested validation scope, the complete local `npm test` suite was not run. Exact-head PR CI remains authoritative for the repository-wide and platform lanes. The live transient Chromium TLS failure is the remaining locally uncovered risk; the deterministic regression covers the resulting pending-fetch behavior at the shared Connector boundary.

## Review focus

- Confirm Connector-owned idle/total deadlines are terminal without disabling retries for immediate network failures or retryable HTTP statuses.
- Confirm the error guidance discourages ineffective outer-timeout increases without forbidding a separately justified retry.
- Confirm the two-file change remains independent of persistence, framework adapters, and UI state.
