### PR TITLE
fix(acp): configure Claude loopback provider

### DIFF
--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -48,12 +48,24 @@ export type AgentAuthentication = {
 // providerId is invalid_params on 1.6.2 (`only "openai" is configurable`).
 export const CODEX_ACP_CONFIGURABLE_PROVIDER_ID = 'openai' as const
 
-export type AgentProviderConfiguration = {
-  providerId: typeof CODEX_ACP_CONFIGURABLE_PROVIDER_ID
-  apiType: 'openai'
-  baseUrl: string
-  headers: Record<string, string>
-}
+// claude-agent-acp exposes its active Anthropic-compatible provider as `main`.
+// Configuring that slot makes the loopback route programmatic settings, which
+// takes precedence over a user's persisted Claude settings.json environment.
+export const CLAUDE_ACP_CONFIGURABLE_PROVIDER_ID = 'main' as const
+
+export type AgentProviderConfiguration =
+  | {
+      providerId: typeof CODEX_ACP_CONFIGURABLE_PROVIDER_ID
+      apiType: 'openai'
+      baseUrl: string
+      headers: Record<string, string>
+    }
+  | {
+      providerId: typeof CLAUDE_ACP_CONFIGURABLE_PROVIDER_ID
+      apiType: 'anthropic'
+      baseUrl: string
+      headers: Record<string, string>
+    }
 
 // How the app's provider maps onto a framework's native model configuration. Claude reads env
 // (ANTHROPIC_*); opencode reads a generated config file referenced by OPENCODE_CONFIG. Fields are

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -618,6 +618,12 @@ describe('AgentBackendResolver configured and explicit targets', () => {
         ANTHROPIC_DEFAULT_FABLE_MODEL: 'fable',
         ANTHROPIC_BASE_URL: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/)
       })
+      expect(backend.providerConfiguration).toEqual({
+        providerId: 'main',
+        apiType: 'anthropic',
+        baseUrl: backend.env.ANTHROPIC_BASE_URL,
+        headers: { authorization: `Bearer ${backend.env.ANTHROPIC_AUTH_TOKEN}` }
+      })
       expect(backend.env).not.toHaveProperty('ANTHROPIC_CUSTOM_MODEL_OPTION')
     } finally {
       await backend.anthropicBridgeLease?.release()

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -383,6 +383,7 @@ export class AgentBackendResolver {
         contextWindow,
         ...(target.provider.supportsImageInput ? { supportsImageInput: true } : {}),
         contextUsageModel: target.effectiveModel,
+        providerConfiguration: transport.providerConfiguration,
         systemPromptAppends: [userSkillDirectoryGuidance, connectorInstructions].filter(
           (append): append is string => Boolean(append)
         ),

--- a/src/main/settings/provider-transport-owner.test.ts
+++ b/src/main/settings/provider-transport-owner.test.ts
@@ -445,6 +445,12 @@ describe('ProviderTransportOwner generations', () => {
       ANTHROPIC_AUTH_TOKEN: 'anthropic-bridge-token',
       ANTHROPIC_API_KEY: 'anthropic-bridge-token'
     })
+    expect(generation.providerConfiguration).toEqual({
+      providerId: 'main',
+      apiType: 'anthropic',
+      baseUrl: 'http://127.0.0.1:43000',
+      headers: { authorization: 'Bearer anthropic-bridge-token' }
+    })
     expect(generation.environment?.NO_PROXY).toBe(generation.environment?.no_proxy)
     expect(generation.anthropicBridgeLease?.setTarget('provider-a/model-a')).toBe(true)
     await generation.release()

--- a/src/main/settings/provider-transport-owner.ts
+++ b/src/main/settings/provider-transport-owner.ts
@@ -2,7 +2,12 @@ import { randomUUID } from 'node:crypto'
 
 import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
 import { netFetchStandard } from '../skills/net-fetch'
-import type { AgentModelCatalogEntry, ResolvedAgentBackend } from '../agent-framework'
+import {
+  CLAUDE_ACP_CONFIGURABLE_PROVIDER_ID,
+  type AgentModelCatalogEntry,
+  type AgentProviderConfiguration,
+  type ResolvedAgentBackend
+} from '../agent-framework'
 import { normalizeResponsesBaseUrl } from '../agent-framework/codex'
 import { opencodeTransportProviderId } from '../agent-framework/opencode'
 import {
@@ -109,6 +114,7 @@ type ProviderTransportGeneration = Readonly<{
   providerModelCatalog?: readonly AgentModelCatalogEntry[]
   responsesBridge?: LeasedResponsesBridgeConnection
   environment?: Record<string, string>
+  providerConfiguration?: AgentProviderConfiguration
   anthropicBridgeLease?: NonNullable<ResolvedAgentBackend['anthropicBridgeLease']>
   providerTransportLease?: NonNullable<ResolvedAgentBackend['providerTransportLease']>
   release: () => Promise<void>
@@ -521,6 +527,12 @@ class ProviderTransportOwner {
             input.activeTarget.provider.type === 'xai-subscription'
           ),
           ...loopbackProxyBypassEnvironment(process.env)
+        },
+        providerConfiguration: {
+          providerId: CLAUDE_ACP_CONFIGURABLE_PROVIDER_ID,
+          apiType: 'anthropic',
+          baseUrl: connection.baseUrl,
+          headers: { authorization: `Bearer ${connection.token}` }
         },
         anthropicBridgeLease: {
           setTarget: (targetId: string) => bridge.setTarget(targetId),


### PR DESCRIPTION
## Problem

Claude Code sessions that use an app-managed Anthropic-compatible loopback bridge currently pass the bridge URL and token only through process environment variables. Claude's persisted `settings.json.env` has higher precedence than the current process environment, so a stale loopback URL can replace the active bridge URL and produce `ECONNREFUSED` even though Open Science started a healthy bridge.

The reported bridge-close timing is not the trigger: correlated logs show the prompt fails before its bridge is released. The same failure is also present in v0.18.2 logs, so it is not established as a v0.19 regression.

Related: #1582

## Proposed change

- Publish the active Claude bridge as claude-agent-acp's configurable `main` provider with `apiType: anthropic`.
- Send the loopback URL and bearer token through the existing ACP `providers/set` initialization path, whose programmatic settings take precedence over persisted Claude settings.
- Keep the existing environment variables for adapter/process compatibility and loopback proxy bypass behavior.

This is intentionally a routing fix, not a direct-mode toggle or a change to the bridge lifecycle.

## Scope

- Historical compatibility: no migration and no historical data handling. Existing Claude settings are not edited; stale values simply stop overriding the active app-managed route.
- State/enums: no new application state or enum values.
- Persistence/data model: no database, schema, persisted field, or data-model change. The existing transient `providerConfiguration` runtime type is widened for Claude's `main`/`anthropic` slot.
- UI/interaction: no UI or interaction change.

ACP compatibility matrix:

- Claude Code + app provider bridge (including the representative xAI OAuth route): affected; now configured through `providers/set`.
- Claude subscription/direct provider path: excluded; it does not use the app loopback transport.
- OpenCode: excluded; it continues to use generated `OPENCODE_CONFIG` and its existing transport.
- Codex Responses and Codex bridge: unchanged; their existing `openai` provider configuration remains covered by the module contract tests.
- Platform: the ACP shape is platform-neutral. Local validation ran on macOS; the reported Windows path and `windows_sensitive` coverage remain authoritative in PR CI.

## Acceptance criteria and validation

The regression assertion was added before the fix and failed consistently with `providerConfiguration` missing, matching the stale-route mechanism. After the final material edit:

- Claude bridge route is emitted as programmatic provider configuration -> `npx vitest run src/main/settings/provider-transport-owner.test.ts -t 'owns Claude bridge credentials'` -> 1 passed.
- Claude backend preserves the bridge URL/token identity for ACP initialization -> `npx vitest run src/main/settings/backend-resolver.test.ts -t 'keeps Claude Code on a recognized alias'` -> 1 passed.
- Settings owner, ACP consumers, Claude/OpenCode/Codex adapter contracts, and Windows-sensitive overlay selection -> `npm run test:module -- settings_backend_resolution` -> 37 files passed, 1 skipped; 646 tests passed, 4 skipped.
- Main-process type contract -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors (256 existing warnings outside this diff).
- Formatting/diff integrity -> changed-file Prettier check and `git diff --check` -> passed.

`test:affected:explain` selects the complete portable suite because `src/main/agent-framework/types.ts` is an unknown module owner. Per task scope, the complete suite is deferred to exact-head PR CI rather than run locally.

## Review focus

- Confirm claude-agent-acp's `main`/`anthropic` provider contract and initialization ordering.
- Confirm the bridge bearer token remains confined to provisional initialize material and is absent from the published generation view.
- Confirm the compatibility exclusions above cover the final diff.

Uncovered risk: if endpoint security blocks TCP loopback itself, programmatic provider selection cannot repair that host-level block; this change addresses stale-route precedence only.
