### PR TITLE
fix(notebook): arbitrate queued execution races

### DIFF
--- a/src/main/notebook/data-execution-admission.ts
+++ b/src/main/notebook/data-execution-admission.ts
@@ -62,6 +62,48 @@ const repairRequiredError = (language: NotebookLanguage): Error =>
       'integrity check. Run the runtime Repair workflow before executing another cell.'
   )
 
+const bindingChangedError = (language: NotebookLanguage): Error =>
+  new Error(
+    `RUNTIME_BINDING_CHANGED: the bound ${language} runtime changed while this cell was queued. ` +
+      'Retry the cell so it is admitted against the current runtime.'
+  )
+
+const bindingUnavailableError = (
+  language: NotebookLanguage,
+  binding: NotebookSessionRuntimeBinding
+): Error =>
+  new Error(
+    `RUNTIME_BINDING_UNAVAILABLE: the bound ${language} runtime is ${binding.status}` +
+      (binding.reason ? ` (${binding.reason})` : '') +
+      '. Call list_notebook_runtimes then notebook_switch_runtime to choose another runtime ' +
+      '(an unspecified choice falls back to the app-managed default). Any prior kernel memory ' +
+      '(variables, imports) for this language was lost.'
+  )
+
+const equalStringArrays = (left: string[] | undefined, right: string[] | undefined): boolean =>
+  left === right ||
+  (left !== undefined &&
+    right !== undefined &&
+    left.length === right.length &&
+    left.every((value, index) => value === right[index]))
+
+const sameRuntimeTarget = (
+  admitted: NotebookSessionRuntimeBinding | undefined,
+  current: NotebookSessionRuntimeBinding | undefined
+): boolean => {
+  if (admitted === undefined || current === undefined) return admitted === current
+  return (
+    admitted.language === current.language &&
+    admitted.runtimeId === current.runtimeId &&
+    admitted.source === current.source &&
+    admitted.interpreterPath === current.interpreterPath &&
+    admitted.envName === current.envName &&
+    admitted.resolvedInterpreter?.command === current.resolvedInterpreter?.command &&
+    equalStringArrays(admitted.resolvedInterpreter?.args, current.resolvedInterpreter?.args) &&
+    admitted.resolvedInterpreter?.condaPrefix === current.resolvedInterpreter?.condaPrefix
+  )
+}
+
 /** Owns data-cell routing plus every fail-closed gate before the executor may be dispatched. */
 class NotebookDataExecutionAdmissionOwner {
   constructor(private readonly options: NotebookDataExecutionAdmissionOwnerOptions) {}
@@ -106,13 +148,7 @@ class NotebookDataExecutionAdmissionOwner {
     } else if (repairRequired) {
       rejection = repairRequiredError(cell.language)
     } else if (binding && (binding.status ?? 'active') !== 'active') {
-      rejection = new Error(
-        `RUNTIME_BINDING_UNAVAILABLE: the bound ${cell.language} runtime is ${binding.status}` +
-          (binding.reason ? ` (${binding.reason})` : '') +
-          '. Call list_notebook_runtimes then notebook_switch_runtime to choose another runtime ' +
-          '(an unspecified choice falls back to the app-managed default). Any prior kernel memory ' +
-          '(variables, imports) for this language was lost.'
-      )
+      rejection = bindingUnavailableError(cell.language, binding)
     } else if (binding?.resolvedInterpreter) {
       resolvedInterpreter = binding.resolvedInterpreter
     } else {
@@ -146,6 +182,7 @@ class NotebookDataExecutionAdmissionOwner {
   }
 
   runShared<Result>(
+    session: NotebookSessionAggregate,
     admission: NotebookDataExecutionAdmission,
     operation: (rejection: unknown | undefined) => Promise<Result>
   ): Promise<Result> {
@@ -153,25 +190,36 @@ class NotebookDataExecutionAdmissionOwner {
       'execution',
       admission.route.environment,
       () => {
+        const currentRoute = this.route(session, admission.language)
+        const currentBinding = session.runtimeBinding(admission.language)
+        if (
+          currentRoute.environment !== admission.route.environment ||
+          currentRoute.processKey !== admission.route.processKey ||
+          !sameRuntimeTarget(admission.binding, currentBinding)
+        ) {
+          return operation(bindingChangedError(admission.language))
+        }
         const repair = this.options.repairPolicy.requirement(
           admission.language,
           admission.route.environment,
-          admission.binding
+          currentBinding
         )
         const postLockRepairRequired =
           this.options.environmentOperations.isRepairBlocked(
             this.options.repairPolicy.blockKey(
               admission.language,
               admission.route.environment,
-              admission.binding
+              currentBinding
             )
           ) || repair.required
+        if (postLockRepairRequired) return operation(repairRequiredError(admission.language))
+        if (currentBinding && (currentBinding.status ?? 'active') !== 'active') {
+          return operation(bindingUnavailableError(admission.language, currentBinding))
+        }
         return operation(
-          postLockRepairRequired
-            ? repairRequiredError(admission.language)
-            : admission.rejection instanceof NotebookRuntimeRepairRequiredError
-              ? undefined
-              : admission.rejection
+          admission.rejection instanceof NotebookRuntimeRepairRequiredError
+            ? undefined
+            : admission.rejection
         )
       }
     )

--- a/src/main/notebook/data-execution-admission.ts
+++ b/src/main/notebook/data-execution-admission.ts
@@ -54,8 +54,10 @@ const defaultEnvironment = (language: NotebookLanguage): string =>
 const processKey = (language: NotebookLanguage, environment: string): string =>
   `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
 
+class NotebookRuntimeRepairRequiredError extends Error {}
+
 const repairRequiredError = (language: NotebookLanguage): Error =>
-  new Error(
+  new NotebookRuntimeRepairRequiredError(
     `RUNTIME_REPAIR_REQUIRED: the bound ${language} runtime failed a protected-package ` +
       'integrity check. Run the runtime Repair workflow before executing another cell.'
   )
@@ -165,7 +167,11 @@ class NotebookDataExecutionAdmissionOwner {
             )
           ) || repair.required
         return operation(
-          postLockRepairRequired ? repairRequiredError(admission.language) : admission.rejection
+          postLockRepairRequired
+            ? repairRequiredError(admission.language)
+            : admission.rejection instanceof NotebookRuntimeRepairRequiredError
+              ? undefined
+              : admission.rejection
         )
       }
     )

--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -27,7 +27,7 @@ import {
   createNotebookEnvironmentLifecycle,
   type NotebookEnvironmentLifecycle
 } from './environment-lifecycle-workflows'
-import type { ProvisionProgress, RuntimeProvisioner } from './provisioner'
+import type { ProvisionProgress, RuntimeProvisioner, RuntimeRepairOptions } from './provisioner'
 
 afterEach(() => clearMigrationPending())
 
@@ -38,7 +38,9 @@ const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisi
   provisionPython: vi.fn().mockResolvedValue(undefined),
   provisionR: vi.fn().mockResolvedValue(undefined),
   upgradeIfNeeded: vi.fn().mockResolvedValue(undefined),
-  repair: vi.fn().mockResolvedValue(undefined),
+  repair: vi.fn().mockImplementation(async (_language, _onProgress, options) => {
+    await options?.onVerified?.()
+  }),
   restoreRelocatedEnvs: vi.fn().mockResolvedValue(undefined),
   cancel: vi.fn(),
   ...over
@@ -143,7 +145,10 @@ describe('createNotebookEnvironmentLifecycle', () => {
     const lifecycle = createLifecycle(provisioner)
     await lifecycle.repair('r')
     // UI repair is the user's Reset: it force-clears the quarantine (force: true).
-    expect(provisioner.repair).toHaveBeenCalledWith('r', expect.any(Function), { force: true })
+    expect(provisioner.repair).toHaveBeenCalledWith('r', expect.any(Function), {
+      force: true,
+      onVerified: expect.any(Function)
+    })
   })
 
   it('publishes a successful verified repair back to the runtime service', async () => {
@@ -155,6 +160,26 @@ describe('createNotebookEnvironmentLifecycle', () => {
 
     expect(onRepairCompleted).toHaveBeenCalledOnce()
     expect(onRepairCompleted).toHaveBeenCalledWith('r')
+  })
+
+  it('publishes repair completion before the provisioner releases the environment lock', async () => {
+    const order: string[] = []
+    const provisioner = fakeProvisioner({
+      repair: vi.fn(async (_language, _onProgress, options?: RuntimeRepairOptions) => {
+        order.push('lock:enter')
+        await options?.onVerified?.()
+        order.push('lock:exit')
+      })
+    })
+    const lifecycle = createLifecycle(provisioner, {
+      onRepairCompleted: async () => {
+        order.push('repair:completed')
+      }
+    })
+
+    await lifecycle.repair('python')
+
+    expect(order).toEqual(['lock:enter', 'repair:completed', 'lock:exit'])
   })
 
   it('does not release runtime-service quarantine when the rebuild fails', async () => {
@@ -333,7 +358,10 @@ describe('createNotebookEnvironmentLifecycle', () => {
 
     // Repair (the Reset entry) proceeds — it's the recovery, so it force-clears rather than refusing.
     await lifecycle.repair('python')
-    expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function), { force: true })
+    expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function), {
+      force: true,
+      onVerified: expect.any(Function)
+    })
 
     // A non-blocked language still provisions.
     await lifecycle.provision('r')

--- a/src/main/notebook/environment-lifecycle-workflows.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.ts
@@ -128,8 +128,10 @@ const createNotebookEnvironmentLifecycle = (
       (report) =>
         withDataRootWrite(async () => {
           if (deps.waitForRecovery) await deps.waitForRecovery()
-          await provisioner.repair(parsedLanguage, report, { force: true })
-          await deps.onRepairCompleted?.(parsedLanguage)
+          await provisioner.repair(parsedLanguage, report, {
+            force: true,
+            onVerified: () => deps.onRepairCompleted?.(parsedLanguage)
+          })
         }),
       (progress) =>
         deps.projectProgress({

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -233,7 +233,7 @@ class NotebookExecutionOwner {
       session,
       runningRun,
       invoke: () =>
-        this.options.dataExecutionAdmission.runShared(admission, async (rejection) => {
+        this.options.dataExecutionAdmission.runShared(session, admission, async (rejection) => {
           if (rejection !== undefined) {
             executedOnLiveKernel = false
             return errorToExecutionResult(rejection, cwdBefore)

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -135,6 +135,67 @@ describe('TimeoutController', () => {
   })
 })
 
+describe('NotebookKernelExecutor request arbitration', () => {
+  it('does not arm the timeout after cancellation wins during synchronous dispatch', async () => {
+    vi.useFakeTimers()
+    try {
+      const cancellation = new AbortController()
+      const kill = vi.fn((signal: NodeJS.Signals) => {
+        void signal
+        return true
+      })
+      const proc = {
+        kind: 'python',
+        env: DEFAULT_PY_ENV,
+        key: `python:${DEFAULT_PY_ENV}`,
+        alive: true,
+        interpreterIdentity: '',
+        child: {
+          kill,
+          stdin: {
+            write: () => {
+              cancellation.abort()
+              return true
+            }
+          }
+        }
+      } as unknown as RequestArbitrationProc
+      const internals = executorRequestInternals(new NotebookKernelExecutor({ platform: 'linux' }))
+      const request = internals.sendRequest(
+        proc,
+        'request-1',
+        {
+          code: 'slow()',
+          cwd: '/workspace',
+          notebookSessionRoot: '/workspace/notebook',
+          dataRoot: '/workspace/notebook/data',
+          runtimeRoot: '/runtime',
+          timeoutMs: 10,
+          signal: cancellation.signal
+        },
+        () => undefined
+      )
+
+      vi.advanceTimersByTime(10)
+      internals.settlePendingResponse(proc, proc.pending, {
+        reqId: 'request-1',
+        stdout: '',
+        stderr: '',
+        error: null,
+        errorLine: null,
+        result: null,
+        cwd: '/workspace',
+        figures: []
+      })
+
+      await expect(request).resolves.toMatchObject({ cancelled: true, timedOut: false })
+      expect(kill.mock.calls.filter(([signal]) => signal === 'SIGINT')).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
 // -- Driver against a fake python loop, gated on a resolvable system python3. ------------------------
 
 const FIXTURE = join(__dirname, '../../../test/fixtures/fake_loop.py')
@@ -189,6 +250,33 @@ type ProcStateLike = {
   env: string
   pending?: { timeout?: TimeoutController }
 }
+type RequestArbitrationProc = {
+  pending?: unknown
+}
+type RequestArbitrationInternals = {
+  sendRequest: (
+    proc: RequestArbitrationProc,
+    reqId: string,
+    request: NotebookExecutionRequest,
+    onDispatch: () => void
+  ) => Promise<{ cancelled: boolean; timedOut: boolean }>
+  settlePendingResponse: (
+    proc: RequestArbitrationProc,
+    pending: unknown,
+    response: {
+      reqId: string
+      stdout: string
+      stderr: string
+      error: string | null
+      errorLine: number | null
+      result: string | null
+      cwd: string
+      figures: []
+    }
+  ) => void
+}
+const executorRequestInternals = (executor: NotebookKernelExecutor): RequestArbitrationInternals =>
+  executor as unknown as RequestArbitrationInternals
 // Composite process key: 'repl' for the control kernel, `${kind}:${env}` for data kernels. `env`
 // defaults to the language's default env so existing single-env call sites need no change.
 const procKeyFor = (kind: 'python' | 'r' | 'repl', env?: string): string =>

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -865,7 +865,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
         reject(error)
         return
       }
-      if (timeout && timeoutMs !== undefined) timeout.arm(timeoutMs)
+      if (timeout && timeoutMs !== undefined && !pending.cancelled) timeout.arm(timeoutMs)
     })
   }
 

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -2168,12 +2168,16 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
       }
     })
 
-    await new DefaultRuntimeProvisioner(deps).repair('python', () => {})
+    await new DefaultRuntimeProvisioner(deps).repair('python', () => {}, {
+      onVerified: () => {
+        order.push('repair:completed')
+      }
+    })
 
     // The lock is taken for the default-python env, the rebuild (runArgv) runs while held, and the lock
-    // is only released after — one contiguous critical section.
+    // and repair completion is published before that one contiguous critical section releases.
     expect(order[0]).toBe(`lock:${DEFAULT_PY_ENV}`)
-    expect(order[order.length - 1]).toBe('unlock')
+    expect(order.slice(-2)).toEqual(['repair:completed', 'unlock'])
     expect(runArgv).toHaveBeenCalled()
   })
 

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -2714,6 +2714,19 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     expect(existsSync(bin)).toBe(true)
   })
 
+  it('does not carry a cancel during repair finalization into the next operation', async () => {
+    const root = makeRoot()
+    const provisioner = serializeProvisioner(new DefaultRuntimeProvisioner(makeDeps(root)))
+
+    await provisioner.repair('python', () => {}, {
+      onVerified: () => {
+        provisioner.cancel('python')
+      }
+    })
+
+    await expect(provisioner.provisionPython(() => {})).resolves.toBeUndefined()
+  })
+
   it('a per-language cancel is dropped while idle (does not arm a future queued Reset)', () => {
     // cancel(lang) while nothing is running/queued must be a pure no-op at this layer (no crash, no
     // lingering arm) — env-ipc.serializeProvisioner is the layer that enforces "no-op when idle" for the

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -98,6 +98,12 @@ export type FetchedBundle = {
   packageSourceDir?: string
 }
 
+export type RuntimeRepairOptions = {
+  force?: boolean
+  // Runs only after the rebuilt interpreter verifies, while the per-environment lock is still held.
+  onVerified?: () => Promise<void> | void
+}
+
 // One default environment specification (A-internal). `version` is the curated interpreter version
 // (e.g. "3.12" / "4.4") — it identifies the staged offline pack via packId(language, version) (see
 // bundle-manifest.ts / stage-default-envs.mjs), so the local bundle adapter looks up the matching
@@ -305,7 +311,7 @@ export interface RuntimeProvisioner {
   repair(
     lang: NotebookLanguage,
     onProgress: (p: ProvisionProgress) => void,
-    opts?: { force?: boolean }
+    opts?: RuntimeRepairOptions
   ): Promise<void>
   // Aborts an in-flight (or skips a queued) provision. Per-language: cancelling one language never
   // aborts another's run. `undefined` aborts whatever is in flight. No-op when idle.
@@ -953,7 +959,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   async repair(
     lang: NotebookLanguage,
     rawProgress: (p: ProvisionProgress) => void,
-    opts?: { force?: boolean }
+    opts?: RuntimeRepairOptions
   ): Promise<void> {
     const onProgress = withLanguage(rawProgress, lang)
     const spec = lang === 'r' ? DEFAULT_R_SPEC : DEFAULT_PYTHON_SPEC
@@ -962,10 +968,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // rebuild), so a package install into this env can't slip in between the rm and the rebuild and
     // write into a half-deleted prefix. The rebuild calls the LOCK-FREE do* variants (not the public
     // provision*), which would otherwise re-acquire this same exclusive lock and deadlock.
-    return this.withEnvPrefixLock(spec.name, () =>
+    return this.withEnvPrefixLock(spec.name, async () => {
       // runLanguage consumes a QUEUED cancel (beginLanguageRun throws) BEFORE the rm below, so
       // cancelling a queued Reset never leaves a deleted-but-not-rebuilt env.
-      this.runLanguage(lang, async () => {
+      await this.runLanguage(lang, async () => {
         // Mark this repair UNINTERRUPTIBLE before any destructive step: once we clear the quarantine
         // and rm the prefix there is no safe stopping point — a per-language Cancel arriving mid-repair
         // would abort the rebuild and leave a missing/half-built env with the block already cleared.
@@ -997,7 +1003,8 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           this.uninterruptible.delete(lang)
         }
       })
-    )
+      await opts?.onVerified?.()
+    })
   }
 
   // Rebuilds envs captured by a data-root relocation (runtime-relocation.exportRuntimeLocks) offline

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -999,11 +999,11 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
             rmSync(rReadyMarkerPath(this.deps.root), { force: true })
             await this.doProvisionR(onProgress)
           }
+          await opts?.onVerified?.()
         } finally {
           this.uninterruptible.delete(lang)
         }
       })
-      await opts?.onVerified?.()
     })
   }
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4884,6 +4884,68 @@ describe('notebook runtime service', () => {
       expect(events).toEqual(['install:start', 'install:end', 'run:run'])
     })
 
+    it('rechecks a stale repair rejection after a queued run acquires the repaired environment', async () => {
+      const root = await createStorageRoot()
+      const firstStarted = createDeferred<void>()
+      const releaseFirst = createDeferred<void>()
+      const executions: string[] = []
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository: new NotebookRunRepository(root),
+        executorFactory: () => ({
+          execute: async (request): Promise<NotebookExecutionResult> => {
+            executions.push(request.code)
+            if (request.code === 'hold_environment()') {
+              firstStarted.resolve()
+              await releaseFirst.promise
+            }
+            return {
+              status: 'completed',
+              stdout: '',
+              stderr: '',
+              traceback: '',
+              cwdAfter: request.cwd,
+              outputs: []
+            }
+          },
+          shutdown: async () => ({ reaped: true })
+        })
+      })
+
+      const first = service.execute({
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        code: 'hold_environment()'
+      })
+      await firstStarted.promise
+
+      addRepairRequired(getRuntimeRoot(root), DEFAULT_PY_ENV, 'protected-identity-change')
+      const repair = service.withEnvLock(DEFAULT_PY_ENV, async () => {
+        await service.completeRuntimeRepair('python')
+      })
+      const queued = service.execute({
+        sessionId: 'session-2',
+        workspaceCwd: root,
+        code: 'run_after_repair()'
+      })
+      await vi.waitFor(async () => {
+        const state = await service.state({ sessionId: 'session-2', workspaceCwd: root })
+        expect(state.cells[0]?.status).toBe('running')
+      })
+      expect(executions).toEqual(['hold_environment()'])
+
+      releaseFirst.resolve()
+      await repair
+      expect(isRepairRequired(getRuntimeRoot(root), DEFAULT_PY_ENV)).toBe(false)
+      const queuedResult = await queued
+      expect(queuedResult.text.traceback).not.toContain('RUNTIME_REPAIR_REQUIRED')
+      expect(queuedResult).toMatchObject({ status: 'completed' })
+      expect(executions).toEqual(['hold_environment()', 'run_after_repair()'])
+      await first
+    })
+
     it('does not block a different-language run behind an install (G2)', async () => {
       const root = await createStorageRoot()
       const events: string[] = []

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4946,6 +4946,96 @@ describe('notebook runtime service', () => {
       await first
     })
 
+    it('does not clear a stale repair rejection after the queued Session changes runtime binding', async () => {
+      const root = await createStorageRoot()
+      const firstStarted = createDeferred<void>()
+      const releaseFirst = createDeferred<void>()
+      const executions: NotebookExecutionRequest[] = []
+      const externalRuntime: DiscoveredInterpreter = {
+        language: 'python',
+        provenance: 'user-own',
+        envId: '/opt/external-python/bin/python',
+        interpreterPath: '/opt/external-python/bin/python',
+        label: 'External Python',
+        version: '3.13.2',
+        runnable: true
+      }
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository: new NotebookRunRepository(root),
+        discoverRuntimes: async (language) => (language === 'python' ? [externalRuntime] : []),
+        notebookRuntimeSettings: {
+          getSnapshot: async (language) => ({
+            language,
+            runtimeEnablement: {
+              enabled: { [externalRuntime.envId]: true },
+              installAuthorized: {}
+            },
+            manualInterpreters: [],
+            packageMirror: {}
+          })
+        },
+        executorFactory: () => ({
+          execute: async (request): Promise<NotebookExecutionResult> => {
+            executions.push(request)
+            if (request.code === 'hold_environment()') {
+              firstStarted.resolve()
+              await releaseFirst.promise
+            }
+            return {
+              status: 'completed',
+              stdout: '',
+              stderr: '',
+              traceback: '',
+              cwdAfter: request.cwd,
+              outputs: []
+            }
+          },
+          shutdown: async () => ({ reaped: true })
+        })
+      })
+
+      const first = service.execute({
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        code: 'hold_environment()'
+      })
+      await firstStarted.promise
+
+      addRepairRequired(getRuntimeRoot(root), DEFAULT_PY_ENV, 'protected-identity-change')
+      const repair = service.withEnvLock(DEFAULT_PY_ENV, async () => {
+        await service.completeRuntimeRepair('python')
+      })
+      const queued = service.execute({
+        sessionId: 'session-2',
+        workspaceCwd: root,
+        code: 'must_not_run_with_stale_binding()'
+      })
+      await vi.waitFor(async () => {
+        const state = await service.state({ sessionId: 'session-2', workspaceCwd: root })
+        expect(state.cells[0]?.status).toBe('running')
+      })
+
+      await service.bindRuntime({
+        sessionId: 'session-2',
+        workspaceCwd: root,
+        language: 'python',
+        runtimeId: externalRuntime.envId
+      })
+      releaseFirst.resolve()
+      await repair
+
+      const queuedResult = await queued
+      expect(queuedResult).toMatchObject({
+        status: 'failed',
+        text: { traceback: expect.stringContaining('RUNTIME_BINDING_CHANGED') }
+      })
+      expect(executions.map((request) => request.code)).toEqual(['hold_environment()'])
+      await first
+    })
+
     it('does not block a different-language run behind an install (G2)', async () => {
       const root = await createStorageRoot()
       const events: string[] = []


### PR DESCRIPTION
## Problem

Four Notebook execution races produced inconsistent lifecycle outcomes:

- A run admitted while runtime repair was required could wait behind the repair's exclusive environment lease, then still reuse its stale pre-lock rejection after the repair completed. The run was persisted as `failed` with `RUNTIME_REPAIR_REQUIRED` instead of executing.
- Production repair released its exclusive environment lock before the lifecycle cleared the durable repair marker and restored bindings. A queued run could acquire a shared lease in that gap and still observe `RUNTIME_REPAIR_REQUIRED` after a successful rebuild.
- Cancellation could fire synchronously during Kernel request dispatch before the timeout was armed. Dispatch then armed the timeout anyway, so one request could be both cancelled and timed out and receive a duplicate SIGINT.
- A Session could change or disable its runtime binding while a repair-blocked run waited for the environment lock. Clearing only the stale repair rejection then dispatched the cell with the old route/interpreter admission even though the Session's current binding selected a different or unavailable runtime.

An active Kernel-crash scenario was also reproduced through the Notebook service boundary. Existing behavior already persists the run as `failed` and the Kernel as `terminated`, so no change or always-green regression test is included for that case.

## Proposed change

- Distinguish runtime-repair admission errors internally and discard only that stale rejection when the post-lock repair check is clear.
- Re-read the Session binding after the environment lock is acquired. A changed route or interpreter identity fails closed with retryable `RUNTIME_BINDING_CHANGED`; a currently unavailable binding retains the existing `RUNTIME_BINDING_UNAVAILABLE` classification.
- Add an internal repair-completion callback that runs only after rebuild verification and before the provisioner releases the per-environment lock; the lifecycle uses it to clear repair markers and restore bindings atomically with repair.
- Keep repair cancellation protection active through the awaited completion callback so a late Cancel cannot leak into the next environment operation.
- Do not arm a request timeout when cancellation has already won during synchronous dispatch.
- Add deterministic regression tests at the lifecycle, provisioner, Notebook runtime, and Kernel request-arbitration boundaries. Each regression failed on the relevant pre-fix implementation for the reported symptom and passes with this change.

## Scope and non-goals

- No database/schema, persisted-format, request/response shape, UI, or interaction changes.
- No new run status or other enum value. `RUNTIME_BINDING_CHANGED` is a transient execution-error classification, not persisted model state.
- No historical migration; previously persisted false failures are not rewritten.
- The `RuntimeProvisioner.repair` options type gains an internal callback only; there is no persisted data-model change and no change to environment contents or provisioning algorithms.
- No changes to Python/R dependency parsing or package-manager error taxonomy.

## Acceptance criteria and validation

- lifecycle publishes repair completion before the environment lock releases -> regression failed twice pre-fix with `lock:enter -> lock:exit -> repair:completed`, then passed after the fix
- the real provisioner invokes repair completion after verification and before unlock -> focused provisioner regression passed
- Cancel during awaited repair finalization does not cancel the next operation -> regression failed twice on the intermediate implementation with `Runtime setup cancelled`, then passed after extending the repair protection boundary
- repaired environment releases a queued run without a stale repair failure -> focused runtime-service regression passed
- binding changed while that run is queued never dispatches the old runtime -> regression failed twice pre-fix with a completed run, then passed with `RUNTIME_BINDING_CHANGED` and zero stale dispatches
- cancellation wins synchronous dispatch without later timeout -> focused kernel-executor regression passed
- affected Notebook modules -> `npx vitest run src/main/notebook/environment-lifecycle-workflows.test.ts src/main/notebook/environment-operation-foundation.test.ts src/main/notebook/provisioner.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/kernel-executor.test.ts` -> 377 passed, 66 existing platform/interpreter-gated tests skipped; after the final error-priority refinement, the complete runtime-service module passed 221 tests with 5 skipped
- all changed source/test files -> `npx eslint` and `npx prettier --check` -> passed
- Node typecheck before rebase -> `npm run typecheck:node` -> blocked only by the unchanged `src/main/acp/claude-agent-acp-patch.test.ts` because the shared main-checkout dependency tree did not export `waitForMcpServers`; no changed Notebook file errors remained. CI's clean dependency install passed Node/Web typecheck on the prior head.

The repository currently has no Notebook module ID in `scripts/ci/module-impact.json`, so affected Notebook test files were run directly instead of claiming `test:module` coverage. Exact-head PR Gate remains authoritative for downstream and platform lanes. Full local `npm test` was intentionally not run.

## Review focus

- Repair verification, durable marker cleanup, in-memory repair-gate cleanup, and binding restoration must finish before the per-environment lock is released.
- Per-language Cancel must remain ignored through repair finalization and must not arm the next environment operation.
- The post-lock admission path must clear only a stale repair-required rejection when the current binding still resolves to the same route and interpreter identity; changed/unavailable bindings must fail closed.
- Existing repair-required error priority must remain intact for quarantined managed bindings.
- Cancellation must remain the sole terminal cause when it fires before timeout arming.
