### PR TITLE
fix(settings): refresh secure storage capability independently

### DIFF
--- a/src/renderer/src/stores/settings-store.architecture.test.ts
+++ b/src/renderer/src/stores/settings-store.architecture.test.ts
@@ -308,9 +308,9 @@ const importBoundaryViolations = (path: string, source = readSource(path)): read
   return violations
 }
 
-// Exact declaration counts for every facade binding. `load` now publishes the Settings snapshot
-// before runtime probes finish, so its locals (and the two `catch (error)` bindings) must stay
-// inventoried here instead of being treated as new facade state.
+// Exact declaration counts for every facade binding. `load` publishes the Settings snapshot before
+// capability probes finish, so its probe-result locals stay inventoried here instead of being
+// treated as new facade state.
 const allowedFacadeVariableCounts = new Map<string, number>([
   ['createInitialSettingsState', 1],
   ['applySnapshot', 1],
@@ -327,11 +327,13 @@ const allowedFacadeVariableCounts = new Map<string, number>([
   ['generation', 1],
   ['shouldInitializeRuntime', 1],
   ['settingsPromise', 1],
+  ['encryptionAvailability', 1],
   ['runtimeInitialization', 1],
   ['snapshot', 1],
-  ['[preflight, encryptionAvailable, npmAvailable]', 1],
+  ['[[encryptionResult], runtimeResults]', 1],
+  ['[preflightResult, npmAvailableResult]', 1],
   ['loadPromise', 1],
-  ['error', 2],
+  ['error', 1],
   ['useSettingsStore', 1]
 ])
 

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -817,6 +817,10 @@ describe('settings store: onboarding completion', () => {
 })
 
 describe('settings store: startup loading', () => {
+  it('defaults secure storage to unavailable until the capability probe succeeds', () => {
+    expect(useSettingsStore.getState().encryptionAvailable).toBe(false)
+  })
+
   it('publishes the settings snapshot before startup probes finish', async () => {
     let resolvePreflight:
       ((value: { claudeReady: boolean; activeProviderReady: boolean }) => void) | undefined
@@ -868,19 +872,23 @@ describe('settings store: startup loading', () => {
     })
   })
 
-  it('refreshes only the lightweight settings snapshot after startup', async () => {
+  it('rechecks secure storage without rerunning startup-only runtime probes', async () => {
     api.getSettings
       .mockResolvedValueOnce({ ...snapshot([]), onboardingCompletedAt: 111 })
       .mockResolvedValueOnce({ ...snapshot([]), onboardingCompletedAt: 222 })
+    api.isEncryptionAvailable.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
 
     await useSettingsStore.getState().load()
     await useSettingsStore.getState().load()
 
     expect(api.getSettings).toHaveBeenCalledTimes(2)
     expect(api.getPreflight).toHaveBeenCalledOnce()
-    expect(api.isEncryptionAvailable).toHaveBeenCalledOnce()
+    expect(api.isEncryptionAvailable).toHaveBeenCalledTimes(2)
     expect(api.isNpmAvailable).toHaveBeenCalledOnce()
-    expect(useSettingsStore.getState().onboardingCompletedAt).toBe(222)
+    expect(useSettingsStore.getState()).toMatchObject({
+      onboardingCompletedAt: 222,
+      encryptionAvailable: true
+    })
   })
 
   it('keeps startup blocked after a Settings authority failure and recovers on retry', async () => {
@@ -911,13 +919,15 @@ describe('settings store: startup loading', () => {
     const rawError = new Error('runtime probe unavailable')
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     api.getPreflight.mockRejectedValueOnce(rawError)
+    api.isEncryptionAvailable.mockResolvedValueOnce(false)
 
     await expect(useSettingsStore.getState().load()).resolves.toBe(true)
 
     expect(useSettingsStore.getState()).toMatchObject({
       isLoaded: true,
       isLoading: false,
-      loadError: undefined
+      loadError: undefined,
+      encryptionAvailable: false
     })
     expect(warn).toHaveBeenCalledWith('Settings loading failed', rawError)
   })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -186,7 +186,7 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   codexManaged: false,
   codebuddyManaged: false,
   onboardingCompletedAt: undefined,
-  encryptionAvailable: true,
+  encryptionAvailable: false,
   packageMirror: undefined,
   networkProxy: DEFAULT_NETWORK_PROXY_SETTINGS,
   reasoningEffort: DEFAULT_REASONING_EFFORT,
@@ -374,9 +374,8 @@ const createSettingsStoreState = (
     getCommands: () => window.api.settings
   }),
 
-  // Loads settings, preflight, and encryption availability in one startup pass. Reopening Settings
-  // reuses this same action and the same Settings reads, skipping the subprocess probes after the
-  // first successful load so feature actions stay in their slices.
+  // Loads settings and capabilities in one pass. Reopening Settings refreshes the lightweight
+  // snapshot and secure-storage capability, while startup-only subprocess probes stay cached.
   load: (options) => {
     // StrictMode replays the startup effect. Reuse that identical in-flight pass so a duplicate
     // request cannot supersede its successful result; an explicit user retry still starts a new
@@ -386,50 +385,77 @@ const createSettingsStoreState = (
     const shouldInitializeRuntime = options?.force || !get().isLoaded
     set(
       shouldInitializeRuntime
-        ? { settingsLoadGeneration: generation, isLoading: true, loadError: undefined }
-        : { settingsLoadGeneration: generation }
+        ? {
+            settingsLoadGeneration: generation,
+            isLoading: true,
+            loadError: undefined,
+            encryptionAvailable: false
+          }
+        : { settingsLoadGeneration: generation, encryptionAvailable: false }
     )
 
     const loadPromise = (async (): Promise<boolean> => {
       const settingsPromise = window.api.settings.getSettings()
+      const encryptionAvailability = Promise.allSettled([
+        window.api.settings.isEncryptionAvailable()
+      ])
       const runtimeInitialization = shouldInitializeRuntime
-        ? Promise.all([
+        ? Promise.allSettled([
             window.api.settings.getPreflight(),
-            window.api.settings.isEncryptionAvailable(),
             window.api.settings.isNpmAvailable()
           ])
         : undefined
-      // A newer forced load may supersede this generation before it awaits the runtime result.
-      // Attach a rejection handler immediately so a stale subprocess failure is never unhandled.
-      void runtimeInitialization?.catch(() => undefined)
 
       try {
         const snapshot = await settingsPromise
 
         if (get().settingsLoadGeneration !== generation) return false
-        if (!runtimeInitialization) {
-          set({ ...applySnapshot(snapshot), loadError: undefined })
-          return true
+
+        // The persisted Settings authority is enough for an existing user to enter Home. Capability
+        // probes continue in this same deduplicated pass; first-run onboarding still waits in App.
+        set({
+          ...applySnapshot(snapshot),
+          ...(shouldInitializeRuntime ? { isLoaded: true } : {}),
+          loadError: undefined
+        })
+
+        const [[encryptionResult], runtimeResults] = await Promise.all([
+          encryptionAvailability,
+          Promise.resolve(runtimeInitialization)
+        ])
+        if (get().settingsLoadGeneration !== generation) return false
+
+        if (encryptionResult.status === 'rejected') {
+          reportSettingsLoadError(encryptionResult.reason)
         }
 
-        // The persisted Settings authority is enough for an existing user to enter Home. Runtime
-        // probes continue in this same deduplicated pass; first-run onboarding still waits in App.
-        set({ ...applySnapshot(snapshot), isLoaded: true, loadError: undefined })
-
-        try {
-          const [preflight, encryptionAvailable, npmAvailable] = await runtimeInitialization
-          if (get().settingsLoadGeneration !== generation) return false
+        if (runtimeResults) {
+          const [preflightResult, npmAvailableResult] = runtimeResults
+          if (preflightResult.status === 'rejected') {
+            reportSettingsLoadError(preflightResult.reason)
+          }
+          if (npmAvailableResult.status === 'rejected') {
+            reportSettingsLoadError(npmAvailableResult.reason)
+          }
 
           set({
-            ...createRuntimeSetupLoadPatch(preflight, npmAvailable),
-            encryptionAvailable,
+            ...createRuntimeSetupLoadPatch(
+              preflightResult.status === 'fulfilled' ? preflightResult.value : get().preflight,
+              npmAvailableResult.status === 'fulfilled'
+                ? npmAvailableResult.value
+                : get().npmAvailable
+            ),
+            encryptionAvailable:
+              encryptionResult.status === 'fulfilled' ? encryptionResult.value : false,
             isLoading: false,
             loadError: undefined
           })
-        } catch (error) {
-          if (get().settingsLoadGeneration !== generation) return false
-          reportSettingsLoadError(error)
-          set({ isLoading: false, loadError: undefined })
+        } else {
+          set({
+            encryptionAvailable:
+              encryptionResult.status === 'fulfilled' ? encryptionResult.value : false,
+            loadError: undefined
+          })
         }
         return true
       } catch (error) {


### PR DESCRIPTION
## Problem

The renderer treated secure storage as available before the capability probe completed. Startup also grouped preflight, secure storage, and npm in one `Promise.all`, so an unrelated probe rejection discarded a successful secure-storage result. After the first load, reopening Settings refreshed only the snapshot and left keychain availability stale.

## Proposed change

- Default secure storage availability to `false` until the probe succeeds.
- Settle preflight, npm, and secure-storage probes independently so one rejection cannot hide another result.
- Recheck secure storage on every Settings load while keeping preflight and npm startup-only.
- Preserve generation checks, StrictMode request deduplication, and Settings-authority failure behavior.

## Scope and non-goals

- No persisted fields, schema changes, migrations, historical-data compatibility, or new enum states.
- No new IPC methods, UI controls, copy, or interaction flows.
- This does not add a manual retry button; reopening Settings uses the existing load boundary to refresh keychain state.

## Acceptance criteria and validation

Regression loop before the fix:

`node node_modules/vitest/vitest.mjs run --root .worktree/secure-storage-capability-state src/renderer/src/stores/settings-store.test.ts -t 'defaults secure storage|rechecks secure storage|keeps valid Settings available'`

- Failed 3/3 with the reported symptoms: optimistic `true`, one secure-storage call across reopen, and a runtime-probe rejection leaving the secure result masked.

Final checks after the last material edit:

- Secure-storage load behavior -> targeted regression loop -> 3 passed.
- Settings store owner and architecture contracts -> `settings-store.test.ts` + `settings-store.architecture.test.ts` -> 130 passed.
- Direct Settings consumers -> targeted `SettingsPage.render.test.tsx` + `CredentialsPanel.render.test.tsx` checks -> 5 passed.
- Renderer types -> `tsc --noEmit -p tsconfig.web.json --composite false` -> passed.
- Changed-source lint -> ESLint on the three changed files -> passed.
- Formatting -> Prettier check on the three changed files -> passed.

Local environment note: the canonical root `package-lock.json` has unrelated uncommitted changes and differs from this worktree. Per project guidance, no dependency Junction or private install was created. The formal `npm test -- <paths>` wrapper therefore stopped in `pretest` because the worktree-local Prisma client is absent; the Vitest test bodies above ran against the existing compatible root dependency tree. Exact-head PR CI remains authoritative for the complete portable and platform checks.

## Review focus

- Fail-closed behavior while secure-storage capability is unknown or rejected.
- Independent application of fulfilled probe results.
- Reopen refresh behavior without rerunning startup-only subprocess probes.
