### PR TITLE
fix(tasks): release raw runtime events after aggregation

### DIFF
--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -2293,6 +2293,111 @@ describe('TaskRunner', () => {
     ])
   })
 
+  it('freezes completion projections before asynchronous artifact finalization', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let signalFinalizeStarted: (() => void) | undefined
+    let finishFinalize: (() => void) | undefined
+    const finalizeStarted = new Promise<void>((resolve) => {
+      signalFinalizeStarted = resolve
+    })
+    const finalizeGate = new Promise<void>((resolve) => {
+      finishFinalize = resolve
+    })
+    const savedSessions: PersistedChatSession[] = []
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-artifact-gate' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'assistant-before-finalize',
+            timestamp: 10,
+            kind: 'message',
+            level: 'info',
+            sessionId: 'session-artifact-gate',
+            role: 'assistant',
+            text: 'Before finalize.'
+          })
+          emitEvent?.({
+            id: 'tool-before-finalize',
+            timestamp: 11,
+            kind: 'tool',
+            level: 'info',
+            sessionId: 'session-artifact-gate',
+            toolCallId: 'tool-finalize',
+            status: 'in_progress'
+          })
+          emitEvent?.({
+            id: 'artifact-before-finalize',
+            timestamp: 12,
+            kind: 'artifact',
+            level: 'info',
+            sessionId: 'session-artifact-gate',
+            artifactClaimId: 'claim-finalize'
+          })
+        }
+      },
+      artifacts: {
+        finalizeRun: async () => {
+          signalFinalizeStarted?.()
+          await finalizeGate
+          return { ok: true, artifacts: [] }
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      }
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Create a report.' })
+    await finalizeStarted
+    emitEvent?.({
+      id: 'assistant-during-finalize',
+      timestamp: 13,
+      kind: 'message',
+      level: 'info',
+      sessionId: 'session-artifact-gate',
+      role: 'assistant',
+      text: 'During finalize.'
+    })
+    emitEvent?.({
+      id: 'tool-during-finalize',
+      timestamp: 14,
+      kind: 'tool',
+      level: 'info',
+      sessionId: 'session-artifact-gate',
+      toolCallId: 'tool-finalize',
+      status: 'completed'
+    })
+    finishFinalize?.()
+    await runner.waitForRun(started.id)
+
+    expect(savedSessions.at(-1)?.messages.at(-1)).toMatchObject({
+      content: 'Before finalize.',
+      eventIds: ['assistant-before-finalize']
+    })
+    expect(savedSessions.at(-1)?.activities).toEqual([
+      expect.objectContaining({
+        id: 'tool-finalize',
+        status: 'in_progress',
+        eventIds: ['tool-before-finalize']
+      })
+    ])
+  })
+
   it('settles a run as failed when final session persistence fails', async () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     let saveCount = 0

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, sep } from 'node:path'
+import { queryObjects } from 'node:v8'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -47,6 +48,8 @@ const session: PersistedChatSession = {
   createdAt: 1,
   updatedAt: 2
 }
+
+class RetainedRunEventPayload {}
 
 type TaskRunnerOverrides = Omit<Partial<TaskRunnerDependencies>, 'sessions'> & {
   sessions?: Omit<Partial<TaskSessionPort>, 'save'> & {
@@ -101,6 +104,52 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
   })
 }
 describe('TaskRunner', () => {
+  it('does not retain raw runtime event payloads during or after a Run', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let finishPrompt: (() => void) | undefined
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const runner = createRunner({
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-created' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'thought-event',
+            timestamp: 10,
+            kind: 'thought',
+            level: 'info',
+            sessionId: 'session-created',
+            text: 'Working',
+            raw: new RetainedRunEventPayload()
+          })
+          await promptGate
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      }
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Review these papers.' })
+    try {
+      expect(queryObjects(RetainedRunEventPayload)).toBe(0)
+    } finally {
+      finishPrompt?.()
+      await runner.waitForRun(started.id)
+    }
+
+    expect(queryObjects(RetainedRunEventPayload)).toBe(0)
+  })
+
   it('returns the Session authority Compute preference from start, get, and wait', async () => {
     const saved: PersistedChatSession[] = []
     const runner = createRunner({

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -321,6 +321,7 @@ const createTaskRunActivities = (
 ): PersistedToolActivity[] =>
   [...accumulator.activities.values()].map((activity, index) => ({
     ...activity,
+    eventIds: [...activity.eventIds],
     sortIndex: now + index
   }))
 
@@ -1259,7 +1260,7 @@ class TaskRunner {
       session.agentFrameworkId === 'claude-code'
         ? normalizeClaudeCodeRefusalText(accumulator.assistantOutput)
         : accumulator.assistantOutput
-    const images = accumulator.images
+    const images = accumulator.images.map((image) => ({ ...image }))
     const terminalStopEvent = accumulator.terminalStop
     const assistantMessageId = this.dependencies.createId()
     const assistantMessage: PersistedChatMessage = {
@@ -1268,7 +1269,7 @@ class TaskRunner {
       content: output,
       status: 'complete',
       responseToMessageId: session.activeRun?.promptMessageId,
-      eventIds: accumulator.assistantEventIds,
+      eventIds: [...accumulator.assistantEventIds],
       images: images.length ? images : undefined,
       ...(terminalStopEvent?.turnUsage
         ? {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -7,6 +7,8 @@ import { ComputeHostPreferenceValidationError } from '../../shared/compute'
 import {
   getAcpRuntimeEventImage,
   getAcpRuntimeEventText,
+  MAX_ACP_MESSAGE_IMAGE_BYTES_PER_MESSAGE,
+  MAX_ACP_MESSAGE_IMAGES_PER_MESSAGE,
   normalizeClaudeCodeRefusalText
 } from '../../shared/acp'
 import type {
@@ -178,8 +180,21 @@ type TaskRunnerDependencies = {
   now: () => number
 }
 
+type PendingTaskRunActivity = Omit<PersistedToolActivity, 'sortIndex'>
+
+type TaskRunEventAccumulator = {
+  assistantOutput: string
+  assistantEventIds: string[]
+  images: PersistedMessageImage[]
+  imageBytes: number
+  terminalStop?: Pick<AcpRuntimeEvent, 'turnUsage' | 'modelCallUsage'>
+  runtimeError?: Pick<AcpRuntimeEvent, 'text' | 'providerError'>
+  activities: Map<string, PendingTaskRunActivity>
+  artifactClaimIds: string[]
+}
+
 type MutableTaskRun = TaskRun & {
-  events: AcpRuntimeEvent[]
+  eventAccumulator?: TaskRunEventAccumulator
   completion: Promise<void>
   promptMessageId: string
   progressPhase: TaskRunProgressPhase
@@ -224,6 +239,90 @@ const isVisibleProviderEvent = (event: AcpRuntimeEvent): boolean =>
   event.role !== 'user' &&
   VISIBLE_PROVIDER_EVENT_KINDS.has(event.kind) &&
   Boolean(event.text?.trim() || event.title?.trim() || getAcpRuntimeEventImage(event))
+
+const createTaskRunEventAccumulator = (): TaskRunEventAccumulator => ({
+  assistantOutput: '',
+  assistantEventIds: [],
+  images: [],
+  imageBytes: 0,
+  activities: new Map(),
+  artifactClaimIds: []
+})
+
+const accumulateToolActivity = (
+  accumulator: TaskRunEventAccumulator,
+  event: AcpRuntimeEvent
+): void => {
+  if (event.kind !== 'tool' || !event.toolCallId) return
+  const existing = accumulator.activities.get(event.toolCallId)
+  const isTerminal = existing?.status === 'completed' || existing?.status === 'failed'
+  const eventIds = existing?.eventIds ?? []
+  eventIds.push(event.id)
+  accumulator.activities.set(event.toolCallId, {
+    id: event.toolCallId,
+    kind: 'tool',
+    title: event.title?.trim() || existing?.title || 'Tool call',
+    status: isTerminal
+      ? existing.status
+      : event.status === 'failed'
+        ? 'failed'
+        : event.status === 'completed'
+          ? 'completed'
+          : 'in_progress',
+    eventIds,
+    providerToolName: event.providerToolName ?? existing?.providerToolName,
+    toolKind: event.toolKind ?? existing?.toolKind,
+    toolContent: event.toolContent ?? existing?.toolContent,
+    toolLocations: event.toolLocations ?? existing?.toolLocations,
+    rawInput: event.rawInput ?? existing?.rawInput,
+    rawOutput: event.rawOutput ?? existing?.rawOutput,
+    terminalOutput: event.terminalOutput ?? existing?.terminalOutput,
+    terminalExitCode: event.terminalExitCode ?? existing?.terminalExitCode,
+    createdAt: existing?.createdAt ?? event.timestamp,
+    updatedAt: isTerminal ? existing.updatedAt : event.timestamp
+  })
+}
+
+const accumulateTaskRunEvent = (
+  accumulator: TaskRunEventAccumulator,
+  event: AcpRuntimeEvent
+): void => {
+  if (event.kind === 'message' && event.role === 'assistant') {
+    accumulator.assistantOutput += getAcpRuntimeEventText(event) ?? ''
+    accumulator.assistantEventIds.push(event.id)
+    const image = getAcpRuntimeEventImage(event)
+    if (
+      image &&
+      accumulator.images.length < MAX_ACP_MESSAGE_IMAGES_PER_MESSAGE &&
+      accumulator.imageBytes + image.byteLength <= MAX_ACP_MESSAGE_IMAGE_BYTES_PER_MESSAGE
+    ) {
+      accumulator.images.push({ id: event.id, ...image })
+      accumulator.imageBytes += image.byteLength
+    }
+  }
+  if (event.kind === 'stop') {
+    accumulator.terminalStop = {
+      turnUsage: event.turnUsage,
+      modelCallUsage: event.modelCallUsage
+    }
+  }
+  if (event.kind === 'error' && event.text?.trim()) {
+    accumulator.runtimeError = { text: event.text, providerError: event.providerError }
+  }
+  if (event.kind === 'artifact' && event.artifactClaimId) {
+    accumulator.artifactClaimIds.push(event.artifactClaimId)
+  }
+  accumulateToolActivity(accumulator, event)
+}
+
+const createTaskRunActivities = (
+  accumulator: TaskRunEventAccumulator,
+  now: number
+): PersistedToolActivity[] =>
+  [...accumulator.activities.values()].map((activity, index) => ({
+    ...activity,
+    sortIndex: now + index
+  }))
 
 const cloneRun = (run: MutableTaskRun): TaskRun => ({
   id: run.id,
@@ -732,7 +831,7 @@ class TaskRunner {
       preferredComputeHostIds: [
         ...(session.selectedComputeHosts ?? session.enabledComputeHosts ?? [])
       ],
-      events: [],
+      eventAccumulator: createTaskRunEventAccumulator(),
       promptMessageId: session.activeRun!.promptMessageId,
       progressPhase: 'accepted' as const,
       providerAccepted: false,
@@ -1051,7 +1150,7 @@ class TaskRunner {
     let completed: CompletedTaskSession | undefined
     let completionError: unknown
     try {
-      completed = await this.completeSession(acceptedSession, run.events)
+      completed = await this.completeSession(acceptedSession, run.eventAccumulator!)
     } catch (error) {
       if (error instanceof PartialTaskCompletionError) {
         completed = error.completion
@@ -1067,6 +1166,7 @@ class TaskRunner {
     const failure = completionError ?? (promptFailureWasCancelled ? undefined : promptError)
     if (failure) {
       await this.failRun(run, acceptedSession, completed, failure)
+      run.eventAccumulator = undefined
       return
     }
 
@@ -1074,8 +1174,10 @@ class TaskRunner {
       await this.dependencies.sessions.save(completed!.session)
     } catch (error) {
       await this.failRun(run, acceptedSession, completed, error)
+      run.eventAccumulator = undefined
       return
     }
+    run.eventAccumulator = undefined
     if (!this.disposed && !run.cancellation && completed!.session.autoReviewEnabled === true) {
       const reviewedMessage = [...completed!.session.messages]
         .reverse()
@@ -1127,9 +1229,7 @@ class TaskRunner {
     completed: CompletedTaskSession | undefined,
     failure: unknown
   ): Promise<void> {
-    const runtimeError = [...run.events]
-      .reverse()
-      .find((event) => event.kind === 'error' && event.text?.trim())
+    const runtimeError = run.eventAccumulator?.runtimeError
     const message = runtimeError?.text?.trim() || toErrorMessage(failure)
     const failed: PersistedChatSession = {
       ...(completed?.session ?? session),
@@ -1152,26 +1252,15 @@ class TaskRunner {
 
   private async completeSession(
     session: PersistedChatSession,
-    events: AcpRuntimeEvent[]
+    accumulator: TaskRunEventAccumulator
   ): Promise<CompletedTaskSession> {
     const now = this.dependencies.now()
-    const assistantEvents = events.filter(
-      (event) => event.kind === 'message' && event.role === 'assistant'
-    )
-    const terminalStopEvent = [...events].reverse().find((event) => event.kind === 'stop')
-    const streamedOutput = assistantEvents
-      .map((event) => getAcpRuntimeEventText(event) ?? '')
-      .join('')
     const output =
       session.agentFrameworkId === 'claude-code'
-        ? normalizeClaudeCodeRefusalText(streamedOutput)
-        : streamedOutput
-    const images = assistantEvents
-      .map((event) => {
-        const image = getAcpRuntimeEventImage(event)
-        return image ? ({ id: event.id, ...image } satisfies PersistedMessageImage) : undefined
-      })
-      .filter((image): image is PersistedMessageImage => Boolean(image))
+        ? normalizeClaudeCodeRefusalText(accumulator.assistantOutput)
+        : accumulator.assistantOutput
+    const images = accumulator.images
+    const terminalStopEvent = accumulator.terminalStop
     const assistantMessageId = this.dependencies.createId()
     const assistantMessage: PersistedChatMessage = {
       id: assistantMessageId,
@@ -1179,7 +1268,7 @@ class TaskRunner {
       content: output,
       status: 'complete',
       responseToMessageId: session.activeRun?.promptMessageId,
-      eventIds: assistantEvents.map((event) => event.id),
+      eventIds: accumulator.assistantEventIds,
       images: images.length ? images : undefined,
       ...(terminalStopEvent?.turnUsage
         ? {
@@ -1194,7 +1283,7 @@ class TaskRunner {
       createdAt: now,
       updatedAt: now
     }
-    const activities = this.createActivities(events, now)
+    const activities = createTaskRunActivities(accumulator, now)
     const finalizedArtifacts: ArtifactFile[] = []
     const buildCompletion = (): CompletedTaskSession => {
       const uniqueArtifacts = [
@@ -1232,11 +1321,10 @@ class TaskRunner {
       }
     }
     let ownershipSessionPersisted = false
-    for (const event of events) {
-      if (event.kind !== 'artifact' || !event.artifactClaimId) continue
+    for (const artifactClaimId of accumulator.artifactClaimIds) {
       try {
         const request = {
-          claimId: event.artifactClaimId,
+          claimId: artifactClaimId,
           messageId: assistantMessageId
         }
         let result = await this.dependencies.artifacts.finalizeRun(request)
@@ -1264,40 +1352,6 @@ class TaskRunner {
     return buildCompletion()
   }
 
-  private createActivities(events: AcpRuntimeEvent[], now: number): PersistedToolActivity[] {
-    const activities = new Map<string, PersistedToolActivity>()
-    for (const event of events) {
-      if (event.kind !== 'tool' || !event.toolCallId) continue
-      const existing = activities.get(event.toolCallId)
-      const isTerminal = existing?.status === 'completed' || existing?.status === 'failed'
-      activities.set(event.toolCallId, {
-        id: event.toolCallId,
-        kind: 'tool',
-        title: event.title?.trim() || existing?.title || 'Tool call',
-        status: isTerminal
-          ? existing.status
-          : event.status === 'failed'
-            ? 'failed'
-            : event.status === 'completed'
-              ? 'completed'
-              : 'in_progress',
-        sortIndex: existing?.sortIndex ?? now + activities.size,
-        eventIds: [...(existing?.eventIds ?? []), event.id],
-        providerToolName: event.providerToolName ?? existing?.providerToolName,
-        toolKind: event.toolKind ?? existing?.toolKind,
-        toolContent: event.toolContent ?? existing?.toolContent,
-        toolLocations: event.toolLocations ?? existing?.toolLocations,
-        rawInput: event.rawInput ?? existing?.rawInput,
-        rawOutput: event.rawOutput ?? existing?.rawOutput,
-        terminalOutput: event.terminalOutput ?? existing?.terminalOutput,
-        terminalExitCode: event.terminalExitCode ?? existing?.terminalExitCode,
-        createdAt: existing?.createdAt ?? event.timestamp,
-        updatedAt: isTerminal ? existing.updatedAt : event.timestamp
-      })
-    }
-    return [...activities.values()]
-  }
-
   private captureEvent(event: AcpRuntimeEvent): void {
     if (!event.sessionId) return
     for (const run of this.runs.values()) {
@@ -1305,7 +1359,7 @@ class TaskRunner {
       if (event.promptMessageId !== undefined && event.promptMessageId !== run.promptMessageId) {
         continue
       }
-      run.events.push(event)
+      if (run.eventAccumulator) accumulateTaskRunEvent(run.eventAccumulator, event)
       if (event.kind === 'plan' && event.planProjection) {
         run.attention =
           event.planProjection.lifecycle === 'awaiting_approval'


### PR DESCRIPTION
## Problem

`TaskRunner` retained every matching `AcpRuntimeEvent` for the lifetime of an active Run and then for up to 200 retained terminal Runs. Completion also filtered, reversed, mapped, and joined the full array, increasing peak memory.

A public-boundary regression reproduced the report on the unchanged implementation through `startRun -> runtimeEvents -> waitForRun`: a unique raw event payload remained strongly reachable after completion (`expected 0, received 1`) in three consecutive runs. A mismatched-Session control released it, isolating the retention to the Run event array.

## Proposed change

- Project runtime events incrementally into the data needed for the final result: assistant output/event ids, bounded images, latest stop/error metadata, per-tool activity, and Artifact claim ids.
- Stop retaining complete provider event objects during the Run.
- Snapshot completion arrays before asynchronous Artifact finalization and release the transient accumulator after Session persistence.
- Preserve Claude Code refusal normalization and the shared event behavior used by Claude Code, OpenCode, Codex Responses, and Codex Bridge.

## Scope and non-goals

- No public Task API fields or IPC contracts change.
- No database schema, migration, persisted-format, enum/status, historical compatibility, or UI interaction change.
- This PR does not impose new truncation limits on final assistant output or the number of durable tool activities. Those require a separate product/persistence policy.

## Acceptance criteria and validation

Checks below ran after the last material implementation edit:

- Raw payload lifetime during and after a Run -> public TaskRunner lifecycle regression -> passed.
- Async completion snapshot consistency -> regression failed before the review fix by appending a late event id without its text, then passed after projection cloning.
- Assistant output, stop usage, tool activities, Artifact finalization, failure, cancellation, and async snapshot projections -> complete `src/main/tasks/task-runner.test.ts` -> 59/59 passed.
- Changed-file formatting -> Prettier check on both changed files -> passed.
- Source lint -> targeted ESLint -> passed.
- Repository lint -> `npm run lint` -> exited 0; existing warnings were limited to unrelated files.
- PR impact classification -> `main_runtime` selective plan generated successfully; CI lanes include policy, format, lint, Node/Web typecheck, interface contracts, i18n, unit, build, and macOS functional/workspace E2E.

Local `npm run typecheck:node` was attempted but the shared main-checkout dependency tree does not match this worktree lockfile: `@agentclientprotocol/claude-agent-acp` lacks the unrelated `waitForMcpServers` export referenced by `claude-agent-acp-patch.test.ts`. Project guidance prevents linking or installing a second dependency tree without an explicit dependency strategy, so PR CI is authoritative for typechecks.

## Review focus

- Equivalence between the former terminal array scan and the incremental projections.
- Completion snapshot immutability across Artifact finalization and Session persistence awaits.
- The point where the accumulator is released relative to failure handling, automatic review, and terminal status publication.