### PR TITLE
test(test-infra): remove line budgets and quiet passing logs

### DIFF
--- a/src/main/artifacts/provenance-repository.architecture.test.ts
+++ b/src/main/artifacts/provenance-repository.architecture.test.ts
@@ -43,9 +43,6 @@ const productionFiles = [
   'provenance-version-writer.ts',
   'write-budget-owner.ts'
 ] as const
-const deepOwnerFiles = productionFiles.filter(
-  (file) => file !== 'provenance-repository.ts' && file !== 'provenance-message-snapshot.ts'
-)
 const sources = new Map(
   productionFiles.map((file) => [file, readFileSync(resolve(__dirname, file), 'utf8')])
 )
@@ -206,22 +203,6 @@ type ModuleImpactManifest = {
 describe('Artifact Provenance repository architecture', () => {
   const facadeFile = sourceFileFor('provenance-repository.ts')
   const facade = classFrom('provenance-repository.ts', 'ArtifactProvenanceRepository')
-
-  it('keeps the facade and deep owners within their approved completion gates', () => {
-    const facadeSource = sources.get('provenance-repository.ts')!
-    const facadeLines = facadeSource.split(/\r?\n/).length - Number(facadeSource.endsWith('\n'))
-    expect(facadeLines).toBeLessThanOrEqual(1200)
-
-    for (const file of deepOwnerFiles) {
-      const source = sources.get(file)!
-      const physicalLines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      expect(physicalLines, file).toBeLessThanOrEqual(660)
-    }
-    for (const [file, source] of sources) {
-      const physicalLines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      expect(physicalLines, file).toBeLessThanOrEqual(1200)
-    }
-  })
 
   it('keeps the established public facade and private projection helpers', () => {
     expect(methods(facade, 'public')).toEqual(

--- a/src/main/delegation/durable-delegated-work.architecture.test.ts
+++ b/src/main/delegation/durable-delegated-work.architecture.test.ts
@@ -9,7 +9,6 @@ describe('durable delegated work architecture', () => {
   it('keeps state owners and projections out of the public composer implementation', () => {
     const composer = readSource('./durable-delegated-work.ts')
 
-    expect(composer.split('\n').length).toBeLessThan(1_120)
     expect(composer).not.toContain('class RootDelegatePermissionOwner')
     expect(composer).not.toContain('class DelegatedWorkProjectionOwner')
     expect(composer).not.toContain('class DelegatedWorkReadModel')

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -284,6 +284,18 @@ describe('logger: formatLine', () => {
 })
 
 describe('logger: redacted sinks', () => {
+  it('keeps the console mirror quiet by default in tests', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-quiet-'))
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    initLogger({ logDir, fileName: 'main.log' })
+
+    createLogger('quiet').warn('captured in the log file')
+    await flushLogs()
+
+    expect(consoleWarn).not.toHaveBeenCalled()
+    expect(await readFile(join(logDir, 'main.log'), 'utf8')).toContain('captured in the log file')
+  })
+
   it('keeps secrets out of the console mirror and every rotated JSONL file', async () => {
     logDir = await mkdtemp(join(tmpdir(), 'os-logger-redaction-'))
     const sentinel = 'sink-opaque-value-7319'

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -31,6 +31,7 @@ export type LoggerConfig = {
 
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024 // 5 MB per file
 const DEFAULT_MAX_FILES = 3 // ~15 MB total ceiling
+const DEFAULT_MIRROR_TO_CONSOLE = process.env.NODE_ENV !== 'test'
 
 let config: LoggerConfig | undefined
 // Serializes appends (and rotation) so concurrent log calls cannot interleave partial lines.
@@ -814,7 +815,7 @@ const initLogger = (options: { logDir: string } & Partial<Omit<LoggerConfig, 'lo
     runId: randomUUID(),
     fileName: 'main.log',
     minLevel: 'debug',
-    mirrorToConsole: true,
+    mirrorToConsole: DEFAULT_MIRROR_TO_CONSOLE,
     maxBytes: DEFAULT_MAX_BYTES,
     maxFiles: DEFAULT_MAX_FILES,
     ...options
@@ -857,7 +858,7 @@ const writeFatalLogSync = (scope: string, message: string, data?: unknown): void
 }
 
 const emit = (level: LogLevel, scope: string, message: string, data?: unknown): void => {
-  const mirror = config?.mirrorToConsole ?? true
+  const mirror = config?.mirrorToConsole ?? DEFAULT_MIRROR_TO_CONSOLE
   const line = formatLine(
     level,
     scope,

--- a/src/main/reviewer/reviewer-orchestrator.architecture.test.ts
+++ b/src/main/reviewer/reviewer-orchestrator.architecture.test.ts
@@ -61,8 +61,6 @@ const privateOwnerPaths = [
 ] as const
 
 const readSource = (path: string): string => readProductionSource(path, projectRoot)
-const rawLineCount = (source: string): number =>
-  source.split(/\r?\n/).length - Number(source.endsWith('\n'))
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
 const portableProjectPath = (path: string): string =>
   relative(projectRoot, path).replaceAll('\\', '/')
@@ -208,16 +206,6 @@ type ModuleImpactManifest = {
 }
 
 describe('Reviewer orchestrator architecture', () => {
-  it('keeps the facade and private owners within their completion gates', () => {
-    expect(rawLineCount(readSource(reviewerPaths.facade))).toBeLessThanOrEqual(600)
-    for (const ownerPath of privateOwnerPaths) {
-      expect(
-        rawLineCount(readSource(ownerPath)),
-        portableProjectPath(ownerPath)
-      ).toBeLessThanOrEqual(660)
-    }
-  })
-
   it('locks the stable facade export inventory', () => {
     expect(exportInventoryFromFacade()).toEqual([
       'type:RunReviewOptions',

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -404,13 +404,6 @@ describe('Session persistence coordinator architecture', () => {
     'SessionDelegatedQuestionPersistenceOwner'
   )
 
-  it('keeps the facade and every deep owner within their completion gates', () => {
-    for (const [file, source] of sources) {
-      const physicalLines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      expect(physicalLines, file).toBeLessThanOrEqual(file === 'coordinator.ts' ? 1000 : 750)
-    }
-  })
-
   it('keeps the established facade, constructor, and module exports', () => {
     expect(methods(facade, 'public')).toEqual(
       [

--- a/src/main/settings/backend-route-planner.architecture.test.ts
+++ b/src/main/settings/backend-route-planner.architecture.test.ts
@@ -76,11 +76,8 @@ const publicOperations = (): string[] => {
 }
 
 describe('Backend route planning ownership', () => {
-  it('keeps the pure planner within forecast and free of live resource ownership', () => {
+  it('keeps the pure planner free of live resource ownership', () => {
     const source = readSource(plannerPath)
-    const lines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-    expect(lines).toBeLessThanOrEqual(500)
-    expect(lines).toBeLessThanOrEqual(660)
     expect(source).not.toMatch(
       /new\s+(?:ResponsesBridge|NativeResponsesCompatibilityProxy|AnthropicProviderBridge|OpenAiProviderBridge)|\.start\(|\.close\(|\blease\b|nextGenerationId|randomUUID|new\s+Map|responsesBridges|nativeResponsesCompatibilityProxies/
     )

--- a/src/main/settings/backend-selection-owner.architecture.test.ts
+++ b/src/main/settings/backend-selection-owner.architecture.test.ts
@@ -76,9 +76,8 @@ const publicOperations = (): string[] => {
 }
 
 describe('Backend selection ownership', () => {
-  it('keeps pure selection policy below the production hard limit', () => {
+  it('keeps pure selection policy free of transport ownership', () => {
     const source = readSource(ownerPath)
-    expect(source.split(/\r?\n/).length - Number(source.endsWith('\n'))).toBeLessThanOrEqual(660)
     expect(source).not.toMatch(
       /ResponsesBridge|NativeResponses|create.*Bridge|start\(|close\(|keyRef|credential|lease|generation|orchestration/i
     )

--- a/src/main/settings/provider-auth-lifecycle.architecture.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.architecture.test.ts
@@ -77,9 +77,8 @@ const publicOperations = (): string[] => {
 }
 
 describe('Provider authentication lifecycle ownership', () => {
-  it('keeps one focused owner below the production hard limit', () => {
+  it('keeps authentication behind the provider owner boundary', () => {
     const source = readSource(ownerPath)
-    expect(source.split(/\r?\n/).length - Number(source.endsWith('\n'))).toBeLessThanOrEqual(660)
     expect(source).not.toMatch(/ipcMain|contextBridge|window\.api/)
     expect(source).toContain('keyRef: encryptKey(token)')
     expect(source).not.toMatch(/keyRef:\s*token\b/)

--- a/src/main/settings/provider-loopback-http-host.architecture.test.ts
+++ b/src/main/settings/provider-loopback-http-host.architecture.test.ts
@@ -21,9 +21,8 @@ const portablePath = (path: string): string => relative(projectRoot, path).repla
 const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 describe('Provider loopback HTTP ownership', () => {
-  it('keeps the fixed lifecycle and security envelope in one bounded module', () => {
+  it('keeps the fixed lifecycle and security envelope in one module', () => {
     const host = readSource(hostPath)
-    expect(host.split(/\r?\n/).length - Number(host.endsWith('\n'))).toBeLessThanOrEqual(300)
     expect(host).toContain('64 * 1024 * 1024')
     expect(host).toContain("randomBytes(24).toString('hex')")
     expect(host).toContain("server.listen(0, '127.0.0.1'")

--- a/src/main/settings/provider-runtime-projection.architecture.test.ts
+++ b/src/main/settings/provider-runtime-projection.architecture.test.ts
@@ -77,9 +77,8 @@ const publicOperations = (): string[] => {
 }
 
 describe('Provider runtime projection ownership', () => {
-  it('keeps one focused owner below the production hard limit', () => {
+  it('keeps persistence out of the runtime projection owner', () => {
     const source = readSource(ownerPath)
-    expect(source.split(/\r?\n/).length - Number(source.endsWith('\n'))).toBeLessThanOrEqual(660)
     expect(source).not.toMatch(/SettingsRepository|setActiveProvider|upsertProvider/)
   })
 

--- a/src/main/settings/provider-transport-owner.architecture.test.ts
+++ b/src/main/settings/provider-transport-owner.architecture.test.ts
@@ -56,11 +56,8 @@ const importsOwner = (path: string): boolean => {
 }
 
 describe('Provider transport ownership', () => {
-  it('keeps one deep acquire seam within the approved ceiling', () => {
+  it('keeps one deep acquire seam behind the transport owner', () => {
     const source = readSource(ownerPath)
-    const lines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-    expect(lines).toBeLessThanOrEqual(600)
-    expect(lines).toBeLessThanOrEqual(660)
     expect(source).not.toMatch(/console\.|JSON\.stringify\([^\n]*(?:key|token|credential)/i)
 
     const declaration = sourceFileFor(ownerPath).statements.find(

--- a/src/main/settings/responses-request-adapter.architecture.test.ts
+++ b/src/main/settings/responses-request-adapter.architecture.test.ts
@@ -37,8 +37,6 @@ const adapterPath = resolve(__dirname, 'responses-request-adapter.ts')
 const bridgePath = resolve(__dirname, 'responses-bridge.ts')
 const hostPath = resolve(__dirname, 'provider-loopback-http-host.ts')
 const readSource = (path: string): string => readProductionSource(path, projectRoot)
-const rawLineCount = (source: string): number =>
-  source.split(/\r?\n/).length - Number(source.endsWith('\n'))
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
 const portableProjectPath = (path: string): string =>
   relative(projectRoot, path).replaceAll('\\', '/')
@@ -130,7 +128,6 @@ const exportInventoryFrom = (path: string): string[] => {
 
 describe('Responses request adapter ownership', () => {
   it('keeps a small, exact conversion interface', () => {
-    expect(rawLineCount(readSource(adapterPath))).toBeLessThanOrEqual(600)
     expect(exportInventoryFrom(adapterPath)).toEqual([
       'type:ResponsesRequestAdapterOptions',
       'value:inputToMessages',

--- a/src/main/settings/responses-response-adapter.architecture.test.ts
+++ b/src/main/settings/responses-response-adapter.architecture.test.ts
@@ -37,8 +37,6 @@ const adapterPath = resolve(__dirname, 'responses-response-adapter.ts')
 const bridgePath = resolve(__dirname, 'responses-bridge.ts')
 const hostPath = resolve(__dirname, 'provider-loopback-http-host.ts')
 const readSource = (path: string): string => readProductionSource(path, projectRoot)
-const rawLineCount = (source: string): number =>
-  source.split(/\r?\n/).length - Number(source.endsWith('\n'))
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
 const portableProjectPath = (path: string): string =>
   relative(projectRoot, path).replaceAll('\\', '/')
@@ -129,9 +127,7 @@ const exportInventoryFrom = (path: string): string[] => {
 }
 
 describe('Responses result adapter ownership', () => {
-  it('keeps exact, bounded adapter and facade interfaces', () => {
-    expect(rawLineCount(readSource(adapterPath))).toBeLessThanOrEqual(600)
-    expect(rawLineCount(readSource(bridgePath))).toBeLessThanOrEqual(600)
+  it('keeps exact adapter and facade interfaces', () => {
     expect(exportInventoryFrom(adapterPath)).toEqual([
       'type:ResponsesStreamWriter',
       'value:ResponsesProtocolError',

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -67,8 +67,6 @@ const settingsPaths = {
   notebookLocalRpcServer: resolve(projectRoot, 'src/main/notebook/local-rpc-server.ts')
 } as const
 const readSource = (path: string): string => readProductionSource(path, projectRoot)
-const rawLineCount = (source: string): number =>
-  source.split(/\r?\n/).length - Number(source.endsWith('\n'))
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
 const portableProjectPath = (path: string): string =>
   relative(projectRoot, path).replaceAll('\\', '/')
@@ -261,37 +259,6 @@ type ModuleImpactManifest = {
 const productionSourcePaths = productionSources()
 
 describe('Settings backend ownership architecture', () => {
-  it('locks the final facade ceilings and every internal owner below the hard limit', () => {
-    // Repository remains one atomic mutation facade; Subagent validation runs inside its CAS write.
-    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(700)
-    expect(rawLineCount(readSource(settingsPaths.subagentModelSettings))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.documentCodec))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.documentStore))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.computeGrantPort))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(600)
-    expect(rawLineCount(readSource(settingsPaths.providerAuthLifecycle))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.providerRuntimeProjection))).toBeLessThanOrEqual(
-      660
-    )
-    expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(600)
-    expect(rawLineCount(readSource(settingsPaths.backendSelection))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.backendRoutePlanner))).toBeLessThanOrEqual(500)
-    expect(rawLineCount(readSource(settingsPaths.providerTransportOwner))).toBeLessThanOrEqual(600)
-    expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(600)
-    expect(rawLineCount(readSource(settingsPaths.responsesProtocolTypes))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.responsesRequestAdapter))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.responsesResponseAdapter))).toBeLessThanOrEqual(
-      660
-    )
-    expect(rawLineCount(readSource(settingsPaths.reviewerModelOwner))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.subagentModelOwner))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.visionModelOwner))).toBeLessThanOrEqual(660)
-    // Main's facade plus typed provider-auth, Subagent/Reviewer/Vision forwarding, proxy projection,
-    // and owner composition.
-    expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1070)
-  })
-
   it('locks the stable module export inventories', () => {
     expect(exportInventoryFrom(settingsPaths.repository)).toEqual([
       'value:SettingsRepository',

--- a/src/main/skills/user-skill-repository.architecture.test.ts
+++ b/src/main/skills/user-skill-repository.architecture.test.ts
@@ -46,7 +46,6 @@ const compatibilityIndexPath = resolve(skillsRoot, 'user-skill-compatibility-ind
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
 
 const readSource = (path: string): string => readProductionSource(path, projectRoot)
-const rawLineCount = (source: string): number => source.trimEnd().split(/\r?\n/).length
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
 const portableProjectPath = (path: string): string =>
   relative(projectRoot, path).replaceAll('\\', '/')
@@ -168,31 +167,6 @@ type ModuleImpactManifest = {
 }
 
 describe('User Skill repository architecture', () => {
-  it('keeps the public facade within the production file budget', () => {
-    expect(rawLineCount(readSource(repositoryPath))).toBeLessThanOrEqual(660)
-  })
-
-  it('keeps the catalog and Personal Skill owner within the production file budget', () => {
-    expect(rawLineCount(readSource(storePath))).toBeLessThanOrEqual(660)
-  })
-
-  it('keeps the GitHub and ZIP import owner within the production file budget', () => {
-    expect(rawLineCount(readSource(bundleOwnerPath))).toBeLessThanOrEqual(660)
-  })
-
-  it('keeps the Agent Home import owner within the production file budget', () => {
-    expect(rawLineCount(readSource(agentHomeOwnerPath))).toBeLessThanOrEqual(660)
-  })
-
-  it('keeps the mutation and transaction owners within the production file budget', () => {
-    expect(rawLineCount(readSource(mutationOwnerPath))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(transactionOwnerPath))).toBeLessThanOrEqual(660)
-  })
-
-  it('keeps the compatibility index within the production file budget', () => {
-    expect(rawLineCount(readSource(compatibilityIndexPath))).toBeLessThanOrEqual(360)
-  })
-
   it('locks the compatibility export and operation inventories', () => {
     expect(exportInventory()).toEqual([
       'type:ImportOutcome',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -357,10 +357,6 @@ const importsFrom = (path: string, source = readSource(path)): readonly ImportRe
   })
   return references
 }
-const physicalLines = (path: string): number => {
-  const source = readSource(path)
-  return source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-}
 const callCounts = (sourceFile: SourceFile): ReadonlyMap<string, number> => {
   const counts = new Map<string, number>()
   const visit = (node: Node): void => {
@@ -531,16 +527,6 @@ const privateOwnerBoundaryViolations = (path: string, source = readSource(path))
 }
 describe('workspace runtime architecture', () => {
   const facadeFile = sourceFileFor(facadePath)
-  it('keeps the facade, deep owners, and presentation adapter within their completion gates', () => {
-    expect(physicalLines(facadePath), 'workspace runtime facade').toBeLessThanOrEqual(605)
-    for (const name of ownerNames) {
-      expect(physicalLines(ownerFilePath(name)), name).toBeLessThanOrEqual(756)
-    }
-    expect(
-      physicalLines(`${subagentPresentationTarget}.ts`),
-      'subagent presentation'
-    ).toBeLessThanOrEqual(220)
-  })
   it('keeps the established runtime interface plus readiness and the child-update selector', () => {
     const runtimeType = typeLiteralAlias(facadeFile, 'WorkspaceAgentRuntime')
     const owner = variableArrow(facadeFile, 'useOwnedWorkspaceAgentRuntime')

--- a/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from 'node:fs'
-import { basename, dirname, extname, relative, resolve } from 'node:path'
+import { dirname, extname, relative, resolve } from 'node:path'
 import {
   createSourceFile,
   forEachChild,
@@ -52,7 +52,6 @@ const queueInternalPaths = {
 } as const
 
 const readSource = (path: string): string => readFileSync(path, 'utf8')
-const rawLineCount = (source: string): number => source.trimEnd().split(/\r?\n/).length
 const portableRelativePath = (path: string): string =>
   relative(rendererRoot, path).replaceAll('\\', '/')
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
@@ -154,29 +153,6 @@ const conversationPanelPropNames = (): string[] => {
 }
 
 describe('workspace page architecture', () => {
-  it('keeps the page and extracted owners within their completion gates', () => {
-    // Session-model fallback adds page wiring for the extracted configuration owner.
-    expect(rawLineCount(readSource(ownerPaths.page))).toBeLessThanOrEqual(1_230)
-    for (const ownerPath of [
-      ownerPaths.layout,
-      ownerPaths.composer,
-      ownerPaths.conversation,
-      ownerPaths.messageQueue,
-      ownerPaths.messageQueueOwner,
-      queueInternalPaths.admission,
-      queueInternalPaths.drain,
-      queueInternalPaths.projection,
-      queueInternalPaths.announcement,
-      ownerPaths.branchSwitchGuard,
-      ownerPaths.sideChat,
-      ownerPaths.session,
-      ownerPaths.sessionDetails,
-      ownerPaths.sessionAgentConfiguration
-    ]) {
-      expect(rawLineCount(readSource(ownerPath)), basename(ownerPath)).toBeLessThanOrEqual(700)
-    }
-  })
-
   it('keeps private controller consumers explicit and bounded', () => {
     expect(importersOf(ownerPaths.composer)).toEqual([
       'pages/workspace/ConversationPanel.tsx',

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -877,10 +877,7 @@ const sessionEventSubscriptions = (): string[] =>
 describe('Session Store architecture', () => {
   const facadeSource = readSource(facadePath)
 
-  it('keeps the compatibility facade and private modules within their completion gates', () => {
-    const physicalLines = facadeSource.split(/\r?\n/).length - Number(facadeSource.endsWith('\n'))
-    expect(physicalLines).toBeLessThanOrEqual(395)
-
+  it('keeps the compatibility facade and private module inventory explicit', () => {
     const actualModules = productionSources()
       .filter((path) =>
         modulePath(path).startsWith(modulePath(resolve(__dirname, 'session-store')))
@@ -890,12 +887,6 @@ describe('Session Store architecture', () => {
     expect(actualModules).toEqual(
       ['session-store.ts', ...ownerNames.map((name) => `${name}.ts`)].sort()
     )
-    for (const file of actualModules) {
-      const source = readSource(resolve(__dirname, file))
-      const lines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      const completionGate = file === 'session-store-persistence-owner.ts' ? 785 : 719
-      expect(lines, file).toBeLessThanOrEqual(completionGate)
-    }
   })
 
   it('locks the established public values, types and actions', () => {

--- a/src/renderer/src/stores/settings-store.architecture.test.ts
+++ b/src/renderer/src/stores/settings-store.architecture.test.ts
@@ -526,13 +526,6 @@ const facadeBoundaryViolations = (source: string): readonly string[] => {
 }
 
 describe('settings store architecture', () => {
-  it('keeps the compatibility facade within its completion gate', () => {
-    const source = readSource(storePath)
-    const physicalLines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-
-    expect(physicalLines).toBeLessThanOrEqual(750)
-  })
-
   it('composes every owner exactly once', () => {
     expect(compositionViolations(readSource(storePath))).toEqual([])
   })

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -70,6 +70,10 @@ it('keeps a safe default timeout for schema-backed hooks', () => {
   expect(vitestConfig.test?.hookTimeout).toBe(30_000)
 })
 
+it('prints captured console output only for failed tests', () => {
+  expect(vitestConfig.test?.silent).toBe('passed-only')
+})
+
 it('pins the full-suite worker cap to the machine rather than leaving it unbounded', () => {
   const available =
     typeof availableParallelism === 'function' ? availableParallelism() : cpus().length

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -119,6 +119,8 @@ export default defineConfig({
     }
   },
   test: {
+    // Keep successful suites quiet while retaining their captured console output on failure.
+    silent: 'passed-only',
     server: {
       deps: {
         inline: ['@file-viewer/renderer-spreadsheet']


### PR DESCRIPTION
## Problem

Architecture tests enforced raw physical-line ceilings, so harmless formatting or cohesive growth could fail independently of dependency direction, ownership, or construction invariants. Main-process logger output was also mirrored during tests, making successful suite logs unnecessarily large.

## Proposed change

- Remove raw line-count assertions from architecture tests while retaining import boundaries, ownership checks, export inventories, module inventories, and unique-construction gates.
- Default logger console mirroring off when NODE_ENV is test; explicit mirrorToConsole: true remains supported.
- Configure Vitest to keep passing tests quiet and print captured console output for failed tests.

## Scope and non-goals

No runtime behavior changes outside test environments. No new complexity metric replaces line counts. No historical-data compatibility, new enum/state values, database changes, or persistence-format changes are involved.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Logger and Vitest output policy -> npx --no-install vitest run vitest.config.test.ts src/main/logger.test.ts -> 2 files, 82 tests passed.
- Retained architecture ownership and construction gates -> targeted Vitest run over the 18 changed architecture files with a 30s scan timeout -> 18 files, 113 tests passed.
- Node types -> npm run typecheck:node -> passed.
- Web types -> npm run typecheck:web -> passed.
- Repository lint -> npm run lint -> passed with 0 errors; 361 pre-existing formatting warnings remain outside this diff.
- Changed-file formatting and whitespace -> Prettier check plus git diff --check -> passed.

The affected-test classifier selects the full plan because vitest.config.ts is a global gate input. Per maintainer direction, the complete npm test suite was not run locally; exact-head PR CI is the final authority.

## Review focus

Please confirm that only raw line-count gates were removed and the remaining architecture tests still pin stable interfaces, dependency direction, owner composition, and construction count. Also confirm that production logger mirroring remains enabled by default outside NODE_ENV=test.