### PR TITLE
fix(update): harden update and runtime install boundaries

### DIFF
--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -33,6 +33,8 @@ export type ResilientDownloadOpts = {
   // ceiling, including response metadata and each streamed chunk. If this and Content-Length are
   // absent, a silently truncated stream cannot be distinguished from a complete unknown-size body.
   expectedSize?: number
+  // When set, every final response URL must remain on this origin after fetch follows redirects.
+  expectedOrigin?: string
   maxRetries?: number
   stallTimeoutMs?: number
   signal?: AbortSignal
@@ -318,6 +320,18 @@ export const resilientDownload = async (
 
       armStall()
       const res = await fetchImpl(url, { headers, signal: combined })
+
+      if (opts.expectedOrigin) {
+        let responseOrigin = ''
+        try {
+          responseOrigin = new URL(res.url).origin
+        } catch {
+          // Invalid/missing final URL fails closed below.
+        }
+        if (responseOrigin !== opts.expectedOrigin) {
+          throw new DownloadResponseIntegrityError('Download response left the trusted origin')
+        }
+      }
 
       if (res.status >= 500) throw new Error(`server error ${res.status}`)
       if (res.status >= 400 && res.status < 500) {

--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClaudeInstallEvent } from '../../shared/settings'
 import {
@@ -12,6 +12,17 @@ import {
   runInstall,
   runInstallWithFallback
 } from './claude-install'
+
+const { terminateProcessTree } = vi.hoisted(() => ({
+  terminateProcessTree: vi.fn(async () => ({ reaped: true }))
+}))
+
+vi.mock('../process-tree', () => ({ terminateProcessTree }))
+
+beforeEach(() => {
+  terminateProcessTree.mockReset()
+  terminateProcessTree.mockResolvedValue({ reaped: true })
+})
 
 // Minimal fake child process exposing the stdout/stderr/exit surface runInstall consumes.
 class FakeChild extends EventEmitter {
@@ -270,6 +281,45 @@ describe('claude-install: run', () => {
 
     expect(result).toMatchObject({ ok: false })
     expect(result.error).toContain('ENOENT')
+  })
+
+  it('settles after bounded tree cleanup when a timed-out child never exits', async () => {
+    vi.useFakeTimers()
+    const child = new FakeChild()
+    terminateProcessTree.mockImplementation(() => new Promise(() => undefined))
+
+    try {
+      const pending = runInstall({
+        source: 'npm',
+        installId: 'install-timeout',
+        onEvent: () => undefined,
+        timeoutMs: 100,
+        spawnImpl: () => child as never,
+        npmPrefixWritable: () => Promise.resolve(true)
+      })
+
+      await Promise.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(terminateProcessTree).toHaveBeenCalledWith(child)
+      let settled = false
+      void pending.then(() => {
+        settled = true
+      })
+      child.emit('exit', null)
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(8_000)
+      await expect(pending).resolves.toMatchObject({
+        installId: 'install-timeout',
+        ok: false,
+        timedOut: true
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('marks an official-script failure region-blocked when it pipes HTML', async () => {

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -14,9 +14,11 @@ import type {
   ClaudeInstallSource,
   NpmAvailability
 } from '../../shared/settings'
+import { terminateProcessTree } from '../process-tree'
 import { augmentedPathEnv } from './shell-path'
 
 const execFileAsync = promisify(execFile)
+const INSTALL_CLEANUP_TIMEOUT_MS = 8_000
 
 // Constructs and runs the one-click claude installer for a chosen source, streaming output back so
 // the UI can show live progress and never spin silently. Command construction is pure and testable;
@@ -365,6 +367,7 @@ const runInstall = async ({
 
     let settled = false
     let timedOut = false
+    let cleanupTimer: ReturnType<typeof setTimeout> | undefined
     // Bounded tail of stdout+stderr, scanned on failure to spot a region-block HTML page.
     let captured = ''
 
@@ -378,6 +381,7 @@ const runInstall = async ({
 
       settled = true
       clearTimeout(timer)
+      if (cleanupTimer !== undefined) clearTimeout(cleanupTimer)
       publisher.flush()
       resolve(result)
     }
@@ -385,7 +389,17 @@ const runInstall = async ({
     const timer = setTimeout(() => {
       timedOut = true
       publisher.log('system', 'Install timed out; terminating.\n')
-      child.kill()
+      const cleanupDeadline = new Promise<void>((resolve) => {
+        cleanupTimer = setTimeout(resolve, INSTALL_CLEANUP_TIMEOUT_MS)
+        cleanupTimer.unref?.()
+      })
+      void Promise.race([
+        terminateProcessTree(child).then(
+          () => undefined,
+          () => undefined
+        ),
+        cleanupDeadline
+      ]).then(() => settle({ installId, ok: false, timedOut: true }))
     }, timeoutMs)
 
     child.stdout.on('data', (data: Buffer) => {
@@ -401,25 +415,25 @@ const runInstall = async ({
     })
 
     child.on('error', (error) => {
+      if (timedOut) return
       settle({ installId, ok: false, error: error.message })
     })
 
     child.on('exit', (code) => {
-      const ok = !timedOut && code === 0
+      if (timedOut) return
+      const ok = code === 0
 
       settle({
         installId,
         ok,
         exitCode: code ?? undefined,
-        timedOut: timedOut || undefined,
         // Only the official script can be served the region-block page; flag it so callers can retry
         // with npm instead of surfacing a cryptic `syntax error near '<'`.
         regionBlocked:
           !ok && source === 'official-script' && isRegionBlockedOutput(captured) ? true : undefined,
         // A non-zero exit that looks like a transient network fault; the caller retries the same
         // source. A timeout is not a clean network signature, so it is not treated as retryable here.
-        retryableNetworkFailure:
-          !ok && !timedOut && isRetryableInstallFailure(captured) ? true : undefined
+        retryableNetworkFailure: !ok && isRetryableInstallFailure(captured) ? true : undefined
       })
     })
   })

--- a/src/main/update/downloader.test.ts
+++ b/src/main/update/downloader.test.ts
@@ -11,6 +11,12 @@ import { downloadInstaller } from './downloader'
 
 const sha256 = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
 
+const responseAt = (url: string, body: BodyInit, init: ResponseInit = {}): Response => {
+  const response = new Response(body, init)
+  Object.defineProperty(response, 'url', { value: url })
+  return response
+}
+
 let dir = ''
 afterEach(async () => {
   if (dir) await rm(dir, { recursive: true, force: true })
@@ -23,7 +29,9 @@ describe('downloadInstaller', () => {
     const body = Buffer.from('installer-bytes')
     const progresses: DownloadProgress[] = []
     const fetchImpl = (() =>
-      Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+      Promise.resolve(
+        responseAt('https://cdn/open-science-0.3.0-mac-arm64.dmg', body, { status: 200 })
+      )) as unknown as typeof fetch
 
     const path = await downloadInstaller(
       {
@@ -52,7 +60,9 @@ describe('downloadInstaller', () => {
     const target = join(dir, 'x.dmg')
     const body = Buffer.from('installer-bytes')
     const fetchImpl = (() =>
-      Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+      Promise.resolve(
+        responseAt('https://cdn/x.dmg', body, { status: 200 })
+      )) as unknown as typeof fetch
 
     await expect(
       downloadInstaller(
@@ -87,7 +97,7 @@ describe('downloadInstaller', () => {
           else signal?.addEventListener('abort', onAbort)
         }
       })
-      return Promise.resolve(new Response(body, { status: 200 }))
+      return Promise.resolve(responseAt('https://cdn/z.dmg', body, { status: 200 }))
     }) as unknown as typeof fetch
 
     const promise = downloadInstaller(

--- a/src/main/update/downloader.ts
+++ b/src/main/update/downloader.ts
@@ -25,6 +25,7 @@ export const downloadInstaller = async (
   resilientDownload(download.url, targetPath, {
     expectedSha256: download.sha256,
     expectedSize: download.size > 0 ? download.size : undefined,
+    expectedOrigin: new URL(download.url).origin,
     signal: deps.signal,
     onProgress: deps.onProgress,
     deps: { fetchImpl: deps.fetchImpl ?? netFetchStandard }

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -71,7 +71,13 @@ const markUpdateReady = (updater: FakeUpdater): void => {
 
 // Fake fetch returning a version.json manifest, so notes hydration never touches the network.
 const manifestFetch = (manifest: object): typeof fetch =>
-  vi.fn(async () => ({ ok: true, json: async () => manifest })) as unknown as typeof fetch
+  vi.fn(
+    async () =>
+      new Response(JSON.stringify(manifest), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+  ) as unknown as typeof fetch
 
 // Fake fetch that always fails, standing in for "no manifest reachable".
 const offlineFetch = (): typeof fetch =>
@@ -318,7 +324,7 @@ describe('ElectronUpdaterStrategy', () => {
     expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
   })
 
-  it('waits for notes hydration after update-available before starting an in-place download', async () => {
+  it('does not let pending notes hydration block an available in-place download', async () => {
     const updater = new FakeUpdater()
     let releaseNotes: (() => void) | undefined
     const notesGate = new Promise<void>((resolve) => {
@@ -326,16 +332,16 @@ describe('ElectronUpdaterStrategy', () => {
     })
     const fetchImpl = vi.fn(async () => {
       await notesGate
-      return {
-        ok: true,
-        json: async () => ({
+      return new Response(
+        JSON.stringify({
           version: '0.3.0',
           releaseDate: '',
           notes: 'cdn notes',
           localizedNotes: { 'zh-Hans': 'CDN 说明' },
           downloads: {}
-        })
-      }
+        }),
+        { status: 200 }
+      )
     }) as unknown as typeof fetch
     const strategy = new ElectronUpdaterStrategy({
       updater,
@@ -349,18 +355,28 @@ describe('ElectronUpdaterStrategy', () => {
       expect.objectContaining({ state: 'available', latest: '0.3.0', notes: 'notes' })
     )
     const downloading = strategy.download()
-    expect(updater.downloadUpdate).not.toHaveBeenCalled()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(
+      await Promise.race([
+        checking.then(() => 'settled'),
+        new Promise<string>((resolve) => setTimeout(() => resolve('pending'), 0))
+      ])
+    ).toBe('settled')
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+    expect((await downloading).state).toBe('ready')
 
     releaseNotes?.()
-    expect(await checking).toEqual(
-      expect.objectContaining({
-        state: 'available',
-        notes: 'cdn notes',
-        localizedNotes: { 'zh-Hans': 'CDN 说明' }
-      })
-    )
-    expect((await downloading).state).toBe('ready')
-    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => {
+      expect(strategy.getStatus()).toEqual(
+        expect.objectContaining({
+          state: 'ready',
+          notes: 'cdn notes',
+          localizedNotes: { 'zh-Hans': 'CDN 说明' }
+        })
+      )
+    })
   })
 
   it('records a failed in-place download without the provider error message', async () => {
@@ -974,8 +990,10 @@ describe('ElectronUpdaterStrategy', () => {
       broadcast: vi.fn(),
       fetchImpl: manifestFetch({ version: '0.3.0', downloads: {}, notes: '## Highlights\n- new' })
     })
-    const status = await strategy.check()
-    expect(status.notes).toBe('## Highlights\n- new')
+    await strategy.check()
+    await vi.waitFor(() => {
+      expect(strategy.getStatus().notes).toBe('## Highlights\n- new')
+    })
   })
 
   it('keeps the GitHub-link fallback when the manifest version does not match', async () => {

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -195,9 +195,6 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private applying = false
   private installerStarted = false
   private pendingInstallRollback?: () => void
-  // In-flight manifest notes fetch for the current update, awaited by check() so the returned
-  // status reflects the hydrated notes.
-  private notesHydration?: Promise<void>
   // Pre-install backend-shutdown gate, owned immutably for the strategy lifetime.
   private readonly installGate?: InstallGate
   private readonly markUpdateShutdown: () => () => void
@@ -261,7 +258,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       // electron-updater's *.yml feed carries no release notes, so the dialog would only get a
       // GitHub link. Hydrate the notes from the CDN manifest (the same version.json the installer
       // flow reads) so the "What's new" section renders in-app.
-      if (i.version) this.notesHydration = this.hydrateNotes(i.version)
+      if (i.version) void this.hydrateNotes(i.version)
     })
     this.updater.on('update-not-available', (info) => {
       if (this.readyCheckStatus && this.status === this.readyCheckStatus) return
@@ -396,8 +393,6 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
             })
           }
         }
-        // Wait for the notes fetch triggered by update-available so the returned status carries them.
-        await this.notesHydration
         providerFailure ??= this.readyCheckError
         if (providerFailure) {
           operation.fail(providerFailure, { result: 'error' })

--- a/src/main/update/manifest.test.ts
+++ b/src/main/update/manifest.test.ts
@@ -7,7 +7,7 @@ const valid = {
   releaseDate: '2026-07-13',
   notes: 'n',
   localizedNotes: { 'zh-Hans': '更新说明', ja: '更新内容', es: 'Notas de la versión' },
-  downloads: { 'mac-arm64': { url: 'https://cdn/a.dmg', size: 1, sha256: 'h' } }
+  downloads: { 'mac-arm64': { url: 'https://cdn/a.dmg', size: 1, sha256: 'a'.repeat(64) } }
 }
 
 describe('parseManifest', () => {
@@ -36,11 +36,91 @@ describe('parseManifest', () => {
       parseManifest({ version: '1.0.0', downloads: {}, localizedNotes: { fr: '' } })
     ).toThrow(/fr/)
   })
+
+  it.each([
+    ['an empty version', { ...valid, version: '' }],
+    ['a partial numeric version', { ...valid, version: '1.2.3broken' }],
+    ['an array downloads value', { ...valid, downloads: [] }],
+    ['an unknown platform key', { ...valid, downloads: { solaris: valid.downloads['mac-arm64'] } }],
+    [
+      'a relative download URL',
+      {
+        ...valid,
+        downloads: { 'mac-arm64': { ...valid.downloads['mac-arm64'], url: '/installer.dmg' } }
+      }
+    ],
+    [
+      'an HTTP download URL',
+      {
+        ...valid,
+        downloads: {
+          'mac-arm64': { ...valid.downloads['mac-arm64'], url: 'http://cdn/installer.dmg' }
+        }
+      }
+    ],
+    [
+      'a non-positive download size',
+      {
+        ...valid,
+        downloads: { 'mac-arm64': { ...valid.downloads['mac-arm64'], size: 0 } }
+      }
+    ],
+    [
+      'a negative download size',
+      {
+        ...valid,
+        downloads: { 'mac-arm64': { ...valid.downloads['mac-arm64'], size: -1 } }
+      }
+    ],
+    [
+      'a NaN download size',
+      {
+        ...valid,
+        downloads: { 'mac-arm64': { ...valid.downloads['mac-arm64'], size: Number.NaN } }
+      }
+    ],
+    [
+      'a non-finite download size',
+      {
+        ...valid,
+        downloads: {
+          'mac-arm64': { ...valid.downloads['mac-arm64'], size: Number.POSITIVE_INFINITY }
+        }
+      }
+    ],
+    [
+      'a non-integer download size',
+      {
+        ...valid,
+        downloads: { 'mac-arm64': { ...valid.downloads['mac-arm64'], size: 1.5 } }
+      }
+    ],
+    [
+      'an unsafe download size',
+      {
+        ...valid,
+        downloads: {
+          'mac-arm64': { ...valid.downloads['mac-arm64'], size: Number.MAX_SAFE_INTEGER + 1 }
+        }
+      }
+    ],
+    [
+      'a malformed SHA-256',
+      {
+        ...valid,
+        downloads: { 'mac-arm64': { ...valid.downloads['mac-arm64'], sha256: 'not-a-sha256' } }
+      }
+    ]
+  ])('rejects %s', (_label, manifest) => {
+    expect(() => parseManifest(manifest)).toThrow()
+  })
 })
 
 describe('fetchManifest', () => {
   it('fetches and parses', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(valid) })
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(valid), { status: 200 }))
     const m = await fetchManifest('https://cdn/version.json', fetchImpl as unknown as typeof fetch)
     expect(m.version).toBe('0.3.0')
     expect(fetchImpl).toHaveBeenCalledWith('https://cdn/version.json', expect.any(Object))
@@ -50,5 +130,41 @@ describe('fetchManifest', () => {
     await expect(
       fetchManifest('https://cdn/version.json', fetchImpl as unknown as typeof fetch)
     ).rejects.toThrow()
+  })
+
+  it('aborts a manifest request at its independent deadline', async () => {
+    const controller = new AbortController()
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal)
+    const fetchImpl = vi.fn((_url: unknown, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true })
+      })
+    }) as unknown as typeof fetch
+
+    try {
+      const pending = fetchManifest('https://cdn/version.json', fetchImpl)
+      controller.abort(new DOMException('manifest deadline', 'TimeoutError'))
+      const outcome = await Promise.race([
+        pending.then(
+          () => 'resolved',
+          () => 'rejected'
+        ),
+        new Promise<string>((resolve) => setTimeout(() => resolve('pending'), 0))
+      ])
+
+      expect(timeout).toHaveBeenCalledWith(15_000)
+      expect(outcome).toBe('rejected')
+    } finally {
+      timeout.mockRestore()
+    }
+  })
+
+  it('rejects a manifest response whose streamed body exceeds the byte ceiling', async () => {
+    const oversized = JSON.stringify({ ...valid, notes: 'x'.repeat(300_000) })
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(oversized, { status: 200 }))
+
+    await expect(
+      fetchManifest('https://cdn/version.json', fetchImpl as unknown as typeof fetch)
+    ).rejects.toThrow(/manifest.*bytes/i)
   })
 })

--- a/src/main/update/manifest.ts
+++ b/src/main/update/manifest.ts
@@ -2,11 +2,45 @@ import { netFetchStandard } from '../skills/net-fetch'
 import type { LocalizedReleaseNotes, PlatformDownload, UpdateManifest } from '../../shared/update'
 
 const LOCALIZED_NOTE_LOCALES = new Set(['zh-Hans', 'zh-Hant', 'ja', 'ko', 'fr', 'ru', 'es'])
+const DOWNLOAD_KEYS = new Set([
+  'mac-arm64',
+  'mac-x64',
+  'win-x64',
+  'linux-x64-appimage',
+  'linux-x64-deb'
+])
+const MANIFEST_TIMEOUT_MS = 15_000
+const MAX_MANIFEST_BYTES = 256 * 1024
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  !!value &&
+  typeof value === 'object' &&
+  !Array.isArray(value) &&
+  Object.getPrototypeOf(value) === Object.prototype
+
+const isReleaseVersion = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(value) &&
+  value.split('.').every((part) => Number.isSafeInteger(Number(part)))
+
+const isHttpsUrl = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false
+  try {
+    return new URL(value).protocol === 'https:'
+  } catch {
+    return false
+  }
+}
 
 const isDownload = (value: unknown): value is PlatformDownload => {
-  const d = value as PlatformDownload
+  if (!isPlainObject(value)) return false
+  const d = value as Partial<PlatformDownload>
   return (
-    !!d && typeof d.url === 'string' && typeof d.size === 'number' && typeof d.sha256 === 'string'
+    isHttpsUrl(d.url) &&
+    Number.isSafeInteger(d.size) &&
+    (d.size ?? 0) > 0 &&
+    typeof d.sha256 === 'string' &&
+    /^[a-f0-9]{64}$/iu.test(d.sha256)
   )
 }
 
@@ -29,25 +63,56 @@ const parseLocalizedNotes = (value: unknown): LocalizedReleaseNotes | undefined 
 // Validates the untrusted CDN payload into a typed manifest. releaseDate/notes are optional in
 // practice, so they default to '' rather than failing the whole check.
 export const parseManifest = (data: unknown): UpdateManifest => {
-  const m = data as UpdateManifest
-  if (
-    !m ||
-    typeof m.version !== 'string' ||
-    typeof m.downloads !== 'object' ||
-    m.downloads === null
-  ) {
+  if (!isPlainObject(data) || !isReleaseVersion(data.version) || !isPlainObject(data.downloads)) {
     throw new Error('Invalid update manifest')
   }
-  for (const [key, value] of Object.entries(m.downloads)) {
-    if (!isDownload(value)) throw new Error(`Invalid download entry: ${key}`)
+
+  const downloads: Record<string, PlatformDownload> = {}
+  for (const [key, value] of Object.entries(data.downloads)) {
+    if (!DOWNLOAD_KEYS.has(key) || !isDownload(value)) {
+      throw new Error(`Invalid download entry: ${key}`)
+    }
+    downloads[key] = value
   }
   return {
-    version: m.version,
-    releaseDate: typeof m.releaseDate === 'string' ? m.releaseDate : '',
-    notes: typeof m.notes === 'string' ? m.notes : '',
-    localizedNotes: parseLocalizedNotes(m.localizedNotes),
-    downloads: m.downloads
+    version: data.version,
+    releaseDate: typeof data.releaseDate === 'string' ? data.releaseDate : '',
+    notes: typeof data.notes === 'string' ? data.notes : '',
+    localizedNotes: parseLocalizedNotes(data.localizedNotes),
+    downloads
   }
+}
+
+const readManifestBody = async (response: Response): Promise<string> => {
+  const declaredLength = response.headers.get('content-length')
+  if (
+    declaredLength &&
+    /^\d+$/u.test(declaredLength) &&
+    Number(declaredLength) > MAX_MANIFEST_BYTES
+  ) {
+    await response.body?.cancel().catch(() => undefined)
+    throw new Error(`Manifest response exceeded ${MAX_MANIFEST_BYTES} bytes`)
+  }
+  if (!response.body) throw new Error('Manifest response had no body')
+
+  const reader = response.body.getReader()
+  const chunks: Buffer[] = []
+  let bytes = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      bytes += value.byteLength
+      if (bytes > MAX_MANIFEST_BYTES) {
+        await reader.cancel().catch(() => undefined)
+        throw new Error(`Manifest response exceeded ${MAX_MANIFEST_BYTES} bytes`)
+      }
+      chunks.push(Buffer.from(value))
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return Buffer.concat(chunks, bytes).toString('utf8')
 }
 
 export const fetchManifest = async (
@@ -56,7 +121,10 @@ export const fetchManifest = async (
   // matching the installer download and language-pack fetch. Node's global fetch bypasses it.
   fetchImpl: typeof fetch = netFetchStandard
 ): Promise<UpdateManifest> => {
-  const response = await fetchImpl(url, { headers: { Accept: 'application/json' } })
+  const response = await fetchImpl(url, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(MANIFEST_TIMEOUT_MS)
+  })
   if (!response.ok) throw new Error(`Manifest fetch failed: ${response.status}`)
-  return parseManifest(await response.json())
+  return parseManifest(JSON.parse(await readManifestBody(response)))
 }

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -10,16 +10,31 @@ import type { UpdateManifest } from '../../shared/update'
 import type { Logger } from '../logger'
 import { UpdateService } from './service'
 
+const VALID_SHA256 = 'a'.repeat(64)
 const manifest: UpdateManifest = {
   version: '0.3.0',
   releaseDate: '',
   notes: 'release notes',
   localizedNotes: { 'zh-Hans': '发行说明' },
-  downloads: { 'mac-arm64': { url: 'https://cdn/x-mac-arm64.dmg', size: 5, sha256: 'h' } }
+  downloads: {
+    'mac-arm64': { url: 'https://cdn/x-mac-arm64.dmg', size: 5, sha256: VALID_SHA256 }
+  }
 }
 
 const jsonResponse = (body: unknown): Response =>
-  ({ ok: true, status: 200, json: () => Promise.resolve(body) }) as unknown as Response
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  })
+
+const responseAt = (url: string, body: BodyInit | null, init: ResponseInit = {}): Response => {
+  const response = new Response(body, init)
+  Object.defineProperty(response, 'url', { value: url })
+  return response
+}
+
+const installerResponse = (body: BodyInit | null, init: ResponseInit = {}): Response =>
+  responseAt('https://statics.aipoch.com/releases/0.3.0/installer.dmg', body, init)
 
 const createLogSpy = (): Logger => ({
   debug: vi.fn(),
@@ -220,7 +235,7 @@ describe('UpdateService.download', () => {
     const fetchImpl = ((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+        : Promise.resolve(installerResponse(body))) as unknown as typeof fetch
     const service = new UpdateService({
       fetchImpl,
       platform: 'darwin',
@@ -258,7 +273,7 @@ describe('UpdateService.download', () => {
         return jsonResponse(manifestForCheck)
       }
       installerFetches += 1
-      return new Response(body, { status: 200 })
+      return installerResponse(body)
     }) as unknown as typeof fetch
     const service = new UpdateService({
       fetchImpl,
@@ -291,7 +306,7 @@ describe('UpdateService.download', () => {
     const fetchImpl = ((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+        : Promise.resolve(installerResponse(body))) as unknown as typeof fetch
     const promptSavePath = vi.fn().mockResolvedValue(join(dir, 'wrong-path.dmg'))
     const defaultDownloadPath = vi.fn(() => target)
     const removeFile = vi.fn((path: string) => rm(path, { force: true }))
@@ -356,7 +371,7 @@ describe('UpdateService.download', () => {
       }
       markInstallerStarted?.()
       await installerGate
-      return new Response(body, { status: 200 })
+      return installerResponse(body)
     }) as unknown as typeof fetch
     const service = new UpdateService({
       fetchImpl,
@@ -399,7 +414,7 @@ describe('UpdateService.download', () => {
           ? Promise.reject(checkFailure)
           : Promise.resolve(jsonResponse(manifestForCheck))
       }
-      return Promise.resolve(new Response(body, { status: 200 }))
+      return Promise.resolve(installerResponse(body))
     }) as unknown as typeof fetch
     const service = new UpdateService({
       fetchImpl,
@@ -446,7 +461,7 @@ describe('UpdateService.download', () => {
     const fetchImpl = ((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+        : Promise.resolve(installerResponse(body))) as unknown as typeof fetch
     const log = createLogSpy()
     const service = new UpdateService({
       fetchImpl,
@@ -494,7 +509,7 @@ describe('UpdateService.download', () => {
     const fetchImpl = ((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+        : Promise.resolve(installerResponse(body))) as unknown as typeof fetch
     const removeFile = vi.fn((path: string) => rm(path, { force: true }))
     const service = new UpdateService({
       fetchImpl,
@@ -531,7 +546,7 @@ describe('UpdateService.download', () => {
     const fetchImpl = ((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+        : Promise.resolve(installerResponse(body))) as unknown as typeof fetch
     const removeFile = vi.fn(() => Promise.resolve())
     const service = new UpdateService({
       fetchImpl,
@@ -555,13 +570,13 @@ describe('UpdateService.download', () => {
   it('does not start the fetch and errors when the first .part cleanup fails', async () => {
     dir = await mkdtemp(join(tmpdir(), 'svc-'))
     const target = join(dir, 'installer.dmg')
-    const manifestForCheck = downloadManifest(11, 'irrelevant')
+    const manifestForCheck = downloadManifest(11, VALID_SHA256)
     let installerFetches = 0
     const fetchImpl = ((input: unknown) => {
       if (String(input).endsWith('version.json'))
         return Promise.resolve(jsonResponse(manifestForCheck))
       installerFetches += 1
-      return Promise.resolve(new Response(Buffer.from('installer-bytes'), { status: 200 }))
+      return Promise.resolve(installerResponse(Buffer.from('installer-bytes')))
     }) as unknown as typeof fetch
     const removeFile = vi.fn(() => Promise.reject(new Error('EACCES: cannot delete .part')))
     const service = new UpdateService({
@@ -595,7 +610,7 @@ describe('UpdateService.download', () => {
     const fetchImpl = ((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+        : Promise.resolve(installerResponse(body))) as unknown as typeof fetch
     // Fail the first cleanup, succeed on the retry.
     const removeFile = vi
       .fn()
@@ -649,12 +664,12 @@ describe('UpdateService.download', () => {
           }
         })
         return Promise.resolve(
-          new Response(stream, { status: 200, headers: { etag: '"installer-v1"' } })
+          installerResponse(stream, { status: 200, headers: { etag: '"installer-v1"' } })
         )
       }
       // Retry: serve the remaining bytes as a 206 partial-content response.
       return Promise.resolve(
-        new Response(body.subarray(2), {
+        installerResponse(body.subarray(2), {
           status: 206,
           headers: {
             etag: '"installer-v1"',
@@ -706,7 +721,7 @@ describe('UpdateService.download', () => {
     const fetchMock = vi.fn((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))
+        : Promise.resolve(installerResponse(body))
     )
     const service = new UpdateService({
       fetchImpl: fetchMock as unknown as typeof fetch,
@@ -727,7 +742,7 @@ describe('UpdateService.download', () => {
   })
 
   it('records a failed installer download without the shell error message', async () => {
-    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    const manifestForCheck = downloadManifest(100, VALID_SHA256)
     const fetchImpl = (() =>
       Promise.resolve(jsonResponse(manifestForCheck))) as unknown as typeof fetch
     const log = createLogSpy()
@@ -762,7 +777,7 @@ describe('UpdateService.download', () => {
   })
 
   it('records manifest URL validation failure without the invalid URL', async () => {
-    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    const manifestForCheck = downloadManifest(100, VALID_SHA256)
     const log = createLogSpy()
     const service = new UpdateService({
       fetchImpl: (() => Promise.resolve(jsonResponse(manifestForCheck))) as unknown as typeof fetch,
@@ -798,7 +813,7 @@ describe('UpdateService.download', () => {
   it('cancel aborts an in-flight download, resets to available, and leaves no partial file', async () => {
     dir = await mkdtemp(join(tmpdir(), 'svc-'))
     const target = join(dir, 'installer.dmg')
-    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    const manifestForCheck = downloadManifest(100, VALID_SHA256)
     let onInstallerFetch: (() => void) | undefined
     const fetched = new Promise<void>((resolve) => (onInstallerFetch = resolve))
     // The installer body hangs (one chunk, no end) and errors on abort, mimicking a real fetch.
@@ -815,7 +830,7 @@ describe('UpdateService.download', () => {
         }
       })
       onInstallerFetch?.()
-      return Promise.resolve(new Response(body, { status: 200 }))
+      return Promise.resolve(installerResponse(body))
     }) as unknown as typeof fetch
     const log = createLogSpy()
     const service = new UpdateService({
@@ -854,7 +869,7 @@ describe('UpdateService.download', () => {
   it('ignores a second download() while one is already in flight', async () => {
     dir = await mkdtemp(join(tmpdir(), 'svc-'))
     const target = join(dir, 'installer.dmg')
-    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    const manifestForCheck = downloadManifest(100, VALID_SHA256)
     let installerFetches = 0
     let onInstallerFetch: (() => void) | undefined
     const fetched = new Promise<void>((resolve) => (onInstallerFetch = resolve))
@@ -872,7 +887,7 @@ describe('UpdateService.download', () => {
         }
       })
       onInstallerFetch?.()
-      return Promise.resolve(new Response(body, { status: 200 }))
+      return Promise.resolve(installerResponse(body))
     }) as unknown as typeof fetch
     const service = new UpdateService({
       fetchImpl,
@@ -927,9 +942,9 @@ describe('UpdateService.download', () => {
           }
         })
         onFirstFetch?.()
-        return Promise.resolve(new Response(hanging, { status: 200 }))
+        return Promise.resolve(installerResponse(hanging))
       }
-      return Promise.resolve(new Response(body, { status: 200 }))
+      return Promise.resolve(installerResponse(body))
     }) as unknown as typeof fetch
     const service = new UpdateService({
       fetchImpl,
@@ -972,7 +987,7 @@ describe('UpdateService.download', () => {
     // start a hidden download after the dialog closed.
     dir = await mkdtemp(join(tmpdir(), 'svc-'))
     const target = join(dir, 'installer.dmg')
-    const manifestForCheck = downloadManifest(100, 'irrelevant')
+    const manifestForCheck = downloadManifest(100, VALID_SHA256)
     let installerFetches = 0
     let onFirstFetch: (() => void) | undefined
     let errorFirstStream: (() => void) | undefined
@@ -990,7 +1005,7 @@ describe('UpdateService.download', () => {
         }
       })
       onFirstFetch?.()
-      return Promise.resolve(new Response(hanging, { status: 200 }))
+      return Promise.resolve(installerResponse(hanging))
     }) as unknown as typeof fetch
     const service = new UpdateService({
       fetchImpl,
@@ -1033,7 +1048,7 @@ describe('UpdateService.download', () => {
     const fetchImpl = ((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+        : Promise.resolve(installerResponse(body))) as unknown as typeof fetch
     let saveCall = 0
     const service = new UpdateService({
       fetchImpl,
@@ -1065,7 +1080,11 @@ describe('UpdateService.download', () => {
       releaseDate: '',
       notes: '',
       downloads: {
-        'mac-arm64': { url: 'https://evil.example/x-mac-arm64.dmg', size: 5, sha256: 'h' }
+        'mac-arm64': {
+          url: 'https://evil.example/x-mac-arm64.dmg',
+          size: 5,
+          sha256: VALID_SHA256
+        }
       }
     }
     const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(offHostManifest)))
@@ -1089,6 +1108,75 @@ describe('UpdateService.download', () => {
     expect(status.error).toBe('Untrusted download host')
     expect(fetchMock).not.toHaveBeenCalled()
     expect(promptSavePath).not.toHaveBeenCalled()
+  })
+
+  it('rejects an HTTP download URL even when its host matches the HTTPS manifest', async () => {
+    const downgradedManifest: UpdateManifest = {
+      version: '0.3.0',
+      releaseDate: '',
+      notes: '',
+      downloads: {
+        'mac-arm64': {
+          url: 'http://cdn.trusted.example/x-mac-arm64.dmg',
+          size: 5,
+          sha256: 'a'.repeat(64)
+        }
+      }
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(downgradedManifest))
+      .mockResolvedValue(installerResponse(null, { status: 404 }))
+    const promptSavePath = vi.fn(() => Promise.resolve('/tmp/should-not-be-used'))
+    const service = new UpdateService({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://cdn.trusted.example/manifest.json',
+      broadcast: vi.fn(),
+      promptSavePath
+    })
+
+    await service.check()
+    fetchMock.mockClear()
+    const status = await service.download()
+
+    expect(status.state).toBe('error')
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(promptSavePath).not.toHaveBeenCalled()
+  })
+
+  it('rejects a followed redirect whose final response leaves the trusted origin', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-origin-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    const fetchImpl = ((input: unknown) =>
+      String(input).endsWith('version.json')
+        ? Promise.resolve(jsonResponse(manifestForCheck))
+        : Promise.resolve(
+            responseAt('https://redirect-target.example/installer.dmg', body, { status: 200 })
+          )) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    await service.check()
+    const status = await service.download()
+
+    expect(status.state).toBe('error')
+    expect(existsSync(target)).toBe(false)
+    expect(existsSync(`${target}.part`)).toBe(false)
   })
 })
 
@@ -1124,7 +1212,7 @@ describe('UpdateService.apply', () => {
     const fetchImpl = ((input: unknown) =>
       String(input).endsWith('version.json')
         ? Promise.resolve(jsonResponse(manifestForCheck))
-        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+        : Promise.resolve(installerResponse(body))) as unknown as typeof fetch
     const service = new UpdateService({
       fetchImpl,
       platform: 'darwin',

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -250,22 +250,25 @@ export class UpdateService implements UpdateStrategy {
     operation.phase('validate-source')
 
     // Defense-in-depth: the sha256 comes from the same manifest as the URL, so it can't catch a
-    // tampered manifest pointing at a hostile host. Require the download to stay on the trusted host.
-    let trustedHost: string
+    // tampered manifest pointing at a hostile source. Keep the installer on the manifest's HTTPS origin.
+    let trustedOrigin: string
     try {
-      trustedHost = new URL(this.manifestUrl).host
+      const manifestUrl = new URL(this.manifestUrl)
+      if (manifestUrl.protocol !== 'https:') throw new URIError('Manifest URL must use HTTPS')
+      trustedOrigin = manifestUrl.origin
     } catch (error) {
       operation.fail(error, { reason: 'invalid-manifest-url' })
       if (this.downloadOperation === operation) this.downloadOperation = undefined
       throw error
     }
-    let downloadHost: string
+    let downloadOrigin: string
     try {
-      downloadHost = new URL(download.url).host
+      const downloadUrl = new URL(download.url)
+      downloadOrigin = downloadUrl.protocol === 'https:' ? downloadUrl.origin : ''
     } catch {
-      downloadHost = ''
+      downloadOrigin = ''
     }
-    if (downloadHost !== trustedHost) {
+    if (downloadOrigin !== trustedOrigin) {
       this.setStatus({ ...this.status, state: 'error', error: 'Untrusted download host' })
       operation.fail(new URIError('Untrusted update source'), { reason: 'untrusted-source' })
       if (this.downloadOperation === operation) this.downloadOperation = undefined


### PR DESCRIPTION
## Problem

Four update/install failure modes could turn damaged or adversarial input into a stuck lifecycle or an unsafe installer fetch:

- a manifest connection/body had no independent deadline or byte ceiling, and native release-note hydration kept the shared check lifecycle pending;
- installer trust compared only `host`, so HTTP downgrade and followed cross-origin redirects escaped the intended HTTPS boundary;
- an installer timeout sent one direct-child kill and still waited indefinitely for `exit`/`error`, keeping the global runtime-install lock occupied;
- manifest parsing admitted semantically invalid versions, URLs, sizes, hashes, container shapes, and platform keys.

## Proposed change

- Bound manifest fetches to 15 seconds and 256 KiB, then validate the untrusted payload as a strict stable-release manifest.
- Treat native release-note hydration as best effort so update availability and download are not gated by notes.
- Require the manifest and installer to share an HTTPS origin, and validate the final response origin after redirects before writing bytes.
- Reuse the process-tree terminator after installer timeout and settle the install promise after an additional bounded cleanup window even if the child never exits.

## Scope and non-goals

- No new dependency, persisted field, database/schema change, data migration, enum value, IPC shape, or public data-model change.
- One intentional interaction timing change: a native update becomes downloadable immediately; release notes may populate asynchronously afterward.
- Existing generated stable manifests remain compatible. Malformed or legacy hand-authored manifests outside the supported `x.y.z`/HTTPS/known-platform contract now fail closed.
- Redirect validation checks the final response origin after the platform fetch implementation follows redirects; this does not replace fetch with a custom per-hop redirect engine.

## Acceptance criteria and validation

Regression tests were added first and run twice against the unfixed implementation. The failures matched the reported behaviors:

- manifest schema/deadline/body limit plus native notes gating: 13 failed, 55 passed;
- protocol downgrade plus final redirect origin: 2 failed, 34 passed;
- stuck installer process-tree cleanup: 1 failed, 61 passed.

Final Test Impact Set, run after the last material edit:

- manifest validation/deadline/body ceiling, native notes lifecycle, origin validation, downloader cleanup -> `vitest run src/main/update/manifest.test.ts src/main/update/electron-updater-strategy.test.ts src/main/update/service.test.ts src/main/update/downloader.test.ts src/main/net/resilient-download.test.ts --reporter=dot` -> 5 files, 131 tests passed;
- timed-out process-tree cleanup and global install-lock consumers -> `vitest run src/main/settings/claude-install.test.ts src/main/settings/agent-runtime-manager.test.ts src/main/process-tree.test.ts --reporter=dot` -> 3 files, 75 tests passed;
- affected Electron main-process types -> `npm run typecheck:node` -> passed;
- changed source/tests -> `npm run lint` -> passed;
- repository impact classifier -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> fail-closed full CI plan because `src/main/net/resilient-download.ts` has no declared module owner.

Per maintainer instruction, the complete local `npm test` suite was not run. Exact-head PR CI is authoritative for the full portable and platform matrix. Windows `taskkill /T` and packaged Electron redirect behavior are not directly exercised on this macOS host; the process-tree contract tests and PR platform lanes cover those risks.

## Review focus

- Whether the strict manifest contract matches every supported release artifact.
- Whether final-response origin validation occurs before any response bytes are persisted, including retries/resume.
- Whether timeout settlement remains bounded without releasing the install lock before the cleanup stage finishes or reaches its deadline.
