### PR TITLE
fix(renderer): surface recoverable file load failures

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx
@@ -287,6 +287,30 @@ describe('ComposerYourFilesMenu', () => {
     expect(container.querySelector('[data-testid="your-files-root-root-1"]')).toBeNull()
   })
 
+  it('keeps failed access removal visible and retryable', async () => {
+    removeGrantedRoot
+      .mockRejectedValueOnce(new Error('permission store unavailable'))
+      .mockResolvedValueOnce([])
+    renderMenu()
+
+    await click(container.querySelector('[data-testid="your-files-remove-root-1"]'))
+    await flush()
+
+    const alert = container.querySelector<HTMLElement>('[role="alert"]')
+    const retry = [...(alert?.querySelectorAll('button') ?? [])].find(
+      (button) => button.textContent === 'Retry'
+    )
+    expect(container.querySelector('[data-testid="your-files-root-root-1"]')).not.toBeNull()
+    expect(alert).not.toBeNull()
+    expect(alert?.textContent).toContain('Could not remove folder access.')
+    expect(retry).not.toBeUndefined()
+
+    await click(retry)
+    await flush()
+
+    expect(container.querySelector('[data-testid="your-files-root-root-1"]')).toBeNull()
+  })
+
   it('shows a quiet inline note when listing a directory fails', async () => {
     listDir.mockRejectedValueOnce(new Error('EACCES: permission denied'))
     renderMenu()

--- a/src/renderer/src/pages/workspace/ComposerYourFilesMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerYourFilesMenu.tsx
@@ -48,6 +48,7 @@ export const ComposerYourFilesMenu = ({
   const [expandedDirs, setExpandedDirs] = useState<Record<string, boolean>>({})
   const [listings, setListings] = useState<Record<string, DirListing>>({})
   const [grantDialogOpen, setGrantDialogOpen] = useState(false)
+  const [rootRemoveStates, setRootRemoveStates] = useState<Record<string, 'removing' | 'error'>>({})
   // Files inserted during this submenu session, keyed `${rootId}:${relativePath}`. Purely local:
   // the set resets when the submenu closes, so the green check marks "added this time".
   const [addedKeys, setAddedKeys] = useState<ReadonlySet<string>>(new Set())
@@ -102,6 +103,21 @@ export const ComposerYourFilesMenu = ({
       mimeType: undefined
     })
     setAddedKeys((previous) => new Set(previous).add(`${root.id}:${relativePath}`))
+  }
+
+  const removeRoot = (rootId: string): void => {
+    setRootRemoveStates((previous) => ({ ...previous, [rootId]: 'removing' }))
+    void remove(rootId)
+      .then(() => {
+        setRootRemoveStates((previous) => {
+          const next = { ...previous }
+          delete next[rootId]
+          return next
+        })
+      })
+      .catch(() => {
+        setRootRemoveStates((previous) => ({ ...previous, [rootId]: 'error' }))
+      })
   }
 
   // Recursive rows for one expanded directory: subdirectories expand further, files are inert
@@ -274,6 +290,7 @@ export const ComposerYourFilesMenu = ({
             ) : null}
             {roots.map((root) => {
               const isExpanded = expandedDirs[root.path] === true
+              const removeState = rootRemoveStates[root.id]
               return (
                 <div key={root.id} data-testid={`your-files-root-${root.id}`}>
                   {/* Fixed height + opacity-based reveal for the × action: hover only changes the
@@ -309,16 +326,32 @@ export const ComposerYourFilesMenu = ({
                       type="button"
                       data-testid={`your-files-remove-${root.id}`}
                       aria-label={t('Remove access to {{name}}', { name: root.name })}
+                      disabled={removeState === 'removing'}
                       onClick={(event) => {
                         event.stopPropagation()
                         event.preventDefault()
-                        void remove(root.id).catch(() => undefined)
+                        removeRoot(root.id)
                       }}
-                      className="relative flex size-[22px] shrink-0 items-center justify-center rounded-[5px] text-text-100 opacity-100 transition-opacity duration-150 hover:bg-bg-300 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 motion-reduce:transition-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:none)]:opacity-100 [@media(pointer:coarse)]:size-11"
+                      className="relative flex size-[22px] shrink-0 items-center justify-center rounded-[5px] text-text-100 opacity-100 transition-opacity duration-150 hover:bg-bg-300 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:none)]:opacity-100 [@media(pointer:coarse)]:size-11"
                     >
                       <X className="size-3.5" strokeWidth={2} aria-hidden="true" />
                     </button>
                   </div>
+                  {removeState === 'error' ? (
+                    <div
+                      role="alert"
+                      className="flex items-center justify-between gap-2 px-2 py-1 text-[11px] leading-4 text-danger-000"
+                    >
+                      <span>{t('Could not remove folder access.')}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeRoot(root.id)}
+                        className="shrink-0 rounded px-1.5 py-0.5 font-medium hover:bg-danger-900 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                      >
+                        {t('Retry')}
+                      </button>
+                    </div>
+                  ) : null}
                   {isExpanded ? renderDirRows(root, root.path, '', 1) : null}
                 </div>
               )

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -269,6 +269,43 @@ describe('PreviewFileSurface Provenance entry', () => {
     expect(usePreviewWorkbenchStore.getState().items).toHaveLength(0)
   })
 
+  it('keeps a failed lineage load visible and retryable without hiding the preview', async () => {
+    window.api.artifacts.getLineage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('lineage unavailable'))
+      .mockResolvedValueOnce({
+        artifactId: 'artifact-1',
+        filename: 'sin.png',
+        originSession: { sessionId: 'session-1', state: 'active', title: 'Sine' },
+        versions: [descriptor, secondDescriptor]
+      })
+
+    await act(async () => {
+      root.render(<PreviewFileSurface item={item} onClose={vi.fn()} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const alert = container.querySelector<HTMLElement>('[role="alert"]')
+    const retry = [...(alert?.querySelectorAll('button') ?? [])].find(
+      (button) => button.textContent === 'Retry'
+    )
+    expect(container.querySelector('[data-testid="preview-content"]')).not.toBeNull()
+    expect(container.querySelector('button[aria-label="Next Artifact version"]')).toBeNull()
+    expect(alert).not.toBeNull()
+    expect(alert?.textContent).toContain('Could not load version history.')
+    expect(retry).not.toBeUndefined()
+
+    await click(retry ?? null)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(container.querySelector('button[aria-label="Next Artifact version"]')).not.toBeNull()
+  })
+
   it('refreshes a stale lineage when a GENERATED click selects a newly finalized version', async () => {
     const getLineage = vi
       .fn()

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -51,6 +51,10 @@ type PreviewFileSurfaceProps = PreviewAnnotationPort & {
   provenanceEntry?: 'menu' | 'leading' | 'trailing'
 }
 
+type LineageLoadState =
+  | { key: string; phase: 'loading' | 'error' }
+  | { key: string; phase: 'loaded'; value?: ArtifactLineageProvenance }
+
 const PreviewProvenanceButton = ({
   item,
   onOpenProvenance,
@@ -378,6 +382,7 @@ const PreviewFileSurface = ({
   onRemoveAnnotation,
   onAnnotationError
 }: PreviewFileSurfaceProps): React.JSX.Element => {
+  const { t } = useTranslation()
   const [provenanceTarget, setProvenanceTarget] = useState<string>()
   // Bumping this token remounts the content tree so a local file is re-read from disk.
   const [reloadToken, setReloadToken] = useState(0)
@@ -385,10 +390,8 @@ const PreviewFileSurface = ({
     key: string
     item: PreviewFileItem
   }>()
-  const [lineageResult, setLineageResult] = useState<{
-    key: string
-    value?: ArtifactLineageProvenance
-  }>()
+  const [lineageLoadState, setLineageLoadState] = useState<LineageLoadState>()
+  const [lineageRetryToken, setLineageRetryToken] = useState(0)
   const projectId = usePreviewWorkbenchStore((state) => state.activeProjectId)
   const storedItem = usePreviewWorkbenchStore((state) =>
     state.items.find((candidate) => candidate.id === item.id)
@@ -414,7 +417,12 @@ const PreviewFileSurface = ({
   // Artifact identity stays unchanged. Refetch and stop consuming the prior snapshot until the
   // matching lineage resolves.
   const lineageRequestKey = `${lineageKey}:${sessionFilesRevision}:${previewItem.selectedVersionId ?? ''}:${previewItem.originSession?.state ?? ''}`
-  const lineage = lineageResult?.key === lineageRequestKey ? lineageResult.value : undefined
+  const lineage =
+    lineageLoadState?.key === lineageRequestKey && lineageLoadState.phase === 'loaded'
+      ? lineageLoadState.value
+      : undefined
+  const lineageFailed =
+    lineageLoadState?.key === lineageRequestKey && lineageLoadState.phase === 'error'
   const exactSelectedVersion = lineage?.versions.find(
     (version) => version.versionId === previewItem.selectedVersionId
   )
@@ -449,9 +457,11 @@ const PreviewFileSurface = ({
         artifactId: previewItem.artifactId
       })
       .then((value) => {
-        if (active) setLineageResult({ key: lineageRequestKey, value })
+        if (active) setLineageLoadState({ key: lineageRequestKey, phase: 'loaded', value })
       })
-      .catch(() => undefined)
+      .catch(() => {
+        if (active) setLineageLoadState({ key: lineageRequestKey, phase: 'error' })
+      })
 
     return () => {
       active = false
@@ -459,6 +469,7 @@ const PreviewFileSurface = ({
   }, [
     lineageKey,
     lineageRequestKey,
+    lineageRetryToken,
     previewItem.artifactId,
     previewItem.sessionId,
     previewItem.source,
@@ -528,7 +539,26 @@ const PreviewFileSurface = ({
         viewInContextDisabled={originSessionArchived}
         tooltipClassName={tooltipClassName}
       />
-      {!showProvenance && lineage ? (
+      {!showProvenance && lineageFailed ? (
+        <div
+          role="alert"
+          className="flex shrink-0 items-center justify-between gap-2 border-b border-border-300/50 bg-danger-900 px-3 py-1 text-[11px] leading-4 text-danger-000"
+        >
+          <span>{t('Could not load version history.')}</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              setLineageLoadState({ key: lineageRequestKey, phase: 'loading' })
+              setLineageRetryToken((token) => token + 1)
+            }}
+            className="h-5 text-danger-000 hover:bg-danger-000/10 hover:text-danger-000"
+          >
+            {t('Retry')}
+          </Button>
+        </div>
+      ) : !showProvenance && lineage ? (
         <ArtifactVersionNavigation
           lineage={lineage}
           selectedVersionId={selectedVersionId}

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -655,6 +655,7 @@
     "Could not load project artifacts.": "No se pudieron cargar los artefactos del proyecto.",
     "Could not load project files": "No se pudieron cargar los archivos del proyecto",
     "Could not load review history.": "No se pudo cargar el historial de revisión.",
+    "Could not load version history.": "No se pudo cargar el historial de versiones.",
     "Could not load token usage.": "No se pudo cargar el uso de tokens.",
     "Could not load runtimes.": "No se pudieron cargar los entornos de ejecución.",
     "Could not mark as read. Try again.": "No se pudo marcar como leído. Inténtelo de nuevo.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -655,6 +655,7 @@
     "Could not load project artifacts.": "Impossible de charger les artefacts du projet.",
     "Could not load project files": "Impossible de charger les fichiers du projet",
     "Could not load review history.": "Impossible de charger l'historique des avis.",
+    "Could not load version history.": "Impossible de charger l’historique des versions.",
     "Could not load token usage.": "Impossible de charger l’utilisation des jetons.",
     "Could not load runtimes.": "Impossible de charger les environnements d'exécution.",
     "Could not mark as read. Try again.": "Impossible de marquer comme lu. Essayer à nouveau.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -616,6 +616,7 @@
     "Could not load project artifacts.": "プロジェクトのアーティファクトをロードできませんでした。",
     "Could not load project files": "プロジェクトファイルをロードできませんでした",
     "Could not load review history.": "レビュー履歴を読み込めませんでした。",
+    "Could not load version history.": "バージョン履歴を読み込めませんでした。",
     "Could not load token usage.": "トークン使用量を読み込めませんでした。",
     "Could not load runtimes.": "ランタイムを読み込めませんでした。",
     "Could not mark as read. Try again.": "既読としてマークできませんでした。もう一度やり直してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -635,6 +635,7 @@
     "Could not load project artifacts.": "프로젝트 아티팩트를 로드할 수 없습니다.",
     "Could not load project files": "프로젝트 파일을 로드할 수 없습니다.",
     "Could not load review history.": "리뷰 기록을 로드할 수 없습니다.",
+    "Could not load version history.": "버전 기록을 불러올 수 없습니다.",
     "Could not load token usage.": "토큰 사용량을 불러올 수 없습니다.",
     "Could not load runtimes.": "런타임을 로드할 수 없습니다.",
     "Could not mark as read. Try again.": "읽음으로 표시할 수 없습니다. 다시 시도해 보세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -646,6 +646,7 @@
     "Could not load project artifacts.": "Не удалось загрузить артефакты проекта.",
     "Could not load project files": "Не удалось загрузить файлы проекта",
     "Could not load review history.": "Не удалось загрузить историю обзора.",
+    "Could not load version history.": "Не удалось загрузить историю версий.",
     "Could not load token usage.": "Не удалось загрузить данные об использовании токенов.",
     "Could not load runtimes.": "Не удалось загрузить среды выполнения.",
     "Could not mark as read. Try again.": "Не удалось отметить как прочитанный. Попробуйте снова.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -687,6 +687,7 @@
     "Could not load project artifacts.": "无法加载项目产物。",
     "Could not load project files": "无法加载项目文件",
     "Could not load review history.": "无法加载审查历史。",
+    "Could not load version history.": "无法加载版本历史记录。",
     "Could not load token usage.": "无法加载词元用量。",
     "Could not load runtimes.": "无法加载运行时。",
     "Could not mark as read. Try again.": "无法标记为已读。请重试。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -686,6 +686,7 @@
     "Could not load project artifacts.": "無法載入專案產物。",
     "Could not load project files": "無法載入專案檔案",
     "Could not load review history.": "無法載入審查歷史。",
+    "Could not load version history.": "無法載入版本歷史記錄。",
     "Could not load token usage.": "無法載入詞元用量。",
     "Could not load runtimes.": "無法載入執行環境。",
     "Could not mark as read. Try again.": "無法標記為已讀。請重試。",


### PR DESCRIPTION
## Summary

- surface directory-access removal failures inline and keep the failed root retryable
- surface Artifact lineage failures without hiding preview content, then restore version navigation after retry
- translate the new version-history error across all seven renderer locales

## Reproduction

- added component-boundary tests that reject the preload API calls used by each user interaction
- each test failed consistently before the fix because no `role="alert"` or retry action was rendered
- after the fix, retrying a successful request removes the root or restores Artifact version navigation

## Validation

- `npx vitest run src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx` (39 passed)
- `npx vitest run src/renderer/src/i18n/resources.test.ts` (743 passed)
- targeted ESLint (passed)
- `npm run typecheck:web` (passed)
- `npm test` was run; 68 unrelated Windows symlink/fixture/timeout failures remain outside the changed files, while both target regression files pass
- full node typecheck is currently blocked by the installed `@agentclientprotocol/claude-agent-acp` package not exporting `waitForMcpServers`
