### PR TITLE
fix(acp): preserve Claude loopback credentials

### DIFF
--- a/src/main/session-details/owner.test.ts
+++ b/src/main/session-details/owner.test.ts
@@ -486,6 +486,27 @@ describe('SessionDetailsOwner', () => {
     expect(warn.mock.calls.at(-1)?.[1]).toMatchObject({ timeout: true })
   })
 
+  it('records an immediate provider authentication failure without misclassifying it as timeout', async () => {
+    const authenticationFailure = Object.assign(new Error('Unauthorized'), {
+      code: -32603,
+      data: { errorKind: 'authentication_failed' },
+      name: 'RequestError'
+    })
+    const { owner, store, warn } = harness([queuedSession()], {
+      inference: async () => Promise.reject(authenticationFailure),
+      inferenceTimeoutMs: 30_000
+    })
+
+    await owner.start()
+    await waitFor(() => store.current().sessionDetailsGeneration?.status === 'failed')
+
+    expect(store.current().sessionDetailsGeneration).toMatchObject({
+      status: 'failed',
+      usageUnavailable: true
+    })
+    expect(warn.mock.calls.at(-1)?.[1]).toMatchObject({ timeout: false })
+  })
+
   it('normalizes usage and drops an inconsistent cache breakdown', async () => {
     const { owner, store } = harness([queuedSession()], {
       inference: async () => ({

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -622,7 +622,7 @@ describe('AgentBackendResolver configured and explicit targets', () => {
         providerId: 'main',
         apiType: 'anthropic',
         baseUrl: backend.env.ANTHROPIC_BASE_URL,
-        headers: { authorization: `Bearer ${backend.env.ANTHROPIC_AUTH_TOKEN}` }
+        headers: { 'x-api-key': backend.env.ANTHROPIC_AUTH_TOKEN }
       })
       expect(backend.env).not.toHaveProperty('ANTHROPIC_CUSTOM_MODEL_OPTION')
     } finally {

--- a/src/main/settings/claude-provider-configuration.integration.test.ts
+++ b/src/main/settings/claude-provider-configuration.integration.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { runInNewContext } from 'node:vm'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { BackendRoutePlan } from './backend-route-planner'
+import { AnthropicProviderBridge } from './anthropic-provider-bridge'
+import type { ProviderRuntimeTarget } from './provider-accounts'
+import { ProviderTransportOwner } from './provider-transport-owner'
+
+const target: ProviderRuntimeTarget = {
+  providerId: 'provider-a',
+  providerType: 'custom',
+  effectiveModel: 'model-a',
+  apiEndpoints: ['anthropic'],
+  provider: {
+    type: 'custom',
+    baseUrl: 'https://provider.example.test',
+    model: 'model-a',
+    key: 'synthetic-upstream-key',
+    apiEndpoints: ['anthropic']
+  },
+  reasoningEffortProfile: { supported: false },
+  frameworkCompatible: true,
+  modelBridgeSupported: false,
+  needsChatResponsesBridge: false,
+  needsNativeResponsesCompatibility: false
+}
+
+const plan: BackendRoutePlan = {
+  modelRoute: 'claude-anthropic',
+  backendProviderId: target.providerId,
+  sessionEffort: 'high',
+  providerModelCatalog: [],
+  transport: {
+    kind: 'claude-anthropic',
+    targets: [
+      {
+        id: 'provider-a/model-a',
+        baseUrl: target.provider.baseUrl!,
+        key: target.provider.key,
+        model: 'model-a'
+      }
+    ],
+    initialTargetId: 'provider-a/model-a'
+  }
+}
+
+const customHeaders = (value: string | undefined): Record<string, string> =>
+  Object.fromEntries(
+    (value ?? '').split('\n').flatMap((line) => {
+      const separator = line.indexOf(':')
+      return separator < 0
+        ? []
+        : [[line.slice(0, separator).trim().toLowerCase(), line.slice(separator + 1).trim()]]
+    })
+  )
+
+type ClaudeProviderConfiguration = NonNullable<
+  Awaited<ReturnType<ProviderTransportOwner['acquire']>>['providerConfiguration']
+>
+
+const loadClaudeProviderEnvAdapter = (): ((
+  config: ClaudeProviderConfiguration
+) => Record<string, string>) => {
+  const require = createRequire(import.meta.url)
+  const source = readFileSync(
+    require.resolve('@agentclientprotocol/claude-agent-acp/dist/acp-agent.js'),
+    'utf8'
+  )
+  const start = source.indexOf('function createEnvForProvider(config)')
+  const end = source.indexOf('\nfunction isValidBaseUrl', start)
+  if (start < 0 || end < 0) throw new Error('Claude ACP provider environment adapter not found.')
+  return runInNewContext(`${source.slice(start, end)}\ncreateEnvForProvider`) as (
+    config: ClaudeProviderConfiguration
+  ) => Record<string, string>
+}
+
+describe('Claude ACP provider configuration', () => {
+  it('preserves the loopback credential through the real Claude adapter and terminalizes upstream 401', async () => {
+    const upstreamFetch = vi.fn(async () =>
+      Response.json(
+        { error: { type: 'authentication_error', message: 'Synthetic credential rejected' } },
+        { status: 401 }
+      )
+    )
+    const owner = new ProviderTransportOwner({
+      createAnthropicProviderBridge: (targets, initialTargetId) =>
+        new AnthropicProviderBridge(targets, initialTargetId, upstreamFetch)
+    })
+    const generation = await owner.acquire({ activeTarget: target, plan })
+
+    try {
+      const adapterEnv = loadClaudeProviderEnvAdapter()(generation.providerConfiguration!)
+      const headers = {
+        ...customHeaders(adapterEnv.ANTHROPIC_CUSTOM_HEADERS),
+        authorization: `Bearer ${adapterEnv.ANTHROPIC_AUTH_TOKEN}`,
+        'content-type': 'application/json'
+      }
+      const send = (): Promise<Response> =>
+        fetch(`${adapterEnv.ANTHROPIC_BASE_URL}/v1/messages?beta=true`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ model: 'ignored', messages: [] })
+        })
+
+      expect(adapterEnv.ANTHROPIC_AUTH_TOKEN).toBe('acp-proxy')
+      expect(customHeaders(adapterEnv.ANTHROPIC_CUSTOM_HEADERS)).toEqual({
+        'x-api-key': generation.environment?.ANTHROPIC_AUTH_TOKEN
+      })
+
+      const startedAt = performance.now()
+      const first = await send()
+      const second = await send()
+
+      expect(performance.now() - startedAt).toBeLessThan(1_000)
+      expect(first.status).toBe(400)
+      expect(second.status).toBe(400)
+      expect(first.headers.get('x-open-science-upstream-status')).toBe('401')
+      expect(second.headers.get('x-open-science-upstream-status')).toBe('401')
+      await expect(first.json()).resolves.toEqual({
+        error: { type: 'authentication_error', message: 'Synthetic credential rejected' }
+      })
+      expect(upstreamFetch).toHaveBeenCalledOnce()
+    } finally {
+      await generation.release()
+    }
+  })
+})

--- a/src/main/settings/provider-transport-owner.test.ts
+++ b/src/main/settings/provider-transport-owner.test.ts
@@ -172,6 +172,7 @@ describe('ProviderTransportOwner generations', () => {
       key: 'openai-token-0',
       model: 'model-a'
     })
+    expect(generation.providerConfiguration).toBeUndefined()
     expect(generation.environment?.NO_PROXY).toBe(generation.environment?.no_proxy)
     await generation.release()
     expect(selector.close).toHaveBeenCalledOnce()
@@ -449,7 +450,7 @@ describe('ProviderTransportOwner generations', () => {
       providerId: 'main',
       apiType: 'anthropic',
       baseUrl: 'http://127.0.0.1:43000',
-      headers: { authorization: 'Bearer anthropic-bridge-token' }
+      headers: { 'x-api-key': 'anthropic-bridge-token' }
     })
     expect(generation.environment?.NO_PROXY).toBe(generation.environment?.no_proxy)
     expect(generation.anthropicBridgeLease?.setTarget('provider-a/model-a')).toBe(true)
@@ -533,6 +534,7 @@ describe('ProviderTransportOwner generations', () => {
     const providerA = generation.providerModelCatalog?.find(
       ({ provider }) => provider.model === 'model-a'
     )?.provider
+    expect(generation.providerConfiguration).toBeUndefined()
     if (!providerA?.openaiBaseUrl || !providerA.key) throw new Error('Missing provider A loopback')
     const sendA = (): Promise<Response> =>
       fetch(`${providerA.openaiBaseUrl}/chat/completions`, {
@@ -585,6 +587,7 @@ describe('ProviderTransportOwner generations', () => {
       model: 'model-a',
       apiEndpoints: ['responses']
     })
+    expect(generation.providerConfiguration).toBeUndefined()
     expect(generation.providerTransportLease?.setTarget(initialTargetId)).toBe(true)
     expect(generation.environment?.NO_PROXY).toBe(generation.environment?.no_proxy)
     await generation.release()

--- a/src/main/settings/provider-transport-owner.ts
+++ b/src/main/settings/provider-transport-owner.ts
@@ -532,7 +532,7 @@ class ProviderTransportOwner {
           providerId: CLAUDE_ACP_CONFIGURABLE_PROVIDER_ID,
           apiType: 'anthropic',
           baseUrl: connection.baseUrl,
-          headers: { authorization: `Bearer ${connection.token}` }
+          headers: { 'x-api-key': connection.token }
         },
         anthropicBridgeLease: {
           setTarget: (targetId: string) => bridge.setTarget(targetId),


### PR DESCRIPTION
## Problem

Claude Code ACP provider configuration used a custom Authorization header for the local Anthropic bridge. claude-agent-acp replaces that credential with its Bearer acp-proxy placeholder, so the loopback rejects the request before AnthropicProviderBridge can process it. The inherited session-details timeout can then obscure the primary authentication failure.

## Change

- Configure the Claude providers/set slot with x-api-key while retaining the existing environment fallback.
- Add an integration contract test against the installed Claude ACP adapter header behavior and the real local Anthropic bridge.
- Verify upstream provider 401 responses terminate promptly, are converted to the deterministic client response, and are replayed without another upstream attempt.
- Verify ACP authentication failures are recorded by session-details as non-timeout failures.

## Compatibility

- Claude Code: affected path fixed and covered at the adapter/provider bridge seam.
- OpenCode: provider configuration remains undefined; routing is unchanged.
- Codex Responses: native Responses transport remains unchanged.
- CodeBuddy: provider configuration remains undefined; routing is unchanged.

Protocol transport, the provider bridge, the main Composer prompt, and restricted session-details remain separate paths. This change does not broaden the 30-second safety timeout or alter architecture, persistence, data models, UI, or historical compatibility.

## Validation

- Focused ACP/provider transport/session-details suite: 8 files, 147 tests passed.
- Targeted Composer runtime Claude explicit-4xx test: 1 passed.
- Node typecheck passed.
- Focused ESLint and Prettier checks passed.
- git diff --check passed.

The full npm test suite was intentionally not run per project guidance.