### PR TITLE
fix(annotations): keep the annotate trigger after code highlighting

### DIFF
--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
@@ -715,6 +715,38 @@ describe('TextAnnotationSurface annotate trigger', () => {
     expect(annotateTrigger()).toBeUndefined()
   })
 
+  it('keeps the trigger after syntax highlighting retargets the selected code', async () => {
+    await act(async () =>
+      root.render(
+        <TextAnnotationSurface
+          source={{
+            kind: 'session-item',
+            sessionId: 'session-1',
+            itemId: 'tool-1',
+            itemType: 'tool-activity',
+            sectionId: 'code'
+          }}
+          activeAnnotations={[]}
+          onAdd={vi.fn()}
+          onError={vi.fn()}
+        >
+          <WorkspaceToolCodeBlock code="const answer = 42" language="typescript" />
+        </TextAnnotationSurface>
+      )
+    )
+    const code = container.querySelector<HTMLElement>('[data-testid="tool-code-block"] code')!
+    await commitSelection(code)
+    expect(annotateTrigger()).toBeDefined()
+
+    await vi.waitFor(() => {
+      expect(
+        container.querySelectorAll('[data-testid="tool-code-block"] code span').length
+      ).toBeGreaterThan(0)
+    })
+    await act(async () => Promise.resolve())
+    expect(annotateTrigger()).toBeDefined()
+  })
+
   it('hides the trigger when streaming replaces the selected message content', async () => {
     const paragraph = await renderSurface()
     await commitSelection(paragraph)

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
@@ -747,6 +747,66 @@ describe('TextAnnotationSurface annotate trigger', () => {
     expect(annotateTrigger()).toBeDefined()
   })
 
+  it('keeps a duplicate quote on the selected occurrence after highlight replacement', async () => {
+    const highlights = installCssHighlightsMock()
+    const onAdd = vi.fn<(annotation: TextAnnotation) => undefined>(() => undefined)
+    try {
+      await act(async () =>
+        root.render(
+          <TextAnnotationSurface
+            source={{ kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }}
+            activeAnnotations={[]}
+            onAdd={onAdd}
+            onError={vi.fn()}
+          >
+            <p>repeat then repeat</p>
+          </TextAnnotationSurface>
+        )
+      )
+      const paragraph = container.querySelector('p')!
+      const range = document.createRange()
+      range.setStart(paragraph.firstChild!, 12)
+      range.setEnd(paragraph.firstChild!, 18)
+      Object.defineProperty(range, 'getBoundingClientRect', {
+        configurable: true,
+        value: () =>
+          ({
+            left: 10,
+            right: 120,
+            top: 20,
+            bottom: 40,
+            width: 110,
+            height: 20,
+            x: 10,
+            y: 20,
+            toJSON: () => ({})
+          }) as DOMRect
+      })
+      const selection = window.getSelection()!
+      selection.removeAllRanges()
+      selection.addRange(range)
+      await act(async () => paragraph.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })))
+      expect(annotateTrigger()).toBeDefined()
+
+      await act(async () => {
+        paragraph.replaceChildren()
+        for (const part of ['repeat', ' then ', 'repeat']) {
+          const token = document.createElement('span')
+          token.textContent = part
+          paragraph.appendChild(token)
+        }
+      })
+      expect(annotateTrigger()).toBeDefined()
+
+      await act(async () => annotateTrigger()?.click())
+      const draftRange = Array.from(highlights.get('agent-annotation-draft') ?? [])[0]
+      expect(draftRange?.toString()).toBe('repeat')
+      expect(draftRange?.startContainer).toBe(paragraph.lastChild?.firstChild)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('hides the trigger when streaming replaces the selected message content', async () => {
     const paragraph = await renderSurface()
     await commitSelection(paragraph)

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.tsx
@@ -15,9 +15,13 @@ import {
   AnnotationMarkers,
   type AnnotationControl
 } from './TextAnnotationEditors'
-import { reconcileTextAnnotationRanges, retargetTextAnnotationRange } from './text-annotation-range'
+import {
+  quoteOccurrenceForRange,
+  reconcileTextAnnotationRanges,
+  retargetTextAnnotationRange
+} from './text-annotation-range'
 
-type SelectionDraft = { quote: string; backward: boolean; range: Range }
+type SelectionDraft = { quote: string; backward: boolean; range: Range; occurrence: number }
 
 const DRAFT_HIGHLIGHT_NAME = 'agent-annotation-draft'
 const draftHighlightRanges = new Map<string, Range>()
@@ -160,10 +164,13 @@ const TextAnnotationSurface = ({
       return
     }
     suppressFollowingClickRef.current = suppressFollowingClick
+    const cloned = range.cloneRange()
+    const content = contentRef.current
     setSelection({
       quote,
       backward: isBackwardSelection(selected),
-      range: range.cloneRange()
+      range: cloned,
+      occurrence: content ? quoteOccurrenceForRange(content, quote, cloned) : 0
     })
   }
 
@@ -226,7 +233,12 @@ const TextAnnotationSurface = ({
     const content = contentRef.current
     const draft = selectionRef.current
     if (!content || !draft) return
-    const nextRange = retargetTextAnnotationRange(content, draft.quote, draft.range)
+    const nextRange = retargetTextAnnotationRange(
+      content,
+      draft.quote,
+      draft.range,
+      draft.occurrence
+    )
     if (nextRange === draft.range) return
     if (nextRange) {
       setSelection({ ...draft, range: nextRange })

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.tsx
@@ -15,7 +15,7 @@ import {
   AnnotationMarkers,
   type AnnotationControl
 } from './TextAnnotationEditors'
-import { reconcileTextAnnotationRanges } from './text-annotation-range'
+import { reconcileTextAnnotationRanges, retargetTextAnnotationRange } from './text-annotation-range'
 
 type SelectionDraft = { quote: string; backward: boolean; range: Range }
 
@@ -75,6 +75,7 @@ const TextAnnotationSurface = ({
   const pendingHighlightKey = `pending-${useId()}`
   const noteInputId = `annotation-note-${useId()}`
   const [selection, setSelection] = useState<SelectionDraft>()
+  const selectionRef = useRef(selection)
   const [open, setOpen] = useState(false)
   const [note, setNote] = useState('')
   const [annotationControls, setAnnotationControls] = useState<readonly AnnotationControl[]>([])
@@ -218,8 +219,28 @@ const TextAnnotationSurface = ({
   }, [matchingAnnotations, measureAnnotationControls])
 
   useLayoutEffect(() => {
+    selectionRef.current = selection
+  }, [selection])
+
+  const retargetDraftSelection = useCallback((): void => {
+    const content = contentRef.current
+    const draft = selectionRef.current
+    if (!content || !draft) return
+    const nextRange = retargetTextAnnotationRange(content, draft.quote, draft.range)
+    if (nextRange === draft.range) return
+    if (nextRange) {
+      setSelection({ ...draft, range: nextRange })
+      return
+    }
+    setSelection(undefined)
+    setOpen(false)
+    setNote('')
+  }, [])
+
+  useLayoutEffect(() => {
     reconcileAnnotationHighlights()
-  }, [children, reconcileAnnotationHighlights])
+    retargetDraftSelection()
+  }, [children, reconcileAnnotationHighlights, retargetDraftSelection])
 
   useLayoutEffect(() => {
     const content = contentRef.current
@@ -231,7 +252,9 @@ const TextAnnotationSurface = ({
       scheduled = true
       queueMicrotask(() => {
         scheduled = false
-        if (!disconnected) reconcileAnnotationHighlights()
+        if (disconnected) return
+        reconcileAnnotationHighlights()
+        retargetDraftSelection()
       })
     })
     observer.observe(content, { childList: true, characterData: true, subtree: true })
@@ -239,7 +262,7 @@ const TextAnnotationSurface = ({
       disconnected = true
       observer.disconnect()
     }
-  }, [reconcileAnnotationHighlights])
+  }, [reconcileAnnotationHighlights, retargetDraftSelection])
 
   useEffect(() => {
     window.addEventListener('resize', measureAnnotationControls)

--- a/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts
@@ -243,4 +243,35 @@ describe('isRangeTriggerVisible', () => {
 
     expect(isRangeTriggerVisible(range, false, viewport)).toBe(true)
   })
+
+  it('keeps the trigger when an overflow ancestor reports a zero-size rectangle', () => {
+    const viewportElement = document.createElement('div')
+    viewportElement.style.overflow = 'hidden'
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'selectable agent reply'
+    viewportElement.appendChild(paragraph)
+    document.body.appendChild(viewportElement)
+    Object.defineProperty(viewportElement, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect(0, 0, 0, 0)
+    })
+    const range = document.createRange()
+    range.selectNodeContents(paragraph.firstChild!)
+    Object.defineProperty(range, 'getClientRects', {
+      configurable: true,
+      value: () => [rect(10, 20, 180, 40)]
+    })
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => rect(10, 20, 180, 40)
+    })
+
+    expect(isRangeTriggerVisible(range, false, viewport)).toBe(true)
+  })
+
+  it('keeps the trigger when the window viewport has no usable size', () => {
+    const range = selectWithRects([rect(10, 20, 180, 40)], rect(10, 20, 180, 40))
+
+    expect(isRangeTriggerVisible(range, false, { width: 0, height: 0 })).toBe(true)
+  })
 })

--- a/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.ts
@@ -59,9 +59,17 @@ const isRangeTriggerVisible = (
   // often still expose a zero-size DOMRect; treat that as missing so placement
   // keeps its existing fallback. Live browser text selections provide a box.
   if (!anchorRect) return true
-  if (
-    !rectsIntersect(anchorRect, { left: 0, right: viewport.width, top: 0, bottom: viewport.height })
-  ) {
+  const viewportRect = {
+    left: 0,
+    right: viewport.width,
+    top: 0,
+    bottom: viewport.height,
+    width: viewport.width,
+    height: viewport.height
+  }
+  // A zero-size window is layout-unusable, not an off-screen selection. jsdom
+  // and pre-layout browsers report that; hiding the trigger would drop a live draft.
+  if (hasUsableAnchorGeometry(viewportRect) && !rectsIntersect(anchorRect, viewportRect)) {
     return false
   }
 
@@ -74,7 +82,14 @@ const isRangeTriggerVisible = (
     const clips = [style.overflow, style.overflowX, style.overflowY].some((overflow) =>
       /^(auto|clip|hidden|scroll)$/.test(overflow)
     )
-    if (clips && !rectsIntersect(anchorRect, ancestor.getBoundingClientRect())) return false
+    if (clips) {
+      const ancestorRect = ancestor.getBoundingClientRect()
+      // Same missing-geometry fallback as the Range itself: an overflow ancestor
+      // with a zero-size box cannot clip a selection that still exists in the tree.
+      if (hasUsableAnchorGeometry(ancestorRect) && !rectsIntersect(anchorRect, ancestorRect)) {
+        return false
+      }
+    }
     ancestor = ancestor.parentElement
   }
   return true

--- a/src/renderer/src/pages/workspace/annotations/text-annotation-range.test.ts
+++ b/src/renderer/src/pages/workspace/annotations/text-annotation-range.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest'
 
-import { reconcileTextAnnotationRanges } from './text-annotation-range'
+import { reconcileTextAnnotationRanges, retargetTextAnnotationRange } from './text-annotation-range'
 
 const rangeAt = (node: Text, start: number, length = 6): Range => {
   const range = document.createRange()
@@ -115,6 +115,46 @@ describe('text annotation range reconciliation', () => {
     )
 
     expect(result.size).toBe(0)
+    surface.remove()
+  })
+})
+
+describe('retargetTextAnnotationRange', () => {
+  it('keeps a still-connected exact range', () => {
+    const { surface, text } = surfaceWithDuplicates()
+    const existing = rangeAt(text, 0)
+
+    expect(retargetTextAnnotationRange(surface, 'repeat', existing)).toBe(existing)
+    surface.remove()
+  })
+
+  it('rebuilds the quote after highlight spans replace the original text node', () => {
+    const surface = document.createElement('div')
+    const code = document.createElement('code')
+    code.appendChild(document.createTextNode('printf shell-command'))
+    surface.appendChild(code)
+    document.body.appendChild(surface)
+    const existing = document.createRange()
+    existing.selectNodeContents(code.firstChild!)
+
+    code.replaceChildren()
+    const token = document.createElement('span')
+    token.appendChild(document.createTextNode('printf shell-command'))
+    code.appendChild(token)
+
+    const restored = retargetTextAnnotationRange(surface, 'printf shell-command', existing)
+    expect(restored).not.toBe(existing)
+    expect(restored?.toString()).toBe('printf shell-command')
+    expect(restored?.startContainer.isConnected).toBe(true)
+    surface.remove()
+  })
+
+  it('returns undefined when the quote is no longer in the surface', () => {
+    const { surface, text } = surfaceWithDuplicates()
+    const existing = rangeAt(text, 0)
+    text.data = 'stream replaced the quote'
+
+    expect(retargetTextAnnotationRange(surface, 'repeat', existing)).toBeUndefined()
     surface.remove()
   })
 })

--- a/src/renderer/src/pages/workspace/annotations/text-annotation-range.test.ts
+++ b/src/renderer/src/pages/workspace/annotations/text-annotation-range.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest'
 
-import { reconcileTextAnnotationRanges, retargetTextAnnotationRange } from './text-annotation-range'
+import {
+  quoteOccurrenceForRange,
+  reconcileTextAnnotationRanges,
+  retargetTextAnnotationRange
+} from './text-annotation-range'
 
 const rangeAt = (node: Text, start: number, length = 6): Range => {
   const range = document.createRange()
@@ -146,6 +150,38 @@ describe('retargetTextAnnotationRange', () => {
     expect(restored).not.toBe(existing)
     expect(restored?.toString()).toBe('printf shell-command')
     expect(restored?.startContainer.isConnected).toBe(true)
+    surface.remove()
+  })
+
+  it('rebuilds a duplicate quote onto the selected occurrence after highlight spans replace it', () => {
+    const surface = document.createElement('div')
+    const code = document.createElement('code')
+    const original = document.createTextNode('repeat then repeat')
+    code.appendChild(original)
+    surface.appendChild(code)
+    document.body.appendChild(surface)
+    const existing = rangeAt(original, 12)
+    const occurrence = quoteOccurrenceForRange(surface, 'repeat', existing)
+    expect(occurrence).toBe(1)
+
+    code.replaceChildren()
+    for (const part of ['repeat', ' then ', 'repeat']) {
+      const token = document.createElement('span')
+      token.appendChild(document.createTextNode(part))
+      code.appendChild(token)
+    }
+
+    const restored = retargetTextAnnotationRange(surface, 'repeat', existing, occurrence)
+    expect(restored).not.toBe(existing)
+    expect(restored?.toString()).toBe('repeat')
+    expect(restored?.startContainer).toBe(code.lastChild?.firstChild)
+    expect(quoteOccurrenceForRange(surface, 'repeat', restored!)).toBe(1)
+    surface.remove()
+  })
+
+  it('counts the first duplicate quote as occurrence 0', () => {
+    const { surface, text } = surfaceWithDuplicates()
+    expect(quoteOccurrenceForRange(surface, 'repeat', rangeAt(text, 0))).toBe(0)
     surface.remove()
   })
 

--- a/src/renderer/src/pages/workspace/annotations/text-annotation-range.ts
+++ b/src/renderer/src/pages/workspace/annotations/text-annotation-range.ts
@@ -72,4 +72,20 @@ const reconcileTextAnnotationRanges = (
   return next
 }
 
-export { rangeForTextOccurrence, reconcileTextAnnotationRanges }
+const retargetTextAnnotationRange = (
+  surface: HTMLElement,
+  quote: string,
+  existing?: Range
+): Range | undefined => {
+  if (
+    existing &&
+    !existing.collapsed &&
+    existing.toString() === quote &&
+    rangeBelongsToSurface(existing, surface)
+  ) {
+    return existing
+  }
+  return rangeForTextOccurrence(surface, quote)
+}
+
+export { rangeForTextOccurrence, reconcileTextAnnotationRanges, retargetTextAnnotationRange }

--- a/src/renderer/src/pages/workspace/annotations/text-annotation-range.ts
+++ b/src/renderer/src/pages/workspace/annotations/text-annotation-range.ts
@@ -1,16 +1,40 @@
+const collectSurfaceTextNodes = (surface: HTMLElement): Text[] => {
+  const walker = document.createTreeWalker(surface, NodeFilter.SHOW_TEXT)
+  const nodes: Text[] = []
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    nodes.push(node as Text)
+  }
+  return nodes
+}
+
+const concatenatedText = (nodes: readonly Text[]): string => nodes.map((node) => node.data).join('')
+
+const rangeStartInSurfaceText = (nodes: readonly Text[], range: Range): number | undefined => {
+  let offset = 0
+  for (const node of nodes) {
+    if (range.startContainer === node) return offset + range.startOffset
+    offset += node.data.length
+  }
+
+  const startContainer = range.startContainer
+  if (startContainer.nodeType !== Node.ELEMENT_NODE) return undefined
+  const child = startContainer.childNodes[range.startOffset] ?? startContainer.lastChild
+  if (!child) return undefined
+  offset = 0
+  for (const node of nodes) {
+    if (child === node || (child instanceof Element && child.contains(node))) return offset
+    offset += node.data.length
+  }
+  return undefined
+}
+
 const rangeForTextOccurrence = (
   surface: HTMLElement,
   quote: string,
   occurrence = 0
 ): Range | undefined => {
-  const walker = document.createTreeWalker(surface, NodeFilter.SHOW_TEXT)
-  const nodes: Text[] = []
-  let text = ''
-  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-    const textNode = node as Text
-    nodes.push(textNode)
-    text += textNode.data
-  }
+  const nodes = collectSurfaceTextNodes(surface)
+  const text = concatenatedText(nodes)
   let start = -1
   let from = 0
   for (let index = 0; index <= occurrence; index += 1) {
@@ -26,7 +50,7 @@ const rangeForTextOccurrence = (
   let endOffset = 0
   for (const node of nodes) {
     const nextOffset = offset + node.data.length
-    if (!startNode && start >= offset && start <= nextOffset) {
+    if (!startNode && start >= offset && start < nextOffset) {
       startNode = node
       startOffset = start - offset
     }
@@ -42,6 +66,21 @@ const rangeForTextOccurrence = (
   range.setStart(startNode, startOffset)
   range.setEnd(endNode, endOffset)
   return range
+}
+
+const quoteOccurrenceForRange = (surface: HTMLElement, quote: string, range: Range): number => {
+  const nodes = collectSurfaceTextNodes(surface)
+  const start = rangeStartInSurfaceText(nodes, range)
+  if (start === undefined) return 0
+  const text = concatenatedText(nodes)
+  let occurrence = 0
+  let from = 0
+  for (;;) {
+    const index = text.indexOf(quote, from)
+    if (index < 0 || index >= start) return occurrence
+    occurrence += 1
+    from = index + quote.length
+  }
 }
 
 type TextAnnotationRangeTarget = Readonly<{ id: string; quote: string }>
@@ -75,7 +114,8 @@ const reconcileTextAnnotationRanges = (
 const retargetTextAnnotationRange = (
   surface: HTMLElement,
   quote: string,
-  existing?: Range
+  existing?: Range,
+  occurrence = 0
 ): Range | undefined => {
   if (
     existing &&
@@ -85,7 +125,12 @@ const retargetTextAnnotationRange = (
   ) {
     return existing
   }
-  return rangeForTextOccurrence(surface, quote)
+  return rangeForTextOccurrence(surface, quote, occurrence)
 }
 
-export { rangeForTextOccurrence, reconcileTextAnnotationRanges, retargetTextAnnotationRange }
+export {
+  quoteOccurrenceForRange,
+  rangeForTextOccurrence,
+  reconcileTextAnnotationRanges,
+  retargetTextAnnotationRange
+}

--- a/src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.test.tsx
@@ -11,6 +11,7 @@ import type {
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 
 import { requestAnnotationReveal } from '../annotations/annotation-reveal'
+import { HighlightedCodeLines } from '../HighlightedCodeLines'
 import { PreviewTextAnnotationSurface } from './PreviewTextAnnotationSurface'
 
 const item = (overrides: Partial<PreviewFileItem> = {}): PreviewFileItem => ({
@@ -439,5 +440,85 @@ describe('PreviewTextAnnotationSurface', () => {
     expect(scrollIntoView).toHaveBeenCalledTimes(1)
     expect(scrollIntoView).toHaveBeenCalledWith({ block: 'center', behavior: 'smooth' })
     delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
+  })
+
+  it('keeps the trigger after preview code highlighting retargets the selected code', async () => {
+    await act(async () => {
+      root.render(
+        <PreviewTextAnnotationSurface
+          item={item({
+            name: 'main.ts',
+            title: 'main.ts',
+            path: '/project/main.ts',
+            format: 'code'
+          })}
+          onAddAnnotation={vi.fn(() => undefined)}
+          onAnnotationError={vi.fn()}
+        >
+          <HighlightedCodeLines code="const answer = 42" language="typescript" />
+        </PreviewTextAnnotationSurface>
+      )
+    })
+    const contentSpan = container.querySelector(
+      '[data-testid="source-line-number"]'
+    )?.nextElementSibling
+    const text = contentSpan?.firstChild
+    if (!text) throw new Error('Preview code text was not rendered')
+    const range = document.createRange()
+    range.selectNodeContents(text)
+    Object.defineProperty(range, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        left: 10,
+        right: 120,
+        top: 20,
+        bottom: 40,
+        width: 110,
+        height: 20,
+        x: 10,
+        y: 20,
+        toJSON: () => ({})
+      })
+    })
+    window.getSelection()?.removeAllRanges()
+    window.getSelection()?.addRange(range)
+    await act(async () => {
+      container
+        .querySelector('[data-preview-text-annotation-surface="true"]')
+        ?.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    })
+    expect(document.querySelector('[data-annotation-trigger]')).not.toBeNull()
+
+    await vi.waitFor(() => {
+      expect(
+        container.querySelectorAll('[data-testid="source-code-token"]').length
+      ).toBeGreaterThan(0)
+    })
+    await act(async () => Promise.resolve())
+    expect(document.querySelector('[data-annotation-trigger]')).not.toBeNull()
+  })
+
+  it('keeps a duplicate preview quote on the selected occurrence after highlight replacement', async () => {
+    await renderSurface({ content: 'repeat then repeat' })
+    await selectRange(12, 18)
+    expect(document.querySelector('[data-annotation-trigger]')).not.toBeNull()
+
+    const paragraph = container.querySelector('p')!
+    await act(async () => {
+      paragraph.replaceChildren()
+      for (const part of ['repeat', ' then ', 'repeat']) {
+        const token = document.createElement('span')
+        token.textContent = part
+        paragraph.appendChild(token)
+      }
+    })
+    expect(document.querySelector('[data-annotation-trigger]')).not.toBeNull()
+
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[data-annotation-trigger]')?.click()
+    )
+    const draftRange = Array.from(registeredRanges)[0]
+    expect(draftRange?.toString()).toBe('repeat')
+    expect(draftRange?.startContainer).toBe(paragraph.lastChild?.firstChild)
   })
 })

--- a/src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.tsx
@@ -15,9 +15,18 @@ import {
   AnnotationMarkers,
   type AnnotationControl
 } from '../annotations/TextAnnotationEditors'
-import { reconcileTextAnnotationRanges } from '../annotations/text-annotation-range'
+import {
+  quoteOccurrenceForRange,
+  reconcileTextAnnotationRanges,
+  retargetTextAnnotationRange
+} from '../annotations/text-annotation-range'
 
-type SelectionDraft = Readonly<{ quote: string; backward: boolean; range: Range }>
+type SelectionDraft = Readonly<{
+  quote: string
+  backward: boolean
+  range: Range
+  occurrence: number
+}>
 
 const DRAFT_HIGHLIGHT_NAME = 'preview-annotation-draft'
 const DRAFT_HIGHLIGHT_STYLE_ID = 'preview-annotation-draft-style'
@@ -78,9 +87,11 @@ export const PreviewTextAnnotationSurface = ({
 }: PreviewFileRendererProps & { children: React.ReactNode }): React.JSX.Element => {
   const { t } = useTranslation()
   const surfaceRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
   const ownedRanges = useRef(new Map<string, Range>())
   const pendingRangeRef = useRef<Range | null>(null)
   const [selection, setSelection] = useState<SelectionDraft>()
+  const selectionRef = useRef(selection)
   const [open, setOpen] = useState(false)
   const [note, setNote] = useState('')
   const [annotationControls, setAnnotationControls] = useState<readonly AnnotationControl[]>([])
@@ -136,22 +147,73 @@ export const PreviewTextAnnotationSurface = ({
   }
 
   useLayoutEffect(() => {
+    selectionRef.current = selection
+  }, [selection])
+
+  const retargetDraftSelection = useCallback((): void => {
+    const content = contentRef.current
+    const draft = selectionRef.current
+    if (!content || !draft) return
+    const nextRange = retargetTextAnnotationRange(
+      content,
+      draft.quote,
+      draft.range,
+      draft.occurrence
+    )
+    if (nextRange === draft.range) return
+    if (nextRange) {
+      setSelection({ ...draft, range: nextRange })
+      return
+    }
+    setSelection(undefined)
+    setOpen(false)
+    setNote('')
+  }, [])
+
+  const reconcilePreviewHighlights = useCallback((): void => {
     const highlight = getDraftHighlight()
     if (!highlight) return
     for (const range of ownedRanges.current.values()) highlight.delete(range)
-    const surface = surfaceRef.current
-    if (!surface) {
+    const content = contentRef.current
+    if (!content) {
       ownedRanges.current.clear()
       return
     }
     ownedRanges.current = reconcileTextAnnotationRanges(
-      surface,
+      content,
       matchingAnnotations,
       ownedRanges.current
     )
     for (const range of ownedRanges.current.values()) highlight.add(range)
     measureAnnotationControls()
-  }, [children, matchingAnnotations, measureAnnotationControls])
+  }, [matchingAnnotations, measureAnnotationControls])
+
+  useLayoutEffect(() => {
+    reconcilePreviewHighlights()
+    retargetDraftSelection()
+  }, [children, reconcilePreviewHighlights, retargetDraftSelection])
+
+  useLayoutEffect(() => {
+    const content = contentRef.current
+    if (!content || typeof MutationObserver === 'undefined') return
+    let scheduled = false
+    let disconnected = false
+    const observer = new MutationObserver(() => {
+      if (scheduled) return
+      scheduled = true
+      queueMicrotask(() => {
+        scheduled = false
+        if (disconnected) return
+        reconcilePreviewHighlights()
+        retargetDraftSelection()
+      })
+    })
+    observer.observe(content, { childList: true, characterData: true, subtree: true })
+    return () => {
+      disconnected = true
+      observer.disconnect()
+    }
+  }, [reconcilePreviewHighlights, retargetDraftSelection])
 
   useEffect(() => {
     window.addEventListener('resize', measureAnnotationControls)
@@ -235,10 +297,13 @@ export const PreviewTextAnnotationSurface = ({
       clearDraft()
       return
     }
+    const cloned = range.cloneRange()
+    const content = contentRef.current
     setSelection({
       quote,
       backward: isBackwardSelection(selected),
-      range: range.cloneRange()
+      range: cloned,
+      occurrence: content ? quoteOccurrenceForRange(content, quote, cloned) : 0
     })
   }
 
@@ -305,7 +370,9 @@ export const PreviewTextAnnotationSurface = ({
       onPointerMove={trackAnnotatedTextHover}
       onPointerLeave={() => setHoveredAnnotationId(undefined)}
     >
-      {children}
+      <div ref={contentRef} className="contents">
+        {children}
+      </div>
       <AnnotationMarkers
         controls={annotationControls}
         hoveredAnnotationId={hoveredAnnotationId}


### PR DESCRIPTION
## Problem

PRs based on `main` fail **PR Gate / Full Module tests (macOS, shard 2/2)** because

`WorkspaceMessageScroller.annotations.test.tsx` → `annotates and restores independent Tool and Notebook transcript sections`

asserts the Annotate trigger exists after selecting tool/notebook code, and the trigger is missing.

Two things hide it after a live selection:

1. `WorkspaceToolCodeBlock` runs Shiki after paint and replaces the selected text node with token spans. The cloned draft `Range` disconnects or collapses, and `isRangeTriggerVisible` then hides the portalled trigger.
2. Tool rows use `overflow-hidden` / `overflow-auto`. In jsdom those ancestors often report a zero-size box. The clip check treated that as “selection is outside the viewport” and hid a still-valid draft.

## Proposed change

- Retarget the live draft `Range` from the surviving quote when surface content mutates but the quoted text is still there (the same path saved annotations already use after highlighting).
- Drop the draft only when the quote is gone, which keeps the existing hide-on-stream / hide-on-remove behavior.
- Skip window and overflow clip checks when the measured box has no usable width or height, matching the existing jsdom missing-geometry fallback.

## Scope and non-goals

- Renderer annotation trigger only. No schema, migration, persisted format, or enum changes.
- Does not change macOS E2E product behavior. The shard 2/2 failure is this unit test; see notes below for the separate E2E finding.

## Acceptance criteria and validation

- Selecting tool/notebook code still shows Annotate after async syntax highlighting.
- Streaming or removing the quoted text still hides the trigger.
- Overflow clipping still hides the trigger when the ancestor box is a real, usable rectangle.

### Evidence (after last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Tool/notebook transcript annotate + restore | `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageScroller.annotations.test.tsx` | pass |
| Draft retarget, hide-on-remove, highlight spans | `npx vitest run src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx` | pass |
| Trigger visibility / zero-size clip fallback | `npx vitest run src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts` | pass |
| Quote retarget helper | `npx vitest run src/renderer/src/pages/workspace/annotations/text-annotation-range.test.ts` | pass |
| Renderer types | `npm run typecheck:web` | pass |
| Changed-file lint | `npx eslint` on the six edited files | pass |

Consumers outside the annotation surface were excluded: the public `TextAnnotationSurface` contract is unchanged. Platform E2E was excluded from local runs; PR Gate remains authoritative for the full portable and macOS suites.

## Review focus

- Mutation-observer retarget vs. the existing hide-when-quote-is-gone tests.
- Zero-size clip fallback still hiding real off-screen selections.

## Historical compatibility

None. No persisted annotation format or stored Range is changed; retarget is in-memory for the live draft only.

## New state / enum values

None.

## Data persistence

None in this PR.

### Related CI note (not fixed here)

**PR Gate / macOS build and E2E** is not failing on every main-based PR. The consistent red check is shard 2/2. One open PR (`#1818`) also failed `e2e/message-tool-layout-stability.spec.ts` because `session-persistence-alert` (“This conversation changed in another window…”) covered the Send button. That is a session-revision race on the persistence path. I did not change persistence, conflict rebase, or stored session shape here — confirm if that should be a follow-up.