### PR TITLE
fix(model-picker): explain unavailable models

### DIFF
--- a/src/renderer/src/pages/settings/ActiveModelSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/ActiveModelSelect.render.test.tsx
@@ -7,6 +7,8 @@ import type { AgentFrameworkView, ProviderView } from '../../../../shared/settin
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { ActiveModelSelect } from './ActiveModelSelect'
 
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
 // Radix Select calls pointer-capture and scroll APIs jsdom does not implement.
 if (!Element.prototype.hasPointerCapture) {
   Element.prototype.hasPointerCapture = (): boolean => false
@@ -15,6 +17,19 @@ if (!Element.prototype.hasPointerCapture) {
 }
 if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = (): void => undefined
+}
+if (!(globalThis as { ResizeObserver?: unknown }).ResizeObserver) {
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe(): void {
+      /* no-op shim for Radix layout measurement in jsdom */
+    }
+    unobserve(): void {
+      /* no-op */
+    }
+    disconnect(): void {
+      /* no-op */
+    }
+  }
 }
 
 let container: HTMLDivElement
@@ -191,6 +206,48 @@ describe('ActiveModelSelect', () => {
     expect(document.body.textContent).not.toContain('not usable with this framework')
     const option = optionByText('ds-1')
     expect(option?.getAttribute('data-disabled')).toBeNull()
+  })
+
+  it('explains a model-specific endpoint mismatch on hover', async () => {
+    const setActiveProvider = vi.fn().mockResolvedValue(undefined)
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: FRAMEWORKS,
+      providers: [
+        provider({
+          id: 'mixed',
+          type: 'official',
+          vendorId: 'opencode',
+          name: 'Mixed catalog',
+          apiEndpoints: ['openai'],
+          models: ['kimi-k2.7-code', 'gpt-5.6-sol']
+        })
+      ],
+      setActiveProvider
+    })
+    render()
+
+    openSelect()
+
+    expect(optionByText('kimi-k2.7-code')?.getAttribute('data-disabled')).toBeNull()
+    const unavailableOption = optionByText('gpt-5.6-sol')
+    expect(unavailableOption?.getAttribute('aria-disabled')).toBe('true')
+
+    const reason = unavailableOption?.getAttribute('aria-label')
+    expect(reason).toContain('gpt-5.6-sol')
+    expect(reason).toContain('/v1/responses')
+    expect(reason).toContain('OpenCode')
+    expect(reason).toContain('/v1/chat/completions')
+
+    await act(async () => {
+      unavailableOption?.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }))
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    })
+
+    expect(document.body.querySelector('[data-slot="tooltip-content"]')?.textContent).toContain(
+      reason
+    )
+    expect(setActiveProvider).not.toHaveBeenCalled()
   })
 
   it('keeps every Chat provider model selectable under Codex (bridge support is static)', () => {

--- a/src/renderer/src/pages/settings/ActiveModelSelect.tsx
+++ b/src/renderer/src/pages/settings/ActiveModelSelect.tsx
@@ -8,6 +8,7 @@ import {
   SelectLabel,
   SelectTrigger
 } from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { selectFrameworkApiEndpoints, useSettingsStore } from '@/stores/settings-store'
 import {
   buildConfiguredModelCatalog,
@@ -15,6 +16,7 @@ import {
 } from '../../../../shared/configured-model-catalog'
 import { ProviderKindIcon } from './provider-icons'
 import { providerKindKey } from './provider-form-value'
+import { modelUnavailableReason } from '../workspace/composer-model-picker-utils'
 
 // The single "active model" selector for settings: one selected model, grouped and tagged by its
 // source provider. Mirrors the composer picker (both drive activeProviderId + activeModel), so
@@ -29,7 +31,11 @@ const ActiveModelSelect = (): React.JSX.Element | null => {
   const activeModel = useSettingsStore((state) => state.activeModel)
   const setActiveProvider = useSettingsStore((state) => state.setActiveProvider)
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
   const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
+  const frameworkName =
+    agentFrameworks.find((framework) => framework.id === agentFrameworkId)?.displayName ??
+    agentFrameworkId
 
   const options = buildConfiguredModelCatalog({
     providers,
@@ -95,20 +101,55 @@ const ActiveModelSelect = (): React.JSX.Element | null => {
                 )}
               </SelectLabel>
               {group.options.map((option) => {
+                if (option.selectable) {
+                  return (
+                    <SelectItem
+                      key={option.key}
+                      value={option.key}
+                      icon={
+                        <ProviderKindIcon
+                          kindKey={providerKindKey(option.providerType, option.vendorId)}
+                          className="size-4"
+                        />
+                      }
+                    >
+                      {option.model || option.providerName}
+                    </SelectItem>
+                  )
+                }
+
+                const reason = modelUnavailableReason(
+                  option,
+                  group.provider,
+                  frameworkName,
+                  frameworkEndpoints,
+                  t
+                )
+
                 return (
-                  <SelectItem
-                    key={option.key}
-                    value={option.key}
-                    disabled={!option.selectable}
-                    icon={
-                      <ProviderKindIcon
-                        kindKey={providerKindKey(option.providerType, option.vendorId)}
-                        className="size-4"
-                      />
-                    }
-                  >
-                    {option.model || option.providerName}
-                  </SelectItem>
+                  <TooltipProvider key={option.key} delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <SelectItem
+                          value={option.key}
+                          disabled
+                          aria-label={reason}
+                          className="data-[disabled]:pointer-events-auto data-[disabled]:cursor-not-allowed"
+                          icon={
+                            <ProviderKindIcon
+                              kindKey={providerKindKey(option.providerType, option.vendorId)}
+                              className="size-4"
+                            />
+                          }
+                        >
+                          {option.model || option.providerName}
+                        </SelectItem>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="max-w-72 leading-5">
+                        {reason}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )
               })}
             </SelectGroup>

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -360,6 +360,59 @@ describe('ComposerModelPicker', () => {
     expect(document.body.textContent).not.toContain('not supported over the Codex')
   })
 
+  it('explains a model-specific endpoint mismatch on hover or focus', async () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: [
+        {
+          id: 'opencode',
+          displayName: 'OpenCode',
+          supportedApiTypes: ['anthropic', 'openai'],
+          supportsSkills: true
+        }
+      ],
+      providers: [
+        provider({
+          id: 'mixed',
+          type: 'official',
+          vendorId: 'opencode',
+          name: 'Mixed catalog',
+          apiEndpoints: ['openai'],
+          models: ['kimi-k2.7-code', 'gpt-5.6-sol']
+        })
+      ],
+      activeProviderId: 'mixed',
+      activeModel: 'kimi-k2.7-code'
+    })
+    render()
+
+    const trigger = container.querySelector('[aria-label="Select model"]')
+    expect(trigger).not.toBeNull()
+    await openMenu(trigger!)
+    const modelRow = modelRowTrigger()
+    expect(modelRow).toBeDefined()
+    await openSubmenu(modelRow!)
+
+    const unavailableItem = menuItems().find((item) =>
+      item.getAttribute('aria-label')?.includes('gpt-5.6-sol')
+    )
+    const reason = unavailableItem?.getAttribute('aria-label')
+    expect(reason).toContain('/v1/responses')
+    expect(reason).toContain('OpenCode')
+    expect(reason).toContain('/v1/chat/completions')
+    expect(reason).not.toContain('Codex Chat Completions bridge')
+    expect(unavailableItem?.getAttribute('aria-disabled')).toBe('true')
+
+    await act(async () => unavailableItem?.focus())
+    await flush()
+
+    expect(document.body.querySelector('[data-slot="tooltip-content"]')?.textContent).toContain(
+      reason
+    )
+    act(() => unavailableItem?.click())
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it('exposes each incompatible provider reason as a focusable, non-actionable menu item', async () => {
     // Claude Code (anthropic-only) + only OpenAI-speaking providers: the menu must state why each
     // provider is unavailable in an item roving focus can reach (not a label or a disabled item, both

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { ProviderKindIcon } from '../settings/provider-icons'
 import { providerKindKey } from '../settings/provider-form-value'
@@ -29,7 +30,7 @@ import {
   resolveProviderReasoningEffortProfile
 } from '../../../../shared/provider-reasoning-effort'
 import { resolveReasoningEffortControl } from '../../../../shared/reasoning-effort'
-import { incompatibilityReason } from './composer-model-picker-utils'
+import { incompatibilityReason, modelUnavailableReason } from './composer-model-picker-utils'
 
 const triggerClassName =
   'flex h-8 min-w-0 max-w-[220px] shrink items-center gap-1 rounded-md px-2.5 text-sm text-text-300 hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50 transition-colors'
@@ -387,23 +388,38 @@ const ComposerModelPicker = ({
                       const optionCompatible = option.selectable
 
                       if (!optionCompatible) {
-                        // Endpoint is fine but this model is statically marked unsupported over the Codex
-                        // bridge. Grey it with a warning icon; the full reason is on hover (title) and read
-                        // by assistive tech (aria-label), so it isn't a long inline string.
-                        const optionReason = `${optionLabel(option)} is not supported over the Codex Chat Completions bridge.`
+                        const optionReason = modelUnavailableReason(
+                          option,
+                          group.provider,
+                          frameworkName,
+                          frameworkEndpoints,
+                          tCommon
+                        )
                         return (
-                          <DropdownMenuItem
+                          <TooltipProvider
                             key={`${option.providerId}:${option.model}`}
-                            aria-disabled
-                            aria-label={optionReason}
-                            title={optionReason}
-                            onSelect={(event) => event.preventDefault()}
-                            className="gap-2 text-text-300"
+                            delayDuration={200}
                           >
-                            <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
-                            <span className="min-w-0 flex-1 truncate">{optionLabel(option)}</span>
-                            <span className="text-xs">unsupported</span>
-                          </DropdownMenuItem>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <DropdownMenuItem
+                                  aria-disabled
+                                  aria-label={optionReason}
+                                  onSelect={(event) => event.preventDefault()}
+                                  className="gap-2 text-text-300"
+                                >
+                                  <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+                                  <span className="min-w-0 flex-1 truncate">
+                                    {optionLabel(option)}
+                                  </span>
+                                  <span className="text-xs">unsupported</span>
+                                </DropdownMenuItem>
+                              </TooltipTrigger>
+                              <TooltipContent side="right" className="max-w-72 leading-5">
+                                {optionReason}
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
                         )
                       }
 

--- a/src/renderer/src/pages/workspace/composer-model-picker-utils.ts
+++ b/src/renderer/src/pages/workspace/composer-model-picker-utils.ts
@@ -1,9 +1,14 @@
 import type { TFunction } from 'i18next'
 
 import {
+  configuredModelApiEndpoints,
+  type ConfiguredModelCatalogEntry
+} from '../../../../shared/configured-model-catalog'
+import {
   providerEndpoints,
   type ChatApiEndpoint,
-  type ProviderType
+  type ProviderType,
+  type ProviderView
 } from '../../../../shared/settings'
 
 // Human-readable route for an endpoint, so a reason reads as a route rather than a vendor name. The
@@ -17,9 +22,30 @@ const ENDPOINT_ROUTE: Record<ChatApiEndpoint, string> = {
 const routeList = (endpoints: readonly ChatApiEndpoint[], t: TFunction): string =>
   endpoints.map((endpoint) => ENDPOINT_ROUTE[endpoint]).join(t(' or '))
 
+export const modelUnavailableReason = (
+  option: Pick<ConfiguredModelCatalogEntry, 'label' | 'model' | 'unavailableReason'>,
+  provider: Pick<ProviderView, 'type' | 'vendorId' | 'apiEndpoints'>,
+  frameworkName: string,
+  frameworkEndpoints: readonly ChatApiEndpoint[],
+  t: TFunction
+): string | undefined => {
+  if (!option.unavailableReason) return undefined
+  if (option.unavailableReason === 'model-bridge-unsupported') {
+    return t(
+      'This model is not supported over the Codex Chat Completions bridge. Pick another model for a Codex session.'
+    )
+  }
+
+  return t('{{model}} uses {{modelRoutes}}, but {{framework}} supports {{frameworkRoutes}}.', {
+    model: option.label,
+    modelRoutes: routeList(configuredModelApiEndpoints(provider, option.model), t),
+    framework: frameworkName,
+    frameworkRoutes: routeList(frameworkEndpoints, t)
+  })
+}
+
 // Why a provider can't drive the current framework, shown on hover next to "· unavailable". One axis:
-// a chat-endpoint mismatch. Keys live in `common` because both the settings alert and the composer
-// picker render this. Framework and provider names are proper nouns and interpolate verbatim.
+// a chat-endpoint mismatch. Framework and provider names are proper nouns and interpolate verbatim.
 export const incompatibilityReason = (
   provider: { apiEndpoints?: readonly ChatApiEndpoint[]; type: ProviderType; name: string },
   frameworkName: string,

--- a/src/shared/configured-model-catalog.ts
+++ b/src/shared/configured-model-catalog.ts
@@ -9,6 +9,7 @@ import {
   isCodexSubscriptionProvider,
   isProviderUsableByFramework,
   isXaiSubscriptionProvider,
+  providerEndpoints,
   providerValidationFailed,
   selectClaudeSubscriptionProvider,
   type AgentFrameworkId,
@@ -52,6 +53,14 @@ export const parseConfiguredModelKey = (
     return undefined
   }
 }
+
+export const configuredModelApiEndpoints = (
+  provider: Pick<ProviderView, 'type' | 'vendorId' | 'apiEndpoints'>,
+  model: string
+): readonly ChatApiEndpoint[] =>
+  provider.type === 'official' && provider.vendorId
+    ? resolveVendorModelApiEndpoints(provider.vendorId, model)
+    : providerEndpoints(provider)
 
 export const buildConfiguredModelInventory = (
   input: Readonly<{
@@ -114,10 +123,7 @@ export const buildConfiguredModelCatalog = (
   return buildConfiguredModelInventory(input).map((entry) => {
     const provider = input.providers.find((candidate) => candidate.id === entry.providerId)!
     const model = entry.model
-    const apiEndpoints =
-      provider.type === 'official' && provider.vendorId
-        ? resolveVendorModelApiEndpoints(provider.vendorId, model)
-        : provider.apiEndpoints
+    const apiEndpoints = configuredModelApiEndpoints(provider, model)
     const frameworkCompatible = isProviderUsableByFramework(
       { apiEndpoints, type: provider.type },
       { id: input.frameworkId, supportedApiTypes: input.frameworkEndpoints }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -2275,6 +2275,7 @@
     "This is how the agent decides when to use the skill — be specific.": "Así es como el agente decide cuándo usar la habilidad: sea específico.",
     "This machine is offline.": "Esta máquina está fuera de línea.",
     "This model is not supported over the Codex Chat Completions bridge. Pick another model for a Codex session.": "Este modelo no es compatible con el puente Codex Chat Completions. Elija otro modelo para una sesión de Codex.",
+    "{{model}} uses {{modelRoutes}}, but {{framework}} supports {{frameworkRoutes}}.": "{{model}} usa {{modelRoutes}}, pero {{framework}} admite {{frameworkRoutes}}.",
     "This permanently deletes the Specialist. Conversations using it will no longer be able to use it.": "Esto elimina permanentemente al especialista. Las conversaciones que lo utilicen ya no podrán utilizarlo.",
     "This project": "Este proyecto",
     "This project has no saved sessions.": "Este proyecto no tiene sesiones guardadas.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -2275,6 +2275,7 @@
     "This is how the agent decides when to use the skill — be specific.": "C’est ainsi que l’agent décide quand utiliser la compétence – soyez précis.",
     "This machine is offline.": "Cette machine est hors ligne.",
     "This model is not supported over the Codex Chat Completions bridge. Pick another model for a Codex session.": "Ce modèle n'est pas pris en charge sur le pont Codex Chat Completions. Choisissez un autre modèle pour une session Codex.",
+    "{{model}} uses {{modelRoutes}}, but {{framework}} supports {{frameworkRoutes}}.": "{{model}} utilise {{modelRoutes}}, mais {{framework}} prend en charge {{frameworkRoutes}}.",
     "This permanently deletes the Specialist. Conversations using it will no longer be able to use it.": "Cela supprime définitivement le spécialiste. Les conversations l’utilisant ne pourront plus l’utiliser.",
     "This project": "Ce projet",
     "This project has no saved sessions.": "Ce projet n'a aucune session enregistrée.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -2178,6 +2178,7 @@
     "This is how the agent decides when to use the skill — be specific.": "これは、エージェントがスキルをいつ使用するかを決定する方法です。具体的に指定してください。",
     "This machine is offline.": "このマシンはオフラインです。",
     "This model is not supported over the Codex Chat Completions bridge. Pick another model for a Codex session.": "このモデルは、Codex Chat Completions ブリッジではサポートされていません。Codex セッション用に別のモデルを選択してください。",
+    "{{model}} uses {{modelRoutes}}, but {{framework}} supports {{frameworkRoutes}}.": "{{model}} は {{modelRoutes}} を使用しますが、{{framework}} は {{frameworkRoutes}} をサポートしています。",
     "This permanently deletes the Specialist. Conversations using it will no longer be able to use it.": "これにより、スペシャリストが完全に削除されます。このスペシャリストを使用している会話では、今後使用できなくなります。",
     "This project": "このプロジェクト",
     "This project has no saved sessions.": "このプロジェクトには保存されたセッションがありません。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -2188,6 +2188,7 @@
     "This is how the agent decides when to use the skill — be specific.": "에이전트가 언제 이 스킬을 사용할지 판단하는 기준입니다. 구체적으로 작성하세요.",
     "This machine is offline.": "이 컴퓨터는 오프라인 상태입니다.",
     "This model is not supported over the Codex Chat Completions bridge. Pick another model for a Codex session.": "이 모델은 Codex Chat Completions 브리지에서 지원되지 않습니다. Codex 세션에 사용할 다른 모델을 선택하세요.",
+    "{{model}} uses {{modelRoutes}}, but {{framework}} supports {{frameworkRoutes}}.": "{{model}} 사용 형식은 {{modelRoutes}}이지만, {{framework}} 지원 형식은 {{frameworkRoutes}}입니다.",
     "This permanently deletes the Specialist. Conversations using it will no longer be able to use it.": "스페셜리스트가 영구 삭제됩니다. 이 스페셜리스트를 사용하는 대화에서는 더 이상 해당 기능을 사용할 수 없습니다.",
     "This project": "이 프로젝트",
     "This project has no saved sessions.": "이 프로젝트에는 저장된 세션이 없습니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -2288,6 +2288,7 @@
     "This is how the agent decides when to use the skill — be specific.": "Это то, как агент определяет, когда использовать навык — будьте конкретны.",
     "This machine is offline.": "Эта машина выключена.",
     "This model is not supported over the Codex Chat Completions bridge. Pick another model for a Codex session.": "Эта модель не поддерживается мостом Codex Chat Completions. Выберите другую модель для сессии Codex.",
+    "{{model}} uses {{modelRoutes}}, but {{framework}} supports {{frameworkRoutes}}.": "{{model}} использует {{modelRoutes}}, но {{framework}} поддерживает {{frameworkRoutes}}.",
     "This permanently deletes the Specialist. Conversations using it will no longer be able to use it.": "Это полностью удалит специалиста. Диалоги, использующие его, больше не смогут его использовать.",
     "This project": "Этот проект",
     "This project has no saved sessions.": "В этом проекте нет сохранённых сессий.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -2249,6 +2249,7 @@
     "This is how the agent decides when to use the skill — be specific.": "智能体依据这句话判断何时使用该技能 —— 写具体些。",
     "This machine is offline.": "此设备已离线。",
     "This model is not supported over the Codex Chat Completions bridge. Pick another model for a Codex session.": "该模型不支持通过 Codex 的 Chat Completions 桥接使用。为 Codex 会话另选一个模型。",
+    "{{model}} uses {{modelRoutes}}, but {{framework}} supports {{frameworkRoutes}}.": "{{model}} 使用 {{modelRoutes}}，但 {{framework}} 支持 {{frameworkRoutes}}。",
     "This permanently deletes the Specialist. Conversations using it will no longer be able to use it.": "这将永久删除该专家。正在使用它的对话将无法再使用它。",
     "This project": "此项目",
     "This project has no saved sessions.": "此项目没有已保存的会话。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -2246,6 +2246,7 @@
     "This is how the agent decides when to use the skill — be specific.": "智能體依據這句話判斷何時使用該技能 —— 寫具體些。",
     "This machine is offline.": "此裝置已離線。",
     "This model is not supported over the Codex Chat Completions bridge. Pick another model for a Codex session.": "該模型不支援透過 Codex 的 Chat Completions 橋接使用。為 Codex 會話另選一個模型。",
+    "{{model}} uses {{modelRoutes}}, but {{framework}} supports {{frameworkRoutes}}.": "{{model}} 使用 {{modelRoutes}}，但 {{framework}} 支援 {{frameworkRoutes}}。",
     "This permanently deletes the Specialist. Conversations using it will no longer be able to use it.": "這將永久刪除該專家。正在使用它的對話將無法再使用它。",
     "This project": "此專案",
     "This project has no saved sessions.": "此專案沒有已儲存的會話。",


### PR DESCRIPTION
## Problem

Mixed-protocol model catalogs can show individual models as disabled without explaining why. The conversation picker also used one bridge-specific explanation for every unavailable model, even when the actual cause was an endpoint mismatch.

## Proposed behavior

- Derive each unavailable reason from the model's resolved API endpoint and the active framework's supported endpoints.
- Show the reason in a compact tooltip on disabled settings options and on hover or keyboard focus in the conversation picker.
- Preserve disabled semantics and prevent unavailable rows from changing the selected model.
- Localize the new endpoint-specific explanation in every renderer locale.

## Scope and non-goals

- No live model-catalog refresh.
- No runtime routing changes or model catalog additions.
- No persisted data or schema changes.
- No new state or enum values.
- No historical-data compatibility path is required.

## Validation

- Targeted model catalog, settings selector, and conversation picker tests: 38 passed.
- `i18n_catalog` module: 743 passed.
- `npm run typecheck:web`
- `npm run lint`

The affected-test planner falls back to the complete suite because the new renderer test path has no declared module owner. The complete suite is left to PR CI.

## Review focus

- Endpoint-specific copy for mixed-protocol catalogs.
- Tooltip behavior without making unavailable choices actionable.
- Renderer locale placeholder parity.
