### PR TITLE
feat(notifications): redesign message center icon system and row layout

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -515,6 +515,23 @@ colors communicate a successful or failed probe/migration result.
   item marks that item read, and the header provides an explicit mark-all action.
 - Show authorization lifecycle state separately from read state. Resolving, rejecting, expiring, or
   cancelling a request does not imply that the user has read its notification.
+- Item icons use two-dimensional encoding: the glyph says what happened, the tone says whether it
+  still needs the user. `task.completed` uses `CircleCheck`, `task.failed` uses `CircleX`,
+  `authorization.required` uses `ShieldCheck`, and `task.needs-attention` refines by wait reason —
+  `MessageCircleQuestion` for `waiting-for-user`, `KeyRound` for `waiting-permission`,
+  `ClipboardList` for `waiting-plan-approval`, and `TriangleAlert` for anomalies such as length or
+  turn limits, refusals, and unclean stops. Pending tones use the `session-waiting`, `success-000`,
+  and `danger-000` tokens on tinted tiles (`bg-*/10`); once a request is settled
+  (`resolved`/`rejected`/`expired`/`cancelled`) or its target is invalidated, the glyph stays but
+  the tone falls back to neutral (`bg-bg-300 text-text-300`), so chromatic tokens only ever mark
+  fresh outcomes or requests that still need a decision. Both the bell panel and the live toast
+  resolve this through the shared `resolveNotificationEventVisual` helper.
+- The desktop panel caps at 440px wide. Rows show the context label and relative time on the meta
+  line, then the title (`font-semibold` while unread, `font-medium text-text-100` once read), then
+  a detail preview clamped to two lines (`line-clamp-2`), then the state as a compact rounded-full
+  chip that reuses the item's tone. Unread rows keep the `bg-bg-100/70` tint and trailing red dot;
+  invalidated rows dim with `opacity-60`. Group headings (`Unread` / `Earlier`) are sticky against
+  the panel background while their section scrolls.
 - Use the same backend-owned list and unread state on Electron, local Web, and remote Web. Native OS
   banners, Dock/taskbar attention, and native badges are optional desktop delivery adapters and must
   not affect whether an inbox item is recorded.

--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -133,6 +133,96 @@ describe('NotificationBell', () => {
     expect(icon?.parentElement?.classList.contains('text-success-000')).toBe(true)
   })
 
+  it('gives failed and waiting items their own glyphs and tones', async () => {
+    const item = useNotificationInboxStore.getState().items[0]
+    useNotificationInboxStore.setState({
+      items: item
+        ? [
+            {
+              ...item,
+              id: 'failed-1',
+              kind: 'task.failed' as const,
+              title: 'Task failed',
+              actionState: undefined
+            },
+            {
+              ...item,
+              id: 'waiting-1',
+              kind: 'task.needs-attention' as const,
+              attentionReason: 'waiting-plan-approval' as const,
+              title: 'Plan waiting',
+              actionState: 'pending' as const
+            }
+          ]
+        : []
+    })
+    await act(async () => root.render(<NotificationBell />))
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+
+    const failedIcon = document.body.querySelector('.lucide-circle-x')
+    expect(failedIcon?.parentElement?.classList.contains('text-danger-000')).toBe(true)
+    const planIcon = document.body.querySelector('.lucide-clipboard-list')
+    expect(planIcon?.parentElement?.classList.contains('text-session-waiting')).toBe(true)
+  })
+
+  it('neutralizes the icon tile and chip once the request is settled', async () => {
+    const item = useNotificationInboxStore.getState().items[0]
+    useNotificationInboxStore.setState({
+      items: item ? [{ ...item, actionState: 'expired' }] : []
+    })
+    await act(async () => root.render(<NotificationBell />))
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+
+    const icon = document.body.querySelector('.lucide-shield-check')
+    expect(icon?.parentElement?.classList.contains('text-text-300')).toBe(true)
+    expect(icon?.parentElement?.classList.contains('text-session-waiting')).toBe(false)
+    const chip = [...document.body.querySelectorAll('span')].find(
+      (span) => span.textContent === 'Expired'
+    )
+    expect(chip?.className).toContain('rounded-full')
+    expect(chip?.className).toContain('border')
+    expect(chip?.className).toContain('text-text-300')
+  })
+
+  it('dims read titles and clamps detail previews to two lines', async () => {
+    const item = useNotificationInboxStore.getState().items[0]
+    useNotificationInboxStore.setState({
+      unreadCount: 0,
+      items: item
+        ? [{ ...item, readAt: Date.now(), summary: 'A long summary that should clamp.' }]
+        : []
+    })
+    await act(async () => root.render(<NotificationBell />))
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+
+    const row = [...document.body.querySelectorAll<HTMLButtonElement>('button')].find((button) =>
+      button.textContent?.includes('Approval needed')
+    )
+    const title = row?.querySelector('.truncate.font-medium')
+    expect(title?.classList.contains('text-text-100')).toBe(true)
+    const detail = [...document.body.querySelectorAll('span')].find(
+      (span) => span.textContent === 'A long summary that should clamp.'
+    )
+    expect(detail?.className).toContain('line-clamp-2')
+  })
+
+  it('keeps group headings sticky inside the scroll container', async () => {
+    await act(async () => root.render(<NotificationBell />))
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+
+    const heading = document.body.querySelector<HTMLElement>('[id$="-unread"]')
+    expect(heading?.className).toContain('sticky')
+    expect(heading?.className).toContain('bg-bg-000')
+  })
+
   it('distinguishes a rejected approval from a resolved one', async () => {
     const item = useNotificationInboxStore.getState().items[0]
     useNotificationInboxStore.setState({

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -30,6 +30,10 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { NotificationErrorBoundary } from './NotificationErrorBoundary'
 import { NotificationEventIcon } from './NotificationEventIcon'
 import {
+  notificationEventToneClasses,
+  resolveNotificationEventVisual
+} from './notification-event-visual'
+import {
   isVisibleNotificationBell,
   NOTIFICATION_CENTER_OPENED_EVENT,
   OPEN_NOTIFICATION_CENTER_EVENT,
@@ -77,7 +81,7 @@ const actionLabel = (
 
 const VIEWPORT_MARGIN = 8
 const PANEL_GAP = 8
-const PANEL_MAX_WIDTH = 408
+const PANEL_MAX_WIDTH = 440
 const MOBILE_MESSAGE_CENTER_QUERY = '(max-width: 47.999rem)'
 
 const clamp = (value: number, minimum: number, maximum: number): number =>
@@ -410,7 +414,10 @@ const NotificationBellContent = ({
                       <section key={group.key} aria-labelledby={`${panelId}-${group.key}`}>
                         <div
                           id={`${panelId}-${group.key}`}
-                          className="px-2.5 pb-0.5 pt-1.5 text-[10px] font-semibold uppercase tracking-wide text-text-300"
+                          className={cn(
+                            'sticky z-10 bg-bg-000 pb-0.5 pt-1.5 text-[10px] font-semibold uppercase tracking-wide text-text-300',
+                            isMobile ? '-mx-2 -top-2 px-[18px]' : '-mx-1.5 -top-1.5 px-4'
+                          )}
                         >
                           {t(group.label)}
                         </div>
@@ -429,6 +436,8 @@ const NotificationBellContent = ({
                           const showEventLabel =
                             item.targetInvalidatedAt === undefined &&
                             (presented.sessionTitle !== undefined || label !== undefined)
+                          const toneClasses =
+                            notificationEventToneClasses[resolveNotificationEventVisual(item).tone]
                           return (
                             <button
                               key={item.id}
@@ -440,15 +449,13 @@ const NotificationBellContent = ({
                                 isMobile ? 'py-2.5' : 'py-2',
                                 item.readAt === undefined && 'bg-bg-100/70',
                                 item.targetInvalidatedAt !== undefined &&
-                                  'cursor-default hover:bg-transparent active:bg-transparent'
+                                  'cursor-default opacity-60 hover:bg-transparent active:bg-transparent'
                               )}
                             >
                               <span
                                 className={cn(
-                                  'mt-0.5 grid size-7 shrink-0 place-items-center rounded-full bg-bg-300 text-text-100',
-                                  item.kind === 'authorization.required' && 'text-session-waiting',
-                                  item.kind === 'task.completed' && 'text-success-000',
-                                  item.kind === 'task.failed' && 'text-danger-000'
+                                  'mt-0.5 grid size-7 shrink-0 place-items-center rounded-full',
+                                  toneClasses.tile
                                 )}
                               >
                                 <NotificationEventIcon notification={item} />
@@ -472,7 +479,10 @@ const NotificationBellContent = ({
                                 <span className="mt-0.5 flex items-start gap-2">
                                   <span
                                     className={cn(
-                                      'min-w-0 flex-1 truncate font-semibold text-text-000',
+                                      'min-w-0 flex-1 truncate',
+                                      item.readAt === undefined
+                                        ? 'font-semibold text-text-000'
+                                        : 'font-medium text-text-100',
                                       isMobile ? 'text-sm' : 'text-xs'
                                     )}
                                   >
@@ -482,7 +492,7 @@ const NotificationBellContent = ({
                                 {detail ? (
                                   <span
                                     className={cn(
-                                      'mt-0.5 block truncate text-text-100',
+                                      'mt-0.5 line-clamp-2 text-text-100',
                                       isMobile ? 'text-sm leading-5' : 'text-[11px] leading-4'
                                     )}
                                   >
@@ -492,19 +502,11 @@ const NotificationBellContent = ({
                                 {showEventLabel ? (
                                   <span
                                     className={cn(
-                                      'mt-0.5 inline-flex items-center gap-1.5 font-medium',
-                                      isMobile ? 'text-xs' : 'text-[10px]',
-                                      item.kind === 'task.completed' && 'text-success-000',
-                                      item.kind === 'task.failed' && 'text-danger-000',
-                                      (item.kind === 'task.needs-attention' ||
-                                        item.kind === 'authorization.required') &&
-                                        'text-session-waiting'
+                                      'mt-1 inline-flex w-fit items-center rounded-full border px-1.5 py-px font-medium',
+                                      isMobile ? 'text-[11px]' : 'text-[10px]',
+                                      toneClasses.chip
                                     )}
                                   >
-                                    <span
-                                      className="size-1.5 rounded-full bg-current"
-                                      aria-hidden="true"
-                                    />
                                     {eventLabel}
                                   </span>
                                 ) : null}

--- a/src/renderer/src/components/NotificationEventIcon.tsx
+++ b/src/renderer/src/components/NotificationEventIcon.tsx
@@ -1,17 +1,12 @@
-import { CircleAlert, CircleCheck, ShieldCheck } from 'lucide-react'
-
 import type { NotificationInboxItem } from '../../../shared/notifications'
+
+import { resolveNotificationEventVisual } from './notification-event-visual'
 
 const NotificationEventIcon = ({
   notification
 }: Readonly<{ notification: NotificationInboxItem }>): React.JSX.Element => {
-  if (notification.kind === 'authorization.required') {
-    return <ShieldCheck className="size-4" strokeWidth={2} aria-hidden="true" />
-  }
-  if (notification.kind === 'task.completed') {
-    return <CircleCheck className="size-4" strokeWidth={2} aria-hidden="true" />
-  }
-  return <CircleAlert className="size-4" strokeWidth={2} aria-hidden="true" />
+  const { Icon } = resolveNotificationEventVisual(notification)
+  return <Icon className="size-4" strokeWidth={2} aria-hidden="true" />
 }
 
 export { NotificationEventIcon }

--- a/src/renderer/src/components/NotificationLiveToast.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.tsx
@@ -36,7 +36,7 @@ import { runNotificationTask } from './notification-safety'
 const AUTO_DISMISS_MS = 6000
 const TOAST_GAP = 8
 const VIEWPORT_MARGIN = 8
-const TOAST_MAX_WIDTH = 360
+const TOAST_MAX_WIDTH = 320
 
 type LiveNotice = Readonly<{
   lead: PresentedNotificationInboxItem

--- a/src/renderer/src/components/NotificationLiveToast.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.tsx
@@ -24,6 +24,10 @@ import {
   type OpenNotificationCenterDetail
 } from './notification-bell-events'
 import {
+  notificationEventToneClasses,
+  resolveNotificationEventVisual
+} from './notification-event-visual'
+import {
   presentNotificationInbox,
   type PresentedNotificationInboxItem
 } from './notification-inbox-presentation'
@@ -242,10 +246,8 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
       <div className="flex items-start gap-2.5">
         <span
           className={cn(
-            'mt-0.5 grid size-7 shrink-0 place-items-center rounded-full bg-bg-300 text-text-100',
-            notification.kind === 'authorization.required' && 'text-session-waiting',
-            notification.kind === 'task.completed' && 'text-success-000',
-            notification.kind === 'task.failed' && 'text-danger-000'
+            'mt-0.5 grid size-7 shrink-0 place-items-center rounded-full',
+            notificationEventToneClasses[resolveNotificationEventVisual(notification).tone].tile
           )}
         >
           <NotificationEventIcon notification={notification} />

--- a/src/renderer/src/components/notification-event-visual.test.ts
+++ b/src/renderer/src/components/notification-event-visual.test.ts
@@ -1,0 +1,93 @@
+import {
+  CircleCheck,
+  CircleX,
+  ClipboardList,
+  KeyRound,
+  MessageCircleQuestion,
+  ShieldCheck,
+  TriangleAlert
+} from 'lucide-react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  notificationEventToneClasses,
+  resolveNotificationEventVisual
+} from './notification-event-visual'
+
+const base = {
+  kind: 'task.completed',
+  attentionReason: undefined,
+  actionState: undefined,
+  targetInvalidatedAt: undefined
+} as const
+
+describe('resolveNotificationEventVisual', () => {
+  it.each([
+    ['task.completed', undefined, CircleCheck, 'success'],
+    ['task.failed', undefined, CircleX, 'danger'],
+    ['authorization.required', undefined, ShieldCheck, 'waiting']
+  ] as const)('maps kind %s to its glyph and tone', (kind, attentionReason, Icon, tone) => {
+    expect(resolveNotificationEventVisual({ ...base, kind, attentionReason })).toEqual({
+      Icon,
+      tone
+    })
+  })
+
+  it.each([
+    ['waiting-for-user', MessageCircleQuestion],
+    ['waiting-permission', KeyRound],
+    ['waiting-plan-approval', ClipboardList],
+    ['task-max-tokens', TriangleAlert],
+    ['task-max-turn-requests', TriangleAlert],
+    ['task-refusal', TriangleAlert],
+    ['task-unclean-stop', TriangleAlert],
+    [undefined, TriangleAlert]
+  ] as const)('maps needs-attention reason %s to %s', (attentionReason, Icon) => {
+    const visual = resolveNotificationEventVisual({
+      ...base,
+      kind: 'task.needs-attention',
+      attentionReason
+    })
+    expect(visual.Icon).toBe(Icon)
+    expect(visual.tone).toBe('waiting')
+  })
+
+  it.each(['resolved', 'rejected', 'expired', 'cancelled'] as const)(
+    'keeps the glyph but neutralizes the tone once %s',
+    (actionState) => {
+      const visual = resolveNotificationEventVisual({
+        ...base,
+        kind: 'authorization.required',
+        actionState
+      })
+      expect(visual.Icon).toBe(ShieldCheck)
+      expect(visual.tone).toBe('neutral')
+    }
+  )
+
+  it('neutralizes pending requests whose target was invalidated', () => {
+    const visual = resolveNotificationEventVisual({
+      ...base,
+      kind: 'task.needs-attention',
+      attentionReason: 'waiting-permission',
+      actionState: 'pending',
+      targetInvalidatedAt: 1
+    })
+    expect(visual.Icon).toBe(KeyRound)
+    expect(visual.tone).toBe('neutral')
+  })
+
+  it('keeps a fresh completed outcome chromatic while pending states stay colored', () => {
+    expect(resolveNotificationEventVisual(base).tone).toBe('success')
+    expect(
+      resolveNotificationEventVisual({ ...base, kind: 'task.failed', actionState: 'pending' }).tone
+    ).toBe('danger')
+  })
+
+  it('provides token-based tile and chip classes for every tone', () => {
+    for (const tone of ['success', 'danger', 'waiting', 'neutral'] as const) {
+      expect(notificationEventToneClasses[tone].tile).toBeTruthy()
+      expect(notificationEventToneClasses[tone].chip).toContain('border')
+    }
+  })
+})

--- a/src/renderer/src/components/notification-event-visual.ts
+++ b/src/renderer/src/components/notification-event-visual.ts
@@ -1,0 +1,80 @@
+import {
+  CircleCheck,
+  CircleX,
+  ClipboardList,
+  KeyRound,
+  MessageCircleQuestion,
+  ShieldCheck,
+  TriangleAlert,
+  type LucideIcon
+} from 'lucide-react'
+
+import type { NotificationInboxItem } from '../../../shared/notifications'
+
+export type NotificationEventTone = 'success' | 'danger' | 'waiting' | 'neutral'
+
+export type NotificationEventVisual = Readonly<{
+  Icon: LucideIcon
+  tone: NotificationEventTone
+}>
+
+// Two-dimensional encoding (GitHub/Linear-style): the glyph says what happened, the tone says
+// whether it still needs the user. Settled lifecycle states always resolve to neutral so the
+// chromatic tokens only ever mark fresh outcomes or requests that still need a decision.
+const SETTLED_ACTION_STATES: ReadonlySet<NotificationInboxItem['actionState']> = new Set([
+  'resolved',
+  'rejected',
+  'expired',
+  'cancelled'
+])
+
+const resolveGlyph = (
+  notification: Pick<NotificationInboxItem, 'kind' | 'attentionReason'>
+): LucideIcon => {
+  if (notification.kind === 'authorization.required') return ShieldCheck
+  if (notification.kind === 'task.completed') return CircleCheck
+  if (notification.kind === 'task.failed') return CircleX
+  if (notification.attentionReason === 'waiting-for-user') return MessageCircleQuestion
+  if (notification.attentionReason === 'waiting-permission') return KeyRound
+  if (notification.attentionReason === 'waiting-plan-approval') return ClipboardList
+  return TriangleAlert
+}
+
+export const resolveNotificationEventVisual = (
+  notification: Pick<
+    NotificationInboxItem,
+    'kind' | 'attentionReason' | 'actionState' | 'targetInvalidatedAt'
+  >
+): NotificationEventVisual => {
+  const Icon = resolveGlyph(notification)
+  const settled =
+    notification.targetInvalidatedAt !== undefined ||
+    SETTLED_ACTION_STATES.has(notification.actionState)
+  if (settled) return { Icon, tone: 'neutral' }
+  if (notification.kind === 'task.completed') return { Icon, tone: 'success' }
+  if (notification.kind === 'task.failed') return { Icon, tone: 'danger' }
+  return { Icon, tone: 'waiting' }
+}
+
+// Shared token classes so the bell panel and the live toast render the same visual language.
+export const notificationEventToneClasses: Record<
+  NotificationEventTone,
+  Readonly<{ tile: string; chip: string }>
+> = {
+  success: {
+    tile: 'bg-success-000/10 text-success-000',
+    chip: 'border-success-000/25 bg-success-000/10 text-success-000'
+  },
+  danger: {
+    tile: 'bg-danger-000/10 text-danger-000',
+    chip: 'border-danger-000/25 bg-danger-000/10 text-danger-000'
+  },
+  waiting: {
+    tile: 'bg-session-waiting/10 text-session-waiting',
+    chip: 'border-session-waiting/25 bg-session-waiting/10 text-session-waiting'
+  },
+  neutral: {
+    tile: 'bg-bg-300 text-text-300',
+    chip: 'border-border-200/70 bg-bg-100 text-text-300'
+  }
+}


### PR DESCRIPTION
## Problem

The message center encoded only three glyphs for the whole notification taxonomy:

- `task.failed` and `task.needs-attention` shared `CircleAlert`, so a failed run and a waiting question were indistinguishable.
- Lifecycle states (`expired` / `cancelled` / `resolved` / `rejected`) were text-only. Settled rows looked identical to rows that still needed a decision (e.g. two identical "Expired" authorization rows next to pending ones).
- Every icon sat on the same neutral tile; color carried no state meaning.
- Detail summaries truncated mid-sentence at one line, and the 408px panel was tight for CJK titles.

## Proposed change

Adopt a two-dimensional visual encoding, referencing GitHub Notifications (glyph = type, color = state, read de-emphasis) and Linear Inbox (settled items lose their accent entirely):

- **Glyph = what happened.** Seven glyphs cover `kind` + `attentionReason`: `CircleCheck` (completed), `CircleX` (failed), `ShieldCheck` (authorization), `MessageCircleQuestion` (waiting-for-user), `KeyRound` (waiting-permission), `ClipboardList` (waiting-plan-approval), `TriangleAlert` (anomalies: length/turn limits, refusal, unclean stop).
- **Tone = whether it still needs you.** Pending items use `session-waiting` / `success-000` / `danger-000` on tinted tiles (`bg-*/10`); settled or target-invalidated items keep their glyph but fall back to neutral (`bg-bg-300 text-text-300`). Chromatic tokens now only ever mark fresh outcomes or pending decisions.
- Both the bell panel and the live toast resolve visuals through one shared pure helper, `resolveNotificationEventVisual` (`notification-event-visual.ts`), with full-matrix unit tests.
- **Layout:** panel width 408 → 440px; state labels become tone-matched rounded chips instead of dot + text; detail previews clamp to two lines (`line-clamp-2`); read titles drop to `font-medium text-text-100` (GitHub-style read de-emphasis); `Unread` / `Earlier` group headings stick to the panel background while their section scrolls; invalidated rows dim with `opacity-60`.
- `docs/design.md` Message Center section updated to document the encoding.

Grouping (`Unread` / `Earlier`) and read semantics are unchanged.

## Scope and non-goals

- No new notification kinds, sources, action states, or attention reasons — the design maps the existing closed taxonomy onto a richer visual vocabulary.
- No persistence, schema, IPC, or contract-catalog changes.
- No Linear-style triage workflows (filters, snooze, done) — out of scope.

## Compatibility / persistence impact

- **Historical data:** fully compatible. Visuals derive from existing persisted fields (`kind`, `source`, `attentionReason`, `actionState`, `readAt`, `targetInvalidatedAt`); old inbox items render with the new visuals automatically. No migration.
- **New enum / state values:** none.
- **Data persistence:** unchanged.

## Acceptance criteria and validation

- Each kind/reason renders its own glyph; settled and invalidated items render neutral; pending items keep their chromatic tone.
- Verified visually against a real inbox via the localhost Web UI (light + dark): unread completed rows show the green tinted tile + chip, expired authorization rows are neutral gray, read titles are de-emphasized.

Evidence mapping (all run after the last material edit, in the worktree):

| Behavior | Command | Result |
| --- | --- | --- |
| Visual resolution matrix (7 glyphs × tones, settled → neutral) | `npx vitest run src/renderer/src/components/notification-event-visual.test.ts` | pass (11 tests) |
| Bell panel rows: tones, chips, read de-emphasis, clamp, sticky headings, existing behaviors | `npx vitest run src/renderer/src/components/NotificationBell.test.tsx` | pass (24 tests) |
| Live toast + inbox presentation unchanged consumers | `npx vitest run src/renderer/src/components/NotificationLiveToast.test.tsx src/renderer/src/components/notification-inbox-presentation.test.ts` | pass |
| i18n guard (no new strings; all labels reuse existing keys) | `npx vitest run src/renderer/src/i18n/resources.test.ts` | pass |
| Renderer types | `npm run typecheck:web` | pass |
| Lint | `npm run lint` | pass (0 errors) |

Per project guidance, the full portable suite is delegated to PR CI (PR Gate), which remains the final validation authority.

## Review focus

- `notification-event-visual.ts` — the kind × state matrix and the token class map.
- `NotificationBell.tsx` row markup — chip, clamp, sticky heading offsets (`-top-1.5` desktop / `-top-2` mobile, matching the scroll container padding).
- Uncovered risk: visual regression snapshots do not cover the message center, so layout review relies on the unit assertions above plus PR CI.
