### PR TITLE
fix(connectors): abort connector polling delays

### DIFF
--- a/src/main/connectors/abortable-delay.ts
+++ b/src/main/connectors/abortable-delay.ts
@@ -1,0 +1,17 @@
+export const abortableDelay = (ms: number, signal?: AbortSignal): Promise<void> => {
+  signal?.throwIfAborted()
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms))
+
+  return new Promise((resolve, reject) => {
+    const finish = (): void => {
+      signal.removeEventListener('abort', abort)
+      resolve()
+    }
+    const abort = (): void => {
+      clearTimeout(timer)
+      reject(signal.reason)
+    }
+    const timer = setTimeout(finish, ms)
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}

--- a/src/main/connectors/descriptors/regulation.ts
+++ b/src/main/connectors/descriptors/regulation.ts
@@ -1,5 +1,6 @@
 import type { ToolContext, ToolDescriptor } from '../types'
 import { netFetchStandard } from '../../skills/net-fetch'
+import { abortableDelay } from '../abortable-delay'
 
 // Gene-regulation domain connector aggregating three public REST APIs, mirroring the upstream
 // mcp-regulation server: ENCODE portal (functional-genomics experiments/biosamples/files), JASPAR
@@ -45,23 +46,6 @@ const ENCODE_UA = 'OpenScience/1.0 (+https://github.com/aipoch/open-science)'
 const ENCODE_TIMEOUT_MS = 60_000
 const ENCODE_RETRIES = 3
 const ENCODE_RETRYABLE = new Set([429, 500, 502, 503, 504])
-const sleep = (ms: number, signal?: AbortSignal): Promise<void> => {
-  signal?.throwIfAborted()
-  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms))
-  return new Promise((resolve, reject) => {
-    const finish = (): void => {
-      signal.removeEventListener('abort', abort)
-      resolve()
-    }
-    const abort = (): void => {
-      clearTimeout(timer)
-      reject(signal.reason)
-    }
-    const timer = setTimeout(finish, ms)
-    signal.addEventListener('abort', abort, { once: true })
-  })
-}
-
 async function encodeFetchJson(url: string, signal?: AbortSignal): Promise<unknown> {
   for (let attempt = 0; ; attempt++) {
     signal?.throwIfAborted()
@@ -77,7 +61,7 @@ async function encodeFetchJson(url: string, signal?: AbortSignal): Promise<unkno
     } catch (err) {
       if (signal?.aborted) throw err
       if (attempt < ENCODE_RETRIES) {
-        await sleep(Math.min(400 * 2 ** attempt, 4000), signal)
+        await abortableDelay(Math.min(400 * 2 ** attempt, 4000), signal)
         continue
       }
       throw err
@@ -89,7 +73,7 @@ async function encodeFetchJson(url: string, signal?: AbortSignal): Promise<unkno
       return res.json()
     }
     if (attempt < ENCODE_RETRIES && ENCODE_RETRYABLE.has(res.status)) {
-      await sleep(Math.min(400 * 2 ** attempt, 4000), signal)
+      await abortableDelay(Math.min(400 * 2 ** attempt, 4000), signal)
       continue
     }
     throw new Error(`HTTP ${res.status} for ${url}`)

--- a/src/main/connectors/descriptors/rna.test.ts
+++ b/src/main/connectors/descriptors/rna.test.ts
@@ -366,6 +366,42 @@ describe('rna / rfam', () => {
     })
   })
 
+  it('aborts the polling delay without starting another request', async () => {
+    vi.useFakeTimers()
+    const cancellation = new AbortController()
+    const fetchJson = vi.fn().mockResolvedValue({})
+    const pending = tool('search_sequence').run!(
+      {
+        credentials: {},
+        signal: cancellation.signal,
+        fetchJson,
+        fetchText: async () => {
+          throw new Error('unused')
+        },
+        fetchJsonWithHeaders: async () => {
+          throw new Error('unused')
+        },
+        postJson: async () => ({ resultURL: 'https://rfam.test/result/1', jobId: 'job-1' })
+      },
+      { sequence: 'GGUUCC', poll_interval_s: 60, max_wait_s: 120 }
+    )
+    let settled = false
+    void pending.catch(() => {
+      settled = true
+    })
+
+    try {
+      await vi.waitFor(() => expect(fetchJson).toHaveBeenCalledOnce())
+      cancellation.abort()
+
+      await vi.waitFor(() => expect(settled).toBe(true))
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+      expect(fetchJson).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('search_sequence surfaces a submit-side error as-is (backend down)', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 500, headers: new Headers() })
     await expect(

--- a/src/main/connectors/descriptors/rna.ts
+++ b/src/main/connectors/descriptors/rna.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import type { ToolContext, ToolDescriptor } from '../types'
+import { abortableDelay } from '../abortable-delay'
 
 // Rfam REST API (https://rfam.org): read-only RNA family data. Mirrors the 9 upstream
 // tooluniverse/rfam methods — family metadata, seed alignment (Stockholm/FASTA), covariance
@@ -211,8 +212,6 @@ function capTextPayload(
   }
   return result
 }
-
-const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 type SearchSubmission = { resultURL?: string; jobId?: string; opened?: string }
 type SearchResult = { hits?: Record<string, unknown[]>; searchSequence?: string }
@@ -480,7 +479,7 @@ export const RNA_TOOLS: ToolDescriptor[] = [
           break
         }
         if (Date.now() >= deadline) break
-        await delay(pollIntervalS * 1000)
+        await abortableDelay(pollIntervalS * 1000, ctx.signal)
       }
       if (!res || res.hits == null) {
         throw new Error(`Rfam sequence search not finished after ${maxWaitS}s (${resultUrl})`)

--- a/src/main/connectors/descriptors/zinc.ts
+++ b/src/main/connectors/descriptors/zinc.ts
@@ -1,5 +1,6 @@
 import type { ToolDescriptor } from '../types'
 import { netFetchStandard } from '../../skills/net-fetch'
+import { abortableDelay } from '../abortable-delay'
 
 // CartBlanche22 (ZINC22 purchasable-compound search) — every search endpoint is ASYNC and
 // POST-only (form-encoded): submit returns a task receipt {"task": "<uuid>"}, and the result is
@@ -181,23 +182,6 @@ function bodyExcerpt(text: string, n = 200): string {
   return excerpt || '<empty body>'
 }
 
-const sleep = (ms: number, signal?: AbortSignal): Promise<void> => {
-  signal?.throwIfAborted()
-  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms))
-  return new Promise((resolve, reject) => {
-    const finish = (): void => {
-      signal.removeEventListener('abort', abort)
-      resolve()
-    }
-    const abort = (): void => {
-      clearTimeout(timer)
-      reject(signal.reason)
-    }
-    const timer = setTimeout(finish, ms)
-    signal.addEventListener('abort', abort, { once: true })
-  })
-}
-
 async function fetchWithTimeout(
   url: string,
   init: RequestInit,
@@ -317,7 +301,7 @@ async function poll(task: string, deadline: number, signal?: AbortSignal): Promi
       )
     }
     const wait = Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now()))
-    await sleep(wait, signal)
+    await abortableDelay(wait, signal)
   }
 }
 

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -1,4 +1,5 @@
 import type { ConnectorCredentials, ToolContext, ToolDescriptor } from './types'
+import { abortableDelay } from './abortable-delay'
 
 const DEFAULT_TIMEOUT_MS = 30_000
 const DEFAULT_TOTAL_TIMEOUT_MS = 120_000
@@ -10,24 +11,6 @@ const DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024 * 1024
 const DEFAULT_RETRIES = 2
 const DEFAULT_BACKOFF_MS = 400
 const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504])
-
-const sleep = (ms: number, signal?: AbortSignal): Promise<void> => {
-  signal?.throwIfAborted()
-  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms))
-
-  return new Promise((resolve, reject) => {
-    const finish = (): void => {
-      signal.removeEventListener('abort', abort)
-      resolve()
-    }
-    const abort = (): void => {
-      clearTimeout(timer)
-      reject(signal.reason)
-    }
-    const timer = setTimeout(finish, ms)
-    signal.addEventListener('abort', abort, { once: true })
-  })
-}
 
 // Some public APIs (e.g. AlphaFold EBI) reject requests without a User-Agent; send a stable one.
 const USER_AGENT =
@@ -212,7 +195,7 @@ export class ParserEngine {
           if (failure instanceof ConnectorResponseTooLargeError) throw failure
           // Network failure or timeout abort — retry a bounded number of times, then give up.
           if (attempt < this.retries) {
-            await sleep(nextDelay(attempt, null), signal)
+            await abortableDelay(nextDelay(attempt, null), signal)
             continue
           }
           if (timedOut) {
@@ -232,7 +215,10 @@ export class ParserEngine {
         }
         // Retry only transient upstream statuses; client errors (4xx except 429) fail fast.
         if (attempt < this.retries && RETRYABLE_STATUS.has(res.status)) {
-          await sleep(nextDelay(attempt, res.headers?.get?.('retry-after') ?? null), signal)
+          await abortableDelay(
+            nextDelay(attempt, res.headers?.get?.('retry-after') ?? null),
+            signal
+          )
           continue
         }
         throw new Error(`HTTP ${res.status} for ${redactUrl(url)}`)


### PR DESCRIPTION
## Problem

RNA sequence search polls an asynchronous Rfam job with a plain timer. If the caller cancels while that timer is pending, the Connector call does not settle until the full poll interval expires. The default delay is 5 seconds and callers may configure a longer interval.

The other retrying Connector paths already use abort-aware delays, but their implementation was copied into the parser engine, ENCODE, and ZINC adapters. That duplication allowed RNA to omit cancellation handling.

If left unchanged, cancellation can appear to hang, retain the pending Connector operation longer than necessary, and delay cleanup. It does not corrupt or persist data.

## Proposed change

- Add one internal abort-aware delay helper using the existing timer and AbortSignal behavior.
- Use it for parser-engine retry backoff, ENCODE retry backoff, ZINC polling, and RNA sequence-search polling.
- Add a regression test at the RNA tool descriptor's public run boundary: cancel during the first polling delay, require immediate AbortError settlement, and verify that no second request starts.

## Scope and non-goals

- Keep provider-specific retry counts, timeout budgets, User-Agent values, retryable status codes, and error messages in their current adapters.
- Do not add a global or general-purpose network layer.
- Do not change Connector APIs, renderer interaction, data models, data relationships, or architecture outside this internal helper extraction.
- Historical compatibility: none required.
- New states or enum values: none.
- Persistence impact: none.
- New data fields: none.

## Acceptance criteria and validation

The regression command was first run against the unfixed delay and failed consistently because the cancelled Promise remained unsettled:

    npm test -- src/main/connectors/descriptors/rna.test.ts -t 'aborts the polling delay without starting another request'

Final evidence after the last material edit:

- RNA polling cancellation -> the command above -> passed (1/1).
- Shared engine, RNA, ENCODE, and ZINC delay behavior -> npm test -- src/main/connectors/engine.test.ts src/main/connectors/descriptors/rna.test.ts src/main/connectors/descriptors/regulation.test.ts src/main/connectors/descriptors/zinc.test.ts -> passed (83/83).
- Main-process type safety -> npm run typecheck:node -> passed.
- Changed-file lint and formatting -> ESLint plus Prettier check on all six changed files -> passed.
- Repository lint -> npm run lint -> passed with 0 errors; 361 pre-existing Prettier warnings remain in unrelated database/notebook tests.

The complete npm test suite was not run locally per maintainer direction. Exact-head PR CI remains the final authority.

Consumer and platform scope: no public interface changed, so no renderer or adapter consumer lane is required locally. The changed behavior uses platform-neutral AbortSignal and timer APIs; existing engine/adapter tests cover active-request cancellation, retry cancellation, fake-timer deadlines, and the new RNA polling case. Cross-platform CI remains uncovered locally.

## Review focus

- Confirm RNA passes the existing ToolContext signal into the shared delay.
- Confirm the extraction preserves existing engine, ENCODE, and ZINC retry semantics.
- Confirm the change remains limited to cancellation and does not normalize provider-specific HTTP policy.
