### PR TITLE
fix(storage): preserve migration integrity

### DIFF
--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -569,8 +569,10 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   // staged-copy resolution for 'recover', inline error for 'invalid') and display the derived
   // `<parent>/OpenScience` path regardless of kind. Never throws.
   const inspectDataRoot = async (request: StorageParentRequest): Promise<DataRootInspection> => {
-    const dataRoot = dataRootForPicked(request.parent)
+    let dataRoot = ''
     try {
+      if (typeof request?.parent !== 'string') throw new Error('The selected folder is not usable.')
+      dataRoot = dataRootForPicked(request.parent)
       const result = await classifyDataRoot(request.parent, resolveDataRoot())
       return { ...result, dataRoot }
     } catch (err) {

--- a/src/main/storage/data-migration.test.ts
+++ b/src/main/storage/data-migration.test.ts
@@ -17,7 +17,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const diskSpace = vi.hoisted(() => ({ availableBytes: undefined as number | undefined }))
+const diskSpace = vi.hoisted(() => ({
+  availableBytes: undefined as number | undefined,
+  hardLinksSupported: true
+}))
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
@@ -30,7 +33,14 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     return actual.statfs(path)
   }) as unknown as typeof actual.statfs
 
-  return { ...actual, statfs }
+  const link = vi.fn(async (...args: Parameters<typeof actual.link>) => {
+    if (!diskSpace.hardLinksSupported) {
+      throw Object.assign(new Error('hard links are not supported'), { code: 'EOPNOTSUPP' })
+    }
+    return actual.link(...args)
+  }) as typeof actual.link
+
+  return { ...actual, link, statfs }
 })
 
 import type { MigrationProgress } from '../../shared/storage'
@@ -46,6 +56,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   diskSpace.availableBytes = undefined
+  diskSpace.hardLinksSupported = true
   await rm(from, { recursive: true, force: true })
   await rm(to, { recursive: true, force: true })
 })
@@ -187,6 +198,63 @@ describe('copyAndVerify', () => {
     await writeFile(join(to, 'artifacts', 'dataset.bin'), 'updated')
     expect(await readFile(join(to, 'artifacts', 'dataset-alias.bin'), 'utf8')).toBe('updated')
     expect(await readFile(sourceAlias, 'utf8')).toBe('shared-data')
+  })
+
+  it('falls back to independent copies when the destination does not support hard links', async () => {
+    const sourceDir = join(from, 'artifacts')
+    const sourceOriginal = join(sourceDir, 'dataset.bin')
+    const sourceAlias = join(sourceDir, 'dataset-alias.bin')
+    await mkdir(sourceDir, { recursive: true })
+    await writeFile(sourceOriginal, 'shared-data')
+    await link(sourceOriginal, sourceAlias)
+    diskSpace.hardLinksSupported = false
+    const progress: MigrationProgress[] = []
+
+    const result = await copyAndVerify({
+      from,
+      to,
+      dirs: ['artifacts'],
+      signal: new AbortController().signal,
+      onProgress: (entry) => progress.push(entry)
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(progress.find((entry) => entry.phase === 'scan')?.totalBytes).toBe(
+      2 * Buffer.byteLength('shared-data')
+    )
+    await writeFile(join(to, 'artifacts', 'dataset.bin'), 'updated')
+    expect(await readFile(join(to, 'artifacts', 'dataset-alias.bin'), 'utf8')).toBe('shared-data')
+  })
+
+  it('accounts for fallback hard-link copies in the destination capacity preflight', async () => {
+    const sourceDir = join(from, 'artifacts')
+    const sourceOriginal = join(sourceDir, 'dataset.bin')
+    const sourceAlias = join(sourceDir, 'dataset-alias.bin')
+    await mkdir(sourceDir, { recursive: true })
+    await writeFile(sourceOriginal, 'shared-data')
+    await link(sourceOriginal, sourceAlias)
+    diskSpace.hardLinksSupported = false
+    diskSpace.availableBytes = Buffer.byteLength('shared-data') + 1
+    const progress: MigrationProgress[] = []
+
+    const result = await copyAndVerify({
+      from,
+      to,
+      dirs: ['artifacts'],
+      signal: new AbortController().signal,
+      onProgress: (entry) => progress.push(entry)
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/space/i)
+    expect(progress).toEqual([
+      {
+        phase: 'scan',
+        copiedBytes: 0,
+        totalBytes: 2 * Buffer.byteLength('shared-data')
+      }
+    ])
+    expect(await exists(join(to, 'artifacts'))).toBe(false)
   })
 
   it('rejects insufficient destination capacity after scanning and before copying', async () => {

--- a/src/main/storage/data-migration.test.ts
+++ b/src/main/storage/data-migration.test.ts
@@ -1,5 +1,6 @@
 import {
   chmod,
+  link,
   lstat,
   mkdtemp,
   mkdir,
@@ -8,12 +9,29 @@ import {
   rm,
   stat,
   symlink,
+  utimes,
   writeFile
 } from 'node:fs/promises'
 import { writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const diskSpace = vi.hoisted(() => ({ availableBytes: undefined as number | undefined }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  const statfs = vi.fn(async (path: Parameters<typeof actual.statfs>[0]) => {
+    if (diskSpace.availableBytes !== undefined) {
+      return { bavail: diskSpace.availableBytes, bsize: 1 } as Awaited<
+        ReturnType<typeof actual.statfs>
+      >
+    }
+    return actual.statfs(path)
+  }) as unknown as typeof actual.statfs
+
+  return { ...actual, statfs }
+})
 
 import type { MigrationProgress } from '../../shared/storage'
 import { copyAndVerify, deleteSources } from './data-migration'
@@ -27,6 +45,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  diskSpace.availableBytes = undefined
   await rm(from, { recursive: true, force: true })
   await rm(to, { recursive: true, force: true })
 })
@@ -93,6 +112,101 @@ describe('copyAndVerify', () => {
     expect(result).toEqual({ ok: true })
     expect(await readFile(join(to, 'open-science.db'), 'utf8')).toBe('sqlite bytes')
     expect(await readFile(join(from, 'open-science.db'), 'utf8')).toBe('sqlite bytes')
+  })
+
+  it('preserves file and directory access and modification times', async () => {
+    const sourceDir = join(from, 'artifacts')
+    const sourceFile = join(sourceDir, 'observations.csv')
+    await mkdir(sourceDir, { recursive: true })
+    await writeFile(sourceFile, 'time,value\n1,42\n')
+    const fileAtime = new Date('2001-02-03T04:05:06.000Z')
+    const fileMtime = new Date('2002-03-04T05:06:07.000Z')
+    const dirAtime = new Date('2003-04-05T06:07:08.000Z')
+    const dirMtime = new Date('2004-05-06T07:08:09.000Z')
+    await utimes(sourceFile, fileAtime, fileMtime)
+    await utimes(sourceDir, dirAtime, dirMtime)
+
+    const result = await copyAndVerify({
+      from,
+      to,
+      dirs: ['artifacts'],
+      signal: new AbortController().signal,
+      onProgress: () => {}
+    })
+
+    expect(result).toEqual({ ok: true })
+    const copiedFile = await stat(join(to, 'artifacts', 'observations.csv'))
+    const copiedDir = await stat(join(to, 'artifacts'))
+    expect(Math.trunc(copiedFile.atimeMs / 1000)).toBe(Math.trunc(fileAtime.getTime() / 1000))
+    expect(Math.trunc(copiedFile.mtimeMs / 1000)).toBe(Math.trunc(fileMtime.getTime() / 1000))
+    expect(Math.trunc(copiedDir.atimeMs / 1000)).toBe(Math.trunc(dirAtime.getTime() / 1000))
+    expect(Math.trunc(copiedDir.mtimeMs / 1000)).toBe(Math.trunc(dirMtime.getTime() / 1000))
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves source directory modes after populating nested content',
+    async () => {
+      const sourceDir = join(from, 'artifacts')
+      const nestedDir = join(sourceDir, 'private')
+      await mkdir(nestedDir, { recursive: true })
+      await writeFile(join(nestedDir, 'results.txt'), 'classified')
+      await chmod(nestedDir, 0o700)
+      await chmod(sourceDir, 0o750)
+
+      const result = await copyAndVerify({
+        from,
+        to,
+        dirs: ['artifacts'],
+        signal: new AbortController().signal,
+        onProgress: () => {}
+      })
+
+      expect(result).toEqual({ ok: true })
+      expect((await stat(join(to, 'artifacts'))).mode & 0o777).toBe(0o750)
+      expect((await stat(join(to, 'artifacts', 'private'))).mode & 0o777).toBe(0o700)
+    }
+  )
+
+  it('preserves hard-link relationships instead of duplicating linked file data', async () => {
+    const sourceDir = join(from, 'artifacts')
+    const sourceOriginal = join(sourceDir, 'dataset.bin')
+    const sourceAlias = join(sourceDir, 'dataset-alias.bin')
+    await mkdir(sourceDir, { recursive: true })
+    await writeFile(sourceOriginal, 'shared-data')
+    await link(sourceOriginal, sourceAlias)
+
+    const result = await copyAndVerify({
+      from,
+      to,
+      dirs: ['artifacts'],
+      signal: new AbortController().signal,
+      onProgress: () => {}
+    })
+
+    expect(result).toEqual({ ok: true })
+    await writeFile(join(to, 'artifacts', 'dataset.bin'), 'updated')
+    expect(await readFile(join(to, 'artifacts', 'dataset-alias.bin'), 'utf8')).toBe('updated')
+    expect(await readFile(sourceAlias, 'utf8')).toBe('shared-data')
+  })
+
+  it('rejects insufficient destination capacity after scanning and before copying', async () => {
+    await seedFixture()
+    diskSpace.availableBytes = 1
+    const progress: MigrationProgress[] = []
+
+    const result = await copyAndVerify({
+      from,
+      to,
+      dirs: ['artifacts', 'uploads'],
+      signal: new AbortController().signal,
+      onProgress: (entry) => progress.push(entry)
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/space/i)
+    expect(progress.map((entry) => entry.phase)).toEqual(['scan'])
+    expect(await exists(join(to, 'artifacts'))).toBe(false)
+    expect(await exists(join(to, 'uploads'))).toBe(false)
   })
 
   it('rejects a same-size destination corruption during content verification', async () => {

--- a/src/main/storage/data-migration.ts
+++ b/src/main/storage/data-migration.ts
@@ -1,6 +1,19 @@
-import { createReadStream, createWriteStream } from 'node:fs'
+import { createReadStream, createWriteStream, type Stats } from 'node:fs'
 import { createHash } from 'node:crypto'
-import { chmod, lstat, mkdir, readdir, readlink, rm, rmdir, stat, symlink } from 'node:fs/promises'
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  readdir,
+  readlink,
+  rm,
+  rmdir,
+  stat,
+  statfs,
+  symlink,
+  utimes
+} from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 
@@ -38,8 +51,8 @@ const exists = async (path: string): Promise<boolean> => {
 }
 
 type ScanResult = {
-  files: string[]
-  directories: string[]
+  files: { relPath: string; stats: Stats }[]
+  directories: { relPath: string; stats: Stats }[]
   symlinks: string[]
   present: boolean
   rootFile: boolean
@@ -49,8 +62,8 @@ type ScanResult = {
 // if `root` doesn't exist). Directories are tracked separately so empty nested folders survive the
 // move; symlinks are recreated as links (never followed) so a conda cache's internal links survive.
 const listEntries = async (root: string): Promise<ScanResult> => {
-  const files: string[] = []
-  const directories: string[] = []
+  const files: ScanResult['files'] = []
+  const directories: ScanResult['directories'] = []
   const symlinks: string[] = []
   const walk = async (dir: string): Promise<void> => {
     const entries = await readdir(join(root, dir), { withFileTypes: true })
@@ -61,10 +74,11 @@ const listEntries = async (root: string): Promise<ScanResult> => {
       // escape out of the tree and no symlink-cycle risk.
       if (entry.isSymbolicLink()) symlinks.push(rel)
       else if (entry.isDirectory()) {
-        directories.push(rel)
+        directories.push({ relPath: rel, stats: await stat(join(root, rel)) })
         await walk(rel)
-      } else if (entry.isFile()) files.push(rel)
-      else throw new NonRegularEntryError(rel)
+      } else if (entry.isFile()) {
+        files.push({ relPath: rel, stats: await stat(join(root, rel)) })
+      } else throw new NonRegularEntryError(rel)
     }
   }
   // A top-level source dir that is itself a symlink/special node must be rejected up front: exists()
@@ -81,10 +95,11 @@ const listEntries = async (root: string): Promise<ScanResult> => {
     throw err
   }
   if (info.isFile()) {
-    files.push('')
+    files.push({ relPath: '', stats: info })
     return { files, directories, symlinks, present: true, rootFile: true }
   }
   if (!info.isDirectory()) throw new NonRegularEntryError(basename(root))
+  directories.push({ relPath: '', stats: info })
   await walk('.')
   return { files, directories, symlinks, present: true, rootFile: false }
 }
@@ -93,9 +108,16 @@ const listEntries = async (root: string): Promise<ScanResult> => {
 const copyFile = async (src: string, dest: string): Promise<void> => {
   await mkdir(dirname(dest), { recursive: true })
   await pipeline(createReadStream(src), createWriteStream(dest))
-  // A stream copy creates dest at the default 0o644; re-apply the source mode so an executable
-  // runtime/pkgs binary (Rscript, a .dylib) micromamba hard-links into a rebuilt env keeps +x.
-  await chmod(dest, (await stat(src)).mode)
+}
+
+// Only files with more than one link participate in hard-link grouping. Some filesystems report an
+// unusable zero inode; treating those as independent avoids accidentally linking unrelated files.
+const hardLinkIdentity = (stats: Stats): string | undefined =>
+  stats.nlink > 1 && stats.ino !== 0 ? `${stats.dev}:${stats.ino}` : undefined
+
+const destinationAvailableBytes = async (path: string): Promise<number> => {
+  const stats = await statfs(path)
+  return stats.bavail * stats.bsize
 }
 
 const hashFile = async (path: string): Promise<string> => {
@@ -132,19 +154,27 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
   try {
     checkAbort()
     const entriesByDir = new Map<string, ScanResult>()
+    const sizedHardLinks = new Set<string>()
     for (const dir of dirs) {
       const srcDir = join(from, dir)
       const entries = await listEntries(srcDir)
       entriesByDir.set(dir, entries)
-      for (const rel of entries.files) {
-        totalBytes += (await stat(join(srcDir, rel))).size
+      for (const file of entries.files) {
+        const identity = hardLinkIdentity(file.stats)
+        if (identity && sizedHardLinks.has(identity)) continue
+        if (identity) sizedHardLinks.add(identity)
+        totalBytes += file.stats.size
       }
     }
     onProgress({ phase: 'scan', copiedBytes, totalBytes })
     checkAbort()
+    if ((await destinationAvailableBytes(to)) < totalBytes) {
+      throw new Error("Can't move your data: the new location does not have enough free space.")
+    }
 
     // Copy every existing from/<dir> into `to`, even if empty — an existing source
     // dir must be mirrored at `to`, not silently dropped.
+    const copiedHardLinks = new Map<string, string>()
     for (const dir of dirs) {
       const srcDir = join(from, dir)
       const entries =
@@ -161,13 +191,29 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
       copiedInto.push(destDir)
       if (!entries.rootFile) {
         await mkdir(destDir, { recursive: true })
-        for (const rel of entries.directories) await mkdir(join(destDir, rel), { recursive: true })
+        for (const directory of entries.directories) {
+          await mkdir(join(destDir, directory.relPath), { recursive: true })
+        }
       }
-      for (const rel of entries.files) {
+      for (const file of entries.files) {
         checkAbort()
-        await copyFile(join(srcDir, rel), join(destDir, rel))
-        copiedBytes += (await stat(join(destDir, rel))).size
-        onProgress({ phase: 'copy', copiedBytes, totalBytes, currentPath: join(dir, rel) })
+        const destination = join(destDir, file.relPath)
+        const identity = hardLinkIdentity(file.stats)
+        const existingDestination = identity ? copiedHardLinks.get(identity) : undefined
+        if (existingDestination) {
+          await mkdir(dirname(destination), { recursive: true })
+          await link(existingDestination, destination)
+        } else {
+          await copyFile(join(srcDir, file.relPath), destination)
+          copiedBytes += file.stats.size
+          if (identity) copiedHardLinks.set(identity, destination)
+        }
+        onProgress({
+          phase: 'copy',
+          copiedBytes,
+          totalBytes,
+          currentPath: join(dir, file.relPath)
+        })
         checkAbort()
       }
       // Symlinks after files so their parent dirs already exist; recreated as links (see copySymlink).
@@ -191,26 +237,32 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
           present: false,
           rootFile: false
         } as ScanResult)
-      for (const rel of entries.directories) {
+      for (const directory of entries.directories) {
         checkAbort()
-        const destStat = await stat(join(to, dir, rel)).catch(() => undefined)
-        if (!destStat?.isDirectory()) throw new Error(`verification failed for ${join(dir, rel)}`)
+        const destStat = await stat(join(to, dir, directory.relPath)).catch(() => undefined)
+        if (!destStat?.isDirectory()) {
+          throw new Error(`verification failed for ${join(dir, directory.relPath)}`)
+        }
       }
-      for (const rel of entries.files) {
+      for (const file of entries.files) {
         checkAbort()
-        const srcSize = (await stat(join(from, dir, rel))).size
-        const destStat = await stat(join(to, dir, rel)).catch(() => undefined)
-        if (!destStat || destStat.size !== srcSize) {
-          throw new Error(`verification failed for ${join(dir, rel)}`)
+        const destStat = await stat(join(to, dir, file.relPath)).catch(() => undefined)
+        if (!destStat || destStat.size !== file.stats.size) {
+          throw new Error(`verification failed for ${join(dir, file.relPath)}`)
         }
         const [sourceChecksum, destinationChecksum] = await Promise.all([
-          hashFile(join(from, dir, rel)),
-          hashFile(join(to, dir, rel))
+          hashFile(join(from, dir, file.relPath)),
+          hashFile(join(to, dir, file.relPath))
         ])
         if (sourceChecksum !== destinationChecksum) {
-          throw new Error(`verification failed for ${join(dir, rel)}: checksum mismatch`)
+          throw new Error(`verification failed for ${join(dir, file.relPath)}: checksum mismatch`)
         }
-        onProgress({ phase: 'verify', copiedBytes, totalBytes, currentPath: join(dir, rel) })
+        onProgress({
+          phase: 'verify',
+          copiedBytes,
+          totalBytes,
+          currentPath: join(dir, file.relPath)
+        })
       }
       // A symlink is verified by its presence AS a link (lstat, not stat, so a dangling target — e.g.
       // a relative conda link resolved before its sibling files land — is not a false failure).
@@ -220,6 +272,27 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
         if (!destStat?.isSymbolicLink())
           throw new Error(`verification failed for ${join(dir, rel)}`)
         onProgress({ phase: 'verify', copiedBytes, totalBytes, currentPath: join(dir, rel) })
+      }
+    }
+
+    // Hash verification reads both sides and can update access times, so restore portable metadata
+    // only after verification. Directories are restored deepest-first because creating children
+    // updates their parents and a restrictive source mode could otherwise block the remaining copy.
+    for (const dir of dirs) {
+      const entries = entriesByDir.get(dir)
+      if (!entries?.present) continue
+      const destDir = join(to, dir)
+      for (const file of entries.files) {
+        checkAbort()
+        const destination = join(destDir, file.relPath)
+        await chmod(destination, file.stats.mode)
+        await utimes(destination, file.stats.atime, file.stats.mtime)
+      }
+      for (const directory of [...entries.directories].reverse()) {
+        checkAbort()
+        const destination = join(destDir, directory.relPath)
+        await chmod(destination, directory.stats.mode)
+        await utimes(destination, directory.stats.atime, directory.stats.mtime)
       }
     }
     checkAbort()

--- a/src/main/storage/data-migration.ts
+++ b/src/main/storage/data-migration.ts
@@ -1,5 +1,5 @@
 import { createReadStream, createWriteStream, type Stats } from 'node:fs'
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import {
   chmod,
   link,
@@ -12,7 +12,8 @@ import {
   stat,
   statfs,
   symlink,
-  utimes
+  utimes,
+  writeFile
 } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
@@ -120,6 +121,32 @@ const destinationAvailableBytes = async (path: string): Promise<number> => {
   return stats.bavail * stats.bsize
 }
 
+const HARD_LINK_UNSUPPORTED_CODES = new Set([
+  'EACCES',
+  'EINVAL',
+  'ENOTSUP',
+  'EOPNOTSUPP',
+  'EPERM',
+  'EXDEV'
+])
+
+const destinationSupportsHardLinks = async (path: string): Promise<boolean> => {
+  const probe = `.open-science-hard-link-test-${randomUUID()}`
+  const source = join(path, `${probe}.source`)
+  const target = join(path, `${probe}.target`)
+  try {
+    await writeFile(source, '', { flag: 'wx' })
+    await link(source, target)
+    return true
+  } catch (error) {
+    if (HARD_LINK_UNSUPPORTED_CODES.has((error as NodeJS.ErrnoException)?.code ?? '')) return false
+    throw error
+  } finally {
+    await rm(target, { force: true })
+    await rm(source, { force: true })
+  }
+}
+
 const hashFile = async (path: string): Promise<string> => {
   const hash = createHash('sha256')
   for await (const chunk of createReadStream(path)) hash.update(chunk as Buffer)
@@ -154,13 +181,25 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
   try {
     checkAbort()
     const entriesByDir = new Map<string, ScanResult>()
-    const sizedHardLinks = new Set<string>()
+    const sourceHardLinks = new Set<string>()
+    let hasRepeatedHardLink = false
     for (const dir of dirs) {
       const srcDir = join(from, dir)
       const entries = await listEntries(srcDir)
       entriesByDir.set(dir, entries)
       for (const file of entries.files) {
         const identity = hardLinkIdentity(file.stats)
+        if (!identity) continue
+        if (sourceHardLinks.has(identity)) hasRepeatedHardLink = true
+        else sourceHardLinks.add(identity)
+      }
+    }
+    checkAbort()
+    const preserveHardLinks = !hasRepeatedHardLink || (await destinationSupportsHardLinks(to))
+    const sizedHardLinks = new Set<string>()
+    for (const entries of entriesByDir.values()) {
+      for (const file of entries.files) {
+        const identity = preserveHardLinks ? hardLinkIdentity(file.stats) : undefined
         if (identity && sizedHardLinks.has(identity)) continue
         if (identity) sizedHardLinks.add(identity)
         totalBytes += file.stats.size
@@ -198,7 +237,7 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
       for (const file of entries.files) {
         checkAbort()
         const destination = join(destDir, file.relPath)
-        const identity = hardLinkIdentity(file.stats)
+        const identity = preserveHardLinks ? hardLinkIdentity(file.stats) : undefined
         const existingDestination = identity ? copiedHardLinks.get(identity) : undefined
         if (existingDestination) {
           await mkdir(dirname(destination), { recursive: true })

--- a/src/main/storage/data-migration.ts
+++ b/src/main/storage/data-migration.ts
@@ -59,6 +59,18 @@ type ScanResult = {
   rootFile: boolean
 }
 
+type PortableMetadataEntry = {
+  relativePath: string
+  mode: number
+  atime: Date
+  mtime: Date
+}
+
+export type PortableMetadataSnapshot = {
+  files: PortableMetadataEntry[]
+  directories: PortableMetadataEntry[]
+}
+
 // Recursively lists regular files, nested directories, and symbolic links under `root` (empty lists
 // if `root` doesn't exist). Directories are tracked separately so empty nested folders survive the
 // move; symlinks are recreated as links (never followed) so a conda cache's internal links survive.
@@ -103,6 +115,71 @@ const listEntries = async (root: string): Promise<ScanResult> => {
   directories.push({ relPath: '', stats: info })
   await walk('.')
   return { files, directories, symlinks, present: true, rootFile: false }
+}
+
+const metadataSnapshotFromEntries = (
+  dirs: string[],
+  entriesByDir: ReadonlyMap<string, ScanResult>
+): PortableMetadataSnapshot => {
+  const snapshot: PortableMetadataSnapshot = { files: [], directories: [] }
+  for (const dir of dirs) {
+    const entries = entriesByDir.get(dir)
+    if (!entries?.present) continue
+    for (const file of entries.files) {
+      snapshot.files.push({
+        relativePath: join(dir, file.relPath),
+        mode: file.stats.mode,
+        atime: file.stats.atime,
+        mtime: file.stats.mtime
+      })
+    }
+    for (const directory of entries.directories) {
+      snapshot.directories.push({
+        relativePath: join(dir, directory.relPath),
+        mode: directory.stats.mode,
+        atime: directory.stats.atime,
+        mtime: directory.stats.mtime
+      })
+    }
+  }
+  return snapshot
+}
+
+export const capturePortableMetadata = async (
+  root: string,
+  dirs: string[]
+): Promise<PortableMetadataSnapshot> => {
+  const entriesByDir = new Map<string, ScanResult>()
+  for (const dir of dirs) entriesByDir.set(dir, await listEntries(join(root, dir)))
+  return metadataSnapshotFromEntries(dirs, entriesByDir)
+}
+
+const restoreTimestamps = async (
+  root: string,
+  snapshot: PortableMetadataSnapshot
+): Promise<void> => {
+  for (const file of snapshot.files) {
+    await utimes(join(root, file.relativePath), file.atime, file.mtime)
+  }
+  for (const directory of [...snapshot.directories].reverse()) {
+    await utimes(join(root, directory.relativePath), directory.atime, directory.mtime)
+  }
+}
+
+export const restorePortableMetadata = async (
+  root: string,
+  snapshot: PortableMetadataSnapshot
+): Promise<void> => {
+  for (const file of snapshot.files) {
+    const destination = join(root, file.relativePath)
+    await chmod(destination, file.mode)
+    await utimes(destination, file.atime, file.mtime)
+  }
+  for (const directory of [...snapshot.directories].reverse()) {
+    const destination = join(root, directory.relativePath)
+    await chmod(destination, directory.mode)
+    await utimes(destination, directory.atime, directory.mtime)
+  }
 }
 
 // Copies a single file, streaming, creating parent dirs as needed.
@@ -194,6 +271,7 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
         else sourceHardLinks.add(identity)
       }
     }
+    const sourceMetadata = metadataSnapshotFromEntries(dirs, entriesByDir)
     checkAbort()
     const preserveHardLinks = !hasRepeatedHardLink || (await destinationSupportsHardLinks(to))
     const sizedHardLinks = new Set<string>()
@@ -314,26 +392,12 @@ export const copyAndVerify = async (opts: MigrateOpts): Promise<MigrationResult>
       }
     }
 
-    // Hash verification reads both sides and can update access times, so restore portable metadata
-    // only after verification. Directories are restored deepest-first because creating children
-    // updates their parents and a restrictive source mode could otherwise block the remaining copy.
-    for (const dir of dirs) {
-      const entries = entriesByDir.get(dir)
-      if (!entries?.present) continue
-      const destDir = join(to, dir)
-      for (const file of entries.files) {
-        checkAbort()
-        const destination = join(destDir, file.relPath)
-        await chmod(destination, file.stats.mode)
-        await utimes(destination, file.stats.atime, file.stats.mtime)
-      }
-      for (const directory of [...entries.directories].reverse()) {
-        checkAbort()
-        const destination = join(destDir, directory.relPath)
-        await chmod(destination, directory.stats.mode)
-        await utimes(destination, directory.stats.atime, directory.stats.mtime)
-      }
-    }
+    // Copying and hash verification read the source and destination. Restore the source timestamps so
+    // the commit phase can take a faithful in-memory snapshot, then restore the staged copy. The
+    // service reapplies that snapshot after its own downstream verification reads.
+    checkAbort()
+    await restoreTimestamps(from, sourceMetadata)
+    await restorePortableMetadata(to, sourceMetadata)
     checkAbort()
   } catch (err) {
     // Rollback: remove whatever was written under `to`; `from` was never touched.

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -1177,6 +1177,17 @@ describe('storage IPC handlers', () => {
     })
   })
 
+  it('inspect-data-root resolves an invalid result for a malformed request', async () => {
+    initDataRoot(dataRoot)
+    registerStorageIpcHandlers(fakeDeps())
+
+    await expect(invoke('storage:inspect-data-root', {})).resolves.toMatchObject({
+      kind: 'invalid',
+      dataRoot: '',
+      error: expect.any(String)
+    })
+  })
+
   it('set-data-root-and-relaunch persists the derived target and relaunches on a move parent', async () => {
     initDataRoot(dataRoot)
     const deps = fakeDeps()

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -1,4 +1,14 @@
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
@@ -1309,6 +1319,53 @@ describe('runDataRootMigration (copy phase)', () => {
 })
 
 describe('commitDataRootSwitch (commit phase)', () => {
+  it('preserves timestamps after target verification and the commit-time recheck', async () => {
+    const sourceFile = join(currentDataRoot, 'artifacts', 'observations.csv')
+    await mkdir(join(currentDataRoot, 'artifacts'), { recursive: true })
+    await writeFile(sourceFile, 'time,value\n1,42\n')
+    const originalAtime = new Date('2001-02-03T04:05:06.000Z')
+    const originalMtime = new Date('2002-03-04T05:06:07.000Z')
+    await utimes(sourceFile, originalAtime, originalMtime)
+
+    const readMigratedFile = async (root: string): Promise<void> => {
+      const file = join(root, 'artifacts', 'observations.csv')
+      if (existsSync(file)) await readFile(file)
+    }
+    let markerToken = ''
+    const copyResult = await runDataRootMigration(
+      {
+        ...fakeDeps(),
+        currentDataRoot,
+        validateProvenanceState: readMigratedFile
+      },
+      emptyParent,
+      {
+        ...runOpts(),
+        onVerified: ({ token }) => {
+          markerToken = token
+        }
+      }
+    )
+    expect(copyResult).toEqual({ ok: true })
+
+    const target = dataRootFor(emptyParent)
+    const commitResult = await commitDataRootSwitch(
+      {
+        currentDataRoot,
+        setDataRoot: vi.fn().mockResolvedValue(undefined),
+        deleteSources: async () => ({ deleted: [], failed: [] }),
+        expectedToken: markerToken,
+        validateProvenanceState: readMigratedFile
+      },
+      emptyParent
+    )
+
+    expect(commitResult).toEqual({ ok: true })
+    const copiedFile = await stat(join(target, 'artifacts', 'observations.csv'))
+    expect(Math.trunc(copiedFile.atimeMs / 1000)).toBe(Math.trunc(originalAtime.getTime() / 1000))
+    expect(Math.trunc(copiedFile.mtimeMs / 1000)).toBe(Math.trunc(originalMtime.getTime() / 1000))
+  })
+
   it('correlates distinct copy and commit operations without reusing the marker token', async () => {
     const deps = fakeDeps()
     const logger = fakeDiagnosticLogger()

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -17,7 +17,12 @@ import {
   resolveConfigRoot,
   samePath
 } from '../storage-root'
-import { copyAndVerify, deleteSources } from './data-migration'
+import {
+  capturePortableMetadata,
+  copyAndVerify,
+  deleteSources,
+  restorePortableMetadata
+} from './data-migration'
 import {
   MIGRATION_MARKER_FILENAME,
   newToken,
@@ -577,12 +582,26 @@ export const runDataRootMigration = async (
     }
   }
 
+  const migrateDirs = [...BASE_MIGRATION_DIRS, RUNTIME_PKGS_DIR]
+  let sourceMetadata
+  try {
+    sourceMetadata = await capturePortableMetadata(deps.currentDataRoot, migrateDirs)
+  } catch (error) {
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    operation.fail(error)
+    return { ok: false, error: 'Could not inspect your data before copying it. Please try again.' }
+  }
+  const restoreSourceMetadata = async (): Promise<void> => {
+    await restorePortableMetadata(deps.currentDataRoot, sourceMetadata)
+  }
+
   const validateProvenanceState = deps.validateProvenanceState ?? defaultValidateProvenanceState
   operation.phase('validate-source')
   try {
     await validateProvenanceState(deps.currentDataRoot)
   } catch (error) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    await restoreSourceMetadata().catch(() => undefined)
     operation.fail(error)
     return {
       ok: false,
@@ -604,8 +623,6 @@ export const runDataRootMigration = async (
       runtimePreservationDegraded = true
     }
   }
-  const migrateDirs = [...BASE_MIGRATION_DIRS, RUNTIME_PKGS_DIR]
-
   const doCopyAndVerify = deps.copyAndVerify ?? copyAndVerify
   let result: MigrationResult
   operation.phase('copy')
@@ -638,6 +655,7 @@ export const runDataRootMigration = async (
     })
   } catch (err) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    await restoreSourceMetadata().catch(() => undefined)
     operation.fail(err)
     return { ok: false, error: 'Could not copy your data. Please try again.' }
   }
@@ -650,6 +668,7 @@ export const runDataRootMigration = async (
     await rm(target, { recursive: true, force: true }).catch(() => {
       stagingCleanupDegraded = true
     })
+    await restoreSourceMetadata().catch(() => undefined)
     if (result.cancelled) {
       operation.cancel({ cancelRequested: true, stagingCleanupDegraded })
     } else {
@@ -660,6 +679,7 @@ export const runDataRootMigration = async (
 
   if (runOpts.signal.aborted) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    await restoreSourceMetadata().catch(() => undefined)
     operation.cancel({ cancelRequested: true })
     return { ok: false, error: 'migration cancelled', cancelled: true }
   }
@@ -669,6 +689,7 @@ export const runDataRootMigration = async (
     await validateProvenanceState(target)
   } catch (error) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    await restoreSourceMetadata().catch(() => undefined)
     operation.fail(error)
     return {
       ok: false,
@@ -682,13 +703,27 @@ export const runDataRootMigration = async (
     inventory = await scanInventory(target, migrateDirs)
   } catch (err) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    await restoreSourceMetadata().catch(() => undefined)
     operation.fail(err)
     return { ok: false, error: 'Could not verify the copied data. Please run the move again.' }
   }
   if (runOpts.signal.aborted) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    await restoreSourceMetadata().catch(() => undefined)
     operation.cancel({ cancelRequested: true })
     return { ok: false, error: 'migration cancelled', cancelled: true }
+  }
+  try {
+    await restoreSourceMetadata()
+    await restorePortableMetadata(target, sourceMetadata)
+  } catch (err) {
+    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    await restoreSourceMetadata().catch(() => undefined)
+    operation.fail(err)
+    return {
+      ok: false,
+      error: 'Could not restore copied data metadata. Please run the move again.'
+    }
   }
   try {
     await writeMigrationMarker(target, {
@@ -771,6 +806,13 @@ export const commitDataRootSwitch = async (
       error: 'The staged copy does not include all required provenance data. Run the move again.'
     })
   }
+  let sourceMetadata
+  try {
+    sourceMetadata = await capturePortableMetadata(deps.currentDataRoot, migratedDirs)
+  } catch (err) {
+    operation.fail(err)
+    return { ok: false, error: 'Could not recheck the copied data. Run the move again.' }
+  }
   let inventories: [MigrationInventory, MigrationInventory]
   try {
     inventories = await Promise.all([
@@ -806,6 +848,14 @@ export const commitDataRootSwitch = async (
       ok: false,
       error: `Could not verify provenance data: ${toErrorMessage(error)}`
     }
+  }
+
+  try {
+    await restorePortableMetadata(deps.currentDataRoot, sourceMetadata)
+    await restorePortableMetadata(target, sourceMetadata)
+  } catch (error) {
+    operation.fail(error)
+    return { ok: false, error: 'Could not restore copied data metadata. Run the move again.' }
   }
 
   operation.phase('persist-pointer')

--- a/src/main/storage/usage.test.ts
+++ b/src/main/storage/usage.test.ts
@@ -1,7 +1,28 @@
 import { link, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const directoryReadFailure = vi.hoisted(() => ({ path: undefined as string | undefined }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  const readdir = vi.fn(
+    async (
+      path: Parameters<typeof actual.readdir>[0],
+      options?: Parameters<typeof actual.readdir>[1]
+    ) => {
+      if (String(path) === directoryReadFailure.path) {
+        throw Object.assign(new Error('permission denied while scanning storage'), {
+          code: 'EACCES'
+        })
+      }
+      return actual.readdir(path, options as never)
+    }
+  ) as unknown as typeof actual.readdir
+
+  return { ...actual, readdir }
+})
 
 import { availableBytes, computeStorageUsage } from './usage'
 
@@ -12,6 +33,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  directoryReadFailure.path = undefined
   await rm(dataRoot, { recursive: true, force: true })
 })
 
@@ -163,6 +185,13 @@ describe('computeStorageUsage', () => {
       { key: 'workspaces', bytes: 0 }
     ])
     expect(usage.totalBytes).toBe(0)
+  })
+
+  it('rejects an incomplete scan instead of reporting an unreadable category as zero bytes', async () => {
+    await writeSized(join(dataRoot, 'artifacts', 'result.bin'), 100)
+    directoryReadFailure.path = join(dataRoot, 'artifacts')
+
+    await expect(computeStorageUsage(dataRoot)).rejects.toMatchObject({ code: 'EACCES' })
   })
 })
 

--- a/src/main/storage/usage.ts
+++ b/src/main/storage/usage.ts
@@ -18,6 +18,11 @@ const CATEGORY_KEYS: UsageCategoryKey[] = [
   'workspaces'
 ]
 
+const isMissingPathError = (error: unknown): boolean => {
+  const code = (error as NodeJS.ErrnoException)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
 // Recursively sums UNIQUE file sizes under `dir`, deduping hard links by (dev, ino) through `seen`
 // (like `du`): a file whose inode was already counted contributes 0. This is essential for the runtime
 // dir — conda envs are hard-linked from the shared pkgs cache, so without dedup the same bytes get
@@ -29,8 +34,9 @@ const dirSize = async (dir: string, seen: Set<string>): Promise<number> => {
   let entries
   try {
     entries = await readdir(dir, { withFileTypes: true })
-  } catch {
-    return 0
+  } catch (error) {
+    if (isMissingPathError(error)) return 0
+    throw error
   }
   let total = 0
   for (const entry of entries) {
@@ -47,8 +53,13 @@ const dirSize = async (dir: string, seen: Set<string>): Promise<number> => {
 
 // Size of one file, or 0 if its inode was already counted via `seen` (hard-link dedup).
 const fileSize = async (path: string, seen: Set<string>): Promise<number> => {
-  const info = await stat(path).catch(() => undefined)
-  if (!info) return 0
+  let info
+  try {
+    info = await stat(path)
+  } catch (error) {
+    if (isMissingPathError(error)) return 0
+    throw error
+  }
   const key = `${info.dev}:${info.ino}`
   if (seen.has(key)) return 0
   seen.add(key)
@@ -83,7 +94,8 @@ const runtimeUsage = async (dir: string): Promise<{ bytes: number; children: Usa
   let envEntries
   try {
     envEntries = await readdir(join(dir, 'envs'), { withFileTypes: true })
-  } catch {
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error
     envEntries = []
   }
   const envBytes = new Map<string, number>()
@@ -100,8 +112,9 @@ const runtimeUsage = async (dir: string): Promise<{ bytes: number; children: Usa
   let topEntries
   try {
     topEntries = await readdir(dir, { withFileTypes: true })
-  } catch {
-    return { bytes: 0, children: [] }
+  } catch (error) {
+    if (isMissingPathError(error)) return { bytes: 0, children: [] }
+    throw error
   }
   for (const entry of topEntries) {
     if (entry.isSymbolicLink()) continue


### PR DESCRIPTION
## Problem

Data-root migration copied bytes but did not preserve portable timestamps, directory modes, or hard-link topology. It also began copying without comparing the scanned source size with destination capacity. Separately, storage-usage scans converted permission and I/O failures into zero-byte results, and malformed `inspectDataRoot` requests escaped a documented never-throws boundary.

## Proposed change

- capture file and directory metadata before provenance/copy reads, rebuild source hard-link groups at destinations that support them, and restore mode/atime/mtime after copy-stage and commit-stage verification;
- probe destination hard-link support and safely fall back to independent copies on unsupported filesystems, including the expanded capacity requirement;
- compare the resulting required bytes with destination `statfs` capacity after scanning but before copying the first file;
- treat only `ENOENT`/`ENOTDIR` as zero-byte absence and propagate incomplete scans into the existing Settings error/retry flow;
- validate and derive the inspected data-root path inside the command owner's exception boundary.

## Scope and non-goals

- No database/schema change, persisted field, marker-version change, shared data-model field, enum value, or new UI state. Metadata snapshots are in-memory only.
- No historical migration is required. Metadata already lost by an earlier migration cannot be reconstructed.
- ACLs, xattrs, ownership, birth time, sparse extents, and guarantees against concurrent external disk consumption remain out of scope. Destination ACL inheritance remains unchanged.

## Acceptance criteria and validation

- metadata, hard links, unsupported-filesystem fallback, capacity preflight, and usage error propagation -> `..\..\node_modules\.bin\vitest.cmd run src/main/storage/data-migration.test.ts src/main/storage/usage.test.ts` -> 25 passed, 6 platform-skipped;
- full copy/provenance/inventory/commit timestamp preservation -> focused `migration-service.test.ts` regression -> 1 passed;
- malformed inspection request -> `..\..\node_modules\.bin\vitest.cmd run src/main/storage/ipc.test.ts -t "resolves an invalid result for a malformed request"` -> 1 passed;
- changed storage source/tests -> targeted `eslint` -> passed;
- changed storage source/tests -> targeted `prettier --check` -> passed.

`npm run typecheck:node` was attempted after the final source edit but is blocked by the shared local dependency tree: `@agentclientprotocol/claude-agent-acp` does not export `waitForMcpServers` for the existing `src/main/acp/claude-agent-acp-patch.test.ts` import. No changed storage file produced a TypeScript diagnostic. PR CI is authoritative for the clean dependency tree and full portable/platform lanes.

The POSIX-only directory-mode assertion is skipped on Windows and is intentionally delegated to the Unix CI lane. No renderer, persistence, database, or Web contract consumer changed, so renderer/E2E/database migration checks are excluded from the local impact set.

## Review focus

- source metadata is captured before provenance/copy reads, restored after staging verification, then reapplied to source and target after the commit-time inventory/provenance recheck;
- hard-link grouping and capacity totals use the same source `(dev, ino)` identity;
- unsupported target filesystems fall back before capacity calculation, so required bytes include every independent copy;
- low-space refusal occurs after the complete scan and before the first copied byte;
- non-missing usage errors reach the existing Settings error/retry state instead of producing a misleading zero.
