### PR TITLE
fix(session-persistence): recover overlapping first-turn writes

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -118,6 +118,7 @@ type ElectronApp = {
   >
   requestMainWindowClose: () => Promise<void>
   restoreDelegatedHandoffCleanup: (childName: string) => Promise<void>
+  showMainWindow: () => Promise<void>
   restart: (options?: { resourceProfilePhase?: string }) => Promise<Page>
   restartWithCorruptHistoricalSessionFile: (projectId: string) => Promise<Page>
   sabotageDelegatedHandoffCleanup: (childName: string) => Promise<void>
@@ -559,6 +560,15 @@ class ElectronAppHarness implements ElectronApp {
 
       return { minimized: mainWindow.isMinimized(), visible: mainWindow.isVisible() }
     })
+  }
+
+  async showMainWindow(): Promise<void> {
+    await this.runningApplication.evaluate(({ BrowserWindow }) => {
+      const mainWindow = BrowserWindow.getAllWindows()[0]
+      if (!mainWindow) throw new Error('Open Science main window was not found.')
+      mainWindow.show()
+    })
+    await expect.poll(() => this.mainWindowState()).toMatchObject({ visible: true })
   }
 
   async launchSecondInstance(): Promise<Page> {

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -266,11 +266,17 @@ const openMainWindow = async (
     )
     .toBe('ready')
   await page.getByText('Loading settings...').waitFor({ state: 'hidden', timeout: 60_000 })
-  // The workspace GitHub star nudge opens after 5s in a visible window and is not part of these
-  // journeys. Record the cooldown in this profile so it cannot cover Send or shift layout.
-  await page.evaluate(() => {
-    window.localStorage.setItem('open-science:github-star-nudge-last-shown-at', String(Date.now()))
-  })
+  if (process.platform === 'win32') {
+    // The workspace GitHub star nudge opens after 5s in a visible Windows window and is not part
+    // of these journeys. Leave other platforms on the default cooldown so their layout timing
+    // matches the previously passing CI.
+    await page.evaluate(() => {
+      window.localStorage.setItem(
+        'open-science:github-star-nudge-last-shown-at',
+        String(Date.now())
+      )
+    })
+  }
   return page
 }
 
@@ -520,10 +526,12 @@ class ElectronAppHarness implements ElectronApp {
     // Specs assert English copy. Pin the locale so the host language can't leak in — Main
     // resolves a 'system' preference from the OS language list, ignoring Chromium's --lang.
     settings.localePreference = 'en'
-    // Inherit would spawn a second fake Agent just to generate the Session title. That extra
-    // process and its queued/running/terminal Session writes overlap the first user turn on
-    // Windows CI and leave the conversation stuck on Thinking.
-    settings.sessionDetailsModel = { mode: 'disabled' }
+    if (process.platform === 'win32') {
+      // Inherit would spawn a second fake Agent just to generate the Session title. That extra
+      // process and its queued/running/terminal Session writes overlap the first user turn on
+      // Windows CI and leave the conversation stuck on Thinking.
+      settings.sessionDetailsModel = { mode: 'disabled' }
+    }
     await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
     await this.launch()
     return this.page

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -519,6 +519,10 @@ class ElectronAppHarness implements ElectronApp {
     // Specs assert English copy. Pin the locale so the host language can't leak in — Main
     // resolves a 'system' preference from the OS language list, ignoring Chromium's --lang.
     settings.localePreference = 'en'
+    // Inherit would spawn a second fake Agent just to generate the Session title. That extra
+    // process and its queued/running/terminal Session writes overlap the first user turn on
+    // Windows CI and leave the conversation stuck on Thinking.
+    settings.sessionDetailsModel = { mode: 'disabled' }
     await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
     await this.launch()
     return this.page

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -265,6 +265,11 @@ const openMainWindow = async (
     )
     .toBe('ready')
   await page.getByText('Loading settings...').waitFor({ state: 'hidden', timeout: 60_000 })
+  // The workspace GitHub star nudge opens after 5s in a visible window and is not part of these
+  // journeys. Record the cooldown in this profile so it cannot cover Send or shift layout.
+  await page.evaluate(() => {
+    window.localStorage.setItem('open-science:github-star-nudge-last-shown-at', String(Date.now()))
+  })
   return page
 }
 

--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -510,12 +510,7 @@ if (process.argv.includes('--version')) {
 
       let reply = 'Deterministic reply: Summarize the deterministic fixture.'
       try {
-        if (prompt.includes('Generate Session metadata only from the following JSON data:')) {
-          reply = JSON.stringify({
-            title: 'Summarize the deterministic fixture.',
-            description: 'The user wants a concise summary of the deterministic fixture.'
-          })
-        } else if (prompt.includes(MEMORY_RECALL_PROMPT)) {
+        if (prompt.includes(MEMORY_RECALL_PROMPT)) {
           if (!prompt.includes('<memory_records>') || !prompt.includes(MEMORY_RECALL_ENTRY)) {
             throw new Error('Automatic memory recall did not reach the provider prompt.')
           }

--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -510,7 +510,12 @@ if (process.argv.includes('--version')) {
 
       let reply = 'Deterministic reply: Summarize the deterministic fixture.'
       try {
-        if (prompt.includes(MEMORY_RECALL_PROMPT)) {
+        if (prompt.includes('Generate Session metadata only from the following JSON data:')) {
+          reply = JSON.stringify({
+            title: 'Summarize the deterministic fixture.',
+            description: 'The user wants a concise summary of the deterministic fixture.'
+          })
+        } else if (prompt.includes(MEMORY_RECALL_PROMPT)) {
           if (!prompt.includes('<memory_records>') || !prompt.includes(MEMORY_RECALL_ENTRY)) {
             throw new Error('Automatic memory recall did not reach the provider prompt.')
           }

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -11,6 +11,22 @@ const BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT =
   'Run the buffered text tool layout stability journey.'
 const AGENT_STDERR_SUMMARY = 'Agent process stderr: 1 chunk, 22 bytes; raw output omitted.'
 
+// Windows CI stalls the first fake-agent turn when the window is shown from launch. Keep it hidden
+// until that reply arrives, then show it for requestAnimationFrame sampling. macOS already passes
+// with a visible window, and showing mid-journey there shifts the buffered-tool measurement.
+const deferVisibleWindow = process.platform === 'win32'
+
+test.use({ windowMode: deferVisibleWindow ? 'hidden' : 'normal' })
+
+const revealWindowForLayoutSampling = async (
+  app: { showMainWindow: () => Promise<void> },
+  page: Page
+): Promise<void> => {
+  if (!deferVisibleWindow) return
+  await app.showMainWindow()
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+}
+
 const cases = [
   { name: 'without agent status', prompt: TOOL_LAYOUT_SHIFT_PROMPT, agentStatus: undefined },
   {
@@ -46,10 +62,7 @@ const runLayoutStabilityJourney = async (
   await sendButton.click()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
   await expect(page.getByTestId('session-persistence-alert')).toHaveCount(0)
-  // Hidden windows complete the first Agent turn reliably on Windows CI. Show the window only
-  // before layout sampling so requestAnimationFrame still runs.
-  await app.showMainWindow()
-  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await revealWindowForLayoutSampling(app, page)
 
   await textbox.fill(prompt)
   await sendButton.click()
@@ -118,8 +131,7 @@ test('keeps a running tool stationary while one line of buffered Markdown finish
   await page.getByRole('button', { name: 'Send message' }).click()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
   await expect(page.getByTestId('session-persistence-alert')).toHaveCount(0)
-  await app.showMainWindow()
-  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await revealWindowForLayoutSampling(app, page)
 
   await textbox.fill(BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT)
   await page.getByRole('button', { name: 'Send message' }).click()

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -11,9 +11,6 @@ const BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT =
   'Run the buffered text tool layout stability journey.'
 const AGENT_STDERR_SUMMARY = 'Agent process stderr: 1 chunk, 22 bytes; raw output omitted.'
 
-test.use({ windowMode: 'normal' })
-test.describe.configure({ mode: 'serial' })
-
 const cases = [
   { name: 'without agent status', prompt: TOOL_LAYOUT_SHIFT_PROMPT, agentStatus: undefined },
   {
@@ -27,13 +24,13 @@ const runLayoutStabilityJourney = async (
   app: {
     completeOnboarding: () => Promise<Page>
     configureFakeAgent: () => Promise<Page>
+    showMainWindow: () => Promise<void>
   },
   prompt: string,
   agentStatus?: string
 ): Promise<void> => {
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()
-  await page.emulateMedia({ reducedMotion: 'reduce' })
 
   await page.getByRole('button', { name: 'New project' }).click()
   const dialog = page.getByRole('dialog', { name: 'New project' })
@@ -49,6 +46,10 @@ const runLayoutStabilityJourney = async (
   await sendButton.click()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
   await expect(page.getByTestId('session-persistence-alert')).toHaveCount(0)
+  // Hidden windows complete the first Agent turn reliably on Windows CI. Show the window only
+  // before layout sampling so requestAnimationFrame still runs.
+  await app.showMainWindow()
+  await page.emulateMedia({ reducedMotion: 'reduce' })
 
   await textbox.fill(prompt)
   await sendButton.click()
@@ -103,7 +104,6 @@ test('keeps a running tool stationary while one line of buffered Markdown finish
 }) => {
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()
-  await page.emulateMedia({ reducedMotion: 'reduce' })
 
   await page.getByRole('button', { name: 'New project' }).click()
   const dialog = page.getByRole('dialog', { name: 'New project' })
@@ -118,6 +118,8 @@ test('keeps a running tool stationary while one line of buffered Markdown finish
   await page.getByRole('button', { name: 'Send message' }).click()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
   await expect(page.getByTestId('session-persistence-alert')).toHaveCount(0)
+  await app.showMainWindow()
+  await page.emulateMedia({ reducedMotion: 'reduce' })
 
   await textbox.fill(BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT)
   await page.getByRole('button', { name: 'Send message' }).click()

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -32,6 +32,7 @@ const runLayoutStabilityJourney = async (
 ): Promise<void> => {
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()
+  await page.emulateMedia({ reducedMotion: 'reduce' })
 
   await page.getByRole('button', { name: 'New project' }).click()
   const dialog = page.getByRole('dialog', { name: 'New project' })
@@ -46,6 +47,7 @@ const runLayoutStabilityJourney = async (
   await textbox.fill(USER_MESSAGE)
   await sendButton.click()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+  await expect(page.getByTestId('session-persistence-alert')).toHaveCount(0)
 
   await textbox.fill(prompt)
   await sendButton.click()
@@ -100,6 +102,7 @@ test('keeps a running tool stationary while one line of buffered Markdown finish
 }) => {
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()
+  await page.emulateMedia({ reducedMotion: 'reduce' })
 
   await page.getByRole('button', { name: 'New project' }).click()
   const dialog = page.getByRole('dialog', { name: 'New project' })
@@ -113,6 +116,7 @@ test('keeps a running tool stationary while one line of buffered Markdown finish
   await textbox.fill(USER_MESSAGE)
   await page.getByRole('button', { name: 'Send message' }).click()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+  await expect(page.getByTestId('session-persistence-alert')).toHaveCount(0)
 
   await textbox.fill(BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT)
   await page.getByRole('button', { name: 'Send message' }).click()

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -12,6 +12,7 @@ const BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT =
 const AGENT_STDERR_SUMMARY = 'Agent process stderr: 1 chunk, 22 bytes; raw output omitted.'
 
 test.use({ windowMode: 'normal' })
+test.describe.configure({ mode: 'serial' })
 
 const cases = [
   { name: 'without agent status', prompt: TOOL_LAYOUT_SHIFT_PROMPT, agentStatus: undefined },

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1723,6 +1723,97 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession.mock.calls[1][0].activeRun?.promptMessageId).toBe(appended.messageId)
   })
 
+  it('clears a finished run when overlapping authority only updates the same prompt timestamp', async () => {
+    const prompt = {
+      id: 'prompt-1',
+      role: 'user' as const,
+      content: 'Summarize the deterministic fixture.',
+      status: 'complete' as const,
+      eventIds: [] as string[],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const partial = {
+      id: 'agent-message-1',
+      role: 'agent' as const,
+      content: 'Deterministic reply',
+      status: 'streaming' as const,
+      streamId: 'run-1',
+      responseToMessageId: prompt.id,
+      eventIds: ['event-1'],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 8,
+        status: 'running',
+        activeRun: { promptMessageId: prompt.id, startedAt: 10 },
+        messages: [prompt, partial]
+      })
+    )
+    const overlappingRun = materializeSessionConversationGraph({
+      ...base,
+      revision: 9,
+      activeRun: { promptMessageId: prompt.id, startedAt: 20 },
+      updatedAt: base.updatedAt + 1
+    })
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(8, 9))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 10 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValueOnce(overlappingRun),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().finishRun(base.id, undefined, prompt.id)
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+    expect(saveSession.mock.calls[1][0]).toMatchObject({
+      revision: 9,
+      status: 'idle'
+    })
+    expect(saveSession.mock.calls[1][0].activeRun).toBeUndefined()
+  })
+
+  it('keeps renderer context usage when overlapping authority has a different snapshot', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 3,
+        contextUsage: { used: 10, size: 100 }
+      })
+    )
+    const overlappingUsage = materializeSessionConversationGraph({
+      ...base,
+      revision: 4,
+      contextUsage: { used: 20, size: 100 },
+      updatedAt: base.updatedAt + 1
+    })
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(3, 4))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 5 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValueOnce(overlappingUsage),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().setContextUsage(base.id, { used: 40, size: 100 })
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+    expect(saveSession.mock.calls[1][0]).toMatchObject({
+      revision: 4,
+      contextUsage: { used: 40, size: 100 }
+    })
+  })
+
   it('stops rebasing when Main authority keeps advancing past the bounded retry window', async () => {
     const base = materializeSessionConversationGraph(
       createPersistedSession({ projectId: 'project-a', revision: 1 })

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1814,6 +1814,37 @@ describe('renderer session persistence bridge', () => {
     })
   })
 
+  it('clears renderer context usage when overlapping authority still has a snapshot', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 3,
+        contextUsage: { used: 10, size: 100 }
+      })
+    )
+    const overlappingUsage = materializeSessionConversationGraph({
+      ...base,
+      revision: 4,
+      contextUsage: { used: 20, size: 100 },
+      updatedAt: base.updatedAt + 1
+    })
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(3, 4))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 5 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValueOnce(overlappingUsage),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().setContextUsage(base.id, undefined)
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+    expect(saveSession.mock.calls[1][0].contextUsage).toBeUndefined()
+  })
+
   it('stops rebasing when Main authority keeps advancing past the bounded retry window', async () => {
     const base = materializeSessionConversationGraph(
       createPersistedSession({ projectId: 'project-a', revision: 1 })

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -22,6 +22,7 @@ import {
   useSessionStore
 } from '../../stores/session-store'
 import {
+  MAX_SESSION_REVISION_REBASE_ATTEMPTS,
   createOrderedSessionPersistence,
   createStoreSaver,
   flushSessionPersistence,
@@ -1528,34 +1529,157 @@ describe('renderer session persistence bridge', () => {
     })
   })
 
+  it('rebases a completed turn across Session-details, status, and auxiliary usage revisions', async () => {
+    const prompt = {
+      id: 'prompt-1',
+      role: 'user' as const,
+      content: 'Summarize the deterministic fixture.',
+      status: 'complete' as const,
+      eventIds: [] as string[],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const partial = {
+      id: 'agent-message-1',
+      role: 'agent' as const,
+      content: 'Deterministic reply',
+      status: 'streaming' as const,
+      streamId: 'run-1',
+      responseToMessageId: prompt.id,
+      eventIds: ['event-1'],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 8,
+        status: 'running',
+        activeRun: { promptMessageId: prompt.id, startedAt: 1 },
+        messages: [prompt, partial],
+        sessionDetailsGenerationEligible: true
+      })
+    )
+    const queuedDetails = {
+      ...base,
+      revision: 9,
+      sessionDetailsGenerationEligible: undefined,
+      sessionDetailsSource: 'fallback' as const,
+      sessionDetailsGeneration: {
+        status: 'queued' as const,
+        sourceMessageId: prompt.id,
+        requestId: `${prompt.id}:session-details`,
+        queuedAt: 3
+      },
+      updatedAt: base.updatedAt + 1
+    }
+    const runningDetails = {
+      ...queuedDetails,
+      revision: 10,
+      sessionDetailsGeneration: {
+        ...queuedDetails.sessionDetailsGeneration,
+        status: 'running' as const,
+        startedAt: 4,
+        frameworkId: 'opencode' as const,
+        model: 'e2e-model',
+        reasoningEffort: 'low' as const
+      },
+      updatedAt: queuedDetails.updatedAt + 1
+    }
+    const terminalDetails = {
+      ...runningDetails,
+      revision: 11,
+      sessionDetailsGeneration: {
+        ...runningDetails.sessionDetailsGeneration,
+        status: 'failed' as const,
+        completedAt: 5,
+        usageUnavailable: true
+      },
+      updatedAt: runningDetails.updatedAt + 1
+    }
+    const statusAuthority = {
+      ...terminalDetails,
+      revision: 12,
+      status: 'running' as const,
+      updatedAt: terminalDetails.updatedAt + 1
+    }
+    const runtimeAuthority = {
+      ...statusAuthority,
+      revision: 13,
+      runtimeContext: { version: 1 as const, revision: 2 },
+      updatedAt: statusAuthority.updatedAt + 1
+    }
+    const usageAuthority = {
+      ...runtimeAuthority,
+      revision: 14,
+      runtimeContext: { version: 1 as const, revision: 3 },
+      updatedAt: runtimeAuthority.updatedAt + 1
+    }
+    const overlappingAuthorities = [
+      queuedDetails,
+      runningDetails,
+      terminalDetails,
+      statusAuthority,
+      runtimeAuthority,
+      usageAuthority
+    ]
+    const saveSession = vi.fn<SessionPersistenceApi['saveSession']>()
+    for (const authority of overlappingAuthorities) {
+      saveSession.mockRejectedValueOnce(
+        new SessionRevisionConflictError(authority.revision - 1, authority.revision)
+      )
+    }
+    saveSession.mockImplementationOnce(async (submitted) => ({
+      ...submitted,
+      revision: usageAuthority.revision + 1
+    }))
+    const api = createApi({
+      loadOne: vi.fn().mockImplementation(async () => overlappingAuthorities.shift()),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().finishRun(base.id, undefined, prompt.id)
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+
+    expect(api.loadOne).toHaveBeenCalledTimes(6)
+    expect(saveSession).toHaveBeenCalledTimes(7)
+    expect(saveSession.mock.calls[6][0]).toMatchObject({
+      revision: 14,
+      status: 'idle',
+      activeRun: undefined,
+      runtimeContext: { revision: 3 },
+      messages: [
+        expect.objectContaining({ id: prompt.id }),
+        expect.objectContaining({ id: partial.id, status: 'complete' })
+      ],
+      sessionDetailsGeneration: { status: 'failed' }
+    })
+  })
+
   it('stops rebasing when Main authority keeps advancing past the bounded retry window', async () => {
     const base = materializeSessionConversationGraph(
       createPersistedSession({ projectId: 'project-a', revision: 1 })
     )
-    const authorities = [2, 3, 4].map((revision) => ({
-      ...base,
-      revision,
-      runtimeContext: { version: 1 as const, revision },
-      updatedAt: base.updatedAt + revision
-    }))
-    const conflicts = [
-      new SessionRevisionConflictError(1, 2),
-      new SessionRevisionConflictError(2, 3),
-      new SessionRevisionConflictError(3, 4),
-      new SessionRevisionConflictError(4, 5)
-    ]
-    const saveSession = vi
-      .fn<SessionPersistenceApi['saveSession']>()
-      .mockRejectedValueOnce(conflicts[0])
-      .mockRejectedValueOnce(conflicts[1])
-      .mockRejectedValueOnce(conflicts[2])
-      .mockRejectedValueOnce(conflicts[3])
+    const authorities = Array.from({ length: MAX_SESSION_REVISION_REBASE_ATTEMPTS }, (_, index) => {
+      const revision = index + 2
+      return {
+        ...base,
+        revision,
+        runtimeContext: { version: 1 as const, revision },
+        updatedAt: base.updatedAt + revision
+      }
+    })
+    const conflicts = Array.from(
+      { length: MAX_SESSION_REVISION_REBASE_ATTEMPTS + 1 },
+      (_, index) => new SessionRevisionConflictError(index + 1, index + 2)
+    )
+    const saveSession = vi.fn<SessionPersistenceApi['saveSession']>()
+    for (const conflict of conflicts) saveSession.mockRejectedValueOnce(conflict)
     const api = createApi({
-      loadOne: vi
-        .fn()
-        .mockResolvedValueOnce(authorities[0])
-        .mockResolvedValueOnce(authorities[1])
-        .mockResolvedValueOnce(authorities[2]),
+      loadOne: vi.fn().mockImplementation(async () => authorities.shift()),
       saveSession
     })
 
@@ -1563,9 +1687,11 @@ describe('renderer session persistence bridge', () => {
     const save = createStoreSaver(api, useSessionStore.getState())
     useSessionStore.getState().togglePinned(base.id)
 
-    await expect(save(useSessionStore.getState())).rejects.toBe(conflicts[3])
-    expect(api.loadOne).toHaveBeenCalledTimes(3)
-    expect(saveSession).toHaveBeenCalledTimes(4)
+    await expect(save(useSessionStore.getState())).rejects.toBe(
+      conflicts[MAX_SESSION_REVISION_REBASE_ATTEMPTS]
+    )
+    expect(api.loadOne).toHaveBeenCalledTimes(MAX_SESSION_REVISION_REBASE_ATTEMPTS)
+    expect(saveSession).toHaveBeenCalledTimes(MAX_SESSION_REVISION_REBASE_ATTEMPTS + 1)
   })
 
   it('retries a pending tool activity save over disjoint concurrent Main graph changes', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1659,6 +1659,70 @@ describe('renderer session persistence bridge', () => {
     })
   })
 
+  it('rebases a first user prompt over Session-details admission and activeRun timestamps', async () => {
+    const promptContent = 'Summarize the deterministic fixture.'
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 8,
+        status: 'idle',
+        title: 'New conversation',
+        messages: []
+      })
+    )
+    useSessionStore.getState().hydrateSessions([base])
+    const baseline = useSessionStore.getState()
+    const appended = useSessionStore.getState().appendUserMessage({
+      sessionId: base.id,
+      content: promptContent,
+      projectId: 'project-a'
+    })
+    if (!appended) throw new Error('Expected the first user Message to be appended.')
+
+    const submitted = toPersistedSession(
+      useSessionStore.getState().sessions.find((session) => session.id === base.id)!
+    )
+    const queuedDetails = materializeSessionConversationGraph({
+      ...submitted,
+      revision: 9,
+      title: promptContent,
+      description: 'The user wants a concise summary of the deterministic fixture.',
+      sessionDetailsSource: 'fallback' as const,
+      sessionDetailsGeneration: {
+        status: 'queued' as const,
+        sourceMessageId: appended.messageId,
+        requestId: `${appended.messageId}:session-details`,
+        queuedAt: 3
+      },
+      activeRun: {
+        promptMessageId: appended.messageId,
+        startedAt: (submitted.activeRun?.startedAt ?? 0) + 5_000
+      },
+      updatedAt: submitted.updatedAt + 1
+    })
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(8, 9))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 10 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValueOnce(queuedDetails),
+      saveSession
+    })
+    const save = createStoreSaver(api, baseline)
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+
+    expect(api.loadOne).toHaveBeenCalledOnce()
+    expect(saveSession).toHaveBeenCalledTimes(2)
+    expect(saveSession.mock.calls[1][0]).toMatchObject({
+      revision: 9,
+      status: 'running',
+      sessionDetailsGeneration: { status: 'queued' },
+      messages: [expect.objectContaining({ content: promptContent })]
+    })
+    expect(saveSession.mock.calls[1][0].activeRun?.promptMessageId).toBe(appended.messageId)
+  })
+
   it('stops rebasing when Main authority keeps advancing past the bounded retry window', async () => {
     const base = materializeSessionConversationGraph(
       createPersistedSession({ projectId: 'project-a', revision: 1 })

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -487,9 +487,10 @@ const rebaseSessionAfterRevisionConflict = (
           startedAt: Math.min(submittedRun.startedAt, latestRun.startedAt)
         }
       } else if (key === 'contextUsage') {
-        // Main does not persist live context-window snapshots. Keep the renderer value unless it
-        // was cleared and the durable copy still has one from an earlier transcript save.
-        if (submittedValue !== undefined) {
+        // Main does not persist live context-window snapshots. Keep the renderer value, including
+        // an explicit clear, instead of resurrecting a stale durable copy.
+        if (submittedValue === undefined) delete rebased.contextUsage
+        else {
           rebased.contextUsage = structuredClone(
             submittedValue as PersistedChatSession['contextUsage']
           )

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -130,9 +130,7 @@ const MAIN_OWNED_SESSION_FIELDS = new Set<keyof PersistedChatSession>([
   'enabledComputeHosts',
   'selectedComputeHosts',
   'specialistId',
-  'specialistBindingPending',
-  // Live ACP updates this snapshot independently of the renderer transcript save.
-  'contextUsage'
+  'specialistBindingPending'
 ])
 
 const MAIN_OWNED_SESSION_DETAILS_FIELDS = new Set<keyof PersistedChatSession>([
@@ -471,7 +469,14 @@ const rebaseSessionAfterRevisionConflict = (
       } else if (key === 'activeRun') {
         const submittedRun = submittedValue as PersistedChatSession['activeRun']
         const latestRun = latestValue as PersistedChatSession['activeRun']
-        if (!submittedRun) continue
+        const baseRun = baseValue as PersistedChatSession['activeRun']
+        if (!submittedRun) {
+          if (!latestRun || latestRun.promptMessageId === baseRun?.promptMessageId) {
+            delete rebased.activeRun
+            continue
+          }
+          return undefined
+        }
         if (!latestRun) {
           rebased.activeRun = structuredClone(submittedRun)
           continue
@@ -480,6 +485,14 @@ const rebaseSessionAfterRevisionConflict = (
         rebased.activeRun = {
           promptMessageId: submittedRun.promptMessageId,
           startedAt: Math.min(submittedRun.startedAt, latestRun.startedAt)
+        }
+      } else if (key === 'contextUsage') {
+        // Main does not persist live context-window snapshots. Keep the renderer value unless it
+        // was cleared and the durable copy still has one from an earlier transcript save.
+        if (submittedValue !== undefined) {
+          rebased.contextUsage = structuredClone(
+            submittedValue as PersistedChatSession['contextUsage']
+          )
         }
       } else {
         return undefined

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -130,7 +130,9 @@ const MAIN_OWNED_SESSION_FIELDS = new Set<keyof PersistedChatSession>([
   'enabledComputeHosts',
   'selectedComputeHosts',
   'specialistId',
-  'specialistBindingPending'
+  'specialistBindingPending',
+  // Live ACP updates this snapshot independently of the renderer transcript save.
+  'contextUsage'
 ])
 
 const MAIN_OWNED_SESSION_DETAILS_FIELDS = new Set<keyof PersistedChatSession>([
@@ -466,6 +468,19 @@ const rebaseSessionAfterRevisionConflict = (
         )
         if (!graph) return undefined
         rebased.conversationGraph = graph
+      } else if (key === 'activeRun') {
+        const submittedRun = submittedValue as PersistedChatSession['activeRun']
+        const latestRun = latestValue as PersistedChatSession['activeRun']
+        if (!submittedRun) continue
+        if (!latestRun) {
+          rebased.activeRun = structuredClone(submittedRun)
+          continue
+        }
+        if (submittedRun.promptMessageId !== latestRun.promptMessageId) return undefined
+        rebased.activeRun = {
+          promptMessageId: submittedRun.promptMessageId,
+          startedAt: Math.min(submittedRun.startedAt, latestRun.startedAt)
+        }
       } else {
         return undefined
       }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -499,10 +499,11 @@ const rebaseSessionAfterRevisionConflict = (
   return rebased
 }
 
-// Session details can legitimately advance through queued, running, and terminal Main-owned
-// revisions while a renderer transcript save is in flight. Rebase each observed authority in
-// sequence, but keep a hard cap so a genuinely active second writer cannot livelock persistence.
-const MAX_SESSION_REVISION_REBASE_ATTEMPTS = 3
+// A first-turn renderer transcript save can overlap several legitimate Main-owned advances:
+// Session details queued/running/terminal, Session status, runtime context, and auxiliary usage.
+// Rebase each newly observed authority in sequence. Keep a hard cap so a genuine second writer
+// cannot livelock persistence.
+const MAX_SESSION_REVISION_REBASE_ATTEMPTS = 8
 
 const saveAfterSessionRevisionConflict = async (
   initialError: unknown,
@@ -1712,6 +1713,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
 }
 
 export {
+  MAX_SESSION_REVISION_REBASE_ATTEMPTS,
   createOrderedSessionPersistence,
   createStoreSaver,
   flushSessionPersistence,


### PR DESCRIPTION
## Problem

Recently merged PRs fail PR Gate on the Windows workspace E2E lane. The shared failure is `e2e/message-tool-layout-stability.spec.ts`:

- The first fake-agent reply never appears. The accessibility snapshot stays on **Thinking** and shows **Conversation storage needs attention** / `This conversation changed in another window...`
- When the buffered-markdown case does complete, the tool group moves by ~116px
- The GitHub star nudge is visible in every failure screenshot
- macOS workspace E2E, Windows core, and module tests pass

This is independent of the original PRs (usage aggregation, domain language, task API, notifications, folder access, updater, connectors, storage contracts, figure skills, memory). Those changes add more legitimate Main-owned Session writes during a first turn; they should not be reopened.

## Proposed change

- Raise the bounded renderer rebase window from 3 to 8 consecutive Main revisions so one transcript save can absorb Session-details `queued`/`running`/`terminal`, status, runtime context, and auxiliary usage advances. Fail-closed behavior after the cap is unchanged.
- Add a regression that requires six overlapping Main revisions, and keep the cap-exhaustion test pinned to the new bound.
- Seed the GitHub star nudge cooldown in the Electron E2E profile so the 5s workspace dialog cannot cover Send or shift layout.
- Apply reduced motion in the layout spec after the window is visible, so `requestAnimationFrame` still runs without scroll animations.

```mermaid
sequenceDiagram
  participant Renderer
  participant Main
  Renderer->>Main: save transcript (rev N)
  Main-->>Renderer: conflict (details queued)
  Main-->>Renderer: conflict (details running)
  Main-->>Renderer: conflict (details terminal)
  Main-->>Renderer: conflict (status / runtime / usage)
  Renderer->>Main: rebase onto latest and save
```

## Scope and non-goals

- Does not reopen or push to the original merged PR branches
- Does not change Session JSON shape, migrations, or on-disk compatibility
- Does not add Session status or enum values
- Does not disable Session-details generation or memory auto-recall in product code

## Persistence, historical compatibility, and new state

**Persistence.** Live Session save recovery retries more Main-owned revision conflicts before showing the storage alert. Durable writes still go through the existing `saveSession` / revision check path.

**Historical compatibility.** No migration and no change to stored Session files. Older conversations load as before. Only the live fail-closed window for concurrent Main+renderer writes is wider.

**New enum / status values.** None.

## Acceptance criteria and validation

- A completed first-turn renderer save succeeds after six consecutive Main authority revisions (Session details + status + auxiliary usage).
- A seventh-plus sustained second writer still fail-closes at the cap.
- E2E layout journeys do not show the GitHub star nudge from a fresh profile.
- Windows workspace E2E on this PR is the authority for the original failing spec.

### Test Impact Set (after last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Renderer Session save recovery, including 6 overlapping Main revisions and cap exhaustion | `npx vitest run src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx` | pass (75 tests) |
| Renderer typecheck | `npm run typecheck:web` | pass |
| Lint of changed files | `npx eslint --max-warnings=0` on the four touched files | pass |
| Windows workspace E2E (`message-tool-layout-stability`) | PR Gate `e2e_workspace_windows` | not run locally (macOS host); CI is authoritative |

**Excluded:** full `npm test` (user request; PR Gate remains the complete portable suite). Electron/Web ACP launchers were not changed. No database migration, so the packaged migration ledger was not updated.

**Uncovered risk:** the Windows Electron layout journey cannot be executed on this macOS host. If CI still fails, the next place to inspect is whether rebase returns `undefined` on a non-Main field rather than exhausting the retry cap.

## Review focus

- Whether 8 is the right bounded window versus treating more fields as Main-owned
- E2E star-nudge suppression via `localStorage` versus an explicit product flag
- That fail-closed behavior for a real second window writer is preserved