### PR TITLE
ci(pr-gate): reject flaky E2E retry passes

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -676,7 +676,7 @@ jobs:
         id: e2e_functional_macos
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_macos') }}
         continue-on-error: true
-        run: npm run test:e2e:journey
+        run: npm run test:e2e:journey -- --fail-on-flaky-tests
       - name: Upload functional failure artifacts
         if: ${{ steps.e2e_functional_macos.outcome == 'failure' }}
         continue-on-error: true
@@ -692,7 +692,7 @@ jobs:
         id: e2e_workspace_macos
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_macos') }}
         continue-on-error: true
-        run: npm run test:e2e:workspace
+        run: npm run test:e2e:workspace -- --fail-on-flaky-tests
       - name: Upload workspace failure artifacts
         if: ${{ steps.e2e_workspace_macos.outcome == 'failure' }}
         continue-on-error: true
@@ -724,7 +724,7 @@ jobs:
         id: e2e_visual_macos
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_visual_macos') }}
         continue-on-error: true
-        run: npm run test:e2e:visual
+        run: npm run test:e2e:visual -- --fail-on-flaky-tests
       - name: Upload visual failure artifacts
         if: ${{ steps.e2e_visual_macos.outcome == 'failure' }}
         continue-on-error: true
@@ -789,7 +789,7 @@ jobs:
         id: e2e_functional_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_windows') }}
         continue-on-error: true
-        run: npm run test:e2e:journey -- --workers=2
+        run: npm run test:e2e:journey -- --workers=2 --fail-on-flaky-tests
       - name: Upload functional failure artifacts
         if: ${{ steps.e2e_functional_windows.outcome == 'failure' }}
         continue-on-error: true
@@ -805,7 +805,7 @@ jobs:
         id: e2e_workspace_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_windows') }}
         continue-on-error: true
-        run: npm run test:e2e:workspace -- --workers=2
+        run: npm run test:e2e:workspace -- --workers=2 --fail-on-flaky-tests
       - name: Upload workspace failure artifacts
         if: ${{ steps.e2e_workspace_windows.outcome == 'failure' }}
         continue-on-error: true
@@ -823,7 +823,7 @@ jobs:
         id: e2e_accessibility_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_accessibility_windows') }}
         continue-on-error: true
-        run: npm run test:e2e:accessibility
+        run: npm run test:e2e:accessibility -- --fail-on-flaky-tests
       - name: Upload legacy accessibility failure artifacts
         if: ${{ steps.e2e_accessibility_windows.outcome == 'failure' }}
         continue-on-error: true

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -434,10 +434,10 @@ describe('PR Gate workflow', () => {
     expect(macosRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)
     expect(macosRuns).toEqual(
       expect.arrayContaining([
-        'npm run test:e2e:journey',
-        'npm run test:e2e:workspace',
+        'npm run test:e2e:journey -- --fail-on-flaky-tests',
+        'npm run test:e2e:workspace -- --fail-on-flaky-tests',
         'npm run test:e2e:accessibility:signal',
-        'npm run test:e2e:visual'
+        'npm run test:e2e:visual -- --fail-on-flaky-tests'
       ])
     )
 
@@ -445,9 +445,9 @@ describe('PR Gate workflow', () => {
     expect(windowsRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)
     expect(windowsRuns).toEqual(
       expect.arrayContaining([
-        'npm run test:e2e:journey -- --workers=2',
-        'npm run test:e2e:workspace -- --workers=2',
-        'npm run test:e2e:accessibility'
+        'npm run test:e2e:journey -- --workers=2 --fail-on-flaky-tests',
+        'npm run test:e2e:workspace -- --workers=2 --fail-on-flaky-tests',
+        'npm run test:e2e:accessibility -- --fail-on-flaky-tests'
       ])
     )
   })
@@ -468,7 +468,7 @@ describe('PR Gate workflow', () => {
     expect(compatibility).toMatchObject({
       id: 'e2e_accessibility_windows',
       'continue-on-error': true,
-      run: 'npm run test:e2e:accessibility'
+      run: 'npm run test:e2e:accessibility -- --fail-on-flaky-tests'
     })
     expect(compatibility?.if).toContain(
       "contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_accessibility_windows')"
@@ -503,7 +503,7 @@ describe('PR Gate workflow', () => {
     )
 
     expect(macosStep?.run).toBe('npm run test:e2e:accessibility:signal')
-    expect(windowsStep?.run).toBe('npm run test:e2e:accessibility')
+    expect(windowsStep?.run).toBe('npm run test:e2e:accessibility -- --fail-on-flaky-tests')
   })
 
   it('collects independent bundle failures before failing the shared runner', () => {


### PR DESCRIPTION
## Problem

Playwright retries failed tests once in CI. The blocking PR functional, workspace, visual, and legacy Windows accessibility commands did not enable strict flaky handling, so a test that failed on its first attempt and passed on retry could leave the PR gate green. Because most of these lanes upload diagnostics only for a final failure, that retry-pass could also leave no retained failure evidence.

## Proposed change

- Pass `--fail-on-flaky-tests` to blocking macOS functional, workspace, and visual E2E commands.
- Pass the same flag to blocking Windows functional, workspace, and legacy accessibility E2E commands while preserving the existing Windows worker count.
- Update the PR Gate workflow contract test to pin those command lines.

Retries remain enabled, so the retry still records whether a failure is transient. A retry-pass now produces a failed step, which activates the existing failure artifact uploads and is collected by the existing platform enforcement step.

## Scope and non-goals

- No Playwright retry-count, reporter, artifact schema, or global Playwright configuration change.
- No new dependencies, workflow jobs, fields, states, data models, persistence, migrations, or user interaction changes.
- The macOS accessibility quality-signal command remains unchanged because validated accessibility findings are intentionally advisory and that step already uploads diagnostics whenever it runs. The legacy Windows accessibility compatibility path remains blocking and is covered.
- No historical data compatibility work is required.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- Retry-pass exit semantics -> deterministic temporary Playwright test -> default exited 0; `--fail-on-flaky-tests` exited 1.
- Blocking PR E2E command contract -> `../../node_modules/.bin/vitest run scripts/ci/pr-gate-workflow.test.ts scripts/ci/check-ci-integrity.test.ts` -> 59 tests passed.
- Workflow and test formatting -> `../../node_modules/.bin/prettier --check .github/workflows/pr-gate.yml scripts/ci/pr-gate-workflow.test.ts` -> passed.
- Patch hygiene -> `git diff --check` -> passed.

The complete local `npm test` suite was intentionally not run for this focused workflow change; exact-head PR Gate CI is the final cross-platform validation authority.

## Review focus

- Confirm every blocking PR E2E command that can retry now rejects retry-passes.
- Confirm the unchanged macOS accessibility signal remains correctly advisory and already retains diagnostics.
