### PR TITLE
fix(updates): harden installer lifecycle

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -73,8 +73,10 @@ open-science update --json
 
 The command updates the installed Open Science application, not the npm package. It reuses the
 application's release feed, artifact selection, checksum verification, and platform installer. If
-Open Science is not running, it starts the local headless service and leaves it available for later
-CLI commands. Use `open-science stop` when it is no longer needed.
+Open Science is not running, it starts the local headless service. It normally leaves that service
+available for later CLI commands. When the update requires a visible installer, the command stops a
+service it started after the installer is safely downloaded; a service that was already running is
+left alone, and the printed next step tells you to run `open-science stop` before the installer.
 
 In-place installation never interrupts active root-agent, subagent, Notebook, or Reviewer work. Stop
 the reported work and run the command again. Platforms that require a visible installer download it

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -941,11 +941,13 @@ export const updateCommand = async (options, dependencies = {}) => {
 
   if (result.outcome === 'manual-action-required' && result.installerPath) {
     const attachedToDesktopApp = serviceStart?.state?.attached === true
-    const ownsService = serviceStart?.started === true && !attachedToDesktopApp
+    const ownedConfigRoot = serviceStart?.state?.configRoot
+    const ownsService =
+      serviceStart?.started === true && !attachedToDesktopApp && typeof ownedConfigRoot === 'string'
     let requiresManualStop = !ownsService
     if (ownsService) {
       try {
-        await deps.stopService(options)
+        await deps.stopService({ ...options, configRoot: ownedConfigRoot })
       } catch {
         // Keep the verified installer handoff actionable even if graceful shutdown fails. The user
         // can retry the existing stop command without downloading the installer again.

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -853,6 +853,7 @@ export const updateCommand = async (options, dependencies = {}) => {
   const quietLog = options.json ? () => {} : (...args) => console.log(...args)
   const deps = {
     ensureService: (startOptions) => startCommand(startOptions, { ...DEFAULT_DEPS, log: quietLog }),
+    stopService: (stopOptions) => stopCommand(stopOptions, { ...DEFAULT_DEPS, log: quietLog }),
     connect: (connectOptions) => connectToOpenScience(connectOptions),
     sleep,
     getBootstrap: updateBootstrap,
@@ -864,7 +865,7 @@ export const updateCommand = async (options, dependencies = {}) => {
     },
     ...dependencies
   }
-  await deps.ensureService({ ...options, open: false })
+  const serviceStart = await deps.ensureService({ ...options, open: false })
   const client = await deps.connect({ configRoot: options.configRoot })
   let result
 
@@ -934,6 +935,25 @@ export const updateCommand = async (options, dependencies = {}) => {
             throw new Error(`Update apply ended in an unexpected state: ${status.state}`)
           }
         }
+      }
+    }
+  }
+
+  if (result.outcome === 'manual-action-required' && result.installerPath) {
+    let requiresManualStop = serviceStart?.started !== true
+    if (serviceStart?.started === true) {
+      try {
+        await deps.stopService(options)
+      } catch {
+        // Keep the verified installer handoff actionable even if graceful shutdown fails. The user
+        // can retry the existing stop command without downloading the installer again.
+        requiresManualStop = true
+      }
+    }
+    if (requiresManualStop) {
+      result = {
+        ...result,
+        nextAction: `Run "open-science stop", then run the installer at ${result.installerPath} and start Open Science again.`
       }
     }
   }

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -940,8 +940,10 @@ export const updateCommand = async (options, dependencies = {}) => {
   }
 
   if (result.outcome === 'manual-action-required' && result.installerPath) {
-    let requiresManualStop = serviceStart?.started !== true
-    if (serviceStart?.started === true) {
+    const attachedToDesktopApp = serviceStart?.state?.attached === true
+    const ownsService = serviceStart?.started === true && !attachedToDesktopApp
+    let requiresManualStop = !ownsService
+    if (ownsService) {
       try {
         await deps.stopService(options)
       } catch {
@@ -950,7 +952,12 @@ export const updateCommand = async (options, dependencies = {}) => {
         requiresManualStop = true
       }
     }
-    if (requiresManualStop) {
+    if (attachedToDesktopApp) {
+      result = {
+        ...result,
+        nextAction: `Quit the running Open Science app, then run the installer at ${result.installerPath} and start Open Science again.`
+      }
+    } else if (requiresManualStop) {
       result = {
         ...result,
         nextAction: `Run "open-science stop", then run the installer at ${result.installerPath} and start Open Science again.`

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1465,7 +1465,10 @@ describe('task CLI', () => {
     const result = await updateCommand(
       { open: true, json: true },
       {
-        ensureService: vi.fn().mockResolvedValue({ started: true }),
+        ensureService: vi.fn().mockResolvedValue({
+          started: true,
+          state: { configRoot: '/data/open-science-owned' }
+        }),
         connect: vi.fn().mockResolvedValue({}),
         getBootstrap: vi.fn().mockResolvedValue({
           appVersion: '1.0.0',
@@ -1484,7 +1487,13 @@ describe('task CLI', () => {
       outcome: 'manual-action-required',
       installerPath: 'C:\\Users\\test\\Downloads\\Open-Science.exe'
     })
-    expect(stopService).toHaveBeenCalledWith(expect.objectContaining({ open: true, json: true }))
+    expect(stopService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        open: true,
+        json: true,
+        configRoot: '/data/open-science-owned'
+      })
+    )
     expect(setExitCode).toHaveBeenCalledWith(6)
   })
 
@@ -1563,7 +1572,10 @@ describe('task CLI', () => {
     const result = await updateCommand(
       { open: true, json: true },
       {
-        ensureService: vi.fn().mockResolvedValue({ started: true }),
+        ensureService: vi.fn().mockResolvedValue({
+          started: true,
+          state: { configRoot: '/data/open-science-owned' }
+        }),
         stopService,
         connect: vi.fn().mockResolvedValue({}),
         getBootstrap: vi.fn().mockResolvedValue({

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1460,6 +1460,7 @@ describe('task CLI', () => {
       throw new Error(`Unexpected command: ${channel}`)
     })
     const setExitCode = vi.fn()
+    const stopService = vi.fn().mockResolvedValue(undefined)
 
     const result = await updateCommand(
       { open: true, json: true },
@@ -1473,6 +1474,7 @@ describe('task CLI', () => {
         supportsCommand: vi.fn().mockResolvedValue(true),
         invokeCommand,
         sleep: vi.fn().mockResolvedValue(undefined),
+        stopService,
         log: vi.fn(),
         setExitCode
       }
@@ -1482,7 +1484,74 @@ describe('task CLI', () => {
       outcome: 'manual-action-required',
       installerPath: 'C:\\Users\\test\\Downloads\\Open-Science.exe'
     })
+    expect(stopService).toHaveBeenCalledWith(expect.objectContaining({ open: true, json: true }))
     expect(setExitCode).toHaveBeenCalledWith(6)
+  })
+
+  it('requires stopping a pre-existing service before running a manual installer', async () => {
+    const installerPath = '/data/update/Open-Science.dmg'
+    const stopService = vi.fn()
+    const result = await updateCommand(
+      { open: true, json: true },
+      {
+        ensureService: vi.fn().mockResolvedValue({ started: false }),
+        stopService,
+        connect: vi.fn().mockResolvedValue({}),
+        getBootstrap: vi.fn().mockResolvedValue({
+          appVersion: '1.0.0',
+          rpcCapabilities: ['update-cli-v1']
+        }),
+        supportsCommand: vi.fn().mockResolvedValue(true),
+        invokeCommand: vi.fn().mockResolvedValue({
+          state: 'ready',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer',
+          localPath: installerPath
+        }),
+        log: vi.fn(),
+        setExitCode: vi.fn()
+      }
+    )
+
+    expect(stopService).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      installerPath,
+      nextAction: expect.stringContaining('open-science stop')
+    })
+  })
+
+  it('keeps the installer handoff when stopping a service started by update fails', async () => {
+    const installerPath = '/data/update/Open-Science.dmg'
+    const stopService = vi.fn().mockRejectedValue(new Error('service still running'))
+    const result = await updateCommand(
+      { open: true, json: true },
+      {
+        ensureService: vi.fn().mockResolvedValue({ started: true }),
+        stopService,
+        connect: vi.fn().mockResolvedValue({}),
+        getBootstrap: vi.fn().mockResolvedValue({
+          appVersion: '1.0.0',
+          rpcCapabilities: ['update-cli-v1']
+        }),
+        supportsCommand: vi.fn().mockResolvedValue(true),
+        invokeCommand: vi.fn().mockResolvedValue({
+          state: 'ready',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer',
+          localPath: installerPath
+        }),
+        log: vi.fn(),
+        setExitCode: vi.fn()
+      }
+    )
+
+    expect(stopService).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({
+      installerPath,
+      nextAction: expect.stringContaining('open-science stop')
+    })
   })
 
   it('reports an already-current installation without downloading or applying', async () => {

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1521,6 +1521,42 @@ describe('task CLI', () => {
     })
   })
 
+  it('requires quitting an attached desktop app before running a manual installer', async () => {
+    const installerPath = '/data/update/Open-Science.dmg'
+    const stopService = vi.fn()
+    const result = await updateCommand(
+      { open: true, json: true },
+      {
+        ensureService: vi.fn().mockResolvedValue({
+          started: true,
+          state: { attached: true }
+        }),
+        stopService,
+        connect: vi.fn().mockResolvedValue({}),
+        getBootstrap: vi.fn().mockResolvedValue({
+          appVersion: '1.0.0',
+          rpcCapabilities: ['update-cli-v1']
+        }),
+        supportsCommand: vi.fn().mockResolvedValue(true),
+        invokeCommand: vi.fn().mockResolvedValue({
+          state: 'ready',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer',
+          localPath: installerPath
+        }),
+        log: vi.fn(),
+        setExitCode: vi.fn()
+      }
+    )
+
+    expect(stopService).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      installerPath,
+      nextAction: expect.stringContaining('Quit the running Open Science app')
+    })
+  })
+
   it('keeps the installer handoff when stopping a service started by update fails', async () => {
     const installerPath = '/data/update/Open-Science.dmg'
     const stopService = vi.fn().mockRejectedValue(new Error('service still running'))

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -4,7 +4,9 @@ import {
   lstat,
   mkdir,
   mkdtemp,
+  open,
   readFile,
+  readdir,
   rm,
   stat,
   symlink,
@@ -13,7 +15,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const pdescribe = describe.skipIf(process.platform === 'win32')
 const symlinkDescribe = describe.skipIf(process.platform === 'win32')
@@ -58,6 +60,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await rm(home, { recursive: true, force: true })
 })
 
@@ -67,6 +70,7 @@ describe('planCliLauncher', () => {
     expect(plan.target).toBe(join(home, '.local', 'bin', 'open-science'))
     expect(plan.mode).toBe(0o755)
     expect(plan.shim).toContain('#!/bin/sh')
+    expect(plan.shim).toContain('Format version: 1')
     expect(plan.shim).toContain('ELECTRON_RUN_AS_NODE=1')
     // Packaged: pins the app path and single-quotes both paths (they contain a space).
     expect(plan.shim).toContain("OPEN_SCIENCE_APP_PATH='/opt/Open Science/open-science'")
@@ -169,6 +173,32 @@ pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
     expect(removed.installed).toBe(false)
     expect((await getCliLauncherStatus(env)).installed).toBe(false)
   })
+
+  it('preserves an existing managed launcher when replacement writing fails', async () => {
+    const originalEnv = posixEnv()
+    const originalPlan = planCliLauncher(originalEnv)
+    await mkdir(originalPlan.binDir, { recursive: true })
+    await writeFile(originalPlan.target, originalPlan.shim, { mode: 0o755 })
+    const originalMode = (await stat(originalPlan.target)).mode & 0o777
+
+    const probe = await open(join(home, 'file-handle-probe'), 'w')
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as { write: typeof probe.write }
+    await probe.close()
+    vi.spyOn(fileHandlePrototype, 'write').mockRejectedValueOnce(
+      Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+    )
+
+    await expect(
+      installCliLauncher(
+        posixEnv({ appExecPath: '/opt/Open Science/open-science-next' }),
+        () => true
+      )
+    ).rejects.toMatchObject({ code: 'ENOSPC' })
+
+    await expect(readFile(originalPlan.target, 'utf8')).resolves.toBe(originalPlan.shim)
+    expect((await stat(originalPlan.target)).mode & 0o777).toBe(originalMode)
+    await expect(readdir(originalPlan.binDir)).resolves.toEqual(['open-science'])
+  })
 })
 
 describe.each([
@@ -213,14 +243,42 @@ describe.each([
     })
   })
 
+  it('does not treat marker text embedded in arbitrary content as app ownership', async () => {
+    const env = createEnv()
+    const plan = planCliLauncher(env)
+    const userContent = [
+      'user-managed launcher',
+      'Open Science command-line launcher. Managed by the app',
+      'still user-managed'
+    ].join('\n')
+    await mkdir(plan.binDir, { recursive: true })
+    await writeFile(plan.target, userContent)
+
+    await expect(installCliLauncher(env, () => true)).rejects.toThrow(
+      'because it is not managed by Open Science'
+    )
+    await expect(readFile(plan.target, 'utf8')).resolves.toBe(userContent)
+  })
+
   it('continues to update and remove launchers carrying the historical ownership marker', async () => {
     const env = createEnv()
     const plan = planCliLauncher(env)
+    const legacyContent =
+      env.platform === 'win32'
+        ? [
+            '@echo off',
+            'rem Open Science command-line launcher. Managed by the app; edits are overwritten on reinstall.',
+            'set ELECTRON_RUN_AS_NODE=1',
+            'legacy launcher'
+          ].join('\r\n')
+        : [
+            '#!/bin/sh',
+            '# Open Science command-line launcher. Managed by the app (Settings -> General -> Command line',
+            "# tool); edits will be overwritten on reinstall. Runs the app's Electron in Node mode.",
+            'legacy launcher'
+          ].join('\n')
     await mkdir(plan.binDir, { recursive: true })
-    await writeFile(
-      plan.target,
-      'Open Science command-line launcher. Managed by the app\nlegacy launcher\n'
-    )
+    await writeFile(plan.target, legacyContent)
 
     await expect(getCliLauncherStatus(env)).resolves.toMatchObject({ installed: true })
     await installCliLauncher(env, () => true)

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -10,7 +10,8 @@ import {
   rm,
   stat,
   symlink,
-  writeFile
+  writeFile,
+  type FileHandle
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -198,6 +199,46 @@ pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
     await expect(readFile(originalPlan.target, 'utf8')).resolves.toBe(originalPlan.shim)
     expect((await stat(originalPlan.target)).mode & 0o777).toBe(originalMode)
     await expect(readdir(originalPlan.binDir)).resolves.toEqual(['open-science'])
+  })
+
+  it('revalidates the open managed launcher after flushing replacement bytes', async () => {
+    const originalEnv = posixEnv()
+    const originalPlan = planCliLauncher(originalEnv)
+    await installCliLauncher(originalEnv)
+
+    const probe = await open(join(home, 'file-handle-probe'), 'w')
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      stat: typeof probe.stat
+      sync: typeof probe.sync
+    }
+    const originalStat = fileHandlePrototype.stat
+    const originalSync = fileHandlePrototype.sync
+    await probe.close()
+    const events: Array<{ operation: 'stat' | 'sync'; fd: number }> = []
+    vi.spyOn(fileHandlePrototype, 'stat').mockImplementation(async function (
+      this: FileHandle,
+      ...args
+    ) {
+      events.push({ operation: 'stat', fd: this.fd })
+      return originalStat.apply(this, args)
+    })
+    vi.spyOn(fileHandlePrototype, 'sync').mockImplementation(async function (
+      this: FileHandle,
+      ...args
+    ) {
+      events.push({ operation: 'sync', fd: this.fd })
+      return originalSync.apply(this, args)
+    })
+
+    const nextEnv = posixEnv({ appExecPath: '/opt/Open Science/open-science-next' })
+    await installCliLauncher(nextEnv)
+
+    const validatedFd = events.find((event) => event.operation === 'stat')?.fd
+    const flushedAt = events.findIndex((event) => event.operation === 'sync')
+    expect(validatedFd).toBeTypeOf('number')
+    expect(flushedAt).toBeGreaterThanOrEqual(0)
+    expect(events.slice(flushedAt + 1)).toContainEqual({ operation: 'stat', fd: validatedFd })
+    await expect(readFile(originalPlan.target, 'utf8')).resolves.toBe(planCliLauncher(nextEnv).shim)
   })
 })
 

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -1,9 +1,22 @@
 import { spawnSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { constants, type Stats } from 'node:fs'
-import { lstat, mkdir, open, rm, type FileHandle } from 'node:fs/promises'
-import { join, posix } from 'node:path'
+import { lstat, mkdir, open, rename, rm, type FileHandle } from 'node:fs/promises'
+import { basename, join, posix } from 'node:path'
 
 import type { CliLauncherStatus } from '../../shared/cli'
+import { defaultFileDurability } from '../storage/file-durability'
+
+const MANAGED_LAUNCHER_HEADER_V1 =
+  'Open Science command-line launcher. Managed by the app. Format version: 1.'
+const LEGACY_POSIX_HEADER =
+  '# Open Science command-line launcher. Managed by the app (Settings -> General -> Command line'
+const LEGACY_POSIX_BODIES = new Set([
+  "# tool); edits will be overwritten on reinstall. Runs the app's Electron in Node mode.",
+  '# tool); edits will be overwritten on reinstall. Mounts the AppImage for this CLI process.'
+])
+const LEGACY_WINDOWS_HEADER =
+  'rem Open Science command-line launcher. Managed by the app; edits are overwritten on reinstall.'
 
 // Everything the launcher planner needs, injected so the pure path/shim logic is testable without
 // Electron or the real filesystem. The IPC wrapper fills these from `app`/`process` at call time.
@@ -73,8 +86,8 @@ const posixShim = (env: CliLauncherEnv): string => {
     const { executable, cliEntry } = appImagePayloadPaths(env)
     return [
       '#!/bin/sh',
-      '# Open Science command-line launcher. Managed by the app (Settings -> General -> Command line',
-      '# tool); edits will be overwritten on reinstall. Mounts the AppImage for this CLI process.',
+      `# ${MANAGED_LAUNCHER_HEADER_V1}`,
+      '# Edits are overwritten on reinstall. Mounts the AppImage for this CLI process.',
       `app_image=${quote(env.appImagePath!)}`,
       'mount_output=$(mktemp "${TMPDIR:-/tmp}/open-science-cli.XXXXXX") || {',
       "  echo 'Open Science could not create a temporary file for the AppImage mount.' >&2",
@@ -121,8 +134,8 @@ const posixShim = (env: CliLauncherEnv): string => {
   const appPathLine = env.packaged ? `OPEN_SCIENCE_APP_PATH=${quote(env.appExecPath)} ` : ''
   return [
     '#!/bin/sh',
-    '# Open Science command-line launcher. Managed by the app (Settings -> General -> Command line',
-    "# tool); edits will be overwritten on reinstall. Runs the app's Electron in Node mode.",
+    `# ${MANAGED_LAUNCHER_HEADER_V1}`,
+    "# Edits are overwritten on reinstall. Runs the app's Electron in Node mode.",
     `${appPathLine}ELECTRON_RUN_AS_NODE=1 exec ${quote(env.appExecPath)} ${quote(env.cliEntryPath)} "$@"`,
     ''
   ].join('\n')
@@ -132,7 +145,8 @@ const windowsShim = (env: CliLauncherEnv): string => {
   const appPathLine = env.packaged ? `set "OPEN_SCIENCE_APP_PATH=${env.appExecPath}"\r\n` : ''
   return [
     '@echo off',
-    'rem Open Science command-line launcher. Managed by the app; edits are overwritten on reinstall.',
+    `rem ${MANAGED_LAUNCHER_HEADER_V1}`,
+    'rem Edits are overwritten on reinstall.',
     'set ELECTRON_RUN_AS_NODE=1',
     `${appPathLine}"${env.appExecPath}" "${env.cliEntryPath}" %*`,
     ''
@@ -275,12 +289,22 @@ const readCliLauncher = async (target: string): Promise<string | undefined> => {
   }
 }
 
-const isManagedCliLauncher = (content: string): boolean =>
-  content.includes('Open Science command-line launcher. Managed by the app')
+const isManagedCliLauncher = (content: string): boolean => {
+  const lines = content.split(/\r?\n/)
+  if (lines[0] === '#!/bin/sh') {
+    return (
+      lines[1] === `# ${MANAGED_LAUNCHER_HEADER_V1}` ||
+      (lines[1] === LEGACY_POSIX_HEADER && LEGACY_POSIX_BODIES.has(lines[2] ?? ''))
+    )
+  }
+  return (
+    lines[0]?.toLowerCase() === '@echo off' &&
+    (lines[1] === `rem ${MANAGED_LAUNCHER_HEADER_V1}` || lines[1] === LEGACY_WINDOWS_HEADER)
+  )
+}
 
 const writeCliLauncher = async (handle: FileHandle, plan: CliLauncherPlan): Promise<void> => {
   const content = Buffer.from(plan.shim)
-  await handle.truncate(0)
   let offset = 0
   while (offset < content.length) {
     const { bytesWritten } = await handle.write(content, offset, content.length - offset, offset)
@@ -288,6 +312,38 @@ const writeCliLauncher = async (handle: FileHandle, plan: CliLauncherPlan): Prom
     offset += bytesWritten
   }
   if (plan.mode !== undefined) await handle.chmod(plan.mode)
+}
+
+// Publish an existing launcher through a same-directory temporary file. Until rename succeeds the
+// old command remains untouched; a write/flush failure therefore cannot truncate a working launcher.
+const replaceCliLauncher = async (plan: CliLauncherPlan, expected: Stats): Promise<void> => {
+  const temporaryPath = join(
+    plan.binDir,
+    `.${basename(plan.target)}.${process.pid}-${randomUUID()}.tmp`
+  )
+  let handle: FileHandle | undefined
+  let published = false
+  try {
+    handle = await open(
+      temporaryPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW ?? 0),
+      plan.mode ?? 0o666
+    )
+    await writeCliLauncher(handle, plan)
+    await handle.sync()
+    await handle.close()
+    handle = undefined
+
+    if (!(await isOpenCliLauncherCurrent(plan.target, expected))) {
+      refuseUnmanagedCliLauncher(plan.target)
+    }
+    await rename(temporaryPath, plan.target)
+    published = true
+    await defaultFileDurability.syncDirectory(plan.binDir)
+  } finally {
+    await handle?.close().catch(() => undefined)
+    if (!published) await rm(temporaryPath, { force: true }).catch(() => undefined)
+  }
 }
 
 const tryCreateCliLauncher = async (plan: CliLauncherPlan): Promise<boolean> => {
@@ -331,19 +387,16 @@ export const installCliLauncher = async (
       break
     }
 
-    const opened = await openStableCliLauncher(plan.target, constants.O_RDWR)
+    const opened = await openStableCliLauncher(plan.target, constants.O_RDONLY)
     if (opened === undefined) continue
     try {
       const existing = await opened.handle.readFile('utf8')
       if (!isManagedCliLauncher(existing)) refuseUnmanagedCliLauncher(plan.target)
-      await writeCliLauncher(opened.handle, plan)
-      if (!(await isOpenCliLauncherCurrent(plan.target, opened.stats))) {
-        refuseUnmanagedCliLauncher(plan.target)
-      }
-      written = true
     } finally {
       await opened.handle.close()
     }
+    await replaceCliLauncher(plan, opened.stats)
+    written = true
   }
   if (!written) throw new Error(`The CLI launcher path kept changing: ${plan.target}`)
 

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -314,9 +314,13 @@ const writeCliLauncher = async (handle: FileHandle, plan: CliLauncherPlan): Prom
   if (plan.mode !== undefined) await handle.chmod(plan.mode)
 }
 
-// Publish an existing launcher through a same-directory temporary file. Until rename succeeds the
-// old command remains untouched; a write/flush failure therefore cannot truncate a working launcher.
-const replaceCliLauncher = async (plan: CliLauncherPlan, expected: Stats): Promise<void> => {
+// Publish an existing launcher through a same-directory temporary file while retaining the handle
+// whose managed contents were validated. Until rename succeeds the old command remains untouched; a
+// write/flush failure therefore cannot truncate a working launcher.
+const replaceCliLauncher = async (
+  plan: CliLauncherPlan,
+  expected: OpenCliLauncher
+): Promise<void> => {
   const temporaryPath = join(
     plan.binDir,
     `.${basename(plan.target)}.${process.pid}-${randomUUID()}.tmp`
@@ -334,7 +338,12 @@ const replaceCliLauncher = async (plan: CliLauncherPlan, expected: Stats): Promi
     await handle.close()
     handle = undefined
 
-    if (!(await isOpenCliLauncherCurrent(plan.target, expected))) {
+    const opened = await expected.handle.stat()
+    if (
+      !isDirectRegularFile(opened) ||
+      !isSameFile(expected.stats, opened) ||
+      !(await isOpenCliLauncherCurrent(plan.target, opened))
+    ) {
       refuseUnmanagedCliLauncher(plan.target)
     }
     await rename(temporaryPath, plan.target)
@@ -392,11 +401,11 @@ export const installCliLauncher = async (
     try {
       const existing = await opened.handle.readFile('utf8')
       if (!isManagedCliLauncher(existing)) refuseUnmanagedCliLauncher(plan.target)
+      await replaceCliLauncher(plan, opened)
+      written = true
     } finally {
       await opened.handle.close()
     }
-    await replaceCliLauncher(plan, opened.stats)
-    written = true
   }
   if (!written) throw new Error(`The CLI launcher path kept changing: ${plan.target}`)
 

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -514,6 +514,24 @@ describe('ElectronUpdaterStrategy', () => {
     expect(strategy.getStatus().state).toBe('ready')
   })
 
+  it('does not download an installer again after the lifecycle is ready', async () => {
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    await strategy.check()
+
+    const ready = await strategy.download()
+    const repeated = await strategy.download()
+
+    expect(ready.state).toBe('ready')
+    expect(repeated).toBe(ready)
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+  })
+
   it('supports cancel followed by an immediate retry to completion', async () => {
     const updater = new FakeUpdater()
     let starts = 0

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -8,7 +8,7 @@ import { isNewer, type UpdateApplyOptions, type UpdateStatus } from '../../share
 import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
 import type { Logger } from '../logger'
 import { fetchManifest } from './manifest'
-import type { InstallGate, UpdateStrategy } from './strategy'
+import { canStartUpdateDownload, type InstallGate, type UpdateStrategy } from './strategy'
 import type { ApplicationEventMap } from '../application-events'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { markApplicationShutdownTrigger } from '../application-shutdown-trigger'
@@ -425,13 +425,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     // including the Windows upgrade-smoke harness talking to 0.18.0+. Wait for the check, then start.
     if (this.checkLifecycle) await this.checkLifecycle
     if (this.applying || this.downloadToken) return this.status
-    if (this.status.state === 'ready') return this.status
-    if (
-      this.status.state !== 'available' &&
-      !(this.status.state === 'error' && this.status.latest)
-    ) {
-      return this.status
-    }
+    if (!canStartUpdateDownload(this.status)) return this.status
 
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-download',

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -254,6 +254,41 @@ describe('UpdateService.download', () => {
     expect(existsSync(target)).toBe(true)
   })
 
+  it('does not download an installer again after the lifecycle is ready', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-ready-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    let installerFetches = 0
+    const fetchImpl = ((input: unknown) => {
+      if (String(input).endsWith('version.json')) {
+        return Promise.resolve(jsonResponse(manifestForCheck))
+      }
+      installerFetches += 1
+      return Promise.resolve(installerResponse(body))
+    }) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    await service.check()
+    const ready = await service.download()
+    const repeated = await service.download()
+
+    expect(ready.state).toBe('ready')
+    expect(repeated).toBe(ready)
+    expect(installerFetches).toBe(1)
+  })
+
   it('waits for an in-flight check before starting a download', async () => {
     dir = await mkdtemp(join(tmpdir(), 'svc-wait-check-'))
     const target = join(dir, 'installer.dmg')
@@ -635,6 +670,7 @@ describe('UpdateService.download', () => {
     // The path was NOT marked fresh after the failure, so the retry cleans both artifacts and succeeds.
     expect(removeFile).toHaveBeenCalledTimes(3)
     expect(retry.state).toBe('ready')
+    expect(retry.error).toBeUndefined()
   })
 
   it('resumes via a Range request on a same-session retry after a cancel', async () => {
@@ -1071,6 +1107,7 @@ describe('UpdateService.download', () => {
     const retry = await service.download()
     expect(retry.state).toBe('ready')
     expect(retry.localPath).toBe(target)
+    expect(retry.error).toBeUndefined()
     expect(existsSync(target)).toBe(true)
   })
 
@@ -1265,6 +1302,29 @@ describe('UpdateService.apply', () => {
       ])
     )
     expect(JSON.stringify(records)).not.toContain('private-installer.dmg')
+  })
+
+  it('keeps a ready installer actionable when the operating system cannot open it', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'open-failure-'))
+    const target = join(dir, 'installer.dmg')
+    const openPath = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('No application is associated with this file')
+      .mockResolvedValueOnce('')
+    const service = await downloadedService(target, { openPath })
+
+    const failed = await service.apply()
+
+    expect(failed).toMatchObject({
+      state: 'ready',
+      localPath: target,
+      error: expect.stringContaining('No application is associated with this file')
+    })
+
+    const retried = await service.apply()
+    expect(openPath).toHaveBeenCalledTimes(2)
+    expect(retried).toMatchObject({ state: 'ready', localPath: target })
+    expect(retried.error).toBeUndefined()
   })
 
   it('returns to available when the downloaded file is missing (e.g. the user deleted it)', async () => {

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -16,7 +16,7 @@ import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnosti
 import type { Logger } from '../logger'
 import { downloadInstaller } from './downloader'
 import { fetchManifest } from './manifest'
-import type { UpdateStrategy } from './strategy'
+import { canStartUpdateDownload, type UpdateStrategy } from './strategy'
 import type { ApplicationEventMap } from '../application-events'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { englishNativeTranslator, type NativeTranslator } from '../locale/main-process-messages'
@@ -238,6 +238,7 @@ export class UpdateService implements UpdateStrategy {
     // requests that arrived after the UI/RPC already observed `available`. Wait, then start.
     if (this.checkLifecycle) await this.checkLifecycle
     if (this.downloadAbort) return this.status
+    if (!canStartUpdateDownload(this.status)) return this.status
 
     const { download } = this.status
     if (!download) return this.status
@@ -333,7 +334,10 @@ export class UpdateService implements UpdateStrategy {
           state: 'downloading',
           progress: 0,
           downloadedBytes: 0,
-          totalBytes: download.size
+          totalBytes: download.size,
+          downloadProgress: undefined,
+          error: undefined,
+          blockedBy: undefined
         })
         operation.phase('transfer')
         const localPath = await downloadInstaller(download, targetPath, {
@@ -400,9 +404,9 @@ export class UpdateService implements UpdateStrategy {
     return this.status
   }
 
-  // Opens the downloaded installer. If the file is gone (e.g. the user deleted it) or fails to open,
-  // drop back to 'available' so the user can re-download in place — the download metadata is still on
-  // the status. With no installer for this platform at all, send them to the public download page.
+  // Opens the downloaded installer. A missing file drops back to 'available' for re-download. When
+  // the file still exists but the OS cannot open it, keep the ready artifact and surface the reason so
+  // the user can retry without another transfer. With no artifact, open the public download page.
   async apply(): Promise<UpdateStatus> {
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-apply',
@@ -416,10 +420,17 @@ export class UpdateService implements UpdateStrategy {
           operation.phase('open-installer')
           const error = await this.openPath(localPath)
           if (!error) {
+            if (this.status.error) this.setStatus({ ...this.status, error: undefined })
             operation.complete({ result: 'installer-opened' })
             return this.status
           }
           operation.fail(new Error('Installer open failed'), { reason: 'open-failed' })
+          this.setStatus({
+            ...this.status,
+            state: 'ready',
+            error: this.translate('Could not open the update installer: {{error}}', { error })
+          })
+          return this.status
         } else {
           operation.fail(new Error('Installer unavailable'), { reason: 'installer-missing' })
         }
@@ -432,7 +443,8 @@ export class UpdateService implements UpdateStrategy {
           ...this.status,
           state: 'available',
           localPath: undefined,
-          progress: undefined
+          progress: undefined,
+          error: undefined
         })
       } else {
         operation.phase('open-download-page')

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -39,6 +39,11 @@ export const createDurableInstallGate =
     return (await confirmRendererDurability()) ? readiness : { completed: false, reaped: false }
   }
 
+// Shared admission invariant for every update provider. A failed transfer with a known release may
+// retry; a completed ready artifact must remain authoritative until check() supersedes it.
+export const canStartUpdateDownload = (status: UpdateStatus): boolean =>
+  status.state === 'available' || (status.state === 'error' && Boolean(status.latest))
+
 // The platform-agnostic update contract the IPC layer and scheduler drive. Two implementations exist:
 // ElectronUpdaterStrategy (win/linux, and signed stable macOS — in-place download/restart) and
 // UpdateService (dev/nightly macOS + any other fallback — manifest download + manual reinstall). Both

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -197,6 +197,27 @@ describe('UpdateDialog', () => {
     expect(document.body.textContent).not.toContain('Restart to update')
   })
 
+  it('shows an installer-open error without replacing the ready retry action', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: {
+        state: 'ready',
+        current: '0.1.0',
+        latest: '0.2.0',
+        applyKind: 'installer',
+        localPath: '/data/update/Open-Science.dmg',
+        error: 'Could not open the update installer: no associated application'
+      }
+    })
+    act(() => root.render(<UpdateDialog />))
+
+    expect(document.body.textContent).toContain(
+      'Could not open the update installer: no associated application'
+    )
+    expect(document.body.textContent).toContain('Open installer')
+    expect(document.body.textContent).not.toContain('Download update')
+  })
+
   it('offers a manual download fallback when the update errors', () => {
     useUpdateStore.setState({
       isDialogOpen: true,

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -149,7 +149,7 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
                 </div>
               ) : null}
 
-              {dialogStatus.state === 'error' ? (
+              {dialogStatus.error ? (
                 <div className="mt-3" role="alert">
                   <p className="text-xs text-destructive">
                     {dialogStatus.error === UPDATE_BACKGROUND_PROCESS_ERROR

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -47,6 +47,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "Ya existen {{count}} Notebooks en el directorio elegido.",
     "Overwrite": "Sobrescribir",
     "Save the update installer": "Guardar el instalador de actualización",
+    "Could not open the update installer: {{error}}": "No se pudo abrir el instalador de actualización: {{error}}",
     "Export Skill": "Exportar habilidad",
     "Skill ZIP": "ZIP de habilidad",
     "ZIP archive": "Archivo ZIP",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -47,6 +47,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "Le dossier choisi contient déjà {{count}} Notebooks.",
     "Overwrite": "Écraser",
     "Save the update installer": "Enregistrer le programme d'installation de la mise à jour",
+    "Could not open the update installer: {{error}}": "Impossible d'ouvrir le programme d'installation de la mise à jour : {{error}}",
     "Export Skill": "Exporter la compétence",
     "Skill ZIP": "Archive ZIP de la compétence",
     "ZIP archive": "Archive ZIP",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -45,6 +45,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "選択したディレクトリには {{count}} 個の Notebook がすでに存在します。",
     "Overwrite": "上書き",
     "Save the update installer": "更新インストーラーを保存",
+    "Could not open the update installer: {{error}}": "更新インストーラーを開けませんでした：{{error}}",
     "Export Skill": "スキルをエクスポート",
     "Skill ZIP": "スキル ZIP",
     "ZIP archive": "ZIP アーカイブ",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -45,6 +45,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "선택한 디렉터리에 이미 Notebook {{count}}개가 있습니다.",
     "Overwrite": "덮어쓰기",
     "Save the update installer": "업데이트 설치 프로그램 저장",
+    "Could not open the update installer: {{error}}": "업데이트 설치 프로그램을 열 수 없습니다: {{error}}",
     "Export Skill": "스킬 내보내기",
     "Skill ZIP": "스킬 ZIP",
     "ZIP archive": "ZIP 아카이브",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -48,6 +48,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "В выбранной папке уже существуют {{count}} Notebook.",
     "Overwrite": "Перезаписать",
     "Save the update installer": "Сохранить установщик обновления",
+    "Could not open the update installer: {{error}}": "Не удалось открыть установщик обновления: {{error}}",
     "Export Skill": "Экспортировать навык",
     "Skill ZIP": "ZIP-архив навыка",
     "ZIP archive": "ZIP-архив",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -45,6 +45,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "所选目录中已存在 {{count}} 个 Notebook。",
     "Overwrite": "覆盖",
     "Save the update installer": "保存更新安装程序",
+    "Could not open the update installer: {{error}}": "无法打开更新安装程序：{{error}}",
     "Export Skill": "导出技能",
     "Skill ZIP": "技能 ZIP",
     "ZIP archive": "ZIP 压缩包",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -45,6 +45,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "所選目錄中已存在 {{count}} 個 Notebook。",
     "Overwrite": "覆寫",
     "Save the update installer": "儲存更新安裝程式",
+    "Could not open the update installer: {{error}}": "無法開啟更新安裝程式：{{error}}",
     "Export Skill": "匯出技能",
     "Skill ZIP": "技能 ZIP",
     "ZIP archive": "ZIP 壓縮檔",

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -38,6 +38,7 @@ export type UpdateStatus = {
   // the dialog can render the shared DownloadProgressLine.
   downloadProgress?: import('./download-progress').DownloadProgress
   localPath?: string // set when state === 'ready'
+  // Terminal lifecycle failure, or retryable action feedback while a ready installer remains usable.
   error?: string
   // Active research that prevented an in-place install. This is deliberately not a new UpdateState:
   // the operation still failed, while callers that need automation can distinguish a safe block.


### PR DESCRIPTION
## Problem

Four update/install paths had inconsistent failure handling:

- replacing an existing managed CLI launcher truncated the live file before replacement bytes were durable;
- the manifest strategy admitted another download after the installer was already `ready`, unlike the electron-updater strategy;
- `open-science update` discarded whether it started the local service and could hand off a manual installer while that owned service remained running;
- a shell failure opening a downloaded installer cleared its path, returned to `available`, and exposed no actionable error to the user.

## Proposed change

- Publish replacement launchers through a synced same-directory temporary file, atomically rename it over the verified managed target, and sync the parent directory where supported.
- Replace substring ownership detection with an exact versioned header while continuing to recognize the exact historical POSIX and Windows headers.
- Share the download admission invariant across both update strategies so `ready` artifacts cannot be downloaded again.
- Stop a manual-update service only when this CLI invocation started and owns it, and bind shutdown to the exact `configRoot` returned by startup. Preserve the installer handoff and require `open-science stop` when a daemon pre-existed or graceful shutdown fails; require quitting the desktop app when startup attached to an already-running app.
- Keep an existing installer `ready` when `shell.openPath()` fails, retain `localPath`, surface the localized OS error, and preserve the Open installer retry action.

## Scope and non-goals

- No new `UpdateState` value, CLI outcome, exit code, or status field.
- No persisted application-data format or database change.
- Existing exact managed launcher headers remain compatible. Arbitrary files that merely contain the old marker away from the header are now preserved as unmanaged.
- This does not replace the two provider-specific concurrency implementations with a new lifecycle owner. Their cancellation, transfer cleanup, and apply gates remain materially different; the shared admission policy and public behavior tests address the reproduced drift without a broad refactor.

## Acceptance criteria and validation

Regression tests were added before production changes and run against the old implementation. The focused command produced 10 deterministic failures matching the reports:

- ENOSPC left the existing launcher empty;
- embedded marker text was accepted as ownership;
- manifest `download()` produced a second ready status/transfer;
- manual update never called the owned-service stop path and omitted the stop instruction;
- installer-open failure returned `available`, cleared `localPath`, and was hidden by the dialog.

Independent PR review then identified three edge cases, each checked before changing production behavior:

- A public-boundary regression test reproduced that `started: true` with `state.attached: true` incorrectly called `stopService`. Commit `97208428` treats attached startup as externally owned and instructs the user to quit the desktop app.
- A public-boundary regression test reproduced that the owned startup `configRoot` was discarded before shutdown. Commit `12e3b7be` requires an exact returned root for ownership and passes it to the stop path.
- A FileHandle ordering seam reproduced that launcher replacement flushed the temporary file after the validated target handle was already closed. Commit `43bfe63b` retains that handle through publication and revalidates the same fd plus path identity after the flush.

After the final material edit:

- launcher publication/ownership -> `src/main/cli-install/launcher.test.ts`, `src/main/cli-install/ipc.test.ts`, `src/main/artifacts/durability.test.ts` -> passed;
- update owner, adapters, IPC, scheduler, downloader, manifest, save-dialog, and host consumer -> all targeted tests under `src/main/update/` plus `src/main/host-application-commands.test.ts` -> passed;
- CLI manual installer lifecycle -> `packages/open-science/cli.test.ts` -> passed;
- renderer retry feedback/store/shared contract/i18n -> `UpdateDialog.lifecycle.test.tsx`, `UpdateDialog.render.test.tsx`, `update-store.test.ts`, `src/shared/update.test.ts`, and `src/renderer/src/i18n/resources.test.ts` -> passed;
- combined Test Impact Set -> 18 files, 1007 tests passed;
- `npm run typecheck:node` -> passed;
- `npm run typecheck:web` -> passed;
- `npm run lint` -> passed.

`npm run test:affected -- --base origin/main --head HEAD --explain` conservatively selected the full suite because `packages/open-science/CLI.md` has ambiguous `cli_sdk`/documentation ownership. Per maintainer direction, the full local `npm test` suite was not run; the focused set above covers the changed owners, interfaces, adapters, and representative consumers. PR CI remains authoritative for the complete portable and platform suites.

## Review focus

- Atomic replacement and mode preservation on Windows, macOS, and Linux. Local macOS tests exercise write failure, retained-handle revalidation, and POSIX publication; Windows rename/file-handle semantics remain a CI risk.
- Exact legacy-header compatibility versus rejecting marker text embedded in user-managed files.
- Service ownership: only an instance started by this `update` invocation is stopped automatically.
- `ready + error` semantics: the verified installer remains actionable, retry success clears the error, and a truly missing file still returns to `available`.

Standard cross-platform Node `rename` has no destination-inode compare-and-swap primitive. The implementation retains and revalidates the opened target immediately before atomic rename, but an uncooperative process can still replace the pathname in the final syscall window on POSIX. A two-rename backup protocol would create a crash window where the command path is missing and would violate this change's primary failure-atomicity requirement, so no such protocol is introduced here.
