### PR TITLE
refactor(storage): consolidate migration contracts

### DIFF
--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -8,6 +8,7 @@ import { app, dialog, shell } from 'electron'
 import type {
   ActiveSessionInfo,
   DataRootInspection,
+  DataRootValidationResult,
   DiscardMigratedCopyResult,
   MigrationOutcome,
   MigrationProgress,
@@ -37,8 +38,7 @@ import {
   discardStagedCopy,
   pauseDataRootWriters,
   runDataRootMigration,
-  validateNewDataRoot,
-  type ValidateResult
+  validateNewDataRoot
 } from './migration-service'
 import { readMigrationMarker } from './migration-marker'
 import { availableBytes, computeStorageUsage } from './usage'
@@ -545,7 +545,9 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   // Onboarding's first-run location step: check a candidate parent before letting the user commit
   // to it. Never throws: validateNewDataRoot already guards fs errors, this catch only covers
   // anything unexpected escaping that contract.
-  const validateDataRoot = async (request: StorageParentRequest): Promise<ValidateResult> => {
+  const validateDataRoot = async (
+    request: StorageParentRequest
+  ): Promise<DataRootValidationResult> => {
     try {
       return await validateNewDataRoot(request.parent, resolveDataRoot())
     } catch (err) {
@@ -588,7 +590,9 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   // resolves would swap the wizard for Home (showing the OLD data root, and burying any failure
   // below). Settings-adopt omits it (onboarding has already completed). Order is load-bearing:
   // classify -> mkdir -> persist settings -> relaunch. On an invalid parent, none of these run.
-  const setDataRootAndRelaunch = async (request: StorageRootRequest): Promise<ValidateResult> => {
+  const setDataRootAndRelaunch = async (
+    request: StorageRootRequest
+  ): Promise<DataRootValidationResult> => {
     const operation = startDiagnosticOperation(logger, {
       operation: 'data-root-selection',
       fields: { onboarding: request.markOnboarding === true }

--- a/src/main/storage/data-migration.test.ts
+++ b/src/main/storage/data-migration.test.ts
@@ -15,7 +15,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { copyAndVerify, deleteSources, type MigrationProgress } from './data-migration'
+import type { MigrationProgress } from '../../shared/storage'
+import { copyAndVerify, deleteSources } from './data-migration'
 
 let from: string
 let to: string
@@ -48,7 +49,7 @@ const exists = async (path: string): Promise<boolean> => {
 }
 
 describe('copyAndVerify', () => {
-  it('copies dirs on the same volume, verifies them, and leaves sources intact', async () => {
+  it('copies dirs, verifies them, and leaves sources intact', async () => {
     await seedFixture()
     const progress: MigrationProgress[] = []
     const result = await copyAndVerify({
@@ -145,29 +146,6 @@ describe('copyAndVerify', () => {
     }
   )
 
-  it('forces the byte-copy branch (simulated cross-device) and produces the same result', async () => {
-    await seedFixture()
-    const progress: MigrationProgress[] = []
-    const result = await copyAndVerify({
-      from,
-      to,
-      dirs: ['artifacts', 'uploads'],
-      signal: new AbortController().signal,
-      onProgress: (p) => progress.push(p),
-      forceCopy: true
-    })
-
-    expect(result).toEqual({ ok: true })
-    expect(await readFile(join(to, 'artifacts', 'a.txt'), 'utf8')).toBe('hello artifacts')
-    expect(await readFile(join(to, 'uploads', 'b.txt'), 'utf8')).toBe('hello uploads')
-    expect(progress.some((p) => p.phase === 'copy')).toBe(true)
-
-    const deleteResult = await deleteSources(from, ['artifacts', 'uploads'])
-    expect(deleteResult.failed).toEqual([])
-    expect(await exists(join(from, 'artifacts'))).toBe(false)
-    expect(await exists(join(from, 'uploads'))).toBe(false)
-  })
-
   it('cancels mid-copy, leaves sources intact, and cleans partial dest', async () => {
     await seedFixture()
     // Add more files so there's something to cancel between.
@@ -179,7 +157,6 @@ describe('copyAndVerify', () => {
       to,
       dirs: ['artifacts', 'uploads'],
       signal: controller.signal,
-      forceCopy: true,
       onProgress: () => {
         if (!seenFirstProgress) {
           seenFirstProgress = true
@@ -210,8 +187,7 @@ describe('copyAndVerify', () => {
       to,
       dirs: ['artifacts', 'uploads'],
       signal: new AbortController().signal,
-      onProgress: () => {},
-      forceCopy: true
+      onProgress: () => {}
     })
 
     expect(result.ok).toBe(false)

--- a/src/main/storage/data-migration.ts
+++ b/src/main/storage/data-migration.ts
@@ -4,14 +4,7 @@ import { chmod, lstat, mkdir, readdir, readlink, rm, rmdir, stat, symlink } from
 import { basename, dirname, join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 
-export type MigrationPhase = 'scan' | 'copy' | 'verify' | 'delete'
-export type MigrationProgress = {
-  phase: MigrationPhase
-  copiedBytes: number
-  totalBytes: number
-  currentPath?: string
-}
-export type MigrationResult = { ok: true } | { ok: false; error: string; cancelled?: boolean }
+import type { MigrationProgress, MigrationResult } from '../../shared/storage'
 
 type MigrateOpts = {
   from: string
@@ -19,10 +12,6 @@ type MigrateOpts = {
   dirs: string[]
   signal: AbortSignal
   onProgress: (p: MigrationProgress) => void
-  // Accepted for interface compatibility (test hook to "force" the byte-copy branch);
-  // this implementation always byte-copies, so it is a no-op. See report for rationale:
-  // rename is skipped entirely to keep multi-dir rollback simple and safe.
-  forceCopy?: boolean
 }
 
 // Thrown internally to unwind to the single catch site; never escapes copyAndVerify.

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -14,7 +14,7 @@ vi.mock('./remote-data-root', () => ({
 
 import { existsSync } from 'node:fs'
 
-import type { MigrationProgress, MigrationResult } from './data-migration'
+import type { MigrationProgress, MigrationResult } from '../../shared/storage'
 import {
   classifyDataRoot,
   commitDataRootSwitch,

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -3,18 +3,21 @@ import { existsSync, readFileSync, readdirSync, type Dirent } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { join, resolve } from 'node:path'
 
+import type {
+  DataRootKind,
+  DataRootRecoveryStatus,
+  DataRootValidationResult,
+  MigrationOutcome,
+  MigrationProgress,
+  MigrationResult
+} from '../../shared/storage'
 import {
   dataRootForPicked,
   isPathInsideOrEqual,
   resolveConfigRoot,
   samePath
 } from '../storage-root'
-import {
-  copyAndVerify,
-  deleteSources,
-  type MigrationProgress,
-  type MigrationResult
-} from './data-migration'
+import { copyAndVerify, deleteSources } from './data-migration'
 import {
   MIGRATION_MARKER_FILENAME,
   newToken,
@@ -42,15 +45,11 @@ export { DATA_ROOT_DIRS } from './data-directories'
 // hardcoded absolute paths, so it is rebuilt on demand at the new root. See design §17.
 export const MIGRATED_DIRS = RELOCATABLE_DATA_DIRS
 
-export type ValidateResult = { ok: true } | { ok: false; error: string }
-
 // Classification of a candidate data root relative to the current one. 'move' = empty and
 // writable, safe for the copy-in migration engine. 'adopt' = already holds our data (a prior
 // migration, or the user's own pre-existing folder) - the pointer should switch to it as-is,
 // never be moved into. 'recover' is a marker-confirmed copy left by an interrupted migration;
 // 'invalid' carries a user-facing reason.
-export type DataRootKind = 'move' | 'adopt' | 'recover' | 'invalid'
-export type DataRootRecoveryStatus = 'copying' | 'verified'
 export type ClassifyResult =
   | { kind: 'recover'; recoveryStatus: DataRootRecoveryStatus; error?: string }
   | {
@@ -313,7 +312,7 @@ export const classifyDataRoot = async (
 export const validateNewDataRoot = async (
   parent: string,
   currentDataRoot: string
-): Promise<ValidateResult> => {
+): Promise<DataRootValidationResult> => {
   const result = await classifyDataRoot(parent, currentDataRoot)
 
   if (result.kind === 'move') return { ok: true }
@@ -334,12 +333,6 @@ export const validateNewDataRoot = async (
 
   return { ok: false, error: result.error ?? 'The selected folder is not usable.' }
 }
-
-// A post-move `setDataRoot` failure is distinguishable from an ordinary migration failure: the
-// data already lives at the target, so the caller needs a different recovery message and must not
-// treat this like a retryable pre-move failure.
-export type MigrationOutcome =
-  MigrationResult | { ok: false; error: string; switchoverFailed: true }
 
 // runtime/ is not copied wholesale (env prefixes and mutable inventory-cache keys bake absolute
 // paths), but its pkgs cache IS relocatable inert data — copied so envs can be rebuilt offline at the
@@ -405,7 +398,6 @@ type MigrationCopyDeps = DataRootWriterPauseDeps & {
     dirs: string[]
     signal: AbortSignal
     onProgress: (p: MigrationProgress) => void
-    forceCopy?: boolean
   }) => Promise<MigrationResult>
   validateProvenanceState?: (root: string) => Promise<void>
 }

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,5 +1,4 @@
-// Renderer-safe copies of storage types whose canonical definitions live in main-only modules
-// (src/main/storage/*), mirroring how ArtifactFile/NotebookRunSummary are shared with preload.
+// Cross-process storage contracts shared by main, preload, and renderer.
 
 export type UsageCategoryKey =
   'artifacts' | 'delegation' | 'uploads' | 'runtime' | 'notebooks' | 'workspaces'
@@ -61,15 +60,12 @@ export type MigrationResult = { ok: true } | { ok: false; error: string; cancell
 export type MigrationOutcome =
   MigrationResult | { ok: false; error: string; switchoverFailed: true }
 
-// Result of validating (or applying) a candidate data root, mirroring main's ValidateResult
 export type DiscardMigratedCopyResult =
   { ok: true; cleanupWarning?: string } | { ok: false; error: string }
 
-// (src/main/storage/migration-service.ts) without importing main-only code into the renderer.
 export type DataRootValidationResult = { ok: true } | { ok: false; error: string }
 
-// Classification of a candidate data root, mirroring main's ClassifyResult
-// (src/main/storage/migration-service.ts). 'move' = empty writable target (copy-in migration).
+// Classification of a candidate data root. 'move' = empty writable target (copy-in migration).
 // 'adopt' = already contains our data (pointer switch only, no move). 'recover' = a durable marker
 // from an interrupted copy that Settings can explicitly finish or discard. 'invalid' carries a reason.
 // `dataRoot` is the derived `<parent>/OpenScience` path, always present so the caller can display


### PR DESCRIPTION
## Problem

Storage migration contracts were duplicated between shared and main modules, leaving compile-time definitions that could drift independently. The `forceCopy` option also implied a separate cross-device branch even though the copy engine never read it and always performed the same byte-copy path.

## Proposed change

- make `src/shared/storage.ts` the canonical contract for migration progress/results, validation results, migration outcomes, and data-root classification values
- import those contracts directly from main storage implementation and tests
- remove the unused `forceCopy` option and the duplicate test that purported to force a branch that does not exist
- keep the real copy, verification, cancellation, and rollback tests

## Scope and non-goals

- no runtime migration, recovery, switchover, or deletion behavior changes
- no interaction or user-visible copy changes
- no dependencies added
- no database schema, persisted fields, data format, or data model changes
- no new enum or state values
- no historical-data compatibility path is required

## Acceptance criteria and validation

Checks below ran after the last material edit.

- byte copy, checksum verification, cancellation cleanup, rollback, and shared storage helpers -> `node ..\..\node_modules\vitest\vitest.mjs run src/main/storage/data-migration.test.ts src/main/storage/migration-service.test.ts src/main/storage/command-owner.atomicity.test.ts src/shared/storage.test.ts` -> 4 files passed; 95 tests passed, 8 platform-conditioned skips
- changed source and tests -> `npm run lint` -> passed

The storage area has no dedicated module ID in `scripts/ci/module-impact.json`, so explicit owner/contract test paths were used instead of describing them as a complete module suite.

Local `npm test -- <paths>` could not pass its Prisma preflight because this worktree intentionally has no private `node_modules`. The canonical checkout lockfile has unrelated uncommitted changes and differs from this worktree, so its dependency tree was not junctioned or modified. Node and Web typechecks were also blocked by that stale shared Prisma/ACP dependency state; reported errors were outside this diff. Exact-head PR Gate remains authoritative for typechecks and broader consumers.

## Review focus

- confirm main now consumes the shared contracts without changing their shapes
- confirm removal of `forceCopy` only deletes a no-op test hook and redundant coverage