### PR TITLE
fix(notebook): strip host LLM routing metadata

### DIFF
--- a/src/main/notebook/local-rpc-server.llm.test.ts
+++ b/src/main/notebook/local-rpc-server.llm.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { HostLlmCallInput, HostLlmResult } from './host-model-service'
+import {
+  HostModelService,
+  type HostLlmBatchItem,
+  type HostLlmCallInput,
+  type HostLlmResult
+} from './host-model-service'
 import { NotebookLocalRpcServer } from './local-rpc-server'
 
 let server: NotebookLocalRpcServer | undefined
@@ -77,6 +82,113 @@ describe('llmCall RPC', () => {
     await expect(unauthorized.json()).resolves.toEqual({
       error: 'A session-bound notebook RPC token is required.'
     })
+  })
+
+  it('keeps active-turn provenance out of single and batch Host LLM inputs', async () => {
+    const hostLlmCall = vi.fn<
+      (
+        input: HostLlmCallInput,
+        signal?: AbortSignal
+      ) => Promise<HostLlmResult | readonly HostLlmBatchItem[]>
+    >(async (input) =>
+      'requests' in input
+        ? input.requests.map((request) => ({
+            text: typeof request === 'string' ? request : request.prompt,
+            model: 'model-a',
+            stopReason: 'end_turn' as const
+          }))
+        : { text: 'PONG', model: 'model-a', stopReason: 'end_turn' }
+    )
+    const hostLlm = {
+      isLlmAvailable: vi.fn(async () => true),
+      isCurrentModelAvailable: vi.fn(async () => true),
+      isListModelsAvailable: vi.fn(async () => true),
+      currentModel: vi.fn(async () => 'model-a'),
+      listModels: vi.fn(async () => ['model-a']),
+      call: hostLlmCall
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostModel: hostLlm,
+      inputRegistry: {
+        registerTurn: vi.fn(async () => undefined),
+        getTurnInputs: vi.fn(() => []),
+        clearSession: vi.fn()
+      }
+    })
+    const control = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+    server.setArtifactProvenanceContext('trusted-session', {
+      rootFrameId: 'root-frame-trusted-session',
+      agentFrameId: 'root-frame-trusted-session',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-1',
+      promptMessageId: 'prompt-1'
+    })
+    await server.registerNotebookTurnInputs({
+      projectId: 'trusted-project',
+      appSessionId: 'trusted-session',
+      promptMessageId: 'prompt-1',
+      uploads: [],
+      references: []
+    })
+
+    const single = await call(control.endpoint, control.token, { request: 'PING' })
+    const batch = await call(control.endpoint, control.token, {
+      requests: ['one', { prompt: 'two' }],
+      options: { max_concurrency: 2 }
+    })
+
+    expect(single.status).toBe(200)
+    expect(batch.status).toBe(200)
+    expect(hostLlmCall.mock.calls.map(([input]) => input)).toEqual([
+      { request: 'PING' },
+      {
+        requests: ['one', { prompt: 'two' }],
+        options: { max_concurrency: 2 }
+      }
+    ])
+    expect(hostLlmCall.mock.calls.every(([, signal]) => signal instanceof AbortSignal)).toBe(true)
+  })
+
+  it('preserves unknown user fields for strict Host LLM input validation', async () => {
+    const captureTarget = vi.fn(async () => {
+      throw new Error('inference should not start')
+    })
+    const hostModel = new HostModelService({
+      captureTarget,
+      captureSessionModel: () => undefined,
+      captureModelCatalog: vi.fn(async () => ({ providers: [] })),
+      runner: {
+        run: vi.fn(),
+        shutdown: vi.fn(async () => undefined),
+        supportsTarget: vi.fn(() => true),
+        sweepStaleProfiles: vi.fn(async () => undefined)
+      } as never
+    })
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostModel
+    })
+    const control = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+
+    const response = await call(control.endpoint, control.token, {
+      request: 'PING',
+      model: 'forged-model'
+    })
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'host.llm single input must contain only request.'
+    })
+    expect(captureTarget).not.toHaveBeenCalled()
   })
 
   it('aborts host inference when the RPC client disconnects', async () => {

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -1949,9 +1949,17 @@ class NotebookLocalRpcServer {
 
     if (method === 'llmCall') {
       if (!this.hostModel) throw new Error('host.llm is not configured.')
-      const { sessionId: _sessionId, projectId: _projectId, ...input } = params
+      const {
+        sessionId: _sessionId,
+        projectId: _projectId,
+        provenanceContext: _provenanceContext,
+        registeredInputFiles: _registeredInputFiles,
+        ...input
+      } = params
       void _sessionId
       void _projectId
+      void _provenanceContext
+      void _registeredInputFiles
       return this.hostModel.call(input as HostLlmCallInput, signal)
     }
 


### PR DESCRIPTION
## Problem

Valid `host.llm` single and batch requests failed during active Notebook turns with errors such as `host.llm single input must contain only request.` The local RPC layer added trusted Provenance and registered-input metadata, then forwarded those internal routing fields into the strict Host LLM request validator.

## Proposed change

Strip the server-owned `provenanceContext` and `registeredInputFiles` fields, together with the existing trusted Session and Project identities, before dispatching `llmCall` to `HostModelService`.

Add regression coverage proving that:

- single and batch calls succeed with active Provenance and registered inputs;
- unknown user-supplied fields remain visible to strict Host LLM validation and are rejected before inference starts.

## Scope and non-goals

This is limited to `llmCall` parameter sanitization and its existing local RPC test module. It does not change Host LLM request shapes, availability checks, model selection, inference execution, other Notebook RPC methods, or user-visible copy.

## Acceptance criteria and validation

All listed passing checks ran after the final material edit.

Evidence mapping:

- Active-turn single and batch routing drops only trusted internal metadata -> targeted Host LLM RPC regression checks -> **27 passed**.
- Host LLM request/result validation and REPL adapter behavior remain compatible -> `npx vitest run src/main/notebook/local-rpc-server.llm.test.ts src/main/notebook/host-model-service.test.ts src/main/notebook/repl-loop.integration.test.ts` -> **52 passed, 31 skipped**.
- Local RPC ownership, capability, and Notebook consumer behavior remain intact -> `npx vitest run src/main/notebook/local-rpc-server.test.ts src/main/notebook/local-rpc-server.llm.test.ts src/main/notebook/local-rpc-server.capabilities.test.ts` -> **69 passed**.
- A forged unknown field is rejected by the real `HostModelService` before target capture -> dedicated regression assertion -> **passed**.
- Node process types remain sound -> `npm run typecheck:node` -> **passed**.
- Linted source remains compliant -> `npm run lint` -> **passed**.
- Final base-to-head diff is limited to the intended implementation and test -> diff check -> **passed**.

`npm run test:affected -- --base origin/main --head HEAD` selected `Mode: full` because the added test file has no module owner. The resulting complete Vitest run did not finish under shared local resources and produced unrelated timeout/resource failures in unchanged runtime, settings, ACP, and renderer suites. The full suite is therefore **not claimed as passed**; the PR Gate is authoritative for complete portable validation.

## Review focus

Please verify that the sanitization removes only server-injected routing metadata, while preserving arbitrary user fields for `HostModelService`'s exact-key rejection. The main uncovered risk is interaction with consumers outside the passing focused suites; the exact-head PR Gate should resolve that risk with its complete validation plan.
