### PR TITLE
fix(platform): correct update and CLI platform handling

### DIFF
--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -443,11 +443,23 @@ describe('buildWindowsPathCommand', () => {
     const script = args[args.length - 1]
     expect(script).toContain(`$binDir = '${binDir}'`)
     expect(script).toContain(`$pendingPath = '${join(binDir, '.open-science-path-pending')}'`)
+    expect(script).toContain(
+      `$pendingTempPath = '${join(binDir, '.open-science-path-pending.tmp')}'`
+    )
     expect(script).toContain(`$receiptPath = '${join(binDir, '.open-science-path-receipt')}'`)
     expect(script).toContain(`$receiptOwner = '${WINDOWS_PATH_RECEIPT_OWNER}'`)
     expect(script).toContain("TrimEnd([char[]]'\\/') -ieq $normalizedBinDir")
     expect(script).toContain("[Environment]::SetEnvironmentVariable('Path'")
+    expect(script).toContain(
+      '$stream = [IO.File]::Open($pendingTempPath, [IO.FileMode]::CreateNew,'
+    )
+    expect(script).toContain(
+      'if ([IO.File]::Exists($pendingTempPath)) { [IO.File]::Delete($pendingTempPath) }'
+    )
     expect(script.indexOf('$stream.Flush($true)')).toBeLessThan(
+      script.indexOf('[IO.File]::Move($pendingTempPath, $pendingPath)')
+    )
+    expect(script.indexOf('[IO.File]::Move($pendingTempPath, $pendingPath)')).toBeLessThan(
       script.lastIndexOf("[Environment]::SetEnvironmentVariable('Path', $next")
     )
     expect(script.lastIndexOf("[Environment]::SetEnvironmentVariable('Path', $next")).toBeLessThan(

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -324,7 +324,7 @@ describe.each([
     await expect(getCliLauncherStatus(env)).resolves.toMatchObject({ installed: true })
     await installCliLauncher(env, () => true)
     await expect(readFile(plan.target, 'utf8')).resolves.toBe(plan.shim)
-    await uninstallCliLauncher(env)
+    await uninstallCliLauncher(env, () => true)
     await expect(readFile(plan.target, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })
@@ -420,6 +420,7 @@ describe('buildWindowsPathCommand', () => {
     expect(args).not.toContain('-args')
     const script = args[args.length - 1]
     expect(script).toContain("$binDir = 'C:\\Users\\me\\AppData\\Roaming\\Open Science\\bin'")
+    expect(script).toContain("TrimEnd([char[]]'\\/') -ieq $normalizedBinDir")
     expect(script).toContain("[Environment]::SetEnvironmentVariable('Path'")
   })
 
@@ -457,13 +458,50 @@ describe('installCliLauncher on Windows PATH edit', () => {
   it('skips the PATH edit entirely when the bin dir is already on PATH', async () => {
     const binDir = join(home, 'AppData', 'Roaming', 'Open Science', 'bin')
     let called = false
-    const status = await installCliLauncher(winEnv({ pathVar: `C:\\Windows;${binDir}` }), () => {
-      called = true
-      return true
-    })
+    const status = await installCliLauncher(
+      winEnv({ pathVar: `C:\\Windows;${binDir.toUpperCase()}\\` }),
+      () => {
+        called = true
+        return true
+      }
+    )
     expect(called).toBe(false)
     expect(status.onPath).toBe(true)
     expect(status.pathHint).toBeUndefined()
+  })
+})
+
+describe('uninstallCliLauncher on Windows PATH edit', () => {
+  it('removes the owned PATH entry before deleting the managed shim', async () => {
+    const env = winEnv()
+    await installCliLauncher(env, () => true)
+    const calls: Array<{ command: string; args: string[] }> = []
+
+    const status = await uninstallCliLauncher(env, (command, args) => {
+      calls.push({ command, args })
+      return true
+    })
+
+    expect(calls).toHaveLength(1)
+    const script = calls[0].args.at(-1) ?? ''
+    expect(script).toContain("TrimEnd([char[]]'\\/') -ine $normalizedBinDir")
+    expect(script).toContain('if ($nextParts.Count -ne $parts.Count)')
+    expect(script).toContain("SetEnvironmentVariable('Path', $next, 'User')")
+    expect(script).toContain('if ($remaining.Count -gt 0) { exit 1 }')
+    expect(status).toMatchObject({ installed: false, onPath: false })
+    await expect(readFile(planCliLauncher(env).target, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('keeps the managed shim so a failed PATH cleanup can be retried', async () => {
+    const env = winEnv()
+    await installCliLauncher(env, () => true)
+
+    await expect(uninstallCliLauncher(env, () => false)).rejects.toThrow('Could not remove')
+    await expect(readFile(planCliLauncher(env).target, 'utf8')).resolves.toContain(
+      'Managed by the app'
+    )
   })
 })
 

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -56,6 +56,13 @@ const winEnv = (overrides: Partial<CliLauncherEnv> = {}): CliLauncherEnv => ({
   ...overrides
 })
 
+const WINDOWS_PATH_RECEIPT_CONTENT = 'Open Science Windows PATH entry. Managed by the app.'
+const windowsPathReceiptPath = (env: CliLauncherEnv): string =>
+  join(planCliLauncher(env).binDir, '.open-science-path-receipt')
+const writeWindowsPathReceipt = async (env: CliLauncherEnv): Promise<void> => {
+  await writeFile(windowsPathReceiptPath(env), WINDOWS_PATH_RECEIPT_CONTENT)
+}
+
 beforeEach(async () => {
   home = await mkdtemp(join(tmpdir(), 'os-cli-'))
 })
@@ -410,18 +417,25 @@ describe('hard-linked launcher safety', () => {
 
 describe('buildWindowsPathCommand', () => {
   it('embeds the bin dir as a PowerShell literal, not via -args', () => {
-    const { command, args } = buildWindowsPathCommand(
-      'C:\\Users\\me\\AppData\\Roaming\\Open Science\\bin'
-    )
+    const binDir = 'C:\\Users\\me\\AppData\\Roaming\\Open Science\\bin'
+    const { command, args } = buildWindowsPathCommand(binDir)
     expect(command).toBe('powershell')
     // The script must be passed to -Command and contain the actual dir literal; -args (the fragile
     // form that could leave $args empty and write the wrong PATH) must not be used.
     expect(args).toContain('-Command')
     expect(args).not.toContain('-args')
     const script = args[args.length - 1]
-    expect(script).toContain("$binDir = 'C:\\Users\\me\\AppData\\Roaming\\Open Science\\bin'")
+    expect(script).toContain(`$binDir = '${binDir}'`)
+    expect(script).toContain(`$receiptPath = '${join(binDir, '.open-science-path-receipt')}'`)
+    expect(script).toContain(`$receiptContent = '${WINDOWS_PATH_RECEIPT_CONTENT}'`)
     expect(script).toContain("TrimEnd([char[]]'\\/') -ieq $normalizedBinDir")
     expect(script).toContain("[Environment]::SetEnvironmentVariable('Path'")
+    expect(script.indexOf("[Environment]::SetEnvironmentVariable('Path', $next")).toBeLessThan(
+      script.indexOf('[IO.File]::WriteAllText')
+    )
+    expect(script).toContain(
+      "try { [Environment]::SetEnvironmentVariable('Path', $current, 'User') } catch {}"
+    )
   })
 
   it("doubles embedded single quotes so a quote in the path can't break out of the literal", () => {
@@ -475,6 +489,7 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
   it('removes the owned PATH entry before deleting the managed shim', async () => {
     const env = winEnv()
     await installCliLauncher(env, () => true)
+    await writeWindowsPathReceipt(env)
     const calls: Array<{ command: string; args: string[] }> = []
 
     const status = await uninstallCliLauncher(env, (command, args) => {
@@ -484,12 +499,16 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
 
     expect(calls).toHaveLength(1)
     const script = calls[0].args.at(-1) ?? ''
-    expect(script).toContain("TrimEnd([char[]]'\\/') -ine $normalizedBinDir")
-    expect(script).toContain('if ($nextParts.Count -ne $parts.Count)')
+    expect(script).toContain('$removeIndex = -1')
+    expect(script).toContain('for ($i = $parts.Count - 1; $i -ge 0; $i--)')
+    expect(script).toContain("TrimEnd([char[]]'\\/') -ieq $normalizedBinDir")
+    expect(script).toContain('if ($i -ne $removeIndex) { $parts[$i] }')
     expect(script).toContain("SetEnvironmentVariable('Path', $next, 'User')")
-    expect(script).toContain('if ($remaining.Count -gt 0) { exit 1 }')
     expect(status).toMatchObject({ installed: false, onPath: false })
     await expect(readFile(planCliLauncher(env).target, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(readFile(windowsPathReceiptPath(env), 'utf8')).rejects.toMatchObject({
       code: 'ENOENT'
     })
   })
@@ -497,11 +516,33 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
   it('keeps the managed shim so a failed PATH cleanup can be retried', async () => {
     const env = winEnv()
     await installCliLauncher(env, () => true)
+    await writeWindowsPathReceipt(env)
 
     await expect(uninstallCliLauncher(env, () => false)).rejects.toThrow('Could not remove')
     await expect(readFile(planCliLauncher(env).target, 'utf8')).resolves.toContain(
       'Managed by the app'
     )
+    await expect(readFile(windowsPathReceiptPath(env), 'utf8')).resolves.toBe(
+      WINDOWS_PATH_RECEIPT_CONTENT
+    )
+  })
+
+  it('preserves a pre-existing user PATH entry when no ownership receipt exists', async () => {
+    const binDir = join(home, 'AppData', 'Roaming', 'Open Science', 'bin')
+    const env = winEnv({ pathVar: `C:\\Windows;${binDir.toUpperCase()}\\` })
+    const runCommand = vi.fn(() => true)
+    await installCliLauncher(env, runCommand)
+
+    const status = await uninstallCliLauncher(env, runCommand)
+
+    expect(runCommand).not.toHaveBeenCalled()
+    expect(status).toMatchObject({ installed: false, onPath: false })
+    await expect(readFile(windowsPathReceiptPath(env), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(readFile(planCliLauncher(env).target, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
   })
 })
 

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -550,11 +550,12 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
     expect(calls).toHaveLength(1)
     const script = calls[0].args.at(-1) ?? ''
     expect(script).toContain("$state = 'owned'")
-    expect(script).toContain('$matches = @(for ($i = 0; $i -lt $parts.Count; $i++)')
+    expect(script).toContain('$matches = @($parts | Where-Object')
     expect(script).toContain("TrimEnd([char[]]'\\/') -ieq $normalizedBinDir")
-    expect(script).toContain('if ($i -ne $removeIndex) { $parts[$i] }')
-    expect(script).toContain("throw 'Multiple equivalent PATH entries make ownership ambiguous.'")
-    expect(script).toContain("SetEnvironmentVariable('Path', $next, 'User')")
+    expect(script).toContain(
+      "throw 'The owned PATH entry no longer matches its recorded snapshot.'"
+    )
+    expect(script).toContain("SetEnvironmentVariable('Path', $beforePath, 'User')")
     expect(status).toMatchObject({ installed: false, onPath: false })
     await expect(readFile(planCliLauncher(env).target, 'utf8')).rejects.toMatchObject({
       code: 'ENOENT'
@@ -564,7 +565,7 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
     })
   })
 
-  it('fails closed for ambiguous duplicates and keeps cleanup retryable', async () => {
+  it('fails closed when ownership continuity no longer matches the recorded snapshot', async () => {
     const env = winEnv()
     await installCliLauncher(env, () => true)
     await writeWindowsPathJournal(env)
@@ -572,7 +573,7 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
     await expect(
       uninstallCliLauncher(env, (_command, args) => {
         expect(args.at(-1)).toContain(
-          "throw 'Multiple equivalent PATH entries make ownership ambiguous.'"
+          "throw 'The owned PATH entry no longer matches its recorded snapshot.'"
         )
         return false
       })

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -514,6 +514,24 @@ describe('installCliLauncher on Windows PATH edit', () => {
     expect(status.onPath).toBe(true)
     expect(status.pathHint).toBeUndefined()
   })
+
+  it.each([
+    ['unmanaged', 'because it is not managed by Open Science'],
+    ['ambiguous', 'The Windows PATH ownership journal is ambiguous.']
+  ] as const)('rejects an %s PATH journal before creating the shim', async (scenario, message) => {
+    const env = winEnv()
+    const plan = planCliLauncher(env)
+    await mkdir(plan.binDir, { recursive: true })
+    if (scenario === 'unmanaged') {
+      await writeFile(windowsPathReceiptPath(env), 'user-owned content')
+    } else {
+      await writeWindowsPathJournal(env, 'pending')
+      await writeWindowsPathJournal(env, 'owned')
+    }
+
+    await expect(installCliLauncher(env, () => true)).rejects.toThrow(message)
+    await expect(readFile(plan.target, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
 })
 
 describe('uninstallCliLauncher on Windows PATH edit', () => {

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -56,11 +56,27 @@ const winEnv = (overrides: Partial<CliLauncherEnv> = {}): CliLauncherEnv => ({
   ...overrides
 })
 
-const WINDOWS_PATH_RECEIPT_CONTENT = 'Open Science Windows PATH entry. Managed by the app.'
+const WINDOWS_PATH_RECEIPT_OWNER = 'Open Science Windows PATH entry. Managed by the app.'
+const windowsPathPendingPath = (env: CliLauncherEnv): string =>
+  join(planCliLauncher(env).binDir, '.open-science-path-pending')
 const windowsPathReceiptPath = (env: CliLauncherEnv): string =>
   join(planCliLauncher(env).binDir, '.open-science-path-receipt')
-const writeWindowsPathReceipt = async (env: CliLauncherEnv): Promise<void> => {
-  await writeFile(windowsPathReceiptPath(env), WINDOWS_PATH_RECEIPT_CONTENT)
+const writeWindowsPathJournal = async (
+  env: CliLauncherEnv,
+  state: 'pending' | 'owned' = 'owned',
+  beforePath = 'C:\\Windows\\System32'
+): Promise<void> => {
+  const binDir = planCliLauncher(env).binDir
+  await writeFile(
+    state === 'pending' ? windowsPathPendingPath(env) : windowsPathReceiptPath(env),
+    JSON.stringify({
+      version: 1,
+      owner: WINDOWS_PATH_RECEIPT_OWNER,
+      binDir,
+      beforePath,
+      afterPath: `${beforePath};${binDir}`
+    })
+  )
 }
 
 beforeEach(async () => {
@@ -426,16 +442,18 @@ describe('buildWindowsPathCommand', () => {
     expect(args).not.toContain('-args')
     const script = args[args.length - 1]
     expect(script).toContain(`$binDir = '${binDir}'`)
+    expect(script).toContain(`$pendingPath = '${join(binDir, '.open-science-path-pending')}'`)
     expect(script).toContain(`$receiptPath = '${join(binDir, '.open-science-path-receipt')}'`)
-    expect(script).toContain(`$receiptContent = '${WINDOWS_PATH_RECEIPT_CONTENT}'`)
+    expect(script).toContain(`$receiptOwner = '${WINDOWS_PATH_RECEIPT_OWNER}'`)
     expect(script).toContain("TrimEnd([char[]]'\\/') -ieq $normalizedBinDir")
     expect(script).toContain("[Environment]::SetEnvironmentVariable('Path'")
-    expect(script.indexOf("[Environment]::SetEnvironmentVariable('Path', $next")).toBeLessThan(
-      script.indexOf('[IO.File]::WriteAllText')
+    expect(script.indexOf('$stream.Flush($true)')).toBeLessThan(
+      script.lastIndexOf("[Environment]::SetEnvironmentVariable('Path', $next")
     )
-    expect(script).toContain(
-      "try { [Environment]::SetEnvironmentVariable('Path', $current, 'User') } catch {}"
+    expect(script.lastIndexOf("[Environment]::SetEnvironmentVariable('Path', $next")).toBeLessThan(
+      script.lastIndexOf('[IO.File]::Move($pendingPath, $receiptPath)')
     )
+    expect(script).toContain("throw 'The pending PATH ownership journal cannot be reconciled.'")
   })
 
   it("doubles embedded single quotes so a quote in the path can't break out of the literal", () => {
@@ -489,7 +507,7 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
   it('removes the owned PATH entry before deleting the managed shim', async () => {
     const env = winEnv()
     await installCliLauncher(env, () => true)
-    await writeWindowsPathReceipt(env)
+    await writeWindowsPathJournal(env)
     const calls: Array<{ command: string; args: string[] }> = []
 
     const status = await uninstallCliLauncher(env, (command, args) => {
@@ -499,10 +517,11 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
 
     expect(calls).toHaveLength(1)
     const script = calls[0].args.at(-1) ?? ''
-    expect(script).toContain('$removeIndex = -1')
-    expect(script).toContain('for ($i = $parts.Count - 1; $i -ge 0; $i--)')
+    expect(script).toContain("$state = 'owned'")
+    expect(script).toContain('$matches = @(for ($i = 0; $i -lt $parts.Count; $i++)')
     expect(script).toContain("TrimEnd([char[]]'\\/') -ieq $normalizedBinDir")
     expect(script).toContain('if ($i -ne $removeIndex) { $parts[$i] }')
+    expect(script).toContain("throw 'Multiple equivalent PATH entries make ownership ambiguous.'")
     expect(script).toContain("SetEnvironmentVariable('Path', $next, 'User')")
     expect(status).toMatchObject({ installed: false, onPath: false })
     await expect(readFile(planCliLauncher(env).target, 'utf8')).rejects.toMatchObject({
@@ -513,18 +532,45 @@ describe('uninstallCliLauncher on Windows PATH edit', () => {
     })
   })
 
-  it('keeps the managed shim so a failed PATH cleanup can be retried', async () => {
+  it('fails closed for ambiguous duplicates and keeps cleanup retryable', async () => {
     const env = winEnv()
     await installCliLauncher(env, () => true)
-    await writeWindowsPathReceipt(env)
+    await writeWindowsPathJournal(env)
 
-    await expect(uninstallCliLauncher(env, () => false)).rejects.toThrow('Could not remove')
+    await expect(
+      uninstallCliLauncher(env, (_command, args) => {
+        expect(args.at(-1)).toContain(
+          "throw 'Multiple equivalent PATH entries make ownership ambiguous.'"
+        )
+        return false
+      })
+    ).rejects.toThrow('Could not remove')
     await expect(readFile(planCliLauncher(env).target, 'utf8')).resolves.toContain(
       'Managed by the app'
     )
-    await expect(readFile(windowsPathReceiptPath(env), 'utf8')).resolves.toBe(
-      WINDOWS_PATH_RECEIPT_CONTENT
+    await expect(readFile(windowsPathReceiptPath(env), 'utf8')).resolves.toContain(
+      WINDOWS_PATH_RECEIPT_OWNER
     )
+  })
+
+  it('reconciles a pending journal only when PATH matches its before or after snapshot', async () => {
+    const env = winEnv()
+    await installCliLauncher(env, () => true)
+    await writeWindowsPathJournal(env, 'pending')
+    const calls: Array<{ command: string; args: string[] }> = []
+
+    await uninstallCliLauncher(env, (command, args) => {
+      calls.push({ command, args })
+      return true
+    })
+
+    const script = calls[0].args.at(-1) ?? ''
+    expect(script).toContain("$state = 'pending'")
+    expect(script).toContain('if ($current -ceq $beforePath) { return }')
+    expect(script).toContain('if ($current -cne $afterPath)')
+    await expect(readFile(windowsPathPendingPath(env), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
   })
 
   it('preserves a pre-existing user PATH entry when no ownership receipt exists', async () => {

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -504,6 +504,38 @@ describe('installCliLauncher on Windows PATH edit', () => {
 })
 
 describe('uninstallCliLauncher on Windows PATH edit', () => {
+  it('cleans up an owned PATH entry even when the managed shim is already missing', async () => {
+    const env = winEnv()
+    await mkdir(planCliLauncher(env).binDir, { recursive: true })
+    await writeWindowsPathJournal(env)
+    const runCommand = vi.fn(() => true)
+
+    const status = await uninstallCliLauncher(env, runCommand)
+
+    expect(runCommand).toHaveBeenCalledOnce()
+    expect(status).toMatchObject({ installed: false, onPath: false })
+    await expect(readFile(windowsPathReceiptPath(env), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('preserves the shim and aborts when an existing PATH journal is unmanaged', async () => {
+    const env = winEnv()
+    await installCliLauncher(env, () => true)
+    await writeFile(windowsPathReceiptPath(env), 'user-owned content')
+    const runCommand = vi.fn(() => true)
+
+    await expect(uninstallCliLauncher(env, runCommand)).rejects.toThrow(
+      'because it is not managed by Open Science'
+    )
+
+    expect(runCommand).not.toHaveBeenCalled()
+    await expect(readFile(planCliLauncher(env).target, 'utf8')).resolves.toContain(
+      'Managed by the app'
+    )
+    await expect(readFile(windowsPathReceiptPath(env), 'utf8')).resolves.toBe('user-owned content')
+  })
+
   it('removes the owned PATH entry before deleting the managed shim', async () => {
     const env = winEnv()
     await installCliLauncher(env, () => true)

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -444,7 +444,7 @@ describe('buildWindowsPathCommand', () => {
     expect(script).toContain(`$binDir = '${binDir}'`)
     expect(script).toContain(`$pendingPath = '${join(binDir, '.open-science-path-pending')}'`)
     expect(script).toContain(
-      `$pendingTempPath = '${join(binDir, '.open-science-path-pending.tmp')}'`
+      "$pendingTempPath = [IO.Path]::Combine([IO.Path]::GetDirectoryName($pendingPath), '.open-science-path-pending.' + [Guid]::NewGuid().ToString('N') + '.tmp')"
     )
     expect(script).toContain(`$receiptPath = '${join(binDir, '.open-science-path-receipt')}'`)
     expect(script).toContain(`$receiptOwner = '${WINDOWS_PATH_RECEIPT_OWNER}'`)
@@ -453,8 +453,9 @@ describe('buildWindowsPathCommand', () => {
     expect(script).toContain(
       '$stream = [IO.File]::Open($pendingTempPath, [IO.FileMode]::CreateNew,'
     )
-    expect(script).toContain(
-      'if ([IO.File]::Exists($pendingTempPath)) { [IO.File]::Delete($pendingTempPath) }'
+    expect(script).toContain('if ($pendingTempCreated -and [IO.File]::Exists($pendingTempPath)) {')
+    expect(script.indexOf('$pendingTempCreated = $true')).toBeGreaterThan(
+      script.indexOf('$stream = [IO.File]::Open($pendingTempPath')
     )
     expect(script.indexOf('$stream.Flush($true)')).toBeLessThan(
       script.indexOf('[IO.File]::Move($pendingTempPath, $pendingPath)')

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -458,13 +458,7 @@ const openManagedWindowsPathJournal = async (
   target: string,
   binDir: string
 ): Promise<OpenCliLauncher | undefined> => {
-  let opened: OpenCliLauncher | undefined
-  try {
-    opened = await openStableCliLauncher(target, constants.O_RDONLY)
-  } catch (error) {
-    if (error instanceof UnmanagedCliLauncherError) return undefined
-    throw error
-  }
+  const opened = await openStableCliLauncher(target, constants.O_RDONLY)
   if (opened === undefined) return undefined
 
   try {
@@ -634,59 +628,62 @@ export const uninstallCliLauncher = async (
 ): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
   const opened = await openStableCliLauncher(plan.target, constants.O_RDONLY)
-  if (opened !== undefined) {
-    let pathJournal: OpenCliLauncher | undefined
-    try {
+  let pathJournal: OpenCliLauncher | undefined
+  try {
+    if (opened !== undefined) {
       const existing = await opened.handle.readFile('utf8')
       if (!isManagedCliLauncher(existing)) refuseUnmanagedCliLauncher(plan.target)
       if (!(await isOpenCliLauncherCurrent(plan.target, opened.stats))) {
         refuseUnmanagedCliLauncher(plan.target)
       }
-      if (env.platform === 'win32') {
-        const journalPaths = [
-          windowsPathPendingPath(plan.binDir),
-          windowsPathReceiptPath(plan.binDir)
-        ]
-        const existingJournalPaths: string[] = []
-        for (const journalPath of journalPaths) {
-          if ((await statCliLauncher(journalPath)) !== undefined) {
-            existingJournalPaths.push(journalPath)
-          }
-        }
-        if (existingJournalPaths.length > 1) {
-          throw new Error('The Windows PATH ownership journal is ambiguous.')
-        }
-        const journalPath = existingJournalPaths[0]
-        if (journalPath !== undefined) {
-          pathJournal = await openManagedWindowsPathJournal(journalPath, plan.binDir)
-        }
-        if (pathJournal !== undefined && journalPath !== undefined) {
-          const journalStats = pathJournal.stats
-          const state = journalPath === journalPaths[0] ? 'pending' : 'owned'
-          const { command, args } = buildWindowsPathRemovalCommand(plan.binDir, journalPath, state)
-          if (!runCommand(command, args)) {
-            throw new Error(`Could not remove ${plan.binDir} from the user PATH.`)
-          }
-          if (!(await isOpenCliLauncherCurrent(journalPath, pathJournal.stats))) {
-            refuseUnmanagedCliLauncher(journalPath)
-          }
-          await pathJournal.handle.close()
-          pathJournal = undefined
-
-          const finalJournal = await statCliLauncher(journalPath)
-          if (finalJournal !== undefined) {
-            if (!isDirectRegularFile(finalJournal) || !isSameFile(finalJournal, journalStats)) {
-              refuseUnmanagedCliLauncher(journalPath)
-            }
-            await rm(journalPath)
-          }
-        }
-      }
-    } finally {
-      await pathJournal?.handle.close()
-      await opened.handle.close()
     }
 
+    if (env.platform === 'win32') {
+      const journalPaths = [
+        windowsPathPendingPath(plan.binDir),
+        windowsPathReceiptPath(plan.binDir)
+      ]
+      const existingJournalPaths: string[] = []
+      for (const journalPath of journalPaths) {
+        if ((await statCliLauncher(journalPath)) !== undefined) {
+          existingJournalPaths.push(journalPath)
+        }
+      }
+      if (existingJournalPaths.length > 1) {
+        throw new Error('The Windows PATH ownership journal is ambiguous.')
+      }
+      const journalPath = existingJournalPaths[0]
+      if (journalPath !== undefined) {
+        const openedJournal =
+          (await openManagedWindowsPathJournal(journalPath, plan.binDir)) ??
+          refuseUnmanagedCliLauncher(journalPath)
+        pathJournal = openedJournal
+
+        const journalStats = openedJournal.stats
+        const state = journalPath === journalPaths[0] ? 'pending' : 'owned'
+        const { command, args } = buildWindowsPathRemovalCommand(plan.binDir, journalPath, state)
+        if (!runCommand(command, args)) {
+          throw new Error(`Could not remove ${plan.binDir} from the user PATH.`)
+        }
+        if (!(await isOpenCliLauncherCurrent(journalPath, openedJournal.stats))) {
+          refuseUnmanagedCliLauncher(journalPath)
+        }
+        await openedJournal.handle.close()
+        pathJournal = undefined
+
+        const finalJournal = await statCliLauncher(journalPath)
+        if (finalJournal !== undefined) {
+          if (!isDirectRegularFile(finalJournal) || !isSameFile(finalJournal, journalStats)) {
+            refuseUnmanagedCliLauncher(journalPath)
+          }
+          await rm(journalPath)
+        }
+      }
+    }
+
+    if (opened === undefined) {
+      return { installed: false, target: plan.target, onPath: false }
+    }
     const final = await statCliLauncher(plan.target)
     if (final !== undefined) {
       if (!isDirectRegularFile(final) || !isSameFile(opened.stats, final)) {
@@ -694,6 +691,9 @@ export const uninstallCliLauncher = async (
       }
       await rm(plan.target)
     }
+  } finally {
+    await pathJournal?.handle.close()
+    await opened?.handle.close()
   }
   return { installed: false, target: plan.target, onPath: false }
 }

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -586,6 +586,21 @@ export const installCliLauncher = async (
   const plan = planCliLauncher(env)
   await mkdir(plan.binDir, { recursive: true })
 
+  if (env.platform === 'win32') {
+    const journalPaths = [windowsPathPendingPath(plan.binDir), windowsPathReceiptPath(plan.binDir)]
+    const existingJournalPaths: string[] = []
+    for (const journalPath of journalPaths) {
+      if ((await statCliLauncher(journalPath)) === undefined) continue
+      existingJournalPaths.push(journalPath)
+      if (parseWindowsPathJournal(await readCliLauncher(journalPath), plan.binDir) === undefined) {
+        refuseUnmanagedCliLauncher(journalPath)
+      }
+    }
+    if (existingJournalPaths.length > 1) {
+      throw new Error('The Windows PATH ownership journal is ambiguous.')
+    }
+  }
+
   let written = false
   for (let attempt = 0; attempt < 3 && !written; attempt += 1) {
     if (await tryCreateCliLauncher(plan)) {
@@ -610,17 +625,6 @@ export const installCliLauncher = async (
   let pathHint: string | undefined
   if (!onPath) {
     if (env.platform === 'win32') {
-      for (const journalPath of [
-        windowsPathPendingPath(plan.binDir),
-        windowsPathReceiptPath(plan.binDir)
-      ]) {
-        if (
-          (await statCliLauncher(journalPath)) !== undefined &&
-          parseWindowsPathJournal(await readCliLauncher(journalPath), plan.binDir) === undefined
-        ) {
-          refuseUnmanagedCliLauncher(journalPath)
-        }
-      }
       const { command, args } = buildWindowsPathCommand(plan.binDir)
       onPath = runCommand(command, args)
       pathHint = onPath

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -190,11 +190,14 @@ const defaultRunCommand: CommandRunner = (command, args) => {
 }
 
 const WINDOWS_PATH_PENDING_NAME = '.open-science-path-pending'
+const WINDOWS_PATH_PENDING_TEMP_NAME = '.open-science-path-pending.tmp'
 const WINDOWS_PATH_RECEIPT_NAME = '.open-science-path-receipt'
 const WINDOWS_PATH_RECEIPT_OWNER = 'Open Science Windows PATH entry. Managed by the app.'
 // The file name is the journal state: pending is flushed before the registry mutation, then renamed
 // to the owned receipt as the commit step. The snapshots let a later run reconcile a crash safely.
 const windowsPathPendingPath = (binDir: string): string => join(binDir, WINDOWS_PATH_PENDING_NAME)
+const windowsPathPendingTempPath = (binDir: string): string =>
+  join(binDir, WINDOWS_PATH_PENDING_TEMP_NAME)
 const windowsPathReceiptPath = (binDir: string): string => join(binDir, WINDOWS_PATH_RECEIPT_NAME)
 const powershellLiteral = (value: string): string => `'${value.replace(/'/g, "''")}'`
 
@@ -238,11 +241,13 @@ const parseWindowsPathJournal = (
 // like `-args <dir>` are unreliable and can leave $args empty, writing the wrong value into PATH.
 export const buildWindowsPathCommand = (binDir: string): { command: string; args: string[] } => {
   const pendingPath = windowsPathPendingPath(binDir)
+  const pendingTempPath = windowsPathPendingTempPath(binDir)
   const receiptPath = windowsPathReceiptPath(binDir)
   const script = [
     "$ErrorActionPreference = 'Stop'",
     `$binDir = ${powershellLiteral(binDir)}`,
     `$pendingPath = ${powershellLiteral(pendingPath)}`,
+    `$pendingTempPath = ${powershellLiteral(pendingTempPath)}`,
     `$receiptPath = ${powershellLiteral(receiptPath)}`,
     `$receiptOwner = ${powershellLiteral(WINDOWS_PATH_RECEIPT_OWNER)}`,
     'function Get-PathParts($value) {',
@@ -277,13 +282,20 @@ export const buildWindowsPathCommand = (binDir: string): { command: string; args
     '    afterPath = $afterPath',
     '  } | ConvertTo-Json -Compress',
     '  $bytes = (New-Object Text.UTF8Encoding($false)).GetBytes($content)',
-    '  $stream = [IO.File]::Open($pendingPath, [IO.FileMode]::CreateNew,',
-    '    [IO.FileAccess]::Write, [IO.FileShare]::None)',
     '  try {',
-    '    $stream.Write($bytes, 0, $bytes.Length)',
-    '    $stream.Flush($true)',
-    '  } finally {',
-    '    $stream.Dispose()',
+    '    if ([IO.File]::Exists($pendingTempPath)) { [IO.File]::Delete($pendingTempPath) }',
+    '    $stream = [IO.File]::Open($pendingTempPath, [IO.FileMode]::CreateNew,',
+    '      [IO.FileAccess]::Write, [IO.FileShare]::None)',
+    '    try {',
+    '      $stream.Write($bytes, 0, $bytes.Length)',
+    '      $stream.Flush($true)',
+    '    } finally {',
+    '      $stream.Dispose()',
+    '    }',
+    '    [IO.File]::Move($pendingTempPath, $pendingPath)',
+    '  } catch {',
+    '    if ([IO.File]::Exists($pendingTempPath)) { [IO.File]::Delete($pendingTempPath) }',
+    '    throw',
     '  }',
     '}',
     "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -190,14 +190,11 @@ const defaultRunCommand: CommandRunner = (command, args) => {
 }
 
 const WINDOWS_PATH_PENDING_NAME = '.open-science-path-pending'
-const WINDOWS_PATH_PENDING_TEMP_NAME = '.open-science-path-pending.tmp'
 const WINDOWS_PATH_RECEIPT_NAME = '.open-science-path-receipt'
 const WINDOWS_PATH_RECEIPT_OWNER = 'Open Science Windows PATH entry. Managed by the app.'
 // The file name is the journal state: pending is flushed before the registry mutation, then renamed
 // to the owned receipt as the commit step. The snapshots let a later run reconcile a crash safely.
 const windowsPathPendingPath = (binDir: string): string => join(binDir, WINDOWS_PATH_PENDING_NAME)
-const windowsPathPendingTempPath = (binDir: string): string =>
-  join(binDir, WINDOWS_PATH_PENDING_TEMP_NAME)
 const windowsPathReceiptPath = (binDir: string): string => join(binDir, WINDOWS_PATH_RECEIPT_NAME)
 const powershellLiteral = (value: string): string => `'${value.replace(/'/g, "''")}'`
 
@@ -241,15 +238,14 @@ const parseWindowsPathJournal = (
 // like `-args <dir>` are unreliable and can leave $args empty, writing the wrong value into PATH.
 export const buildWindowsPathCommand = (binDir: string): { command: string; args: string[] } => {
   const pendingPath = windowsPathPendingPath(binDir)
-  const pendingTempPath = windowsPathPendingTempPath(binDir)
   const receiptPath = windowsPathReceiptPath(binDir)
   const script = [
     "$ErrorActionPreference = 'Stop'",
     `$binDir = ${powershellLiteral(binDir)}`,
     `$pendingPath = ${powershellLiteral(pendingPath)}`,
-    `$pendingTempPath = ${powershellLiteral(pendingTempPath)}`,
     `$receiptPath = ${powershellLiteral(receiptPath)}`,
     `$receiptOwner = ${powershellLiteral(WINDOWS_PATH_RECEIPT_OWNER)}`,
+    "$pendingTempPath = [IO.Path]::Combine([IO.Path]::GetDirectoryName($pendingPath), '.open-science-path-pending.' + [Guid]::NewGuid().ToString('N') + '.tmp')",
     'function Get-PathParts($value) {',
     "  return @($value -split ';' | Where-Object { $_ -ne '' })",
     '}',
@@ -282,10 +278,11 @@ export const buildWindowsPathCommand = (binDir: string): { command: string; args
     '    afterPath = $afterPath',
     '  } | ConvertTo-Json -Compress',
     '  $bytes = (New-Object Text.UTF8Encoding($false)).GetBytes($content)',
+    '  $pendingTempCreated = $false',
     '  try {',
-    '    if ([IO.File]::Exists($pendingTempPath)) { [IO.File]::Delete($pendingTempPath) }',
     '    $stream = [IO.File]::Open($pendingTempPath, [IO.FileMode]::CreateNew,',
     '      [IO.FileAccess]::Write, [IO.FileShare]::None)',
+    '    $pendingTempCreated = $true',
     '    try {',
     '      $stream.Write($bytes, 0, $bytes.Length)',
     '      $stream.Flush($true)',
@@ -294,7 +291,9 @@ export const buildWindowsPathCommand = (binDir: string): { command: string; args
     '    }',
     '    [IO.File]::Move($pendingTempPath, $pendingPath)',
     '  } catch {',
-    '    if ([IO.File]::Exists($pendingTempPath)) { [IO.File]::Delete($pendingTempPath) }',
+    '    if ($pendingTempCreated -and [IO.File]::Exists($pendingTempPath)) {',
+    '      [IO.File]::Delete($pendingTempPath)',
+    '    }',
     '    throw',
     '  }',
     '}',

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -220,7 +220,8 @@ const parseWindowsPathJournal = (
       typeof value.binDir !== 'string' ||
       normalizeWindowsPathEntry(value.binDir) !== normalizeWindowsPathEntry(binDir) ||
       (beforePath !== null && typeof beforePath !== 'string') ||
-      typeof value.afterPath !== 'string'
+      typeof value.afterPath !== 'string' ||
+      isOnPath(binDir, beforePath ?? '', 'win32')
     ) {
       return undefined
     }
@@ -260,7 +261,8 @@ export const buildWindowsPathCommand = (binDir: string): { command: string; args
     "  $expectedAfter = (@(Get-PathParts $journal.beforePath) + $binDir) -join ';'",
     '  if ($journal.version -ne 1 -or $journal.owner -cne $receiptOwner -or',
     "      $journal.binDir.TrimEnd([char[]]'\\/') -ine $binDir.TrimEnd([char[]]'\\/') -or",
-    '      -not $beforeIsValid -or $journal.afterPath -isnot [string] -or',
+    '      -not $beforeIsValid -or (Get-MatchCount $journal.beforePath) -ne 0 -or',
+    '      $journal.afterPath -isnot [string] -or',
     '      $journal.afterPath -cne $expectedAfter) {',
     "    throw 'The PATH ownership journal is not managed by Open Science.'",
     '  }',
@@ -330,10 +332,15 @@ const buildWindowsPathRemovalCommand = (
     "catch { throw 'The PATH ownership journal is not managed by Open Science.' }",
     '  $beforeIsValid = $null -eq $journal.beforePath -or $journal.beforePath -is [string]',
     "$beforeParts = @($journal.beforePath -split ';' | Where-Object { $_ -ne '' })",
+    "$normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
+    '  $beforeMatchCount = @($beforeParts | Where-Object {',
+    "    $_.TrimEnd([char[]]'\\/') -ieq $normalizedBinDir",
+    '  }).Count',
     "  $expectedAfter = (@($beforeParts) + $binDir) -join ';'",
     'if ($journal.version -ne 1 -or $journal.owner -cne $receiptOwner -or',
     "    $journal.binDir.TrimEnd([char[]]'\\/') -ine $binDir.TrimEnd([char[]]'\\/') -or",
-    '    -not $beforeIsValid -or $journal.afterPath -isnot [string] -or',
+    '    -not $beforeIsValid -or $beforeMatchCount -ne 0 -or',
+    '    $journal.afterPath -isnot [string] -or',
     '    $journal.afterPath -cne $expectedAfter) {',
     "  throw 'The PATH ownership journal is not managed by Open Science.'",
     '}',
@@ -341,9 +348,8 @@ const buildWindowsPathRemovalCommand = (
     '$afterPath = $journal.afterPath',
     "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
     "$parts = @($current -split ';' | Where-Object { $_ -ne '' })",
-    "$normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
-    '$matches = @(for ($i = 0; $i -lt $parts.Count; $i++) {',
-    "  if ($parts[$i].TrimEnd([char[]]'\\/') -ieq $normalizedBinDir) { $i }",
+    '$matches = @($parts | Where-Object {',
+    "  $_.TrimEnd([char[]]'\\/') -ieq $normalizedBinDir",
     '})',
     "if ($state -ceq 'pending') {",
     '  if ($current -ceq $beforePath) { return }',
@@ -351,17 +357,11 @@ const buildWindowsPathRemovalCommand = (
     "    throw 'The pending PATH ownership journal cannot be reconciled.'",
     '  }',
     '}',
-    'if ($matches.Count -gt 1) {',
-    "  throw 'Multiple equivalent PATH entries make ownership ambiguous.'",
+    'if ($matches.Count -eq 0) { return }',
+    'if ($current -cne $afterPath) {',
+    "  throw 'The owned PATH entry no longer matches its recorded snapshot.'",
     '}',
-    'if ($matches.Count -eq 1) {',
-    '  $removeIndex = $matches[0]',
-    '  $nextParts = @(for ($i = 0; $i -lt $parts.Count; $i++) {',
-    '    if ($i -ne $removeIndex) { $parts[$i] }',
-    '  })',
-    "  $next = $nextParts -join ';'",
-    "  [Environment]::SetEnvironmentVariable('Path', $next, 'User')",
-    '}'
+    "[Environment]::SetEnvironmentVariable('Path', $beforePath, 'User')"
   ].join('\n')
   return { command: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
 }

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -50,10 +50,13 @@ export type CliLauncherPlan = {
 // target platform (not the host's path.delimiter) so the check is correct regardless of where it runs.
 const isOnPath = (binDir: string, pathVar: string, platform: NodeJS.Platform): boolean => {
   const separator = platform === 'win32' ? ';' : ':'
+  const normalize = (entry: string): string =>
+    platform === 'win32' ? entry.replace(/[\\/]+$/, '').toLowerCase() : entry
+  const normalizedBinDir = normalize(binDir)
   return pathVar
     .split(separator)
     .filter(Boolean)
-    .some((entry) => entry === binDir)
+    .some((entry) => normalize(entry) === normalizedBinDir)
 }
 
 const isLinuxAppImage = (env: CliLauncherEnv): boolean =>
@@ -193,10 +196,30 @@ export const buildWindowsPathCommand = (binDir: string): { command: string; args
     `$binDir = ${literal}`,
     "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
     "$parts = @($current -split ';' | Where-Object { $_ -ne '' })",
-    'if ($parts -notcontains $binDir) {',
+    "$normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
+    "if (-not ($parts | Where-Object { $_.TrimEnd([char[]]'\\/') -ieq $normalizedBinDir })) {",
     "  $next = (@($parts) + $binDir) -join ';'",
     "  [Environment]::SetEnvironmentVariable('Path', $next, 'User')",
     '}'
+  ].join('\n')
+  return { command: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
+}
+
+const buildWindowsPathRemovalCommand = (binDir: string): { command: string; args: string[] } => {
+  const literal = `'${binDir.replace(/'/g, "''")}'`
+  const script = [
+    `$binDir = ${literal}`,
+    "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
+    "$parts = @($current -split ';' | Where-Object { $_ -ne '' })",
+    "$normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
+    "$nextParts = @($parts | Where-Object { $_.TrimEnd([char[]]'\\/') -ine $normalizedBinDir })",
+    'if ($nextParts.Count -ne $parts.Count) {',
+    "  $next = $nextParts -join ';'",
+    "  [Environment]::SetEnvironmentVariable('Path', $next, 'User')",
+    '}',
+    "$remaining = @([Environment]::GetEnvironmentVariable('Path', 'User') -split ';' |",
+    "  Where-Object { $_.TrimEnd([char[]]'\\/') -ieq $normalizedBinDir })",
+    'if ($remaining.Count -gt 0) { exit 1 }'
   ].join('\n')
   return { command: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
 }
@@ -425,7 +448,10 @@ export const installCliLauncher = async (
   return { installed: true, target: plan.target, onPath, pathHint }
 }
 
-export const uninstallCliLauncher = async (env: CliLauncherEnv): Promise<CliLauncherStatus> => {
+export const uninstallCliLauncher = async (
+  env: CliLauncherEnv,
+  runCommand: CommandRunner = defaultRunCommand
+): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
   const opened = await openStableCliLauncher(plan.target, constants.O_RDONLY)
   if (opened !== undefined) {
@@ -434,6 +460,12 @@ export const uninstallCliLauncher = async (env: CliLauncherEnv): Promise<CliLaun
       if (!isManagedCliLauncher(existing)) refuseUnmanagedCliLauncher(plan.target)
       if (!(await isOpenCliLauncherCurrent(plan.target, opened.stats))) {
         refuseUnmanagedCliLauncher(plan.target)
+      }
+      if (env.platform === 'win32') {
+        const { command, args } = buildWindowsPathRemovalCommand(plan.binDir)
+        if (!runCommand(command, args)) {
+          throw new Error(`Could not remove ${plan.binDir} from the user PATH.`)
+        }
       }
     } finally {
       await opened.handle.close()

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -186,40 +186,70 @@ const defaultRunCommand: CommandRunner = (command, args) => {
   return result.status === 0
 }
 
+const WINDOWS_PATH_RECEIPT_NAME = '.open-science-path-receipt'
+const WINDOWS_PATH_RECEIPT_CONTENT = 'Open Science Windows PATH entry. Managed by the app.'
+// The receipt is written only after the app appends the directory. Without it, uninstall preserves
+// matching PATH entries so legacy installs and user-managed entries are never claimed retroactively.
+const windowsPathReceiptPath = (binDir: string): string => join(binDir, WINDOWS_PATH_RECEIPT_NAME)
+const powershellLiteral = (value: string): string => `'${value.replace(/'/g, "''")}'`
+
 // Builds the PowerShell invocation that appends binDir to the persistent per-user PATH
 // (HKCU\Environment), without an admin prompt. The path is embedded as a single-quoted PowerShell
 // literal (single quotes doubled) rather than passed via `-args`: under `-Command`, trailing tokens
 // like `-args <dir>` are unreliable and can leave $args empty, writing the wrong value into PATH.
 export const buildWindowsPathCommand = (binDir: string): { command: string; args: string[] } => {
-  const literal = `'${binDir.replace(/'/g, "''")}'`
+  const receiptPath = windowsPathReceiptPath(binDir)
   const script = [
-    `$binDir = ${literal}`,
+    "$ErrorActionPreference = 'Stop'",
+    `$binDir = ${powershellLiteral(binDir)}`,
+    `$receiptPath = ${powershellLiteral(receiptPath)}`,
+    `$receiptContent = ${powershellLiteral(WINDOWS_PATH_RECEIPT_CONTENT)}`,
     "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
     "$parts = @($current -split ';' | Where-Object { $_ -ne '' })",
     "$normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
     "if (-not ($parts | Where-Object { $_.TrimEnd([char[]]'\\/') -ieq $normalizedBinDir })) {",
+    '  $hasReceipt = Test-Path -LiteralPath $receiptPath',
+    '  if ($hasReceipt) {',
+    '    if ([IO.File]::ReadAllText($receiptPath) -ne $receiptContent) {',
+    "      throw 'The PATH ownership receipt is not managed by Open Science.'",
+    '    }',
+    '  }',
     "  $next = (@($parts) + $binDir) -join ';'",
     "  [Environment]::SetEnvironmentVariable('Path', $next, 'User')",
+    '  if (-not $hasReceipt) {',
+    '    try {',
+    '      [IO.File]::WriteAllText($receiptPath, $receiptContent)',
+    '    } catch {',
+    "      try { [Environment]::SetEnvironmentVariable('Path', $current, 'User') } catch {}",
+    '      throw',
+    '    }',
+    '  }',
     '}'
   ].join('\n')
   return { command: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
 }
 
 const buildWindowsPathRemovalCommand = (binDir: string): { command: string; args: string[] } => {
-  const literal = `'${binDir.replace(/'/g, "''")}'`
   const script = [
-    `$binDir = ${literal}`,
+    "$ErrorActionPreference = 'Stop'",
+    `$binDir = ${powershellLiteral(binDir)}`,
     "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
     "$parts = @($current -split ';' | Where-Object { $_ -ne '' })",
     "$normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
-    "$nextParts = @($parts | Where-Object { $_.TrimEnd([char[]]'\\/') -ine $normalizedBinDir })",
-    'if ($nextParts.Count -ne $parts.Count) {',
+    '$removeIndex = -1',
+    'for ($i = $parts.Count - 1; $i -ge 0; $i--) {',
+    "  if ($parts[$i].TrimEnd([char[]]'\\/') -ieq $normalizedBinDir) {",
+    '    $removeIndex = $i',
+    '    break',
+    '  }',
+    '}',
+    'if ($removeIndex -ge 0) {',
+    '  $nextParts = @(for ($i = 0; $i -lt $parts.Count; $i++) {',
+    '    if ($i -ne $removeIndex) { $parts[$i] }',
+    '  })',
     "  $next = $nextParts -join ';'",
     "  [Environment]::SetEnvironmentVariable('Path', $next, 'User')",
-    '}',
-    "$remaining = @([Environment]::GetEnvironmentVariable('Path', 'User') -split ';' |",
-    "  Where-Object { $_.TrimEnd([char[]]'\\/') -ieq $normalizedBinDir })",
-    'if ($remaining.Count -gt 0) { exit 1 }'
+    '}'
   ].join('\n')
   return { command: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
 }
@@ -310,6 +340,35 @@ const readCliLauncher = async (target: string): Promise<string | undefined> => {
   } finally {
     await opened.handle.close()
   }
+}
+
+const openManagedWindowsPathReceipt = async (
+  binDir: string
+): Promise<OpenCliLauncher | undefined> => {
+  const receiptPath = windowsPathReceiptPath(binDir)
+  let opened: OpenCliLauncher | undefined
+  try {
+    opened = await openStableCliLauncher(receiptPath, constants.O_RDONLY)
+  } catch (error) {
+    if (error instanceof UnmanagedCliLauncherError) return undefined
+    throw error
+  }
+  if (opened === undefined) return undefined
+
+  try {
+    const content = await opened.handle.readFile('utf8')
+    if (
+      content === WINDOWS_PATH_RECEIPT_CONTENT &&
+      (await isOpenCliLauncherCurrent(receiptPath, opened.stats))
+    ) {
+      return opened
+    }
+  } catch (error) {
+    await opened.handle.close()
+    throw error
+  }
+  await opened.handle.close()
+  return undefined
 }
 
 const isManagedCliLauncher = (content: string): boolean => {
@@ -436,6 +495,13 @@ export const installCliLauncher = async (
   let pathHint: string | undefined
   if (!onPath) {
     if (env.platform === 'win32') {
+      const receiptPath = windowsPathReceiptPath(plan.binDir)
+      if (
+        (await statCliLauncher(receiptPath)) !== undefined &&
+        (await readCliLauncher(receiptPath)) !== WINDOWS_PATH_RECEIPT_CONTENT
+      ) {
+        refuseUnmanagedCliLauncher(receiptPath)
+      }
       const { command, args } = buildWindowsPathCommand(plan.binDir)
       onPath = runCommand(command, args)
       pathHint = onPath
@@ -455,6 +521,7 @@ export const uninstallCliLauncher = async (
   const plan = planCliLauncher(env)
   const opened = await openStableCliLauncher(plan.target, constants.O_RDONLY)
   if (opened !== undefined) {
+    let pathReceipt: OpenCliLauncher | undefined
     try {
       const existing = await opened.handle.readFile('utf8')
       if (!isManagedCliLauncher(existing)) refuseUnmanagedCliLauncher(plan.target)
@@ -462,12 +529,31 @@ export const uninstallCliLauncher = async (
         refuseUnmanagedCliLauncher(plan.target)
       }
       if (env.platform === 'win32') {
-        const { command, args } = buildWindowsPathRemovalCommand(plan.binDir)
-        if (!runCommand(command, args)) {
-          throw new Error(`Could not remove ${plan.binDir} from the user PATH.`)
+        pathReceipt = await openManagedWindowsPathReceipt(plan.binDir)
+        if (pathReceipt !== undefined) {
+          const receiptPath = windowsPathReceiptPath(plan.binDir)
+          const receiptStats = pathReceipt.stats
+          const { command, args } = buildWindowsPathRemovalCommand(plan.binDir)
+          if (!runCommand(command, args)) {
+            throw new Error(`Could not remove ${plan.binDir} from the user PATH.`)
+          }
+          if (!(await isOpenCliLauncherCurrent(receiptPath, pathReceipt.stats))) {
+            refuseUnmanagedCliLauncher(receiptPath)
+          }
+          await pathReceipt.handle.close()
+          pathReceipt = undefined
+
+          const finalReceipt = await statCliLauncher(receiptPath)
+          if (finalReceipt !== undefined) {
+            if (!isDirectRegularFile(finalReceipt) || !isSameFile(finalReceipt, receiptStats)) {
+              refuseUnmanagedCliLauncher(receiptPath)
+            }
+            await rm(receiptPath)
+          }
         }
       }
     } finally {
+      await pathReceipt?.handle.close()
       await opened.handle.close()
     }
 

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -48,10 +48,13 @@ export type CliLauncherPlan = {
 
 // PATH entries are ';'-separated on Windows and ':'-separated elsewhere. Derive the separator from the
 // target platform (not the host's path.delimiter) so the check is correct regardless of where it runs.
+const normalizeWindowsPathEntry = (entry: string): string =>
+  entry.replace(/[\\/]+$/, '').toLowerCase()
+
 const isOnPath = (binDir: string, pathVar: string, platform: NodeJS.Platform): boolean => {
   const separator = platform === 'win32' ? ';' : ':'
-  const normalize = (entry: string): string =>
-    platform === 'win32' ? entry.replace(/[\\/]+$/, '').toLowerCase() : entry
+  const normalize =
+    platform === 'win32' ? normalizeWindowsPathEntry : (entry: string): string => entry
   const normalizedBinDir = normalize(binDir)
   return pathVar
     .split(separator)
@@ -186,64 +189,173 @@ const defaultRunCommand: CommandRunner = (command, args) => {
   return result.status === 0
 }
 
+const WINDOWS_PATH_PENDING_NAME = '.open-science-path-pending'
 const WINDOWS_PATH_RECEIPT_NAME = '.open-science-path-receipt'
-const WINDOWS_PATH_RECEIPT_CONTENT = 'Open Science Windows PATH entry. Managed by the app.'
-// The receipt is written only after the app appends the directory. Without it, uninstall preserves
-// matching PATH entries so legacy installs and user-managed entries are never claimed retroactively.
+const WINDOWS_PATH_RECEIPT_OWNER = 'Open Science Windows PATH entry. Managed by the app.'
+// The file name is the journal state: pending is flushed before the registry mutation, then renamed
+// to the owned receipt as the commit step. The snapshots let a later run reconcile a crash safely.
+const windowsPathPendingPath = (binDir: string): string => join(binDir, WINDOWS_PATH_PENDING_NAME)
 const windowsPathReceiptPath = (binDir: string): string => join(binDir, WINDOWS_PATH_RECEIPT_NAME)
 const powershellLiteral = (value: string): string => `'${value.replace(/'/g, "''")}'`
+
+type WindowsPathJournal = {
+  version: 1
+  owner: typeof WINDOWS_PATH_RECEIPT_OWNER
+  binDir: string
+  beforePath: string | null
+  afterPath: string
+}
+
+const parseWindowsPathJournal = (
+  content: string | undefined,
+  binDir: string
+): WindowsPathJournal | undefined => {
+  if (content === undefined) return undefined
+  try {
+    const value = JSON.parse(content) as Partial<WindowsPathJournal>
+    const beforePath = value.beforePath
+    if (
+      value.version !== 1 ||
+      value.owner !== WINDOWS_PATH_RECEIPT_OWNER ||
+      typeof value.binDir !== 'string' ||
+      normalizeWindowsPathEntry(value.binDir) !== normalizeWindowsPathEntry(binDir) ||
+      (beforePath !== null && typeof beforePath !== 'string') ||
+      typeof value.afterPath !== 'string'
+    ) {
+      return undefined
+    }
+    const expectedAfterPath = [...(beforePath ?? '').split(';').filter(Boolean), binDir].join(';')
+    return value.afterPath === expectedAfterPath ? (value as WindowsPathJournal) : undefined
+  } catch {
+    return undefined
+  }
+}
 
 // Builds the PowerShell invocation that appends binDir to the persistent per-user PATH
 // (HKCU\Environment), without an admin prompt. The path is embedded as a single-quoted PowerShell
 // literal (single quotes doubled) rather than passed via `-args`: under `-Command`, trailing tokens
 // like `-args <dir>` are unreliable and can leave $args empty, writing the wrong value into PATH.
 export const buildWindowsPathCommand = (binDir: string): { command: string; args: string[] } => {
+  const pendingPath = windowsPathPendingPath(binDir)
   const receiptPath = windowsPathReceiptPath(binDir)
   const script = [
     "$ErrorActionPreference = 'Stop'",
     `$binDir = ${powershellLiteral(binDir)}`,
+    `$pendingPath = ${powershellLiteral(pendingPath)}`,
     `$receiptPath = ${powershellLiteral(receiptPath)}`,
-    `$receiptContent = ${powershellLiteral(WINDOWS_PATH_RECEIPT_CONTENT)}`,
+    `$receiptOwner = ${powershellLiteral(WINDOWS_PATH_RECEIPT_OWNER)}`,
+    'function Get-PathParts($value) {',
+    "  return @($value -split ';' | Where-Object { $_ -ne '' })",
+    '}',
+    'function Get-MatchCount($value) {',
+    "  $normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
+    '  return @(Get-PathParts $value | Where-Object {',
+    "    $_.TrimEnd([char[]]'\\/') -ieq $normalizedBinDir",
+    '  }).Count',
+    '}',
+    'function Read-PathJournal($path) {',
+    '  try { $journal = [IO.File]::ReadAllText($path) | ConvertFrom-Json }',
+    "  catch { throw 'The PATH ownership journal is not managed by Open Science.' }",
+    '  $beforeIsValid = $null -eq $journal.beforePath -or $journal.beforePath -is [string]',
+    "  $expectedAfter = (@(Get-PathParts $journal.beforePath) + $binDir) -join ';'",
+    '  if ($journal.version -ne 1 -or $journal.owner -cne $receiptOwner -or',
+    "      $journal.binDir.TrimEnd([char[]]'\\/') -ine $binDir.TrimEnd([char[]]'\\/') -or",
+    '      -not $beforeIsValid -or $journal.afterPath -isnot [string] -or',
+    '      $journal.afterPath -cne $expectedAfter) {',
+    "    throw 'The PATH ownership journal is not managed by Open Science.'",
+    '  }',
+    '  return $journal',
+    '}',
+    'function Write-PendingJournal($beforePath, $afterPath) {',
+    '  $content = [ordered]@{',
+    '    version = 1',
+    '    owner = $receiptOwner',
+    '    binDir = $binDir',
+    '    beforePath = $beforePath',
+    '    afterPath = $afterPath',
+    '  } | ConvertTo-Json -Compress',
+    '  $bytes = (New-Object Text.UTF8Encoding($false)).GetBytes($content)',
+    '  $stream = [IO.File]::Open($pendingPath, [IO.FileMode]::CreateNew,',
+    '    [IO.FileAccess]::Write, [IO.FileShare]::None)',
+    '  try {',
+    '    $stream.Write($bytes, 0, $bytes.Length)',
+    '    $stream.Flush($true)',
+    '  } finally {',
+    '    $stream.Dispose()',
+    '  }',
+    '}',
     "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
-    "$parts = @($current -split ';' | Where-Object { $_ -ne '' })",
-    "$normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
-    "if (-not ($parts | Where-Object { $_.TrimEnd([char[]]'\\/') -ieq $normalizedBinDir })) {",
-    '  $hasReceipt = Test-Path -LiteralPath $receiptPath',
-    '  if ($hasReceipt) {',
-    '    if ([IO.File]::ReadAllText($receiptPath) -ne $receiptContent) {',
-    "      throw 'The PATH ownership receipt is not managed by Open Science.'",
-    '    }',
+    'if ([IO.File]::Exists($pendingPath) -and [IO.File]::Exists($receiptPath)) {',
+    "  throw 'The PATH ownership journal is ambiguous.'",
+    '}',
+    'if ([IO.File]::Exists($pendingPath)) {',
+    '  $journal = Read-PathJournal $pendingPath',
+    '  if ($current -ceq $journal.afterPath) {',
+    '    [IO.File]::Move($pendingPath, $receiptPath)',
+    '    return',
     '  }',
-    "  $next = (@($parts) + $binDir) -join ';'",
-    "  [Environment]::SetEnvironmentVariable('Path', $next, 'User')",
-    '  if (-not $hasReceipt) {',
-    '    try {',
-    '      [IO.File]::WriteAllText($receiptPath, $receiptContent)',
-    '    } catch {',
-    "      try { [Environment]::SetEnvironmentVariable('Path', $current, 'User') } catch {}",
-    '      throw',
-    '    }',
+    '  if ($current -cne $journal.beforePath) {',
+    "    throw 'The pending PATH ownership journal cannot be reconciled.'",
     '  }',
-    '}'
+    "  [Environment]::SetEnvironmentVariable('Path', $journal.afterPath, 'User')",
+    '  [IO.File]::Move($pendingPath, $receiptPath)',
+    '  return',
+    '}',
+    'if ([IO.File]::Exists($receiptPath)) {',
+    '  $null = Read-PathJournal $receiptPath',
+    '  if ((Get-MatchCount $current) -gt 0) { return }',
+    '  [IO.File]::Delete($receiptPath)',
+    '}',
+    'if ((Get-MatchCount $current) -gt 0) { return }',
+    "$next = (@(Get-PathParts $current) + $binDir) -join ';'",
+    'Write-PendingJournal $current $next',
+    "[Environment]::SetEnvironmentVariable('Path', $next, 'User')",
+    '[IO.File]::Move($pendingPath, $receiptPath)'
   ].join('\n')
   return { command: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
 }
 
-const buildWindowsPathRemovalCommand = (binDir: string): { command: string; args: string[] } => {
+const buildWindowsPathRemovalCommand = (
+  binDir: string,
+  journalPath: string,
+  state: 'pending' | 'owned'
+): { command: string; args: string[] } => {
   const script = [
     "$ErrorActionPreference = 'Stop'",
     `$binDir = ${powershellLiteral(binDir)}`,
+    `$journalPath = ${powershellLiteral(journalPath)}`,
+    `$receiptOwner = ${powershellLiteral(WINDOWS_PATH_RECEIPT_OWNER)}`,
+    `$state = ${powershellLiteral(state)}`,
+    'try { $journal = [IO.File]::ReadAllText($journalPath) | ConvertFrom-Json }',
+    "catch { throw 'The PATH ownership journal is not managed by Open Science.' }",
+    '  $beforeIsValid = $null -eq $journal.beforePath -or $journal.beforePath -is [string]',
+    "$beforeParts = @($journal.beforePath -split ';' | Where-Object { $_ -ne '' })",
+    "  $expectedAfter = (@($beforeParts) + $binDir) -join ';'",
+    'if ($journal.version -ne 1 -or $journal.owner -cne $receiptOwner -or',
+    "    $journal.binDir.TrimEnd([char[]]'\\/') -ine $binDir.TrimEnd([char[]]'\\/') -or",
+    '    -not $beforeIsValid -or $journal.afterPath -isnot [string] -or',
+    '    $journal.afterPath -cne $expectedAfter) {',
+    "  throw 'The PATH ownership journal is not managed by Open Science.'",
+    '}',
+    '$beforePath = $journal.beforePath',
+    '$afterPath = $journal.afterPath',
     "$current = [Environment]::GetEnvironmentVariable('Path', 'User')",
     "$parts = @($current -split ';' | Where-Object { $_ -ne '' })",
     "$normalizedBinDir = $binDir.TrimEnd([char[]]'\\/')",
-    '$removeIndex = -1',
-    'for ($i = $parts.Count - 1; $i -ge 0; $i--) {',
-    "  if ($parts[$i].TrimEnd([char[]]'\\/') -ieq $normalizedBinDir) {",
-    '    $removeIndex = $i',
-    '    break',
+    '$matches = @(for ($i = 0; $i -lt $parts.Count; $i++) {',
+    "  if ($parts[$i].TrimEnd([char[]]'\\/') -ieq $normalizedBinDir) { $i }",
+    '})',
+    "if ($state -ceq 'pending') {",
+    '  if ($current -ceq $beforePath) { return }',
+    '  if ($current -cne $afterPath) {',
+    "    throw 'The pending PATH ownership journal cannot be reconciled.'",
     '  }',
     '}',
-    'if ($removeIndex -ge 0) {',
+    'if ($matches.Count -gt 1) {',
+    "  throw 'Multiple equivalent PATH entries make ownership ambiguous.'",
+    '}',
+    'if ($matches.Count -eq 1) {',
+    '  $removeIndex = $matches[0]',
     '  $nextParts = @(for ($i = 0; $i -lt $parts.Count; $i++) {',
     '    if ($i -ne $removeIndex) { $parts[$i] }',
     '  })',
@@ -342,13 +454,13 @@ const readCliLauncher = async (target: string): Promise<string | undefined> => {
   }
 }
 
-const openManagedWindowsPathReceipt = async (
+const openManagedWindowsPathJournal = async (
+  target: string,
   binDir: string
 ): Promise<OpenCliLauncher | undefined> => {
-  const receiptPath = windowsPathReceiptPath(binDir)
   let opened: OpenCliLauncher | undefined
   try {
-    opened = await openStableCliLauncher(receiptPath, constants.O_RDONLY)
+    opened = await openStableCliLauncher(target, constants.O_RDONLY)
   } catch (error) {
     if (error instanceof UnmanagedCliLauncherError) return undefined
     throw error
@@ -357,10 +469,8 @@ const openManagedWindowsPathReceipt = async (
 
   try {
     const content = await opened.handle.readFile('utf8')
-    if (
-      content === WINDOWS_PATH_RECEIPT_CONTENT &&
-      (await isOpenCliLauncherCurrent(receiptPath, opened.stats))
-    ) {
+    const journal = parseWindowsPathJournal(content, binDir)
+    if (journal !== undefined && (await isOpenCliLauncherCurrent(target, opened.stats))) {
       return opened
     }
   } catch (error) {
@@ -495,12 +605,16 @@ export const installCliLauncher = async (
   let pathHint: string | undefined
   if (!onPath) {
     if (env.platform === 'win32') {
-      const receiptPath = windowsPathReceiptPath(plan.binDir)
-      if (
-        (await statCliLauncher(receiptPath)) !== undefined &&
-        (await readCliLauncher(receiptPath)) !== WINDOWS_PATH_RECEIPT_CONTENT
-      ) {
-        refuseUnmanagedCliLauncher(receiptPath)
+      for (const journalPath of [
+        windowsPathPendingPath(plan.binDir),
+        windowsPathReceiptPath(plan.binDir)
+      ]) {
+        if (
+          (await statCliLauncher(journalPath)) !== undefined &&
+          parseWindowsPathJournal(await readCliLauncher(journalPath), plan.binDir) === undefined
+        ) {
+          refuseUnmanagedCliLauncher(journalPath)
+        }
       }
       const { command, args } = buildWindowsPathCommand(plan.binDir)
       onPath = runCommand(command, args)
@@ -521,7 +635,7 @@ export const uninstallCliLauncher = async (
   const plan = planCliLauncher(env)
   const opened = await openStableCliLauncher(plan.target, constants.O_RDONLY)
   if (opened !== undefined) {
-    let pathReceipt: OpenCliLauncher | undefined
+    let pathJournal: OpenCliLauncher | undefined
     try {
       const existing = await opened.handle.readFile('utf8')
       if (!isManagedCliLauncher(existing)) refuseUnmanagedCliLauncher(plan.target)
@@ -529,31 +643,47 @@ export const uninstallCliLauncher = async (
         refuseUnmanagedCliLauncher(plan.target)
       }
       if (env.platform === 'win32') {
-        pathReceipt = await openManagedWindowsPathReceipt(plan.binDir)
-        if (pathReceipt !== undefined) {
-          const receiptPath = windowsPathReceiptPath(plan.binDir)
-          const receiptStats = pathReceipt.stats
-          const { command, args } = buildWindowsPathRemovalCommand(plan.binDir)
+        const journalPaths = [
+          windowsPathPendingPath(plan.binDir),
+          windowsPathReceiptPath(plan.binDir)
+        ]
+        const existingJournalPaths: string[] = []
+        for (const journalPath of journalPaths) {
+          if ((await statCliLauncher(journalPath)) !== undefined) {
+            existingJournalPaths.push(journalPath)
+          }
+        }
+        if (existingJournalPaths.length > 1) {
+          throw new Error('The Windows PATH ownership journal is ambiguous.')
+        }
+        const journalPath = existingJournalPaths[0]
+        if (journalPath !== undefined) {
+          pathJournal = await openManagedWindowsPathJournal(journalPath, plan.binDir)
+        }
+        if (pathJournal !== undefined && journalPath !== undefined) {
+          const journalStats = pathJournal.stats
+          const state = journalPath === journalPaths[0] ? 'pending' : 'owned'
+          const { command, args } = buildWindowsPathRemovalCommand(plan.binDir, journalPath, state)
           if (!runCommand(command, args)) {
             throw new Error(`Could not remove ${plan.binDir} from the user PATH.`)
           }
-          if (!(await isOpenCliLauncherCurrent(receiptPath, pathReceipt.stats))) {
-            refuseUnmanagedCliLauncher(receiptPath)
+          if (!(await isOpenCliLauncherCurrent(journalPath, pathJournal.stats))) {
+            refuseUnmanagedCliLauncher(journalPath)
           }
-          await pathReceipt.handle.close()
-          pathReceipt = undefined
+          await pathJournal.handle.close()
+          pathJournal = undefined
 
-          const finalReceipt = await statCliLauncher(receiptPath)
-          if (finalReceipt !== undefined) {
-            if (!isDirectRegularFile(finalReceipt) || !isSameFile(finalReceipt, receiptStats)) {
-              refuseUnmanagedCliLauncher(receiptPath)
+          const finalJournal = await statCliLauncher(journalPath)
+          if (finalJournal !== undefined) {
+            if (!isDirectRegularFile(finalJournal) || !isSameFile(finalJournal, journalStats)) {
+              refuseUnmanagedCliLauncher(journalPath)
             }
-            await rm(receiptPath)
+            await rm(journalPath)
           }
         }
       }
     } finally {
-      await pathReceipt?.handle.close()
+      await pathJournal?.handle.close()
       await opened.handle.close()
     }
 

--- a/src/renderer/src/pages/settings/AppVersionSection.render.test.tsx
+++ b/src/renderer/src/pages/settings/AppVersionSection.render.test.tsx
@@ -115,6 +115,21 @@ describe('AppVersionSection', () => {
   })
 
   it.each([
+    ['restart', 'Restart to update'],
+    ['installer', 'Update downloaded — open the installer to finish']
+  ] as const)('shows the ready instruction for the %s apply strategy', (applyKind, message) => {
+    useUpdateStore.setState({
+      status: { state: 'ready', current: '0.2.0', latest: '0.3.0', applyKind }
+    })
+
+    act(() => {
+      root.render(<AppVersionSection />)
+    })
+
+    expect(container.textContent).toContain(message)
+  })
+
+  it.each([
     ['downloading', true],
     ['ready', false]
   ] as const)('sets check availability while the update is %s', (state, disabled) => {

--- a/src/renderer/src/pages/settings/AppVersionSection.tsx
+++ b/src/renderer/src/pages/settings/AppVersionSection.tsx
@@ -59,7 +59,9 @@ const AppVersionSection = ({
       case 'downloading':
         return t('Downloading… {{percent}}%', { percent: status.progress ?? 0 })
       case 'ready':
-        return t('Update downloaded — open the installer to finish')
+        return status.applyKind === 'restart'
+          ? t('Restart to update')
+          : t('Update downloaded — open the installer to finish')
       case 'up-to-date':
         return t('You are on the latest version')
       case 'error':

--- a/src/shared/update.test.ts
+++ b/src/shared/update.test.ts
@@ -44,6 +44,8 @@ describe('platformDownloadKey', () => {
     expect(platformDownloadKey('darwin', 'x64')).toBe('mac-x64')
     expect(platformDownloadKey('win32', 'x64')).toBe('win-x64')
     expect(platformDownloadKey('linux', 'x64')).toBe('linux-x64-deb')
+    expect(platformDownloadKey('win32', 'arm64')).toBeNull()
+    expect(platformDownloadKey('linux', 'arm64')).toBeNull()
     expect(platformDownloadKey('freebsd' as NodeJS.Platform, 'x64')).toBeNull()
   })
 })
@@ -57,6 +59,8 @@ describe('selectDownload', () => {
   })
   it('returns null when no entry matches', () => {
     expect(selectDownload(manifest, 'darwin', 'x64')).toBeNull()
+    expect(selectDownload(manifest, 'win32', 'arm64')).toBeNull()
+    expect(selectDownload(manifest, 'linux', 'arm64')).toBeNull()
   })
 })
 

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -75,9 +75,12 @@ export const isNewer = (latest: string, current: string): boolean =>
 // Maps the host to its manifest download key. Linux prefers the deb; selectDownload falls back to
 // the AppImage when the deb is absent.
 export const platformDownloadKey = (platform: NodeJS.Platform, arch: string): string | null => {
-  if (platform === 'darwin') return arch === 'arm64' ? 'mac-arm64' : 'mac-x64'
-  if (platform === 'win32') return 'win-x64'
-  if (platform === 'linux') return 'linux-x64-deb'
+  if (platform === 'darwin') {
+    if (arch === 'arm64') return 'mac-arm64'
+    if (arch === 'x64') return 'mac-x64'
+  }
+  if (platform === 'win32' && arch === 'x64') return 'win-x64'
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64-deb'
   return null
 }
 
@@ -88,7 +91,7 @@ export const selectDownload = (
 ): PlatformDownload | null => {
   const key = platformDownloadKey(platform, arch)
   if (key && manifest.downloads[key]) return manifest.downloads[key]
-  if (platform === 'linux' && manifest.downloads['linux-x64-appimage']) {
+  if (platform === 'linux' && arch === 'x64' && manifest.downloads['linux-x64-appimage']) {
     return manifest.downloads['linux-x64-appimage']
   }
   return null


### PR DESCRIPTION
## Problem

- Settings always instructed users to open an installer for a ready update, even when Windows/Linux use the restart apply strategy.
- Manifest selection mapped every Windows/Linux architecture to x64 artifacts and could therefore select an incompatible download on ARM64.
- Windows CLI PATH checks were case-sensitive and did not normalize trailing separators; uninstall removed the managed shim without removing the app-managed user PATH entry.

## Proposed change

- Make the Settings ready message follow `applyKind`, reusing the existing translated `Restart to update` copy.
- Return no manifest artifact for unsupported architectures and limit the Linux x64 AppImage fallback to x64 hosts.
- Normalize Windows PATH entries case-insensitively with trailing separators removed for both process and persistent-user checks.
- Before Windows installation mutates the user PATH, write and durably flush the before/after PATH snapshots to a unique same-directory temporary journal, then atomically publish it as `pending`. Atomically rename `pending` to the owned receipt after the registry mutation; a later install or uninstall can reconcile an interrupted mutation from those snapshots.
- During Windows uninstall, reconcile a valid journal independently of whether the shim still exists, then remove the shim if present. Restore the recorded `beforePath` only when the current PATH exactly matches `afterPath`; if no equivalent entry remains, clean up only the journal and shim. Any other continuity mismatch, conflicting or unmanaged journal, or unreconcilable pending state fails closed while preserving PATH, journal, and any shim.

## Scope and non-goals

- This does not add ARM64 Windows/Linux artifacts or manifest keys; unsupported architectures fail closed until those artifacts exist.
- This does not claim existing or legacy PATH entries retroactively. A managed shim without the new receipt is removed while its PATH entries are preserved.
- Strict ownership continuity means automatic uninstall can require manual PATH resolution if the user changes PATH after installation while an equivalent app bin entry remains.
- No dependency, database, renderer contract, or update-state shape changes are included.

## Historical compatibility, state, and persistence

- Historical compatibility: strict forward-only ownership. Legacy shims without a receipt still install, report status, and uninstall normally, but uninstall preserves their PATH entries. There is no receipt adoption or orphan cleanup heuristic.
- New enum/state values: the private Windows PATH journal has `pending` and `owned` states, encoded by `.open-science-path-pending` and `.open-science-path-receipt`; no shared update or renderer enum changes.
- Persistence: the journal is stored beside the managed shim and contains a version, ownership marker, canonical bin directory, and the local user PATH snapshots immediately before and after the app-owned append. Creation uses a unique `.open-science-path-pending.<guid>.tmp` name; only a temporary file successfully created by the current process is removed on handled failure, and only a fully flushed file is atomically published as `pending`. A process or machine crash before publication can leave one small temporary file beside the shim; later runs ignore it and do not delete it because ownership cannot be proven. The committed journal is removed after successful cleanup. There is no database field, migration, or schema change.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Settings ready copy follows `applyKind` -> `npm test -- src/renderer/src/pages/settings/AppVersionSection.render.test.tsx` (included in combined focused run) -> passed.
- Unsupported Windows/Linux architectures cannot select x64 artifacts -> `npm test -- src/shared/update.test.ts` (included in combined focused run) -> passed.
- Windows PATH normalization, atomic pending-journal publication, interrupted-write retry safety, crash recovery, strict snapshot continuity, pre-write journal validation, shim-independent journal cleanup, unmanaged-journal rejection, fail-closed behavior, cleanup ordering, and legacy preservation -> `npm test -- src/main/cli-install/launcher.test.ts` -> 51 tests passed after rebasing onto `origin/main`.
- Combined focused run -> `npm test -- src/renderer/src/pages/settings/AppVersionSection.render.test.tsx src/shared/update.test.ts src/main/cli-install/launcher.test.ts` -> 3 files / 70 tests passed after rebasing onto `origin/main`.
- Main-process types -> `npm run typecheck:node` -> passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting -> `npx prettier --check ...` -> passed.
- Impact explanation -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> full CI plan because these paths are not registered to a module owner.

The complete local `npm test` suite was intentionally not run; PR CI is the final authority for the classifier-selected full plan and Windows-specific execution.

## Review focus

- Confirm that unsupported architectures should fail closed rather than inventing not-yet-supported manifest keys.
- Confirm the Windows ownership protocol: a uniquely named temporary journal is flushed and atomically published as pending before the registry mutation, temporary-file cleanup is limited to files created by the current process, owned state is committed by same-directory rename, valid journals are reconciled independently of the shim, and automatic cleanup requires exact `afterPath` continuity while receipt-less legacy entries remain untouched.
