### PR TITLE
fix(workspace): dismiss session preview when actions open

### DIFF
--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -271,19 +271,21 @@ const SessionHoverPreview = ({
   onPreviewRequest,
   canRename = false,
   onRenameTitle,
+  previewSuppressed = false,
   children
 }: {
   session: SessionPreviewDetails
   onPreviewRequest?: SessionPreviewRequest
   canRename?: boolean
   onRenameTitle?: SessionRenameRequest
+  previewSuppressed?: boolean
   children: ReactElement
 }): React.JSX.Element => {
   const context = useContext(SessionHoverPreviewContext)
   if (!context) throw new Error('SessionHoverPreview must be inside SessionHoverPreviewProvider')
 
   const { activeSessionId, closeNow, requestOpen } = context
-  const open = activeSessionId === session.id
+  const open = !previewSuppressed && activeSessionId === session.id
   const onPreviewRequestRef = useRef(onPreviewRequest)
   // Radix types the trigger ref as its default anchor element; with asChild the rendered element
   // is the caller's child, and only Element-level APIs (contains/matches) are used here.
@@ -314,6 +316,10 @@ const SessionHoverPreview = ({
 
   useEffect(() => () => closeNow(session.id), [closeNow, session.id])
 
+  useEffect(() => {
+    if (previewSuppressed) closeNow(session.id)
+  }, [closeNow, previewSuppressed, session.id])
+
   const requestClose = useCallback((): void => {
     if (editingRef.current) return
     // Focus moved into the portaled card (e.g. Tab from the row to the rename control): keep the
@@ -340,7 +346,7 @@ const SessionHoverPreview = ({
       openDelay={SESSION_HOVER_PREVIEW_DELAY_MS}
       closeDelay={SESSION_HOVER_PREVIEW_SKIP_DELAY_MS}
       onOpenChange={(nextOpen) => {
-        if (nextOpen) {
+        if (nextOpen && !previewSuppressed) {
           requestOpen(session.id)
           return
         }
@@ -350,7 +356,9 @@ const SessionHoverPreview = ({
       <HoverCardTrigger
         ref={triggerRef}
         asChild
-        onPointerEnter={() => requestOpen(session.id)}
+        onPointerEnter={() => {
+          if (!previewSuppressed) requestOpen(session.id)
+        }}
         onPointerLeave={(event) => {
           if (event.currentTarget.matches(':focus-visible')) return
           if (
@@ -361,7 +369,13 @@ const SessionHoverPreview = ({
           }
           requestClose()
         }}
-        onFocus={() => requestOpen(session.id)}
+        onFocus={(event) => {
+          if (!(event.target instanceof Element) || !event.target.matches(':focus-visible')) {
+            event.preventDefault()
+            return
+          }
+          if (!previewSuppressed) requestOpen(session.id)
+        }}
         onBlur={(event) => {
           if (event.currentTarget.matches(':hover')) return
           if (

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -357,6 +357,84 @@ describe('WorkspaceSidebar accessible render', () => {
     }
   })
 
+  it('closes the Session preview when its actions menu opens', async () => {
+    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const session = createSession({ id: 'menu-session', title: 'Menu Session' })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkspaceSidebar
+            projectName="Example project"
+            sessions={[session]}
+            activeSessionId={session.id}
+            canCreateConversation
+            canMutateConversations
+            canDeleteConversations
+            onGoHome={vi.fn()}
+            onNewConversation={vi.fn()}
+            isFilesOpen={false}
+            onOpenFiles={vi.fn()}
+            onOpenSession={vi.fn()}
+            onRenameSession={vi.fn()}
+            canDownloadArtifacts
+            onDownloadArtifacts={vi.fn()}
+            onViewNotebook={vi.fn()}
+            onExportSession={vi.fn()}
+            onTogglePin={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onOpenSettings={vi.fn()}
+            onOpenProjectSettings={vi.fn()}
+            onNewProject={vi.fn()}
+            canDownloadProjectArtifacts
+            onDownloadProjectArtifacts={vi.fn()}
+          />
+        )
+      })
+
+      const actionsTrigger = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Open actions for Menu Session"]'
+      )
+      if (!actionsTrigger) throw new Error('Session actions trigger did not render')
+      const pointerOver = new MouseEvent('pointerover', { bubbles: true })
+      Object.defineProperty(pointerOver, 'pointerType', { value: 'mouse' })
+
+      await act(async () => actionsTrigger.dispatchEvent(pointerOver))
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).not.toBeNull()
+
+      await act(async () =>
+        actionsTrigger.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+      )
+
+      expect(document.body.querySelector('[data-slot="dropdown-menu-content"]')).not.toBeNull()
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
+
+      const actionsMenu = document.body.querySelector<HTMLElement>(
+        '[data-slot="dropdown-menu-content"]'
+      )
+      if (!actionsMenu) throw new Error('Session actions menu did not render')
+      await act(async () =>
+        actionsMenu.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+      )
+
+      expect(document.body.querySelector('[data-slot="dropdown-menu-content"]')).toBeNull()
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
+
+      await act(async () =>
+        actionsTrigger.dispatchEvent(
+          new FocusEvent('focusin', { bubbles: true, relatedTarget: actionsMenu })
+        )
+      )
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+    }
+  })
+
   it('closes an active Session preview when its row is removed', async () => {
     vi.useFakeTimers()
     const { SessionHoverPreview, SessionHoverPreviewProvider } =
@@ -420,6 +498,10 @@ describe('WorkspaceSidebar accessible render', () => {
       })
       const trigger = container.querySelector('button')
       if (!trigger) throw new Error('Session preview trigger did not render')
+      const matches = trigger.matches.bind(trigger)
+      vi.spyOn(trigger, 'matches').mockImplementation((selector) =>
+        selector === ':focus-visible' ? true : matches(selector)
+      )
 
       await act(async () => trigger.focus())
 
@@ -634,6 +716,10 @@ describe('WorkspaceSidebar accessible render', () => {
       })
       const [trigger, outside] = Array.from(container.querySelectorAll('button'))
       if (!trigger || !outside) throw new Error('Session preview triggers did not render')
+      const matches = trigger.matches.bind(trigger)
+      vi.spyOn(trigger, 'matches').mockImplementation((selector) =>
+        selector === ':focus-visible' ? true : matches(selector)
+      )
 
       await act(async () => trigger.focus())
       const titleButton = document.body.querySelector<HTMLElement>(

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -93,6 +93,8 @@ type WorkspaceSidebarProps = {
 type WorkspaceSidebarViewProps = WorkspaceSidebarProps & {
   now: number
   showSessionShortcuts?: boolean
+  openSessionActionsId?: string | null
+  onSessionActionsOpenChange?: (sessionId: string, open: boolean) => void
 }
 
 // Maps each session status to the left-side indicator dot using emitted theme colors.
@@ -246,7 +248,9 @@ const WorkspaceSidebarView = ({
   isMobileOpen = false,
   onMobileClose,
   now,
-  showSessionShortcuts = false
+  showSessionShortcuts = false,
+  openSessionActionsId = null,
+  onSessionActionsOpenChange
 }: WorkspaceSidebarViewProps): React.JSX.Element => {
   const { t } = useTranslation()
   const sections = getSessionSections(sessions, now)
@@ -521,7 +525,11 @@ const WorkspaceSidebarView = ({
                             )}
                           />
 
-                          <DropdownMenu>
+                          <DropdownMenu
+                            onOpenChange={(menuOpen) => {
+                              onSessionActionsOpenChange?.(session.id, menuOpen)
+                            }}
+                          >
                             <DropdownMenuTrigger asChild>
                               <button
                                 type="button"
@@ -652,6 +660,7 @@ const WorkspaceSidebarView = ({
                         session={session}
                         onPreviewRequest={onPreviewSession}
                         canRename={canMutateConversations && onRenameSessionTitle !== undefined}
+                        previewSuppressed={openSessionActionsId === session.id}
                         onRenameTitle={
                           onRenameSessionTitle
                             ? (title) => onRenameSessionTitle(session, title)
@@ -709,6 +718,7 @@ const WorkspaceSidebar = (props: WorkspaceSidebarProps): React.JSX.Element => {
   const { onOpenSession, sessions } = props
   const [now, setNow] = useState(Date.now)
   const [showSessionShortcuts, setShowSessionShortcuts] = useState(false)
+  const [openSessionActionsId, setOpenSessionActionsId] = useState<string | null>(null)
   const nextSectionRefreshAt = getNextSessionSectionRefreshAt(sessions, now)
   const isMac = window.api?.platform === 'darwin'
 
@@ -773,7 +783,19 @@ const WorkspaceSidebar = (props: WorkspaceSidebarProps): React.JSX.Element => {
     }
   }, [isMac, now, onOpenSession, sessions])
 
-  return <WorkspaceSidebarView {...props} now={now} showSessionShortcuts={showSessionShortcuts} />
+  return (
+    <WorkspaceSidebarView
+      {...props}
+      now={now}
+      showSessionShortcuts={showSessionShortcuts}
+      openSessionActionsId={openSessionActionsId}
+      onSessionActionsOpenChange={(sessionId, open) => {
+        setOpenSessionActionsId((current) =>
+          open ? sessionId : current === sessionId ? null : current
+        )
+      }}
+    />
+  )
 }
 
 export { WorkspaceSidebar }


### PR DESCRIPTION
## Problem

Opening the Session actions menu while its hover preview is visible allows the title and description card to overlap the menu. Closing the menu can also return focus to the actions trigger and reopen the preview, requiring an extra click to dismiss it.

## Proposed change

Track the open Session actions menu in the WorkspaceSidebar state owner and suppress the matching hover preview for the full menu lifecycle. Ignore programmatic focus return unless the focused control matches :focus-visible, preserving keyboard access without reopening the preview after menu dismissal.

Add a user-facing interaction regression test covering preview display, menu opening, menu dismissal, and programmatic focus return. Existing keyboard-focus coverage explicitly verifies that focus-visible navigation still opens the preview.

## Scope and non-goals

- Changes only the desktop Session hover preview and Session actions menu interaction.
- Does not change menu contents, visual tokens, mobile menu behavior, persistence, or Session data.
- Adds no user-visible copy or localization keys.

## Acceptance criteria and validation

- Menu opening closes the matching Session preview -> npm test -- src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx -> 44 tests passed.
- Menu dismissal and programmatic focus return do not reopen the preview -> covered by the same interaction suite -> passed.
- Keyboard focus-visible navigation still opens and keeps the interactive preview usable -> covered by the same interaction suite -> passed.
- Final affected test plan -> npm run test:affected -- --base f25e2817 --head HEAD -> full fallback passed: 1,229 files and 20,083 tests; 15 files and 232 tests skipped by suite configuration.
- Renderer types -> npm run typecheck:web -> passed.
- Lint -> npm run lint -> passed with 0 errors; 256 existing Prettier warnings are outside this diff.
- Whitespace validation -> git diff --check -> passed.

All listed checks ran after the final material edit.

## Review focus

Please verify the focus handoff between the two Radix portals: pointer-opened menus must keep the preview closed through focus return, while keyboard focus-visible navigation must retain access to the interactive preview title.

Uncovered risk: final manual visual confirmation in the packaged Electron UI and independent review are still pending; CI remains authoritative for platform-specific behavior.