### PR TITLE
fix(acp): bound agent stderr diagnostics

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -571,7 +571,7 @@ if (process.argv.includes('--version')) {
           if (prompt.includes(TOOL_STATUS_LAYOUT_SHIFT_PROMPT)) {
             process.stderr.write('Layout fixture status.\n')
           }
-          await delay(750)
+          await delay(prompt.includes(TOOL_STATUS_LAYOUT_SHIFT_PROMPT) ? 2_000 : 750)
 
           const finalMessageId = `e2e-message-${nextMessageId++}`
           await context.client.notify(acp.methods.client.session.update, {

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -9,6 +9,7 @@ const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
 const TOOL_STATUS_LAYOUT_SHIFT_PROMPT = 'Run the status-bearing layout stability journey.'
 const BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT =
   'Run the buffered text tool layout stability journey.'
+const AGENT_STDERR_SUMMARY = 'Agent process stderr: 1 chunk, 22 bytes; raw output omitted.'
 
 test.use({ windowMode: 'normal' })
 
@@ -17,7 +18,7 @@ const cases = [
   {
     name: 'with agent status',
     prompt: TOOL_STATUS_LAYOUT_SHIFT_PROMPT,
-    agentStatus: 'Layout fixture status.'
+    agentStatus: AGENT_STDERR_SUMMARY
   }
 ] as const
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -22719,6 +22719,107 @@ describe('ACP runtime — agent process lifecycle logging', () => {
     }
   })
 
+  it('does not attribute delayed stderr to a later prompt in the same session', async () => {
+    warnLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    const firstResponse = createDeferred<PromptResponse>()
+    const secondResponse = createDeferred<PromptResponse>()
+    const responses = [firstResponse, secondResponse]
+    const fakeAgent = startFakeAgent(process, ['stderr-session'], {
+      onPrompt: () => responses.shift()!.promise
+    })
+    const events: AcpRuntimeEvent[] = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const firstPrompt = runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'first analysis'
+    })
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    events.length = 0
+    vi.useFakeTimers()
+    let secondPrompt: Promise<PromptResponse> | undefined
+    try {
+      process.stderr.emit('data', Buffer.from('first prompt diagnostic'))
+      firstResponse.resolve({ stopReason: 'end_turn' })
+      await firstPrompt
+
+      secondPrompt = runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'second analysis'
+      })
+      await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(2))
+      await vi.advanceTimersByTimeAsync(1000)
+
+      const warning = events.find((event) => event.kind === 'system' && event.title === 'agent')
+      expect(warning).toBeDefined()
+      expect(warning?.sessionId).toBeUndefined()
+      expect(warning?.promptMessageId).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+      secondResponse.resolve({ stopReason: 'end_turn' })
+      await secondPrompt
+    }
+  })
+
+  it('keeps known non-actionable Codex stderr out of runtime warning events', async () => {
+    warnLogSpy.mockClear()
+    const process = new FakeAgentProcess()
+    const promptResponse = createDeferred<PromptResponse>()
+    const fakeAgent = startFakeAgent(process, ['stderr-session'], {
+      onPrompt: () => promptResponse.promise,
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+    })
+    const events: AcpRuntimeEvent[] = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'codex:provider-a',
+        modelRoute: 'codex-responses',
+        executablePath: '/bin/codex',
+        env: {}
+      }),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: session.sessionId, text: 'run analysis' })
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    events.length = 0
+    vi.useFakeTimers()
+    try {
+      process.stderr.emit(
+        'data',
+        Buffer.from(
+          [
+            'Warning: Skill descriptions were shortened to fit the 2% skills context budget.',
+            'Codex can still see every skill, but some descriptions are shorter.',
+            'Disable unused skills or plugins to leave more room for the rest.',
+            'Warning: Falling back from WebSockets to HTTPS transport. request timed out'
+          ].join('\n')
+        )
+      )
+      await vi.advanceTimersByTimeAsync(1000)
+
+      expect(warnLogSpy.mock.calls.some(([message]) => message === 'agent stderr summary')).toBe(
+        true
+      )
+      expect(events.some((event) => event.kind === 'system' && event.title === 'agent')).toBe(false)
+    } finally {
+      vi.useRealTimers()
+      promptResponse.resolve({ stopReason: 'end_turn' })
+      await prompt
+    }
+  })
+
   it('labels a late stderr with the framework captured at bind time, not the current one', async () => {
     warnLogSpy.mockClear()
     const oldProcess = new FakeAgentProcess()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -22600,31 +22600,123 @@ describe('ACP runtime — agent process lifecycle logging', () => {
     expect(JSON.stringify(call?.[1])).not.toMatch(/sensitive pipe failure|sensitive-socket|9090/)
   })
 
-  it('logs agent stderr with the framework the process was spawned under', async () => {
-    warnLogSpy.mockClear()
-    const process = new FakeAgentProcess()
-    startFakeAgent(process, ['stderr-session'])
-    const runtime = new AcpRuntime({
-      appVersion: '0.1.0',
-      defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
-    })
+  it.each(PERMISSION_PROJECTION_FRAMEWORKS)(
+    'summarizes bursty %s stderr without exposing raw output by default',
+    async (_name, framework, modelRoute, backendId) => {
+      warnLogSpy.mockClear()
+      const process = new FakeAgentProcess()
+      const promptResponse = createDeferred<PromptResponse>()
+      const fakeAgent = startFakeAgent(process, ['stderr-session'], {
+        onPrompt: () => promptResponse.promise,
+        ...(framework.id === 'codex'
+          ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
+          : {})
+      })
+      const events: AcpRuntimeEvent[] = []
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        }),
+        callbacks: { onEvent: (event) => events.push(event) }
+      })
 
-    await runtime.createSession({ cwd: '/workspace' })
-    process.stderr.emit('data', Buffer.from('provider auth failed'))
+      const session = await runtime.createSession({ cwd: '/workspace' })
+      const prompt = runtime.sendPrompt({ sessionId: session.sessionId, text: 'run analysis' })
+      await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+      warnLogSpy.mockClear()
+      events.length = 0
+      vi.useFakeTimers()
+      try {
+        for (let index = 0; index < 10; index += 1) {
+          process.stderr.emit('data', Buffer.from('private-path:/lab/run-42/result.csv'))
+        }
 
-    const call = warnLogSpy.mock.calls.find(([message]) => message === 'agent stderr')
-    expect(call).toBeDefined()
-    const data = call?.[1] as {
-      text: string
-      framework: string
-      status: string
-      sessionCount: number
+        await vi.advanceTimersByTimeAsync(1000)
+
+        expect(warnLogSpy.mock.calls).toEqual([
+          [
+            'agent stderr summary',
+            {
+              errorCategory: 'process-stderr',
+              framework: framework.id,
+              status: 'connected',
+              sessionCount: 1,
+              chunkCount: 10,
+              byteCount: 350,
+              windowMs: 1000,
+              chunksPerSecond: 10
+            }
+          ]
+        ])
+        expect(events).toHaveLength(1)
+        expect(events[0]).toMatchObject({
+          kind: 'system',
+          level: 'warning',
+          sessionId: 'stderr-session',
+          title: 'agent',
+          text: 'Agent process stderr: 10 chunks, 350 bytes; raw output omitted.'
+        })
+        expect(JSON.stringify({ logs: warnLogSpy.mock.calls, events })).not.toContain(
+          'private-path:/lab/run-42/result.csv'
+        )
+      } finally {
+        vi.useRealTimers()
+        promptResponse.resolve({ stopReason: 'end_turn' })
+        await prompt
+      }
     }
-    expect(data.text).toBe('provider auth failed')
-    expect(data.framework).toBe('claude-code')
-    expect(data.status).toBe('connected')
-    expect(data.sessionCount).toBe(1)
+  )
+
+  it('caps explicitly enabled raw stderr samples by UTF-8 bytes', async () => {
+    warnLogSpy.mockClear()
+    const previousRawStderr = process.env.OPEN_SCIENCE_AGENT_STDERR
+    process.env.OPEN_SCIENCE_AGENT_STDERR = 'raw'
+    try {
+      const agentProcess = new FakeAgentProcess()
+      startFakeAgent(agentProcess, ['raw-stderr-session'])
+      const events: AcpRuntimeEvent[] = []
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(agentProcess),
+        callbacks: { onEvent: (event) => events.push(event) }
+      })
+
+      await runtime.createSession({ cwd: '/workspace' })
+      warnLogSpy.mockClear()
+      events.length = 0
+      vi.useFakeTimers()
+      agentProcess.stderr.emit('data', Buffer.from('测'.repeat(3000)))
+
+      await vi.advanceTimersByTimeAsync(1000)
+
+      const call = warnLogSpy.mock.calls.find(([message]) => message === 'agent stderr summary')
+      expect(call).toBeDefined()
+      const data = call?.[1] as {
+        byteCount: number
+        rawSample: string
+        rawSampleTruncated: boolean
+      }
+      expect(data.byteCount).toBe(9000)
+      expect(data.rawSampleTruncated).toBe(true)
+      expect(Buffer.byteLength(data.rawSample, 'utf8')).toBeLessThanOrEqual(4096)
+      expect(data.rawSample).toMatch(/^测+$/)
+      expect(events).toHaveLength(1)
+      expect(events[0]?.text).toContain('…[truncated]')
+    } finally {
+      vi.useRealTimers()
+      if (previousRawStderr === undefined) delete process.env.OPEN_SCIENCE_AGENT_STDERR
+      else process.env.OPEN_SCIENCE_AGENT_STDERR = previousRawStderr
+    }
   })
 
   it('labels a late stderr with the framework captured at bind time, not the current one', async () => {
@@ -22654,10 +22746,16 @@ describe('ACP runtime — agent process lifecycle logging', () => {
     await runtime.createSession({ cwd: '/workspace' })
     await runtime.disconnect()
     await runtime.createSession({ cwd: '/workspace' })
-    oldProcess.stderr.emit('data', Buffer.from('slow tail output'))
+    vi.useFakeTimers()
+    try {
+      oldProcess.stderr.emit('data', Buffer.from('slow tail output'))
+      await vi.advanceTimersByTimeAsync(1000)
 
-    const call = warnLogSpy.mock.calls.find(([message]) => message === 'agent stderr')
-    expect((call?.[1] as { framework: string }).framework).toBe('claude-code')
+      const call = warnLogSpy.mock.calls.find(([message]) => message === 'agent stderr summary')
+      expect((call?.[1] as { framework: string }).framework).toBe('claude-code')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -405,6 +405,22 @@ const MAX_RAW_AGENT_STDERR_SAMPLE_BYTES = 4096
 // Support-only opt-in. Raw agent stderr can contain research data, local paths, and tool output.
 const RAW_AGENT_STDERR_ENV = 'OPEN_SCIENCE_AGENT_STDERR'
 
+// Preserve the renderer's existing suppression for the two exact informational diagnostics Codex
+// emits during successful turns. Evaluate each adapter-delivered stderr block independently, as the
+// pre-aggregation event path did; any additional content makes the whole window actionable.
+const isNonActionableCodexStderr = (text: string): boolean => {
+  const withoutSkillBudgetNotice = text.replace(
+    /Warning:\s*Skill descriptions were shortened to fit the 2% skills context budget\.\s*Codex can still see every skill, but some descriptions are shorter\.\s*Disable unused skills or plugins to leave more room for the rest\.\s*/gi,
+    ''
+  )
+  const withoutTransportFallback = withoutSkillBudgetNotice.replace(
+    /Warning:\s*Falling back from WebSockets to HTTPS transport\.\s*request timed out\s*/gi,
+    ''
+  )
+
+  return withoutTransportFallback.trim().length === 0
+}
+
 const utf8PrefixWithinBytes = (value: string, maxBytes: number): string => {
   if (maxBytes <= 0) return ''
   if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value
@@ -434,7 +450,9 @@ type AgentStderrWindow = {
   rawSampleBytes: number
   rawSampleTruncated: boolean
   sessionId?: string
+  interactionSequence?: number
   sessionAttributionConsistent: boolean
+  nonActionableCodexOnly: boolean
   eventEligible: boolean
   timer: ReturnType<typeof setTimeout>
 }
@@ -2459,13 +2477,22 @@ class AcpRuntime {
     const disposition = this.processEventDisposition(context.process, context.epoch)
     const inFlight = disposition === 'current' ? this.getInFlightSessionIds() : []
     const sessionId = inFlight.length === 1 ? inFlight[0] : undefined
+    const interactionSequence = sessionId
+      ? this.sessionInteractions.current(sessionId)?.sequence
+      : undefined
     const existing = this.agentStderrWindows.get(context.process)
     if (existing) {
       existing.chunkCount += 1
       existing.byteCount += Buffer.byteLength(text, 'utf8')
       existing.eventEligible &&= disposition === 'current'
-      if (existing.sessionId !== sessionId) {
+      existing.nonActionableCodexOnly &&=
+        context.framework === 'codex' && isNonActionableCodexStderr(text)
+      if (
+        existing.sessionId !== sessionId ||
+        existing.interactionSequence !== interactionSequence
+      ) {
         existing.sessionId = undefined
+        existing.interactionSequence = undefined
         existing.sessionAttributionConsistent = false
       }
       this.appendAgentStderrSample(existing, text)
@@ -2488,7 +2515,9 @@ class AcpRuntime {
       rawSampleBytes: 0,
       rawSampleTruncated: false,
       sessionId,
+      interactionSequence,
       sessionAttributionConsistent: true,
+      nonActionableCodexOnly: context.framework === 'codex' && isNonActionableCodexStderr(text),
       eventEligible: disposition === 'current',
       timer
     }
@@ -2549,10 +2578,23 @@ class AcpRuntime {
     ) {
       return
     }
+    if (window.nonActionableCodexOnly) return
+
+    const inFlight = this.getInFlightSessionIds()
+    const currentSessionId = inFlight.length === 1 ? inFlight[0] : undefined
+    const currentInteractionSequence = currentSessionId
+      ? this.sessionInteractions.current(currentSessionId)?.sequence
+      : undefined
+    const sessionId =
+      window.sessionAttributionConsistent &&
+      window.sessionId === currentSessionId &&
+      window.interactionSequence === currentInteractionSequence
+        ? window.sessionId
+        : undefined
     this.pushEvent({
       kind: 'system',
       level: 'warning',
-      sessionId: window.sessionAttributionConsistent ? window.sessionId : undefined,
+      sessionId,
       title: 'agent',
       text: includeRaw ? `${summary}\n${window.rawSample}${rawSuffix}` : summary
     })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -400,6 +400,44 @@ const PERMISSION_CANCELLED_CONTINUATION_TEXT =
 
 const PLAN_CONTINUATION_CLAIM_MAX_ATTEMPTS = 3
 const PLAN_CONTINUATION_CLAIM_RETRY_BASE_DELAY_MS = 25
+const AGENT_STDERR_REPORT_WINDOW_MS = 1000
+const MAX_RAW_AGENT_STDERR_SAMPLE_BYTES = 4096
+// Support-only opt-in. Raw agent stderr can contain research data, local paths, and tool output.
+const RAW_AGENT_STDERR_ENV = 'OPEN_SCIENCE_AGENT_STDERR'
+
+const utf8PrefixWithinBytes = (value: string, maxBytes: number): string => {
+  if (maxBytes <= 0) return ''
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value
+
+  let low = 0
+  let high = Math.min(value.length, maxBytes)
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2)
+    if (Buffer.byteLength(value.slice(0, middle), 'utf8') <= maxBytes) low = middle
+    else high = middle - 1
+  }
+  // Do not retain half of a UTF-16 surrogate pair at the byte boundary.
+  if (low > 0 && value.charCodeAt(low - 1) >= 0xd800 && value.charCodeAt(low - 1) <= 0xdbff) {
+    low -= 1
+  }
+  return value.slice(0, low)
+}
+
+type AgentStderrWindow = {
+  process: ChildProcessWithoutNullStreams
+  framework: AgentFrameworkId
+  epoch: number
+  startedAt: number
+  chunkCount: number
+  byteCount: number
+  rawSample: string
+  rawSampleBytes: number
+  rawSampleTruncated: boolean
+  sessionId?: string
+  sessionAttributionConsistent: boolean
+  eventEligible: boolean
+  timer: ReturnType<typeof setTimeout>
+}
 
 type PlanContinuationClaimRetry = {
   commandId: string
@@ -450,6 +488,7 @@ class AcpRuntime {
   >
   private durablePlanContinuations?: Map<string, { projectId: string; commandId: string }>
   private readonly planContinuationClaimRetries = new Map<string, PlanContinuationClaimRetry>()
+  private readonly agentStderrWindows = new Map<ChildProcessWithoutNullStreams, AgentStderrWindow>()
   private restoredContinuationContextResetSessionIds?: Set<string>
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
@@ -2415,29 +2454,107 @@ class AcpRuntime {
     text: string,
     context: Parameters<AcpAgentConnectionHooks['onProcessStderr']>[1]
   ): void {
-    // Always capture agent stderr in the log — it's the primary clue when a turn stalls or the
-    // agent misbehaves (auth loops, MCP connection failures, tool errors) in a packaged build.
-    if (text) {
-      log.warn('agent stderr', {
-        text,
-        framework: context.framework,
-        status: this.snapshotOwner.status,
-        sessionCount: this.activeSessionIds().length
-      })
+    if (!text) return
+
+    const disposition = this.processEventDisposition(context.process, context.epoch)
+    const inFlight = disposition === 'current' ? this.getInFlightSessionIds() : []
+    const sessionId = inFlight.length === 1 ? inFlight[0] : undefined
+    const existing = this.agentStderrWindows.get(context.process)
+    if (existing) {
+      existing.chunkCount += 1
+      existing.byteCount += Buffer.byteLength(text, 'utf8')
+      existing.eventEligible &&= disposition === 'current'
+      if (existing.sessionId !== sessionId) {
+        existing.sessionId = undefined
+        existing.sessionAttributionConsistent = false
+      }
+      this.appendAgentStderrSample(existing, text)
+      return
     }
 
-    if (this.processEventDisposition(context.process, context.epoch) !== 'current' || !text) return
+    const timer = setTimeout(
+      () => this.flushAgentProcessStderr(context.process),
+      AGENT_STDERR_REPORT_WINDOW_MS
+    )
+    timer.unref?.()
+    const window: AgentStderrWindow = {
+      process: context.process,
+      framework: context.framework,
+      epoch: context.epoch,
+      startedAt: Date.now(),
+      chunkCount: 1,
+      byteCount: Buffer.byteLength(text, 'utf8'),
+      rawSample: '',
+      rawSampleBytes: 0,
+      rawSampleTruncated: false,
+      sessionId,
+      sessionAttributionConsistent: true,
+      eventEligible: disposition === 'current',
+      timer
+    }
+    this.appendAgentStderrSample(window, text)
+    this.agentStderrWindows.set(context.process, window)
+  }
 
-    // Attribute stderr to a session only when exactly one prompt is in flight — then it's
-    // unambiguously that turn's. With zero or multiple concurrent prompts, omit the sessionId
-    // rather than risk pinning it to the wrong conversation's waiting indicator.
-    const inFlight = this.getInFlightSessionIds()
+  private includeRawAgentStderr(): boolean {
+    return process.env[RAW_AGENT_STDERR_ENV]?.trim().toLowerCase() === 'raw'
+  }
+
+  private appendAgentStderrSample(window: AgentStderrWindow, text: string): void {
+    if (!this.includeRawAgentStderr()) return
+    let available = MAX_RAW_AGENT_STDERR_SAMPLE_BYTES - window.rawSampleBytes
+    if (available <= 0) {
+      window.rawSampleTruncated = true
+      return
+    }
+    if (window.rawSample) {
+      window.rawSample += '\n'
+      window.rawSampleBytes += 1
+      available -= 1
+    }
+    const prefix = utf8PrefixWithinBytes(text, available)
+    window.rawSample += prefix
+    window.rawSampleBytes += Buffer.byteLength(prefix, 'utf8')
+    if (prefix.length < text.length) window.rawSampleTruncated = true
+  }
+
+  private flushAgentProcessStderr(process: ChildProcessWithoutNullStreams): void {
+    const window = this.agentStderrWindows.get(process)
+    if (!window) return
+    this.agentStderrWindows.delete(process)
+    clearTimeout(window.timer)
+
+    const windowMs = Math.max(1, Date.now() - window.startedAt)
+    const includeRaw = this.includeRawAgentStderr() && window.rawSample.length > 0
+    const chunkLabel = window.chunkCount === 1 ? 'chunk' : 'chunks'
+    const summary = `Agent process stderr: ${window.chunkCount} ${chunkLabel}, ${window.byteCount} bytes; ${includeRaw ? 'bounded raw sample follows' : 'raw output omitted'}.`
+    const rawSuffix = window.rawSampleTruncated ? '\n…[truncated]' : ''
+    log.warn('agent stderr summary', {
+      errorCategory: 'process-stderr',
+      framework: window.framework,
+      status: this.snapshotOwner.status,
+      sessionCount: this.activeSessionIds().length,
+      chunkCount: window.chunkCount,
+      byteCount: window.byteCount,
+      windowMs,
+      chunksPerSecond: Number(((window.chunkCount * 1000) / windowMs).toFixed(1)),
+      ...(includeRaw
+        ? { rawSample: window.rawSample, rawSampleTruncated: window.rawSampleTruncated }
+        : {})
+    })
+
+    if (
+      !window.eventEligible ||
+      this.processEventDisposition(window.process, window.epoch) !== 'current'
+    ) {
+      return
+    }
     this.pushEvent({
       kind: 'system',
       level: 'warning',
-      sessionId: inFlight.length === 1 ? inFlight[0] : undefined,
+      sessionId: window.sessionAttributionConsistent ? window.sessionId : undefined,
       title: 'agent',
-      text
+      text: includeRaw ? `${summary}\n${window.rawSample}${rawSuffix}` : summary
     })
   }
 
@@ -2467,6 +2584,7 @@ class AcpRuntime {
     signal: NodeJS.Signals | null,
     context: Parameters<AcpAgentConnectionHooks['onProcessExit']>[2]
   ): void {
+    this.flushAgentProcessStderr(context.process)
     const processDisposition = this.processEventDisposition(context.process, context.epoch)
     log.info('agent process exit', {
       code,


### PR DESCRIPTION
## Problem

Each Agent process stderr chunk was copied verbatim into the main-process log and an ACP system warning. Ordinary research content, local paths, command output, and tool diagnostics are not credential-shaped, so the logger's redaction policy preserved them. A noisy Agent therefore amplified the same raw payload through the logger write chain, ACP publication, TaskRunner event capture, and WebSocket delivery.

The ACP retained history is already bounded, so this is not an unbounded-history bug. The reproducible problem is raw-content exposure plus per-chunk real-time fan-out and queued log work.

## Proposed change

- Aggregate stderr per Agent process into one-second windows.
- Log only metadata by default: framework, lifecycle status, Session count, diagnostic category, chunk count, byte count, window duration, and observed chunk rate.
- Publish one bounded system-warning summary per window, preserving a Session id only while attribution remains unambiguous for the whole window.
- Keep raw stderr support-only and opt-in through `OPEN_SCIENCE_AGENT_STDERR=raw`.
- Cap an opted-in raw sample at 4096 UTF-8 bytes and mark truncation.
- Flush a pending summary when the Agent process exits.

## Scope and non-goals

- No database, persisted format, migration, or historical-compatibility change.
- No new state enum or shared ACP event field.
- No renderer setting or interaction flow is added. The existing warning becomes a metadata summary instead of verbatim stderr by default.
- This PR does not redesign the general logger Promise queue, TaskRunner retention, or WebSocket backpressure. Reducing this source to one small record per second removes the reported amplification at its common origin; other noisy log sources remain a separate concern.

## Acceptance criteria and validation

The regression test was run before the fix and failed deterministically: ten stderr chunks produced ten `agent stderr` log calls containing `private-path:/lab/run-42/result.csv`, matching the report.

Source-impact checks after the implementation edit:

- Default privacy, rate limiting, raw opt-in byte cap, lifecycle behavior, and all four execution routes (Claude Code, OpenCode, Codex Responses, Codex Bridge) -> `vitest run src/main/acp/runtime.test.ts` -> 571 passed.
- Common process stderr adapter plus representative TaskRunner and WebSocket consumers -> targeted Vitest set -> 97 passed.
- Final combined owner/consumer Test Impact Set -> targeted Vitest set -> 668 passed.
- Changed TypeScript files -> targeted ESLint -> passed.

Downstream interaction check after aligning the existing status-bearing layout fixture with the metadata summary:

- `playwright test e2e/message-tool-layout-stability.spec.ts` -> 3 passed locally.

Local `npm run typecheck:node` was blocked by the shared dependency tree mismatch: `@agentclientprotocol/claude-agent-acp/dist/acp-agent.js` does not export `waitForMcpServers`. The identical error reproduced on the unmodified `main` checkout. Exact-head PR CI subsequently passed Static checks, including node/web typecheck.

Full `npm test` was intentionally not run. Exact-head PR CI passed the complete required matrix, including macOS module shards, module coverage, Windows core, macOS build and E2E, Windows E2E, CodeQL, and PR Gate.

## Review focus

- Default outputs contain no raw stderr.
- Per-process windows cannot mix Session attribution.
- The support-only raw path remains strictly byte-bounded for multibyte scientific text.
- Process replacement and exit cannot publish a stale Session warning.
