### PR TITLE
fix(workspace): retry plan projection recovery

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -467,6 +467,7 @@ const createPanelDefaults = (): PanelProps => ({
   },
   conversation: {
     optimisticMessage: undefined,
+    planProjectionRecoveryError: false,
     availability: {
       submit: false,
       submitMode: undefined,

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -203,6 +203,7 @@ describe('WorkspacePage send gate while compacting', () => {
     await act(async () => {
       root.unmount()
     })
+    vi.useRealTimers()
     container.remove()
   })
 
@@ -349,6 +350,38 @@ describe('WorkspacePage send gate while compacting', () => {
 
     expect(window.api.acp.getPlanProjection).toHaveBeenCalledWith('proj-1', 'sess-a')
     expect(useSessionStore.getState().sessions[0]?.status).toBe('idle')
+  })
+
+  it('recovers a restored Plan wait after a transient authority read failure', async () => {
+    vi.useFakeTimers()
+    let rejectFirstProjection!: (error: Error) => void
+    const firstProjection = new Promise<ActivePlanProjection | null>((_resolve, reject) => {
+      rejectFirstProjection = reject
+    })
+    useSessionStore.setState({
+      sessions: [createSession({ status: 'waiting-plan-approval' })],
+      selectedSessionId: 'sess-a'
+    })
+    vi.mocked(window.api.acp.getPlanProjection).mockReturnValue(firstProjection)
+
+    await renderPage()
+    vi.mocked(window.api.acp.getPlanProjection).mockResolvedValue(null)
+    await act(async () => {
+      rejectFirstProjection(new Error('temporary projection read failure'))
+      await firstProjection.catch(() => undefined)
+    })
+
+    expect(conversationProps.view.actionError).toBe('Unable to restore plan state. Retrying…')
+    expect(conversationProps.view.canEditDraft).toBe(false)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+
+    expect(window.api.acp.getPlanProjection).toHaveBeenCalledTimes(2)
+    expect(useSessionStore.getState().sessions[0]?.status).toBe('idle')
+    expect(conversationProps.view.actionError).toBeNull()
+    expect(conversationProps.view.canEditDraft).toBe(true)
   })
 
   it('submits restored Plan-card feedback through the atomic human-gated Plan command', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -23,7 +23,8 @@ import {
   projectSessionActionability,
   resolveRootPermissionPending,
   sessionAwaitsHistoryReplay,
-  useSessionStore
+  useSessionStore,
+  type ChatSession
 } from '@/stores/session-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
@@ -81,6 +82,17 @@ type WorkspacePageProps = {
 const newConversationDraftKeyFor = (projectId: string): string => `new:${projectId}`
 const OPEN_DIALOG_SELECTOR =
   '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
+const planProjectionRecoveryPorts = {
+  getProjection: (projectId: string, sessionId: string) =>
+    window.api.acp.getPlanProjection(projectId, sessionId),
+  getSession: (sessionId: string) =>
+    useSessionStore.getState().sessions.find((session) => session.id === sessionId),
+  setProjection: (
+    sessionId: string,
+    projection: NonNullable<ChatSession['activePlanProjection']>
+  ) => useSessionStore.getState().setActivePlanProjection(sessionId, projection),
+  finishRun: (sessionId: string) => useSessionStore.getState().finishRun(sessionId)
+}
 
 const WorkspacePage = ({
   isSessionPersistenceHydrated,
@@ -123,7 +135,6 @@ const WorkspacePage = ({
   const clearSelection = useSessionStore((state) => state.clearSelection)
   const setAutoReviewEnabled = useSessionStore((state) => state.setAutoReviewEnabled)
   const setFixLoopActive = useSessionStore((state) => state.setFixLoopActive)
-  const setActivePlanProjection = useSessionStore((state) => state.setActivePlanProjection)
   const previewItems = usePreviewWorkbenchStore((state) => state.items)
   const previewPanelState = usePreviewWorkbenchStore((state) => state.panelState)
   const previewOpenRequestVersion = usePreviewWorkbenchStore((state) => state.openRequestVersion)
@@ -388,37 +399,6 @@ const WorkspacePage = ({
       (activeProviderType !== undefined && isCodexSubscriptionProvider(activeProviderType)
         ? 'Side chat is unavailable for Codex subscription because strict tool isolation cannot be enforced.'
         : undefined))
-
-  useEffect(() => {
-    const getPlanProjection = window.api.acp?.getPlanProjection
-    if (
-      !activeSession ||
-      activeSession.activePlanProjection ||
-      !getPlanProjection ||
-      (activeSession.status !== 'waiting-plan-approval' && !activeSession.runtimeContext?.plan)
-    ) {
-      return
-    }
-    let cancelled = false
-    void getPlanProjection(activeSession.projectId, activeSession.id)
-      .then((projection) => {
-        if (cancelled) return
-        if (projection) {
-          setActivePlanProjection(activeSession.id, projection)
-          return
-        }
-        const current = useSessionStore
-          .getState()
-          .sessions.find((session) => session.id === activeSession.id)
-        if (current?.status === 'waiting-plan-approval' && !current.activePlanProjection) {
-          useSessionStore.getState().finishRun(activeSession.id)
-        }
-      })
-      .catch(() => undefined)
-    return () => {
-      cancelled = true
-    }
-  }, [activeSession, setActivePlanProjection])
   const canArchiveSession = sessionController.lifecycle.canArchive
   const visiblePermissionRequests = useMemo(
     () =>
@@ -508,7 +488,11 @@ const WorkspacePage = ({
     abortFixLoop: (request) => window.api.reviewer.abortFixLoop(request),
     getSession: (sessionId) =>
       useSessionStore.getState().sessions.find((candidate) => candidate.id === sessionId),
-    subscribeSessionChanges: useSessionStore.subscribe
+    subscribeSessionChanges: useSessionStore.subscribe,
+    planProjectionRecovery:
+      typeof window.api.acp?.getPlanProjection === 'function'
+        ? planProjectionRecoveryPorts
+        : undefined
   })
   // "Request review" is disabled when:
   //   - there is no active session or no completed agent turn yet, OR
@@ -631,7 +615,11 @@ const WorkspacePage = ({
     activeSession.runtimeContext?.permission?.state === 'pending'
       ? (activeSession.error ?? actionError)
       : null
+  const planProjectionRecoveryError = conversation.planProjectionRecoveryError
+    ? t('Unable to restore plan state. Retrying…')
+    : null
   const visibleActionError =
+    planProjectionRecoveryError ??
     attachmentError ??
     sessionController.view.exportError ??
     (activeSession ? durablePermissionError : actionError)

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import type { PermissionProfileId } from '../../../../shared/permission-profiles'
 import type { SessionAgentConfiguration } from '../../../../shared/settings'
@@ -9,6 +9,7 @@ import type {
   ChatSession,
   SessionActionabilityProjection
 } from '@/stores/session-store'
+import type { ActivePlanProjection } from '../../../../shared/session-plan/contract'
 import type { WorkspaceAgentRuntime } from '@/lib/acp/useWorkspaceAgentRuntime'
 
 import {
@@ -46,6 +47,13 @@ type DraftSubmitIntent = {
 }
 
 type RestoredPlanResponse = { decision: 'approved' | 'rejected' } | { feedback: string }
+
+type PlanProjectionRecoveryPorts = {
+  getProjection: (projectId: string, sessionId: string) => Promise<ActivePlanProjection | null>
+  getSession: (sessionId: string) => ChatSession | undefined
+  setProjection: (sessionId: string, projection: ActivePlanProjection) => void
+  finishRun: (sessionId: string) => void
+}
 
 type ConversationComposer = {
   view: Pick<
@@ -105,10 +113,12 @@ type WorkspaceConversationControllerOptions = {
   abortFixLoop: (request: { projectId: string; appSessionId: string }) => Promise<unknown>
   getSession: (sessionId: string) => ChatSession | undefined
   subscribeSessionChanges: (listener: () => void) => () => void
+  planProjectionRecovery?: PlanProjectionRecoveryPorts
 }
 
 type WorkspaceConversationController = {
   optimisticMessage: ChatMessage | undefined
+  planProjectionRecoveryError: boolean
   availability: {
     submit: boolean
     submitMode: 'send' | 'queue' | undefined
@@ -137,6 +147,71 @@ type WorkspaceConversationController = {
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
+
+const usePlanProjectionRecovery = (
+  activeSession: ChatSession | undefined,
+  ports: PlanProjectionRecoveryPorts | undefined
+): boolean => {
+  const [errorSessionId, setErrorSessionId] = useState<string>()
+  const sessionId = activeSession?.id
+  const projectId = activeSession?.projectId
+  const status = activeSession?.status
+  const projection = activeSession?.activePlanProjection
+  const hasRuntimePlan = Boolean(activeSession?.runtimeContext?.plan)
+
+  useEffect(() => {
+    if (
+      !sessionId ||
+      !projectId ||
+      projection ||
+      !ports ||
+      (status !== 'waiting-plan-approval' && !hasRuntimePlan)
+    ) {
+      return
+    }
+    let cancelled = false
+    let retryTimer: number | undefined
+    let retryAttempt = 0
+    const refresh = async (): Promise<void> => {
+      try {
+        const currentProjection = await ports.getProjection(projectId, sessionId)
+        if (cancelled) return
+        setErrorSessionId((current) => (current === sessionId ? undefined : current))
+        if (currentProjection) {
+          ports.setProjection(sessionId, currentProjection)
+          return
+        }
+        const currentSession = ports.getSession(sessionId)
+        if (
+          currentSession?.status === 'waiting-plan-approval' &&
+          !currentSession.activePlanProjection
+        ) {
+          ports.finishRun(sessionId)
+        }
+      } catch {
+        if (cancelled) return
+        setErrorSessionId(sessionId)
+        retryTimer = window.setTimeout(
+          () => void refresh(),
+          Math.min(1_000 * 2 ** retryAttempt++, 30_000)
+        )
+      }
+    }
+    void refresh()
+    return () => {
+      cancelled = true
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer)
+    }
+  }, [hasRuntimePlan, ports, projectId, projection, sessionId, status])
+
+  return Boolean(
+    ports &&
+    sessionId &&
+    !projection &&
+    (status === 'waiting-plan-approval' || hasRuntimePlan) &&
+    errorSessionId === sessionId
+  )
+}
 
 const hasRuntimeInteraction = (options: WorkspaceConversationControllerOptions): boolean => {
   const sessionId = options.activeSession?.id
@@ -263,6 +338,10 @@ const useWorkspaceConversationController = (
   }, [options])
   const inFlightDraftKeysRef = useRef(new Set<string>())
   const [optimisticMessages, setOptimisticMessages] = useState<Record<string, ChatMessage>>({})
+  const planProjectionRecoveryError = usePlanProjectionRecovery(
+    options.activeSession,
+    options.planProjectionRecovery
+  )
   const messageQueue = useWorkspaceMessageQueueController({
     activeSession: options.activeSession,
     promptInFlightSessionIds: options.promptInFlightSessionIds,
@@ -566,6 +645,7 @@ const useWorkspaceConversationController = (
     optimisticMessage: options.activeSession
       ? optimisticMessages[options.activeSession.id]
       : undefined,
+    planProjectionRecoveryError,
     availability: {
       submit: submitImmediately || queueDraft,
       submitMode: submitImmediately ? 'send' : queueDraft ? 'queue' : undefined,

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -2281,6 +2281,7 @@
     "Unable to determine the producer execution for this version.": "No se puede determinar qué ejecución produjo esta versión.",
     "Unable to read the selected content file.": "No se puede leer el archivo de contenido seleccionado.",
     "Unable to read the selected reference files.": "No se pueden leer los archivos de referencia seleccionados.",
+    "Unable to restore plan state. Retrying…": "No se pudo restaurar el estado del plan. Reintentando…",
     "Unable to save this skill.": "No se puede guardar esta habilidad.",
     "Unable to send Plan feedback.": "No se pueden enviar comentarios sobre el plan.",
     "Unable to update the Plan.": "No se puede actualizar el plan.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -2281,6 +2281,7 @@
     "Unable to determine the producer execution for this version.": "Impossible de déterminer l'exécution du producteur pour cette version.",
     "Unable to read the selected content file.": "Impossible de lire le fichier de contenu sélectionné.",
     "Unable to read the selected reference files.": "Impossible de lire les fichiers de référence sélectionnés.",
+    "Unable to restore plan state. Retrying…": "Impossible de restaurer l’état du plan. Nouvelle tentative…",
     "Unable to save this skill.": "Impossible de sauvegarder cette compétence.",
     "Unable to send Plan feedback.": "Impossible d'envoyer des commentaires sur le plan.",
     "Unable to update the Plan.": "Impossible de mettre à jour le plan.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -2182,6 +2182,7 @@
     "Unable to determine the producer execution for this version.": "このバージョンの生成元実行を特定できません。",
     "Unable to read the selected content file.": "選択したコンテンツファイルを読み取れません。",
     "Unable to read the selected reference files.": "選択した参照ファイルを読み取ることができません。",
+    "Unable to restore plan state. Retrying…": "プランの状態を復元できません。再試行しています…",
     "Unable to save this skill.": "このスキルを保存できません。",
     "Unable to send Plan feedback.": "プランのフィードバックを送信できません。",
     "Unable to update the Plan.": "プランを更新できません。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -2192,6 +2192,7 @@
     "Unable to determine the producer execution for this version.": "이 버전의 생산자 실행을 확인할 수 없습니다.",
     "Unable to read the selected content file.": "선택한 콘텐츠 파일을 읽을 수 없습니다.",
     "Unable to read the selected reference files.": "선택한 참조 파일을 읽을 수 없습니다.",
+    "Unable to restore plan state. Retrying…": "계획 상태를 복원할 수 없습니다. 다시 시도하는 중…",
     "Unable to save this skill.": "이 스킬을 저장할 수 없습니다.",
     "Unable to send Plan feedback.": "계획 피드백을 보낼 수 없습니다.",
     "Unable to update the Plan.": "계획을 업데이트할 수 없습니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -2296,6 +2296,7 @@
     "Unable to determine the producer execution for this version.": "Не удалось определить выполнение производителя для этой версии.",
     "Unable to read the selected content file.": "Не удалось прочитать выбранный файл содержимого.",
     "Unable to read the selected reference files.": "Не удалось прочитать выбранные файлы справочных данных.",
+    "Unable to restore plan state. Retrying…": "Не удалось восстановить состояние плана. Повторная попытка…",
     "Unable to save this skill.": "Не удалось сохранить навык.",
     "Unable to send Plan feedback.": "Не удалось отправить обратную связь по плану.",
     "Unable to update the Plan.": "Не удалось обновить план.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -2253,6 +2253,7 @@
     "Unable to determine the producer execution for this version.": "无法确定该版本的生成方执行记录。",
     "Unable to read the selected content file.": "无法读取所选内容文件。",
     "Unable to read the selected reference files.": "无法读取所选参考文件。",
+    "Unable to restore plan state. Retrying…": "无法恢复计划状态。正在重试…",
     "Unable to save this skill.": "无法保存此技能。",
     "Unable to send Plan feedback.": "无法发送计划反馈。",
     "Unable to update the Plan.": "无法更新计划。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -2250,6 +2250,7 @@
     "Unable to determine the producer execution for this version.": "無法確定該版本的產生方執行記錄。",
     "Unable to read the selected content file.": "無法讀取所選內容檔案。",
     "Unable to read the selected reference files.": "無法讀取所選參考檔案。",
+    "Unable to restore plan state. Retrying…": "無法恢復計畫狀態。正在重試…",
     "Unable to save this skill.": "無法儲存此技能。",
     "Unable to send Plan feedback.": "無法傳送計畫回饋。",
     "Unable to update the Plan.": "無法更新計畫。",


### PR DESCRIPTION
## Problem

A restored Session could remain `waiting-plan-approval` without an active Plan projection. If the Main-owned projection read failed, WorkspacePage silently swallowed the rejection, leaving the Plan card unavailable while draft editing remained disabled.

## Proposed change

- move Plan projection recovery behind injected workspace conversation-controller ports;
- show `Unable to restore plan state. Retrying…` after a failed authority read;
- retry with exponential backoff from 1 second, capped at 30 seconds, while the same Session still needs recovery;
- project an authoritative Plan when returned, or finish the stale wait when Main confirms there is no pending Plan;
- translate the recovery message in all seven renderer locales.

## Scope and non-goals

- No new IPC command, ACP protocol change, Agent-framework-specific path, persisted format, database schema, migration, or status enum.
- Historical Sessions already persisted in `waiting-plan-approval` are supported without migration.
- When Main returns `null`, the existing `finishRun` path can persist the recovered `idle` status through the existing Session persistence flow.

## Acceptance criteria and validation

The regression test was added before the fix and failed twice on the original code because the expected recovery warning was `null`, matching the silently swallowed failure.

- restart recovery, warning, retry, and stale-wait unlock -> `npm run test:module -- workspace_page` -> 25 files / 576 tests passed
- ConversationPanel controller-interface consumer -> `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` -> 127 tests passed
- renderer locale completeness and script checks -> `npx vitest run src/renderer/src/i18n/resources.test.ts` -> 743 tests passed
- renderer type safety -> `npm run typecheck:web` -> passed
- linted source and tests -> `npm run lint` -> passed

These checks ran after the last material production edit. No downstream module or platform lane was added locally because the exported WorkspacePage props and Main IPC contract are unchanged, the module manifest declares no workspace_page consumers, and the change uses browser timers without platform-specific paths. Exact-head PR CI remains authoritative for the full selected plan.

## Review focus

- cancellation and single-flight behavior when Session projections change during recovery;
- capped exponential retry timing;
- treating Main-owned `null` projection authority as confirmation that a stale Plan wait can end safely.