### PR TITLE
test(ci): keep architecture scans and Windows schema hooks within budget

### DIFF
--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -20,6 +20,10 @@ const SESSION_ID = 'session-a'
 
 const storageKey = (storageRoot: string, path: string): string =>
   relative(storageRoot, path).split(sep).join('/')
+// Hosted Windows runners rebuild the migration ledger in beforeEach. The
+// Windows full-test workflow's 60s CLI hook budget does not override the
+// Vitest project config, so schema-backed hooks still die at 30s.
+const WINDOWS_SQLITE_HOOK_TIMEOUT_MS = 120_000
 
 const createSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
   id: SESSION_ID,
@@ -44,12 +48,12 @@ describe('ManagedFileIndexRepository', () => {
     client = createProjectDbClient(storageRoot)
     await migrateApplicationDatabase(client)
     repository = new ManagedFileIndexRepository(() => Promise.resolve(client), storageRoot)
-  })
+  }, WINDOWS_SQLITE_HOOK_TIMEOUT_MS)
 
   afterEach(async () => {
     await client.$disconnect()
     await rm(storageRoot, { recursive: true, force: true })
-  })
+  }, WINDOWS_SQLITE_HOOK_TIMEOUT_MS)
 
   it('indexes uploads and all finalized managed artifacts without requiring a message link', async () => {
     const uploadPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')

--- a/src/main/session-persistence/deletion-integration.test.ts
+++ b/src/main/session-persistence/deletion-integration.test.ts
@@ -22,6 +22,10 @@ import { SessionRepository } from './repository'
 
 const PROJECT_ID = 'project-a'
 const SESSION_ID = 'session-a'
+// Hosted Windows runners rebuild the migration ledger in beforeEach. The
+// Windows full-test workflow's 60s CLI hook budget does not override the
+// Vitest project config, so schema-backed hooks still die at 30s.
+const WINDOWS_SQLITE_HOOK_TIMEOUT_MS = 120_000
 
 describe('managed-file deletion integration', () => {
   let storageRoot: string
@@ -96,12 +100,12 @@ describe('managed-file deletion integration', () => {
     await sessions.saveSession(createSession(uploadPath, artifactPath))
     await coordinator.loadAll()
     await expect(files.getOverview(PROJECT_ID)).resolves.toMatchObject({ totalCount: 2 })
-  })
+  }, WINDOWS_SQLITE_HOOK_TIMEOUT_MS)
 
   afterEach(async () => {
     await client.$disconnect()
     await rm(storageRoot, { recursive: true, force: true })
-  })
+  }, WINDOWS_SQLITE_HOOK_TIMEOUT_MS)
 
   it('soft-deletes indexed rows but retains upload and artifact bytes after session deletion', async () => {
     const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -43,7 +43,18 @@ const facadePath = resolve(__dirname, 'useWorkspaceAgentRuntime.ts')
 const manifestPath = resolve(__dirname, '../../../../../scripts/ci/module-impact.json')
 const architectureTestPath =
   'src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts'
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+// Full-tree AST scans parse every renderer production file. Nightly coverage
+// on a loaded runner exceeds Vitest's 15s default when each case re-parses
+// the same tree; keep a 60s budget and reuse parsed imports within the file.
+const ARCHITECTURE_SCAN_TIMEOUT_MS = 60_000
+const sourceTextCache = new Map<string, string>()
+const readSource = (path: string): string => {
+  const cached = sourceTextCache.get(path)
+  if (cached !== undefined) return cached
+  const source = readFileSync(path, 'utf8')
+  sourceTextCache.set(path, source)
+  return source
+}
 const normalizePathSeparators = (path: string): string => path.replace(/\\/g, '/')
 const modulePath = (path: string): string =>
   normalizePathSeparators(path.replace(/\.[cm]?[jt]sx?$/, ''))
@@ -55,7 +66,9 @@ const sourceFileFor = (path: string, source = readSource(path)): SourceFile =>
     true,
     extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
   )
+let productionSourcePaths: readonly string[] | undefined
 const productionSources = (): readonly string[] => {
+  if (productionSourcePaths) return productionSourcePaths
   const paths: string[] = []
   const visit = (directory: string): void => {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
@@ -67,7 +80,8 @@ const productionSources = (): readonly string[] => {
     }
   }
   visit(rendererRoot)
-  return paths.sort()
+  productionSourcePaths = paths.sort()
+  return productionSourcePaths
 }
 const ownerNames = [
   'workspace-runtime-event-owner',
@@ -301,9 +315,16 @@ const loaderBindingsIn = (scope: Node, inherited: LoaderBindings): LoaderBinding
   }
   return { requireAliases: aliases, specifiers, wrappers }
 }
-const importsFrom = (path: string, source = readSource(path)): readonly ImportReference[] => {
+const fileImportCache = new Map<string, readonly ImportReference[]>()
+const importsFrom = (path: string, source?: string): readonly ImportReference[] => {
+  const useFileCache = source === undefined
+  if (useFileCache) {
+    const cached = fileImportCache.get(path)
+    if (cached) return cached
+  }
+  const resolvedSource = source ?? readSource(path)
   const references: ImportReference[] = []
-  const sourceFile = sourceFileFor(path, source)
+  const sourceFile = sourceFileFor(path, resolvedSource)
   const visit = (node: Node, inherited: LoaderBindings): void => {
     const bindings = isLoaderScope(node) ? loaderBindingsIn(node, inherited) : inherited
     if (
@@ -355,6 +376,7 @@ const importsFrom = (path: string, source = readSource(path)): readonly ImportRe
     specifiers: new Map(),
     wrappers: new Map()
   })
+  if (useFileCache) fileImportCache.set(path, references)
   return references
 }
 const callCounts = (sourceFile: SourceFile): ReadonlyMap<string, number> => {
@@ -504,7 +526,7 @@ const workspaceRuntimeBoundaryTargets = new Set([
   workspaceEventsTarget,
   ...privateRuntimeTargets
 ])
-const privateOwnerBoundaryViolations = (path: string, source = readSource(path)): string[] => {
+const privateOwnerBoundaryViolations = (path: string, source?: string): string[] => {
   const consumer = normalizePathSeparators(relative(rendererRoot, path))
   const isWorkspaceRuntimeModule = workspaceRuntimeBoundaryTargets.has(modulePath(path))
   return importsFrom(path, source).flatMap((reference) => {
@@ -625,30 +647,38 @@ describe('workspace runtime architecture', () => {
       subagentPresentationTarget
     )
   })
-  it('keeps private owners behind the public facade', () => {
-    const violations = productionSources().flatMap((path) => privateOwnerBoundaryViolations(path))
-    expect(violations).toEqual([])
-  })
-  it('keeps the hook consumer on the named facade interface', () => {
-    const hookConsumers: string[] = []
-    const unsupportedFacadeImports: string[] = []
-    for (const path of productionSources()) {
-      for (const reference of importsFrom(path)) {
-        if (reference.target !== facadeTarget) continue
-        const consumer = normalizePathSeparators(relative(rendererRoot, path))
-        if (reference.kind !== 'import' || !reference.names) {
-          unsupportedFacadeImports.push(consumer)
+  it(
+    'keeps private owners behind the public facade',
+    () => {
+      const violations = productionSources().flatMap((path) => privateOwnerBoundaryViolations(path))
+      expect(violations).toEqual([])
+    },
+    ARCHITECTURE_SCAN_TIMEOUT_MS
+  )
+  it(
+    'keeps the hook consumer on the named facade interface',
+    () => {
+      const hookConsumers: string[] = []
+      const unsupportedFacadeImports: string[] = []
+      for (const path of productionSources()) {
+        for (const reference of importsFrom(path)) {
+          if (reference.target !== facadeTarget) continue
+          const consumer = normalizePathSeparators(relative(rendererRoot, path))
+          if (reference.kind !== 'import' || !reference.names) {
+            unsupportedFacadeImports.push(consumer)
+          }
+          if (reference.names?.includes('useWorkspaceAgentRuntime')) hookConsumers.push(consumer)
         }
-        if (reference.names?.includes('useWorkspaceAgentRuntime')) hookConsumers.push(consumer)
       }
-    }
-    expect(unsupportedFacadeImports).toEqual([])
-    expect(hookConsumers).toEqual([
-      'lib/compute/useJobAnalysisEffect.ts',
-      'pages/workspace/WorkspacePage.tsx',
-      'pages/workspace/workspace-message-queue-controller.ts'
-    ])
-  })
+      expect(unsupportedFacadeImports).toEqual([])
+      expect(hookConsumers).toEqual([
+        'lib/compute/useJobAnalysisEffect.ts',
+        'pages/workspace/WorkspacePage.tsx',
+        'pages/workspace/workspace-message-queue-controller.ts'
+      ])
+    },
+    ARCHITECTURE_SCAN_TIMEOUT_MS
+  )
   it('keeps the delegated runtime transport subscription in the App-level owner', () => {
     expect(
       productionSources()


### PR DESCRIPTION
## Problem

Nightly `build / Verify` on `main` (`33113718645`, SHA `1a623155`) failed two portable tests:

- `useWorkspaceAgentRuntime.architecture.test.ts` — `keeps private owners behind the public facade` timed out at the 15s default (the file took 30.8s). The next assertion, `keeps the hook consumer on the named facade interface`, re-parses the same renderer tree.
- `WorkspaceMessageItem.actions.test.tsx` — `Annotate entry not found`. That SHA predates #1826 and #1837; current `main` already passes both annotation suites locally.

The same architecture timeout is the likely shared cause of recently merged PR Gate failures: `Full Module tests (macOS, shard 2/2)` uses `--coverage` and `--reporter=blob`, so the shard log hides the failing case and the merge job then fails the PR.

Windows Full Test (`33123121726`, SHA `e311957d`) separately failed schema-backed `beforeEach` hooks at **30s** in:

- `src/main/session-persistence/deletion-integration.test.ts`
- `src/main/project-files/repository.test.ts`

The workflow already passes `--hookTimeout=60000`, but Vitest project configs still apply the repository 30s budget.

## Proposed change

- Cache renderer source text, production paths, and file-backed import graphs inside the workspace-runtime architecture suite so later assertions reuse the first scan.
- Give the two full-tree architecture assertions a 60s budget so a loaded coverage runner cannot fail them at 15s.
- Give the two Windows schema-hook suites a 120s `beforeEach` / `afterEach` budget, matching the SQLite test-timeout pattern from #1827.

## Scope and non-goals

- Test budgets and architecture-scan caching only. No production code, schema, or persisted-format changes.
- Does not change `vitest.config.ts` defaults or CI workflow files.
- Does not address the Windows managed-preview mutation check (see Review focus).
- Does not change annotation production code; #1826 / #1837 already cover the Nightly annotate-entry miss.

## Acceptance criteria and validation

- Architecture full-tree scans reuse parsed imports after the first assertion.
- Those two assertions use a 60s timeout.
- The two Windows schema-hook files use a 120s hook budget.
- No schema, enum, or persistence-format change.

### Test impact set

Checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Architecture scans and loader-guard assertions | `npx vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts` | pass (11) |
| Same file under coverage (Nightly-like) | `VITEST_DEFER_COVERAGE_THRESHOLDS=1 npx vitest run … --coverage` | pass (11); first scan 9.1s, later scans 1ms |
| Workspace runtime module | `npm run test:module -- workspace_runtime` | pass (356) |
| Session persistence module | `npm run test:module -- session_persistence` | pass (359) |
| Project files repository module | `npm run test:module -- project_files_repository` | pass (234) |
| SQLite hook suites | `npx vitest run src/main/session-persistence/deletion-integration.test.ts src/main/project-files/repository.test.ts` | pass (55) |
| Lint | `npx eslint` on the three changed files | pass |

Excluded: full `npm test` (PR Gate / Nightly remain authoritative), live Windows hosted-runner confirmation (Windows Full Test after merge).

## Review focus

- Whether caching file-backed `importsFrom` still lets the synthetic loader-bypass cases observe custom source.
- Whether 60s is the right architecture budget versus moving the scan into a longer hook.
- Whether per-file 120s hook budgets are enough, or the repository `hookTimeout: 30000` should be raised because CLI `--hookTimeout` does not override Vitest projects.

### Historical compatibility

None. No stored rows, files, or wire formats change.

### New state / enum values

None.

### Data persistence

Not changed in this PR. Called out because Windows Full Test also failed `managed-preview-protocol.test.ts`: overwriting a 192KB file during a strict protocol stream resolved instead of rejecting `/changed during (protocol )?streaming/i`. The check uses `ino` / `mtimeNs` / `dev` on the open handle. Windows in-place overwrite often keeps the same inode, and `fileHandle.stat()` may not observe the mutation. That is a Windows preview-integrity gap, not a test-budget issue, and needs a product decision before changing production code.

### Uncovered risks

- Other architecture suites that scan the full tree without caching could still hit 15s under coverage.
- Other `migrateApplicationDatabase` `beforeEach` hooks can still die at 30s on Windows if they are slower than the two files raised here.
- Runtime Resource Soak (`33081384823`) failed to upload `test-results` on Windows; that is a separate soak-harness issue.
- Annotation tests failed on the Nightly SHA and the Windows SHA before #1837; they pass on current `main` and are not changed here.