### PR TITLE
fix(web-service): reject malformed URL encoding

### DIFF
--- a/src/main/web-service/auth.ts
+++ b/src/main/web-service/auth.ts
@@ -80,7 +80,13 @@ const cookieToken = (request: IncomingMessage): string | undefined => {
   const cookies = request.headers.cookie?.split(';') ?? []
   for (const cookie of cookies) {
     const [name, ...value] = cookie.trim().split('=')
-    if (name === COOKIE_NAME) return decodeURIComponent(value.join('='))
+    if (name === COOKIE_NAME) {
+      try {
+        return decodeURIComponent(value.join('='))
+      } catch {
+        return undefined
+      }
+    }
   }
   return undefined
 }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -143,6 +143,54 @@ afterEach(async () => {
 })
 
 describe('startWebHttpServer', () => {
+  it('rejects malformed URL encoding at the public HTTP boundary', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: {
+        channels: () => ['projects:list'],
+        invoke: vi.fn(),
+        releaseClient: vi.fn(),
+        dispose: vi.fn()
+      },
+      tasks: {
+        runWithCallerContext,
+        subscribeProgress: vi.fn(() => vi.fn()),
+        getRun: vi.fn()
+      } as never,
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const base = `http://127.0.0.1:${server.port}`
+
+    const statuses = await Promise.all([
+      fetch(`${base}/api/bootstrap`, {
+        headers: { cookie: 'open_science_web_token=%' }
+      }).then((response) => response.status),
+      fetch(`${base}/rpc/%`, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer test-token',
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+      }).then((response) => response.status),
+      fetch(`${base}/api/v1/runs/%`, {
+        headers: { authorization: 'Bearer test-token' }
+      }).then((response) => response.status)
+    ])
+
+    expect(statuses).toEqual([401, 400, 400])
+  })
+
   it('retains a parsed body reservation when the client disconnects before its handler completes', async () => {
     const body = JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
     const bodyBytes = Buffer.byteLength(body)

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -318,6 +318,15 @@ const json = (response: ServerResponse, status: number, value: unknown): void =>
   response.end(content)
 }
 
+const hasValidUrlPathEncoding = (pathname: string): boolean => {
+  try {
+    decodeURI(pathname)
+    return true
+  } catch {
+    return false
+  }
+}
+
 const webRpcError = (
   response: ServerResponse,
   status: number,
@@ -942,6 +951,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       if (!authorized) {
         response.writeHead(401, { 'content-type': 'text/plain; charset=utf-8' })
         response.end('Unauthorized')
+        return
+      }
+      if (!hasValidUrlPathEncoding(url.pathname)) {
+        json(response, 400, { error: 'Malformed URL encoding.' })
         return
       }
       if (auth.ok && auth.queryToken && request.method === 'GET' && url.pathname === '/') {


### PR DESCRIPTION
## Problem

Malformed percent-encoding in the Web authentication cookie or REST/RPC path components causes `decodeURIComponent` to throw. Those client-controlled failures currently reach the generic request catch and return HTTP 500, which misclassifies the request, pollutes server-error monitoring, and misleads callers.

## Proposed change

- Treat a malformed `open_science_web_token` cookie as invalid credentials so the request returns 401.
- Validate URL path encoding once after authorization and before route dispatch so authenticated malformed paths return 400.
- Add a public HTTP regression test covering malformed Cookie, RPC path, and REST resource ID inputs.

## Scope and non-goals

- No database, persisted-format, historical-compatibility, schema, data-model, or migration changes.
- No new fields, enum values, application states, or UI workflow changes.
- Valid URL encoding and genuine internal failures retain their existing behavior.
- WebSocket handling is unchanged; its existing catch already rejects malformed authentication input with 401.

## Acceptance criteria and validation

Checks below ran after the final material edit:

- malformed Cookie/RPC/REST behavior -> targeted public HTTP regression test -> passed (1 test)
- Web authentication and HTTP server behavior -> `vitest run src/main/web-service/auth.test.ts src/main/web-service/http-server.test.ts` -> passed (37 passed, 3 skipped)
- linted source and test files -> targeted ESLint -> passed
- repository lint -> full ESLint with cache disabled -> passed
- Node type safety -> `tsc --noEmit -p tsconfig.node.json --composite false` -> blocked by the existing `waitForMcpServers` export mismatch in `src/main/acp/claude-agent-acp-patch.test.ts`; the unmodified main checkout fails identically

The regression was observed twice before the fix as `[500, 500, 500]` versus expected `[401, 400, 400]`, then passed after the fix. The complete `npm test` suite was intentionally not run; PR Gate remains authoritative for the full portable and platform plan.

## Review focus

- Whether malformed cookie encoding should remain indistinguishable from other invalid credentials.
- Whether validating path encoding once at the authenticated HTTP boundary is preferable to duplicating decoding guards in each REST/RPC route.
- Confirm the 400/401 classification without broadening the handling of genuine internal errors.