### PR TITLE
fix(web-service): bound WebSocket broadcast buffering

### DIFF
--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -763,7 +763,7 @@ describe('startWebHttpServer', () => {
         level: 'info',
         sessionId: 'session-1',
         kind: 'message',
-        text: 'x'.repeat(16 * 1024 * 1024)
+        text: 'x'.repeat(17 * 1024 * 1024)
       }
     ])
 
@@ -850,10 +850,28 @@ describe('startWebHttpServer', () => {
     applicationEvents.publish('settings:connector-runtime-changed', undefined)
 
     const replayed: unknown[] = []
+    const bufferedAmount = vi
+      .spyOn(WebSocket.prototype, 'bufferedAmount', 'get')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValue(16 * 1024 * 1024)
     const secondSocket = new WebSocket(eventSocketUrl(0))
-    secondSocket.on('message', (data) => replayed.push(JSON.parse(data.toString())))
+    const replayCompleted = new Promise<'ready' | 'closed'>((resolve) => {
+      secondSocket.on('message', (data) => {
+        const message = JSON.parse(data.toString()) as { kind?: string }
+        replayed.push(message)
+        if (message.kind === 'ready') resolve('ready')
+      })
+      secondSocket.once('close', () => resolve('closed'))
+    })
     await new Promise<void>((resolve) => secondSocket.once('open', resolve))
-    await vi.waitFor(() => expect(replayed).toHaveLength(3))
+    const replayOutcome = await Promise.race([
+      replayCompleted,
+      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 500))
+    ])
+    bufferedAmount.mockRestore()
+
+    expect(replayOutcome).toBe('ready')
     expect(replayed).toEqual([
       expect.objectContaining({
         kind: 'event',

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -703,6 +703,53 @@ describe('startWebHttpServer', () => {
     publicSocket.close()
   })
 
+  it('disconnects an event socket whose outgoing messages are already backlogged', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: {
+        channels: () => [],
+        invoke: vi.fn(),
+        releaseClient: vi.fn(),
+        dispose: vi.fn()
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const socket = new WebSocket(`ws://127.0.0.1:${server.port}/api/v1/events?token=test-token`)
+    await new Promise<void>((resolve) => socket.once('open', resolve))
+    const closed = new Promise<'closed'>((resolve) => socket.once('close', () => resolve('closed')))
+    const bufferedAmount = vi
+      .spyOn(WebSocket.prototype, 'bufferedAmount', 'get')
+      .mockReturnValue(Number.MAX_SAFE_INTEGER)
+
+    applicationEvents.publish('acp:event', [
+      {
+        id: 'event-1',
+        timestamp: 1,
+        level: 'info',
+        sessionId: 'session-1',
+        kind: 'message',
+        text: 'Backlogged event'
+      }
+    ])
+    const outcome = await Promise.race([
+      closed,
+      new Promise<'still-open'>((resolve) => setTimeout(() => resolve('still-open'), 250))
+    ])
+    bufferedAmount.mockRestore()
+
+    expect(outcome).toBe('closed')
+  })
+
   it('replays internal renderer events published while the Web client is disconnected', async () => {
     const server = await startTestWebHttpServer({
       host: '127.0.0.1',

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -703,7 +703,7 @@ describe('startWebHttpServer', () => {
     publicSocket.close()
   })
 
-  it('disconnects an event socket whose outgoing messages are already backlogged', async () => {
+  it('disconnects event sockets before their outgoing backlog exceeds the byte limit', async () => {
     const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
@@ -748,6 +748,31 @@ describe('startWebHttpServer', () => {
     bufferedAmount.mockRestore()
 
     expect(outcome).toBe('closed')
+
+    const oversizedSocket = new WebSocket(
+      `ws://127.0.0.1:${server.port}/api/v1/events?token=test-token`
+    )
+    await new Promise<void>((resolve) => oversizedSocket.once('open', resolve))
+    const oversizedClosed = new Promise<'closed'>((resolve) =>
+      oversizedSocket.once('close', () => resolve('closed'))
+    )
+    applicationEvents.publish('acp:event', [
+      {
+        id: 'event-2',
+        timestamp: 2,
+        level: 'info',
+        sessionId: 'session-1',
+        kind: 'message',
+        text: 'x'.repeat(16 * 1024 * 1024)
+      }
+    ])
+
+    await expect(
+      Promise.race([
+        oversizedClosed,
+        new Promise<'still-open'>((resolve) => setTimeout(() => resolve('still-open'), 250))
+      ])
+    ).resolves.toBe('closed')
   })
 
   it('replays internal renderer events published while the Web client is disconnected', async () => {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -54,6 +54,8 @@ const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 const MIN_GZIP_BYTES = 1_024
 const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 const DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS = 10_000
+// Match the renderer replay window so a reconnect can catch up while live-only queues stay bounded.
+const MAX_WEBSOCKET_BUFFERED_BYTES = 16 * 1024 * 1024
 const TASK_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1_000
 const MAX_TASK_IDEMPOTENCY_ENTRIES = 1_024
 const MAX_TASK_IDEMPOTENCY_BYTES = 64 * 1024 * 1024
@@ -150,6 +152,24 @@ const publicApplicationCommandError = (
   error instanceof ApplicationCommandError
     ? toApplicationCommandErrorEnvelope(error)
     : { code: 'command-failed', message: INTERNAL_SERVER_ERROR_MESSAGE }
+
+const sendWebSocketMessage = (socket: WebSocket, message: string): boolean => {
+  if (socket.readyState !== WebSocket.OPEN) return false
+  if (socket.bufferedAmount >= MAX_WEBSOCKET_BUFFERED_BYTES) {
+    socket.terminate()
+    return false
+  }
+
+  try {
+    socket.send(message, (error) => {
+      if (error) socket.terminate()
+    })
+    return true
+  } catch {
+    socket.terminate()
+    return false
+  }
+}
 
 export type ExternalWebAccessAuthorization = {
   kind: 'authorized' | 'authorized-pairing-manager'
@@ -1017,11 +1037,11 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         const afterValue = url.searchParams.get('after')
         const after = afterValue === null ? Number.NaN : Number(afterValue)
         for (const message of internalEventStream.resume({ streamId, after })) {
-          socket.send(message)
+          if (!sendWebSocketMessage(socket, message)) break
         }
       }
     }
-    sockets.add(socket)
+    if (socket.readyState === WebSocket.OPEN) sockets.add(socket)
   })
 
   const removeBroadcastSink = options.applicationEvents.subscribe((event) => {
@@ -1036,20 +1056,21 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       ? internalEventStream.publish(internalProjection)
       : undefined
     for (const socket of sockets) {
-      if (socket.readyState !== WebSocket.OPEN) continue
       if (publicEventSockets.has(socket)) {
-        for (const publicMessage of publicMessages) socket.send(publicMessage)
+        for (const publicMessage of publicMessages) {
+          if (!sendWebSocketMessage(socket, publicMessage)) break
+        }
       } else if (internalEventSockets.get(socket) === 'replay') {
-        if (replayInternalMessage) socket.send(replayInternalMessage)
+        if (replayInternalMessage) sendWebSocketMessage(socket, replayInternalMessage)
       } else if (legacyInternalMessage) {
-        socket.send(legacyInternalMessage)
+        sendWebSocketMessage(socket, legacyInternalMessage)
       }
     }
   })
   const removeTaskProgressSink = options.tasks?.subscribeProgress((event) => {
     const message = JSON.stringify(projectPublicTaskProgressEvent(event))
     for (const socket of publicEventSockets) {
-      if (socket.readyState === WebSocket.OPEN) socket.send(message)
+      sendWebSocketMessage(socket, message)
     }
   })
 
@@ -1089,8 +1110,8 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       }
       awaitingPong.add(socket)
       socket.ping()
-      if (publicEventSockets.has(socket)) socket.send(publicHeartbeat)
-      else if (internalEventSockets.has(socket)) socket.send(internalHeartbeat)
+      if (publicEventSockets.has(socket)) sendWebSocketMessage(socket, publicHeartbeat)
+      else if (internalEventSockets.has(socket)) sendWebSocketMessage(socket, internalHeartbeat)
     }
   }, options.eventHeartbeatIntervalMs ?? DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS)
 

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -155,7 +155,7 @@ const publicApplicationCommandError = (
 
 const sendWebSocketMessage = (socket: WebSocket, message: string): boolean => {
   if (socket.readyState !== WebSocket.OPEN) return false
-  if (socket.bufferedAmount >= MAX_WEBSOCKET_BUFFERED_BYTES) {
+  if (socket.bufferedAmount + Buffer.byteLength(message) > MAX_WEBSOCKET_BUFFERED_BYTES) {
     socket.terminate()
     return false
   }

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -54,8 +54,8 @@ const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 const MIN_GZIP_BYTES = 1_024
 const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 const DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS = 10_000
-// Match the renderer replay window so a reconnect can catch up while live-only queues stay bounded.
-const MAX_WEBSOCKET_BUFFERED_BYTES = 16 * 1024 * 1024
+// The replay stream retains 16 MiB. Keep 64 KiB for its mandatory ready frame and framing overhead.
+const MAX_WEBSOCKET_BUFFERED_BYTES = 16 * 1024 * 1024 + 64 * 1024
 const TASK_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1_000
 const MAX_TASK_IDEMPOTENCY_ENTRIES = 1_024
 const MAX_TASK_IDEMPOTENCY_BYTES = 64 * 1024 * 1024


### PR DESCRIPTION
## Problem

Every WebSocket broadcast path called `socket.send()` directly. A client can keep answering Ping while its application-message queue grows, so a slow local browser, remote browser, or proxy-limited connection can retain an unbounded amount of outbound data in the Electron main process.

The regression test drives the real HTTP/WebSocket event boundary and exposes a saturated `bufferedAmount`. Before the fix, the connection remained open in four consecutive runs (`expected closed`, received `still-open`). Follow-up red tests also reproduced a single oversized-frame bypass and replay completion being rejected at the retained-window boundary.

## Proposed change

- Route replay frames, application-event broadcasts, task progress, and heartbeat messages through one guarded sender.
- Terminate before a send when existing pending bytes plus the serialized frame would exceed 16 MiB of replay data plus 64 KiB of bounded control/framing headroom.
- Supply a send callback and terminate the connection when an asynchronous or synchronous send fails.
- Reserve enough bounded headroom for the mandatory replay `ready` frame and up to 2,048 WebSocket frame headers.
- Cover accumulated backlog, a single oversized frame, and replay completion at the existing public WebSocket behavior boundary.

## Scope and non-goals

- No event coalescing or dropping policy is introduced; those would change event semantics.
- No protocol payload, API field, architecture boundary, or data model changes.
- The modern Web UI keeps its existing cursor-based reconnect and replay behavior. The public SDK keeps its existing contract: a closed event iterator is resubscribed by its caller.
- The only interaction change is that a consumer which would exceed the bounded per-connection byte budget is disconnected instead of continuing to consume main-process memory.

## Compatibility, state, and persistence

- **Historical compatibility:** no stored format or historical data compatibility impact. Existing Web clients remain wire-compatible.
- **New state or enum values:** none.
- **Persistence:** none; no database, migration, file format, or durable state changes.

## Acceptance criteria and validation

All listed passing local checks ran after the last material edit.

- Slow-consumer eviction, oversized-frame rejection, replay completion, and existing Web server behavior -> `vitest run src/main/web-service/http-server.test.ts` -> 27/27 passed.
- Web UI disconnect recovery, cursor replay, and subscription retention -> targeted `src/renderer/web/bootstrap.test.ts` reconnect/replay cases -> 3/3 passed.
- Changed source/test lint -> ESLint on both changed files -> passed.
- Changed source/test formatting -> Prettier check on both changed files -> passed.
- Repository lint -> 0 errors; existing warnings remain in untouched files.
- Node typecheck was attempted locally but the shared dependency tree does not match this worktree lockfile: the only reported error is an unrelated missing `waitForMcpServers` export in `src/main/acp/claude-agent-acp-patch.test.ts`. PR CI's clean dependency environment is authoritative for this check.

Consumer and platform lanes are otherwise excluded locally because this is a private transport policy change: no exported interface, wire schema, platform API, or event projection changed. PR Gate remains authoritative for exact-head classification and full portable/platform coverage.

## Review focus

- Whether 64 KiB is sufficient bounded headroom above the 16 MiB retained replay window for the mandatory `ready` frame and framing overhead.
- Whether immediate termination is preferred to a graceful close whose close frame would sit behind the already-backlogged data.
