### PR TITLE
fix(acp): resume interrupted Claude responses

### DIFF
--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -1,5 +1,6 @@
 import {
   isClaudeApiConnectionFailure,
+  isClaudeApiResponseInterruption,
   PROVIDER_CONNECTION_FAILED_PREFIX,
   PROVIDER_RESOURCE_NOT_FOUND_PREFIX
 } from '../../shared/run-error-classification'
@@ -28,9 +29,9 @@ type UpstreamDetail = { text: string; type?: string }
 // bare "not found" substring, so a benign message like "rate limit config not found" isn't reworded.
 const NOT_FOUND_PATTERN =
   /resource[\s_-]?not[\s_-]?found|no such (?:model|resource)|not[\s_-]?found\s*:/i
-// Claude Code wraps upstream provider HTTP 4xx as `Internal error: API Error: 4xx …`. Unreachable-API
-// connection failures use the shared `API Error: Unable to connect to API` matcher. 5xx stays excluded:
-// an untagged internal 5xx may still be an adapter defect.
+// Claude Code wraps upstream provider HTTP 4xx as `Internal error: API Error: 4xx …`. Its two fixed
+// connection wrappers use shared exact matchers. 5xx stays excluded: an untagged internal 5xx may
+// still be an adapter defect.
 const CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN = /^\s*internal error:\s*api error:\s*4\d{2}\b/i
 
 // Converts an unknown thrown value into its base message string.
@@ -143,7 +144,7 @@ const isProviderNotFound = (
   return isApiError(error) || /resource_not_found/i.test(raw) || hasNotFoundType
 }
 
-// claude-agent-acp currently forwards some explicit provider 4xx and connect-time failures as a
+// claude-agent-acp currently forwards some explicit provider 4xx and transport failures as a
 // generic ACP internal RequestError with `data.errorKind: 'unknown'`. The fixed wrapper and JSON-RPC
 // code are the remaining machine-stable boundary; require both so ordinary app errors containing a
 // status number or the word "connect" stay reportable. Do not infer 5xx ownership here:
@@ -154,7 +155,8 @@ const isClaudeProviderApiError = (error: unknown): boolean =>
   error.name === 'RequestError' &&
   errorCode(error) === -32603 &&
   (CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN.test(error.message) ||
-    isClaudeApiConnectionFailure(error.message))
+    isClaudeApiConnectionFailure(error.message) ||
+    isClaudeApiResponseInterruption(error.message))
 
 const connectionFailureDetail = (message: string): string | undefined =>
   message.match(/\(([A-Za-z][A-Za-z0-9_-]{0,63})\)\s*$/)?.[1]
@@ -208,7 +210,7 @@ const isProviderErrorKind = (error: unknown): boolean => {
 //   - the agent tagged the failure as an upstream `APIError` (covers auth/rate/quota/5xx/etc.), or
 //   - the agent tagged `data.errorKind: 'provider-error'` (the bridges' machine-readable marker), or
 //   - Claude Code emitted its fixed ACP internal wrapper with an explicit provider 4xx status or
-//     an unreachable-API connection failure, or
+//     a recognized transport failure, or
 //   - it is a provider "resource not found" (wrong model id / endpoint), which requires the same
 //     upstream signal (see isProviderNotFound) and is never a bare ACP protocol not-found.
 export const isProviderPromptError = (error: unknown): boolean => {

--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -424,6 +424,21 @@ describe('AcpPromptOutcomeFinalizer', () => {
       providerError: true
     },
     {
+      name: 'Claude Code API connection closed mid-response',
+      error: Object.assign(
+        new Error(
+          'Internal error: API Error: Connection closed mid-response. The response above may be incomplete.'
+        ),
+        {
+          code: -32603,
+          data: { errorKind: 'server_error' },
+          name: 'RequestError'
+        }
+      ),
+      recoverable: undefined,
+      providerError: true
+    },
+    {
       name: 'ACP error',
       error: new Error('protocol failed'),
       recoverable: undefined,

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -1083,6 +1083,54 @@ describe('workspace runtime events', () => {
     expect(session.errorReportable).toBe(false)
   })
 
+  it('projects a Claude Code mid-response connection closure as a resumable interrupted turn', async () => {
+    const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'event-partial-response',
+        role: 'assistant',
+        messageId: 'assistant-message-1',
+        promptMessageId,
+        text: 'The first result is complete. Next I will'
+      })
+    )
+
+    const errorText =
+      'Internal error: API Error: Connection closed mid-response. The response above may be incomplete.'
+    const applied = await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'event-mid-response-closed',
+        kind: 'error',
+        level: 'error',
+        providerError: true,
+        promptMessageId,
+        title: 'Prompt failed',
+        text: errorText,
+        turnUsage: { inputTokens: 21, cacheTokens: 8, outputTokens: 13, turnCount: 1 }
+      })
+    )
+
+    expect(applied).toBe(true)
+    const session = useSessionStore.getState().sessions[0]
+    expect(session).toMatchObject({
+      status: 'error',
+      interrupted: true,
+      error: errorText,
+      resumeRecovery: {
+        kind: 'resume-required',
+        cause: 'connection-lost',
+        promptMessageId
+      }
+    })
+    expect(session.errorReportable).toBeUndefined()
+    expect(session.messages[0]).toMatchObject({ id: promptMessageId, interrupted: true })
+    expect(session.messages[1]).toMatchObject({
+      content: 'The first result is complete. Next I will',
+      status: 'error',
+      turnUsage: { inputTokens: 21, cacheTokens: 8, outputTokens: 13, turnCount: 1 }
+    })
+  })
+
   it('surfaces a session-scoped agent warning as the waiting-indicator status, cleared on stop', async () => {
     const applied = await applyWorkspaceRuntimeEvent(
       createEvent({ id: 'event-1', kind: 'system', level: 'warning', text: 'retrying request…' })

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -26,6 +26,7 @@ import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 import { useNavigationStore } from '../../stores/navigation-store'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
+import { isClaudeApiResponseInterruption } from '../../../../shared/run-error-classification'
 import {
   getActivityGroupTitleFromToolEvent,
   isActivityGroupToolEvent
@@ -884,18 +885,36 @@ const applyWorkspaceRuntimeEvent = async (
       return true
     }
 
-    // A model-provider failure (upstream LLM/HTTP error the agent relayed, tagged structurally in the
-    // runtime) keeps its message but is not a bug worth a GitHub issue — hide the report button. For
-    // everything else, defer to failRun's text tier (undefined) rather than forcing reportable=true: a
-    // non-recovered overflow reaches here (repeat inside cooldown, nothing to replay, detached session)
-    // with providerError=false but IS a client-side/size failure the text tier recognizes as expected —
-    // forcing true here would wrongly show and persist the report button over it. Opaque ACP-layer
-    // failures still fall through the text tier to reportable.
-    store.failRun(event.sessionId, getEventErrorText(event), {
-      reportable: event.providerError ? false : undefined,
-      promptMessageId: event.promptMessageId ?? activeSession?.activeRun?.promptMessageId,
-      contextWindowSample: getTerminalContextWindowSample(event)
-    })
+    const errorText = getEventErrorText(event)
+
+    // Claude Code can close its provider stream after partial output. That is not a completed turn or
+    // an app defect: settle the partial projection and reuse the durable, user-triggered Resume path.
+    // Require both the structural provider tag and the fixed wrapper so unrelated provider failures
+    // keep their existing terminal-error behavior.
+    if (event.providerError && isClaudeApiResponseInterruption(errorText)) {
+      store.interruptRun(
+        event.sessionId,
+        'connection-lost',
+        errorText,
+        event.promptMessageId ?? activeSession?.activeRun?.promptMessageId,
+        getTerminalContextWindowSample(event),
+        event.turnUsage,
+        event.modelCallUsage
+      )
+    } else {
+      // A model-provider failure (upstream LLM/HTTP error the agent relayed, tagged structurally in the
+      // runtime) keeps its message but is not a bug worth a GitHub issue — hide the report button. For
+      // everything else, defer to failRun's text tier (undefined) rather than forcing reportable=true: a
+      // non-recovered overflow reaches here (repeat inside cooldown, nothing to replay, detached session)
+      // with providerError=false but IS a client-side/size failure the text tier recognizes as expected —
+      // forcing true here would wrongly show and persist the report button over it. Opaque ACP-layer
+      // failures still fall through the text tier to reportable.
+      store.failRun(event.sessionId, errorText, {
+        reportable: event.providerError ? false : undefined,
+        promptMessageId: event.promptMessageId ?? activeSession?.activeRun?.promptMessageId,
+        contextWindowSample: getTerminalContextWindowSample(event)
+      })
+    }
     const failedSession = useSessionStore
       .getState()
       .sessions.find((session) => session.id === event.sessionId)

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -91,6 +91,16 @@ describe('isReportableRunFailure (text tier)', () => {
     expect(isReportableRunFailure('Run failed: connection reset')).toBe(true)
   })
 
+  it('recognizes the Claude Code mid-response connection interruption without broad text guessing', () => {
+    const live =
+      'Internal error: API Error: Connection closed mid-response. The response above may be incomplete.'
+    const wrapped = `Error invoking remote method 'acp:send-prompt': Error: ${live}`
+
+    expect(isReportableRunFailure(live)).toBe(false)
+    expect(isReportableRunFailure(wrapped)).toBe(false)
+    expect(isReportableRunFailure('Connection closed mid-response')).toBe(true)
+  })
+
   it('recognizes the actionable provider connection reminder without the structural flag', () => {
     expect(
       isReportableRunFailure(

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -10,10 +10,11 @@ import { isUnsupportedCodexAcpVersionError } from './codex-runtime'
 // This module owns only the SECONDARY, text-based tier: recognizing the app's OWN crafted reminder
 // strings (which we author, so an exact-match set is reliable) so their report button is hidden even
 // on the paths that don't carry the structural flag (a persisted pre-flag session, or a renderer-side
-// failRun call). One additional fixed Claude Code wrapper is recognized here (`API Error: Unable to
-// connect to API`) so historical sessions and createSession failRun hide Report without rewriting
-// stored records. Arbitrary provider text is still not guessed. It is a pure, dependency-light leaf
-// module (like media-overflow.ts) usable from both processes.
+// failRun call). Two fixed Claude Code transport wrappers are recognized here (`API Error: Unable to
+// connect to API` and `API Error: Connection closed mid-response`) so historical sessions and
+// createSession failRun hide Report without rewriting stored records. Arbitrary provider text is still
+// not guessed. It is a pure, dependency-light leaf module (like media-overflow.ts) usable from both
+// processes.
 
 // App-crafted resume-failure messages (useWorkspaceAgentRuntime.getResumeFailureMessage). Each is the
 // actionable text the app writes when it recognizes a specific resume cause. The generic
@@ -106,11 +107,22 @@ export const PROVIDER_CONNECTION_FAILED_PREFIX = 'Could not connect to the model
 // pre-flag sessions hide Report without a stored-schema migration. Match the distinctive
 // `API Error: Unable to connect to API` phrase only — not a generic "connection" or "connect" word.
 const CLAUDE_API_CONNECTION_FAILURE_PATTERN = /(?:^|:\s*)api error:\s*unable to connect to api\b/i
+const CLAUDE_API_RESPONSE_INTERRUPTION_PATTERN =
+  /(?:^|:\s*)api error:\s*connection closed mid-response\b/i
 
 export const isClaudeApiConnectionFailure = (error: string | null | undefined): boolean => {
   const message = error?.trim()
   if (!message) return false
   return CLAUDE_API_CONNECTION_FAILURE_PATTERN.test(message)
+}
+
+// Claude Code's fixed wrapper for a response stream that ended after partial output. Keep this
+// separate from connect-time failures: the latter gets base-URL/proxy guidance, while this one is
+// projected as an interrupted turn that can use the existing Resume flow.
+export const isClaudeApiResponseInterruption = (error: string | null | undefined): boolean => {
+  const message = error?.trim()
+  if (!message) return false
+  return CLAUDE_API_RESPONSE_INTERRUPTION_PATTERN.test(message)
 }
 
 // The exact app-crafted messages an equality check recognizes as expected.
@@ -152,8 +164,8 @@ export const isExpectedRunFailure = (error: string | null | undefined): boolean 
   // share this leading phrase, so one prefix covers the createSession path (which is not reworded) and
   // any framework name. It is app-authored setup guidance ("Open Settings → Model"), not a bug.
   if (message.startsWith(ACTIVE_MODEL_INCOMPATIBLE_PREFIX)) return true
-  // Claude Code's fixed unreachable-API wrapper (createSession / persisted pre-flag sessions).
-  if (isClaudeApiConnectionFailure(message)) return true
+  // Claude Code's fixed transport wrappers (createSession / persisted pre-flag sessions).
+  if (isClaudeApiConnectionFailure(message) || isClaudeApiResponseInterruption(message)) return true
   // A request-size overflow the app auto-recovers from — never a reportable bug.
   return isMediaOverflowError(message)
 }


### PR DESCRIPTION
## Problem

Claude Code can terminate an upstream response stream with:

`Internal error: API Error: Connection closed mid-response. The response above may be incomplete.`

The locked `claude-agent-acp` adapter exposes this as a `RequestError` (`code: -32603`, `errorKind: server_error`). Open Science did not classify that fixed wrapper as provider-owned, so a partially streamed turn became an ordinary reportable failure. Users saw no supported way to continue the interrupted request.

External reports show this is an upstream Claude Code transport failure rather than an Open Science ACP defect: [canonical issue](https://github.com/anthropics/claude-code/issues/69336), [duplicate with the exact message](https://github.com/anthropics/claude-code/issues/80825), and [frequency report](https://github.com/anthropics/claude-code/issues/83183).

## Proposed change

- Recognize only Claude Code's fixed `API Error: Connection closed mid-response` wrapper.
- Tag the ACP failure as provider-owned.
- Project a live matching error as the existing `connection-lost` interrupted-turn state, which exposes the existing user-triggered Resume flow and preserves partial output, prompt identity, usage, and context-window evidence.
- Treat the same exact text as non-reportable for historical sessions without rewriting persisted records.

## Scope and non-goals

- No schema, field, architecture, or new state-enum change. This reuses persisted `resumeRecovery.kind = resume-required` and `cause = connection-lost`.
- No persistence migration. Newly observed matching failures persist through the existing interrupted-turn format; historical records only receive the exact text-classification fallback and do not gain a retroactive Resume marker.
- No automatic retry. Resume remains user initiated because already-completed tool side effects are not generally idempotent.
- No broad connection-error heuristic. Nearby generic text remains reportable.
- The new trigger is Claude Code-specific. OpenCode, Codex Responses, and Codex Bridge behavior is unchanged; the existing continuation implementation and parameterized continuation tests remain shared across frameworks.

## Acceptance criteria and validation

The regression tests were first run against the unfixed code and failed in three ways matching the report: `providerError` was false, the text was reportable, and the renderer produced no `connection-lost` Resume recovery marker.

Final evidence below was run after the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Claude ACP wrapper is provider-owned | `vitest run src/main/acp/prompt-error.test.ts src/main/acp/prompt-outcome-finalizer.test.ts` | passed |
| Exact historical text fallback hides Report without broad matching | `vitest run src/shared/run-error-classification.test.ts` | passed |
| Partial response becomes a resumable interrupted turn | `vitest run src/renderer/src/lib/acp/workspace-events.test.ts` | passed |
| Existing continuation contract remains valid across supported frameworks | `vitest run src/main/acp/interrupted-turn-continuation.test.ts` | passed |
| Combined affected test set | the five targeted files above | 157/157 passed |
| Main/shared types | `tsc --noEmit -p tsconfig.node.json --composite false` | passed |
| Renderer/shared types | `tsc --noEmit -p tsconfig.web.json --composite false` | passed |
| Changed source/test lint and whitespace | `eslint --no-cache <changed files>`; `git diff --check` | passed |

The full `npm test` suite was intentionally not run; exact-head PR Gate/CI is authoritative for the complete portable and platform lanes.

Uncovered risk: a real provider stream drop is nondeterministic and was not induced against the live service. The regression fixture uses the exact externally reported message and the locked adapter's observed wire shape. Resume asks the agent not to repeat completed work, but cannot guarantee idempotency for external side effects already performed before disconnection.

## Review focus

- Whether the matcher is sufficiently narrow for Claude Code's stable wrapper.
- Whether `interruptRun(..., 'connection-lost')` is the right projection for partial provider output.
- Whether preserving forward-only Resume compatibility for historical records is preferable to a persistence migration.
