### PR TITLE
fix(workspace): align session hover card with row

### DIFF
--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -20,11 +20,7 @@ const SESSION_HOVER_PREVIEW_DELAY_MS = 0
 // Radix-internal close grace while the pointer crosses from the row onto the card; the explicit
 // pointer-leave handlers below still close the card as soon as the hover region is left for good.
 const SESSION_HOVER_PREVIEW_SKIP_DELAY_MS = 300
-// align="start" anchors the card's top edge to the trigger's top edge; the trigger is the whole
-// session row (py-1.5) and the card adds 1px border + p-4, so shift the card up to land the card
-// title on the same baseline as the hovered row title (Popper rounds subpixels, hence -12 for the
-// 11px design offset). For a title-only card this also centers the card vertically on the row.
-const SESSION_HOVER_PREVIEW_ALIGN_OFFSET_PX = -12
+const SESSION_HOVER_PREVIEW_ALIGN_OFFSET_PX = 0
 
 type SessionPreviewContent = {
   title: string
@@ -398,7 +394,7 @@ const SessionHoverPreview = ({
           requestClose()
         }}
         onEscapeKeyDown={() => requestClose()}
-        className="max-w-none overflow-visible bg-transparent py-0 pr-0 pl-2.5 text-inherit shadow-none motion-reduce:animate-none"
+        className="max-w-none overflow-visible border-0 bg-transparent p-0 text-inherit shadow-none motion-reduce:animate-none"
       >
         <SessionHoverPreviewCard
           session={session}

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -249,8 +249,11 @@ describe('WorkspaceSidebar accessible render', () => {
 
   it('opens pointer previews immediately and switches directly to the next Session', async () => {
     vi.useFakeTimers()
-    const { SessionHoverPreview, SessionHoverPreviewProvider } =
-      await import('./SessionHoverPreview')
+    const {
+      SESSION_HOVER_PREVIEW_ALIGN_OFFSET_PX,
+      SessionHoverPreview,
+      SessionHoverPreviewProvider
+    } = await import('./SessionHoverPreview')
     const firstPreviewRequest = vi.fn().mockResolvedValue(undefined)
     const secondPreviewRequest = vi.fn().mockResolvedValue(undefined)
     const container = document.createElement('div')
@@ -288,6 +291,12 @@ describe('WorkspaceSidebar accessible render', () => {
       expect(document.body.querySelector('[data-slot="session-hover-preview"]')?.textContent).toBe(
         'First SessionFirst Description'
       )
+      const hoverRegion = document.body.querySelector<HTMLElement>(
+        '[data-slot="hovercard-content"]'
+      )
+      expect(SESSION_HOVER_PREVIEW_ALIGN_OFFSET_PX).toBe(0)
+      expect(hoverRegion?.classList).toContain('border-0')
+      expect(hoverRegion?.classList).toContain('p-0')
       expect(firstPreviewRequest).toHaveBeenCalledOnce()
 
       const leave = new MouseEvent('pointerout', { bubbles: true, relatedTarget: second })


### PR DESCRIPTION
## Problem

The Session hover preview inherited an outer border, kept left padding between the sidebar and card, and applied a negative vertical alignment offset. This produced the gray frame, horizontal gap, and top-edge mismatch visible in the reported UI.

## Proposed change

- remove the hover-region border and padding so only the preview card surface remains
- reset the alignment offset so the card top follows the hovered Session row
- add focused render assertions for the wrapper border, padding, and alignment offset

## Scope and non-goals

This is a renderer-only layout fix. It does not change Session data, persisted formats, historical compatibility, state or enum values, public interfaces, or user-visible copy.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Session preview wrapper is borderless and flush with the sidebar: browser computed border `0px`, left padding `0px`
- preview aligns with the hovered row: browser geometry delta was approximately `-0.20px` vertically and `-0.02px` horizontally from subpixel rounding
- `npm run test:module -- workspace_page` — passed, 25 files / 586 tests
- `npm run typecheck:web` — passed
- `npm run lint` — passed with 0 errors; 256 pre-existing warnings remain in unrelated main-process test files
- `npm run build:web` — passed for real-browser verification

The complete local `npm test` suite was intentionally not run; PR CI remains authoritative for the complete portable and platform lanes. No additional platform-specific risk is expected because the change uses existing Radix positioning and CSS utility overrides.

## Review focus

Please verify that the `HoverCardContent` overrides keep the interactive hover region flush with the card while preserving the existing pointer transition and inline rename behavior.