### PR TITLE
feat(providers): add Tencent TokenHub

### DIFF
--- a/src/main/settings/anthropic-provider-bridge.test.ts
+++ b/src/main/settings/anthropic-provider-bridge.test.ts
@@ -14,6 +14,7 @@ import {
 
 type CapturedRequest = {
   authorization?: string
+  apiKey?: string
   body: Record<string, unknown>
   path?: string
 }
@@ -46,6 +47,9 @@ const createUpstream = (): {
       const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>
       requests.push({
         authorization: request.headers.authorization,
+        ...(typeof request.headers['x-api-key'] === 'string'
+          ? { apiKey: request.headers['x-api-key'] }
+          : {}),
         body,
         path: request.url
       })
@@ -148,6 +152,39 @@ describe('AnthropicProviderBridge', () => {
 
     expect(response.status).toBe(401)
     expect(upstream.requests).toEqual([])
+  })
+
+  it('uses x-api-key for an upstream target that requires Anthropic API-key authentication', async () => {
+    const upstream = createUpstream()
+    servers.push(upstream.server)
+    const target: AnthropicProviderBridgeTarget = {
+      id: 'tencent/hy4-preview',
+      baseUrl: await listen(upstream.server),
+      key: 'tokenhub-key',
+      model: 'hy4-preview',
+      useApiKeyHeader: true
+    }
+    const bridge = new AnthropicProviderBridge([target], target.id)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+
+    await fetch(`${connection.baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${connection.token}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ model: 'ignored', messages: [] })
+    })
+
+    expect(upstream.requests).toEqual([
+      {
+        authorization: undefined,
+        apiKey: 'tokenhub-key',
+        body: { model: 'hy4-preview', messages: [] },
+        path: '/v1/messages'
+      }
+    ])
   })
 
   it('filters Fetch Metadata headers before invoking the upstream fetch', async () => {

--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -54,6 +54,7 @@ export type AnthropicProviderBridgeTarget = Readonly<{
   baseUrl: string
   key?: string
   model: string
+  useApiKeyHeader?: boolean
 }>
 
 export type AnthropicProviderBridgeConnection = Readonly<{
@@ -61,7 +62,11 @@ export type AnthropicProviderBridgeConnection = Readonly<{
   token: string
 }>
 
-const requestHeaders = (request: ProviderLoopbackHttpRequest, key?: string): Headers => {
+const requestHeaders = (
+  request: ProviderLoopbackHttpRequest,
+  key?: string,
+  useApiKeyHeader = false
+): Headers => {
   const headers = new Headers()
   for (const [name, value] of Object.entries(request.headers)) {
     const normalized = name.toLowerCase()
@@ -80,7 +85,10 @@ const requestHeaders = (request: ProviderLoopbackHttpRequest, key?: string): Hea
       headers.set(name, value)
     }
   }
-  if (key) headers.set('authorization', `Bearer ${key}`)
+  if (key) {
+    if (useApiKeyHeader) headers.set('x-api-key', key)
+    else headers.set('authorization', `Bearer ${key}`)
+  }
   headers.set('content-type', 'application/json')
   return headers
 }
@@ -181,7 +189,7 @@ export class AnthropicProviderBridge {
 
     const target = this.target
     const body = JSON.stringify({ ...parsed, model: target.model })
-    const headersToForward = requestHeaders(request, target.key)
+    const headersToForward = requestHeaders(request, target.key, target.useApiKeyHeader)
     const replayKey = providerRequestFingerprint(
       target.id,
       `${requestUrl.pathname}${requestUrl.search}`,

--- a/src/main/settings/backend-route-planner.test.ts
+++ b/src/main/settings/backend-route-planner.test.ts
@@ -298,7 +298,7 @@ describe('BackendRoutePlanner provider candidates', () => {
     })
     const targetB = makeTarget(providerB, {
       apiEndpoints: ['anthropic'],
-      provider: { apiEndpoints: ['anthropic'] }
+      provider: { apiEndpoints: ['anthropic'], vendorId: 'tencent' }
     })
     const providers: BackendRouteProviderPort = {
       resolveRuntimeTarget: vi.fn((provider) => {
@@ -333,7 +333,8 @@ describe('BackendRoutePlanner provider candidates', () => {
           id: JSON.stringify(['provider-b', 'model-b']),
           baseUrl: 'https://provider-b.example/anthropic',
           key: 'plain-provider-key',
-          model: 'model-b'
+          model: 'model-b',
+          useApiKeyHeader: true
         }
       ],
       initialTargetId: JSON.stringify(['provider-a', 'model-a'])

--- a/src/main/settings/backend-route-planner.ts
+++ b/src/main/settings/backend-route-planner.ts
@@ -13,6 +13,7 @@ import {
   type ModelReasoningEffort,
   type ResolvedReasoningEffort
 } from '../../shared/reasoning-effort'
+import { usesVendorAnthropicApiKeyHeader } from '../../shared/provider-registry'
 import {
   REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
   REQUEST_SKILL_IMPORT_TOOL_NAME,
@@ -322,7 +323,11 @@ class BackendRoutePlanner {
                 id: claudeTargetId(candidate.providerId, model),
                 baseUrl,
                 ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
-                model
+                model,
+                ...(candidate.provider.vendorId &&
+                usesVendorAnthropicApiKeyHeader(candidate.provider.vendorId)
+                  ? { useApiKeyHeader: true }
+                  : {})
               })
             ]
       })

--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -127,6 +127,50 @@ describe('ProviderRuntimeProjectionOwner', () => {
     expect(owner.toProviderView(provider).supportsImageInput).toBe(false)
   })
 
+  it('projects regional Tencent Hy4 across every supported framework', () => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: 'tencent-tokenhub',
+      type: 'official',
+      vendorId: 'tencent',
+      region: 'singapore',
+      name: 'Tencent TokenHub'
+    }
+
+    for (const frameworkId of ['claude-code', 'opencode', 'codex', 'codebuddy'] as const) {
+      expect(
+        owner.resolveRuntimeTarget(
+          provider,
+          { kind: 'required', model: 'hy4-preview' },
+          getAgentFramework(frameworkId)
+        )
+      ).toMatchObject({
+        effectiveModel: 'hy4-preview',
+        apiEndpoints: ['anthropic', 'openai', 'responses'],
+        frameworkCompatible: true,
+        provider: {
+          vendorId: 'tencent',
+          baseUrl: 'https://tokenhub-intl.tencentmaas.com',
+          openaiBaseUrl: 'https://tokenhub-intl.tencentmaas.com/v1',
+          model: 'hy4-preview',
+          contextWindow: 1_000_000,
+          supportsImageInput: false
+        }
+      })
+    }
+
+    expect(
+      owner.resolveRuntimeTarget(
+        provider,
+        { kind: 'required', model: 'hy4-preview' },
+        getAgentFramework('codex')
+      )
+    ).toMatchObject({
+      needsChatResponsesBridge: false,
+      needsNativeResponsesCompatibility: true
+    })
+  })
+
   it('routes mixed OpenCode Zen models only through their documented protocol', () => {
     const owner = new ProviderRuntimeProjectionOwner()
     const provider: StoredProvider = {

--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -133,7 +133,7 @@ describe('ProviderRuntimeProjectionOwner', () => {
       id: 'tencent-tokenhub',
       type: 'official',
       vendorId: 'tencent',
-      region: 'singapore',
+      region: 'international',
       name: 'Tencent TokenHub'
     }
 
@@ -150,8 +150,8 @@ describe('ProviderRuntimeProjectionOwner', () => {
         frameworkCompatible: true,
         provider: {
           vendorId: 'tencent',
-          baseUrl: 'https://tokenhub-intl.tencentmaas.com',
-          openaiBaseUrl: 'https://tokenhub-intl.tencentmaas.com/v1',
+          baseUrl: 'https://tokenhub-intl.tencentcloudmaas.com',
+          openaiBaseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/v1',
           model: 'hy4-preview',
           contextWindow: 1_000_000,
           supportsImageInput: false

--- a/src/main/settings/provider-transport-owner.test.ts
+++ b/src/main/settings/provider-transport-owner.test.ts
@@ -7,6 +7,7 @@ import {
   type ProviderTransportOwnerOptions
 } from './provider-transport-owner'
 import { OpenAiProviderBridge, type OpenAiProviderBridgeTarget } from './openai-provider-bridge'
+import type { AnthropicProviderBridgeTarget } from './anthropic-provider-bridge'
 import type { ChatProviderCompatibilityTarget } from './chat-provider-compatibility'
 
 type ResponsesBridgeStub = ReturnType<
@@ -495,6 +496,49 @@ describe('ProviderTransportOwner generations', () => {
 
     expect(bridges[0]?.close).toHaveBeenCalledTimes(1)
     expect(bridges[1]?.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses TokenHub x-api-key authentication for OpenCode Anthropic traffic', async () => {
+    const bridge = makeAnthropicBridge()
+    let targets: readonly AnthropicProviderBridgeTarget[] = []
+    const owner = new ProviderTransportOwner({
+      createAnthropicProviderBridge: (registered) => {
+        targets = registered
+        return bridge
+      }
+    })
+    const target: ProviderRuntimeTarget = {
+      ...makeTarget(),
+      apiEndpoints: ['anthropic'],
+      needsChatResponsesBridge: false,
+      provider: {
+        ...makeTarget().provider,
+        vendorId: 'tencent',
+        apiEndpoints: ['anthropic']
+      }
+    }
+
+    const generation = await owner.acquire({
+      activeTarget: target,
+      plan: {
+        ...makePlan({ kind: 'direct' }),
+        modelRoute: 'opencode-anthropic',
+        transport: {
+          kind: 'opencode-anthropic',
+          targets: [{ id: 'opencode/provider-a/model-a', target }]
+        }
+      }
+    })
+
+    expect(targets).toEqual([
+      expect.objectContaining({
+        baseUrl: 'https://provider.example',
+        key: 'plain-provider-key',
+        model: 'model-a',
+        useApiKeyHeader: true
+      })
+    ])
+    await generation.release()
   })
 
   it('invalidates OpenCode replay caches across A to B to A target changes', async () => {

--- a/src/main/settings/provider-transport-owner.ts
+++ b/src/main/settings/provider-transport-owner.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
 import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
+import { usesVendorAnthropicApiKeyHeader } from '../../shared/provider-registry'
 import { netFetchStandard } from '../skills/net-fetch'
 import {
   CLAUDE_ACP_CONFIGURABLE_PROVIDER_ID,
@@ -428,7 +429,11 @@ class ProviderTransportOwner {
                       id: targetId,
                       baseUrl: normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? ''),
                       ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
-                      model
+                      model,
+                      ...(candidate.provider.vendorId &&
+                      usesVendorAnthropicApiKeyHeader(candidate.provider.vendorId)
+                        ? { useApiKeyHeader: true }
+                        : {})
                     }
                   ],
                   targetId

--- a/src/main/settings/record-codec.test.ts
+++ b/src/main/settings/record-codec.test.ts
@@ -67,6 +67,28 @@ describe('settings record codec', () => {
     ).toBeUndefined()
   })
 
+  it('preserves Tencent TokenHub provider identity and region', () => {
+    expect(
+      sanitizeProvider({
+        id: 'tencent-tokenhub',
+        type: 'official',
+        name: 'Tencent TokenHub',
+        vendorId: 'tencent',
+        region: 'singapore',
+        keyRef: 'encrypted:key',
+        keyMask: 'sk-…abcd'
+      })
+    ).toEqual({
+      id: 'tencent-tokenhub',
+      type: 'official',
+      name: 'Tencent TokenHub',
+      vendorId: 'tencent',
+      region: 'singapore',
+      keyRef: 'encrypted:key',
+      keyMask: 'sk-…abcd'
+    })
+  })
+
   it('keeps only recognized Claude and Codex metadata fields', () => {
     expect(
       sanitizeClaudeInfo({ resolvedPath: 'claude-bin', version: '1.0.0', ignored: true })

--- a/src/main/settings/record-codec.test.ts
+++ b/src/main/settings/record-codec.test.ts
@@ -74,7 +74,7 @@ describe('settings record codec', () => {
         type: 'official',
         name: 'Tencent TokenHub',
         vendorId: 'tencent',
-        region: 'singapore',
+        region: 'international',
         keyRef: 'encrypted:key',
         keyMask: 'sk-…abcd'
       })
@@ -83,7 +83,7 @@ describe('settings record codec', () => {
       type: 'official',
       name: 'Tencent TokenHub',
       vendorId: 'tencent',
-      region: 'singapore',
+      region: 'international',
       keyRef: 'encrypted:key',
       keyMask: 'sk-…abcd'
     })

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -47,6 +47,25 @@ describe('validate: request construction', () => {
     expect(request.url).toBe('https://api.anthropic.com/v1/messages')
   })
 
+  it('uses x-api-key for Tencent TokenHub Messages validation', () => {
+    const request = buildValidationRequest(
+      {
+        type: 'official',
+        vendorId: 'tencent',
+        baseUrl: 'https://tokenhub.tencentmaas.com',
+        model: 'hy4-preview',
+        key: 'tokenhub-key',
+        apiEndpoints: ['anthropic', 'openai', 'responses']
+      },
+      false,
+      ['anthropic']
+    )
+
+    expect(request.url).toBe('https://tokenhub.tencentmaas.com/v1/messages')
+    expect(request.headers['x-api-key']).toBe('tokenhub-key')
+    expect(request.headers.authorization).toBeUndefined()
+  })
+
   it('throws for a missing or unparseable base URL', () => {
     expect(() => buildValidationRequest({ type: 'custom' })).toThrow(/missing base url/i)
     expect(() => buildValidationRequest({ type: 'custom', baseUrl: 'not a url' })).toThrow(

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -4,6 +4,7 @@ import type {
   ValidationCategory
 } from '../../shared/settings'
 import { preferredEndpoint } from '../../shared/settings'
+import { usesVendorAnthropicApiKeyHeader } from '../../shared/provider-registry'
 import {
   normalizeAnthropicBaseUrl,
   openAiChatCompletionsUrl,
@@ -134,7 +135,11 @@ const buildAnthropicValidationRequest = (provider: ResolvedProvider): Validation
   }
 
   if (provider.key) {
-    headers.authorization = `Bearer ${provider.key}`
+    if (provider.vendorId && usesVendorAnthropicApiKeyHeader(provider.vendorId)) {
+      headers['x-api-key'] = provider.key
+    } else {
+      headers.authorization = `Bearer ${provider.key}`
+    }
   }
 
   const body = JSON.stringify({

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -214,7 +214,7 @@ describe('provider-kind helpers', () => {
       type: 'official',
       name: 'Tencent TokenHub',
       vendorId: 'tencent',
-      region: 'china',
+      region: 'international',
       model: '',
       contextWindow: '',
       maxInputTokens: '',

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -214,7 +214,7 @@ describe('provider-kind helpers', () => {
       type: 'official',
       name: 'Tencent TokenHub',
       vendorId: 'tencent',
-      region: 'guangzhou',
+      region: 'china',
       model: '',
       contextWindow: '',
       maxInputTokens: '',

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -176,6 +176,7 @@ describe('provider-kind helpers', () => {
 
     expect(apiKeys).toContain('official:deepseek')
     expect(apiKeys).toContain('official:openai')
+    expect(apiKeys).toContain('official:tencent')
     // The two subscription sign-ins each get their own group, parallel to one another, rather than
     // the Claude one hiding under Official API.
     expect(groupKeys('codex')).toEqual(['codex-subscription'])
@@ -204,6 +205,16 @@ describe('provider-kind helpers', () => {
       name: 'MiniMax',
       vendorId: 'minimax',
       region: 'global',
+      model: '',
+      contextWindow: '',
+      maxInputTokens: '',
+      maxOutputTokens: ''
+    })
+    expect(providerKindPatch('official:tencent')).toEqual({
+      type: 'official',
+      name: 'Tencent TokenHub',
+      vendorId: 'tencent',
+      region: 'guangzhou',
       model: '',
       contextWindow: '',
       maxInputTokens: '',

--- a/src/renderer/src/pages/settings/provider-icons.render.test.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.render.test.tsx
@@ -14,4 +14,13 @@ describe('ProviderKindIcon', () => {
       expect(html).not.toContain('text-muted-foreground')
     }
   )
+
+  it('renders the Tencent Cloud provider logo for Tencent TokenHub', () => {
+    const html = renderToStaticMarkup(<ProviderKindIcon kindKey="official:tencent" />)
+
+    expect(html).toContain('<svg')
+    expect(html).toContain('<title>TencentCloud</title>')
+    expect(html).toContain('#006EFF')
+    expect(html).not.toContain('text-muted-foreground')
+  })
 })

--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -4,6 +4,7 @@ import { CirclePlus, Sparkles } from 'lucide-react'
 import ClaudeColor from '@lobehub/icons/es/Claude/components/Color'
 import Codex from '@lobehub/icons/es/Codex/components/Mono'
 import OpenCode from '@lobehub/icons/es/OpenCode/components/Mono'
+import TencentCloudColor from '@lobehub/icons/es/TencentCloud/components/Color'
 
 import { cn } from '@/lib/utils'
 import anthropicLogo from '@/assets/provider-icons/anthropic.svg'
@@ -112,6 +113,16 @@ export const ProviderKindIcon = ({
       <OpenCode
         size={20}
         className={cn('size-5 shrink-0 text-foreground', className)}
+        aria-hidden="true"
+      />
+    )
+  }
+
+  if (kindKey === 'official:tencent') {
+    return (
+      <TencentCloudColor
+        size={20}
+        className={cn('size-5 shrink-0', className)}
         aria-hidden="true"
       />
     )

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -16,6 +16,7 @@ import {
   resolveVendorModelsUrl,
   resolveVendorModelReasoningEffort,
   resolveVendorOpenAiBaseUrl,
+  usesVendorAnthropicApiKeyHeader,
   vendorHasRegions,
   type OfficialVendorId
 } from './provider-registry'
@@ -36,6 +37,7 @@ describe('provider registry', () => {
     expect(isOfficialVendorId('deepseek')).toBe(true)
     expect(isOfficialVendorId('openai')).toBe(true)
     expect(isOfficialVendorId('xai')).toBe(true)
+    expect(isOfficialVendorId('tencent')).toBe(true)
     expect(isOfficialVendorId(undefined)).toBe(false)
     expect(isOfficialVendorId(42)).toBe(false)
   })
@@ -415,6 +417,32 @@ describe('provider registry', () => {
     // so refresh-from-vendor is hidden and the Doubao Seed chat catalog stays curated.
     expect(resolveVendorModelsUrl('volcengine')).toBeUndefined()
     expect(defaultVendorModel('volcengine')).toBe('doubao-seed-2-1-pro-260628')
+  })
+
+  it('routes Tencent TokenHub through all three APIs with regional keys and Hy4 preview', () => {
+    expect(resolveVendorApiEndpoints('tencent')).toEqual(['anthropic', 'openai', 'responses'])
+    expect(usesVendorAnthropicApiKeyHeader('tencent')).toBe(true)
+    expect(usesVendorAnthropicApiKeyHeader('deepseek')).toBe(false)
+    expect(vendorHasRegions('tencent')).toBe(true)
+    expect(resolveVendorBaseUrl('tencent')).toBe('https://tokenhub.tencentmaas.com')
+    expect(resolveVendorOpenAiBaseUrl('tencent')).toBe('https://tokenhub.tencentmaas.com/v1')
+    expect(resolveVendorBaseUrl('tencent', 'singapore')).toBe(
+      'https://tokenhub-intl.tencentmaas.com'
+    )
+    expect(resolveVendorOpenAiBaseUrl('tencent', 'singapore')).toBe(
+      'https://tokenhub-intl.tencentmaas.com/v1'
+    )
+    expect(resolveVendorApiKeyUrl('tencent')).toBe(
+      'https://console.cloud.tencent.com/tokenhub/apikey'
+    )
+    expect(resolveVendorModelsUrl('tencent')).toBeUndefined()
+    expect(defaultVendorModel('tencent')).toBe('hy4-preview')
+    expect(resolveModelContextWindow('tencent', 'hy4-preview')).toBe(1_000_000)
+    expect(isVendorModelResponsesSupported('tencent', 'hy4-preview')).toBe(true)
+    expect(isVendorModelMultimodal('tencent', 'hy4-preview')).toBe(false)
+    expect(resolveVendorModelReasoningEffort('tencent', 'hy4-preview')).toEqual({
+      supported: false
+    })
   })
 
   it('routes Grok through xAI Chat Completions and Responses with a curated model catalog', () => {

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -426,14 +426,17 @@ describe('provider registry', () => {
     expect(vendorHasRegions('tencent')).toBe(true)
     expect(resolveVendorBaseUrl('tencent')).toBe('https://tokenhub.tencentmaas.com')
     expect(resolveVendorOpenAiBaseUrl('tencent')).toBe('https://tokenhub.tencentmaas.com/v1')
-    expect(resolveVendorBaseUrl('tencent', 'singapore')).toBe(
-      'https://tokenhub-intl.tencentmaas.com'
-    )
-    expect(resolveVendorOpenAiBaseUrl('tencent', 'singapore')).toBe(
-      'https://tokenhub-intl.tencentmaas.com/v1'
-    )
     expect(resolveVendorApiKeyUrl('tencent')).toBe(
       'https://console.cloud.tencent.com/tokenhub/apikey'
+    )
+    expect(resolveVendorBaseUrl('tencent', 'international')).toBe(
+      'https://tokenhub-intl.tencentcloudmaas.com'
+    )
+    expect(resolveVendorOpenAiBaseUrl('tencent', 'international')).toBe(
+      'https://tokenhub-intl.tencentcloudmaas.com/v1'
+    )
+    expect(resolveVendorApiKeyUrl('tencent', 'international')).toBe(
+      'https://console.tencentcloud.com/tokenhub/apikey'
     )
     expect(resolveVendorModelsUrl('tencent')).toBeUndefined()
     expect(defaultVendorModel('tencent')).toBe('hy4-preview')

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -419,7 +419,7 @@ describe('provider registry', () => {
     expect(defaultVendorModel('volcengine')).toBe('doubao-seed-2-1-pro-260628')
   })
 
-  it('routes Tencent TokenHub through all three APIs with regional keys and Hy4 preview', () => {
+  it('routes Tencent TokenHub through all three APIs with regional keys and curated models', () => {
     expect(resolveVendorApiEndpoints('tencent')).toEqual(['anthropic', 'openai', 'responses'])
     expect(usesVendorAnthropicApiKeyHeader('tencent')).toBe(true)
     expect(usesVendorAnthropicApiKeyHeader('deepseek')).toBe(false)
@@ -440,7 +440,21 @@ describe('provider registry', () => {
     )
     expect(resolveVendorModelsUrl('tencent')).toBeUndefined()
     expect(defaultVendorModel('tencent')).toBe('hy4-preview')
+    expect(getOfficialVendor('tencent')?.models.map(({ id }) => id)).toEqual([
+      'hy4-preview',
+      'glm-5.3',
+      'glm-5.3-flash',
+      'kimi-k3',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'minimax-m3'
+    ])
     expect(resolveModelContextWindow('tencent', 'hy4-preview')).toBe(1_000_000)
+    expect(resolveModelContextWindow('tencent', 'kimi-k3')).toBe(1_048_576)
+    expect(isVendorModelResponsesSupported('tencent', 'glm-5.3')).toBe(true)
+    expect(isVendorModelResponsesSupported('tencent', 'deepseek-v4-flash')).toBe(true)
+    expect(isVendorModelResponsesSupported('tencent', 'deepseek-v4-pro')).toBe(true)
+    expect(isVendorModelResponsesSupported('tencent', 'minimax-m3')).toBe(true)
     expect(isVendorModelResponsesSupported('tencent', 'hy4-preview')).toBe(true)
     expect(isVendorModelMultimodal('tencent', 'hy4-preview')).toBe(false)
     expect(resolveVendorModelReasoningEffort('tencent', 'hy4-preview')).toEqual({

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -424,19 +424,19 @@ describe('provider registry', () => {
     expect(usesVendorAnthropicApiKeyHeader('tencent')).toBe(true)
     expect(usesVendorAnthropicApiKeyHeader('deepseek')).toBe(false)
     expect(vendorHasRegions('tencent')).toBe(true)
-    expect(resolveVendorBaseUrl('tencent')).toBe('https://tokenhub.tencentmaas.com')
-    expect(resolveVendorOpenAiBaseUrl('tencent')).toBe('https://tokenhub.tencentmaas.com/v1')
-    expect(resolveVendorApiKeyUrl('tencent')).toBe(
-      'https://console.cloud.tencent.com/tokenhub/apikey'
-    )
-    expect(resolveVendorBaseUrl('tencent', 'international')).toBe(
-      'https://tokenhub-intl.tencentcloudmaas.com'
-    )
-    expect(resolveVendorOpenAiBaseUrl('tencent', 'international')).toBe(
+    expect(resolveVendorBaseUrl('tencent')).toBe('https://tokenhub-intl.tencentcloudmaas.com')
+    expect(resolveVendorOpenAiBaseUrl('tencent')).toBe(
       'https://tokenhub-intl.tencentcloudmaas.com/v1'
     )
-    expect(resolveVendorApiKeyUrl('tencent', 'international')).toBe(
+    expect(resolveVendorApiKeyUrl('tencent')).toBe(
       'https://console.tencentcloud.com/tokenhub/apikey'
+    )
+    expect(resolveVendorBaseUrl('tencent', 'china')).toBe('https://tokenhub.tencentmaas.com')
+    expect(resolveVendorOpenAiBaseUrl('tencent', 'china')).toBe(
+      'https://tokenhub.tencentmaas.com/v1'
+    )
+    expect(resolveVendorApiKeyUrl('tencent', 'china')).toBe(
+      'https://console.cloud.tencent.com/tokenhub/apikey'
     )
     expect(resolveVendorModelsUrl('tencent')).toBeUndefined()
     expect(defaultVendorModel('tencent')).toBe('hy4-preview')

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -31,6 +31,7 @@ export type OfficialVendorId =
   | 'xiaomimimo'
   | 'sensenova'
   | 'volcengine'
+  | 'tencent'
   | 'opencode-go'
   | 'opencode'
   | 'openrouter'
@@ -70,6 +71,9 @@ export type OfficialVendor = {
   // for legacy Anthropic-compatible vendor entries. A dual-endpoint vendor lists both, e.g.
   // ['anthropic', 'openai'].
   apiEndpoints?: readonly ChatApiEndpoint[]
+  // Whether Anthropic Messages authenticates with `x-api-key` instead of `Authorization: Bearer`.
+  // Absent keeps the existing bearer behavior used by the other compatible vendors.
+  anthropicApiKeyHeader?: boolean
   // Model ids offered in the composer once a key is stored. First entry is the default selection when
   // the vendor is first added.
   models: OfficialModel[]
@@ -617,6 +621,34 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         'doubao-seed-2-0-mini-260215'
       ]
     }
+  },
+  {
+    id: 'tencent',
+    label: 'Tencent TokenHub',
+    reasoningEffort: 'unsupported',
+    // TokenHub exposes Anthropic Messages, OpenAI Chat Completions, and Responses from regional
+    // hosts. API keys are region-bound, so keep Guangzhou and Singapore as explicit choices rather
+    // than silently retrying a credential against the other site. The broader TokenHub catalog also
+    // contains non-language models, so this provider stays curated instead of enabling live refresh.
+    apiEndpoints: ['anthropic', 'openai', 'responses'],
+    anthropicApiKeyHeader: true,
+    regions: [
+      {
+        id: 'guangzhou',
+        label: 'China (Guangzhou)',
+        baseUrl: 'https://tokenhub.tencentmaas.com',
+        openaiBaseUrl: 'https://tokenhub.tencentmaas.com/v1'
+      },
+      {
+        id: 'singapore',
+        label: 'Singapore',
+        baseUrl: 'https://tokenhub-intl.tencentmaas.com',
+        openaiBaseUrl: 'https://tokenhub-intl.tencentmaas.com/v1'
+      }
+    ],
+    apiKeyUrl: 'https://console.cloud.tencent.com/tokenhub/apikey',
+    models: [{ id: 'hy4-preview', contextWindow: 1_000_000 }]
+    // Hy4 preview is text-only in TokenHub's model matrix, so no `multimodal` rule.
   },
   {
     id: 'opencode-go',
@@ -1213,6 +1245,9 @@ export const resolveVendorApiEndpoints = (id: OfficialVendorId): ChatApiEndpoint
   const endpoints = VENDORS_BY_ID.get(id)?.apiEndpoints
   return endpoints && endpoints.length > 0 ? [...endpoints] : ['anthropic']
 }
+
+export const usesVendorAnthropicApiKeyHeader = (id: OfficialVendorId): boolean =>
+  VENDORS_BY_ID.get(id)?.anthropicApiKeyHeader === true
 
 // Models a vendor is statically known not to drive over the Codex Responses->Chat bridge (see
 // OfficialVendor.bridgeUnsupportedModels). Empty for every vendor whose whole catalog converts.

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -634,18 +634,18 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     anthropicApiKeyHeader: true,
     regions: [
       {
-        id: 'china',
-        label: 'China (Guangzhou)',
-        baseUrl: 'https://tokenhub.tencentmaas.com',
-        openaiBaseUrl: 'https://tokenhub.tencentmaas.com/v1',
-        apiKeyUrl: 'https://console.cloud.tencent.com/tokenhub/apikey'
-      },
-      {
         id: 'international',
         label: 'International (Singapore)',
         baseUrl: 'https://tokenhub-intl.tencentcloudmaas.com',
         openaiBaseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/v1',
         apiKeyUrl: 'https://console.tencentcloud.com/tokenhub/apikey'
+      },
+      {
+        id: 'china',
+        label: 'China (Guangzhou)',
+        baseUrl: 'https://tokenhub.tencentmaas.com',
+        openaiBaseUrl: 'https://tokenhub.tencentmaas.com/v1',
+        apiKeyUrl: 'https://console.cloud.tencent.com/tokenhub/apikey'
       }
     ],
     models: [{ id: 'hy4-preview', contextWindow: 1_000_000 }]

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -627,26 +627,27 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     label: 'Tencent TokenHub',
     reasoningEffort: 'unsupported',
     // TokenHub exposes Anthropic Messages, OpenAI Chat Completions, and Responses from regional
-    // hosts. API keys are region-bound, so keep Guangzhou and Singapore as explicit choices rather
-    // than silently retrying a credential against the other site. The broader TokenHub catalog also
-    // contains non-language models, so this provider stays curated instead of enabling live refresh.
+    // hosts. China and International are separate account sites with distinct consoles, API keys,
+    // and domains, so keep the site explicit rather than retrying credentials across editions. The
+    // broader TokenHub catalog also contains non-language models, so this provider stays curated.
     apiEndpoints: ['anthropic', 'openai', 'responses'],
     anthropicApiKeyHeader: true,
     regions: [
       {
-        id: 'guangzhou',
+        id: 'china',
         label: 'China (Guangzhou)',
         baseUrl: 'https://tokenhub.tencentmaas.com',
-        openaiBaseUrl: 'https://tokenhub.tencentmaas.com/v1'
+        openaiBaseUrl: 'https://tokenhub.tencentmaas.com/v1',
+        apiKeyUrl: 'https://console.cloud.tencent.com/tokenhub/apikey'
       },
       {
-        id: 'singapore',
-        label: 'Singapore',
-        baseUrl: 'https://tokenhub-intl.tencentmaas.com',
-        openaiBaseUrl: 'https://tokenhub-intl.tencentmaas.com/v1'
+        id: 'international',
+        label: 'International (Singapore)',
+        baseUrl: 'https://tokenhub-intl.tencentcloudmaas.com',
+        openaiBaseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/v1',
+        apiKeyUrl: 'https://console.tencentcloud.com/tokenhub/apikey'
       }
     ],
-    apiKeyUrl: 'https://console.cloud.tencent.com/tokenhub/apikey',
     models: [{ id: 'hy4-preview', contextWindow: 1_000_000 }]
     // Hy4 preview is text-only in TokenHub's model matrix, so no `multimodal` rule.
   },

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -648,8 +648,17 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         apiKeyUrl: 'https://console.cloud.tencent.com/tokenhub/apikey'
       }
     ],
-    models: [{ id: 'hy4-preview', contextWindow: 1_000_000 }]
-    // Hy4 preview is text-only in TokenHub's model matrix, so no `multimodal` rule.
+    models: [
+      { id: 'hy4-preview', contextWindow: 1_000_000 },
+      { id: 'glm-5.3', contextWindow: 1_000_000 },
+      { id: 'glm-5.3-flash', contextWindow: 1_000_000 },
+      { id: 'kimi-k3', contextWindow: 1_048_576 },
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
+      { id: 'minimax-m3', contextWindow: 1_000_000 }
+    ]
+    // The curated language models above are text-only in TokenHub's model matrix, so no
+    // `multimodal` rule.
   },
   {
     id: 'opencode-go',


### PR DESCRIPTION
## Problem

Open Science does not expose Tencent's current TokenHub service as an official provider, so users
cannot select `hy4-preview` or follow the region-bound TokenHub API-key flow. TokenHub is distinct
from the legacy Hunyuan endpoint and Tencent Cloud SecretId/SecretKey signing.

Official references:

- [TokenHub model catalog](https://cloud.tencent.com/document/product/1823/130051)
- [API usage and regional endpoints](https://cloud.tencent.com/document/product/1823/130078)
- [Language-model protocols and authentication](https://cloud.tencent.com/document/product/1823/130079)
- [API-key management](https://cloud.tencent.com/document/product/1823/130090)
- [International API usage](https://www.tencentcloud.com/document/product/1300/78941)
- [International language-model catalog](https://www.tencentcloud.com/document/product/1300/80632)
- [International API-key management](https://www.tencentcloud.com/document/product/1300/78949)
- [LobeHub TencentCloud Provider icon](https://lobehub.com/icons/tencentcloud)

## Proposed change

- Register `Tencent TokenHub` as official vendor `tencent`.
- Offer International (Singapore, default) and China (Guangzhou) sites with their distinct console,
  API-key link, and endpoint domain family.
- Keep `hy4-preview` as the default and curate `glm-5.3`, `glm-5.3-flash`, `kimi-k3`,
  `deepseek-v4-flash`, `deepseek-v4-pro`, and `minimax-m3` from TokenHub's current language-model
  catalog.
- Enable Anthropic Messages, OpenAI Chat Completions, and native Responses.
- Route TokenHub Anthropic Messages through its documented `x-api-key` header while retaining the
  existing Bearer behavior for Chat Completions and Responses.
- Reuse the existing provider picker, encrypted key storage, runtime projection, and generic bridges.
- Render Tencent TokenHub with LobeHub's bundled color `TencentCloud` Provider icon.

## Scope and non-goals

- The built-in catalog is intentionally limited to the requested current language models; it does
  not mirror TokenHub's full catalog.
- International Silicon Valley and additional per-site regions are not included in the initial
  curated choices; International defaults to Singapore's global scheduling scope.
- No live `/v1/models` refresh: TokenHub's broader catalog includes non-language model families.
- No legacy `api.hunyuan.cloud.tencent.com` endpoint or TC3 SecretId/SecretKey signing.
- No dedicated Tencent adapter, new dependency, copied icon asset, IPC method, schema migration, or
  renderer copy.

## Acceptance criteria and validation

All listed local checks ran after the last relevant material edit.

- Registry, regional endpoints, model metadata, settings sanitization, runtime projection, and picker
  seed -> final focused Vitest set -> 5 files passed, 137 tests passed.
- International-first ordering and default URL/API-key link -> final focused Vitest rerun -> 2 files
  passed, 81 tests passed.
- Curated Tencent model IDs and LobeHub Provider icon -> final focused Vitest set -> 2 files passed,
  66 tests passed.
- Anthropic `x-api-key`, route planning, fallback transport ownership, and validation request ->
  focused Vitest set -> 3 files passed, 66 tests passed; final validation fixture rerun -> 1 file
  passed, 43 tests passed.
- Provider account owner/contract/consumer coverage ->
  `npm run test:module -- settings_provider_accounts` -> 21 files passed, 408 tests passed.
- Backend resolution owner/contract/consumer coverage ->
  `npm run test:module -- settings_backend_resolution` -> 37 files passed, 1 skipped; 657 tests
  passed, 4 skipped.
- Main-process typing -> `npm run typecheck:node` -> passed.
- Renderer/shared typing -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting -> `npx prettier --check <19 changed files>` -> passed.
- Patch whitespace -> `git diff --check` -> passed.

The exact-head affected-test explanation falls back to the complete Vitest suite because
`src/main/settings/validate.ts` is not declared as a module owner. Per the requested local test
scope, the complete `npm test` fallback was not run locally; the exact-head PR Gate and platform CI
are authoritative for that coverage.

Uncovered live-service risks: no maintainer TokenHub credential was used, so account entitlement,
regional key matching, current preview availability/limits, retained `reasoning_content` behavior,
and Hy4 tool-call edge cases remain to be exercised against the live service.

## Historical compatibility

- Existing providers and custom legacy Hunyuan/TokenHub records are unchanged; there is no automatic
  migration because legacy, China-site, and International-site keys/endpoints are not interchangeable.
- Downgrading after saving a Tencent official provider is not lossless: an older app does not know
  vendor ID `tencent` and its current sanitizer will drop that provider record and active selection.
- No existing provider or model ID is renamed.

## New state / enum values

- Adds `tencent` to `OfficialVendorId`.
- Reuses the existing string `region` field with `china` and `international`; these encode the
  account site while the labels show the representative Guangzhou/Singapore API region. They are
  registry values, not new lifecycle/database enums.
- Adds an internal, non-persisted vendor capability flag for Anthropic `x-api-key` authentication.
- Adds no `ProviderType`, validation category, lifecycle state, or database enum.

## Persistence impact

- Reuses `settings.json` v2 official-provider fields: `vendorId`, `region`, encrypted `keyRef`, masked
  `keyMask`, validation metadata, `activeProviderId`, and `activeModel`.
- No settings schema-version change, SQLite/Prisma change, migration, or new persistent field.
- Plaintext API keys remain transient and are not logged or stored by this change.

## Review focus

- Verify the International/China console and domain split and International-first default ordering.
- Verify protocol-specific auth: `x-api-key` only for Anthropic Messages and Bearer for
  Chat/Responses.
- Verify the curated TokenHub language-model IDs and that `hy4-preview` remains the default.
- Verify the bundled LobeHub `TencentCloud` color icon renders for the official provider.
