### PR TITLE
fix(web-service): bound concurrent HTTP request bodies

### DIFF
--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -86,7 +86,8 @@ const accessOnlyExternalAccess = (): ExternalWebAccessAuthorization => ({
 })
 const startBudgetTestServer = async (
   requestBodyBudgets: NonNullable<Parameters<typeof startWebHttpServer>[0]['requestBodyBudgets']>,
-  onExternalAuthorization?: () => void
+  onExternalAuthorization?: () => void,
+  invoke: TestWebServerOptions['rpc']['invoke'] = vi.fn().mockResolvedValue([])
 ): ReturnType<typeof startWebHttpServer> => {
   const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
   roots.push(staticRoot)
@@ -99,7 +100,7 @@ const startBudgetTestServer = async (
     requestBodyBudgets,
     rpc: {
       channels: () => ['projects:list'],
-      invoke: vi.fn().mockResolvedValue([]),
+      invoke,
       releaseClient: vi.fn(),
       dispose: vi.fn()
     },
@@ -142,6 +143,72 @@ afterEach(async () => {
 })
 
 describe('startWebHttpServer', () => {
+  it('retains a parsed body reservation when the client disconnects before its handler completes', async () => {
+    const body = JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+    const bodyBytes = Buffer.byteLength(body)
+    let markHandlerStarted: () => void = () => undefined
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve
+    })
+    let finishFirstHandler: (value: unknown) => void = () => undefined
+    const firstHandler = new Promise<unknown>((resolve) => {
+      finishFirstHandler = resolve
+    })
+    const invoke = vi
+      .fn<TestWebServerOptions['rpc']['invoke']>()
+      .mockImplementationOnce(async () => {
+        markHandlerStarted()
+        return firstHandler
+      })
+      .mockResolvedValue([])
+    const server = await startBudgetTestServer(
+      {
+        perRequestBytes: bodyBytes,
+        perClientInFlightBytes: bodyBytes,
+        serverInFlightBytes: bodyBytes
+      },
+      undefined,
+      invoke
+    )
+
+    const firstRequest = httpRequest({
+      host: '127.0.0.1',
+      port: server.port,
+      path: '/rpc/projects%3Alist',
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+        'content-length': String(bodyBytes),
+        'x-open-science-client': 'first-client'
+      }
+    })
+    firstRequest.on('error', () => undefined)
+    firstRequest.end(body)
+    await handlerStarted
+    const firstClosed = new Promise<void>((resolve) => firstRequest.once('close', resolve))
+    firstRequest.destroy()
+    await firstClosed
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-open-science-client': 'second-client'
+        },
+        body
+      })
+
+      expect(response.status).toBe(503)
+      expect(await response.json()).toMatchObject({ error: { code: 'handler_error' } })
+      expect(invoke).toHaveBeenCalledOnce()
+    } finally {
+      finishFirstHandler([])
+    }
+  })
+
   it.each([
     {
       dimension: 'server',

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1,5 +1,6 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { request as httpRequest, ServerResponse } from 'node:http'
+import { connect } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -83,6 +84,43 @@ const accessOnlyExternalAccess = (): ExternalWebAccessAuthorization => ({
   kind: 'authorized' as const,
   isCurrent: () => true
 })
+const startBudgetTestServer = async (
+  requestBodyBudgets: NonNullable<Parameters<typeof startWebHttpServer>[0]['requestBodyBudgets']>,
+  onExternalAuthorization?: () => void
+): ReturnType<typeof startWebHttpServer> => {
+  const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
+  roots.push(staticRoot)
+  await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
+  const server = await startTestWebHttpServer({
+    host: '127.0.0.1',
+    port: 0,
+    token: 'test-token',
+    staticRoot,
+    requestBodyBudgets,
+    rpc: {
+      channels: () => ['projects:list'],
+      invoke: vi.fn().mockResolvedValue([]),
+      releaseClient: vi.fn(),
+      dispose: vi.fn()
+    },
+    externalAccess: {
+      authorizeHttp: async () => {
+        onExternalAuthorization?.()
+        return accessOnlyExternalAccess()
+      },
+      authorizeWebSocket: async () => undefined
+    },
+    bootstrap: {
+      appName: 'Open Science',
+      appVersion: '0.0.0',
+      configRoot: '/fake/root',
+      platform: 'test',
+      versions: { electron: '1', chrome: '1', node: '1' }
+    }
+  })
+  servers.push(server)
+  return server
+}
 const runWithCallerContext = <Result>(_context: CallerContext, operation: () => Result): Result =>
   operation()
 
@@ -104,6 +142,145 @@ afterEach(async () => {
 })
 
 describe('startWebHttpServer', () => {
+  it.each([
+    {
+      dimension: 'server',
+      budgets: {
+        perRequestBytes: 64,
+        perClientInFlightBytes: 64,
+        serverInFlightBytes: 64
+      },
+      firstClientId: 'first-client',
+      secondClientId: 'second-client',
+      expectedStatus: 503
+    },
+    {
+      dimension: 'client',
+      budgets: {
+        perRequestBytes: 64,
+        perClientInFlightBytes: 64,
+        serverInFlightBytes: 128
+      },
+      firstClientId: 'shared-client',
+      secondClientId: 'shared-client',
+      expectedStatus: 429
+    }
+  ])(
+    'rejects a declared body before reading when concurrent requests exhaust the $dimension byte budget',
+    async ({ budgets, firstClientId, secondClientId, expectedStatus }) => {
+      let authorizeCount = 0
+      let markFirstAuthorized: () => void = () => undefined
+      const firstAuthorized = new Promise<void>((resolve) => {
+        markFirstAuthorized = resolve
+      })
+      const server = await startBudgetTestServer(budgets, () => {
+        authorizeCount += 1
+        if (authorizeCount === 1) markFirstAuthorized()
+      })
+
+      const firstRequest = httpRequest({
+        host: '127.0.0.1',
+        port: server.port,
+        path: '/rpc/projects%3Alist',
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': '64',
+          'x-open-science-client': firstClientId
+        }
+      })
+      firstRequest.on('error', () => undefined)
+      firstRequest.write('{')
+      await firstAuthorized
+      await new Promise<void>((resolve) => setImmediate(resolve))
+
+      try {
+        const response = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-open-science-client': secondClientId
+          },
+          body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+        })
+
+        expect(response.status).toBe(expectedStatus)
+        expect(await response.json()).toMatchObject({
+          error: { code: 'handler_error' }
+        })
+      } finally {
+        const firstClosed = new Promise<void>((resolve) => firstRequest.once('close', resolve))
+        firstRequest.destroy()
+        await firstClosed
+      }
+
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      const retry = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-open-science-client': secondClientId
+        },
+        body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+      })
+      expect(retry.status).toBe(200)
+    }
+  )
+
+  it.each([
+    {
+      transport: 'declared',
+      bodyHeaders: ['Content-Length: 65'],
+      body: ''
+    },
+    {
+      transport: 'chunked',
+      bodyHeaders: ['Transfer-Encoding: chunked'],
+      body: `41\r\n${'x'.repeat(65)}\r\n`
+    }
+  ])(
+    'rejects an oversized $transport body and closes the connection',
+    async ({ bodyHeaders, body }) => {
+      const server = await startBudgetTestServer({
+        perRequestBytes: 64,
+        perClientInFlightBytes: 128,
+        serverInFlightBytes: 128
+      })
+
+      const socket = connect({ host: '127.0.0.1', port: server.port })
+      const chunks: Buffer[] = []
+      socket.on('data', (chunk: Buffer) => chunks.push(chunk))
+      socket.on('error', () => undefined)
+      await new Promise<void>((resolve) => socket.once('connect', resolve))
+      const closed = new Promise<string>((resolve) =>
+        socket.once('close', () => resolve(Buffer.concat(chunks).toString()))
+      )
+
+      socket.write(
+        `${[
+          'POST /rpc/projects%3Alist HTTP/1.1',
+          `Host: 127.0.0.1:${server.port}`,
+          'Authorization: Bearer test-token',
+          'Content-Type: application/json',
+          ...bodyHeaders,
+          'Connection: keep-alive',
+          '',
+          ''
+        ].join('\r\n')}${body}`
+      )
+
+      const response = await Promise.race([
+        closed,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('oversized request connection stayed open')), 1_000)
+        )
+      ])
+      expect(response).toContain('HTTP/1.1 413')
+      expect(response.toLowerCase()).toContain('connection: close')
+      expect(response).toContain('Request body is too large.')
+    }
+  )
+
   it('preserves valid idempotency entries when replay capacity is full', async () => {
     const registry = new TaskIdempotencyRegistry(2, 8_192)
     const first = vi.fn().mockResolvedValue('first result')

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -51,6 +51,10 @@ import type {
 import { TaskApiError, type HeadlessTaskApi } from './task-api'
 
 const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
+// Preserve one maximum-size request per logical client while leaving the same amount of capacity
+// for other authenticated clients. Browser uploads use much smaller 8 MiB chunks in normal use.
+const MAX_CLIENT_IN_FLIGHT_RPC_BODY_BYTES = 64 * 1024 * 1024
+const MAX_SERVER_IN_FLIGHT_RPC_BODY_BYTES = 128 * 1024 * 1024
 const MIN_GZIP_BYTES = 1_024
 const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 const DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS = 10_000
@@ -103,6 +107,7 @@ type WebServerOptions = {
   applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb'>
   applicationEvents: ApplicationEventSource
   eventHeartbeatIntervalMs?: number
+  requestBodyBudgets?: RequestBodyBudgets
   externalAccess?: ExternalWebAccess
   tasks?: Pick<
     HeadlessTaskApi,
@@ -128,6 +133,87 @@ type WebServerOptions = {
     configRoot: string
     platform: string
     versions: { electron: string; chrome: string; node: string }
+  }
+}
+
+type RequestBodyBudgets = Readonly<{
+  perRequestBytes: number
+  perClientInFlightBytes: number
+  serverInFlightBytes: number
+}>
+
+type RequestBodyBudgetDimension = 'request' | 'client' | 'server'
+
+type RequestBodyBudgetLease = {
+  clientId: string
+  reservedBytes: number
+  released: boolean
+}
+
+class RequestBodyBudgetExceededError extends Error {
+  readonly name = 'RequestBodyBudgetExceededError'
+
+  constructor(readonly dimension: RequestBodyBudgetDimension) {
+    super(
+      dimension === 'request'
+        ? 'Request body is too large.'
+        : dimension === 'client'
+          ? 'Too many request body bytes are already in flight for this client.'
+          : 'The server is temporarily at its request body capacity.'
+    )
+  }
+}
+
+class RequestBodyBudgetRegistry {
+  private serverInFlightBytes = 0
+  private readonly clientInFlightBytes = new Map<string, number>()
+
+  constructor(private readonly budgets: RequestBodyBudgets) {
+    for (const [name, value] of Object.entries(budgets)) {
+      if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new TypeError(`${name} must be a positive safe integer.`)
+      }
+    }
+  }
+
+  reserve(clientId: string, bytes: number): RequestBodyBudgetLease {
+    const lease: RequestBodyBudgetLease = { clientId, reservedBytes: 0, released: false }
+    this.increase(lease, bytes)
+    return lease
+  }
+
+  increase(lease: RequestBodyBudgetLease, bytes: number): void {
+    if (lease.released) throw new Error('Cannot increase a released request body budget lease.')
+    if (!Number.isSafeInteger(bytes) || bytes < 0) {
+      throw new TypeError('Request body budget increments must be non-negative safe integers.')
+    }
+
+    const requestBytes = lease.reservedBytes + bytes
+    if (requestBytes > this.budgets.perRequestBytes) {
+      throw new RequestBodyBudgetExceededError('request')
+    }
+    const clientBytes = (this.clientInFlightBytes.get(lease.clientId) ?? 0) + bytes
+    if (clientBytes > this.budgets.perClientInFlightBytes) {
+      throw new RequestBodyBudgetExceededError('client')
+    }
+    const serverBytes = this.serverInFlightBytes + bytes
+    if (serverBytes > this.budgets.serverInFlightBytes) {
+      throw new RequestBodyBudgetExceededError('server')
+    }
+
+    lease.reservedBytes = requestBytes
+    this.serverInFlightBytes = serverBytes
+    if (clientBytes === 0) this.clientInFlightBytes.delete(lease.clientId)
+    else this.clientInFlightBytes.set(lease.clientId, clientBytes)
+  }
+
+  release(lease: RequestBodyBudgetLease): void {
+    if (lease.released) return
+    lease.released = true
+    this.serverInFlightBytes -= lease.reservedBytes
+    const clientBytes = (this.clientInFlightBytes.get(lease.clientId) ?? 0) - lease.reservedBytes
+    if (clientBytes === 0) this.clientInFlightBytes.delete(lease.clientId)
+    else this.clientInFlightBytes.set(lease.clientId, clientBytes)
   }
 }
 
@@ -218,17 +304,57 @@ const webRpcError = (
   })
 }
 
-const readJsonBody = async (request: IncomingMessage): Promise<unknown> => {
+const declaredContentLength = (request: IncomingMessage): number | undefined => {
+  const value = request.headers['content-length']
+  if (typeof value !== 'string' || !/^\d+$/u.test(value)) return undefined
+  const length = Number(value)
+  return Number.isSafeInteger(length) ? length : undefined
+}
+
+const closeRequestAfterResponse = (request: IncomingMessage, response: ServerResponse): void => {
+  response.shouldKeepAlive = false
+  if (!response.headersSent) response.setHeader('connection', 'close')
+  if (response.writableFinished) request.destroy()
+  else response.once('finish', () => request.destroy())
+}
+
+const readJsonBody = async (
+  request: IncomingMessage,
+  response: ServerResponse,
+  registry: RequestBodyBudgetRegistry
+): Promise<unknown> => {
+  const clientId = String(request.headers['x-open-science-client'] ?? 'web')
+  const declared = declaredContentLength(request)
+  let lease: RequestBodyBudgetLease
+  try {
+    lease = registry.reserve(clientId, declared ?? 0)
+  } catch (error) {
+    if (error instanceof RequestBodyBudgetExceededError) {
+      closeRequestAfterResponse(request, response)
+    }
+    throw error
+  }
+  const release = (): void => registry.release(lease)
+  response.once('finish', release)
+  response.once('close', release)
+
   const chunks: Buffer[] = []
   let size = 0
-  for await (const chunk of request) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-    size += buffer.length
-    if (size > MAX_RPC_BODY_BYTES) throw new Error('RPC request body is too large.')
-    chunks.push(buffer)
+  try {
+    for await (const chunk of request) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      size += buffer.length
+      if (declared === undefined) registry.increase(lease, buffer.length)
+      chunks.push(buffer)
+    }
+  } catch (error) {
+    if (error instanceof RequestBodyBudgetExceededError) {
+      closeRequestAfterResponse(request, response)
+    }
+    throw error
   }
   if (chunks.length === 0) return {}
-  return JSON.parse(Buffer.concat(chunks).toString('utf8'), (_key, child) => {
+  return JSON.parse(Buffer.concat(chunks, size).toString('utf8'), (_key, child) => {
     if (
       child &&
       typeof child === 'object' &&
@@ -423,6 +549,21 @@ const assertExternalAuthorizationCurrent = (
 }
 
 const taskError = (response: ServerResponse, error: unknown): void => {
+  if (error instanceof RequestBodyBudgetExceededError) {
+    const status = error.dimension === 'request' ? 413 : error.dimension === 'client' ? 429 : 503
+    json(response, status, {
+      error: {
+        code:
+          error.dimension === 'request'
+            ? 'payload_too_large'
+            : error.dimension === 'client'
+              ? 'client_busy'
+              : 'server_busy',
+        message: error.message
+      }
+    })
+    return
+  }
   if (error instanceof SyntaxError) {
     json(response, 400, {
       error: { code: 'invalid_request', message: 'Request body must be valid JSON.' }
@@ -538,6 +679,7 @@ const handleTaskApiRequest = async (
   url: URL,
   tasks: NonNullable<WebServerOptions['tasks']>,
   callerContext: CallerContext,
+  requestBodyBudgetRegistry: RequestBodyBudgetRegistry,
   idempotencyRegistry: TaskIdempotencyRegistry,
   externalAuthorization?: ExternalWebAccessAuthorization
 ): Promise<boolean> =>
@@ -549,7 +691,11 @@ const handleTaskApiRequest = async (
         return true
       }
       if (url.pathname === '/api/v1/projects' && request.method === 'POST') {
-        const body = (await readJsonBody(request)) as CreateTaskProjectRequest
+        const body = (await readJsonBody(
+          request,
+          response,
+          requestBodyBudgetRegistry
+        )) as CreateTaskProjectRequest
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 201, {
           data: await runIdempotentTask(
@@ -565,7 +711,11 @@ const handleTaskApiRequest = async (
       }
       const projectMatch = url.pathname.match(/^\/api\/v1\/projects\/([^/]+)$/)
       if (projectMatch && request.method === 'PATCH') {
-        const body = (await readJsonBody(request)) as UpdateTaskProjectRequest
+        const body = (await readJsonBody(
+          request,
+          response,
+          requestBodyBudgetRegistry
+        )) as UpdateTaskProjectRequest
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, {
           data: await tasks.updateProject(decodeURIComponent(projectMatch[1]), body)
@@ -580,7 +730,11 @@ const handleTaskApiRequest = async (
         return true
       }
       if (url.pathname === '/api/v1/runs' && request.method === 'POST') {
-        const body = (await readJsonBody(request)) as StartTaskRunRequest
+        const body = (await readJsonBody(
+          request,
+          response,
+          requestBodyBudgetRegistry
+        )) as StartTaskRunRequest
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 202, {
           data: await runIdempotentTask(
@@ -603,7 +757,7 @@ const handleTaskApiRequest = async (
       }
       const cancelRunMatch = url.pathname.match(/^\/api\/v1\/runs\/([^/]+)\/cancel$/)
       if (cancelRunMatch && request.method === 'POST') {
-        await readJsonBody(request)
+        await readJsonBody(request, response, requestBodyBudgetRegistry)
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, {
           data: await tasks.cancelRun(decodeURIComponent(cancelRunMatch[1]))
@@ -622,7 +776,9 @@ const handleTaskApiRequest = async (
         /^\/api\/v1\/sessions\/([^/]+)\/plan\/respond$/
       )
       if (sessionPlanResponseMatch && request.method === 'POST' && tasks.respondSessionPlan) {
-        const body = parseTaskPlanResponseRequest(await readJsonBody(request))
+        const body = parseTaskPlanResponseRequest(
+          await readJsonBody(request, response, requestBodyBudgetRegistry)
+        )
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, {
           data: await tasks.respondSessionPlan(
@@ -730,6 +886,13 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   const internalEventStream = new InternalWebEventStream()
   const commandClient = createApplicationCommandClient()
   const taskIdempotencyRegistry = new TaskIdempotencyRegistry()
+  const requestBodyBudgetRegistry = new RequestBodyBudgetRegistry(
+    options.requestBodyBudgets ?? {
+      perRequestBytes: MAX_RPC_BODY_BYTES,
+      perClientInFlightBytes: MAX_CLIENT_IN_FLIGHT_RPC_BODY_BYTES,
+      serverInFlightBytes: MAX_SERVER_IN_FLIGHT_RPC_BODY_BYTES
+    }
+  )
   const clientLeases = new ClientLeaseRegistry((clientId) => {
     commandClient.releaseClient('web', clientId)
   })
@@ -757,7 +920,6 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         response.end('Unauthorized')
         return
       }
-
       if (auth.ok && auth.queryToken && request.method === 'GET' && url.pathname === '/') {
         persistAuthCookie(response, options.token)
         url.searchParams.delete('token')
@@ -822,6 +984,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
                 }
               : {})
           }),
+          requestBodyBudgetRegistry,
           taskIdempotencyRegistry,
           externalAuthorization
         ))
@@ -843,8 +1006,17 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         }
         let body: unknown
         try {
-          body = await readJsonBody(request)
+          body = await readJsonBody(request, response, requestBodyBudgetRegistry)
         } catch (error) {
+          if (error instanceof RequestBodyBudgetExceededError) {
+            webRpcError(
+              response,
+              error.dimension === 'request' ? 413 : error.dimension === 'client' ? 429 : 503,
+              error.dimension === 'request' ? 'invalid_request' : 'handler_error',
+              error.message
+            )
+            return
+          }
           webRpcError(
             response,
             400,

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -167,6 +167,7 @@ class RequestBodyBudgetExceededError extends Error {
 class RequestBodyBudgetRegistry {
   private serverInFlightBytes = 0
   private readonly clientInFlightBytes = new Map<string, number>()
+  private readonly requestLeases = new WeakMap<IncomingMessage, RequestBodyBudgetLease>()
 
   constructor(private readonly budgets: RequestBodyBudgets) {
     for (const [name, value] of Object.entries(budgets)) {
@@ -176,9 +177,10 @@ class RequestBodyBudgetRegistry {
     }
   }
 
-  reserve(clientId: string, bytes: number): RequestBodyBudgetLease {
+  reserve(request: IncomingMessage, clientId: string, bytes: number): RequestBodyBudgetLease {
     const lease: RequestBodyBudgetLease = { clientId, reservedBytes: 0, released: false }
     this.increase(lease, bytes)
+    this.requestLeases.set(request, lease)
     return lease
   }
 
@@ -207,7 +209,10 @@ class RequestBodyBudgetRegistry {
     else this.clientInFlightBytes.set(lease.clientId, clientBytes)
   }
 
-  release(lease: RequestBodyBudgetLease): void {
+  release(request: IncomingMessage): void {
+    const lease = this.requestLeases.get(request)
+    if (!lease) return
+    this.requestLeases.delete(request)
     if (lease.released) return
     lease.released = true
     this.serverInFlightBytes -= lease.reservedBytes
@@ -327,17 +332,13 @@ const readJsonBody = async (
   const declared = declaredContentLength(request)
   let lease: RequestBodyBudgetLease
   try {
-    lease = registry.reserve(clientId, declared ?? 0)
+    lease = registry.reserve(request, clientId, declared ?? 0)
   } catch (error) {
     if (error instanceof RequestBodyBudgetExceededError) {
       closeRequestAfterResponse(request, response)
     }
     throw error
   }
-  const release = (): void => registry.release(lease)
-  response.once('finish', release)
-  response.once('close', release)
-
   const chunks: Buffer[] = []
   let size = 0
   try {
@@ -1122,6 +1123,8 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       json(response, 500, {
         error: INTERNAL_SERVER_ERROR_MESSAGE
       })
+    } finally {
+      requestBodyBudgetRegistry.release(request)
     }
   }
   const server = createServer((request, response) =>


### PR DESCRIPTION
## Problem

Authenticated Web RPC and Task API requests were limited to 64 MiB individually, but each handler
buffered independently and concurrently. A request could retain streamed chunks, a concatenated
Buffer, decoded text, parsed JSON, and revived base64 binary values, while the server had no
per-client or aggregate in-flight byte budget. Declared oversized bodies were also not rejected
from `Content-Length` before reading.

## Proposed change

- Preserve the existing 64 MiB per-request compatibility ceiling.
- Reserve up to 64 MiB per logical Web client and 128 MiB across one running Web server.
- Reserve valid declared lengths before reading and account chunked bodies as bytes arrive.
- Hold reservations until the request handler completes, including after an early client disconnect,
  then release them idempotently.
- Return HTTP 413, 429, or 503 for request, client, or server exhaustion and close rejected request
  connections without consuming the remaining body.
- Cover the behavior through real authenticated HTTP connections, including declared and chunked
  bodies and successful admission after a prior reservation is released.

## Scope and non-goals

- Large scientific files keep their existing paths: uploads remain split into at most 8 MiB chunks,
  and managed artifact downloads remain streamed.
- This change does not lower the normal RPC limit without production payload-size evidence.
- This change does not add a new upload protocol or a separate concurrent-request-count limiter;
  byte admission directly bounds the reported memory risk.
- There are no persisted-format, historical-compatibility, database, or domain-state changes.
- Web RPC reuses existing protocol error codes. No protocol enum value is added.

## Acceptance criteria and validation

- Concurrent request bodies are bounded per client and per server, including while a parsed body is
  retained by a handler after its client disconnects.
  - `vitest run src/main/web-service/http-server.test.ts` -> 31 passed.
- Declared oversized bodies fail before their body is sent; chunked bodies fail on the first byte
  over budget; rejected connections close; released reservations admit later requests.
  - `vitest run src/main/web-service/http-server.test.ts` -> 31 passed.
- Changed Main-process source and tests satisfy lint.
  - `eslint src/main/web-service/http-server.ts src/main/web-service/http-server.test.ts --max-warnings 0`
    -> passed.
  - `eslint --cache .` -> exited 0 with 256 pre-existing Prettier warnings in unrelated test files.
- Node type checking was attempted after the final material edit.
  - `tsc --noEmit -p tsconfig.node.json --composite false` -> blocked by the shared dependency tree:
    `@agentclientprotocol/claude-agent-acp/dist/acp-agent.js` does not export `waitForMcpServers`.
    The identical error reproduces on the unchanged main checkout.

The listed checks ran after the last material edit. Per maintainer direction, the complete local
`npm test` suite was not run; PR Gate and selected CI lanes are authoritative.

## Review focus

- Admission and release accounting for declared versus chunked bodies.
- Connection-close behavior when a body is rejected before being consumed.
- Default 64 MiB client / 128 MiB server balance for large scientific workloads.
- The client identity header is a fairness boundary for cooperating authenticated clients; the
  server-wide budget remains the authoritative bound if a client changes that header.
