### PR TITLE
fix(notifications): enforce mobile message-center modality

### DIFF
--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -67,6 +67,35 @@ const stubMobileViewport = (): void => {
   )
 }
 
+const stubMutableViewport = (): { setMobile: (mobile: boolean) => void } => {
+  let matches = false
+  const listeners = new Set<() => void>()
+  const media = {
+    get matches() {
+      return matches
+    },
+    media: '(max-width: 47.999rem)',
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn((_event: string, listener: () => void) => listeners.add(listener)),
+    removeEventListener: vi.fn((_event: string, listener: () => void) =>
+      listeners.delete(listener)
+    ),
+    dispatchEvent: vi.fn()
+  }
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => media)
+  )
+  return {
+    setMobile: (mobile) => {
+      matches = mobile
+      listeners.forEach((listener) => listener())
+    }
+  }
+}
+
 describe('NotificationBell', () => {
   it('renders a red-dot entry point with an accessible unread count and pending state', async () => {
     await act(async () => root.render(<NotificationBell />))
@@ -669,5 +698,30 @@ describe('NotificationBell', () => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
     })
     expect(document.activeElement).toBe(visibleTrigger)
+  })
+
+  it('moves focus into an open message center when the viewport becomes mobile', async () => {
+    const viewport = stubMutableViewport()
+    container.id = 'root'
+    await act(async () => root.render(<NotificationBell />))
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')
+    trigger?.focus()
+    await act(async () => trigger?.click())
+    expect(
+      document.body
+        .querySelector<HTMLElement>('[aria-label="Message center"]')
+        ?.hasAttribute('aria-modal')
+    ).toBe(false)
+
+    await act(async () => viewport.setMobile(true))
+
+    const dialog = document.body.querySelector<HTMLElement>('[aria-label="Message center"]')
+    expect(dialog?.getAttribute('aria-modal')).toBe('true')
+    expect(container.inert).toBe(true)
+    expect(dialog?.contains(document.activeElement)).toBe(true)
+
+    await act(async () => trigger?.focus())
+    expect(dialog?.contains(document.activeElement)).toBe(true)
   })
 })

--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -700,6 +700,44 @@ describe('NotificationBell', () => {
     expect(document.activeElement).toBe(visibleTrigger)
   })
 
+  it('restores a visible bell when an open mobile message center unmounts', async () => {
+    stubMobileViewport()
+    container.id = 'root'
+    await act(async () =>
+      root.render(
+        <>
+          <NotificationBell key="route-bell" />
+          <NotificationBell key="persistent-bell" />
+        </>
+      )
+    )
+
+    const [routeTrigger, persistentTrigger] = container.querySelectorAll<HTMLButtonElement>(
+      '[data-notification-bell-trigger="true"]'
+    )
+    persistentTrigger!.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 36,
+        height: 36,
+        top: 0,
+        right: 36,
+        bottom: 36,
+        left: 0,
+        toJSON: () => ({})
+      }) as DOMRect
+    routeTrigger?.focus()
+    await act(async () => routeTrigger?.click())
+
+    await act(async () => root.render(<NotificationBell key="persistent-bell" />))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(document.activeElement).toBe(persistentTrigger)
+  })
+
   it('moves focus into an open message center when the viewport becomes mobile', async () => {
     const viewport = stubMutableViewport()
     container.id = 'root'

--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -700,43 +700,51 @@ describe('NotificationBell', () => {
     expect(document.activeElement).toBe(visibleTrigger)
   })
 
-  it('restores a visible bell when an open mobile message center unmounts', async () => {
-    stubMobileViewport()
-    container.id = 'root'
-    await act(async () =>
-      root.render(
-        <>
-          <NotificationBell key="route-bell" />
-          <NotificationBell key="persistent-bell" />
-        </>
+  it.each([
+    ['while still mobile', false],
+    ['after becoming desktop', true]
+  ])(
+    'restores a visible bell when an open mobile center unmounts %s',
+    async (_, becomesDesktop) => {
+      const viewport = stubMutableViewport()
+      viewport.setMobile(true)
+      container.id = 'root'
+      await act(async () =>
+        root.render(
+          <>
+            <NotificationBell key="route-bell" />
+            <NotificationBell key="persistent-bell" />
+          </>
+        )
       )
-    )
 
-    const [routeTrigger, persistentTrigger] = container.querySelectorAll<HTMLButtonElement>(
-      '[data-notification-bell-trigger="true"]'
-    )
-    persistentTrigger!.getBoundingClientRect = () =>
-      ({
-        x: 0,
-        y: 0,
-        width: 36,
-        height: 36,
-        top: 0,
-        right: 36,
-        bottom: 36,
-        left: 0,
-        toJSON: () => ({})
-      }) as DOMRect
-    routeTrigger?.focus()
-    await act(async () => routeTrigger?.click())
+      const [routeTrigger, persistentTrigger] = container.querySelectorAll<HTMLButtonElement>(
+        '[data-notification-bell-trigger="true"]'
+      )
+      persistentTrigger!.getBoundingClientRect = () =>
+        ({
+          x: 0,
+          y: 0,
+          width: 36,
+          height: 36,
+          top: 0,
+          right: 36,
+          bottom: 36,
+          left: 0,
+          toJSON: () => ({})
+        }) as DOMRect
+      routeTrigger?.focus()
+      await act(async () => routeTrigger?.click())
+      if (becomesDesktop) await act(async () => viewport.setMobile(false))
 
-    await act(async () => root.render(<NotificationBell key="persistent-bell" />))
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0))
-    })
+      await act(async () => root.render(<NotificationBell key="persistent-bell" />))
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
 
-    expect(document.activeElement).toBe(persistentTrigger)
-  })
+      expect(document.activeElement).toBe(persistentTrigger)
+    }
+  )
 
   it('moves focus into an open message center when the viewport becomes mobile', async () => {
     const viewport = stubMutableViewport()

--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -626,4 +626,48 @@ describe('NotificationBell', () => {
     await act(async () => dismiss?.click())
     expect(document.activeElement).toBe(trigger)
   })
+
+  it('restores a visible bell when the mobile opener becomes inert', async () => {
+    stubMobileViewport()
+    container.id = 'root'
+    await act(async () =>
+      root.render(
+        <>
+          <div data-testid="mobile-sidebar">
+            <NotificationBell
+              onOpen={() =>
+                container.querySelector('[data-testid="mobile-sidebar"]')?.setAttribute('inert', '')
+              }
+            />
+          </div>
+          <NotificationBell />
+        </>
+      )
+    )
+
+    const [sidebarTrigger, visibleTrigger] = container.querySelectorAll<HTMLButtonElement>(
+      '[data-notification-bell-trigger="true"]'
+    )
+    const visibleRect = (): DOMRect =>
+      ({
+        x: 0,
+        y: 0,
+        width: 36,
+        height: 36,
+        top: 0,
+        right: 36,
+        bottom: 36,
+        left: 0,
+        toJSON: () => ({})
+      }) as DOMRect
+    sidebarTrigger!.getBoundingClientRect = visibleRect
+    visibleTrigger!.getBoundingClientRect = visibleRect
+    sidebarTrigger?.focus()
+    await act(async () => sidebarTrigger?.click())
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(document.activeElement).toBe(visibleTrigger)
+  })
 })

--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -584,4 +584,46 @@ describe('NotificationBell', () => {
     await act(async () => close?.click())
     expect(trigger?.getAttribute('aria-expanded')).toBe('false')
   })
+
+  it('keeps mobile message-center focus modal and restores its trigger on dismissal', async () => {
+    stubMobileViewport()
+    container.id = 'root'
+    await act(async () =>
+      root.render(
+        <>
+          <button type="button">Background action</button>
+          <NotificationBell />
+        </>
+      )
+    )
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')
+    trigger?.focus()
+    await act(async () => trigger?.click())
+
+    const dialog = document.body.querySelector<HTMLElement>('[aria-label="Message center"]')
+    expect(container.inert).toBe(true)
+    expect(container.getAttribute('aria-hidden')).toBe('true')
+    expect(dialog?.contains(document.activeElement)).toBe(true)
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button')?.focus()
+    })
+    expect(dialog?.contains(document.activeElement)).toBe(true)
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(document.activeElement).toBe(trigger)
+    expect(container.inert).toBe(false)
+    expect(container.getAttribute('aria-hidden')).toBeNull()
+
+    trigger?.focus()
+    await act(async () => trigger?.click())
+    const dismiss = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Dismiss messages"]'
+    )
+    await act(async () => dismiss?.click())
+    expect(document.activeElement).toBe(trigger)
+  })
 })

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -237,14 +237,7 @@ const NotificationBellContent = ({
     }
   }, [isMobile, open])
 
-  useEffect(() => {
-    if (open && isMobile) {
-      mobileWasOpenRef.current = true
-      return
-    }
-    if (open || !mobileWasOpenRef.current) return
-    mobileWasOpenRef.current = false
-
+  const restoreMobileFocus = useCallback((): void => {
     const activeElement = document.activeElement
     if (
       activeElement instanceof HTMLElement &&
@@ -262,7 +255,17 @@ const NotificationBellContent = ({
             document.querySelectorAll<HTMLElement>('[data-notification-bell-trigger="true"]')
           ).find(isVisibleNotificationBell)
     returnFocusTarget?.focus()
-  }, [isMobile, open])
+  }, [])
+
+  useEffect(() => {
+    if (open && isMobile) {
+      mobileWasOpenRef.current = true
+      return
+    }
+    if (open || !mobileWasOpenRef.current) return
+    mobileWasOpenRef.current = false
+    restoreMobileFocus()
+  }, [isMobile, open, restoreMobileFocus])
 
   useEffect(() => {
     const openFromLiveToast = (event: Event): void => {
@@ -394,7 +397,10 @@ const NotificationBellContent = ({
                 onMountAutoFocus={(event) => {
                   if (!isMobile) event.preventDefault()
                 }}
-                onUnmountAutoFocus={(event) => event.preventDefault()}
+                onUnmountAutoFocus={(event) => {
+                  event.preventDefault()
+                  if (isMobile) restoreMobileFocus()
+                }}
               >
                 <div
                   className={cn(

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -133,6 +133,7 @@ const NotificationBellContent = ({
   const triggerRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
   const mobileWasOpenRef = useRef(false)
+  const previousIsMobileRef = useRef(isMobile)
   const [position, setPosition] = useState<CSSProperties>({
     left: VIEWPORT_MARGIN,
     top: VIEWPORT_MARGIN
@@ -209,6 +210,12 @@ const NotificationBellContent = ({
     if (!open) return
     if (!isMobile) updatePanelPosition()
   }, [isMobile, open, updatePanelPosition])
+
+  useEffect(() => {
+    const becameMobile = isMobile && !previousIsMobileRef.current
+    previousIsMobileRef.current = isMobile
+    if (open && becameMobile) panelRef.current?.focus()
+  }, [isMobile, open])
 
   useEffect(() => {
     if (!open || !isMobile) return

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -2,6 +2,7 @@
  * states: default · hover · focus · active · disabled · loading · error · success
  * contrast: pass (40–41) · pre-emit critique: P5 H5 E5 S5 R5 V4
  */
+import { FocusScope } from '@radix-ui/react-focus-scope'
 import { Bell, CheckCheck, X } from 'lucide-react'
 import {
   type CSSProperties,
@@ -131,6 +132,7 @@ const NotificationBellContent = ({
   const rootRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
+  const mobileWasOpenRef = useRef(false)
   const [position, setPosition] = useState<CSSProperties>({
     left: VIEWPORT_MARGIN,
     top: VIEWPORT_MARGIN
@@ -205,17 +207,48 @@ const NotificationBellContent = ({
 
   useLayoutEffect(() => {
     if (!open) return
-    if (isMobile) panelRef.current?.focus()
-    else updatePanelPosition()
+    if (!isMobile) updatePanelPosition()
   }, [isMobile, open, updatePanelPosition])
 
   useEffect(() => {
     if (!open || !isMobile) return
     const previousOverflow = document.body.style.overflow
+    const appRoot = document.getElementById('root')
+    const previousAriaHidden = appRoot?.getAttribute('aria-hidden') ?? null
+    const previousInert = appRoot?.inert ?? false
     document.body.style.overflow = 'hidden'
+    if (appRoot) {
+      appRoot.inert = true
+      appRoot.setAttribute('aria-hidden', 'true')
+    }
     return () => {
       document.body.style.overflow = previousOverflow
+      if (!appRoot) return
+      appRoot.inert = previousInert
+      if (previousAriaHidden === null) appRoot.removeAttribute('aria-hidden')
+      else appRoot.setAttribute('aria-hidden', previousAriaHidden)
     }
+  }, [isMobile, open])
+
+  useEffect(() => {
+    if (open && isMobile) {
+      mobileWasOpenRef.current = true
+      return
+    }
+    if (open || !mobileWasOpenRef.current) return
+    mobileWasOpenRef.current = false
+
+    const activeElement = document.activeElement
+    if (
+      activeElement instanceof HTMLElement &&
+      activeElement !== document.body &&
+      document.contains(activeElement)
+    ) {
+      return
+    }
+
+    const trigger = triggerRef.current
+    if (trigger?.isConnected && !trigger.closest('[inert]')) trigger.focus()
   }, [isMobile, open])
 
   useEffect(() => {
@@ -329,7 +362,7 @@ const NotificationBellContent = ({
                   className="fixed inset-0 z-[80] bg-black/45 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-200 active:bg-black/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring motion-reduce:animate-none"
                 />
               ) : null}
-              <div
+              <FocusScope
                 ref={panelRef}
                 id={panelId}
                 role="dialog"
@@ -343,6 +376,12 @@ const NotificationBellContent = ({
                     ? 'inset-x-0 bottom-0 z-[90] flex h-[min(82dvh,760px)] w-full max-w-full flex-col rounded-t-2xl border-b-0 pb-[env(safe-area-inset-bottom)] shadow-dialog motion-safe:animate-in motion-safe:slide-in-from-bottom motion-safe:duration-200 motion-reduce:animate-none'
                     : 'z-modal rounded-xl shadow-menu'
                 )}
+                loop={isMobile}
+                trapped={isMobile}
+                onMountAutoFocus={(event) => {
+                  if (!isMobile) event.preventDefault()
+                }}
+                onUnmountAutoFocus={(event) => event.preventDefault()}
               >
                 <div
                   className={cn(
@@ -361,10 +400,7 @@ const NotificationBellContent = ({
                       <button
                         type="button"
                         aria-label={t('Close messages')}
-                        onClick={() => {
-                          setOpen(false)
-                          triggerRef.current?.focus()
-                        }}
+                        onClick={() => setOpen(false)}
                         className="inline-flex size-11 shrink-0 items-center justify-center rounded-lg text-text-300 transition-colors duration-150 ease-out hover:bg-bg-300 hover:text-text-000 active:bg-bg-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg-000"
                       >
                         <X className="size-5" strokeWidth={2} aria-hidden="true" />
@@ -524,7 +560,7 @@ const NotificationBellContent = ({
                     ))
                   )}
                 </div>
-              </div>
+              </FocusScope>
             </>,
             document.body
           )

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -248,7 +248,13 @@ const NotificationBellContent = ({
     }
 
     const trigger = triggerRef.current
-    if (trigger?.isConnected && !trigger.closest('[inert]')) trigger.focus()
+    const returnFocusTarget =
+      trigger?.isConnected && !trigger.closest('[inert], [aria-hidden="true"]')
+        ? trigger
+        : Array.from(
+            document.querySelectorAll<HTMLElement>('[data-notification-bell-trigger="true"]')
+          ).find(isVisibleNotificationBell)
+    returnFocusTarget?.focus()
   }, [isMobile, open])
 
   useEffect(() => {

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -399,7 +399,7 @@ const NotificationBellContent = ({
                 }}
                 onUnmountAutoFocus={(event) => {
                   event.preventDefault()
-                  if (isMobile) restoreMobileFocus()
+                  if (mobileWasOpenRef.current) restoreMobileFocus()
                 }}
               >
                 <div

--- a/src/renderer/src/components/notification-bell-events.ts
+++ b/src/renderer/src/components/notification-bell-events.ts
@@ -4,6 +4,7 @@ export const NOTIFICATION_CENTER_OPENED_EVENT = 'open-science:notification-cente
 export type OpenNotificationCenterDetail = Readonly<{ bellId?: string }>
 
 export const isVisibleNotificationBell = (element: HTMLElement): boolean => {
+  if (element.closest('[inert], [aria-hidden="true"]')) return false
   const rect = element.getBoundingClientRect()
   const style = window.getComputedStyle(element)
   return (


### PR DESCRIPTION
## Problem

On mobile, the message center declares `role="dialog"` and `aria-modal="true"`, but previously only locked body scrolling. Keyboard focus could move into the obscured application, dismissal did not always restore a usable bell trigger, and responsive or navigation transitions could leave focus on `document.body` or outside the modal.

## Proposed change

- Let Radix `FocusScope` own mobile initial focus, focus trapping, and focus looping.
- Mark the application root `inert` and `aria-hidden` while the portaled mobile drawer is open, restoring its prior values on close.
- Restore the invoking bell after mobile dismissal, or fall back to another visible bell when the opener becomes inert or unmounts during navigation.
- Preserve focus restoration if a mobile center crosses to desktop before unmounting.
- Exclude inert and `aria-hidden` notification bells from fallback visibility checks.
- Move focus into an already-open center when it transitions from desktop to mobile modality.
- Add public interaction regressions for background focus, Escape and overlay dismissal, inert and unmounted openers, and breakpoint transitions.

## Scope and non-goals

- Desktop message-center behavior and positioning are unchanged.
- No dependencies or user-visible copy are added.
- No architecture, data fields, enum values, data models, migrations, or persistence behavior change.
- No historical-data compatibility work is required.

## Acceptance criteria and validation

The regression tests were first confirmed to fail on the pre-fix implementation for the reported focus-isolation and focus-restoration behavior.

| Affected behavior | Final check | Result |
| --- | --- | --- |
| Mobile modality, dismissal, fallback focus restoration, responsive transitions, and unmount lifecycle | `npx --no-install vitest run src/renderer/src/components/NotificationBell.test.tsx` | 29 passed |
| Renderer type safety | `npm run typecheck:web` | Passed |
| Lint rules | `npm run lint` | Passed |
| Final impact classification | `npm run test:affected:explain -- --base origin/main --head HEAD` | Full plan selected because this shared component has no module owner; complete coverage delegated to PR Gate per maintainer direction |

All listed passing checks ran after the last material edit.

PR Gate passed static checks, both full module-test shards, module coverage, Windows core, and macOS build/E2E. Its remaining Windows E2E failure is unrelated to the notification center: one settings-persistence test passed only on retry and the workspace message-tool layout test timed out without opening this surface.

Uncovered risk: browser-level manual verification was unavailable because the in-app browser blocked localhost navigation. The retained component tests exercise the actual DOM focus, responsive, dismissal, and unmount boundaries.

## Review focus

Please review `FocusScope` lifecycle timing, background-isolation cleanup and focus-restoration ordering, fallback selection when the invoking bell becomes inert or unmounts, and focus ownership across both breakpoint directions.
