### PR TITLE
fix(database): enforce file artifact data constraints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -320,6 +320,7 @@ model ManagedFileSessionSync {
   projectId         String
   sessionId         String
   filesRevision     Int
+  isComplete        Boolean   @default(true)
   groupSortAtMs     BigInt
   artifactCount     Int       @default(0)
   uploadCount       Int       @default(0)

--- a/prisma/sqlite-check-constraints.json
+++ b/prisma/sqlite-check-constraints.json
@@ -181,14 +181,59 @@
       "expression": "\"source\" IN ('artifact', 'upload')"
     },
     {
+      "tableName": "ManagedFile",
+      "name": "ManagedFile_nonnegative_check",
+      "expression": "\"sizeBytes\" >= 0 AND (\"mtimeMs\" IS NULL OR \"mtimeMs\" >= 0) AND \"sortAtMs\" >= 0"
+    },
+    {
+      "tableName": "ManagedFile",
+      "name": "ManagedFile_storageKey_check",
+      "expression": "length(trim(\"storageKey\")) > 0"
+    },
+    {
+      "tableName": "ManagedFile",
+      "name": "ManagedFile_deletion_check",
+      "expression": "((\"deletedAt\" IS NULL AND \"deleteOperationId\" IS NULL) OR (\"deletedAt\" IS NOT NULL AND \"deleteOperationId\" IS NOT NULL))"
+    },
+    {
+      "tableName": "ManagedFileSessionSync",
+      "name": "ManagedFileSessionSync_nonnegative_check",
+      "expression": "\"filesRevision\" >= 0 AND \"artifactCount\" >= 0 AND \"uploadCount\" >= 0"
+    },
+    {
+      "tableName": "ManagedFileSessionSync",
+      "name": "ManagedFileSessionSync_isComplete_check",
+      "expression": "\"isComplete\" IN (false, true)"
+    },
+    {
+      "tableName": "ManagedFileSessionSync",
+      "name": "ManagedFileSessionSync_deletion_check",
+      "expression": "((\"deletedAt\" IS NULL AND \"deleteOperationId\" IS NULL) OR (\"deletedAt\" IS NOT NULL AND \"deleteOperationId\" IS NOT NULL))"
+    },
+    {
       "tableName": "UploadVersion",
       "name": "UploadVersion_state_check",
       "expression": "\"state\" IN ('staging', 'ready')"
     },
     {
+      "tableName": "UploadVersion",
+      "name": "UploadVersion_metadata_check",
+      "expression": "\"versionNumber\" >= 1 AND \"sizeBytes\" >= 0 AND length(trim(\"contentStorageKey\")) > 0 AND length(trim(\"filename\")) > 0 AND length(trim(\"originalFilename\")) > 0 AND length(\"checksum\") = 64 AND \"checksum\" NOT GLOB '*[^0-9a-f]*'"
+    },
+    {
       "tableName": "ArtifactMessageSnapshot",
       "name": "ArtifactMessageSnapshot_state_check",
       "expression": "\"state\" IN ('staging', 'ready')"
+    },
+    {
+      "tableName": "ArtifactMessageSnapshot",
+      "name": "ArtifactMessageSnapshot_messageCount_check",
+      "expression": "\"messageCount\" >= 0"
+    },
+    {
+      "tableName": "ArtifactMessageSnapshot",
+      "name": "ArtifactMessageSnapshot_readyChecksum_check",
+      "expression": "\"state\" <> 'ready' OR (length(\"checksum\") = 64 AND \"checksum\" NOT GLOB '*[^0-9a-f]*')"
     },
     {
       "tableName": "ArtifactVersion",
@@ -216,6 +261,21 @@
       "expression": "((\"executionSnapshotJson\" IS NULL AND \"executionSnapshotChecksum\" IS NULL AND \"executionSnapshotStorageKey\" IS NULL AND \"executionSnapshotSchemaVersion\" IS NULL) OR (\"executionSnapshotJson\" IS NOT NULL AND \"executionSnapshotChecksum\" IS NOT NULL AND \"executionSnapshotStorageKey\" IS NOT NULL AND \"executionSnapshotSchemaVersion\" IS NOT NULL))"
     },
     {
+      "tableName": "ArtifactVersion",
+      "name": "ArtifactVersion_nonnegative_check",
+      "expression": "\"versionNumber\" >= 1 AND \"sizeBytes\" >= 0 AND \"evidenceSchemaVersion\" >= 1 AND (\"executionSnapshotSchemaVersion\" IS NULL OR \"executionSnapshotSchemaVersion\" >= 1)"
+    },
+    {
+      "tableName": "ArtifactVersion",
+      "name": "ArtifactVersion_producerRun_check",
+      "expression": "((\"producerRunId\" IS NULL AND \"producerRunIndex\" IS NULL) OR (\"producerRunId\" IS NOT NULL AND length(trim(\"producerRunId\")) > 0 AND \"producerRunIndex\" IS NOT NULL AND \"producerRunIndex\" >= 0))"
+    },
+    {
+      "tableName": "ArtifactVersion",
+      "name": "ArtifactVersion_publishedMetadata_check",
+      "expression": "\"state\" NOT IN ('pending', 'finalized') OR (length(trim(\"contentStorageKey\")) > 0 AND length(trim(\"evidenceStorageKey\")) > 0 AND length(\"checksum\") = 64 AND \"checksum\" NOT GLOB '*[^0-9a-f]*' AND length(\"evidenceChecksum\") = 64 AND \"evidenceChecksum\" NOT GLOB '*[^0-9a-f]*')"
+    },
+    {
       "tableName": "ArtifactVersionInput",
       "name": "ArtifactVersionInput_sourceKind_check",
       "expression": "\"sourceKind\" IN ('artifact-version', 'upload-version')"
@@ -229,6 +289,11 @@
       "tableName": "ArtifactVersionInput",
       "name": "ArtifactVersionInput_strongestAssociation_check",
       "expression": "\"strongestAssociation\" IN ('turn-attached', 'resolver-accessed', 'captured-version')"
+    },
+    {
+      "tableName": "ArtifactVersionInput",
+      "name": "ArtifactVersionInput_metadata_check",
+      "expression": "\"ordinal\" >= 0 AND (\"sourceVersionNumber\" IS NULL OR \"sourceVersionNumber\" >= 1) AND \"sizeBytes\" >= 0 AND length(\"checksum\") = 64 AND \"checksum\" NOT GLOB '*[^0-9a-f]*' AND length(trim(\"storageKey\")) > 0"
     },
     {
       "tableName": "ReviewScopeSnapshot",

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -72,6 +72,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0017_agent_memory_project_scope',
     checksum: '0e27d60b24a623fd0b080266be42e4560ad7dd4188c93b081ee94a655c800ba9'
+  },
+  {
+    id: '0018_file_artifact_data_constraints',
+    checksum: '9e0fb5295794abdf94b7ccee8978b80df7fecc4475ad4eb314ea6fbe4876e859'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -20,7 +20,7 @@ import { PrismaClient } from '@prisma/client'
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
     expect(MIGRATION_MANIFEST.at(-1)?.checksum).toBe(
-      '0e27d60b24a623fd0b080266be42e4560ad7dd4188c93b081ee94a655c800ba9'
+      '9e0fb5295794abdf94b7ccee8978b80df7fecc4475ad4eb314ea6fbe4876e859'
     )
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST.slice(0, -1))).toThrow(
@@ -50,7 +50,7 @@ describe('packaged database migration ledger smoke', () => {
       await client.$executeRawUnsafe('DROP INDEX "Review_sessionId_idx"')
       await client.$executeRawUnsafe('DROP INDEX "Finding_reviewId_idx"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_file_artifact_data_constraints')`
       )
       await client.$executeRawUnsafe(
         'ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"'

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -289,11 +289,12 @@ describe('Provenance Message snapshots', () => {
     const legacyPayload: Record<string, unknown> = { ...snapshotPayload, schemaVersion: 2 }
     delete legacyPayload.activities
     delete legacyPayload.activityGroups
+    const legacyBytes = `${JSON.stringify(legacyPayload, null, 2)}\n`
     await client.artifactMessageSnapshot.update({
       where: { id: row.messageSnapshot!.id },
-      data: { checksum: '' }
+      data: { checksum: createHash('sha256').update(legacyBytes).digest('hex') }
     })
-    await writeFile(snapshotPath, `${JSON.stringify(legacyPayload, null, 2)}\n`, 'utf8')
+    await writeFile(snapshotPath, legacyBytes, 'utf8')
     await expect(
       provenance.getVersionProvenance({
         projectId: 'project-1',
@@ -304,22 +305,17 @@ describe('Provenance Message snapshots', () => {
     ).resolves.toMatchObject({
       messages: { state: 'available', activities: [], activityGroups: [] }
     })
-    await writeFile(snapshotPath, `${JSON.stringify(snapshotPayload, null, 2)}\n`, 'utf8')
+    const currentBytes = `${JSON.stringify(snapshotPayload, null, 2)}\n`
+    await writeFile(snapshotPath, currentBytes, 'utf8')
     await client.artifactMessageSnapshot.update({
       where: { id: row.messageSnapshot!.id },
-      data: { checksum: '' }
+      data: { checksum: createHash('sha256').update(currentBytes).digest('hex') }
     })
     expect(JSON.stringify(read.messages)).not.toContain('/secret')
     expect(JSON.stringify(read.messages)).not.toContain('aGVsbG8=')
 
-    // A legacy empty checksum is backfilled from structurally valid bytes. Once established, a
-    // same-shape content edit must fail deletion instead of silently retaining corrupted evidence.
-    await provenance.getVersionMessages({
-      projectId: 'project-1',
-      appSessionId: 'session-1',
-      artifactId: version.artifactId,
-      versionId: version.versionId
-    })
+    // Once the checksum is established, a same-shape content edit must fail deletion instead of
+    // silently retaining corrupted evidence.
     const tamperedPayload = structuredClone(snapshotPayload) as typeof snapshotPayload & {
       messages: Array<Record<string, unknown>>
     }
@@ -646,7 +642,7 @@ describe('Provenance Message snapshots', () => {
     await client.fileOriginSession.create({
       data: { projectId: 'project-1', sessionId: 'session-1' }
     })
-    const createStagingSnapshot = async (id: string, corruptChecksum = false): Promise<void> => {
+    const createStagingSnapshot = async (id: string, corruptChecksum = false): Promise<string> => {
       const storageKey = `artifacts/project-1/session-1/.provenance/message-snapshots/${id}.json`
       const terminalMessageId = `message-${id}`
       const payload = {
@@ -672,6 +668,7 @@ describe('Provenance Message snapshots', () => {
       const path = join(storageRoot!, ...storageKey.split('/'))
       await mkdir(dirname(path), { recursive: true })
       await writeFile(path, serialized, 'utf8')
+      const checksum = createHash('sha256').update(serialized).digest('hex')
       await client.artifactMessageSnapshot.create({
         data: {
           id,
@@ -683,14 +680,13 @@ describe('Provenance Message snapshots', () => {
           terminalMessageId,
           state: 'staging',
           storageKey,
-          checksum: corruptChecksum
-            ? 'f'.repeat(64)
-            : createHash('sha256').update(serialized).digest('hex'),
+          checksum: corruptChecksum ? 'f'.repeat(64) : '',
           messageCount: 1
         }
       })
+      return checksum
     }
-    await createStagingSnapshot('snapshot-valid-1')
+    const validChecksum = await createStagingSnapshot('snapshot-valid-1')
     await createStagingSnapshot('snapshot-corrupt-1', true)
     const snapshots = new ProvenanceMessageSnapshotRepository({
       storageRoot,
@@ -701,7 +697,7 @@ describe('Provenance Message snapshots', () => {
 
     await expect(
       client.artifactMessageSnapshot.findUniqueOrThrow({ where: { id: 'snapshot-valid-1' } })
-    ).resolves.toMatchObject({ state: 'ready' })
+    ).resolves.toMatchObject({ state: 'ready', checksum: validChecksum })
     await expect(
       client.artifactMessageSnapshot.findUnique({ where: { id: 'snapshot-corrupt-1' } })
     ).resolves.toBeNull()

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
-import type { PrismaClient } from '@prisma/client'
+import type { ArtifactMessageSnapshot, PrismaClient } from '@prisma/client'
 
 import {
   materializeSessionConversationGraph,
@@ -466,6 +466,14 @@ class ProvenanceMessageSnapshotRepository {
     })
   }
 
+  async recoverLegacyMessageSnapshotsForMigration(): Promise<void> {
+    const client = await this.options.getClient()
+    const staging = await client.artifactMessageSnapshot.findMany({
+      where: { state: 'staging', checksum: '' }
+    })
+    for (const snapshot of staging) await this.promoteStagingMessageSnapshot(snapshot)
+  }
+
   private async recoverStagingMessageSnapshots(): Promise<void> {
     const client = await this.options.getClient()
     const staging = await client.artifactMessageSnapshot.findMany({
@@ -473,40 +481,7 @@ class ProvenanceMessageSnapshotRepository {
     })
     for (const snapshot of staging) {
       try {
-        // Reuse the same immutable-file validation as normal reads. The temporary state override is
-        // local to validation; SQLite remains staging until the promotion transaction commits.
-        await this.verifyReadySnapshot(
-          { ...snapshot, state: 'ready' },
-          {
-            rootFrameId: snapshot.rootFrameId,
-            agentFrameId: snapshot.agentFrameId,
-            messageBranchId: snapshot.messageBranchId,
-            terminalMessageId: snapshot.terminalMessageId
-          },
-          'staging'
-        )
-        await client.$transaction(async (transaction) => {
-          const promoted = await transaction.artifactMessageSnapshot.updateMany({
-            where: { id: snapshot.id, state: 'staging' },
-            data: { state: 'ready' }
-          })
-          if (promoted.count !== 1) {
-            throw new Error(`Artifact Message snapshot recovery raced: ${snapshot.id}`)
-          }
-          await transaction.artifactVersion.updateMany({
-            where: {
-              state: 'finalized',
-              rootFrameId: snapshot.rootFrameId,
-              agentFrameId: snapshot.agentFrameId,
-              messageBranchId: snapshot.messageBranchId,
-              messageId: snapshot.terminalMessageId,
-              artifact: {
-                is: { projectId: snapshot.projectId, sessionId: snapshot.sessionId }
-              }
-            },
-            data: { messageSnapshotId: snapshot.id }
-          })
-        })
+        await this.promoteStagingMessageSnapshot(snapshot)
       } catch {
         const deleted = await client.artifactMessageSnapshot.deleteMany({
           where: { id: snapshot.id, state: 'staging' }
@@ -530,6 +505,42 @@ class ProvenanceMessageSnapshotRepository {
         ])
       }
     }
+  }
+
+  private async promoteStagingMessageSnapshot(snapshot: ArtifactMessageSnapshot): Promise<void> {
+    const client = await this.options.getClient()
+    // Reuse the same immutable-file validation as normal reads. The temporary state override is
+    // local to validation; SQLite remains staging until the promotion transaction commits.
+    await this.verifyReadySnapshot(
+      { ...snapshot, state: 'ready' },
+      {
+        rootFrameId: snapshot.rootFrameId,
+        agentFrameId: snapshot.agentFrameId,
+        messageBranchId: snapshot.messageBranchId,
+        terminalMessageId: snapshot.terminalMessageId
+      },
+      'staging'
+    )
+    await client.$transaction(async (transaction) => {
+      const promoted = await transaction.artifactMessageSnapshot.updateMany({
+        where: { id: snapshot.id, state: 'staging' },
+        data: { state: 'ready' }
+      })
+      if (promoted.count !== 1) {
+        throw new Error(`Artifact Message snapshot recovery raced: ${snapshot.id}`)
+      }
+      await transaction.artifactVersion.updateMany({
+        where: {
+          state: 'finalized',
+          rootFrameId: snapshot.rootFrameId,
+          agentFrameId: snapshot.agentFrameId,
+          messageBranchId: snapshot.messageBranchId,
+          messageId: snapshot.terminalMessageId,
+          artifact: { is: { projectId: snapshot.projectId, sessionId: snapshot.sessionId } }
+        },
+        data: { messageSnapshotId: snapshot.id }
+      })
+    })
   }
 
   private async recoverStagingReviewScopeSnapshots(): Promise<void> {

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -482,7 +482,8 @@ class ProvenanceMessageSnapshotRepository {
             agentFrameId: snapshot.agentFrameId,
             messageBranchId: snapshot.messageBranchId,
             terminalMessageId: snapshot.terminalMessageId
-          }
+          },
+          'staging'
         )
         await client.$transaction(async (transaction) => {
           const promoted = await transaction.artifactMessageSnapshot.updateMany({
@@ -860,7 +861,8 @@ class ProvenanceMessageSnapshotRepository {
       agentFrameId: string
       messageBranchId: string
       terminalMessageId: string
-    }
+    },
+    checksumBackfillState: 'ready' | 'staging' = 'ready'
   ): Promise<void> {
     if (snapshot.state !== 'ready') {
       throw new Error(`Artifact Message snapshot is not ready: ${snapshot.id}`)
@@ -914,7 +916,7 @@ class ProvenanceMessageSnapshotRepository {
     if (!snapshot.checksum) {
       const client = await this.options.getClient()
       const updated = await client.artifactMessageSnapshot.updateMany({
-        where: { id: snapshot.id, state: 'ready', checksum: '' },
+        where: { id: snapshot.id, state: checksumBackfillState, checksum: '' },
         data: { checksum }
       })
       if (updated.count !== 1) {

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -3225,6 +3225,7 @@ describe('artifact provenance repository', () => {
     await client.artifactVersion.update({
       where: { id: ancestryProbe.id },
       data: {
+        producerRunId: 'missing-execution-run',
         producerRunIndex: 0,
         executionSnapshotJson: null,
         executionSnapshotChecksum: null,
@@ -3238,6 +3239,7 @@ describe('artifact provenance repository', () => {
     await client.artifactVersion.update({
       where: { id: ancestryProbe.id },
       data: {
+        producerRunId: ancestryProbe.producerRunId,
         producerRunIndex: ancestryProbe.producerRunIndex,
         executionSnapshotJson: ancestryProbe.executionSnapshotJson,
         executionSnapshotChecksum: ancestryProbe.executionSnapshotChecksum,

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -10,6 +10,7 @@ import { createProjectDbClient } from '../projects/prisma-client'
 import { migrateApplicationDatabase, verifyCurrentApplicationSchema } from './migration-service'
 
 const CURRENT_AGENT_MEMORY_MIGRATION_ID = '0017_agent_memory_project_scope'
+const CURRENT_FILE_ARTIFACT_MIGRATION_ID = '0018_file_artifact_data_constraints'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -290,20 +291,21 @@ describe('agent memory project scope migration', () => {
 
     await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: CURRENT_AGENT_MEMORY_MIGRATION_ID
+      migrationId: CURRENT_FILE_ARTIFACT_MIGRATION_ID
     })
   })
 
   it('replays an unledgered partial memory migration and restores missing triggers', async () => {
     await client.$executeRawUnsafe('DROP TRIGGER "MemoryEntry_fts_update"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" = ?`,
-      CURRENT_AGENT_MEMORY_MIGRATION_ID
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?)`,
+      CURRENT_AGENT_MEMORY_MIGRATION_ID,
+      CURRENT_FILE_ARTIFACT_MIGRATION_ID
     )
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      applied: [CURRENT_AGENT_MEMORY_MIGRATION_ID],
-      to: CURRENT_AGENT_MEMORY_MIGRATION_ID
+      applied: [CURRENT_AGENT_MEMORY_MIGRATION_ID, CURRENT_FILE_ARTIFACT_MIGRATION_ID],
+      to: CURRENT_FILE_ARTIFACT_MIGRATION_ID
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -783,7 +783,7 @@ describe('application database (integration)', () => {
         backupClient.$queryRaw<Array<{ id: string }>>`
           SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([{ id: '0016_compute_job_sensitive_data_encryption' }])
+      ).resolves.toEqual([{ id: '0017_agent_memory_project_scope' }])
     } finally {
       await backupClient.$disconnect()
     }

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -128,7 +128,8 @@ describe('application database (integration)', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
 
@@ -742,7 +743,7 @@ describe('application database (integration)', () => {
   it('backs up legacy data through the shared client on a portable storage path', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open science 数据 legacy backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
-    const backupPath = `${databasePath}.before-0017_agent_memory_project_scope.backup`
+    const backupPath = `${databasePath}.before-0018_file_artifact_data_constraints.backup`
     const seedClient = createProjectDbClient(storageRoot)
     try {
       await seedClient.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -1158,7 +1159,8 @@ describe('application database (integration)', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
 

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -62,15 +62,22 @@ describe('Compute Job sensitive data encryption migration', () => {
 
     await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope'],
+      applied: [
+        '0016_compute_job_sensitive_data_encryption',
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
+      ],
       from: '0015_session_model_call_usage',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_file_artifact_data_constraints'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0017_agent_memory_project_scope.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0018_file_artifact_data_constraints.backup`)
     ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<

--- a/src/main/database/database-domain-constraints.test.ts
+++ b/src/main/database/database-domain-constraints.test.ts
@@ -207,4 +207,229 @@ describe('database domain constraints', () => {
     }
     expect(accepted).toEqual([])
   })
+
+  it('rejects invalid managed-file and immutable provenance metadata', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-file-artifact-constraints-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+
+    const checksum = 'a'.repeat(64)
+    await client.$executeRawUnsafe(
+      `INSERT INTO "FileOriginSession" ("projectId","sessionId","updatedAt") VALUES ('project','session',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactLineage" ("id","projectId","sessionId","normalizedFilename","filename","updatedAt") VALUES ('artifact','project','session','result.txt','result.txt',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "UploadFile" ("id","projectId","sessionId","filename","originalFilename","updatedAt") VALUES ('upload','project','session','input.txt','input.txt',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "UploadVersion" ("id","uploadFileId","versionNumber","state","contentStorageKey","filename","originalFilename","sizeBytes","checksum","updatedAt") VALUES ('upload-version','upload',1,'ready','uploads/content','input.txt','input.txt',1,'${checksum}',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactMessageSnapshot" ("id","projectId","sessionId","rootFrameId","agentFrameId","messageBranchId","terminalMessageId","state","storageKey","checksum","messageCount","updatedAt") VALUES ('snapshot','project','session','root','agent','branch','message','staging','snapshots/message.json','${checksum}',1,CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactVersion" ("id","artifactId","versionNumber","filename","artifactRunId","rootFrameId","agentFrameId","messageBranchId","runtimeSegmentId","promptMessageId","state","contentStorageKey","evidenceStorageKey","sizeBytes","checksum","evidenceJson","evidenceChecksum","evidenceSchemaVersion","updatedAt") VALUES ('artifact-version','artifact',1,'result.txt','run','root','agent','branch','segment','prompt','pending','artifacts/content','artifacts/evidence.json',1,'${checksum}','{}','${checksum}',1,CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactVersionInput" ("id","artifactVersionId","ordinal","inputFileVersionId","sourceKind","sourceFileId","sourceArtifactVersionId","sourceVersionNumber","sourceProjectId","sourceSessionId","filename","sizeBytes","checksum","storageKey","strongestAssociation") VALUES ('input','artifact-version',0,'artifact-version','artifact-version','artifact','artifact-version',1,'project','session','result.txt',1,'${checksum}','artifacts/content','turn-attached')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ManagedFile" ("source","sourceFileId","projectId","sessionId","displayName","storageKey","sizeBytes","mtimeMs","sortAtMs","updatedAt") VALUES ('artifact','artifact','project','session','result.txt','artifacts/content',1,1,1,CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ManagedFileSessionSync" ("projectId","sessionId","filesRevision","groupSortAtMs","artifactCount","uploadCount") VALUES ('project','session',1,1,1,1)`
+    )
+
+    const invalidWrites = [
+      {
+        name: 'ManagedFile.sizeBytes',
+        sql: `UPDATE "ManagedFile" SET "sizeBytes" = -1 WHERE "sourceFileId" = 'artifact'`,
+        restore: `UPDATE "ManagedFile" SET "sizeBytes" = 1 WHERE "sourceFileId" = 'artifact'`
+      },
+      {
+        name: 'ManagedFile.mtimeMs',
+        sql: `UPDATE "ManagedFile" SET "mtimeMs" = -1 WHERE "sourceFileId" = 'artifact'`,
+        restore: `UPDATE "ManagedFile" SET "mtimeMs" = 1 WHERE "sourceFileId" = 'artifact'`
+      },
+      {
+        name: 'ManagedFile.sortAtMs',
+        sql: `UPDATE "ManagedFile" SET "sortAtMs" = -1 WHERE "sourceFileId" = 'artifact'`,
+        restore: `UPDATE "ManagedFile" SET "sortAtMs" = 1 WHERE "sourceFileId" = 'artifact'`
+      },
+      {
+        name: 'ManagedFile.storageKey',
+        sql: `UPDATE "ManagedFile" SET "storageKey" = ' ' WHERE "sourceFileId" = 'artifact'`,
+        restore: `UPDATE "ManagedFile" SET "storageKey" = 'artifacts/content' WHERE "sourceFileId" = 'artifact'`
+      },
+      {
+        name: 'ManagedFile deletedAt without operation',
+        sql: `UPDATE "ManagedFile" SET "deletedAt" = CURRENT_TIMESTAMP WHERE "sourceFileId" = 'artifact'`,
+        restore: `UPDATE "ManagedFile" SET "deletedAt" = NULL WHERE "sourceFileId" = 'artifact'`
+      },
+      {
+        name: 'ManagedFile operation without deletedAt',
+        sql: `UPDATE "ManagedFile" SET "deleteOperationId" = 'delete' WHERE "sourceFileId" = 'artifact'`,
+        restore: `UPDATE "ManagedFile" SET "deleteOperationId" = NULL WHERE "sourceFileId" = 'artifact'`
+      },
+      {
+        name: 'ManagedFileSessionSync.filesRevision',
+        sql: `UPDATE "ManagedFileSessionSync" SET "filesRevision" = -2 WHERE "sessionId" = 'session'`,
+        restore: `UPDATE "ManagedFileSessionSync" SET "filesRevision" = 1 WHERE "sessionId" = 'session'`
+      },
+      {
+        name: 'ManagedFileSessionSync.artifactCount',
+        sql: `UPDATE "ManagedFileSessionSync" SET "artifactCount" = -1 WHERE "sessionId" = 'session'`,
+        restore: `UPDATE "ManagedFileSessionSync" SET "artifactCount" = 1 WHERE "sessionId" = 'session'`
+      },
+      {
+        name: 'ManagedFileSessionSync.uploadCount',
+        sql: `UPDATE "ManagedFileSessionSync" SET "uploadCount" = -1 WHERE "sessionId" = 'session'`,
+        restore: `UPDATE "ManagedFileSessionSync" SET "uploadCount" = 1 WHERE "sessionId" = 'session'`
+      },
+      {
+        name: 'ManagedFileSessionSync deletedAt without operation',
+        sql: `UPDATE "ManagedFileSessionSync" SET "deletedAt" = CURRENT_TIMESTAMP WHERE "sessionId" = 'session'`,
+        restore: `UPDATE "ManagedFileSessionSync" SET "deletedAt" = NULL WHERE "sessionId" = 'session'`
+      },
+      {
+        name: 'ManagedFileSessionSync operation without deletedAt',
+        sql: `UPDATE "ManagedFileSessionSync" SET "deleteOperationId" = 'delete' WHERE "sessionId" = 'session'`,
+        restore: `UPDATE "ManagedFileSessionSync" SET "deleteOperationId" = NULL WHERE "sessionId" = 'session'`
+      },
+      {
+        name: 'UploadVersion.versionNumber',
+        sql: `UPDATE "UploadVersion" SET "versionNumber" = 0 WHERE "id" = 'upload-version'`,
+        restore: `UPDATE "UploadVersion" SET "versionNumber" = 1 WHERE "id" = 'upload-version'`
+      },
+      {
+        name: 'UploadVersion.sizeBytes',
+        sql: `UPDATE "UploadVersion" SET "sizeBytes" = -1 WHERE "id" = 'upload-version'`,
+        restore: `UPDATE "UploadVersion" SET "sizeBytes" = 1 WHERE "id" = 'upload-version'`
+      },
+      {
+        name: 'UploadVersion.contentStorageKey',
+        sql: `UPDATE "UploadVersion" SET "contentStorageKey" = ' ' WHERE "id" = 'upload-version'`,
+        restore: `UPDATE "UploadVersion" SET "contentStorageKey" = 'uploads/content' WHERE "id" = 'upload-version'`
+      },
+      {
+        name: 'UploadVersion.filename',
+        sql: `UPDATE "UploadVersion" SET "filename" = ' ' WHERE "id" = 'upload-version'`,
+        restore: `UPDATE "UploadVersion" SET "filename" = 'input.txt' WHERE "id" = 'upload-version'`
+      },
+      {
+        name: 'UploadVersion.originalFilename',
+        sql: `UPDATE "UploadVersion" SET "originalFilename" = ' ' WHERE "id" = 'upload-version'`,
+        restore: `UPDATE "UploadVersion" SET "originalFilename" = 'input.txt' WHERE "id" = 'upload-version'`
+      },
+      {
+        name: 'UploadVersion.checksum',
+        sql: `UPDATE "UploadVersion" SET "checksum" = ' ' WHERE "id" = 'upload-version'`,
+        restore: `UPDATE "UploadVersion" SET "checksum" = '${checksum}' WHERE "id" = 'upload-version'`
+      },
+      {
+        name: 'ArtifactMessageSnapshot.messageCount',
+        sql: `UPDATE "ArtifactMessageSnapshot" SET "messageCount" = -1 WHERE "id" = 'snapshot'`,
+        restore: `UPDATE "ArtifactMessageSnapshot" SET "messageCount" = 1 WHERE "id" = 'snapshot'`
+      },
+      {
+        name: 'ArtifactMessageSnapshot ready checksum',
+        sql: `UPDATE "ArtifactMessageSnapshot" SET "state" = 'ready', "checksum" = 'invalid' WHERE "id" = 'snapshot'`,
+        restore: `UPDATE "ArtifactMessageSnapshot" SET "state" = 'staging', "checksum" = '${checksum}' WHERE "id" = 'snapshot'`
+      },
+      {
+        name: 'ArtifactVersion.versionNumber',
+        sql: `UPDATE "ArtifactVersion" SET "versionNumber" = 0 WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "versionNumber" = 1 WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion.sizeBytes',
+        sql: `UPDATE "ArtifactVersion" SET "sizeBytes" = -1 WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "sizeBytes" = 1 WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion.evidenceSchemaVersion',
+        sql: `UPDATE "ArtifactVersion" SET "evidenceSchemaVersion" = 0 WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "evidenceSchemaVersion" = 1 WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion.executionSnapshotSchemaVersion',
+        sql: `UPDATE "ArtifactVersion" SET "executionSnapshotJson" = '{}', "executionSnapshotChecksum" = '${checksum}', "executionSnapshotStorageKey" = 'artifacts/execution.json', "executionSnapshotSchemaVersion" = 0 WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "executionSnapshotJson" = NULL, "executionSnapshotChecksum" = NULL, "executionSnapshotStorageKey" = NULL, "executionSnapshotSchemaVersion" = NULL WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion producer id without index',
+        sql: `UPDATE "ArtifactVersion" SET "producerRunId" = 'producer' WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "producerRunId" = NULL WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion producer index without id',
+        sql: `UPDATE "ArtifactVersion" SET "producerRunIndex" = 0 WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "producerRunIndex" = NULL WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion negative producer index',
+        sql: `UPDATE "ArtifactVersion" SET "producerRunId" = 'producer', "producerRunIndex" = -1 WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "producerRunId" = NULL, "producerRunIndex" = NULL WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion published content storage',
+        sql: `UPDATE "ArtifactVersion" SET "contentStorageKey" = ' ' WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "contentStorageKey" = 'artifacts/content' WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion published evidence storage',
+        sql: `UPDATE "ArtifactVersion" SET "evidenceStorageKey" = ' ' WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "evidenceStorageKey" = 'artifacts/evidence.json' WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion published content checksum',
+        sql: `UPDATE "ArtifactVersion" SET "checksum" = 'invalid' WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "checksum" = '${checksum}' WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersion published evidence checksum',
+        sql: `UPDATE "ArtifactVersion" SET "evidenceChecksum" = 'invalid' WHERE "id" = 'artifact-version'`,
+        restore: `UPDATE "ArtifactVersion" SET "evidenceChecksum" = '${checksum}' WHERE "id" = 'artifact-version'`
+      },
+      {
+        name: 'ArtifactVersionInput.ordinal',
+        sql: `UPDATE "ArtifactVersionInput" SET "ordinal" = -1 WHERE "id" = 'input'`,
+        restore: `UPDATE "ArtifactVersionInput" SET "ordinal" = 0 WHERE "id" = 'input'`
+      },
+      {
+        name: 'ArtifactVersionInput.sourceVersionNumber',
+        sql: `UPDATE "ArtifactVersionInput" SET "sourceVersionNumber" = 0 WHERE "id" = 'input'`,
+        restore: `UPDATE "ArtifactVersionInput" SET "sourceVersionNumber" = 1 WHERE "id" = 'input'`
+      },
+      {
+        name: 'ArtifactVersionInput.sizeBytes',
+        sql: `UPDATE "ArtifactVersionInput" SET "sizeBytes" = -1 WHERE "id" = 'input'`,
+        restore: `UPDATE "ArtifactVersionInput" SET "sizeBytes" = 1 WHERE "id" = 'input'`
+      },
+      {
+        name: 'ArtifactVersionInput.checksum',
+        sql: `UPDATE "ArtifactVersionInput" SET "checksum" = ' ' WHERE "id" = 'input'`,
+        restore: `UPDATE "ArtifactVersionInput" SET "checksum" = '${checksum}' WHERE "id" = 'input'`
+      },
+      {
+        name: 'ArtifactVersionInput.storageKey',
+        sql: `UPDATE "ArtifactVersionInput" SET "storageKey" = ' ' WHERE "id" = 'input'`,
+        restore: `UPDATE "ArtifactVersionInput" SET "storageKey" = 'artifacts/content' WHERE "id" = 'input'`
+      }
+    ]
+
+    const accepted: string[] = []
+    for (const invalidWrite of invalidWrites) {
+      try {
+        await client.$executeRawUnsafe(invalidWrite.sql)
+        accepted.push(invalidWrite.name)
+        await client.$executeRawUnsafe(invalidWrite.restore)
+      } catch {
+        // Expected: the SQLite CHECK contract rejects the write.
+      }
+    }
+    expect(accepted).toEqual([])
+  })
 })

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -89,7 +89,7 @@ const seedValidAffectedRows = async (client: PrismaClient): Promise<void> => {
       "checksum","storageKey","strongestAssociation"
     ) VALUES (
       'input','version',0,'version','artifact-version','lineage','version','project','session',
-      'result.txt',0,'checksum','content','turn-attached'
+      'result.txt',0,'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','content','turn-attached'
     )`
   )
   await client.$executeRawUnsafe(
@@ -156,10 +156,11 @@ describe('database JSON constraints migration', () => {
           '0014_review_query_indexes',
           '0015_session_model_call_usage',
           '0016_compute_job_sensitive_data_encryption',
-          '0017_agent_memory_project_scope'
+          '0017_agent_memory_project_scope',
+          '0018_file_artifact_data_constraints'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0017_agent_memory_project_scope'
+        to: '0018_file_artifact_data_constraints'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).rejects.toMatchObject({
         code: 'ENOENT'
@@ -183,9 +184,12 @@ describe('database JSON constraints migration', () => {
       ).rejects.toMatchObject({ code: 'ENOENT' })
       await expect(
         access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
-      ).resolves.toBeUndefined()
+      ).rejects.toMatchObject({ code: 'ENOENT' })
       await expect(
         access(`${databasePath}.before-0017_agent_memory_project_scope.backup`)
+      ).resolves.toBeUndefined()
+      await expect(
+        access(`${databasePath}.before-0018_file_artifact_data_constraints.backup`)
       ).resolves.toBeUndefined()
 
       await expect(

--- a/src/main/database/database-json-constraints.test.ts
+++ b/src/main/database/database-json-constraints.test.ts
@@ -73,7 +73,7 @@ describe('database JSON and remaining domain constraints', () => {
         "checksum","storageKey","strongestAssociation"
       ) VALUES (
         'input','version',0,'version','artifact-version','lineage','version','project','session',
-        'result.txt',0,'checksum','content','turn-attached'
+        'result.txt',0,'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','content','turn-attached'
       )`
       )
       await client.$executeRawUnsafe(

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -114,7 +114,8 @@ describe('database startup logging', () => {
               '0014_review_query_indexes',
               '0015_session_model_call_usage',
               '0016_compute_job_sensitive_data_encryption',
-              '0017_agent_memory_project_scope'
+              '0017_agent_memory_project_scope',
+              '0018_file_artifact_data_constraints'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/file-artifact-data-constraints-migration.test.ts
+++ b/src/main/database/file-artifact-data-constraints-migration.test.ts
@@ -1,0 +1,163 @@
+import { access, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import { MIGRATION_MANIFEST, migrateApplicationDatabase } from './migration-service'
+import { applySqliteMigrationOperations } from './sqlite-schema-migrations'
+
+const MIGRATION_ID = '0018_file_artifact_data_constraints'
+const CHECKSUM = 'a'.repeat(64)
+
+const createDatabaseAtMigration0016 = async (client: PrismaClient): Promise<void> => {
+  const migration0017Index = MIGRATION_MANIFEST.findIndex(
+    (migration) => migration.id === MIGRATION_ID
+  )
+  if (migration0017Index < 0) throw new Error(`Missing ${MIGRATION_ID} from the manifest.`)
+  const prefix = MIGRATION_MANIFEST.slice(0, migration0017Index)
+  for (const migration of prefix) {
+    for (const statement of migration.statements) await client.$executeRawUnsafe(statement)
+    if ('operations' in migration) {
+      await client.$transaction((transaction) =>
+        applySqliteMigrationOperations(transaction, migration.operations)
+      )
+    }
+  }
+  await client.$executeRawUnsafe(`CREATE TABLE "_open_science_migrations" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "checksum" TEXT NOT NULL,
+    "appliedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "_open_science_migrations_checksum_check"
+      CHECK (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
+  )`)
+  for (const migration of prefix) {
+    await client.$executeRawUnsafe(
+      `INSERT INTO "_open_science_migrations" ("id", "checksum") VALUES (?, ?)`,
+      migration.id,
+      migration.checksum
+    )
+  }
+}
+
+describe('file and Artifact data constraints migration', () => {
+  let client: PrismaClient | undefined
+  let storageRoot: string | undefined
+
+  afterEach(async () => {
+    await client?.$disconnect()
+    if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
+  })
+
+  it('preserves valid provenance and repairs the supported historical states', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-file-artifact-0017-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    client = createProjectDbClient(storageRoot)
+    await createDatabaseAtMigration0016(client)
+
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Project" ("id","name","updatedAt") VALUES ('project','Project',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "FileOriginSession" ("projectId","sessionId","updatedAt") VALUES ('project','session',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactLineage" ("id","projectId","sessionId","normalizedFilename","filename","updatedAt") VALUES ('artifact','project','session','result.txt','result.txt',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "UploadFile" ("id","projectId","sessionId","filename","originalFilename","updatedAt") VALUES ('upload','project','session','input.txt','input.txt',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "UploadVersion" ("id","uploadFileId","versionNumber","state","contentStorageKey","filename","originalFilename","sizeBytes","checksum","updatedAt") VALUES ('upload-version','upload',1,'ready','uploads/content','input.txt','input.txt',1,'${CHECKSUM}',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "VisionEvidence" ("id","projectId","sessionId","sourceKind","uploadVersionId","imageChecksum","mimeType","extractorFingerprint","evidenceSchemaVersion","evidenceJson","evidenceChecksum","updatedAt") VALUES ('vision','project','session','upload-version','upload-version','${CHECKSUM}','image/png','${CHECKSUM}',1,'{}','${CHECKSUM}',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactMessageSnapshot" ("id","projectId","sessionId","rootFrameId","agentFrameId","messageBranchId","terminalMessageId","state","storageKey","checksum","messageCount","updatedAt") VALUES ('snapshot','project','session','root','agent','branch','message','ready','snapshots/message.json','',1,CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactVersion" ("id","artifactId","versionNumber","filename","artifactRunId","rootFrameId","agentFrameId","messageBranchId","runtimeSegmentId","promptMessageId","messageSnapshotId","state","contentStorageKey","evidenceStorageKey","sizeBytes","checksum","evidenceJson","evidenceChecksum","evidenceSchemaVersion","updatedAt") VALUES ('artifact-version','artifact',1,'result.txt','run','root','agent','branch','segment','prompt','snapshot','pending','artifacts/content','artifacts/evidence.json',1,'${CHECKSUM}','{}','${CHECKSUM}',1,CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactVersionInput" ("id","artifactVersionId","ordinal","inputFileVersionId","sourceKind","sourceFileId","sourceUploadVersionId","sourceVersionNumber","sourceProjectId","sourceSessionId","filename","sizeBytes","checksum","storageKey","strongestAssociation") VALUES ('input','artifact-version',0,'upload-version','upload-version','upload','upload-version',1,'project','session','input.txt',1,'${CHECKSUM}','uploads/content','turn-attached')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ManagedFile" ("seq","source","sourceFileId","projectId","sessionId","displayName","storageKey","sizeBytes","sortAtMs","updatedAt","deletedAt") VALUES (41,'artifact','artifact','project','session','result.txt','artifacts/content',1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ManagedFileSessionSync" ("projectId","sessionId","filesRevision","groupSortAtMs","artifactCount","uploadCount","deletedAt") VALUES ('project','session',-1,1,1,1,CURRENT_TIMESTAMP)`
+    )
+
+    await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toEqual({
+      adoptedLegacy: false,
+      applied: [MIGRATION_ID],
+      from: '0016_compute_job_sensitive_data_encryption',
+      to: MIGRATION_ID
+    })
+    await expect(
+      client.$queryRawUnsafe(
+        `SELECT "filesRevision", "isComplete", "deleteOperationId" FROM "ManagedFileSessionSync" WHERE "sessionId" = 'session'`
+      )
+    ).resolves.toEqual([
+      {
+        filesRevision: 0,
+        isComplete: false,
+        deleteOperationId: 'migration-0018:project:session'
+      }
+    ])
+    await expect(
+      client.$queryRawUnsafe(
+        `SELECT "deleteOperationId" FROM "ManagedFile" WHERE "sourceFileId" = 'artifact'`
+      )
+    ).resolves.toEqual([{ deleteOperationId: 'migration-0018:41' }])
+    await expect(
+      client.$queryRawUnsafe(
+        `SELECT "state", "checksum" FROM "ArtifactMessageSnapshot" WHERE "id" = 'snapshot'`
+      )
+    ).resolves.toEqual([{ state: 'staging', checksum: '' }])
+    await expect(client.$queryRawUnsafe('PRAGMA foreign_key_check')).resolves.toEqual([])
+
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ManagedFile" ("source","sourceFileId","projectId","sessionId","displayName","storageKey","sizeBytes","sortAtMs","updatedAt") VALUES ('upload','next-file','project','session','next.txt','uploads/next',0,2,CURRENT_TIMESTAMP)`
+    )
+    await expect(
+      client.$queryRawUnsafe(`SELECT "seq" FROM "ManagedFile" WHERE "sourceFileId" = 'next-file'`)
+    ).resolves.toEqual([{ seq: 42 }])
+  })
+
+  it('fails closed and rolls back when other historical metadata is invalid', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-file-artifact-0017-invalid-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    client = createProjectDbClient(storageRoot)
+    await createDatabaseAtMigration0016(client)
+    await client.$executeRawUnsafe(
+      `INSERT INTO "FileOriginSession" ("projectId","sessionId","updatedAt") VALUES ('project','session',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "UploadFile" ("id","projectId","sessionId","filename","originalFilename","updatedAt") VALUES ('upload','project','session','input.txt','input.txt',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "UploadVersion" ("id","uploadFileId","versionNumber","state","contentStorageKey","filename","originalFilename","sizeBytes","checksum","updatedAt") VALUES ('invalid','upload',1,'ready','uploads/content','input.txt','input.txt',-1,'${CHECKSUM}',CURRENT_TIMESTAMP)`
+    )
+
+    await expect(migrateApplicationDatabase(client, { databasePath })).rejects.toMatchObject({
+      code: 'database_validation_failed',
+      migrationId: MIGRATION_ID
+    })
+    await expect(
+      client.$queryRawUnsafe(
+        `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1`
+      )
+    ).resolves.toEqual([{ id: '0016_compute_job_sensitive_data_encryption' }])
+    await expect(
+      client.$queryRawUnsafe(`PRAGMA table_info("ManagedFileSessionSync")`)
+    ).resolves.not.toEqual([expect.objectContaining({ name: 'isComplete' })])
+    await expect(
+      client.$queryRawUnsafe(`SELECT "sizeBytes" FROM "UploadVersion" WHERE "id" = 'invalid'`)
+    ).resolves.toEqual([{ sizeBytes: -1n }])
+    await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
+  })
+})

--- a/src/main/database/file-artifact-data-constraints-migration.test.ts
+++ b/src/main/database/file-artifact-data-constraints-migration.test.ts
@@ -94,7 +94,7 @@ describe('file and Artifact data constraints migration', () => {
     await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toEqual({
       adoptedLegacy: false,
       applied: [MIGRATION_ID],
-      from: '0016_compute_job_sensitive_data_encryption',
+      from: '0017_agent_memory_project_scope',
       to: MIGRATION_ID
     })
     await expect(
@@ -151,7 +151,7 @@ describe('file and Artifact data constraints migration', () => {
       client.$queryRawUnsafe(
         `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1`
       )
-    ).resolves.toEqual([{ id: '0016_compute_job_sensitive_data_encryption' }])
+    ).resolves.toEqual([{ id: '0017_agent_memory_project_scope' }])
     await expect(
       client.$queryRawUnsafe(`PRAGMA table_info("ManagedFileSessionSync")`)
     ).resolves.not.toEqual([expect.objectContaining({ name: 'isComplete' })])

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -238,12 +238,16 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "updatedAt" DATETIME NOT NULL,
     "deletedAt" DATETIME,
     "deleteOperationId" TEXT,
-    CONSTRAINT "ManagedFile_source_check" CHECK ("source" IN ('artifact', 'upload'))
+    CONSTRAINT "ManagedFile_source_check" CHECK ("source" IN ('artifact', 'upload')),
+    CONSTRAINT "ManagedFile_nonnegative_check" CHECK ("sizeBytes" >= 0 AND ("mtimeMs" IS NULL OR "mtimeMs" >= 0) AND "sortAtMs" >= 0),
+    CONSTRAINT "ManagedFile_storageKey_check" CHECK (length(trim("storageKey")) > 0),
+    CONSTRAINT "ManagedFile_deletion_check" CHECK ((("deletedAt" IS NULL AND "deleteOperationId" IS NULL) OR ("deletedAt" IS NOT NULL AND "deleteOperationId" IS NOT NULL)))
 );`,
   `CREATE TABLE IF NOT EXISTS "ManagedFileSessionSync" (
     "projectId" TEXT NOT NULL,
     "sessionId" TEXT NOT NULL,
     "filesRevision" INTEGER NOT NULL,
+    "isComplete" BOOLEAN NOT NULL DEFAULT true,
     "groupSortAtMs" BIGINT NOT NULL,
     "artifactCount" INTEGER NOT NULL DEFAULT 0,
     "uploadCount" INTEGER NOT NULL DEFAULT 0,
@@ -251,7 +255,10 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "deletedAt" DATETIME,
     "deleteOperationId" TEXT,
 
-    PRIMARY KEY ("projectId", "sessionId")
+    PRIMARY KEY ("projectId", "sessionId"),
+    CONSTRAINT "ManagedFileSessionSync_nonnegative_check" CHECK ("filesRevision" >= 0 AND "artifactCount" >= 0 AND "uploadCount" >= 0),
+    CONSTRAINT "ManagedFileSessionSync_isComplete_check" CHECK ("isComplete" IN (false, true)),
+    CONSTRAINT "ManagedFileSessionSync_deletion_check" CHECK ((("deletedAt" IS NULL AND "deleteOperationId" IS NULL) OR ("deletedAt" IS NOT NULL AND "deleteOperationId" IS NOT NULL)))
 );`,
   `CREATE TABLE IF NOT EXISTS "FileOriginSession" (
     "projectId" TEXT NOT NULL,
@@ -304,7 +311,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "registeredAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL,
     CONSTRAINT "UploadVersion_uploadFileId_fkey" FOREIGN KEY ("uploadFileId") REFERENCES "UploadFile" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT "UploadVersion_state_check" CHECK ("state" IN ('staging', 'ready'))
+    CONSTRAINT "UploadVersion_state_check" CHECK ("state" IN ('staging', 'ready')),
+    CONSTRAINT "UploadVersion_metadata_check" CHECK ("versionNumber" >= 1 AND "sizeBytes" >= 0 AND length(trim("contentStorageKey")) > 0 AND length(trim("filename")) > 0 AND length(trim("originalFilename")) > 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
 );`,
   `CREATE TABLE IF NOT EXISTS "VisionEvidence" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -347,7 +355,9 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL,
     CONSTRAINT "ArtifactMessageSnapshot_projectId_sessionId_fkey" FOREIGN KEY ("projectId", "sessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
-    CONSTRAINT "ArtifactMessageSnapshot_state_check" CHECK ("state" IN ('staging', 'ready'))
+    CONSTRAINT "ArtifactMessageSnapshot_state_check" CHECK ("state" IN ('staging', 'ready')),
+    CONSTRAINT "ArtifactMessageSnapshot_messageCount_check" CHECK ("messageCount" >= 0),
+    CONSTRAINT "ArtifactMessageSnapshot_readyChecksum_check" CHECK ("state" <> 'ready' OR (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*'))
 );`,
   `CREATE TABLE IF NOT EXISTS "ArtifactVersion" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -388,7 +398,10 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ArtifactVersion_filename_check" CHECK (length("filename") > 0),
     CONSTRAINT "ArtifactVersion_evidenceJson_check" CHECK (json_valid("evidenceJson") AND json_type("evidenceJson") = 'object'),
     CONSTRAINT "ArtifactVersion_executionSnapshotJson_check" CHECK ("executionSnapshotJson" IS NULL OR (json_valid("executionSnapshotJson") AND json_type("executionSnapshotJson") = 'object')),
-    CONSTRAINT "ArtifactVersion_executionSnapshotBundle_check" CHECK ((("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL)))
+    CONSTRAINT "ArtifactVersion_executionSnapshotBundle_check" CHECK ((("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL))),
+    CONSTRAINT "ArtifactVersion_nonnegative_check" CHECK ("versionNumber" >= 1 AND "sizeBytes" >= 0 AND "evidenceSchemaVersion" >= 1 AND ("executionSnapshotSchemaVersion" IS NULL OR "executionSnapshotSchemaVersion" >= 1)),
+    CONSTRAINT "ArtifactVersion_producerRun_check" CHECK ((("producerRunId" IS NULL AND "producerRunIndex" IS NULL) OR ("producerRunId" IS NOT NULL AND length(trim("producerRunId")) > 0 AND "producerRunIndex" IS NOT NULL AND "producerRunIndex" >= 0))),
+    CONSTRAINT "ArtifactVersion_publishedMetadata_check" CHECK ("state" NOT IN ('pending', 'finalized') OR (length(trim("contentStorageKey")) > 0 AND length(trim("evidenceStorageKey")) > 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*' AND length("evidenceChecksum") = 64 AND "evidenceChecksum" NOT GLOB '*[^0-9a-f]*'))
 );`,
   `CREATE TABLE IF NOT EXISTS "ArtifactVersionInput" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -415,7 +428,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ArtifactVersionInput_sourceProjectId_sourceSessionId_fkey" FOREIGN KEY ("sourceProjectId", "sourceSessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
     CONSTRAINT "ArtifactVersionInput_sourceKind_check" CHECK ("sourceKind" IN ('artifact-version', 'upload-version')),
     CONSTRAINT "ArtifactVersionInput_sourceIdentity_check" CHECK ((("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR ("sourceKind" = 'upload-version' AND "sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL AND "inputFileVersionId" = "sourceUploadVersionId"))),
-    CONSTRAINT "ArtifactVersionInput_strongestAssociation_check" CHECK ("strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version'))
+    CONSTRAINT "ArtifactVersionInput_strongestAssociation_check" CHECK ("strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version')),
+    CONSTRAINT "ArtifactVersionInput_metadata_check" CHECK ("ordinal" >= 0 AND ("sourceVersionNumber" IS NULL OR "sourceVersionNumber" >= 1) AND "sizeBytes" >= 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*' AND length(trim("storageKey")) > 0)
 );`,
   `CREATE TABLE IF NOT EXISTS "ReviewFindingDisposition" (
     "id" TEXT NOT NULL PRIMARY KEY,

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -20,7 +20,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0018_test_suffix'
+  const id = '0019_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -264,10 +264,11 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ],
       from: null,
-      to: '0017_agent_memory_project_scope'
+      to: '0018_file_artifact_data_constraints'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -280,8 +281,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0017_agent_memory_project_scope',
-      to: '0017_agent_memory_project_scope'
+      from: '0018_file_artifact_data_constraints',
+      to: '0018_file_artifact_data_constraints'
     })
   })
 
@@ -343,7 +344,7 @@ describe('application database migrations', () => {
     await client.$executeRawUnsafe('ALTER TABLE "SessionTurnUsage" DROP COLUMN "cachedWriteTokens"')
     await client.$executeRawUnsafe('ALTER TABLE "SessionTurnUsage" DROP COLUMN "modelCallCount"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_file_artifact_data_constraints')`
     )
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.project.create({ data: { id: 'project-1', name: 'Project' } })
@@ -358,7 +359,8 @@ describe('application database migrations', () => {
       applied: [
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
     await expect(
@@ -429,7 +431,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -474,7 +477,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0017_agent_memory_project_scope'
+      to: '0018_file_artifact_data_constraints'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -497,7 +500,7 @@ describe('application database migrations', () => {
     await removeComputePasswordAuthSchema(client)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope')`)
+      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_file_artifact_data_constraints')`)
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: [
@@ -512,10 +515,11 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_file_artifact_data_constraints'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -583,10 +587,11 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_file_artifact_data_constraints'
     })
     await expect(
       client.$queryRaw<
@@ -705,7 +710,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0017_agent_memory_project_scope'
+      migrationId: '0018_file_artifact_data_constraints'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -721,9 +726,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0018_test_suffix'],
-      from: '0017_agent_memory_project_scope',
-      to: '0018_test_suffix'
+      applied: ['0019_test_suffix'],
+      from: '0018_file_artifact_data_constraints',
+      to: '0019_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -747,7 +752,8 @@ describe('application database migrations', () => {
       { id: '0015_session_model_call_usage' },
       { id: '0016_compute_job_sensitive_data_encryption' },
       { id: '0017_agent_memory_project_scope' },
-      { id: '0018_test_suffix' }
+      { id: '0018_file_artifact_data_constraints' },
+      { id: '0019_test_suffix' }
     ])
   })
 
@@ -816,10 +822,11 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_file_artifact_data_constraints'
     })
     expect(backupEvents).toEqual([
       {
@@ -901,6 +908,11 @@ describe('application database migrations', () => {
         migrationId: '0017_agent_memory_project_scope',
         path: `${databasePath}.before-0017_agent_memory_project_scope.backup`,
         reused: false
+      },
+      {
+        migrationId: '0018_file_artifact_data_constraints',
+        path: `${databasePath}.before-0018_file_artifact_data_constraints.backup`,
+        reused: false
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -921,9 +933,12 @@ describe('application database migrations', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0017_agent_memory_project_scope.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0018_file_artifact_data_constraints.backup`)
     ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<Array<{ agentContext: string; name: string }>>`
@@ -954,7 +969,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0018_test_suffix'
+      migrationId: '0019_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -983,7 +998,8 @@ describe('application database migrations', () => {
       { id: '0014_review_query_indexes' },
       { id: '0015_session_model_call_usage' },
       { id: '0016_compute_job_sensitive_data_encryption' },
-      { id: '0017_agent_memory_project_scope' }
+      { id: '0017_agent_memory_project_scope' },
+      { id: '0018_file_artifact_data_constraints' }
     ])
   })
 
@@ -1048,7 +1064,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0018_test_suffix'
+      migrationId: '0019_test_suffix'
     })
   })
 
@@ -1091,9 +1107,10 @@ describe('application database migrations', () => {
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
-        '0018_test_suffix'
+        '0018_file_artifact_data_constraints',
+        '0019_test_suffix'
       ],
-      to: '0018_test_suffix'
+      to: '0019_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -1334,7 +1351,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
     await expect(
@@ -1448,7 +1466,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1514,7 +1533,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
     await expect(
@@ -1583,7 +1603,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -1686,7 +1707,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
     await expect(
@@ -1709,6 +1731,7 @@ describe('application database migrations', () => {
     const modelCallUsageBackupPath = `${databasePath}.before-0015_session_model_call_usage.backup`
     const computeJobEncryptionBackupPath = `${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`
     const agentMemoryBackupPath = `${databasePath}.before-0017_agent_memory_project_scope.backup`
+    const fileArtifactConstraintsBackupPath = `${databasePath}.before-0018_file_artifact_data_constraints.backup`
     const backupEvents: unknown[] = []
     client = createProjectDbClient(storageRoot)
     await client.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -1751,7 +1774,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ]
     })
     expect(backupEvents).toEqual([
@@ -1839,6 +1863,11 @@ describe('application database migrations', () => {
         migrationId: '0017_agent_memory_project_scope',
         path: agentMemoryBackupPath,
         reused: false
+      },
+      {
+        migrationId: '0018_file_artifact_data_constraints',
+        path: fileArtifactConstraintsBackupPath,
+        reused: false
       }
     ])
     await expect(
@@ -1846,8 +1875,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0016_compute_job_sensitive_data_encryption.backup',
-      'open-science.db.before-0017_agent_memory_project_scope.backup'
+      'open-science.db.before-0017_agent_memory_project_scope.backup',
+      'open-science.db.before-0018_file_artifact_data_constraints.backup'
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentContextBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -1858,12 +1887,13 @@ describe('application database migrations', () => {
     await expect(access(sessionProjectionBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(reviewQueryIndexesBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(modelCallUsageBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(access(computeJobEncryptionBackupPath)).resolves.toBeUndefined()
+    await expect(access(computeJobEncryptionBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentMemoryBackupPath)).resolves.toBeUndefined()
+    await expect(access(fileArtifactConstraintsBackupPath)).resolves.toBeUndefined()
     await expect(client.project.count()).resolves.toBe(1)
 
     const backupClient = new PrismaClient({
-      datasources: { db: { url: `file:${agentMemoryBackupPath.replaceAll('\\', '/')}` } }
+      datasources: { db: { url: `file:${fileArtifactConstraintsBackupPath.replaceAll('\\', '/')}` } }
     })
     try {
       await expect(
@@ -1875,7 +1905,7 @@ describe('application database migrations', () => {
         backupClient.$queryRaw<Array<{ id: string }>>`
           SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([{ id: '0016_compute_job_sensitive_data_encryption' }])
+      ).resolves.toEqual([{ id: '0017_agent_memory_project_scope' }])
     } finally {
       await backupClient.$disconnect()
     }
@@ -2308,6 +2338,11 @@ describe('application database migrations', () => {
         migrationId: '0017_agent_memory_project_scope',
         path: `${databasePath}.before-0017_agent_memory_project_scope.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0018_file_artifact_data_constraints',
+        path: `${databasePath}.before-0018_file_artifact_data_constraints.backup`,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -2372,6 +2407,10 @@ describe('application database migrations', () => {
       {
         migrationId: '0017_agent_memory_project_scope',
         path: `${databasePath}.before-0017_agent_memory_project_scope.backup`
+      },
+      {
+        migrationId: '0018_file_artifact_data_constraints',
+        path: `${databasePath}.before-0018_file_artifact_data_constraints.backup`
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -2405,8 +2444,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0016_compute_job_sensitive_data_encryption.backup',
       'open-science.db.before-0017_agent_memory_project_scope.backup',
+      'open-science.db.before-0018_file_artifact_data_constraints.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -1893,7 +1893,9 @@ describe('application database migrations', () => {
     await expect(client.project.count()).resolves.toBe(1)
 
     const backupClient = new PrismaClient({
-      datasources: { db: { url: `file:${fileArtifactConstraintsBackupPath.replaceAll('\\', '/')}` } }
+      datasources: {
+        db: { url: `file:${fileArtifactConstraintsBackupPath.replaceAll('\\', '/')}` }
+      }
     })
     try {
       await expect(

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -36,6 +36,7 @@ import {
   MEMORY_AUXILIARY_SCHEMA_OBJECTS,
   MEMORY_AUXILIARY_TABLE_NAMES
 } from './migrations/0017-agent-memory-project-scope'
+import { fileArtifactDataConstraintsMigration } from './migrations/0018-file-artifact-data-constraints'
 import {
   applySqliteMigrationOperations,
   type SqliteMigrationOperation
@@ -285,6 +286,12 @@ const COMPUTE_JOB_SENSITIVE_DATA_ENCRYPTION_CHECKSUM = checksumMigrationPayload(
   computeJobSensitiveDataEncryptionMigration.verifiers,
   computeJobSensitiveDataEncryptionMigration.operations
 )
+const FILE_ARTIFACT_DATA_CONSTRAINTS_CHECKSUM = checksumMigrationPayload(
+  fileArtifactDataConstraintsMigration.id,
+  fileArtifactDataConstraintsMigration.statements,
+  fileArtifactDataConstraintsMigration.verifiers,
+  fileArtifactDataConstraintsMigration.operations
+)
 const DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints = Object.fromEntries(
   databaseDomainConstraintsMigration.verifiers[0].tables.map(({ table, constraints }) => [
     table,
@@ -348,6 +355,15 @@ const AGENT_MEMORY_PROJECT_SCOPE_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstr
         Object.fromEntries(constraints.map(({ name, expression }) => [name, expression]))
       ])
   )
+const FILE_ARTIFACT_DATA_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints = Object.fromEntries(
+  fileArtifactDataConstraintsMigration.verifiers
+    .filter((verifier) => verifier.kind === 'check-constraints-exist')
+    .flatMap((verifier) => verifier.tables)
+    .map(({ table, constraints }) => [
+      table,
+      Object.fromEntries(constraints.map(({ name, expression }) => [name, expression]))
+    ])
+)
 const mergeAllowedSuffixChecks = (
   ...contracts: readonly AllowedSuffixCheckConstraints[]
 ): AllowedSuffixCheckConstraints => {
@@ -459,6 +475,12 @@ const MIGRATION_MANIFEST = [
   {
     ...agentMemoryProjectScopeMigration,
     checksum: AGENT_MEMORY_PROJECT_SCOPE_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...fileArtifactDataConstraintsMigration,
+    checksum: FILE_ARTIFACT_DATA_CONSTRAINTS_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }
@@ -1380,6 +1402,11 @@ const migrateApplicationDatabaseWithManifest = async (
       candidate.id === agentMemoryProjectScopeMigration.id &&
       candidate.checksum === AGENT_MEMORY_PROJECT_SCOPE_CHECKSUM
   )
+  const adoptsFileArtifactDataConstraints = manifest.some(
+    (candidate) =>
+      candidate.id === fileArtifactDataConstraintsMigration.id &&
+      candidate.checksum === FILE_ARTIFACT_DATA_CONSTRAINTS_CHECKSUM
+  )
   const adoptedLegacy = appliedCount === 0 && hasExistingApplicationTables
   const allowedSuffixChecks = mergeAllowedSuffixChecks(
     adoptsDatabaseDomainConstraints ? DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS : {},
@@ -1388,7 +1415,8 @@ const migrateApplicationDatabaseWithManifest = async (
     adoptsVisionEvidence ? VISION_EVIDENCE_ALLOWED_SUFFIX_CHECKS : {},
     adoptsComputePasswordAuth ? COMPUTE_PASSWORD_AUTH_ALLOWED_SUFFIX_CHECKS : {},
     adoptsCrossResourceTags ? CROSS_RESOURCE_TAGS_ALLOWED_SUFFIX_CHECKS : {},
-    adoptsAgentMemoryProjectScope ? AGENT_MEMORY_PROJECT_SCOPE_ALLOWED_SUFFIX_CHECKS : {}
+    adoptsAgentMemoryProjectScope ? AGENT_MEMORY_PROJECT_SCOPE_ALLOWED_SUFFIX_CHECKS : {},
+    adoptsFileArtifactDataConstraints ? FILE_ARTIFACT_DATA_ALLOWED_SUFFIX_CHECKS : {}
   )
 
   let nextIndex = appliedCount
@@ -1433,6 +1461,7 @@ export {
   TAG_ORDERING_CHECKSUM,
   REVIEW_QUERY_INDEXES_CHECKSUM,
   AGENT_MEMORY_PROJECT_SCOPE_CHECKSUM,
+  FILE_ARTIFACT_DATA_CONSTRAINTS_CHECKSUM,
   DatabaseMigrationError,
   checksumMigrationPayload,
   classifyDatabaseFailure,

--- a/src/main/database/migrations/0018-file-artifact-data-constraints.ts
+++ b/src/main/database/migrations/0018-file-artifact-data-constraints.ts
@@ -1,0 +1,611 @@
+/* Immutable 0018 migration snapshot. Do not regenerate after release. */
+
+const fileArtifactDataConstraintsMigration = {
+  id: '0018_file_artifact_data_constraints',
+  statements: [] as const,
+  operations: [
+    {
+      kind: 'add-column-if-missing',
+      version: 1,
+      tableName: 'ManagedFileSessionSync',
+      columnName: 'isComplete',
+      definition: 'BOOLEAN NOT NULL DEFAULT true'
+    },
+    {
+      kind: 'execute-statements',
+      version: 1,
+      statements: [
+        `UPDATE "ManagedFileSessionSync" SET "filesRevision" = 0, "isComplete" = false WHERE "filesRevision" = -1`,
+        `UPDATE "ManagedFile" SET "deleteOperationId" = 'migration-0018:' || "seq" WHERE "deletedAt" IS NOT NULL AND "deleteOperationId" IS NULL`,
+        `UPDATE "ManagedFileSessionSync" SET "deleteOperationId" = 'migration-0018:' || "projectId" || ':' || "sessionId" WHERE "deletedAt" IS NOT NULL AND "deleteOperationId" IS NULL`,
+        `UPDATE "ArtifactMessageSnapshot" SET "state" = 'staging' WHERE "state" = 'ready' AND "checksum" = ''`
+      ]
+    },
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'ManagedFile',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ManagedFile" (
+    "seq" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "source" TEXT NOT NULL,
+    "sourceFileId" TEXT NOT NULL,
+    "sourceVersionId" TEXT,
+    "checksum" TEXT,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "messageId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "mimeType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "mtimeMs" BIGINT,
+    "sortAtMs" BIGINT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "deletedAt" DATETIME,
+    "deleteOperationId" TEXT,
+    CONSTRAINT "ManagedFile_source_check" CHECK ("source" IN ('artifact', 'upload')),
+    CONSTRAINT "ManagedFile_nonnegative_check" CHECK ("sizeBytes" >= 0 AND ("mtimeMs" IS NULL OR "mtimeMs" >= 0) AND "sortAtMs" >= 0),
+    CONSTRAINT "ManagedFile_storageKey_check" CHECK (length(trim("storageKey")) > 0),
+    CONSTRAINT "ManagedFile_deletion_check" CHECK ((("deletedAt" IS NULL AND "deleteOperationId" IS NULL) OR ("deletedAt" IS NOT NULL AND "deleteOperationId" IS NOT NULL)))
+);`,
+          columns: [
+            'seq',
+            'source',
+            'sourceFileId',
+            'sourceVersionId',
+            'checksum',
+            'projectId',
+            'sessionId',
+            'messageId',
+            'displayName',
+            'storageKey',
+            'mimeType',
+            'sizeBytes',
+            'mtimeMs',
+            'sortAtMs',
+            'createdAt',
+            'updatedAt',
+            'deletedAt',
+            'deleteOperationId'
+          ]
+        },
+        {
+          tableName: 'ManagedFileSessionSync',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ManagedFileSessionSync" (
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "filesRevision" INTEGER NOT NULL,
+    "isComplete" BOOLEAN NOT NULL DEFAULT true,
+    "groupSortAtMs" BIGINT NOT NULL,
+    "artifactCount" INTEGER NOT NULL DEFAULT 0,
+    "uploadCount" INTEGER NOT NULL DEFAULT 0,
+    "syncedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deletedAt" DATETIME,
+    "deleteOperationId" TEXT,
+
+    PRIMARY KEY ("projectId", "sessionId"),
+    CONSTRAINT "ManagedFileSessionSync_nonnegative_check" CHECK ("filesRevision" >= 0 AND "artifactCount" >= 0 AND "uploadCount" >= 0),
+    CONSTRAINT "ManagedFileSessionSync_isComplete_check" CHECK ("isComplete" IN (false, true)),
+    CONSTRAINT "ManagedFileSessionSync_deletion_check" CHECK ((("deletedAt" IS NULL AND "deleteOperationId" IS NULL) OR ("deletedAt" IS NOT NULL AND "deleteOperationId" IS NOT NULL)))
+);`,
+          columns: [
+            'projectId',
+            'sessionId',
+            'filesRevision',
+            'isComplete',
+            'groupSortAtMs',
+            'artifactCount',
+            'uploadCount',
+            'syncedAt',
+            'deletedAt',
+            'deleteOperationId'
+          ]
+        },
+        {
+          tableName: 'UploadVersion',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "UploadVersion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "uploadFileId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "contentStorageKey" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "createdAt" DATETIME,
+    "registeredAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UploadVersion_uploadFileId_fkey" FOREIGN KEY ("uploadFileId") REFERENCES "UploadFile" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "UploadVersion_state_check" CHECK ("state" IN ('staging', 'ready')),
+    CONSTRAINT "UploadVersion_metadata_check" CHECK ("versionNumber" >= 1 AND "sizeBytes" >= 0 AND length(trim("contentStorageKey")) > 0 AND length(trim("filename")) > 0 AND length(trim("originalFilename")) > 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
+);`,
+          columns: [
+            'id',
+            'uploadFileId',
+            'versionNumber',
+            'state',
+            'contentStorageKey',
+            'filename',
+            'originalFilename',
+            'contentType',
+            'sizeBytes',
+            'checksum',
+            'createdAt',
+            'registeredAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'VisionEvidence',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "VisionEvidence" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "sourceKind" TEXT NOT NULL,
+    "uploadVersionId" TEXT,
+    "sourceMessageId" TEXT,
+    "sourceImageId" TEXT,
+    "imageChecksum" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "extractorFingerprint" TEXT NOT NULL,
+    "evidenceSchemaVersion" INTEGER NOT NULL,
+    "evidenceJson" TEXT NOT NULL,
+    "evidenceChecksum" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "VisionEvidence_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "VisionEvidence_uploadVersionId_fkey" FOREIGN KEY ("uploadVersionId") REFERENCES "UploadVersion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "VisionEvidence_sourceKind_check" CHECK ("sourceKind" IN ('upload-version', 'message-image')),
+    CONSTRAINT "VisionEvidence_sourceIdentity_check" CHECK ((("sourceKind" = 'upload-version' AND "uploadVersionId" IS NOT NULL AND "sourceMessageId" IS NULL AND "sourceImageId" IS NULL) OR ("sourceKind" = 'message-image' AND "uploadVersionId" IS NULL AND "sourceMessageId" IS NOT NULL AND "sourceImageId" IS NOT NULL))),
+    CONSTRAINT "VisionEvidence_schemaVersion_check" CHECK ("evidenceSchemaVersion" >= 1),
+    CONSTRAINT "VisionEvidence_imageChecksum_check" CHECK (length("imageChecksum") = 64 AND "imageChecksum" NOT GLOB '*[^0-9a-f]*'),
+    CONSTRAINT "VisionEvidence_extractorFingerprint_check" CHECK (length("extractorFingerprint") = 64 AND "extractorFingerprint" NOT GLOB '*[^0-9a-f]*'),
+    CONSTRAINT "VisionEvidence_evidenceChecksum_check" CHECK (length("evidenceChecksum") = 64 AND "evidenceChecksum" NOT GLOB '*[^0-9a-f]*'),
+    CONSTRAINT "VisionEvidence_evidenceJson_check" CHECK (json_valid("evidenceJson") AND json_type("evidenceJson") = 'object')
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'sourceKind',
+            'uploadVersionId',
+            'sourceMessageId',
+            'sourceImageId',
+            'imageChecksum',
+            'mimeType',
+            'extractorFingerprint',
+            'evidenceSchemaVersion',
+            'evidenceJson',
+            'evidenceChecksum',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'ArtifactMessageSnapshot',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ArtifactMessageSnapshot" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "rootFrameId" TEXT NOT NULL,
+    "agentFrameId" TEXT NOT NULL,
+    "messageBranchId" TEXT NOT NULL,
+    "terminalMessageId" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "storageKey" TEXT NOT NULL,
+    "checksum" TEXT NOT NULL DEFAULT '',
+    "messageCount" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ArtifactMessageSnapshot_projectId_sessionId_fkey" FOREIGN KEY ("projectId", "sessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactMessageSnapshot_state_check" CHECK ("state" IN ('staging', 'ready')),
+    CONSTRAINT "ArtifactMessageSnapshot_messageCount_check" CHECK ("messageCount" >= 0),
+    CONSTRAINT "ArtifactMessageSnapshot_readyChecksum_check" CHECK ("state" <> 'ready' OR (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*'))
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'rootFrameId',
+            'agentFrameId',
+            'messageBranchId',
+            'terminalMessageId',
+            'state',
+            'storageKey',
+            'checksum',
+            'messageCount',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'ArtifactVersion',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ArtifactVersion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "artifactId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "filename" TEXT NOT NULL,
+    "artifactRunId" TEXT NOT NULL,
+    "writeOperationId" TEXT,
+    "writeRequestChecksum" TEXT,
+    "rootFrameId" TEXT NOT NULL,
+    "agentFrameId" TEXT NOT NULL,
+    "messageBranchId" TEXT NOT NULL,
+    "runtimeSegmentId" TEXT NOT NULL,
+    "promptMessageId" TEXT NOT NULL,
+    "notebookSessionId" TEXT,
+    "producerRunId" TEXT,
+    "producerRunIndex" INTEGER,
+    "messageId" TEXT,
+    "messageSnapshotId" TEXT,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "contentStorageKey" TEXT NOT NULL,
+    "evidenceStorageKey" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "evidenceJson" TEXT NOT NULL,
+    "evidenceChecksum" TEXT NOT NULL,
+    "evidenceSchemaVersion" INTEGER NOT NULL DEFAULT 1,
+    "executionSnapshotJson" TEXT,
+    "executionSnapshotChecksum" TEXT,
+    "executionSnapshotStorageKey" TEXT,
+    "executionSnapshotSchemaVersion" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ArtifactVersion_artifactId_fkey" FOREIGN KEY ("artifactId") REFERENCES "ArtifactLineage" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersion_messageSnapshotId_fkey" FOREIGN KEY ("messageSnapshotId") REFERENCES "ArtifactMessageSnapshot" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersion_state_check" CHECK ("state" IN ('staging', 'pending', 'finalized')),
+    CONSTRAINT "ArtifactVersion_filename_check" CHECK (length("filename") > 0),
+    CONSTRAINT "ArtifactVersion_evidenceJson_check" CHECK (json_valid("evidenceJson") AND json_type("evidenceJson") = 'object'),
+    CONSTRAINT "ArtifactVersion_executionSnapshotJson_check" CHECK ("executionSnapshotJson" IS NULL OR (json_valid("executionSnapshotJson") AND json_type("executionSnapshotJson") = 'object')),
+    CONSTRAINT "ArtifactVersion_executionSnapshotBundle_check" CHECK ((("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL))),
+    CONSTRAINT "ArtifactVersion_nonnegative_check" CHECK ("versionNumber" >= 1 AND "sizeBytes" >= 0 AND "evidenceSchemaVersion" >= 1 AND ("executionSnapshotSchemaVersion" IS NULL OR "executionSnapshotSchemaVersion" >= 1)),
+    CONSTRAINT "ArtifactVersion_producerRun_check" CHECK ((("producerRunId" IS NULL AND "producerRunIndex" IS NULL) OR ("producerRunId" IS NOT NULL AND length(trim("producerRunId")) > 0 AND "producerRunIndex" IS NOT NULL AND "producerRunIndex" >= 0))),
+    CONSTRAINT "ArtifactVersion_publishedMetadata_check" CHECK ("state" NOT IN ('pending', 'finalized') OR (length(trim("contentStorageKey")) > 0 AND length(trim("evidenceStorageKey")) > 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*' AND length("evidenceChecksum") = 64 AND "evidenceChecksum" NOT GLOB '*[^0-9a-f]*'))
+);`,
+          columns: [
+            'id',
+            'artifactId',
+            'versionNumber',
+            'filename',
+            'artifactRunId',
+            'writeOperationId',
+            'writeRequestChecksum',
+            'rootFrameId',
+            'agentFrameId',
+            'messageBranchId',
+            'runtimeSegmentId',
+            'promptMessageId',
+            'notebookSessionId',
+            'producerRunId',
+            'producerRunIndex',
+            'messageId',
+            'messageSnapshotId',
+            'state',
+            'contentStorageKey',
+            'evidenceStorageKey',
+            'contentType',
+            'sizeBytes',
+            'checksum',
+            'evidenceJson',
+            'evidenceChecksum',
+            'evidenceSchemaVersion',
+            'executionSnapshotJson',
+            'executionSnapshotChecksum',
+            'executionSnapshotStorageKey',
+            'executionSnapshotSchemaVersion',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'ArtifactVersionInput',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ArtifactVersionInput" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "artifactVersionId" TEXT NOT NULL,
+    "ordinal" INTEGER NOT NULL,
+    "inputFileVersionId" TEXT NOT NULL,
+    "sourceKind" TEXT NOT NULL,
+    "sourceFileId" TEXT NOT NULL,
+    "sourceArtifactVersionId" TEXT,
+    "sourceUploadVersionId" TEXT,
+    "sourceVersionNumber" INTEGER,
+    "sourceCreatedAt" DATETIME,
+    "sourceProjectId" TEXT NOT NULL,
+    "sourceSessionId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "strongestAssociation" TEXT NOT NULL,
+    CONSTRAINT "ArtifactVersionInput_artifactVersionId_fkey" FOREIGN KEY ("artifactVersionId") REFERENCES "ArtifactVersion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceArtifactVersionId_fkey" FOREIGN KEY ("sourceArtifactVersionId") REFERENCES "ArtifactVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceUploadVersionId_fkey" FOREIGN KEY ("sourceUploadVersionId") REFERENCES "UploadVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceProjectId_sourceSessionId_fkey" FOREIGN KEY ("sourceProjectId", "sourceSessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceKind_check" CHECK ("sourceKind" IN ('artifact-version', 'upload-version')),
+    CONSTRAINT "ArtifactVersionInput_sourceIdentity_check" CHECK ((("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR ("sourceKind" = 'upload-version' AND "sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL AND "inputFileVersionId" = "sourceUploadVersionId"))),
+    CONSTRAINT "ArtifactVersionInput_strongestAssociation_check" CHECK ("strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version')),
+    CONSTRAINT "ArtifactVersionInput_metadata_check" CHECK ("ordinal" >= 0 AND ("sourceVersionNumber" IS NULL OR "sourceVersionNumber" >= 1) AND "sizeBytes" >= 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*' AND length(trim("storageKey")) > 0)
+);`,
+          columns: [
+            'id',
+            'artifactVersionId',
+            'ordinal',
+            'inputFileVersionId',
+            'sourceKind',
+            'sourceFileId',
+            'sourceArtifactVersionId',
+            'sourceUploadVersionId',
+            'sourceVersionNumber',
+            'sourceCreatedAt',
+            'sourceProjectId',
+            'sourceSessionId',
+            'filename',
+            'contentType',
+            'sizeBytes',
+            'checksum',
+            'storageKey',
+            'strongestAssociation'
+          ]
+        }
+      ],
+      dropOrder: [
+        'ArtifactVersionInput',
+        'VisionEvidence',
+        'ArtifactVersion',
+        'ArtifactMessageSnapshot',
+        'UploadVersion',
+        'ManagedFile',
+        'ManagedFileSessionSync'
+      ],
+      indexes: [
+        `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "deletedAt", "sortAtMs", "seq");`,
+        `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "source", "deletedAt", "sortAtMs", "seq");`,
+        `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_sessionId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "sessionId", "source", "deletedAt", "sortAtMs", "seq");`,
+        `CREATE INDEX IF NOT EXISTS "ManagedFile_sessionId_deletedAt_idx" ON "ManagedFile"("sessionId", "deletedAt");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_sourceFileId_key" ON "ManagedFile"("projectId", "source", "sourceFileId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_storageKey_key" ON "ManagedFile"("projectId", "source", "storageKey");`,
+        `CREATE INDEX IF NOT EXISTS "ManagedFileSessionSync_projectId_deletedAt_groupSortAtMs_sessionId_idx" ON "ManagedFileSessionSync"("projectId", "deletedAt", "groupSortAtMs", "sessionId");`,
+        `CREATE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_state_registeredAt_idx" ON "UploadVersion"("uploadFileId", "state", "registeredAt");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_versionNumber_key" ON "UploadVersion"("uploadFileId", "versionNumber");`,
+        `CREATE INDEX IF NOT EXISTS "VisionEvidence_projectId_sessionId_idx" ON "VisionEvidence"("projectId", "sessionId");`,
+        `CREATE INDEX IF NOT EXISTS "VisionEvidence_sessionId_idx" ON "VisionEvidence"("sessionId");`,
+        `CREATE INDEX IF NOT EXISTS "VisionEvidence_uploadVersionId_idx" ON "VisionEvidence"("uploadVersionId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactMessageSnapshot_projectId_sessionId_state_idx" ON "ArtifactMessageSnapshot"("projectId", "sessionId", "state");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactMessageSnapshot_projectId_sessionId_agentFrameId_messageBranchId_terminalMessageId_key" ON "ArtifactMessageSnapshot"("projectId", "sessionId", "agentFrameId", "messageBranchId", "terminalMessageId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_writeOperationId_key" ON "ArtifactVersion"("writeOperationId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_createdAt_idx" ON "ArtifactVersion"("artifactId", "createdAt");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactRunId_state_idx" ON "ArtifactVersion"("artifactRunId", "state");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_rootFrameId_agentFrameId_messageBranchId_promptMessageId_idx" ON "ArtifactVersion"("rootFrameId", "agentFrameId", "messageBranchId", "promptMessageId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageId_idx" ON "ArtifactVersion"("messageId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageSnapshotId_idx" ON "ArtifactVersion"("messageSnapshotId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_versionNumber_key" ON "ArtifactVersion"("artifactId", "versionNumber");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceKind_inputFileVersionId_idx" ON "ArtifactVersionInput"("sourceKind", "inputFileVersionId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceArtifactVersionId_idx" ON "ArtifactVersionInput"("sourceArtifactVersionId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceUploadVersionId_idx" ON "ArtifactVersionInput"("sourceUploadVersionId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceProjectId_sourceSessionId_idx" ON "ArtifactVersionInput"("sourceProjectId", "sourceSessionId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_sourceKind_inputFileVersionId_key" ON "ArtifactVersionInput"("artifactVersionId", "sourceKind", "inputFileVersionId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_ordinal_key" ON "ArtifactVersionInput"("artifactVersionId", "ordinal");`
+      ]
+    }
+  ] as const,
+  verifiers: [
+    {
+      kind: 'column-exists',
+      version: 1,
+      table: 'ManagedFileSessionSync',
+      column: 'isComplete'
+    },
+    {
+      kind: 'check-constraints-exist',
+      version: 1,
+      tables: [
+        {
+          table: 'ManagedFile',
+          constraints: [
+            {
+              name: 'ManagedFile_nonnegative_check',
+              expression: `"sizeBytes" >= 0 AND ("mtimeMs" IS NULL OR "mtimeMs" >= 0) AND "sortAtMs" >= 0`
+            },
+            {
+              name: 'ManagedFile_storageKey_check',
+              expression: `length(trim("storageKey")) > 0`
+            },
+            {
+              name: 'ManagedFile_deletion_check',
+              expression: `(("deletedAt" IS NULL AND "deleteOperationId" IS NULL) OR ("deletedAt" IS NOT NULL AND "deleteOperationId" IS NOT NULL))`
+            }
+          ]
+        },
+        {
+          table: 'ManagedFileSessionSync',
+          constraints: [
+            {
+              name: 'ManagedFileSessionSync_nonnegative_check',
+              expression: `"filesRevision" >= 0 AND "artifactCount" >= 0 AND "uploadCount" >= 0`
+            },
+            {
+              name: 'ManagedFileSessionSync_isComplete_check',
+              expression: `"isComplete" IN (false, true)`
+            },
+            {
+              name: 'ManagedFileSessionSync_deletion_check',
+              expression: `(("deletedAt" IS NULL AND "deleteOperationId" IS NULL) OR ("deletedAt" IS NOT NULL AND "deleteOperationId" IS NOT NULL))`
+            }
+          ]
+        },
+        {
+          table: 'UploadVersion',
+          constraints: [
+            {
+              name: 'UploadVersion_metadata_check',
+              expression: `"versionNumber" >= 1 AND "sizeBytes" >= 0 AND length(trim("contentStorageKey")) > 0 AND length(trim("filename")) > 0 AND length(trim("originalFilename")) > 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*'`
+            }
+          ]
+        },
+        {
+          table: 'ArtifactMessageSnapshot',
+          constraints: [
+            {
+              name: 'ArtifactMessageSnapshot_messageCount_check',
+              expression: `"messageCount" >= 0`
+            },
+            {
+              name: 'ArtifactMessageSnapshot_readyChecksum_check',
+              expression: `"state" <> 'ready' OR (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')`
+            }
+          ]
+        },
+        {
+          table: 'ArtifactVersion',
+          constraints: [
+            {
+              name: 'ArtifactVersion_nonnegative_check',
+              expression: `"versionNumber" >= 1 AND "sizeBytes" >= 0 AND "evidenceSchemaVersion" >= 1 AND ("executionSnapshotSchemaVersion" IS NULL OR "executionSnapshotSchemaVersion" >= 1)`
+            },
+            {
+              name: 'ArtifactVersion_producerRun_check',
+              expression: `(("producerRunId" IS NULL AND "producerRunIndex" IS NULL) OR ("producerRunId" IS NOT NULL AND length(trim("producerRunId")) > 0 AND "producerRunIndex" IS NOT NULL AND "producerRunIndex" >= 0))`
+            },
+            {
+              name: 'ArtifactVersion_publishedMetadata_check',
+              expression: `"state" NOT IN ('pending', 'finalized') OR (length(trim("contentStorageKey")) > 0 AND length(trim("evidenceStorageKey")) > 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*' AND length("evidenceChecksum") = 64 AND "evidenceChecksum" NOT GLOB '*[^0-9a-f]*')`
+            }
+          ]
+        },
+        {
+          table: 'ArtifactVersionInput',
+          constraints: [
+            {
+              name: 'ArtifactVersionInput_metadata_check',
+              expression: `"ordinal" >= 0 AND ("sourceVersionNumber" IS NULL OR "sourceVersionNumber" >= 1) AND "sizeBytes" >= 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*' AND length(trim("storageKey")) > 0`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      kind: 'indexes-exist',
+      version: 1,
+      indexes: [
+        {
+          name: 'ManagedFile_projectId_deletedAt_sortAtMs_seq_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "deletedAt", "sortAtMs", "seq");`
+        },
+        {
+          name: 'ManagedFile_projectId_source_deletedAt_sortAtMs_seq_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "source", "deletedAt", "sortAtMs", "seq");`
+        },
+        {
+          name: 'ManagedFile_projectId_sessionId_source_deletedAt_sortAtMs_seq_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_sessionId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "sessionId", "source", "deletedAt", "sortAtMs", "seq");`
+        },
+        {
+          name: 'ManagedFile_sessionId_deletedAt_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFile_sessionId_deletedAt_idx" ON "ManagedFile"("sessionId", "deletedAt");`
+        },
+        {
+          name: 'ManagedFile_projectId_source_sourceFileId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_sourceFileId_key" ON "ManagedFile"("projectId", "source", "sourceFileId");`
+        },
+        {
+          name: 'ManagedFile_projectId_source_storageKey_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_storageKey_key" ON "ManagedFile"("projectId", "source", "storageKey");`
+        },
+        {
+          name: 'ManagedFileSessionSync_projectId_deletedAt_groupSortAtMs_sessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFileSessionSync_projectId_deletedAt_groupSortAtMs_sessionId_idx" ON "ManagedFileSessionSync"("projectId", "deletedAt", "groupSortAtMs", "sessionId");`
+        },
+        {
+          name: 'UploadVersion_uploadFileId_state_registeredAt_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_state_registeredAt_idx" ON "UploadVersion"("uploadFileId", "state", "registeredAt");`
+        },
+        {
+          name: 'UploadVersion_uploadFileId_versionNumber_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_versionNumber_key" ON "UploadVersion"("uploadFileId", "versionNumber");`
+        },
+        {
+          name: 'VisionEvidence_projectId_sessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "VisionEvidence_projectId_sessionId_idx" ON "VisionEvidence"("projectId", "sessionId");`
+        },
+        {
+          name: 'VisionEvidence_sessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "VisionEvidence_sessionId_idx" ON "VisionEvidence"("sessionId");`
+        },
+        {
+          name: 'VisionEvidence_uploadVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "VisionEvidence_uploadVersionId_idx" ON "VisionEvidence"("uploadVersionId");`
+        },
+        {
+          name: 'ArtifactMessageSnapshot_projectId_sessionId_state_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactMessageSnapshot_projectId_sessionId_state_idx" ON "ArtifactMessageSnapshot"("projectId", "sessionId", "state");`
+        },
+        {
+          name: 'ArtifactMessageSnapshot_projectId_sessionId_agentFrameId_messageBranchId_terminalMessageId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactMessageSnapshot_projectId_sessionId_agentFrameId_messageBranchId_terminalMessageId_key" ON "ArtifactMessageSnapshot"("projectId", "sessionId", "agentFrameId", "messageBranchId", "terminalMessageId");`
+        },
+        {
+          name: 'ArtifactVersion_writeOperationId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_writeOperationId_key" ON "ArtifactVersion"("writeOperationId");`
+        },
+        {
+          name: 'ArtifactVersion_artifactId_createdAt_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_createdAt_idx" ON "ArtifactVersion"("artifactId", "createdAt");`
+        },
+        {
+          name: 'ArtifactVersion_artifactRunId_state_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactRunId_state_idx" ON "ArtifactVersion"("artifactRunId", "state");`
+        },
+        {
+          name: 'ArtifactVersion_rootFrameId_agentFrameId_messageBranchId_promptMessageId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_rootFrameId_agentFrameId_messageBranchId_promptMessageId_idx" ON "ArtifactVersion"("rootFrameId", "agentFrameId", "messageBranchId", "promptMessageId");`
+        },
+        {
+          name: 'ArtifactVersion_messageId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageId_idx" ON "ArtifactVersion"("messageId");`
+        },
+        {
+          name: 'ArtifactVersion_messageSnapshotId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageSnapshotId_idx" ON "ArtifactVersion"("messageSnapshotId");`
+        },
+        {
+          name: 'ArtifactVersion_artifactId_versionNumber_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_versionNumber_key" ON "ArtifactVersion"("artifactId", "versionNumber");`
+        },
+        {
+          name: 'ArtifactVersionInput_sourceKind_inputFileVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceKind_inputFileVersionId_idx" ON "ArtifactVersionInput"("sourceKind", "inputFileVersionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_sourceArtifactVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceArtifactVersionId_idx" ON "ArtifactVersionInput"("sourceArtifactVersionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_sourceUploadVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceUploadVersionId_idx" ON "ArtifactVersionInput"("sourceUploadVersionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_sourceProjectId_sourceSessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceProjectId_sourceSessionId_idx" ON "ArtifactVersionInput"("sourceProjectId", "sourceSessionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_artifactVersionId_sourceKind_inputFileVersionId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_sourceKind_inputFileVersionId_key" ON "ArtifactVersionInput"("artifactVersionId", "sourceKind", "inputFileVersionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_artifactVersionId_ordinal_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_ordinal_key" ON "ArtifactVersionInput"("artifactVersionId", "ordinal");`
+        }
+      ]
+    }
+  ] as const
+}
+
+export { fileArtifactDataConstraintsMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -76,10 +76,11 @@ describe('notification attention metadata migration', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_file_artifact_data_constraints'
       ],
       from: '0006_database_domain_constraints',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_file_artifact_data_constraints'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)
@@ -101,9 +102,12 @@ describe('notification attention metadata migration', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0017_agent_memory_project_scope.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0018_file_artifact_data_constraints.backup`)
     ).resolves.toBeUndefined()
 
     await expect(

--- a/src/main/database/sqlite-schema-migrations.ts
+++ b/src/main/database/sqlite-schema-migrations.ts
@@ -37,7 +37,24 @@ type SqliteRebuildTableSetOperation = {
   indexes: readonly string[]
 }
 
-type SqliteMigrationOperation = SqliteRebuildTableSetOperation
+type SqliteAddColumnIfMissingOperation = {
+  kind: 'add-column-if-missing'
+  version: 1
+  tableName: string
+  columnName: string
+  definition: string
+}
+
+type SqliteExecuteStatementsOperation = {
+  kind: 'execute-statements'
+  version: 1
+  statements: readonly string[]
+}
+
+type SqliteMigrationOperation =
+  | SqliteAddColumnIfMissingOperation
+  | SqliteExecuteStatementsOperation
+  | SqliteRebuildTableSetOperation
 
 const quoteIdentifier = (value: string): string => `"${value.replaceAll('"', '""')}"`
 const quoteLiteral = (value: string): string => `'${value.replaceAll("'", "''")}'`
@@ -295,6 +312,21 @@ const applySqliteMigrationOperations = async (
 ): Promise<void> => {
   for (const operation of operations) {
     switch (operation.kind) {
+      case 'add-column-if-missing': {
+        const columns = await readTableColumns(client, operation.tableName)
+        if (!columns.includes(operation.columnName)) {
+          await migrationSqlExecutor.execute(
+            client,
+            `ALTER TABLE ${quoteIdentifier(operation.tableName)} ADD COLUMN ${quoteIdentifier(operation.columnName)} ${operation.definition}`
+          )
+        }
+        break
+      }
+      case 'execute-statements':
+        for (const statement of operation.statements) {
+          await migrationSqlExecutor.execute(client, statement)
+        }
+        break
       case 'rebuild-table-set':
         await applyRebuildTableSet(client, operation)
         break

--- a/src/main/project-files/mutation-owner.ts
+++ b/src/main/project-files/mutation-owner.ts
@@ -16,10 +16,6 @@ import {
   type ProjectFilesClientProvider
 } from './mutation-projection'
 
-// Valid persisted revisions are non-negative. A collision loser stores this sentinel so it cannot
-// take the revision fast path and can claim the canonical row after its current owner is deleted.
-const RETRYABLE_COLLISION_REVISION = -1
-
 type ManagedFileSoftDeleteToken = string
 type ManagedFileSyncOptions = { force?: boolean }
 
@@ -48,6 +44,7 @@ class ProjectFilesMutationOwner {
       if (
         !options.force &&
         currentSync?.filesRevision === revision &&
+        currentSync.isComplete &&
         currentSync.deletedAt === null &&
         (await isFileProjectionCurrent(client, session.projectId, session.id))
       ) {
@@ -166,13 +163,14 @@ class ProjectFilesMutationOwner {
           ...preservedRows
         ])
 
+        const projectionDeleteOperationId = randomUUID()
         await tx.managedFile.updateMany({
           where: {
             projectId: session.projectId,
             sessionId: session.id,
             ...(retainedSeqs.size > 0 ? { seq: { notIn: [...retainedSeqs] } } : {})
           },
-          data: { deletedAt: now }
+          data: { deletedAt: now, deleteOperationId: projectionDeleteOperationId }
         })
 
         const artifactCount = [...retainedSources.values()].filter(
@@ -189,16 +187,16 @@ class ProjectFilesMutationOwner {
           create: {
             projectId: session.projectId,
             sessionId: session.id,
-            filesRevision:
-              hasActiveCollision || hasIncompleteFiles ? RETRYABLE_COLLISION_REVISION : revision,
+            filesRevision: revision,
+            isComplete: !hasActiveCollision && !hasIncompleteFiles,
             groupSortAtMs,
             artifactCount,
             uploadCount,
             syncedAt: now
           },
           update: {
-            filesRevision:
-              hasActiveCollision || hasIncompleteFiles ? RETRYABLE_COLLISION_REVISION : revision,
+            filesRevision: revision,
+            isComplete: !hasActiveCollision && !hasIncompleteFiles,
             groupSortAtMs,
             artifactCount,
             uploadCount,
@@ -465,11 +463,13 @@ class ProjectFilesMutationOwner {
           projectId,
           sessionId,
           filesRevision: 0,
+          isComplete: true,
           groupSortAtMs,
           artifactCount: artifactFiles.length,
           uploadCount: uploadFiles.length
         },
         update: {
+          isComplete: true,
           groupSortAtMs,
           artifactCount: artifactFiles.length,
           uploadCount: uploadFiles.length,

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -259,7 +259,7 @@ describe('ManagedFileIndexRepository', () => {
       sizeBytes: BigInt(versionNumber === 1 ? 9 : 12),
       checksum: checksumCharacter.repeat(64),
       evidenceJson: '{"schema_version":1}',
-      evidenceChecksum: checksumCharacter.toUpperCase().repeat(64),
+      evidenceChecksum: checksumCharacter.repeat(64),
       createdAt: new Date(`2026-07-28T00:00:0${versionNumber}.000Z`)
     })
     await client.artifactVersion.create({
@@ -1213,6 +1213,12 @@ describe('ManagedFileIndexRepository', () => {
         artifacts: [{ id: 'current', kind: 'managed-file', path: currentPath, name: 'current.txt' }]
       })
     )
+    await expect(
+      client.managedFile.findFirstOrThrow({ where: { sourceFileId: 'old' } })
+    ).resolves.toMatchObject({
+      deletedAt: expect.any(Date),
+      deleteOperationId: expect.any(String)
+    })
 
     const token = await repository.softDeleteSession(PROJECT_ID, SESSION_ID)
     await repository.restoreSession(PROJECT_ID, SESSION_ID, token)
@@ -2136,6 +2142,11 @@ describe('ManagedFileIndexRepository', () => {
     })
 
     await expect(repository.syncSession(session)).resolves.toEqual(['upload'])
+    await expect(
+      client.managedFileSessionSync.findUniqueOrThrow({
+        where: { projectId_sessionId: { projectId: PROJECT_ID, sessionId: SESSION_ID } }
+      })
+    ).resolves.toMatchObject({ filesRevision: session.filesRevision, isComplete: false })
     await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
       totalCount: 1,
       uploadCount: 1,
@@ -2145,6 +2156,11 @@ describe('ManagedFileIndexRepository', () => {
 
     await writeManagedFile(missingArtifactPath, 'ready')
     await expect(repository.syncSession(session)).resolves.toEqual(['artifact'])
+    await expect(
+      client.managedFileSessionSync.findUniqueOrThrow({
+        where: { projectId_sessionId: { projectId: PROJECT_ID, sessionId: SESSION_ID } }
+      })
+    ).resolves.toMatchObject({ filesRevision: session.filesRevision, isComplete: true })
     await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
       totalCount: 2,
       uploadCount: 1,

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -43,7 +43,7 @@ import { createProjectDbClient, migrateApplicationDatabase } from '../projects/p
 
 const createDatabaseBeforeFileArtifactConstraints = async (client: PrismaClient): Promise<void> => {
   const migrationIndex = MIGRATION_MANIFEST.findIndex(
-    (migration) => migration.id === '0017_file_artifact_data_constraints'
+    (migration) => migration.id === '0018_file_artifact_data_constraints'
   )
   if (migrationIndex < 0) throw new Error('Missing file and Artifact constraints migration.')
   const prefix = MIGRATION_MANIFEST.slice(0, migrationIndex)

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { PrismaClient } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 // classifyDataRoot now derives the target via storage-root's dataRootForParent, so migration-service
@@ -36,6 +37,39 @@ import {
 import { withDataRootWrite } from './migration-state'
 import { operationJournalPath, RuntimeOperationJournal } from '../notebook/operation-journal'
 import type { Logger } from '../logger'
+import { MIGRATION_MANIFEST } from '../database/migration-service'
+import { applySqliteMigrationOperations } from '../database/sqlite-schema-migrations'
+import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+
+const createDatabaseBeforeFileArtifactConstraints = async (client: PrismaClient): Promise<void> => {
+  const migrationIndex = MIGRATION_MANIFEST.findIndex(
+    (migration) => migration.id === '0017_file_artifact_data_constraints'
+  )
+  if (migrationIndex < 0) throw new Error('Missing file and Artifact constraints migration.')
+  const prefix = MIGRATION_MANIFEST.slice(0, migrationIndex)
+  for (const migration of prefix) {
+    for (const statement of migration.statements) await client.$executeRawUnsafe(statement)
+    if ('operations' in migration) {
+      await client.$transaction((transaction) =>
+        applySqliteMigrationOperations(transaction, migration.operations)
+      )
+    }
+  }
+  await client.$executeRawUnsafe(`CREATE TABLE "_open_science_migrations" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "checksum" TEXT NOT NULL,
+    "appliedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "_open_science_migrations_checksum_check"
+      CHECK (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
+  )`)
+  for (const migration of prefix) {
+    await client.$executeRawUnsafe(
+      `INSERT INTO "_open_science_migrations" ("id", "checksum") VALUES (?, ?)`,
+      migration.id,
+      migration.checksum
+    )
+  }
+}
 
 // Writes a verified staging marker for `<parent>/OpenScience`, as a completed copy phase would have.
 const seedVerifiedMarker = async (
@@ -870,6 +904,77 @@ describe('runDataRootMigration (copy phase)', () => {
       })
     )
     expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('unfinished Artifact staging')
+  })
+
+  it('relocates a legacy Message snapshot immediately after its database constraints upgrade', async () => {
+    const authorityRoot = join(currentParent, 'config')
+    const previousE2eRoot = process.env.OPEN_SCIENCE_E2E_STORAGE_ROOT
+    process.env.OPEN_SCIENCE_E2E_STORAGE_ROOT = authorityRoot
+    const client = createProjectDbClient(authorityRoot)
+    const snapshotId = 'snapshot-legacy'
+    const storageKey = `artifacts/project-1/session-1/.provenance/message-snapshots/${snapshotId}.json`
+    const payload = JSON.stringify({
+      schemaVersion: 2,
+      snapshotId,
+      rootFrameId: 'root-1',
+      agentFrameId: 'agent-1',
+      messageBranchId: 'branch-1',
+      terminalMessageId: 'message-1',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'agent',
+          content: 'saved artifact',
+          createdAt: 1
+        }
+      ]
+    })
+
+    try {
+      await mkdir(authorityRoot, { recursive: true })
+      await mkdir(
+        join(currentDataRoot, 'artifacts/project-1/session-1/.provenance/message-snapshots'),
+        {
+          recursive: true
+        }
+      )
+      await writeFile(join(currentDataRoot, storageKey), payload)
+      await createDatabaseBeforeFileArtifactConstraints(client)
+      await client.fileOriginSession.create({
+        data: { projectId: 'project-1', sessionId: 'session-1' }
+      })
+      await client.artifactMessageSnapshot.create({
+        data: {
+          id: snapshotId,
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          rootFrameId: 'root-1',
+          agentFrameId: 'agent-1',
+          messageBranchId: 'branch-1',
+          terminalMessageId: 'message-1',
+          state: 'ready',
+          storageKey,
+          checksum: '',
+          messageCount: 1
+        }
+      })
+      await migrateApplicationDatabase(client)
+      await client.$disconnect()
+
+      const deps = fakeDeps()
+      const result = await runDataRootMigration(
+        { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook },
+        emptyParent,
+        runOpts()
+      )
+
+      expect(result).toEqual({ ok: true })
+      expect(existsSync(join(dataRootFor(emptyParent), storageKey))).toBe(true)
+    } finally {
+      await client.$disconnect()
+      if (previousE2eRoot === undefined) delete process.env.OPEN_SCIENCE_E2E_STORAGE_ROOT
+      else process.env.OPEN_SCIENCE_E2E_STORAGE_ROOT = previousE2eRoot
+    }
   })
 
   it('diagnoses target provenance verification failure without retaining its error', async () => {

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -31,7 +31,10 @@ import { waitForDataRootWriters } from './migration-state'
 import { DEFAULT_MAX_ENV_RELATIVE_PATH, PACK_PATH_BUDGET_FILE } from '../notebook/bundle-manifest'
 import { windowsDefaultEnvPrefixReserve } from '../notebook/runtime-paths'
 import { RELOCATABLE_DATA_DIRS } from './data-directories'
-import { validateProvenanceMigrationState } from './provenance-migration-validation'
+import {
+  recoverLegacyMessageSnapshotsForMigration,
+  validateProvenanceMigrationState
+} from './provenance-migration-validation'
 import { disconnectProjectDbClient } from '../projects/prisma-client'
 import { createLogger, type Logger } from '../logger'
 import { startDiagnosticOperation } from '../diagnostics/operation'
@@ -351,8 +354,11 @@ const RUNTIME_ENVIRONMENT_INVENTORY_DIR = join('runtime', 'provenance', 'environ
 export const PROJECT_DATABASE_FILE = 'open-science.db'
 const BASE_MIGRATION_DIRS = [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
 
-const defaultValidateProvenanceState = (dataRoot: string): Promise<void> =>
-  validateProvenanceMigrationState(dataRoot, resolveConfigRoot())
+const defaultValidateProvenanceState = async (dataRoot: string): Promise<void> => {
+  const authorityRoot = resolveConfigRoot()
+  await recoverLegacyMessageSnapshotsForMigration(dataRoot, authorityRoot)
+  await validateProvenanceMigrationState(dataRoot, authorityRoot)
+}
 
 type MigrationInventory = NonNullable<MigrationMarker['inventory']>
 

--- a/src/main/storage/provenance-migration-validation.test.ts
+++ b/src/main/storage/provenance-migration-validation.test.ts
@@ -2,14 +2,48 @@ import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { validateProvenanceMigrationState } from './provenance-migration-validation'
+import { MIGRATION_MANIFEST } from '../database/migration-service'
+import { applySqliteMigrationOperations } from '../database/sqlite-schema-migrations'
 import { operationJournalPath, RuntimeOperationJournal } from '../notebook/operation-journal'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 
 let root: string
 const sha256 = (value: string | Buffer): string => createHash('sha256').update(value).digest('hex')
+
+const createDatabaseBeforeFileArtifactConstraints = async (client: PrismaClient): Promise<void> => {
+  const migrationIndex = MIGRATION_MANIFEST.findIndex(
+    (migration) => migration.id === '0017_file_artifact_data_constraints'
+  )
+  if (migrationIndex < 0) throw new Error('Missing file and Artifact constraints migration.')
+  const prefix = MIGRATION_MANIFEST.slice(0, migrationIndex)
+  for (const migration of prefix) {
+    for (const statement of migration.statements) await client.$executeRawUnsafe(statement)
+    if ('operations' in migration) {
+      await client.$transaction((transaction) =>
+        applySqliteMigrationOperations(transaction, migration.operations)
+      )
+    }
+  }
+  await client.$executeRawUnsafe(`CREATE TABLE "_open_science_migrations" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "checksum" TEXT NOT NULL,
+    "appliedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "_open_science_migrations_checksum_check"
+      CHECK (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
+  )`)
+  for (const migration of prefix) {
+    await client.$executeRawUnsafe(
+      `INSERT INTO "_open_science_migrations" ("id", "checksum") VALUES (?, ?)`,
+      migration.id,
+      migration.checksum
+    )
+  }
+}
 
 beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), 'open-science-provenance-migration-'))
@@ -371,7 +405,7 @@ describe('validateProvenanceMigrationState', () => {
       mkdir(dataRoot, { recursive: true })
     ])
     const client = createProjectDbClient(authorityRoot)
-    await migrateApplicationDatabase(client)
+    await createDatabaseBeforeFileArtifactConstraints(client)
     await client.fileOriginSession.create({
       data: { projectId: 'project-1', sessionId: 'session-1' }
     })

--- a/src/main/storage/provenance-migration-validation.test.ts
+++ b/src/main/storage/provenance-migration-validation.test.ts
@@ -17,7 +17,7 @@ const sha256 = (value: string | Buffer): string => createHash('sha256').update(v
 
 const createDatabaseBeforeFileArtifactConstraints = async (client: PrismaClient): Promise<void> => {
   const migrationIndex = MIGRATION_MANIFEST.findIndex(
-    (migration) => migration.id === '0017_file_artifact_data_constraints'
+    (migration) => migration.id === '0018_file_artifact_data_constraints'
   )
   if (migrationIndex < 0) throw new Error('Missing file and Artifact constraints migration.')
   const prefix = MIGRATION_MANIFEST.slice(0, migrationIndex)

--- a/src/main/storage/provenance-migration-validation.ts
+++ b/src/main/storage/provenance-migration-validation.ts
@@ -6,6 +6,7 @@ import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { validateConversationGraph } from '../../shared/conversation-graph'
 import { NOTEBOOK_RUN_FILE } from '../../shared/notebook'
 import { normalizeSessionFile } from '../../shared/session-persistence'
+import { ProvenanceMessageSnapshotRepository } from '../artifacts/provenance-message-snapshot'
 import { operationJournalPath, RuntimeOperationJournal } from '../notebook/operation-journal'
 import { createProjectDbClient } from '../projects/prisma-client'
 
@@ -541,6 +542,28 @@ const validateSqliteStore = async (dataRoot: string, authorityRoot: string): Pro
         }
       }
     }
+  } finally {
+    await client.$disconnect()
+  }
+}
+
+export const recoverLegacyMessageSnapshotsForMigration = async (
+  dataRoot: string,
+  authorityRoot: string
+): Promise<void> => {
+  const databasePath = join(authorityRoot, 'open-science.db')
+  if (!(await fileExists(databasePath))) return
+  const client = createProjectDbClient(authorityRoot)
+  try {
+    const table = await client.$queryRawUnsafe<Array<{ name: string }>>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'ArtifactMessageSnapshot'"
+    )
+    if (table.length === 0) return
+    const snapshots = new ProvenanceMessageSnapshotRepository({
+      storageRoot: dataRoot,
+      getClient: async () => client
+    })
+    await snapshots.recoverLegacyMessageSnapshotsForMigration()
   } finally {
     await client.$disconnect()
   }


### PR DESCRIPTION
## Problem

Managed files, immutable upload/artifact versions, message snapshots, and artifact inputs rely on
application validation for several numeric, storage, checksum, publication, and tombstone
invariants. Raw SQLite writes can currently persist values that make file lineage or published
provenance internally inconsistent.

## Proposed change

- Add the requested SQLite CHECK constraints for `ManagedFile`, `ManagedFileSessionSync`,
  `UploadVersion`, `ArtifactMessageSnapshot`, `ArtifactVersion`, and `ArtifactVersionInput`.
- Replace the negative `filesRevision` retry sentinel with persisted
  `ManagedFileSessionSync.isComplete` and pair projection tombstones with operation IDs.
- Add immutable migration `0017_file_artifact_data_constraints`, after the existing
  `0016_compute_job_sensitive_data_encryption` migration, including retained backup,
  deterministic supported-history repairs, table/index/FK reconstruction, and packaged-ledger
  pinning.
- Recover legacy ready message snapshots with empty checksums through staging: validate immutable
  bytes, backfill SHA-256, then promote to ready.

## Scope and non-goals

- Persistence changes: one non-null Boolean column with default `true`; six constrained tables are
  rebuilt, plus dependent `VisionEvidence` so its `UploadVersion` foreign key remains canonical.
- Historical compatibility: revision `-1` becomes revision `0` plus `isComplete=false`; missing
  tombstone operation IDs receive deterministic migration IDs; ready snapshots with empty checksum
  become staging and are recovered from verified bytes. Other invalid historical rows fail closed
  and retain the pre-migration backup.
- No enum or enum value is added. No user-visible copy changes.
- This PR does not broaden repair policy for other invalid historical metadata.
- Related issue: none.

## Acceptance criteria and validation

All listed checks ran against the final material code state before commit.

- Requested SQLite invariants -> `vitest run src/main/database` -> 12 files, 118 tests passed.
- Packaged migration identity/replay -> `vitest run scripts/database-migration-ledger-smoke.test.ts`
  -> 11 tests passed.
- Managed-file projection behavior -> project-files module plus final repository rerun -> 38 passed,
  1 skipped in the repository suite; other project-files files passed.
- Message snapshot recovery -> `vitest run src/main/artifacts/provenance-message-snapshot.test.ts` ->
  8 tests passed.
- Artifact consumers -> artifacts module -> 242 passed, 1 skipped; one unrelated notebook
  source-observation test fails identically on `main`.
- Upload consumers -> uploads module -> 107 passed, 3 skipped; two symlink tests fail with Windows
  `EPERM` identically on `main`.
- Generated schema -> `node scripts/generate-database-schema.mjs --check` -> passed.
- Prisma schema -> `prisma validate --schema prisma/schema.prisma` -> passed.
- Lint and whitespace -> full ESLint and `git diff --check` -> passed.
- Node typecheck remains blocked by the existing `waitForMcpServers` export error in
  `claude-agent-acp-patch.test.ts`; the same command and error reproduce on `main`.

The complete `npm run test` suite was intentionally not run; CI owns the full test matrix for this
PR. Local coverage was split by affected module as requested.

## Review focus

- Confirm the strict 64-character lowercase SHA-256 contract and the published-state definition
  (`ready` uploads/snapshots and `pending`/`finalized` artifact versions).
- Review the bounded historical repairs versus fail-closed cases in migration 0017.
- Verify the seven-table rebuild order preserves `VisionEvidence`/artifact input foreign keys,
  indexes, and the `ManagedFile` AUTOINCREMENT boundary.
