### PR TITLE
fix(a11y): expose required form semantics

### DIFF
--- a/src/renderer/src/pages/home/ProjectFormDialog.tsx
+++ b/src/renderer/src/pages/home/ProjectFormDialog.tsx
@@ -103,6 +103,7 @@ const ProjectFormDialog = ({
                 </label>
                 <Input
                   id="project-form-name"
+                  aria-required={true}
                   value={nameDraft}
                   onChange={(event) => onNameChange(event.target.value)}
                   placeholder={t('e.g. Reproduction of published research')}

--- a/src/renderer/src/pages/home/home-dialogs.render.test.tsx
+++ b/src/renderer/src/pages/home/home-dialogs.render.test.tsx
@@ -170,6 +170,7 @@ describe('home dialogs shared chrome', () => {
       agentContextField
     ].forEach((field) => expectDialogFormFieldClassName(field?.props.className))
     expect(descriptionField?.props['aria-describedby']).toBe('project-form-description-help')
+    expect(nameField?.props['aria-required']).toBe(true)
     expect(nameField?.props.maxLength).toBe(200)
     expect(descriptionField?.props.maxLength).toBe(1000)
     expect(descriptionField?.props.placeholder).toBe('Describe what this project is about…')

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -243,6 +243,18 @@ describe('ConnectorAddForm (local command)', () => {
       root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
     })
 
+    expect(
+      document.body.querySelector('[aria-label="Display name"]')?.getAttribute('aria-required')
+    ).toBe('true')
+    expect(
+      document.body.querySelector('[aria-label="Command"]')?.getAttribute('aria-required')
+    ).toBe('true')
+    expect(
+      document.body
+        .querySelector('[aria-label="I trust this connector"]')
+        ?.getAttribute('aria-required')
+    ).toBe('true')
+
     setValue('Display name', 'Memory')
     expect(addButton()?.disabled).toBe(true)
 
@@ -341,6 +353,14 @@ describe('ConnectorAddForm (local command)', () => {
       document.body.querySelector<HTMLTextAreaElement>('[aria-label="Environment variables"]')
         ?.value
     ).toBe('API_TOKEN=')
+    const environment = document.body.querySelector<HTMLTextAreaElement>(
+      '[aria-label="Environment variables"]'
+    )
+    expect(environment?.getAttribute('aria-required')).toBe('true')
+    expect(environment?.getAttribute('aria-describedby')).toBe('connector-env-help')
+    expect(document.body.querySelector('#connector-env-help')?.textContent).toContain(
+      'Required: API_TOKEN.'
+    )
     checkTrust()
     expect(addButton()?.disabled).toBe(true)
 
@@ -368,7 +388,36 @@ describe('ConnectorAddForm (remote server)', () => {
       )
     })
 
-    expect(document.body.querySelector('[aria-label="Server URL"]')).not.toBeNull()
+    expect(
+      document.body.querySelector('[aria-label="Server URL"]')?.getAttribute('aria-required')
+    ).toBe('true')
+  })
+
+  it('associates imported required header names with the Headers field', () => {
+    act(() => {
+      root.render(
+        <ConnectorAddForm
+          initialTemplate={{
+            schemaVersion: 1,
+            kind: 'open-science.connector',
+            name: 'header-auth',
+            displayName: 'Header Auth',
+            transport: 'streamable_http',
+            url: 'https://mcp.example.test',
+            requiredSecrets: { headers: ['Authorization'] }
+          }}
+          onDone={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      )
+    })
+
+    const headers = document.body.querySelector('[aria-label="Headers"]')
+    expect(headers?.getAttribute('aria-required')).toBe('true')
+    expect(headers?.getAttribute('aria-describedby')).toBe('connector-headers-help')
+    expect(document.body.querySelector('#connector-headers-help')?.textContent).toContain(
+      'Required: Authorization.'
+    )
   })
 
   it('reveals uncommon OAuth registration settings only when selected', () => {
@@ -421,6 +470,19 @@ describe('ConnectorAddForm (remote server)', () => {
         '(optional)'
       )
     }
+    expect(authorizationServer?.getAttribute('aria-required')).toBe('true')
+    const clientId = document.body.querySelector('[aria-label="Client ID"]')
+    expect(clientId?.getAttribute('aria-required')).toBe('true')
+
+    setValue('Client secret', 'configured-secret')
+    expect(authorizationServer?.getAttribute('aria-invalid')).toBe('true')
+    expect(authorizationServer?.getAttribute('aria-describedby')).toBe(
+      'connector-oauth-server-error'
+    )
+    expect(clientId?.getAttribute('aria-invalid')).toBe('true')
+    expect(clientId?.getAttribute('aria-describedby')).toBe('connector-oauth-client-id-error')
+    expect(document.body.querySelector('#connector-oauth-server-error')).not.toBeNull()
+    expect(document.body.querySelector('#connector-oauth-client-id-error')).not.toBeNull()
     expect(document.body.querySelector('[aria-label="Default callback URI"]')).not.toBeNull()
   })
 
@@ -562,6 +624,9 @@ describe('ConnectorAddForm (remote server)', () => {
     expect(
       document.body.querySelector<HTMLInputElement>('[aria-label="Redirect URI"]')?.value
     ).toBe('http://127.0.0.1:8080/callback')
+    expect(
+      document.body.querySelector('[aria-label="Client secret"]')?.getAttribute('aria-required')
+    ).toBe('true')
     checkTrust()
     expect(addButton()?.disabled).toBe(true)
     setValue('Client secret', 'local-client-secret')

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -297,6 +297,11 @@ export function ConnectorAddForm({
   const requiredEnvironment = initialTemplate?.requiredSecrets?.environment ?? []
   const requiredHeaders = initialTemplate?.requiredSecrets?.headers ?? []
   const requiresOAuthClientSecret = initialTemplate?.requiredSecrets?.oauthClientSecret === true
+  const authorizationServerError =
+    usePreRegisteredOAuthClient &&
+    Boolean(clientId.trim() || clientSecret.trim()) &&
+    !authorizationServerUrl.trim()
+  const clientIdError = Boolean(clientSecret.trim() && !clientId.trim())
   const copyDefaultCallbackUri = async (): Promise<void> => {
     if (!navigator.clipboard?.writeText) return
     try {
@@ -489,6 +494,7 @@ export function ConnectorAddForm({
           <Input
             id="connector-name"
             aria-label={t('Display name')}
+            aria-required="true"
             value={displayName}
             placeholder={t('e.g. Memory server')}
             onChange={(event) => setDisplayName(event.target.value)}
@@ -502,7 +508,7 @@ export function ConnectorAddForm({
               <RequiredMark />
             </label>
             <Select value={commandChoice} onValueChange={setCommandChoice}>
-              <SelectTrigger aria-label={t('Command')}>
+              <SelectTrigger id="connector-command" aria-label={t('Command')} aria-required="true">
                 <span>
                   {t(
                     COMMAND_OPTIONS.find((o) => o.value === commandChoice)?.labelKey ??
@@ -521,6 +527,7 @@ export function ConnectorAddForm({
             {commandChoice === 'other' ? (
               <Input
                 aria-label={t('Custom command')}
+                aria-required="true"
                 value={customCommand}
                 placeholder="/absolute/path/to/executable"
                 className="font-mono"
@@ -537,6 +544,7 @@ export function ConnectorAddForm({
             <Input
               id="connector-url"
               aria-label={t('Server URL')}
+              aria-required="true"
               value={url}
               placeholder="https://example.com/mcp"
               className="font-mono"
@@ -572,6 +580,7 @@ export function ConnectorAddForm({
                 <Input
                   id="connector-name-id"
                   aria-label={t('Connector name')}
+                  aria-required={!isEdit || undefined}
                   value={currentName}
                   disabled={isEdit}
                   aria-invalid={nameError ? true : undefined}
@@ -682,13 +691,15 @@ export function ConnectorAddForm({
                     <Textarea
                       id="connector-env"
                       aria-label={t('Environment variables')}
+                      aria-required={requiredEnvironment.length > 0 || undefined}
+                      aria-describedby="connector-env-help"
                       value={envText}
                       rows={3}
                       placeholder={'KEY=value\nANOTHER_KEY=value'}
                       className="resize-y font-mono text-[13px]"
                       onChange={(event) => setEnvText(event.target.value)}
                     />
-                    <p className={helperClassName}>
+                    <p id="connector-env-help" className={helperClassName}>
                       {t('One KEY=VALUE per line.')}
                       {initialTemplate?.requiredSecrets?.environment?.length
                         ? ' ' +
@@ -800,15 +811,22 @@ export function ConnectorAddForm({
                           <Input
                             id="connector-oauth-server"
                             aria-label={t('Authorization server URL')}
+                            aria-required={usePreRegisteredOAuthClient || undefined}
+                            aria-invalid={authorizationServerError || undefined}
+                            aria-describedby={
+                              authorizationServerError ? 'connector-oauth-server-error' : undefined
+                            }
                             value={authorizationServerUrl}
                             placeholder={t('Auto-discover from MCP server')}
                             className="font-mono"
                             onChange={(event) => setAuthorizationServerUrl(event.target.value)}
                           />
-                          {usePreRegisteredOAuthClient &&
-                          (clientId.trim() || clientSecret.trim()) &&
-                          !authorizationServerUrl.trim() ? (
-                            <p className="text-xs leading-5 text-destructive">
+                          {authorizationServerError ? (
+                            <p
+                              id="connector-oauth-server-error"
+                              className="text-xs leading-5 text-destructive"
+                              role="alert"
+                            >
                               {t(
                                 'Authorization server URL is required for a pre-registered client.'
                               )}
@@ -859,6 +877,11 @@ export function ConnectorAddForm({
                             <Input
                               id="connector-oauth-client-id"
                               aria-label={t('Client ID')}
+                              aria-required="true"
+                              aria-invalid={clientIdError || undefined}
+                              aria-describedby={
+                                clientIdError ? 'connector-oauth-client-id-error' : undefined
+                              }
                               value={clientId}
                               placeholder={t('Pre-registered client ID')}
                               className="font-mono"
@@ -872,8 +895,12 @@ export function ConnectorAddForm({
                                 }
                               }}
                             />
-                            {clientSecret.trim() && !clientId.trim() ? (
-                              <p className="text-xs leading-5 text-destructive">
+                            {clientIdError ? (
+                              <p
+                                id="connector-oauth-client-id-error"
+                                className="text-xs leading-5 text-destructive"
+                                role="alert"
+                              >
                                 {t('Client ID is required when a client secret is configured.')}
                               </p>
                             ) : null}
@@ -955,6 +982,7 @@ export function ConnectorAddForm({
                             <Input
                               id="connector-oauth-client-secret"
                               aria-label={t('Client secret')}
+                              aria-required={requiresOAuthClientSecret || undefined}
                               type="password"
                               value={clientSecret}
                               placeholder={
@@ -1026,13 +1054,15 @@ export function ConnectorAddForm({
                       <Textarea
                         id="connector-headers"
                         aria-label={t('Headers')}
+                        aria-required={requiredHeaders.length > 0 || undefined}
+                        aria-describedby="connector-headers-help"
                         value={headersText}
                         rows={3}
                         placeholder={'Authorization: Bearer <token>\nX-Api-Key: <key>'}
                         className="resize-y font-mono text-[13px]"
                         onChange={(event) => setHeadersText(event.target.value)}
                       />
-                      <p className={helperClassName}>
+                      <p id="connector-headers-help" className={helperClassName}>
                         <Trans
                           i18nKey="One <code>Name: Value</code> per line (not JSON)."
                           components={{ code: <span className="font-mono" /> }}
@@ -1063,6 +1093,7 @@ export function ConnectorAddForm({
             <input
               type="checkbox"
               aria-label={t('I trust this connector')}
+              aria-required="true"
               checked={trusted}
               className="mt-0.5 size-4 shrink-0"
               onChange={(event) => setTrusted(event.target.checked)}

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -33,11 +33,13 @@ const render = (
   {
     onChange = vi.fn(),
     errors,
+    hasStoredKey = false,
     showCodexSubscriptions = false,
     showClaudeIsolated = false
   }: {
     onChange?: () => void
     errors?: ProviderFormErrors
+    hasStoredKey?: boolean
     showCodexSubscriptions?: boolean
     showClaudeIsolated?: boolean
   } = {}
@@ -48,6 +50,7 @@ const render = (
         value={value}
         onChange={onChange}
         errors={errors}
+        hasStoredKey={hasStoredKey}
         showCodexSubscriptions={showCodexSubscriptions}
         showClaudeIsolated={showClaudeIsolated}
       />
@@ -569,8 +572,35 @@ describe('ProviderForm field switching', () => {
       }
     })
 
-    expect(container.textContent).toContain('Base URL is required.')
-    expect(container.textContent).toContain('API key is required.')
-    expect(container.textContent).toContain('Model is required.')
+    const baseUrl = container.querySelector<HTMLInputElement>('[aria-label="Base URL"]')
+    const key = container.querySelector<HTMLInputElement>('[aria-label="API key"]')
+    const model = container.querySelector<HTMLInputElement>('[aria-label="Model"]')
+
+    for (const [field, errorId] of [
+      [baseUrl, 'provider-base-url-error'],
+      [key, 'provider-key-error'],
+      [model, 'provider-model-error']
+    ] as const) {
+      expect(field?.getAttribute('aria-required')).toBe('true')
+      expect(field?.getAttribute('aria-invalid')).toBe('true')
+      expect(field?.getAttribute('aria-describedby')).toBe(errorId)
+      expect(container.querySelector(`#${errorId}`)).not.toBeNull()
+    }
+
+    expect(container.querySelector('#provider-base-url-error')?.textContent).toBe(
+      'Base URL is required.'
+    )
+    expect(container.querySelector('#provider-key-error')?.textContent).toBe('API key is required.')
+    expect(container.querySelector('#provider-model-error')?.textContent).toBe('Model is required.')
+  })
+
+  it('does not require a replacement API key when an edit keeps the stored key', () => {
+    render(createEmptyProviderFormValue({ type: 'official' }), { hasStoredKey: true })
+
+    expect(
+      container
+        .querySelector<HTMLInputElement>('[aria-label="API key"]')
+        ?.getAttribute('aria-required')
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -227,6 +227,7 @@ const ProviderForm = ({
     key: string
   }>()
   const keyVisible = revealedKeyDraft?.kind === selectedKey && revealedKeyDraft.key === value.key
+  const keyRequired = needsKey || !hasStoredKey
 
   const advancedVisible =
     advancedOpen || Boolean(errors.maxInputTokens) || Boolean(errors.maxOutputTokens)
@@ -264,6 +265,9 @@ const ProviderForm = ({
         <Input
           id="provider-key"
           aria-label={t('API key')}
+          aria-required={keyRequired || undefined}
+          aria-invalid={Boolean(needsKey || errors.key) || undefined}
+          aria-describedby={needsKey || errors.key ? 'provider-key-error' : undefined}
           type={keyVisible ? 'text' : 'password'}
           value={value.key}
           disabled={disabled}
@@ -299,11 +303,11 @@ const ProviderForm = ({
         </button>
       </div>
       {needsKey ? (
-        <p className={fieldErrorClassName} role="alert">
+        <p id="provider-key-error" className={fieldErrorClassName} role="alert">
           {t('The stored key could not be decrypted. Enter it again to continue.')}
         </p>
       ) : errors.key ? (
-        <p className={fieldErrorClassName} role="alert">
+        <p id="provider-key-error" className={fieldErrorClassName} role="alert">
           {t(errors.key)}
         </p>
       ) : null}
@@ -518,13 +522,16 @@ const ProviderForm = ({
             <Input
               id="provider-base-url"
               aria-label={t('Base URL')}
+              aria-required="true"
+              aria-invalid={Boolean(errors.baseUrl) || undefined}
+              aria-describedby={errors.baseUrl ? 'provider-base-url-error' : undefined}
               value={value.baseUrl}
               disabled={disabled}
               placeholder={t('https://gateway.example')}
               onChange={(event) => onChange({ baseUrl: event.target.value })}
             />
             {errors.baseUrl ? (
-              <p className={fieldErrorClassName} role="alert">
+              <p id="provider-base-url-error" className={fieldErrorClassName} role="alert">
                 {t(errors.baseUrl)}
               </p>
             ) : null}
@@ -569,13 +576,16 @@ const ProviderForm = ({
             <Input
               id="provider-model"
               aria-label={t('Model')}
+              aria-required="true"
+              aria-invalid={Boolean(errors.model) || undefined}
+              aria-describedby={errors.model ? 'provider-model-error' : undefined}
               value={value.model}
               disabled={disabled}
               placeholder={t('e.g. deepseek-v4-flash')}
               onChange={(event) => onChange({ model: event.target.value })}
             />
             {errors.model ? (
-              <p className={fieldErrorClassName} role="alert">
+              <p id="provider-model-error" className={fieldErrorClassName} role="alert">
                 {t(errors.model)}
               </p>
             ) : null}


### PR DESCRIPTION
## Problem

Required-field markers in Provider and Connector forms were visual-only, while Project name relied on a disabled submit button without required semantics. Provider and conditional OAuth errors were also not programmatically associated with their inputs, so assistive technology could not reliably identify missing or invalid fields.

## Proposed change

- expose conditional required state on Provider, Connector, OAuth, imported-secret, trust, and Project-name controls
- expose invalid state only when an existing validation error is present
- give Provider and Connector OAuth errors stable IDs and connect them with aria-describedby
- connect imported environment/header requirements to their existing helper text
- preserve the current submit-button and validation interaction

## Scope and non-goals

No schema, data-model, persisted-state, enum, migration, or historical-data changes. This does not add a form framework, new validation state, or a form-level error summary.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- required and error semantics for Provider, Connector, and Project forms -> targeted Vitest render tests -> 57 passed
- renderer TypeScript contracts -> Web typecheck -> passed
- changed renderer source and tests -> targeted ESLint -> passed
- patch formatting -> git diff --check -> passed

The changed files are not assigned to a module in scripts/ci/module-impact.json, so no local module suite claims broader ownership coverage. PR Gate CI is authoritative for the final affected-test and platform plan. Full npm test was intentionally not run locally.

## Review focus

Please verify the conditional required semantics for stored Provider keys, pre-registered OAuth fields, and imported Connector secrets. Visible behavior and persistence should remain unchanged.