### PR TITLE
fix(projects): report pending deletion cleanup

### DIFF
--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -259,6 +259,11 @@ describe('Compute service architecture', () => {
       'await projectDeletionCoordinator.recoverPendingDeletions()',
       backgroundSessionRecovery
     )
+    const committedDeletionWake = source.indexOf(
+      "event.payload.status === 'cleanup-pending'",
+      backgroundProjectRecovery
+    )
+    const wakeCall = source.indexOf('projectDeletionRecovery.wake()', committedDeletionWake)
 
     expect(projectBarriers).toBeGreaterThan(-1)
     expect(jobBarriers).toBeGreaterThan(projectBarriers)
@@ -268,6 +273,8 @@ describe('Compute service architecture', () => {
     expect(backgroundOrphanRecovery).toBeGreaterThan(backgroundRecovery)
     expect(backgroundSessionRecovery).toBeGreaterThan(backgroundOrphanRecovery)
     expect(backgroundProjectRecovery).toBeGreaterThan(backgroundSessionRecovery)
+    expect(committedDeletionWake).toBeGreaterThan(backgroundProjectRecovery)
+    expect(wakeCall).toBeGreaterThan(committedDeletionWake)
   })
 
   it('gives Compute Job shutdown the transport cancellation budget', () => {

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -800,9 +800,7 @@ describe('Data and content application commands', () => {
     expect(deps.sessions.editDetails).toHaveBeenCalledWith(editDetailsRequest)
     expect(deps.withDataRootWrite).toHaveBeenCalledTimes(6)
     expect(deps.events.publish).toHaveBeenCalledWith('project:updated', deps.project)
-    expect(deps.events.publish).not.toHaveBeenCalledWith('project:deleted', {
-      projectId: 'project-1'
-    })
+    expect(deps.events.publish).not.toHaveBeenCalledWith('project:deleted', expect.anything())
     expect(deps.events.publish).toHaveBeenCalledWith('session:deleted', deleteSessionRequest)
   })
 

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -124,7 +124,7 @@ const createDependencies = () => {
   }
   const projects = {
     create: vi.fn(async () => project),
-    delete: vi.fn(async () => undefined),
+    delete: vi.fn(async () => ({ status: 'cleanup-pending' as const })),
     get: vi.fn(async () => project),
     list: vi.fn(async () => [project]),
     updateArchive: vi.fn(async () => project),
@@ -751,10 +751,12 @@ describe('Data and content application commands', () => {
         invocation([updateRequest] as const)
       )
     ).resolves.toBe(deps.project)
-    await router.dispatcher.invoke(
-      dataContentApplicationCommands.projectDelete,
-      invocation([deleteProjectRequest] as const)
-    )
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.projectDelete,
+        invocation([deleteProjectRequest] as const)
+      )
+    ).resolves.toEqual({ status: 'cleanup-pending' })
     await expect(
       router.dispatcher.invoke(dataContentApplicationCommands.sessionLoadAll, invocation([]))
     ).resolves.toBe(loadResult)
@@ -798,7 +800,7 @@ describe('Data and content application commands', () => {
     expect(deps.sessions.editDetails).toHaveBeenCalledWith(editDetailsRequest)
     expect(deps.withDataRootWrite).toHaveBeenCalledTimes(6)
     expect(deps.events.publish).toHaveBeenCalledWith('project:updated', deps.project)
-    expect(deps.events.publish).toHaveBeenCalledWith('project:deleted', {
+    expect(deps.events.publish).not.toHaveBeenCalledWith('project:deleted', {
       projectId: 'project-1'
     })
     expect(deps.events.publish).toHaveBeenCalledWith('session:deleted', deleteSessionRequest)

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -237,7 +237,7 @@ const dataContentApplicationCommands = Object.freeze({
   projectDelete: defineApplicationCommand<
     'projects:delete',
     readonly [request: Projects.DeleteProjectRequest],
-    void
+    Projects.ProjectDeletionOutcome
   >('projects:delete', Projects.projectApplicationCommandContracts.delete),
   projectGet: projectCommand(
     'projects:get',
@@ -500,12 +500,7 @@ const registerDataContentApplicationCommands = (
         publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectCreated, project)
         return project
       },
-      'projects:delete': async ({ args }) => {
-        await dependencies.projects.delete(args[0].id)
-        publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectDeleted, {
-          projectId: args[0].id
-        })
-      },
+      'projects:delete': ({ args }) => dependencies.projects.delete(args[0].id),
       'projects:get': ({ args }) => dependencies.projects.get(args[0]),
       'projects:list': () => dependencies.projects.list(),
       'projects:update-archive': async ({ args }) => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2445,11 +2445,19 @@ const createApplicationModules = async (
         )
     }
   )
+  const removeProjectDeletionRecoveryWake = applicationEvents.subscribe((event) => {
+    if (event.channel === 'project:deleted' && event.payload.status === 'cleanup-pending') {
+      projectDeletionRecovery.wake()
+    }
+  })
   await modules.add(projectDeletionRecovery, (recovery) => ({
     name: 'project-deletion-recovery',
     capability: undefined,
     start: () => recovery.start(),
-    dispose: () => recovery.stop()
+    dispose: async () => {
+      removeProjectDeletionRecoveryWake()
+      await recovery.stop()
+    }
   }))
   declareElectronAdapter('side-chat', () =>
     registerSideChatIpcHandlers(sideChatRuntime, {

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -81,6 +81,7 @@ describe('ProjectDeletionCoordinator', () => {
     expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
     expect(abortProjectDeletion).not.toHaveBeenCalled()
     expect(events.publish).toHaveBeenCalledWith('memory:changed', { revision: 7 })
+    expect(events.publish).toHaveBeenCalledWith('project:deleted', { projectId: 'project-1' })
     expect(vi.mocked(permissionGrants.prune).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(projects.delete).mock.invocationCallOrder[0]
     )
@@ -233,7 +234,7 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.delete).not.toHaveBeenCalled()
     expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
 
-    await expect(coordinator.deleteProject('project-1')).resolves.toBeUndefined()
+    await expect(coordinator.deleteProject('project-1')).resolves.toEqual({ status: 'deleted' })
 
     expect(permissionGrants.prune).toHaveBeenCalledTimes(2)
     expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(2)
@@ -258,7 +259,7 @@ describe('ProjectDeletionCoordinator', () => {
       permissionGrants
     )
 
-    await expect(coordinator.deleteProject('project-1')).resolves.toBeUndefined()
+    await expect(coordinator.deleteProject('project-1')).resolves.toEqual({ status: 'deleted' })
 
     expect(projects.delete).toHaveBeenCalledWith('project-1')
     expect(sessions.completeProjectSessionDeletion).toHaveBeenCalledWith('project-1')
@@ -309,9 +310,9 @@ describe('ProjectDeletionCoordinator', () => {
       }
     )
 
-    await expect(coordinator.deleteProject('project-1')).rejects.toThrow(
-      'Project derived cleanup failed: project-1'
-    )
+    await expect(coordinator.deleteProject('project-1')).resolves.toEqual({
+      status: 'cleanup-pending'
+    })
 
     expect(projectExists).toBe(false)
     expect(intentExists).toBe(true)
@@ -684,7 +685,7 @@ describe('ProjectDeletionCoordinator', () => {
     })
     const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
-    await expect(coordinator.deleteProject('project-2')).resolves.toBeUndefined()
+    await expect(coordinator.deleteProject('project-2')).resolves.toEqual({ status: 'deleted' })
 
     await expect(coordinator.waitForProjectOperations(['project-1'])).rejects.toThrow(
       'tail cleanup unavailable'
@@ -746,7 +747,9 @@ describe('ProjectDeletionCoordinator', () => {
     })
     const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
-    await expect(coordinator.deleteProject('project-1')).rejects.toThrow('tombstone busy')
+    await expect(coordinator.deleteProject('project-1')).resolves.toEqual({
+      status: 'cleanup-pending'
+    })
 
     expect(projects.delete).toHaveBeenCalledWith('project-1')
     expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
@@ -775,6 +778,7 @@ describe('ProjectDeletionCoordinator', () => {
       .mockRejectedValueOnce(cleanupFailure)
       .mockResolvedValueOnce(undefined)
     const completeProjectDeletion = vi.fn()
+    const events = { publish: vi.fn() }
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
@@ -785,16 +789,22 @@ describe('ProjectDeletionCoordinator', () => {
         beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
         finalizeProjectDeletion,
         completeProjectDeletion
-      }
+      },
+      events
     )
 
-    await expect(coordinator.deleteProject('project-1')).rejects.toBe(cleanupFailure)
+    await expect(coordinator.deleteProject('project-1')).resolves.toEqual({
+      status: 'cleanup-pending'
+    })
 
     expect(projectExists).toBe(false)
     expect(intentExists).toBe(true)
     expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
     expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
     expect(completeProjectDeletion).not.toHaveBeenCalled()
+    expect(events.publish).not.toHaveBeenCalledWith('project:deleted', {
+      projectId: 'project-1'
+    })
 
     await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
 
@@ -802,6 +812,29 @@ describe('ProjectDeletionCoordinator', () => {
     expect(sessions.completeProjectSessionDeletion).toHaveBeenCalledWith('project-1')
     expect(intentExists).toBe(false)
     expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
+  })
+
+  it('publishes Project deletion when background recovery reaches the terminal state', async () => {
+    const projects = createProjects()
+    projects.get = vi.fn().mockResolvedValue(null)
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
+    const events = { publish: vi.fn() }
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      createSessions(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      events
+    )
+
+    await coordinator.recoverPendingDeletions()
+
+    expect(events.publish).toHaveBeenCalledWith('project:deleted', {
+      projectId: 'project-1'
+    })
+    expect(events.publish).toHaveBeenCalledOnce()
   })
 
   it('keeps the recovery intent until derived project cleanup has finished', async () => {

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -81,7 +81,28 @@ describe('ProjectDeletionCoordinator', () => {
     expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
     expect(abortProjectDeletion).not.toHaveBeenCalled()
     expect(events.publish).toHaveBeenCalledWith('memory:changed', { revision: 7 })
-    expect(events.publish).toHaveBeenCalledWith('project:deleted', { projectId: 'project-1' })
+    expect(events.publish).toHaveBeenCalledWith('project:deleted', {
+      projectId: 'project-1',
+      status: 'cleanup-pending'
+    })
+    expect(events.publish).toHaveBeenCalledWith('project:deleted', {
+      projectId: 'project-1',
+      status: 'deleted'
+    })
+    const pendingEventIndex = events.publish.mock.calls.findIndex(
+      ([channel, payload]) =>
+        channel === 'project:deleted' &&
+        (payload as { status?: string }).status === 'cleanup-pending'
+    )
+    expect(pendingEventIndex).toBeGreaterThan(-1)
+    const pendingEventOrder = events.publish.mock.invocationCallOrder[pendingEventIndex]
+    expect(pendingEventOrder).toBeDefined()
+    expect(vi.mocked(projects.delete).mock.invocationCallOrder[0]).toBeLessThan(
+      pendingEventOrder as number
+    )
+    expect(pendingEventOrder).toBeLessThan(
+      reviews.deleteReviewsForProject.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    )
     expect(vi.mocked(permissionGrants.prune).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(projects.delete).mock.invocationCallOrder[0]
     )
@@ -297,6 +318,7 @@ describe('ProjectDeletionCoordinator', () => {
     const provenance = { deleteProjectProvenance: vi.fn().mockResolvedValue(undefined) }
     const completeProjectDeletion = vi.fn()
     const abortProjectDeletion = vi.fn()
+    const events = { publish: vi.fn() }
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
@@ -307,7 +329,8 @@ describe('ProjectDeletionCoordinator', () => {
         beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
         completeProjectDeletion,
         abortProjectDeletion
-      }
+      },
+      events
     )
 
     await expect(coordinator.deleteProject('project-1')).resolves.toEqual({
@@ -321,6 +344,10 @@ describe('ProjectDeletionCoordinator', () => {
     expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
     expect(completeProjectDeletion).not.toHaveBeenCalled()
     expect(abortProjectDeletion).not.toHaveBeenCalled()
+    expect(events.publish).toHaveBeenCalledWith('project:deleted', {
+      projectId: 'project-1',
+      status: 'cleanup-pending'
+    })
 
     await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
 
@@ -456,6 +483,19 @@ describe('ProjectDeletionCoordinator', () => {
     expect(recover).toHaveBeenCalledOnce()
     await vi.advanceTimersByTimeAsync(1)
     expect(recover).toHaveBeenCalledTimes(2)
+
+    await recovery.stop()
+  })
+
+  it('wakes background recovery after its successful startup run has completed', async () => {
+    const recover = vi.fn().mockResolvedValue(undefined)
+    const recovery = new ProjectDeletionRecoveryLoop(recover)
+
+    recovery.start()
+    await vi.waitFor(() => expect(recover).toHaveBeenCalledOnce())
+
+    recovery.wake()
+    await vi.waitFor(() => expect(recover).toHaveBeenCalledTimes(2))
 
     await recovery.stop()
   })
@@ -803,7 +843,8 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
     expect(completeProjectDeletion).not.toHaveBeenCalled()
     expect(events.publish).not.toHaveBeenCalledWith('project:deleted', {
-      projectId: 'project-1'
+      projectId: 'project-1',
+      status: 'deleted'
     })
 
     await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
@@ -832,7 +873,8 @@ describe('ProjectDeletionCoordinator', () => {
     await coordinator.recoverPendingDeletions()
 
     expect(events.publish).toHaveBeenCalledWith('project:deleted', {
-      projectId: 'project-1'
+      projectId: 'project-1',
+      status: 'deleted'
     })
     expect(events.publish).toHaveBeenCalledOnce()
   })

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -1,5 +1,5 @@
 import { isCurrentInFlight } from '../../shared/in-flight-promise'
-import type { Project } from '../../shared/projects'
+import type { Project, ProjectDeletionOutcome } from '../../shared/projects'
 import type { ProjectSessionDeletionResult } from '../session-persistence/coordinator'
 import type { ProjectSessionDeletionState } from '../session-persistence/repository'
 import { withDataRootWrite } from '../storage/migration-state'
@@ -56,6 +56,8 @@ type ProjectDeletionFailure = {
   projectId: string
   error: unknown
 }
+
+type ProjectDeletionAttempt = { status: 'deleted' } | { status: 'cleanup-pending'; error: unknown }
 
 class ProjectDeletionRecoveryError extends AggregateError {
   readonly failures: readonly ProjectDeletionFailure[]
@@ -157,23 +159,27 @@ class ProjectDeletionCoordinator {
 
   // Enqueues before yielding so two callers in the same event-loop turn cannot publish competing
   // recovery promises. The queue tail swallows failures only to keep later recovery work runnable.
-  deleteProject(projectId: string): Promise<void> {
+  deleteProject(projectId: string): Promise<ProjectDeletionOutcome> {
     const deletion = this.operationQueue.then(() =>
       withDataRootWrite(async () => {
         const recoveryComplete = await this.waitForProjectOperationsNow([projectId])
         this.isRecoveryComplete = false
         try {
-          await this.runDeletion(projectId)
+          const outcome = await this.runDeletion(projectId)
           // Preserve sticky completion only when scoped admission did not suppress failures owned by
-          // other Projects. Suppressed durable intents must remain eligible for retry.
-          this.isRecoveryComplete = recoveryComplete
+          // other Projects. Suppressed or newly pending durable intents must remain eligible for retry.
+          this.isRecoveryComplete = outcome.status === 'deleted' && recoveryComplete
+          return outcome
         } catch (error) {
           this.isRecoveryComplete = false
           throw error
         }
       })
     )
-    this.operationQueue = deletion.catch(() => undefined)
+    this.operationQueue = deletion.then(
+      () => undefined,
+      () => undefined
+    )
     return deletion
   }
 
@@ -252,14 +258,15 @@ class ProjectDeletionCoordinator {
   // retry authority before any destructive runtime cleanup. Once the intent exists, every failure
   // remains fail-closed: the Project may still be visible, but recovery retains the fence and replays
   // quiescence before continuing durable deletion.
-  private async runDeletion(projectId: string): Promise<void> {
+  private async runDeletion(projectId: string): Promise<ProjectDeletionOutcome> {
     const project = await this.projects.get(projectId)
-    if (!project) return
+    if (!project) return { status: 'deleted' }
 
     await this.createDeletionIntentWithFence(projectId)
     await this.lifecycle?.beforeProjectDelete(projectId)
     await this.sessions.deleteProjectSessions(projectId)
-    await this.finishDeletion(projectId)
+    const attempt = await this.finishDeletion(projectId)
+    return attempt.status === 'deleted' ? attempt : { status: 'cleanup-pending' }
   }
 
   private async createDeletionIntentWithFence(projectId: string): Promise<void> {
@@ -307,7 +314,10 @@ class ProjectDeletionCoordinator {
           retainedProjectIds.add(projectId)
           continue
         }
-        await this.finishDeletion(projectId)
+        const attempt = await this.finishDeletion(projectId)
+        if (attempt.status === 'cleanup-pending') {
+          failures.push({ projectId, error: attempt.error })
+        }
       } catch (error) {
         failures.push({ projectId, error })
       }
@@ -336,7 +346,10 @@ class ProjectDeletionCoordinator {
           await this.lifecycle?.abortProjectDeletion?.(projectId)
           continue
         }
-        await this.finishDeletion(projectId)
+        const attempt = await this.finishDeletion(projectId)
+        if (attempt.status === 'cleanup-pending') {
+          failures.push({ projectId, error: attempt.error })
+        }
       } catch (error) {
         failures.push({ projectId, error })
       }
@@ -344,10 +357,10 @@ class ProjectDeletionCoordinator {
     return failures
   }
 
-  // The Project becomes an invisible metadata tombstone only after every fallible authority cleanup
-  // succeeds. Keeping it active with the deletion intent through pruning lets the renderer report a
-  // failure without publishing false success; replaying this tail is idempotent.
-  private async finishDeletion(projectId: string): Promise<void> {
+  // Authority pruning must succeed before the Project becomes an invisible metadata tombstone. The
+  // remaining fallible cleanup runs after that commit and is replayable from the durable intent, so
+  // foreground callers can distinguish an intact Project from committed deletion with pending cleanup.
+  private async finishDeletion(projectId: string): Promise<ProjectDeletionAttempt> {
     // Prune is transactional and idempotent. Run it before the soft delete so a Registry/database
     // failure retains the visible Project plus its durable intent for an explicit or startup retry.
     await this.permissionGrants?.prune({ kind: 'project', projectId })
@@ -363,30 +376,41 @@ class ProjectDeletionCoordinator {
       ?.finalizeOwnerDeletion?.({ kind: 'project', projectId })
       .catch(() => undefined)
 
-    // Retain the durable intent on failure so startup or an explicit retry can finish cleanup.
+    // Retain the durable intent on failure so startup or background recovery can finish cleanup. The
+    // foreground caller receives an explicit committed outcome instead of mistaking this tail for an
+    // intact Project, while recovery keeps the original error for diagnostics and retry scheduling.
     try {
       await this.reviews?.deleteReviewsForProject(projectId)
     } catch (error) {
-      throw new AggregateError([error], 'Project derived cleanup failed: ' + projectId)
+      return {
+        status: 'cleanup-pending',
+        error: new AggregateError([error], 'Project derived cleanup failed: ' + projectId)
+      }
     }
 
-    // Session deletion retains provenance, but Project deletion is terminal. This tail is replayed
-    // from the durable intent after a crash, so derived SQLite rows and immutable bytes are
-    // eventually removed even after the Project metadata row has become an invisible tombstone.
-    await this.provenance?.deleteProjectProvenance(projectId)
+    try {
+      // Session deletion retains provenance, but Project deletion is terminal. This tail is replayed
+      // from the durable intent after a crash, so derived SQLite rows and immutable bytes are
+      // eventually removed even after the Project metadata row has become an invisible tombstone.
+      await this.provenance?.deleteProjectProvenance(projectId)
 
-    // Fallible runtime/profile cleanup must finish while the existing intent and Session tombstone
-    // still provide retry authority. The completion callback below is reserved for releasing the
-    // in-memory fences only after both durable markers have been removed.
-    await this.lifecycle?.finalizeProjectDeletion?.(projectId)
+      // Fallible runtime/profile cleanup must finish while the existing intent and Session tombstone
+      // still provide retry authority. The completion callback below is reserved for releasing the
+      // in-memory fences only after both durable markers have been removed.
+      await this.lifecycle?.finalizeProjectDeletion?.(projectId)
 
-    // The marked Session tombstone is the durable phase boundary. Remove it only after every Project
-    // tail has completed, and keep the intent if physical cleanup fails so recovery retries it.
-    await this.sessions.completeProjectSessionDeletion(projectId)
+      // The marked Session tombstone is the durable phase boundary. Remove it only after every Project
+      // tail has completed, and keep the intent if physical cleanup fails so recovery retries it.
+      await this.sessions.completeProjectSessionDeletion(projectId)
 
-    // Keep the intent until all derived and tombstone cleanup has completed.
-    await this.projects.deleteDeletionIntent(projectId)
+      // Keep the intent until all derived and tombstone cleanup has completed.
+      await this.projects.deleteDeletionIntent(projectId)
+    } catch (error) {
+      return { status: 'cleanup-pending', error }
+    }
     this.lifecycle?.completeProjectDeletion?.(projectId)
+    this.events?.publish('project:deleted', { projectId })
+    return { status: 'deleted' }
   }
 }
 

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -85,6 +85,7 @@ class ProjectDeletionRecoveryLoop {
   private timer: ReturnType<typeof setTimeout> | undefined
   private started = false
   private running = false
+  private rerunRequested = false
   private activeRun: Promise<void> | undefined
 
   constructor(
@@ -101,8 +102,22 @@ class ProjectDeletionRecoveryLoop {
     this.run()
   }
 
+  // Foreground deletion can create durable retry work after the one-shot startup scan has already
+  // completed. Wake immediately, while coalescing requests that arrive during an active run.
+  wake(): void {
+    if (!this.started) return
+    if (this.running) {
+      this.rerunRequested = true
+      return
+    }
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = undefined
+    this.run()
+  }
+
   async stop(): Promise<void> {
     this.started = false
+    this.rerunRequested = false
     if (this.timer) clearTimeout(this.timer)
     this.timer = undefined
     await this.activeRun
@@ -116,9 +131,13 @@ class ProjectDeletionRecoveryLoop {
       .then(
         () => {
           this.running = false
+          if (!this.started || !this.rerunRequested) return
+          this.rerunRequested = false
+          this.run()
         },
         (error: unknown) => {
           this.running = false
+          this.rerunRequested = false
           try {
             this.onError(error)
           } catch {
@@ -364,11 +383,16 @@ class ProjectDeletionCoordinator {
     // Prune is transactional and idempotent. Run it before the soft delete so a Registry/database
     // failure retains the visible Project plus its durable intent for an explicit or startup retry.
     await this.permissionGrants?.prune({ kind: 'project', projectId })
-    const projectDeletion = (await this.projects.get(projectId))
-      ? await this.projects.delete(projectId)
-      : undefined
+    const projectExists = Boolean(await this.projects.get(projectId))
+    const projectDeletion = projectExists ? await this.projects.delete(projectId) : undefined
     if (projectDeletion) {
       this.events?.publish('memory:changed', { revision: projectDeletion.memoryRevision })
+    }
+    if (projectExists) {
+      // Metadata deletion is the user-visible commit point. Other renderer windows must evict their
+      // stale Project/Session projections immediately, while retaining an explicit pending marker
+      // until the terminal event below confirms that replayable cleanup has finished.
+      this.events?.publish('project:deleted', { projectId, status: 'cleanup-pending' })
     }
     // The metadata tombstone commits outside the Registry mutation queue. A remember/restore already
     // in flight may have updated its cache around that commit, so enqueue one non-failing barrier.
@@ -409,7 +433,7 @@ class ProjectDeletionCoordinator {
       return { status: 'cleanup-pending', error }
     }
     this.lifecycle?.completeProjectDeletion?.(projectId)
-    this.events?.publish('project:deleted', { projectId })
+    this.events?.publish('project:deleted', { projectId, status: 'deleted' })
     return { status: 'deleted' }
   }
 }

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   CreateProjectRequest,
   Project,
+  ProjectDeletionOutcome,
   UpdateProjectArchiveRequest,
   UpdateProjectRequest
 } from '../../shared/projects'
@@ -24,7 +25,7 @@ type ProjectHandlers = {
   create: (request: CreateProjectRequest) => Promise<Project>
   update: (request: UpdateProjectRequest) => Promise<Project>
   updateArchive: (request: UpdateProjectArchiveRequest) => Promise<Project>
-  delete: (id: string) => Promise<void>
+  delete: (id: string) => Promise<ProjectDeletionOutcome>
 }
 
 // Production repositories backed by the SQLite database under the (dev-aware) storage root. The client is
@@ -88,7 +89,7 @@ const createProjectHandlers = (
   },
   delete: async (id) => {
     await deletionCoordinator.waitForProjectOperations([id])
-    await deletionCoordinator.deleteProject(id)
+    return deletionCoordinator.deleteProject(id)
   }
 })
 

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -1273,7 +1273,7 @@ describe('useLifecycleSync', () => {
       root.render(<Harness isSessionPersistenceHydrated={false} />)
     })
     await act(async () => {
-      listeners.projectDeleted?.({ projectId: project.id })
+      listeners.projectDeleted?.({ projectId: project.id, status: 'deleted' })
     })
 
     await act(async () => {
@@ -1297,11 +1297,39 @@ describe('useLifecycleSync', () => {
     })
     await act(async () => container.querySelector<HTMLButtonElement>('button')?.click())
     await act(async () => {
-      listeners.projectDeleted?.({ projectId: project.id })
+      listeners.projectDeleted?.({ projectId: project.id, status: 'deleted' })
     })
 
     expect(useProjectStore.getState().projects).toEqual([])
     expect(useSessionStore.getState().sessions).toEqual([])
     expect(useNavigationStore.getState().view).toBe('home')
+  })
+
+  it('removes another window committed deletion while tracking cleanup until terminal recovery', async () => {
+    await act(async () => {
+      listeners.projectCreated?.(project)
+      listeners.sessionCreated?.({ session, originClientId: 'web:external' })
+    })
+    await act(async () => container.querySelector<HTMLButtonElement>('button')?.click())
+    await act(async () => {
+      listeners.projectDeleted?.({
+        projectId: project.id,
+        status: 'cleanup-pending'
+      })
+    })
+
+    expect(useProjectStore.getState().projects).toEqual([])
+    expect(useSessionStore.getState().sessions).toEqual([])
+    expect(useProjectStore.getState().pendingDeletionCleanupProjectIds.has(project.id)).toBe(true)
+    expect(useNavigationStore.getState().view).toBe('home')
+
+    await act(async () => {
+      listeners.projectDeleted?.({
+        projectId: project.id,
+        status: 'deleted'
+      })
+    })
+
+    expect(useProjectStore.getState().pendingDeletionCleanupProjectIds.has(project.id)).toBe(false)
   })
 })

--- a/src/renderer/src/hooks/useLifecycleSync.ts
+++ b/src/renderer/src/hooks/useLifecycleSync.ts
@@ -139,11 +139,11 @@ const useLifecycleSync = ({
         }
       })
     })
-    const removeProjectDeleted = window.api.projects.onDeleted(({ projectId }) => {
+    const removeProjectDeleted = window.api.projects.onDeleted(({ projectId, status }) => {
       applyOrQueue(
         `project:${projectId}`,
         () => {
-          useProjectStore.getState().removeProject(projectId)
+          useProjectStore.getState().removeProject(projectId, { status })
           useSessionStore.getState().removeSessionsForProject(projectId)
           if (useNavigationStore.getState().activeProjectId === projectId) {
             useNavigationStore.getState().goHome('automatic')

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -137,7 +137,7 @@ describe('HomePage persistence recovery', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
-    deleteProject = vi.fn().mockResolvedValue(undefined)
+    deleteProject = vi.fn().mockResolvedValue({ status: 'deleted' })
     useProjectStore.setState({
       ...createInitialProjectState(),
       projects: [project],
@@ -351,11 +351,44 @@ describe('HomePage persistence recovery', () => {
     expect(useProjectStore.getState().projects).toContainEqual(project)
     warn.mockRestore()
 
-    deleteProject.mockResolvedValueOnce(undefined)
+    deleteProject.mockResolvedValueOnce({ status: 'deleted' })
     await act(async () => confirm?.click())
 
     expect(deleteProject).toHaveBeenCalledTimes(2)
     expect(confirm?.dataset.hasProject).toBe('false')
     expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('removes committed Project state and explains pending background cleanup', async () => {
+    deleteProject.mockResolvedValueOnce({ status: 'cleanup-pending' })
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      projectId: project.id,
+      cwd: '/workspace/project-1',
+      content: 'Saved conversation'
+    })
+
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+
+    const deleteAction = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Delete'
+    )
+    await act(async () => deleteAction?.click())
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-testid="confirm-project-delete"]')?.click()
+    )
+
+    expect(useSessionStore.getState().sessions).toEqual([])
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'Project deleted. Cleanup will continue in the background.'
+    )
+    expect(
+      container.querySelector<HTMLButtonElement>('[data-testid="confirm-project-delete"]')?.dataset
+        .hasProject
+    ).toBe('false')
   })
 })

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -360,7 +360,12 @@ describe('HomePage persistence recovery', () => {
   })
 
   it('removes committed Project state and explains pending background cleanup', async () => {
-    deleteProject.mockResolvedValueOnce({ status: 'cleanup-pending' })
+    deleteProject.mockImplementationOnce(async () => {
+      useProjectStore.setState({
+        pendingDeletionCleanupProjectIds: new Set([project.id])
+      } as never)
+      return { status: 'cleanup-pending' }
+    })
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
       projectId: project.id,
@@ -390,5 +395,9 @@ describe('HomePage persistence recovery', () => {
       container.querySelector<HTMLButtonElement>('[data-testid="confirm-project-delete"]')?.dataset
         .hasProject
     ).toBe('false')
+
+    await act(async () => useProjectStore.getState().removeProject(project.id))
+
+    expect(container.querySelector('[role="status"]')).toBeNull()
   })
 })

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -176,6 +176,9 @@ const HomePage = ({
 }: HomePageProps): React.JSX.Element => {
   const { t } = useTranslation()
   const projects = useProjectStore((state) => state.projects)
+  const hasPendingProjectCleanup = useProjectStore(
+    (state) => state.pendingDeletionCleanupProjectIds.size > 0
+  )
   const loadError = useProjectStore((state) => state.loadError)
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const updateProject = useProjectStore((state) => state.updateProject)
@@ -208,7 +211,6 @@ const HomePage = ({
   const [projectToDelete, setProjectToDelete] = useState<Project | undefined>(undefined)
   const [isDeletingProject, setIsDeletingProject] = useState(false)
   const [deleteProjectError, setDeleteProjectError] = useState<string | undefined>(undefined)
-  const [projectCleanupNotice, setProjectCleanupNotice] = useState<string | undefined>(undefined)
   const [archivingProjectIds, setArchivingProjectIds] = useState<Set<string>>(() => new Set())
   const [pinningProjectIds, setPinningProjectIds] = useState<Set<string>>(() => new Set())
   const [projectActionError, setProjectActionError] = useState<string | undefined>(undefined)
@@ -464,7 +466,6 @@ const HomePage = ({
     if (!canDeleteProjects) return
 
     setDeleteProjectError(undefined)
-    setProjectCleanupNotice(undefined)
     setProjectToDelete(project)
   }
 
@@ -593,12 +594,9 @@ const HomePage = ({
     setDeleteProjectError(undefined)
 
     void deleteProject(projectId)
-      .then((outcome) => {
+      .then(() => {
         useSessionStore.getState().removeSessionsForProject(projectId)
         setProjectToDelete(undefined)
-        if (outcome.status === 'cleanup-pending') {
-          setProjectCleanupNotice(t('Project deleted. Cleanup will continue in the background.'))
-        }
       })
       .catch((error: unknown) => {
         // Durable deletion failed; keep the target and in-memory sessions visible so the user can
@@ -881,12 +879,12 @@ const HomePage = ({
                 {projectActionError}
               </div>
             ) : null}
-            {projectCleanupNotice ? (
+            {hasPendingProjectCleanup ? (
               <div
                 className="mb-3 rounded-2xl border border-status-warning-foreground/30 bg-status-warning-surface/40 px-4 py-3 text-sm text-status-warning-foreground dark:border-status-warning-dark-foreground/30 dark:bg-status-warning-dark-surface/20 dark:text-status-warning-dark-foreground"
                 role="status"
               >
-                {projectCleanupNotice}
+                {t('Project deleted. Cleanup will continue in the background.')}
               </div>
             ) : null}
             {loadError ? (

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -208,6 +208,7 @@ const HomePage = ({
   const [projectToDelete, setProjectToDelete] = useState<Project | undefined>(undefined)
   const [isDeletingProject, setIsDeletingProject] = useState(false)
   const [deleteProjectError, setDeleteProjectError] = useState<string | undefined>(undefined)
+  const [projectCleanupNotice, setProjectCleanupNotice] = useState<string | undefined>(undefined)
   const [archivingProjectIds, setArchivingProjectIds] = useState<Set<string>>(() => new Set())
   const [pinningProjectIds, setPinningProjectIds] = useState<Set<string>>(() => new Set())
   const [projectActionError, setProjectActionError] = useState<string | undefined>(undefined)
@@ -463,6 +464,7 @@ const HomePage = ({
     if (!canDeleteProjects) return
 
     setDeleteProjectError(undefined)
+    setProjectCleanupNotice(undefined)
     setProjectToDelete(project)
   }
 
@@ -591,9 +593,12 @@ const HomePage = ({
     setDeleteProjectError(undefined)
 
     void deleteProject(projectId)
-      .then(() => {
+      .then((outcome) => {
         useSessionStore.getState().removeSessionsForProject(projectId)
         setProjectToDelete(undefined)
+        if (outcome.status === 'cleanup-pending') {
+          setProjectCleanupNotice(t('Project deleted. Cleanup will continue in the background.'))
+        }
       })
       .catch((error: unknown) => {
         // Durable deletion failed; keep the target and in-memory sessions visible so the user can
@@ -874,6 +879,14 @@ const HomePage = ({
                 role="alert"
               >
                 {projectActionError}
+              </div>
+            ) : null}
+            {projectCleanupNotice ? (
+              <div
+                className="mb-3 rounded-2xl border border-status-warning-foreground/30 bg-status-warning-surface/40 px-4 py-3 text-sm text-status-warning-foreground dark:border-status-warning-dark-foreground/30 dark:bg-status-warning-dark-surface/20 dark:text-status-warning-dark-foreground"
+                role="status"
+              >
+                {projectCleanupNotice}
               </div>
             ) : null}
             {loadError ? (

--- a/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
@@ -45,7 +45,7 @@ describe('ArchivedPanel', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     updateArchive.mockReset().mockResolvedValue({ ...session, archivedAt: undefined })
-    deleteProject.mockReset().mockResolvedValue(undefined)
+    deleteProject.mockReset().mockResolvedValue({ status: 'deleted' })
     deleteSession.mockReset().mockResolvedValue({ status: 'deleted', runtimeDetached: true })
     window.api = {
       sessions: { updateArchive, deleteSession },
@@ -243,6 +243,43 @@ describe('ArchivedPanel', () => {
     expect(deleteProject).toHaveBeenCalledWith(project.id)
     expect(window.api.acp.getState).not.toHaveBeenCalled()
     expect(window.api.acp.deleteSession).not.toHaveBeenCalled()
+    expect(onNavigate).toHaveBeenCalledWith({ kind: 'list' })
+  })
+
+  it('removes committed archived Project state and explains pending background cleanup', async () => {
+    const archivedProject = { ...project, archivedAt: 2 }
+    deleteProject.mockResolvedValueOnce({ status: 'cleanup-pending' })
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [archivedProject],
+      isLoaded: true,
+      deleteProject
+    })
+    const onNavigate = vi.fn()
+    await act(async () =>
+      root.render(
+        <ArchivedPanel
+          view={{ kind: 'project', projectId: archivedProject.id }}
+          onNavigate={onNavigate}
+        />
+      )
+    )
+
+    const openDelete = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Delete project')
+    )
+    await act(async () => openDelete?.click())
+    const dialog = document.body.querySelector<HTMLElement>('[role=alertdialog]')
+    const confirmDelete = Array.from(
+      dialog?.querySelectorAll<HTMLButtonElement>('button') ?? []
+    ).find((button) => button.textContent === 'Delete')
+    await act(async () => confirmDelete?.click())
+
+    expect(useSessionStore.getState().sessions).toEqual([])
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'Project deleted. Cleanup will continue in the background.'
+    )
+    expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'list' })
   })
 

--- a/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
@@ -248,7 +248,12 @@ describe('ArchivedPanel', () => {
 
   it('removes committed archived Project state and explains pending background cleanup', async () => {
     const archivedProject = { ...project, archivedAt: 2 }
-    deleteProject.mockResolvedValueOnce({ status: 'cleanup-pending' })
+    deleteProject.mockImplementationOnce(async () => {
+      useProjectStore.setState({
+        pendingDeletionCleanupProjectIds: new Set([project.id])
+      } as never)
+      return { status: 'cleanup-pending' }
+    })
     useProjectStore.setState({
       ...createInitialProjectState(),
       projects: [archivedProject],
@@ -281,6 +286,10 @@ describe('ArchivedPanel', () => {
     )
     expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'list' })
+
+    await act(async () => useProjectStore.getState().removeProject(project.id))
+
+    expect(container.querySelector('[role="status"]')).toBeNull()
   })
 
   it('shows Project recovery in Settings and keeps deletion unavailable until retry succeeds', async () => {

--- a/src/renderer/src/pages/settings/ArchivedPanel.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.tsx
@@ -48,6 +48,7 @@ const ArchivedPanel = ({
   const [sessionToDelete, setSessionToDelete] = useState<ChatSession | undefined>()
   const [busyKey, setBusyKey] = useState<string | undefined>()
   const [panelError, setPanelError] = useState<string | undefined>()
+  const [panelNotice, setPanelNotice] = useState<string | undefined>()
   const [projectDeleteError, setProjectDeleteError] = useState<string | undefined>()
   const [sessionDeleteError, setSessionDeleteError] = useState<
     'runtime' | 'persistence' | undefined
@@ -138,6 +139,7 @@ const ArchivedPanel = ({
   const openProjectDeleteDialog = (project: Project): void => {
     if (!canDeleteProjects) return
     setProjectDeleteError(undefined)
+    setPanelNotice(undefined)
     setProjectToDelete(project)
   }
 
@@ -155,10 +157,13 @@ const ArchivedPanel = ({
     setBusyKey(`project:${project.id}`)
     setProjectDeleteError(undefined)
     void (async () => {
-      await deleteProject(project.id)
+      const outcome = await deleteProject(project.id)
       useSessionStore.getState().removeSessionsForProject(project.id)
       useArchiveUndoStore.getState().dismissProject(project.id)
       setProjectToDelete(undefined)
+      if (outcome.status === 'cleanup-pending') {
+        setPanelNotice(t('Project deleted. Cleanup will continue in the background.'))
+      }
     })()
       .then(() => onNavigate({ kind: 'list' }))
       .catch((deleteError: unknown) => {
@@ -222,6 +227,14 @@ const ArchivedPanel = ({
       {panelError ? (
         <p role="alert" className="text-sm text-danger-000">
           {panelError}
+        </p>
+      ) : null}
+      {panelNotice ? (
+        <p
+          role="status"
+          className="rounded-md border border-status-warning-foreground/30 bg-status-warning-surface/40 px-3 py-2 text-sm text-status-warning-foreground dark:border-status-warning-dark-foreground/30 dark:bg-status-warning-dark-surface/20 dark:text-status-warning-dark-foreground"
+        >
+          {panelNotice}
         </p>
       ) : null}
       {selectedProject ? (

--- a/src/renderer/src/pages/settings/ArchivedPanel.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.tsx
@@ -40,6 +40,9 @@ const ArchivedPanel = ({
   const { t } = useTranslation()
   const formatDate = useDateTimeFormat()
   const projects = useProjectStore((state) => state.projects)
+  const hasPendingProjectCleanup = useProjectStore(
+    (state) => state.pendingDeletionCleanupProjectIds.size > 0
+  )
   const updateProjectArchive = useProjectStore((state) => state.updateProjectArchive)
   const deleteProject = useProjectStore((state) => state.deleteProject)
   const sessions = useSessionStore((state) => state.sessions)
@@ -48,7 +51,6 @@ const ArchivedPanel = ({
   const [sessionToDelete, setSessionToDelete] = useState<ChatSession | undefined>()
   const [busyKey, setBusyKey] = useState<string | undefined>()
   const [panelError, setPanelError] = useState<string | undefined>()
-  const [panelNotice, setPanelNotice] = useState<string | undefined>()
   const [projectDeleteError, setProjectDeleteError] = useState<string | undefined>()
   const [sessionDeleteError, setSessionDeleteError] = useState<
     'runtime' | 'persistence' | undefined
@@ -139,7 +141,6 @@ const ArchivedPanel = ({
   const openProjectDeleteDialog = (project: Project): void => {
     if (!canDeleteProjects) return
     setProjectDeleteError(undefined)
-    setPanelNotice(undefined)
     setProjectToDelete(project)
   }
 
@@ -157,13 +158,10 @@ const ArchivedPanel = ({
     setBusyKey(`project:${project.id}`)
     setProjectDeleteError(undefined)
     void (async () => {
-      const outcome = await deleteProject(project.id)
+      await deleteProject(project.id)
       useSessionStore.getState().removeSessionsForProject(project.id)
       useArchiveUndoStore.getState().dismissProject(project.id)
       setProjectToDelete(undefined)
-      if (outcome.status === 'cleanup-pending') {
-        setPanelNotice(t('Project deleted. Cleanup will continue in the background.'))
-      }
     })()
       .then(() => onNavigate({ kind: 'list' }))
       .catch((deleteError: unknown) => {
@@ -229,12 +227,12 @@ const ArchivedPanel = ({
           {panelError}
         </p>
       ) : null}
-      {panelNotice ? (
+      {hasPendingProjectCleanup ? (
         <p
           role="status"
           className="rounded-md border border-status-warning-foreground/30 bg-status-warning-surface/40 px-3 py-2 text-sm text-status-warning-foreground dark:border-status-warning-dark-foreground/30 dark:bg-status-warning-dark-surface/20 dark:text-status-warning-dark-foreground"
         >
-          {panelNotice}
+          {t('Project deleted. Cleanup will continue in the background.')}
         </p>
       ) : null}
       {selectedProject ? (

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -118,6 +118,11 @@ describe('project store', () => {
 
     expect(outcome).toEqual({ status: 'cleanup-pending' })
     expect(useProjectStore.getState().projects.map((project) => project.id)).toEqual(['keep'])
+    expect(useProjectStore.getState().pendingDeletionCleanupProjectIds.has('drop')).toBe(true)
+
+    useProjectStore.getState().removeProject('drop')
+
+    expect(useProjectStore.getState().pendingDeletionCleanupProjectIds.has('drop')).toBe(false)
   })
 })
 

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -124,6 +124,23 @@ describe('project store', () => {
 
     expect(useProjectStore.getState().pendingDeletionCleanupProjectIds.has('drop')).toBe(false)
   })
+
+  it('does not let a late pending command result supersede terminal lifecycle state', async () => {
+    const commandResult = createDeferred<{ status: 'cleanup-pending' }>()
+    useProjectStore.setState({
+      projects: [createProject({ id: 'drop' })],
+      isLoaded: true
+    })
+    setProjectsApi({ delete: vi.fn().mockReturnValue(commandResult.promise) })
+
+    const deletion = useProjectStore.getState().deleteProject('drop')
+    useProjectStore.getState().removeProject('drop', { status: 'deleted' })
+    commandResult.resolve({ status: 'cleanup-pending' })
+
+    await expect(deletion).resolves.toEqual({ status: 'cleanup-pending' })
+    expect(useProjectStore.getState().pendingDeletionCleanupProjectIds.has('drop')).toBe(false)
+    expect(useProjectStore.getState().projectDeletionRequests.size).toBe(0)
+  })
 })
 
 const createDeferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -107,15 +107,16 @@ describe('project store', () => {
     expect(useProjectStore.getState().projects[0]).toEqual(created)
   })
 
-  it('drops a deleted project from the cache', async () => {
+  it('returns cleanup-pending while dropping a committed Project deletion from the cache', async () => {
     useProjectStore.setState({
       projects: [createProject({ id: 'keep' }), createProject({ id: 'drop' })],
       isLoaded: true
     })
-    setProjectsApi({ delete: vi.fn().mockResolvedValue(undefined) })
+    setProjectsApi({ delete: vi.fn().mockResolvedValue({ status: 'cleanup-pending' }) })
 
-    await useProjectStore.getState().deleteProject('drop')
+    const outcome = await useProjectStore.getState().deleteProject('drop')
 
+    expect(outcome).toEqual({ status: 'cleanup-pending' })
     expect(useProjectStore.getState().projects.map((project) => project.id)).toEqual(['keep'])
   })
 })

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand'
 import type {
   CreateProjectRequest,
   Project,
+  ProjectDeletionOutcome,
   UpdateProjectArchiveRequest,
   UpdateProjectRequest
 } from '../../../shared/projects'
@@ -18,7 +19,7 @@ type ProjectStore = ProjectStoreData & {
   createProject: (request: CreateProjectRequest) => Promise<Project | undefined>
   updateProject: (request: UpdateProjectRequest) => Promise<Project | undefined>
   updateProjectArchive: (request: UpdateProjectArchiveRequest) => Promise<Project>
-  deleteProject: (id: string) => Promise<void>
+  deleteProject: (id: string) => Promise<ProjectDeletionOutcome>
   upsertProject: (project: Project) => void
   removeProject: (id: string) => void
 }
@@ -109,12 +110,13 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     return project
   },
 
-  // Deletes a project row and drops it from the cache. Session cascade is handled by the session store.
+  // Drops committed Project deletion from the cache. Session cascade is handled by the session store.
   deleteProject: async (id) => {
-    await window.api.projects.delete({ id })
+    const outcome = await window.api.projects.delete({ id })
 
     projectMutationSequence += 1
     set((state) => ({ projects: state.projects.filter((project) => project.id !== id) }))
+    return outcome
   },
 
   upsertProject: (project) => {

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -11,6 +11,10 @@ import type {
 type ProjectStoreData = {
   projects: Project[]
   pendingDeletionCleanupProjectIds: Set<string>
+  projectDeletionRequests: Map<
+    string,
+    { generation: number; lifecycleStatus?: ProjectDeletionOutcome['status'] }
+  >
   isLoaded: boolean
   loadError: string | undefined
 }
@@ -45,10 +49,12 @@ const upsertProjectList = (projects: Project[], project: Project): Project[] => 
 
 let projectLoadSequence = 0
 let projectMutationSequence = 0
+let projectDeletionRequestGeneration = 0
 
 export const createInitialProjectState = (): ProjectStoreData => ({
   projects: [],
   pendingDeletionCleanupProjectIds: new Set(),
+  projectDeletionRequests: new Map(),
   isLoaded: false,
   loadError: undefined
 })
@@ -114,17 +120,48 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
   // Drops committed Project deletion from the cache. Session cascade is handled by the session store.
   deleteProject: async (id) => {
-    const outcome = await window.api.projects.delete({ id })
+    const generation = ++projectDeletionRequestGeneration
+    set((state) => {
+      const projectDeletionRequests = new Map(state.projectDeletionRequests)
+      projectDeletionRequests.set(id, { generation })
+      return { projectDeletionRequests }
+    })
+
+    let outcome: ProjectDeletionOutcome
+    try {
+      outcome = await window.api.projects.delete({ id })
+    } catch (error) {
+      set((state) => {
+        const projectDeletionRequests = new Map(state.projectDeletionRequests)
+        if (projectDeletionRequests.get(id)?.generation === generation) {
+          projectDeletionRequests.delete(id)
+        }
+        return { projectDeletionRequests }
+      })
+      throw error
+    }
 
     projectMutationSequence += 1
     set((state) => {
+      const projectDeletionRequests = new Map(state.projectDeletionRequests)
+      const request = projectDeletionRequests.get(id)
+      const isCurrentRequest = request?.generation === generation
+      if (isCurrentRequest) projectDeletionRequests.delete(id)
+
+      // Lifecycle events are the authoritative cross-window ordering stream. If one arrived while
+      // this command was in flight, its newer pending/terminal projection must win over the RPC result.
+      if (!isCurrentRequest || request.lifecycleStatus !== undefined) {
+        return { projectDeletionRequests }
+      }
+
       const pendingDeletionCleanupProjectIds = new Set(state.pendingDeletionCleanupProjectIds)
       if (outcome.status === 'cleanup-pending') pendingDeletionCleanupProjectIds.add(id)
       else pendingDeletionCleanupProjectIds.delete(id)
 
       return {
         projects: state.projects.filter((project) => project.id !== id),
-        pendingDeletionCleanupProjectIds
+        pendingDeletionCleanupProjectIds,
+        projectDeletionRequests
       }
     })
     return outcome
@@ -139,12 +176,18 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     projectMutationSequence += 1
     set((state) => {
       const pendingDeletionCleanupProjectIds = new Set(state.pendingDeletionCleanupProjectIds)
-      if (outcome.status === 'cleanup-pending') pendingDeletionCleanupProjectIds.add(id)
+      const projectDeletionRequests = new Map(state.projectDeletionRequests)
+      const request = projectDeletionRequests.get(id)
+      const lifecycleStatus = request?.lifecycleStatus === 'deleted' ? 'deleted' : outcome.status
+      if (request) projectDeletionRequests.set(id, { ...request, lifecycleStatus })
+
+      if (lifecycleStatus === 'cleanup-pending') pendingDeletionCleanupProjectIds.add(id)
       else pendingDeletionCleanupProjectIds.delete(id)
 
       return {
         projects: state.projects.filter((project) => project.id !== id),
-        pendingDeletionCleanupProjectIds
+        pendingDeletionCleanupProjectIds,
+        projectDeletionRequests
       }
     })
   }

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -22,7 +22,7 @@ type ProjectStore = ProjectStoreData & {
   updateProjectArchive: (request: UpdateProjectArchiveRequest) => Promise<Project>
   deleteProject: (id: string) => Promise<ProjectDeletionOutcome>
   upsertProject: (project: Project) => void
-  removeProject: (id: string) => void
+  removeProject: (id: string, outcome?: ProjectDeletionOutcome) => void
 }
 
 // Keep raw IPC diagnostics in the developer channel while renderer state remains path-safe.
@@ -135,11 +135,12 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     set((state) => ({ projects: upsertProjectList(state.projects, project) }))
   },
 
-  removeProject: (id) => {
+  removeProject: (id, outcome = { status: 'deleted' }) => {
     projectMutationSequence += 1
     set((state) => {
       const pendingDeletionCleanupProjectIds = new Set(state.pendingDeletionCleanupProjectIds)
-      pendingDeletionCleanupProjectIds.delete(id)
+      if (outcome.status === 'cleanup-pending') pendingDeletionCleanupProjectIds.add(id)
+      else pendingDeletionCleanupProjectIds.delete(id)
 
       return {
         projects: state.projects.filter((project) => project.id !== id),

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -10,6 +10,7 @@ import type {
 
 type ProjectStoreData = {
   projects: Project[]
+  pendingDeletionCleanupProjectIds: Set<string>
   isLoaded: boolean
   loadError: string | undefined
 }
@@ -47,6 +48,7 @@ let projectMutationSequence = 0
 
 export const createInitialProjectState = (): ProjectStoreData => ({
   projects: [],
+  pendingDeletionCleanupProjectIds: new Set(),
   isLoaded: false,
   loadError: undefined
 })
@@ -115,7 +117,16 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     const outcome = await window.api.projects.delete({ id })
 
     projectMutationSequence += 1
-    set((state) => ({ projects: state.projects.filter((project) => project.id !== id) }))
+    set((state) => {
+      const pendingDeletionCleanupProjectIds = new Set(state.pendingDeletionCleanupProjectIds)
+      if (outcome.status === 'cleanup-pending') pendingDeletionCleanupProjectIds.add(id)
+      else pendingDeletionCleanupProjectIds.delete(id)
+
+      return {
+        projects: state.projects.filter((project) => project.id !== id),
+        pendingDeletionCleanupProjectIds
+      }
+    })
     return outcome
   },
 
@@ -126,6 +137,14 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
   removeProject: (id) => {
     projectMutationSequence += 1
-    set((state) => ({ projects: state.projects.filter((project) => project.id !== id) }))
+    set((state) => {
+      const pendingDeletionCleanupProjectIds = new Set(state.pendingDeletionCleanupProjectIds)
+      pendingDeletionCleanupProjectIds.delete(id)
+
+      return {
+        projects: state.projects.filter((project) => project.id !== id),
+        pendingDeletionCleanupProjectIds
+      }
+    })
   }
 }))

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -671,6 +671,7 @@
     "Could not delete project.": "No se pudo eliminar el proyecto.",
     "Could not delete session.": "No se pudo eliminar la sesión.",
     "Could not delete the project. Please try again.": "No se pudo eliminar el proyecto. Inténtelo de nuevo.",
+    "Project deleted. Cleanup will continue in the background.": "Proyecto eliminado. La limpieza continuará en segundo plano.",
     "Could not disconnect Claude from Open Science.": "No se pudo desconectar Claude de Open Science.",
     "Could not export this Skill.": "No se pudo exportar esta habilidad.",
     "Could not import the selected skills.": "No se pudieron importar las habilidades seleccionadas.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -47,7 +47,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "Le dossier choisi contient déjà {{count}} Notebooks.",
     "Overwrite": "Écraser",
     "Save the update installer": "Enregistrer le programme d'installation de la mise à jour",
-    "Could not open the update installer: {{error}}": "Impossible d'ouvrir le programme d'installation de la mise à jour : {{error}}",
+    "Could not open the update installer: {{error}}": "Impossible d'ouvrir le programme d'installation de la mise à jour: {{error}}",
     "Export Skill": "Exporter la compétence",
     "Skill ZIP": "Archive ZIP de la compétence",
     "ZIP archive": "Archive ZIP",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -671,6 +671,7 @@
     "Could not delete project.": "Impossible de supprimer le projet.",
     "Could not delete session.": "Impossible de supprimer la session.",
     "Could not delete the project. Please try again.": "Impossible de supprimer le projet. Veuillez réessayer.",
+    "Project deleted. Cleanup will continue in the background.": "Projet supprimé. Le nettoyage se poursuivra en arrière-plan.",
     "Could not disconnect Claude from Open Science.": "Impossible de déconnecter Claude de Open Science.",
     "Could not export this Skill.": "Impossible d'exporter cette compétence.",
     "Could not import the selected skills.": "Impossible d'importer les compétences sélectionnées.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -632,6 +632,7 @@
     "Could not delete project.": "プロジェクトを削除できませんでした。",
     "Could not delete session.": "セッションを削除できませんでした。",
     "Could not delete the project. Please try again.": "プロジェクトを削除できませんでした。もう一度試してください。",
+    "Project deleted. Cleanup will continue in the background.": "プロジェクトを削除しました。クリーンアップはバックグラウンドで続行されます。",
     "Could not disconnect Claude from Open Science.": "Claude を Open Science から切断できませんでした。",
     "Could not export this Skill.": "このスキルをエクスポートできませんでした。",
     "Could not import the selected skills.": "選択したスキルをインポートできませんでした。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -651,6 +651,7 @@
     "Could not delete project.": "프로젝트를 삭제할 수 없습니다.",
     "Could not delete session.": "세션을 삭제할 수 없습니다.",
     "Could not delete the project. Please try again.": "프로젝트를 삭제할 수 없습니다. 다시 시도해 주세요.",
+    "Project deleted. Cleanup will continue in the background.": "프로젝트가 삭제되었습니다. 정리는 백그라운드에서 계속됩니다.",
     "Could not disconnect Claude from Open Science.": "Open Science에서 Claude 연결을 해제하지 못했습니다.",
     "Could not export this Skill.": "스킬을 내보낼 수 없습니다.",
     "Could not import the selected skills.": "선택한 스킬을 가져올 수 없습니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -662,6 +662,7 @@
     "Could not delete project.": "Не удалось удалить проект.",
     "Could not delete session.": "Не удалось удалить сессию.",
     "Could not delete the project. Please try again.": "Не удалось удалить проект. Попробуйте снова.",
+    "Project deleted. Cleanup will continue in the background.": "Проект удалён. Очистка продолжится в фоновом режиме.",
     "Could not disconnect Claude from Open Science.": "Не удалось отключить Claude от Open Science.",
     "Could not export this Skill.": "Не удалось экспортировать этот навык.",
     "Could not import the selected skills.": "Не удалось импортировать выбранные навыки.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -703,6 +703,7 @@
     "Could not delete project.": "无法删除项目。",
     "Could not delete session.": "无法删除会话。",
     "Could not delete the project. Please try again.": "无法删除项目。请重试。",
+    "Project deleted. Cleanup will continue in the background.": "项目已删除。清理将在后台继续。",
     "Could not disconnect Claude from Open Science.": "无法断开 Claude 与 Open Science 的连接。",
     "Could not export this Skill.": "无法导出此技能。",
     "Could not import the selected skills.": "无法导入所选技能。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -702,6 +702,7 @@
     "Could not delete project.": "無法刪除專案。",
     "Could not delete session.": "無法刪除會話。",
     "Could not delete the project. Please try again.": "無法刪除專案。請重試。",
+    "Project deleted. Cleanup will continue in the background.": "專案已刪除。清理將在背景繼續。",
     "Could not disconnect Claude from Open Science.": "無法中斷 Claude 與 Open Science 的連線。",
     "Could not export this Skill.": "無法匯出此技能。",
     "Could not import the selected skills.": "無法匯入所選技能。",

--- a/src/shared/lifecycle-events.ts
+++ b/src/shared/lifecycle-events.ts
@@ -1,4 +1,4 @@
-import type { Project } from './projects'
+import type { Project, ProjectDeletionOutcome } from './projects'
 import type { PersistedChatSession } from './session-persistence'
 
 type SessionUpsertEvent = {
@@ -15,7 +15,7 @@ const MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID = 'main:enabled-compute-hos
 const MAIN_DELEGATED_WORK_LIFECYCLE_CLIENT_ID = 'main:delegated-work'
 const MAIN_SESSION_DETAILS_LIFECYCLE_CLIENT_ID = 'main:session-details'
 
-type ProjectDeletedEvent = {
+type ProjectDeletedEvent = ProjectDeletionOutcome & {
   projectId: string
 }
 

--- a/src/shared/projects.test.ts
+++ b/src/shared/projects.test.ts
@@ -56,7 +56,12 @@ describe('project application command contracts', () => {
     expect(projectApplicationCommandContracts.delete.args.parse([{ id: 'project-1' }])).toEqual([
       { id: 'project-1' }
     ])
-    expect(projectApplicationCommandContracts.delete.result.parse(undefined)).toBeUndefined()
+    expect(
+      projectApplicationCommandContracts.delete.result.parse({ status: 'deleted' })
+    ).toEqual({ status: 'deleted' })
+    expect(
+      projectApplicationCommandContracts.delete.result.parse({ status: 'cleanup-pending' })
+    ).toEqual({ status: 'cleanup-pending' })
   })
 
   it('rejects malformed and surplus public fields', () => {

--- a/src/shared/projects.test.ts
+++ b/src/shared/projects.test.ts
@@ -56,9 +56,9 @@ describe('project application command contracts', () => {
     expect(projectApplicationCommandContracts.delete.args.parse([{ id: 'project-1' }])).toEqual([
       { id: 'project-1' }
     ])
-    expect(
-      projectApplicationCommandContracts.delete.result.parse({ status: 'deleted' })
-    ).toEqual({ status: 'deleted' })
+    expect(projectApplicationCommandContracts.delete.result.parse({ status: 'deleted' })).toEqual({
+      status: 'deleted'
+    })
     expect(
       projectApplicationCommandContracts.delete.result.parse({ status: 'cleanup-pending' })
     ).toEqual({ status: 'cleanup-pending' })

--- a/src/shared/projects.ts
+++ b/src/shared/projects.ts
@@ -51,6 +51,11 @@ export const updateProjectRequestSchema = z
 
 export const deleteProjectRequestSchema = z.object({ id: z.string() }).strict()
 
+export const projectDeletionOutcomeSchema = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('deleted') }).strict(),
+  z.object({ status: z.literal('cleanup-pending') }).strict()
+])
+
 export const updateProjectArchiveRequestSchema = z
   .object({
     id: z.string(),
@@ -65,6 +70,7 @@ export type Project = z.infer<typeof projectSchema>
 export type CreateProjectRequest = z.infer<typeof createProjectRequestSchema>
 export type UpdateProjectRequest = z.infer<typeof updateProjectRequestSchema>
 export type DeleteProjectRequest = z.infer<typeof deleteProjectRequestSchema>
+export type ProjectDeletionOutcome = z.infer<typeof projectDeletionOutcomeSchema>
 export type UpdateProjectArchiveRequest = z.infer<typeof updateProjectArchiveRequestSchema>
 
 export const projectApplicationCommandContracts = Object.freeze({
@@ -90,6 +96,6 @@ export const projectApplicationCommandContracts = Object.freeze({
   ),
   delete: defineApplicationCommandContract(
     validationCodec(z.tuple([deleteProjectRequestSchema])),
-    validationCodec(z.undefined())
+    validationCodec(projectDeletionOutcomeSchema)
   )
 })

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -190,6 +190,7 @@ import type {
   CreateProjectRequest,
   DeleteProjectRequest,
   Project,
+  ProjectDeletionOutcome,
   UpdateProjectArchiveRequest,
   UpdateProjectRequest
 } from './projects'
@@ -1238,13 +1239,10 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     undefined,
     RUNTIME_VALIDATED
   ]),
-  'projects.delete': callable<(request: DeleteProjectRequest) => Promise<void>>()('projects', [
-    'projects:delete',
-    WEB,
-    undefined,
-    undefined,
-    RUNTIME_VALIDATED
-  ]),
+  'projects.delete': callable<(request: DeleteProjectRequest) => Promise<ProjectDeletionOutcome>>()(
+    'projects',
+    ['projects:delete', WEB, undefined, undefined, RUNTIME_VALIDATED]
+  ),
   'projects.get': callable<(id: string) => Promise<Project | null>>()('projects', [
     'projects:get',
     WEB,


### PR DESCRIPTION
## Problem

Project deletion soft-deletes Project metadata before several fallible cleanup tails. When one of those tails failed, the command rejected even though the Project was already absent from ordinary queries, so Home and Archived Settings retained stale Project and Session state and offered a misleading deletion retry. Background recovery could later finish the durable intent, but only the foreground command adapter published `project:deleted`, leaving Renderer caches stale until reload.

## Proposed change

- Add an explicit Project deletion command outcome: `deleted` or `cleanup-pending`.
- Keep failures before the soft-delete commit as rejections.
- Return `cleanup-pending` after the commit while retaining the existing deletion intent for background retry.
- Make `ProjectDeletionCoordinator` the single publisher of terminal `project:deleted` events for foreground and recovery completion.
- Remove the Project and its Sessions from the initiating Renderer for both committed outcomes; show a translated non-blocking warning while cleanup remains pending.

```mermaid
flowchart LR
  A[Delete command] --> B{Soft-delete committed?}
  B -- No, operation fails --> C[Reject and keep Project visible]
  B -- Yes, tail completes --> D[deleted]
  B -- Yes, tail fails --> E[cleanup-pending]
  E --> F[Background recovery]
  F --> D
  D --> G[Coordinator publishes project:deleted]
```

## Scope and non-goals

- No Prisma schema, migration, persisted field, or persisted enum changes.
- No historical data migration or compatibility path is required; existing deletion intents and Session tombstones remain the retry authority.
- The new status values are transient application-command/Renderer contract values only.
- No change to deletion ordering, retry delay, or legacy tombstone adoption.
- Durable event delivery across a process crash remains out of scope; this keeps the existing in-process lifecycle-event model.

## Acceptance criteria and validation

Red regression evidence on the unmodified implementation:

- post-commit cleanup test rejected with `side chat profile busy` instead of resolving `cleanup-pending`;
- background recovery completed with zero `project:deleted` publications;
- the command adapter returned `undefined` instead of the owner outcome;
- Renderer tests had no cleanup-pending status notice.

Final evidence after rebasing onto the latest `main`:

- affected Project deletion modules: 8 files, 126 tests passed;
- locale owner and i18n catalog guards: 2 files, 750 tests passed;
- PR Gate: both full macOS module shards, coverage aggregation, static checks, Windows core, Windows E2E, macOS build/E2E, CodeQL, PR policy, and AI review passed;
- the latest `main` introduced one unrelated French high-punctuation catalog violation; the existing guard reproduced it in two macOS CI runs, and the one-character catalog correction is isolated in `fix(i18n): keep French high punctuation attached`.

Per the requested workflow, no full local `npm test` run was performed; complete portable coverage came from PR Gate.

## Review focus

- Confirm only failures after the Project soft-delete commit become `cleanup-pending`; pre-commit failures still reject.
- Confirm pending outcomes leave recovery non-sticky so the durable intent is retried.
- Confirm `project:deleted` is emitted once from the coordinator on foreground or background terminal completion and never duplicated by the command adapter.
- Confirm the warning copy and seven locale entries accurately describe a committed deletion rather than asking the user to retry.
