### PR TITLE
fix(session-persistence): reject linked authority paths

### DIFF
--- a/src/main/session-persistence/repository-queue.test.ts
+++ b/src/main/session-persistence/repository-queue.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 
 const fsMock = vi.hoisted(() => ({
+  lstat: vi.fn(),
   mkdir: vi.fn(),
   open: vi.fn(),
   readFile: vi.fn(),
@@ -56,6 +57,15 @@ const createSession = (id: string, projectId = 'project-a'): PersistedChatSessio
 describe('session persistence repository save ordering', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    fsMock.lstat.mockImplementation((path: string) =>
+      path.endsWith('.json')
+        ? Promise.reject(Object.assign(new Error('not found'), { code: 'ENOENT' }))
+        : Promise.resolve({
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false
+          })
+    )
     fsMock.open.mockResolvedValue({
       close: vi.fn().mockResolvedValue(undefined),
       sync: vi.fn().mockResolvedValue(undefined)

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -1,4 +1,14 @@
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, utimes, writeFile } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  utimes,
+  writeFile
+} from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
@@ -18,10 +28,16 @@ import {
 } from './repository'
 
 let storageRoot: string | undefined
+let externalRoot: string | undefined
 
 const createStorageRoot = async (): Promise<string> => {
   storageRoot = await mkdtemp(join(tmpdir(), 'open-science-sessions-'))
   return storageRoot
+}
+
+const createExternalRoot = async (): Promise<string> => {
+  externalRoot = await mkdtemp(join(tmpdir(), 'open-science-sessions-external-'))
+  return externalRoot
 }
 
 const createSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
@@ -62,6 +78,10 @@ afterEach(async () => {
   if (storageRoot) {
     await rm(storageRoot, { recursive: true, force: true })
     storageRoot = undefined
+  }
+  if (externalRoot) {
+    await rm(externalRoot, { recursive: true, force: true })
+    externalRoot = undefined
   }
 })
 
@@ -1289,6 +1309,110 @@ describe('session persistence repository (per-session files)', () => {
     expect(readDirectoryEntries).toHaveBeenCalledWith(projectDir)
   })
 
+  it('rejects saving through a symbolic link at the active sessions root', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    await symlink(
+      outside,
+      join(root, 'sessions'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const repository = new SessionRepository(root)
+
+    const saveRejected = await repository.saveSession(createSession()).then(
+      () => false,
+      () => true
+    )
+    const escaped = await readFile(join(outside, 'project-a', 'session-1.json'), 'utf8').then(
+      () => true,
+      () => false
+    )
+
+    expect({ saveRejected, escaped }).toEqual({ saveRejected: true, escaped: false })
+  })
+
+  it('rejects saving through a symbolic link at an active Project directory', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    await mkdir(join(root, 'sessions'), { recursive: true })
+    await symlink(
+      outside,
+      join(root, 'sessions', 'project-a'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const repository = new SessionRepository(root)
+
+    const saveRejected = await repository.saveSession(createSession()).then(
+      () => false,
+      () => true
+    )
+    const escaped = await readFile(join(outside, 'session-1.json'), 'utf8').then(
+      () => true,
+      () => false
+    )
+
+    expect({ saveRejected, escaped }).toEqual({ saveRejected: true, escaped: false })
+  })
+
+  it('marks the active Session scan incomplete for a symbolic-link Project entry', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    await mkdir(join(root, 'sessions'), { recursive: true })
+    await writeFile(
+      join(outside, 'session-1.json'),
+      JSON.stringify({ version: 2, session: createSession() }),
+      'utf8'
+    )
+    await symlink(
+      outside,
+      join(root, 'sessions', 'project-a'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const scan = await new SessionRepository(root).loadAllWithDiagnostics({ mode: 'read-only' })
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(false)
+  })
+
+  it('marks the active Session scan incomplete for a symbolic-link sessions root', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    await mkdir(join(outside, 'project-a'), { recursive: true })
+    await writeFile(
+      join(outside, 'project-a', 'session-1.json'),
+      JSON.stringify({ version: 2, session: createSession() }),
+      'utf8'
+    )
+    await symlink(
+      outside,
+      join(root, 'sessions'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const scan = await new SessionRepository(root).loadAllWithDiagnostics({ mode: 'read-only' })
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(false)
+  })
+
+  it('marks the active Session scan incomplete for a symbolic-link JSON entry', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    const projectDir = join(root, 'sessions', 'project-a')
+    await mkdir(projectDir, { recursive: true })
+    await symlink(
+      outside,
+      join(projectDir, 'session-1.json'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const scan = await new SessionRepository(root).loadAllWithDiagnostics({ mode: 'read-only' })
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(false)
+  })
+
   it('distinguishes an unreadable Session from an absent Session for terminal mutations', async () => {
     const root = await createStorageRoot()
     const session = createSession()
@@ -1935,7 +2059,9 @@ describe('session persistence repository (per-session files)', () => {
   })
 
   it('rejects ownership checks when the durable Session catalog is unreadable', async () => {
-    const repository = new SessionRepository(await createStorageRoot(), {
+    const root = await createStorageRoot()
+    await mkdir(join(root, 'sessions'), { recursive: true })
+    const repository = new SessionRepository(root, {
       readDirectoryEntries: vi
         .fn()
         .mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -1354,6 +1354,147 @@ describe('session persistence repository (per-session files)', () => {
     expect({ saveRejected, escaped }).toEqual({ saveRejected: true, escaped: false })
   })
 
+  it('rejects saving committed Project authority through a linked deletion root', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    await mkdir(join(outside, 'project-a'), { recursive: true })
+    await symlink(
+      outside,
+      join(root, 'deleted-sessions'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const repository = new SessionRepository(root)
+
+    const saveRejected = await repository.saveCommittedProjectSession(createSession()).then(
+      () => false,
+      () => true
+    )
+    const escaped = await readFile(join(outside, 'project-a', 'session-1.json'), 'utf8').then(
+      () => true,
+      () => false
+    )
+
+    expect({ saveRejected, escaped }).toEqual({ saveRejected: true, escaped: false })
+  })
+
+  it('marks committed Project authority incomplete through a linked deletion root', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    await mkdir(join(outside, 'project-a'), { recursive: true })
+    await writeFile(
+      join(outside, 'project-a', 'session-1.json'),
+      JSON.stringify({ version: 2, session: createSession() }),
+      'utf8'
+    )
+    await symlink(
+      outside,
+      join(root, 'deleted-sessions'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const loaded = await new SessionRepository(root).loadCommittedProjectWithDiagnostics(
+      'project-a'
+    )
+
+    expect(loaded).toEqual({ sessions: [], isComplete: false })
+  })
+
+  it('rejects moving live Project authority through a linked deletion root', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    const session = createSession()
+    const repository = new SessionRepository(root)
+    await repository.saveSession(session)
+    await symlink(
+      outside,
+      join(root, 'deleted-sessions'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const deletionRejected = await repository.deleteProjectSessions(session.projectId).then(
+      () => false,
+      () => true
+    )
+    const escaped = await readFile(
+      join(outside, session.projectId, `${session.id}.json`),
+      'utf8'
+    ).then(
+      () => true,
+      () => false
+    )
+    const liveRemains = await readFile(
+      join(root, 'sessions', session.projectId, `${session.id}.json`),
+      'utf8'
+    ).then(
+      () => true,
+      () => false
+    )
+
+    expect({ deletionRejected, escaped, liveRemains }).toEqual({
+      deletionRejected: true,
+      escaped: false,
+      liveRemains: true
+    })
+  })
+
+  it('rejects completing Project deletion through a linked deletion root', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    const externalProject = join(outside, 'project-a')
+    const externalAuthority = join(externalProject, 'keep.json')
+    await mkdir(externalProject, { recursive: true })
+    await writeFile(externalAuthority, 'external authority', 'utf8')
+    await symlink(
+      outside,
+      join(root, 'deleted-sessions'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const repository = new SessionRepository(root)
+
+    const completionRejected = await repository.completeProjectSessionDeletion('project-a').then(
+      () => false,
+      () => true
+    )
+    const externalRemains = await readFile(externalAuthority, 'utf8').then(
+      () => true,
+      () => false
+    )
+
+    expect({ completionRejected, externalRemains }).toEqual({
+      completionRejected: true,
+      externalRemains: true
+    })
+  })
+
+  it('rejects classifying Project deletion authority through a linked deletion root', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    await mkdir(join(outside, 'project-a'), { recursive: true })
+    await symlink(
+      outside,
+      join(root, 'deleted-sessions'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    await expect(
+      new SessionRepository(root).getProjectSessionDeletionState('project-a')
+    ).rejects.toThrow(/Deleted Session root/i)
+  })
+
+  it('rejects listing Project deletion authority through a linked deletion root', async () => {
+    const root = await createStorageRoot()
+    const outside = await createExternalRoot()
+    await symlink(
+      outside,
+      join(root, 'deleted-sessions'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    await expect(new SessionRepository(root).listLegacyProjectSessionTombstones()).rejects.toThrow(
+      /Deleted Session root/i
+    )
+  })
+
   it('marks the active Session scan incomplete for a symbolic-link Project entry', async () => {
     const root = await createStorageRoot()
     const outside = await createExternalRoot()

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -783,6 +783,10 @@ class SessionRepository {
     projectId: string
   ): Promise<ProjectSessionLoadDiagnostics> {
     const safeProjectId = assertSafeSegment(projectId)
+    const deletedSessionsBoundary = await this.inspectDirectoryBoundary(this.deletedSessionsDir)
+    if (deletedSessionsBoundary !== 'valid') {
+      return { sessions: [], isComplete: deletedSessionsBoundary === 'missing' }
+    }
     return this.readProjectSessionsAtDirectory(
       safeProjectId,
       this.deletedProjectDir(safeProjectId),
@@ -854,6 +858,7 @@ class SessionRepository {
       if ((await this.getProjectSessionDeletionState(session.projectId)) !== 'legacy-committed') {
         throw new Error('Cannot save a Session outside committed Project deletion authority.')
       }
+      await this.ensureDirectoryBoundary(this.deletedSessionsDir, 'Deleted Session root')
       const key = `${session.projectId}:${session.id}`
       const durableSession: PersistedChatSession = {
         ...session,
@@ -942,10 +947,10 @@ class SessionRepository {
       const safeProjectId = assertSafeSegment(projectId)
       const state = await this.getProjectSessionDeletionState(safeProjectId)
       if (state === 'legacy-committed' || state === 'prepared') return
+      await this.ensureDirectoryBoundary(this.deletedSessionsDir, 'Deleted Session root')
 
       const liveProjectDir = this.projectDir(safeProjectId)
       const deletedProjectDir = this.deletedProjectDir(safeProjectId)
-      await mkdir(this.deletedSessionsDir, { recursive: true })
       await this.dependencies.remove(deletedProjectDir, { recursive: true, force: true })
       await mkdir(liveProjectDir, { recursive: true })
       await writeFile(join(liveProjectDir, PROJECT_DELETION_COMMIT_MARKER), '', 'utf8')
@@ -956,6 +961,9 @@ class SessionRepository {
 
   async getProjectSessionDeletionState(projectId: string): Promise<ProjectSessionDeletionState> {
     const safeProjectId = assertSafeSegment(projectId)
+    if ((await this.inspectDirectoryBoundary(this.deletedSessionsDir)) === 'invalid') {
+      throw new Error('Deleted Session root is not a regular directory.')
+    }
     const deletedProjectDir = this.deletedProjectDir(safeProjectId)
     const liveProjectDir = this.projectDir(safeProjectId)
     const markerPath = join(deletedProjectDir, PROJECT_DELETION_COMMIT_MARKER)
@@ -1017,7 +1025,13 @@ class SessionRepository {
 
   async completeProjectSessionDeletion(projectId: string): Promise<void> {
     await this.operationScheduler.runProject(projectId, async () => {
-      await this.dependencies.remove(this.deletedProjectDir(assertSafeSegment(projectId)), {
+      const safeProjectId = assertSafeSegment(projectId)
+      const deletedSessionsBoundary = await this.inspectDirectoryBoundary(this.deletedSessionsDir)
+      if (deletedSessionsBoundary === 'missing') return
+      if (deletedSessionsBoundary === 'invalid') {
+        throw new Error('Deleted Session root is not a regular directory.')
+      }
+      await this.dependencies.remove(this.deletedProjectDir(safeProjectId), {
         recursive: true,
         force: true
       })
@@ -1026,6 +1040,11 @@ class SessionRepository {
   }
 
   async listLegacyProjectSessionTombstones(): Promise<string[]> {
+    const deletedSessionsBoundary = await this.inspectDirectoryBoundary(this.deletedSessionsDir)
+    if (deletedSessionsBoundary === 'missing') return []
+    if (deletedSessionsBoundary === 'invalid') {
+      throw new Error('Deleted Session root is not a regular directory.')
+    }
     let entries
     try {
       entries = await readdir(this.deletedSessionsDir, { withFileTypes: true })

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -164,6 +164,7 @@ type ProjectSessionLoadDiagnostics = {
 }
 
 type ProjectSessionDeletionState = 'live' | 'legacy-committed' | 'prepared' | 'absent'
+type FilesystemBoundaryState = 'missing' | 'valid' | 'invalid'
 
 class UnsupportedSessionFileError extends DurableJsonRecoveryBarrierError {}
 
@@ -333,6 +334,43 @@ class SessionRepository {
 
   private deletedProjectDir(projectId: string): string {
     return join(this.deletedSessionsDir, assertSafeSegment(projectId))
+  }
+
+  private async inspectDirectoryBoundary(path: string): Promise<FilesystemBoundaryState> {
+    try {
+      const metadata = await lstat(path)
+      return metadata.isDirectory() && !metadata.isSymbolicLink() ? 'valid' : 'invalid'
+    } catch (error) {
+      return isMissingFileError(error) ? 'missing' : 'invalid'
+    }
+  }
+
+  private async inspectFileBoundary(path: string): Promise<FilesystemBoundaryState> {
+    try {
+      const metadata = await lstat(path)
+      return metadata.isFile() && !metadata.isSymbolicLink() ? 'valid' : 'invalid'
+    } catch (error) {
+      return isMissingFileError(error) ? 'missing' : 'invalid'
+    }
+  }
+
+  private async inspectActiveProjectBoundary(projectId: string): Promise<FilesystemBoundaryState> {
+    const sessions = await this.inspectDirectoryBoundary(this.sessionsDir)
+    if (sessions !== 'valid') return sessions
+    return this.inspectDirectoryBoundary(this.projectDir(projectId))
+  }
+
+  private async ensureDirectoryBoundary(path: string, label: string): Promise<void> {
+    await mkdir(path, { recursive: true })
+    if ((await this.inspectDirectoryBoundary(path)) !== 'valid') {
+      throw new Error(`${label} is not a regular directory.`)
+    }
+  }
+
+  private async assertFileBoundary(path: string, label: string): Promise<void> {
+    if ((await this.inspectFileBoundary(path)) === 'invalid') {
+      throw new Error(`${label} is not a regular file.`)
+    }
   }
 
   // Loads every per-session file plus the manifest.
@@ -588,6 +626,7 @@ class SessionRepository {
     sessionId: string
   ): Promise<PersistedChatSession | undefined> {
     const safeProjectId = assertSafeSegment(projectId)
+    if ((await this.inspectActiveProjectBoundary(safeProjectId)) !== 'valid') return undefined
     return (
       await this.readSessionFile(
         this.sessionFilePath(safeProjectId, assertSafeSegment(sessionId)),
@@ -605,6 +644,9 @@ class SessionRepository {
   ): Promise<SessionLoadDiagnostic> {
     const safeProjectId = assertSafeSegment(projectId)
     const safeSessionId = assertSafeSegment(sessionId)
+    const projectBoundary = await this.inspectActiveProjectBoundary(safeProjectId)
+    if (projectBoundary === 'invalid') return { status: 'unreadable' }
+    if (projectBoundary === 'missing') return { status: 'missing' }
     const read = await this.readSessionFile(
       this.sessionFilePath(safeProjectId, safeSessionId),
       safeProjectId,
@@ -1018,6 +1060,7 @@ class SessionRepository {
 
   // Writes through a unique temp file, then atomically replaces the target session file.
   private async writeSession(session: PersistedChatSession): Promise<void> {
+    await this.ensureDirectoryBoundary(this.sessionsDir, 'Active Session root')
     await this.writeSessionToDirectory(session, this.projectDir(session.projectId))
   }
 
@@ -1037,9 +1080,12 @@ class SessionRepository {
     const filePath = join(projectDirectory, `${assertSafeSegment(session.id)}.json`)
     const sanitizedSession = sanitizeSessionUploadedAttachments(session)
 
-    await mkdir(projectDirectory, { recursive: true })
+    await this.ensureDirectoryBoundary(projectDirectory, 'Session Project directory')
+    await this.assertFileBoundary(filePath, 'Session file')
     await this.preservePreS2Backup(filePath, sanitizedSession)
     await this.preservePreSubagentModelBackup(filePath, sanitizedSession)
+    await this.ensureDirectoryBoundary(projectDirectory, 'Session Project directory')
+    await this.assertFileBoundary(filePath, 'Session file')
     await this.atomicWrite(filePath, createSessionFile(encodeSessionDataPaths(sanitizedSession)))
   }
 
@@ -1145,7 +1191,8 @@ class SessionRepository {
   }
 
   private async writeManifest(request: SaveSessionManifestRequest): Promise<void> {
-    await mkdir(this.sessionsDir, { recursive: true })
+    await this.ensureDirectoryBoundary(this.sessionsDir, 'Active Session root')
+    await this.assertFileBoundary(this.manifestPath, 'Session manifest')
     await this.atomicWrite(this.manifestPath, normalizeSessionManifest(request))
   }
 
@@ -1162,6 +1209,21 @@ class SessionRepository {
     manifest: PersistedSessionManifest
     warning?: SessionLoadWarning
   }> {
+    const sessionsBoundary = await this.inspectDirectoryBoundary(this.sessionsDir)
+    if (sessionsBoundary === 'missing') return { manifest: createEmptySessionManifest() }
+    if (
+      sessionsBoundary === 'invalid' ||
+      (await this.inspectFileBoundary(this.manifestPath)) === 'invalid'
+    ) {
+      return {
+        manifest: createEmptySessionManifest(),
+        warning: {
+          kind: 'manifest-unreadable',
+          fileName: MANIFEST_FILE,
+          recovered: false
+        }
+      }
+    }
     try {
       const read = await readDurableJsonFile(
         this.manifestPath,
@@ -1234,7 +1296,8 @@ class SessionRepository {
         missingDirectoryIsIncomplete: true,
         quarantineInvalidFiles: options.quarantineInvalidFiles,
         warnings,
-        scanMetrics: options.scanMetrics
+        scanMetrics: options.scanMetrics,
+        sessionsBoundaryValidated: true
       })
       sessions.push(...project.sessions)
       isComplete &&= project.isComplete
@@ -1251,9 +1314,16 @@ class SessionRepository {
       quarantineInvalidFiles?: boolean
       warnings?: SessionLoadWarning[]
       scanMetrics?: SessionScanMetrics
+      sessionsBoundaryValidated?: boolean
     } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
     const projectId = assertSafeSegment(projectIdValue)
+    if (!options.sessionsBoundaryValidated) {
+      const sessionsBoundary = await this.inspectDirectoryBoundary(this.sessionsDir)
+      if (sessionsBoundary !== 'valid') {
+        return { sessions: [], isComplete: sessionsBoundary === 'missing' }
+      }
+    }
     return this.readProjectSessionsAtDirectory(
       projectId,
       join(this.sessionsDir, projectId),
@@ -1272,6 +1342,10 @@ class SessionRepository {
       scanMetrics?: SessionScanMetrics
     } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
+    const directoryBoundary = await this.inspectDirectoryBoundary(projectDir)
+    if (directoryBoundary === 'invalid') {
+      return { sessions: [], isComplete: false }
+    }
     let recoveryComplete = true
     try {
       await recoverDurableJsonDirectory(
@@ -1289,7 +1363,8 @@ class SessionRepository {
       recoveryComplete = false
     }
     const sessionFiles = await this.listSessionFileNames(projectDir, {
-      missingIsIncomplete: options.missingDirectoryIsIncomplete
+      missingIsIncomplete: options.missingDirectoryIsIncomplete,
+      directoryBoundaryValidated: directoryBoundary === 'valid'
     })
     const sessions: PersistedChatSession[] = []
     const activeQuarantines = new Set(sessionFiles.quarantinedPrimaryFileNames)
@@ -1347,6 +1422,18 @@ class SessionRepository {
     wasQuarantined?: boolean
     warning?: SessionLoadWarning
   }> {
+    const initialBoundary = await this.inspectFileBoundary(filePath)
+    if (initialBoundary === 'invalid') {
+      return {
+        isComplete: false,
+        warning: {
+          kind: 'unreadable',
+          projectId,
+          fileName: basename(filePath),
+          recovered: false
+        }
+      }
+    }
     let read:
       | { status: 'found'; value: { session: PersistedChatSession; bytes: number } }
       | { status: 'missing' }
@@ -1421,6 +1508,17 @@ class SessionRepository {
         }
       }
     }
+    if (initialBoundary === 'missing' && (await this.inspectFileBoundary(filePath)) !== 'valid') {
+      return {
+        isComplete: false,
+        warning: {
+          kind: 'unreadable',
+          projectId,
+          fileName: basename(filePath),
+          recovered: false
+        }
+      }
+    }
     if (options.scanMetrics) options.scanMetrics.sessionBytes += read.value.bytes
     return { session: read.value.session, isComplete: true }
   }
@@ -1461,12 +1559,16 @@ class SessionRepository {
 
   // ENOENT is an authoritative empty directory; any other readdir failure is a partial scan.
   private async listDirectoryNames(dir: string): Promise<{ names: string[]; isComplete: boolean }> {
+    const boundary = await this.inspectDirectoryBoundary(dir)
+    if (boundary !== 'valid') {
+      return { names: [], isComplete: boundary === 'missing' }
+    }
     try {
       const entries = await this.dependencies.readDirectoryEntries(dir)
 
       return {
         names: entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name),
-        isComplete: true
+        isComplete: entries.every((entry) => entry.isDirectory() || entry.isFile())
       }
     } catch (error) {
       return { names: [], isComplete: isMissingFileError(error) }
@@ -1478,12 +1580,22 @@ class SessionRepository {
   // In-progress temp writes stay excluded and non-ENOENT directory failures disable reconciliation.
   private async listSessionFileNames(
     dir: string,
-    options: { missingIsIncomplete?: boolean } = {}
+    options: { missingIsIncomplete?: boolean; directoryBoundaryValidated?: boolean } = {}
   ): Promise<{
     names: string[]
     isComplete: boolean
     quarantinedPrimaryFileNames: string[]
   }> {
+    if (!options.directoryBoundaryValidated) {
+      const boundary = await this.inspectDirectoryBoundary(dir)
+      if (boundary !== 'valid') {
+        return {
+          names: [],
+          isComplete: boundary === 'missing' && !options.missingIsIncomplete,
+          quarantinedPrimaryFileNames: []
+        }
+      }
+    }
     try {
       const entries = await this.dependencies.readDirectoryEntries(dir)
 
@@ -1497,8 +1609,9 @@ class SessionRepository {
               !entry.name.includes('.invalid-')
           )
           .map((entry) => entry.name),
-        isComplete: true,
+        isComplete: entries.every((entry) => entry.isFile() || !entry.name.includes('.json')),
         quarantinedPrimaryFileNames: entries.flatMap((entry) => {
+          if (!entry.isFile()) return []
           const match = /^(.*\.json)\.invalid-\d+-\d+$/u.exec(entry.name)
           return match ? [match[1]] : []
         })


### PR DESCRIPTION
## Problem

Active Session persistence did not validate symbolic-link boundaries consistently. A linked `sessions` root or Project directory allowed `saveSession()` to write authoritative JSON outside the configured storage root. Directory scans also ignored linked Project entries and JSON-shaped special nodes while reporting `isComplete: true`, allowing downstream reconciliation to treat hidden Session authority as absent.

## Proposed change

- validate the active `sessions` root, Project directory, and Session file with non-following metadata checks
- reject writes through linked or non-regular authority paths
- mark scans incomplete when Project links or JSON-shaped special nodes are present
- validate the same boundaries for direct Session reads
- keep anomalous nodes in place instead of deleting, quarantining, or migrating them
- add cross-platform regression coverage using POSIX directory links and Windows junctions
- complete the queue-test filesystem mock with the new `lstat` boundary metadata

## Scope and non-goals

- no database, persisted JSON, public interface, renderer, or domain-model changes
- no new persisted or domain enum values; the `missing | valid | invalid` classification is repository-internal only
- existing regular historical Session data remains compatible
- intentionally linked historical Session layouts now fail closed and require manual conversion to regular directories/files; this PR does not migrate them automatically
- does not attempt to eliminate a same-user concurrent path-swap TOCTOU race, which would require a substantially different native directory-handle design

## Acceptance criteria and validation

Production behavior checks ran after the final production edit. After CI identified an incomplete hoisted filesystem mock, the latest test-only edit was validated together with its repository owner file.

- linked root/Project writes are rejected and no external JSON is created -> focused symbolic-link regression loop -> 5 passed
- linked Project and JSON-shaped nodes make scans incomplete -> focused symbolic-link regression loop -> 5 passed
- existing Session persistence/recovery behavior remains intact -> `repository.test.ts` -> 79 passed
- Session persistence owner, contract, and representative consumer behavior after the final production edit -> module impact set -> 7 files, 360 passed
- queue scheduling plus repository owner behavior after the latest test-mock edit -> `repository.test.ts` + `repository-queue.test.ts` -> 2 files, 81 passed
- changed files match repository formatting and lint rules -> Prettier, targeted ESLint, and `git diff --check` -> passed
- Node typecheck was attempted after the final production commit but the shared local dependency tree lacks the `waitForMcpServers` export expected by `src/main/acp/claude-agent-acp-patch.test.ts`; no diagnostic referenced the changed files. PR CI uses a clean install and is authoritative.

The complete portable suite was not run locally; PR Gate and its selected platform lanes are authoritative.

## Review focus

- fail-closed completeness semantics for anomalous authority nodes
- preservation of missing-directory and durable-temp recovery behavior
- whether rejecting, rather than migrating, intentional historical symlink layouts is the correct compatibility boundary
- metadata-operation cost: each scanned boundary is validated once, with repeated checks skipped after validation