### PR TITLE
fix(credentials): reject insecure Linux storage backend

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -187,7 +187,14 @@ const launchOpenScience = async (
 
   if (process.platform === 'linux') {
     await application.evaluate(({ safeStorage }) => {
+      // Linux CI has no desktop keyring. Keep its isolated test cipher, but make this
+      // Playwright-controlled main process report a secure test backend so fake credentials can
+      // exercise the production Settings path without adding a production security bypass.
       safeStorage.setUsePlainTextEncryption(true)
+      Object.defineProperty(safeStorage, 'getSelectedStorageBackend', {
+        configurable: true,
+        value: () => 'gnome_libsecret'
+      })
     })
   }
 

--- a/src/main/compute/credential-vault.ts
+++ b/src/main/compute/credential-vault.ts
@@ -3,6 +3,7 @@ import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
 import { platform } from 'node:os'
 
 import type { ComputePasswordCapability } from '../../shared/compute'
+import { isSecureStorageAvailable, type SecureStorageCipher } from '../secure-storage'
 import { ComputeConnectionError } from './connection-broker'
 
 const MAX_PASSWORD_BYTES = 16 * 1024
@@ -13,26 +14,8 @@ type StoredComputeCredential = Readonly<{ ciphertext: Buffer; revision?: number 
 interface ComputeCredentialReader {
   getCredential(computeHostId: string): Promise<StoredComputeCredential | null>
 }
-export interface SecureStorageCipher {
-  isEncryptionAvailable(): boolean
-  getSelectedStorageBackend?(): string
-  encryptString(value: string): Buffer
-  decryptString(value: Buffer): string
-}
 export type ComputeCredentialCipher = SecureStorageCipher
 export type ProtectedJsonContainer = 'object' | 'array'
-
-export const isSecureStorageAvailable = (
-  cipher: SecureStorageCipher = safeStorage,
-  currentPlatform: NodeJS.Platform = platform()
-): boolean => {
-  try {
-    if (!cipher.isEncryptionAvailable()) return false
-    return !(currentPlatform === 'linux' && cipher.getSelectedStorageBackend?.() === 'basic_text')
-  } catch {
-    return false
-  }
-}
 
 export class OptionalSecureStorageStringProtection {
   private failed = false
@@ -268,5 +251,10 @@ class CredentialVault {
   }
 }
 
-export { CredentialVault, MAX_PASSWORD_BYTES, validateComputePassword }
-export type { ComputeCredentialReader, CredentialPasswordLease, StoredComputeCredential }
+export { CredentialVault, MAX_PASSWORD_BYTES, isSecureStorageAvailable, validateComputePassword }
+export type {
+  ComputeCredentialReader,
+  CredentialPasswordLease,
+  SecureStorageCipher,
+  StoredComputeCredential
+}

--- a/src/main/secure-storage.ts
+++ b/src/main/secure-storage.ts
@@ -1,0 +1,24 @@
+import { safeStorage } from 'electron'
+import { platform } from 'node:os'
+
+interface SecureStorageCipher {
+  isEncryptionAvailable(): boolean
+  getSelectedStorageBackend?(): string
+  encryptString(value: string): Buffer
+  decryptString(value: Buffer): string
+}
+
+const isSecureStorageAvailable = (
+  cipher: SecureStorageCipher = safeStorage,
+  currentPlatform: NodeJS.Platform = platform()
+): boolean => {
+  try {
+    if (!cipher.isEncryptionAvailable()) return false
+    return !(currentPlatform === 'linux' && cipher.getSelectedStorageBackend?.() === 'basic_text')
+  } catch {
+    return false
+  }
+}
+
+export { isSecureStorageAvailable }
+export type { SecureStorageCipher }

--- a/src/main/settings/crypto.test.ts
+++ b/src/main/settings/crypto.test.ts
@@ -2,7 +2,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // Toggleable keychain state so the reduced-protection fallback (keychain unavailable) can be tested
 // alongside the normal encrypted path. Hoisted so the vi.mock factory can read it.
-const keychain = vi.hoisted(() => ({ available: true }))
+const keychain = vi.hoisted(() => ({
+  available: true,
+  backend: 'gnome_libsecret',
+  platform: 'linux' as NodeJS.Platform
+}))
+
+vi.mock('node:os', () => ({ platform: () => keychain.platform }))
 
 // Fake safeStorage: a reversible "encryption" so the crypto wrapper's base64/prefix handling and
 // round-trip contract can be tested without a real OS keychain. encryptString mirrors Electron by
@@ -10,6 +16,7 @@ const keychain = vi.hoisted(() => ({ available: true }))
 vi.mock('electron', () => ({
   safeStorage: {
     isEncryptionAvailable: () => keychain.available,
+    getSelectedStorageBackend: () => keychain.backend,
     encryptString: (plaintext: string) => {
       if (!keychain.available) throw new Error('Encryption is not available.')
 
@@ -29,10 +36,13 @@ vi.mock('electron', () => ({
   }
 }))
 
-const { decryptKey, encryptKey, maskKey, tryDecryptKey } = await import('./crypto')
+const { decryptKey, encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey } =
+  await import('./crypto')
 
 afterEach(() => {
   keychain.available = true
+  keychain.backend = 'gnome_libsecret'
+  keychain.platform = 'linux'
 })
 
 describe('crypto', () => {
@@ -56,6 +66,17 @@ describe('crypto', () => {
     keychain.available = false
 
     expect(() => encryptKey('sk-secret-value')).toThrow(/secure credential storage is unavailable/i)
+  })
+
+  it('rejects reads and writes through Electron basic_text on Linux', () => {
+    keychain.backend = 'basic_text'
+    const encryptedRef = `enc:${Buffer.from('cipher:stored-secret').toString('base64')}`
+    const legacyRef = `plain:${Buffer.from('legacy-secret').toString('base64')}`
+
+    expect(isEncryptionAvailable()).toBe(false)
+    expect(() => encryptKey('new-secret')).toThrow(/secure credential storage is unavailable/i)
+    expect(tryDecryptKey(encryptedRef)).toBeUndefined()
+    expect(tryDecryptKey(legacyRef)).toBeUndefined()
   })
 
   it('still reads a legacy plain: ref so it can be migrated after upgrade', () => {

--- a/src/main/settings/crypto.ts
+++ b/src/main/settings/crypto.ts
@@ -1,6 +1,8 @@
 import { safeStorage } from 'electron'
 
-// Wraps Electron safeStorage for provider credential material. Plaintext values exist only transiently in main
+import { isSecureStorageAvailable } from '../secure-storage'
+
+// Wraps Electron safeStorage for Settings credential material. Plaintext values exist only transiently in main
 // memory (during validation and env assembly); at rest they are OS-encrypted ciphertext, and the
 // renderer only ever sees the masked hint produced by maskKey().
 
@@ -10,8 +12,8 @@ const KEY_REF_PREFIX = 'enc:'
 // Legacy reduced-protection refs remain readable for migration, but new writes never create them.
 const PLAIN_REF_PREFIX = 'plain:'
 
-// Reports whether the OS keychain backing safeStorage is usable on this machine.
-const isEncryptionAvailable = (): boolean => safeStorage.isEncryptionAvailable()
+// Reports whether safeStorage is backed by an OS credential vault on this machine.
+const isEncryptionAvailable = (): boolean => isSecureStorageAvailable()
 
 // Turns plaintext into an OS-protected keyRef. Saving secrets fails closed when safeStorage is absent.
 const encryptKey = (plaintext: string): string => {
@@ -28,6 +30,12 @@ const encryptKey = (plaintext: string): string => {
 
 // Decrypts a stored keyRef. `plain:` is accepted only for backwards-compatible migration.
 const decryptKey = (keyRef: string): string => {
+  if (!isEncryptionAvailable()) {
+    throw new Error(
+      'Secure credential storage is unavailable. Unlock the system keychain and retry.'
+    )
+  }
+
   if (keyRef.startsWith(PLAIN_REF_PREFIX)) {
     return Buffer.from(keyRef.slice(PLAIN_REF_PREFIX.length), 'base64').toString('utf8')
   }


### PR DESCRIPTION
## Problem

Electron can report encryption as available on Linux while using the `basic_text` backend. Compute already rejects that backend, but Settings treated it as OS-secure storage, allowing Provider, Connector, OAuth, GitHub, Claude, NCBI, and OpenAlex credentials to be persisted and presenting the secure-storage UI promise.

## Proposed change

- Move the existing fail-closed safe-storage capability check into one main-process module.
- Reuse it from Compute and Settings.
- Reject both Settings credential reads and writes while Linux uses `basic_text`.
- Preserve the existing Compute exports so current consumers remain compatible.
- Keep Linux E2E credential setup isolated by reporting a deterministic secure test backend only inside the Playwright-controlled Electron process; production has no CI or environment bypass.

## Scope and non-goals

- No database migration, schema change, new persisted field, new enum value, IPC change, or new user-visible copy.
- Existing `enc:` and `plain:` values are not modified or deleted. They are treated as unavailable while `basic_text` is selected; users may need to re-enter and rotate credentials after enabling a secure backend.
- Automatic migration is intentionally excluded because existing `enc:` values do not record which backend created them.

## Acceptance criteria and validation

Production checks ran after the last production edit; the E2E checks ran after the Linux fixture follow-up.

- Linux `basic_text` read/write rejection and Settings availability: `npm run test:module -- settings_provider_accounts` — 409 passed.
- Shared Compute capability and credential behavior: `npm run test:module -- compute_service` — 824 passed, 6 skipped by the module suite.
- Settings IPC/facade and representative consumers: `npm run test:module -- settings_service_facade` — 819 passed.
- Direct Connector and GitHub credential consumers: `npm test -- src/main/settings/connector-settings.test.ts src/main/settings/skill-catalog.test.ts` — 83 passed.
- E2E application build: `npm run build:e2e` — passed.
- Linux launch fixture contract: `npm run test:e2e -- e2e/launch-environment.spec.ts` — 6 passed.
- Real Agent provider credential path: `npm run test:e2e -- e2e/certification/provider-bridge.spec.ts` — 1 passed.
- Main-process types: `npm run typecheck:node` — passed.
- Source lint: `npm run lint` plus focused fixture ESLint — passed.
- Formatting and whitespace: Prettier check and `git diff --check` — passed.

The full local `npm test` suite was not run by request; exact-head PR CI remains authoritative for the complete portable and platform-selected suites.

## Review focus

- Linux backend detection remains identical to Compute's established standard.
- Settings now fails closed for historical reads as well as new writes.
- Provider, Connector, GitHub, and Compute consumers all reach the same internal capability seam without changing their public interfaces.
- The Linux E2E accommodation exists only in the test fixture and does not weaken production rejection of `basic_text`.
