### PR TITLE
fix(startup): reuse standard settings error notice

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -950,7 +950,7 @@ describe('App startup routing', () => {
     expect(container.querySelector('[data-testid="onboarding-page"]')).toBeNull()
   })
 
-  it('shows a settings load error and retries the complete initialization', async () => {
+  it('shows a settings load error in the standard error notice and retries initialization', async () => {
     mocks.settings.loadError = 'settings IPC unavailable'
     mocks.settings.load.mockReset().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
 
@@ -958,15 +958,14 @@ describe('App startup routing', () => {
 
     const shell = container.querySelector('[role="alert"]')
     expect(shell?.textContent).toContain('settings IPC unavailable')
+    expect(shell?.querySelector('section > svg[aria-hidden="true"]')).not.toBeNull()
     expect(shell?.classList.contains('min-h-svh')).toBe(true)
     expect(shell?.classList.contains('h-screen')).toBe(false)
     expect(shell?.classList.contains('text-foreground')).toBe(true)
     expect(shell?.classList.contains('text-muted-foreground')).toBe(false)
     expect(mocks.settings.checkEnvironment).not.toHaveBeenCalled()
 
-    const retry = container.querySelector<HTMLButtonElement>(
-      '[data-testid="settings-startup-retry"]'
-    )
+    const retry = container.querySelector<HTMLButtonElement>('button')
     expect(retry).not.toBeNull()
     expect(retry?.dataset.slot).toBe('button')
     expect(retry?.className).toContain('focus-visible:ring-3')

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { CloseConfirmModal } from '@/components/CloseConfirmModal'
 import { ConnectorAuthToast } from '@/components/ConnectorAuthToast'
 import { DataRootMissingDialog } from '@/components/DataRootMissingDialog'
+import { ErrorNotice } from '@/components/error-notice'
 import { GlobalSearchDialog } from '@/components/global-search/GlobalSearchDialog'
 import { LegacyDataMoveDialog } from '@/components/LegacyDataMoveDialog'
 import { LifecycleToast } from '@/components/LifecycleToast'
@@ -13,7 +14,6 @@ import { PermissionUndoSnackbar } from '@/components/PermissionUndoSnackbar'
 import { SessionCatalogRecoveryAlert } from '@/components/SessionCatalogRecoveryAlert'
 import { SessionPersistenceAlert } from '@/components/SessionPersistenceAlert'
 import { UpdateDialog } from '@/components/UpdateDialog'
-import { Button } from '@/components/ui/button'
 import { WebEventRecoveryDialog } from '@/components/WebEventRecoveryDialog'
 import { useApplicationEventBindings } from '@/hooks/useApplicationEventBindings'
 import { useApplicationStartup } from '@/hooks/useApplicationStartup'
@@ -57,24 +57,15 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
           role="alert"
           className="flex min-h-svh items-center justify-center bg-background p-6 text-foreground"
         >
-          <div className="w-full max-w-md rounded-xl border border-border bg-card p-5 text-card-foreground shadow-sm">
-            <h1 className="text-base font-semibold text-foreground">
-              {t('Settings could not be loaded')}
-            </h1>
-            <p className="mt-2 break-words text-sm text-muted-foreground">
-              {startup.settings.loadError}
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              data-testid="settings-startup-retry"
-              disabled={startup.settings.isLoading}
-              onClick={() => void startup.settings.retry()}
-              className="mt-4"
-            >
-              {startup.settings.isLoading ? t('Retrying…') : t('Retry')}
-            </Button>
-          </div>
+          <ErrorNotice
+            title={t('Settings could not be loaded')}
+            description={startup.settings.loadError}
+            primaryButton={{
+              label: startup.settings.isLoading ? t('Retrying…') : t('Retry'),
+              onClick: () => void startup.settings.retry(),
+              loading: startup.settings.isLoading
+            }}
+          />
         </main>
       )
     }


### PR DESCRIPTION
## Summary

- replace the hand-written settings startup error card with the shared `ErrorNotice`
- preserve the existing settings error message and complete retry initialization flow
- add an application-boundary regression assertion for the standard error notice

## Reproduction

The regression assertion was run twice against the original implementation. Both runs failed at the same assertion because the startup error alert did not contain the standard notice's brand mark. The same test passes after the fix.

## Testing

- `npx vitest run src/renderer/src/App.test.tsx` (57 passed)
- `npx vitest run src/renderer/src/App.test.tsx src/renderer/src/components/error-notice.test.tsx src/renderer/src/i18n/resources.test.ts` (804 passed)
- `npm run typecheck:web`
- `npx eslint src/renderer/src/ApplicationPresentationHost.tsx src/renderer/src/App.test.tsx`
- `npx prettier --check src/renderer/src/ApplicationPresentationHost.tsx src/renderer/src/App.test.tsx`

Full `npm test` was also attempted. It reported 68 failures in unrelated suites, primarily Windows temporary-directory/symlink `EPERM` errors, downstream storage failures, parallel timeouts, and runtime-skill staging `ENOENT` errors.
