### PR TITLE
fix(project-files): persist index completeness across restarts

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -357,6 +357,13 @@ model ManagedFileSessionSync {
   @@index([projectId, deletedAt, groupSortAtMs, sessionId])
 }
 
+// Singleton completeness marker for catalog-wide Project Files reconciliation. Per-Session retry
+// state remains represented by ManagedFileSessionSync.filesRevision < 0.
+model ManagedFileIndexState {
+  id                       String  @id
+  isReconciliationComplete Boolean @default(true)
+}
+
 // Narrow origin lifecycle retained after a live Session JSON is deleted. This is not a second
 // editable Session model; it exists only to preserve managed-file ownership and deletion state.
 model FileOriginSession {

--- a/prisma/sqlite-check-constraints.json
+++ b/prisma/sqlite-check-constraints.json
@@ -196,6 +196,11 @@
       "expression": "\"source\" IN ('artifact', 'upload')"
     },
     {
+      "tableName": "ManagedFileIndexState",
+      "name": "ManagedFileIndexState_identity_check",
+      "expression": "\"id\" = 'project-files-index' AND \"isReconciliationComplete\" IN (false, true)"
+    },
+    {
       "tableName": "UploadVersion",
       "name": "UploadVersion_state_check",
       "expression": "\"state\" IN ('staging', 'ready')"

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -626,6 +626,7 @@
     },
     "project_files_repository": {
       "ownerPaths": [
+        "src/main/project-files/index-state.ts",
         "src/main/project-files/mutation-owner.ts",
         "src/main/project-files/mutation-projection.ts",
         "src/main/project-files/query-owner.ts",

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -80,6 +80,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0019_session_usage_attribution',
     checksum: 'c505fe7e55e8428d29e8506ad305c04fd46d8def53385a1f7839fba21047ab9d'
+  },
+  {
+    id: '0020_project_files_index_state',
+    checksum: '3db4a30baa2b4614e29205ed56b2682c0579f1a91f5a2d293d21925253ed7fd1'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -20,7 +20,7 @@ import { PrismaClient } from '@prisma/client'
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
     expect(MIGRATION_MANIFEST.at(-1)?.checksum).toBe(
-      'c505fe7e55e8428d29e8506ad305c04fd46d8def53385a1f7839fba21047ab9d'
+      '3db4a30baa2b4614e29205ed56b2682c0579f1a91f5a2d293d21925253ed7fd1'
     )
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST.slice(0, -1))).toThrow(
@@ -93,7 +93,7 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" = '0019_session_usage_attribution'`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_project_files_index_state')`
       )
 
       await migrateApplicationDatabase(client)
@@ -154,7 +154,7 @@ describe('packaged database migration ledger smoke', () => {
       await client.$executeRawUnsafe('DROP INDEX "Review_sessionId_idx"')
       await client.$executeRawUnsafe('DROP INDEX "Finding_reviewId_idx"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_project_files_index_state')`
       )
       await client.$executeRawUnsafe(
         'ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"'

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -11,7 +11,8 @@ import { migrateApplicationDatabase, verifyCurrentApplicationSchema } from './mi
 
 const CURRENT_AGENT_MEMORY_MIGRATION_ID = '0017_agent_memory_project_scope'
 const SESSION_AUXILIARY_USAGE_MIGRATION_ID = '0018_session_auxiliary_turn_usage'
-const CURRENT_MIGRATION_ID = '0019_session_usage_attribution'
+const SESSION_USAGE_ATTRIBUTION_MIGRATION_ID = '0019_session_usage_attribution'
+const CURRENT_MIGRATION_ID = '0020_project_files_index_state'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -299,9 +300,10 @@ describe('agent memory project scope migration', () => {
   it('replays an unledgered partial memory migration and restores missing triggers', async () => {
     await client.$executeRawUnsafe('DROP TRIGGER "MemoryEntry_fts_update"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
+      SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
       CURRENT_MIGRATION_ID
     )
 
@@ -309,6 +311,7 @@ describe('agent memory project scope migration', () => {
       applied: [
         CURRENT_AGENT_MEMORY_MIGRATION_ID,
         SESSION_AUXILIARY_USAGE_MIGRATION_ID,
+        SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -130,7 +130,8 @@ describe('application database (integration)', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
 
@@ -744,7 +745,7 @@ describe('application database (integration)', () => {
   it('backs up legacy data through the shared client on a portable storage path', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open science 数据 legacy backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
-    const backupPath = `${databasePath}.before-0018_session_auxiliary_turn_usage.backup`
+    const backupPath = `${databasePath}.before-0019_session_usage_attribution.backup`
     const seedClient = createProjectDbClient(storageRoot)
     try {
       await seedClient.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -784,7 +785,7 @@ describe('application database (integration)', () => {
         backupClient.$queryRaw<Array<{ id: string }>>`
           SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([{ id: '0017_agent_memory_project_scope' }])
+      ).resolves.toEqual([{ id: '0018_session_auxiliary_turn_usage' }])
     } finally {
       await backupClient.$disconnect()
     }
@@ -1162,7 +1163,8 @@ describe('application database (integration)', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
 

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -66,10 +66,11 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ],
       from: '0015_session_model_call_usage',
-      to: '0019_session_usage_attribution'
+      to: '0020_project_files_index_state'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
@@ -79,9 +80,12 @@ describe('Compute Job sensitive data encryption migration', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0019_session_usage_attribution.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0020_project_files_index_state.backup`)
     ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -158,10 +158,11 @@ describe('database JSON constraints migration', () => {
           '0016_compute_job_sensitive_data_encryption',
           '0017_agent_memory_project_scope',
           '0018_session_auxiliary_turn_usage',
-          '0019_session_usage_attribution'
+          '0019_session_usage_attribution',
+          '0020_project_files_index_state'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0019_session_usage_attribution'
+        to: '0020_project_files_index_state'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).rejects.toMatchObject({
         code: 'ENOENT'
@@ -191,9 +192,12 @@ describe('database JSON constraints migration', () => {
       ).rejects.toMatchObject({ code: 'ENOENT' })
       await expect(
         access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
-      ).resolves.toBeUndefined()
+      ).rejects.toMatchObject({ code: 'ENOENT' })
       await expect(
         access(`${databasePath}.before-0019_session_usage_attribution.backup`)
+      ).resolves.toBeUndefined()
+      await expect(
+        access(`${databasePath}.before-0020_project_files_index_state.backup`)
       ).resolves.toBeUndefined()
 
       await expect(

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -116,7 +116,8 @@ describe('database startup logging', () => {
               '0016_compute_job_sensitive_data_encryption',
               '0017_agent_memory_project_scope',
               '0018_session_auxiliary_turn_usage',
-              '0019_session_usage_attribution'
+              '0019_session_usage_attribution',
+              '0020_project_files_index_state'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -277,6 +277,11 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
 
     PRIMARY KEY ("projectId", "sessionId")
 );`,
+  `CREATE TABLE IF NOT EXISTS "ManagedFileIndexState" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "isReconciliationComplete" BOOLEAN NOT NULL DEFAULT true,
+    CONSTRAINT "ManagedFileIndexState_identity_check" CHECK ("id" = 'project-files-index' AND "isReconciliationComplete" IN (false, true))
+);`,
   `CREATE TABLE IF NOT EXISTS "FileOriginSession" (
     "projectId" TEXT NOT NULL,
     "sessionId" TEXT NOT NULL,
@@ -760,6 +765,7 @@ const RUNTIME_SCHEMA_TABLES = [
   'ProjectDeletionIntent',
   'ManagedFile',
   'ManagedFileSessionSync',
+  'ManagedFileIndexState',
   'FileOriginSession',
   'ArtifactLineage',
   'UploadFile',

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -20,7 +20,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0020_test_suffix'
+  const id = '0021_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -266,10 +266,11 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ],
       from: null,
-      to: '0019_session_usage_attribution'
+      to: '0020_project_files_index_state'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -282,8 +283,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0019_session_usage_attribution',
-      to: '0019_session_usage_attribution'
+      from: '0020_project_files_index_state',
+      to: '0020_project_files_index_state'
     })
   })
 
@@ -351,7 +352,7 @@ describe('application database migrations', () => {
       'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
     )
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_project_files_index_state')`
     )
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.project.create({ data: { id: 'project-1', name: 'Project' } })
@@ -368,7 +369,8 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
     await expect(
@@ -441,7 +443,8 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -486,7 +489,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0019_session_usage_attribution'
+      to: '0020_project_files_index_state'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -509,7 +512,7 @@ describe('application database migrations', () => {
     await removeComputePasswordAuthSchema(client)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution')`)
+      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_project_files_index_state')`)
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: [
@@ -526,10 +529,11 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0019_session_usage_attribution'
+      to: '0020_project_files_index_state'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -599,10 +603,11 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0019_session_usage_attribution'
+      to: '0020_project_files_index_state'
     })
     await expect(
       client.$queryRaw<
@@ -721,7 +726,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0019_session_usage_attribution'
+      migrationId: '0020_project_files_index_state'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -737,9 +742,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0020_test_suffix'],
-      from: '0019_session_usage_attribution',
-      to: '0020_test_suffix'
+      applied: ['0021_test_suffix'],
+      from: '0020_project_files_index_state',
+      to: '0021_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -765,7 +770,8 @@ describe('application database migrations', () => {
       { id: '0017_agent_memory_project_scope' },
       { id: '0018_session_auxiliary_turn_usage' },
       { id: '0019_session_usage_attribution' },
-      { id: '0020_test_suffix' }
+      { id: '0020_project_files_index_state' },
+      { id: '0021_test_suffix' }
     ])
   })
 
@@ -836,10 +842,11 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0019_session_usage_attribution'
+      to: '0020_project_files_index_state'
     })
     expect(backupEvents).toEqual([
       {
@@ -931,6 +938,11 @@ describe('application database migrations', () => {
         migrationId: '0019_session_usage_attribution',
         path: `${databasePath}.before-0019_session_usage_attribution.backup`,
         reused: false
+      },
+      {
+        migrationId: '0020_project_files_index_state',
+        path: `${databasePath}.before-0020_project_files_index_state.backup`,
+        reused: false
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -957,9 +969,12 @@ describe('application database migrations', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0019_session_usage_attribution.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0020_project_files_index_state.backup`)
     ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<Array<{ agentContext: string; name: string }>>`
@@ -990,7 +1005,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0020_test_suffix'
+      migrationId: '0021_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -1021,7 +1036,8 @@ describe('application database migrations', () => {
       { id: '0016_compute_job_sensitive_data_encryption' },
       { id: '0017_agent_memory_project_scope' },
       { id: '0018_session_auxiliary_turn_usage' },
-      { id: '0019_session_usage_attribution' }
+      { id: '0019_session_usage_attribution' },
+      { id: '0020_project_files_index_state' }
     ])
   })
 
@@ -1086,7 +1102,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0020_test_suffix'
+      migrationId: '0021_test_suffix'
     })
   })
 
@@ -1131,9 +1147,10 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_test_suffix'
+        '0020_project_files_index_state',
+        '0021_test_suffix'
       ],
-      to: '0020_test_suffix'
+      to: '0021_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -1376,7 +1393,8 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
     await expect(
@@ -1492,7 +1510,8 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1560,7 +1579,8 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
     await expect(
@@ -1631,7 +1651,8 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -1736,7 +1757,8 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
     await expect(
@@ -1761,6 +1783,7 @@ describe('application database migrations', () => {
     const agentMemoryBackupPath = `${databasePath}.before-0017_agent_memory_project_scope.backup`
     const auxiliaryUsageBackupPath = `${databasePath}.before-0018_session_auxiliary_turn_usage.backup`
     const usageAttributionBackupPath = `${databasePath}.before-0019_session_usage_attribution.backup`
+    const projectFilesIndexStateBackupPath = `${databasePath}.before-0020_project_files_index_state.backup`
     const backupEvents: unknown[] = []
     client = createProjectDbClient(storageRoot)
     await client.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -1805,7 +1828,8 @@ describe('application database migrations', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ]
     })
     expect(backupEvents).toEqual([
@@ -1903,6 +1927,11 @@ describe('application database migrations', () => {
         migrationId: '0019_session_usage_attribution',
         path: usageAttributionBackupPath,
         reused: false
+      },
+      {
+        migrationId: '0020_project_files_index_state',
+        path: projectFilesIndexStateBackupPath,
+        reused: false
       }
     ])
     await expect(
@@ -1910,8 +1939,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0018_session_auxiliary_turn_usage.backup',
-      'open-science.db.before-0019_session_usage_attribution.backup'
+      'open-science.db.before-0019_session_usage_attribution.backup',
+      'open-science.db.before-0020_project_files_index_state.backup'
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentContextBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -1924,12 +1953,13 @@ describe('application database migrations', () => {
     await expect(access(modelCallUsageBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(computeJobEncryptionBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentMemoryBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(access(auxiliaryUsageBackupPath)).resolves.toBeUndefined()
+    await expect(access(auxiliaryUsageBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(usageAttributionBackupPath)).resolves.toBeUndefined()
+    await expect(access(projectFilesIndexStateBackupPath)).resolves.toBeUndefined()
     await expect(client.project.count()).resolves.toBe(1)
 
     const backupClient = new PrismaClient({
-      datasources: { db: { url: `file:${auxiliaryUsageBackupPath.replaceAll('\\', '/')}` } }
+      datasources: { db: { url: `file:${usageAttributionBackupPath.replaceAll('\\', '/')}` } }
     })
     try {
       await expect(
@@ -1941,7 +1971,7 @@ describe('application database migrations', () => {
         backupClient.$queryRaw<Array<{ id: string }>>`
           SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([{ id: '0017_agent_memory_project_scope' }])
+      ).resolves.toEqual([{ id: '0018_session_auxiliary_turn_usage' }])
     } finally {
       await backupClient.$disconnect()
     }
@@ -2384,6 +2414,11 @@ describe('application database migrations', () => {
         migrationId: '0019_session_usage_attribution',
         path: `${databasePath}.before-0019_session_usage_attribution.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0020_project_files_index_state',
+        path: `${databasePath}.before-0020_project_files_index_state.backup`,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -2456,6 +2491,10 @@ describe('application database migrations', () => {
       {
         migrationId: '0019_session_usage_attribution',
         path: `${databasePath}.before-0019_session_usage_attribution.backup`
+      },
+      {
+        migrationId: '0020_project_files_index_state',
+        path: `${databasePath}.before-0020_project_files_index_state.backup`
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -2489,8 +2528,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0018_session_auxiliary_turn_usage.backup',
       'open-science.db.before-0019_session_usage_attribution.backup',
+      'open-science.db.before-0020_project_files_index_state.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -38,6 +38,7 @@ import {
 } from './migrations/0017-agent-memory-project-scope'
 import { sessionAuxiliaryTurnUsageMigration } from './migrations/0018-session-auxiliary-turn-usage'
 import { sessionUsageAttributionMigration } from './migrations/0019-session-usage-attribution'
+import { projectFilesIndexStateMigration } from './migrations/0020-project-files-index-state'
 import {
   applySqliteMigrationOperations,
   type SqliteMigrationOperation
@@ -293,6 +294,12 @@ const SESSION_USAGE_ATTRIBUTION_CHECKSUM = checksumMigrationPayload(
   sessionUsageAttributionMigration.verifiers,
   sessionUsageAttributionMigration.operations
 )
+const PROJECT_FILES_INDEX_STATE_CHECKSUM = checksumMigrationPayload(
+  projectFilesIndexStateMigration.id,
+  projectFilesIndexStateMigration.statements,
+  projectFilesIndexStateMigration.verifiers,
+  projectFilesIndexStateMigration.operations
+)
 const COMPUTE_JOB_SENSITIVE_DATA_ENCRYPTION_CHECKSUM = checksumMigrationPayload(
   computeJobSensitiveDataEncryptionMigration.id,
   computeJobSensitiveDataEncryptionMigration.statements,
@@ -495,6 +502,12 @@ const MIGRATION_MANIFEST = [
   {
     ...sessionUsageAttributionMigration,
     checksum: SESSION_USAGE_ATTRIBUTION_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...projectFilesIndexStateMigration,
+    checksum: PROJECT_FILES_INDEX_STATE_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }
@@ -762,6 +775,7 @@ const verifyCurrentApplicationSchema = async (client: PrismaClient): Promise<voi
   await runMigrationVerifiers(client, agentMemoryProjectScopeMigration.verifiers)
   await runMigrationVerifiers(client, sessionAuxiliaryTurnUsageMigration.verifiers)
   await runMigrationVerifiers(client, sessionUsageAttributionMigration.verifiers)
+  await runMigrationVerifiers(client, projectFilesIndexStateMigration.verifiers)
 }
 
 const readLedger = async (client: PrismaClient): Promise<LedgerRow[]> => {

--- a/src/main/database/migrations/0020-project-files-index-state.ts
+++ b/src/main/database/migrations/0020-project-files-index-state.ts
@@ -1,12 +1,12 @@
 const projectFilesIndexStateMigration = {
   id: '0020_project_files_index_state',
   statements: [
-    `CREATE TABLE "ManagedFileIndexState" (
+    `CREATE TABLE IF NOT EXISTS "ManagedFileIndexState" (
       "id" TEXT NOT NULL PRIMARY KEY,
       "isReconciliationComplete" BOOLEAN NOT NULL DEFAULT true,
       CONSTRAINT "ManagedFileIndexState_identity_check" CHECK ("id" = 'project-files-index' AND "isReconciliationComplete" IN (false, true))
     )`,
-    `INSERT INTO "ManagedFileIndexState" ("id", "isReconciliationComplete")
+    `INSERT OR IGNORE INTO "ManagedFileIndexState" ("id", "isReconciliationComplete")
       VALUES ('project-files-index', true)`
   ] as const,
   operations: [] as const,
@@ -27,6 +27,15 @@ const projectFilesIndexStateMigration = {
           ]
         }
       ]
+    },
+    {
+      kind: 'table-value-equals',
+      version: 1,
+      table: 'ManagedFileIndexState',
+      keyColumn: 'id',
+      keyValue: 'project-files-index',
+      valueColumn: 'id',
+      expectedValue: 'project-files-index'
     }
   ] as const
 }

--- a/src/main/database/migrations/0020-project-files-index-state.ts
+++ b/src/main/database/migrations/0020-project-files-index-state.ts
@@ -1,0 +1,34 @@
+const projectFilesIndexStateMigration = {
+  id: '0020_project_files_index_state',
+  statements: [
+    `CREATE TABLE "ManagedFileIndexState" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "isReconciliationComplete" BOOLEAN NOT NULL DEFAULT true,
+      CONSTRAINT "ManagedFileIndexState_identity_check" CHECK ("id" = 'project-files-index' AND "isReconciliationComplete" IN (false, true))
+    )`,
+    `INSERT INTO "ManagedFileIndexState" ("id", "isReconciliationComplete")
+      VALUES ('project-files-index', true)`
+  ] as const,
+  operations: [] as const,
+  verifiers: [
+    { kind: 'table-exists', version: 1, table: 'ManagedFileIndexState' },
+    {
+      kind: 'check-constraints-exist',
+      version: 1,
+      tables: [
+        {
+          table: 'ManagedFileIndexState',
+          constraints: [
+            {
+              name: 'ManagedFileIndexState_identity_check',
+              expression:
+                '"id" = \'project-files-index\' AND "isReconciliationComplete" IN (false, true)'
+            }
+          ]
+        }
+      ]
+    }
+  ] as const
+}
+
+export { projectFilesIndexStateMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -78,10 +78,11 @@ describe('notification attention metadata migration', () => {
         '0016_compute_job_sensitive_data_encryption',
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
-        '0019_session_usage_attribution'
+        '0019_session_usage_attribution',
+        '0020_project_files_index_state'
       ],
       from: '0006_database_domain_constraints',
-      to: '0019_session_usage_attribution'
+      to: '0020_project_files_index_state'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)
@@ -109,9 +110,12 @@ describe('notification attention metadata migration', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
-    ).resolves.toBeUndefined()
+    ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       access(`${databasePath}.before-0019_session_usage_attribution.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0020_project_files_index_state.backup`)
     ).resolves.toBeUndefined()
 
     await expect(

--- a/src/main/database/project-files-index-state-migration.test.ts
+++ b/src/main/database/project-files-index-state-migration.test.ts
@@ -86,6 +86,26 @@ describe('Project Files index state migration', () => {
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
 
+  it('seeds the singleton marker when adopting an existing generated table', async () => {
+    const databasePath = join(storageRoot, 'open-science.db')
+    await createDatabaseAtPreviousMigration(client)
+    await client.$executeRawUnsafe(`CREATE TABLE "ManagedFileIndexState" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "isReconciliationComplete" BOOLEAN NOT NULL DEFAULT true,
+      CONSTRAINT "ManagedFileIndexState_identity_check" CHECK ("id" = 'project-files-index' AND "isReconciliationComplete" IN (false, true))
+    )`)
+
+    await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toMatchObject({
+      adoptedLegacy: false,
+      applied: [MIGRATION_ID]
+    })
+    await expect(
+      client.$queryRaw<Array<{ id: string; isReconciliationComplete: boolean }>>`
+        SELECT "id", "isReconciliationComplete" FROM "ManagedFileIndexState"
+      `
+    ).resolves.toEqual([{ id: 'project-files-index', isReconciliationComplete: true }])
+  })
+
   it('enforces the singleton identity at the database boundary', async () => {
     await migrateApplicationDatabase(client)
 

--- a/src/main/database/project-files-index-state-migration.test.ts
+++ b/src/main/database/project-files-index-state-migration.test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import {
+  MIGRATION_MANIFEST,
+  migrateApplicationDatabase,
+  verifyCurrentApplicationSchema
+} from './migration-service'
+import { applySqliteMigrationOperations } from './sqlite-schema-migrations'
+
+const MIGRATION_ID = '0020_project_files_index_state'
+
+const createDatabaseAtPreviousMigration = async (client: PrismaClient): Promise<void> => {
+  const migrationIndex = MIGRATION_MANIFEST.findIndex((migration) => migration.id === MIGRATION_ID)
+  const prefix = MIGRATION_MANIFEST.slice(0, migrationIndex)
+  for (const migration of prefix) {
+    for (const statement of migration.statements) await client.$executeRawUnsafe(statement)
+    if ('operations' in migration) {
+      await client.$transaction((transaction) =>
+        applySqliteMigrationOperations(transaction, migration.operations)
+      )
+    }
+  }
+  await client.$executeRawUnsafe(`CREATE TABLE "_open_science_migrations" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "checksum" TEXT NOT NULL,
+    "appliedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "_open_science_migrations_checksum_check"
+      CHECK (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
+  )`)
+  for (const migration of prefix) {
+    await client.$executeRawUnsafe(
+      `INSERT INTO "_open_science_migrations" ("id", "checksum") VALUES (?, ?)`,
+      migration.id,
+      migration.checksum
+    )
+  }
+}
+
+describe('Project Files index state migration', () => {
+  let storageRoot = ''
+  let client: PrismaClient
+
+  beforeEach(async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-project-files-state-migration-'))
+    client = createProjectDbClient(storageRoot)
+  })
+
+  afterEach(async () => {
+    await client.$disconnect()
+    await rm(storageRoot, { recursive: true, force: true })
+  })
+
+  it('seeds a compatibility-first complete marker when upgrading the previous schema', async () => {
+    const databasePath = join(storageRoot, 'open-science.db')
+    await createDatabaseAtPreviousMigration(client)
+
+    await expect(
+      client.$queryRaw<Array<{ name: string }>>`
+        SELECT "name" FROM "sqlite_schema"
+        WHERE "type" = 'table' AND "name" = 'ManagedFileIndexState'
+      `
+    ).resolves.toEqual([])
+
+    await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toMatchObject({
+      adoptedLegacy: false,
+      applied: [MIGRATION_ID]
+    })
+    await expect(
+      client.$queryRaw<Array<{ id: string; isReconciliationComplete: boolean }>>`
+        SELECT "id", "isReconciliationComplete" FROM "ManagedFileIndexState"
+      `
+    ).resolves.toEqual([{ id: 'project-files-index', isReconciliationComplete: true }])
+    await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
+
+    await client.$executeRaw`
+      UPDATE "ManagedFileIndexState"
+      SET "isReconciliationComplete" = false
+      WHERE "id" = 'project-files-index'
+    `
+    await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
+  })
+
+  it('enforces the singleton identity at the database boundary', async () => {
+    await migrateApplicationDatabase(client)
+
+    await expect(
+      client.$executeRaw`
+        INSERT INTO "ManagedFileIndexState" ("id", "isReconciliationComplete")
+        VALUES ('other', true)
+      `
+    ).rejects.toThrow()
+  })
+})

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -84,7 +84,7 @@ const fileIndex: SessionFileIndex = {
   softDeleteProject: async () => 'delete-project',
   reconcileActiveSessions: async () => undefined,
   reconcileProjectSessions: async () => undefined,
-  markReconciliationIncomplete: () => undefined
+  markReconciliationIncomplete: async () => undefined
 }
 
 type CompositionHarness = Readonly<{

--- a/src/main/project-files/index-state.ts
+++ b/src/main/project-files/index-state.ts
@@ -1,0 +1,46 @@
+import { Prisma } from '@prisma/client'
+
+import type { ProjectFilesClient } from './mutation-projection'
+
+const PROJECT_FILES_INDEX_STATE_ID = 'project-files-index'
+
+type ManagedFileIndexStateRow = {
+  isIndexComplete: boolean | bigint
+}
+
+const readProjectFilesIndexComplete = async (
+  client: ProjectFilesClient,
+  projectIds: string[]
+): Promise<boolean> => {
+  const rows = await client.$queryRaw<ManagedFileIndexStateRow[]>(Prisma.sql`
+    SELECT CASE WHEN
+      EXISTS (
+        SELECT 1 FROM "ManagedFileIndexState"
+        WHERE "id" = ${PROJECT_FILES_INDEX_STATE_ID}
+          AND "isReconciliationComplete" = true
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM "ManagedFileSessionSync"
+        WHERE "projectId" IN (${Prisma.join(projectIds)})
+          AND "filesRevision" < 0
+          AND "deletedAt" IS NULL
+      )
+    THEN true ELSE false END AS "isIndexComplete"
+  `)
+
+  return rows[0]?.isIndexComplete === true || rows[0]?.isIndexComplete === 1n
+}
+
+const setProjectFilesReconciliationComplete = async (
+  client: ProjectFilesClient,
+  isComplete: boolean
+): Promise<void> => {
+  await client.$executeRaw`
+    INSERT INTO "ManagedFileIndexState" ("id", "isReconciliationComplete")
+    VALUES (${PROJECT_FILES_INDEX_STATE_ID}, ${isComplete})
+    ON CONFLICT("id") DO UPDATE SET
+      "isReconciliationComplete" = excluded."isReconciliationComplete"
+  `
+}
+
+export { readProjectFilesIndexComplete, setProjectFilesReconciliationComplete }

--- a/src/main/project-files/index-state.ts
+++ b/src/main/project-files/index-state.ts
@@ -5,8 +5,11 @@ import type { ProjectFilesClient } from './mutation-projection'
 const PROJECT_FILES_INDEX_STATE_ID = 'project-files-index'
 
 type ManagedFileIndexStateRow = {
-  isIndexComplete: boolean | bigint
+  isIndexComplete: boolean | bigint | number
 }
+
+const isSqliteTrue = (value: boolean | bigint | number | undefined): boolean =>
+  value === true || value === 1n || value === 1
 
 const readProjectFilesIndexComplete = async (
   client: ProjectFilesClient,
@@ -28,7 +31,7 @@ const readProjectFilesIndexComplete = async (
     THEN true ELSE false END AS "isIndexComplete"
   `)
 
-  return rows[0]?.isIndexComplete === true || rows[0]?.isIndexComplete === 1n
+  return isSqliteTrue(rows[0]?.isIndexComplete)
 }
 
 const setProjectFilesReconciliationComplete = async (
@@ -43,4 +46,4 @@ const setProjectFilesReconciliationComplete = async (
   `
 }
 
-export { readProjectFilesIndexComplete, setProjectFilesReconciliationComplete }
+export { isSqliteTrue, readProjectFilesIndexComplete, setProjectFilesReconciliationComplete }

--- a/src/main/project-files/mutation-owner.ts
+++ b/src/main/project-files/mutation-owner.ts
@@ -5,7 +5,6 @@ import type { ProjectFileSource } from '../../shared/project-files'
 import { createLogger } from '../logger'
 import {
   buildProjectCollisionFilters,
-  describeError,
   extractSessionFiles,
   fileIdentity,
   getChangedSources,
@@ -16,6 +15,7 @@ import {
   type ProjectFilesClient,
   type ProjectFilesClientProvider
 } from './mutation-projection'
+import { setProjectFilesReconciliationComplete } from './index-state'
 
 const log = createLogger('project-files')
 
@@ -29,8 +29,7 @@ type ManagedFileSyncOptions = { force?: boolean }
 // Owns every Project Files projection mutation and its completeness state. The public repository
 // delegates here while retaining the stable caller interface and the query orchestration for FI2.
 class ProjectFilesMutationOwner {
-  private readonly incompleteSessions = new Map<string, string>()
-  private isReconciliationIncomplete = false
+  private hasPendingIncompleteState = false
 
   constructor(
     private readonly getClient: ProjectFilesClientProvider,
@@ -54,7 +53,6 @@ class ProjectFilesMutationOwner {
         currentSync.deletedAt === null &&
         (await isFileProjectionCurrent(client, session.projectId, session.id))
       ) {
-        this.incompleteSessions.delete(sessionKey(session.projectId, session.id))
         return []
       }
 
@@ -214,15 +212,34 @@ class ProjectFilesMutationOwner {
         return transactionChangedSources
       })
 
-      const key = sessionKey(session.projectId, session.id)
-      if (hasIncompleteFiles) {
-        this.incompleteSessions.set(key, extraction.errors.join('; '))
-      } else {
-        this.incompleteSessions.delete(key)
-      }
       return changedSources
     } catch (error) {
-      this.incompleteSessions.set(sessionKey(session.projectId, session.id), describeError(error))
+      // Preserve the retry marker when a failure occurs before the normal transaction can write it.
+      // If SQLite itself is unavailable, retain the original sync error instead of masking it.
+      try {
+        const client = await this.getClient()
+        await client.managedFileSessionSync.upsert({
+          where: { projectId_sessionId: { projectId: session.projectId, sessionId: session.id } },
+          create: {
+            projectId: session.projectId,
+            sessionId: session.id,
+            filesRevision: RETRYABLE_COLLISION_REVISION,
+            groupSortAtMs: BigInt(session.updatedAt),
+            artifactCount: 0,
+            uploadCount: 0
+          },
+          update: {
+            filesRevision: RETRYABLE_COLLISION_REVISION,
+            syncedAt: new Date(),
+            deletedAt: null,
+            deleteOperationId: null
+          }
+        })
+      } catch {
+        // Fall back to the global durable marker before the next observable read. Do not clear this
+        // flag when a different concurrent Session persists its own retry marker successfully.
+        this.hasPendingIncompleteState = true
+      }
       throw error
     }
   }
@@ -318,8 +335,13 @@ class ProjectFilesMutationOwner {
     sessions: PersistedChatSession[],
     projectId?: string
   ): Promise<void> {
+    const reconcilesEntireCatalog = projectId === undefined
     try {
       const client = await this.getClient()
+      if (reconcilesEntireCatalog) {
+        await setProjectFilesReconciliationComplete(client, false)
+        this.hasPendingIncompleteState = false
+      }
       const activeKeys = new Set(
         sessions.map((session) => sessionKey(session.projectId, session.id))
       )
@@ -368,14 +390,12 @@ class ProjectFilesMutationOwner {
       for (const origin of retainedOrigins) {
         await this.rebuildRetainedOriginProjection(client, origin.projectId, origin.sessionId)
       }
-      for (const key of this.incompleteSessions.keys()) {
-        if ((!projectId || key.startsWith(`${projectId}:`)) && !activeKeys.has(key)) {
-          this.incompleteSessions.delete(key)
-        }
+      if (reconcilesEntireCatalog) {
+        await setProjectFilesReconciliationComplete(client, true)
+        this.hasPendingIncompleteState = false
       }
-      if (!projectId) this.isReconciliationIncomplete = false
     } catch (error) {
-      this.isReconciliationIncomplete = true
+      this.hasPendingIncompleteState = true
       throw error
     }
   }
@@ -506,15 +526,22 @@ class ProjectFilesMutationOwner {
     })
   }
 
-  markReconciliationIncomplete(): void {
-    this.isReconciliationIncomplete = true
+  async markReconciliationIncomplete(): Promise<void> {
+    this.hasPendingIncompleteState = true
+    try {
+      const client = await this.getClient()
+      await setProjectFilesReconciliationComplete(client, false)
+      this.hasPendingIncompleteState = false
+    } catch {
+      // This marker is diagnostic state: preserve the caller's primary failure and retry before
+      // the next observable Project Files read.
+    }
   }
 
-  isIndexComplete(projectId: string): boolean {
-    return (
-      !this.isReconciliationIncomplete &&
-      ![...this.incompleteSessions.keys()].some((key) => key.startsWith(`${projectId}:`))
-    )
+  async flushPendingIncompleteState(client: ProjectFilesClient): Promise<void> {
+    if (!this.hasPendingIncompleteState) return
+    await setProjectFilesReconciliationComplete(client, false)
+    this.hasPendingIncompleteState = false
   }
 }
 

--- a/src/main/project-files/mutation-owner.ts
+++ b/src/main/project-files/mutation-owner.ts
@@ -25,11 +25,17 @@ const RETRYABLE_COLLISION_REVISION = -1
 
 type ManagedFileSoftDeleteToken = string
 type ManagedFileSyncOptions = { force?: boolean }
+type PendingSessionIncompleteState = {
+  projectId: string
+  sessionId: string
+  groupSortAtMs: bigint
+}
 
 // Owns every Project Files projection mutation and its completeness state. The public repository
 // delegates here while retaining the stable caller interface and the query orchestration for FI2.
 class ProjectFilesMutationOwner {
-  private hasPendingIncompleteState = false
+  private readonly pendingIncompleteSessions = new Map<string, PendingSessionIncompleteState>()
+  private hasPendingReconciliationIncompleteState = false
 
   constructor(
     private readonly getClient: ProjectFilesClientProvider,
@@ -41,6 +47,7 @@ class ProjectFilesMutationOwner {
     options: ManagedFileSyncOptions = {}
   ): Promise<ProjectFileSource[]> {
     const revision = normalizeRevision(session.filesRevision)
+    const key = sessionKey(session.projectId, session.id)
     try {
       const client = await this.getClient()
       const currentSync = await client.managedFileSessionSync.findUnique({
@@ -53,6 +60,7 @@ class ProjectFilesMutationOwner {
         currentSync.deletedAt === null &&
         (await isFileProjectionCurrent(client, session.projectId, session.id))
       ) {
+        this.pendingIncompleteSessions.delete(key)
         return []
       }
 
@@ -212,33 +220,27 @@ class ProjectFilesMutationOwner {
         return transactionChangedSources
       })
 
+      this.pendingIncompleteSessions.delete(key)
       return changedSources
     } catch (error) {
       // Preserve the retry marker when a failure occurs before the normal transaction can write it.
       // If SQLite itself is unavailable, retain the original sync error instead of masking it.
       try {
         const client = await this.getClient()
-        await client.managedFileSessionSync.upsert({
-          where: { projectId_sessionId: { projectId: session.projectId, sessionId: session.id } },
-          create: {
-            projectId: session.projectId,
-            sessionId: session.id,
-            filesRevision: RETRYABLE_COLLISION_REVISION,
-            groupSortAtMs: BigInt(session.updatedAt),
-            artifactCount: 0,
-            uploadCount: 0
-          },
-          update: {
-            filesRevision: RETRYABLE_COLLISION_REVISION,
-            syncedAt: new Date(),
-            deletedAt: null,
-            deleteOperationId: null
-          }
+        await this.persistSessionIncompleteState(client, {
+          projectId: session.projectId,
+          sessionId: session.id,
+          groupSortAtMs: BigInt(session.updatedAt)
         })
+        this.pendingIncompleteSessions.delete(key)
       } catch {
-        // Fall back to the global durable marker before the next observable read. Do not clear this
-        // flag when a different concurrent Session persists its own retry marker successfully.
-        this.hasPendingIncompleteState = true
+        // Retry the Session-scoped marker before the next observable read. Tracking the owning
+        // Session lets a later successful retry clear only its own pending failure.
+        this.pendingIncompleteSessions.set(key, {
+          projectId: session.projectId,
+          sessionId: session.id,
+          groupSortAtMs: BigInt(session.updatedAt)
+        })
       }
       throw error
     }
@@ -340,7 +342,7 @@ class ProjectFilesMutationOwner {
       const client = await this.getClient()
       if (reconcilesEntireCatalog) {
         await setProjectFilesReconciliationComplete(client, false)
-        this.hasPendingIncompleteState = false
+        this.hasPendingReconciliationIncompleteState = false
       }
       const activeKeys = new Set(
         sessions.map((session) => sessionKey(session.projectId, session.id))
@@ -390,12 +392,17 @@ class ProjectFilesMutationOwner {
       for (const origin of retainedOrigins) {
         await this.rebuildRetainedOriginProjection(client, origin.projectId, origin.sessionId)
       }
+      for (const key of this.pendingIncompleteSessions.keys()) {
+        if ((!projectId || key.startsWith(`${projectId}:`)) && !activeKeys.has(key)) {
+          this.pendingIncompleteSessions.delete(key)
+        }
+      }
       if (reconcilesEntireCatalog) {
         await setProjectFilesReconciliationComplete(client, true)
-        this.hasPendingIncompleteState = false
+        this.hasPendingReconciliationIncompleteState = false
       }
     } catch (error) {
-      this.hasPendingIncompleteState = true
+      this.hasPendingReconciliationIncompleteState = true
       throw error
     }
   }
@@ -527,11 +534,11 @@ class ProjectFilesMutationOwner {
   }
 
   async markReconciliationIncomplete(): Promise<void> {
-    this.hasPendingIncompleteState = true
+    this.hasPendingReconciliationIncompleteState = true
     try {
       const client = await this.getClient()
       await setProjectFilesReconciliationComplete(client, false)
-      this.hasPendingIncompleteState = false
+      this.hasPendingReconciliationIncompleteState = false
     } catch {
       // This marker is diagnostic state: preserve the caller's primary failure and retry before
       // the next observable Project Files read.
@@ -539,9 +546,39 @@ class ProjectFilesMutationOwner {
   }
 
   async flushPendingIncompleteState(client: ProjectFilesClient): Promise<void> {
-    if (!this.hasPendingIncompleteState) return
-    await setProjectFilesReconciliationComplete(client, false)
-    this.hasPendingIncompleteState = false
+    if (this.hasPendingReconciliationIncompleteState) {
+      await setProjectFilesReconciliationComplete(client, false)
+      this.hasPendingReconciliationIncompleteState = false
+    }
+    for (const [key, state] of this.pendingIncompleteSessions) {
+      await this.persistSessionIncompleteState(client, state)
+      this.pendingIncompleteSessions.delete(key)
+    }
+  }
+
+  private async persistSessionIncompleteState(
+    client: ProjectFilesClient,
+    state: PendingSessionIncompleteState
+  ): Promise<void> {
+    await client.managedFileSessionSync.upsert({
+      where: {
+        projectId_sessionId: { projectId: state.projectId, sessionId: state.sessionId }
+      },
+      create: {
+        projectId: state.projectId,
+        sessionId: state.sessionId,
+        filesRevision: RETRYABLE_COLLISION_REVISION,
+        groupSortAtMs: state.groupSortAtMs,
+        artifactCount: 0,
+        uploadCount: 0
+      },
+      update: {
+        filesRevision: RETRYABLE_COLLISION_REVISION,
+        syncedAt: new Date(),
+        deletedAt: null,
+        deleteOperationId: null
+      }
+    })
   }
 }
 

--- a/src/main/project-files/mutation-owner.ts
+++ b/src/main/project-files/mutation-owner.ts
@@ -555,12 +555,17 @@ class ProjectFilesMutationOwner {
     }
   }
 
-  async flushPendingIncompleteState(client: ProjectFilesClient): Promise<void> {
+  async flushPendingIncompleteState(
+    client: ProjectFilesClient,
+    projectIds: readonly string[]
+  ): Promise<void> {
     if (this.hasPendingReconciliationIncompleteState) {
       await setProjectFilesReconciliationComplete(client, false)
       this.hasPendingReconciliationIncompleteState = false
     }
-    for (const key of [...this.pendingIncompleteSessions.keys()]) {
+    const requestedProjectIds = new Set(projectIds)
+    for (const [key, pendingState] of [...this.pendingIncompleteSessions.entries()]) {
+      if (!requestedProjectIds.has(pendingState.projectId)) continue
       await this.withSessionSyncLock(key, async () => {
         const state = this.pendingIncompleteSessions.get(key)
         if (!state) return

--- a/src/main/project-files/mutation-owner.ts
+++ b/src/main/project-files/mutation-owner.ts
@@ -607,9 +607,7 @@ class ProjectFilesMutationOwner {
       },
       update: {
         filesRevision: RETRYABLE_COLLISION_REVISION,
-        syncedAt: new Date(),
-        deletedAt: null,
-        deleteOperationId: null
+        syncedAt: new Date()
       }
     })
   }

--- a/src/main/project-files/mutation-owner.ts
+++ b/src/main/project-files/mutation-owner.ts
@@ -35,6 +35,8 @@ type PendingSessionIncompleteState = {
 // delegates here while retaining the stable caller interface and the query orchestration for FI2.
 class ProjectFilesMutationOwner {
   private readonly pendingIncompleteSessions = new Map<string, PendingSessionIncompleteState>()
+  // Keep a deferred -1 marker from committing after a successful retry for the same Session.
+  private readonly sessionSyncTails = new Map<string, Promise<void>>()
   private hasPendingReconciliationIncompleteState = false
 
   constructor(
@@ -46,8 +48,16 @@ class ProjectFilesMutationOwner {
     session: PersistedChatSession,
     options: ManagedFileSyncOptions = {}
   ): Promise<ProjectFileSource[]> {
-    const revision = normalizeRevision(session.filesRevision)
     const key = sessionKey(session.projectId, session.id)
+    return this.withSessionSyncLock(key, () => this.syncSessionLocked(session, options, key))
+  }
+
+  private async syncSessionLocked(
+    session: PersistedChatSession,
+    options: ManagedFileSyncOptions,
+    key: string
+  ): Promise<ProjectFileSource[]> {
+    const revision = normalizeRevision(session.filesRevision)
     try {
       const client = await this.getClient()
       const currentSync = await client.managedFileSessionSync.findUnique({
@@ -550,9 +560,32 @@ class ProjectFilesMutationOwner {
       await setProjectFilesReconciliationComplete(client, false)
       this.hasPendingReconciliationIncompleteState = false
     }
-    for (const [key, state] of this.pendingIncompleteSessions) {
-      await this.persistSessionIncompleteState(client, state)
-      this.pendingIncompleteSessions.delete(key)
+    for (const key of [...this.pendingIncompleteSessions.keys()]) {
+      await this.withSessionSyncLock(key, async () => {
+        const state = this.pendingIncompleteSessions.get(key)
+        if (!state) return
+        await this.persistSessionIncompleteState(client, state)
+        if (this.pendingIncompleteSessions.get(key) === state) {
+          this.pendingIncompleteSessions.delete(key)
+        }
+      })
+    }
+  }
+
+  private async withSessionSyncLock<T>(key: string, action: () => Promise<T>): Promise<T> {
+    const previous = this.sessionSyncTails.get(key) ?? Promise.resolve()
+    let release: () => void = () => undefined
+    const current = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const tail = previous.then(() => current)
+    this.sessionSyncTails.set(key, tail)
+    await previous
+    try {
+      return await action()
+    } finally {
+      release()
+      if (this.sessionSyncTails.get(key) === tail) this.sessionSyncTails.delete(key)
     }
   }
 

--- a/src/main/project-files/mutation-projection.ts
+++ b/src/main/project-files/mutation-projection.ts
@@ -26,6 +26,7 @@ type ProjectFilesClient = Pick<
   | 'uploadFile'
   | 'artifactVersion'
   | 'uploadVersion'
+  | '$executeRaw'
   | '$queryRaw'
   | '$transaction'
 >

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -12,7 +12,8 @@ import type {
   SearchArtifactsRequest,
   SearchArtifactsResult
 } from '../../shared/project-files'
-import type { ProjectFilesClientProvider } from './mutation-projection'
+import type { ProjectFilesClient, ProjectFilesClientProvider } from './mutation-projection'
+import { readProjectFilesIndexComplete } from './index-state'
 import {
   countMatchingArtifacts,
   decodeFileCursor,
@@ -32,14 +33,12 @@ import {
   toSafeCount
 } from './query-support'
 
-type ProjectFilesIndexCompletenessReader = (projectId: string) => boolean
-
-// Owns the read-model orchestration while completeness remains authoritative in the mutation owner.
+// Owns read-model orchestration, including completeness reads from the durable projection state.
 class ProjectFilesQueryOwner {
   constructor(
     private readonly getClient: ProjectFilesClientProvider,
     private readonly dataRoot: string,
-    private readonly readIndexComplete: ProjectFilesIndexCompletenessReader
+    private readonly beforeRead: (client: ProjectFilesClient) => Promise<void>
   ) {}
 
   async getOverview(
@@ -50,7 +49,8 @@ class ProjectFilesQueryOwner {
     requireIdentifier(projectId, 'projectId')
     const search = normalizeSearch(rawSearch)
     const client = await this.getClient()
-    const [totalCount, uploadCount, artifactCount, artifactGroupCount] = search
+    await this.beforeRead(client)
+    const [totalCount, uploadCount, artifactCount, artifactGroupCount, isIndexComplete] = search
       ? await getMatchingOverviewCounts(client, projectId, search)
       : await Promise.all([
           client.managedFile.count({ where: { projectId, deletedAt: null } }),
@@ -58,7 +58,8 @@ class ProjectFilesQueryOwner {
           client.managedFile.count({ where: { projectId, source: 'artifact', deletedAt: null } }),
           client.managedFileSessionSync.count({
             where: { projectId, deletedAt: null, artifactCount: { gt: 0 } }
-          })
+          }),
+          readProjectFilesIndexComplete(client, [projectId])
         ])
 
     return {
@@ -66,7 +67,7 @@ class ProjectFilesQueryOwner {
       uploadCount,
       artifactCount,
       artifactGroupCount,
-      isIndexComplete: this.readIndexComplete(projectId)
+      isIndexComplete
     }
   }
 
@@ -86,6 +87,7 @@ class ProjectFilesQueryOwner {
     }
     const normalizedRequest = { ...request, collection: normalizedCollection }
     const client = await this.getClient()
+    await this.beforeRead(client)
     const limit = normalizeLimit(request.limit)
     const search = normalizeSearch(request.search)
     const source =
@@ -191,8 +193,9 @@ class ProjectFilesQueryOwner {
       ? decodeSearchArtifactCursor(request.primaryCursor, request.primaryProjectId, search)
       : undefined
     const client = await this.getClient()
+    await this.beforeRead(client)
     const excludedSessionIds = search?.excludedSessionIds ?? []
-    const [primaryRows, primaryTotalCount, otherRows] = await Promise.all([
+    const [primaryRows, primaryTotalCount, otherRows, isIndexComplete] = await Promise.all([
       listMatchingArtifacts(
         client,
         request.primaryProjectId,
@@ -210,7 +213,8 @@ class ProjectFilesQueryOwner {
             excludedSessionIds,
             request.otherLimit
           )
-        : Promise.resolve([])
+        : Promise.resolve([]),
+      readProjectFilesIndexComplete(client, [request.primaryProjectId, ...otherProjectIds])
     ])
     const primaryPageRows = primaryRows.slice(0, primaryLimit)
     const lastPrimaryRow = primaryPageRows.at(-1)
@@ -252,9 +256,7 @@ class ProjectFilesQueryOwner {
             : undefined
       },
       other: otherRows.map(toItem),
-      isIndexComplete: [request.primaryProjectId, ...otherProjectIds].every((projectId) =>
-        this.readIndexComplete(projectId)
-      )
+      isIndexComplete
     }
   }
 
@@ -522,4 +524,3 @@ class ProjectFilesQueryOwner {
 }
 
 export { ProjectFilesQueryOwner }
-export type { ProjectFilesIndexCompletenessReader }

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -454,6 +454,7 @@ class ProjectFilesQueryOwner {
   async listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage> {
     requireIdentifier(request.projectId, 'projectId')
     const client = await this.getClient()
+    await this.beforeRead(client)
     const limit = normalizeLimit(request.limit)
     const search = normalizeSearch(request.search)
     const cursor = request.cursor ? decodeGroupCursor(request.cursor, request) : undefined

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -38,7 +38,10 @@ class ProjectFilesQueryOwner {
   constructor(
     private readonly getClient: ProjectFilesClientProvider,
     private readonly dataRoot: string,
-    private readonly beforeRead: (client: ProjectFilesClient) => Promise<void>
+    private readonly beforeRead: (
+      client: ProjectFilesClient,
+      projectIds: readonly string[]
+    ) => Promise<void>
   ) {}
 
   async getOverview(
@@ -49,7 +52,7 @@ class ProjectFilesQueryOwner {
     requireIdentifier(projectId, 'projectId')
     const search = normalizeSearch(rawSearch)
     const client = await this.getClient()
-    await this.beforeRead(client)
+    await this.beforeRead(client, [projectId])
     const [totalCount, uploadCount, artifactCount, artifactGroupCount, isIndexComplete] = search
       ? await getMatchingOverviewCounts(client, projectId, search)
       : await Promise.all([
@@ -87,7 +90,7 @@ class ProjectFilesQueryOwner {
     }
     const normalizedRequest = { ...request, collection: normalizedCollection }
     const client = await this.getClient()
-    await this.beforeRead(client)
+    await this.beforeRead(client, [request.projectId])
     const limit = normalizeLimit(request.limit)
     const search = normalizeSearch(request.search)
     const source =
@@ -193,7 +196,7 @@ class ProjectFilesQueryOwner {
       ? decodeSearchArtifactCursor(request.primaryCursor, request.primaryProjectId, search)
       : undefined
     const client = await this.getClient()
-    await this.beforeRead(client)
+    await this.beforeRead(client, [request.primaryProjectId, ...otherProjectIds])
     const excludedSessionIds = search?.excludedSessionIds ?? []
     const [primaryRows, primaryTotalCount, otherRows, isIndexComplete] = await Promise.all([
       listMatchingArtifacts(
@@ -454,7 +457,7 @@ class ProjectFilesQueryOwner {
   async listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage> {
     requireIdentifier(request.projectId, 'projectId')
     const client = await this.getClient()
-    await this.beforeRead(client)
+    await this.beforeRead(client, [request.projectId])
     const limit = normalizeLimit(request.limit)
     const search = normalizeSearch(request.search)
     const cursor = request.cursor ? decodeGroupCursor(request.cursor, request) : undefined

--- a/src/main/project-files/query-support.ts
+++ b/src/main/project-files/query-support.ts
@@ -11,6 +11,7 @@ import type {
   ProjectFileSource
 } from '../../shared/project-files'
 import { createUploadVersionReference } from '../../shared/uploads'
+import { isSqliteTrue } from './index-state'
 import type { ProjectFilesClient } from './mutation-projection'
 
 const MAX_PAGE_LIMIT = 100
@@ -60,7 +61,7 @@ type SearchOverviewRow = {
   uploadCount: bigint
   artifactCount: bigint
   artifactGroupCount: bigint
-  isIndexComplete: boolean | bigint
+  isIndexComplete: boolean | bigint | number
 }
 
 const normalizeLimit = (limit: number): number => {
@@ -165,7 +166,7 @@ const getMatchingOverviewCounts = async (
     toSafeCount(counts?.uploadCount ?? 0n, 'upload search result count'),
     toSafeCount(counts?.artifactCount ?? 0n, 'artifact search result count'),
     toSafeCount(counts?.artifactGroupCount ?? 0n, 'artifact group count'),
-    counts?.isIndexComplete === true || counts?.isIndexComplete === 1n
+    isSqliteTrue(counts?.isIndexComplete)
   ]
 }
 

--- a/src/main/project-files/query-support.ts
+++ b/src/main/project-files/query-support.ts
@@ -60,6 +60,7 @@ type SearchOverviewRow = {
   uploadCount: bigint
   artifactCount: bigint
   artifactGroupCount: bigint
+  isIndexComplete: boolean | bigint
 }
 
 const normalizeLimit = (limit: number): number => {
@@ -125,7 +126,7 @@ const getMatchingOverviewCounts = async (
   client: ProjectFilesClient,
   projectId: string,
   search: NormalizedSearch
-): Promise<[number, number, number, number]> => {
+): Promise<[number, number, number, number, boolean]> => {
   const rows = await client.$queryRaw<SearchOverviewRow[]>(Prisma.sql`
     SELECT
       COUNT(file."seq") AS "totalCount",
@@ -133,7 +134,20 @@ const getMatchingOverviewCounts = async (
       COALESCE(SUM(CASE WHEN file."source" = 'artifact' THEN 1 ELSE 0 END), 0) AS "artifactCount",
       COUNT(DISTINCT CASE
         WHEN file."source" = 'artifact' AND sync."sessionId" IS NOT NULL THEN file."sessionId"
-      END) AS "artifactGroupCount"
+      END) AS "artifactGroupCount",
+      CASE WHEN
+        EXISTS (
+          SELECT 1 FROM "ManagedFileIndexState"
+          WHERE "id" = 'project-files-index'
+            AND "isReconciliationComplete" = true
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM "ManagedFileSessionSync" AS incomplete
+          WHERE incomplete."projectId" = ${projectId}
+            AND incomplete."filesRevision" < 0
+            AND incomplete."deletedAt" IS NULL
+        )
+      THEN true ELSE false END AS "isIndexComplete"
     FROM "ManagedFile" AS file
     LEFT JOIN "ManagedFileSessionSync" AS sync
       ON sync."projectId" = file."projectId"
@@ -150,7 +164,8 @@ const getMatchingOverviewCounts = async (
     toSafeCount(counts?.totalCount ?? 0n, 'search result count'),
     toSafeCount(counts?.uploadCount ?? 0n, 'upload search result count'),
     toSafeCount(counts?.artifactCount ?? 0n, 'artifact search result count'),
-    toSafeCount(counts?.artifactGroupCount ?? 0n, 'artifact group count')
+    toSafeCount(counts?.artifactGroupCount ?? 0n, 'artifact group count'),
+    counts?.isIndexComplete === true || counts?.isIndexComplete === 1n
   ]
 }
 

--- a/src/main/project-files/repository.architecture.test.ts
+++ b/src/main/project-files/repository.architecture.test.ts
@@ -25,6 +25,7 @@ import {
 import { describe, expect, it } from 'vitest'
 
 const productionFiles = [
+  'index-state.ts',
   'mutation-owner.ts',
   'mutation-projection.ts',
   'query-owner.ts',
@@ -167,11 +168,13 @@ describe('Project Files repository architecture', () => {
     expect(supportSource).not.toMatch(/from ['"].*\/repository['"]/)
   })
 
-  it('keeps query orchestration read-only and completeness state in the mutation owner', () => {
+  it('keeps query orchestration read-only and reads completeness from durable state', () => {
     const querySource = sources.get('query-owner.ts')!
     expect(querySource).not.toMatch(/\.(?:create|delete|update|updateMany|upsert)\s*\(\s*\{/)
     expect(querySource).not.toContain('incompleteSessions')
     expect(querySource).not.toContain('isReconciliationIncomplete')
+    expect(querySource).toContain('readProjectFilesIndexComplete')
     expect(querySource).not.toMatch(/from ['"].*\/repository['"]/)
+    expect(sources.get('repository.ts')).not.toContain('isIndexComplete(projectId)')
   })
 })

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1403,7 +1403,7 @@ describe('ManagedFileIndexRepository', () => {
     vi.spyOn(client.managedFileSessionSync, 'upsert').mockImplementation((async (
       args: Parameters<typeof originalUpsert>[0]
     ) => {
-      if (args.where.projectId_sessionId.projectId === unrelatedProjectId) {
+      if (args.where.projectId_sessionId?.projectId === unrelatedProjectId) {
         throw new Error('unrelated project is locked')
       }
       return originalUpsert(args)

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -850,7 +850,7 @@ describe('ManagedFileIndexRepository', () => {
       totalCount: 1,
       artifactCount: 1,
       artifactGroupCount: 1,
-      isIndexComplete: true
+      isIndexComplete: false
     })
     await expect(
       repository.listFiles({
@@ -1181,6 +1181,52 @@ describe('ManagedFileIndexRepository', () => {
     const projectToken = await repository.softDeleteProject(PROJECT_ID)
     await repository.restoreProject(PROJECT_ID, projectToken)
     expect((await repository.getOverview(PROJECT_ID)).isIndexComplete).toBe(false)
+  })
+
+  it('preserves incomplete state after the repository is recreated', async () => {
+    const missingPath = join(
+      storageRoot,
+      'artifacts',
+      'default-project',
+      SESSION_ID,
+      'message-1',
+      'missing-after-restart.txt'
+    )
+    await repository.syncSession(
+      createSession({
+        artifacts: [
+          {
+            id: 'missing-after-restart',
+            kind: 'managed-file',
+            path: missingPath,
+            name: 'missing-after-restart.txt'
+          }
+        ]
+      })
+    )
+    expect((await repository.getOverview(PROJECT_ID)).isIndexComplete).toBe(false)
+
+    const restartedRepository = new ManagedFileIndexRepository(
+      () => Promise.resolve(client),
+      storageRoot
+    )
+
+    expect((await restartedRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(false)
+  })
+
+  it('preserves reconciliation incomplete state after the repository is recreated', async () => {
+    await repository.markReconciliationIncomplete()
+    expect((await repository.getOverview(PROJECT_ID)).isIndexComplete).toBe(false)
+
+    const restartedRepository = new ManagedFileIndexRepository(
+      () => Promise.resolve(client),
+      storageRoot
+    )
+
+    expect((await restartedRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(false)
+
+    await restartedRepository.reconcileActiveSessions([])
+    expect((await restartedRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(true)
   })
 
   it('does not revive stale file rows when a session deletion is compensated', async () => {

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1386,6 +1386,34 @@ describe('ManagedFileIndexRepository', () => {
     expect((await restartedRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(false)
   })
 
+  it('does not flush another project pending Session marker before a read', async () => {
+    const unrelatedProjectId = 'unrelated-project'
+    let databaseAvailable = false
+    const transientRepository = new ManagedFileIndexRepository(() => {
+      if (!databaseAvailable) return Promise.reject(new Error('database temporarily unavailable'))
+      return Promise.resolve(client)
+    }, storageRoot)
+
+    await expect(
+      transientRepository.syncSession(createSession({ projectId: unrelatedProjectId }))
+    ).rejects.toThrow('database temporarily unavailable')
+    databaseAvailable = true
+
+    const originalUpsert = client.managedFileSessionSync.upsert.bind(client.managedFileSessionSync)
+    vi.spyOn(client.managedFileSessionSync, 'upsert').mockImplementation((async (
+      args: Parameters<typeof originalUpsert>[0]
+    ) => {
+      if (args.where.projectId_sessionId.projectId === unrelatedProjectId) {
+        throw new Error('unrelated project is locked')
+      }
+      return originalUpsert(args)
+    }) as unknown as typeof originalUpsert)
+
+    await expect(transientRepository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      isIndexComplete: true
+    })
+  })
+
   it('does not revive stale file rows when a session deletion is compensated', async () => {
     const oldPath = join(
       storageRoot,

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1318,6 +1318,51 @@ describe('ManagedFileIndexRepository', () => {
     })
   })
 
+  it('does not revive a deleted Session when flushing its pending incomplete marker', async () => {
+    const artifactPath = join(
+      storageRoot,
+      'artifacts',
+      PROJECT_ID,
+      SESSION_ID,
+      'message-1',
+      'deleted-pending.txt'
+    )
+    await writeManagedFile(artifactPath, 'indexed')
+    const session = createSession({
+      artifacts: [
+        {
+          id: 'deleted-pending',
+          kind: 'managed-file',
+          path: artifactPath,
+          name: 'deleted-pending.txt'
+        }
+      ]
+    })
+    await repository.syncSession(session)
+
+    let databaseAvailable = false
+    const transientRepository = new ManagedFileIndexRepository(() => {
+      if (!databaseAvailable) return Promise.reject(new Error('database temporarily unavailable'))
+      return Promise.resolve(client)
+    }, storageRoot)
+    await expect(transientRepository.syncSession(session)).rejects.toThrow(
+      'database temporarily unavailable'
+    )
+    databaseAvailable = true
+    await transientRepository.softDeleteSession(PROJECT_ID, SESSION_ID)
+
+    await expect(
+      transientRepository.listArtifactGroups({ projectId: PROJECT_ID, limit: 10 })
+    ).resolves.toEqual({ items: [], totalCount: 0 })
+    const restartedRepository = new ManagedFileIndexRepository(
+      () => Promise.resolve(client),
+      storageRoot
+    )
+    await expect(
+      restartedRepository.listArtifactGroups({ projectId: PROJECT_ID, limit: 10 })
+    ).resolves.toEqual({ items: [], totalCount: 0 })
+  })
+
   it('flushes a pending Session marker before listing Artifact groups', async () => {
     let databaseAvailable = false
     const transientRepository = new ManagedFileIndexRepository(() => {

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1258,6 +1258,64 @@ describe('ManagedFileIndexRepository', () => {
     expect((await transientRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(true)
   })
 
+  it('does not let a concurrent pending-marker flush overwrite a successful Session retry', async () => {
+    let databaseAvailable = false
+    const transientRepository = new ManagedFileIndexRepository(() => {
+      if (!databaseAvailable) return Promise.reject(new Error('database temporarily unavailable'))
+      return Promise.resolve(client)
+    }, storageRoot)
+    const session = createSession()
+
+    await expect(transientRepository.syncSession(session)).rejects.toThrow(
+      'database temporarily unavailable'
+    )
+    databaseAvailable = true
+
+    let releaseTransactionReturn: () => void = () => undefined
+    const transactionMayReturn = new Promise<void>((resolve) => {
+      releaseTransactionReturn = resolve
+    })
+    let reportTransactionCommitted: () => void = () => undefined
+    const transactionCommitted = new Promise<void>((resolve) => {
+      reportTransactionCommitted = resolve
+    })
+    const originalTransaction = client.$transaction.bind(client)
+    vi.spyOn(client, '$transaction').mockImplementation((async (...args: unknown[]) => {
+      const result = await Reflect.apply(originalTransaction, client, args)
+      reportTransactionCommitted()
+      await transactionMayReturn
+      return result
+    }) as typeof client.$transaction)
+
+    let releasePendingMarker: () => void = () => undefined
+    const pendingMarkerMayPersist = new Promise<void>((resolve) => {
+      releasePendingMarker = resolve
+    })
+    const originalUpsert = client.managedFileSessionSync.upsert.bind(client.managedFileSessionSync)
+    vi.spyOn(client.managedFileSessionSync, 'upsert').mockImplementation(async (args) => {
+      await pendingMarkerMayPersist
+      return originalUpsert(args)
+    })
+
+    const retry = transientRepository.syncSession(session)
+    await transactionCommitted
+    const overview = transientRepository.getOverview(PROJECT_ID)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    releaseTransactionReturn()
+    await expect(retry).resolves.toEqual([])
+    releasePendingMarker()
+
+    await expect(overview).resolves.toMatchObject({ isIndexComplete: true })
+    const restartedRepository = new ManagedFileIndexRepository(
+      () => Promise.resolve(client),
+      storageRoot
+    )
+    await expect(restartedRepository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      isIndexComplete: true
+    })
+  })
+
   it('flushes a pending Session marker before listing Artifact groups', async () => {
     let databaseAvailable = false
     const transientRepository = new ManagedFileIndexRepository(() => {

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -13,6 +13,8 @@ import {
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+import { readProjectFilesIndexComplete } from './index-state'
+import type { ProjectFilesClient } from './mutation-projection'
 import { createManagedFileIndexRepository, ManagedFileIndexRepository } from './repository'
 
 const PROJECT_ID = 'project-a'
@@ -54,6 +56,16 @@ describe('ManagedFileIndexRepository', () => {
     await client.$disconnect()
     await rm(storageRoot, { recursive: true, force: true })
   }, WINDOWS_SQLITE_HOOK_TIMEOUT_MS)
+
+  it('accepts numeric SQLite true values when reading completeness', async () => {
+    const numericBooleanClient = {
+      $queryRaw: vi.fn(async () => [{ isIndexComplete: 1 }])
+    } as unknown as ProjectFilesClient
+
+    await expect(readProjectFilesIndexComplete(numericBooleanClient, [PROJECT_ID])).resolves.toBe(
+      true
+    )
+  })
 
   it('indexes uploads and all finalized managed artifacts without requiring a message link', async () => {
     const uploadPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')
@@ -1244,6 +1256,29 @@ describe('ManagedFileIndexRepository', () => {
 
     await expect(transientRepository.syncSession(session)).resolves.toEqual([])
     expect((await transientRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(true)
+  })
+
+  it('flushes a pending Session marker before listing Artifact groups', async () => {
+    let databaseAvailable = false
+    const transientRepository = new ManagedFileIndexRepository(() => {
+      if (!databaseAvailable) return Promise.reject(new Error('database temporarily unavailable'))
+      return Promise.resolve(client)
+    }, storageRoot)
+
+    await expect(transientRepository.syncSession(createSession())).rejects.toThrow(
+      'database temporarily unavailable'
+    )
+    databaseAvailable = true
+
+    await expect(
+      transientRepository.listArtifactGroups({ projectId: PROJECT_ID, limit: 10 })
+    ).resolves.toEqual({ items: [], totalCount: 0 })
+
+    const restartedRepository = new ManagedFileIndexRepository(
+      () => Promise.resolve(client),
+      storageRoot
+    )
+    expect((await restartedRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(false)
   })
 
   it('does not revive stale file rows when a session deletion is compensated', async () => {

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1229,6 +1229,23 @@ describe('ManagedFileIndexRepository', () => {
     expect((await restartedRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(true)
   })
 
+  it('clears a pending Session marker after the same Session retries successfully', async () => {
+    let databaseAvailable = false
+    const transientRepository = new ManagedFileIndexRepository(() => {
+      if (!databaseAvailable) return Promise.reject(new Error('database temporarily unavailable'))
+      return Promise.resolve(client)
+    }, storageRoot)
+    const session = createSession()
+
+    await expect(transientRepository.syncSession(session)).rejects.toThrow(
+      'database temporarily unavailable'
+    )
+    databaseAvailable = true
+
+    await expect(transientRepository.syncSession(session)).resolves.toEqual([])
+    expect((await transientRepository.getOverview(PROJECT_ID)).isIndexComplete).toBe(true)
+  })
+
   it('does not revive stale file rows when a session deletion is compensated', async () => {
     const oldPath = join(
       storageRoot,

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1292,10 +1292,12 @@ describe('ManagedFileIndexRepository', () => {
       releasePendingMarker = resolve
     })
     const originalUpsert = client.managedFileSessionSync.upsert.bind(client.managedFileSessionSync)
-    vi.spyOn(client.managedFileSessionSync, 'upsert').mockImplementation(async (args) => {
+    vi.spyOn(client.managedFileSessionSync, 'upsert').mockImplementation((async (
+      args: Parameters<typeof originalUpsert>[0]
+    ) => {
       await pendingMarkerMayPersist
       return originalUpsert(args)
-    })
+    }) as unknown as typeof originalUpsert)
 
     const retry = transientRepository.syncSession(session)
     await transactionCommitted

--- a/src/main/project-files/repository.ts
+++ b/src/main/project-files/repository.ts
@@ -31,8 +31,8 @@ class ManagedFileIndexRepository {
 
   constructor(getClient: ProjectFilesClientProvider, dataRoot: string) {
     this.mutationOwner = new ProjectFilesMutationOwner(getClient, dataRoot)
-    this.queryOwner = new ProjectFilesQueryOwner(getClient, dataRoot, (projectId) =>
-      this.mutationOwner.isIndexComplete(projectId)
+    this.queryOwner = new ProjectFilesQueryOwner(getClient, dataRoot, (client) =>
+      this.mutationOwner.flushPendingIncompleteState(client)
     )
   }
 
@@ -71,8 +71,8 @@ class ManagedFileIndexRepository {
     return this.mutationOwner.reconcileProjectSessions(projectId, sessions)
   }
 
-  markReconciliationIncomplete(): void {
-    this.mutationOwner.markReconciliationIncomplete()
+  markReconciliationIncomplete(): Promise<void> {
+    return this.mutationOwner.markReconciliationIncomplete()
   }
 
   async getOverview(

--- a/src/main/project-files/repository.ts
+++ b/src/main/project-files/repository.ts
@@ -31,8 +31,8 @@ class ManagedFileIndexRepository {
 
   constructor(getClient: ProjectFilesClientProvider, dataRoot: string) {
     this.mutationOwner = new ProjectFilesMutationOwner(getClient, dataRoot)
-    this.queryOwner = new ProjectFilesQueryOwner(getClient, dataRoot, (client) =>
-      this.mutationOwner.flushPendingIncompleteState(client)
+    this.queryOwner = new ProjectFilesQueryOwner(getClient, dataRoot, (client, projectIds) =>
+      this.mutationOwner.flushPendingIncompleteState(client, projectIds)
     )
   }
 

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -5069,7 +5069,7 @@ describe('SessionPersistenceCoordinator', () => {
       })
     })
     const fileIndex = createFileIndex({
-      markReconciliationIncomplete: vi.fn(() => {
+      markReconciliationIncomplete: vi.fn(async () => {
         order.push('mark-incomplete')
       }),
       softDeleteProject: vi.fn(async () => {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -136,7 +136,7 @@ type SessionFileIndex = {
   softDeleteProject(projectId: string): Promise<ManagedFileSoftDeleteToken>
   reconcileProjectSessions(projectId: string, sessions: PersistedChatSession[]): Promise<void>
   reconcileActiveSessions(sessions: PersistedChatSession[]): Promise<void>
-  markReconciliationIncomplete(): void
+  markReconciliationIncomplete(): Promise<void>
 }
 
 type SessionProvenancePersistence = {
@@ -294,7 +294,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
       // Once any renderer has observed a degraded snapshot, later loads are no longer allowed to
       // treat the process as an untouched startup boundary for destructive cleanup.
       this.destructiveStartupWindowOpen = false
-      this.fileIndex.markReconciliationIncomplete()
+      await this.fileIndex.markReconciliationIncomplete()
       const operation = startDiagnosticOperation(this.log, {
         operation: 'session-hydration',
         cpuUsage: SESSION_CPU_TRACE_ENABLED ? process.cpuUsage : undefined,
@@ -377,7 +377,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
       if (!hasAuthoritativeSessionCatalog) {
         // Without the full active-session set, absent rows may still be owned by unreadable or
         // quarantined JSON, so every derived owner must remain incomplete and untouched.
-        this.fileIndex.markReconciliationIncomplete()
+        await this.fileIndex.markReconciliationIncomplete()
         operation.complete({
           status: 'partial',
           sessionCount: sessions.length,
@@ -415,7 +415,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         }
         if (recoveryFailureCount > 0) {
           this.stateOwner.replaceMetadata(sessions, false)
-          this.fileIndex.markReconciliationIncomplete()
+          await this.fileIndex.markReconciliationIncomplete()
           result = {
             ...result,
             sessions,
@@ -476,7 +476,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
 
       if (reconciliation.status === 'degraded') {
         this.stateOwner.markMetadataIncomplete()
-        this.fileIndex.markReconciliationIncomplete()
+        await this.fileIndex.markReconciliationIncomplete()
         operation.fail(reconciliation.failure, {
           status: 'degraded',
           hydrationAvailable: true,
@@ -850,7 +850,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
           }
         } catch {
           // Unknown durable state is treated as committed: retain the in-memory tombstone and intent.
-          this.fileIndex.markReconciliationIncomplete()
+          await this.fileIndex.markReconciliationIncomplete()
         }
         throw error
       }
@@ -892,7 +892,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     return this.operationScheduler.runGlobal(async () => {
       const scan = await this.repository.loadAllWithDiagnostics()
       if (!scan.isComplete) {
-        this.fileIndex.markReconciliationIncomplete()
+        await this.fileIndex.markReconciliationIncomplete()
         this.notifyFilesChanged({
           projectId,
           sources: ['artifact', 'upload'],

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -68,7 +68,7 @@ type SessionDeletionFileIndex = {
   softDeleteProject(projectId: string): Promise<ManagedFileSoftDeleteToken>
   reconcileProjectSessions(projectId: string, sessions: PersistedChatSession[]): Promise<void>
   reconcileActiveSessions(sessions: PersistedChatSession[]): Promise<void>
-  markReconciliationIncomplete(): void
+  markReconciliationIncomplete(): Promise<void>
 }
 
 type SessionDeletionProvenance = {
@@ -304,7 +304,7 @@ class SessionPersistenceDeletionOwner {
                 'Cannot adopt a legacy Project tombstone with incomplete Session authority.'
               )
             }
-            this.fileIndex.markReconciliationIncomplete()
+            await this.fileIndex.markReconciliationIncomplete()
           }
           for (const session of scan.sessions) {
             let cleanup: { hasUnsafeResidual: boolean }
@@ -322,14 +322,14 @@ class SessionPersistenceDeletionOwner {
                 error instanceof OrphanLegacyUploadAuthorityMissingError
               ) {
                 await this.computeJobs?.commitProjectJobDeletion(projectId)
-                this.fileIndex.markReconciliationIncomplete()
+                await this.fileIndex.markReconciliationIncomplete()
                 await this.fileIndex.softDeleteProject(projectId)
                 await this.notifySessionsDeleted(deletedSessionIds)
                 return { status: 'orphan-retained', reason: 'missing-upload-authority' }
               }
               throw error
             }
-            if (cleanup.hasUnsafeResidual) this.fileIndex.markReconciliationIncomplete()
+            if (cleanup.hasUnsafeResidual) await this.fileIndex.markReconciliationIncomplete()
           }
         }
         if (deletionState === 'legacy-committed') {
@@ -452,10 +452,10 @@ class SessionPersistenceDeletionOwner {
           }
           if (recoveryFailed) throw recoveryError
         } else {
-          this.fileIndex.markReconciliationIncomplete()
+          await this.fileIndex.markReconciliationIncomplete()
         }
       } catch (restoreError) {
-        this.fileIndex.markReconciliationIncomplete()
+        await this.fileIndex.markReconciliationIncomplete()
         operation.fail(restoreError, { failurePhase, recoveryPhase })
         throw restoreError
       }
@@ -490,11 +490,11 @@ class SessionPersistenceDeletionOwner {
         await this.fileIndex.reconcileActiveSessions(scan.result.sessions)
       } else {
         this.stateOwner.markMetadataIncomplete()
-        this.fileIndex.markReconciliationIncomplete()
+        await this.fileIndex.markReconciliationIncomplete()
       }
     } catch {
       this.stateOwner.markMetadataIncomplete()
-      this.fileIndex.markReconciliationIncomplete()
+      await this.fileIndex.markReconciliationIncomplete()
     }
 
     for (const change of survivorChanges) {


### PR DESCRIPTION
## Problem

Project Files index completeness was held primarily in `ProjectFilesMutationOwner` memory. A failed Session file sync did persist `ManagedFileSessionSync.filesRevision = -1`, but queries ignored that durable retry marker. Catalog-wide reconciliation failure was not persisted at all.

After an application restart, a ready Session Summary projection can avoid rescanning Session JSON. The recreated repository therefore had empty in-memory failure state and could report `isIndexComplete: true` for an incomplete index, allowing zero or partial results to be treated as authoritative by Files Overview, downloads, and global search.

## Proposed change

- Derive project completeness from active `ManagedFileSessionSync.filesRevision < 0` rows.
- Persist catalog-wide reconciliation completeness in a constrained singleton `ManagedFileIndexState` row.
- Mark reconciliation incomplete before reconciliation work and complete only after it succeeds.
- Read completeness in the query owner from SQLite instead of a synchronous mutation-owner callback.
- Preserve the original operation error when the completeness marker cannot immediately be written, and retry the conservative global marker before the next observable Project Files read.
- Track fallback marker writes by Session so a successful retry clears only that Session without hiding unrelated pending failures.
- Normalize SQLite raw booleans across `true`, `1n`, and numeric `1`, and flush pending state before Artifact group projection reads.
- Make the singleton migration idempotently seed a missing row when adopting an already-generated table, while preserving an existing persisted `false` value.
- Serialize pending-marker flushes with synchronization of the same Session so a late `-1` write cannot overwrite a successful retry.
- Preserve Session deletion tombstones when flushing a deferred incomplete marker.
- Flush deferred Session markers only for the projects involved in the current read, so one
  project's locked marker cannot block an unrelated project's Files view.
- Pin migration `0020_project_files_index_state` in packaged migration-ledger certification and replay fixtures.
- Add public Repository regression coverage that recreates the Repository over the same database after both a Session indexing failure and a reconciliation failure.

## Scope and non-goals

- Data persistence changes: adds migration `0020_project_files_index_state` and the `ManagedFileIndexState` singleton table.
- Historical compatibility: existing databases are seeded with catalog reconciliation complete. Existing negative Session revisions remain authoritative and immediately make their projects incomplete. A catalog-wide failure from a pre-fix process cannot be reconstructed historically; the next reconciliation establishes the durable state.
- No new enum values.
- No Project Files IPC contract, renderer interaction, or user-visible behavior changes.
- No Session JSON or Session Summary data-model changes.
- No attempt to force a Session JSON rescan when its Summary projection is already ready.
- Includes an independent one-character French punctuation correction inherited from current
  `main`; without it, the full Module shard fails its existing locale invariant.

## Acceptance criteria and validation

Before the production fix, the two new restart tests failed repeatedly at the public `ManagedFileIndexRepository.getOverview()` boundary with `expected false, received true`. Both pass after the fix. Eight AI-review follow-up regressions also failed before their fixes: successful retry remained incomplete, numeric SQLite true parsed as false, Artifact group reads failed to persist pending state before restart, an adopted table could omit the singleton row, a concurrent pending flush could overwrite a successful retry, a pending flush could revive a deleted Session group, packaged ledger certification stopped at migration 0019, and a Project A read attempted to flush Project B's locked marker. All now pass.

Final checks after the last material edit:

- `vitest` Project Files module: 66 passed, 1 skipped.
- Project Files index-state migration suite: 3 passed.
- Packaged database migration-ledger smoke: 12 passed.
- Module-impact validation: 9 passed.
- Generated database schema consistency check: passed.
- `vitest` Session Persistence coordinator: 149 passed.
- `vitest` Session deletion integration: 16 passed.
- `vitest` artifact finalization recovery integration: 14 passed.
- Targeted ESLint for the final touched implementation and migration files: passed.
- i18n resources guard: 743 passed; locale-owner suite: 7 passed.
- `git diff --check`: passed before commit; committed worktree is clean.

Additional affected checks run during implementation:

- Other affected migration suites: 23 passed.
- Migration service suite excluding one stale generated-client case: 60 passed, 1 skipped.
- Application database integration excluding two stale generated-client cases: 20 passed, 2 skipped.
- Full repository ESLint: passed.

Uncovered/local environment risks:

- This worktree intentionally reused the main checkout dependencies because its lockfile differs. That Prisma Client was generated from the old schema, so three legacy-classification tests see `ManagedFileIndexState` as an unknown table. Their remaining assertions pass when those cases are excluded; CI's fresh generated client is authoritative.
- Node TypeScript checking reaches one unrelated dependency mismatch: the reused `@agentclientprotocol/claude-agent-acp` package lacks the branch-expected `waitForMcpServers` export. No changed file reports a type error.
- Full `npm test` was not run locally as requested; PR CI owns the full matrix.

## Review focus

- Compatibility-first `true` seed for existing databases versus conservatively marking every upgraded catalog incomplete.
- State transitions around reconciliation failure/crash and successful retry.
- Completeness SQL for active negative Session revisions, including searched overviews and cross-project artifact search.
- Keeping the query owner read-only while removing completeness authority from process memory.
