### PR TITLE
fix(session-persistence): rebase consecutive authority updates

### DIFF
--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1425,6 +1425,149 @@ describe('renderer session persistence bridge', () => {
     })
   })
 
+  it('rebases a completed turn across consecutive Main Session-details revisions', async () => {
+    const prompt = {
+      id: 'prompt-1',
+      role: 'user' as const,
+      content: 'Summarize the deterministic fixture.',
+      status: 'complete' as const,
+      eventIds: [] as string[],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const partial = {
+      id: 'agent-message-1',
+      role: 'agent' as const,
+      content: 'Deterministic reply',
+      status: 'streaming' as const,
+      streamId: 'run-1',
+      responseToMessageId: prompt.id,
+      eventIds: ['event-1'],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 8,
+        status: 'running',
+        activeRun: { promptMessageId: prompt.id, startedAt: 1 },
+        messages: [prompt, partial],
+        sessionDetailsGenerationEligible: true
+      })
+    )
+    const queuedDetails = {
+      ...base,
+      revision: 9,
+      sessionDetailsGenerationEligible: undefined,
+      sessionDetailsSource: 'fallback' as const,
+      sessionDetailsGeneration: {
+        status: 'queued' as const,
+        sourceMessageId: prompt.id,
+        requestId: `${prompt.id}:session-details`,
+        queuedAt: 3
+      },
+      updatedAt: base.updatedAt + 1
+    }
+    const runningDetails = {
+      ...queuedDetails,
+      revision: 10,
+      sessionDetailsGeneration: {
+        ...queuedDetails.sessionDetailsGeneration,
+        status: 'running' as const,
+        startedAt: 4,
+        frameworkId: 'opencode' as const,
+        model: 'e2e-model',
+        reasoningEffort: 'low' as const
+      },
+      updatedAt: queuedDetails.updatedAt + 1
+    }
+    const terminalDetails = {
+      ...runningDetails,
+      revision: 11,
+      sessionDetailsGeneration: {
+        ...runningDetails.sessionDetailsGeneration,
+        status: 'failed' as const,
+        completedAt: 5,
+        usageUnavailable: true
+      },
+      updatedAt: runningDetails.updatedAt + 1
+    }
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(8, 9))
+      .mockRejectedValueOnce(new SessionRevisionConflictError(9, 10))
+      .mockRejectedValueOnce(new SessionRevisionConflictError(10, 11))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 12 }))
+    const api = createApi({
+      loadOne: vi
+        .fn()
+        .mockResolvedValueOnce(queuedDetails)
+        .mockResolvedValueOnce(runningDetails)
+        .mockResolvedValueOnce(terminalDetails),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().finishRun(base.id, undefined, prompt.id)
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+
+    expect(api.loadOne).toHaveBeenCalledTimes(3)
+    expect(saveSession).toHaveBeenCalledTimes(4)
+    expect(saveSession.mock.calls[3][0]).toMatchObject({
+      revision: 11,
+      status: 'idle',
+      activeRun: undefined,
+      messages: [
+        expect.objectContaining({ id: prompt.id }),
+        expect.objectContaining({ id: partial.id, status: 'complete' })
+      ],
+      sessionDetailsGeneration: { status: 'failed' }
+    })
+  })
+
+  it('stops rebasing when Main authority keeps advancing past the bounded retry window', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({ projectId: 'project-a', revision: 1 })
+    )
+    const authorities = [2, 3, 4].map((revision) => ({
+      ...base,
+      revision,
+      runtimeContext: { version: 1 as const, revision },
+      updatedAt: base.updatedAt + revision
+    }))
+    const conflicts = [
+      new SessionRevisionConflictError(1, 2),
+      new SessionRevisionConflictError(2, 3),
+      new SessionRevisionConflictError(3, 4),
+      new SessionRevisionConflictError(4, 5)
+    ]
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(conflicts[0])
+      .mockRejectedValueOnce(conflicts[1])
+      .mockRejectedValueOnce(conflicts[2])
+      .mockRejectedValueOnce(conflicts[3])
+    const api = createApi({
+      loadOne: vi
+        .fn()
+        .mockResolvedValueOnce(authorities[0])
+        .mockResolvedValueOnce(authorities[1])
+        .mockResolvedValueOnce(authorities[2]),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().togglePinned(base.id)
+
+    await expect(save(useSessionStore.getState())).rejects.toBe(conflicts[3])
+    expect(api.loadOne).toHaveBeenCalledTimes(3)
+    expect(saveSession).toHaveBeenCalledTimes(4)
+  })
+
   it('retries a pending tool activity save over disjoint concurrent Main graph changes', async () => {
     const base = materializeSessionConversationGraph(
       createPersistedSession({

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -498,6 +498,47 @@ const rebaseSessionAfterRevisionConflict = (
   return rebased
 }
 
+// Session details can legitimately advance through queued, running, and terminal Main-owned
+// revisions while a renderer transcript save is in flight. Rebase each observed authority in
+// sequence, but keep a hard cap so a genuinely active second writer cannot livelock persistence.
+const MAX_SESSION_REVISION_REBASE_ATTEMPTS = 3
+
+const saveAfterSessionRevisionConflict = async (
+  initialError: unknown,
+  initialBase: PersistedChatSession,
+  initialSubmitted: PersistedChatSession,
+  loadLatest: () => Promise<PersistedChatSession | undefined>,
+  save: (session: PersistedChatSession) => Promise<PersistedChatSession>
+): Promise<PersistedChatSession> => {
+  if (!isSessionRevisionConflictError(initialError)) throw initialError
+  let conflict: unknown = initialError
+  let base = initialBase
+  let submitted = initialSubmitted
+
+  for (let attempt = 0; attempt < MAX_SESSION_REVISION_REBASE_ATTEMPTS; attempt += 1) {
+    let latest: PersistedChatSession | undefined
+    try {
+      latest = await loadLatest()
+    } catch {
+      throw conflict
+    }
+    if (!latest) throw conflict
+    const rebased = rebaseSessionAfterRevisionConflict(base, submitted, latest)
+    if (!rebased) throw conflict
+
+    try {
+      return await save(rebased)
+    } catch (error) {
+      if (!isSessionRevisionConflictError(error)) throw error
+      conflict = error
+      base = latest
+      submitted = rebased
+    }
+  }
+
+  throw conflict
+}
+
 const mergeSaveSessionOptions = (
   previous: SaveSessionOptions | undefined,
   next: SaveSessionOptions | undefined
@@ -714,24 +755,20 @@ const saveSessionInOrder = async (
         if (!isSessionRevisionConflictError(error)) throw error
         const base = persistence.getAcknowledgedSession(submitted.id)
         if (!base) throw error
-
-        let latest: PersistedChatSession | undefined
-        try {
-          latest = await loadPersistedSession(
-            {
-              projectId: submitted.projectId,
-              sessionId: submitted.id
-            },
-            api
-          )
-        } catch {
-          throw error
-        }
-        const rebased = latest
-          ? rebaseSessionAfterRevisionConflict(base, submitted, latest)
-          : undefined
-        if (!rebased) throw error
-        return retry(rebased)
+        return saveAfterSessionRevisionConflict(
+          error,
+          base,
+          submitted,
+          () =>
+            loadPersistedSession(
+              {
+                projectId: submitted.projectId,
+                sessionId: submitted.id
+              },
+              api
+            ),
+          retry
+        )
       }
     )
     unresolvedSessionRevisionConflictTargets.delete(target)
@@ -1093,22 +1130,20 @@ const createStoreSaver = (
     if (!isSessionRevisionConflictError(error)) throw error
     const base = acknowledgedSessions.get(submitted.id)
     if (!base) throw error
-    let latest: PersistedChatSession | undefined
-    try {
-      latest = await loadPersistedSession(
-        {
-          projectId: submitted.projectId,
-          sessionId: submitted.id
-        },
-        api
-      )
-    } catch {
-      throw error
-    }
-    if (!latest) throw error
-    const rebased = rebaseSessionAfterRevisionConflict(base, submitted, latest)
-    if (!rebased) throw error
-    return options ? save(rebased, options) : save(rebased)
+    return saveAfterSessionRevisionConflict(
+      error,
+      base,
+      submitted,
+      () =>
+        loadPersistedSession(
+          {
+            projectId: submitted.projectId,
+            sessionId: submitted.id
+          },
+          api
+        ),
+      (rebased) => (options ? save(rebased, options) : save(rebased))
+    )
   }
 
   return (state, options) => {


### PR DESCRIPTION
## Summary

- Rebase a renderer Session save across each newly observed Main-owned authority revision instead of stopping after the first safe rebase.
- Bound the recovery window to three rebases, matching Session details' queued/running/terminal transitions while preserving the existing fail-closed behavior for sustained multi-writer contention.
- Add a deterministic completed-turn regression and a retry-cap regression.

## Failure evidence

GitHub Actions run [`33152075059`](https://github.com/aipoch/open-science/actions/runs/33152075059), `macOS build and E2E`:

- Attempt 1 ([job `98786196670`](https://github.com/aipoch/open-science/actions/runs/33152075059/job/98786196670)): both completed-tool-group cases reached a visible completed first reply, then `session-persistence-alert` covered `Send message`. Each retry passed, so `--fail-on-flaky-tests` failed the job.
- Attempt 2 ([job `98789459493`](https://github.com/aipoch/open-science/actions/runs/33152075059/job/98789459493)): the layout cases passed, but the mobile archive journey did not show `archive-undo-snackbar`. Its trace shows both the same persistence alert and Main's `Finish or stop this session before archiving.` rejection. The retry passed, so `--fail-on-flaky-tests` again failed the job.
- Build, functional, accessibility, visual, Windows core/E2E, and both complete Vitest shards passed. PR #1859 did not change renderer persistence or these E2E paths; this is an independent fix and does not modify or reopen #1859.

## Root cause

A fast completed turn can overlap Main's legitimate Session-details authority transitions (`queued` -> `running` -> terminal). The renderer's terminal `idle` save could safely rebase one revision conflict, but the recovery path attempted only one rebase/save. If Main advanced again before that retry committed, the second revision conflict escaped to the persistence alert. The renderer still displayed its in-memory completed/idle projection while durable state remained running:

- the alert intercepted the next layout-test send;
- archive correctly rejected the still-running durable Session before a snackbar could be created.

The fix repeatedly loads and three-way rebases the next authority, carrying the prior rebased candidate forward. It does not relax any same-field or same-graph-identity conflict rule. Three failed rebase attempts remain a hard stop, so a genuinely active second writer still surfaces the existing alert.

## Test Impact Set

- Completed turn -> renderer revision-conflict seam -> `rtk npx vitest run src/renderer/src/lib/session-persistence/session-persistence.test.ts -t 'rebases a completed turn across consecutive Main Session-details revisions'` -> **pre-fix FAIL** on the second conflict (`expected 9, actual 10`); **post-fix PASS** across queued/running/terminal authority revisions.
- Conflict safety cap -> renderer revision-conflict seam -> `rtk npx vitest run src/renderer/src/lib/session-persistence/session-persistence.test.ts` -> **54 passed**, including a fourth-conflict rejection after the three-rebase cap and the existing graph/branch fail-closed cases.
- Persistence integration -> renderer owner and direct consumers -> `rtk npx vitest run src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx` -> **74 passed**; `rtk npx vitest run src/renderer/src/hooks/useQuitPersistenceFlush.test.ts src/renderer/src/pages/home/HomePage.persistence.test.tsx` -> **13 passed**.
- Renderer contracts -> TypeScript/lint -> `rtk npm run typecheck:web`; `rtk npx eslint src/renderer/src/lib/session-persistence/session-persistence.ts src/renderer/src/lib/session-persistence/session-persistence.test.ts` -> **passed**.
- Electron package -> final latest-main checkout -> `rtk npm run build:e2e` -> **passed**.
- macOS workspace journeys -> OpenCode fake-agent path -> `CI=1 rtk npx playwright test e2e/message-tool-layout-stability.spec.ts e2e/workspace-conversation.spec.ts --grep 'keeps a completed tool group stationary|archives a completed session from its mobile sidebar actions' --repeat-each=5 --retries=0 --workers=1` -> **15 passed, 0 failed**.
- Dependency plan -> `rtk npm run test:affected -- --base origin/main --head HEAD --explain` -> reports full mode because `src/renderer/src/lib/session-persistence/session-persistence.test.ts` has no registered module owner. Per this task's explicit instruction, the local complete `npm test` suite was not run; required PR CI is the complete-suite authority.

## Coverage and risk

Covered: the renderer persistence owner, ordered explicit saves, React persistence integration, quit/Home consumers, the macOS OpenCode fake-agent layout paths, and mobile archive behavior. The deterministic test models the same Session-details revision sequence that races the terminal turn.

Not run locally: Windows/Linux Electron, other Agent Framework launchers/models, unrelated renderer consumers from CodeGraph's broad transitive set, and the complete Vitest suite. The changed seam is below framework/model adapters; required CI covers the excluded platform and suite combinations. Residual risk is intentionally bounded: more than three consecutive safe authority advances still fail closed and present the existing retry UI.

There are no new compatibility branches, enums, persisted fields, schema/data-model changes, or user-interaction changes. No user-visible strings were added.

Independent review requested: please verify the three-attempt bound, the carry-forward rebase base/candidate, and that sustained or semantic conflicts still fail closed.
