### PR TITLE
fix(agent-framework): block CodeBuddy Bash Python execution

### DIFF
--- a/src/main/agent-framework/codebuddy.test.ts
+++ b/src/main/agent-framework/codebuddy.test.ts
@@ -55,10 +55,8 @@ describe('codebuddy framework', () => {
       '--setting-sources',
       'user',
       '--tools',
-      expect.not.stringMatching(/Agent|Skill|Workflow|Task|WebFetch|WebSearch/),
+      expect.not.stringMatching(/Agent|Skill|Workflow|Task|WebFetch|WebSearch|Bash/),
       '--disallowedTools',
-      'Bash(python:*)',
-      'Bash(python3:*)',
       'Bash(curl:*)',
       'Bash(wget:*)',
       'Bash(aria2c:*)',
@@ -156,7 +154,7 @@ describe('codebuddy framework', () => {
     expect(spawnedEnv?.NO_PROXY).toBe('inherited-bypass.example.test')
   })
 
-  it('removes every shell tool on Windows where the CodeBuddy sandbox is unavailable', () => {
+  it('keeps native Bash absent on Windows too', () => {
     const framework = createCodeBuddyFramework({ platform: 'win32' })
     const config = framework.prepareModelConfig(provider, {
       storageRoot: 'C:\\app-data',
@@ -172,7 +170,7 @@ describe('codebuddy framework', () => {
     expect(settings.sandbox.enabled).toBe(false)
   })
 
-  it('keeps CodeBuddy from running Python through its native Bash tool', () => {
+  it('routes shell work through the app-owned Notebook tool instead of native Bash', () => {
     const config = createCodeBuddyFramework({ platform: 'linux' }).prepareModelConfig(provider, {
       storageRoot: '/app-data',
       executablePath: '/usr/bin/codebuddy',
@@ -181,9 +179,7 @@ describe('codebuddy framework', () => {
     })
     const tools = config.args?.[config.args.indexOf('--tools') + 1]
 
-    expect(tools).toContain('Bash')
-    expect(config.args).toContain('Bash(python:*)')
-    expect(config.args).toContain('Bash(python3:*)')
+    expect(tools).not.toContain('Bash')
   })
 
   it('replays dynamic MCP servers when activating the target Session before a prompt', async () => {

--- a/src/main/agent-framework/codebuddy.test.ts
+++ b/src/main/agent-framework/codebuddy.test.ts
@@ -57,6 +57,8 @@ describe('codebuddy framework', () => {
       '--tools',
       expect.not.stringMatching(/Agent|Skill|Workflow|Task|WebFetch|WebSearch/),
       '--disallowedTools',
+      'Bash(python:*)',
+      'Bash(python3:*)',
       'Bash(curl:*)',
       'Bash(wget:*)',
       'Bash(aria2c:*)',
@@ -168,6 +170,20 @@ describe('codebuddy framework', () => {
     expect(tools).toBe('Read,Write,Edit,Glob,Grep')
     expect(config.args).toContain('Bash(curl:*)')
     expect(settings.sandbox.enabled).toBe(false)
+  })
+
+  it('keeps CodeBuddy from running Python through its native Bash tool', () => {
+    const config = createCodeBuddyFramework({ platform: 'linux' }).prepareModelConfig(provider, {
+      storageRoot: '/app-data',
+      executablePath: '/usr/bin/codebuddy',
+      systemPromptAppends: [],
+      reasoningEfforts: []
+    })
+    const tools = config.args?.[config.args.indexOf('--tools') + 1]
+
+    expect(tools).toContain('Bash')
+    expect(config.args).toContain('Bash(python:*)')
+    expect(config.args).toContain('Bash(python3:*)')
   })
 
   it('replays dynamic MCP servers when activating the target Session before a prompt', async () => {

--- a/src/main/agent-framework/codebuddy.ts
+++ b/src/main/agent-framework/codebuddy.ts
@@ -52,9 +52,7 @@ const recordValue = (value: unknown): Record<string, unknown> =>
 // lifecycle, Skill routing, Connector ownership, and permission owners.
 const CODEBUDDY_LOCAL_TOOLS = ['Read', 'Write', 'Edit', 'Glob', 'Grep']
 const CODEBUDDY_CLEANUP_PERIOD_DAYS = 7
-const CODEBUDDY_BASH_DENY_RULES = [
-  'Bash(python:*)',
-  'Bash(python3:*)',
+const CODEBUDDY_NETWORK_DENY_RULES = [
   'Bash(curl:*)',
   'Bash(wget:*)',
   'Bash(aria2c:*)',
@@ -78,14 +76,6 @@ const CODEBUDDY_BASH_DENY_RULES = [
   'Bash(git ls-remote:*)',
   'Bash(git submodule:*)'
 ] as const
-
-const codeBuddyTools = (platform: NodeJS.Platform): string =>
-  [
-    ...CODEBUDDY_LOCAL_TOOLS,
-    // CodeBuddy's OS-level Bash sandbox is available only on macOS and Linux. Keep every shell
-    // tool absent on Windows rather than relying on a prompt to prevent direct network access.
-    ...(platform === 'win32' ? [] : ['Bash'])
-  ].join(',')
 
 export const codeBuddyStorageDir = (storageRoot: string): string => join(storageRoot, 'codebuddy')
 
@@ -229,9 +219,11 @@ export const createCodeBuddyFramework = ({
         '--setting-sources',
         'user',
         '--tools',
-        codeBuddyTools(platform),
+        // Shell execution stays on the app-owned Notebook tool so Python/R requests follow its
+        // kernel-routing contract instead of CodeBuddy's prefix-bypassable native Bash rules.
+        CODEBUDDY_LOCAL_TOOLS.join(','),
         '--disallowedTools',
-        ...CODEBUDDY_BASH_DENY_RULES,
+        ...CODEBUDDY_NETWORK_DENY_RULES,
         ...(persistentSystemPrompt ? ['--system-prompt-file', systemPromptPath] : [])
       ],
       sessionModel: provider.model,

--- a/src/main/agent-framework/codebuddy.ts
+++ b/src/main/agent-framework/codebuddy.ts
@@ -52,7 +52,9 @@ const recordValue = (value: unknown): Record<string, unknown> =>
 // lifecycle, Skill routing, Connector ownership, and permission owners.
 const CODEBUDDY_LOCAL_TOOLS = ['Read', 'Write', 'Edit', 'Glob', 'Grep']
 const CODEBUDDY_CLEANUP_PERIOD_DAYS = 7
-const CODEBUDDY_NETWORK_DENY_RULES = [
+const CODEBUDDY_BASH_DENY_RULES = [
+  'Bash(python:*)',
+  'Bash(python3:*)',
   'Bash(curl:*)',
   'Bash(wget:*)',
   'Bash(aria2c:*)',
@@ -229,7 +231,7 @@ export const createCodeBuddyFramework = ({
         '--tools',
         codeBuddyTools(platform),
         '--disallowedTools',
-        ...CODEBUDDY_NETWORK_DENY_RULES,
+        ...CODEBUDDY_BASH_DENY_RULES,
         ...(persistentSystemPrompt ? ['--system-prompt-file', systemPromptPath] : [])
       ],
       sessionModel: provider.model,


### PR DESCRIPTION
## Problem

CodeBuddy exposed its native Bash tool on macOS and Linux. A request such as “用 python 绘制 sin” could therefore produce `Bash(python -c ...)` and bypass the app-owned persistent Notebook runtime. Command-prefix deny rules are not a complete boundary because absolute paths, versioned interpreters, and wrappers can bypass them.

## Proposed change

- Remove native `Bash` from CodeBuddy's model-callable tool list on every platform.
- Keep ordinary shell work available through the app-owned `open-science-notebook/bash_execute` tool.
- Add a regression test at the public framework launch-configuration boundary.

The final regression test was run three times before the production change and failed consistently because the Linux tool list was `Read,Write,Edit,Glob,Grep,Bash`. It passes after native Bash is removed.

## Scope and non-goals

- CodeBuddy-specific; Claude Code, OpenCode, Codex Responses, and Codex Bridge behavior is unchanged.
- Applies to every model routed through CodeBuddy. Windows already omitted Bash; macOS and Linux now match that boundary.
- No ACP wire-shape, MCP registration, subscription, lifecycle, model, UI, data-model, persisted-format, historical-compatibility, migration, or new-state changes.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- CodeBuddy does not expose native Bash and continues to mount its Notebook MCP server -> `npm test -- src/main/agent-framework/codebuddy.test.ts` -> 11/11 passed.
- Ordinary app-owned shell execution remains registered and forwarded -> `npm test -- src/main/notebook/mcp-server.test.ts -t 'bash_execute'` -> 4/4 passed.
- Node adapter types remain valid -> `npm run typecheck:node` -> passed.
- Changed files satisfy lint and formatting -> `npx eslint src/main/agent-framework/codebuddy.ts src/main/agent-framework/codebuddy.test.ts` and `npx prettier --check ...` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 256 pre-existing unrelated formatting warnings in database/Notebook tests.

Per the requested local scope, the full portable suite was not run. Exact-head PR Gate remains authoritative for selected consumer and platform coverage.

## Review focus

Please verify that CodeBuddy has no native Bash surface while ordinary shell work remains available through the app-owned Notebook tool.
