### PR TITLE
fix(codebuddy): disable runtime error reporting

### DIFF
--- a/src/main/agent-framework/codebuddy.test.ts
+++ b/src/main/agent-framework/codebuddy.test.ts
@@ -48,6 +48,8 @@ describe('codebuddy framework', () => {
       CODEBUDDY_DISABLE_FORK_SUBAGENT: '1',
       CODEBUDDY_CODE_DISABLE_BACKGROUND_TASKS: '1',
       DISABLE_AUTOUPDATER: '1',
+      DISABLE_TELEMETRY: '1',
+      DISABLE_ERROR_REPORTING: '1',
       NO_BROWSER: '1'
     })
     expect(config.args).toEqual([
@@ -152,6 +154,8 @@ describe('codebuddy framework', () => {
     )[2].env
     expect(spawnedEnv?.HTTPS_PROXY).toBe('http://inherited-proxy.example.test:3128')
     expect(spawnedEnv?.NO_PROXY).toBe('inherited-bypass.example.test')
+    expect(spawnedEnv?.DISABLE_TELEMETRY).toBe('1')
+    expect(spawnedEnv?.DISABLE_ERROR_REPORTING).toBe('1')
   })
 
   it('keeps native Bash absent on Windows too', () => {

--- a/src/main/agent-framework/codebuddy.ts
+++ b/src/main/agent-framework/codebuddy.ts
@@ -178,6 +178,7 @@ export const createCodeBuddyFramework = ({
         CODEBUDDY_SKIP_GIT_BASH_CHECK: '1',
         DISABLE_AUTOUPDATER: '1',
         DISABLE_TELEMETRY: '1',
+        DISABLE_ERROR_REPORTING: '1',
         NO_BROWSER: '1'
       },
       configFiles: [

--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -8,6 +8,8 @@ import OpenCode from '@lobehub/icons/es/OpenCode/components/Mono'
 import { cn } from '@/lib/utils'
 import anthropicLogo from '@/assets/provider-icons/anthropic.svg'
 import claudeLogo from '@/assets/provider-icons/claude.svg'
+// CodeBuddy is a third-party product mark used only to identify its compatible ACP runtime.
+// Keep it separate from Open Science branding and avoid implying affiliation or endorsement.
 import codebuddyLogo from '@/assets/provider-icons/codebuddy.svg'
 import grokLogo from '@/assets/provider-icons/grok.svg'
 import bailianLogo from '@/assets/provider-icons/bailian.svg'


### PR DESCRIPTION
## Problem

The CodeBuddy launcher disables telemetry but did not explicitly disable the runtime error-reporting channel. The source also lacked a clear boundary comment around the CodeBuddy provider icon.

## Proposed change

- Set DISABLE_ERROR_REPORTING=1 in the CodeBuddy launch environment.
- Lock both telemetry and error-reporting flags at the prepared configuration and final spawned-process environment boundaries.
- Document in English that the CodeBuddy logo identifies the compatible ACP runtime and remains separate from Open Science branding.

## Scope and non-goals

- CodeBuddy only; shared ACP behavior and other agent frameworks are unchanged.
- No persisted data, schema, migration, or new enum/state value.
- Already-running CodeBuddy processes need a reconnect or restart before receiving the new environment variable.

## Acceptance criteria and validation

All listed checks ran after the last material edit and after rebasing onto the current main branch.

| Behavior | Command or method | Result |
| --- | --- | --- |
| Prepared and final child environments contain both disable flags | npx vitest run src/main/agent-framework/codebuddy.test.ts | 11 tests passed |
| Main-process types remain valid | npm run typecheck:node | Passed |
| Renderer types remain valid | npm run typecheck:web | Passed |
| Changed files satisfy lint rules | npx eslint on the three changed files | Passed with no findings |
| Repository lint baseline | npm run lint | Passed with 0 errors; 256 pre-existing unrelated warnings |
| Patch formatting | git diff --check origin/main...HEAD | Passed |
| Fixed runtime outbound observation | Verified package-integrity CodeBuddy 2.138.0, empty allowlisted environment, isolated temporary config, local mock provider, and 20 ms process-tree TCP/UDP sampling from startup through a completed ACP session | Exit 0; session created; only 127.0.0.1 connections observed; no non-loopback connection observed |

The affected-test planner selects the full fallback because codebuddy.test.ts has no module owner entry. The full local suite was not run; PR CI is the full-suite verification boundary for this focused change.

Uncovered risk: the outbound check is a sampled process-level observation, not an operating-system firewall guarantee, and it does not include a flag-off fault-injection baseline.

## Review focus

- Confirm the flags survive the configuration-to-spawn boundary on every CodeBuddy launch path.
- Confirm the provider-icon comment communicates a compatibility-only identification boundary.

Related issue: none.