### PR TITLE
fix(claude-code): avoid shadowing tool permissions

### DIFF
--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -102,11 +102,27 @@ describe('claudeCodeFramework', () => {
     })
   })
 
-  it('routes canonical Skill calls through the isolated read-only runtime loader', () => {
+  it('routes canonical Skill calls through the isolated read-only runtime loader', async () => {
+    type PreToolUseCallback = (
+      input: unknown,
+      toolUseId: string | undefined,
+      options: { signal: AbortSignal }
+    ) => Promise<{
+      hookSpecificOutput?: {
+        hookEventName?: string
+        permissionDecision?: string
+      }
+    }>
+
+    const existingPreToolUseHook: PreToolUseCallback = async () => ({})
     const setup = claudeCodeFramework.buildSessionSetup({
       systemPromptAppends: [],
       skillRuntimeScope: 'all',
       sessionOptions: {
+        allowedTools: ['Read'],
+        hooks: {
+          PreToolUse: [{ matcher: 'Bash', hooks: [existingPreToolUseHook] }]
+        },
         [OPEN_SCIENCE_SKILL_RUNTIME_SESSION_OPTION]: {
           command: '/app/electron',
           entryPath: '/app/main.js',
@@ -116,10 +132,13 @@ describe('claudeCodeFramework', () => {
     })
     const options = (setup.meta?.claudeCode as { options: Record<string, unknown> }).options
     const servers = options.mcpServers as Record<string, Record<string, unknown>>
+    const hooks = options.hooks as {
+      PreToolUse: Array<{ matcher?: string; hooks: PreToolUseCallback[] }>
+    }
 
     expect(options).not.toHaveProperty(OPEN_SCIENCE_SKILL_RUNTIME_SESSION_OPTION)
     expect(options.toolAliases).toEqual({ Skill: LOAD_SKILL_TOOL_CALLABLE_NAME })
-    expect(options.allowedTools).toEqual([LOAD_SKILL_TOOL_CALLABLE_NAME])
+    expect.soft(options.allowedTools).toEqual(['Read'])
     expect(servers[SKILL_RUNTIME_MCP_SERVER_NAME]).toMatchObject({
       type: 'stdio',
       command: '/app/electron',
@@ -127,6 +146,32 @@ describe('claudeCodeFramework', () => {
       env: {
         ELECTRON_RUN_AS_NODE: '1',
         [SKILL_RUNTIME_ROOT_ENV]: '/runtime/revision'
+      }
+    })
+    expect(hooks.PreToolUse[0]).toMatchObject({
+      matcher: 'Bash',
+      hooks: [existingPreToolUseHook]
+    })
+
+    const loadSkillHook = hooks.PreToolUse.find(
+      (hook) => hook.matcher === LOAD_SKILL_TOOL_CALLABLE_NAME
+    )
+    expect(loadSkillHook).toBeDefined()
+
+    const decision = await loadSkillHook!.hooks[0](
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: LOAD_SKILL_TOOL_CALLABLE_NAME,
+        tool_input: { name: 'literature-review' },
+        tool_use_id: 'tool-use-1'
+      },
+      'tool-use-1',
+      { signal: new AbortController().signal }
+    )
+    expect(decision).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'allow'
       }
     })
   })

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -118,14 +118,26 @@ export const claudeCodeFramework: AgentFramework = {
           Skill: LOAD_SKILL_TOOL_CALLABLE_NAME
         }
       : sessionOptions.toolAliases
-    const allowedTools = skillRuntimeEnabled
-      ? [
-          ...new Set([
-            ...stringArrayValue(sessionOptions.allowedTools),
-            LOAD_SKILL_TOOL_CALLABLE_NAME
-          ])
-        ]
-      : sessionOptions.allowedTools
+    const sessionHooks = recordValue(sessionOptions.hooks)
+    const hooks = skillRuntimeEnabled
+      ? {
+          ...sessionHooks,
+          PreToolUse: [
+            ...(Array.isArray(sessionHooks.PreToolUse) ? sessionHooks.PreToolUse : []),
+            {
+              matcher: LOAD_SKILL_TOOL_CALLABLE_NAME,
+              hooks: [
+                async () => ({
+                  hookSpecificOutput: {
+                    hookEventName: 'PreToolUse' as const,
+                    permissionDecision: 'allow' as const
+                  }
+                })
+              ]
+            }
+          ]
+        }
+      : sessionOptions.hooks
     const disallowedTools = Object.freeze([
       ...new Set([
         ...stringArrayValue(sessionOptions.disallowedTools),
@@ -154,7 +166,7 @@ export const claudeCodeFramework: AgentFramework = {
           ...sessionOptions,
           ...(mcpServers !== undefined ? { mcpServers } : {}),
           ...(toolAliases !== undefined ? { toolAliases } : {}),
-          ...(allowedTools !== undefined ? { allowedTools } : {}),
+          ...(hooks !== undefined ? { hooks } : {}),
           disallowedTools,
           managedSettings,
           env,


### PR DESCRIPTION
## Problem

Claude Code sessions with the Open Science Skill runtime enabled add the bare
`mcp__skills__load_skill` name to `allowedTools`. The Claude SDK also receives ACP's
`canUseTool` callback, so the bare allow rule shadows that callback and emits
`CLAUDE_SDK_CAN_USE_TOOL_SHADOWED` on stderr.

## Proposed change

- Stop adding the Skill loader to `allowedTools`.
- Auto-approve only `mcp__skills__load_skill` through an exact `PreToolUse` hook.
- Preserve backend-provided `allowedTools`, existing `PreToolUse` hooks, and all other hook events.
- Add a regression test through `claudeCodeFramework.buildSessionSetup()` that exercises the emitted
  hook decision.

## Scope and non-goals

This change is limited to Claude Code Skill-runtime session setup. It does not change ACP's general
permission flow, user-defined allow rules, other runtime backends, or the Skill loader implementation.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Skill session options avoid the shadowing bare allow rule while retaining automatic Skill loading
  -> `npm test -- src/main/agent-framework/claude-code.test.ts`
  -> 15 tests passed.
- Main and renderer TypeScript contracts remain valid
  -> `npm run typecheck`
  -> passed.
- Repository lint policy remains satisfied
  -> `npm run lint`
  -> passed with 256 existing warnings in unchanged files and 0 errors.
- Final fallback selected for the unregistered module-owner path
  -> `npm test`
  -> 1,228 test files passed, 16 skipped; 20,071 tests passed, 235 skipped.

Uncovered risk: no live Claude Code process/E2E session was exercised locally. The regression test
checks the SDK option and hook contract used by the installed Claude SDK version.

## Review focus

Please focus on the exact `PreToolUse` matcher and the merge behavior that preserves caller-provided
hooks and `allowedTools`.
