### PR TITLE
fix(updater): allow retry after failed download

### DIFF
--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -363,10 +363,13 @@ describe('ElectronUpdaterStrategy', () => {
     expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
   })
 
-  it('records a failed in-place download without the provider error message', async () => {
+  it('preserves the offer and retries after a failed in-place download', async () => {
     const updater = new FakeUpdater()
+    let starts = 0
     updater.runDownload = async () => {
-      throw new Error('private updater diagnostic detail')
+      starts += 1
+      if (starts === 1) throw new Error('private updater diagnostic detail')
+      updater.emit('update-downloaded', { version: '0.3.0' })
     }
     const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
@@ -381,9 +384,22 @@ describe('ElectronUpdaterStrategy', () => {
       vi.mocked(log[level]).mockClear()
     }
 
-    const status = await strategy.download()
+    const failed = await strategy.download()
+    const retry = await strategy.download()
 
-    expect(status.error).toBe('private updater diagnostic detail')
+    expect.soft(failed).toEqual(
+      expect.objectContaining({
+        state: 'error',
+        current: '0.2.0',
+        latest: '0.3.0',
+        notes: 'notes',
+        totalBytes: 10000,
+        error: 'private updater diagnostic detail'
+      })
+    )
+    expect.soft(retry.state).toBe('ready')
+    expect.soft(retry.error).toBeUndefined()
+    expect.soft(starts).toBe(2)
     const records = diagnosticRecords(log)
     expect(records).toEqual(
       expect.arrayContaining([

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -431,7 +431,12 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     if (this.checkLifecycle) await this.checkLifecycle
     if (this.applying || this.downloadToken) return this.status
     if (this.status.state === 'ready') return this.status
-    if (this.status.state !== 'available') return this.status
+    if (
+      this.status.state !== 'available' &&
+      !(this.status.state === 'error' && this.status.latest)
+    ) {
+      return this.status
+    }
 
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-download',
@@ -448,7 +453,15 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     const generation = ++this.downloadGeneration
     const token = this.createCancellationToken()
     this.downloadToken = token
-    this.setStatus({ ...this.status, state: 'downloading', progress: 0, downloadedBytes: 0 })
+    this.setStatus({
+      ...this.status,
+      state: 'downloading',
+      progress: 0,
+      downloadedBytes: 0,
+      downloadProgress: undefined,
+      error: undefined,
+      blockedBy: undefined
+    })
 
     const lifecycle = (async () => {
       try {
@@ -473,6 +486,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         // rejects and can't poison the next download()'s drain.
         if (!token.cancelled) {
           this.setStatus({
+            ...this.status,
             state: 'error',
             error: error instanceof Error ? error.message : 'Download failed'
           })


### PR DESCRIPTION
## Problem

When an in-place update download fails, the strategy replaces the active offer with a minimal error status. This drops the offered version, release notes, and artifact size, which closes the update dialog. Error statuses that do retain an offered version still cannot retry because download only accepts the available state.

## Proposed change

- preserve the active offer when a download fails
- allow an error status with an offered version to transition back to downloading
- clear attempt-local error and progress fields before retrying
- extend the existing public strategy test to prove the first failure preserves metadata and the second download reaches ready

## Scope and non-goals

- no new UpdateState value
- no new UpdateStatus field
- no persistence, migration, or historical-data compatibility change
- no renderer or interaction redesign
- no generalized state-machine refactor

## Acceptance criteria and validation

The regression test was run twice against the original implementation and deterministically failed because latest, notes, and totalBytes were missing, the retry remained in error, and the updater started only once.

Final checks, run after the last material edit:

- update module behavior: focused src/main/update run passed 8 files and 107 tests
- linted source: full ESLint run passed
- diff hygiene: git diff --check passed
- Node typecheck: attempted, but the shared local dependency tree does not match this worktree lockfile; an unrelated ACP test imports waitForMcpServers from an installed package version that does not export it

PR CI is authoritative for the clean-lockfile Node typecheck and packaged/platform lanes. No full local npm test was run, per maintainer request.

## Review focus

Please verify that treating error statuses carrying latest as restartable downloads is the intended recovery behavior for in-place updates, and that attempt-local error/progress fields are reset without dropping offer metadata.