### PR TITLE
fix(usage): aggregate auxiliary model tokens

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,6 +140,27 @@ model SessionModelCallUsage {
   @@unique([sessionId, messageId, callIndex])
 }
 
+// One provider-reported logical turn outside the durable Agent message graph. These facts have no
+// Session foreign key because a projection rebuild temporarily deletes and recreates live Session
+// rows; direct auxiliary consumption must survive that rebuild.
+model SessionAuxiliaryTurnUsage {
+  sessionId         String
+  eventId           String
+  source            String
+  frameworkId       String
+  model             String?
+  completedAtMs     BigInt
+  inputTokens       BigInt
+  cacheTokens       BigInt
+  cachedReadTokens  BigInt?
+  cachedWriteTokens BigInt?
+  outputTokens      BigInt
+  modelCallCount    Int?
+
+  @@id([sessionId, eventId])
+  @@index([completedAtMs])
+}
+
 // One user-authored root-frame run, excluding hidden control and delegated caller messages.
 model SessionRun {
   sessionId   String

--- a/prisma/sqlite-check-constraints.json
+++ b/prisma/sqlite-check-constraints.json
@@ -46,6 +46,21 @@
       "expression": "\"inputTokens\" >= 0 AND \"cacheTokens\" >= 0 AND \"outputTokens\" >= 0 AND ((\"cachedReadTokens\" IS NULL AND \"cachedWriteTokens\" IS NULL) OR (\"cachedReadTokens\" >= 0 AND \"cachedWriteTokens\" >= 0)) AND (\"contextUsedTokens\" IS NULL OR \"contextUsedTokens\" >= 0) AND (\"contextWindowSize\" IS NULL OR \"contextWindowSize\" > 0)"
     },
     {
+      "tableName": "SessionAuxiliaryTurnUsage",
+      "name": "SessionAuxiliaryTurnUsage_identity_check",
+      "expression": "length(trim(\"sessionId\")) > 0 AND length(trim(\"eventId\")) > 0 AND length(trim(\"frameworkId\")) > 0 AND (\"model\" IS NULL OR length(trim(\"model\")) > 0)"
+    },
+    {
+      "tableName": "SessionAuxiliaryTurnUsage",
+      "name": "SessionAuxiliaryTurnUsage_source_check",
+      "expression": "\"source\" IN ('reviewer', 'side-chat', 'vision', 'session-details', 'host-llm', 'artifact-code-reconstruction', 'context-compaction')"
+    },
+    {
+      "tableName": "SessionAuxiliaryTurnUsage",
+      "name": "SessionAuxiliaryTurnUsage_nonnegative_check",
+      "expression": "\"completedAtMs\" >= 0 AND \"inputTokens\" >= 0 AND \"cacheTokens\" >= 0 AND \"outputTokens\" >= 0 AND ((\"cachedReadTokens\" IS NULL AND \"cachedWriteTokens\" IS NULL) OR (\"cachedReadTokens\" >= 0 AND \"cachedWriteTokens\" >= 0)) AND (\"modelCallCount\" IS NULL OR \"modelCallCount\" > 0)"
+    },
+    {
       "tableName": "SessionRun",
       "name": "SessionRun_nonnegative_check",
       "expression": "length(trim(\"messageId\")) > 0 AND \"createdAtMs\" >= 0"

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -72,6 +72,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0017_agent_memory_project_scope',
     checksum: '0e27d60b24a623fd0b080266be42e4560ad7dd4188c93b081ee94a655c800ba9'
+  },
+  {
+    id: '0018_session_auxiliary_turn_usage',
+    checksum: 'ceb7280f5f87150c99c5807bf88353ed0fa2b589f8c862fc62e4d2a81e2a01fc'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -20,7 +20,7 @@ import { PrismaClient } from '@prisma/client'
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
     expect(MIGRATION_MANIFEST.at(-1)?.checksum).toBe(
-      '0e27d60b24a623fd0b080266be42e4560ad7dd4188c93b081ee94a655c800ba9'
+      'ceb7280f5f87150c99c5807bf88353ed0fa2b589f8c862fc62e4d2a81e2a01fc'
     )
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST.slice(0, -1))).toThrow(
@@ -50,7 +50,7 @@ describe('packaged database migration ledger smoke', () => {
       await client.$executeRawUnsafe('DROP INDEX "Review_sessionId_idx"')
       await client.$executeRawUnsafe('DROP INDEX "Finding_reviewId_idx"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage')`
       )
       await client.$executeRawUnsafe(
         'ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"'

--- a/src/main/acp/artifact-code-reconstruction-runner.test.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.test.ts
@@ -145,6 +145,46 @@ describe('Artifact code reconstruction backend profiles', () => {
 })
 
 describe('ArtifactCodeReconstructionRunner cleanup', () => {
+  it('records provider-reported Artifact reconstruction usage', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-usage-'))
+    const usage = { inputTokens: 13, cacheTokens: 3, outputTokens: 5, turnCount: 1 }
+    vi.spyOn(RestrictedInferenceRunner.prototype, 'run').mockResolvedValue({
+      text: 'result',
+      frameworkId: 'claude-code',
+      model: 'model-a',
+      stopReason: 'end_turn',
+      usage
+    })
+    const recordUsage = vi.fn(async () => undefined)
+    const runner = new ArtifactCodeReconstructionRunner({
+      appVersion: '0.11.0',
+      configRoot: temporaryRoot,
+      captureTarget: vi.fn(),
+      resolveTarget: vi.fn(),
+      recordUsage
+    })
+
+    await runner.run(
+      'evidence',
+      { ...target, frameworkId: 'claude-code' },
+      {
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      }
+    )
+
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        source: 'artifact-code-reconstruction',
+        frameworkId: 'claude-code',
+        model: 'model-a',
+        usage
+      })
+    )
+  })
+
   it('keeps Artifact output unbounded at the restricted inference Seam', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-output-'))
     const text = 'x'.repeat(300 * 1024)

--- a/src/main/acp/artifact-code-reconstruction-runner.test.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.test.ts
@@ -185,6 +185,29 @@ describe('ArtifactCodeReconstructionRunner cleanup', () => {
     )
   })
 
+  it('records provider usage attached to an ordinary reconstruction error', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-error-usage-'))
+    const usage = { inputTokens: 7, cacheTokens: 1, outputTokens: 2, turnCount: 1 }
+    vi.spyOn(RestrictedInferenceRunner.prototype, 'run').mockRejectedValue(
+      Object.assign(new Error('provider failed'), { usage })
+    )
+    const recordUsage = vi.fn(async () => undefined)
+    const runner = new ArtifactCodeReconstructionRunner({
+      appVersion: '0.11.0',
+      configRoot: temporaryRoot,
+      captureTarget: vi.fn(),
+      resolveTarget: vi.fn(),
+      recordUsage
+    })
+
+    await expect(
+      runner.run('evidence', target, { projectId: 'project-1', sessionId: 'session-1' })
+    ).rejects.toThrow('provider failed')
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'artifact-code-reconstruction', usage })
+    )
+  })
+
   it('keeps Artifact output unbounded at the restricted inference Seam', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-output-'))
     const text = 'x'.repeat(300 * 1024)

--- a/src/main/acp/artifact-code-reconstruction-runner.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.ts
@@ -6,6 +6,7 @@ import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
 import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
 import { prepareRestrictedBackend } from './restricted-runtime-profile'
 import {
+  extractRestrictedInferenceUsage,
   RestrictedInferenceError,
   RestrictedInferenceRunner,
   resolveRestrictedInferenceModel
@@ -119,7 +120,7 @@ export class ArtifactCodeReconstructionRunner {
         eventId,
         target.frameworkId,
         target.model.kind === 'required' ? target.model.id : undefined,
-        error instanceof RestrictedInferenceError ? error.usage : undefined
+        extractRestrictedInferenceUsage(error)
       )
       if (error instanceof RestrictedInferenceError && error.code === 'tool-violation') {
         throw new Error('The selected agent attempted to use a tool during code reconstruction.')

--- a/src/main/acp/artifact-code-reconstruction-runner.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.ts
@@ -1,6 +1,9 @@
+import { randomUUID } from 'node:crypto'
+
 import { isCodexSubscriptionProviderId, type AgentFrameworkId } from '../../shared/settings'
 import type { ResolvedAgentBackend } from '../agent-framework'
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
+import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
 import { prepareRestrictedBackend } from './restricted-runtime-profile'
 import {
   RestrictedInferenceError,
@@ -35,7 +38,10 @@ type ArtifactCodeReconstructionRunnerOptions = {
     }
   ) => Promise<ResolvedAgentBackend>
   now?: () => number
+  recordUsage?: (record: SessionAuxiliaryTurnUsageRecord) => Promise<unknown>
 }
+
+type ArtifactCodeReconstructionRunContext = Readonly<{ projectId: string; sessionId: string }>
 
 export const prepareBackend = (
   backend: ResolvedAgentBackend,
@@ -86,11 +92,13 @@ export class ArtifactCodeReconstructionRunner {
 
   async run(
     prompt: string,
-    target: ExplicitAgentBackendTarget
+    target: ExplicitAgentBackendTarget,
+    context?: ArtifactCodeReconstructionRunContext
   ): Promise<ArtifactCodeReconstructionRunResult> {
     if (this.shuttingDown) throw new Error('Artifact code reconstruction is shutting down.')
     if (this.running) throw new Error('Artifact code reconstruction is already running.')
     this.running = true
+    const eventId = randomUUID()
     try {
       const result = await this.inference.run({
         prompt,
@@ -99,12 +107,20 @@ export class ArtifactCodeReconstructionRunner {
         agentName: RECONSTRUCTION_AGENT_NAME,
         description: 'One-shot Artifact code reconstruction without tools.'
       })
+      await this.recordUsage(context, eventId, result.frameworkId, result.model, result.usage)
       return {
         text: result.text,
         frameworkId: result.frameworkId,
         model: result.model
       }
     } catch (error) {
+      await this.recordUsage(
+        context,
+        eventId,
+        target.frameworkId,
+        target.model.kind === 'required' ? target.model.id : undefined,
+        error instanceof RestrictedInferenceError ? error.usage : undefined
+      )
       if (error instanceof RestrictedInferenceError && error.code === 'tool-violation') {
         throw new Error('The selected agent attempted to use a tool during code reconstruction.')
       }
@@ -130,8 +146,31 @@ export class ArtifactCodeReconstructionRunner {
     }
   }
 
+  private async recordUsage(
+    context: ArtifactCodeReconstructionRunContext | undefined,
+    eventId: string,
+    frameworkId: SessionAuxiliaryTurnUsageRecord['frameworkId'],
+    model: string | undefined,
+    usage: SessionAuxiliaryTurnUsageRecord['usage'] | undefined
+  ): Promise<void> {
+    if (!context || !usage || !this.options.recordUsage) return
+    await this.options
+      .recordUsage({
+        ...context,
+        eventId,
+        source: 'artifact-code-reconstruction',
+        frameworkId,
+        model,
+        completedAtMs: Date.now(),
+        usage
+      })
+      .catch(() => undefined)
+  }
+
   async shutdown(): Promise<void> {
     this.shuttingDown = true
     await this.inference.shutdown()
   }
 }
+
+export type { ArtifactCodeReconstructionRunContext }

--- a/src/main/acp/context-compaction-workflow.test.ts
+++ b/src/main/acp/context-compaction-workflow.test.ts
@@ -72,6 +72,7 @@ const createHarness = (input?: {
   session?: FakeSession
   cancelCompaction?: (sessionId: string) => Promise<void>
   beforePromptDispatch?: (input: { appSessionId: string; session: ActiveSession }) => Promise<void>
+  usage?: ConstructorParameters<typeof AcpContextCompactionWorkflow>[0]['usage']
 }): {
   cancelCompaction: ReturnType<typeof vi.fn>
   context: ContextUsageTracker
@@ -114,6 +115,7 @@ const createHarness = (input?: {
     emitState,
     errorMessage: (error) => (error instanceof Error ? error.message : String(error)),
     beforePromptDispatch: input?.beforePromptDispatch,
+    usage: input?.usage,
     serialization: new AcpProviderPromptSerializationOwner(),
     cancelCompaction
   })
@@ -133,6 +135,36 @@ const createHarness = (input?: {
 }
 
 describe('AcpContextCompactionWorkflow', () => {
+  it('records provider usage for the hidden native compaction turn', async () => {
+    const session = fakeSession([stop('end_turn')])
+    const record = vi.fn(async () => undefined)
+    const finalize = vi.fn(async () => ({
+      turnUsage: { inputTokens: 20, cacheTokens: 4, outputTokens: 2 },
+      modelTurnCount: 1
+    }))
+    const harness = createHarness({
+      session,
+      usage: {
+        begin: vi.fn(async () => ({ finalize, cancel: vi.fn() })),
+        record,
+        cwd: () => '/workspace',
+        model: () => 'model-a'
+      }
+    })
+
+    await harness.workflow.compact({ sessionId: 'app-session' })
+
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'app-session',
+        eventId: expect.stringMatching(/^context-compaction:/u),
+        frameworkId: 'claude-code',
+        model: 'model-a',
+        facts: expect.objectContaining({ modelTurnCount: 1 })
+      })
+    )
+  })
+
   it('runs a manual native control turn without projecting its hidden output', async () => {
     const hidden = notification('Compacting conversation history')
     const session = fakeSession([update(hidden), stop('end_turn')])

--- a/src/main/acp/context-compaction-workflow.test.ts
+++ b/src/main/acp/context-compaction-workflow.test.ts
@@ -136,8 +136,10 @@ const createHarness = (input?: {
 
 describe('AcpContextCompactionWorkflow', () => {
   it('records provider usage for the hidden native compaction turn', async () => {
-    const session = fakeSession([stop('end_turn')])
+    const hidden = notification('Compacting conversation history')
+    const session = fakeSession([update(hidden), stop('end_turn')])
     const record = vi.fn(async () => undefined)
+    const observe = vi.fn()
     const finalize = vi.fn(async () => ({
       turnUsage: { inputTokens: 20, cacheTokens: 4, outputTokens: 2 },
       modelTurnCount: 1
@@ -145,7 +147,7 @@ describe('AcpContextCompactionWorkflow', () => {
     const harness = createHarness({
       session,
       usage: {
-        begin: vi.fn(async () => ({ finalize, cancel: vi.fn() })),
+        begin: vi.fn(async () => ({ observe, finalize, cancel: vi.fn() })),
         record,
         cwd: () => '/workspace',
         model: () => 'model-a'
@@ -154,6 +156,7 @@ describe('AcpContextCompactionWorkflow', () => {
 
     await harness.workflow.compact({ sessionId: 'app-session' })
 
+    expect(observe).toHaveBeenCalledWith(hidden)
     expect(record).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'app-session',

--- a/src/main/acp/context-compaction-workflow.ts
+++ b/src/main/acp/context-compaction-workflow.ts
@@ -8,6 +8,7 @@ import type { ContextUsageTracker, SessionEstimateInput } from './context-usage-
 import type { AcpPromptContentOwner } from './prompt-content-owner'
 import type { AcpProviderPromptSerializationOwner } from './provider-prompt-serialization-owner'
 import type { RuntimeEventInput } from './runtime-snapshot-owner'
+import type { AcpProviderTurnProbe, AcpProviderTurnResult } from './provider-turn-adapter'
 import type {
   AcpCompactionSessionInteractionScope,
   AcpPromptSessionInteractionScope,
@@ -39,6 +40,23 @@ type AcpContextCompactionWorkflowOptions = Readonly<{
   cancelCompaction: (sessionId: string) => Promise<void>
   beforePromptDispatch?: (input: { appSessionId: string; session: ActiveSession }) => Promise<void>
   serialization: Pick<AcpProviderPromptSerializationOwner, 'run'>
+  usage?: Readonly<{
+    begin: (input: {
+      providerSessionId: string
+      cwd: string
+      frameworkId: AgentFramework['id']
+    }) => Promise<AcpProviderTurnProbe>
+    record: (input: {
+      sessionId: string
+      eventId: string
+      frameworkId: AgentFramework['id']
+      model?: string
+      completedAtMs: number
+      facts: AcpProviderTurnResult
+    }) => Promise<unknown>
+    cwd: (sessionId: string) => string
+    model: () => string | undefined
+  }>
 }>
 
 type AcpAutomaticCompactionRequest = Readonly<{
@@ -207,62 +225,93 @@ class AcpContextCompactionWorkflow {
         this.options.sessions.currentFramework(),
         async () => {
           await this.options.beforePromptDispatch?.({ appSessionId: sessionId, session })
-          let failureText: string | undefined
-          const promptFailure = new Promise<never>((_, reject) => {
-            session.prompt([{ type: 'text', text: strategy.command }]).catch(reject)
+          const frameworkId = this.options.sessions.currentFramework().id
+          let usageProbe = await this.options.usage?.begin({
+            providerSessionId: session.sessionId,
+            cwd: this.options.usage.cwd(sessionId),
+            frameworkId
           })
-          for (;;) {
-            const message = await Promise.race([session.nextUpdate(), promptFailure])
-            if (message.kind === 'stop') {
-              if (message.response.stopReason === 'cancelled') {
-                restoreContext()
+          try {
+            let failureText: string | undefined
+            const promptFailure = new Promise<never>((_, reject) => {
+              session.prompt([{ type: 'text', text: strategy.command }]).catch(reject)
+            })
+            for (;;) {
+              const message = await Promise.race([session.nextUpdate(), promptFailure])
+              if (message.kind === 'stop') {
+                if (usageProbe) {
+                  const facts = await usageProbe.finalize({ response: message.response })
+                  usageProbe = undefined
+                  if (facts.turnUsage) {
+                    await this.options.usage
+                      ?.record({
+                        sessionId,
+                        eventId: toolCallId,
+                        frameworkId,
+                        model: this.options.usage.model(),
+                        completedAtMs: Date.now(),
+                        facts
+                      })
+                      .catch((error) =>
+                        log.warn(
+                          'context compaction Usage persistence failed',
+                          errorLogFields(error)
+                        )
+                      )
+                  }
+                }
+                if (message.response.stopReason === 'cancelled') {
+                  restoreContext()
+                  this.publishEvent({
+                    kind: 'compaction',
+                    compactionReason: reason,
+                    level: 'info',
+                    sessionId,
+                    status: 'cancelled',
+                    title: 'Context compaction cancelled',
+                    toolCallId
+                  })
+                  return message.response
+                }
+                if (message.response.stopReason !== 'end_turn') {
+                  throw new Error(
+                    `Context compaction stopped before completion: ${message.response.stopReason}`
+                  )
+                }
+                if (failureText) throw new Error(failureText)
+                this.options.context.resetAfterCompaction(
+                  sessionId,
+                  this.options.contextEstimateInput(sessionId),
+                  checkpoint,
+                  this.options.selectedContextWindow(sessionId)
+                )
+                this.options.promptContent.resetSession(sessionId)
                 this.publishEvent({
                   kind: 'compaction',
                   compactionReason: reason,
                   level: 'info',
                   sessionId,
-                  status: 'cancelled',
-                  title: 'Context compaction cancelled',
+                  status: 'completed',
+                  title: 'Context compacted',
                   toolCallId
                 })
                 return message.response
               }
-              if (message.response.stopReason !== 'end_turn') {
-                throw new Error(
-                  `Context compaction stopped before completion: ${message.response.stopReason}`
-                )
-              }
-              if (failureText) throw new Error(failureText)
-              this.options.context.resetAfterCompaction(
-                sessionId,
-                this.options.contextEstimateInput(sessionId),
-                checkpoint,
-                this.options.selectedContextWindow(sessionId)
-              )
-              this.options.promptContent.resetSession(sessionId)
-              this.publishEvent({
-                kind: 'compaction',
-                compactionReason: reason,
-                level: 'info',
-                sessionId,
-                status: 'completed',
-                title: 'Context compacted',
-                toolCallId
-              })
-              return message.response
-            }
 
-            const update = message.notification.update
-            if (
-              !failureText &&
-              strategy.failureTextPrefix &&
-              update.sessionUpdate === 'agent_message_chunk' &&
-              update.content.type === 'text' &&
-              update.content.text.trimStart().startsWith(strategy.failureTextPrefix)
-            ) {
-              failureText = update.content.text.trim()
+              const update = message.notification.update
+              if (
+                !failureText &&
+                strategy.failureTextPrefix &&
+                update.sessionUpdate === 'agent_message_chunk' &&
+                update.content.type === 'text' &&
+                update.content.text.trimStart().startsWith(strategy.failureTextPrefix)
+              ) {
+                failureText = update.content.text.trim()
+              }
+              this.options.routeHiddenNotification(message.notification, sessionId)
             }
-            this.options.routeHiddenNotification(message.notification, sessionId)
+          } finally {
+            await Promise.resolve(usageProbe?.cancel()).catch(() => undefined)
           }
         }
       )

--- a/src/main/acp/context-compaction-workflow.ts
+++ b/src/main/acp/context-compaction-workflow.ts
@@ -298,6 +298,7 @@ class AcpContextCompactionWorkflow {
                 return message.response
               }
 
+              usageProbe?.observe?.(message.notification)
               const update = message.notification.update
               if (
                 !failureText &&

--- a/src/main/acp/image-input-compatibility-owner.test.ts
+++ b/src/main/acp/image-input-compatibility-owner.test.ts
@@ -45,11 +45,14 @@ describe('ImageInputCompatibilityOwner', () => {
       }),
       frameworkId: 'opencode' as const,
       model: 'vision-model',
-      stopReason: 'end_turn' as const
+      stopReason: 'end_turn' as const,
+      usage: { inputTokens: 8, cacheTokens: 1, outputTokens: 2, turnCount: 1 }
     }))
+    const recordUsage = vi.fn(async () => undefined)
     const owner = new ImageInputCompatibilityOwner({
       captureTarget: vi.fn(async () => target),
-      runner: { run }
+      runner: { run },
+      recordUsage
     })
     const secondImage: ContentBlock = {
       ...image,
@@ -59,7 +62,9 @@ describe('ImageInputCompatibilityOwner', () => {
 
     const prepared = await owner.prepare({
       content: [{ type: 'text', text: 'What changed?' }, image, secondImage],
-      supportsImageInput: false
+      supportsImageInput: false,
+      projectId: 'project-1',
+      sessionId: 'session-1'
     })
 
     expect(prepared).toEqual([
@@ -84,6 +89,17 @@ describe('ImageInputCompatibilityOwner', () => {
       expect.objectContaining({
         target,
         images: [expect.objectContaining({ mimeType: 'image/png', byteLength: 5 })]
+      })
+    )
+    expect(recordUsage).toHaveBeenCalledTimes(2)
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        source: 'vision',
+        frameworkId: 'opencode',
+        model: 'vision-model',
+        usage: expect.objectContaining({ inputTokens: 8, outputTokens: 2 })
       })
     )
   })

--- a/src/main/acp/image-input-compatibility-owner.test.ts
+++ b/src/main/acp/image-input-compatibility-owner.test.ts
@@ -104,6 +104,30 @@ describe('ImageInputCompatibilityOwner', () => {
     )
   })
 
+  it('records provider usage attached to an ordinary Vision error', async () => {
+    const usage = { inputTokens: 7, cacheTokens: 1, outputTokens: 2, turnCount: 1 }
+    const recordUsage = vi.fn(async () => undefined)
+    const owner = new ImageInputCompatibilityOwner({
+      captureTarget: vi.fn(async () => target),
+      runner: {
+        run: vi.fn(async () => {
+          throw Object.assign(new Error('provider failed'), { usage })
+        })
+      },
+      recordUsage
+    })
+
+    await expect(
+      owner.prepare({
+        content: [image],
+        supportsImageInput: false,
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      })
+    ).rejects.toThrow('provider failed')
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({ source: 'vision', usage }))
+  })
+
   it('accepts a scalar uncertainty from the Vision model', async () => {
     const owner = new ImageInputCompatibilityOwner({
       captureTarget: vi.fn(async () => target),

--- a/src/main/acp/image-input-compatibility-owner.ts
+++ b/src/main/acp/image-input-compatibility-owner.ts
@@ -18,7 +18,7 @@ import {
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
 import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
 import {
-  RestrictedInferenceError,
+  extractRestrictedInferenceUsage,
   type RestrictedInferenceResult,
   type RestrictedInferenceRunInput
 } from './restricted-inference-runner'
@@ -611,7 +611,7 @@ class ImageInputCompatibilityOwner {
       await this.recordUsage(context, eventId, result.frameworkId, result.model, result.usage)
       return parseEvidence(result.text)
     } catch (error) {
-      const usage = error instanceof RestrictedInferenceError ? error.usage : undefined
+      const usage = extractRestrictedInferenceUsage(error)
       await this.recordUsage(
         context,
         eventId,

--- a/src/main/acp/image-input-compatibility-owner.ts
+++ b/src/main/acp/image-input-compatibility-owner.ts
@@ -1,5 +1,5 @@
 import type { ContentBlock } from '@agentclientprotocol/sdk'
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 import {
   MAX_ACP_MESSAGE_IMAGE_BYTES_PER_MESSAGE,
@@ -16,9 +16,11 @@ import {
   VISION_MODEL_NOT_CONFIGURED_MESSAGE
 } from '../../shared/run-error-classification'
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
-import type {
-  RestrictedInferenceResult,
-  RestrictedInferenceRunInput
+import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
+import {
+  RestrictedInferenceError,
+  type RestrictedInferenceResult,
+  type RestrictedInferenceRunInput
 } from './restricted-inference-runner'
 import type { VisionEvidencePersistence, VisionEvidenceSource } from './vision-evidence-repository'
 import { isRecord } from './value-guards'
@@ -79,6 +81,7 @@ type ImageInputCompatibilityOwnerOptions = Readonly<{
     'run'
   >
   evidenceRepository?: VisionEvidencePersistence
+  recordUsage?: (record: SessionAuxiliaryTurnUsageRecord) => Promise<unknown>
 }>
 
 type PrepareImageInputCompatibilityInput = Readonly<{
@@ -551,7 +554,7 @@ class ImageInputCompatibilityOwner {
       }
     }
 
-    const evidence = await this.run(image, target, context.signal)
+    const evidence = await this.run(image, target, context)
     if (
       identityKey &&
       context.projectId &&
@@ -591,19 +594,55 @@ class ImageInputCompatibilityOwner {
   private async run(
     image: AcpMessageImage,
     target: ExplicitAgentBackendTarget,
-    signal?: AbortSignal
+    context: Readonly<{ projectId?: string; sessionId?: string; signal?: AbortSignal }>
   ): Promise<ImageEvidence> {
-    const result = await this.options.runner.run({
-      prompt: 'Extract complete canonical image evidence.',
-      images: [image],
-      target,
-      systemPrompt: VISION_SYSTEM_PROMPT,
-      agentName: 'open-science-vision-evidence',
-      description: 'Extract bounded evidence from one attached image without tools.',
-      signal,
-      outputLimitBytes: MAX_EVIDENCE_OUTPUT_BYTES
-    })
-    return parseEvidence(result.text)
+    const eventId = randomUUID()
+    try {
+      const result = await this.options.runner.run({
+        prompt: 'Extract complete canonical image evidence.',
+        images: [image],
+        target,
+        systemPrompt: VISION_SYSTEM_PROMPT,
+        agentName: 'open-science-vision-evidence',
+        description: 'Extract bounded evidence from one attached image without tools.',
+        signal: context.signal,
+        outputLimitBytes: MAX_EVIDENCE_OUTPUT_BYTES
+      })
+      await this.recordUsage(context, eventId, result.frameworkId, result.model, result.usage)
+      return parseEvidence(result.text)
+    } catch (error) {
+      const usage = error instanceof RestrictedInferenceError ? error.usage : undefined
+      await this.recordUsage(
+        context,
+        eventId,
+        target.frameworkId,
+        target.model.kind === 'required' ? target.model.id : undefined,
+        usage
+      )
+      throw error
+    }
+  }
+
+  private async recordUsage(
+    context: Readonly<{ projectId?: string; sessionId?: string }>,
+    eventId: string,
+    frameworkId: SessionAuxiliaryTurnUsageRecord['frameworkId'],
+    model: string | undefined,
+    usage: RestrictedInferenceResult['usage']
+  ): Promise<void> {
+    if (!context.projectId || !context.sessionId || !usage || !this.options.recordUsage) return
+    await this.options
+      .recordUsage({
+        projectId: context.projectId,
+        sessionId: context.sessionId,
+        eventId,
+        source: 'vision',
+        frameworkId,
+        model,
+        completedAtMs: Date.now(),
+        usage
+      })
+      .catch(() => undefined)
   }
 }
 

--- a/src/main/acp/prompt-preparation-owner.test.ts
+++ b/src/main/acp/prompt-preparation-owner.test.ts
@@ -307,7 +307,8 @@ describe('AcpPromptPreparationOwner', () => {
         home: '/codex',
         bridgeSkillsAvailable: true,
         selectSkills: expect.any(Function),
-        signal: expect.any(AbortSignal)
+        signal: expect.any(AbortSignal),
+        observeUsage: expect.any(Function)
       }
     })
     expect(fixture.promptContent.prepare).toHaveBeenCalledWith(

--- a/src/main/acp/prompt-preparation-owner.ts
+++ b/src/main/acp/prompt-preparation-owner.ts
@@ -6,7 +6,7 @@ import type { UploadedAttachment } from '../../shared/uploads'
 import type { FileReference } from '../../shared/artifacts'
 import { resolveFileTextBudget } from '../../shared/history-preamble'
 import type { NotebookHandoffContext } from '../notebook/runtime-service'
-import type { ResolvedAgentBackend } from '../agent-framework'
+import type { ResolvedAgentBackend, SkillSelectorUsageObservation } from '../agent-framework'
 import { createLogger, errorLogFields } from '../logger'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
 import type {
@@ -161,6 +161,17 @@ class AcpPromptPreparationOwner {
       const requestText = this.options.presentation.continuationText(input.request)
       const computeExecutionTargetReminder =
         this.options.presentation.computeExecutionTargetReminder(input.selectedComputeHostIds ?? [])
+      const observeSelectorUsage = ({
+        usage,
+        sourceInvocationId
+      }: SkillSelectorUsageObservation): void => {
+        const contextUsedTokens = usage.inputTokens + (usage.cachedReadTokens ?? 0)
+        preDispatchModelCalls.push({
+          ...usage,
+          ...(sourceInvocationId ? { sourceInvocationId } : {}),
+          ...(Number.isSafeInteger(contextUsedTokens) ? { contextUsedTokens } : {})
+        })
+      }
       const skillPreparation = await input.turnSkill.prepareProvider({
         frameworkId: input.backend.framework.id,
         selectionText: [input.request.text, computeExecutionTargetReminder]
@@ -170,9 +181,10 @@ class AcpPromptPreparationOwner {
         codex: {
           home: input.backend.adapter.codexHome,
           bridgeSkillsAvailable: input.bridgeSkillsAvailable,
-          selectSkills: async (text, catalog, signal) =>
-            (await this.options.selectBridgeSkills(text, catalog, signal)) ?? [],
-          signal: input.signal
+          selectSkills: async (text, catalog, signal, observeUsage) =>
+            (await this.options.selectBridgeSkills(text, catalog, signal, observeUsage)) ?? [],
+          signal: input.signal,
+          observeUsage: observeSelectorUsage
         },
         ...(input.backend.framework.id === 'codebuddy'
           ? {
@@ -183,14 +195,7 @@ class AcpPromptPreparationOwner {
                   (await this.options.selectBridgeSkills(text, catalog, signal, observeUsage)) ??
                   [],
                 signal: input.signal,
-                observeUsage: ({ usage, sourceInvocationId }) => {
-                  const contextUsedTokens = usage.inputTokens + (usage.cachedReadTokens ?? 0)
-                  preDispatchModelCalls.push({
-                    ...usage,
-                    ...(sourceInvocationId ? { sourceInvocationId } : {}),
-                    ...(Number.isSafeInteger(contextUsedTokens) ? { contextUsedTokens } : {})
-                  })
-                }
+                observeUsage: observeSelectorUsage
               }
             }
           : {})

--- a/src/main/acp/provider-prompt-executor.test.ts
+++ b/src/main/acp/provider-prompt-executor.test.ts
@@ -502,4 +502,22 @@ describe('AcpProviderPromptExecutor', () => {
     fixture.executor.observeProviderMessage(providerMessage)
     expect(fixture.probe.observe).toHaveBeenCalledOnce()
   })
+
+  it('observes externally driven turns through the provider message route', async () => {
+    const fixture = setup()
+    const response: PromptResponse = { stopReason: 'end_turn' }
+    const observation = await fixture.executor.beginObservation({
+      providerSessionId: 'provider-1',
+      cwd: '/workspace',
+      frameworkId: 'claude-code'
+    })
+    const providerMessage = { sessionId: 'provider-1', message: { type: 'result' } }
+
+    fixture.executor.observeProviderMessage(providerMessage)
+    await observation.finalize({ response })
+    fixture.executor.observeProviderMessage(providerMessage)
+
+    expect(fixture.probe.observe).toHaveBeenCalledOnce()
+    expect(fixture.probe.finalize).toHaveBeenCalledWith({ response })
+  })
 })

--- a/src/main/acp/provider-prompt-executor.test.ts
+++ b/src/main/acp/provider-prompt-executor.test.ts
@@ -513,9 +513,9 @@ describe('AcpProviderPromptExecutor', () => {
     })
     const providerMessage = { sessionId: 'provider-1', message: { type: 'result' } }
 
-    fixture.executor.observeProviderMessage(providerMessage)
+    observation.observe?.(providerMessage)
     await observation.finalize({ response })
-    fixture.executor.observeProviderMessage(providerMessage)
+    observation.observe?.(providerMessage)
 
     expect(fixture.probe.observe).toHaveBeenCalledOnce()
     expect(fixture.probe.finalize).toHaveBeenCalledWith({ response })

--- a/src/main/acp/provider-prompt-executor.ts
+++ b/src/main/acp/provider-prompt-executor.ts
@@ -185,6 +185,9 @@ class AcpProviderPromptExecutor {
       }
     }
     return {
+      observe: (message) => {
+        if (open) this.observeProviderMessage(message)
+      },
       finalize: async ({ response }) => {
         if (!open) return EMPTY_FACTS
         open = false

--- a/src/main/acp/provider-prompt-executor.ts
+++ b/src/main/acp/provider-prompt-executor.ts
@@ -41,6 +41,13 @@ type AcpProviderPromptExecutorOptions = Readonly<{
   opencodeUsageFetch?: typeof fetch
 }>
 
+type ProviderTurnObservationInput = Readonly<{
+  providerSessionId: string
+  cwd: string
+  frameworkId: AgentFrameworkId
+  reportBestEffortFailure?: (stage: ProviderPromptObservationStage, error: unknown) => void
+}>
+
 type ProviderPromptOutcome =
   | Readonly<{ kind: 'not-dispatched' }>
   | Readonly<{ kind: 'superseded'; response: PromptResponse }>
@@ -152,6 +159,53 @@ class AcpProviderPromptExecutor {
       observation.probe.observe(message)
     } catch (error) {
       reportBestEffort(observation.report, 'observe', error)
+    }
+  }
+
+  async beginObservation(input: ProviderTurnObservationInput): Promise<AcpProviderTurnProbe> {
+    const token = Symbol(input.providerSessionId)
+    let probe = NOOP_PROBE
+    try {
+      probe = await this.adapterFor(input.frameworkId).begin({
+        providerSessionId: input.providerSessionId,
+        cwd: input.cwd
+      })
+    } catch (error) {
+      reportBestEffort(input.reportBestEffortFailure, 'begin', error)
+    }
+    this.observations.set(input.providerSessionId, {
+      token,
+      probe,
+      report: input.reportBestEffortFailure
+    })
+    let open = true
+    const release = (): void => {
+      if (this.observations.get(input.providerSessionId)?.token === token) {
+        this.observations.delete(input.providerSessionId)
+      }
+    }
+    return {
+      finalize: async ({ response }) => {
+        if (!open) return EMPTY_FACTS
+        open = false
+        release()
+        try {
+          return normalizeFacts(response, await probe.finalize({ response }))
+        } catch (error) {
+          reportBestEffort(input.reportBestEffortFailure, 'finalize', error)
+          return normalizeFacts(response, EMPTY_FACTS)
+        }
+      },
+      cancel: async () => {
+        if (!open) return
+        open = false
+        release()
+        try {
+          await probe.cancel()
+        } catch (error) {
+          reportBestEffort(input.reportBestEffortFailure, 'cancel', error)
+        }
+      }
     }
   }
 
@@ -285,4 +339,9 @@ class AcpProviderPromptExecutor {
 }
 
 export { AcpProviderPromptExecutor }
-export type { ProviderPromptExecutionInput, ProviderPromptObservationStage, ProviderPromptOutcome }
+export type {
+  ProviderPromptExecutionInput,
+  ProviderPromptObservationStage,
+  ProviderPromptOutcome,
+  ProviderTurnObservationInput
+}

--- a/src/main/acp/restricted-inference-runner.ts
+++ b/src/main/acp/restricted-inference-runner.ts
@@ -3,7 +3,12 @@ import { mkdir, mkdtemp, readdir, rm, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { isCodexSubscriptionProviderId } from '../../shared/settings'
-import type { AcpMessageImage, AcpRuntimeEvent, AcpTurnTokenUsage } from '../../shared/acp'
+import {
+  sanitizeAcpTurnTokenUsage,
+  type AcpMessageImage,
+  type AcpRuntimeEvent,
+  type AcpTurnTokenUsage
+} from '../../shared/acp'
 import type { AgentFrameworkId } from '../../shared/settings'
 import type { ResolvedAgentBackend } from '../agent-framework'
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
@@ -27,6 +32,12 @@ class RestrictedInferenceError extends Error {
   ) {
     super(message)
   }
+}
+
+const extractRestrictedInferenceUsage = (error: unknown): AcpTurnTokenUsage | undefined => {
+  if (error instanceof RestrictedInferenceError) return error.usage
+  if (!(error instanceof Error)) return undefined
+  return sanitizeAcpTurnTokenUsage(Object.getOwnPropertyDescriptor(error, 'usage')?.value)
 }
 
 type RestrictedInferenceResult = Readonly<{
@@ -354,6 +365,7 @@ class RestrictedInferenceRunner {
 
 export {
   DEFAULT_OUTPUT_LIMIT_BYTES,
+  extractRestrictedInferenceUsage,
   RestrictedInferenceError,
   RestrictedInferenceRunner,
   resolveRestrictedInferenceModel

--- a/src/main/acp/reviewer-session-owner.ts
+++ b/src/main/acp/reviewer-session-owner.ts
@@ -75,6 +75,7 @@ export type ReviewerSessionRequest = {
 
 export type ReviewerSessionResult = {
   session: ActiveSession
+  cwd: string
   promptPrefix?: string
   role: ReviewerSessionRole
 }
@@ -208,7 +209,12 @@ export class ReviewerSessionOwner {
         identityActivated = true
         this.dependencies.registerBridgeSession(session.sessionId)
 
-        return { session, promptPrefix: setup.promptPrefix, role: REVIEWER_SESSION_ROLE }
+        return {
+          session,
+          cwd: reviewerCwd,
+          promptPrefix: setup.promptPrefix,
+          role: REVIEWER_SESSION_ROLE
+        }
       } catch (error) {
         let startupError = error
         if (!identityActivated) {

--- a/src/main/acp/runtime-activity.ts
+++ b/src/main/acp/runtime-activity.ts
@@ -13,7 +13,7 @@ export type AcpRuntimeActivity = Pick<
   AcpRuntime,
   'buildReviewerSession' | 'disposeReviewerSession' | 'sendPrompt' | 'sendApplicationPrompt'
 > &
-  Partial<Pick<AcpRuntime, 'captureBackend'>>
+  Partial<Pick<AcpRuntime, 'captureBackend' | 'beginProviderTurnObservation'>>
 
 export type AcpRuntimeActivityOwner = {
   withActivity: <T>(

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -158,6 +158,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
   imageInputCompatibility?: AcpRuntimeOptions['imageInputCompatibility']
   resolveComputeExecutionTargetIds?: AcpRuntimeOptions['resolveComputeExecutionTargetIds']
   memory?: AcpRuntimeOptions['memory']
+  auxiliaryUsage?: AcpRuntimeOptions['auxiliaryUsage']
 }
 
 // Composes the compatibility façade while the coordinator remains the cross-generation Session owner.
@@ -199,7 +200,8 @@ const createAcpRuntime = ({
   sideChatRelays,
   imageInputCompatibility,
   resolveComputeExecutionTargetIds,
-  memory
+  memory,
+  auxiliaryUsage
 }: AcpRuntimeCompositionOptions): AcpRuntimeCoordinator => {
   const configRoot = resolveConfigRoot()
   const dataRoot = resolveDataRoot()
@@ -254,6 +256,7 @@ const createAcpRuntime = ({
           : settingsService.captureActiveAgentBackendSelection()
       const runtimeOptions: AcpRuntimeOptions = {
         appVersion: app.getVersion(),
+        auxiliaryUsage,
         // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
         defaultCwd,
         resolveBackend: async (context) =>

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -82,6 +82,7 @@ const createFakeRuntime = (options: {
   applyReasoningEffortChange: ReturnType<typeof vi.fn>
   applyModelChange: ReturnType<typeof vi.fn>
   captureBackend: ReturnType<typeof vi.fn>
+  beginProviderTurnObservation: ReturnType<typeof vi.fn>
   captureSessionModel: ReturnType<typeof vi.fn>
   setPermissionProfile: ReturnType<typeof vi.fn>
   respondToPermission: ReturnType<typeof vi.fn>
@@ -146,6 +147,10 @@ const createFakeRuntime = (options: {
   const applyReasoningEffortChange = vi.fn(async () => true)
   const applyModelChange = vi.fn(async () => true)
   const captureBackend = vi.fn(() => ({ backendId: `${options.frameworkId}:owned` }) as never)
+  const beginProviderTurnObservation = vi.fn(async () => ({
+    finalize: vi.fn(async () => ({})),
+    cancel: vi.fn()
+  }))
   const captureSessionModel = vi.fn((sessionId: string) => ({
     backend: { backendId: `${options.frameworkId}:owned` },
     appliedModel: `${sessionId}:applied`
@@ -280,6 +285,7 @@ const createFakeRuntime = (options: {
     applyReasoningEffortChange,
     applyModelChange,
     captureBackend,
+    beginProviderTurnObservation,
     captureSessionModel,
     setPermissionProfile,
     respondToPermission,
@@ -309,6 +315,7 @@ const createFakeRuntime = (options: {
     applyReasoningEffortChange,
     applyModelChange,
     captureBackend,
+    beginProviderTurnObservation,
     captureSessionModel,
     setPermissionProfile,
     respondToPermission,
@@ -4175,13 +4182,21 @@ describe('AcpRuntimeCoordinator', () => {
       oldActivityStarted.resolve()
       await releaseOldActivity.promise
       oldBackendId = runtime.captureBackend?.().backendId
+      await runtime.beginProviderTurnObservation?.({
+        providerSessionId: 'reviewer-old',
+        cwd: '/workspace'
+      })
       await runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
     })
     await oldActivityStarted.promise
 
     await coordinator.requestAgentFrameworkSwitch()
-    await coordinator.withActivity({}, (runtime) => {
+    await coordinator.withActivity({}, async (runtime) => {
       newBackendId = runtime.captureBackend?.().backendId
+      await runtime.beginProviderTurnObservation?.({
+        providerSessionId: 'reviewer-new',
+        cwd: '/workspace'
+      })
       return runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
     })
     releaseOldActivity.resolve()
@@ -4189,6 +4204,14 @@ describe('AcpRuntimeCoordinator', () => {
 
     expect(vi.mocked(created[0].runtime.buildReviewerSession)).toHaveBeenCalledOnce()
     expect(vi.mocked(created[1].runtime.buildReviewerSession)).toHaveBeenCalledOnce()
+    expect(created[0].beginProviderTurnObservation).toHaveBeenCalledWith({
+      providerSessionId: 'reviewer-old',
+      cwd: '/workspace'
+    })
+    expect(created[1].beginProviderTurnObservation).toHaveBeenCalledWith({
+      providerSessionId: 'reviewer-new',
+      cwd: '/workspace'
+    })
     expect(oldBackendId).toBe('claude-code:owned')
     expect(newBackendId).toBe('codex:owned')
   })

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1431,6 +1431,7 @@ class AcpRuntimeCoordinator {
 
     return {
       captureBackend: () => runtime.captureBackend(),
+      beginProviderTurnObservation: (input) => runtime.beginProviderTurnObservation(input),
       buildReviewerSession: (request) => this.buildReviewerSessionOnRuntime(runtime, request),
       disposeReviewerSession: (session) => {
         this.reviewerRuntimes.delete(session)

--- a/src/main/acp/runtime-prompt-composition.ts
+++ b/src/main/acp/runtime-prompt-composition.ts
@@ -212,6 +212,36 @@ const composeAcpRuntimePromptOwners = (
       })
     },
     serialization: base.providerPromptSerialization,
+    ...(options.auxiliaryUsage
+      ? {
+          usage: {
+            begin: (input) => base.providerPromptExecutor.beginObservation(input),
+            cwd: (sessionId) =>
+              session.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().cwd ??
+              base.snapshotOwner.cwd,
+            model: () =>
+              base.backendGeneration.current.context.model ??
+              base.backendGeneration.current.session.model,
+            record: async ({ sessionId, eventId, frameworkId, model, completedAtMs, facts }) => {
+              const projectId = await options.auxiliaryUsage!.projectIdForSession(sessionId)
+              if (!projectId) return
+              await options.auxiliaryUsage!.record({
+                projectId,
+                sessionId,
+                eventId,
+                source: 'context-compaction',
+                frameworkId,
+                model,
+                completedAtMs,
+                usage: {
+                  ...facts.turnUsage!,
+                  ...(facts.modelTurnCount === undefined ? {} : { turnCount: facts.modelTurnCount })
+                }
+              })
+            }
+          }
+        }
+      : {}),
     cancelCompaction: async (sessionId) => {
       const connection = base.connectionResources.connection
       const active = activeSession(sessionId)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -13010,6 +13010,7 @@ describe('ACP runtime session management', () => {
     })
     const { session } = built
     expect(built.role).toBe('reviewer')
+    expect(built.cwd).toMatch(/open-science-reviewer-/)
     expect(session.sessionId).toBe('reviewer-session-1')
     expect(reviewerOwnerProbe(runtime).contextFor('reviewer-session-1')).toEqual({
       frameworkId: 'claude-code',
@@ -22464,7 +22465,8 @@ describe('ACP runtime skill force-load + nudge', () => {
     expect(selectSkills).toHaveBeenCalledWith(
       '用 PubMed 搜索肿瘤免疫文章',
       catalog,
-      expect.any(AbortSignal)
+      expect.any(AbortSignal),
+      expect.any(Function)
     )
     expect(receivedPrompt).toEqual([
       {
@@ -25816,7 +25818,8 @@ describe('Specialist Skill scoping', () => {
     expect(selectSkills).toHaveBeenCalledWith(
       'use the new connector',
       [newConnector],
-      expect.any(AbortSignal)
+      expect.any(AbortSignal),
+      expect.any(Function)
     )
     expect(receivedPrompt).toEqual([
       {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -175,6 +175,12 @@ type AcpRuntimeOptions = {
   appVersion: string
   defaultCwd: string
   callbacks?: AcpRuntimeCallbacks
+  auxiliaryUsage?: Readonly<{
+    projectIdForSession: (sessionId: string) => Promise<string | undefined>
+    record: (
+      input: import('../session-persistence/auxiliary-turn-usage').SessionAuxiliaryTurnUsageRecord
+    ) => Promise<unknown>
+  }>
   permissionGrantStore?: ConversationPermissionGrantStore
   permissionGrantRegistry?: PermissionGrantRegistry
   permissionGrantContext?: Readonly<{ projectId: string; sessionId: string }>
@@ -717,6 +723,16 @@ class AcpRuntime {
 
   captureBackend(): AcpBackendGenerationView {
     return this.backend
+  }
+
+  beginProviderTurnObservation(input: {
+    providerSessionId: string
+    cwd: string
+  }): ReturnType<AcpProviderPromptExecutor['beginObservation']> {
+    return this.providerPromptExecutor.beginObservation({
+      ...input,
+      frameworkId: this.framework.id
+    })
   }
 
   captureSessionModel(

--- a/src/main/acp/turn-skill-owner.ts
+++ b/src/main/acp/turn-skill-owner.ts
@@ -36,6 +36,9 @@ type ProviderPreparationInput = Readonly<{
     bridgeSkillsAvailable: boolean
     selectSkills: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>['selectSkills']
     signal?: AbortSignal
+    observeUsage?: Parameters<
+      NonNullable<ResolvedAgentBackend['responsesBridgeLease']>['selectSkills']
+    >[3]
   }>
   codebuddy?: Readonly<{
     root?: string
@@ -411,7 +414,9 @@ class AcpTurnSkillOwner {
     }
     if (catalog.length === 0) return []
     try {
-      const selected = await codex.selectSkills(input.selectionText, catalog, codex.signal)
+      const selected = codex.observeUsage
+        ? await codex.selectSkills(input.selectionText, catalog, codex.signal, codex.observeUsage)
+        : await codex.selectSkills(input.selectionText, catalog, codex.signal)
       if (!selected) return []
       const offered = new Set(catalog.map((skill) => `${skill.name}\u0000${skill.path}`))
       return selected.filter((skill) => offered.has(`${skill.name}\u0000${skill.path}`))

--- a/src/main/artifacts/code-reconstruction.ts
+++ b/src/main/artifacts/code-reconstruction.ts
@@ -34,7 +34,8 @@ type CodeReconstructionRunner = {
   captureTarget(): Promise<ExplicitAgentBackendTarget>
   run(
     prompt: string,
-    target: ExplicitAgentBackendTarget
+    target: ExplicitAgentBackendTarget,
+    context: Readonly<{ projectId: string; sessionId: string }>
   ): Promise<{ text: string; frameworkId: AgentFrameworkId; model: string }>
 }
 
@@ -672,7 +673,10 @@ export class ArtifactCodeReconstructionService {
       // resolved at spawn time by the runner.
       const target = await this.options.runner.captureTarget()
       const context = buildContext(source)
-      const result = await this.options.runner.run(buildPrompt(context.serialized), target)
+      const result = await this.options.runner.run(buildPrompt(context.serialized), target, {
+        projectId: request.projectId,
+        sessionId: request.appSessionId
+      })
       const code = normalizeResponse(result.text)
       value = {
         origin: 'llm',

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -10,6 +10,7 @@ import { createProjectDbClient } from '../projects/prisma-client'
 import { migrateApplicationDatabase, verifyCurrentApplicationSchema } from './migration-service'
 
 const CURRENT_AGENT_MEMORY_MIGRATION_ID = '0017_agent_memory_project_scope'
+const CURRENT_MIGRATION_ID = '0018_session_auxiliary_turn_usage'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -290,20 +291,21 @@ describe('agent memory project scope migration', () => {
 
     await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: CURRENT_AGENT_MEMORY_MIGRATION_ID
+      migrationId: CURRENT_MIGRATION_ID
     })
   })
 
   it('replays an unledgered partial memory migration and restores missing triggers', async () => {
     await client.$executeRawUnsafe('DROP TRIGGER "MemoryEntry_fts_update"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" = ?`,
-      CURRENT_AGENT_MEMORY_MIGRATION_ID
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?)`,
+      CURRENT_AGENT_MEMORY_MIGRATION_ID,
+      CURRENT_MIGRATION_ID
     )
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      applied: [CURRENT_AGENT_MEMORY_MIGRATION_ID],
-      to: CURRENT_AGENT_MEMORY_MIGRATION_ID
+      applied: [CURRENT_AGENT_MEMORY_MIGRATION_ID, CURRENT_MIGRATION_ID],
+      to: CURRENT_MIGRATION_ID
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -128,7 +128,8 @@ describe('application database (integration)', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
 
@@ -1158,7 +1159,8 @@ describe('application database (integration)', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
 

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -62,15 +62,22 @@ describe('Compute Job sensitive data encryption migration', () => {
 
     await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope'],
+      applied: [
+        '0016_compute_job_sensitive_data_encryption',
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
+      ],
       from: '0015_session_model_call_usage',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_session_auxiliary_turn_usage'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0017_agent_memory_project_scope.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
     ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -156,10 +156,11 @@ describe('database JSON constraints migration', () => {
           '0014_review_query_indexes',
           '0015_session_model_call_usage',
           '0016_compute_job_sensitive_data_encryption',
-          '0017_agent_memory_project_scope'
+          '0017_agent_memory_project_scope',
+          '0018_session_auxiliary_turn_usage'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0017_agent_memory_project_scope'
+        to: '0018_session_auxiliary_turn_usage'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).rejects.toMatchObject({
         code: 'ENOENT'
@@ -183,9 +184,12 @@ describe('database JSON constraints migration', () => {
       ).rejects.toMatchObject({ code: 'ENOENT' })
       await expect(
         access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
-      ).resolves.toBeUndefined()
+      ).rejects.toMatchObject({ code: 'ENOENT' })
       await expect(
         access(`${databasePath}.before-0017_agent_memory_project_scope.backup`)
+      ).resolves.toBeUndefined()
+      await expect(
+        access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
       ).resolves.toBeUndefined()
 
       await expect(

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -114,7 +114,8 @@ describe('database startup logging', () => {
               '0014_review_query_indexes',
               '0015_session_model_call_usage',
               '0016_compute_job_sensitive_data_encryption',
-              '0017_agent_memory_project_scope'
+              '0017_agent_memory_project_scope',
+              '0018_session_auxiliary_turn_usage'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -94,6 +94,25 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "SessionModelCallUsage_identity_check" CHECK (length(trim("messageId")) > 0 AND length(trim("callId")) > 0 AND "callIndex" >= 0 AND ("sourceInvocationId" IS NULL OR length(trim("sourceInvocationId")) > 0) AND ("frameworkId" IS NULL OR length(trim("frameworkId")) > 0) AND ("backendId" IS NULL OR length(trim("backendId")) > 0) AND ("model" IS NULL OR length(trim("model")) > 0)),
     CONSTRAINT "SessionModelCallUsage_nonnegative_check" CHECK ("inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("contextUsedTokens" IS NULL OR "contextUsedTokens" >= 0) AND ("contextWindowSize" IS NULL OR "contextWindowSize" > 0))
 );`,
+  `CREATE TABLE IF NOT EXISTS "SessionAuxiliaryTurnUsage" (
+    "sessionId" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "frameworkId" TEXT NOT NULL,
+    "model" TEXT,
+    "completedAtMs" BIGINT NOT NULL,
+    "inputTokens" BIGINT NOT NULL,
+    "cacheTokens" BIGINT NOT NULL,
+    "cachedReadTokens" BIGINT,
+    "cachedWriteTokens" BIGINT,
+    "outputTokens" BIGINT NOT NULL,
+    "modelCallCount" INTEGER,
+
+    PRIMARY KEY ("sessionId", "eventId"),
+    CONSTRAINT "SessionAuxiliaryTurnUsage_identity_check" CHECK (length(trim("sessionId")) > 0 AND length(trim("eventId")) > 0 AND length(trim("frameworkId")) > 0 AND ("model" IS NULL OR length(trim("model")) > 0)),
+    CONSTRAINT "SessionAuxiliaryTurnUsage_source_check" CHECK ("source" IN ('reviewer', 'side-chat', 'vision', 'session-details', 'host-llm', 'artifact-code-reconstruction', 'context-compaction')),
+    CONSTRAINT "SessionAuxiliaryTurnUsage_nonnegative_check" CHECK ("completedAtMs" >= 0 AND "inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("modelCallCount" IS NULL OR "modelCallCount" > 0))
+);`,
   `CREATE TABLE IF NOT EXISTS "SessionRun" (
     "sessionId" TEXT NOT NULL,
     "messageId" TEXT NOT NULL,
@@ -642,6 +661,7 @@ const RUNTIME_SCHEMA_INDEX_DDLS = [
   `CREATE INDEX IF NOT EXISTS "PendingSessionReconciliation_projectId_idx" ON "PendingSessionReconciliation"("projectId");`,
   `CREATE INDEX IF NOT EXISTS "SessionTurnUsage_completedAtMs_idx" ON "SessionTurnUsage"("completedAtMs");`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "SessionModelCallUsage_sessionId_messageId_callIndex_key" ON "SessionModelCallUsage"("sessionId", "messageId", "callIndex");`,
+  `CREATE INDEX IF NOT EXISTS "SessionAuxiliaryTurnUsage_completedAtMs_idx" ON "SessionAuxiliaryTurnUsage"("completedAtMs");`,
   `CREATE INDEX IF NOT EXISTS "SessionRun_createdAtMs_idx" ON "SessionRun"("createdAtMs");`,
   `CREATE INDEX IF NOT EXISTS "SessionArtifactRef_artifactId_artifactCreatedAtMs_idx" ON "SessionArtifactRef"("artifactId", "artifactCreatedAtMs");`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "PermissionGrant_fingerprint_key" ON "PermissionGrant"("fingerprint");`,
@@ -722,6 +742,7 @@ const RUNTIME_SCHEMA_TABLES = [
   'PendingSessionReconciliation',
   'SessionTurnUsage',
   'SessionModelCallUsage',
+  'SessionAuxiliaryTurnUsage',
   'SessionRun',
   'SessionArtifactRef',
   'PermissionGrant',

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -20,7 +20,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0018_test_suffix'
+  const id = '0019_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -264,10 +264,11 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ],
       from: null,
-      to: '0017_agent_memory_project_scope'
+      to: '0018_session_auxiliary_turn_usage'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -280,8 +281,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0017_agent_memory_project_scope',
-      to: '0017_agent_memory_project_scope'
+      from: '0018_session_auxiliary_turn_usage',
+      to: '0018_session_auxiliary_turn_usage'
     })
   })
 
@@ -343,7 +344,7 @@ describe('application database migrations', () => {
     await client.$executeRawUnsafe('ALTER TABLE "SessionTurnUsage" DROP COLUMN "cachedWriteTokens"')
     await client.$executeRawUnsafe('ALTER TABLE "SessionTurnUsage" DROP COLUMN "modelCallCount"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage')`
     )
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.project.create({ data: { id: 'project-1', name: 'Project' } })
@@ -358,7 +359,8 @@ describe('application database migrations', () => {
       applied: [
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
     await expect(
@@ -429,7 +431,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -474,7 +477,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0017_agent_memory_project_scope'
+      to: '0018_session_auxiliary_turn_usage'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -497,7 +500,7 @@ describe('application database migrations', () => {
     await removeComputePasswordAuthSchema(client)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope')`)
+      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage')`)
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: [
@@ -512,10 +515,11 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_session_auxiliary_turn_usage'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -583,10 +587,11 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_session_auxiliary_turn_usage'
     })
     await expect(
       client.$queryRaw<
@@ -705,7 +710,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0017_agent_memory_project_scope'
+      migrationId: '0018_session_auxiliary_turn_usage'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -721,9 +726,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0018_test_suffix'],
-      from: '0017_agent_memory_project_scope',
-      to: '0018_test_suffix'
+      applied: ['0019_test_suffix'],
+      from: '0018_session_auxiliary_turn_usage',
+      to: '0019_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -747,7 +752,8 @@ describe('application database migrations', () => {
       { id: '0015_session_model_call_usage' },
       { id: '0016_compute_job_sensitive_data_encryption' },
       { id: '0017_agent_memory_project_scope' },
-      { id: '0018_test_suffix' }
+      { id: '0018_session_auxiliary_turn_usage' },
+      { id: '0019_test_suffix' }
     ])
   })
 
@@ -816,10 +822,11 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_session_auxiliary_turn_usage'
     })
     expect(backupEvents).toEqual([
       {
@@ -901,6 +908,11 @@ describe('application database migrations', () => {
         migrationId: '0017_agent_memory_project_scope',
         path: `${databasePath}.before-0017_agent_memory_project_scope.backup`,
         reused: false
+      },
+      {
+        migrationId: '0018_session_auxiliary_turn_usage',
+        path: `${databasePath}.before-0018_session_auxiliary_turn_usage.backup`,
+        reused: false
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -921,9 +933,12 @@ describe('application database migrations', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0017_agent_memory_project_scope.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
     ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<Array<{ agentContext: string; name: string }>>`
@@ -954,7 +969,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0018_test_suffix'
+      migrationId: '0019_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -983,7 +998,8 @@ describe('application database migrations', () => {
       { id: '0014_review_query_indexes' },
       { id: '0015_session_model_call_usage' },
       { id: '0016_compute_job_sensitive_data_encryption' },
-      { id: '0017_agent_memory_project_scope' }
+      { id: '0017_agent_memory_project_scope' },
+      { id: '0018_session_auxiliary_turn_usage' }
     ])
   })
 
@@ -1048,7 +1064,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0018_test_suffix'
+      migrationId: '0019_test_suffix'
     })
   })
 
@@ -1091,9 +1107,10 @@ describe('application database migrations', () => {
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
-        '0018_test_suffix'
+        '0018_session_auxiliary_turn_usage',
+        '0019_test_suffix'
       ],
-      to: '0018_test_suffix'
+      to: '0019_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -1334,7 +1351,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
     await expect(
@@ -1448,7 +1466,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1514,7 +1533,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
     await expect(
@@ -1583,7 +1603,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -1686,7 +1707,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
     await expect(
@@ -1709,6 +1731,7 @@ describe('application database migrations', () => {
     const modelCallUsageBackupPath = `${databasePath}.before-0015_session_model_call_usage.backup`
     const computeJobEncryptionBackupPath = `${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`
     const agentMemoryBackupPath = `${databasePath}.before-0017_agent_memory_project_scope.backup`
+    const auxiliaryUsageBackupPath = `${databasePath}.before-0018_session_auxiliary_turn_usage.backup`
     const backupEvents: unknown[] = []
     client = createProjectDbClient(storageRoot)
     await client.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -1751,7 +1774,8 @@ describe('application database migrations', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ]
     })
     expect(backupEvents).toEqual([
@@ -1839,6 +1863,11 @@ describe('application database migrations', () => {
         migrationId: '0017_agent_memory_project_scope',
         path: agentMemoryBackupPath,
         reused: false
+      },
+      {
+        migrationId: '0018_session_auxiliary_turn_usage',
+        path: auxiliaryUsageBackupPath,
+        reused: false
       }
     ])
     await expect(
@@ -1846,8 +1875,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0016_compute_job_sensitive_data_encryption.backup',
-      'open-science.db.before-0017_agent_memory_project_scope.backup'
+      'open-science.db.before-0017_agent_memory_project_scope.backup',
+      'open-science.db.before-0018_session_auxiliary_turn_usage.backup'
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentContextBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -1858,8 +1887,9 @@ describe('application database migrations', () => {
     await expect(access(sessionProjectionBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(reviewQueryIndexesBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(modelCallUsageBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(access(computeJobEncryptionBackupPath)).resolves.toBeUndefined()
+    await expect(access(computeJobEncryptionBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentMemoryBackupPath)).resolves.toBeUndefined()
+    await expect(access(auxiliaryUsageBackupPath)).resolves.toBeUndefined()
     await expect(client.project.count()).resolves.toBe(1)
 
     const backupClient = new PrismaClient({
@@ -2308,6 +2338,11 @@ describe('application database migrations', () => {
         migrationId: '0017_agent_memory_project_scope',
         path: `${databasePath}.before-0017_agent_memory_project_scope.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0018_session_auxiliary_turn_usage',
+        path: `${databasePath}.before-0018_session_auxiliary_turn_usage.backup`,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -2372,6 +2407,10 @@ describe('application database migrations', () => {
       {
         migrationId: '0017_agent_memory_project_scope',
         path: `${databasePath}.before-0017_agent_memory_project_scope.backup`
+      },
+      {
+        migrationId: '0018_session_auxiliary_turn_usage',
+        path: `${databasePath}.before-0018_session_auxiliary_turn_usage.backup`
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -2405,8 +2444,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0016_compute_job_sensitive_data_encryption.backup',
       'open-science.db.before-0017_agent_memory_project_scope.backup',
+      'open-science.db.before-0018_session_auxiliary_turn_usage.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -36,6 +36,7 @@ import {
   MEMORY_AUXILIARY_SCHEMA_OBJECTS,
   MEMORY_AUXILIARY_TABLE_NAMES
 } from './migrations/0017-agent-memory-project-scope'
+import { sessionAuxiliaryTurnUsageMigration } from './migrations/0018-session-auxiliary-turn-usage'
 import {
   applySqliteMigrationOperations,
   type SqliteMigrationOperation
@@ -279,6 +280,12 @@ const AGENT_MEMORY_PROJECT_SCOPE_CHECKSUM = checksumMigrationPayload(
   agentMemoryProjectScopeMigration.verifiers,
   agentMemoryProjectScopeMigration.operations
 )
+const SESSION_AUXILIARY_TURN_USAGE_CHECKSUM = checksumMigrationPayload(
+  sessionAuxiliaryTurnUsageMigration.id,
+  sessionAuxiliaryTurnUsageMigration.statements,
+  sessionAuxiliaryTurnUsageMigration.verifiers,
+  sessionAuxiliaryTurnUsageMigration.operations
+)
 const COMPUTE_JOB_SENSITIVE_DATA_ENCRYPTION_CHECKSUM = checksumMigrationPayload(
   computeJobSensitiveDataEncryptionMigration.id,
   computeJobSensitiveDataEncryptionMigration.statements,
@@ -341,6 +348,16 @@ const CROSS_RESOURCE_TAGS_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints =
 const AGENT_MEMORY_PROJECT_SCOPE_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints =
   Object.fromEntries(
     agentMemoryProjectScopeMigration.verifiers
+      .filter((verifier) => verifier.kind === 'check-constraints-exist')
+      .flatMap((verifier) => verifier.tables)
+      .map(({ table, constraints }) => [
+        table,
+        Object.fromEntries(constraints.map(({ name, expression }) => [name, expression]))
+      ])
+  )
+const SESSION_AUXILIARY_TURN_USAGE_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints =
+  Object.fromEntries(
+    sessionAuxiliaryTurnUsageMigration.verifiers
       .filter((verifier) => verifier.kind === 'check-constraints-exist')
       .flatMap((verifier) => verifier.tables)
       .map(({ table, constraints }) => [
@@ -459,6 +476,12 @@ const MIGRATION_MANIFEST = [
   {
     ...agentMemoryProjectScopeMigration,
     checksum: AGENT_MEMORY_PROJECT_SCOPE_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...sessionAuxiliaryTurnUsageMigration,
+    checksum: SESSION_AUXILIARY_TURN_USAGE_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }
@@ -724,6 +747,7 @@ const verifyCurrentApplicationSchema = async (client: PrismaClient): Promise<voi
     triggerNames: memoryTriggerNames
   })
   await runMigrationVerifiers(client, agentMemoryProjectScopeMigration.verifiers)
+  await runMigrationVerifiers(client, sessionAuxiliaryTurnUsageMigration.verifiers)
 }
 
 const readLedger = async (client: PrismaClient): Promise<LedgerRow[]> => {
@@ -1380,6 +1404,11 @@ const migrateApplicationDatabaseWithManifest = async (
       candidate.id === agentMemoryProjectScopeMigration.id &&
       candidate.checksum === AGENT_MEMORY_PROJECT_SCOPE_CHECKSUM
   )
+  const adoptsSessionAuxiliaryTurnUsage = manifest.some(
+    (candidate) =>
+      candidate.id === sessionAuxiliaryTurnUsageMigration.id &&
+      candidate.checksum === SESSION_AUXILIARY_TURN_USAGE_CHECKSUM
+  )
   const adoptedLegacy = appliedCount === 0 && hasExistingApplicationTables
   const allowedSuffixChecks = mergeAllowedSuffixChecks(
     adoptsDatabaseDomainConstraints ? DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS : {},
@@ -1388,7 +1417,8 @@ const migrateApplicationDatabaseWithManifest = async (
     adoptsVisionEvidence ? VISION_EVIDENCE_ALLOWED_SUFFIX_CHECKS : {},
     adoptsComputePasswordAuth ? COMPUTE_PASSWORD_AUTH_ALLOWED_SUFFIX_CHECKS : {},
     adoptsCrossResourceTags ? CROSS_RESOURCE_TAGS_ALLOWED_SUFFIX_CHECKS : {},
-    adoptsAgentMemoryProjectScope ? AGENT_MEMORY_PROJECT_SCOPE_ALLOWED_SUFFIX_CHECKS : {}
+    adoptsAgentMemoryProjectScope ? AGENT_MEMORY_PROJECT_SCOPE_ALLOWED_SUFFIX_CHECKS : {},
+    adoptsSessionAuxiliaryTurnUsage ? SESSION_AUXILIARY_TURN_USAGE_ALLOWED_SUFFIX_CHECKS : {}
   )
 
   let nextIndex = appliedCount

--- a/src/main/database/migrations/0018-session-auxiliary-turn-usage.ts
+++ b/src/main/database/migrations/0018-session-auxiliary-turn-usage.ts
@@ -1,0 +1,61 @@
+const auxiliaryTurnUsageIndexes = [
+  {
+    name: 'SessionAuxiliaryTurnUsage_completedAtMs_idx',
+    sql: `CREATE INDEX "SessionAuxiliaryTurnUsage_completedAtMs_idx" ON "SessionAuxiliaryTurnUsage"("completedAtMs")`
+  }
+] as const
+
+const sessionAuxiliaryTurnUsageMigration = {
+  id: '0018_session_auxiliary_turn_usage',
+  statements: [
+    `CREATE TABLE "SessionAuxiliaryTurnUsage" (
+      "sessionId" TEXT NOT NULL,
+      "eventId" TEXT NOT NULL,
+      "source" TEXT NOT NULL,
+      "frameworkId" TEXT NOT NULL,
+      "model" TEXT,
+      "completedAtMs" BIGINT NOT NULL,
+      "inputTokens" BIGINT NOT NULL,
+      "cacheTokens" BIGINT NOT NULL,
+      "cachedReadTokens" BIGINT,
+      "cachedWriteTokens" BIGINT,
+      "outputTokens" BIGINT NOT NULL,
+      "modelCallCount" INTEGER,
+      PRIMARY KEY ("sessionId", "eventId"),
+      CONSTRAINT "SessionAuxiliaryTurnUsage_identity_check" CHECK (length(trim("sessionId")) > 0 AND length(trim("eventId")) > 0 AND length(trim("frameworkId")) > 0 AND ("model" IS NULL OR length(trim("model")) > 0)),
+      CONSTRAINT "SessionAuxiliaryTurnUsage_source_check" CHECK ("source" IN ('reviewer', 'side-chat', 'vision', 'session-details', 'host-llm', 'artifact-code-reconstruction', 'context-compaction')),
+      CONSTRAINT "SessionAuxiliaryTurnUsage_nonnegative_check" CHECK ("completedAtMs" >= 0 AND "inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("modelCallCount" IS NULL OR "modelCallCount" > 0))
+    )`,
+    ...auxiliaryTurnUsageIndexes.map(({ sql }) => sql)
+  ] as const,
+  operations: [] as const,
+  verifiers: [
+    { kind: 'table-exists', version: 1, table: 'SessionAuxiliaryTurnUsage' },
+    {
+      kind: 'check-constraints-exist',
+      version: 1,
+      tables: [
+        {
+          table: 'SessionAuxiliaryTurnUsage',
+          constraints: [
+            {
+              name: 'SessionAuxiliaryTurnUsage_identity_check',
+              expression: `length(trim("sessionId")) > 0 AND length(trim("eventId")) > 0 AND length(trim("frameworkId")) > 0 AND ("model" IS NULL OR length(trim("model")) > 0)`
+            },
+            {
+              name: 'SessionAuxiliaryTurnUsage_source_check',
+              expression: `"source" IN ('reviewer', 'side-chat', 'vision', 'session-details', 'host-llm', 'artifact-code-reconstruction', 'context-compaction')`
+            },
+            {
+              name: 'SessionAuxiliaryTurnUsage_nonnegative_check',
+              expression: `"completedAtMs" >= 0 AND "inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("modelCallCount" IS NULL OR "modelCallCount" > 0)`
+            }
+          ]
+        }
+      ]
+    },
+    { kind: 'indexes-exist', version: 1, indexes: auxiliaryTurnUsageIndexes }
+  ] as const
+}
+
+export { sessionAuxiliaryTurnUsageMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -76,10 +76,11 @@ describe('notification attention metadata migration', () => {
         '0014_review_query_indexes',
         '0015_session_model_call_usage',
         '0016_compute_job_sensitive_data_encryption',
-        '0017_agent_memory_project_scope'
+        '0017_agent_memory_project_scope',
+        '0018_session_auxiliary_turn_usage'
       ],
       from: '0006_database_domain_constraints',
-      to: '0017_agent_memory_project_scope'
+      to: '0018_session_auxiliary_turn_usage'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)
@@ -101,9 +102,12 @@ describe('notification attention metadata migration', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0017_agent_memory_project_scope.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
     ).resolves.toBeUndefined()
 
     await expect(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -212,6 +212,10 @@ import { registerSideChatIpcHandlers } from './side-chat/ipc'
 import { SideChatRuntimeOwner } from './side-chat/runtime-owner'
 import { type SessionPersistenceBackend } from './session-persistence/ipc'
 import { MainMessageAttributionAuthority } from './session-persistence/message-attribution-authority'
+import {
+  SessionAuxiliaryTurnUsageRecorder,
+  type SessionAuxiliaryTurnUsageRecord
+} from './session-persistence/auxiliary-turn-usage'
 import { SessionDeletionOwner } from './session-deletion/owner'
 import { buildSessionDetailsUserPrompt, createSessionDetailsOwner } from './session-details/owner'
 import { tryDecryptKey } from './settings/crypto'
@@ -532,6 +536,20 @@ const createApplicationModules = async (
       ),
     (projectId, sessionId) => runtimeRef.current?.hasLiveSession(projectId, sessionId) ?? false
   )
+  const auxiliaryUsageLog = createLogger('session-usage:auxiliary')
+  const auxiliaryUsageRecorder = new SessionAuxiliaryTurnUsageRecorder(() =>
+    getProjectDbClient(resolveStorageRoot())
+  )
+  const recordAuxiliaryUsage = async (record: SessionAuxiliaryTurnUsageRecord): Promise<void> => {
+    try {
+      await auxiliaryUsageRecorder.record(record)
+    } catch (error) {
+      auxiliaryUsageLog.warn('auxiliary turn Usage persistence failed', {
+        source: record.source,
+        ...diagnosticErrorFields(error)
+      })
+    }
+  }
   const projectRepository = createDefaultProjectRepository()
   const previewStateRepository = createDefaultPreviewStateRepository()
 
@@ -1911,7 +1929,8 @@ const createApplicationModules = async (
       profileNamespace: 'host-llm',
       resolveTarget: (target, context) =>
         settingsService.resolveExplicitAgentBackend(target, context)
-    })
+    }),
+    recordUsage: recordAuxiliaryUsage
   })
   const hostViewImageService = new HostViewImageService({
     catalog: projectFilesRepository,
@@ -2072,7 +2091,8 @@ const createApplicationModules = async (
     new ImageInputCompatibilityOwner({
       captureTarget: () => settingsService.admitVisionModel(),
       runner: visionInferenceRunner,
-      evidenceRepository: visionEvidenceRepository
+      evidenceRepository: visionEvidenceRepository,
+      recordUsage: recordAuxiliaryUsage
     }),
     (owner) => ({
       name: 'image-input-compatibility',
@@ -2246,6 +2266,11 @@ const createApplicationModules = async (
       sideChatRelays: mainPromptSideChatRelay,
       imageInputCompatibility,
       memory: memoryService,
+      auxiliaryUsage: {
+        projectIdForSession: (sessionId) =>
+          sessionPersistenceCoordinator.sessionProjectId(sessionId),
+        record: recordAuxiliaryUsage
+      },
       resolveComputeExecutionTargetIds: (sessionId) => hostsRegistry.getSelected(sessionId)
     },
     (options) => {
@@ -2316,6 +2341,7 @@ const createApplicationModules = async (
             sideChatId
           })
       },
+      recordUsage: recordAuxiliaryUsage,
       onEvent: (event) => broadcastToRenderers('side-chat:event', event),
       setParentInteractionsPaused: (sessionId, paused) => {
         if (paused) {
@@ -2428,7 +2454,8 @@ const createApplicationModules = async (
       configRoot,
       captureTarget: () => settingsService.captureActiveExplicitAgentBackendTarget(),
       resolveTarget: (target, context) =>
-        settingsService.resolveExplicitAgentBackend(target, context)
+        settingsService.resolveExplicitAgentBackend(target, context),
+      recordUsage: recordAuxiliaryUsage
     },
     (options) => {
       const runner = new ArtifactCodeReconstructionRunner(options)
@@ -3273,7 +3300,8 @@ const createApplicationModules = async (
       projectId: string,
       sessionId: string,
       mutation: () => Promise<Result>
-    ) => sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+    ) => sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation),
+    recordUsage: recordAuxiliaryUsage
   }
   const reviewerCommandOwner = createReviewerCommandOwner(reviewerOptions)
   reviewerCommandOwnerRef.current = reviewerCommandOwner

--- a/src/main/notebook/host-model-service.test.ts
+++ b/src/main/notebook/host-model-service.test.ts
@@ -177,6 +177,28 @@ describe('HostModelService', () => {
     )
   })
 
+  it('records provider usage attached to an ordinary inference error', async () => {
+    const recordUsage = vi.fn(async () => undefined)
+    const usage = { inputTokens: 7, cacheTokens: 1, outputTokens: 2, turnCount: 1 }
+    const { service } = makeService(
+      async () => {
+        throw Object.assign(new Error('provider failed'), { usage })
+      },
+      target,
+      undefined,
+      undefined,
+      recordUsage
+    )
+
+    await expect(
+      service.call({ request: 'question' }, undefined, {
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      })
+    ).rejects.toThrow('host.llm inference failed.')
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({ source: 'host-llm', usage }))
+  })
+
   it('returns the exact model projected by the calling Session backend', async () => {
     const { service } = makeService(async () => inferenceResult('unused'))
     await expect(service.currentModel('session-a')).resolves.toBe('claude-session-model')

--- a/src/main/notebook/host-model-service.test.ts
+++ b/src/main/notebook/host-model-service.test.ts
@@ -87,7 +87,8 @@ const makeService = (
   captureModelCatalog: () => Promise<{
     providers: readonly ProviderView[]
     claudeSubscriptionProviderId?: ClaudeSubscriptionProviderId
-  }> = async () => ({ providers: [provider('provider-a', ['model-a'])] })
+  }> = async () => ({ providers: [provider('provider-a', ['model-a'])] }),
+  recordUsage?: ConstructorParameters<typeof HostModelService>[0]['recordUsage']
 ): {
   service: HostModelService
   runner: RunnerHarness
@@ -107,7 +108,8 @@ const makeService = (
       captureTarget,
       captureSessionModel,
       captureModelCatalog,
-      runner
+      runner,
+      recordUsage
     }),
     runner,
     captureTarget
@@ -115,6 +117,66 @@ const makeService = (
 }
 
 describe('HostModelService', () => {
+  it('records each provider-reported host.llm inference against the trusted Session', async () => {
+    const recordUsage = vi.fn(async () => undefined)
+    const { service } = makeService(
+      async () =>
+        inferenceResult('answer', {
+          usage: { inputTokens: 11, cacheTokens: 2, outputTokens: 3, turnCount: 1 }
+        }),
+      target,
+      undefined,
+      undefined,
+      recordUsage
+    )
+
+    await expect(
+      service.call({ request: 'question' }, undefined, {
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      })
+    ).resolves.toMatchObject({ text: 'answer' })
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        source: 'host-llm',
+        frameworkId: 'claude-code',
+        model: 'model-a',
+        usage: expect.objectContaining({ inputTokens: 11, outputTokens: 3 })
+      })
+    )
+  })
+
+  it('records provider-reported usage when host.llm is cancelled', async () => {
+    const recordUsage = vi.fn(async () => undefined)
+    const usage = { inputTokens: 7, cacheTokens: 1, outputTokens: 2, turnCount: 1 }
+    const { service } = makeService(
+      async () => {
+        throw new RestrictedInferenceError('cancelled', 'private detail', usage)
+      },
+      target,
+      undefined,
+      undefined,
+      recordUsage
+    )
+
+    await expect(
+      service.call({ request: 'question' }, undefined, {
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      })
+    ).rejects.toThrow('host.llm call was cancelled.')
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'host-llm',
+        frameworkId: 'claude-code',
+        model: 'model-a',
+        usage
+      })
+    )
+  })
+
   it('returns the exact model projected by the calling Session backend', async () => {
     const { service } = makeService(async () => inferenceResult('unused'))
     await expect(service.currentModel('session-a')).resolves.toBe('claude-session-model')

--- a/src/main/notebook/host-model-service.ts
+++ b/src/main/notebook/host-model-service.ts
@@ -12,6 +12,7 @@ import {
 } from '../../shared/settings'
 import {
   DEFAULT_OUTPUT_LIMIT_BYTES,
+  extractRestrictedInferenceUsage,
   RestrictedInferenceError,
   type RestrictedInferenceResult,
   type RestrictedInferenceRunner
@@ -407,7 +408,7 @@ class HostModelService {
         await this.recordUsage(context, eventId, result.frameworkId, result.model, result.usage)
         return result
       } catch (error) {
-        const usage = error instanceof RestrictedInferenceError ? error.usage : undefined
+        const usage = extractRestrictedInferenceUsage(error)
         await this.recordUsage(
           context,
           eventId,

--- a/src/main/notebook/host-model-service.ts
+++ b/src/main/notebook/host-model-service.ts
@@ -1,4 +1,7 @@
+import { randomUUID } from 'node:crypto'
+
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
+import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
 import type { AcpBackendGenerationView } from '../acp/backend-generation-owner'
 import { getAgentFramework } from '../agent-framework'
 import { buildConfiguredModelCatalog } from '../../shared/configured-model-catalog'
@@ -71,7 +74,10 @@ type HostModelServiceOptions = Readonly<{
   ) => Readonly<{ backend: AcpBackendGenerationView; appliedModel?: string }> | undefined
   captureModelCatalog: () => Promise<HostModelCatalogSnapshot>
   runner: HostLlmRunner
+  recordUsage?: (record: SessionAuxiliaryTurnUsageRecord) => Promise<unknown>
 }>
+
+type HostLlmCallContext = Readonly<{ projectId: string; sessionId: string }>
 
 const exactKeys = (value: Record<string, unknown>, allowed: readonly string[]): boolean =>
   Object.keys(value).every((key) => allowed.includes(key))
@@ -259,7 +265,8 @@ class HostModelService {
 
   async call(
     input: HostLlmCallInput,
-    callerSignal?: AbortSignal
+    callerSignal?: AbortSignal,
+    context?: HostLlmCallContext
   ): Promise<HostLlmResult | readonly HostLlmBatchItem[]> {
     if (this.shuttingDown) throw new Error('host.llm is shutting down.')
     if (!isRecord(input)) throw new TypeError('host.llm RPC input must be an object.')
@@ -292,13 +299,13 @@ class HostModelService {
       if (parsed.every((request) => 'error' in request)) {
         return Object.freeze(parsed.map((request) => Object.freeze({ error: request.error! })))
       }
-      return this.runBatch(parsed, concurrency, callerSignal)
+      return this.runBatch(parsed, concurrency, callerSignal, context)
     }
 
     if (!exactKeys(payload, ['request']) || !Object.hasOwn(payload, 'request')) {
       throw new TypeError('host.llm single input must contain only request.')
     }
-    return this.runSingle(promptFor(payload.request), callerSignal)
+    return this.runSingle(promptFor(payload.request), callerSignal, context)
   }
 
   private async captureTarget(signal: AbortSignal): Promise<ExplicitAgentBackendTarget> {
@@ -380,30 +387,73 @@ class HostModelService {
   private async runInference(
     prompt: string,
     target: ExplicitAgentBackendTarget,
-    signal: AbortSignal
+    signal: AbortSignal,
+    context?: HostLlmCallContext
   ): Promise<RestrictedInferenceResult> {
     const release = await this.acquireRunSlot(signal)
     try {
       if (signal.aborted) throw new RestrictedInferenceError('cancelled', 'Cancelled.')
-      return await this.options.runner.run({
-        prompt,
-        target,
-        systemPrompt: HOST_LLM_SYSTEM_PROMPT,
-        agentName: 'open-science-host-llm',
-        description: 'One-shot host.llm inference without tools.',
-        signal,
-        outputLimitBytes: DEFAULT_OUTPUT_LIMIT_BYTES
-      })
+      const eventId = randomUUID()
+      try {
+        const result = await this.options.runner.run({
+          prompt,
+          target,
+          systemPrompt: HOST_LLM_SYSTEM_PROMPT,
+          agentName: 'open-science-host-llm',
+          description: 'One-shot host.llm inference without tools.',
+          signal,
+          outputLimitBytes: DEFAULT_OUTPUT_LIMIT_BYTES
+        })
+        await this.recordUsage(context, eventId, result.frameworkId, result.model, result.usage)
+        return result
+      } catch (error) {
+        const usage = error instanceof RestrictedInferenceError ? error.usage : undefined
+        await this.recordUsage(
+          context,
+          eventId,
+          target.frameworkId,
+          target.model.kind === 'required' ? target.model.id : undefined,
+          usage
+        )
+        throw error
+      }
     } finally {
       release()
     }
   }
 
-  private async runSingle(prompt: string, callerSignal?: AbortSignal): Promise<HostLlmResult> {
+  private async recordUsage(
+    context: HostLlmCallContext | undefined,
+    eventId: string,
+    frameworkId: SessionAuxiliaryTurnUsageRecord['frameworkId'],
+    model: string | undefined,
+    usage: RestrictedInferenceResult['usage']
+  ): Promise<void> {
+    if (!context || !usage || !this.options.recordUsage) return
+    await this.options
+      .recordUsage({
+        ...context,
+        eventId,
+        source: 'host-llm',
+        frameworkId,
+        model,
+        completedAtMs: Date.now(),
+        usage
+      })
+      .catch(() => undefined)
+  }
+
+  private async runSingle(
+    prompt: string,
+    callerSignal?: AbortSignal,
+    context?: HostLlmCallContext
+  ): Promise<HostLlmResult> {
     const scope = this.callScope(callerSignal)
     try {
       const target = await this.captureTarget(scope.controller.signal)
-      return projectResult(await this.runInference(prompt, target, scope.controller.signal))
+      return projectResult(
+        await this.runInference(prompt, target, scope.controller.signal, context)
+      )
     } catch (error) {
       throw new Error(publicError(error))
     } finally {
@@ -414,7 +464,8 @@ class HostModelService {
   private async runBatch(
     parsed: readonly (Readonly<{ prompt: string }> | Readonly<{ error: string }>)[],
     concurrency: number,
-    callerSignal?: AbortSignal
+    callerSignal?: AbortSignal,
+    context?: HostLlmCallContext
   ): Promise<readonly HostLlmBatchItem[]> {
     const scope = this.callScope(callerSignal)
     try {
@@ -436,7 +487,7 @@ class HostModelService {
           }
           try {
             results[index] = projectResult(
-              await this.runInference(request.prompt, target, scope.controller.signal)
+              await this.runInference(request.prompt, target, scope.controller.signal, context)
             )
           } catch (error) {
             if (scope.controller.signal.aborted) throw error
@@ -481,6 +532,7 @@ export type {
   HostLlmRequest,
   HostLlmResult,
   HostModelServiceOptions,
+  HostLlmCallContext,
   HostModelCatalogSnapshot,
   HostLlmUsage
 }

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -307,7 +307,8 @@ type NotebookLocalRpcServerOptions = {
     listModels(): Promise<readonly string[]>
     call(
       input: HostLlmCallInput,
-      signal?: AbortSignal
+      signal?: AbortSignal,
+      context?: Readonly<{ projectId: string; sessionId: string }>
     ): Promise<HostLlmResult | readonly HostLlmBatchItem[]>
   }
   hostViewImage?: {
@@ -2152,17 +2153,23 @@ class NotebookLocalRpcServer {
     if (method === 'llmCall') {
       if (!this.hostModel) throw new Error('host.llm is not configured.')
       const {
-        sessionId: _sessionId,
-        projectId: _projectId,
+        sessionId,
+        projectId,
         provenanceContext: _provenanceContext,
         registeredInputFiles: _registeredInputFiles,
         ...input
       } = params
-      void _sessionId
-      void _projectId
+      if (
+        typeof sessionId !== 'string' ||
+        !sessionId ||
+        typeof projectId !== 'string' ||
+        !projectId
+      ) {
+        throw new RpcHttpError(403, 'host.llm trusted Session identity is incomplete.')
+      }
       void _provenanceContext
       void _registeredInputFiles
-      return this.hostModel.call(input as HostLlmCallInput, signal)
+      return this.hostModel.call(input as HostLlmCallInput, signal, { projectId, sessionId })
     }
 
     if (method === 'currentModelCall') {

--- a/src/main/reviewer/acp-runtime.ts
+++ b/src/main/reviewer/acp-runtime.ts
@@ -11,7 +11,7 @@ export type ReviewerAcpRuntime = Pick<
   AcpRuntime,
   'buildReviewerSession' | 'disposeReviewerSession' | 'sendPrompt' | 'sendApplicationPrompt'
 > &
-  Partial<Pick<AcpRuntime, 'captureBackend'>> &
+  Partial<Pick<AcpRuntime, 'captureBackend' | 'beginProviderTurnObservation'>> &
   Partial<AcpRuntimeActivityOwner>
 
 export const withReviewerRuntimeActivity = <T>(

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -19,6 +19,7 @@ import { runReview } from './orchestrator'
 import { flagStaleReviews } from './stale-reviews'
 import { ReviewRepository } from './repository'
 import type { ReviewerAcpRuntime } from './acp-runtime'
+import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
 import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { SessionRepository } from '../session-persistence/repository'
@@ -116,6 +117,7 @@ type ReviewerIpcOptions = {
     session: PersistedChatSession,
     configuration: SessionAgentConfiguration
   ) => Promise<PersistedChatSession>
+  recordUsage?: (record: SessionAuxiliaryTurnUsageRecord) => Promise<unknown>
 }
 
 type ReviewerCommandOwner = Readonly<{
@@ -460,7 +462,8 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
           fixLoopAbortControllers.delete(effectiveMainSessionKey)
           broadcastFixLoopEnd(projectId, effectiveMainSessionId)
         },
-        fixLoopAbortSignal: projectAdmission.signal
+        fixLoopAbortSignal: projectAdmission.signal,
+        recordUsage: options.recordUsage
       })
         .catch((error: unknown) => {
           // runReview records expected failures as lifecycle='error' itself; an unexpected throw here

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -17,6 +17,7 @@ import { buildHistoryPreamble } from '../../shared/history-preamble'
 import { runReviewAssessment } from './review-assessment-owner'
 import { runReviewerFixLoop } from './reviewer-fix-loop-owner'
 import type { AcpSessionAgentTarget } from '../../shared/acp'
+import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
 
 export { buildReviewerPrompt } from './review-assessment-owner'
 export { driveReviewerToStop } from './reviewer-session-driver'
@@ -107,6 +108,7 @@ export type RunReviewOptions = {
   // How long the fix loop waits for the correction turn to reach durable session storage. The main
   // agent can finish before the renderer's persistence queue flushes, so a single immediate read races.
   sessionRefreshTimeoutMs?: number
+  recordUsage?: (record: SessionAuxiliaryTurnUsageRecord) => Promise<unknown>
 }
 
 // Default drive-loop guards. The wall-clock timeout is the primary backstop against a reviewer that
@@ -150,7 +152,8 @@ const runReviewWithSession = async (
     onFixLoopStart,
     onFixLoopEnd,
     fixLoopAbortSignal,
-    sessionRefreshTimeoutMs = DEFAULT_SESSION_REFRESH_TIMEOUT_MS
+    sessionRefreshTimeoutMs = DEFAULT_SESSION_REFRESH_TIMEOUT_MS,
+    recordUsage
   } = options
 
   const assessment = await runReviewAssessment({
@@ -172,7 +175,8 @@ const runReviewWithSession = async (
     onStarted,
     reviewerTimeoutMs,
     reviewerMaxUpdates,
-    abortSignal: fixLoopAbortSignal
+    abortSignal: fixLoopAbortSignal,
+    recordUsage
   })
   const finalReview = assessment.review
   if (finalReview.lifecycle === 'error') return finalReview
@@ -206,7 +210,8 @@ const runReviewWithSession = async (
         reviewerMaxUpdates,
         maxRounds: fixLoopMaxRounds,
         sessionRefreshTimeoutMs,
-        abortSignal: fixLoopAbortSignal
+        abortSignal: fixLoopAbortSignal,
+        recordUsage
       })
     } finally {
       onFixLoopEnd?.()

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -224,6 +224,7 @@ const runtime = (contextModel?: string, sessionModel?: string): AcpRuntime =>
     buildReviewerSession: async () => {
       outsideMutation('acp:build')
       return {
+        cwd: '/tmp/reviewer-session',
         session: {
           sessionId: 'reviewer-session',
           prompt: () => {
@@ -352,6 +353,10 @@ describe('review assessment owner', () => {
         usage: { inputTokens: 13, cacheTokens: 2, outputTokens: 5, turnCount: 2 }
       })
     )
+    expect(acpRuntime.beginProviderTurnObservation).toHaveBeenCalledWith({
+      providerSessionId: 'reviewer-session',
+      cwd: '/tmp/reviewer-session'
+    })
   })
 
   it('completes an explicit empty initial assessment and classifies its completion log', async () => {

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -31,6 +31,10 @@ const harness = vi.hoisted(() => ({
         kind: string
         stopReason?: string
         response?: { stopReason: 'end_turn' }
+        notification?: {
+          sessionId: string
+          update: { sessionUpdate: string; [key: string]: unknown }
+        }
         update?: { sessionUpdate?: string; [key: string]: unknown }
       }>)
     | undefined,
@@ -320,19 +324,33 @@ describe('review assessment owner', () => {
   it('records normalized Reviewer usage for the owning Session', async () => {
     const reviewRepository = makeRepository()
     const acpRuntime = runtime('reviewer-runtime-model')
+    const observe = vi.fn()
     const finalize = vi.fn(async () => ({
       turnUsage: { inputTokens: 13, cacheTokens: 2, outputTokens: 5 },
       modelTurnCount: 2
     }))
     vi.mocked(acpRuntime).beginProviderTurnObservation = vi.fn(async () => ({
+      observe,
       finalize,
       cancel: vi.fn()
     }))
-    harness.nextUpdate = async () => ({
-      kind: 'stop',
-      stopReason: 'end_turn',
-      response: { stopReason: 'end_turn' }
-    })
+    const usageNotification = {
+      sessionId: 'reviewer-session',
+      update: { sessionUpdate: 'usage_update', used: 10, size: 128_000 }
+    }
+    const updates = [
+      {
+        kind: 'session_update',
+        notification: usageNotification,
+        update: usageNotification.update
+      },
+      {
+        kind: 'stop',
+        stopReason: 'end_turn',
+        response: { stopReason: 'end_turn' as const }
+      }
+    ]
+    harness.nextUpdate = async () => updates.shift()!
     const recordUsage = vi.fn(async () => undefined)
 
     await runReviewAssessment({
@@ -357,6 +375,7 @@ describe('review assessment owner', () => {
       providerSessionId: 'reviewer-session',
       cwd: '/tmp/reviewer-session'
     })
+    expect(observe).toHaveBeenCalledWith(usageNotification)
   })
 
   it('completes an explicit empty initial assessment and classifies its completion log', async () => {

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PrismaClient } from '@prisma/client'
 
 import type { AcpRuntime } from '../acp/runtime'
+import { getAgentFramework } from '../agent-framework'
 import type {
   NewCheck,
   Review,
@@ -29,6 +30,7 @@ const harness = vi.hoisted(() => ({
     | (() => Promise<{
         kind: string
         stopReason?: string
+        response?: { stopReason: 'end_turn' }
         update?: { sessionUpdate?: string; [key: string]: unknown }
       }>)
     | undefined,
@@ -207,6 +209,7 @@ const runtime = (contextModel?: string, sessionModel?: string): AcpRuntime =>
     ...(contextModel || sessionModel
       ? {
           captureBackend: () => ({
+            framework: getAgentFramework('codex'),
             context: {
               ...(contextModel ? { model: contextModel } : {}),
               supportsImageInput: false
@@ -311,6 +314,44 @@ describe('review assessment owner', () => {
       'write:commit',
       'mutation:end'
     ])
+  })
+
+  it('records normalized Reviewer usage for the owning Session', async () => {
+    const reviewRepository = makeRepository()
+    const acpRuntime = runtime('reviewer-runtime-model')
+    const finalize = vi.fn(async () => ({
+      turnUsage: { inputTokens: 13, cacheTokens: 2, outputTokens: 5 },
+      modelTurnCount: 2
+    }))
+    vi.mocked(acpRuntime).beginProviderTurnObservation = vi.fn(async () => ({
+      finalize,
+      cancel: vi.fn()
+    }))
+    harness.nextUpdate = async () => ({
+      kind: 'stop',
+      stopReason: 'end_turn',
+      response: { stopReason: 'end_turn' }
+    })
+    const recordUsage = vi.fn(async () => undefined)
+
+    await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      acpRuntime,
+      mode: 'initial',
+      recordUsage
+    })
+
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        eventId: 'assessment-review:initial',
+        source: 'reviewer',
+        frameworkId: 'codex',
+        model: 'reviewer-runtime-model',
+        usage: { inputTokens: 13, cacheTokens: 2, outputTokens: 5, turnCount: 2 }
+      })
+    )
   })
 
   it('completes an explicit empty initial assessment and classifies its completion log', async () => {

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -264,7 +264,7 @@ export const runReviewAssessment = async (
       try {
         probe = await acpRuntime.beginProviderTurnObservation?.({
           providerSessionId: reviewerSession!.sessionId,
-          cwd: reviewerCwd
+          cwd: built.cwd
         })
         const promptRequest = reviewerSession!.prompt([{ type: 'text', text: prompt }])
         void Promise.resolve(promptRequest).catch(() => undefined)

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -273,6 +273,7 @@ export const runReviewAssessment = async (
           { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates, signal: abortSignal },
           {
             ...reviewerLogDriveCallbacks,
+            onNotification: (notification) => probe?.observe?.(notification),
             onStop: (value) => {
               response = value
             }

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -14,6 +14,8 @@ import type {
 } from '../../shared/reviewer'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { createLogger, errorLogFields } from '../logger'
+import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
+import type { AcpProviderTurnProbe } from '../acp/provider-turn-adapter'
 import type { ReviewerAcpRuntime } from './acp-runtime'
 import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
 import { ReviewerHostServer, type ArtifactVersionContentResolver } from './host-sdk'
@@ -49,6 +51,7 @@ type CommonAssessmentOptions = {
   reviewerTimeoutMs: number
   reviewerMaxUpdates: number
   abortSignal?: AbortSignal
+  recordUsage?: (record: SessionAuxiliaryTurnUsageRecord) => Promise<unknown>
 }
 
 type InitialAssessmentOptions = CommonAssessmentOptions & {
@@ -154,7 +157,8 @@ export const runReviewAssessment = async (
     onReviewUpdate,
     reviewerTimeoutMs,
     reviewerMaxUpdates,
-    abortSignal
+    abortSignal,
+    recordUsage
   } = options
   const trackedChecks = options.mode === 'tracked' ? options.trackedChecks : []
 
@@ -229,8 +233,9 @@ export const runReviewAssessment = async (
     await mcpServer.start()
 
     const reviewerPrompt = buildReviewerPrompt(scope, options.mode, trackedChecks)
+    const reviewerCwd = session.cwd || homedir()
     const built = await acpRuntime.buildReviewerSession({
-      cwd: session.cwd || homedir(),
+      cwd: reviewerCwd,
       mcpServers: [mcpServer.toAcpMcpServerConfig()],
       systemPromptAppend: REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
     })
@@ -250,12 +255,56 @@ export const runReviewAssessment = async (
     const reviewerPromptText = built.promptPrefix
       ? `${built.promptPrefix}\n\n${reviewerPrompt}`
       : reviewerPrompt
-    reviewerSession.prompt([{ type: 'text', text: reviewerPromptText }])
-    const stopReason = await driveReviewerToStop(
-      reviewerSession,
-      { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates, signal: abortSignal },
-      reviewerLogDriveCallbacks
-    )
+    const runReviewerTurn = async (
+      prompt: string,
+      eventId: string
+    ): Promise<string | undefined> => {
+      let probe: AcpProviderTurnProbe | undefined
+      let response: Parameters<AcpProviderTurnProbe['finalize']>[0]['response'] | undefined
+      try {
+        probe = await acpRuntime.beginProviderTurnObservation?.({
+          providerSessionId: reviewerSession!.sessionId,
+          cwd: reviewerCwd
+        })
+        const promptRequest = reviewerSession!.prompt([{ type: 'text', text: prompt }])
+        void Promise.resolve(promptRequest).catch(() => undefined)
+        const stopReason = await driveReviewerToStop(
+          reviewerSession!,
+          { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates, signal: abortSignal },
+          {
+            ...reviewerLogDriveCallbacks,
+            onStop: (value) => {
+              response = value
+            }
+          }
+        )
+        if (probe && response) {
+          const facts = await probe.finalize({ response })
+          probe = undefined
+          if (facts.turnUsage && recordUsage && backend) {
+            await recordUsage({
+              projectId,
+              sessionId,
+              eventId,
+              source: 'reviewer',
+              frameworkId: backend.framework.id,
+              model: runtimeModel ?? (review.model || undefined),
+              completedAtMs: Date.now(),
+              usage: {
+                ...facts.turnUsage,
+                ...(facts.modelTurnCount === undefined ? {} : { turnCount: facts.modelTurnCount })
+              }
+            }).catch((error) =>
+              log.warn('Reviewer Usage persistence failed', errorLogFields(error))
+            )
+          }
+        }
+        return stopReason
+      } finally {
+        await Promise.resolve(probe?.cancel()).catch(() => undefined)
+      }
+    }
+    const stopReason = await runReviewerTurn(reviewerPromptText, `${review.id}:initial`)
     if (options.mode === 'initial') {
       log.info('reviewer session stopped', { reviewId: review.id, stopReason })
     }
@@ -264,11 +313,9 @@ export const runReviewAssessment = async (
         reviewId: review.id,
         stopReason
       })
-      reviewerSession.prompt([{ type: 'text', text: REVIEWER_PROTOCOL_RECOVERY_PROMPT }])
-      const recoveryStopReason = await driveReviewerToStop(
-        reviewerSession,
-        { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates, signal: abortSignal },
-        reviewerLogDriveCallbacks
+      const recoveryStopReason = await runReviewerTurn(
+        REVIEWER_PROTOCOL_RECOVERY_PROMPT,
+        `${review.id}:recovery`
       )
       log.info('reviewer recovery session stopped', {
         reviewId: review.id,

--- a/src/main/reviewer/reviewer-fix-loop-owner.ts
+++ b/src/main/reviewer/reviewer-fix-loop-owner.ts
@@ -13,6 +13,7 @@ import {
 import type { ReviewerAcpRuntime } from './acp-runtime'
 import { ReviewerCorrectionOwner } from './correction'
 import type { ArtifactVersionContentResolver } from './host-sdk'
+import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
 import { runReviewAssessment } from './review-assessment-owner'
 import type { ReviewRepository } from './repository'
 import { toErrorMessage } from '../error-message'
@@ -61,6 +62,7 @@ type ReviewerFixLoopOptions = {
   sessionRefreshTimeoutMs: number
   // Optional abort signal: when aborted, the loop exits at the next round boundary.
   abortSignal?: AbortSignal
+  recordUsage?: (record: SessionAuxiliaryTurnUsageRecord) => Promise<unknown>
 }
 
 const waitForCorrectionAgentMessage = async (options: {
@@ -129,7 +131,8 @@ export const runReviewerFixLoop = async (options: ReviewerFixLoopOptions): Promi
     reviewerMaxUpdates,
     maxRounds,
     sessionRefreshTimeoutMs,
-    abortSignal
+    abortSignal,
+    recordUsage
   } = options
 
   let openChecks = [...options.openChecks]
@@ -321,7 +324,8 @@ export const runReviewerFixLoop = async (options: ReviewerFixLoopOptions): Promi
       onReviewUpdate,
       reviewerTimeoutMs,
       reviewerMaxUpdates,
-      trackedChecks: openChecks
+      trackedChecks: openChecks,
+      recordUsage
     })
     const reReviewResult = scopedResult.review
 

--- a/src/main/reviewer/reviewer-session-driver.ts
+++ b/src/main/reviewer/reviewer-session-driver.ts
@@ -1,7 +1,7 @@
 // Drives one Reviewer ACP session to its terminal update while projecting its streamed action log.
 
 import { extractProviderToolName, extractTerminalMeta } from '../acp/runtime-events'
-import type { PromptResponse } from '@agentclientprotocol/sdk'
+import type { PromptResponse, SessionNotification } from '@agentclientprotocol/sdk'
 import type { ReviewerLogEntry } from '../../shared/reviewer'
 
 type ReviewerLogLimits = {
@@ -38,6 +38,7 @@ type DrivableSession = {
     kind: string
     stopReason?: string
     response?: PromptResponse
+    notification?: SessionNotification
     update?: { sessionUpdate?: string; [key: string]: unknown }
   }>
 }
@@ -56,6 +57,7 @@ type DriveCallbacks = {
   onUpdate?: (entry: ReviewerLogEntry) => void
   // Reuse one state object when multiple drives append to the same persisted Review log.
   logState?: { budget?: ReviewerLogBudget }
+  onNotification?: (notification: SessionNotification) => void
   onStop?: (response: PromptResponse) => void
 }
 
@@ -445,7 +447,7 @@ export const driveReviewerToStop = async (
 ): Promise<string | undefined> => {
   const { timeoutMs, maxUpdates, signal } = options
   const logLimits = { ...DEFAULT_REVIEWER_LOG_LIMITS, ...options.logLimits }
-  const { onUpdate, logState, onStop } = callbacks ?? {}
+  const { onUpdate, logState, onNotification, onStop } = callbacks ?? {}
   let logBudget = logState?.budget
   if (!logBudget && onUpdate) {
     logBudget = new ReviewerLogBudget(logLimits.maxLogBytes, onUpdate)
@@ -498,6 +500,7 @@ export const driveReviewerToStop = async (
         return result.stopReason
       }
 
+      if (result.notification) onNotification?.(result.notification)
       const sessionUpdate = result.update?.sessionUpdate ?? ''
 
       // Only discrete updates count toward the loop cap; streaming content chunks do not (they scale

--- a/src/main/reviewer/reviewer-session-driver.ts
+++ b/src/main/reviewer/reviewer-session-driver.ts
@@ -1,6 +1,7 @@
 // Drives one Reviewer ACP session to its terminal update while projecting its streamed action log.
 
 import { extractProviderToolName, extractTerminalMeta } from '../acp/runtime-events'
+import type { PromptResponse } from '@agentclientprotocol/sdk'
 import type { ReviewerLogEntry } from '../../shared/reviewer'
 
 type ReviewerLogLimits = {
@@ -36,6 +37,7 @@ type DrivableSession = {
   nextUpdate: () => Promise<{
     kind: string
     stopReason?: string
+    response?: PromptResponse
     update?: { sessionUpdate?: string; [key: string]: unknown }
   }>
 }
@@ -54,6 +56,7 @@ type DriveCallbacks = {
   onUpdate?: (entry: ReviewerLogEntry) => void
   // Reuse one state object when multiple drives append to the same persisted Review log.
   logState?: { budget?: ReviewerLogBudget }
+  onStop?: (response: PromptResponse) => void
 }
 
 // In-flight accumulator for streaming content (thought/message chunks are assembled into whole entries).
@@ -442,7 +445,7 @@ export const driveReviewerToStop = async (
 ): Promise<string | undefined> => {
   const { timeoutMs, maxUpdates, signal } = options
   const logLimits = { ...DEFAULT_REVIEWER_LOG_LIMITS, ...options.logLimits }
-  const { onUpdate, logState } = callbacks ?? {}
+  const { onUpdate, logState, onStop } = callbacks ?? {}
   let logBudget = logState?.budget
   if (!logBudget && onUpdate) {
     logBudget = new ReviewerLogBudget(logLimits.maxLogBytes, onUpdate)
@@ -491,6 +494,7 @@ export const driveReviewerToStop = async (
       if (result.kind === 'stop') {
         // Flush any in-flight streaming chunks before returning.
         flushAccumulator(acc, emitUpdate)
+        if (result.response) onStop?.(result.response)
         return result.stopReason
       }
 

--- a/src/main/session-persistence/auxiliary-turn-usage.ts
+++ b/src/main/session-persistence/auxiliary-turn-usage.ts
@@ -1,0 +1,112 @@
+import { Prisma, type PrismaClient } from '@prisma/client'
+
+import type { AcpTurnTokenUsage } from '../../shared/acp'
+
+const SESSION_AUXILIARY_TURN_USAGE_SOURCES = [
+  'reviewer',
+  'side-chat',
+  'vision',
+  'session-details',
+  'host-llm',
+  'artifact-code-reconstruction',
+  'context-compaction'
+] as const
+
+type SessionAuxiliaryTurnUsageSource = (typeof SESSION_AUXILIARY_TURN_USAGE_SOURCES)[number]
+
+type SessionAuxiliaryTurnUsageRecord = Readonly<{
+  projectId: string
+  sessionId: string
+  eventId: string
+  source: SessionAuxiliaryTurnUsageSource
+  frameworkId: string
+  model?: string
+  completedAtMs: number
+  usage: AcpTurnTokenUsage
+}>
+
+type AuxiliaryUsageClient = () => Promise<PrismaClient>
+
+const nonEmpty = (value: string, field: string): string => {
+  if (!value.trim()) throw new Error(`Auxiliary turn Usage ${field} must not be empty.`)
+  return value
+}
+
+const nonNegative = (value: number, field: string): bigint => {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Auxiliary turn Usage ${field} must be a non-negative safe integer.`)
+  }
+  return BigInt(value)
+}
+
+const optionalNonNegative = (value: number | undefined, field: string): bigint | null =>
+  value === undefined ? null : nonNegative(value, field)
+
+const optionalPositiveInt = (value: number | undefined, field: string): number | null => {
+  if (value === undefined) return null
+  if (!Number.isSafeInteger(value) || value <= 0 || value > 2_147_483_647) {
+    throw new Error(`Auxiliary turn Usage ${field} must be a positive SQLite Int.`)
+  }
+  return value
+}
+
+class SessionAuxiliaryTurnUsageRecorder {
+  constructor(private readonly client: AuxiliaryUsageClient) {}
+
+  async record(input: SessionAuxiliaryTurnUsageRecord): Promise<boolean> {
+    const projectId = nonEmpty(input.projectId, 'projectId')
+    const sessionId = nonEmpty(input.sessionId, 'sessionId')
+    const eventId = nonEmpty(input.eventId, 'eventId')
+    const frameworkId = nonEmpty(input.frameworkId, 'frameworkId')
+    const model = input.model === undefined ? null : nonEmpty(input.model, 'model')
+    const cachedReadTokens = optionalNonNegative(input.usage.cachedReadTokens, 'cachedReadTokens')
+    const cachedWriteTokens = optionalNonNegative(
+      input.usage.cachedWriteTokens,
+      'cachedWriteTokens'
+    )
+    if ((cachedReadTokens === null) !== (cachedWriteTokens === null)) {
+      throw new Error('Auxiliary turn Usage cache read/write detail must be reported together.')
+    }
+
+    const client = await this.client()
+    try {
+      return await client.$transaction(async (tx) => {
+        const owner = await tx.session.findFirst({
+          where: { id: sessionId, projectId, deletedAtMs: null },
+          select: { id: true }
+        })
+        if (!owner) throw new Error('Auxiliary turn Usage Session ownership is unavailable.')
+        const existing = await tx.sessionAuxiliaryTurnUsage.findUnique({
+          where: { sessionId_eventId: { sessionId, eventId } },
+          select: { eventId: true }
+        })
+        if (existing) return false
+        await tx.sessionAuxiliaryTurnUsage.create({
+          data: {
+            sessionId,
+            eventId,
+            source: input.source,
+            frameworkId,
+            model,
+            completedAtMs: nonNegative(input.completedAtMs, 'completedAtMs'),
+            inputTokens: nonNegative(input.usage.inputTokens, 'inputTokens'),
+            cacheTokens: nonNegative(input.usage.cacheTokens, 'cacheTokens'),
+            cachedReadTokens,
+            cachedWriteTokens,
+            outputTokens: nonNegative(input.usage.outputTokens, 'outputTokens'),
+            modelCallCount: optionalPositiveInt(input.usage.turnCount, 'modelCallCount')
+          }
+        })
+        return true
+      })
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        return false
+      }
+      throw error
+    }
+  }
+}
+
+export { SESSION_AUXILIARY_TURN_USAGE_SOURCES, SessionAuxiliaryTurnUsageRecorder }
+export type { SessionAuxiliaryTurnUsageRecord, SessionAuxiliaryTurnUsageSource }

--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -18,6 +18,7 @@ import {
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { ProjectRepository } from '../projects/repository'
 import { buildSessionProjection, SessionProjectionRepository } from './projection'
+import { SessionAuxiliaryTurnUsageRecorder } from './auxiliary-turn-usage'
 import { SessionRepository } from './repository'
 import type { SessionLoadDiagnostic } from './repository'
 
@@ -199,6 +200,46 @@ describe('Session projection', () => {
     })
   })
 
+  it('projects provider-reported Session Details usage as one auxiliary event', () => {
+    const input = session('session-details')
+    input.sessionDetailsGeneration = {
+      status: 'failed',
+      sourceMessageId: 'session-details-run',
+      requestId: 'details-request',
+      queuedAt: 110,
+      startedAt: 111,
+      completedAt: 112,
+      frameworkId: 'codex',
+      providerId: 'provider-1',
+      model: 'gpt-5',
+      reasoningEffort: 'low',
+      usage: {
+        inputTokens: 7,
+        cacheTokens: 2,
+        cachedReadTokens: 2,
+        cachedWriteTokens: 0,
+        outputTokens: 3,
+        turnCount: 1
+      }
+    }
+
+    expect(buildSessionProjection(input).sessionDetailsUsage).toEqual([
+      {
+        eventId: 'details-request',
+        source: 'session-details',
+        frameworkId: 'codex',
+        model: 'gpt-5',
+        completedAtMs: 112n,
+        inputTokens: 7n,
+        cacheTokens: 2n,
+        cachedReadTokens: 2n,
+        cachedWriteTokens: 0n,
+        outputTokens: 3n,
+        modelCallCount: 1
+      }
+    ])
+  })
+
   it('marks pending Artifact paths for one-time startup recovery', () => {
     const pending = session('pending-artifact')
     pending.artifacts![0].path = '/managed/.pending/run-1/report.md'
@@ -296,6 +337,64 @@ describe('Session projection', () => {
     await expect(client.session.count()).resolves.toBe(75)
     await expect(client.sessionTurnUsage.count()).resolves.toBe(75)
     await expect(client.sessionModelCallUsage.count()).resolves.toBe(150)
+  })
+
+  it('keeps direct auxiliary usage across rebuilds, aggregates it, and removes it on deletion', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-auxiliary-usage-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({
+      data: { id: 'project-1', name: 'Project', createdAt: new Date(50) }
+    })
+    const repository = new SessionProjectionRepository(async () => client!)
+    const projected = await repository.prepareSave(session('auxiliary', 100))
+    await repository.commitSave(projected)
+    const recorder = new SessionAuxiliaryTurnUsageRecorder(async () => client!)
+    const record = {
+      projectId: 'project-1',
+      sessionId: projected.id,
+      eventId: 'side-stop-1',
+      source: 'side-chat' as const,
+      frameworkId: 'codebuddy',
+      model: 'model-a',
+      completedAtMs: 120,
+      usage: {
+        inputTokens: 5,
+        cacheTokens: 2,
+        cachedReadTokens: 2,
+        cachedWriteTokens: 0,
+        outputTokens: 4,
+        turnCount: 1
+      }
+    }
+
+    await expect(recorder.record(record)).resolves.toBe(true)
+    await expect(
+      recorder.record({ ...record, usage: { ...record.usage, inputTokens: 999 } })
+    ).resolves.toBe(false)
+    await repository.replaceAll([projected])
+
+    await expect(
+      client.sessionAuxiliaryTurnUsage.findMany({ where: { sessionId: projected.id } })
+    ).resolves.toMatchObject([
+      { eventId: 'side-stop-1', source: 'side-chat', inputTokens: 5n, modelCallCount: 1 }
+    ])
+    await expect(repository.usage()).resolves.toMatchObject({
+      usageEvents: expect.arrayContaining([
+        expect.objectContaining({
+          timestamp: 120,
+          inputTokens: 5,
+          cacheTokens: 2,
+          outputTokens: 4,
+          rootRunUsage: false
+        })
+      ])
+    })
+
+    await repository.commitDelete(projected.projectId, projected.id)
+    await expect(
+      client.sessionAuxiliaryTurnUsage.count({ where: { sessionId: projected.id } })
+    ).resolves.toBe(0)
   })
 
   it('does not replace Session authority when an invalid projection integer rejects the save', async () => {

--- a/src/main/session-persistence/projection.ts
+++ b/src/main/session-persistence/projection.ts
@@ -16,7 +16,7 @@ import {
 } from '../../shared/session-persistence'
 
 const PROJECTION_STATE_ID = 'session-projection'
-const PROJECTION_VERSION = 2
+const PROJECTION_VERSION = 3
 const SESSION_NUMBER_SEQUENCE_ID = 'global'
 const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
 const MAX_SQLITE_INT = 2_147_483_647
@@ -59,6 +59,19 @@ type SessionProjection = Readonly<{
     outputTokens: bigint
     contextUsedTokens: bigint | null
     contextWindowSize: bigint | null
+  }>
+  sessionDetailsUsage: Array<{
+    eventId: string
+    source: 'session-details'
+    frameworkId: string
+    model: string | null
+    completedAtMs: bigint
+    inputTokens: bigint
+    cacheTokens: bigint
+    cachedReadTokens: bigint | null
+    cachedWriteTokens: bigint | null
+    outputTokens: bigint
+    modelCallCount: number | null
   }>
   runs: Array<{ messageId: string; createdAtMs: bigint }>
   artifactRefs: Array<{ artifactId: string; artifactCreatedAtMs: bigint | null }>
@@ -140,6 +153,23 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
     assertNullableBigInt(usage.cachedWriteTokens, 'turnUsage.cachedWriteTokens')
     assertBigInt(usage.outputTokens, 'turnUsage.outputTokens')
     if (usage.modelCallCount !== null) assertInt(usage.modelCallCount, 'turnUsage.modelCallCount')
+  }
+  for (const usage of projection.sessionDetailsUsage) {
+    assertNonEmptyText(usage.eventId, 'sessionDetailsUsage.eventId')
+    assertNonEmptyText(usage.frameworkId, 'sessionDetailsUsage.frameworkId')
+    assertNullableNonEmptyText(usage.model, 'sessionDetailsUsage.model')
+    assertBigInt(usage.completedAtMs, 'sessionDetailsUsage.completedAtMs')
+    assertBigInt(usage.inputTokens, 'sessionDetailsUsage.inputTokens')
+    assertBigInt(usage.cacheTokens, 'sessionDetailsUsage.cacheTokens')
+    assertNullableBigInt(usage.cachedReadTokens, 'sessionDetailsUsage.cachedReadTokens')
+    assertNullableBigInt(usage.cachedWriteTokens, 'sessionDetailsUsage.cachedWriteTokens')
+    assertBigInt(usage.outputTokens, 'sessionDetailsUsage.outputTokens')
+    if (usage.modelCallCount !== null) {
+      assertInt(usage.modelCallCount, 'sessionDetailsUsage.modelCallCount')
+      if (usage.modelCallCount === 0) {
+        throw new Error('Session projection sessionDetailsUsage.modelCallCount must be positive.')
+      }
+    }
   }
   assertUnique(
     projection.turnUsage.map(({ messageId }) => messageId),
@@ -257,11 +287,38 @@ const hasPendingArtifact = (session: PersistedChatSession): boolean => {
 export const buildSessionProjection = (session: PersistedChatSession): SessionProjection => {
   const turnUsage: SessionProjection['turnUsage'][number][] = []
   const modelCalls: SessionProjection['modelCalls'][number][] = []
+  const sessionDetailsUsage: SessionProjection['sessionDetailsUsage'][number][] = []
   const runs: SessionProjection['runs'][number][] = []
   const associatedArtifactCreatedAt = new Map<string, number>()
   const runtimeSegments = new Map(
     (session.conversationGraph?.runtimeSegments ?? []).map((segment) => [segment.id, segment])
   )
+  const details = session.sessionDetailsGeneration
+  if (
+    details &&
+    'completedAt' in details &&
+    'frameworkId' in details &&
+    details.frameworkId &&
+    'usage' in details &&
+    details.usage
+  ) {
+    sessionDetailsUsage.push({
+      eventId: details.requestId,
+      source: 'session-details',
+      frameworkId: details.frameworkId,
+      model: details.model || null,
+      completedAtMs: toBigInt(details.completedAt),
+      inputTokens: toBigInt(details.usage.inputTokens),
+      cacheTokens: toBigInt(details.usage.cacheTokens),
+      cachedReadTokens: toOptionalBigInt(details.usage.cachedReadTokens),
+      cachedWriteTokens: toOptionalBigInt(details.usage.cachedWriteTokens),
+      outputTokens: toBigInt(details.usage.outputTokens),
+      modelCallCount:
+        details.usage.turnCount === undefined || details.usage.turnCount <= 0
+          ? null
+          : finiteNonNegativeInteger(details.usage.turnCount)
+    })
+  }
 
   for (const { message, isRootFrame, runtimeSegmentId } of projectionMessages(session)) {
     const associationTimestamp = message.completedAt ?? message.createdAt
@@ -376,6 +433,7 @@ export const buildSessionProjection = (session: PersistedChatSession): SessionPr
     },
     turnUsage,
     modelCalls,
+    sessionDetailsUsage,
     runs,
     artifactRefs
   }
@@ -420,6 +478,9 @@ const replaceChildren = async (
   projection: SessionProjection
 ): Promise<void> => {
   await tx.sessionTurnUsage.deleteMany({ where: { sessionId } })
+  await tx.sessionAuxiliaryTurnUsage.deleteMany({
+    where: { sessionId, source: 'session-details' }
+  })
   await tx.sessionRun.deleteMany({ where: { sessionId } })
   await tx.sessionArtifactRef.deleteMany({ where: { sessionId } })
   if (projection.turnUsage.length > 0) {
@@ -430,6 +491,11 @@ const replaceChildren = async (
   if (projection.modelCalls.length > 0) {
     await tx.sessionModelCallUsage.createMany({
       data: projection.modelCalls.map((usage) => ({ sessionId, ...usage }))
+    })
+  }
+  if (projection.sessionDetailsUsage.length > 0) {
+    await tx.sessionAuxiliaryTurnUsage.createMany({
+      data: projection.sessionDetailsUsage.map((usage) => ({ sessionId, ...usage }))
     })
   }
   if (projection.runs.length > 0) {
@@ -665,6 +731,7 @@ export class SessionProjectionRepository {
         return
       }
       await tx.sessionTurnUsage.deleteMany({ where: { sessionId } })
+      await tx.sessionAuxiliaryTurnUsage.deleteMany({ where: { sessionId } })
       await tx.sessionRun.deleteMany({ where: { sessionId } })
       await tx.sessionArtifactRef.deleteMany({ where: { sessionId } })
       await tx.session.updateMany({
@@ -700,6 +767,9 @@ export class SessionProjectionRepository {
     const modelCalls = projected.flatMap(({ session, projection }) =>
       projection.modelCalls.map((usage) => ({ sessionId: session.id, ...usage }))
     )
+    const sessionDetailsUsage = projected.flatMap(({ session, projection }) =>
+      projection.sessionDetailsUsage.map((usage) => ({ sessionId: session.id, ...usage }))
+    )
     const runs = projected.flatMap(({ session, projection }) =>
       projection.runs.map((run) => ({ sessionId: session.id, ...run }))
     )
@@ -721,7 +791,14 @@ export class SessionProjectionRepository {
             ...(liveSessionIds.length > 0 ? [{ id: { in: liveSessionIds } }] : [])
           ]
         }
-      })
+      }),
+      ...(liveSessionIds.length > 0
+        ? [
+            client.sessionAuxiliaryTurnUsage.deleteMany({
+              where: { sessionId: { in: liveSessionIds }, source: 'session-details' }
+            })
+          ]
+        : [])
     ]
     for (const chunk of chunksOf(projected, 40)) {
       writes.push(
@@ -735,6 +812,9 @@ export class SessionProjectionRepository {
     }
     for (const chunk of chunksOf(modelCalls, 100)) {
       writes.push(client.sessionModelCallUsage.createMany({ data: chunk }))
+    }
+    for (const chunk of chunksOf(sessionDetailsUsage, 100)) {
+      writes.push(client.sessionAuxiliaryTurnUsage.createMany({ data: chunk }))
     }
     for (const chunk of chunksOf(runs, 200)) {
       writes.push(client.sessionRun.createMany({ data: chunk }))
@@ -774,13 +854,14 @@ export class SessionProjectionRepository {
 
   async usage(): Promise<SessionUsageProjection> {
     const client = await this.client()
-    const [projects, sessions, usage, runs, artifacts] = await client.$transaction([
+    const [projects, sessions, usage, auxiliaryUsage, runs, artifacts] = await client.$transaction([
       client.project.findMany({ select: { createdAt: true } }),
       client.session.findMany({
         where: { deletedAtMs: null },
-        select: { createdAtMs: true }
+        select: { id: true, createdAtMs: true }
       }),
       client.sessionTurnUsage.findMany({ where: { session: { deletedAtMs: null } } }),
+      client.sessionAuxiliaryTurnUsage.findMany(),
       client.sessionRun.findMany({
         where: { session: { deletedAtMs: null } },
         select: { createdAtMs: true }
@@ -790,6 +871,7 @@ export class SessionProjectionRepository {
         select: { artifactId: true, artifactCreatedAtMs: true }
       })
     ])
+    const liveSessionIds = new Set(sessions.map(({ id }) => id))
     const artifactCreatedAt = new Map<string, number | undefined>()
     for (const artifact of artifacts) {
       const timestamp =
@@ -806,13 +888,28 @@ export class SessionProjectionRepository {
         (timestamp): timestamp is number => timestamp !== undefined
       ),
       runsAt: runs.map(({ createdAtMs }) => Number(createdAtMs)),
-      usageEvents: usage.map((event) => ({
-        timestamp: Number(event.completedAtMs),
-        inputTokens: Number(event.inputTokens),
-        cacheTokens: Number(event.cacheTokens),
-        outputTokens: Number(event.outputTokens),
-        rootRunUsage: event.isRootFrame
-      })),
+      usageEvents: [
+        ...usage.map((event) => ({
+          timestamp: Number(event.completedAtMs),
+          inputTokens: Number(event.inputTokens),
+          cacheTokens: Number(event.cacheTokens),
+          outputTokens: Number(event.outputTokens),
+          rootRunUsage: event.isRootFrame
+        })),
+        ...auxiliaryUsage.flatMap((event) =>
+          liveSessionIds.has(event.sessionId)
+            ? [
+                {
+                  timestamp: Number(event.completedAtMs),
+                  inputTokens: Number(event.inputTokens),
+                  cacheTokens: Number(event.cacheTokens),
+                  outputTokens: Number(event.outputTokens),
+                  rootRunUsage: false
+                }
+              ]
+            : []
+        )
+      ],
       totalArtifacts: artifactCreatedAt.size
     }
   }

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -880,6 +880,11 @@ describe('native Responses compatibility', () => {
         return new Response(
           JSON.stringify({
             id: 'resp-skills',
+            usage: {
+              input_tokens: 12,
+              input_tokens_details: { cached_tokens: 3 },
+              output_tokens: 4
+            },
             output: [
               {
                 type: 'function_call',
@@ -916,9 +921,20 @@ describe('native Responses compatibility', () => {
       }
     ]
 
-    await expect(proxy.selectSkills('查找肿瘤免疫相关的生物医学文献', catalog)).resolves.toEqual([
-      { name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }
-    ])
+    const observeUsage = vi.fn()
+    await expect(
+      proxy.selectSkills('查找肿瘤免疫相关的生物医学文献', catalog, undefined, observeUsage)
+    ).resolves.toEqual([{ name: 'mcp-pubmed', path: '/skills/pubmed/SKILL.md' }])
+    expect(observeUsage).toHaveBeenCalledWith({
+      sourceInvocationId: 'resp-skills',
+      usage: {
+        inputTokens: 9,
+        cacheTokens: 3,
+        cachedReadTokens: 3,
+        cachedWriteTokens: 0,
+        outputTokens: 4
+      }
+    })
     expect(fetchImpl).toHaveBeenCalledOnce()
     const [url, init] = fetchImpl.mock.calls[0]
     expect(String(url)).toBe('https://api.minimaxi.com/v1/responses')

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -30,6 +30,7 @@ import {
   providerRequestFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
+import { normalizeOpenAiChatModelStepUsage } from './openai-chat-usage'
 
 // Responses payloads are intentionally open-ended across providers. Keep the compatibility boundary
 // permissive, then validate the fields this module rewrites before touching them.
@@ -573,9 +574,8 @@ export class NativeResponsesCompatibilityProxy {
     text: string,
     catalog: ResponsesBridgeSkillCandidate[],
     signal?: AbortSignal,
-    _observeUsage?: (observation: SkillSelectorUsageObservation) => void
+    observeUsage?: (observation: SkillSelectorUsageObservation) => void
   ): Promise<ResponsesBridgeSkillInput[]> {
-    void _observeUsage
     if (!text.trim() || catalog.length === 0 || signal?.aborted) return []
     const explicit = selectExplicitConnectorSkills(text, catalog)
     if (explicit.length > 0) return explicit
@@ -640,6 +640,13 @@ export class NativeResponsesCompatibilityProxy {
         return []
       }
       const payload = (await response.json()) as JsonObject
+      const usage = normalizeOpenAiChatModelStepUsage(payload.usage)
+      if (usage) {
+        observeUsage?.({
+          usage,
+          ...(typeof payload.id === 'string' ? { sourceInvocationId: payload.id } : {})
+        })
+      }
       const output = Array.isArray(payload.output) ? payload.output : []
       const call = output.find(
         (item: unknown) =>

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -468,6 +468,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
   it('coalesces streamed transcript chunks into the latest durable projection', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-coalesce-'))
     const persistence = createPersistence()
+    const recordUsage = vi.fn(async () => undefined)
     let runtimeOptions: AcpRuntimeOptions | undefined
     const owner = new SideChatRuntimeOwner({
       appVersion: '0.11.0',
@@ -476,6 +477,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       resolveTarget: vi.fn(async () => backend(claudeCodeFramework)),
       relay: createRelayOwner(),
       persistence,
+      recordUsage,
       onEvent: vi.fn(),
       createRuntime: (options) => {
         runtimeOptions = options
@@ -510,7 +512,8 @@ describe('SideChatRuntimeOwner lifecycle', () => {
               id: 'stop-coalesced',
               timestamp: 101,
               sessionId: request.sessionId,
-              kind: 'stop'
+              kind: 'stop',
+              turnUsage: { inputTokens: 9, cacheTokens: 2, outputTokens: 3, turnCount: 1 }
             } as never)
             return { stopReason: 'end_turn' as const }
           }),
@@ -528,6 +531,20 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       text: 'Stream'
     })
     await vi.waitFor(() => expect(persistence.save).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() =>
+      expect(recordUsage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'project-1',
+          sessionId: 'main-coalesce',
+          eventId: 'stop-coalesced',
+          source: 'side-chat',
+          frameworkId: 'claude-code',
+          model: 'model-a',
+          completedAtMs: 101,
+          usage: expect.objectContaining({ inputTokens: 9, outputTokens: 3 })
+        })
+      )
+    )
     expect(owner.list().chats[0]?.entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'assistant-coalesced', text: 'x'.repeat(20_000) })

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -536,7 +536,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
         expect.objectContaining({
           projectId: 'project-1',
           sessionId: 'main-coalesce',
-          eventId: 'stop-coalesced',
+          eventId: `${started.sideSessionId}:user-1`,
           source: 'side-chat',
           frameworkId: 'claude-code',
           model: 'model-a',

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -530,6 +530,19 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       projectId: 'project-1',
       text: 'Stream'
     })
+    await expect(
+      runtimeOptions!.auxiliaryUsage!.projectIdForSession('provider-coalesce')
+    ).resolves.toBe('project-1')
+    await runtimeOptions!.auxiliaryUsage!.record({
+      projectId: 'project-1',
+      sessionId: 'provider-coalesce',
+      eventId: 'context-compaction:side-chat',
+      source: 'context-compaction',
+      frameworkId: 'claude-code',
+      model: 'model-a',
+      completedAtMs: 100,
+      usage: { inputTokens: 7, cacheTokens: 1, outputTokens: 2, turnCount: 1 }
+    })
     await vi.waitFor(() => expect(persistence.save).toHaveBeenCalledTimes(2))
     await vi.waitFor(() =>
       expect(recordUsage).toHaveBeenCalledWith(
@@ -544,6 +557,14 @@ describe('SideChatRuntimeOwner lifecycle', () => {
           usage: expect.objectContaining({ inputTokens: 9, outputTokens: 3 })
         })
       )
+    )
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'main-coalesce',
+        eventId: 'context-compaction:side-chat',
+        source: 'context-compaction'
+      })
     )
     expect(owner.list().chats[0]?.entries).toEqual(
       expect.arrayContaining([
@@ -988,6 +1009,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
   it('hydrates a dormant Side chat without starting ACP and resumes it on the next Follow up', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-resume-'))
     const persistence = createPersistence()
+    const recordUsage = vi.fn(async () => undefined)
     const resumeSession = vi.fn(async () => ({
       sessionId: 'side-chat-restored',
       providerSessionId: 'provider-restored',
@@ -1021,6 +1043,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       })),
       relay: createRelayOwner(),
       persistence,
+      recordUsage,
       onEvent: vi.fn(),
       createRuntime
     })
@@ -1057,6 +1080,19 @@ describe('SideChatRuntimeOwner lifecycle', () => {
 
     await owner.send({ sideSessionId: 'side-chat-restored', text: 'Continue' })
 
+    await expect(
+      runtimeOptions!.auxiliaryUsage!.projectIdForSession('side-chat-restored')
+    ).resolves.toBe('project-1')
+    await runtimeOptions!.auxiliaryUsage!.record({
+      projectId: 'project-1',
+      sessionId: 'side-chat-restored',
+      eventId: 'context-compaction:restored-side-chat',
+      source: 'context-compaction',
+      frameworkId: 'claude-code',
+      completedAtMs: 30,
+      usage: { inputTokens: 5, cacheTokens: 0, outputTokens: 1, turnCount: 1 }
+    })
+
     expect(resumeSession).toHaveBeenCalledWith({
       sessionId: 'side-chat-restored',
       providerSessionId: 'provider-restored',
@@ -1069,6 +1105,14 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       expect.objectContaining({ sessionId: 'side-chat-restored', text: 'Continue' })
     )
     expect(sendPrompt.mock.calls[0]?.[0]).not.toHaveProperty('historyPreamble')
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'main-restored',
+        eventId: 'context-compaction:restored-side-chat',
+        source: 'context-compaction'
+      })
+    )
     expect(persistence.save).toHaveBeenCalledWith(
       expect.objectContaining({
         parentSessionId: 'main-restored',

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -1280,7 +1280,7 @@ class SideChatRuntimeOwner {
             this.options.recordUsage!({
               projectId: active.projectId,
               sessionId: active.parentSessionId,
-              eventId: event.id,
+              eventId: `${active.sideSessionId}:user-${active.entrySequence}`,
               source: 'side-chat',
               frameworkId: active.frameworkId,
               ...(active.model ? { model: active.model } : {}),

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -29,6 +29,7 @@ import {
 import type { AgentModelChangeTarget, ResolvedAgentBackend } from '../agent-framework'
 import { modelFacingAppMcpToolName } from '../agent-framework/app-mcp-names'
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
+import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
 import { createLogger, diagnosticErrorFields } from '../logger'
 import { AgentMcpHttpHost } from '../acp/mcp-http-host'
 import { prepareRestrictedBackend } from '../acp/restricted-runtime-profile'
@@ -121,6 +122,7 @@ type SideChatRuntimeOwnerOptions = Readonly<{
     }): Promise<boolean>
   }>
   onEvent: (event: SideChatRuntimeEvent) => void
+  recordUsage?: (record: SessionAuxiliaryTurnUsageRecord) => Promise<unknown>
   setParentInteractionsPaused?: (parentSessionId: string, paused: boolean) => void
   createRuntime?: (options: AcpRuntimeOptions) => SideChatRuntimePort
 }>
@@ -1271,6 +1273,28 @@ class SideChatRuntimeOwner {
       active.error = event.text ?? event.title ?? 'Side chat failed.'
     } else if (event.kind === 'stop') {
       active.running = false
+      if (event.turnUsage && this.options.recordUsage) {
+        active.persistTail = active.persistTail
+          .catch(() => undefined)
+          .then(() =>
+            this.options.recordUsage!({
+              projectId: active.projectId,
+              sessionId: active.parentSessionId,
+              eventId: event.id,
+              source: 'side-chat',
+              frameworkId: active.frameworkId,
+              ...(active.model ? { model: active.model } : {}),
+              completedAtMs: event.timestamp,
+              usage: event.turnUsage!
+            })
+          )
+          .then(
+            () => undefined,
+            (error) => {
+              log.warn('Side chat Usage persistence failed', diagnosticErrorFields(error))
+            }
+          )
+      }
     }
     const revision = this.touch(active)
     this.queuePersist(active, event.kind === 'error' ? 'error' : 'open')

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -434,9 +434,11 @@ class SideChatRuntimeOwner {
       const bridge = initialBackend.responsesBridgeLease
 
       const runtimeRef: { current?: SideChatRuntimePort } = {}
+      const auxiliaryUsage = this.createRuntimeAuxiliaryUsage(() => activeChat)
       const runtimeOptions: AcpRuntimeOptions = {
         appVersion: this.options.appVersion,
         defaultCwd: cwd,
+        ...(auxiliaryUsage ? { auxiliaryUsage } : {}),
         resolveBackend: () => {
           if (backend) {
             backendTransferred = true
@@ -919,9 +921,11 @@ class SideChatRuntimeOwner {
       const initialBackend = backend
       const bridge = initialBackend.responsesBridgeLease
       const runtimeRef: { current?: SideChatRuntimePort } = {}
+      const auxiliaryUsage = this.createRuntimeAuxiliaryUsage(() => activeChat)
       const runtimeOptions: AcpRuntimeOptions = {
         appVersion: this.options.appVersion,
         defaultCwd: cwd,
+        ...(auxiliaryUsage ? { auxiliaryUsage } : {}),
         resolveBackend: () => {
           if (backend) {
             backendTransferred = true
@@ -1238,6 +1242,39 @@ class SideChatRuntimeOwner {
           ...diagnosticErrorFields(error)
         })
       })
+  }
+
+  private createRuntimeAuxiliaryUsage(
+    active: () => ActiveSideChat | undefined
+  ): AcpRuntimeOptions['auxiliaryUsage'] {
+    const recordUsage = this.options.recordUsage
+    if (!recordUsage) return undefined
+
+    const resolveActive = (runtimeSessionId: string): ActiveSideChat | undefined => {
+      const current = active()
+      if (
+        !current ||
+        current.closing ||
+        current.runtimeSessionId !== runtimeSessionId ||
+        this.activeByParent.get(current.parentSessionId) !== current
+      ) {
+        return undefined
+      }
+      return current
+    }
+
+    return {
+      projectIdForSession: async (runtimeSessionId) => resolveActive(runtimeSessionId)?.projectId,
+      record: async (record) => {
+        const current = resolveActive(record.sessionId)
+        if (!current) return
+        await recordUsage({
+          ...record,
+          projectId: current.projectId,
+          sessionId: current.parentSessionId
+        })
+      }
+    }
   }
 
   private handleRuntimeEvent(active: ActiveSideChat, event: AcpRuntimeEvent): void {


### PR DESCRIPTION
## Problem

Settings Usage currently aggregates durable Session turn facts, so provider-reported tokens from Reviewer, Side Chat, Vision, Session Details generation, host.llm, Artifact code reconstruction fallback, and native context compaction are omitted. Delegate turns already use the existing Session turn usage path.

## Proposed change

- Add SessionAuxiliaryTurnUsage as one append-oriented SQLite fact table keyed by Session and event identity.
- Persist exact provider-reported input, cache, cache read/write, output, model-call count, framework, and model facts for the seven auxiliary sources.
- Keep failed and cancelled calls when the provider reports usage; never estimate missing usage.
- Fold native Responses skill-selector usage into the owning SessionTurnUsage fact instead of creating an auxiliary event.
- Union auxiliary facts into the existing Settings Usage projection with rootRunUsage false, so token totals and activity increase without inflating run counts or coverage.

## Scope and non-goals

- No new renderer copy or Usage UI category is added.
- No provider/backend/status/total/JSON columns and no source/framework/model indexes are added.
- The auxiliary table intentionally has no Session foreign key because projection rebuilds replace live Session rows; direct auxiliary facts must survive rebuilds.

### Historical compatibility

- Session Details usage already present in durable Session JSON is backfilled by projection version 3.
- Historical Reviewer, Side Chat, Vision, host.llm, Artifact reconstruction, and context-compaction usage cannot be recovered reliably and is not estimated.
- Historical Delegate usage remains covered by the existing SessionTurnUsage projection.

### Persisted-format impact

- Adds migration 0018_session_auxiliary_turn_usage and the SessionAuxiliaryTurnUsage table.
- Explicit Session deletion removes its auxiliary facts; projection rebuild preserves direct facts and replaces only Session Details-derived rows; Project soft deletion retains usage history.
- frameworkId is required and model is nullable so usage remains attributable across ACP frameworks and provider-default model cases.

### State impact

- Adds a table-local source discriminator constrained to reviewer, side-chat, vision, session-details, host-llm, artifact-code-reconstruction, and context-compaction.
- No existing lifecycle or application enum gains a new value.

## Acceptance criteria and validation

The following checks ran after the final rebase onto origin/main at 3e706b7e:

- Type safety for main and renderer consumers -> npm run typecheck -> passed.
- Source and persistence lint contracts -> npm run lint -> passed.
- Generated schema and migration contract -> npm run db:schema:check plus diff whitespace check -> passed.
- Database migration, projection, ACP observation, Reviewer, Side Chat, Vision, Artifact reconstruction, and host.llm behavior -> 12 focused Vitest files -> 269 passed.
- Native Responses and Notebook RPC loopback adapters -> 2 focused Vitest files -> 33 passed.

The complete npm test suite was intentionally not run per maintainer direction; exact-head PR CI is authoritative for the complete and platform-specific lanes.

## Review focus

- First-write-wins event identity and ownership validation in the auxiliary recorder.
- Rebuild/deletion semantics for the no-FK auxiliary fact table.
- Provider observation boundaries, especially cancelled/failed turns and avoiding duplicate observation.
- Usage aggregation keeps auxiliary token facts out of run-count and coverage metrics.

Uncovered local risk: providers that omit usage cannot be reconstructed, and cross-platform packaging remains covered by PR CI.