### PR TITLE
fix(folder-access): serialize grant dialog submissions

### DIFF
--- a/src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx
@@ -66,6 +66,16 @@ const flush = async (): Promise<void> => {
   })
 }
 
+const deferGrant = (): ((roots: GrantedLocalRoot[]) => void) => {
+  let resolveGrant!: (roots: GrantedLocalRoot[]) => void
+  grantRoot.mockReturnValue(
+    new Promise<GrantedLocalRoot[]>((resolve) => {
+      resolveGrant = resolve
+    })
+  )
+  return resolveGrant
+}
+
 beforeEach(() => {
   useGrantedFoldersStore.setState(createInitialGrantedFoldersState())
   listDir = vi.fn(async (path: string): Promise<LocalDirListing> => ({
@@ -545,6 +555,137 @@ describe('GrantFolderAccessDialog', () => {
     // The failure clears on navigation.
     await click(document.body.querySelector('[data-testid="grant-access-crumb-home"]'))
     expect(document.body.textContent).not.toContain('Directory could not be accessed.')
+  })
+
+  it('submits one grant and disables actions when Grant is clicked twice before it settles', async () => {
+    const resolveGrant = deferGrant()
+    renderDialog()
+    await flush()
+
+    await click(document.body.querySelector('[data-testid="grant-access-folder-Projects"]'))
+    const grantButton = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="grant-access-grant"]'
+    )
+    const cancelButton = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="grant-access-cancel"]'
+    )
+    await act(async () => {
+      grantButton?.click()
+      grantButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(grantRoot).toHaveBeenCalledTimes(1)
+    expect(grantButton?.disabled).toBe(true)
+    expect(cancelButton?.disabled).toBe(true)
+
+    await act(async () => {
+      resolveGrant([grantedRoot])
+      await Promise.resolve()
+    })
+  })
+
+  it('ignores a grant response from a closed instance after the dialog reopens', async () => {
+    const resolveGrant = deferGrant()
+    const onGranted = vi.fn()
+    const onOpenChange = vi.fn()
+    act(() => {
+      root.render(
+        <GrantFolderAccessDialog open onOpenChange={onOpenChange} onGranted={onGranted} />
+      )
+    })
+    await flush()
+
+    await click(document.body.querySelector('[data-testid="grant-access-folder-Projects"]'))
+    await click(document.body.querySelector('[data-testid="grant-access-grant"]'))
+
+    act(() => {
+      root.render(
+        <GrantFolderAccessDialog open={false} onOpenChange={onOpenChange} onGranted={onGranted} />
+      )
+    })
+    act(() => {
+      root.render(
+        <GrantFolderAccessDialog open onOpenChange={onOpenChange} onGranted={onGranted} />
+      )
+    })
+    await flush()
+    onOpenChange.mockClear()
+
+    await act(async () => {
+      resolveGrant([grantedRoot])
+      await Promise.resolve()
+    })
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+    expect(onGranted).not.toHaveBeenCalled()
+    expect(document.body.textContent).toContain('Grant folder access')
+  })
+
+  it('keeps the selected folder and access fixed while a grant is pending', async () => {
+    const resolveGrant = deferGrant()
+    const onOpenChange = vi.fn()
+    act(() => {
+      root.render(<GrantFolderAccessDialog open onOpenChange={onOpenChange} />)
+    })
+    await flush()
+
+    await click(document.body.querySelector('[data-testid="grant-access-folder-Projects"]'))
+    await click(document.body.querySelector('[data-testid="grant-access-grant"]'))
+    listDir.mockClear()
+
+    await click(document.body.querySelector('[data-testid="grant-access-crumb-home"]'))
+    await click(document.body.querySelector('[role="radio"][aria-checked="false"]'))
+    await click(document.body.querySelector('[data-testid="grant-access-close"]'))
+
+    expect(listDir).not.toHaveBeenCalled()
+    expect(
+      document.body.querySelector('[data-testid="grant-access-crumb-current"]')?.textContent
+    ).toBe('Projects')
+    expect(
+      Array.from(document.body.querySelectorAll('[role="radio"]')).map((radio) =>
+        radio.getAttribute('aria-checked')
+      )
+    ).toEqual(['true', 'false'])
+    expect(onOpenChange).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveGrant([grantedRoot])
+      await Promise.resolve()
+    })
+  })
+
+  it('does not dismiss the dialog from outside interaction or Escape while granting', async () => {
+    const resolveGrant = deferGrant()
+    const onOpenChange = vi.fn()
+    act(() => {
+      root.render(<GrantFolderAccessDialog open onOpenChange={onOpenChange} />)
+    })
+    await flush()
+
+    await click(document.body.querySelector('[data-testid="grant-access-folder-Projects"]'))
+    await click(document.body.querySelector('[data-testid="grant-access-grant"]'))
+
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    await act(async () => {
+      outside.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+      outside.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }))
+      await Promise.resolve()
+    })
+    expect(onOpenChange).not.toHaveBeenCalled()
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+      await Promise.resolve()
+    })
+    expect(onOpenChange).not.toHaveBeenCalled()
+
+    outside.remove()
+    await act(async () => {
+      resolveGrant([grantedRoot])
+      await Promise.resolve()
+    })
   })
 
   it('grants the current folder, closes, and reports the new root', async () => {

--- a/src/renderer/src/pages/workspace/GrantFolderAccessDialog.tsx
+++ b/src/renderer/src/pages/workspace/GrantFolderAccessDialog.tsx
@@ -140,10 +140,12 @@ const CurrentCrumb = ({
 // with the default access level and no leftover grant error.
 const GrantFolderAccessDialogContent = ({
   onOpenChange,
-  onGranted
+  onGranted,
+  onGrantingChange
 }: {
   onOpenChange: (open: boolean) => void
   onGranted?: (root: GrantedLocalRoot) => void
+  onGrantingChange: (granting: boolean) => void
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const roots = useGrantedFoldersStore((state) => state.roots)
@@ -191,6 +193,17 @@ const GrantFolderAccessDialogContent = ({
   }
   const [access, setAccess] = useState<GrantedLocalRootAccess>('ro')
   const [grantFailed, setGrantFailed] = useState(false)
+  const [isGranting, setIsGranting] = useState(false)
+  const grantingRef = useRef(false)
+  const grantAttemptRef = useRef(0)
+  useEffect(
+    () => () => {
+      grantAttemptRef.current += 1
+      grantingRef.current = false
+      onGrantingChange(false)
+    },
+    [onGrantingChange]
+  )
 
   // On mount: resolve home (the initial location), enumerate the mounted drives for the drive
   // dropdown, and refresh the granted roots so handleGrant's fallback can tell which root the
@@ -286,17 +299,30 @@ const GrantFolderAccessDialogContent = ({
   const isHome = home !== undefined && sameLocalDirectory(cwd, home, platform)
 
   const handleGrant = async (): Promise<void> => {
+    if (grantingRef.current) return
+    grantingRef.current = true
+    const attempt = ++grantAttemptRef.current
+    setIsGranting(true)
+    onGrantingChange(true)
     try {
       const nextRoots = await grant(cwd, access)
+      if (attempt !== grantAttemptRef.current) return
       const granted =
         nextRoots.find((root) => sameLocalDirectory(root.path, cwd, platform)) ??
         nextRoots.find((root) => !roots.some((existing) => existing.id === root.id))
       onOpenChange(false)
       if (granted) onGranted?.(granted)
     } catch {
+      if (attempt !== grantAttemptRef.current) return
       // Main rejected the candidate (unreadable, home itself): state it quietly next to the
       // buttons; navigation clears the message.
       setGrantFailed(true)
+    } finally {
+      if (attempt === grantAttemptRef.current) {
+        grantingRef.current = false
+        setIsGranting(false)
+        onGrantingChange(false)
+      }
     }
   }
 
@@ -332,7 +358,24 @@ const GrantFolderAccessDialogContent = ({
       <Dialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
       <Dialog.Content
         data-testid="grant-folder-access-dialog"
+        onClickCapture={(event) => {
+          if (!isGranting) return
+          event.preventDefault()
+          event.stopPropagation()
+        }}
+        onKeyDownCapture={(event) => {
+          if (!isGranting) return
+          event.preventDefault()
+          event.stopPropagation()
+        }}
+        onEscapeKeyDown={(event) => {
+          if (isGranting) event.preventDefault()
+        }}
         onInteractOutside={(event) => {
+          if (isGranting) {
+            event.preventDefault()
+            return
+          }
           // The drive dropdown portals its content to <body>, outside this dialog's DOM: while
           // it is open, an outside click (a menu item, or the overlay the click falls through to
           // while the modal menu disables pointer events elsewhere) reaches this layer as an
@@ -359,6 +402,7 @@ const GrantFolderAccessDialogContent = ({
               aria-label={t('Close')}
               data-testid="grant-access-close"
               className={dialogCloseButtonClassName}
+              disabled={isGranting}
             >
               <X className="size-4" aria-hidden="true" />
             </Button>
@@ -565,6 +609,7 @@ const GrantFolderAccessDialogContent = ({
             <RadioGroup.Root
               aria-label={t('Access level')}
               value={access}
+              disabled={isGranting}
               onValueChange={(value) => setAccess(value as GrantedLocalRootAccess)}
               orientation="horizontal"
               className="flex items-center gap-2.5"
@@ -578,6 +623,7 @@ const GrantFolderAccessDialogContent = ({
               variant="ghost"
               className={dialogCancelButtonClassName}
               data-testid="grant-access-cancel"
+              disabled={isGranting}
               onClick={() => onOpenChange(false)}
             >
               {t('Cancel')}
@@ -585,7 +631,7 @@ const GrantFolderAccessDialogContent = ({
             <Button
               type="button"
               data-testid="grant-access-grant"
-              disabled={isHome}
+              disabled={isHome || isGranting}
               onClick={() => void handleGrant()}
               className="bg-primary text-primary-foreground hover:bg-primary/80 disabled:bg-primary disabled:text-primary-foreground disabled:opacity-40"
             >
@@ -607,12 +653,29 @@ export const GrantFolderAccessDialog = ({
   onOpenChange: (open: boolean) => void
   // Called with the granted root after a successful grant (the dialog has already closed).
   onGranted?: (root: GrantedLocalRoot) => void
-}): React.JSX.Element => (
-  <Dialog.Root open={open} onOpenChange={onOpenChange}>
-    <Dialog.Portal>
-      {open ? (
-        <GrantFolderAccessDialogContent onOpenChange={onOpenChange} onGranted={onGranted} />
-      ) : null}
-    </Dialog.Portal>
-  </Dialog.Root>
-)
+}): React.JSX.Element => {
+  const grantingRef = useRef(false)
+  const handleGrantingChange = useCallback((granting: boolean): void => {
+    grantingRef.current = granting
+  }, [])
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && grantingRef.current) return
+        onOpenChange(nextOpen)
+      }}
+    >
+      <Dialog.Portal>
+        {open ? (
+          <GrantFolderAccessDialogContent
+            onOpenChange={onOpenChange}
+            onGranted={onGranted}
+            onGrantingChange={handleGrantingChange}
+          />
+        ) : null}
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}


### PR DESCRIPTION
## Problem

`GrantFolderAccessDialog` allowed more than one grant request to start before the first request settled. A pending request could also outlive its rendered dialog instance, close a newly reopened dialog, invoke `onGranted` for the old folder, or let the user change the selected folder and access while the old request still owned the completion callback.

The persistence layer already upserts by canonical path, so duplicate clicks normally did not create duplicate rows, but they still caused duplicate IPC/filesystem/database work and stale UI effects.

## Proposed change

- acquire a synchronous ref lock before awaiting the grant request;
- expose a transient `isGranting` state that disables Grant, Cancel, Close, and the access radio group;
- freeze remaining dialog interactions at the content capture boundary and reject Radix outside/Escape dismissal while a grant is pending;
- assign each request an attempt generation and invalidate it when its dialog content unmounts, so only the current attempt may close the dialog, show an error, or invoke `onGranted`;
- add public-boundary interaction regressions for double click, close/reopen, folder/access changes, and outside/Escape dismissal.

## Scope and non-goals

- No database schema, migration, persisted format, or historical-data compatibility change.
- No new domain state or enum value; `isGranting` and the attempt generation are component-local transient state.
- No IPC, Zustand store, or `GrantedLocalRoot` model change.
- An IPC request already sent before an owner-forced unmount is not cancellable and may still persist; only its stale UI side effects are suppressed.

## Acceptance criteria and validation

The regression tests were first observed failing on the unmodified behavior: double click called `grantRoot` twice, an old completion called `onOpenChange(false)` after reopen, pending navigation called `listDir` for the new path, and outside/Escape produced two dismissal callbacks.

Final checks ran after the last material edit:

- grant lifecycle and Radix layering -> `vitest run src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx src/renderer/src/pages/workspace/GrantFolderAccessDialog.layers.test.tsx` -> 29 passed;
- Project Files and composer consumer integration -> targeted `vitest run` for `grants a folder through the dialog and browses it` and `opens the grant dialog from the Grant folder… action` -> 2 passed;
- renderer type safety -> `npm run typecheck:web` -> passed;
- lint -> `npm run lint` -> passed;
- whitespace -> `git diff --check` -> passed.

The complete portable and platform suites were not run locally; PR Gate remains authoritative for those lanes.

## Review focus

- the synchronous lock is acquired before the first `await`;
- unmount invalidation prevents an old attempt from controlling a later dialog instance;
- successful current attempts bypass the Radix dismissal guard and retain the existing close-then-`onGranted` behavior;
- all busy-state changes remain transient and local to this dialog.