### PR TITLE
fix(connectors): disable cancel while saving

### DIFF
--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -493,6 +493,54 @@ describe('ConnectorAddForm (remote server)', () => {
     expect(onDone).toHaveBeenCalledOnce()
   })
 
+  it('keeps Cancel disabled while an OAuth server is being added', async () => {
+    const created = {
+      id: 'oauth-mcp',
+      name: 'oauth-mcp',
+      displayName: 'OAuth MCP',
+      transport: 'streamable_http' as const,
+      enabled: false,
+      url: 'https://mcp.example.test',
+      oauth: { hasTokens: false }
+    }
+    let resolveAdd!: (server: typeof created) => void
+    const onCancel = vi.fn()
+    useSettingsStore.setState({
+      addCustomServer: vi.fn(
+        () =>
+          new Promise<typeof created>((resolve) => {
+            resolveAdd = resolve
+          })
+      ),
+      authenticateCustomServer: vi.fn().mockResolvedValue(undefined),
+      cancelCustomServerAuthentication: vi.fn().mockResolvedValue(undefined)
+    })
+    act(() => {
+      root.render(
+        <ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={onCancel} />
+      )
+    })
+
+    setValue('Display name', 'OAuth MCP')
+    setValue('Server URL', 'https://mcp.example.test')
+    openAdvancedSettings()
+    selectOption('Authentication', 'OAuth')
+    checkTrust()
+    act(() => addButton()?.click())
+
+    const cancel = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Cancel'
+    )
+    expect(cancel?.disabled).toBe(true)
+    act(() => cancel?.click())
+    expect(onCancel).not.toHaveBeenCalled()
+
+    await act(async () => resolveAdd(created))
+    expect(useSettingsStore.getState().authenticateCustomServer).toHaveBeenCalledWith({
+      id: 'oauth-mcp'
+    })
+  })
+
   it('shows the default callback before revealing a different registered URI', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.defineProperty(navigator, 'clipboard', {

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -1080,7 +1080,7 @@ export function ConnectorAddForm({
         ) : null}
 
         <div className="flex items-center justify-end gap-2">
-          <Button type="button" variant="ghost" onClick={onCancel}>
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={submitting}>
             {tCommon('Cancel')}
           </Button>
           <Button type="button" onClick={() => void handleSubmit()} disabled={!canSubmit}>


### PR DESCRIPTION
## Problem

Connector add/edit requests are not cancellable, but the form left Cancel enabled while a save was pending. Cancel navigated back to the Connector list and unmounted the form without stopping the mutation. The Connector could therefore still be created or updated, and a newly created OAuth Connector could lose the form-owned sign-in continuation.

## Proposed change

- Disable Cancel while the add/update mutation is pending.
- Add a renderer regression test with a controlled pending OAuth add request.
- Verify that Cancel remains inert and OAuth authentication starts after creation completes.

## Scope and non-goals

- No data fields, enum values, schema changes, or persisted-format changes.
- No historical-data compatibility work is required.
- No Settings-wide navigation lock or store-level OAuth attempt coordinator is introduced.
- Closing or navigating away through other Settings controls remains outside this narrowly scoped fix.

## Acceptance criteria and validation

The regression test was run twice before the production change and failed both times because `Cancel.disabled` was `false` while the add request was pending.

Final checks ran after the last material edit:

- Save-time Cancel lock and OAuth continuation -> `node ..\..\node_modules\vitest\vitest.mjs run src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx` -> 23 tests passed.
- Renderer type safety -> `node ..\..\node_modules\typescript\bin\tsc --noEmit -p tsconfig.web.json --composite false` -> passed.
- Lint -> `node ..\..\node_modules\eslint\bin\eslint.js --cache .` -> passed.

The complete portable suite was intentionally left to PR CI, per maintainer direction.

## Review focus

- Confirm that native button disabling is the intended interaction while the underlying settings mutation cannot be cancelled.
- Confirm that Settings-wide navigation locking is not required for this focused report.
