### PR TITLE
fix(notebook): preserve R kernel across repeated cancellation

### DIFF
--- a/resources/notebook/r_loop.R
+++ b/resources/notebook/r_loop.R
@@ -1470,9 +1470,9 @@ rm(namespace_state)
 base::local({
   state <- new.env(parent = emptyenv())
   state$during_read <- FALSE
-  # Retain the fully read frame's identity until its response is emitted. A SIGINT can otherwise
-  # escape between the local read/eval handlers and terminate Rscript without acknowledging it.
-  state$current_req_id <- NULL
+  # Retain the fully read frame until its response is emitted. A SIGINT can otherwise unwind
+  # read_request after consuming the body and discard the request before it is acknowledged.
+  state$current_req <- NULL
 
   read_request <- function() {
     empty_streak <- 0L
@@ -1518,9 +1518,25 @@ base::local({
         body_empty <- 0L
         acc <- c(acc, chunk)
       }
-      code <- if (n > 0L) rawToChar(acc, multiple = FALSE) else ""
-      state$current_req_id <- req_id
-      return(list(req_id = req_id, code = code, operation = operation))
+      req <- tryCatch(
+        {
+          code <- if (n > 0L) rawToChar(acc, multiple = FALSE) else ""
+          req <- list(req_id = req_id, code = code, operation = operation)
+          state$current_req <- req
+          req
+        },
+        interrupt = function(cnd) {
+          state$during_read <- TRUE
+          req <- list(
+            req_id = req_id,
+            code = if (n > 0L) rawToChar(acc, multiple = FALSE) else "",
+            operation = operation
+          )
+          state$current_req <- req
+          req
+        }
+      )
+      return(req)
     }
   }
 
@@ -1564,8 +1580,9 @@ base::local({
           req <- tryCatch(
             read_request(),
             interrupt = function(cnd) {
+              req <- state$current_req
               state$during_read <- TRUE
-              "retry"
+              if (is.null(req)) "retry" else req
             }
           )
           if (is.null(req)) break
@@ -1587,19 +1604,23 @@ base::local({
             },
             interrupt = function(cnd) interrupted_response(req$req_id)
           )
-          suspendInterrupts(emit(resp))
-          state$current_req_id <- NULL
+          suspendInterrupts({
+            emit(resp)
+            state$current_req <- NULL
+          })
         }
         FALSE
       },
       interrupt = function(cnd) {
-        req_id <- state$current_req_id
-        if (is.null(req_id)) {
+        req <- state$current_req
+        if (is.null(req)) {
           state$during_read <- TRUE
         } else {
           state$during_read <- FALSE
-          suspendInterrupts(emit(interrupted_response(req_id)))
-          state$current_req_id <- NULL
+          suspendInterrupts({
+            emit(interrupted_response(req$req_id))
+            state$current_req <- NULL
+          })
         }
         TRUE
       }

--- a/resources/notebook/r_loop.R
+++ b/resources/notebook/r_loop.R
@@ -1470,6 +1470,9 @@ rm(namespace_state)
 base::local({
   state <- new.env(parent = emptyenv())
   state$during_read <- FALSE
+  # Retain the fully read frame's identity until its response is emitted. A SIGINT can otherwise
+  # escape between the local read/eval handlers and terminate Rscript without acknowledging it.
+  state$current_req_id <- NULL
 
   read_request <- function() {
     empty_streak <- 0L
@@ -1516,6 +1519,7 @@ base::local({
         acc <- c(acc, chunk)
       }
       code <- if (n > 0L) rawToChar(acc, multiple = FALSE) else ""
+      state$current_req_id <- req_id
       return(list(req_id = req_id, code = code, operation = operation))
     }
   }
@@ -1551,34 +1555,56 @@ base::local({
     )
   }
 
+  # Keep one interrupt handler active across request-boundary transitions as well as response emit.
+  # The inner loop normally runs until EOF; a late interrupt unwinds only to this recovery point.
   repeat {
-    req <- tryCatch(
-      read_request(),
+    keep_running <- tryCatch(
+      {
+        repeat {
+          req <- tryCatch(
+            read_request(),
+            interrupt = function(cnd) {
+              state$during_read <- TRUE
+              "retry"
+            }
+          )
+          if (is.null(req)) break
+          if (identical(req, "retry")) next
+          resp <- tryCatch(
+            {
+              if (isTRUE(state$during_read)) {
+                state$during_read <- FALSE
+                interrupted_response(req$req_id)
+              } else {
+                result <- if (identical(req$operation, "inspect_namespace")) {
+                  list(namespace = inspect_namespace(identical(req$code, "private")))
+                } else {
+                  run(req)
+                }
+                result$req_id <- req$req_id
+                result
+              }
+            },
+            interrupt = function(cnd) interrupted_response(req$req_id)
+          )
+          suspendInterrupts(emit(resp))
+          state$current_req_id <- NULL
+        }
+        FALSE
+      },
       interrupt = function(cnd) {
-        state$during_read <- TRUE
-        "retry"
+        req_id <- state$current_req_id
+        if (is.null(req_id)) {
+          state$during_read <- TRUE
+        } else {
+          state$during_read <- FALSE
+          suspendInterrupts(emit(interrupted_response(req_id)))
+          state$current_req_id <- NULL
+        }
+        TRUE
       }
     )
-    if (is.null(req)) break
-    if (identical(req, "retry")) next
-    resp <- tryCatch(
-      {
-        if (isTRUE(state$during_read)) {
-          state$during_read <- FALSE
-          interrupted_response(req$req_id)
-        } else {
-          result <- if (identical(req$operation, "inspect_namespace")) {
-            list(namespace = inspect_namespace(identical(req$code, "private")))
-          } else {
-            run(req)
-          }
-          result$req_id <- req$req_id
-          result
-        }
-      },
-      interrupt = function(cnd) interrupted_response(req$req_id)
-    )
-    emit(resp)
+    if (!isTRUE(keep_running)) break
   }
 }, envir = base::list2env(
   base::list(

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -2134,6 +2134,65 @@ describe.skipIf(!rExecutable || !rScriptExecutable)('NotebookKernelExecutor (rea
   )
 
   it.skipIf(process.platform === 'win32')(
+    'preserves a fully read R request when SIGINT lands before dispatch',
+    async () => {
+      cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-frame-cancel-'))
+      const request = baseRequest(cwdDir)
+      await stubEnvR(request.runtimeRoot, DEFAULT_R_ENV)
+      const sourcePath = join(__dirname, '../../../resources/notebook/r_loop.R')
+      const loopPath = join(cwdDir, 'r_loop.R')
+      const frameDecoded = 'code <- if (n > 0L) rawToChar(acc, multiple = FALSE) else ""'
+      const marker = '__OPEN_SCIENCE_R_FRAME_DECODED__'
+      const loop = await readFile(sourcePath, 'utf8')
+      expect(loop).toContain(frameDecoded)
+      await writeFile(
+        loopPath,
+        loop.replace(
+          frameDecoded,
+          `${frameDecoded}\n      if (identical(code, "Sys.sleep(30)")) {\n        cat("${marker}\\n")\n        flush(stdout())\n        Sys.sleep(0.5)\n      }`
+        )
+      )
+      const executor = new NotebookKernelExecutor({ rLoopPath: loopPath, platform: 'linux' })
+
+      try {
+        await expect(
+          executor.execute({ ...request, code: 'preserved_after_cancel <- 41', language: 'r' })
+        ).resolves.toMatchObject({ status: 'completed' })
+        const child = procFor(executor, 'r')?.child as ChildProcessWithoutNullStreams
+        const frameDecodedByR = new Promise<void>((resolve) => {
+          const onData = (chunk: Buffer): void => {
+            if (!chunk.toString().includes(marker)) return
+            child.stdout.off('data', onData)
+            resolve()
+          }
+          child.stdout.on('data', onData)
+        })
+        const cancellation = new AbortController()
+        const run = executor.execute({
+          ...request,
+          code: 'Sys.sleep(30)',
+          language: 'r',
+          signal: cancellation.signal
+        })
+
+        await frameDecodedByR
+        cancellation.abort()
+        await expect(run).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+        const next = await executor.execute({
+          ...request,
+          code: 'cat(preserved_after_cancel + 1)',
+          language: 'r'
+        })
+        expect(next).toMatchObject({ status: 'completed', stdout: '42', traceback: '' })
+        expect(procFor(executor, 'r')?.child).toBe(child)
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    15_000
+  )
+
+  it.skipIf(process.platform === 'win32')(
     'preserves the R namespace across an in-eval cancel and 50 dispatch cancels',
     async () => {
       cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-cancel-stress-'))

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -293,7 +293,8 @@ const abortOnNextStdinWrite = (
   child: ChildProcessWithoutNullStreams,
   cancellation: AbortController
 ): void => {
-  const originalWrite = child.stdin.write.bind(child.stdin)
+  const originalWrite = child.stdin.write
+  const write = originalWrite.bind(child.stdin)
   let abortOnWrite = true
   child.stdin.write = ((
     chunk: string | Uint8Array,
@@ -302,10 +303,10 @@ const abortOnNextStdinWrite = (
   ) => {
     const result =
       typeof encoding === 'function'
-        ? originalWrite(chunk, encoding)
+        ? write(chunk, encoding)
         : encoding === undefined
-          ? originalWrite(chunk, cb)
-          : originalWrite(chunk, encoding, cb)
+          ? write(chunk, cb)
+          : write(chunk, encoding, cb)
     if (abortOnWrite) {
       abortOnWrite = false
       child.stdin.write = originalWrite
@@ -2164,14 +2165,16 @@ describe.skipIf(!rExecutable || !rScriptExecutable)('NotebookKernelExecutor (rea
         for (let i = 0; i < 50; i++) {
           const cancellation = new AbortController()
           abortOnNextStdinWrite(child, cancellation)
-          await expect(
-            executor.execute({
-              ...request,
-              code: 'Sys.sleep(30)',
-              language: 'r',
-              signal: cancellation.signal
-            })
-          ).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+          const result = await executor.execute({
+            ...request,
+            code: 'Sys.sleep(1)',
+            language: 'r',
+            signal: cancellation.signal
+          })
+          expect(result, `dispatch cancellation ${i + 1}`).toMatchObject({
+            status: 'cancelled',
+            traceback: ''
+          })
         }
 
         const next = await executor.execute({


### PR DESCRIPTION
## Problem

A late POSIX SIGINT can escape between the R loop local read/evaluation handlers and response emission. Rscript then exits with Execution halted, the persistent namespace is lost, and the stress test can attach its next abort hook to the stale child so that the next request reports completed instead of cancelled.

## Proposed change

- Keep one recoverable interrupt boundary active across R request transitions and response emission.
- Track only the current in-memory request ID so a late interrupt can emit the matching interrupt acknowledgement before the loop continues.
- Restore the exact original stdin write method in the stress helper and shorten the cancelled sleep while retaining 50 repeated cancellations and per-iteration diagnostics.

## Scope and non-goals

No public API, architecture boundary, UI interaction, data model, persisted format, database schema, migration, external status enum, or historical-data compatibility change. Windows retains its existing terminate-and-respawn cancellation behavior.

## Acceptance criteria and validation

The checks below ran against the final material implementation:

- repeated R cancellation and namespace preservation -> rtk npm test -- src/main/notebook/kernel-executor.test.ts -> 89 passed, 1 skipped
- R SIGINT protocol alignment and acknowledgement -> RUN_KERNEL=1 OPEN_SCIENCE_TEST_R_ENV=/usr/local rtk npm test -- src/main/notebook/r-loop.integration.test.ts -t SIGINT -> 3 passed, 43 not selected
- Node process types -> rtk npm run typecheck:node -> passed
- linted source and tests -> rtk npm run lint -> passed

A complete local npm test run was intentionally not run; PR CI is the authority for the full portable and platform suites.

## Review focus

Please focus on the lifetime of current_req_id around EOF, normal response emission, and the outer interrupt recovery handler. The state is process-local and never reaches the wire or persistence.