### PR TITLE
fix(remote-access): enforce lifecycle and request contracts

### DIFF
--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -121,6 +121,15 @@ export class CliUsageError extends Error {
   }
 }
 
+const parsePortOption = (value) => {
+  const normalized = value.trim()
+  const port = Number(normalized)
+  if (!/^\d+$/.test(normalized) || !Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new CliUsageError(`Invalid port: ${value}`)
+  }
+  return port
+}
+
 export const parseCliArgs = (argv) => {
   const args = [...argv]
   const command = args.shift()
@@ -179,11 +188,7 @@ export const parseCliArgs = (argv) => {
     }
   }
   if (options.port !== undefined) {
-    const port = Number.parseInt(options.port, 10)
-    if (!Number.isInteger(port) || port < 1 || port > 65535) {
-      throw new CliUsageError(`Invalid port: ${options.port}`)
-    }
-    options.port = port
+    options.port = parsePortOption(options.port)
   }
   if (options.approvalProfile && !['ask', 'auto', 'full'].includes(options.approvalProfile)) {
     throw new CliUsageError(`Invalid approval profile: ${options.approvalProfile}`)

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -29,6 +29,11 @@ const listProjects = async (): Promise<Array<{ id: string; name: string }>> => [
 ]
 
 describe('task CLI', () => {
+  it('rejects ports that are not complete decimal values', () => {
+    expect(() => parseCliArgs(['start', '--port', '44100xyz'])).toThrow('Invalid port: 44100xyz')
+    expect(() => parseCliArgs(['start', '--port', '0'])).toThrow('Invalid port: 0')
+  })
+
   it('parses the first milestone run interface', () => {
     expect(
       parseCliArgs(['project', 'create', 'Research', '--agent-context', 'Always cite sources.'])

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -296,7 +296,16 @@ describe('application command composition', () => {
   })
 
   it('late-binds the single Remote Access owner and fails closed around its lifetime', async () => {
-    const snapshot = Object.freeze({ lifecycle: 'disabled' })
+    const snapshot = Object.freeze({
+      canManage: true,
+      canManagePairing: true,
+      mode: 'off' as const,
+      enabled: false,
+      lifecycle: 'disabled' as const,
+      remoteIt: Object.freeze({ installed: false, loggedIn: false, registered: false }),
+      pendingRequests: Object.freeze([]),
+      trustedBrowsers: Object.freeze([])
+    })
     const firstSnapshot = vi.fn(() => snapshot)
     const firstOwner = {
       snapshot: firstSnapshot,
@@ -307,7 +316,9 @@ describe('application command composition', () => {
       reject: vi.fn(),
       revoke: vi.fn()
     }
-    const replacementSnapshot = vi.fn(() => Object.freeze({ lifecycle: 'running' }))
+    const replacementSnapshot = vi.fn(() =>
+      Object.freeze({ ...snapshot, mode: 'remoteit' as const, enabled: true, lifecycle: 'running' })
+    )
     const replacementOwner = { ...firstOwner, snapshot: replacementSnapshot }
     const composition = createApplicationCommandComposition(dependencies())
 

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -506,6 +506,35 @@ describe('Host application commands', () => {
     expect(dependencies.remoteAccess.detect).not.toHaveBeenCalled()
   })
 
+  it('rejects malformed Remote Access arguments before entering an owner', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerHostApplicationCommands(router.registrar, dependencies)
+    const cases: Array<readonly [string, readonly unknown[]]> = [
+      ['remote-access:approve', [undefined]],
+      ['remote-access:detect', [{}]],
+      ['remote-access:disable', [{}]],
+      ['remote-access:get-snapshot', [{}]],
+      ['remote-access:reject', [undefined]],
+      ['remote-access:revoke-browser', [undefined]],
+      ['remote-access:set-mode', [{ mode: 'invalid' }]]
+    ]
+
+    for (const [channel, args] of cases) {
+      await expect(
+        router.dispatcher.invoke(commandByName(channel), invocation(args))
+      ).rejects.toMatchObject({ code: 'invalid-command-arguments' })
+    }
+
+    expect(dependencies.remoteAccess.approve).not.toHaveBeenCalled()
+    expect(dependencies.remoteAccess.detect).not.toHaveBeenCalled()
+    expect(dependencies.remoteAccess.disable).not.toHaveBeenCalled()
+    expect(dependencies.remoteAccess.snapshot).not.toHaveBeenCalled()
+    expect(dependencies.remoteAccess.reject).not.toHaveBeenCalled()
+    expect(dependencies.remoteAccess.revoke).not.toHaveBeenCalled()
+    expect(dependencies.remoteAccess.setMode).not.toHaveBeenCalled()
+  })
+
   it('keeps pending-notification token validation ahead of owner mutation', async () => {
     const dependencies = createDependencies()
     const router = createApplicationCommandRouter()

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -24,6 +24,7 @@ import type {
   RevokeRemoteBrowserRequest,
   SetRemoteAccessModeRequest
 } from '../shared/remote-access'
+import { remoteAccessApplicationCommandContracts } from '../shared/remote-access'
 import type {
   ReviewRunRequest,
   ReviewRunResult,
@@ -184,33 +185,35 @@ const remoteAccessCommands = Object.freeze({
     'remote-access:approve',
     readonly [request: ApproveRemotePairingRequest],
     RemoteAccessSnapshot
-  >('remote-access:approve'),
+  >('remote-access:approve', remoteAccessApplicationCommandContracts.approve),
   detect: defineApplicationCommand<'remote-access:detect', readonly [], RemoteAccessSnapshot>(
-    'remote-access:detect'
+    'remote-access:detect',
+    remoteAccessApplicationCommandContracts.detect
   ),
   disable: defineApplicationCommand<'remote-access:disable', readonly [], RemoteAccessSnapshot>(
-    'remote-access:disable'
+    'remote-access:disable',
+    remoteAccessApplicationCommandContracts.disable
   ),
   getSnapshot: defineApplicationCommand<
     'remote-access:get-snapshot',
     readonly [],
     RemoteAccessSnapshot
-  >('remote-access:get-snapshot'),
+  >('remote-access:get-snapshot', remoteAccessApplicationCommandContracts.getSnapshot),
   reject: defineApplicationCommand<
     'remote-access:reject',
     readonly [request: RemotePairingRequestId],
     RemoteAccessSnapshot
-  >('remote-access:reject'),
+  >('remote-access:reject', remoteAccessApplicationCommandContracts.reject),
   revokeBrowser: defineApplicationCommand<
     'remote-access:revoke-browser',
     readonly [request: RevokeRemoteBrowserRequest],
     RemoteAccessSnapshot
-  >('remote-access:revoke-browser'),
+  >('remote-access:revoke-browser', remoteAccessApplicationCommandContracts.revokeBrowser),
   setMode: defineApplicationCommand<
     'remote-access:set-mode',
     readonly [request: SetRemoteAccessModeRequest],
     RemoteAccessSnapshot
-  >('remote-access:set-mode')
+  >('remote-access:set-mode', remoteAccessApplicationCommandContracts.setMode)
 })
 
 const reviewerCommands = Object.freeze({

--- a/src/main/remote-access/ipc.test.ts
+++ b/src/main/remote-access/ipc.test.ts
@@ -1,16 +1,31 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<
+  string,
+  (event: { sender: { id: number } }, request?: unknown) => unknown
+>()
 
 vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }))
+vi.mock('../ipc-handler-registry', () => ({
+  ipcMainHandle: (
+    channel: string,
+    handler: (event: { sender: { id: number } }, request?: unknown) => unknown
+  ) => handlers.set(channel, handler)
+}))
 
 import {
   canManagePairing,
   isDesktopCaller,
+  registerRemoteAccessIpcHandlers,
   requireDesktopCaller,
   requirePairingManager
 } from './ipc'
 import { createElectronCallerContext, createWebCallerContext } from '../caller-context'
+import type { RemoteAccessService } from './service'
 
 describe('remote access IPC authorization', () => {
+  beforeEach(() => handlers.clear())
+
   it.each([
     ['Electron desktop', createElectronCallerContext(7), true],
     ['local Web', createWebCallerContext('local-browser'), false],
@@ -67,5 +82,42 @@ describe('remote access IPC authorization', () => {
     expect(canManagePairing(context)).toBe(true)
     expect(() => requireDesktopCaller(context)).toThrow()
     expect(() => requirePairingManager(context)).not.toThrow()
+  })
+
+  it('rejects malformed payloads before entering the service', async () => {
+    const service = {
+      approve: vi.fn(),
+      detect: vi.fn(),
+      disable: vi.fn(),
+      snapshot: vi.fn(),
+      reject: vi.fn(),
+      revoke: vi.fn(),
+      setMode: vi.fn()
+    }
+    registerRemoteAccessIpcHandlers(service as unknown as RemoteAccessService)
+    const event = { sender: { id: 7 } }
+    const cases: Array<readonly [string, unknown]> = [
+      ['remote-access:get-snapshot', { unexpected: true }],
+      ['remote-access:detect', { unexpected: true }],
+      ['remote-access:disable', { unexpected: true }],
+      ['remote-access:approve', undefined],
+      ['remote-access:reject', undefined],
+      ['remote-access:revoke-browser', undefined],
+      ['remote-access:set-mode', { mode: 'invalid' }]
+    ]
+
+    for (const [channel, payload] of cases) {
+      await expect(
+        Promise.resolve().then(() => handlers.get(channel)?.(event, payload))
+      ).rejects.toThrow()
+    }
+
+    expect(service.approve).not.toHaveBeenCalled()
+    expect(service.detect).not.toHaveBeenCalled()
+    expect(service.disable).not.toHaveBeenCalled()
+    expect(service.snapshot).not.toHaveBeenCalled()
+    expect(service.reject).not.toHaveBeenCalled()
+    expect(service.revoke).not.toHaveBeenCalled()
+    expect(service.setMode).not.toHaveBeenCalled()
   })
 })

--- a/src/main/remote-access/ipc.ts
+++ b/src/main/remote-access/ipc.ts
@@ -1,9 +1,4 @@
-import type {
-  ApproveRemotePairingRequest,
-  RemotePairingRequestId,
-  RevokeRemoteBrowserRequest,
-  SetRemoteAccessModeRequest
-} from '../../shared/remote-access'
+import { remoteAccessApplicationCommandContracts } from '../../shared/remote-access'
 import { callerContextForEvent, hasCallerAuthority, type CallerContext } from '../caller-context'
 import { ipcMainHandle } from '../ipc-handler-registry'
 import { RemoteAccessService } from './service'
@@ -31,44 +26,48 @@ const requirePairingManager = (context: CallerContext): void => {
 }
 
 export const registerRemoteAccessIpcHandlers = (service: RemoteAccessService): void => {
-  ipcMainHandle('remote-access:get-snapshot', (event) => {
+  ipcMainHandle('remote-access:get-snapshot', (event, ...args) => {
+    remoteAccessApplicationCommandContracts.getSnapshot.args.parse(args)
     const context = callerContextForEvent(event)
     const desktop = isDesktopCaller(context)
     return service.snapshot(desktop, canManagePairing(context))
   })
-  ipcMainHandle('remote-access:detect', async (event) => {
+  ipcMainHandle('remote-access:detect', async (event, ...args) => {
+    remoteAccessApplicationCommandContracts.detect.args.parse(args)
     requireDesktopCaller(callerContextForEvent(event))
     return service.detect()
   })
-  ipcMainHandle('remote-access:set-mode', async (event, request: SetRemoteAccessModeRequest) => {
+  ipcMainHandle('remote-access:set-mode', async (event, ...args) => {
+    const [request] = remoteAccessApplicationCommandContracts.setMode.args.parse(args)
     requireDesktopCaller(callerContextForEvent(event))
     return service.setMode(request.mode)
   })
-  ipcMainHandle('remote-access:disable', async (event) => {
+  ipcMainHandle('remote-access:disable', async (event, ...args) => {
+    remoteAccessApplicationCommandContracts.disable.args.parse(args)
     requireDesktopCaller(callerContextForEvent(event))
     return service.disable()
   })
-  ipcMainHandle('remote-access:approve', async (event, request: ApproveRemotePairingRequest) => {
+  ipcMainHandle('remote-access:approve', async (event, ...args) => {
+    const [request] = remoteAccessApplicationCommandContracts.approve.args.parse(args)
     const context = callerContextForEvent(event)
     requirePairingManager(context)
     const desktop = isDesktopCaller(context)
     return service.approve(request, desktop, canManagePairing(context))
   })
-  ipcMainHandle('remote-access:reject', (event, request: RemotePairingRequestId) => {
+  ipcMainHandle('remote-access:reject', (event, ...args) => {
+    const [request] = remoteAccessApplicationCommandContracts.reject.args.parse(args)
     const context = callerContextForEvent(event)
     requirePairingManager(context)
     const desktop = isDesktopCaller(context)
     return service.reject(request.requestId, desktop, canManagePairing(context))
   })
-  ipcMainHandle(
-    'remote-access:revoke-browser',
-    async (event, request: RevokeRemoteBrowserRequest) => {
-      const context = callerContextForEvent(event)
-      requirePairingManager(context)
-      const desktop = isDesktopCaller(context)
-      return service.revoke(request.browserId, desktop, canManagePairing(context))
-    }
-  )
+  ipcMainHandle('remote-access:revoke-browser', async (event, ...args) => {
+    const [request] = remoteAccessApplicationCommandContracts.revokeBrowser.args.parse(args)
+    const context = callerContextForEvent(event)
+    requirePairingManager(context)
+    const desktop = isDesktopCaller(context)
+    return service.revoke(request.browserId, desktop, canManagePairing(context))
+  })
 }
 
 export { canManagePairing, isDesktopCaller, requireDesktopCaller, requirePairingManager }

--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { RemoteSessionPairingManager } from './pairing'
-import { RemoteAccessRepository } from './repository'
+import { RemoteAccessRepository, TRUSTED_BROWSER_TTL_MS } from './repository'
 import type { RemotePairingDecision } from '../../shared/remote-access'
 
 const roots: string[] = []
@@ -259,6 +259,155 @@ describe('RemoteSessionPairingManager', () => {
     ).resolves.toBe('denied')
   })
 
+  it('rejects and removes a trusted browser after its 180-day authorization expires', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const repository = new RemoteAccessRepository(root)
+    let now = 0
+    const options = {
+      repository,
+      isAllowedRemoteHost: (hostname: string) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn(),
+      now: () => now
+    }
+    const manager = await RemoteSessionPairingManager.create(options)
+    const pairingResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/'),
+      pairingResponse.response,
+      new URL('https://home.example.ts.net/')
+    )
+    const pendingCookie = cookiePair(pairingResponse.headers.get('set-cookie') as string)
+    await manager.approve(manager.pendingViews()[0].id, 'always')
+    const statusResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/__open_science_remote/pair/status', { cookie: pendingCookie }),
+      statusResponse.response,
+      new URL('https://home.example.ts.net/__open_science_remote/pair/status')
+    )
+    const sessionCookie = cookiePair((statusResponse.headers.get('set-cookie') as string[])[0])
+
+    now = 15_552_000_001
+    const restartedManager = await RemoteSessionPairingManager.create(options)
+    await expect(
+      restartedManager.webAccess.authorizeHttp(
+        request('/', { cookie: sessionCookie }),
+        response().response,
+        new URL('https://home.example.ts.net/')
+      )
+    ).resolves.toBe('handled')
+    await vi.waitFor(async () => {
+      expect((await repository.load()).trustedBrowsers).toHaveLength(0)
+    })
+  })
+
+  it('rejects a trusted browser that expires while its last-seen update is queued', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const repository = new RemoteAccessRepository(root)
+    let now = 0
+    const manager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn(),
+      now: () => now
+    })
+    const pairingResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/'),
+      pairingResponse.response,
+      new URL('https://home.example.ts.net/')
+    )
+    const pendingCookie = cookiePair(pairingResponse.headers.get('set-cookie') as string)
+    await manager.approve(manager.pendingViews()[0].id, 'always')
+    const statusResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/__open_science_remote/pair/status', { cookie: pendingCookie }),
+      statusResponse.response,
+      new URL('https://home.example.ts.net/__open_science_remote/pair/status')
+    )
+    const sessionCookie = cookiePair((statusResponse.headers.get('set-cookie') as string[])[0])
+
+    let releaseSave: (() => void) | undefined
+    const saveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve
+    })
+    const persist = repository.save.bind(repository)
+    const save = vi
+      .spyOn(repository, 'save')
+      .mockReturnValueOnce(saveGate)
+      .mockImplementation((value) => persist(value))
+    const preferenceUpdate = manager.setModePreference('off')
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+
+    now = TRUSTED_BROWSER_TTL_MS - 1
+    const authorization = manager.webAccess.authorizeHttp(
+      request('/', { cookie: sessionCookie }),
+      response().response,
+      new URL('https://home.example.ts.net/')
+    )
+    now = TRUSTED_BROWSER_TTL_MS
+    releaseSave?.()
+    await preferenceUpdate
+
+    await expect(authorization).resolves.toBe('handled')
+    expect((await repository.load()).trustedBrowsers).toHaveLength(0)
+  })
+
+  it('rejects a trusted browser that expires while its last-seen update is saving', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const repository = new RemoteAccessRepository(root)
+    let now = 0
+    const manager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn(),
+      now: () => now
+    })
+    const pairingResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/'),
+      pairingResponse.response,
+      new URL('https://home.example.ts.net/')
+    )
+    const pendingCookie = cookiePair(pairingResponse.headers.get('set-cookie') as string)
+    await manager.approve(manager.pendingViews()[0].id, 'always')
+    const statusResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/__open_science_remote/pair/status', { cookie: pendingCookie }),
+      statusResponse.response,
+      new URL('https://home.example.ts.net/__open_science_remote/pair/status')
+    )
+    const sessionCookie = cookiePair((statusResponse.headers.get('set-cookie') as string[])[0])
+
+    let releaseSave: (() => void) | undefined
+    const saveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve
+    })
+    const persist = repository.save.bind(repository)
+    const save = vi.spyOn(repository, 'save').mockImplementationOnce(async (value) => {
+      await saveGate
+      await persist(value)
+    })
+    now = TRUSTED_BROWSER_TTL_MS - 1
+    const authorization = manager.webAccess.authorizeHttp(
+      request('/', { cookie: sessionCookie }),
+      response().response,
+      new URL('https://home.example.ts.net/')
+    )
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+
+    now = TRUSTED_BROWSER_TTL_MS
+    releaseSave?.()
+
+    await expect(authorization).resolves.toBe('handled')
+    expect((await repository.load()).trustedBrowsers).toHaveLength(0)
+  })
+
   it('keeps a trusted browser authorized when revocation cannot be persisted', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
     roots.push(root)
@@ -336,7 +485,7 @@ describe('RemoteSessionPairingManager', () => {
     roots.push(root)
     const repository = new RemoteAccessRepository(root)
     await repository.save({
-      version: 4,
+      version: 5,
       mode: 'remoteit-public',
       trustedBrowsers: [
         {
@@ -345,7 +494,8 @@ describe('RemoteSessionPairingManager', () => {
           platform: 'macOS',
           tokenHash: 'first-token',
           createdAt: 1,
-          lastSeenAt: 1
+          lastSeenAt: 1,
+          expiresAt: Number.MAX_SAFE_INTEGER
         },
         {
           id: 'second-browser',
@@ -353,7 +503,8 @@ describe('RemoteSessionPairingManager', () => {
           platform: 'Windows',
           tokenHash: 'second-token',
           createdAt: 2,
-          lastSeenAt: 2
+          lastSeenAt: 2,
+          expiresAt: Number.MAX_SAFE_INTEGER
         }
       ]
     })
@@ -498,6 +649,154 @@ describe('RemoteSessionPairingManager', () => {
       expect((await repository.load()).trustedBrowsers).toHaveLength(0)
     })
     expect(save).toHaveBeenCalledTimes(2)
+  })
+
+  it('publishes pending-request expiration without waiting for another pairing operation', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(0)
+      const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+      roots.push(root)
+      const onChanged = vi.fn()
+      const manager = await RemoteSessionPairingManager.create({
+        repository: new RemoteAccessRepository(root),
+        isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+        isEnabled: () => true,
+        onChanged
+      })
+      await manager.webAccess.authorizeHttp(
+        request('/'),
+        response().response,
+        new URL('https://home.example.ts.net/')
+      )
+      expect(manager.pendingViews()).toHaveLength(1)
+      onChanged.mockClear()
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1_000 + 1)
+
+      expect(onChanged).toHaveBeenCalledOnce()
+      expect(manager.pendingViews()).toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('publishes expiration while a persistent approval is still saving', async () => {
+    vi.useFakeTimers()
+    let releaseSave: (() => void) | undefined
+    let approval: Promise<void> | undefined
+    let manager: RemoteSessionPairingManager | undefined
+    try {
+      vi.setSystemTime(0)
+      const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+      roots.push(root)
+      const repository = new RemoteAccessRepository(root)
+      const onChanged = vi.fn()
+      manager = await RemoteSessionPairingManager.create({
+        repository,
+        isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+        isEnabled: () => true,
+        onChanged
+      })
+      await manager.webAccess.authorizeHttp(
+        request('/'),
+        response().response,
+        new URL('https://home.example.ts.net/')
+      )
+      const saveGate = new Promise<void>((resolve) => {
+        releaseSave = resolve
+      })
+      vi.spyOn(repository, 'save').mockReturnValueOnce(saveGate)
+      onChanged.mockClear()
+
+      approval = manager.approve(manager.pendingViews()[0].id, 'always')
+      await vi.waitFor(() => expect(repository.save).toHaveBeenCalledOnce())
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1_000 + 1)
+
+      expect(onChanged).toHaveBeenCalledOnce()
+      expect(manager.pendingViews()).toHaveLength(0)
+    } finally {
+      releaseSave?.()
+      await approval?.catch(() => undefined)
+      manager?.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('removes an unclaimed persistent approval without waiting for another operation', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(0)
+      const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+      roots.push(root)
+      const repository = new RemoteAccessRepository(root)
+      const onChanged = vi.fn()
+      const manager = await RemoteSessionPairingManager.create({
+        repository,
+        isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+        isEnabled: () => true,
+        onChanged
+      })
+      await manager.webAccess.authorizeHttp(
+        request('/'),
+        response().response,
+        new URL('https://home.example.ts.net/')
+      )
+      await manager.approve(manager.pendingViews()[0].id, 'always')
+      expect((await repository.load()).trustedBrowsers).toHaveLength(1)
+      onChanged.mockClear()
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1_000 + 1)
+
+      await vi.waitFor(async () => {
+        expect((await repository.load()).trustedBrowsers).toHaveLength(0)
+      })
+      expect(onChanged).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('actively removes a claimed trusted browser when its 180-day authorization expires', async () => {
+    vi.useFakeTimers()
+    let manager: RemoteSessionPairingManager | undefined
+    try {
+      vi.setSystemTime(0)
+      const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+      roots.push(root)
+      const repository = new RemoteAccessRepository(root)
+      const onChanged = vi.fn()
+      manager = await RemoteSessionPairingManager.create({
+        repository,
+        isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+        isEnabled: () => true,
+        onChanged
+      })
+      const pairingResponse = response()
+      await manager.webAccess.authorizeHttp(
+        request('/'),
+        pairingResponse.response,
+        new URL('https://home.example.ts.net/')
+      )
+      const pendingCookie = cookiePair(pairingResponse.headers.get('set-cookie') as string)
+      await manager.approve(manager.pendingViews()[0].id, 'always')
+      await manager.webAccess.authorizeHttp(
+        request('/__open_science_remote/pair/status', { cookie: pendingCookie }),
+        response().response,
+        new URL('https://home.example.ts.net/__open_science_remote/pair/status')
+      )
+      onChanged.mockClear()
+
+      await vi.advanceTimersByTimeAsync(TRUSTED_BROWSER_TTL_MS + 1)
+
+      await vi.waitFor(async () => {
+        expect((await repository.load()).trustedBrowsers).toHaveLength(0)
+      })
+      expect(onChanged).toHaveBeenCalledOnce()
+    } finally {
+      manager?.dispose()
+      vi.useRealTimers()
+    }
   })
 
   it('rejects an invalid pairing decision without granting or persisting access', async () => {

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -15,6 +15,7 @@ import { REMOTE_PAIR_STATUS_PATH, renderPairingPage } from './pairing-page'
 import {
   defaultRemoteAccessState,
   RemoteAccessRepository,
+  TRUSTED_BROWSER_TTL_MS,
   type StoredRemoteAccess,
   type StoredTrustedBrowser
 } from './repository'
@@ -23,9 +24,10 @@ const PAIRING_COOKIE = 'open_science_remote_pairing'
 const SESSION_COOKIE = 'open_science_remote_session'
 const PAIRING_TTL_MS = 10 * 60 * 1_000
 const ONE_TIME_SESSION_TTL_MS = 12 * 60 * 60 * 1_000
-const TRUSTED_COOKIE_MAX_AGE_SECONDS = 180 * 24 * 60 * 60
 const MAX_PENDING_REQUESTS = 20
 const LAST_SEEN_WRITE_INTERVAL_MS = 60_000
+const MAX_TIMER_DELAY_MS = 2_147_483_647
+const CLEANUP_RETRY_MS = 1_000
 
 type BrowserDescription = { browser: string; platform: string }
 
@@ -87,7 +89,7 @@ const readCookies = (request: IncomingMessage): Map<string, string> => {
 
 const sessionCookie = (value: string, persistent: boolean): string =>
   `${SESSION_COOKIE}=${encodeURIComponent(value)}; HttpOnly; Secure; SameSite=${persistent ? 'Lax' : 'Strict'}; Path=/${
-    persistent ? `; Max-Age=${TRUSTED_COOKIE_MAX_AGE_SECONDS}` : ''
+    persistent ? `; Max-Age=${TRUSTED_BROWSER_TTL_MS / 1_000}` : ''
   }`
 
 const pairingCookie = (value: string): string =>
@@ -162,7 +164,9 @@ export class RemoteSessionPairingManager {
   private readonly now: () => number
   private storedMutationQueue: Promise<void> = Promise.resolve()
   private unclaimedTrustedBrowserCleanupTask: Promise<void> | undefined
+  private expirationTimer: ReturnType<typeof setTimeout> | undefined
   private authorizationGeneration = 0
+  private disposed = false
 
   private constructor(
     private readonly options: PairingManagerOptions,
@@ -170,6 +174,7 @@ export class RemoteSessionPairingManager {
   ) {
     this.stored = stored
     this.now = options.now ?? Date.now
+    this.scheduleExpirationTimer()
   }
 
   static async create(options: PairingManagerOptions): Promise<RemoteSessionPairingManager> {
@@ -247,7 +252,9 @@ export class RemoteSessionPairingManager {
   }
 
   trustedViews(): TrustedRemoteBrowserView[] {
+    this.pruneExpired()
     return [...this.stored.trustedBrowsers]
+      .filter((browser) => !this.unclaimedTrustedBrowserCleanup.has(browser.id))
       .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
       .map(({ id, browser, platform, createdAt, lastSeenAt }) => ({
         id,
@@ -282,13 +289,15 @@ export class RemoteSessionPairingManager {
           expiresAt: this.now() + ONE_TIME_SESSION_TTL_MS
         })
       } else {
+        const createdAt = this.now()
         const trusted: StoredTrustedBrowser = {
           id: sessionId,
           browser: request.browser,
           platform: request.platform,
           tokenHash: hash(secret),
-          createdAt: this.now(),
-          lastSeenAt: this.now()
+          createdAt,
+          lastSeenAt: createdAt,
+          expiresAt: createdAt + TRUSTED_BROWSER_TTL_MS
         }
         await this.commitStoredMutation((stored) => ({
           ...stored,
@@ -306,6 +315,7 @@ export class RemoteSessionPairingManager {
       }
 
       request.status = 'approved'
+      this.scheduleExpirationTimer()
       this.options.onChanged()
     } catch (error) {
       if (
@@ -345,6 +355,7 @@ export class RemoteSessionPairingManager {
         }
         return { ...stored, trustedBrowsers }
       })
+      this.scheduleExpirationTimer()
       this.options.onChanged()
     } finally {
       this.pendingRevocations.delete(browserId)
@@ -360,9 +371,18 @@ export class RemoteSessionPairingManager {
     )
     this.pending.clear()
     this.oneTimeSessions.clear()
+    this.scheduleExpirationTimer()
     this.options.onChanged()
     const changed = await this.cleanupUnclaimedTrustedBrowsers(unclaimedTrustedBrowsers)
+    this.scheduleExpirationTimer()
     if (changed) this.options.onChanged()
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    if (this.expirationTimer) clearTimeout(this.expirationTimer)
+    this.expirationTimer = undefined
   }
 
   readonly webAccess: ExternalWebAccess = {
@@ -499,6 +519,7 @@ export class RemoteSessionPairingManager {
       status: 'pending'
     }
     this.pending.set(id, pending)
+    this.scheduleExpirationTimer()
     response.setHeader('set-cookie', pairingCookie(`${id}.${secret}`))
     this.options.onChanged()
     return pending
@@ -532,6 +553,7 @@ export class RemoteSessionPairingManager {
     }
     if (pending.status === 'rejected' || !pending.grant) {
       this.pending.delete(pending.id)
+      this.scheduleExpirationTimer()
       response.setHeader('set-cookie', clearCookie(PAIRING_COOKIE))
       json(response, 200, { status: 'rejected' })
       return
@@ -542,6 +564,7 @@ export class RemoteSessionPairingManager {
       clearCookie(PAIRING_COOKIE)
     ])
     this.pending.delete(pending.id)
+    this.scheduleExpirationTimer()
     json(response, 200, { status: 'approved' })
   }
 
@@ -561,14 +584,32 @@ export class RemoteSessionPairingManager {
     if (this.pendingRevocations.has(id)) return undefined
 
     const trusted = this.stored.trustedBrowsers.find((browser) => browser.id === id)
-    if (!trusted || !safeHashEqual(trusted.tokenHash, tokenHash)) return undefined
+    if (!trusted) return undefined
+    if (this.unclaimedTrustedBrowserCleanup.has(id)) return undefined
+    if (trusted.expiresAt <= this.now()) {
+      const changed = await this.removeStoredTrustedBrowsers(new Set([id]))
+      this.scheduleExpirationTimer()
+      if (changed) this.options.onChanged()
+      return undefined
+    }
+    if (!safeHashEqual(trusted.tokenHash, tokenHash)) return undefined
     if (this.now() - trusted.lastSeenAt >= LAST_SEEN_WRITE_INTERVAL_MS) {
       let authorized = false
-      const changed = await this.commitStoredMutation((stored) => {
+      let expired = false
+      let authorizedExpiresAt: number | undefined
+      let changed = await this.commitStoredMutation((stored) => {
         const current = stored.trustedBrowsers.find((browser) => browser.id === id)
         if (!current || !safeHashEqual(current.tokenHash, tokenHash)) return undefined
-        authorized = true
         const lastSeenAt = this.now()
+        if (current.expiresAt <= lastSeenAt) {
+          expired = true
+          return {
+            ...stored,
+            trustedBrowsers: stored.trustedBrowsers.filter((browser) => browser.id !== id)
+          }
+        }
+        authorized = true
+        authorizedExpiresAt = current.expiresAt
         if (lastSeenAt - current.lastSeenAt < LAST_SEEN_WRITE_INTERVAL_MS) return undefined
         return {
           ...stored,
@@ -577,8 +618,14 @@ export class RemoteSessionPairingManager {
           )
         }
       })
-      if (!authorized) return undefined
+      if (authorizedExpiresAt !== undefined && authorizedExpiresAt <= this.now()) {
+        authorized = false
+        expired = true
+        changed = (await this.removeStoredTrustedBrowsers(new Set([id]))) || changed
+      }
+      if (expired) this.scheduleExpirationTimer()
       if (changed) this.options.onChanged()
+      if (!authorized) return undefined
     }
     return { kind: 'trusted', sessionId: id }
   }
@@ -637,14 +684,19 @@ export class RemoteSessionPairingManager {
         if (this.unclaimedTrustedBrowserCleanupTask !== cleanupTask) return
         this.unclaimedTrustedBrowserCleanupTask = undefined
         if (succeeded) this.scheduleUnclaimedTrustedBrowserCleanup()
+        this.scheduleExpirationTimer()
       })
     this.unclaimedTrustedBrowserCleanupTask = cleanupTask
   }
 
   private pruneExpired(): void {
     const now = this.now()
+    let pendingViewsChanged = false
     for (const [id, request] of this.pending) {
       if (request.expiresAt > now) continue
+      if (request.status === 'pending' || request.status === 'approving') {
+        pendingViewsChanged = true
+      }
       if (request.grant?.decision === 'always') {
         this.unclaimedTrustedBrowserCleanup.add(request.grant.sessionId)
       } else if (request.grant?.decision === 'once') {
@@ -655,7 +707,43 @@ export class RemoteSessionPairingManager {
     for (const [id, session] of this.oneTimeSessions) {
       if (session.expiresAt <= now) this.oneTimeSessions.delete(id)
     }
+    for (const browser of this.stored.trustedBrowsers) {
+      if (browser.expiresAt <= now) this.unclaimedTrustedBrowserCleanup.add(browser.id)
+    }
     this.scheduleUnclaimedTrustedBrowserCleanup()
+    this.scheduleExpirationTimer()
+    if (pendingViewsChanged) this.options.onChanged()
+  }
+
+  private scheduleExpirationTimer(): void {
+    if (this.expirationTimer) clearTimeout(this.expirationTimer)
+    this.expirationTimer = undefined
+    if (this.disposed) return
+
+    const now = this.now()
+    const deadlines = [
+      ...[...this.pending.values()].map((request) => request.expiresAt),
+      ...[...this.oneTimeSessions.values()].map((session) => session.expiresAt),
+      ...this.stored.trustedBrowsers.flatMap((browser) =>
+        this.unclaimedTrustedBrowserCleanup.has(browser.id) ||
+        this.pendingRevocations.has(browser.id)
+          ? []
+          : [browser.expiresAt]
+      ),
+      ...(this.unclaimedTrustedBrowserCleanup.size > 0 && !this.unclaimedTrustedBrowserCleanupTask
+        ? [now + CLEANUP_RETRY_MS]
+        : [])
+    ]
+    if (deadlines.length === 0) return
+
+    const delay = Math.max(0, Math.min(Math.min(...deadlines) - now, MAX_TIMER_DELAY_MS))
+    const timer = setTimeout(() => {
+      if (this.expirationTimer !== timer) return
+      this.expirationTimer = undefined
+      this.pruneExpired()
+    }, delay)
+    timer.unref()
+    this.expirationTimer = timer
   }
 }
 

--- a/src/main/remote-access/repository.test.ts
+++ b/src/main/remote-access/repository.test.ts
@@ -23,7 +23,7 @@ describe('RemoteAccessRepository', () => {
     )
 
     await expect(new RemoteAccessRepository(root).load()).resolves.toMatchObject({
-      version: 4,
+      version: 5,
       mode: 'remoteit'
     })
     await expect(readdir(root)).resolves.toEqual(['remote-access.json'])
@@ -34,13 +34,13 @@ describe('RemoteAccessRepository', () => {
     roots.push(root)
     const repository = new RemoteAccessRepository(root)
     expect(await repository.load()).toEqual({
-      version: 4,
+      version: 5,
       mode: 'off',
       trustedBrowsers: []
     })
 
     await repository.save({
-      version: 4,
+      version: 5,
       mode: 'remoteit',
       remoteItAppServiceId: 'service-1',
       trustedBrowsers: [
@@ -50,7 +50,8 @@ describe('RemoteAccessRepository', () => {
           platform: 'iOS/iPadOS',
           tokenHash: 'a'.repeat(64),
           createdAt: 10,
-          lastSeenAt: 20
+          lastSeenAt: 20,
+          expiresAt: 15_552_000_010
         }
       ]
     })
@@ -71,19 +72,19 @@ describe('RemoteAccessRepository', () => {
         enabled: true,
         trustedBrowsers: []
       })
-    ).toEqual({ version: 4, mode: 'off', trustedBrowsers: [] })
+    ).toEqual({ version: 5, mode: 'off', trustedBrowsers: [] })
     expect(
       parseStored({
         version: 3,
         mode: 'removed-provider-mode',
         trustedBrowsers: []
       })
-    ).toEqual({ version: 4, mode: 'off', trustedBrowsers: [] })
+    ).toEqual({ version: 5, mode: 'off', trustedBrowsers: [] })
   })
 
-  it.each([1, 2, 3, 4])('accepts supported configuration version %i', (version) => {
+  it.each([1, 2, 3, 4, 5])('accepts supported configuration version %i', (version) => {
     expect(parseStored({ version, mode: 'off', trustedBrowsers: [] })).toEqual({
-      version: 4,
+      version: 5,
       mode: 'off',
       trustedBrowsers: []
     })
@@ -93,7 +94,7 @@ describe('RemoteAccessRepository', () => {
     ['malformed JSON', '{'],
     [
       'a future schema version',
-      JSON.stringify({ version: 5, mode: 'remoteit-public', trustedBrowsers: [] })
+      JSON.stringify({ version: 6, mode: 'remoteit-public', trustedBrowsers: [] })
     ]
   ])('rejects %s instead of treating it as first-run state', async (_case, contents) => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-remote-repository-invalid-'))
@@ -120,9 +121,31 @@ describe('RemoteAccessRepository', () => {
         trustedBrowsers: []
       })
     ).toMatchObject({
-      version: 4,
+      version: 5,
       mode: 'remoteit',
       remoteItAppServiceId: 'service-1'
+    })
+  })
+
+  it('derives the original 180-day expiration for trusted browsers from version 4', () => {
+    expect(
+      parseStored({
+        version: 4,
+        mode: 'remoteit-public',
+        trustedBrowsers: [
+          {
+            id: 'browser-1',
+            browser: 'Safari',
+            platform: 'iOS/iPadOS',
+            tokenHash: 'a'.repeat(64),
+            createdAt: 10,
+            lastSeenAt: 20
+          }
+        ]
+      })
+    ).toMatchObject({
+      version: 5,
+      trustedBrowsers: [{ id: 'browser-1', expiresAt: 15_552_000_010 }]
     })
   })
 
@@ -137,7 +160,7 @@ describe('RemoteAccessRepository', () => {
         trustedBrowsers: []
       })
     ).toMatchObject({
-      version: 4,
+      version: 5,
       mode: 'remoteit-public',
       remoteItAppServiceId: 'app-service',
       remoteItBrowserServiceId: 'browser-service',
@@ -153,11 +176,11 @@ describe('RemoteAccessRepository', () => {
     const repository = new RemoteAccessRepository(configRoot)
 
     await expect(
-      repository.save({ version: 4, mode: 'remoteit', trustedBrowsers: [] })
+      repository.save({ version: 5, mode: 'remoteit', trustedBrowsers: [] })
     ).rejects.toThrow()
 
     await rm(configRoot)
-    await repository.save({ version: 4, mode: 'remoteit-public', trustedBrowsers: [] })
+    await repository.save({ version: 5, mode: 'remoteit-public', trustedBrowsers: [] })
 
     await expect(repository.load()).resolves.toMatchObject({ mode: 'remoteit-public' })
   })

--- a/src/main/remote-access/repository.ts
+++ b/src/main/remote-access/repository.ts
@@ -4,7 +4,8 @@ import type { RemoteAccessMode } from '../../shared/remote-access'
 import { readDurableJsonFile, writeDurableJsonFile } from '../storage/durable-json-file'
 
 const REMOTE_ACCESS_FILE = 'remote-access.json'
-const REMOTE_ACCESS_VERSION = 4 as const
+const REMOTE_ACCESS_VERSION = 5 as const
+const TRUSTED_BROWSER_TTL_MS = 180 * 24 * 60 * 60 * 1_000
 
 export type StoredTrustedBrowser = {
   id: string
@@ -13,6 +14,7 @@ export type StoredTrustedBrowser = {
   tokenHash: string
   createdAt: number
   lastSeenAt: number
+  expiresAt: number
 }
 
 export type StoredRemoteAccess = {
@@ -33,7 +35,7 @@ const defaults = (): StoredRemoteAccess => ({
 const optionalString = (value: unknown): string | undefined =>
   typeof value === 'string' && value.trim() ? value.trim() : undefined
 
-const parseBrowser = (value: unknown): StoredTrustedBrowser | undefined => {
+const parseBrowser = (value: unknown, storedVersion: number): StoredTrustedBrowser | undefined => {
   if (!value || typeof value !== 'object') return undefined
   const input = value as Record<string, unknown>
   const id = optionalString(input.id)
@@ -43,7 +45,14 @@ const parseBrowser = (value: unknown): StoredTrustedBrowser | undefined => {
   if (!id || !browser || !platform || !tokenHash) return undefined
   const createdAt = typeof input.createdAt === 'number' ? input.createdAt : Date.now()
   const lastSeenAt = typeof input.lastSeenAt === 'number' ? input.lastSeenAt : createdAt
-  return { id, browser, platform, tokenHash, createdAt, lastSeenAt }
+  const expiresAt =
+    typeof input.expiresAt === 'number'
+      ? input.expiresAt
+      : storedVersion < REMOTE_ACCESS_VERSION
+        ? createdAt + TRUSTED_BROWSER_TTL_MS
+        : undefined
+  if (expiresAt === undefined) return undefined
+  return { id, browser, platform, tokenHash, createdAt, lastSeenAt, expiresAt }
 }
 
 const parseStored = (value: unknown): StoredRemoteAccess => {
@@ -54,9 +63,10 @@ const parseStored = (value: unknown): StoredRemoteAccess => {
   if (typeof input.version !== 'number' || !Number.isInteger(input.version) || input.version < 1) {
     throw new Error('Invalid remote access configuration version.')
   }
-  if (input.version > REMOTE_ACCESS_VERSION) {
+  const storedVersion = input.version
+  if (storedVersion > REMOTE_ACCESS_VERSION) {
     throw new Error(
-      `Remote access configuration version ${input.version} was created by a newer version of Open Science.`
+      `Remote access configuration version ${storedVersion} was created by a newer version of Open Science.`
     )
   }
   const mode: RemoteAccessMode =
@@ -77,7 +87,7 @@ const parseStored = (value: unknown): StoredRemoteAccess => {
         : undefined,
     trustedBrowsers: Array.isArray(input.trustedBrowsers)
       ? input.trustedBrowsers.flatMap((entry) => {
-          const parsed = parseBrowser(entry)
+          const parsed = parseBrowser(entry, storedVersion)
           return parsed ? [parsed] : []
         })
       : []
@@ -112,4 +122,9 @@ export class RemoteAccessRepository {
   }
 }
 
-export { REMOTE_ACCESS_FILE, defaults as defaultRemoteAccessState, parseStored }
+export {
+  REMOTE_ACCESS_FILE,
+  TRUSTED_BROWSER_TTL_MS,
+  defaults as defaultRemoteAccessState,
+  parseStored
+}

--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -302,7 +302,7 @@ describe('RemoteAccessService', () => {
   it('ignores an invalid legacy Browser URL when authorizing App access', async () => {
     const repository = await createRepository()
     await repository.save({
-      version: 4,
+      version: 5,
       mode: 'remoteit',
       remoteItAppServiceId: 'app-service',
       remoteItBrowserServiceId: 'browser-service',
@@ -330,7 +330,7 @@ describe('RemoteAccessService', () => {
   it('disconnects the revoked trusted browser immediately', async () => {
     const repository = await createRepository()
     await repository.save({
-      version: 4,
+      version: 5,
       mode: 'remoteit-public',
       trustedBrowsers: [
         {
@@ -339,7 +339,8 @@ describe('RemoteAccessService', () => {
           platform: 'macOS',
           tokenHash: '00',
           createdAt: 1,
-          lastSeenAt: 1
+          lastSeenAt: 1,
+          expiresAt: Number.MAX_SAFE_INTEGER
         }
       ]
     })

--- a/src/main/remote-access/service.ts
+++ b/src/main/remote-access/service.ts
@@ -425,8 +425,12 @@ export class RemoteAccessService {
     this.error = undefined
     this.notifyChanged()
     this.shutdownPromise = this.serialize(async () => {
-      await invalidation
-      this.webController = undefined
+      try {
+        await invalidation
+      } finally {
+        this.pairing.dispose()
+        this.webController = undefined
+      }
     })
     return this.shutdownPromise
   }

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -255,6 +255,42 @@ describe('createWebServiceController', () => {
     expect(h.startServer).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps replacement state when start is requested while the previous server closes', async () => {
+    let releaseFirstClose: (() => void) | undefined
+    const firstCloseGate = new Promise<void>((resolve) => {
+      releaseFirstClose = resolve
+    })
+    const firstClose = vi.fn(async () => firstCloseGate)
+    const startServer = vi.fn(async (options: StartOptions) => ({
+      port: options.port,
+      closeExternalConnections: vi.fn(),
+      close: options.port === 44100 ? firstClose : vi.fn().mockResolvedValue(undefined)
+    }))
+    let statePort: number | undefined
+    const h = makeController({
+      startServer,
+      writeState: vi.fn(async (_configRoot, state) => {
+        statePort = state.port
+      }),
+      removeState: vi.fn(async () => {
+        statePort = undefined
+      })
+    })
+    const stopped = vi.fn()
+    h.controller.onStopped(stopped)
+    await h.controller.ensureStarted(44100, { attached: true })
+
+    const close = h.controller.close()
+    await vi.waitFor(() => expect(firstClose).toHaveBeenCalledOnce())
+    const restart = h.controller.ensureStarted(44101, { attached: true })
+    releaseFirstClose?.()
+    await Promise.all([close, restart])
+
+    expect(startServer).toHaveBeenCalledTimes(2)
+    expect(statePort).toBe(44101)
+    expect(stopped).toHaveBeenCalledOnce()
+  })
+
   it('preserves Task run state and its caller lease across a restartable close', async () => {
     const project = {
       id: 'project-1',

--- a/src/main/web-service/index.test.ts
+++ b/src/main/web-service/index.test.ts
@@ -25,5 +25,14 @@ describe('parseWebModeOptions', () => {
     expect(() => parseWebModeOptions(['electron', '--serve=nope'], {})).toThrow(
       'Invalid Open Science web port'
     )
+    expect(() => parseWebModeOptions(['electron', '--serve=44100abc'], {})).toThrow(
+      'Invalid Open Science web port'
+    )
+    expect(() => parseWebModeOptions(['electron', '--serve='], {})).toThrow(
+      'Invalid Open Science web port'
+    )
+    expect(() => parseWebModeOptions(['electron'], { OPEN_SCIENCE_WEB_PORT: '44100xyz' })).toThrow(
+      'Invalid Open Science web port'
+    )
   })
 })

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -124,6 +124,7 @@ const createWebServiceController = (
       }
     | undefined
   let starting: Promise<{ port: number; url: string }> | undefined
+  let closing: Promise<void> | undefined
   let disposal: Promise<void> | undefined
   let disposed = false
   const stoppedListeners = new Set<() => void>()
@@ -139,10 +140,18 @@ const createWebServiceController = (
     }
   }
 
-  const close = async (): Promise<void> => {
-    const pending = starting
-    if (pending) await pending.catch(() => undefined)
-    await closeRunning()
+  const close = (): Promise<void> => {
+    if (closing) return closing
+    const operation = (async () => {
+      const pending = starting
+      if (pending) await pending.catch(() => undefined)
+      await closeRunning()
+    })()
+    const settled = operation.finally(() => {
+      if (closing === settled) closing = undefined
+    })
+    closing = settled
+    return settled
   }
 
   const dispose = (): Promise<void> => {
@@ -226,6 +235,8 @@ const createWebServiceController = (
     port: number,
     { attached }: { attached: boolean }
   ): Promise<{ port: number; url: string }> => {
+    if (disposed) throw new Error('Web service controller is disposed.')
+    if (closing) await closing
     if (disposed) throw new Error('Web service controller is disposed.')
     if (running) {
       const token = await loadWebToken(running.configRoot)

--- a/src/main/web-service/options.ts
+++ b/src/main/web-service/options.ts
@@ -6,6 +6,15 @@ export type WebModeOptions = {
   port: number
 }
 
+const parseWebPort = (value: string): number => {
+  const normalized = value.trim()
+  const port = Number(normalized)
+  if (!/^\d+$/.test(normalized) || !Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid Open Science web port: ${value}`)
+  }
+  return port
+}
+
 const parseWebModeOptions = (
   argv: string[],
   env: NodeJS.ProcessEnv = process.env
@@ -14,15 +23,12 @@ const parseWebModeOptions = (
   // native menus (e.g. the tray context menu) render invisibly (electron/electron#48982).
   const headless = argv.includes('--open-science-headless')
   const serveArg = argv.find((arg) => arg === '--serve' || arg.startsWith('--serve='))
-  const envPort = env.OPEN_SCIENCE_WEB_PORT?.trim()
+  const envPort = env.OPEN_SCIENCE_WEB_PORT?.trim() || undefined
   const enabled = headless || Boolean(serveArg) || Boolean(envPort)
   const requestedPort = serveArg?.startsWith('--serve=')
     ? serveArg.slice('--serve='.length)
     : envPort
-  const parsedPort = requestedPort ? Number.parseInt(requestedPort, 10) : DEFAULT_WEB_PORT
-  if (!Number.isInteger(parsedPort) || parsedPort < 0 || parsedPort > 65535) {
-    throw new Error(`Invalid Open Science web port: ${requestedPort}`)
-  }
+  const parsedPort = requestedPort === undefined ? DEFAULT_WEB_PORT : parseWebPort(requestedPort)
   return { enabled, headless, port: parsedPort }
 }
 

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -643,6 +643,7 @@ describe('ConnectorAddForm (remote server)', () => {
   })
 
   it('requires an imported OAuth client secret locally and submits pre-registered credentials', async () => {
+    useSettingsStore.setState({ encryptionAvailable: true })
     act(() => {
       root.render(
         <ConnectorAddForm

--- a/src/shared/remote-access.ts
+++ b/src/shared/remote-access.ts
@@ -1,3 +1,7 @@
+import { z } from 'zod'
+
+import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
+
 export type RemoteAccessLifecycle = 'disabled' | 'starting' | 'running' | 'stopping' | 'error'
 export type RemoteAccessMode = 'off' | 'remoteit' | 'remoteit-public'
 
@@ -76,5 +80,127 @@ export type RevokeRemoteBrowserRequest = {
 export type SetRemoteAccessModeRequest = {
   mode: RemoteAccessMode
 }
+
+export const remoteAccessModeSchema: z.ZodType<RemoteAccessMode> = z.enum([
+  'off',
+  'remoteit',
+  'remoteit-public'
+])
+export const remotePairingDecisionSchema: z.ZodType<RemotePairingDecision> = z.enum([
+  'once',
+  'always'
+])
+export const approveRemotePairingRequestSchema: z.ZodType<ApproveRemotePairingRequest> = z
+  .object({
+    requestId: z.string().min(1),
+    decision: remotePairingDecisionSchema
+  })
+  .strict()
+export const remotePairingRequestIdSchema: z.ZodType<RemotePairingRequestId> = z
+  .object({ requestId: z.string().min(1) })
+  .strict()
+export const revokeRemoteBrowserRequestSchema: z.ZodType<RevokeRemoteBrowserRequest> = z
+  .object({ browserId: z.string().min(1) })
+  .strict()
+export const setRemoteAccessModeRequestSchema: z.ZodType<SetRemoteAccessModeRequest> = z
+  .object({ mode: remoteAccessModeSchema })
+  .strict()
+
+const remoteAccessLifecycleSchema: z.ZodType<RemoteAccessLifecycle> = z.enum([
+  'disabled',
+  'starting',
+  'running',
+  'stopping',
+  'error'
+])
+const remoteItServiceSchema: z.ZodType<RemoteItService> = z
+  .object({
+    id: z.string(),
+    host: z.string(),
+    port: z.number().int().nonnegative().max(65535),
+    enabled: z.boolean(),
+    ready: z.boolean()
+  })
+  .strict()
+const remoteItInstallationSchema: z.ZodType<RemoteItInstallation> = z
+  .object({
+    installed: z.boolean(),
+    loggedIn: z.boolean(),
+    registered: z.boolean(),
+    binaryPath: z.string().optional(),
+    version: z.string().optional(),
+    account: z.string().optional(),
+    deviceId: z.string().optional(),
+    service: remoteItServiceSchema.optional(),
+    error: z.string().optional()
+  })
+  .strict()
+const remotePairingRequestViewSchema: z.ZodType<RemotePairingRequestView> = z
+  .object({
+    id: z.string(),
+    code: z.string(),
+    browser: z.string(),
+    platform: z.string(),
+    address: z.string().optional(),
+    requestedAt: z.number().finite(),
+    expiresAt: z.number().finite()
+  })
+  .strict()
+const trustedRemoteBrowserViewSchema: z.ZodType<TrustedRemoteBrowserView> = z
+  .object({
+    id: z.string(),
+    browser: z.string(),
+    platform: z.string(),
+    createdAt: z.number().finite(),
+    lastSeenAt: z.number().finite()
+  })
+  .strict()
+export const remoteAccessSnapshotSchema: z.ZodType<RemoteAccessSnapshot> = z
+  .object({
+    canManage: z.boolean(),
+    canManagePairing: z.boolean(),
+    mode: remoteAccessModeSchema,
+    enabled: z.boolean(),
+    lifecycle: remoteAccessLifecycleSchema,
+    accessUrl: z.string().optional(),
+    remoteItPublicUrl: z.string().optional(),
+    error: z.string().optional(),
+    remoteIt: remoteItInstallationSchema,
+    pendingRequests: z.array(remotePairingRequestViewSchema),
+    trustedBrowsers: z.array(trustedRemoteBrowserViewSchema)
+  })
+  .strict()
+
+const remoteAccessSnapshotResult = validationCodec(remoteAccessSnapshotSchema)
+export const remoteAccessApplicationCommandContracts = Object.freeze({
+  approve: defineApplicationCommandContract(
+    validationCodec(z.tuple([approveRemotePairingRequestSchema])),
+    remoteAccessSnapshotResult
+  ),
+  detect: defineApplicationCommandContract(
+    validationCodec(z.tuple([])),
+    remoteAccessSnapshotResult
+  ),
+  disable: defineApplicationCommandContract(
+    validationCodec(z.tuple([])),
+    remoteAccessSnapshotResult
+  ),
+  getSnapshot: defineApplicationCommandContract(
+    validationCodec(z.tuple([])),
+    remoteAccessSnapshotResult
+  ),
+  reject: defineApplicationCommandContract(
+    validationCodec(z.tuple([remotePairingRequestIdSchema])),
+    remoteAccessSnapshotResult
+  ),
+  revokeBrowser: defineApplicationCommandContract(
+    validationCodec(z.tuple([revokeRemoteBrowserRequestSchema])),
+    remoteAccessSnapshotResult
+  ),
+  setMode: defineApplicationCommandContract(
+    validationCodec(z.tuple([setRemoteAccessModeRequestSchema])),
+    remoteAccessSnapshotResult
+  )
+})
 
 export const REMOTE_ACCESS_CHANGED_CHANNEL = 'remote-access:changed'


### PR DESCRIPTION
## Problem

Five externally reported lifecycle and input-contract defects were reproduced against the previous implementation:

1. **Web service stop/start race.** An immediate start during an in-flight close could launch a replacement server before the old close removed state. The old instance could then delete the replacement state file and publish a stale stopped event, leaving CLI discovery to time out.
2. **The 180-day trust limit was browser-only.** A copied cookie remained valid server-side indefinitely because trusted-browser records had no expiry.
3. **Pairing expiry was request-driven.** Pending requests and unclaimed or expired trusted records could remain visible/on disk until another operation happened.
4. **Port parsing accepted suffix garbage.** Values such as 44100abc were silently truncated, and an explicitly empty --serve= fell back to the default.
5. **Remote Access commands lacked runtime request contracts.** Malformed Web RPC or Electron IPC payloads could reach handlers, select unintended branches, or fail as internal errors.

## Proposed solution

- Serialize replacement starts behind the active close promise and deduplicate concurrent closes.
- Persist trusted-browser expiresAt, enforce it during authorization (including queue/save boundary races), and migrate legacy v1-v4 records as createdAt + 180 days.
- Maintain one unref'ed nearest-deadline timer for pending requests, one-time grants, trusted-browser expiry, and cleanup retry; persist cleanup and broadcast visible changes.
- Parse the complete port string before range checks. Main-process port 0 behavior remains supported; the standalone CLI still rejects port 0.
- Define shared strict Zod tuple/object contracts for all seven Remote Access commands and apply them to both application-command/Web RPC routing and Electron IPC.

## Scope and tradeoffs

- **Persistence/data model:** remote-access storage moves to version 5 and adds expiresAt to trusted-browser records.
- **Historical compatibility:** v1-v4 records derive expiresAt from createdAt; already older-than-180-day records are removed on load/cleanup. Malformed v5 records without expiresAt are dropped.
- **Interaction:** settings snapshots now update automatically when a visible pairing request expires. No UI polling was added.
- **Enums/state:** no enum values or lifecycle states were added.
- **Architecture:** the pairing manager owns one expiry timer and exposes disposal through service shutdown. Web-service start/close share one lifecycle barrier.
- **Intentionally deferred:** no trusted-browser count cap (needs a product limit/eviction policy), no separate claimExpiresAt field, and no forced teardown of already-established connections at token expiry because that would change active-session semantics.
- **Port parser sharing:** TypeScript main and the published standalone JavaScript CLI use the same strict behavior/test matrix, but no new cross-package build dependency was introduced solely to share source text.

## Validation

Regression tests were added before each fix and observed failing for the reported behavior, including replacement state deletion, post-180-day authorization, absent timer broadcasts/cleanup, permissive port parsing, malformed command dispatch, and expiry races across queued/in-flight persistence.

- 15 focused module/consumer test files: **189 passed, 4 skipped**
- Final five-issue module set: **125 passed, 4 skipped**
- npm run lint: **passed**
- npm run typecheck:node: blocked by the existing workspace dependency mismatch:
  src/main/acp/claude-agent-acp-patch.test.ts(9,3) imports waitForMcpServers, which the installed @agentclientprotocol/claude-agent-acp package does not export.

Full-suite coverage is left to PR CI as requested.

## Review focus

- v1-v4 trusted-browser expiry migration behavior
- timer ownership, retry, and shutdown disposal
- parity between Web RPC and Electron IPC request rejection
- preservation of main port 0 versus CLI port 0 policy