### PR TITLE
fix(connectors): stop reporting undecryptable credentials

### DIFF
--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -141,6 +141,64 @@ describe('ConnectorSettingsModule', () => {
     expect(snapshot.ncbi).toEqual({ contactEmail: 'second@lab.org', hasApiKey: false })
   })
 
+  it('does not report undecryptable credentials as configured', async () => {
+    await service.setNcbiCredentials({ apiKey: 'ncbi-secret' })
+    await service.setOpenAlexCredential({ apiKey: 'openalex-secret' })
+    await addCustomServer({
+      name: 'local-secrets',
+      transport: 'stdio',
+      command: 'example-mcp',
+      env: { API_TOKEN: 'local-secret', DAMAGED_TOKEN: 'damaged-secret' }
+    })
+    await addCustomServer({
+      name: 'remote-secrets',
+      transport: 'streamable_http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer remote-secret' }
+    })
+    await addCustomServer({
+      name: 'oauth-secrets',
+      transport: 'streamable_http',
+      url: 'https://example.com/oauth-mcp',
+      oauth: {
+        authorizationServerUrl: 'https://example.com/oauth',
+        clientId: 'registered-client',
+        clientSecret: 'client-secret'
+      }
+    })
+
+    const stored = (await repository.getSettings()).connectors?.customMcpServers?.find(
+      ({ name }) => name === 'local-secrets'
+    )
+    await repository.updateCustomServer(stored!.id, {
+      ...stored!,
+      envRefs: { ...stored!.envRefs, DAMAGED_TOKEN: 'not-a-key-ref' }
+    })
+    expect(
+      (await service.listConnectors()).customServers.find(({ name }) => name === 'local-secrets')
+        ?.hasEnv
+    ).toBe(false)
+
+    keychain.available = false
+    const snapshot = await service.listConnectors()
+
+    expect({
+      ncbi: snapshot.ncbi.hasApiKey,
+      openAlex: snapshot.openAlex?.hasApiKey,
+      localEnv: snapshot.customServers.find(({ name }) => name === 'local-secrets')?.hasEnv,
+      remoteHeaders: snapshot.customServers.find(({ name }) => name === 'remote-secrets')
+        ?.hasHeaders,
+      oauthClientSecret: snapshot.customServers.find(({ name }) => name === 'oauth-secrets')?.oauth
+        ?.hasClientSecret
+    }).toEqual({
+      ncbi: false,
+      openAlex: false,
+      localEnv: false,
+      remoteHeaders: false,
+      oauthClientSecret: false
+    })
+  })
+
   it('encrypts OpenAlex at rest and exposes only configured state', async () => {
     let snapshot = await service.setOpenAlexCredential({ apiKey: 'openalex-secret' })
     expect(snapshot.openAlex).toEqual({ hasApiKey: true })

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -85,6 +85,14 @@ const validateOAuthRegistration = (
   }
 }
 
+const hasResolvedSecretRecord = (
+  refs: Record<string, string> | undefined,
+  values: Record<string, string> | undefined
+): boolean => {
+  const names = Object.keys(refs ?? values ?? {})
+  return names.length > 0 && names.every((name) => Object.hasOwn(values ?? {}, name))
+}
+
 // Owns durable Connector policy, secret migration/projection, and custom-server mutation. Live MCP
 // clients, approval decisions, Specialist bindings, and refresh workflows remain outside this module.
 class ConnectorSettingsModule {
@@ -622,11 +630,14 @@ class ConnectorSettingsModule {
   }
 
   private ncbiView(connectors: StoredConnectors | undefined): NcbiCredentialsView {
-    return { contactEmail: connectors?.contactEmail, hasApiKey: !!connectors?.ncbiApiKeyRef }
+    return {
+      contactEmail: connectors?.contactEmail,
+      hasApiKey: tryDecryptKey(connectors?.ncbiApiKeyRef) !== undefined
+    }
   }
 
   private openAlexView(connectors: StoredConnectors | undefined): OpenAlexCredentialView {
-    return { hasApiKey: Boolean(connectors?.openAlexApiKeyRef) }
+    return { hasApiKey: tryDecryptKey(connectors?.openAlexApiKeyRef) !== undefined }
   }
 
   private toCustomServerViews(connectors: StoredConnectors | undefined): CustomServerView[] {
@@ -666,11 +677,11 @@ class ConnectorSettingsModule {
           url: server.url,
           ...(server.transport !== 'stdio'
             ? {
-                hasHeaders: Boolean(Object.keys(server.headerRefs ?? server.headers ?? {}).length)
+                hasHeaders: hasResolvedSecretRecord(server.headerRefs, server.headers)
               }
             : {}),
           ...(server.transport === 'stdio'
-            ? { hasEnv: Boolean(Object.keys(server.envRefs ?? server.env ?? {}).length) }
+            ? { hasEnv: hasResolvedSecretRecord(server.envRefs, server.env) }
             : {}),
           ...(server.oauth
             ? {
@@ -685,7 +696,7 @@ class ConnectorSettingsModule {
                   ...(server.oauth.clientId ? { clientId: server.oauth.clientId } : {}),
                   ...(server.oauth.redirectUri ? { redirectUri: server.oauth.redirectUri } : {}),
                   hasTokens: Boolean(server.oauthState?.tokens?.access_token),
-                  hasClientSecret: Boolean(server.oauthClientSecretRef)
+                  hasClientSecret: server.oauthClientSecret !== undefined
                 }
               }
             : {}),


### PR DESCRIPTION
## Problem

Connector ciphertext may remain in settings after device migration, a keychain reset, or ciphertext corruption even though the current machine cannot decrypt it. The main process already omitted those values from runtime requests, but the renderer snapshot derived NCBI, OpenAlex, custom environment, static-header, and OAuth client-secret indicators from ciphertext-reference presence. Settings therefore reported credentials as configured while requests ran without them.

## Proposed change

- Derive the existing renderer-safe credential indicators from successfully decrypted values.
- Treat a custom environment/header credential group as unresolved when any stored entry fails to decrypt, including partial ciphertext damage.
- Add a public-boundary regression test through ConnectorSettingsModule.listConnectors covering whole-keychain failure and one damaged entry.

## Scope and non-goals

- No new credentialStatus enum or other shared response field.
- No IPC contract, persisted settings format, migration, database, or user-visible string changes.
- No change to runtime credential resolution or request dispatch; the fix corrects the status projection only.
- Existing ciphertext remains preserved so the user can replace the unusable credential through the current flow.

## Acceptance criteria and validation

The regression test was run twice before the fix and failed deterministically with all four reported indicators received as true instead of false. After the final material edit:

- Credential projection regression and module behavior -> npm test -- src/main/settings/connector-settings.test.ts -> 50 passed.
- Main-process TypeScript surface -> npm run typecheck:node -> passed.
- Repository lint rules -> npm run lint -> passed.
- Changed-file formatting -> npx prettier --check src/main/settings/connector-settings.ts src/main/settings/connector-settings.test.ts -> passed.

npm run test:affected -- --base origin/main --head HEAD --explain falls back to the complete Vitest suite because src/main/settings/connector-settings.ts has no registered module owner. The full local suite was intentionally not run; PR Gate and CI remain the authority for that fallback plan and platform coverage.

## Review focus

Please verify the conservative projection semantics: a credential group is reported configured only when every stored secret entry resolved, preventing partial damage from retaining a misleading configured state.