### PR TITLE
fix(workspace): keep config-change markers honest and behind the barrier

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1880,6 +1880,72 @@ describe('workspace agent message sending', () => {
     vi.restoreAllMocks()
   })
 
+  it('does not pin a catalog fallback model onto an unpinned send target', async () => {
+    const runtime = {
+      state: createSnapshot(['transport-session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'continue on the account default',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription',
+      agentModel: 'gpt-5.4',
+      agentConfiguration: {
+        providerId: 'builtin-codex-subscription',
+        reasoningEffort: 'default'
+      }
+    })
+
+    const target = useSessionStore.getState().sessions[0].messages[0]?.agentTarget
+    expect(target).toEqual({
+      frameworkId: 'codex',
+      backendId: 'codex:builtin-codex-subscription',
+      providerId: 'builtin-codex-subscription',
+      reasoningEffort: 'default'
+    })
+    expect(target).not.toHaveProperty('model')
+  })
+
+  it('stamps an explicit configuration model onto the send target', async () => {
+    const runtime = {
+      state: createSnapshot(['transport-session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'pin a model',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:builtin-codex-subscription',
+      agentModel: 'gpt-5.4',
+      agentConfiguration: {
+        providerId: 'builtin-codex-subscription',
+        model: 'gpt-5.4',
+        reasoningEffort: 'high'
+      }
+    })
+
+    expect(useSessionStore.getState().sessions[0].messages[0]?.agentTarget).toEqual({
+      frameworkId: 'codex',
+      backendId: 'codex:builtin-codex-subscription',
+      providerId: 'builtin-codex-subscription',
+      model: 'gpt-5.4',
+      reasoningEffort: 'high'
+    })
+  })
+
   it('forwards and durably stores Plan first for an existing Session', async () => {
     const runtime = {
       state: createSnapshot(['transport-session-1']),

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -113,18 +113,18 @@ const errorMessage = (error: unknown): string =>
 
 // Snapshots the target a send actually runs with. Only a complete identity (framework + admitted
 // provider configuration) is stamped; a partial snapshot would mark false config changes.
+// Unpinned configurations omit model; catalog fallbacks on agentModel are not persisted.
 const resolveSendAgentTarget = (
   input: Readonly<{
     agentFrameworkId?: AgentFrameworkId
     agentBackendId?: string
-    agentModel?: string
     agentConfiguration?: SessionAgentConfiguration
   }>
 ): PersistedMessageAgentTarget | undefined => {
   const configuration = input.agentConfiguration
   if (!input.agentFrameworkId || !configuration) return undefined
   const backendId = input.agentBackendId?.trim()
-  const model = configuration.model ?? (input.agentModel?.trim() || undefined)
+  const model = configuration.model?.trim() || undefined
   return {
     frameworkId: input.agentFrameworkId,
     ...(backendId ? { backendId } : {}),
@@ -617,7 +617,6 @@ const sendWorkspaceMessage = async (
       agentTarget: resolveSendAgentTarget({
         agentFrameworkId: prepared.appendOwnership.agentFrameworkId ?? input.agentFrameworkId,
         agentBackendId: prepared.appendOwnership.agentBackendId ?? input.agentBackendId,
-        agentModel: input.agentModel,
         agentConfiguration: input.agentConfiguration
       }),
       preserveSelection: input.preserveSelection

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -1840,6 +1840,77 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     ).toBeNull()
   })
 
+  it('hides a configuration divider with its owning follow-up while the presentation barrier is open', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const firstPrompt = createMessage({
+      id: 'prompt-config-barrier',
+      content: 'First send',
+      sortIndex: 1,
+      createdAt: 100,
+      agentTarget: {
+        frameworkId: 'claude-code',
+        providerId: 'provider-a',
+        model: 'model-a',
+        reasoningEffort: 'default'
+      }
+    })
+    const firstAnswer = createMessage({
+      id: 'answer-config-barrier',
+      role: 'agent',
+      content: 'Hold this streaming presentation open until the follow-up is revealed.',
+      status: 'streaming',
+      streamId: 'stream-config-barrier',
+      responseToMessageId: firstPrompt.id,
+      sortIndex: 2,
+      createdAt: 101
+    })
+    const followUp = createMessage({
+      id: 'prompt-config-follow-up',
+      content: 'Follow-up after a model change',
+      sortIndex: 3,
+      createdAt: 102,
+      agentTarget: {
+        frameworkId: 'claude-code',
+        providerId: 'provider-a',
+        model: 'model-b',
+        reasoningEffort: 'default'
+      }
+    })
+    const render = async (messages: ChatMessage[]): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller
+            activeSession={createSession({
+              messages,
+              activeRun: { promptMessageId: firstPrompt.id, startedAt: 100 }
+            })}
+            onSendEditedMessage={vi.fn()}
+          />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render([firstPrompt])
+    await render([firstPrompt, firstAnswer])
+    await render([firstPrompt, firstAnswer, followUp])
+
+    expect(container.querySelector('[data-testid="session-config-change"]')).toBeNull()
+    expect(container.textContent).not.toContain('Follow-up after a model change')
+
+    await act(async () => vi.advanceTimersByTimeAsync(5_000))
+
+    expect(container.querySelector('[data-testid="session-config-change"]')).not.toBeNull()
+    expect(container.textContent).toContain('Follow-up after a model change')
+  })
+
   it('renders a Review under its visible chain root when its persisted scope anchor is dangling', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     useReviewStore.getState().handleReviewUpdate({

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -65,7 +65,10 @@ import { WorkspaceRunMarks } from './WorkspaceRunMarks'
 import type { ArtifactMentionPart, EditAnnotationTarget } from './WorkspaceMessageItem'
 import { useWorkspaceArtifactVisibility, type MessageArtifact } from './WorkspaceArtifactVisibility'
 import { useWorkspaceMessageEditState } from './workspace-message-edit-state-context'
-import { createConversationItems } from './workspace-conversation-items'
+import {
+  createConversationItems,
+  hidesBehindPresentationBarrier
+} from './workspace-conversation-items'
 import type { ActivityExpansionOverrides } from './workspace-tool-activity-groups'
 import { createWorkspaceConversationTimeline } from './workspace-conversation-timeline'
 import { useSessionJobStore } from '@/stores/session-job-store'
@@ -1323,13 +1326,14 @@ const WorkspaceMessageScrollerImpl = ({
               />
               {/* Messages and tool activities share one sorted transcript timeline. */}
               {transcriptWindow.entries.map(({ item, itemIndex }) => {
-                // Only later text messages stay behind the presentation barrier; tool,
-                // activity, and other non-message rows render in real time so their
-                // running state stays visible while the reply paces above them.
+                // Later text messages and their config-change dividers stay behind the
+                // presentation barrier. Tool, activity, and other non-message rows render
+                // in real time so their running state stays visible while the reply paces
+                // above them.
                 if (
                   presentationBarrierIndex >= 0 &&
                   itemIndex > presentationBarrierIndex &&
-                  (item.type === 'message' || item.type === 'subagent-message')
+                  hidesBehindPresentationBarrier(item.type)
                 ) {
                   return null
                 }

--- a/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
+++ b/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
@@ -37,4 +37,32 @@ describe('useTranscriptWindow', () => {
 
     act(() => root.unmount())
   })
+
+  it('keeps config-change dividers behind the presentation barrier with their owning message', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const timeline = [
+      { id: 'message-1', type: 'message' },
+      { id: 'message-2', type: 'message' },
+      { id: 'session-config-change-message-3', type: 'session-config-change' },
+      { id: 'message-3', type: 'message' },
+      { id: 'activity-1', type: 'activity' }
+    ] as WorkspaceConversationTimelineItem[]
+    const result = {
+      current: undefined as unknown as ReturnType<typeof useTranscriptWindow>
+    }
+    const HookHarness = (): null => {
+      result.current = useTranscriptWindow('session-1', timeline, 1, createRef())
+      return null
+    }
+
+    act(() => root.render(<HookHarness />))
+    expect(result.current.entries.map((entry) => entry.item.id)).toEqual([
+      'message-1',
+      'message-2',
+      'activity-1'
+    ])
+
+    act(() => root.unmount())
+  })
 })

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -7,6 +7,7 @@ import {
   type RefObject
 } from 'react'
 
+import { hidesBehindPresentationBarrier } from './workspace-conversation-items'
 import type { WorkspaceConversationTimelineItem } from './workspace-conversation-timeline'
 import { findMessageTarget } from './workspace-run-marks'
 
@@ -162,9 +163,7 @@ const useTranscriptWindow = (
           const withinPresentationWindow =
             itemIndex >= presentationStart && itemIndex <= presentationBarrierIndex
           const liveActivityAfterBarrier =
-            itemIndex > presentationBarrierIndex &&
-            item.type !== 'message' &&
-            item.type !== 'subagent-message'
+            itemIndex > presentationBarrierIndex && !hidesBehindPresentationBarrier(item.type)
           return withinPresentationWindow || liveActivityAfterBarrier ? [{ item, itemIndex }] : []
         })
       : items.slice(start, end).map((item, offset) => ({ item, itemIndex: start + offset }))

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
@@ -663,6 +663,42 @@ describe('workspace conversation items', () => {
       expect(configChangeItems(session)).toEqual([])
     })
 
+    it('stays quiet when consecutive unpinned targets omit the model', () => {
+      const unpinned = {
+        frameworkId: 'codex' as const,
+        providerId: 'builtin-codex-subscription',
+        reasoningEffort: 'default' as const
+      }
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, unpinned),
+          stampedUserMessage('message-2', 2, unpinned)
+        ]
+      }
+
+      expect(configChangeItems(session)).toEqual([])
+    })
+
+    it('marks pinning a model after an unpinned subscription send', () => {
+      const unpinned = {
+        frameworkId: 'codex' as const,
+        providerId: 'builtin-codex-subscription',
+        reasoningEffort: 'default' as const
+      }
+      const session: ChatSession = {
+        ...baseSession,
+        messages: [
+          stampedUserMessage('message-1', 1, unpinned),
+          stampedUserMessage('message-2', 2, { ...unpinned, model: 'gpt-5.4' })
+        ]
+      }
+
+      expect(configChangeItems(session).map((item) => item.id)).toEqual([
+        'session-config-change-message-2'
+      ])
+    })
+
     it('marks a branched session first send whose config differs from the copied history', () => {
       const session: ChatSession = {
         ...baseSession,

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.ts
@@ -222,6 +222,13 @@ const formatActivityTitle = (
   return t('Using tool: {{name}}', { name: toolName })
 }
 
+// Config-change dividers are annotations on the following user Message. Hide them with that
+// Message (and other message-like rows) so they cannot appear while the owning turn is still
+// behind the presentation barrier. Tool and activity rows stay live so running work remains
+// visible above the paced reply.
+const hidesBehindPresentationBarrier = (type: string): boolean =>
+  type === 'message' || type === 'subagent-message' || type === 'session-config-change'
+
 // Two send targets describe the same turn configuration only when every routed field matches.
 const agentTargetsMatch = (
   left: PersistedMessageAgentTarget,
@@ -391,6 +398,7 @@ export {
   formatActivityTitle,
   formatNotebookToolName,
   getNotebookToolSuffix,
+  hidesBehindPresentationBarrier,
   isActivityActive,
   resolveTurnTerminalAgentMessageIds,
   isContextCompactionActivity


### PR DESCRIPTION
## Problem

#1825 merged with a red PR Gate and two unadopted Codex review findings. The shard failure was the pre-existing `Annotate entry not found` case already fixed by #1826. The remaining review issues were real product bugs in the new timeline markers:

- An unpinned Codex subscription send stamped the first catalog model onto `agentTarget.model`, so later catalog/default churn could emit a false configuration divider.
- A follow-up sent while the previous assistant message was still revealing showed the config-change divider live, because that row was treated as a non-message activity rather than as part of the owning user Message.

## Proposed change

- Stamp `PersistedMessageAgentTarget.model` only from the admitted `SessionAgentConfiguration.model`. Catalog fallbacks stay on runtime `agentModel` and are not persisted.
- Hide `session-config-change` rows with messages and subagent messages behind the presentation barrier, including the transcript window's live-after-barrier set.

## Scope and non-goals

- Follow-up to #1825 only. No ACP protocol, IPC, catalog, or Prisma changes.
- Does not change divider copy, icons, or when an explicit pin/framework/effort change should mark the timeline.
- Does not backfill or rewrite already-persisted snapshots.

## Historical data compatibility

- Pre-#1825 messages still have no `agentTarget` and still neither emit nor move the baseline.
- Messages already persisted by #1825 with a catalog-fallback `model` keep that value. The next unpinned send after this fix omits `model`, so **one divider may appear** at the first unpinned send after upgrade when the previous snapshot had a fallback model. Cosmetic; no migration.

## New state / persisted data

- No new fields, schema version, or enum values.
- Write-path change only: `agentTarget.model` is omitted when the admitted configuration leaves model unset (unpinned subscription / provider default). Explicit `configuration.model` is still stamped.

## Acceptance criteria and validation

- Unpinned send + catalog fallback `agentModel` → persisted snapshot has no `model`.
- Explicit `configuration.model` is still stamped.
- Consecutive omitted-model snapshots stay quiet; pinning a model after an unpinned send marks a divider.
- While the previous assistant reply is still revealing, the divider and its owning follow-up stay hidden; both appear after the barrier clears.
- Live tool/activity rows after the barrier still render.

### Test impact set

Checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Unpinned vs explicit model stamp | `npx vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t 'does not pin a catalog fallback\|stamps an explicit configuration model'` | pass |
| Divider derivation for omitted/pinned model | `npx vitest run src/renderer/src/pages/workspace/workspace-conversation-items.test.ts` | pass (38) |
| Transcript window barrier membership | `npx vitest run src/renderer/src/pages/workspace/use-transcript-window.test.tsx` | pass (2) |
| Scroller hides divider with owning follow-up | `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx` | pass (50) |
| Runtime owner line-count gate | `npx vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts -t 'keeps the facade, deep owners'` | pass |
| #1826 annotation CI regression | `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx` | pass (70) |
| Renderer types | `npm run typecheck:web` | pass |
| Changed files | `npx eslint` on the eight touched files | pass |

Excluded: full `npm test` (PR Gate remains authoritative); Windows lanes (no path/process change); Electron launch (renderer-only, reachable via Web).

Uncovered risks: no live visual pass of the divider during a streaming follow-up; ACP protocol paths are unchanged (`claude-code`, `opencode`, `codex-response`, `codex-bridge` still share `sendWorkspaceMessage`).

## Review focus

- Omitting `model` is the intended unpinned/default identity, matching the divider's existing "provider default" label path.
- Whether a one-time divider after upgrade (fallback-stamped history → omitted-model send) is acceptable versus rewriting old snapshots.