### PR TITLE
fix(tooling): exclude local artifacts and quiet warnings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-electron_mirror=https://npmmirror.com/mirrors/electron/
-electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ export default defineConfig(
       '**/node_modules',
       '**/dist',
       '**/out',
+      // Local package caches and generated scratch trees are not repository source.
+      '**/.pnpm-store/**',
+      '**/tmp/**',
       // Packaged e2e build output (electron-builder --dir into dist-e2e-*); bundled JS, not source.
       '**/dist-e2e-*',
       // Runtime kernel loop scripts shipped as raw resources (CommonJS, not part of the TS source tree).

--- a/scripts/ci/npm-ci.mjs
+++ b/scripts/ci/npm-ci.mjs
@@ -4,8 +4,7 @@ import { spawnSync } from 'node:child_process'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-// Official GitHub artifact URLs. Project .npmrc pins npmmirror.com for local installs; GitHub-hosted
-// runners cannot always resolve that host (`getaddrinfo ENOTFOUND npmmirror.com`).
+// Official GitHub artifact URLs used by the Electron installers on GitHub-hosted runners.
 export const GITHUB_ELECTRON_MIRROR = 'https://github.com/electron/electron/releases/download/'
 export const GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR =
   'https://github.com/electron-userland/electron-builder-binaries/releases/download/'
@@ -17,8 +16,6 @@ export function shouldForceGitHubElectronMirrors(env = process.env) {
 export function githubElectronMirrorEnv(env = process.env) {
   return {
     ...env,
-    npm_config_electron_mirror: GITHUB_ELECTRON_MIRROR,
-    npm_config_electron_builder_binaries_mirror: GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR,
     ELECTRON_MIRROR: GITHUB_ELECTRON_MIRROR,
     ELECTRON_BUILDER_BINARIES_MIRROR: GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR
   }

--- a/scripts/ci/npm-ci.test.ts
+++ b/scripts/ci/npm-ci.test.ts
@@ -16,29 +16,25 @@ describe('npm ci Electron mirror policy', () => {
   it('forces GitHub Electron artifact URLs on GitHub Actions', () => {
     const env = npmCiEnv({
       GITHUB_ACTIONS: 'true',
-      npm_config_electron_mirror: 'https://npmmirror.com/mirrors/electron/',
       PATH: '/usr/bin'
     })
 
     expect(shouldForceGitHubElectronMirrors({ GITHUB_ACTIONS: 'true' })).toBe(true)
-    expect(env.npm_config_electron_mirror).toBe(GITHUB_ELECTRON_MIRROR)
-    expect(env.npm_config_electron_builder_binaries_mirror).toBe(
-      GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR
-    )
     expect(env.ELECTRON_MIRROR).toBe(GITHUB_ELECTRON_MIRROR)
     expect(env.ELECTRON_BUILDER_BINARIES_MIRROR).toBe(GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR)
+    expect(env).not.toHaveProperty('npm_config_electron_mirror')
+    expect(env).not.toHaveProperty('npm_config_electron_builder_binaries_mirror')
     expect(env.PATH).toBe('/usr/bin')
   })
 
-  it('leaves local installs on the repository npmmirror pin', () => {
+  it('preserves caller-provided local mirror environment', () => {
     const env = npmCiEnv({
-      npm_config_electron_mirror: 'https://npmmirror.com/mirrors/electron/',
+      ELECTRON_MIRROR: 'https://npmmirror.com/mirrors/electron/',
       PATH: '/usr/bin'
     })
 
     expect(shouldForceGitHubElectronMirrors({})).toBe(false)
-    expect(env.npm_config_electron_mirror).toBe('https://npmmirror.com/mirrors/electron/')
-    expect(env.ELECTRON_MIRROR).toBeUndefined()
+    expect(env.ELECTRON_MIRROR).toBe('https://npmmirror.com/mirrors/electron/')
   })
 
   it('runs npm ci with the resolved environment and platform command', () => {
@@ -58,9 +54,7 @@ describe('npm ci Electron mirror policy', () => {
       'npm',
       ['ci', '--no-audit'],
       expect.objectContaining({
-        env: expect.objectContaining({
-          npm_config_electron_mirror: GITHUB_ELECTRON_MIRROR
-        }),
+        env: expect.objectContaining({ ELECTRON_MIRROR: GITHUB_ELECTRON_MIRROR }),
         shell: false,
         stdio: 'inherit'
       })

--- a/test/setup-jsdom-polyfills.ts
+++ b/test/setup-jsdom-polyfills.ts
@@ -13,23 +13,20 @@ if (!(globalThis as { ResizeObserver?: unknown }).ResizeObserver) {
   }
 }
 
-// Node 26 exposes an unusable experimental localStorage getter unless --localstorage-file is set,
-// which can shadow jsdom's implementation and fail renderer tests before their first assertion.
-// Install the browser-compatible in-memory surface only when the active environment has none.
-if (typeof globalThis.localStorage === 'undefined') {
-  const values = new Map<string, string>()
-  const localStorage: Storage = {
-    get length() {
-      return values.size
-    },
-    clear: () => values.clear(),
-    getItem: (key) => values.get(String(key)) ?? null,
-    key: (index) => [...values.keys()][index] ?? null,
-    removeItem: (key) => values.delete(String(key)),
-    setItem: (key, value) => values.set(String(key), String(value))
-  }
-  Object.defineProperty(globalThis, 'localStorage', {
-    configurable: true,
-    value: localStorage
-  })
+// Node 26 exposes an unusable experimental localStorage getter unless --localstorage-file is set.
+// Install a consistent browser-compatible surface without reading that warning-producing getter.
+const values = new Map<string, string>()
+const localStorage: Storage = {
+  get length() {
+    return values.size
+  },
+  clear: () => values.clear(),
+  getItem: (key) => values.get(String(key)) ?? null,
+  key: (index) => [...values.keys()][index] ?? null,
+  removeItem: (key) => values.delete(String(key)),
+  setItem: (key, value) => values.set(String(key), String(value))
 }
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: localStorage
+})


### PR DESCRIPTION
## Problem

- `eslint --cache .` traverses repository-local package caches and scratch trees because `.pnpm-store/` and `tmp/` are not ignored.
- The project `.npmrc` uses unsupported Electron mirror keys. npm 11 warns on every invocation and says the keys will stop working in the next major version.
- The Vitest localStorage setup reads Node 26's experimental global getter while deciding whether to install its polyfill, producing one warning per worker.

## Proposed change

- Ignore `.pnpm-store` and `tmp` trees in the flat ESLint config.
- Remove the unsupported project `.npmrc` keys and stop passing their `npm_config_*` aliases in CI. Keep the Electron installers on their supported `ELECTRON_MIRROR` and `ELECTRON_BUILDER_BINARIES_MIRROR` variables.
- Install the existing in-memory localStorage test surface directly, without reading Node's warning-producing getter.

## Scope and non-goals

- No application runtime architecture, user interaction, data model, schema, enum state, persisted format, migration, or historical-data compatibility changes.
- Local installs no longer default to npmmirror. Developers who need a mirror can set the supported Electron environment variables in their own environment.
- No new dependency or postinstall wrapper is introduced.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- ESLint cache/scratch exclusion -> `ESLint.isPathIgnored()` for `.pnpm-store/probe.js` and `tmp/probe.js` -> both `true`.
- npm configuration warning removal -> `npm config list` -> exits successfully without unknown project-config warnings.
- CI mirror environment and Node 26 test setup -> `npm test -- scripts/ci/npm-ci.test.ts src/renderer/src/stores/theme-store.test.ts` -> 2 files / 11 tests passed, without the localStorage ExperimentalWarning.
- Repository lint -> `npm run lint` -> passed.
- Impact selection -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> full PR plan selected because the diff changes global validation inputs.

Per maintainer direction, the complete local `npm test` suite was not run. Exact-head PR CI is the validation authority for the complete portable and platform-selected suites; that remains the uncovered risk until checks pass.

## Review focus

- Confirm the CI install helper now exposes only installer-supported mirror variables.
- Confirm replacing test localStorage consistently across workers does not rely on Node's experimental getter.
