### PR TITLE
fix(settings): prevent stale provider catalog writes

### DIFF
--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -14,6 +14,9 @@ import { getAgentFramework } from '../agent-framework'
 import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 
 vi.mock('electron', () => ({
+  net: {
+    fetch: (input: string, init?: RequestInit) => globalThis.fetch(input, init)
+  },
   safeStorage: {
     isEncryptionAvailable: () => true,
     encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
@@ -577,6 +580,121 @@ describe('ProviderAccountsModule', () => {
         }
       })
     ).resolves.toMatchObject({ ok: false, category: 'incompatible' })
+  })
+
+  it('discards a model catalog fetched for a provider target changed during refresh', async () => {
+    await module.upsertProvider({
+      type: 'official',
+      name: 'DeepSeek',
+      vendorId: 'deepseek',
+      model: 'deepseek-v4-pro',
+      key: 'old-key'
+    })
+    const original = (await repository.getSettings()).providers[0]
+    const requestStarted = deferred<void>()
+    const response = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        requestStarted.resolve()
+        return response.promise
+      })
+    )
+
+    const refresh = module.refreshProviderModels({ providerId: original.id })
+    await requestStarted.promise
+    await module.upsertProvider({
+      id: original.id,
+      requireExisting: true,
+      type: 'official',
+      name: 'OpenAI replacement',
+      vendorId: 'openai',
+      key: 'new-key'
+    })
+    const edited = (await repository.getSettings()).providers[0]
+    response.resolve(Response.json({ data: [{ id: 'deepseek-v5' }] }))
+
+    await expect(refresh).resolves.toMatchObject({ ok: true, models: ['deepseek-v5'] })
+    await expect(repository.getSettings()).resolves.toMatchObject({
+      providers: [
+        expect.objectContaining({
+          id: original.id,
+          name: 'OpenAI replacement',
+          vendorId: 'openai',
+          keyRef: edited.keyRef
+        })
+      ]
+    })
+    expect((await repository.getSettings()).providers[0].fetchedModels).toBeUndefined()
+  })
+
+  it('preserves unrelated provider edits while applying a pending model catalog refresh', async () => {
+    await module.upsertProvider({
+      type: 'official',
+      name: 'DeepSeek',
+      vendorId: 'deepseek',
+      key: 'old-key'
+    })
+    const original = (await repository.getSettings()).providers[0]
+    const requestStarted = deferred<void>()
+    const response = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        requestStarted.resolve()
+        return response.promise
+      })
+    )
+
+    const refresh = module.refreshProviderModels({ providerId: original.id })
+    await requestStarted.promise
+    await module.upsertProvider({
+      id: original.id,
+      requireExisting: true,
+      type: 'official',
+      name: 'Renamed DeepSeek',
+      vendorId: 'deepseek'
+    })
+    response.resolve(Response.json({ data: [{ id: 'deepseek-v5' }] }))
+
+    await expect(refresh).resolves.toMatchObject({ ok: true, models: ['deepseek-v5'] })
+    await expect(repository.getSettings()).resolves.toMatchObject({
+      providers: [
+        expect.objectContaining({
+          id: original.id,
+          name: 'Renamed DeepSeek',
+          keyRef: original.keyRef,
+          fetchedModels: ['deepseek-v5']
+        })
+      ]
+    })
+  })
+
+  it('does not recreate a provider deleted while its model catalog refresh is pending', async () => {
+    await module.upsertProvider({
+      type: 'official',
+      name: 'DeepSeek',
+      vendorId: 'deepseek',
+      key: 'old-key'
+    })
+    const providerId = (await repository.getSettings()).providers[0].id
+    const requestStarted = deferred<void>()
+    const response = deferred<Response>()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        requestStarted.resolve()
+        return response.promise
+      })
+    )
+
+    const refresh = module.refreshProviderModels({ providerId })
+    await requestStarted.promise
+    await module.deleteProvider(providerId)
+    response.resolve(Response.json({ data: [{ id: 'deepseek-v5' }] }))
+
+    await expect(refresh).resolves.toMatchObject({ ok: true, models: ['deepseek-v5'] })
+    await expect(repository.getSettings()).resolves.toMatchObject({ providers: [] })
   })
 
   it.each(['contextWindow', 'maxInputTokens', 'maxOutputTokens'] as const)(

--- a/src/main/settings/provider-model-catalog-owner.ts
+++ b/src/main/settings/provider-model-catalog-owner.ts
@@ -62,7 +62,7 @@ export class ProviderModelCatalogOwner {
     const models = isXaiSubscriptionProvider(stored.type)
       ? result.models.filter((model) => model.startsWith('grok-'))
       : result.models
-    await this.repository.upsertProvider({ ...stored, fetchedModels: models })
+    await this.repository.updateProviderModelCatalogIfTargetMatches(stored, models)
     return { ok: true, category: 'ok', models }
   }
 }

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -89,6 +89,38 @@ class SettingsRepository {
     })
   }
 
+  // Records a fetched catalog only while the provider still points at the target that produced it.
+  // The patch is applied to the current record so unrelated edits made during the network request
+  // are preserved, and a deleted provider can never be recreated by a stale completion.
+  async updateProviderModelCatalogIfTargetMatches(
+    expectedProvider: StoredProvider,
+    fetchedModels: string[]
+  ): Promise<boolean> {
+    let applied = false
+
+    await this.mutate((settings) => {
+      const index = settings.providers.findIndex((provider) => provider.id === expectedProvider.id)
+      if (index < 0) return settings
+
+      const currentProvider = settings.providers[index]
+      if (
+        currentProvider.type !== expectedProvider.type ||
+        currentProvider.vendorId !== expectedProvider.vendorId ||
+        currentProvider.region !== expectedProvider.region ||
+        currentProvider.keyRef !== expectedProvider.keyRef
+      ) {
+        return settings
+      }
+
+      const providers = [...settings.providers]
+      providers[index] = { ...currentProvider, fetchedModels }
+      applied = true
+      return { ...settings, providers }
+    })
+
+    return applied
+  }
+
   // Updates the single claude-isolated provider record (id is fixed at builtin-claude-isolated).
   // The patch carries only the key-bearing fields the controller writes — model/lastValidatedAt/etc
   // stay on whatever the renderer/service previously set, so a paste does not stomp the validated-at

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -394,6 +394,7 @@ describe('Settings backend ownership architecture', () => {
       'updateClaudeIsolatedValidationIfKeyMatches',
       'updateClaudeSharedValidationIfUnchanged',
       'updateCustomServer',
+      'updateProviderModelCatalogIfTargetMatches',
       'upsertClaudeIsolatedProvider',
       'upsertProvider'
     ])


### PR DESCRIPTION
## Problem

Refreshing a provider model catalog read the complete provider before the network request and wrote that stale object back after the request completed. A concurrent provider edit could restore the old credential and provider fields, while a concurrent deletion could recreate the provider.

The final regression tests reproduce three concrete outcomes on the old implementation: a catalog fetched for an old target is persisted over a replacement target, an unrelated provider edit is overwritten, and a deleted provider is recreated.

## Proposed change

Add a repository-level compare-and-set update for fetchedModels. The mutation applies only when the provider still exists and its type, vendorId, region, and keyRef still match the request target. It patches fetchedModels onto the current record instead of writing the pre-request snapshot.

## Scope and non-goals

- No persisted field, schema, migration, enum, or historical-data compatibility change.
- No IPC or renderer interaction change; Save remains available while refresh is running.
- No new refresh-result status. A stale successful response is returned to the caller but is not persisted.
- The change intentionally protects the persistence boundary rather than relying on one UI entry point to serialize edits.

## Acceptance criteria and validation

- Changed target during refresh -> provider edit remains authoritative and stale fetchedModels is discarded.
- Unrelated edit during refresh -> edit remains authoritative and fetchedModels is applied to the current record.
- Deletion during refresh -> provider remains deleted.

Final local evidence after the last material edit:

- Provider refresh concurrency regression tests: 3 passed. The same final tests were run against the old write path and failed 3 of 3 with the reported overwrite/resurrection symptoms.
- settings_repository plus settings_provider_accounts declared Vitest sets: 38 of 39 files passed; 1005 tests passed and 1 skipped. The only failing file contains 7 existing Windows symlink tests that stop at fs.symlink with EPERM under the current account.
- npm run lint: passed.
- npm run typecheck:node: blocked by the existing canonical dependency tree; src/main/acp/claude-agent-acp-patch.test.ts imports waitForMcpServers, which the installed @agentclientprotocol/claude-agent-acp package does not export.
- Canonical Prisma Client fingerprint matches this worktree schema.

Behavior-to-check mapping:

- Provider target CAS and deletion safety -> src/main/settings/provider-accounts.test.ts -> passed.
- Repository/provider ownership boundary -> src/main/settings/settings-backend.architecture.test.ts -> passed.
- Settings repository and provider-account owner/contract/consumer coverage -> declared module Vitest union -> 1005 passed; 7 unrelated symlink-permission failures as noted above.
- Source style -> npm run lint -> passed.

PR CI remains authoritative for the complete portable and platform-selected checks.

## Review focus

- Whether type, vendorId, region, and keyRef are the complete identity of the model-list request target.
- Whether preserving all current provider fields while patching only fetchedModels matches the intended concurrent-edit semantics.