### PR TITLE
refactor(domain-language): align session and specialist boundaries

### DIFF
--- a/src/main/acp/codex-completion-handoff.integration.test.ts
+++ b/src/main/acp/codex-completion-handoff.integration.test.ts
@@ -24,7 +24,7 @@ import type { NotebookRuntimeService } from '../notebook/runtime-service'
 import {
   emptyFullAccessConfig,
   emptySelectedConfig,
-  type SpecialistProfileView
+  type SpecialistView
 } from '../../shared/specialist'
 
 class FakeAgentProcess extends EventEmitter {
@@ -50,7 +50,7 @@ const profile = (
   name: string,
   skills: string[],
   connectors: string[]
-): SpecialistProfileView => ({
+): SpecialistView => ({
   id,
   name,
   displayName: name,
@@ -122,7 +122,7 @@ describe('Codex approved handoff', () => {
       ['approved-skill'],
       ['molecule']
     )
-    const resolveSpecialist = (specialistId: string): SpecialistProfileView =>
+    const resolveSpecialist = (specialistId: string): SpecialistView =>
       specialistId === approvedSpecialist.id ? approvedSpecialist : oldSpecialist
     let approvedBinding = oldSpecialist.id
     const notebookPromptMessageIds: string[] = []

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -168,7 +168,7 @@ const registerWithFakes = (overrides?: {
   onSessionUnavailable?: (sessionId: string) => void
   onAllSessionsCancellationRequested?: () => void
   beforeSessionDelete?: (sessionId: string) => Promise<void>
-  profileService?: { resolveRunnableById: (id: string) => Promise<unknown> }
+  specialistService?: { resolveRunnableById: (id: string) => Promise<unknown> }
   specialistSkillCatalog?: Array<{ id: string; frameworkName: string; displayName: string }>
   provisionedConnectorSkillNames?: string[]
   customMcpServers?: Array<{ id: string; name: string }>
@@ -211,7 +211,7 @@ const registerWithFakes = (overrides?: {
     onAllSessionsCancellationRequested: overrides?.onAllSessionsCancellationRequested,
     beforeSessionDelete: overrides?.beforeSessionDelete,
     initializationBarrier: overrides?.initializationBarrier,
-    profileService: overrides?.profileService as never,
+    specialistService: overrides?.specialistService as never,
     memory: overrides?.memory,
     delegatedNotebookConnection: overrides?.delegatedNotebookConnection
   }
@@ -659,15 +659,15 @@ describe('ACP runtime composition — memory eligibility', () => {
 })
 
 describe('ACP runtime composition — Specialist identity resolver', () => {
-  it('passes a ProfileService-backed resolver into each runtime', async () => {
+  it('passes a SpecialistService-backed resolver into each runtime', async () => {
     const profile = {
       name: 'RNA-seq Reviewer',
       systemPrompt: 'Review RNA-seq quality.',
       enabled: true
     }
-    const profileService = { resolveRunnableById: vi.fn().mockResolvedValue(profile) }
+    const specialistService = { resolveRunnableById: vi.fn().mockResolvedValue(profile) }
 
-    registerWithFakes({ profileService })
+    registerWithFakes({ specialistService })
 
     const options = AcpRuntimeMock.mock.calls.at(-1)?.[0] as {
       resolveSpecialistIdentity?: (id: string, framework: string) => Promise<unknown>
@@ -679,11 +679,11 @@ describe('ACP runtime composition — Specialist identity resolver', () => {
       append: expect.stringContaining('RNA-seq Reviewer'),
       prefix: ''
     })
-    expect(profileService.resolveRunnableById).toHaveBeenCalledWith('uuid-1')
+    expect(specialistService.resolveRunnableById).toHaveBeenCalledWith('uuid-1')
   })
 
-  it('wires the production ProfileService and live catalog into the Specialist Skill resolver', async () => {
-    const profileService = {
+  it('wires the production SpecialistService and live catalog into the Specialist Skill resolver', async () => {
+    const specialistService = {
       resolveRunnableById: vi.fn().mockResolvedValue({
         enabled: true,
         capabilityMode: 'selected',
@@ -692,7 +692,7 @@ describe('ACP runtime composition — Specialist identity resolver', () => {
       })
     }
     registerWithFakes({
-      profileService,
+      specialistService,
       specialistSkillCatalog: [
         { id: 'main-disabled', frameworkName: 'Main Disabled', displayName: 'Main Disabled' }
       ]
@@ -709,7 +709,7 @@ describe('ACP runtime composition — Specialist identity resolver', () => {
   })
 
   it('merges only the specialist-allowed connector skills into the whitelist (selected mode)', async () => {
-    const profileService = {
+    const specialistService = {
       resolveRunnableById: vi.fn().mockResolvedValue({
         enabled: true,
         capabilityMode: 'selected',
@@ -722,7 +722,7 @@ describe('ACP runtime composition — Specialist identity resolver', () => {
       })
     }
     registerWithFakes({
-      profileService,
+      specialistService,
       specialistSkillCatalog: [{ id: 'skill-a', frameworkName: 'Skill A', displayName: 'Skill A' }],
       provisionedConnectorSkillNames: ['mcp-chemistry', 'mcp-literature']
     })
@@ -737,7 +737,7 @@ describe('ACP runtime composition — Specialist identity resolver', () => {
   })
 
   it('projects a custom Connector UUID to its public runtime skill name', async () => {
-    const profileService = {
+    const specialistService = {
       resolveRunnableById: vi.fn().mockResolvedValue({
         enabled: true,
         capabilityMode: 'selected',
@@ -750,7 +750,7 @@ describe('ACP runtime composition — Specialist identity resolver', () => {
       })
     }
     registerWithFakes({
-      profileService,
+      specialistService,
       provisionedConnectorSkillNames: ['mcp-public-route'],
       customMcpServers: [{ id: 'custom-server-uuid', name: 'public-route' }]
     })
@@ -765,7 +765,7 @@ describe('ACP runtime composition — Specialist identity resolver', () => {
   })
 
   it('excludes full-access blocked connectors from the whitelist (full mode)', async () => {
-    const profileService = {
+    const specialistService = {
       resolveRunnableById: vi.fn().mockResolvedValue({
         enabled: true,
         capabilityMode: 'full',
@@ -778,7 +778,7 @@ describe('ACP runtime composition — Specialist identity resolver', () => {
       })
     }
     registerWithFakes({
-      profileService,
+      specialistService,
       specialistSkillCatalog: [],
       provisionedConnectorSkillNames: ['mcp-chemistry', 'mcp-literature']
     })

--- a/src/main/acp/opencode-immediate-handoff.integration.test.ts
+++ b/src/main/acp/opencode-immediate-handoff.integration.test.ts
@@ -18,8 +18,8 @@ import {
 } from '../agents/completion-gate'
 import { AgentsService, type AgentsCatalogSource } from '../agents/agents-service'
 import type { ApprovalGateway } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistView } from '../../shared/specialist'
+import type { SpecialistService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
 import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
 import {
@@ -151,7 +151,7 @@ const startFakeOpenCodeProvider = (
   }
 }
 
-const specialist: SpecialistProfileView = {
+const specialist: SpecialistView = {
   id: 'specialist-new',
   name: 'New Specialist',
   displayName: 'New Specialist',
@@ -233,13 +233,13 @@ describe('OpenCode immediate handoff production path', () => {
       decide: vi.fn(async () => ({ status: 'approved' as const }))
     }
     const agents = new AgentsService({
-      profileService: {
+      specialistService: {
         getByName: vi.fn(async () => specialist),
         getById: vi.fn(async () => specialist),
         resolveRunnableByName: vi.fn(async () => specialist),
         resolveRunnableById: vi.fn(async () => specialist),
         list: vi.fn(async () => [specialist])
-      } as unknown as ProfileService,
+      } as unknown as SpecialistService,
       catalog,
       approvalGateway,
       sessionBinding: {

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -38,7 +38,7 @@ import {
   buildSpecialistIdentityAppend,
   buildSpecialistIdentityPrefix
 } from '../specialist/identity'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistService } from '../specialist/service'
 import { resolveConfigRoot, resolveDataRoot, resolveStorageRoot } from '../storage-root'
 import type { UploadRepository } from '../uploads/repository'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
@@ -138,7 +138,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
   onSessionDeleteStarted?: (sessionId: string) => void
   beforeSessionDelete?: (sessionId: string) => Promise<void>
   afterSessionDelete?: (sessionId: string, retained: boolean) => void
-  profileService?: ProfileService
+  specialistService?: SpecialistService
   sessionPersistenceCoordinator?: Pick<
     SessionPersistenceCoordinator,
     | 'readSessionRuntimeContext'
@@ -188,7 +188,7 @@ const createAcpRuntime = ({
   onSessionDeleteStarted,
   beforeSessionDelete,
   afterSessionDelete,
-  profileService,
+  specialistService,
   sessionPersistenceCoordinator,
   delegatedWork,
   fixedBackend,
@@ -461,11 +461,11 @@ const createAcpRuntime = ({
               }
             }
           : {}),
-        resolveSpecialistIdentity: profileService
+        resolveSpecialistIdentity: specialistService
           ? async (specialistId: string, frameworkId: string) => {
               let profile
               try {
-                profile = await profileService.resolveRunnableById(specialistId)
+                profile = await specialistService.resolveRunnableById(specialistId)
               } catch {
                 // Profile not found or corrupt
                 return undefined
@@ -477,10 +477,10 @@ const createAcpRuntime = ({
               return { append: '', prefix }
             }
           : undefined,
-        resolveSpecialistSkills: profileService
+        resolveSpecialistSkills: specialistService
           ? async (specialistId) => {
               try {
-                const profile = await profileService.resolveRunnableById(specialistId)
+                const profile = await specialistService.resolveRunnableById(specialistId)
                 if (!profile.enabled) {
                   return { kind: 'unavailable', reason: 'The bound specialist is disabled.' }
                 }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -258,7 +258,7 @@ type AcpRuntimeOptions = {
   // Injectable only for the authenticated OpenCode loopback usage snapshots; production uses fetch.
   opencodeUsageFetch?: typeof fetch
   // Resolves the identity-inject text for a specialist UUID at session-creation time.
-  // The main process reads the latest Profile from ProfileService; the runtime never caches it.
+  // The main process reads the latest Profile from SpecialistService; the runtime never caches it.
   // Returns undefined when the specialist is not found, disabled, or its Profile is corrupt —
   // the caller should have validated before calling createSession.
   resolveSpecialistIdentity?: (

--- a/src/main/agents/agents-dispatch.test.ts
+++ b/src/main/agents/agents-dispatch.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { AgentsService, type AgentsCatalogSource } from './agents-service'
 import type { ApprovalGateway, ApprovalResult, SwitchNotifier } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistView } from '../../shared/specialist'
+import type { SpecialistService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
 
 const noopCatalog = (): AgentsCatalogSource => ({
@@ -11,14 +11,14 @@ const noopCatalog = (): AgentsCatalogSource => ({
   getConnectors: vi.fn(async () => ({ enabledIds: [], autoAllowIds: [] }))
 })
 
-const withExplicitResolvers = (service: ProfileService): ProfileService => {
+const withExplicitResolvers = (service: SpecialistService): SpecialistService => {
   service.resolveRunnableByName = vi.fn(async (name: string) => service.getByName(name))
   service.resolveRunnableById = vi.fn(async (id: string) => service.getById(id))
   service.resolveCustomMutationByName = vi.fn(async (name: string) => service.getByName(name))
   return service
 }
 
-const noopProfileService = (): ProfileService =>
+const noopSpecialistService = (): SpecialistService =>
   withExplicitResolvers({
     list: vi.fn(async () => []),
     getByName: vi.fn(async () => {
@@ -27,12 +27,12 @@ const noopProfileService = (): ProfileService =>
     getById: vi.fn(async () => {
       throw new Error('not found')
     })
-  } as unknown as ProfileService)
+  } as unknown as SpecialistService)
 
 describe('AgentsService.dispatch — extensible operation dispatcher', () => {
   it('routes a read op identically to read()', async () => {
     const service = new AgentsService({
-      profileService: {
+      specialistService: {
         list: vi.fn(async () => [
           {
             id: 'sp-1',
@@ -48,7 +48,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
           }
         ]),
         getByName: vi.fn()
-      } as unknown as ProfileService,
+      } as unknown as SpecialistService,
       catalog: noopCatalog()
     })
     const viaDispatch = await service.dispatch({ op: 'list' })
@@ -61,7 +61,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
 
   it('rejects an unknown op with a sanitized host.agents.<op>: error', async () => {
     const service = new AgentsService({
-      profileService: noopProfileService(),
+      specialistService: noopSpecialistService(),
       catalog: noopCatalog()
     })
     await expect(service.dispatch({ op: 'rename' })).rejects.toThrow(/host\.agents\.rename:/)
@@ -69,7 +69,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
 
   it('rejects a malformed request (no op) with a host.agents.unknown: error', async () => {
     const service = new AgentsService({
-      profileService: noopProfileService(),
+      specialistService: noopSpecialistService(),
       catalog: noopCatalog()
     })
     await expect(service.dispatch({})).rejects.toThrow(/host\.agents\.unknown:/)
@@ -90,10 +90,10 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
           fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
           selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
           revision: 1
-        }) as SpecialistProfileView
+        }) as SpecialistView
     )
     const service = new AgentsService({
-      profileService: { list: vi.fn(), getByName } as unknown as ProfileService,
+      specialistService: { list: vi.fn(), getByName } as unknown as SpecialistService,
       catalog: noopCatalog()
     })
     // Sandbox tries to forge a session, a specialist id, a switch target, and a reconfigure flag.
@@ -119,7 +119,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
     // With no gateway wired, delete surfaces a sanitized "not configured" error rather than
     // silently no-op'ing.
     const service = new AgentsService({
-      profileService: noopProfileService(),
+      specialistService: noopSpecialistService(),
       catalog: noopCatalog()
     })
     await expect(service.dispatch({ op: 'delete', params: {} })).rejects.toThrow(
@@ -127,7 +127,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
     )
   })
 
-  it('ordinary mutations route to ProfileService (no longer fail-closed)', async () => {
+  it('ordinary mutations route to SpecialistService (no longer fail-closed)', async () => {
     const created = vi.fn(async () => ({
       id: 'sp-1',
       name: 'Bio',
@@ -141,7 +141,10 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
       revision: 1
     }))
     const service = new AgentsService({
-      profileService: { ...noopProfileService(), create: created } as unknown as ProfileService,
+      specialistService: {
+        ...noopSpecialistService(),
+        create: created
+      } as unknown as SpecialistService,
       catalog: noopCatalog()
     })
     const result = (await service.dispatch({ op: 'create', params: { name: 'Bio' } })) as {
@@ -173,7 +176,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
 
   it('switch fails closed when its approval/binding/persistence seams are not configured', async () => {
     const service = new AgentsService({
-      profileService: noopProfileService(),
+      specialistService: noopSpecialistService(),
       catalog: noopCatalog()
     })
     await expect(
@@ -183,7 +186,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
 
   it('reads unchanged: existing list/get/list_skills behavior preserved', async () => {
     const service = new AgentsService({
-      profileService: noopProfileService(),
+      specialistService: noopSpecialistService(),
       catalog: noopCatalog()
     })
     await expect(service.read({ op: 'list' })).resolves.toEqual([])
@@ -196,7 +199,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
 })
 
 describe('AgentsService.dispatch — switch op routing (issue 05)', () => {
-  const specialist = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  const specialist = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
     id: 'sp-1',
     name: 'BIO_EXPERT',
     displayName: 'Bio Expert',
@@ -212,7 +215,7 @@ describe('AgentsService.dispatch — switch op routing (issue 05)', () => {
 
   type BuildServiceResult = {
     service: AgentsService
-    profileService: ProfileService
+    specialistService: SpecialistService
     sessionBinding: SessionBindingService
     persist: (sessionId: string, specialistId: string | undefined) => Promise<void>
     notify: SwitchNotifier['notify']
@@ -220,11 +223,11 @@ describe('AgentsService.dispatch — switch op routing (issue 05)', () => {
   }
 
   const buildService = (opts: {
-    profiles?: SpecialistProfileView[]
+    profiles?: SpecialistView[]
     decision?: ApprovalResult
   }): BuildServiceResult => {
     const profiles = opts.profiles ?? [specialist()]
-    const profileService = withExplicitResolvers({
+    const specialistService = withExplicitResolvers({
       list: vi.fn(async () => profiles),
       getByName: vi.fn(async (name: string) => {
         const found = profiles.find((p) => p.name === name)
@@ -236,7 +239,7 @@ describe('AgentsService.dispatch — switch op routing (issue 05)', () => {
         if (!found) throw new Error(`Specialist ${id} not found.`)
         return found
       })
-    } as unknown as ProfileService)
+    } as unknown as SpecialistService)
     const sessionBinding = {
       setBinding: vi.fn(),
       getBinding: vi.fn()
@@ -248,14 +251,14 @@ describe('AgentsService.dispatch — switch op routing (issue 05)', () => {
     }
     const notifier: SwitchNotifier = { notify }
     const service = new AgentsService({
-      profileService,
+      specialistService,
       catalog: noopCatalog(),
       approvalGateway: gateway,
       switchNotifier: notifier,
       sessionBinding,
       persistSessionSpecialist: persist
     })
-    return { service, profileService, sessionBinding, persist, notify, gateway }
+    return { service, specialistService, sessionBinding, persist, notify, gateway }
   }
 
   it('routes an approved switch through the dispatcher and persists + broadcasts', async () => {
@@ -334,7 +337,7 @@ describe('AgentsService.dispatch — switch op routing (issue 05)', () => {
 })
 
 describe('AgentsService.dispatch — mutation routing (privileged delete + ordinary update)', () => {
-  const specialist = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  const specialist = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
     id: 'sp-1',
     name: 'Bio',
     displayName: 'Bio',
@@ -349,16 +352,16 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
   })
 
   const buildService = (opts: {
-    profiles?: SpecialistProfileView[]
+    profiles?: SpecialistView[]
     decision?: ApprovalResult
   }): {
     service: AgentsService
-    profileService: ProfileService
+    specialistService: SpecialistService
     gateway: ApprovalGateway
     invalidateCatalog: ReturnType<typeof vi.fn>
   } => {
     const profiles = opts.profiles ?? [specialist()]
-    const profileService = withExplicitResolvers({
+    const specialistService = withExplicitResolvers({
       list: vi.fn(async () => profiles),
       getByName: vi.fn(async (name: string) => {
         const found = profiles.find((p) => p.name === name)
@@ -369,22 +372,22 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
         throw new Error('unexpected')
       }),
       delete: vi.fn(async () => undefined)
-    } as unknown as ProfileService)
+    } as unknown as SpecialistService)
     const gateway: ApprovalGateway = {
       decide: vi.fn(async (): Promise<ApprovalResult> => opts.decision ?? { status: 'approved' })
     }
     const invalidateCatalog = vi.fn(async () => undefined)
     const service = new AgentsService({
-      profileService,
+      specialistService,
       catalog: noopCatalog(),
       approvalGateway: gateway,
       invalidateCatalog
     })
-    return { service, profileService, gateway, invalidateCatalog }
+    return { service, specialistService, gateway, invalidateCatalog }
   }
 
   it('routes a displayName edit through the ordinary mutation path', async () => {
-    // The ProfileService returns the real post-write record; the dispatcher
+    // The SpecialistService returns the real post-write record; the dispatcher
     // must surface it verbatim, not echo the request patch.
     const updated = specialist({
       displayName: 'Biology',
@@ -392,23 +395,23 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
       systemPrompt: 'UPDATE READ-BACK PROMPT SENTINEL',
       revision: 4
     })
-    const { service, profileService, gateway } = buildService({
+    const { service, specialistService, gateway } = buildService({
       profiles: [specialist()]
     })
-    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
+    ;(specialistService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
 
     const result = (await service.dispatch({
       op: 'update',
       params: { name: 'Bio', patch: { display_name: 'Biology', description: 'new', revision: 3 } }
-    })) as SpecialistProfileView
+    })) as SpecialistView
 
-    // Ordinary path returns a projected AgentDetailReadModel (no {status:'updated'} envelope).
+    // Ordinary path returns a projected SpecialistDetailReadModel (no {status:'updated'} envelope).
     expect(result.name).toBe('Bio')
     expect(result.displayName).toBe('Biology')
     expect(result.revision).toBe(4)
     expect(result.systemPrompt).toBe('UPDATE READ-BACK PROMPT SENTINEL')
     // The ordinary path pinned the re-resolved name -> id and revision before update.
-    const updateArgs = (profileService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    const updateArgs = (specialistService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
     expect(updateArgs.id).toBe('sp-1')
     expect(updateArgs.revision).toBe(3)
     expect(updateArgs.name).toBeUndefined()
@@ -418,16 +421,16 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
 
   it('a non-name update stays on the ordinary-mutation path (not the privileged module)', async () => {
     const ordinaryReturn = specialist({ description: 'edited', revision: 4 })
-    const profileService = withExplicitResolvers({
-      ...noopProfileService(),
+    const specialistService = withExplicitResolvers({
+      ...noopSpecialistService(),
       getByName: vi.fn(async () => specialist()),
       update: vi.fn(async () => ordinaryReturn)
-    } as unknown as ProfileService)
+    } as unknown as SpecialistService)
     const gateway: ApprovalGateway = {
       decide: vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
     }
     const service = new AgentsService({
-      profileService,
+      specialistService,
       catalog: noopCatalog(),
       approvalGateway: gateway
     })
@@ -437,7 +440,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
       params: { name: 'Bio', patch: { description: 'edited', revision: 3 } }
     })) as { id: string; description: string }
 
-    // Ordinary path returns a projected AgentDetailReadModel (no {status:'updated'} envelope).
+    // Ordinary path returns a projected SpecialistDetailReadModel (no {status:'updated'} envelope).
     expect(result.id).toBe('sp-1')
     expect(result.description).toBe('edited')
     // The privileged gateway was NOT consulted for a non-name update.
@@ -455,13 +458,13 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
       revision: 4
     })
     const attachSkill = vi.fn(async () => attached)
-    const profileService = withExplicitResolvers({
-      ...noopProfileService(),
+    const specialistService = withExplicitResolvers({
+      ...noopSpecialistService(),
       getByName: vi.fn(async () => specialist()),
       attachSkill
-    } as unknown as ProfileService)
+    } as unknown as SpecialistService)
     const service = new AgentsService({
-      profileService,
+      specialistService,
       catalog: {
         ...noopCatalog(),
         listSkillCatalog: vi.fn(async () => [
@@ -480,7 +483,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     const result = (await service.dispatch({
       op: 'attach_skill',
       params: { name: 'Bio', skill_ref: 'skill-1', revision: 3 }
-    })) as SpecialistProfileView
+    })) as SpecialistView
 
     expect(result.systemPrompt).toBe('ATTACH READ-BACK PROMPT SENTINEL')
     expect(result.selectedCapabilities.skillIds).toEqual(['skill-1'])
@@ -488,11 +491,11 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
   })
 
   it('routes delete through applyDelete and returns { status: deleted, name }', async () => {
-    const { service, profileService, invalidateCatalog } = buildService({
+    const { service, specialistService, invalidateCatalog } = buildService({
       profiles: [specialist()]
     })
     // getByName throws "not found" after delete -> absence verified.
-    ;(profileService.getByName as ReturnType<typeof vi.fn>)
+    ;(specialistService.getByName as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce(specialist())
       .mockRejectedValueOnce(new Error('Specialist "Bio" not found.'))
 
@@ -502,12 +505,12 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     })) as { status: string; name: string }
 
     expect(result).toEqual({ status: 'deleted', name: 'Bio' })
-    expect(profileService.delete as ReturnType<typeof vi.fn>).toHaveBeenCalledWith('sp-1', 3)
+    expect(specialistService.delete as ReturnType<typeof vi.fn>).toHaveBeenCalledWith('sp-1', 3)
     expect(invalidateCatalog).toHaveBeenCalledTimes(1)
   })
 
   it('a declined delete returns the structured declined shape and mutates nothing', async () => {
-    const { service, profileService, invalidateCatalog } = buildService({
+    const { service, specialistService, invalidateCatalog } = buildService({
       profiles: [specialist()],
       decision: { status: 'declined', operation: 'delete', reason: 'user cancelled' }
     })
@@ -518,12 +521,12 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     })
 
     expect(result).toEqual({ status: 'declined', operation: 'delete', reason: 'user cancelled' })
-    expect(profileService.delete as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(specialistService.delete as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
     expect(invalidateCatalog).not.toHaveBeenCalled()
   })
 
   it('a stale revision fails closed with a sanitized error (no mutation, no retry)', async () => {
-    const { service, profileService, invalidateCatalog } = buildService({
+    const { service, specialistService, invalidateCatalog } = buildService({
       // Live revision drifted to 5 while the reviewed revision was 3.
       profiles: [specialist({ revision: 5 })]
     })
@@ -531,14 +534,14 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     await expect(
       service.dispatch({ op: 'delete', params: { name: 'Bio', revision: 3 } })
     ).rejects.toThrow(/host\.agents\.delete:.*reviewed revision 3/)
-    expect(profileService.delete as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(specialistService.delete as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
     expect(invalidateCatalog).not.toHaveBeenCalled()
   })
 
   it('delete never clears session bindings (no binding sink invoked)', async () => {
-    const { service, profileService } = buildService({ profiles: [specialist()] })
+    const { service, specialistService } = buildService({ profiles: [specialist()] })
     // getByName resolves the live record pre-delete, then throws "not found" post-delete (absence).
-    ;(profileService.getByName as ReturnType<typeof vi.fn>)
+    ;(specialistService.getByName as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce(specialist())
       .mockRejectedValueOnce(new Error('Specialist "Bio" not found.'))
     // The result surface and dispatcher carry NO binding-clearance path; the contract is that bound
@@ -564,15 +567,15 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
   })
 
   const buildServiceWithSkills = (opts: {
-    profiles: SpecialistProfileView[]
+    profiles: SpecialistView[]
     decision?: ApprovalResult
   }): {
     service: AgentsService
-    profileService: ProfileService
+    specialistService: SpecialistService
     gateway: ApprovalGateway
     invalidateCatalog: ReturnType<typeof vi.fn>
   } => {
-    const profileService = withExplicitResolvers({
+    const specialistService = withExplicitResolvers({
       list: vi.fn(async () => opts.profiles),
       getByName: vi.fn(async (name: string) => {
         const found = opts.profiles.find((p) => p.name === name)
@@ -583,33 +586,33 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
         throw new Error('unexpected')
       }),
       delete: vi.fn(async () => undefined)
-    } as unknown as ProfileService)
+    } as unknown as SpecialistService)
     const gateway: ApprovalGateway = {
       decide: vi.fn(async (): Promise<ApprovalResult> => opts.decision ?? { status: 'approved' })
     }
     const invalidateCatalog = vi.fn(async () => undefined)
     const service = new AgentsService({
-      profileService,
+      specialistService,
       catalog: skillCatalog(),
       approvalGateway: gateway,
       invalidateCatalog
     })
-    return { service, profileService, gateway, invalidateCatalog }
+    return { service, specialistService, gateway, invalidateCatalog }
   }
 
   it('a displayName patch that also edits skill_names applies both atomically', async () => {
-    // The ProfileService returns the real post-write record (new label, bumped revision, and the new
+    // The SpecialistService returns the real post-write record (new label, bumped revision, and the new
     // selected capability collection). The dispatcher must surface it verbatim, not echo the request.
-    const updated: SpecialistProfileView = {
+    const updated: SpecialistView = {
       ...specialist({ displayName: 'Biology', revision: 4 }),
       capabilityMode: 'selected',
       selectedCapabilities: { skillIds: ['sk-reviewer'], connectorIds: [], connectorTools: [] },
       fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] }
     }
-    const { service, profileService, gateway } = buildServiceWithSkills({
+    const { service, specialistService, gateway } = buildServiceWithSkills({
       profiles: [specialist()]
     })
-    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
+    ;(specialistService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
 
     const result = (await service.dispatch({
       op: 'update',
@@ -617,7 +620,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
         name: 'Bio',
         patch: { display_name: 'Biology', skill_names: ['sk-reviewer'], revision: 3 }
       }
-    })) as SpecialistProfileView
+    })) as SpecialistView
 
     expect(result.name).toBe('Bio')
     expect(result.displayName).toBe('Biology')
@@ -627,7 +630,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
 
     // The ordinary path received the complete patch: displayName + resolved capability fields. The
     // skill ref was resolved to its stable id and projected onto the patch (not stripped).
-    const updateArgs = (profileService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    const updateArgs = (specialistService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
     expect(updateArgs.name).toBeUndefined()
     expect(updateArgs.displayName).toBe('Biology')
     expect(updateArgs.capabilityMode).toBe('selected')
@@ -641,7 +644,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
 
   it('a combined displayName+capability patch with a stale revision fails closed', async () => {
     // Live revision drifted to 5 while the reviewed revision was 3.
-    const { service, profileService, invalidateCatalog } = buildServiceWithSkills({
+    const { service, specialistService, invalidateCatalog } = buildServiceWithSkills({
       profiles: [specialist({ revision: 5 })]
     })
 
@@ -654,32 +657,32 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
         }
       })
     ).rejects.toThrow(/host\.agents\.update:.*revision/)
-    expect(profileService.update as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(specialistService.update as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
     expect(invalidateCatalog).not.toHaveBeenCalled()
   })
 
   // A displayName patch that also toggles `enabled` must land both in one CAS-backed update.
   it('a displayName patch that also toggles enabled applies both changes atomically', async () => {
     const updated = specialist({ displayName: 'Biology', revision: 4, enabled: false })
-    const { service, profileService } = buildService({ profiles: [specialist()] })
-    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
+    const { service, specialistService } = buildService({ profiles: [specialist()] })
+    ;(specialistService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
 
     const result = (await service.dispatch({
       op: 'update',
       params: { name: 'Bio', patch: { display_name: 'Biology', enabled: false, revision: 3 } }
-    })) as SpecialistProfileView
+    })) as SpecialistView
 
     expect(result.name).toBe('Bio')
     expect(result.displayName).toBe('Biology')
     expect(result.enabled).toBe(false)
     expect(result.revision).toBe(4)
-    expect(profileService.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+    expect(specialistService.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'sp-1', revision: 3, displayName: 'Biology', enabled: false })
     )
   })
 
   it('rejects a displayName patch carrying an unknown field with a sanitized error', async () => {
-    const { service, profileService, invalidateCatalog } = buildService({
+    const { service, specialistService, invalidateCatalog } = buildService({
       profiles: [specialist()]
     })
 
@@ -692,7 +695,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
         }
       })
     ).rejects.toThrow(/host\.agents\.update:.*Unknown field "malicious_field"/)
-    expect(profileService.update as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+    expect(specialistService.update as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
     expect(invalidateCatalog).not.toHaveBeenCalled()
   })
 })
@@ -707,7 +710,7 @@ describe('AgentsService — injected seams are fake-able and routed (composition
     }
     const fakeNotifier: SwitchNotifier = { notify: vi.fn() }
     const service = new AgentsService({
-      profileService: noopProfileService(),
+      specialistService: noopSpecialistService(),
       catalog: noopCatalog(),
       approvalGateway: fakeGateway,
       switchNotifier: fakeNotifier

--- a/src/main/agents/agents-mutations.test.ts
+++ b/src/main/agents/agents-mutations.test.ts
@@ -4,16 +4,16 @@ import { executeAgentsMutation, type AgentsMutationCatalog } from './agents-muta
 import type { ConnectorReadModel, SkillCatalogReadModel } from './agents-service'
 import type {
   CreateSpecialistInput,
-  SpecialistProfileView,
+  SpecialistView,
   UpdateSpecialistInput
 } from '../../shared/specialist'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistService } from '../specialist/service'
 
 // ---------------------------------------------------------------------------
 // Stubs
 // ---------------------------------------------------------------------------
 
-const baseProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+const baseProfile = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'sp-1',
   name: 'Bio',
   displayName: 'Bio',
@@ -27,23 +27,23 @@ const baseProfile = (overrides: Partial<SpecialistProfileView> = {}): Specialist
   ...overrides
 })
 
-// A ProfileService fake that records every mutation call and returns a read-back view built from the
+// A SpecialistService fake that records every mutation call and returns a read-back view built from the
 // stored config so we can assert real read-back (not echoed input).
-const makeProfileService = (
-  initial: SpecialistProfileView[]
-): ProfileService & {
+const makeSpecialistService = (
+  initial: SpecialistView[]
+): SpecialistService & {
   calls: { method: string; args: unknown[] }[]
-  setStored: (next: SpecialistProfileView[]) => void
+  setStored: (next: SpecialistView[]) => void
 } => {
-  let stored: SpecialistProfileView[] = initial
+  let stored: SpecialistView[] = initial
   const calls: { method: string; args: unknown[] }[] = []
-  const bump = (view: SpecialistProfileView): SpecialistProfileView => ({
+  const bump = (view: SpecialistView): SpecialistView => ({
     ...view,
     revision: view.revision + 1
   })
   const svc = {
     calls,
-    setStored(next: SpecialistProfileView[]) {
+    setStored(next: SpecialistView[]) {
       stored = next
     },
     async list() {
@@ -61,7 +61,7 @@ const makeProfileService = (
     },
     async create(input: CreateSpecialistInput) {
       calls.push({ method: 'create', args: [input] })
-      const view: SpecialistProfileView = {
+      const view: SpecialistView = {
         id: 'sp-new',
         name: input.name,
         displayName: input.displayName ?? input.name,
@@ -90,7 +90,7 @@ const makeProfileService = (
       calls.push({ method: 'update', args: [input] })
       const idx = stored.findIndex((p) => p.id === input.id)
       if (idx < 0) throw new Error(`Specialist ${input.id} not found after update.`)
-      const merged: SpecialistProfileView = { ...stored[idx] }
+      const merged: SpecialistView = { ...stored[idx] }
       if (input.displayName !== undefined) merged.displayName = input.displayName
       if (input.description !== undefined) merged.description = input.description
       if (input.systemPrompt !== undefined) merged.systemPrompt = input.systemPrompt
@@ -220,7 +220,7 @@ const makeProfileService = (
       stored = stored.map((p, i) => (i === idx ? next : p))
       return next
     }
-  } as unknown as ProfileService & typeof svc
+  } as unknown as SpecialistService & typeof svc
   return svc
 }
 
@@ -267,62 +267,62 @@ const makeCatalog = (
 
 describe('executeAgentsMutation — payload validation (rejects before reaching the repo)', () => {
   it('rejects an unknown create field', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog([], [])
     await expect(
       executeAgentsMutation(
         { op: 'create', params: { name: 'Bio', bogus_field: 'x' } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.create:/)
   })
 
   it('rejects a malformed name type on create', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog([], [])
     await expect(
       executeAgentsMutation(
         { op: 'create', params: { name: 42 } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.create:/)
   })
 
   it('rejects a non-finite revision on update', async () => {
-    const svc = makeProfileService([baseProfile()])
+    const svc = makeSpecialistService([baseProfile()])
     const { catalog } = makeCatalog([], [])
     await expect(
       executeAgentsMutation(
         { op: 'update', params: { name: 'Bio', patch: { revision: Number.NaN } } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.update:/)
   })
 
   it('rejects a non-array skill_names on create', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog([], [])
     await expect(
       executeAgentsMutation(
         { op: 'create', params: { name: 'Bio', skill_names: 'demo' } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.create:/)
   })
 
   it('rejects unknown update fields', async () => {
-    const svc = makeProfileService([baseProfile()])
+    const svc = makeSpecialistService([baseProfile()])
     const { catalog } = makeCatalog([], [])
     await expect(
       executeAgentsMutation(
         { op: 'update', params: { name: 'Bio', patch: { revision: 1, oops: true } } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.update:/)
   })
 
   it('rejects connector tool-method / include-exclude patterns as out of scope', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(skills(), connectors())
     // Connector tool scope is a later milestone; the agreed object does not name these fields, so
     // they are rejected as unknown before reaching the repository.
@@ -332,13 +332,13 @@ describe('executeAgentsMutation — payload validation (rejects before reaching 
           op: 'create',
           params: { name: 'Bio', connector_tools: [{ connectorId: 'c', includedMethods: ['x'] }] }
         },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.create:/)
     await expect(
       executeAgentsMutation(
         { op: 'create', params: { name: 'Bio2', include_tools_pattern: 'c.*' } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.create:/)
   })
@@ -346,12 +346,12 @@ describe('executeAgentsMutation — payload validation (rejects before reaching 
 
 describe('executeAgentsMutation — create', () => {
   it('create with neither capability array produces Full access', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(skills(), connectors())
     const result = (await executeAgentsMutation(
       { op: 'create', params: { name: 'Bio', description: 'd', system_prompt: 'p' } },
-      { profileService: svc, catalog }
-    )) as SpecialistProfileView
+      { specialistService: svc, catalog }
+    )) as SpecialistView
     expect(svc.calls[0].method).toBe('create')
     const passed = svc.calls[0].args[0] as CreateSpecialistInput
     expect(passed.capabilityMode).toBe('full')
@@ -359,12 +359,12 @@ describe('executeAgentsMutation — create', () => {
   })
 
   it('create with skill_names produces Selected and stores connector collection empty', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'Skill One' }), connectors())
     const result = (await executeAgentsMutation(
       { op: 'create', params: { name: 'Bio', skill_names: ['sk1'] } },
-      { profileService: svc, catalog }
-    )) as SpecialistProfileView
+      { specialistService: svc, catalog }
+    )) as SpecialistView
     const passed = svc.calls[0].args[0] as CreateSpecialistInput
     expect(passed.capabilityMode).toBe('selected')
     expect(passed.selectedCapabilities?.skillIds).toEqual(['sk1'])
@@ -373,11 +373,11 @@ describe('executeAgentsMutation — create', () => {
   })
 
   it('create with connector_names produces Selected and stores skill collection empty', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(skills(), connectors({ id: 'c1', displayName: 'Conn' }))
     await executeAgentsMutation(
       { op: 'create', params: { name: 'Bio', connector_names: ['c1'] } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     const passed = svc.calls[0].args[0] as CreateSpecialistInput
     expect(passed.capabilityMode).toBe('selected')
@@ -386,7 +386,7 @@ describe('executeAgentsMutation — create', () => {
   })
 
   it('create accepts the full agreed object and returns a real read-back (not echoed input)', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(
       skills({ id: 'sk1', name: 'Skill One' }),
       connectors({ id: 'c1', displayName: 'Conn' })
@@ -406,8 +406,8 @@ describe('executeAgentsMutation — create', () => {
           connector_names: ['c1']
         }
       },
-      { profileService: svc, catalog }
-    )) as SpecialistProfileView
+      { specialistService: svc, catalog }
+    )) as SpecialistView
     // read-back is a real view: it carries id + revision + enabled always true (create default),
     // and capability resolved against the stable IDs, not the echoed public name.
     expect(result.id).toBe('sp-new')
@@ -418,40 +418,40 @@ describe('executeAgentsMutation — create', () => {
   })
 
   it('create rejects a missing name', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog([], [])
     await expect(
-      executeAgentsMutation({ op: 'create', params: {} }, { profileService: svc, catalog })
+      executeAgentsMutation({ op: 'create', params: {} }, { specialistService: svc, catalog })
     ).rejects.toThrow(/host\.agents\.create:/)
   })
 
   it('create resolves a skill public name to its stable id and persists only the id', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(skills({ id: 'stable-1', name: 'Skill One' }), connectors())
     await executeAgentsMutation(
       { op: 'create', params: { name: 'Bio', skill_names: ['Skill One'] } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     const passed = svc.calls[0].args[0] as CreateSpecialistInput
     expect(passed.selectedCapabilities?.skillIds).toEqual(['stable-1'])
   })
 
   it('create resolves a connector immutable name to its stable id', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(
       skills(),
       connectors({ id: 'stable-c', name: 'my-connector', displayName: 'My Connector' })
     )
     await executeAgentsMutation(
       { op: 'create', params: { name: 'Bio', connector_names: ['my-connector'] } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     const passed = svc.calls[0].args[0] as CreateSpecialistInput
     expect(passed.selectedCapabilities?.connectorIds).toEqual(['stable-c'])
   })
 
   it('create rejects an ambiguous skill name and instructs to use the stable id', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(
       skills({ id: 'a', name: 'Dup' }, { id: 'b', name: 'Dup' }),
       connectors()
@@ -459,21 +459,21 @@ describe('executeAgentsMutation — create', () => {
     await expect(
       executeAgentsMutation(
         { op: 'create', params: { name: 'Bio', skill_names: ['Dup'] } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/stable id/)
   })
 
   it('create allows a Main-disabled installed skill to be assigned', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(
       skills({ id: 'sk1', name: 'Disabled', mainEnabled: false }),
       connectors()
     )
     const result = (await executeAgentsMutation(
       { op: 'create', params: { name: 'Bio', skill_names: ['sk1'] } },
-      { profileService: svc, catalog }
-    )) as SpecialistProfileView
+      { specialistService: svc, catalog }
+    )) as SpecialistView
     expect(svc.calls[0].method).toBe('create')
     expect(result.capabilityMode).toBe('selected')
   })
@@ -481,7 +481,7 @@ describe('executeAgentsMutation — create', () => {
 
 describe('executeAgentsMutation — update', () => {
   it('update supports description, system instructions, icon, color, enabled, mode, skills, connectors', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1 })])
     const { catalog } = makeCatalog(
       skills({ id: 'sk1', name: 'Skill One' }),
       connectors({ id: 'c1', displayName: 'Conn' })
@@ -503,8 +503,8 @@ describe('executeAgentsMutation — update', () => {
           }
         }
       },
-      { profileService: svc, catalog }
-    )) as SpecialistProfileView
+      { specialistService: svc, catalog }
+    )) as SpecialistView
     expect(svc.calls[0].method).toBe('update')
     const passed = svc.calls[0].args[0] as UpdateSpecialistInput
     expect(passed.description).toBe('new desc')
@@ -523,7 +523,7 @@ describe('executeAgentsMutation — update', () => {
   })
 
   it('update({ unrestricted: true }) switches to Full without destroying the stored Selected config', async () => {
-    const svc = makeProfileService([
+    const svc = makeSpecialistService([
       baseProfile({
         revision: 1,
         selectedCapabilities: { skillIds: ['sk1'], connectorIds: ['c1'], connectorTools: [] }
@@ -532,7 +532,7 @@ describe('executeAgentsMutation — update', () => {
     const { catalog } = makeCatalog(skills(), connectors())
     await executeAgentsMutation(
       { op: 'update', params: { name: 'Bio', patch: { revision: 1, unrestricted: true } } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     const passed = svc.calls[0].args[0] as UpdateSpecialistInput
     expect(passed.capabilityMode).toBe('full')
@@ -541,7 +541,7 @@ describe('executeAgentsMutation — update', () => {
   })
 
   it('update providing skill_names exactly replaces the collection and switches to Selected', async () => {
-    const svc = makeProfileService([
+    const svc = makeSpecialistService([
       baseProfile({
         revision: 1,
         capabilityMode: 'full',
@@ -557,7 +557,7 @@ describe('executeAgentsMutation — update', () => {
         op: 'update',
         params: { name: 'Bio', patch: { revision: 1, skill_names: ['new1', 'new2'] } }
       },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     const passed = svc.calls[0].args[0] as UpdateSpecialistInput
     expect(passed.capabilityMode).toBe('selected')
@@ -567,7 +567,7 @@ describe('executeAgentsMutation — update', () => {
   })
 
   it('update preserving omitted collections: skill_names omitted keeps existing skills', async () => {
-    const svc = makeProfileService([
+    const svc = makeSpecialistService([
       baseProfile({
         revision: 1,
         capabilityMode: 'selected',
@@ -577,7 +577,7 @@ describe('executeAgentsMutation — update', () => {
     const { catalog } = makeCatalog(skills(), connectors({ id: 'c1', displayName: 'C' }))
     await executeAgentsMutation(
       { op: 'update', params: { name: 'Bio', patch: { revision: 1, connector_names: ['c1'] } } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     const passed = svc.calls[0].args[0] as UpdateSpecialistInput
     expect(passed.selectedCapabilities?.connectorIds).toEqual(['c1'])
@@ -586,12 +586,12 @@ describe('executeAgentsMutation — update', () => {
   })
 
   it('update requires a matching revision; a stale revision fails without merge/retry', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 5 })])
+    const svc = makeSpecialistService([baseProfile({ revision: 5 })])
     const { catalog } = makeCatalog(skills(), connectors())
     await expect(
       executeAgentsMutation(
         { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'x' } } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.update:/)
     expect(svc.calls).toHaveLength(0)
@@ -599,29 +599,29 @@ describe('executeAgentsMutation — update', () => {
 
   it('a non-name update does not request a permission card (no approval gateway call)', async () => {
     const decide = vi.fn(async () => ({ status: 'approved' as const }))
-    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1 })])
     const { catalog } = makeCatalog(skills(), connectors())
     await executeAgentsMutation(
       { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'x' } } },
-      { profileService: svc, catalog, approvalGateway: { decide } }
+      { specialistService: svc, catalog, approvalGateway: { decide } }
     )
     expect(decide).not.toHaveBeenCalled()
   })
 
   it('update reads changes from the nested patch', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1 })])
     const { catalog } = makeCatalog(skills(), connectors())
     const result = (await executeAgentsMutation(
       { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'nested desc' } } },
-      { profileService: svc, catalog }
-    )) as SpecialistProfileView
+      { specialistService: svc, catalog }
+    )) as SpecialistView
     const passed = svc.calls[0].args[0] as UpdateSpecialistInput
     expect(passed.description).toBe('nested desc')
     expect(result.revision).toBe(2)
   })
 
   it('update changes displayName without changing the immutable name', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1 })])
     const { catalog } = makeCatalog(skills(), connectors())
     const decide = vi.fn()
     const result = (await executeAgentsMutation(
@@ -629,19 +629,19 @@ describe('executeAgentsMutation — update', () => {
         op: 'update',
         params: { name: 'Bio', patch: { revision: 1, display_name: 'New label' } }
       },
-      { profileService: svc, catalog, approvalGateway: { decide } }
-    )) as SpecialistProfileView
+      { specialistService: svc, catalog, approvalGateway: { decide } }
+    )) as SpecialistView
     expect(result).toMatchObject({ name: 'Bio', displayName: 'New label' })
     expect(decide).not.toHaveBeenCalled()
   })
 
   it('update requires a nested patch object', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1 })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1 })])
     const { catalog } = makeCatalog(skills(), connectors())
     await expect(
       executeAgentsMutation(
         { op: 'update', params: { name: 'Bio' } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.update:/)
     expect(svc.calls).toHaveLength(0)
@@ -650,31 +650,31 @@ describe('executeAgentsMutation — update', () => {
 
 describe('executeAgentsMutation — attach/detach mutate current mode without switching it', () => {
   it('Selected attach_skill adds an inclusion; detach removes it', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
     const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'S' }), connectors())
     await executeAgentsMutation(
       { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 1 } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls[0]).toEqual({ method: 'attachSkill', args: ['sp-1', 'sk1', 1, 'selected'] })
     await executeAgentsMutation(
       { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 2 } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls[1]).toEqual({ method: 'detachSkill', args: ['sp-1', 'sk1', 2, 'selected'] })
   })
 
   it('Full attach_skill removes an exclusion; detach adds one', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'full' })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'full' })])
     const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'S' }), connectors())
     await executeAgentsMutation(
       { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 1 } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls[0]).toEqual({ method: 'attachSkill', args: ['sp-1', 'sk1', 1, 'full'] })
     await executeAgentsMutation(
       { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 2 } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls[1]).toEqual({ method: 'detachSkill', args: ['sp-1', 'sk1', 2, 'full'] })
   })
@@ -685,14 +685,14 @@ describe('executeAgentsMutation — attach/detach mutate current mode without sw
   // literal display name reaches detachSkill instead of the resolved stable id. The existing tests
   // above used a ref that equals the stable id, so they passed even with the bug.
   it('detach_skill resolves a public name to the stable catalog id (not the literal ref)', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
     const { catalog } = makeCatalog(
       skills({ id: 'sk-stable', name: 'Skill One', displayName: 'Skill One' }),
       connectors()
     )
     await executeAgentsMutation(
       { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'Skill One', revision: 1 } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls[0]).toEqual({
       method: 'detachSkill',
@@ -701,20 +701,20 @@ describe('executeAgentsMutation — attach/detach mutate current mode without sw
   })
 
   it('attach_connector / detach_connector follow the same mode rules', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
     const { catalog } = makeCatalog(skills(), connectors({ id: 'c1', displayName: 'C' }))
     await executeAgentsMutation(
       { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'c1', revision: 1 } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls[0]).toEqual({
       method: 'attachConnector',
       args: ['sp-1', 'c1', 1, 'selected']
     })
-    const svc2 = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'full' })])
+    const svc2 = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'full' })])
     await executeAgentsMutation(
       { op: 'detach_connector', params: { name: 'Bio', connector_ref: 'c1', revision: 1 } },
-      { profileService: svc2, catalog }
+      { specialistService: svc2, catalog }
     )
     expect(svc2.calls[0]).toEqual({
       method: 'detachConnector',
@@ -723,23 +723,23 @@ describe('executeAgentsMutation — attach/detach mutate current mode without sw
   })
 
   it('attach/detach rejects a missing revision', async () => {
-    const svc = makeProfileService([baseProfile()])
+    const svc = makeSpecialistService([baseProfile()])
     const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'S' }), connectors())
     await expect(
       executeAgentsMutation(
         { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'sk1' } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.attach_skill:/)
   })
 
   it('attach/detach rejects unknown params', async () => {
-    const svc = makeProfileService([baseProfile()])
+    const svc = makeSpecialistService([baseProfile()])
     const { catalog } = makeCatalog(skills({ id: 'sk1', name: 'S' }), connectors())
     await expect(
       executeAgentsMutation(
         { op: 'detach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 1, extra: 1 } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.detach_skill:/)
   })
@@ -747,7 +747,7 @@ describe('executeAgentsMutation — attach/detach mutate current mode without sw
 
 describe('executeAgentsMutation — Connector availability gate', () => {
   it('cannot newly attach an unavailable custom connector', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
     const { catalog } = makeCatalog(
       skills(),
       connectors({ id: 'dead', source: 'custom', availability: 'unavailable' })
@@ -755,14 +755,14 @@ describe('executeAgentsMutation — Connector availability gate', () => {
     await expect(
       executeAgentsMutation(
         { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'dead', revision: 1 } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.attach_connector:/)
     expect(svc.calls).toHaveLength(0)
   })
 
   it('cannot newly attach an unauthenticated custom connector', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
     const { catalog } = makeCatalog(
       skills(),
       connectors({ id: 'unauth', source: 'custom', availability: 'unauthenticated' })
@@ -770,13 +770,13 @@ describe('executeAgentsMutation — Connector availability gate', () => {
     await expect(
       executeAgentsMutation(
         { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'unauth', revision: 1 } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.attach_connector:/)
   })
 
   it('create with an unavailable custom connector in connector_names is rejected', async () => {
-    const svc = makeProfileService([])
+    const svc = makeSpecialistService([])
     const { catalog } = makeCatalog(
       skills(),
       connectors({ id: 'dead', source: 'custom', availability: 'unavailable' })
@@ -784,20 +784,20 @@ describe('executeAgentsMutation — Connector availability gate', () => {
     await expect(
       executeAgentsMutation(
         { op: 'create', params: { name: 'Bio', connector_names: ['dead'] } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.create:/)
   })
 
   it('an available custom connector can be attached', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
     const { catalog } = makeCatalog(
       skills(),
       connectors({ id: 'ok', source: 'custom', availability: 'available' })
     )
     await executeAgentsMutation(
       { op: 'attach_connector', params: { name: 'Bio', connector_ref: 'ok', revision: 1 } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls[0]).toEqual({ method: 'attachConnector', args: ['sp-1', 'ok', 1, 'selected'] })
   })
@@ -805,7 +805,7 @@ describe('executeAgentsMutation — Connector availability gate', () => {
   it('detach passes through a stale reference no longer in the catalog (still removable)', async () => {
     // An existing stale reference that has since been removed from the catalog must still be
     // detachable. detach falls back to the literal stable id when nothing matches.
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
     const { catalog } = makeCatalog(
       skills(),
       // 'stale-connector' is NOT in the catalog.
@@ -816,7 +816,7 @@ describe('executeAgentsMutation — Connector availability gate', () => {
         op: 'detach_connector',
         params: { name: 'Bio', connector_ref: 'stale-connector', revision: 1 }
       },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls[0]).toEqual({
       method: 'detachConnector',
@@ -826,27 +826,27 @@ describe('executeAgentsMutation — Connector availability gate', () => {
 })
 
 describe('executeAgentsMutation — no direct repo writes, no duplicated rules', () => {
-  it('all mutations delegate to ProfileService (never write the repository directly)', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
+  it('all mutations delegate to SpecialistService (never write the repository directly)', async () => {
+    const svc = makeSpecialistService([baseProfile({ revision: 1, capabilityMode: 'selected' })])
     const { catalog } = makeCatalog(
       skills({ id: 'sk1', name: 'S' }),
       connectors({ id: 'c1', displayName: 'C' })
     )
     await executeAgentsMutation(
       { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'd' } } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     await executeAgentsMutation(
       { op: 'attach_skill', params: { name: 'Bio', skill_ref: 'sk1', revision: 2 } },
-      { profileService: svc, catalog }
+      { specialistService: svc, catalog }
     )
     expect(svc.calls.map((c) => c.method)).toEqual(['update', 'attachSkill'])
   })
 })
 
 describe('executeAgentsMutation — errors are sanitized', () => {
-  it('ProfileService internal secret never reaches the sandbox', async () => {
-    const svc = makeProfileService([])
+  it('SpecialistService internal secret never reaches the sandbox', async () => {
+    const svc = makeSpecialistService([])
     svc.create = vi.fn(async () => {
       throw new Error('internal secret: apikey=ABCDEF')
     })
@@ -854,18 +854,18 @@ describe('executeAgentsMutation — errors are sanitized', () => {
     await expect(
       executeAgentsMutation(
         { op: 'create', params: { name: 'Bio' } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow('host.agents.create: Internal operation failed.')
   })
 
   it('a repo revision-conflict surfaces as a sanitized host.agents.update: error', async () => {
-    const svc = makeProfileService([baseProfile({ revision: 5 })])
+    const svc = makeSpecialistService([baseProfile({ revision: 5 })])
     const { catalog } = makeCatalog(skills(), connectors())
     await expect(
       executeAgentsMutation(
         { op: 'update', params: { name: 'Bio', patch: { revision: 1, description: 'x' } } },
-        { profileService: svc, catalog }
+        { specialistService: svc, catalog }
       )
     ).rejects.toThrow(/host\.agents\.update:/)
   })

--- a/src/main/agents/agents-mutations.ts
+++ b/src/main/agents/agents-mutations.ts
@@ -1,15 +1,15 @@
 // host.agents ordinary-mutation operation module (issue 03).
 //
-// This module implements ordinary Profile mutations + read-back: create, mutable-field update,
+// This module implements ordinary Specialist mutations + read-back: create, mutable-field update,
 // enable/disable, and incremental whole-Skill/whole-Connector attach/detach. It is deliberately a
 // standalone module so issue 08 can compose it into the shared dispatcher without changing issues
 // 04/05. The privileged delete and switch operations stay out of scope here — they
 // require the injected approval gateway.
 //
 // Design rules (design.md §4/§5/§8, PRD §2/§4):
-//  - ProfileService is the SINGLE domain mutation service. This module never writes the repository
+//  - SpecialistService is the SINGLE domain mutation service. This module never writes the repository
 //    directly and never re-implements the Full/Selected collection rules; it only translates the
-//    private snake_case transport input into ProfileService input and delegates.
+//    private snake_case transport input into SpecialistService input and delegates.
 //  - Every successful mutation returns an actual post-write camelCase Profile read-back, never an
 //    echo of the requested input.
 //  - Skill/Connector references resolve an exact catalog ID first, otherwise an unambiguous public
@@ -26,12 +26,12 @@
 
 import type { ConnectorReadModel, SkillCatalogReadModel } from './agents-service'
 import { applyNameOrIdFilter } from './agents-service'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistService } from '../specialist/service'
 import type {
   CreateSpecialistInput,
   SpecialistCapabilityMode,
   SpecialistFullAccessConfig,
-  SpecialistProfileView,
+  SpecialistView,
   SpecialistSelectedConfig,
   UpdateSpecialistInput
 } from '../../shared/specialist'
@@ -54,7 +54,7 @@ export type AgentsMutationCatalog = {
 // stable for the privileged slices, but ordinary mutations never call it (ordinary mutations do not
 // request a system permission card).
 export type AgentsMutationDeps = {
-  profileService: ProfileService
+  specialistService: SpecialistService
   catalog: AgentsMutationCatalog
   approvalGateway?: ApprovalGateway
 }
@@ -188,7 +188,7 @@ export type CapabilityProjection = {
 // collections and connectorTools). `method` scopes error messages.
 export const projectCapabilityFields = async (
   patch: Record<string, unknown>,
-  current: SpecialistProfileView,
+  current: SpecialistView,
   catalog: AgentsMutationCatalog,
   method: string
 ): Promise<CapabilityProjection> => {
@@ -244,7 +244,7 @@ const CREATE_ALLOWED_KEYS = new Set([
 const handleCreate = async (
   params: Record<string, unknown>,
   deps: AgentsMutationDeps
-): Promise<SpecialistProfileView> => {
+): Promise<SpecialistView> => {
   rejectUnknownKeys(params, CREATE_ALLOWED_KEYS, 'create')
 
   const name = isString(params.name) ? params.name : throwShape('name is required')
@@ -256,7 +256,7 @@ const handleCreate = async (
   const iconKey = optionalStringOrThrow(params.icon_key, 'icon key')
   const colorKey = optionalStringOrThrow(params.color_key, 'color key')
 
-  // `enabled` is accepted (design.md §4 create object) but ProfileService.create always starts a
+  // `enabled` is accepted (design.md §4 create object) but SpecialistService.create always starts a
   // new specialist enabled; the update op toggles it. We validate the shape and ignore the value so
   // a malformed boolean is rejected before reaching the repository.
   if (params.enabled !== undefined && !isBoolean(params.enabled)) {
@@ -308,7 +308,7 @@ const handleCreate = async (
     input.selectedCapabilities = emptySelectedConfig()
   }
 
-  return deps.profileService.create(input)
+  return deps.specialistService.create(input)
 }
 
 // ---------------------------------------------------------------------------
@@ -333,7 +333,7 @@ export const UPDATE_ALLOWED_KEYS = new Set([
 const handleUpdate = async (
   params: Record<string, unknown>,
   deps: AgentsMutationDeps
-): Promise<SpecialistProfileView> => {
+): Promise<SpecialistView> => {
   const name = isString(params.name) ? params.name : throwShape('name is required')
 
   // params.name resolves the immutable Specialist name; every field in patch is a change.
@@ -346,7 +346,7 @@ const handleUpdate = async (
     throw agentsPublicError('revision must be a positive integer.')
   }
 
-  const current = await deps.profileService.resolveCustomMutationByName(name)
+  const current = await deps.specialistService.resolveCustomMutationByName(name)
   if (current.revision !== revision) {
     throw agentsPublicError('revision does not match the current specialist revision.')
   }
@@ -381,7 +381,7 @@ const handleUpdate = async (
     input.fullAccess = capability.fullAccess
   }
 
-  return deps.profileService.update(input)
+  return deps.specialistService.update(input)
 }
 
 // ---------------------------------------------------------------------------
@@ -396,7 +396,7 @@ const handleAttachDetach = async (
   op: AttachDetachOp,
   params: Record<string, unknown>,
   deps: AgentsMutationDeps
-): Promise<SpecialistProfileView> => {
+): Promise<SpecialistView> => {
   rejectUnknownKeys(params, ATTACH_DETACH_ALLOWED_KEYS, op)
 
   const name = isString(params.name) ? params.name : throwShape('name is required')
@@ -410,7 +410,7 @@ const handleAttachDetach = async (
     ? (params[refKey] as string)
     : throwShape(`${refKey} is required`)
 
-  const current = await deps.profileService.resolveCustomMutationByName(name)
+  const current = await deps.specialistService.resolveCustomMutationByName(name)
   if (current.revision !== revision) {
     throw agentsPublicError('revision does not match the current specialist revision.')
   }
@@ -436,13 +436,13 @@ const handleAttachDetach = async (
   }
 
   if (op === 'attach_skill')
-    return deps.profileService.attachSkill(current.id, stableId, revision, mode)
+    return deps.specialistService.attachSkill(current.id, stableId, revision, mode)
   if (op === 'detach_skill')
-    return deps.profileService.detachSkill(current.id, stableId, revision, mode)
+    return deps.specialistService.detachSkill(current.id, stableId, revision, mode)
   if (op === 'attach_connector') {
-    return deps.profileService.attachConnector(current.id, stableId, revision, mode)
+    return deps.specialistService.attachConnector(current.id, stableId, revision, mode)
   }
-  return deps.profileService.detachConnector(current.id, stableId, revision, mode)
+  return deps.specialistService.detachConnector(current.id, stableId, revision, mode)
 }
 
 // Resolves a reference to a stable id when it matches the catalog, otherwise returns the literal
@@ -494,7 +494,7 @@ function throwShape(message: string): never {
 export async function executeAgentsMutation(
   request: AgentsOrdinaryMutationRequest,
   deps: AgentsMutationDeps
-): Promise<SpecialistProfileView> {
+): Promise<SpecialistView> {
   const method = request.op
   const params = request.params
   try {

--- a/src/main/agents/agents-repl.integration.test.ts
+++ b/src/main/agents/agents-repl.integration.test.ts
@@ -15,12 +15,12 @@ import {
   type KernelLoopResponse
 } from '../notebook/kernel-protocol'
 import { AgentsService, type AgentsCatalogSource, type AgentsReadOp } from './agents-service'
-import { createProfileService, type ProfileService } from '../specialist/service'
+import { createSpecialistService, type SpecialistService } from '../specialist/service'
 import type { StoredConnectors } from '../settings/types'
 
 // Run with: RUN_KERNEL=1 npx vitest run src/main/agents/agents-repl.integration.test.ts
 // Exercises the real resources/notebook/repl_loop.js against a real NotebookLocalRpcServer wired
-// to a real AgentsService + ProfileService, covering the full host.agents tracer bullet.
+// to a real AgentsService + SpecialistService, covering the full host.agents tracer bullet.
 const gate = process.env.RUN_KERNEL ? describe : describe.skip
 
 const LOOP = join(__dirname, '../../../resources/notebook/repl_loop.js')
@@ -122,8 +122,8 @@ gate('host.agents repl integration', () => {
   beforeAll(async () => {
     profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-profile-'))
     runtimeStorage = await mkdtemp(join(tmpdir(), 'os-agents-runtime-'))
-    const profileService = createProfileService(profileStorage)
-    agentsService = new AgentsService({ profileService, catalog: stubCatalog })
+    const specialistService = createSpecialistService(profileStorage)
+    agentsService = new AgentsService({ specialistService, catalog: stubCatalog })
     const notebookService = new NotebookRuntimeService({
       configRoot: runtimeStorage,
       dataRoot: runtimeStorage,
@@ -161,8 +161,8 @@ gate('host.agents repl integration', () => {
     token = connection.token
     releaseControl = connection.release
 
-    // Seed a specialist profile directly through the authoritative ProfileService.
-    await profileService.create({
+    // Seed a specialist profile directly through the authoritative SpecialistService.
+    await specialistService.create({
       name: 'Bio Expert',
       description: 'secret: apikey=XYZ',
       systemPrompt: 'RPC SYSTEM PROMPT SENTINEL',
@@ -390,13 +390,13 @@ gate('host.agents repl integration', () => {
   it('redacts dependency error details before they reach the Agent sandbox', async () => {
     const originalService = agentsService
     agentsService = new AgentsService({
-      profileService: {
+      specialistService: {
         list: async () => {
           throw new Error(
             'request failed: token=secret-token path=/Users/alice/project params={"prompt":"private"} HOME=/Users/alice'
           )
         }
-      } as unknown as ProfileService,
+      } as unknown as SpecialistService,
       catalog: stubCatalog
     })
     const { child, send } = startLoop({

--- a/src/main/agents/agents-repl.mutations.integration.test.ts
+++ b/src/main/agents/agents-repl.mutations.integration.test.ts
@@ -15,12 +15,12 @@ import {
   type KernelLoopResponse
 } from '../notebook/kernel-protocol'
 import { AgentsService, type AgentsCatalogSource } from './agents-service'
-import { createProfileService } from '../specialist/service'
+import { createSpecialistService } from '../specialist/service'
 import type { StoredConnectors } from '../settings/types'
 
 // Run with: RUN_KERNEL=1 npx vitest run src/main/agents/agents-repl.mutations.integration.test.ts
 // Exercises the real resources/notebook/repl_loop.js against a real NotebookLocalRpcServer wired
-// to a real AgentsService + ProfileService, covering the host.agents ordinary-mutation slice:
+// to a real AgentsService + SpecialistService, covering the host.agents ordinary-mutation slice:
 // create, representative exact update, representative attach/detach, stale revision, stable catalog
 // resolution, read-back, and the absence of additional permission requests on ordinary mutations.
 const gate = process.env.RUN_KERNEL ? describe : describe.skip
@@ -113,8 +113,8 @@ gate('host.agents repl mutation integration', () => {
   beforeAll(async () => {
     profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-mut-profile-'))
     runtimeStorage = await mkdtemp(join(tmpdir(), 'os-agents-mut-runtime-'))
-    const profileService = createProfileService(profileStorage)
-    const agentsService = new AgentsService({ profileService, catalog: stubCatalog })
+    const specialistService = createSpecialistService(profileStorage)
+    const agentsService = new AgentsService({ specialistService, catalog: stubCatalog })
     const notebookService = new NotebookRuntimeService({
       configRoot: runtimeStorage,
       dataRoot: runtimeStorage,

--- a/src/main/agents/agents-repl.privileged.integration.test.ts
+++ b/src/main/agents/agents-repl.privileged.integration.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../notebook/kernel-protocol'
 import { AgentsService, type AgentsCatalogSource } from './agents-service'
 import { passthroughApprovalGateway } from './passthrough-approval-gateway'
-import { createProfileService } from '../specialist/service'
+import { createSpecialistService } from '../specialist/service'
 import { SessionBindingService } from '../specialist/session-binding'
 import type { StoredConnectors } from '../settings/types'
 import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contract'
@@ -25,7 +25,7 @@ import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contra
 //
 // Proves the privileged Specialist-management slice end-to-end through the real
 // resources/notebook/repl_loop.js + NotebookLocalRpcServer, wired exactly the way production
-// (src/main/ipc.ts) composes it: a real ProfileService, the real SessionBindingService, the
+// (src/main/ipc.ts) composes it: a real SpecialistService, the real SessionBindingService, the
 // milestone's passthroughApprovalGateway (always-approved), a durable persisted-binding sink, the
 // SwitchNotifier broadcast, and the catalog-invalidation callback.
 //
@@ -136,15 +136,15 @@ const composeService = (opts: {
   invalidateCount: () => number
   approvalCount: () => number
 } => {
-  const profileService = createProfileService(opts.profileStorage)
-  const sessionBinding = new SessionBindingService(profileService)
+  const specialistService = createSpecialistService(opts.profileStorage)
+  const sessionBinding = new SessionBindingService(specialistService)
   const durableBindings = new Map<string, string | undefined>()
   const notified: Array<{ sessionId: string; targetName: string | null }> = []
   let invalidated = 0
   let approvals = 0
   const approvalGateway = opts.gateway ?? passthroughApprovalGateway
   const agentsService = new AgentsService({
-    profileService,
+    specialistService,
     catalog: stubCatalog,
     sessionBinding,
     approvalGateway: {
@@ -444,7 +444,7 @@ gate('host.agents repl privileged integration', () => {
       expect(updated.name).toBe('ATOM_PROBE')
       expect(updated.displayName).toBe('Atom Analyzer')
       expect(updated.description).toBe('after')
-      // Revision was bumped by the authoritative ProfileService, not echoed.
+      // Revision was bumped by the authoritative SpecialistService, not echoed.
       expect(updated.revision).toBe(created.revision + 1)
     })
   })

--- a/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+++ b/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
@@ -15,12 +15,12 @@ import {
   type KernelLoopResponse
 } from '../notebook/kernel-protocol'
 import { AgentsService, type AgentsCatalogSource } from './agents-service'
-import { createProfileService } from '../specialist/service'
+import { createSpecialistService } from '../specialist/service'
 import {
   resolveEffectiveSpecialistSkills,
   filterSpecialistConnectorSkills,
   type SpecialistSkillCatalogEntry,
-  type SpecialistProfileView
+  type SpecialistView
 } from '../../shared/specialist'
 import type { StoredConnectors } from '../settings/types'
 
@@ -112,9 +112,9 @@ const stubCatalog: AgentsCatalogSource = {
   })
 }
 
-// Projects the read-back into the SpecialistProfileView shape the runtime resolvers consume.
-const asProfile = (readBack: Record<string, unknown>): SpecialistProfileView =>
-  readBack as unknown as SpecialistProfileView
+// Projects the read-back into the SpecialistView shape the runtime resolvers consume.
+const asProfile = (readBack: Record<string, unknown>): SpecialistView =>
+  readBack as unknown as SpecialistView
 
 gate('host.agents repl runtime whitelist consumption', () => {
   let rpcServer: NotebookLocalRpcServer
@@ -127,8 +127,8 @@ gate('host.agents repl runtime whitelist consumption', () => {
   beforeAll(async () => {
     profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-rt-profile-'))
     runtimeStorage = await mkdtemp(join(tmpdir(), 'os-agents-rt-runtime-'))
-    const profileService = createProfileService(profileStorage)
-    const agentsService = new AgentsService({ profileService, catalog: stubCatalog })
+    const specialistService = createSpecialistService(profileStorage)
+    const agentsService = new AgentsService({ specialistService, catalog: stubCatalog })
     const notebookService = new NotebookRuntimeService({
       configRoot: runtimeStorage,
       dataRoot: runtimeStorage,

--- a/src/main/agents/agents-service.test.ts
+++ b/src/main/agents/agents-service.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { AgentsService, type AgentsCatalogSource } from './agents-service'
-import type { SpecialistProfileView } from '../../shared/specialist'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistView } from '../../shared/specialist'
+import type { SpecialistService } from '../specialist/service'
 import type { StoredConnectors } from '../settings/types'
 
-const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+const profile = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'sp-1',
   name: 'Bio Expert',
   displayName: 'Bio Expert',
@@ -21,7 +21,7 @@ const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProf
   ...overrides
 })
 
-const profileService = (profiles: SpecialistProfileView[]): ProfileService =>
+const specialistService = (profiles: SpecialistView[]): SpecialistService =>
   ({
     list: vi.fn(async () => profiles),
     getByName: vi.fn(async (name: string) => {
@@ -29,7 +29,7 @@ const profileService = (profiles: SpecialistProfileView[]): ProfileService =>
       if (!found) throw new Error(`Specialist "${name}" not found.`)
       return found
     })
-  }) as unknown as ProfileService
+  }) as unknown as SpecialistService
 
 const catalog = (overrides: Partial<AgentsCatalogSource> = {}): AgentsCatalogSource => ({
   listSkillCatalog: vi.fn(async () => [
@@ -57,7 +57,7 @@ const catalog = (overrides: Partial<AgentsCatalogSource> = {}): AgentsCatalogSou
 describe('AgentsService read surface', () => {
   it('list() returns summary records without system prompts or a synthetic Reviewer row', async () => {
     const service = new AgentsService({
-      profileService: profileService([profile()]),
+      specialistService: specialistService([profile()]),
       catalog: catalog()
     })
     const result = (await service.list()) as Awaited<ReturnType<typeof service.list>>
@@ -72,7 +72,7 @@ describe('AgentsService read surface', () => {
 
   it('get(name) returns detail including the system prompt', async () => {
     const service = new AgentsService({
-      profileService: profileService([profile()]),
+      specialistService: specialistService([profile()]),
       catalog: catalog()
     })
     const got = await service.get({ name: 'Bio Expert' })
@@ -99,7 +99,7 @@ describe('AgentsService read surface', () => {
 
   it('get() rejects a missing name with a host.agents.get-prefixed error', async () => {
     const service = new AgentsService({
-      profileService: profileService([]),
+      specialistService: specialistService([]),
       catalog: catalog()
     })
     await expect(service.read({ op: 'get', params: {} })).rejects.toThrow(/host\.agents\.get:/)
@@ -107,7 +107,7 @@ describe('AgentsService read surface', () => {
 
   it('list_skills() returns the full catalog including Main-disabled skills', async () => {
     const service = new AgentsService({
-      profileService: profileService([]),
+      specialistService: specialistService([]),
       catalog: catalog()
     })
     const skills = await service.listSkills({})
@@ -157,7 +157,7 @@ describe('AgentsService read surface', () => {
       ]
     }
     const service = new AgentsService({
-      profileService: profileService([]),
+      specialistService: specialistService([]),
       catalog: catalog({ getConnectors: vi.fn(async () => stored) })
     })
     const connectors = await service.listConnectors({})
@@ -181,7 +181,7 @@ describe('AgentsService read surface', () => {
 
   it('filters by exact stable id first', async () => {
     const service = new AgentsService({
-      profileService: profileService([]),
+      specialistService: specialistService([]),
       catalog: catalog()
     })
     const result = await service.listSkills({ name_or_id: 'personal-foo' })
@@ -191,7 +191,7 @@ describe('AgentsService read surface', () => {
 
   it('rejects an ambiguous public name with a stable-id instruction', async () => {
     const service = new AgentsService({
-      profileService: profileService([]),
+      specialistService: specialistService([]),
       catalog: catalog({
         listSkillCatalog: vi.fn(async () => [
           {
@@ -227,7 +227,7 @@ describe('AgentsService read surface', () => {
       })
     }
     const service = new AgentsService({
-      profileService: failing as unknown as ProfileService,
+      specialistService: failing as unknown as SpecialistService,
       catalog: catalog()
     })
     await expect(service.read({ op: 'list' })).rejects.toThrow(
@@ -236,10 +236,10 @@ describe('AgentsService read surface', () => {
   })
 })
 
-// A ProfileService fake with the mutation surface dispatch needs for privileged ops (update/delete
+// A SpecialistService fake with the mutation surface dispatch needs for privileged ops (update/delete
 // + absence verification), so a delete/name-changing-update can complete end-to-end through
 // dispatch without a real store.
-const mutatingProfileService = (profiles: SpecialistProfileView[]): ProfileService => {
+const mutatingSpecialistService = (profiles: SpecialistView[]): SpecialistService => {
   let store = [...profiles]
   const service = {
     list: vi.fn(async () => [...store]),
@@ -265,7 +265,7 @@ const mutatingProfileService = (profiles: SpecialistProfileView[]): ProfileServi
       if (idx < 0) throw new Error('not found')
       store = store.filter((p) => p.id !== id)
     })
-  } as unknown as ProfileService
+  } as unknown as SpecialistService
   service.resolveCustomMutationByName = vi.fn(async (name: string) => service.getByName(name))
   return service
 }
@@ -286,11 +286,11 @@ describe('AgentsService connector runtime availability', () => {
         }
       ]
     }
-    const profiles = mutatingProfileService([profile()])
+    const profiles = mutatingSpecialistService([profile()])
     const attachConnector = vi.fn(async () => profile())
     profiles.attachConnector = attachConnector
     const service = new AgentsService({
-      profileService: profiles,
+      specialistService: profiles,
       catalog: catalog({ getConnectors: vi.fn(async () => stored) }),
       customServerAvailability: (id) => (id === 'cust-1' ? 'unavailable' : undefined)
     })
@@ -311,7 +311,7 @@ describe('AgentsService privileged dispatch — trusted session threading', () =
   it('threads the trusted calling session into the delete approval request', async () => {
     const seenSessions: unknown[] = []
     const service = new AgentsService({
-      profileService: mutatingProfileService([profile()]),
+      specialistService: mutatingSpecialistService([profile()]),
       catalog: catalog(),
       approvalGateway: {
         decide: async (request) => {
@@ -333,7 +333,7 @@ describe('AgentsService privileged dispatch — trusted session threading', () =
   it('updates displayName without changing immutable name or consulting approval', async () => {
     const decided: unknown[] = []
     const service = new AgentsService({
-      profileService: mutatingProfileService([profile()]),
+      specialistService: mutatingSpecialistService([profile()]),
       catalog: catalog(),
       approvalGateway: {
         decide: async (request) => {
@@ -352,7 +352,7 @@ describe('AgentsService privileged dispatch — trusted session threading', () =
       },
       { sessionId: 'trusted-session-2' }
     )
-    expect(result).toEqual<SpecialistProfileView>(
+    expect(result).toEqual<SpecialistView>(
       expect.objectContaining({ name: 'Bio Expert', displayName: 'Chem Expert' })
     )
     expect(decided).toHaveLength(0)
@@ -361,7 +361,7 @@ describe('AgentsService privileged dispatch — trusted session threading', () =
   it('passes an empty session to the gateway when no trusted context is supplied (test compatibility)', async () => {
     const seenSessions: unknown[] = []
     const service = new AgentsService({
-      profileService: mutatingProfileService([profile()]),
+      specialistService: mutatingSpecialistService([profile()]),
       catalog: catalog(),
       approvalGateway: {
         decide: async (request) => {

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -1,6 +1,6 @@
 // host.agents adapter: the control-plane SDK's server-side read surface.
 //
-// This module is the ONLY place that turns internal Profile/catalog records into the public
+// This module is the ONLY place that turns internal Specialist/catalog records into the public
 // `host.agents.*` read models. It is deliberately decoupled from the concrete SettingsService and
 // ConnectorService via the AgentsServiceDeps interface, so the RPC server can wire the real
 // services in production while tests pass lightweight stubs.
@@ -10,7 +10,7 @@
 //  - Public data is projected explicitly — never return internal repository objects.
 //  - Errors are sanitized and prefixed `host.agents.<method>:` so they never leak system
 //    instructions, connector args, credentials, headers, environment values, or tokens.
-//  - The ProfileService and catalog services remain authoritative; nothing is copied here.
+//  - The SpecialistService and catalog services remain authoritative; nothing is copied here.
 
 import { CONNECTOR_CATALOG, type ConnectorMeta } from '../connectors/catalog'
 import {
@@ -18,9 +18,9 @@ import {
   type CustomMcpFailureAvailability
 } from '../connectors/custom-mcp-bootstrap'
 import { getConnectorTools } from '../connectors/registry'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import type { StoredConnectors } from '../settings/types'
 import {
   isAgentsOpName,
@@ -62,7 +62,7 @@ export type AgentsCatalogSource = {
 }
 
 export type AgentsServiceDeps = {
-  profileService: ProfileService
+  specialistService: SpecialistService
   catalog: AgentsCatalogSource
   // Runtime failures are projected separately from durable Settings. Keeping this as a narrow,
   // optional resolver lets host.agents share the authoritative custom MCP status without owning
@@ -86,7 +86,7 @@ export type AgentsServiceDeps = {
   persistSessionSpecialist?: (sessionId: string, specialistId: string | undefined) => Promise<void>
   // Invalidates the runtime catalog (Settings/picker/runtime capability resolution) after a successful
   // privileged mutation (delete). Ordinary mutations already invalidate via the
-  // existing ProfileService/catalog-change broadcast path; the privileged delete runs through a
+  // existing SpecialistService/catalog-change broadcast path; the privileged delete runs through a
   // dedicated module that calls this only on success.
   invalidateCatalog?: () => Promise<void> | void
   deleteSpecialist?: (request: SpecialistDeleteRequest) => Promise<SpecialistDeleteResult>
@@ -98,8 +98,8 @@ export type AgentsServiceDeps = {
 
 // Listing Specialists is a discovery operation, so its collection shape is limited to the five
 // fields needed to identify and present a Specialist. Callers that need editable configuration must
-// explicitly request one profile via get().
-export type AgentSummaryReadModel = {
+// explicitly request one Specialist via get().
+export type SpecialistSummaryReadModel = {
   id: string
   name: string
   displayName: string
@@ -109,13 +109,13 @@ export type AgentSummaryReadModel = {
 
 // Single-Agent details and mutation read-backs retain the prompt so callers can inspect, edit, and
 // verify a complete Specialist configuration.
-export type AgentDetailReadModel = AgentSummaryReadModel & {
+export type SpecialistDetailReadModel = SpecialistSummaryReadModel & {
   systemPrompt: string
   iconKey?: string
   colorKey?: string
   capabilityMode: 'full' | 'selected'
-  fullAccess: SpecialistProfileView['fullAccess']
-  selectedCapabilities: SpecialistProfileView['selectedCapabilities']
+  fullAccess: SpecialistView['fullAccess']
+  selectedCapabilities: SpecialistView['selectedCapabilities']
   revision: number
 }
 
@@ -166,7 +166,7 @@ class AgentsCallError extends AgentsSafeError {
 const asString = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined
 
-const projectAgentSummary = (profile: SpecialistProfileView): AgentSummaryReadModel => ({
+const projectAgentSummary = (profile: SpecialistView): SpecialistSummaryReadModel => ({
   id: profile.id,
   name: profile.name,
   displayName: profile.displayName ?? profile.name,
@@ -174,7 +174,7 @@ const projectAgentSummary = (profile: SpecialistProfileView): AgentSummaryReadMo
   enabled: profile.enabled
 })
 
-const projectAgentDetail = (profile: SpecialistProfileView): AgentDetailReadModel => ({
+const projectAgentDetail = (profile: SpecialistView): SpecialistDetailReadModel => ({
   ...projectAgentSummary(profile),
   systemPrompt: profile.systemPrompt,
   iconKey: profile.iconKey,
@@ -226,7 +226,7 @@ export class AgentsService {
       if (opName === 'list_skills') return await this.listSkills(params)
       if (opName === 'list_connectors') return await this.listConnectors(params)
       // Ordinary mutations (issue 03): create, update of mutable fields, and whole-Skill/whole-Connector
-      // attach/detach. Routed to the standalone mutation module, which delegates to ProfileService,
+      // attach/detach. Routed to the standalone mutation module, which delegates to SpecialistService,
       // resolves name/id references, gates unavailable connectors, and returns a real read-back.
       if (
         opName === 'create' ||
@@ -240,7 +240,7 @@ export class AgentsService {
           await executeAgentsMutation(
             { op: opName, params } as Parameters<typeof executeAgentsMutation>[0],
             {
-              profileService: this.deps.profileService,
+              specialistService: this.deps.specialistService,
               catalog: this.mutationCatalog(),
               approvalGateway: this.deps.approvalGateway
             }
@@ -257,7 +257,7 @@ export class AgentsService {
       }
       // host.agents.delete(name, { revision }) — privileged (issue 04). Routes through the injected
       // approval gateway, re-resolves name -> ID, verifies the reviewed revision, deletes via
-      // ProfileService, verifies absence, invalidates the catalog, and returns the read-back. Bound
+      // SpecialistService, verifies absence, invalidates the catalog, and returns the read-back. Bound
       // conversations are NOT silently switched to Main Agent (design.md §10).
       if (opName === 'delete') return await this.runDelete(params, context)
       // The dispatcher covers every operation the contract names. An unrecognized op was already
@@ -302,7 +302,7 @@ export class AgentsService {
       )
     }
     const operation = new SwitchOperation({
-      profileService: this.deps.profileService,
+      specialistService: this.deps.specialistService,
       sessionBinding,
       approvalGateway,
       switchNotifier,
@@ -319,7 +319,7 @@ export class AgentsService {
   }
 
   // host.agents.delete(name, { revision }) — privileged (issue 04). Approves via the injected gateway,
-  // re-resolves name -> ID, verifies the reviewed revision, deletes via ProfileService, verifies
+  // re-resolves name -> ID, verifies the reviewed revision, deletes via SpecialistService, verifies
   // absence, invalidates the catalog, and returns `{ status: "deleted", name }`. Session ID bindings
   // are NEVER cleared or rewritten — bound conversations resolve unavailable later (design.md §10).
   // The trusted calling session is threaded from server context (mirroring runSwitch) so the
@@ -345,7 +345,7 @@ export class AgentsService {
       throw agentsPublicError('revision must be a positive integer.')
     }
     return applyDelete({
-      profileService: this.deps.profileService,
+      specialistService: this.deps.specialistService,
       decide: (request) => approvalGateway.decide(request),
       currentName,
       reviewedRevision: revision,
@@ -355,18 +355,18 @@ export class AgentsService {
     })
   }
 
-  // Returns custom Specialist Profiles only — never synthesizes the Settings-only Reviewer row.
-  async list(): Promise<AgentSummaryReadModel[]> {
-    const profiles = await this.deps.profileService.list()
+  // Returns custom Specialists only — never synthesizes the Settings-only Reviewer row.
+  async list(): Promise<SpecialistSummaryReadModel[]> {
+    const profiles = await this.deps.specialistService.list()
     return profiles.map(projectAgentSummary)
   }
 
-  // Resolves the exact public Specialist name to the current Profile and returns a renderer-safe
+  // Resolves the exact public Specialist name to the current configuration and returns a renderer-safe
   // read model including stable id and revision.
-  async get(params: { name?: unknown }): Promise<AgentDetailReadModel> {
+  async get(params: { name?: unknown }): Promise<SpecialistDetailReadModel> {
     const name = asString(params.name)
     if (!name) throw agentsPublicError('name is required')
-    const profile = await this.deps.profileService.getByName(name)
+    const profile = await this.deps.specialistService.getByName(name)
     return projectAgentDetail(profile)
   }
 

--- a/src/main/agents/completion-gate.execute-control.integration.test.ts
+++ b/src/main/agents/completion-gate.execute-control.integration.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import type { AcpStateSnapshot } from '../../shared/acp'
 import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
 import { NotebookRunRepository } from '../notebook/repository'
@@ -52,9 +52,9 @@ type ExecuteControlHarness = {
 const createExecuteControlHarness = async (
   options: {
     onApproval?: (
-      current: SpecialistProfileView | undefined,
+      current: SpecialistView | undefined,
       approvalIndex: number
-    ) => SpecialistProfileView | undefined
+    ) => SpecialistView | undefined
     connectorCall?: () => Promise<unknown>
     approvalGateway?: ApprovalGateway
     runtime?: CompletionGateRuntime
@@ -605,12 +605,12 @@ describe('completion gate through the real host.agents SDK and executeControl se
   it.each([
     {
       drift: 'rename',
-      mutate: (current: SpecialistProfileView | undefined) =>
+      mutate: (current: SpecialistView | undefined) =>
         current ? { ...current, name: 'Renamed Specialist' } : undefined
     },
     {
       drift: 'disable',
-      mutate: (current: SpecialistProfileView | undefined) =>
+      mutate: (current: SpecialistView | undefined) =>
         current ? { ...current, enabled: false } : undefined
     },
     {
@@ -619,12 +619,12 @@ describe('completion gate through the real host.agents SDK and executeControl se
     },
     {
       drift: 'revision',
-      mutate: (current: SpecialistProfileView | undefined) =>
+      mutate: (current: SpecialistView | undefined) =>
         current ? { ...current, revision: current.revision + 1 } : undefined
     },
     {
       drift: 'identity replacement',
-      mutate: (current: SpecialistProfileView | undefined) =>
+      mutate: (current: SpecialistView | undefined) =>
         current ? { ...current, id: 'replacement-specialist' } : undefined
     }
   ])(

--- a/src/main/agents/completion-gate.integration.test.ts
+++ b/src/main/agents/completion-gate.integration.test.ts
@@ -11,8 +11,8 @@ import {
   runCompletionGatedTool
 } from './completion-gate'
 import type { ApprovalResult } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistView } from '../../shared/specialist'
+import type { SpecialistService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
 import { AgentsService, type AgentsCatalogSource } from './agents-service'
 import {
@@ -37,7 +37,7 @@ import {
   type CompletionGateAgentHarness
 } from './completion-gate.test-harness'
 
-const specialist: SpecialistProfileView = approvedSpecialist()
+const specialist: SpecialistView = approvedSpecialist()
 const catalog: AgentsCatalogSource = {
   listSkillCatalog: async () => [],
   getConnectors: async () => ({ enabledIds: [], autoAllowIds: [] })
@@ -1000,12 +1000,12 @@ describe('completion gate tracer bullet', () => {
     })
     const coordinator = new CompletionGateCoordinator(runtime)
     const agents = new AgentsService({
-      profileService: {
+      specialistService: {
         getByName: vi.fn(async () => specialist),
         resolveRunnableByName: vi.fn(async () => specialist),
         resolveRunnableById: vi.fn(async () => specialist),
         list: vi.fn(async () => [specialist])
-      } as unknown as ProfileService,
+      } as unknown as SpecialistService,
       catalog,
       approvalGateway: { decide: vi.fn(async () => ({ status: 'approved' as const })) },
       sessionBinding: {

--- a/src/main/agents/completion-gate.test-harness.ts
+++ b/src/main/agents/completion-gate.test-harness.ts
@@ -1,8 +1,8 @@
 import { vi, type Mock } from 'vitest'
 
 import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistView } from '../../shared/specialist'
+import type { SpecialistService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
 import { AgentsService, type AgentsCatalogSource } from './agents-service'
 import {
@@ -22,9 +22,7 @@ const catalog: AgentsCatalogSource = {
   getConnectors: async () => ({ enabledIds: [], autoAllowIds: [] })
 }
 
-export const approvedSpecialist = (
-  overrides: Partial<SpecialistProfileView> = {}
-): SpecialistProfileView => ({
+export const approvedSpecialist = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'specialist-approved',
   name: 'Approved Specialist',
   displayName: 'Approved Specialist',
@@ -51,11 +49,11 @@ export const deferred = <T = void>(): {
 
 type HarnessOptions = {
   approval?: ApprovalResult
-  initialProfile?: SpecialistProfileView
+  initialProfile?: SpecialistView
   onApproval?: (
-    current: SpecialistProfileView | undefined,
+    current: SpecialistView | undefined,
     approvalIndex: number
-  ) => SpecialistProfileView | undefined
+  ) => SpecialistView | undefined
   approvalGateway?: ApprovalGateway
   runtime?: CompletionGateRuntime
   coordinator?: CompletionGateCoordinator
@@ -78,10 +76,9 @@ export type CapturedHandoff = Extract<CompletionDisposition, { kind: 'capture-fo
 export const createCompletionGateAgentHarness = (
   options: HarnessOptions = {}
 ): CompletionGateAgentHarness => {
-  let currentProfile: SpecialistProfileView | undefined =
-    options.initialProfile ?? approvedSpecialist()
+  let currentProfile: SpecialistView | undefined = options.initialProfile ?? approvedSpecialist()
   let approvalCount = 0
-  const profileService = {
+  const specialistService = {
     getByName: vi.fn(async (name: string) => {
       if (!currentProfile || currentProfile.name !== name) {
         throw new Error(`Specialist "${name}" not found.`)
@@ -107,7 +104,7 @@ export const createCompletionGateAgentHarness = (
       return currentProfile
     }),
     list: vi.fn(async () => (currentProfile ? [currentProfile] : []))
-  } as unknown as ProfileService
+  } as unknown as SpecialistService
   const defaultApprovalGateway: ApprovalGateway = {
     decide: vi.fn(async () => {
       approvalCount += 1
@@ -150,7 +147,7 @@ export const createCompletionGateAgentHarness = (
     setBinding: vi.fn()
   } as unknown as SessionBindingService
   const agents = new AgentsService({
-    profileService,
+    specialistService,
     catalog,
     approvalGateway,
     approvalLifecycle: lifecycle,

--- a/src/main/agents/customize/fake-host-agents.ts
+++ b/src/main/agents/customize/fake-host-agents.ts
@@ -7,13 +7,13 @@
 // structured decline result, and the sanitized `host.agents.<method>:` errors — without depending on
 // the not-yet-built mutation modules (issues 03/04/05).
 //
-// The fake is intentionally faithful to the CONTRACT, not to ProfileService internals: it owns its
+// The fake is intentionally faithful to the CONTRACT, not to SpecialistService internals: it owns its
 // own minimal profile records and catalogs. Behavior mirrors the rules in design.md §5 (capability
 // semantics), §8 (revision + read-back), §10 (delete leaves bindings unavailable).
 
 import type {
-  AgentDetailReadModel,
-  AgentSummaryReadModel,
+  SpecialistDetailReadModel,
+  SpecialistSummaryReadModel,
   ConnectorReadModel,
   SkillCatalogReadModel
 } from '../agents-service'
@@ -119,7 +119,7 @@ export class FakeHostAgents {
     }
   }
 
-  private projectSummary(profile: FakeProfileRecord): AgentSummaryReadModel {
+  private projectSummary(profile: FakeProfileRecord): SpecialistSummaryReadModel {
     return {
       id: profile.id,
       name: profile.name,
@@ -129,7 +129,7 @@ export class FakeHostAgents {
     }
   }
 
-  private project(profile: FakeProfileRecord): AgentDetailReadModel {
+  private project(profile: FakeProfileRecord): SpecialistDetailReadModel {
     return {
       id: profile.id,
       name: profile.name,
@@ -156,13 +156,13 @@ export class FakeHostAgents {
 
   // ----- public read surface -----------------------------------------------------
 
-  async list(): Promise<AgentSummaryReadModel[]> {
+  async list(): Promise<SpecialistSummaryReadModel[]> {
     return Array.from(this.profiles.values())
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((profile) => this.projectSummary(profile))
   }
 
-  async get(name: string): Promise<AgentDetailReadModel> {
+  async get(name: string): Promise<SpecialistDetailReadModel> {
     const profile = this.profiles.get(name)
     if (!profile) throw agentsError('get', `Specialist "${name}" not found.`)
     return this.project(profile)
@@ -191,7 +191,7 @@ export class FakeHostAgents {
     unrestricted?: boolean
     skillNames?: string[]
     connectorNames?: string[]
-  }): Promise<AgentDetailReadModel> {
+  }): Promise<SpecialistDetailReadModel> {
     const method = 'create'
     const name = input.name
     if (!name || typeof name !== 'string') throw agentsError(method, 'name is required')
@@ -241,7 +241,7 @@ export class FakeHostAgents {
       connectorNames?: string[]
       revision?: number
     }
-  ): Promise<AgentDetailReadModel> {
+  ): Promise<SpecialistDetailReadModel> {
     const method = 'update'
     const existing = this.profiles.get(name)
     if (!existing) throw agentsError(method, `Specialist "${name}" not found.`)
@@ -281,7 +281,7 @@ export class FakeHostAgents {
     name: string,
     skillRef: string,
     options: { revision?: number } = {}
-  ): Promise<AgentDetailReadModel> {
+  ): Promise<SpecialistDetailReadModel> {
     return this.mutateCollection(name, 'skill', skillRef, 'attach', options.revision)
   }
 
@@ -289,7 +289,7 @@ export class FakeHostAgents {
     name: string,
     skillRef: string,
     options: { revision?: number } = {}
-  ): Promise<AgentDetailReadModel> {
+  ): Promise<SpecialistDetailReadModel> {
     return this.mutateCollection(name, 'skill', skillRef, 'detach', options.revision)
   }
 
@@ -297,7 +297,7 @@ export class FakeHostAgents {
     name: string,
     connectorRef: string,
     options: { revision?: number } = {}
-  ): Promise<AgentDetailReadModel> {
+  ): Promise<SpecialistDetailReadModel> {
     return this.mutateCollection(name, 'connector', connectorRef, 'attach', options.revision)
   }
 
@@ -305,7 +305,7 @@ export class FakeHostAgents {
     name: string,
     connectorRef: string,
     options: { revision?: number } = {}
-  ): Promise<AgentDetailReadModel> {
+  ): Promise<SpecialistDetailReadModel> {
     return this.mutateCollection(name, 'connector', connectorRef, 'detach', options.revision)
   }
 
@@ -315,7 +315,7 @@ export class FakeHostAgents {
     ref: string,
     action: 'attach' | 'detach',
     revision: number | undefined
-  ): AgentDetailReadModel {
+  ): SpecialistDetailReadModel {
     const method = `${action}${kind[0].toUpperCase()}${kind.slice(1)}`
     const existing = this.profiles.get(name)
     if (!existing) throw agentsError(method, `Specialist "${name}" not found.`)

--- a/src/main/agents/customize/workflow.ts
+++ b/src/main/agents/customize/workflow.ts
@@ -12,7 +12,7 @@
 //  - privileged mutations (delete and switch): explain the impending action, then
 //    invoke the SDK — the standard permission card is the single authorization point.
 
-import type { AgentDetailReadModel, ConnectorReadModel } from '../agents-service'
+import type { SpecialistDetailReadModel, ConnectorReadModel } from '../agents-service'
 
 // ---------------------------------------------------------------------------
 // Scope clarification (design.md §5: never silently grant Full)
@@ -61,7 +61,7 @@ export type ReviewedTargetState = {
 }
 
 export const buildReviewedTarget = (
-  profile: AgentDetailReadModel,
+  profile: SpecialistDetailReadModel,
   connectorCatalog: ConnectorReadModel[] = []
 ): ReviewedTargetState => {
   const connectorNameById = new Map(connectorCatalog.map(({ id, name }) => [id, name]))

--- a/src/main/agents/specialist-approval-presentation.test.ts
+++ b/src/main/agents/specialist-approval-presentation.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import { mapDeleteApprovalCard, mapSwitchApprovalCard } from './specialist-approval-presentation'
 import type { SpecialistPermissionCardPayload } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 
-const baseProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+const baseProfile = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'sp-1',
   name: 'DATA_ANALYST',
   displayName: 'Data Analyst',

--- a/src/main/agents/specialist-approval-presentation.ts
+++ b/src/main/agents/specialist-approval-presentation.ts
@@ -20,13 +20,11 @@ import type {
   SpecialistDeleteCardPayload,
   SpecialistSwitchCardPayload
 } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 
 // Renders the delete card (prototype scene 8). Bound conversations resolve as unavailable and are
 // NOT silently switched to Main Agent (design.md §10).
-export const mapDeleteApprovalCard = (
-  current: SpecialistProfileView
-): SpecialistDeleteCardPayload => ({
+export const mapDeleteApprovalCard = (current: SpecialistView): SpecialistDeleteCardPayload => ({
   kind: 'delete',
   name: current.name,
   boundConversationsUnavailable: true

--- a/src/main/agents/specialist-privileged-ops.test.ts
+++ b/src/main/agents/specialist-privileged-ops.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { applyDelete } from './specialist-privileged-ops'
 import type { AgentDeletedResult, AgentDeclinedResult } from './specialist-privileged-ops'
 import type { ApprovalResult } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import type { SpecialistDeleteResult } from '../../shared/specialist-package'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistService } from '../specialist/service'
 
-const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+const profile = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'sp-1',
   name: 'DATA_ANALYST',
   displayName: 'Data Analyst',
@@ -42,21 +42,21 @@ const specialistDeleteFailureCodes = [
 ] as const satisfies readonly SpecialistDeleteFailureCode[]
 
 type FakeService = {
-  service: ProfileService
+  service: SpecialistService
   calls: {
     update: Array<{ id: string; patch: Record<string, unknown>; revision: number }>
     delete: Array<{ id: string; revision?: number }>
     getByName: string[]
   }
-  getStore: () => SpecialistProfileView[]
-  setStore: (s: SpecialistProfileView[]) => void
+  getStore: () => SpecialistView[]
+  setStore: (s: SpecialistView[]) => void
 }
 
-// A ProfileService fake that records mutations and lets tests simulate drift (revision mismatch,
+// A SpecialistService fake that records mutations and lets tests simulate drift (revision mismatch,
 // rename, deletion) between card creation and approval.
 const makeService = (opts: {
-  initial?: SpecialistProfileView[]
-  onUpdate?: (id: string, patch: Record<string, unknown>, revision: number) => SpecialistProfileView
+  initial?: SpecialistView[]
+  onUpdate?: (id: string, patch: Record<string, unknown>, revision: number) => SpecialistView
   onDelete?: (id: string, revision?: number) => void
 }): FakeService => {
   let store = opts.initial ? [...opts.initial] : []
@@ -101,13 +101,13 @@ const makeService = (opts: {
       }
       store = store.filter((p) => p.id !== id)
     })
-  } as unknown as ProfileService
+  } as unknown as SpecialistService
   service.resolveCustomMutationByName = vi.fn(async (name: string) => service.getByName(name))
   return {
     service,
     calls,
     getStore: () => store,
-    setStore: (s: SpecialistProfileView[]) => (store = s)
+    setStore: (s: SpecialistView[]) => (store = s)
   }
 }
 
@@ -116,7 +116,7 @@ describe('applyDelete — approved delete', () => {
     const bindingClearCalls: string[] = []
     const { service, calls } = makeService({ initial: [profile()] })
     const result = await applyDelete({
-      profileService: service,
+      specialistService: service,
       decide: async () => fakeApproved(),
       currentName: 'DATA_ANALYST',
       reviewedRevision: 3,
@@ -135,7 +135,7 @@ describe('applyDelete — approved delete', () => {
   it('returns a structured declined result {operation:"delete"} with no mutation', async () => {
     const { service, calls } = makeService({ initial: [profile()] })
     const result = await applyDelete({
-      profileService: service,
+      specialistService: service,
       decide: async () => fakeDeclined('delete'),
       currentName: 'DATA_ANALYST',
       reviewedRevision: 3
@@ -148,7 +148,7 @@ describe('applyDelete — approved delete', () => {
     const { service } = makeService({ initial: [profile()] })
     // Provide a no-op binding sink; the contract is that delete NEVER clears/rewrites it.
     await applyDelete({
-      profileService: service,
+      specialistService: service,
       decide: async () => fakeApproved(),
       currentName: 'DATA_ANALYST',
       reviewedRevision: 3,
@@ -169,7 +169,7 @@ describe('applyDelete — approved delete', () => {
       .mockRejectedValue(new Error('I/O error: corrupt specialist store'))
     await expect(
       applyDelete({
-        profileService: service,
+        specialistService: service,
         decide: async () => fakeApproved(),
         currentName: 'DATA_ANALYST',
         reviewedRevision: 3
@@ -183,7 +183,7 @@ describe('applyDelete — approved delete', () => {
       const { service } = makeService({ initial: [profile()] })
       await expect(
         applyDelete({
-          profileService: service,
+          specialistService: service,
           decide: async () => fakeApproved(),
           currentName: 'DATA_ANALYST',
           reviewedRevision: 3,
@@ -197,7 +197,7 @@ describe('applyDelete — approved delete', () => {
     const { service } = makeService({ initial: [profile()] })
     await expect(
       applyDelete({
-        profileService: service,
+        specialistService: service,
         decide: async () => fakeApproved(),
         currentName: 'DATA_ANALYST',
         reviewedRevision: 3,
@@ -212,7 +212,7 @@ describe('applyDelete — approved delete', () => {
     const { service } = makeService({ initial: [profile({ revision: 4 })] })
     await expect(
       applyDelete({
-        profileService: service,
+        specialistService: service,
         decide: async () => fakeApproved(),
         currentName: 'DATA_ANALYST',
         reviewedRevision: 3
@@ -224,7 +224,7 @@ describe('applyDelete — approved delete', () => {
     const { service } = makeService({ initial: [profile()] })
     const seen: unknown[] = []
     await applyDelete({
-      profileService: service,
+      specialistService: service,
       decide: async (request) => {
         seen.push(request.session)
         return fakeApproved()
@@ -245,7 +245,7 @@ describe('no-state-change guarantees on decline', () => {
     const invalidated = vi.fn()
     const { service, calls } = makeService({ initial: [profile()] })
     await applyDelete({
-      profileService: service,
+      specialistService: service,
       decide: async () => fakeDeclined('delete'),
       currentName: 'DATA_ANALYST',
       reviewedRevision: 3,
@@ -259,7 +259,7 @@ describe('no-state-change guarantees on decline', () => {
     const invalidated = vi.fn()
     const { service } = makeService({ initial: [profile()] })
     await applyDelete({
-      profileService: service,
+      specialistService: service,
       decide: async () => fakeApproved(),
       currentName: 'DATA_ANALYST',
       reviewedRevision: 3,

--- a/src/main/agents/specialist-privileged-ops.ts
+++ b/src/main/agents/specialist-privileged-ops.ts
@@ -4,7 +4,7 @@
 // host.agents.update (including renames) is an ordinary chat-reviewed mutation handled by the issue
 // 03 module; only DELETE passes through this approval-gated module (issue 04). It is deliberately
 // standalone and independently testable: it consumes ONLY issue 02's ApprovalGateway contract and
-// the existing ProfileService. It does NOT import issue 03 (ordinary mutation) or issue 05 (switch)
+// the existing SpecialistService. It does NOT import issue 03 (ordinary mutation) or issue 05 (switch)
 // implementation modules. Issue 08 composes it into the dispatcher.
 //
 // Design rules mirrored from design.md §8/§10 and the issue 04 acceptance criteria:
@@ -23,12 +23,12 @@ import type {
   ApprovalResult,
   TrustedCallingSession
 } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import type {
   SpecialistDeleteRequest,
   SpecialistDeleteResult
 } from '../../shared/specialist-package'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistService } from '../specialist/service'
 import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
 class PrivilegedOpError extends AgentsSafeError {
@@ -65,13 +65,13 @@ export type DeleteResult = AgentDeletedResult | AgentDeclinedResult
 // the ONLY authority is this re-resolution, performed after approval.
 const reResolveForMutation = async (
   method: string,
-  profileService: ProfileService,
+  specialistService: SpecialistService,
   currentName: string,
   reviewedRevision: number
-): Promise<SpecialistProfileView> => {
-  let current: SpecialistProfileView
+): Promise<SpecialistView> => {
+  let current: SpecialistView
   try {
-    current = await profileService.resolveCustomMutationByName(currentName)
+    current = await specialistService.resolveCustomMutationByName(currentName)
   } catch (error) {
     // Target was renamed or deleted after card creation.
     throw new PrivilegedOpError(method, error)
@@ -92,7 +92,7 @@ const reResolveForMutation = async (
 // ---------------------------------------------------------------------------
 
 export type PrivilegedOpDeps = {
-  profileService: ProfileService
+  specialistService: SpecialistService
   // The injected approval gateway (issue 02 contract). Real production wiring is the ACP-backed
   // gateway; tests pass fakes. A decline is a normal result, never a thrown error.
   decide: (request: Parameters<ApprovalGateway['decide']>[0]) => Promise<ApprovalResult>
@@ -122,12 +122,12 @@ export type ApplyDeleteDeps = PrivilegedOpDeps & {
 }
 
 // Approves and deletes a Specialist. On approval, re-resolves name -> ID, verifies the reviewed
-// revision, deletes through ProfileService, verifies absence, invalidates the catalog, and returns
+// revision, deletes through SpecialistService, verifies absence, invalidates the catalog, and returns
 // `{ status: "deleted", name }`. Session ID bindings are NEVER cleared or rewritten. On decline,
 // returns `{ status: "declined", operation: "delete" }` with NO mutation. On drift/failure, throws a
 // sanitized `host.agents.delete:` error.
 export const applyDelete = async (deps: ApplyDeleteDeps): Promise<DeleteResult> => {
-  const { profileService, currentName, reviewedRevision, clearSessionBindings } = deps
+  const { specialistService, currentName, reviewedRevision, clearSessionBindings } = deps
 
   const decision = await deps.decide({
     operation: 'delete',
@@ -144,7 +144,7 @@ export const applyDelete = async (deps: ApplyDeleteDeps): Promise<DeleteResult> 
 
   const current = await reResolveForMutation(
     'delete',
-    profileService,
+    specialistService,
     currentName,
     reviewedRevision
   )
@@ -158,7 +158,7 @@ export const applyDelete = async (deps: ApplyDeleteDeps): Promise<DeleteResult> 
       })
       if (result.status === 'failed') throw agentsPublicError(result.code)
     } else {
-      await profileService.delete(current.id, current.revision)
+      await specialistService.delete(current.id, current.revision)
     }
   } catch (error) {
     throw new PrivilegedOpError('delete', error)
@@ -169,7 +169,7 @@ export const applyDelete = async (deps: ApplyDeleteDeps): Promise<DeleteResult> 
   // is diagnosable instead of being silently misreported as a successful deletion.
   let stillPresent = false
   try {
-    await profileService.getByName(currentName)
+    await specialistService.getByName(currentName)
     stillPresent = true
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/src/main/agents/switch-operation.test.ts
+++ b/src/main/agents/switch-operation.test.ts
@@ -19,11 +19,11 @@ import type {
   PendingSwitch,
   SwitchNotifier
 } from '../../shared/agents-contract'
-import type { SpecialistProfileView } from '../../shared/specialist'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistView } from '../../shared/specialist'
+import type { SpecialistService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
 
-const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+const profile = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'sp-1',
   name: 'BIO_EXPERT',
   displayName: 'Bio Expert',
@@ -39,10 +39,10 @@ const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProf
   ...overrides
 })
 
-const makeProfileService = (
-  profiles: SpecialistProfileView[],
-  overrides: Partial<ProfileService> = {}
-): ProfileService => {
+const makeSpecialistService = (
+  profiles: SpecialistView[],
+  overrides: Partial<SpecialistService> = {}
+): SpecialistService => {
   const service = {
     list: vi.fn(async () => profiles),
     getByName: vi.fn(async (name: string) => {
@@ -56,7 +56,7 @@ const makeProfileService = (
       return found
     }),
     ...overrides
-  } as unknown as ProfileService
+  } as unknown as SpecialistService
   service.resolveRunnableByName =
     overrides.resolveRunnableByName ?? vi.fn(async (name: string) => service.getByName(name))
   service.resolveRunnableById =
@@ -90,7 +90,7 @@ const approvingGateway = (): ApprovalGateway => ({
 describe('SwitchOperation — target resolution', () => {
   it('switches to a builtin through the runnable resolver without exposing it to custom queries', async () => {
     const builtin = profile({ id: 'builtin-curator', name: 'BUILTIN_CURATOR', revision: 0 })
-    const ps = makeProfileService([builtin], {
+    const ps = makeSpecialistService([builtin], {
       getByName: vi.fn(async () => {
         throw new Error('custom-only query must not be used')
       }),
@@ -101,7 +101,7 @@ describe('SwitchOperation — target resolution', () => {
       resolveRunnableById: vi.fn(async () => builtin)
     })
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -118,12 +118,12 @@ describe('SwitchOperation — target resolution', () => {
   })
 
   it('resolves an enabled custom Specialist by exact public name and returns persisted binding', async () => {
-    const ps = makeProfileService([profile()])
+    const ps = makeSpecialistService([profile()])
     const binding = makeSessionBinding(new Map())
     const persist = vi.fn(async () => undefined)
     const notify = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: binding,
       approvalGateway: approvingGateway(),
       switchNotifier: { notify },
@@ -147,12 +147,12 @@ describe('SwitchOperation — target resolution', () => {
   })
 
   it('null name selects Main Agent without creating a mutable Main Profile', async () => {
-    const ps = makeProfileService([profile()])
+    const ps = makeSpecialistService([profile()])
     const binding = makeSessionBinding(new Map([['session-trusted', 'sp-1']]))
     const persist = vi.fn(async () => undefined)
     const notify = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: binding,
       approvalGateway: approvingGateway(),
       switchNotifier: { notify },
@@ -179,11 +179,11 @@ describe('SwitchOperation — target resolution', () => {
   })
 
   it('rejects a disabled Specialist with a host.agents.switch-prefixed error before approval', async () => {
-    const ps = makeProfileService([profile({ enabled: false })])
+    const ps = makeSpecialistService([profile({ enabled: false })])
     const gateway = approvingGateway()
     const binding = makeSessionBinding(new Map())
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: binding,
       approvalGateway: gateway,
       switchNotifier: { notify: vi.fn() },
@@ -198,9 +198,9 @@ describe('SwitchOperation — target resolution', () => {
   })
 
   it('rejects an unknown name with a host.agents.switch-prefixed error', async () => {
-    const ps = makeProfileService([])
+    const ps = makeSpecialistService([])
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: { decide: vi.fn() },
       switchNotifier: { notify: vi.fn() },
@@ -212,11 +212,11 @@ describe('SwitchOperation — target resolution', () => {
   })
 
   it('does not accept a sandbox-supplied session id: uses only the trusted context', async () => {
-    const ps = makeProfileService([profile()])
+    const ps = makeSpecialistService([profile()])
     const binding = makeSessionBinding(new Map())
     const persist = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: binding,
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -235,7 +235,7 @@ describe('SwitchOperation — target resolution', () => {
 
   it('fails closed when no trusted calling session identity is present', async () => {
     const op = new SwitchOperation({
-      profileService: makeProfileService([profile()]),
+      specialistService: makeSpecialistService([profile()]),
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: { decide: vi.fn() },
       switchNotifier: { notify: vi.fn() },
@@ -265,7 +265,7 @@ describe('SwitchOperation — approval gateway', () => {
         })
       }
       const op = new SwitchOperation({
-        profileService: makeProfileService([profile()]),
+        specialistService: makeSpecialistService([profile()]),
         sessionBinding: makeSessionBinding(new Map()),
         approvalGateway: gateway,
         approvalLifecycle: { onAwaitingApproval, settleApproval },
@@ -302,10 +302,10 @@ describe('SwitchOperation — approval gateway', () => {
   )
 
   it('emits the shared switch approval request shape with the trusted session', async () => {
-    const ps = makeProfileService([profile()])
+    const ps = makeSpecialistService([profile()])
     const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: { decide },
       switchNotifier: { notify: vi.fn() },
@@ -324,13 +324,13 @@ describe('SwitchOperation — approval gateway', () => {
   it('summary.name is the CURRENT specialist (not the target) for a specialist→specialist switch', async () => {
     // The approval card shows current → target. `summary.name` must carry the CURRENT binding's public
     // name so the struck-through label is correct; `summary.target` carries the destination.
-    const ps = makeProfileService([
+    const ps = makeSpecialistService([
       profile({ id: 'sp-current', name: 'CURRENT' }),
       profile({ id: 'sp-target', name: 'TARGET' })
     ])
     const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       // The session is currently bound to the "CURRENT" specialist.
       sessionBinding: makeSessionBinding(new Map([['session-trusted', 'sp-current']])),
       approvalGateway: { decide },
@@ -349,10 +349,10 @@ describe('SwitchOperation — approval gateway', () => {
 
   it('summary.name is the CURRENT specialist for a specialist→Main switch (target: null)', async () => {
     // Reverting to Main still names the current specialist in `summary.name`; `target` is null.
-    const ps = makeProfileService([profile({ id: 'sp-current', name: 'CURRENT' })])
+    const ps = makeSpecialistService([profile({ id: 'sp-current', name: 'CURRENT' })])
     const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map([['session-trusted', 'sp-current']])),
       approvalGateway: { decide },
       switchNotifier: { notify: vi.fn() },
@@ -371,10 +371,10 @@ describe('SwitchOperation — approval gateway', () => {
   it('summary.name is omitted when the session is currently on Main (no current binding)', async () => {
     // From Main → Specialist there is no current specialist name to show; `summary.name` is omitted
     // (it stays out of the object, never carries the target as the current name).
-    const ps = makeProfileService([profile({ id: 'sp-target', name: 'TARGET' })])
+    const ps = makeSpecialistService([profile({ id: 'sp-target', name: 'TARGET' })])
     const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: { decide },
       switchNotifier: { notify: vi.fn() },
@@ -398,7 +398,7 @@ describe('SwitchOperation — approval gateway', () => {
   })
 
   it('decline returns { status: "declined", operation: "switch" } and changes nothing', async () => {
-    const ps = makeProfileService([profile()])
+    const ps = makeSpecialistService([profile()])
     const binding = makeSessionBinding(new Map([['session-trusted', undefined]]))
     const persist = vi.fn(async () => undefined)
     const notify = vi.fn(async () => undefined)
@@ -409,7 +409,7 @@ describe('SwitchOperation — approval gateway', () => {
       }))
     }
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: binding,
       approvalGateway: gateway,
       switchNotifier: { notify },
@@ -428,7 +428,7 @@ describe('SwitchOperation — approval gateway', () => {
 describe('SwitchOperation — approval-time re-validation (fail closed)', () => {
   it('fails closed when the target was renamed between approval and commit', async () => {
     let resolveCount = 0
-    const ps = makeProfileService([profile()])
+    const ps = makeSpecialistService([profile()])
     // On the approval-time re-resolution, the profile is gone (renamed away / deleted).
     ps.getByName = vi.fn(async (name: string) => {
       resolveCount += 1
@@ -436,7 +436,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
       throw new Error(`Specialist "${name}" not found.`)
     })
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -450,7 +450,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
 
   it('fails closed when the target was disabled after approval', async () => {
     let resolveCount = 0
-    const ps = makeProfileService([profile()])
+    const ps = makeSpecialistService([profile()])
     ps.getByName = vi.fn(async (name: string) => {
       resolveCount += 1
       if (resolveCount === 1) return profile({ name, enabled: true })
@@ -458,7 +458,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
     })
     const persist = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -472,7 +472,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
 
   it('fails closed on revision drift when a reviewed revision was carried', async () => {
     let resolveCount = 0
-    const ps = makeProfileService([profile({ revision: 3 })])
+    const ps = makeSpecialistService([profile({ revision: 3 })])
     ps.getByName = vi.fn(async (name: string) => {
       resolveCount += 1
       if (resolveCount === 1) return profile({ name, revision: 3 })
@@ -480,7 +480,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
     })
     const persist = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -494,7 +494,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
 
   it('fails closed on revision drift observed during approval when the public SDK omitted a revision', async () => {
     let resolveCount = 0
-    const ps = makeProfileService([profile({ revision: 3 })])
+    const ps = makeSpecialistService([profile({ revision: 3 })])
     ps.getByName = vi.fn(async (name: string) => {
       resolveCount += 1
       if (resolveCount === 1) return profile({ name, revision: 3 })
@@ -502,7 +502,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
     })
     const persist = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -517,7 +517,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
 
   it('fails closed when a different profile takes over the approved public name', async () => {
     let resolveCount = 0
-    const ps = makeProfileService([profile({ id: 'approved-id' })])
+    const ps = makeSpecialistService([profile({ id: 'approved-id' })])
     ps.getByName = vi.fn(async (name: string) => {
       resolveCount += 1
       if (resolveCount === 1) return profile({ id: 'approved-id', name })
@@ -525,7 +525,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
     })
     const persist = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -539,11 +539,11 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
   })
 
   it('does not broaden to Main Agent on target failure', async () => {
-    const ps = makeProfileService([])
+    const ps = makeSpecialistService([])
     const binding = makeSessionBinding(new Map())
     const persist = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: binding,
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -560,14 +560,14 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
 
 describe('SwitchOperation — last-write-wins & restart survival', () => {
   it('multiple approved switches before the next message are last-write-wins', async () => {
-    const ps = makeProfileService([
+    const ps = makeSpecialistService([
       profile({ id: 'sp-1', name: 'A' }),
       profile({ id: 'sp-2', name: 'B' })
     ])
     const persist = vi.fn(async () => undefined)
     const notify = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify },
@@ -592,14 +592,14 @@ describe('SwitchOperation — last-write-wins & restart survival', () => {
   })
 
   it('a stale completion does not overwrite a newer approved target', async () => {
-    const ps = makeProfileService([
+    const ps = makeSpecialistService([
       profile({ id: 'sp-1', name: 'A' }),
       profile({ id: 'sp-2', name: 'B' })
     ])
     const persist = vi.fn(async () => undefined)
     const notify = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify },
@@ -624,7 +624,7 @@ describe('SwitchOperation — last-write-wins & restart survival', () => {
     // call. The guard must still order interleaved commits because the dispatcher shares ONE
     // sequencer across those instances — without it, per-instance counters reset and a stale older
     // completion overwrites the newer target.
-    const ps = makeProfileService([
+    const ps = makeSpecialistService([
       profile({ id: 'sp-1', name: 'A' }),
       profile({ id: 'sp-2', name: 'B' })
     ])
@@ -633,7 +633,7 @@ describe('SwitchOperation — last-write-wins & restart survival', () => {
     const sharedSequencer = new SwitchCommitSequencer()
     const makeOp = (): SwitchOperation =>
       new SwitchOperation({
-        profileService: ps,
+        specialistService: ps,
         sessionBinding: makeSessionBinding(new Map()),
         approvalGateway: approvingGateway(),
         switchNotifier: { notify },
@@ -655,9 +655,9 @@ describe('SwitchOperation — last-write-wins & restart survival', () => {
   })
 
   it('successful switch returns actual persisted binding/pending read-back', async () => {
-    const ps = makeProfileService([profile({ id: 'sp-9', name: 'Z', revision: 7 })])
+    const ps = makeSpecialistService([profile({ id: 'sp-9', name: 'Z', revision: 7 })])
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -676,7 +676,7 @@ describe('SwitchOperation — last-write-wins & restart survival', () => {
   })
 
   it('approval immediately persists + broadcasts a pending-reconfigure notification', async () => {
-    const ps = makeProfileService([profile()])
+    const ps = makeSpecialistService([profile()])
     const persist = vi.fn(async () => undefined)
     const order: string[] = []
     const notify = vi.fn(async () => {
@@ -686,7 +686,7 @@ describe('SwitchOperation — last-write-wins & restart survival', () => {
       order.push('persist')
     })
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify },
@@ -700,7 +700,7 @@ describe('SwitchOperation — last-write-wins & restart survival', () => {
 describe('SwitchOperation — sanitization and no-sensitive-data', () => {
   it('sanitizes persistence failure as a host.agents.switch-prefixed error', async () => {
     const op = new SwitchOperation({
-      profileService: makeProfileService([profile()]),
+      specialistService: makeSpecialistService([profile()]),
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -718,11 +718,11 @@ describe('SwitchOperation — sanitization and no-sensitive-data', () => {
     // applies at the next send. A notify rejection must NOT surface as a thrown error to the caller —
     // the switch has already committed (persisted + set in memory). Only persist/setBinding errors
     // remain fatal.
-    const ps = makeProfileService([profile({ id: 'sp-1', name: 'BIO_EXPERT' })])
+    const ps = makeSpecialistService([profile({ id: 'sp-1', name: 'BIO_EXPERT' })])
     const persist = vi.fn(async () => undefined)
     const binding = makeSessionBinding(new Map())
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: binding,
       approvalGateway: approvingGateway(),
       switchNotifier: {
@@ -745,7 +745,7 @@ describe('SwitchOperation — sanitization and no-sensitive-data', () => {
     const persist = vi.fn(async () => undefined)
     const binding = makeSessionBinding(new Map())
     const op = new SwitchOperation({
-      profileService: makeProfileService([profile({ id: 'sp-1', name: 'BIO_EXPERT' })]),
+      specialistService: makeSpecialistService([profile({ id: 'sp-1', name: 'BIO_EXPERT' })]),
       sessionBinding: binding,
       approvalGateway: approvingGateway(),
       switchNotifier: {
@@ -765,11 +765,11 @@ describe('SwitchOperation — sanitization and no-sensitive-data', () => {
   })
 
   it('approval summary and notifications contain no system instructions or sensitive data', async () => {
-    const ps = makeProfileService([profile({ systemPrompt: 'SECRET INSTRUCTIONS' })])
+    const ps = makeSpecialistService([profile({ systemPrompt: 'SECRET INSTRUCTIONS' })])
     const decide = vi.fn(async (): Promise<ApprovalResult> => ({ status: 'approved' }))
     const notify = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: { decide },
       switchNotifier: { notify },
@@ -795,7 +795,7 @@ describe('SwitchOperation — durable next-message reconfigure lifecycle', () =>
     const runtimeSwitch = vi.fn(async () => ({ contextReset: false }))
     // The deps deliberately have NO runtime-switch callback: the module physically cannot call it.
     const op = new SwitchOperation({
-      profileService: makeProfileService([profile()]),
+      specialistService: makeSpecialistService([profile()]),
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -806,10 +806,10 @@ describe('SwitchOperation — durable next-message reconfigure lifecycle', () =>
   })
 
   it('persists the binding immediately so it survives application restart before the next message', async () => {
-    const ps = makeProfileService([profile({ id: 'sp-7', name: 'Z' })])
+    const ps = makeSpecialistService([profile({ id: 'sp-7', name: 'Z' })])
     const persist = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -823,7 +823,7 @@ describe('SwitchOperation — durable next-message reconfigure lifecycle', () =>
   it('broadcasts the pending-reconfigure intent the renderer/runtime consumes at the next send', async () => {
     const notify = vi.fn(async () => undefined) as unknown as SwitchNotifier['notify']
     const op = new SwitchOperation({
-      profileService: makeProfileService([profile({ name: 'SQL_WRANGLER' })]),
+      specialistService: makeSpecialistService([profile({ name: 'SQL_WRANGLER' })]),
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify },
@@ -839,7 +839,7 @@ describe('SwitchOperation — durable next-message reconfigure lifecycle', () =>
     // operation has already failed closed at approval-time re-validation — there is no path that
     // clears the binding to Main on failure.
     let resolveCount = 0
-    const ps = makeProfileService([profile({ name: 'FLAKY' })])
+    const ps = makeSpecialistService([profile({ name: 'FLAKY' })])
     ps.getByName = vi.fn(async (name: string) => {
       resolveCount += 1
       if (resolveCount === 1) return profile({ name, enabled: true })
@@ -847,7 +847,7 @@ describe('SwitchOperation — durable next-message reconfigure lifecycle', () =>
     })
     const persist = vi.fn(async () => undefined)
     const op = new SwitchOperation({
-      profileService: ps,
+      specialistService: ps,
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify: vi.fn() },
@@ -869,7 +869,7 @@ describe('SwitchOperation — does not import issue 03/04 implementation', () =>
     // The notifier contract is the single sink; confirming it is invoked with PendingSwitch shape.
     const notify = vi.fn(async () => undefined) as unknown as SwitchNotifier['notify']
     const op = new SwitchOperation({
-      profileService: makeProfileService([profile()]),
+      specialistService: makeSpecialistService([profile()]),
       sessionBinding: makeSessionBinding(new Map()),
       approvalGateway: approvingGateway(),
       switchNotifier: { notify },

--- a/src/main/agents/switch-operation.ts
+++ b/src/main/agents/switch-operation.ts
@@ -26,8 +26,8 @@ import type {
   TrustedCallingSession
 } from '../../shared/agents-contract'
 import type { HandoffApprovalContext } from '../../shared/handoff-lifecycle'
-import type { SpecialistProfileView } from '../../shared/specialist'
-import type { ProfileService } from '../specialist/service'
+import type { SpecialistView } from '../../shared/specialist'
+import type { SpecialistService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
 import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
@@ -46,7 +46,7 @@ class SwitchError extends AgentsSafeError {
 // no parallel switch service. The runtime reconfigure callback is intentionally NOT part of this
 // module: it runs at the safe next-message boundary, not inside this SDK call.
 export type SwitchOperationDeps = {
-  profileService: ProfileService
+  specialistService: SpecialistService
   sessionBinding: SessionBindingService
   approvalGateway: ApprovalGateway
   switchNotifier: SwitchNotifier
@@ -306,11 +306,11 @@ export class SwitchOperation {
   // Specialist; a disabled or unknown target fails closed before the approval gateway is consulted.
   private async resolveTarget(
     targetName: string | null
-  ): Promise<{ kind: 'main' } | { kind: 'specialist'; profile: SpecialistProfileView }> {
+  ): Promise<{ kind: 'main' } | { kind: 'specialist'; profile: SpecialistView }> {
     if (targetName === null) return { kind: 'main' }
-    let profile: SpecialistProfileView
+    let profile: SpecialistView
     try {
-      profile = await this.deps.profileService.resolveRunnableByName(targetName)
+      profile = await this.deps.specialistService.resolveRunnableByName(targetName)
     } catch (error) {
       throw new SwitchError(error)
     }
@@ -358,7 +358,7 @@ export class SwitchOperation {
     const specialistId = this.deps.sessionBinding.getBinding(sessionId)
     if (!specialistId) return undefined
     try {
-      const current = await this.deps.profileService.resolveRunnableById(specialistId)
+      const current = await this.deps.specialistService.resolveRunnableById(specialistId)
       return current.name
     } catch {
       return undefined
@@ -371,16 +371,16 @@ export class SwitchOperation {
   // Failure fails closed and never broadens to Main Agent. Returns the commit descriptor
   // (specialistId/revision or Main).
   private async resolveForCommit(
-    preResolved: { kind: 'main' } | { kind: 'specialist'; profile: SpecialistProfileView },
+    preResolved: { kind: 'main' } | { kind: 'specialist'; profile: SpecialistView },
     reviewedRevision: number | undefined
   ): Promise<PendingCommit> {
     if (preResolved.kind === 'main') {
       return { generation: 0, specialistId: undefined, targetName: null }
     }
     const name = preResolved.profile.name
-    let profile: SpecialistProfileView
+    let profile: SpecialistView
     try {
-      profile = await this.deps.profileService.resolveRunnableByName(name)
+      profile = await this.deps.specialistService.resolveRunnableByName(name)
     } catch (error) {
       // Renamed or deleted between approval and commit.
       throw new SwitchError(error)

--- a/src/main/compute/application-commands.test.ts
+++ b/src/main/compute/application-commands.test.ts
@@ -283,6 +283,19 @@ describe('Compute application commands', () => {
     expect(dependencies.bookmarks.set).toHaveBeenCalledWith('ssh:cluster', ['/work'])
   })
 
+  it('normalizes the legacy conversation approval scope at the command boundary', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerComputeApplicationCommands(router.registrar, dependencies)
+
+    await router.dispatcher.invoke(
+      computeApplicationCommands.approvalRespond,
+      invocation([{ id: 'approval-1', decision: 'conversation' }])
+    )
+
+    expect(dependencies.compute.approvalRespond).toHaveBeenCalledWith('approval-1', 'session')
+  })
+
   it('serializes RemoteFsError details for both remote filesystem commands', async () => {
     const dependencies = createDependencies()
     const router = createApplicationCommandRouter()

--- a/src/main/compute/application-commands.ts
+++ b/src/main/compute/application-commands.ts
@@ -1,4 +1,8 @@
-import type { ComputeApprovalDecision, DeleteComputeHostRequest } from '../../shared/compute'
+import {
+  normalizeComputeApprovalDecision,
+  type ComputeApprovalDecisionInput,
+  type DeleteComputeHostRequest
+} from '../../shared/compute'
 import {
   LIFECYCLE_CHANNELS,
   MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID
@@ -168,7 +172,7 @@ const computeApplicationCommands = Object.freeze({
   >('compute:reveal-in-folder'),
   approvalRespond: defineApplicationCommand<
     'compute:approval-respond',
-    readonly [{ id: string; decision: ComputeApprovalDecision }],
+    readonly [{ id: string; decision: ComputeApprovalDecisionInput }],
     OwnerResult<ComputeCommandOwner, 'approvalRespond'>
   >('compute:approval-respond'),
   approvalReplay: defineApplicationCommand<
@@ -358,7 +362,10 @@ const registerComputeApplicationCommands = (
         if (!canSatisfyHumanApproval(callerContext)) {
           throw new Error('Only a current human caller can respond to compute approval requests.')
         }
-        return dependencies.compute.approvalRespond(args[0].id, args[0].decision)
+        return dependencies.compute.approvalRespond(
+          args[0].id,
+          normalizeComputeApprovalDecision(args[0].decision)
+        )
       },
       'compute:approval-replay': ({ args, callerContext }) => {
         if (!canSatisfyHumanApproval(callerContext)) {

--- a/src/main/compute/compute-approval-broker.test.ts
+++ b/src/main/compute/compute-approval-broker.test.ts
@@ -743,8 +743,8 @@ describe('ComputeApprovalBroker', () => {
     expect(broadcast).not.toHaveBeenCalled()
   })
 
-  // ── conversation scope ────────────────────────────────────────────────────────────
-  it('records a conversation grant and skips the card on a matching second request', async () => {
+  // ── session scope ────────────────────────────────────────────────────────────
+  it('records a session grant and skips the card on a matching second request', async () => {
     const timer = makeTimer()
     let broadcastCount = 0
     let n = 0
@@ -761,19 +761,19 @@ describe('ComputeApprovalBroker', () => {
     const req = makeRequest({ provider_id: 'ssh:biowulf' })
     const ctx = { sessionId: 'session-A', projectId: 'proj-1', operation: 'call_command' }
 
-    // First request: user approves with 'conversation' scope.
+    // First request: user approves with 'session' scope.
     const firstPromise = broker.requestWithContext(req, ctx)
     // requestWithContext calls checkProjectGrant (async), then request(). We must wait for the
     // broadcast before responding. Use setImmediate to let the microtask queue drain.
     await Promise.resolve()
-    broker.respond('id-1', 'conversation')
+    broker.respond('id-1', 'session')
     const first = await firstPromise
-    expect(first).toBe('conversation')
+    expect(first).toBe('session')
     expect(broadcastCount).toBe(1)
 
-    // Second request: same (operation, provider_id) → conversation grant hits, no broadcast.
+    // Second request: same (operation, provider_id) → session grant hits, no broadcast.
     const second = await broker.requestWithContext(req, ctx)
-    expect(second).toBe('conversation')
+    expect(second).toBe('session')
     expect(broadcastCount).toBe(1) // still only 1 broadcast
   })
 
@@ -837,7 +837,7 @@ describe('ComputeApprovalBroker', () => {
     await decision
   })
 
-  it('does NOT persist conversation grants across broker instances (session boundary)', async () => {
+  it('does NOT persist session grants across broker instances (session boundary)', async () => {
     // A new ComputeApprovalBroker has no in-memory grants → must show card again.
     const timer = makeTimer()
     let broadcastCount = 0
@@ -1009,7 +1009,7 @@ describe('ComputeApprovalBroker — download operation', () => {
     await expect(decision).resolves.toBe('once')
   })
 
-  it('conversation grant for (download, provider) skips card on repeat', async () => {
+  it('session grant for (download, provider) skips card on repeat', async () => {
     const timer = makeTimer()
     let broadcastCount = 0
     let n = 0
@@ -1028,13 +1028,13 @@ describe('ComputeApprovalBroker — download operation', () => {
 
     const firstPromise = broker.requestWithContext(req, ctx)
     await Promise.resolve()
-    broker.respond('id-1', 'conversation')
-    await expect(firstPromise).resolves.toBe('conversation')
+    broker.respond('id-1', 'session')
+    await expect(firstPromise).resolves.toBe('session')
     expect(broadcastCount).toBe(1)
 
-    // Second download request: conversation grant for (download, ssh:biowulf) → no card.
+    // Second download request: session grant for (download, ssh:biowulf) → no card.
     const second = await broker.requestWithContext(req, ctx)
-    expect(second).toBe('conversation')
+    expect(second).toBe('session')
     expect(broadcastCount).toBe(1)
   })
 
@@ -1049,12 +1049,12 @@ describe('ComputeApprovalBroker — download operation', () => {
       checkProjectGrant: () => Promise.resolve(false)
     })
 
-    // Grant conversation scope for call_command.
+    // Grant session scope for call_command.
     const cmdReq = makeRequest({ provider_id: 'ssh:biowulf' })
     const cmdCtx = { sessionId: 'sess', projectId: 'p', operation: 'call_command' }
     const p1 = broker.requestWithContext(cmdReq, cmdCtx)
     await Promise.resolve()
-    broker.respond('id-1', 'conversation')
+    broker.respond('id-1', 'session')
     await p1
 
     // download for same provider must still show card (different operation key).

--- a/src/main/compute/compute-approval-broker.ts
+++ b/src/main/compute/compute-approval-broker.ts
@@ -66,9 +66,9 @@ type PendingComputeApproval = {
 // open (a Promise) while the user decides; auto-denies after timeoutMs to prevent indefinite hangs.
 // Follows the same promise + broadcast + IPC-respond pattern as ApprovalBroker in connectors.
 //
-// The wire protocol retains `conversation`, but the production adapter translates it to a durable
-// Session grant. Project and Global use the same Registry; settings.json is read only for lazy legacy
-// Project migration. Callers without the adapter retain the older in-memory/test hooks below.
+// Session-scoped decisions become durable grants in production. Project and Global use the same
+// Registry; settings.json is read only for lazy legacy Project migration. Callers without the
+// adapter retain the older in-memory/test hooks below.
 //
 // Use request() for legacy callers that do not supply context (only 'once'/'deny' can result).
 // Use requestWithContext() to enable grant memory.
@@ -89,7 +89,7 @@ export class ComputeApprovalBroker {
   >()
 
   // Legacy fallback used only when no durable adapter is supplied.
-  private readonly conversationGrants = new Set<string>()
+  private readonly sessionGrants = new Set<string>()
 
   private readonly timeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -154,7 +154,7 @@ export class ComputeApprovalBroker {
     for (const entry of this.pending.values()) replay(entry.request, entry.context)
   }
 
-  // Like request(), but checks conversation and project grants first. If a grant matches, resolves
+  // Like request(), but checks Session and Project grants first. If a grant matches, resolves
   // immediately without broadcasting. When the user responds with a scope that has memory, records it.
   requestWithContext(
     info: Omit<ComputeApprovalRequest, 'id'>,
@@ -210,7 +210,7 @@ export class ComputeApprovalBroker {
           providerGeneration
         )
         if (requestWasCancelled() || !providerIsCurrent) return 'deny'
-        if (durableScope === 'session') return 'conversation'
+        if (durableScope === 'session') return 'session'
         return durableScope
       }
     }
@@ -230,16 +230,16 @@ export class ComputeApprovalBroker {
       }
     }
 
-    // ── conversation grant check (session in-memory) ───────────────────────────────
-    const convKey = `${sessionId}:${operation}:${providerId}`
-    if (!requiresExplicitApproval && this.conversationGrants.has(convKey)) {
+    // ── Session grant check (in-memory fallback) ───────────────────────────────────
+    const sessionGrantKey = `${sessionId}:${operation}:${providerId}`
+    if (!requiresExplicitApproval && this.sessionGrants.has(sessionGrantKey)) {
       const providerIsCurrent = await this.isProviderCurrent(
         providerId,
         ctx.ownerId,
         providerGeneration
       )
       if (requestWasCancelled() || !providerIsCurrent) return 'deny'
-      return 'conversation'
+      return 'session'
     }
 
     // ── no grant — show approval card ─────────────────────────────────────────────
@@ -274,8 +274,8 @@ export class ComputeApprovalBroker {
         { sessionId, projectId, operation, providerId },
         decision
       )
-    } else if (decision === 'conversation') {
-      this.conversationGrants.add(convKey)
+    } else if (decision === 'session') {
+      this.sessionGrants.add(sessionGrantKey)
     } else if (decision === 'project' && this.deps.saveProjectGrant) {
       await this.deps.saveProjectGrant({ projectId, operation, providerId })
     }
@@ -323,8 +323,8 @@ export class ComputeApprovalBroker {
     this.cancellingSessions.add(sessionId)
     this.completingSessionCancellations.delete(sessionId)
     this.pausedSessions.delete(sessionId)
-    for (const key of this.conversationGrants) {
-      if (key.startsWith(`${sessionId}:`)) this.conversationGrants.delete(key)
+    for (const key of this.sessionGrants) {
+      if (key.startsWith(`${sessionId}:`)) this.sessionGrants.delete(key)
     }
     for (const [id, entry] of this.pending) {
       if (entry.context?.sessionId === sessionId) this.settle(id, 'deny', 'cancelled')
@@ -342,7 +342,7 @@ export class ComputeApprovalBroker {
       if (!entry.context) this.settle(id, 'deny', 'cancelled')
     }
     this.pausedSessions.clear()
-    this.conversationGrants.clear()
+    this.sessionGrants.clear()
   }
 
   completeGlobalCancellation(): void {
@@ -385,8 +385,8 @@ export class ComputeApprovalBroker {
   async invalidateProvider(providerId: string): Promise<void> {
     this.invalidatingProviders.add(providerId)
     this.providerGenerations.set(providerId, (this.providerGenerations.get(providerId) ?? 0) + 1)
-    for (const key of this.conversationGrants) {
-      if (key.endsWith(`:${providerId}`)) this.conversationGrants.delete(key)
+    for (const key of this.sessionGrants) {
+      if (key.endsWith(`:${providerId}`)) this.sessionGrants.delete(key)
     }
     for (const [id, entry] of this.pending) {
       if (entry.providerId === providerId) this.settle(id, 'deny', 'cancelled')

--- a/src/main/compute/compute-job-workflow-owner.test.ts
+++ b/src/main/compute/compute-job-workflow-owner.test.ts
@@ -428,7 +428,7 @@ describe('ComputeJobWorkflowOwner.submitJob', () => {
     const { repo: jobRepo } = makeJobRepo()
     const { repo } = makeRepo()
 
-    const requestWithContext = vi.fn(() => Promise.resolve('conversation' as const))
+    const requestWithContext = vi.fn(() => Promise.resolve('session' as const))
     const broker = {
       request: vi.fn(),
       requestWithContext,

--- a/src/main/compute/compute-remote-operation-owner.test.ts
+++ b/src/main/compute/compute-remote-operation-owner.test.ts
@@ -1179,7 +1179,7 @@ describe('ComputeRemoteOperationOwner.download (session-cache)', () => {
     }
     const broker: ComputeApprovalBroker = {
       request: vi.fn(() => Promise.resolve('once')),
-      requestWithContext: vi.fn(() => Promise.resolve('conversation')),
+      requestWithContext: vi.fn(() => Promise.resolve('session')),
       respond: vi.fn()
     } as unknown as ComputeApprovalBroker
 

--- a/src/main/compute/electron-ipc-adapter.ts
+++ b/src/main/compute/electron-ipc-adapter.ts
@@ -1,16 +1,17 @@
 import type { IpcMainInvokeEvent } from 'electron'
 import { z } from 'zod'
 
-import type {
-  ChangeComputeHostAuthenticationRequest,
-  ComputeApprovalDecision,
-  ComputeJobsListFilter,
-  ComputeJobsPendingNotificationFilter,
-  CreateComputeHostRequest,
-  CreatePasswordComputeHostRequest,
-  DeleteComputeHostRequest,
-  DetailsAuthor,
-  ResetPasswordComputeHostRequest
+import {
+  normalizeComputeApprovalDecision,
+  type ChangeComputeHostAuthenticationRequest,
+  type ComputeApprovalDecisionInput,
+  type ComputeJobsListFilter,
+  type ComputeJobsPendingNotificationFilter,
+  type CreateComputeHostRequest,
+  type CreatePasswordComputeHostRequest,
+  type DeleteComputeHostRequest,
+  type DetailsAuthor,
+  type ResetPasswordComputeHostRequest
 } from '../../shared/compute'
 import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
 import type { DownloadDest, SerializableRemoteFsError } from '../../shared/remote-fs'
@@ -96,9 +97,9 @@ const downloadDestSchema = z.discriminatedUnion('kind', [
 const computeApprovalResponseSchema = z
   .object({
     id: z.string(),
-    decision: z.enum(['once', 'conversation', 'project', 'global', 'deny'])
+    decision: z.enum(['once', 'session', 'conversation', 'project', 'global', 'deny'])
   })
-  .strict() satisfies z.ZodType<{ id: string; decision: ComputeApprovalDecision }>
+  .strict() satisfies z.ZodType<{ id: string; decision: ComputeApprovalDecisionInput }>
 
 const computeJobsListFilterSchema = z.union([
   z.object({ sessionId: z.string(), status: stringArraySchema.optional() }).strict(),
@@ -243,10 +244,10 @@ const registerComputeIpcHandlerSet = ({ handlers, enabledHosts }: ComputeIpcAdap
   handleComputeIpc('compute:reveal-in-folder', (_event, filePath) => {
     handlers.revealInFolder(filePath)
   })
-  // Renderer responds to an in-flight approval card (issue 04/05). Decision now carries the
-  // chosen scope: 'once' | 'conversation' | 'project' | 'global' | 'deny'.
+  // Renderer responds to an in-flight approval card. Legacy `conversation` input is normalized at
+  // this transport boundary; the broker only receives the canonical Session scope.
   handleComputeIpc('compute:approval-respond', (_event, request) => {
-    handlers.approvalRespond(request.id, request.decision)
+    handlers.approvalRespond(request.id, normalizeComputeApprovalDecision(request.decision))
   })
   handleComputeIpc('compute:approval-replay', (_event, id) => handlers.approvalReplay(id))
   handleComputeIpc('compute:approval-replay-pending', () => handlers.approvalReplayPending())

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -2245,6 +2245,45 @@ describe('installComputeIpcHandlers', () => {
     await expect(decision).resolves.toBe('deny')
   })
 
+  it('normalizes the legacy conversation approval scope at the Electron boundary', async () => {
+    const broker = new ComputeApprovalBroker({
+      broadcast: vi.fn(),
+      generateId: () => 'approval-1',
+      setTimer: vi.fn(() => 1 as never),
+      clearTimer: vi.fn()
+    })
+    const computeHandlers = createComputeHandlers(
+      mockRepository({}),
+      undefined,
+      mockService({}),
+      broker
+    )
+    installComputeIpcHandlers({
+      handlers: computeHandlers,
+      enabledHosts: {
+        get: vi.fn(() => []),
+        set: vi.fn(),
+        setHostEnabled: vi.fn(),
+        setHostSelected: vi.fn()
+      }
+    })
+    const decision = broker.request({
+      provider_id: 'ssh:biowulf',
+      provider_name: 'biowulf',
+      shape: 'direct_ssh',
+      intent: 'Inspect the environment',
+      command_preview: 'env',
+      command_full: 'env'
+    })
+
+    await invokeHandler('compute:approval-respond', {
+      id: 'approval-1',
+      decision: 'conversation'
+    })
+
+    await expect(decision).resolves.toBe('session')
+  })
+
   it('routes enabled-hosts IPC through the authoritative owner and publishes its result', async () => {
     const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
     const session: PersistedChatSession = {

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -185,8 +185,7 @@ type ComputeHandlers = {
   computeService: ComputeService
   connectionBroker: ComputeConnectionBroker
   concurrencyManager?: ConcurrencyManager
-  // Responds to a pending approval request from the renderer. Decision now includes
-  // 'conversation' and 'project' scopes in addition to 'once' and 'deny' (issue 05).
+  // Responds to a pending approval request from the renderer with a canonical app-owned scope.
   approvalRespond: (id: string, decision: ComputeApprovalDecision) => void
   approvalReplay: (id: string) => ComputeApprovalRequest | null
   approvalReplayPending: () => void

--- a/src/main/compute/permission-grant-adapter.test.ts
+++ b/src/main/compute/permission-grant-adapter.test.ts
@@ -19,7 +19,7 @@ describe('compute permission grant adapter', () => {
     const registry = { remember } as unknown as PermissionGrantRegistry
     const adapter = createComputePermissionGrantAdapter(registry)
 
-    await adapter.remember(context, 'conversation')
+    await adapter.remember(context, 'session')
     await adapter.remember(context, 'global')
 
     expect(remember).toHaveBeenNthCalledWith(1, {

--- a/src/main/compute/permission-grant-adapter.ts
+++ b/src/main/compute/permission-grant-adapter.ts
@@ -53,7 +53,7 @@ const computeScope = (
   context: ComputeGrantContext,
   decision: ComputeApprovalDecision
 ): PermissionGrantScope | undefined => {
-  if (decision === 'conversation') {
+  if (decision === 'session') {
     return { kind: 'session', projectId: context.projectId, sessionId: context.sessionId }
   }
   if (decision === 'project') return { kind: 'project', projectId: context.projectId }

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -4,7 +4,7 @@ import type { ApplicationModule } from '../application-runtime'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import type { ConnectorApplicationSettingsCapabilities } from '../settings/service-capabilities'
 import type { UploadRepository } from '../uploads/repository'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import type {
   ConnectorApprovalRequest,
   ConversationSkillImportApprovalRequest
@@ -35,7 +35,7 @@ export type ConnectorApplicationDeps = {
   fetchImpl: typeof fetch
   resolveApiKey: (ref?: string) => string | undefined
   permissionGrantRegistry?: PermissionGrantRegistry
-  resolveSpecialistProfile: (specialistId: string) => Promise<SpecialistProfileView | undefined>
+  resolveSpecialistProfile: (specialistId: string) => Promise<SpecialistView | undefined>
   localToolHandlers?: Record<
     string,
     (

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -3,7 +3,7 @@ import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { ConnectorService } from './service'
 import { ParserEngine } from './engine'
 import { McpClientManager, McpToolCallError } from './mcp-client-manager'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import type { CustomMcpServerConfig } from './mcp-client-manager'
 
 const internal = { origin: 'internal' as const }
@@ -1603,7 +1603,7 @@ describe('ConnectorService', () => {
 })
 
 describe('ConnectorService specialist capability gate', () => {
-  const specialist = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+  const specialist = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
     id: 'specialist-1',
     name: 'Connector Bot',
     description: '',

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -16,7 +16,7 @@ import { ConnectorPermissionBroker } from '../permission-grants/connector-broker
 import type { ConnectorPermissionRequest } from '../permission-grants/connector-broker'
 import type { PermissionGrantScope } from '../../shared/permission-grants'
 import type { ApprovalDecision, ConnectorApprovalScope } from '../../shared/settings'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 
 type McpClientManagerLike = {
   listTools(config: CustomMcpServerConfig, signal?: AbortSignal): Promise<Array<{ name: string }>>
@@ -68,7 +68,7 @@ type ConnectorServiceDeps = {
   // Resolves the current specialist profile immediately before agent dispatch. This is intentionally
   // a function (rather than a session-start snapshot) so edited/deleted profiles take effect on the
   // next connector call.
-  resolveSpecialistProfile?: (specialistId: string) => Promise<SpecialistProfileView | undefined>
+  resolveSpecialistProfile?: (specialistId: string) => Promise<SpecialistView | undefined>
   onCustomServerAvailabilityChanged?: (
     serverId: string,
     availability: CustomMcpFailureAvailability | undefined

--- a/src/main/delegation/authenticated-delegate-caller.ts
+++ b/src/main/delegation/authenticated-delegate-caller.ts
@@ -4,7 +4,7 @@ type AuthenticatedDelegateCaller = Readonly<{
   session: SessionKey
   frameId: string
   role: 'main' | 'delegate' | 'reviewer'
-  parentSpecialistProfileId?: string
+  parentSpecialistId?: string
   originMessageId: string
   toolInvocationId: string
   attemptId?: string

--- a/src/main/delegation/delegated-work-admission.ts
+++ b/src/main/delegation/delegated-work-admission.ts
@@ -171,7 +171,7 @@ class DelegatedWorkAdmissionPolicy {
 
   async admit(
     requestOrRequests: DurableDelegateRequest | readonly DurableDelegateRequest[],
-    parentSpecialistProfileId?: string
+    parentSpecialistId?: string
   ): Promise<
     Readonly<{
       requests: readonly DurableDelegateRequest[]
@@ -191,9 +191,9 @@ class DelegatedWorkAdmissionPolicy {
         : prepareStructuredOutputSchema(request.outputSchema)
     )
     const inheritedAgent = requests.some((request) => request.profile === undefined)
-      ? parentSpecialistProfileId === undefined
+      ? parentSpecialistId === undefined
         ? ({ kind: 'main' } as const)
-        : await this.resolveAgent(parentSpecialistProfileId)
+        : await this.resolveAgent(parentSpecialistId)
       : undefined
     const resolvedAgents = await Promise.all(
       requests.map((request) =>

--- a/src/main/delegation/durable-delegated-work-contract.ts
+++ b/src/main/delegation/durable-delegated-work-contract.ts
@@ -2,7 +2,7 @@ import type { ArtifactFile } from '../../shared/artifacts'
 import type { AcpAgentRuntimeUpdate, AcpPermissionScope } from '../../shared/acp'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import type { ReviewWithChecks } from '../../shared/reviewer'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import type { AuthenticatedDelegateCaller } from './authenticated-delegate-caller'
 import type { JsonSchema } from './structured-output'
 import type { AgentUserChoiceRequest, AgentUserChoiceResult } from '../../shared/elicitation'
@@ -36,10 +36,7 @@ type DurableDelegateRequest = Readonly<{
 }>
 
 type SpecialistDelegationProfile = Readonly<
-  Pick<
-    SpecialistProfileView,
-    'id' | 'name' | 'displayName' | 'enabled' | 'setupPending' | 'revision'
-  >
+  Pick<SpecialistView, 'id' | 'name' | 'displayName' | 'enabled' | 'setupPending' | 'revision'>
 >
 
 type ParentMessageDelivery = Readonly<{

--- a/src/main/delegation/durable-delegated-work.test.ts
+++ b/src/main/delegation/durable-delegated-work.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import type { ArtifactFile } from '../../shared/artifacts'
 import type { ReviewWithChecks } from '../../shared/reviewer'
-import { createProfileService } from '../specialist/service'
+import { createSpecialistService } from '../specialist/service'
 import { createDeterministicDelegateExecution } from './deterministic-execution'
 import { DelegateMessagePreAcceptanceError } from './execution-port'
 import {
@@ -2180,7 +2180,7 @@ describe('durable delegated work', () => {
     const work = createDurableDelegatedWork({ execution, records, resolveSpecialist })
 
     const outcome = await work.delegate(
-      { ...caller, parentSpecialistProfileId: 'parent-specialist' },
+      { ...caller, parentSpecialistId: 'parent-specialist' },
       [
         { task: 'Inherited first', name: 'Inherited first' },
         { task: 'Explicit second', name: 'Explicit second', profile: 'explicit-specialist' },
@@ -2244,7 +2244,7 @@ describe('durable delegated work', () => {
 
     await expect(
       work.delegate(
-        { ...caller, parentSpecialistProfileId: 'deleted-parent-specialist' },
+        { ...caller, parentSpecialistId: 'deleted-parent-specialist' },
         [
           { task: 'Inherited child', name: 'Inherited child' },
           { task: 'Explicit child', name: 'Explicit child', profile: 'explicit-specialist' }
@@ -2261,7 +2261,7 @@ describe('durable delegated work', () => {
   it('accepts either a stable Specialist id or its unique exact public name while an omitted profile stays Main', async () => {
     const storage = await mkdtemp(join(tmpdir(), 'delegated-profile-reference-'))
     try {
-      const profiles = createProfileService(storage)
+      const profiles = createSpecialistService(storage)
       const selected = await profiles.create({
         name: 'EVIDENCE_ANALYST',
         displayName: 'Evidence Analyst'
@@ -4228,7 +4228,7 @@ describe('durable delegated work', () => {
     const resolveSpecialist = vi.fn(async () => liveProfile)
     const work = createDurableDelegatedWork({ execution, records, resolveSpecialist })
     const dispatched = await work.delegate(
-      { ...caller, parentSpecialistProfileId: liveProfile.id },
+      { ...caller, parentSpecialistId: liveProfile.id },
       { task: 'Specialist analysis', name: 'Specialist analysis' },
       { wait: false }
     )
@@ -4241,7 +4241,7 @@ describe('durable delegated work', () => {
     await work.sendMessage(
       {
         ...caller,
-        parentSpecialistProfileId: 'different-current-parent',
+        parentSpecialistId: 'different-current-parent',
         toolInvocationId: 'specialist-continuation'
       },
       dispatched.children[0].frameId,

--- a/src/main/delegation/durable-delegated-work.ts
+++ b/src/main/delegation/durable-delegated-work.ts
@@ -686,7 +686,7 @@ const createDurableDelegatedWork = (
     }
     const { requests, resolvedAgents, contracts } = await admissionPolicy.admit(
       requestOrRequests,
-      caller.parentSpecialistProfileId
+      caller.parentSpecialistId
     )
     const executionModelAdmission = await options.resolveExecutionModel(caller)
     const executionModel = executionModelAdmission.snapshot

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -8,7 +8,7 @@ import type {
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { materializeSessionConversationGraph } from '../../shared/session-persistence'
 import { resolveActiveConversationMessages } from '../../shared/conversation-graph'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import type { AgentFrameworkId } from '../../shared/settings'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import type { DelegatedQuestionAnswer } from '../../shared/session-persistence'
@@ -62,10 +62,10 @@ type ProductionDelegatedWorkOptions = Readonly<{
   }>
   resolveSpecialist?(
     profileId: string
-  ): Promise<SpecialistProfileView | undefined> | SpecialistProfileView | undefined
+  ): Promise<SpecialistView | undefined> | SpecialistView | undefined
   resolveSpecialistReference?(
     profileReference: string
-  ): Promise<SpecialistProfileView | undefined> | SpecialistProfileView | undefined
+  ): Promise<SpecialistView | undefined> | SpecialistView | undefined
   artifactEvidence?: DelegatedArtifactEvidenceOptions
   reviewEvidence?: DelegatedReviewEvidenceOptions
   parentMessages?: Readonly<{

--- a/src/main/delegation/session-record-adapter.test.ts
+++ b/src/main/delegation/session-record-adapter.test.ts
@@ -18,7 +18,7 @@ import {
   type SessionMutationRepository
 } from '../session-persistence/coordinator'
 import { SpecialistRepository } from '../specialist/repository'
-import { ProfileService } from '../specialist/service'
+import { SpecialistService } from '../specialist/service'
 import {
   createDeterministicDelegateExecution,
   type ExecutionControl
@@ -1584,7 +1584,7 @@ describe('Session delegated-work adapter', () => {
       session: key,
       frameId: rootFrameId,
       role: 'main',
-      parentSpecialistProfileId: 'stable-specialist-id',
+      parentSpecialistId: 'stable-specialist-id',
       originMessageId: rootPrompt.id,
       toolInvocationId: 'specialist-tool-call'
     }
@@ -1638,7 +1638,7 @@ describe('Session delegated-work adapter', () => {
         selectedCapabilities: emptySelectedConfig()
       })
       const profileRepository = new SpecialistRepository(profileStorage)
-      const profiles = new ProfileService(profileRepository, {
+      const profiles = new SpecialistService(profileRepository, {
         load: async () => ({
           entries: [builtin('secret-builtin-id-a'), builtin('secret-builtin-id-b')],
           diagnostics: []

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -235,7 +235,7 @@ import {
 import { createDelegationSettlementContinuationDispatch } from './delegation/settlement-continuation-dispatch'
 import { createSettingsWorkflows } from './settings/workflows'
 import { showSettingsSaveDialog } from './settings/save-dialog'
-import { ProfileService } from './specialist/service'
+import { SpecialistService } from './specialist/service'
 import { SpecialistRepository } from './specialist/repository'
 import { BuiltinSpecialistRegistry } from './specialist/builtin-registry'
 import { composeBuiltinSkillCatalog } from './specialist/package/builtin-skill-catalog'
@@ -1119,10 +1119,10 @@ const createApplicationModules = async (
     protectedSpecialistIds: ['reviewer'],
     protectedSpecialistNames: ['Reviewer']
   })
-  const profileService = new ProfileService(specialistRepository, builtinRegistry)
+  const specialistService = new SpecialistService(specialistRepository, builtinRegistry)
   const marketplaceRepository = new MarketplaceRepository(resolveStorageRoot())
   const marketplaceOperationCoordinator = new MarketplaceOperationCoordinator()
-  await profileService.ensureBuiltinCatalogReady()
+  await specialistService.ensureBuiltinCatalogReady()
   composition.phase('builtin-specialists')
   const tagService = new TagService(
     new TagRepository(() => getProjectDbClient(configRoot)),
@@ -1130,7 +1130,7 @@ const createApplicationModules = async (
       listSkills: () => settingsService.listSkills(),
       listConnectors: () => settingsService.listConnectors(),
       listSpecialists: async () =>
-        (await profileService.listForSettings()).filter(({ kind }) => kind !== 'reviewer')
+        (await specialistService.listForSettings()).filter(({ kind }) => kind !== 'reviewer')
     }),
     applicationEvents
   )
@@ -1238,7 +1238,7 @@ const createApplicationModules = async (
     getDisabledSkillIds: async () =>
       (await settingsRepository.getSettings()).disabledSkillIds ?? [],
     getInstalledSpecialists: async () =>
-      (await profileService.list()).map((profile) => ({
+      (await specialistService.list()).map((profile) => ({
         id: profile.id,
         revision: profile.revision,
         ...(profile.modifiedSinceImport === undefined
@@ -1250,7 +1250,7 @@ const createApplicationModules = async (
           : {})
       })),
     markMarketplaceManaged: async (id, expectedRevision) => {
-      await profileService.markMarketplaceManaged(id, expectedRevision)
+      await specialistService.markMarketplaceManaged(id, expectedRevision)
     },
     setSkillsMainEnabled: async (ids, enabled) => {
       await settingsRepository.setSkillsEnabled([...new Set(ids)], enabled)
@@ -1273,7 +1273,7 @@ const createApplicationModules = async (
   )
   // Per-session specialist binding store. Shared between the SET_SESSION_SPECIALIST barrier
   // (validate + record) and the runtime switch so a hot-switch lands on the same source of truth.
-  const sessionBindingService = new SessionBindingService(profileService)
+  const sessionBindingService = new SessionBindingService(specialistService)
   const specialistPersistLog = createLogger('specialist:persist')
   const loadSessionSpecialistBinding = async (
     sessionId: string
@@ -1332,7 +1332,7 @@ const createApplicationModules = async (
     (event) => broadcastToRenderers(SPECIALIST_IPC.HANDOFF_LIFECYCLE_CHANGED, event),
     async ({ targetName }) => {
       if (targetName === null) return undefined
-      const profile = await profileService.resolveRunnableByName(targetName)
+      const profile = await specialistService.resolveRunnableByName(targetName)
       return { specialistId: profile.id, revision: profile.revision }
     }
   )
@@ -1452,7 +1452,7 @@ const createApplicationModules = async (
       permissionGrantRegistry,
       resolveSpecialistProfile: async (specialistId) => {
         try {
-          return await profileService.resolveRunnableById(specialistId)
+          return await specialistService.resolveRunnableById(specialistId)
         } catch {
           return undefined
         }
@@ -1562,7 +1562,7 @@ const createApplicationModules = async (
   const agentComputeService = new AgentComputeService(computeService, hostsRegistry)
   // host.agents control-plane SDK (issue 02/05): read Specialist/catalog surface plus the durable
   // immediate-handoff lifecycle. The catalog adapter delegates to the authoritative
-  // SettingsService + ProfileService; switch() reuses the SAME SessionBindingService and durable
+  // SettingsService + SpecialistService; switch() reuses the SAME SessionBindingService and durable
   // session-file persistence seam the SET_SESSION_SPECIALIST IPC handler uses (no parallel switch
   // service). The runtime reconfigure callback is intentionally NOT wired here — it runs at the safe
   // next-message boundary, not inside the SDK call. Privileged operations use the existing ACP
@@ -1593,7 +1593,7 @@ const createApplicationModules = async (
     })
   })
   const agentsService = new AgentsService({
-    profileService,
+    specialistService,
     catalog: {
       listSkillCatalog: () => settingsService.listSpecialistSkillCatalog(),
       getConnectors: () => settingsService.getConnectors()
@@ -1609,7 +1609,7 @@ const createApplicationModules = async (
     deleteSpecialist: (request) => specialistPackageService.deleteSpecialist(request),
     // Catalog invalidation after a successful privileged mutation: reconnect live sessions so the
     // agent respawns (re-provisioning skills) and re-applies the updated Specialist whitelist. The
-    // ProfileService already broadcasts specialist:catalog-changed on update/delete; this refreshes the
+    // SpecialistService already broadcasts specialist:catalog-changed on update/delete; this refreshes the
     // RUNTIME capability resolution (mirrors the Settings IPC path's onProfilesChanged callback).
     invalidateCatalog: () => void runtime.requestSkillsReload(),
     persistSessionSpecialist: (sessionId, specialistId) =>
@@ -1634,7 +1634,7 @@ const createApplicationModules = async (
         conversationSkillImporter.authorizeReferencedUploads(projectId, sessionId, paths),
       settingsService,
       permissionGrantRegistry,
-      profileService,
+      specialistService,
       sessionPersistenceCoordinator
     },
     notebookRpcServer: requireNotebookRpcServer,
@@ -1713,9 +1713,9 @@ const createApplicationModules = async (
       return { path: resolved.path, filename: resolved.name }
     },
     frameworks: delegatedFrameworks,
-    resolveSpecialist: (profileId) => profileService.resolveRunnableById(profileId),
+    resolveSpecialist: (profileId) => specialistService.resolveRunnableById(profileId),
     resolveSpecialistReference: (profileReference) =>
-      profileService.resolveRunnableByReference(profileReference),
+      specialistService.resolveRunnableByReference(profileReference),
     artifactEvidence: {
       turns: delegatedArtifactTurns,
       artifactStorageSessionId: ({ sessionId }) => sessionId,
@@ -1955,7 +1955,7 @@ const createApplicationModules = async (
       isHostSkillsAvailable: (sessionId) =>
         runtimeRef.current?.getSessionFramework(sessionId) !== 'codebuddy',
       resolveSpecialistSkillIds: async (specialistId) => {
-        const profile = await profileService.resolveRunnableById(specialistId)
+        const profile = await specialistService.resolveRunnableById(specialistId)
         if (!profile.enabled) return []
         const effective = resolveEffectiveSpecialistSkills(
           profile,
@@ -2240,7 +2240,7 @@ const createApplicationModules = async (
       afterSessionDelete: (sessionId, retained) =>
         computeIpcModule.handlers.approvalFinishSessionDeletion(sessionId, retained),
       initializationBarrier: initialConnectorSkillsReady,
-      profileService,
+      specialistService,
       sessionPersistenceCoordinator,
       delegatedWork: delegatedWork.root,
       sideChatRelays: mainPromptSideChatRelay,
@@ -2535,7 +2535,7 @@ const createApplicationModules = async (
     resolveSwitchReadBack: async (sessionId, targetName) => {
       const specialistId = sessionBindingService.getBinding(sessionId)
       const revision = specialistId
-        ? (await profileService.resolveRunnableById(specialistId)).revision
+        ? (await specialistService.resolveRunnableById(specialistId)).revision
         : undefined
       return {
         status: 'approved',
@@ -2872,7 +2872,7 @@ const createApplicationModules = async (
   )
   declareElectronAdapter('specialist', () =>
     registerSpecialistIpcHandlers(
-      profileService,
+      specialistService,
       sessionBindingService,
       sessionSpecialistReconfiguration,
       // A specialist capability edit (skills/connectors/enabled) must reach live sessions on the next
@@ -3456,7 +3456,7 @@ const createApplicationModules = async (
     taskAgent,
     taskControls: {
       specialists: {
-        resolve: (reference) => profileService.resolveRunnableByReference(reference)
+        resolve: (reference) => specialistService.resolveRunnableByReference(reference)
       }
     },
     computePreferences: sessionEnabledComputeHostsOwner,

--- a/src/main/notebook/local-rpc-server.delegated-work.test.ts
+++ b/src/main/notebook/local-rpc-server.delegated-work.test.ts
@@ -796,7 +796,7 @@ describe('authenticated delegatedWorkCall route', () => {
 
     expect(response.status).toBe(200)
     expect(delegate).toHaveBeenCalledWith(
-      expect.objectContaining({ parentSpecialistProfileId: 'trusted-specialist' }),
+      expect.objectContaining({ parentSpecialistId: 'trusted-specialist' }),
       { task: 'Inherit trusted identity', name: 'Inherit trusted identity' },
       {}
     )

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import { AgentComputeService } from '../compute/agent-compute-service'
 import { ConnectorService } from '../connectors/service'
 import { NotebookLocalRpcServer } from './local-rpc-server'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 
 const fakeConnector = {
   call: async (s: string, m: string, a: Record<string, unknown>) => ({ s, m, a })
@@ -122,7 +122,7 @@ describe('mcpCall RPC', () => {
   })
 
   it('rejects a tool name passed as the server without reporting a Specialist permission denial', async () => {
-    const specialist: SpecialistProfileView = {
+    const specialist: SpecialistView = {
       id: 'literature-specialist',
       name: 'Literature Specialist',
       description: '',

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -2658,12 +2658,12 @@ class NotebookLocalRpcServer {
       if (!projectId || !sessionId || !frameId || !originMessageId || !toolInvocationId) {
         throw new RpcHttpError(403, 'delegated-work caller identity is incomplete.')
       }
-      const parentSpecialistProfileId = this.sessionSpecialists.get(sessionId)
+      const parentSpecialistId = this.sessionSpecialists.get(sessionId)
       const caller: AuthenticatedDelegateCaller = {
         session: { projectId, sessionId },
         frameId,
         role,
-        ...(parentSpecialistProfileId ? { parentSpecialistProfileId } : {}),
+        ...(parentSpecialistId ? { parentSpecialistId } : {}),
         ...(attemptId ? { attemptId } : {}),
         originMessageId,
         toolInvocationId: delegationCallId

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -12,7 +12,7 @@ import { listenForLocalRpc } from '../local-rpc-transport'
 import { hostSdkHelp } from '../host-sdk/help'
 import { NotebookLocalRpcServer } from './local-rpc-server'
 import { AgentsService } from '../agents/agents-service'
-import { createProfileService } from '../specialist/service'
+import { createSpecialistService } from '../specialist/service'
 import { createDeterministicDelegateExecution } from '../delegation/deterministic-execution'
 import { createInMemoryDelegatedWorkRecords } from '../delegation/durable-delegated-work'
 import { createTestDurableDelegatedWork as createDurableDelegatedWork } from '../delegation/durable-delegated-work-test-fixture'
@@ -351,7 +351,7 @@ describe('repl_loop local RPC transport', () => {
 
   it('discovers a public Specialist and delegates by its stable id and exact name through the authenticated REPL', async () => {
     const profileStorage = await mkdtemp(join(tmpdir(), 'repl-delegate-profile-roundtrip-'))
-    const profiles = createProfileService(profileStorage)
+    const profiles = createSpecialistService(profileStorage)
     const selected = await profiles.create({
       name: 'EVIDENCE_ANALYST',
       displayName: 'Evidence Analyst'
@@ -370,7 +370,7 @@ describe('repl_loop local RPC transport', () => {
       resolveSpecialistReference: (reference) => profiles.resolveRunnableByReference(reference)
     })
     const agents = new AgentsService({
-      profileService: profiles,
+      specialistService: profiles,
       catalog: {
         listSkillCatalog: async () => [],
         getConnectors: async () => undefined

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -507,7 +507,7 @@ describe('runtime state ownership architecture', () => {
     ['../notebook/local-rpc-server', 'NotebookLocalRpcServer'],
     ['../artifacts/repository', 'ArtifactRepository'],
     ['../tasks/task-runner', 'TaskRunner'],
-    ['../specialist/service', 'ProfileService'],
+    ['../specialist/service', 'SpecialistService'],
     ['../ipc', 'createApplicationModules'],
     ['../renderer-broadcast', 'broadcastToRenderers'],
     ['../web-service/http-server', 'WebHttpServer'],

--- a/src/main/specialist/identity.test.ts
+++ b/src/main/specialist/identity.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { buildSpecialistIdentityAppend, buildSpecialistIdentityPrefix } from './identity'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
 
-const makeProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+const makeProfile = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'uuid-1',
   name: 'RNA-seq Reviewer',
   description: 'Reviews RNA-seq analysis quality.',

--- a/src/main/specialist/identity.ts
+++ b/src/main/specialist/identity.ts
@@ -2,12 +2,12 @@
 // The profile specializes the common Open Science Agent identity. Capability enforcement remains
 // separate and authoritative.
 
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 
 // Sentinel retained in both delivery forms so diagnostics and compatibility tests can detect it.
 export const SPECIALIST_IDENTITY_TAG = '[open-science:specialist-identity]'
 
-const buildSpecialistIdentity = (profile: SpecialistProfileView): string => {
+const buildSpecialistIdentity = (profile: SpecialistView): string => {
   const prompt = profile.systemPrompt.trim()
   if (!prompt) return ''
 
@@ -25,12 +25,12 @@ const buildSpecialistIdentity = (profile: SpecialistProfileView): string => {
 
 // Builds the system-prompt APPEND text for Claude Code (preset 'claude_code', append mode).
 // Returns an empty string when there is nothing to inject (no systemPrompt set).
-export const buildSpecialistIdentityAppend = (profile: SpecialistProfileView): string => {
+export const buildSpecialistIdentityAppend = (profile: SpecialistView): string => {
   return buildSpecialistIdentity(profile)
 }
 
 // Builds the per-turn PROMPT PREFIX text for Codex and OpenCode (no session-meta append channel).
 // Returns an empty string when there is nothing to inject (no systemPrompt set).
-export const buildSpecialistIdentityPrefix = (profile: SpecialistProfileView): string => {
+export const buildSpecialistIdentityPrefix = (profile: SpecialistView): string => {
   return buildSpecialistIdentity(profile)
 }

--- a/src/main/specialist/ipc.test.ts
+++ b/src/main/specialist/ipc.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import { SPECIALIST_IPC } from '../../shared/specialist'
 import { SPECIALIST_MARKETPLACE_IPC } from '../../shared/specialist-marketplace'
 import { SessionBindingService } from './session-binding'
 import { registerSpecialistIpcHandlers } from './ipc'
-import type { ProfileService } from './service'
+import type { SpecialistService } from './service'
 import { SessionSpecialistReconfiguration } from './session-reconfiguration'
 
 const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
@@ -30,16 +30,16 @@ const profile = {
   fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
   selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
   revision: 1
-} as SpecialistProfileView
+} as SpecialistView
 
-const createProfileService = (): ProfileService =>
+const createSpecialistService = (): SpecialistService =>
   ({
     getById: vi.fn().mockResolvedValue(profile),
     resolveRunnableById: vi.fn().mockResolvedValue(profile),
     listForSettings: vi.fn().mockResolvedValue([]),
     listForSettingsSnapshot: vi.fn().mockResolvedValue({ items: [], integrity: { status: 'ok' } }),
     subscribe: vi.fn()
-  }) as unknown as ProfileService
+  }) as unknown as SpecialistService
 
 const createReconfigurationStub = (): Pick<SessionSpecialistReconfiguration, 'requestSwitch'> => ({
   requestSwitch: vi.fn().mockResolvedValue({ status: 'applied', contextReset: false })
@@ -48,7 +48,7 @@ const createReconfigurationStub = (): Pick<SessionSpecialistReconfiguration, 're
 describe('specialist session IPC', () => {
   it('adds exact Marketplace provenance to the Settings catalog without persisting it', async () => {
     handlers.clear()
-    const importedProfile: SpecialistProfileView = {
+    const importedProfile: SpecialistView = {
       ...profile,
       origin: 'imported',
       importBaseline: {
@@ -58,7 +58,7 @@ describe('specialist session IPC', () => {
       }
     }
     const service = {
-      ...createProfileService(),
+      ...createSpecialistService(),
       listForSettingsSnapshot: vi.fn().mockResolvedValue({
         items: [
           { kind: 'custom' as const, ...importedProfile },
@@ -66,7 +66,7 @@ describe('specialist session IPC', () => {
         ],
         integrity: { status: 'ok' as const }
       })
-    } as unknown as ProfileService
+    } as unknown as SpecialistService
     const marketplace = {
       list: vi.fn(),
       installedSpecialistProvenance: vi
@@ -127,9 +127,9 @@ describe('specialist session IPC', () => {
       integrity: { status: 'ok' as const }
     }
     const service = {
-      ...createProfileService(),
+      ...createSpecialistService(),
       listForSettingsSnapshot: vi.fn().mockResolvedValue(snapshot)
-    } as unknown as ProfileService
+    } as unknown as SpecialistService
     const marketplace = {
       list: vi.fn(),
       installedSpecialistProvenance: vi.fn().mockRejectedValue(new Error('invalid provenance')),
@@ -182,8 +182,8 @@ describe('specialist session IPC', () => {
       install: vi.fn().mockResolvedValue({ status: 'failed', code: 'candidate-invalid' })
     }
     registerSpecialistIpcHandlers(
-      createProfileService(),
-      new SessionBindingService(createProfileService()),
+      createSpecialistService(),
+      new SessionBindingService(createSpecialistService()),
       createReconfigurationStub(),
       undefined,
       undefined,
@@ -245,8 +245,8 @@ describe('specialist session IPC', () => {
       dispose: vi.fn()
     }
     registerSpecialistIpcHandlers(
-      createProfileService(),
-      new SessionBindingService(createProfileService()),
+      createSpecialistService(),
+      new SessionBindingService(createSpecialistService()),
       createReconfigurationStub(),
       undefined,
       undefined,
@@ -304,8 +304,8 @@ describe('specialist session IPC', () => {
       dispose: vi.fn()
     }
     registerSpecialistIpcHandlers(
-      createProfileService(),
-      new SessionBindingService(createProfileService()),
+      createSpecialistService(),
+      new SessionBindingService(createSpecialistService()),
       createReconfigurationStub(),
       undefined,
       undefined,
@@ -349,12 +349,12 @@ describe('specialist session IPC', () => {
   it('broadcasts only an invalidation signal without profile prompts or resource paths', () => {
     let notify: (() => void) | undefined
     const service = {
-      ...createProfileService(),
+      ...createSpecialistService(),
       subscribe: vi.fn((listener: () => void) => {
         notify = listener
         return vi.fn()
       })
-    } as unknown as ProfileService
+    } as unknown as SpecialistService
 
     registerSpecialistIpcHandlers(
       service,
@@ -372,9 +372,9 @@ describe('specialist session IPC', () => {
   it('skips runtime invalidation only for appearance-only updates', async () => {
     handlers.clear()
     const service = {
-      ...createProfileService(),
+      ...createSpecialistService(),
       update: vi.fn().mockResolvedValue(profile)
-    } as unknown as ProfileService
+    } as unknown as SpecialistService
     const onProfilesChanged = vi.fn()
 
     registerSpecialistIpcHandlers(
@@ -407,10 +407,10 @@ describe('specialist session IPC', () => {
 
   it('routes a session specialist switch through the reconfiguration owner', async () => {
     handlers.clear()
-    const binding = new SessionBindingService(createProfileService())
+    const binding = new SessionBindingService(createSpecialistService())
     const reconfiguration = createReconfigurationStub()
 
-    registerSpecialistIpcHandlers(createProfileService(), binding, reconfiguration)
+    registerSpecialistIpcHandlers(createSpecialistService(), binding, reconfiguration)
 
     const handler = handlers.get(SPECIALIST_IPC.SET_SESSION_SPECIALIST)
     expect(handler).toBeDefined()
@@ -424,7 +424,7 @@ describe('specialist session IPC', () => {
 
   it('does not leave durable, Main-memory, and runtime Specialist bindings silently divergent', async () => {
     handlers.clear()
-    const service = createProfileService()
+    const service = createSpecialistService()
     const binding = new SessionBindingService(service)
     binding.setBinding('session-1', 'specialist-old')
     let durableBinding: {
@@ -480,11 +480,11 @@ describe('specialist session IPC', () => {
 
   it('returns only the renderer-safe template save result from main', async () => {
     handlers.clear()
-    const binding = new SessionBindingService(createProfileService())
+    const binding = new SessionBindingService(createSpecialistService())
     const exportContributionTemplate = vi.fn().mockResolvedValue({ saved: true })
 
     registerSpecialistIpcHandlers(
-      createProfileService(),
+      createSpecialistService(),
       binding,
       createReconfigurationStub(),
       undefined,
@@ -500,7 +500,7 @@ describe('specialist session IPC', () => {
 
   it('keeps archive bytes in main and validates install requests before the package service', async () => {
     handlers.clear()
-    const binding = new SessionBindingService(createProfileService())
+    const binding = new SessionBindingService(createSpecialistService())
     const preview = vi.fn().mockResolvedValue({
       candidateToken: 'candidate-1',
       summary: { id: 'safe-id' },
@@ -512,7 +512,7 @@ describe('specialist session IPC', () => {
     const once = vi.fn()
 
     registerSpecialistIpcHandlers(
-      createProfileService(),
+      createSpecialistService(),
       binding,
       createReconfigurationStub(),
       undefined,
@@ -582,8 +582,8 @@ describe('specialist session IPC', () => {
       .mockResolvedValue({ saved: true, filePath: '/downloads/report.json' })
 
     registerSpecialistIpcHandlers(
-      createProfileService(),
-      new SessionBindingService(createProfileService()),
+      createSpecialistService(),
+      new SessionBindingService(createSpecialistService()),
       createReconfigurationStub(),
       undefined,
       undefined,
@@ -660,8 +660,8 @@ describe('specialist session IPC', () => {
       deleteSpecialist
     }
     registerSpecialistIpcHandlers(
-      createProfileService(),
-      new SessionBindingService(createProfileService()),
+      createSpecialistService(),
+      new SessionBindingService(createSpecialistService()),
       createReconfigurationStub(),
       onProfilesChanged,
       undefined,

--- a/src/main/specialist/ipc.ts
+++ b/src/main/specialist/ipc.ts
@@ -7,14 +7,14 @@ import type {
   DuplicateSpecialistRequest,
   CreateSpecialistInput,
   SpecialistCatalogSnapshot,
-  SpecialistProfileView,
+  SpecialistView,
   SetSessionSpecialistRequest,
   SetSessionSpecialistResponse,
   ResolveSessionSpecialistRequest,
   SessionSpecialistResolution
 } from '../../shared/specialist'
 import { SPECIALIST_IPC } from '../../shared/specialist'
-import { ProfileService } from './service'
+import { SpecialistService } from './service'
 import { SessionBindingService } from './session-binding'
 import { createLogger } from '../logger'
 import { broadcastToRenderers } from '../renderer-broadcast'
@@ -233,14 +233,14 @@ const broadcastCatalogChanged = (): void => {
 }
 
 // Registers all specialist IPC handlers against ipcMain.
-// Call once per app lifecycle, after the ProfileService is ready.
+// Call once per app lifecycle, after the SpecialistService is ready.
 export const registerSpecialistIpcHandlers = (
-  service: ProfileService,
+  service: SpecialistService,
   sessionBindingService: SessionBindingService,
   // One owner commits desired+pending, applies runtime, then clears pending. Keeping this transaction
   // behind one port prevents IPC from independently advancing disk, Main memory, and runtime.
   sessionReconfiguration: Pick<SessionSpecialistReconfiguration, 'requestSwitch'>,
-  // Notifies the runtime that a specialist profile's capabilities changed (skills/connectors/enabled).
+  // Notifies the runtime that a Specialist's capabilities changed (skills/connectors/enabled).
   // The runtime reconnects so live sessions re-provision skills and re-apply the updated whitelist on
   // the next turn. Optional so headless/tests can omit it.
   onProfilesChanged?: () => void,
@@ -295,7 +295,7 @@ export const registerSpecialistIpcHandlers = (
 
   ipcMainHandle(
     SPECIALIST_IPC.CREATE,
-    async (_event, request: CreateSpecialistRequest): Promise<SpecialistProfileView> => {
+    async (_event, request: CreateSpecialistRequest): Promise<SpecialistView> => {
       // Re-validate in main process — renderer input is untrusted.
       try {
         return await service.create(request)
@@ -431,7 +431,7 @@ export const registerSpecialistIpcHandlers = (
 
   ipcMainHandle(
     SPECIALIST_IPC.UPDATE,
-    async (_event, request: UpdateSpecialistRequest): Promise<SpecialistProfileView> => {
+    async (_event, request: UpdateSpecialistRequest): Promise<SpecialistView> => {
       // Re-validate in main process — renderer input is untrusted.
       try {
         const updated = await service.update(request)
@@ -448,7 +448,7 @@ export const registerSpecialistIpcHandlers = (
 
   ipcMainHandle(
     SPECIALIST_IPC.SET_ENABLED,
-    async (_event, request: SetSpecialistEnabledRequest): Promise<SpecialistProfileView> => {
+    async (_event, request: SetSpecialistEnabledRequest): Promise<SpecialistView> => {
       try {
         const updated = await service.setEnabled(request.id, request.enabled)
         onProfilesChanged?.()

--- a/src/main/specialist/package/release-certification.test.ts
+++ b/src/main/specialist/package/release-certification.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { SpecialistPackageCatalogSnapshot } from '../../../shared/specialist-package'
 import { UserSkillSpecialistPackageAdapter } from '../../skills/specialist-package-adapter'
 import { SpecialistRepository } from '../repository'
-import { ProfileService } from '../service'
+import { SpecialistService } from '../service'
 import {
   buildContributionTemplateZip,
   buildDeterministicSpecialistZip
@@ -102,7 +102,7 @@ describe('Specialist contribution release certification', () => {
       })
     }
 
-    await expect(new ProfileService(repository).list()).resolves.toEqual(
+    await expect(new SpecialistService(repository).list()).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'template-no-skills', ownedSkillIds: [] }),
         expect.objectContaining({
@@ -156,7 +156,7 @@ describe('Specialist contribution release certification', () => {
       status: 'installed'
     })
 
-    const profiles = new ProfileService(repository)
+    const profiles = new SpecialistService(repository)
     const imported = await profiles.getById('overwrite-roundtrip')
     await profiles.update({
       id: imported.id,
@@ -240,7 +240,7 @@ describe('Specialist contribution release certification', () => {
       targetPackages.install({ candidateToken: targetPreview.candidateToken })
     ).resolves.toMatchObject({ status: 'installed' })
 
-    const restored = await new ProfileService(targetRepository).getById(replaced.id)
+    const restored = await new SpecialistService(targetRepository).getById(replaced.id)
     expect(restored).toMatchObject({
       id: replaced.id,
       packageVersion: replaced.packageVersion,

--- a/src/main/specialist/package/service.test.ts
+++ b/src/main/specialist/package/service.test.ts
@@ -15,7 +15,7 @@ import { UserSkillRepository } from '../../skills/user-skill-repository'
 import type { FetchLike } from '../../skills/github-import'
 import { SettingsRepository } from '../../settings/repository'
 import { SpecialistRepository } from '../repository'
-import { ProfileService } from '../service'
+import { SpecialistService } from '../service'
 import { MarketplaceOperationCoordinator } from '../marketplace/operation-coordinator'
 import { SpecialistPackageService, specialistExportFileName } from './service'
 import { NOOP_SPECIALIST_PACKAGE_SKILL_PORT, type SpecialistPackageSkillPort } from './skill-port'
@@ -771,7 +771,7 @@ describe('SpecialistPackageService', () => {
       })
     )
 
-    const profiles = new ProfileService(repository)
+    const profiles = new SpecialistService(repository)
     const bumped = await profiles.update({
       id: 'research-synth',
       revision: 4,
@@ -1222,7 +1222,9 @@ describe('SpecialistPackageService', () => {
         origin: 'imported'
       }
     })
-    await expect(new ProfileService(repository).getById('research-synth')).resolves.toMatchObject({
+    await expect(
+      new SpecialistService(repository).getById('research-synth')
+    ).resolves.toMatchObject({
       systemPrompt: 'Private imported instructions.',
       enabled: false,
       revision: 5,
@@ -1252,7 +1254,7 @@ describe('SpecialistPackageService', () => {
       'specialist.overwrite-same-version'
     )
 
-    await new ProfileService(repository).update({
+    await new SpecialistService(repository).update({
       id: 'research-synth',
       revision: 1,
       description: 'Locally edited.'
@@ -1345,7 +1347,7 @@ describe('SpecialistPackageService', () => {
       status: 'installed',
       specialist: { origin: 'marketplace', enabled: true }
     })
-    await new ProfileService(repository).update({
+    await new SpecialistService(repository).update({
       id: 'research-synth',
       revision: 1,
       iconKey: 'dna',
@@ -1363,7 +1365,9 @@ describe('SpecialistPackageService', () => {
       undefined,
       { activateAfterInstall: true, origin: 'marketplace' }
     )
-    await expect(new ProfileService(repository).getById('research-synth')).resolves.toMatchObject({
+    await expect(
+      new SpecialistService(repository).getById('research-synth')
+    ).resolves.toMatchObject({
       origin: 'marketplace',
       packageVersion: '1.4.0',
       description: 'Publisher update.',
@@ -1390,7 +1394,7 @@ describe('SpecialistPackageService', () => {
     const initial = await service.preview(validZip())
     await service.install({ candidateToken: initial.candidateToken })
 
-    await new ProfileService(repository).update({
+    await new SpecialistService(repository).update({
       id: 'research-synth',
       revision: 1,
       iconKey: 'dna',
@@ -1402,7 +1406,7 @@ describe('SpecialistPackageService', () => {
       expect.objectContaining({ code: 'specialist.overwrite-local-modifications' })
     )
 
-    await new ProfileService(repository).update({
+    await new SpecialistService(repository).update({
       id: 'research-synth',
       revision: 2,
       capabilityMode: 'full',
@@ -1503,7 +1507,7 @@ describe('SpecialistPackageService', () => {
       catalog: async () => catalog
     })
     const preview = await service.preview(validZip())
-    await new ProfileService(repository).update({
+    await new SpecialistService(repository).update({
       id: 'research-synth',
       revision: 2,
       systemPrompt: 'Concurrent edit must survive.'
@@ -1512,7 +1516,9 @@ describe('SpecialistPackageService', () => {
     await expect(
       service.install({ candidateToken: preview.candidateToken, confirmOverwrite: true })
     ).resolves.toEqual({ status: 'failed', code: 'revision-conflict' })
-    await expect(new ProfileService(repository).getById('research-synth')).resolves.toMatchObject({
+    await expect(
+      new SpecialistService(repository).getById('research-synth')
+    ).resolves.toMatchObject({
       systemPrompt: 'Concurrent edit must survive.',
       revision: 3
     })
@@ -1557,7 +1563,7 @@ describe('SpecialistPackageService', () => {
       code: 'stale-candidate'
     })
 
-    const restarted = new ProfileService(new SpecialistRepository(storageDir))
+    const restarted = new SpecialistService(new SpecialistRepository(storageDir))
     await expect(restarted.getById('research-synth')).resolves.toMatchObject({
       name: 'Research Synthesizer',
       systemPrompt: 'Private imported instructions.',
@@ -1603,7 +1609,9 @@ describe('SpecialistPackageService', () => {
         setupPending: false
       }
     })
-    await expect(new ProfileService(repository).getById('research-synth')).resolves.toMatchObject({
+    await expect(
+      new SpecialistService(repository).getById('research-synth')
+    ).resolves.toMatchObject({
       enabled: true,
       setupPending: false
     })
@@ -1611,7 +1619,7 @@ describe('SpecialistPackageService', () => {
 
   it('does not erase a profile created while package Skill preparation is paused', async () => {
     const repository = new SpecialistRepository(storageDir)
-    const profiles = new ProfileService(repository)
+    const profiles = new SpecialistService(repository)
     let preparationStarted!: () => void
     let resumePreparation!: () => void
     const started = new Promise<void>((resolve) => {
@@ -1652,7 +1660,7 @@ describe('SpecialistPackageService', () => {
 
   it('does not erase a profile update made while package Skill preparation is paused', async () => {
     const repository = new SpecialistRepository(storageDir)
-    const profiles = new ProfileService(repository)
+    const profiles = new SpecialistService(repository)
     const existing = await profiles.create({
       name: 'EXISTING_PROFILE',
       description: 'Before concurrent update.'
@@ -1739,7 +1747,7 @@ describe('SpecialistPackageService', () => {
 
   it('preserves old durable state and blocks later package mutation when recovery cannot complete', async () => {
     const repository = new SpecialistRepository(storageDir)
-    const profiles = new ProfileService(repository)
+    const profiles = new SpecialistService(repository)
     const existing = await profiles.create({
       name: 'EXISTING_SPECIALIST',
       systemPrompt: 'Keep me.'
@@ -1769,7 +1777,7 @@ describe('SpecialistPackageService', () => {
 
   it('rolls back a failed Specialist document swap without changing the old durable state', async () => {
     const repository = new SpecialistRepository(storageDir)
-    const profiles = new ProfileService(repository)
+    const profiles = new SpecialistService(repository)
     const existing = await profiles.create({
       name: 'EXISTING_SPECIALIST',
       systemPrompt: 'Keep me.'
@@ -1821,7 +1829,7 @@ describe('SpecialistPackageService', () => {
 
   it('rolls back an interrupted Specialist transaction on restart before accepting a new mutation', async () => {
     const repository = new SpecialistRepository(storageDir)
-    const profiles = new ProfileService(repository)
+    const profiles = new SpecialistService(repository)
     const existing = await profiles.create({ name: 'EXISTING_SPECIALIST' })
     const before = await repository.getAll()
     const partial = {
@@ -1854,7 +1862,7 @@ describe('SpecialistPackageService', () => {
       status: 'installed'
     })
 
-    const recoveredProfiles = new ProfileService(new SpecialistRepository(storageDir))
+    const recoveredProfiles = new SpecialistService(new SpecialistRepository(storageDir))
     await expect(recoveredProfiles.getById(existing.id)).resolves.toBeDefined()
     await expect(recoveredProfiles.getById('partial-specialist')).rejects.toThrow(/not found/i)
     await expect(recoveredProfiles.getById('research-synth')).resolves.toBeDefined()
@@ -2050,7 +2058,7 @@ describe('SpecialistPackageService', () => {
         deleteSkillIds: ['exclusive']
       })
     ).resolves.toEqual({ status: 'deleted' })
-    await expect(new ProfileService(repository).getById('research-synth')).rejects.toThrow(
+    await expect(new SpecialistService(repository).getById('research-synth')).rejects.toThrow(
       /not found/i
     )
     await expect(new UserSkillRepository(storageDir).list()).resolves.toEqual([
@@ -2112,7 +2120,7 @@ describe('SpecialistPackageService', () => {
 
     expect(deletionSettled).toBe(false)
     await expect(
-      new ProfileService(repository).getById('managed-specialist')
+      new SpecialistService(repository).getById('managed-specialist')
     ).resolves.toBeDefined()
 
     releaseOperation?.()
@@ -2173,7 +2181,7 @@ describe('SpecialistPackageService', () => {
         deleteSkillIds: [skillId]
       })
     ).resolves.toEqual({ status: 'deleted' })
-    await expect(new ProfileService(repository).getById('research-synth')).rejects.toThrow(
+    await expect(new SpecialistService(repository).getById('research-synth')).rejects.toThrow(
       /not found/i
     )
     await expect(userSkills.list()).resolves.toEqual([])
@@ -2275,7 +2283,7 @@ describe('SpecialistPackageService', () => {
       })
     })
     const preview = await service.previewSpecialistDelete({ id: 'owner' })
-    await new ProfileService(repository).update({
+    await new SpecialistService(repository).update({
       id: 'concurrent',
       revision: 1,
       selectedCapabilities: {
@@ -2292,7 +2300,7 @@ describe('SpecialistPackageService', () => {
         deleteSkillIds: ['linked-skill']
       })
     ).resolves.toEqual({ status: 'failed', code: 'stale-preview' })
-    await expect(new ProfileService(repository).getById('owner')).resolves.toBeDefined()
+    await expect(new SpecialistService(repository).getById('owner')).resolves.toBeDefined()
   })
 
   it('rejects a selected deletion when the Main Agent starts using the Skill', async () => {
@@ -2338,7 +2346,7 @@ describe('SpecialistPackageService', () => {
         deleteSkillIds: ['linked-skill']
       })
     ).resolves.toEqual({ status: 'failed', code: 'stale-preview' })
-    await expect(new ProfileService(repository).getById('owner')).resolves.toBeDefined()
+    await expect(new SpecialistService(repository).getById('owner')).resolves.toBeDefined()
   })
 
   it('rechecks Main Agent usage after acquiring the Skill mutation lock', async () => {
@@ -2392,7 +2400,7 @@ describe('SpecialistPackageService', () => {
       })
     ).resolves.toEqual({ status: 'failed', code: 'stale-preview' })
     expect(prepareDeletion).not.toHaveBeenCalled()
-    await expect(new ProfileService(repository).getById('owner')).resolves.toBeDefined()
+    await expect(new SpecialistService(repository).getById('owner')).resolves.toBeDefined()
   })
 
   it('completes deletion when the live catalog shares the Skill mutation owner', async () => {
@@ -2441,7 +2449,7 @@ describe('SpecialistPackageService', () => {
         deleteSkillIds: [skillId]
       })
     ).resolves.toEqual({ status: 'deleted' })
-    await expect(new ProfileService(repository).getById('owner')).rejects.toThrow(/not found/i)
+    await expect(new SpecialistService(repository).getById('owner')).rejects.toThrow(/not found/i)
     await expect(userSkills.list()).resolves.toEqual([])
   }, 2_000)
 
@@ -2576,7 +2584,7 @@ describe('SpecialistPackageService', () => {
         deleteSkillIds: ['rollback-skill']
       })
     ).resolves.toEqual({ status: 'failed', code: 'commit-failed' })
-    await expect(new ProfileService(repository).getById('rollback-owner')).resolves.toBeDefined()
+    await expect(new SpecialistService(repository).getById('rollback-owner')).resolves.toBeDefined()
     await expect(skillPort.snapshot()).resolves.toEqual([
       expect.objectContaining({ id: 'rollback-skill', ownerIds: ['rollback-owner'] })
     ])

--- a/src/main/specialist/package/transaction.ts
+++ b/src/main/specialist/package/transaction.ts
@@ -3,7 +3,7 @@ import { readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { SpecialistPackageValidationPlan } from '../../../shared/specialist-package'
-import type { SpecialistProfileView } from '../../../shared/specialist'
+import type { SpecialistView } from '../../../shared/specialist'
 import { emptyFullAccessConfig } from '../../../shared/specialist'
 import { createLogger } from '../../logger'
 import { SpecialistRepository } from '../repository'
@@ -45,7 +45,7 @@ export class SpecialistPackageRecoveryError extends Error {
 export class SpecialistPackageRevisionConflictError extends Error {}
 export class SpecialistPackageRollbackError extends Error {}
 
-const toView = (stored: StoredSpecialist): SpecialistProfileView => ({
+const toView = (stored: StoredSpecialist): SpecialistView => ({
   ...stored,
   displayName: stored.displayName ?? stored.name,
   modifiedSinceImport:
@@ -135,7 +135,7 @@ export class SpecialistPackageTransaction {
     overwrite?: { expectedRevision: number },
     assertApprovedImpact?: (document: Readonly<StoredSpecialists>) => Promise<void>,
     options?: { activateAfterInstall?: boolean; origin?: SpecialistOrigin }
-  ): Promise<SpecialistProfileView> {
+  ): Promise<SpecialistView> {
     const run = this.queue.then(async () => {
       await this.recover()
       const before = await this.repository.getAll()

--- a/src/main/specialist/repository.ts
+++ b/src/main/specialist/repository.ts
@@ -485,7 +485,7 @@ export class SpecialistRepository {
 
   // Atomically replaces the document only when no owner mutation has changed it
   // since the caller took its snapshot. Package transactions use this after their
-  // asynchronous preparation work so a successful ProfileService mutation can
+  // asynchronous preparation work so a successful SpecialistService mutation can
   // never be overwritten by a stale whole-document snapshot.
   async replaceAllIfUnchanged(
     expected: StoredSpecialists,

--- a/src/main/specialist/service.test.ts
+++ b/src/main/specialist/service.test.ts
@@ -4,25 +4,25 @@ import { mkdir, rm } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-import { ProfileService } from './service'
+import { SpecialistService } from './service'
 import { SpecialistRepository } from './repository'
 import type { BuiltinSpecialistRegistryEntry } from '../../shared/specialist-package'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
 
 let tmpDir: string
-let service: ProfileService
+let service: SpecialistService
 
 beforeEach(async () => {
   tmpDir = join(tmpdir(), `profile-service-${randomUUID()}`)
   await mkdir(tmpDir, { recursive: true })
-  service = new ProfileService(new SpecialistRepository(tmpDir))
+  service = new SpecialistService(new SpecialistRepository(tmpDir))
 })
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
 })
 
-describe('ProfileService.list', () => {
+describe('SpecialistService.list', () => {
   it('fails the whole runnable catalog with structured diagnostics when any builtin is invalid', async () => {
     const diagnostic = {
       severity: 'error' as const,
@@ -31,7 +31,7 @@ describe('ProfileService.list', () => {
       path: 'manifest.json',
       relatedId: 'missing-skill'
     }
-    const guarded = new ProfileService(new SpecialistRepository(tmpDir), {
+    const guarded = new SpecialistService(new SpecialistRepository(tmpDir), {
       load: async () => ({ entries: [], diagnostics: [diagnostic] })
     })
 
@@ -59,7 +59,7 @@ describe('ProfileService.list', () => {
       fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
       selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] }
     }
-    const withBuiltin = new ProfileService(new SpecialistRepository(tmpDir), {
+    const withBuiltin = new SpecialistService(new SpecialistRepository(tmpDir), {
       load: async () => ({ entries: [builtin], diagnostics: [] })
     })
     const custom = await withBuiltin.create({ name: 'CUSTOM_CURATOR' })
@@ -89,7 +89,7 @@ describe('ProfileService.list', () => {
   })
 })
 
-describe('ProfileService.create', () => {
+describe('SpecialistService.create', () => {
   it('returns structured read-only errors for builtin and Reviewer mutation targets', async () => {
     const builtin: BuiltinSpecialistRegistryEntry = {
       kind: 'builtin',
@@ -104,7 +104,7 @@ describe('ProfileService.create', () => {
       fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
       selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] }
     }
-    const guarded = new ProfileService(new SpecialistRepository(tmpDir), {
+    const guarded = new SpecialistService(new SpecialistRepository(tmpDir), {
       load: async () => ({ entries: [builtin], diagnostics: [] })
     })
     const builtinError = { code: 'SPECIALIST_READ_ONLY', targetKind: 'builtin' }
@@ -268,7 +268,7 @@ describe('ProfileService.create', () => {
   })
 })
 
-describe('ProfileService.getById', () => {
+describe('SpecialistService.getById', () => {
   it('returns the specialist by id', async () => {
     const created = await service.create({ name: 'RNA-seq Reviewer' })
     const found = await service.getById(created.id)
@@ -280,7 +280,7 @@ describe('ProfileService.getById', () => {
   })
 })
 
-describe('ProfileService.getByName', () => {
+describe('SpecialistService.getByName', () => {
   it('returns specialist by name', async () => {
     const created = await service.create({ name: 'RNA-seq Reviewer' })
     const found = await service.getByName(created.name)
@@ -292,7 +292,7 @@ describe('ProfileService.getByName', () => {
   })
 })
 
-describe('ProfileService.setEnabled', () => {
+describe('SpecialistService.setEnabled', () => {
   it('toggles enabled state', async () => {
     const created = await service.create({ name: 'My Bot' })
     const disabled = await service.setEnabled(created.id, false)
@@ -348,7 +348,7 @@ describe('ProfileService.setEnabled', () => {
   })
 })
 
-describe('ProfileService.update', () => {
+describe('SpecialistService.update', () => {
   it('allows only appearance edits for Marketplace-managed Specialists', async () => {
     const repo = new SpecialistRepository(tmpDir)
     await repo.insert({
@@ -495,7 +495,7 @@ describe('ProfileService.update', () => {
     })
 
     expect(updated).toMatchObject({ packageVersion: '1.0.0', revision: created.revision + 1 })
-    const restarted = new ProfileService(new SpecialistRepository(tmpDir))
+    const restarted = new SpecialistService(new SpecialistRepository(tmpDir))
     await expect(restarted.getById(created.id)).resolves.toMatchObject({ packageVersion: '1.0.0' })
   })
 
@@ -516,7 +516,7 @@ describe('ProfileService.update', () => {
       revision: created.revision + 1
     })
 
-    const restarted = new ProfileService(new SpecialistRepository(tmpDir))
+    const restarted = new SpecialistService(new SpecialistRepository(tmpDir))
     await expect(restarted.getById(created.id)).resolves.toMatchObject({
       name: 'My Bot',
       displayName: 'My Disabled Bot',
@@ -699,7 +699,7 @@ describe('ProfileService.update', () => {
   })
 })
 
-describe('ProfileService.listForSettings', () => {
+describe('SpecialistService.listForSettings', () => {
   it('includes custom specialists', async () => {
     await service.create({ name: 'My Bot' })
     const items = await service.listForSettings()
@@ -719,7 +719,7 @@ describe('ProfileService.listForSettings', () => {
   })
 })
 
-describe('ProfileService.subscribe', () => {
+describe('SpecialistService.subscribe', () => {
   it('notifies listener after create', async () => {
     const listener = vi.fn()
     service.subscribe(listener)
@@ -744,7 +744,7 @@ describe('ProfileService.subscribe', () => {
   })
 })
 
-describe('ProfileService lifecycle mutations', () => {
+describe('SpecialistService lifecycle mutations', () => {
   it('rejects malformed delete payloads without removing the profile', async () => {
     const created = await service.create({ name: 'Safe Bot' })
 
@@ -805,7 +805,7 @@ describe('ProfileService lifecycle mutations', () => {
   })
 })
 
-describe('ProfileService restart persistence', () => {
+describe('SpecialistService restart persistence', () => {
   it('persists enabled=false across a service restart (re-create from same store)', async () => {
     const created = await service.create({ name: 'PERSISTENT_BOT' })
     expect(created.enabled).toBe(true)
@@ -813,7 +813,7 @@ describe('ProfileService restart persistence', () => {
     await service.setEnabled(created.id, false)
 
     // Simulate restart: create a new service instance from the same storage directory.
-    const restarted = new ProfileService(new SpecialistRepository(tmpDir))
+    const restarted = new SpecialistService(new SpecialistRepository(tmpDir))
     const afterRestart = await restarted.getById(created.id)
     expect(afterRestart.enabled).toBe(false)
   })
@@ -827,7 +827,7 @@ describe('ProfileService restart persistence', () => {
       selectedCapabilities: { skillIds: ['skill-x'], connectorIds: ['conn-y'], connectorTools: [] }
     })
 
-    const restarted = new ProfileService(new SpecialistRepository(tmpDir))
+    const restarted = new SpecialistService(new SpecialistRepository(tmpDir))
     const found = await restarted.getById(created.id)
 
     expect(found.id).toBe(created.id)
@@ -839,7 +839,7 @@ describe('ProfileService restart persistence', () => {
   })
 })
 
-describe('ProfileService session binding with stable IDs', () => {
+describe('SpecialistService session binding with stable IDs', () => {
   it('keeps the UUID stable after a display-name edit — a stored session binding still resolves', async () => {
     const created = await service.create({ name: 'RNA_REVIEWER' })
     const originalId = created.id
@@ -874,7 +874,7 @@ describe('ProfileService session binding with stable IDs', () => {
   })
 })
 
-describe('ProfileService stable Skill/Connector references', () => {
+describe('SpecialistService stable Skill/Connector references', () => {
   it('skill attachment tracks by ID — renamed display name does not break the binding', async () => {
     // Attach a skill by stable ID. In a real app the skill catalog has a stable id
     // and a separate display name. Profile stores the id, never the display name.

--- a/src/main/specialist/service.ts
+++ b/src/main/specialist/service.ts
@@ -11,7 +11,7 @@ import type {
 import type {
   BuiltinSpecialistEntry,
   SpecialistCatalogSnapshot,
-  SpecialistProfileView,
+  SpecialistView,
   SpecialistListItem,
   CreateSpecialistInput,
   UpdateSpecialistInput,
@@ -91,7 +91,7 @@ const MAX_AVAILABLE_SPECIALIST_NAMES = 8
 
 const specialistReferenceError = (
   reason: 'unknown' | 'ambiguous' | 'unavailable',
-  profiles: readonly SpecialistProfileView[]
+  profiles: readonly SpecialistView[]
 ): Error => {
   const names = [
     ...new Set(
@@ -144,7 +144,7 @@ export class BuiltinSpecialistConformanceError extends Error {
 // View projection
 // ---------------------------------------------------------------------------
 
-const toView = (s: StoredSpecialist): SpecialistProfileView => ({
+const toView = (s: StoredSpecialist): SpecialistView => ({
   id: s.id,
   name: s.name,
   displayName: s.displayName ?? s.name,
@@ -216,13 +216,13 @@ const assertCreateInputShape = (input: CreateSpecialistInput): void => {
 }
 
 // ---------------------------------------------------------------------------
-// ProfileService
+// SpecialistService
 // ---------------------------------------------------------------------------
 
-// The single domain service for Specialist Profiles.
+// The single domain service for Specialists.
 // Settings, IPC handlers, and future SDK callers must use this — never bypass
 // it to write directly to the repository.
-export class ProfileService {
+export class SpecialistService {
   private readonly listeners: Set<() => void> = new Set()
   private builtinEntriesPromise: Promise<readonly BuiltinSpecialistRegistryEntry[]> | undefined
 
@@ -277,7 +277,7 @@ export class ProfileService {
   }
 
   // Returns all custom specialists as views (no Reviewer, no Main Agent, no None).
-  async list(): Promise<SpecialistProfileView[]> {
+  async list(): Promise<SpecialistView[]> {
     const doc = await this.repo.getAll()
     return doc.specialists.map(toView)
   }
@@ -299,7 +299,7 @@ export class ProfileService {
     return { items, integrity: snapshot.integrity }
   }
 
-  async resolveRunnableById(id: string): Promise<SpecialistProfileView> {
+  async resolveRunnableById(id: string): Promise<SpecialistView> {
     const custom = await this.list()
     const customMatch = custom.find((profile) => profile.id === id)
     if (customMatch) return customMatch
@@ -308,7 +308,7 @@ export class ProfileService {
     throw new Error(`Runnable Specialist ${id} not found.`)
   }
 
-  async resolveRunnableByName(name: string): Promise<SpecialistProfileView> {
+  async resolveRunnableByName(name: string): Promise<SpecialistView> {
     const custom = await this.list()
     const customMatch = custom.find((profile) => profile.name === name)
     if (customMatch) return customMatch
@@ -317,7 +317,7 @@ export class ProfileService {
     throw new Error(`Runnable Specialist "${name}" not found.`)
   }
 
-  async resolveRunnableByReference(reference: string): Promise<SpecialistProfileView> {
+  async resolveRunnableByReference(reference: string): Promise<SpecialistView> {
     const profiles = [
       ...(await this.list()),
       ...(await this.builtinEntries()).map((entry) => this.toBuiltinView(entry))
@@ -339,26 +339,26 @@ export class ProfileService {
     return selected
   }
 
-  async getById(id: string): Promise<SpecialistProfileView> {
+  async getById(id: string): Promise<SpecialistView> {
     const doc = await this.repo.getAll()
     const found = doc.specialists.find((s) => s.id === id)
     if (!found) throw new Error(`Specialist ${id} not found.`)
     return toView(found)
   }
 
-  async getByName(name: string): Promise<SpecialistProfileView> {
+  async getByName(name: string): Promise<SpecialistView> {
     const doc = await this.repo.getAll()
     const found = doc.specialists.find((s) => s.name === name)
     if (!found) throw new Error(`Specialist "${name}" not found.`)
     return toView(found)
   }
 
-  async resolveCustomMutationByName(name: string): Promise<SpecialistProfileView> {
+  async resolveCustomMutationByName(name: string): Promise<SpecialistView> {
     await this.assertCreatableName(name)
     return this.getByName(name)
   }
 
-  async create(input: CreateSpecialistInput): Promise<SpecialistProfileView> {
+  async create(input: CreateSpecialistInput): Promise<SpecialistView> {
     assertCreateInputShape(input)
     await this.assertCreatableName(input.name)
 
@@ -415,7 +415,7 @@ export class ProfileService {
     return toView(stored)
   }
 
-  async setEnabled(id: string, enabled: boolean): Promise<SpecialistProfileView> {
+  async setEnabled(id: string, enabled: boolean): Promise<SpecialistView> {
     if (typeof id !== 'string' || !id.trim()) {
       throw new Error('Specialist id must be a non-empty string.')
     }
@@ -437,7 +437,7 @@ export class ProfileService {
   // Atomically patches presentation/instructions fields on an existing specialist.
   // The stable name is immutable. `revision` must match the stored record
   // (optimistic concurrency); the repository bumps it and rejects stale writes.
-  async update(input: UpdateSpecialistInput): Promise<SpecialistProfileView> {
+  async update(input: UpdateSpecialistInput): Promise<SpecialistView> {
     if (!input || typeof input.id !== 'string' || typeof input.revision !== 'number') {
       throw new Error('Update requires id and revision.')
     }
@@ -506,10 +506,7 @@ export class ProfileService {
     return toView(updated)
   }
 
-  async markMarketplaceManaged(
-    id: string,
-    expectedRevision: number
-  ): Promise<SpecialistProfileView> {
+  async markMarketplaceManaged(id: string, expectedRevision: number): Promise<SpecialistView> {
     const current = await this.getById(id)
     if (current.revision !== expectedRevision) {
       throw new Error(`Revision conflict: expected ${expectedRevision}, found ${current.revision}.`)
@@ -573,7 +570,7 @@ export class ProfileService {
     field: 'skillIds' | 'connectorIds' | 'excludedSkillIds' | 'excludedConnectorIds',
     value: string,
     attach: boolean
-  ): Promise<SpecialistProfileView> {
+  ): Promise<SpecialistView> {
     await this.assertContentMutableId(id)
     const current = await this.getById(id)
     if (mode === 'full') {
@@ -597,7 +594,7 @@ export class ProfileService {
     skillId: string,
     expectedRevision: number,
     mode: SpecialistCapabilityMode = 'selected'
-  ): Promise<SpecialistProfileView> {
+  ): Promise<SpecialistView> {
     return this.patchCollection(
       id,
       expectedRevision,
@@ -613,7 +610,7 @@ export class ProfileService {
     skillId: string,
     expectedRevision: number,
     mode: SpecialistCapabilityMode = 'selected'
-  ): Promise<SpecialistProfileView> {
+  ): Promise<SpecialistView> {
     return this.patchCollection(
       id,
       expectedRevision,
@@ -629,7 +626,7 @@ export class ProfileService {
     connectorId: string,
     expectedRevision: number,
     mode: SpecialistCapabilityMode = 'selected'
-  ): Promise<SpecialistProfileView> {
+  ): Promise<SpecialistView> {
     return this.patchCollection(
       id,
       expectedRevision,
@@ -645,7 +642,7 @@ export class ProfileService {
     connectorId: string,
     expectedRevision: number,
     mode: SpecialistCapabilityMode = 'selected'
-  ): Promise<SpecialistProfileView> {
+  ): Promise<SpecialistView> {
     return this.patchCollection(
       id,
       expectedRevision,
@@ -678,9 +675,9 @@ export class ProfileService {
 // Factory
 // ---------------------------------------------------------------------------
 
-export const createProfileService = (
+export const createSpecialistService = (
   storageDir: string,
   builtinRegistry?: { load(): Promise<BuiltinSpecialistRegistryResult> }
-): ProfileService => {
-  return new ProfileService(new SpecialistRepository(storageDir), builtinRegistry)
+): SpecialistService => {
+  return new SpecialistService(new SpecialistRepository(storageDir), builtinRegistry)
 }

--- a/src/main/specialist/session-binding.test.ts
+++ b/src/main/specialist/session-binding.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
 import { SessionBindingService } from './session-binding'
-import type { ProfileService } from './service'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistService } from './service'
+import type { SpecialistView } from '../../shared/specialist'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+const makeProfile = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'uuid-sp1',
   name: 'DEBUGGER',
   displayName: 'Debugger',
@@ -22,7 +22,7 @@ const makeProfile = (overrides: Partial<SpecialistProfileView> = {}): Specialist
   ...overrides
 })
 
-const makeService = (profiles: Map<string, SpecialistProfileView> = new Map()): ProfileService => {
+const makeService = (profiles: Map<string, SpecialistView> = new Map()): SpecialistService => {
   return {
     getById: vi.fn(async (id: string) => {
       const p = profiles.get(id)
@@ -34,7 +34,7 @@ const makeService = (profiles: Map<string, SpecialistProfileView> = new Map()): 
       if (!p) throw new Error(`Runnable Specialist ${id} not found.`)
       return p
     })
-  } as unknown as ProfileService
+  } as unknown as SpecialistService
 }
 
 // ---------------------------------------------------------------------------
@@ -79,20 +79,20 @@ describe('SessionBindingService.setBinding', () => {
 describe('SessionBindingService.resolve', () => {
   it('resolves builtin bindings through the runnable catalog instead of the custom repository query', async () => {
     const builtin = makeProfile({ id: 'builtin-curator', name: 'BUILTIN_CURATOR', revision: 0 })
-    const profileService = {
+    const specialistService = {
       getById: vi.fn(async () => {
         throw new Error('custom-only query must not be used')
       }),
       resolveRunnableById: vi.fn(async () => builtin)
-    } as unknown as ProfileService
-    const svc = new SessionBindingService(profileService)
+    } as unknown as SpecialistService
+    const svc = new SessionBindingService(specialistService)
     svc.setBinding('restored-session', builtin.id)
 
     await expect(svc.resolve('restored-session')).resolves.toEqual({
       kind: 'bound',
       profile: builtin
     })
-    expect(profileService.getById).not.toHaveBeenCalled()
+    expect(specialistService.getById).not.toHaveBeenCalled()
   })
 
   it("returns 'main' when no binding is recorded", async () => {
@@ -220,7 +220,7 @@ describe('SessionBindingService — None clears binding', () => {
 describe('SessionBindingService — lazy profile update', () => {
   it('reads the latest profile on each resolve (not a cached snapshot)', async () => {
     const profile = makeProfile({ revision: 1, systemPrompt: 'v1' })
-    const catalog = new Map<string, SpecialistProfileView>([['uuid-sp1', profile]])
+    const catalog = new Map<string, SpecialistView>([['uuid-sp1', profile]])
     const svc = new SessionBindingService(makeService(catalog))
     svc.setBinding('session-a', 'uuid-sp1')
 
@@ -246,7 +246,7 @@ describe('SessionBindingService — lazy profile update', () => {
     // changes. Correct behavior: each resolve() call reads the latest catalog on demand; the service
     // holds no subscriber that iterates sessions or triggers any resume operation.
     const profile = makeProfile({ id: 'uuid-sp1', revision: 1 })
-    const catalog = new Map<string, SpecialistProfileView>([['uuid-sp1', profile]])
+    const catalog = new Map<string, SpecialistView>([['uuid-sp1', profile]])
     const svc = new SessionBindingService(makeService(catalog))
     svc.setBinding('session-a', 'uuid-sp1')
 
@@ -275,9 +275,9 @@ describe('SessionBindingService — lazy profile update', () => {
 
 describe('SessionBindingService.resolve — I/O failure discrimination', () => {
   it("returns 'unavailable' with an I/O reason for non-not-found errors", async () => {
-    const brokenService: ProfileService = {
+    const brokenService: SpecialistService = {
       getById: vi.fn().mockRejectedValue(new Error('EACCES: permission denied'))
-    } as unknown as ProfileService
+    } as unknown as SpecialistService
     const svc = new SessionBindingService(brokenService)
     svc.setBinding('session-a', 'uuid-sp1')
 
@@ -339,7 +339,7 @@ describe('SessionBindingService.clearSession — deletion wiring', () => {
 describe('SessionBindingService — restart round-trip simulation', () => {
   it('binding is the new UUID after simulated restart (re-create service with persisted UUID)', async () => {
     const profile = makeProfile({ id: 'uuid-sp2', name: 'RESEARCHER' })
-    const catalog = new Map<string, SpecialistProfileView>([['uuid-sp2', profile]])
+    const catalog = new Map<string, SpecialistView>([['uuid-sp2', profile]])
 
     // First service instance — represents the running app.
     const svc1 = new SessionBindingService(makeService(catalog))

--- a/src/main/specialist/session-binding.ts
+++ b/src/main/specialist/session-binding.ts
@@ -2,7 +2,7 @@
 //
 // Responsibilities:
 //   • Record a mutable Specialist ID binding for each app session (in memory).
-//   • Resolve that binding against the live ProfileService catalog to produce a
+//   • Resolve that binding against the live SpecialistService catalog to produce a
 //     SessionSpecialistResolution (main | bound | unavailable).
 //   • Act as the named seam for the reconfigure barrier: the future SDK
 //     host.agents.switch() will resolve name→UUID and call setBinding() here,
@@ -13,8 +13,8 @@
 // live in-memory view and the resolution logic.
 
 import { createLogger } from '../logger'
-import type { ProfileService } from './service'
-import type { SessionSpecialistResolution, SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistService } from './service'
+import type { SessionSpecialistResolution, SpecialistView } from '../../shared/specialist'
 
 const log = createLogger('specialist.session-binding')
 
@@ -22,7 +22,7 @@ export class SessionBindingService {
   // sessionId → specialist UUID (undefined = no binding = main agent)
   private readonly bindings = new Map<string, string | undefined>()
 
-  constructor(private readonly profileService: ProfileService) {}
+  constructor(private readonly specialistService: SpecialistService) {}
 
   // Records (or clears) the specialist UUID for one session. Persisting the
   // UUID to the session file is the caller's responsibility (IPC handler writes
@@ -56,9 +56,9 @@ export class SessionBindingService {
     const specialistId = overrideSpecialistId ?? this.bindings.get(sessionId)
     if (!specialistId) return { kind: 'main' }
 
-    let profile: SpecialistProfileView | undefined
+    let profile: SpecialistView | undefined
     try {
-      profile = await this.profileService.resolveRunnableById(specialistId)
+      profile = await this.specialistService.resolveRunnableById(specialistId)
     } catch (error) {
       // Distinguish a genuine not-found (profile deleted) from a transient I/O failure (corrupt
       // store, permission error). getById throws "Specialist <id> not found." for missing profiles;

--- a/src/main/specialist/session-reconfiguration.test.ts
+++ b/src/main/specialist/session-reconfiguration.test.ts
@@ -14,8 +14,8 @@ vi.mock('../logger', async (importOriginal) => {
   }
 })
 
-import type { SpecialistProfileView } from '../../shared/specialist'
-import type { ProfileService } from './service'
+import type { SpecialistView } from '../../shared/specialist'
+import type { SpecialistService } from './service'
 import { SessionBindingService } from './session-binding'
 import { SessionSpecialistReconfiguration } from './session-reconfiguration'
 
@@ -29,12 +29,12 @@ const profile = {
   fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
   selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
   revision: 1
-} satisfies SpecialistProfileView
+} satisfies SpecialistView
 
 const bindingService = (): SessionBindingService =>
   new SessionBindingService({
     resolveRunnableById: vi.fn().mockResolvedValue(profile)
-  } as unknown as ProfileService)
+  } as unknown as SpecialistService)
 
 const deferred = (): { promise: Promise<void>; resolve: () => void } => {
   let resolve!: () => void

--- a/src/main/specialist/specialist-identity-injection.test.ts
+++ b/src/main/specialist/specialist-identity-injection.test.ts
@@ -10,7 +10,7 @@ import {
 import { AcpRuntime } from '../acp/runtime.test-utils'
 import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
-import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistView } from '../../shared/specialist'
 import * as acp from '@agentclientprotocol/sdk'
 import { EventEmitter } from 'node:events'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
@@ -171,7 +171,7 @@ const startFakeAgentWithModes = (
 // Profile helpers
 // ---------------------------------------------------------------------------
 
-const makeProfile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
+const makeProfile = (overrides: Partial<SpecialistView> = {}): SpecialistView => ({
   id: 'uuid-sp1',
   name: 'RNA-seq Reviewer',
   description: 'Reviews RNA-seq analysis quality.',

--- a/src/main/specialist/types.ts
+++ b/src/main/specialist/types.ts
@@ -1,4 +1,4 @@
-// Main-process-only stored shapes for the specialist profile store (specialists.json).
+// Main-process-only stored shapes for the specialists.json store.
 // No secret fields; systemPrompt is considered non-secret user content.
 
 import type {

--- a/src/renderer/src/components/app-icons/registry.ts
+++ b/src/renderer/src/components/app-icons/registry.ts
@@ -70,7 +70,7 @@ import { MoleculeIcon, PetriDishIcon } from './custom-glyphs'
 // Lucide export when one fits; add a hand-drawn glyph in ./custom-glyphs otherwise.
 //
 // Icons are chosen to read as a Specialist's identity (a role or discipline), not as
-// app features. Icon keys are persisted (e.g. SpecialistProfileView.iconKey) and must
+// app features. Icon keys are persisted (e.g. SpecialistView.iconKey) and must
 // never be renamed or removed; unknown keys resolve to DEFAULT_APP_ICON. Labels are
 // i18n keys: render them through t(entry.label) — every label needs catalog entries in
 // es / fr / ja / ko / ru / zh-Hans / zh-Hant (the English literal below anchors the

--- a/src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
@@ -139,7 +139,7 @@ describe('ComputeApprovalDialog', () => {
   it.each([
     ['Deny', 'deny'],
     ['Once', 'once'],
-    ['This session', 'conversation']
+    ['This session', 'session']
   ] as const)('keeps the %s approval decision', (label, decision) => {
     useComputeStore.setState({ pendingApprovals: [request] })
     act(() => root.render(<ComputeApprovalDialog />))

--- a/src/renderer/src/pages/settings/ComputeApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ComputeApprovalDialog.tsx
@@ -69,7 +69,7 @@ export function ComputeApprovalDialog({
   }
   const deny = (): void => submitResponse('deny')
   const approveOnce = (): void => submitResponse('once')
-  const approveSession = (): void => submitResponse('conversation')
+  const approveSession = (): void => submitResponse('session')
   const confirmBroadScope = (): void => {
     if (!pendingBroadScope) return
     const { requestId, scope } = pendingBroadScope

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { LinkSafetyModal } from '@/components/streamdown/LinkSafetyModal'
 import { APP } from '../../../../shared/app-config'
 import type { ProviderView } from '../../../../shared/settings'
-import type { SpecialistProfileView } from '../../../../shared/specialist'
+import type { SpecialistView } from '../../../../shared/specialist'
 import { i18next } from '@/i18n'
 import { createInitialComputeState, useComputeStore } from '@/stores/compute-store'
 import { createInitialMemoryState, useMemoryStore } from '@/stores/memory-store'
@@ -3183,7 +3183,7 @@ describe('SettingsPage layout', () => {
   it('opens directly on a specialist editor when the store has a pending specialist', async () => {
     // The switch approval card deep-links to one specialist's editor: the intent is published
     // before the dialog opens, and the catalog resolves that profile.
-    const researcher: SpecialistProfileView = {
+    const researcher: SpecialistView = {
       id: 'spc-1',
       name: 'RESEARCHER',
       displayName: 'Researcher',
@@ -3225,7 +3225,7 @@ describe('SettingsPage layout', () => {
   })
 
   it('navigates from a specialist capability row to the skill detail and back', async () => {
-    const researcher: SpecialistProfileView = {
+    const researcher: SpecialistView = {
       id: 'spc-1',
       name: 'RESEARCHER',
       displayName: 'Researcher',
@@ -3278,7 +3278,7 @@ describe('SettingsPage layout', () => {
   })
 
   it('navigates from a Skill usage popover to Specialist Settings and back', async () => {
-    const researcher: SpecialistProfileView = {
+    const researcher: SpecialistView = {
       id: 'spc-usage',
       name: 'RESEARCHER',
       displayName: 'Researcher',
@@ -3331,7 +3331,7 @@ describe('SettingsPage layout', () => {
   })
 
   it('navigates from a Connector usage popover to Specialist Settings and back', async () => {
-    const researcher: SpecialistProfileView = {
+    const researcher: SpecialistView = {
       id: 'spc-connector-usage',
       name: 'RESEARCHER',
       displayName: 'Researcher',
@@ -3382,7 +3382,7 @@ describe('SettingsPage layout', () => {
   })
 
   it('routes connector capability rows to detail or edit by server kind', async () => {
-    const researcher: SpecialistProfileView = {
+    const researcher: SpecialistView = {
       id: 'spc-2',
       name: 'RESEARCHER',
       displayName: 'Researcher',
@@ -3503,7 +3503,7 @@ describe('SettingsPage layout', () => {
   })
 
   it('keeps unsaved specialist edits across a capability detail round trip', async () => {
-    const researcher: SpecialistProfileView = {
+    const researcher: SpecialistView = {
       id: 'spc-3',
       name: 'RESEARCHER',
       displayName: 'Researcher',

--- a/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
@@ -11,7 +11,7 @@ import { useSpecialistStore } from '@/stores/specialist-store'
 import {
   SPECIALIST_DESCRIPTION_MAX_LENGTH,
   SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH,
-  type SpecialistProfileView
+  type SpecialistView
 } from '../../../../shared/specialist'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -1233,7 +1233,7 @@ describe('SpecialistEditor', () => {
   })
 
   it('restores an unsaved edit after navigating to a detail page and back', async () => {
-    const profile: SpecialistProfileView = {
+    const profile: SpecialistView = {
       id: 'skills-bot',
       name: 'Skills Bot',
       description: 'Original description',
@@ -1332,7 +1332,7 @@ describe('SpecialistEditor', () => {
   })
 
   it('drops the editor draft after a successful save or an explicit cancel', async () => {
-    const profile: SpecialistProfileView = {
+    const profile: SpecialistView = {
       id: 'draft-bot',
       name: 'Draft Bot',
       description: 'Original description',
@@ -1398,7 +1398,7 @@ describe('SpecialistEditor', () => {
   })
 
   it('ignores a stale draft when the specialist revision advanced meanwhile', async () => {
-    const profile: SpecialistProfileView = {
+    const profile: SpecialistView = {
       id: 'stale-bot',
       name: 'Stale Bot',
       description: 'Original description',
@@ -1526,7 +1526,7 @@ describe('SpecialistEditor', () => {
   })
 
   it('clears the editor draft from the store after a successful save', async () => {
-    const profile: SpecialistProfileView = {
+    const profile: SpecialistView = {
       id: 'save-clears-draft',
       name: 'Save Clears Draft',
       description: 'Original',

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -26,7 +26,7 @@ import {
   type CreateSpecialistInput,
   type UpdateSpecialistInput,
   type SpecialistFieldError,
-  type SpecialistProfileView
+  type SpecialistView
 } from '../../../../shared/specialist'
 import { SpecialistAvatar } from './specialist-avatar'
 import { AVATAR_COLORS, SPECIALIST_COLOR_OPTIONS } from './specialist-icons'
@@ -42,12 +42,12 @@ type SpecialistEditorProps = {
   // Edit mode: when provided, the form is prefilled from this profile and Save
   // calls onSaveEdit (with id + revision for optimistic concurrency) instead of
   // onSave.
-  editSpecialist?: SpecialistProfileView
+  editSpecialist?: SpecialistView
   initialInput?: CreateSpecialistInput
   onSaveEdit?: (input: UpdateSpecialistInput) => Promise<void>
   // Called when the user clicks "Reload" after a revision conflict.
   // Should fetch the latest profile from the store and return it.
-  onReload?: () => Promise<SpecialistProfileView | undefined>
+  onReload?: () => Promise<SpecialistView | undefined>
   // Called when a selected Skill row is clicked to view that Skill in Settings.
   onOpenSkillDetail?: (skillId: string) => void
   // Called when a selected Connector row is clicked to view that Connector in

--- a/src/renderer/src/pages/settings/useSpecialistEditorForm.ts
+++ b/src/renderer/src/pages/settings/useSpecialistEditorForm.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
-import type { CreateSpecialistInput, SpecialistProfileView } from '../../../../shared/specialist'
+import type { CreateSpecialistInput, SpecialistView } from '../../../../shared/specialist'
 import {
   CREATE_SPECIALIST_DRAFT_KEY,
   useSpecialistStore,
@@ -8,7 +8,7 @@ import {
 
 // Seeds a form from a stored profile. Used both at mount (edit mode) and after an
 // explicit Reload following a revision conflict.
-export const formFromProfile = (profile: SpecialistProfileView): SpecialistEditorFormDraft => ({
+export const formFromProfile = (profile: SpecialistView): SpecialistEditorFormDraft => ({
   id: profile.id,
   name: profile.displayName ?? profile.name,
   packageVersion: profile.packageVersion ?? '0.1.0',
@@ -45,7 +45,7 @@ export const formFromCreateInput = (
 })
 
 type UseSpecialistEditorFormOptions = {
-  editSpecialist?: SpecialistProfileView
+  editSpecialist?: SpecialistView
   initialInput?: CreateSpecialistInput
 }
 

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.specialist-delete.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.specialist-delete.render.test.tsx
@@ -3,14 +3,14 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AcpPermissionRequest } from '../../../../shared/acp'
-import type { SpecialistProfileView } from '../../../../shared/specialist'
+import type { SpecialistView } from '../../../../shared/specialist'
 import { useSpecialistStore } from '@/stores/specialist-store'
 
 import { PermissionApprovalControls } from './PermissionApprovalControls'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
-const sqlProfile: SpecialistProfileView = {
+const sqlProfile: SpecialistView = {
   id: 'spc-sql',
   name: 'SQL_WRANGLER',
   displayName: 'SQL Wrangler',

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.specialist-switch.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.specialist-switch.render.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AcpPermissionRequest } from '../../../../shared/acp'
-import type { SpecialistProfileView } from '../../../../shared/specialist'
+import type { SpecialistView } from '../../../../shared/specialist'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { useSettingsStore } from '@/stores/settings-store'
 
@@ -11,7 +11,7 @@ import { PermissionApprovalControls } from './PermissionApprovalControls'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
-const researchProfile: SpecialistProfileView = {
+const researchProfile: SpecialistView = {
   id: 'spc-1',
   name: 'RESEARCHER',
   displayName: 'Researcher',
@@ -60,7 +60,7 @@ afterEach(() => {
   container.remove()
 })
 
-const statisticianProfile: SpecialistProfileView = {
+const statisticianProfile: SpecialistView = {
   id: 'spc-2',
   name: 'STATISTICIAN',
   displayName: 'Statistician',

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
@@ -18,7 +18,7 @@ import {
 import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
-import type { SpecialistListItem, SpecialistProfileView } from '../../../../shared/specialist'
+import type { SpecialistListItem, SpecialistView } from '../../../../shared/specialist'
 
 type RunnableSpecialistItem = Exclude<SpecialistListItem, { kind: 'reviewer' }>
 
@@ -36,7 +36,7 @@ type SpecialistSubmenuProps = {
 // "Unavailable" otherwise. Kept compact so the trigger never wraps. Takes the
 // resolved strings rather than calling t() so it stays a pure helper.
 const capsuleLabel = (
-  selected: SpecialistProfileView | undefined,
+  selected: SpecialistView | undefined,
   unavailable: boolean,
   labels: { none: string; unavailable: string }
 ): string => {

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -2,7 +2,7 @@ import { create, type StoreApi } from 'zustand'
 import type {
   SpecialistListItem,
   SpecialistDocumentIntegrity,
-  SpecialistProfileView,
+  SpecialistView,
   CreateSpecialistInput,
   UpdateSpecialistInput
 } from '../../../shared/specialist'
@@ -55,8 +55,8 @@ type SpecialistStoreData = {
 
 type SpecialistStoreActions = {
   load: () => Promise<void>
-  create: (input: CreateSpecialistInput) => Promise<SpecialistProfileView>
-  update: (input: UpdateSpecialistInput) => Promise<SpecialistProfileView>
+  create: (input: CreateSpecialistInput) => Promise<SpecialistView>
+  update: (input: UpdateSpecialistInput) => Promise<SpecialistView>
   setEnabled: (id: string, enabled: boolean) => Promise<void>
   previewDelete: (id: string) => Promise<SpecialistDeletePreview>
   delete: (

--- a/src/shared/agents-contract.ts
+++ b/src/shared/agents-contract.ts
@@ -90,7 +90,7 @@ export type AgentsReadRequest =
 
 // Placeholder write/switch ops. Their params intentionally mirror design.md §4/§5 and PRD §2/§4
 // (snake_case fields). They are UNVALIDATED beyond shape here on purpose: the real mutation modules
-// (issues 03/04/05) own the domain validation against ProfileService. We only enforce that an
+// (issues 03/04/05) own the domain validation against SpecialistService. We only enforce that an
 // unknown op is rejected and that a recognized op is allowed through, so the dispatcher union is
 // the extension point.
 export type AgentsWriteRequest =

--- a/src/shared/compute.ts
+++ b/src/shared/compute.ts
@@ -268,10 +268,15 @@ export type ComputeCallError = {
   retry_after_user_action: boolean
 }
 
-// Broker-owned durable scopes. `conversation` remains the wire value for compatibility, but is
-// presented and persisted as a Session grant; Agent ACP adapters still receive only allow-once.
-export type ComputeApprovalScope = 'once' | 'conversation' | 'project' | 'global'
+// Broker-owned durable scopes. Legacy clients may still submit `conversation`; transport adapters
+// normalize it to `session` before the decision enters the broker.
+export type ComputeApprovalScope = 'once' | 'session' | 'project' | 'global'
 export type ComputeApprovalDecision = ComputeApprovalScope | 'deny'
+export type ComputeApprovalDecisionInput = ComputeApprovalDecision | 'conversation'
+
+export const normalizeComputeApprovalDecision = (
+  decision: ComputeApprovalDecisionInput
+): ComputeApprovalDecision => (decision === 'conversation' ? 'session' : decision)
 
 // Approval request broadcast from main to the renderer for a compute:call_command invocation.
 // provider_name is the human-readable display name; shape is the host topology string.

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -371,7 +371,7 @@ import type {
   SetSpecialistEnabledRequest,
   DuplicateSpecialistRequest,
   SpecialistCatalogSnapshot,
-  SpecialistProfileView,
+  SpecialistView,
   SetSessionSpecialistRequest,
   SetSessionSpecialistResponse,
   ResolveSessionSpecialistRequest,
@@ -1824,9 +1824,10 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'specialist.cancelPackage': callable<
     (request: SpecialistPackageInstallRequest) => Promise<void>
   >()('specialist', ['specialist:package-cancel', ELECTRON]),
-  'specialist.create': callable<
-    (request: CreateSpecialistRequest) => Promise<SpecialistProfileView>
-  >()('specialist', ['specialist:create', ELECTRON]),
+  'specialist.create': callable<(request: CreateSpecialistRequest) => Promise<SpecialistView>>()(
+    'specialist',
+    ['specialist:create', ELECTRON]
+  ),
   'specialist.delete': callable<
     (request: SpecialistDeleteRequest) => Promise<SpecialistDeleteResult>
   >()('specialist', ['specialist:delete', ELECTRON]),
@@ -1900,14 +1901,15 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     () => Promise<{ cancelled: true } | SpecialistPackageCandidatePreview>
   >()('specialist', ['specialist:package-select', ELECTRON]),
   'specialist.setEnabled': callable<
-    (request: SetSpecialistEnabledRequest) => Promise<SpecialistProfileView>
+    (request: SetSpecialistEnabledRequest) => Promise<SpecialistView>
   >()('specialist', ['specialist:set-enabled', ELECTRON]),
   'specialist.setSessionSpecialist': callable<
     (request: SetSessionSpecialistRequest) => Promise<SetSessionSpecialistResponse>
   >()('specialist', ['specialist:set-session-specialist', ELECTRON]),
-  'specialist.update': callable<
-    (request: UpdateSpecialistRequest) => Promise<SpecialistProfileView>
-  >()('specialist', ['specialist:update', ELECTRON]),
+  'specialist.update': callable<(request: UpdateSpecialistRequest) => Promise<SpecialistView>>()(
+    'specialist',
+    ['specialist:update', ELECTRON]
+  ),
   'storage.cancelMigrate': callable<() => Promise<void>>()('storage', [
     'storage:cancel-migrate',
     LOCAL

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -652,7 +652,7 @@ export type PersistedChatSession = {
   // value; only the dedicated archive command changes it.
   archivedAt?: number
   // Desired Specialist ID for this Session. Absent means Main Agent. The Profile is resolved fresh
-  // from ProfileService before every turn via the ID.
+  // from SpecialistService before every turn via the ID.
   specialistId?: string
   // Main-owned commit marker. True means the desired binding above is durable, but the live Agent
   // runtime has not yet confirmed that it applied the same target. User prompts fail closed until
@@ -3878,7 +3878,7 @@ const sanitizeSession = (
   if (hasSelectedComputeHosts || enabledComputeHosts.length > 0) {
     sanitized.selectedComputeHosts = selectedComputeHosts
   }
-  // Specialist ID: accept any non-empty string. The main process validates it against ProfileService
+  // Specialist ID: accept any non-empty string. The main process validates it against SpecialistService
   // at send time; the sanitizer only ensures the value is safe to re-persist.
   const specialistId = asString(session.specialistId)
   if (specialistId) sanitized.specialistId = specialistId

--- a/src/shared/specialist-package.ts
+++ b/src/shared/specialist-package.ts
@@ -220,7 +220,7 @@ export type SpecialistPackageSkillConflictResolution = {
 }
 
 export type SpecialistPackageInstallResult =
-  | { status: 'installed'; specialist: import('./specialist').SpecialistProfileView }
+  | { status: 'installed'; specialist: import('./specialist').SpecialistView }
   | {
       status: 'failed'
       code:

--- a/src/shared/specialist.ts
+++ b/src/shared/specialist.ts
@@ -1,4 +1,4 @@
-// Shared types and validation for Personal Specialist Profiles.
+// Shared types and validation for reusable Specialists.
 // All mutation rules live here so Settings, SDK, and runtime share one contract.
 
 import { RESOURCE_ID_MAX_LENGTH, inferResourceId, validateResourceId } from './resource-id'
@@ -79,7 +79,7 @@ export type PendingSwitchBroadcast = {
   targetName: string | null
 }
 
-// Session switching request types — resolution type is declared after SpecialistProfileView below.
+// Session switching request types — resolution type is declared after SpecialistView below.
 export type SetSessionSpecialistRequest = {
   sessionId: string
   // undefined clears the binding (reverts to Main Agent).
@@ -160,8 +160,7 @@ export type SpecialistMarketplaceProvenance = {
 // session. Full access includes future entries by construction, while selected is an explicit list.
 export const resolveEffectiveSpecialistSkills = (
   specialist:
-    | Pick<SpecialistProfileView, 'capabilityMode' | 'fullAccess' | 'selectedCapabilities'>
-    | undefined,
+    Pick<SpecialistView, 'capabilityMode' | 'fullAccess' | 'selectedCapabilities'> | undefined,
   catalog: SpecialistSkillCatalogEntry[]
 ): EffectiveSpecialistSkills => {
   if (specialist === undefined) return { kind: 'main' }
@@ -197,7 +196,7 @@ export const resolveEffectiveSpecialistSkills = (
 // The per-call ConnectorService gate enforces the same config at execution time.
 export const filterSpecialistConnectorSkills = (
   connectorSkillNames: string[],
-  specialist: Pick<SpecialistProfileView, 'capabilityMode' | 'fullAccess' | 'selectedCapabilities'>
+  specialist: Pick<SpecialistView, 'capabilityMode' | 'fullAccess' | 'selectedCapabilities'>
 ): string[] => {
   const isAllowed =
     specialist.capabilityMode === 'full'
@@ -209,8 +208,8 @@ export const filterSpecialistConnectorSkills = (
   })
 }
 
-// Renderer-safe view of one specialist profile (no secret fields).
-export type SpecialistProfileView = {
+// Renderer-safe view of one Specialist (no secret fields).
+export type SpecialistView = {
   id: string
   name: string // immutable-reference-safe public UPPER_SNAKE identifier
   displayName?: string
@@ -253,12 +252,12 @@ export type BuiltinSpecialistEntry = {
   kind: 'builtin'
   readonly: true
   version: string
-} & SpecialistProfileView
+} & SpecialistView
 
 // Exhaustive Settings/runtime catalog discriminant. Reviewer remains a placeholder, never a
-// runnable profile.
+// runnable Specialist.
 export type SpecialistListItem =
-  ({ kind: 'custom' } & SpecialistProfileView) | BuiltinSpecialistEntry | ReviewerEntry
+  ({ kind: 'custom' } & SpecialistView) | BuiltinSpecialistEntry | ReviewerEntry
 
 export type SpecialistDocumentIntegrityIssue = Readonly<{
   code:
@@ -284,13 +283,13 @@ export type SpecialistCatalogSnapshot = Readonly<{
   integrity: SpecialistDocumentIntegrity
 }>
 
-// Resolution of a session's specialist binding at send time (requires SpecialistProfileView above).
+// Resolution of a session's specialist binding at send time (requires SpecialistView above).
 // 'main'        — no binding, main agent is used.
-// 'bound'       — a valid enabled profile was found.
+// 'bound'       — a valid enabled Specialist was found.
 // 'unavailable' — the bound Specialist ID is unknown, disabled, or corrupt (send must be blocked).
 export type SessionSpecialistResolution =
   | { kind: 'main' }
-  | { kind: 'bound'; profile: SpecialistProfileView }
+  | { kind: 'bound'; profile: SpecialistView }
   | { kind: 'unavailable'; reason: string }
 
 // Input for creating a new specialist.


### PR DESCRIPTION
## Problem

The same domain concepts had multiple names at active boundaries:

- `Session` and `Conversation` crossed persistence, public APIs, and Compute approval scopes.
- Reusable Specialist configuration appeared as `agent`, `profile`, and `specialist`, most visibly in the `host.agents` adapter.

This becomes risky when a change crosses one of those boundaries: a contributor can treat a Conversation Graph as the durable workspace owner, persist a transport-only scope name, or treat reusable Specialist configuration as the running Agent. Leaving it unresolved increases the chance of duplicate ownership models, incompatible approval handling, and misleading APIs.

Canonical meanings used by this change:

- **Session** — durable research/workspace container.
- **Conversation Graph** — the internal message and execution graph owned by a Session.
- **Agent** — a running execution subject.
- **Specialist** — reusable instructions and capability configuration applied to an Agent.
- **Profile** — a qualified implementation/persistence/provider term, not the standalone Specialist domain name.

## Proposed change

- Make `session` the canonical in-process Compute approval scope.
- Continue accepting legacy `conversation` input at Electron and application-command boundaries, then normalize it immediately.
- Rename the Specialist-domain service, renderer-safe view, `host.agents` read models, dependency fields, and delegated-parent identifier to Specialist terminology.
- Update direct consumers and tests without changing runtime behavior.

## Scope and non-goals

- No new data fields, Prisma/SQLite schema changes, migrations, or `specialists.json` changes.
- No new durable lifecycle/status enum values.
- No UI flow or displayed-copy changes.
- No dependency changes.
- No rename of public `host.agents` methods, IPC channels, JSON keys, package schema keys, or persisted Session fields.
- No big-bang rename of historical persistence implementation names such as `PersistedChatSession`.

## Historical compatibility, persistence, and state

- Existing clients that send Compute approval decision `conversation` remain compatible at both supported transport boundaries.
- Existing durable Compute grants already use Permission Grant scope `{ kind: "session" }`; their storage format is unchanged and no data migration is required.
- The canonical TypeScript decision union replaces internal `conversation` with `session`; the boundary input union temporarily accepts both. This is input compatibility, not a new persisted state.

## Acceptance criteria and validation

- Canonical Compute scope and legacy normalization -> `npm run test:module -- compute_service` -> 31 files passed, 1 skipped; 824 tests passed, 6 skipped.
- Specialist service/read-model boundary and direct owner consumers -> focused Vitest command for Specialist and `host.agents` owners -> 7 files passed; 212 tests passed.
- Specialist package and delegated-work consumers -> focused Vitest command -> 4 files passed; 164 tests passed.
- Renderer consumers and approval interaction -> focused Vitest command -> 5 files passed; 156 tests passed.
- Main/shared compile surface -> `npm run typecheck:node` -> passed.
- Renderer/shared compile surface -> `npm run typecheck:web` -> passed.
- Changed TypeScript/TSX files -> ESLint with `--no-cache` -> passed.
- Final changed files -> Prettier check and `git diff --check` -> passed.

`test:affected:explain` selects the full CI plan because mechanically renamed integration-test files do not all have a declared module owner. Per maintainer direction, the complete portable/platform matrix is left to the exact-head PR Gate rather than running the full local `npm test` suite.

## Review focus

- Confirm `conversation` appears only in the explicit legacy input compatibility path and its tests.
- Confirm renamed Specialist symbols do not alter public wire shapes or serialized fields.
- Confirm the test-impact mapping covers the final diff; independent review is still required before treating the change as fully verified.
