### PR TITLE
feat(providers): add Tencent subscription plans

### DIFF
--- a/src/main/settings/backend-route-planner.test.ts
+++ b/src/main/settings/backend-route-planner.test.ts
@@ -346,6 +346,53 @@ describe('BackendRoutePlanner provider candidates', () => {
     )
   })
 
+  it.each([
+    [
+      'Tencent Coding Plan',
+      'tencentcodingplan' as const,
+      'https://api.lkeap.cloud.tencent.com/coding/anthropic'
+    ],
+    [
+      'Tencent Token Plan',
+      'tencenttokenplan' as const,
+      'https://tokenhub-intl.tencentcloudmaas.com/plan/anthropic'
+    ]
+  ])('keeps %s Claude bridge targets on bearer authentication', (_, vendorId, baseUrl) => {
+    const provider = makeStoredProvider({
+      type: 'official',
+      vendorId,
+      apiEndpoints: ['anthropic'],
+      baseUrl,
+      model: 'deepseek-v4-pro-202606'
+    })
+    const target = makeTarget(provider, {
+      apiEndpoints: ['anthropic'],
+      // Official providers project to the custom credential transport while retaining vendorId.
+      provider: { type: 'custom', vendorId, apiEndpoints: ['anthropic'] }
+    })
+
+    const plan = makePlanner().planBackend({
+      settings: { ...makeSettings(provider), agentFrameworkId: 'claude-code' },
+      frameworkId: 'claude-code',
+      target,
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.transport).toEqual({
+      kind: 'claude-anthropic',
+      targets: [
+        {
+          id: JSON.stringify([provider.id, provider.model]),
+          baseUrl,
+          key: 'plain-provider-key',
+          model: provider.model
+        }
+      ],
+      initialTargetId: JSON.stringify([provider.id, provider.model])
+    })
+  })
+
   it('filters model catalogs by route and preserves deduplicated effort slots', () => {
     const provider = makeStoredProvider()
     const active = makeTarget(provider, {

--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -171,6 +171,53 @@ describe('ProviderRuntimeProjectionOwner', () => {
     })
   })
 
+  it.each([
+    {
+      vendorId: 'tencentcodingplan' as const,
+      name: 'Tencent Coding Plan',
+      model: 'deepseek-v4-flash-202605',
+      baseUrl: 'https://api.lkeap.cloud.tencent.com/coding/anthropic',
+      openaiBaseUrl: 'https://api.lkeap.cloud.tencent.com/coding/v3'
+    },
+    {
+      vendorId: 'tencenttokenplan' as const,
+      name: 'Tencent Token Plan',
+      model: 'glm-5.2',
+      baseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/plan/anthropic',
+      openaiBaseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/plan/v3'
+    }
+  ])('projects $name across every supported framework', (expected) => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: expected.vendorId,
+      type: 'official',
+      vendorId: expected.vendorId,
+      name: expected.name
+    }
+
+    for (const frameworkId of ['claude-code', 'opencode', 'codex', 'codebuddy'] as const) {
+      expect(
+        owner.resolveRuntimeTarget(
+          provider,
+          { kind: 'required', model: expected.model },
+          getAgentFramework(frameworkId)
+        )
+      ).toMatchObject({
+        effectiveModel: expected.model,
+        apiEndpoints: ['anthropic', 'openai'],
+        frameworkCompatible: true,
+        needsChatResponsesBridge: frameworkId === 'codex',
+        needsNativeResponsesCompatibility: false,
+        provider: {
+          vendorId: expected.vendorId,
+          baseUrl: expected.baseUrl,
+          openaiBaseUrl: expected.openaiBaseUrl,
+          model: expected.model
+        }
+      })
+    }
+  })
+
   it('routes mixed OpenCode Zen models only through their documented protocol', () => {
     const owner = new ProviderRuntimeProjectionOwner()
     const provider: StoredProvider = {

--- a/src/main/settings/record-codec.test.ts
+++ b/src/main/settings/record-codec.test.ts
@@ -67,23 +67,27 @@ describe('settings record codec', () => {
     ).toBeUndefined()
   })
 
-  it('preserves Tencent TokenHub provider identity and region', () => {
+  it.each([
+    ['tencent', 'Tencent TokenHub', 'international'],
+    ['tencentcodingplan', 'Tencent Coding Plan', undefined],
+    ['tencenttokenplan', 'Tencent Token Plan', undefined]
+  ] as const)('preserves the %s provider identity', (vendorId, name, region) => {
     expect(
       sanitizeProvider({
-        id: 'tencent-tokenhub',
+        id: vendorId,
         type: 'official',
-        name: 'Tencent TokenHub',
-        vendorId: 'tencent',
-        region: 'international',
+        name,
+        vendorId,
+        region,
         keyRef: 'encrypted:key',
         keyMask: 'sk-…abcd'
       })
     ).toEqual({
-      id: 'tencent-tokenhub',
+      id: vendorId,
       type: 'official',
-      name: 'Tencent TokenHub',
-      vendorId: 'tencent',
-      region: 'international',
+      name,
+      vendorId,
+      ...(region ? { region } : {}),
       keyRef: 'encrypted:key',
       keyMask: 'sk-…abcd'
     })

--- a/src/main/settings/validate.test.ts
+++ b/src/main/settings/validate.test.ts
@@ -66,6 +66,38 @@ describe('validate: request construction', () => {
     expect(request.headers.authorization).toBeUndefined()
   })
 
+  it.each([
+    [
+      'Tencent Coding Plan',
+      'tencentcodingplan' as const,
+      'https://api.lkeap.cloud.tencent.com/coding/anthropic',
+      'deepseek-v4-pro-202606'
+    ],
+    [
+      'Tencent Token Plan',
+      'tencenttokenplan' as const,
+      'https://tokenhub-intl.tencentcloudmaas.com/plan/anthropic',
+      'deepseek-v4-pro-202606'
+    ]
+  ])('uses bearer authentication for %s Messages validation', (_, vendorId, baseUrl, model) => {
+    const request = buildValidationRequest(
+      {
+        type: 'official',
+        vendorId,
+        baseUrl,
+        model,
+        key: 'plan-key',
+        apiEndpoints: ['anthropic', 'openai']
+      },
+      false,
+      ['anthropic']
+    )
+
+    expect(request.url).toBe(`${baseUrl}/v1/messages`)
+    expect(request.headers.authorization).toBe('Bearer plan-key')
+    expect(request.headers['x-api-key']).toBeUndefined()
+  })
+
   it('throws for a missing or unparseable base URL', () => {
     expect(() => buildValidationRequest({ type: 'custom' })).toThrow(/missing base url/i)
     expect(() => buildValidationRequest({ type: 'custom', baseUrl: 'not a url' })).toThrow(

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -177,6 +177,8 @@ describe('provider-kind helpers', () => {
     expect(apiKeys).toContain('official:deepseek')
     expect(apiKeys).toContain('official:openai')
     expect(apiKeys).toContain('official:tencent')
+    expect(apiKeys).toContain('official:tencentcodingplan')
+    expect(apiKeys).toContain('official:tencenttokenplan')
     // The two subscription sign-ins each get their own group, parallel to one another, rather than
     // the Claude one hiding under Official API.
     expect(groupKeys('codex')).toEqual(['codex-subscription'])
@@ -215,6 +217,26 @@ describe('provider-kind helpers', () => {
       name: 'Tencent TokenHub',
       vendorId: 'tencent',
       region: 'international',
+      model: '',
+      contextWindow: '',
+      maxInputTokens: '',
+      maxOutputTokens: ''
+    })
+    expect(providerKindPatch('official:tencentcodingplan')).toEqual({
+      type: 'official',
+      name: 'Tencent Coding Plan',
+      vendorId: 'tencentcodingplan',
+      region: undefined,
+      model: '',
+      contextWindow: '',
+      maxInputTokens: '',
+      maxOutputTokens: ''
+    })
+    expect(providerKindPatch('official:tencenttokenplan')).toEqual({
+      type: 'official',
+      name: 'Tencent Token Plan',
+      vendorId: 'tencenttokenplan',
+      region: undefined,
       model: '',
       contextWindow: '',
       maxInputTokens: '',

--- a/src/renderer/src/pages/settings/provider-icons.render.test.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.render.test.tsx
@@ -15,12 +15,15 @@ describe('ProviderKindIcon', () => {
     }
   )
 
-  it('renders the Tencent Cloud provider logo for Tencent TokenHub', () => {
-    const html = renderToStaticMarkup(<ProviderKindIcon kindKey="official:tencent" />)
+  it.each(['official:tencent', 'official:tencentcodingplan', 'official:tencenttokenplan'])(
+    'renders the Tencent Cloud provider logo for %s',
+    (kindKey) => {
+      const html = renderToStaticMarkup(<ProviderKindIcon kindKey={kindKey} />)
 
-    expect(html).toContain('<svg')
-    expect(html).toContain('<title>TencentCloud</title>')
-    expect(html).toContain('#006EFF')
-    expect(html).not.toContain('text-muted-foreground')
-  })
+      expect(html).toContain('<svg')
+      expect(html).toContain('<title>TencentCloud</title>')
+      expect(html).toContain('#006EFF')
+      expect(html).not.toContain('text-muted-foreground')
+    }
+  )
 })

--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -49,7 +49,8 @@ export const AgentFrameworkIcon = ({
 
 // Official vendor brand marks, bundled as assets. Providers from the same vendor share one mark:
 // Bailian and Bailian for Plan, Kimi and Kimi For Coding, Zhipu and GLM Coding Plan, and StepFun and
-// Step Plan. Any vendor without an entry falls back to a neutral glyph rather than a made-up logo.
+// Step Plan. Tencent providers use the bundled icon component below. Any vendor without an entry
+// falls back to a neutral glyph rather than a made-up logo.
 // Custom uses a plus-in-circle.
 const VENDOR_LOGO: Partial<Record<OfficialVendorId, string>> = {
   openai: openaiLogo,
@@ -118,7 +119,11 @@ export const ProviderKindIcon = ({
     )
   }
 
-  if (kindKey === 'official:tencent') {
+  if (
+    kindKey === 'official:tencent' ||
+    kindKey === 'official:tencentcodingplan' ||
+    kindKey === 'official:tencenttokenplan'
+  ) {
     return (
       <TencentCloudColor
         size={20}

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -47,7 +47,7 @@
     "{{count}} notebooks already exist in the chosen directory._other": "Le dossier choisi contient déjà {{count}} Notebooks.",
     "Overwrite": "Écraser",
     "Save the update installer": "Enregistrer le programme d'installation de la mise à jour",
-    "Could not open the update installer: {{error}}": "Impossible d'ouvrir le programme d'installation de la mise à jour : {{error}}",
+    "Could not open the update installer: {{error}}": "Impossible d'ouvrir le programme d'installation de la mise à jour : {{error}}",
     "Export Skill": "Exporter la compétence",
     "Skill ZIP": "Archive ZIP de la compétence",
     "ZIP archive": "Archive ZIP",

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -38,6 +38,8 @@ describe('provider registry', () => {
     expect(isOfficialVendorId('openai')).toBe(true)
     expect(isOfficialVendorId('xai')).toBe(true)
     expect(isOfficialVendorId('tencent')).toBe(true)
+    expect(isOfficialVendorId('tencentcodingplan')).toBe(true)
+    expect(isOfficialVendorId('tencenttokenplan')).toBe(true)
     expect(isOfficialVendorId(undefined)).toBe(false)
     expect(isOfficialVendorId(42)).toBe(false)
   })
@@ -460,6 +462,57 @@ describe('provider registry', () => {
     expect(resolveVendorModelReasoningEffort('tencent', 'hy4-preview')).toEqual({
       supported: false
     })
+  })
+
+  it('routes Tencent Coding Plan through its mainland subscription endpoints', () => {
+    expect(resolveVendorApiEndpoints('tencentcodingplan')).toEqual(['anthropic', 'openai'])
+    expect(vendorHasRegions('tencentcodingplan')).toBe(false)
+    expect(resolveVendorBaseUrl('tencentcodingplan')).toBe(
+      'https://api.lkeap.cloud.tencent.com/coding/anthropic'
+    )
+    expect(resolveVendorOpenAiBaseUrl('tencentcodingplan')).toBe(
+      'https://api.lkeap.cloud.tencent.com/coding/v3'
+    )
+    expect(resolveVendorApiKeyUrl('tencentcodingplan')).toBe(
+      'https://console.cloud.tencent.com/tokenhub/codingplan'
+    )
+    expect(getOfficialVendor('tencentcodingplan')?.models.map(({ id }) => id)).toEqual([
+      'deepseek-v4-flash-202605',
+      'deepseek-v4-pro-202606',
+      'minimax-m2.7',
+      'glm-5',
+      'glm-5.1',
+      'glm-5.2',
+      'hy3'
+    ])
+    expect(defaultVendorModel('tencentcodingplan')).toBe('deepseek-v4-flash-202605')
+    expect(resolveVendorModelsUrl('tencentcodingplan')).toBeUndefined()
+    expect(isVendorModelResponsesSupported('tencentcodingplan', 'glm-5.2')).toBe(false)
+  })
+
+  it('routes Tencent Token Plan through its international subscription endpoints', () => {
+    expect(resolveVendorApiEndpoints('tencenttokenplan')).toEqual(['anthropic', 'openai'])
+    expect(vendorHasRegions('tencenttokenplan')).toBe(false)
+    expect(resolveVendorBaseUrl('tencenttokenplan')).toBe(
+      'https://tokenhub-intl.tencentcloudmaas.com/plan/anthropic'
+    )
+    expect(resolveVendorOpenAiBaseUrl('tencenttokenplan')).toBe(
+      'https://tokenhub-intl.tencentcloudmaas.com/plan/v3'
+    )
+    expect(resolveVendorApiKeyUrl('tencenttokenplan')).toBe(
+      'https://console.intl.cloud.tencent.com/tokenhub/tokenplan'
+    )
+    expect(getOfficialVendor('tencenttokenplan')?.models.map(({ id }) => id)).toEqual([
+      'glm-5.2',
+      'kimi-k2.6',
+      'deepseek-v4-pro-202606',
+      'deepseek-v4-flash-202605',
+      'minimax-m3'
+    ])
+    expect(defaultVendorModel('tencenttokenplan')).toBe('glm-5.2')
+    expect(resolveVendorModelsUrl('tencenttokenplan')).toBeUndefined()
+    expect(isVendorModelMultimodal('tencenttokenplan', 'kimi-k2.6')).toBe(true)
+    expect(isVendorModelMultimodal('tencenttokenplan', 'glm-5.2')).toBe(false)
   })
 
   it('routes Grok through xAI Chat Completions and Responses with a curated model catalog', () => {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -667,8 +667,9 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     label: 'Tencent Coding Plan',
     reasoningEffort: 'unsupported',
     // Mainland China's subscription plan exposes separate Anthropic Messages and OpenAI Chat
-    // Completions routes. Its accepted aliases are intentionally omitted so the picker shows each
-    // model once; the first documented id for each model is the canonical selection.
+    // Completions routes. Tencent documents ANTHROPIC_AUTH_TOKEN for the former, so it keeps the
+    // default Authorization: Bearer transport. Accepted aliases are intentionally omitted so the
+    // picker shows each model once; the first documented id is the canonical selection.
     apiEndpoints: ['anthropic', 'openai'],
     baseUrl: 'https://api.lkeap.cloud.tencent.com/coding/anthropic',
     openaiBaseUrl: 'https://api.lkeap.cloud.tencent.com/coding/v3',
@@ -688,7 +689,8 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     label: 'Tencent Token Plan',
     reasoningEffort: 'unsupported',
     // The international subscription is a distinct product with its own key, endpoints, and model
-    // catalog. Keep it separate from both mainland Coding Plan and pay-as-you-go Tencent TokenHub.
+    // catalog. Its Claude Code guide also uses ANTHROPIC_AUTH_TOKEN (Authorization: Bearer). Keep it
+    // separate from both mainland Coding Plan and pay-as-you-go Tencent TokenHub.
     apiEndpoints: ['anthropic', 'openai'],
     baseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/plan/anthropic',
     openaiBaseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/plan/v3',

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -32,6 +32,8 @@ export type OfficialVendorId =
   | 'sensenova'
   | 'volcengine'
   | 'tencent'
+  | 'tencentcodingplan'
+  | 'tencenttokenplan'
   | 'opencode-go'
   | 'opencode'
   | 'openrouter'
@@ -659,6 +661,46 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     ]
     // The curated language models above are text-only in TokenHub's model matrix, so no
     // `multimodal` rule.
+  },
+  {
+    id: 'tencentcodingplan',
+    label: 'Tencent Coding Plan',
+    reasoningEffort: 'unsupported',
+    // Mainland China's subscription plan exposes separate Anthropic Messages and OpenAI Chat
+    // Completions routes. Its accepted aliases are intentionally omitted so the picker shows each
+    // model once; the first documented id for each model is the canonical selection.
+    apiEndpoints: ['anthropic', 'openai'],
+    baseUrl: 'https://api.lkeap.cloud.tencent.com/coding/anthropic',
+    openaiBaseUrl: 'https://api.lkeap.cloud.tencent.com/coding/v3',
+    apiKeyUrl: 'https://console.cloud.tencent.com/tokenhub/codingplan',
+    models: [
+      { id: 'deepseek-v4-flash-202605', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-pro-202606', contextWindow: 1_000_000 },
+      { id: 'minimax-m2.7', contextWindow: 204_800 },
+      { id: 'glm-5', contextWindow: 200_000 },
+      { id: 'glm-5.1', contextWindow: 200_000 },
+      { id: 'glm-5.2', contextWindow: 1_000_000 },
+      { id: 'hy3', contextWindow: 256_000 }
+    ]
+  },
+  {
+    id: 'tencenttokenplan',
+    label: 'Tencent Token Plan',
+    reasoningEffort: 'unsupported',
+    // The international subscription is a distinct product with its own key, endpoints, and model
+    // catalog. Keep it separate from both mainland Coding Plan and pay-as-you-go Tencent TokenHub.
+    apiEndpoints: ['anthropic', 'openai'],
+    baseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/plan/anthropic',
+    openaiBaseUrl: 'https://tokenhub-intl.tencentcloudmaas.com/plan/v3',
+    apiKeyUrl: 'https://console.intl.cloud.tencent.com/tokenhub/tokenplan',
+    models: [
+      { id: 'glm-5.2', contextWindow: 1_000_000 },
+      { id: 'kimi-k2.6', contextWindow: 256_000 },
+      { id: 'deepseek-v4-pro-202606', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-flash-202605', contextWindow: 1_000_000 },
+      { id: 'minimax-m3', contextWindow: 1_000_000 }
+    ],
+    multimodal: { multimodalModels: ['kimi-k2.6'] }
   },
   {
     id: 'opencode-go',


### PR DESCRIPTION
## Problem

Open Science supports Tencent TokenHub's pay-as-you-go API, but not Tencent's subscription plans. Mainland China Coding Plan and the international Token Plan use separate credentials, endpoints, and model catalogs, so modeling them as regions of the existing provider would expose invalid model/region combinations.

## Proposed change

- Add `Tencent Coding Plan` with the documented mainland Anthropic and OpenAI-compatible endpoints.
- Add `Tencent Token Plan` with the documented international Anthropic and OpenAI-compatible endpoints.
- Curate each plan's supported models independently and omit Auto and duplicate alias IDs.
- Reuse the Tencent Cloud provider icon and existing official-provider setup flow.
- Preserve both new official vendor identities through the settings codec.

References:

- https://cloud.tencent.com/document/product/1823/130098
- https://cloud.tencent.com/announce/detail/2432
- https://intl.cloud.tencent.com/document/product/1300/81038
- https://intl.cloud.tencent.com/document/product/1300/81315

## Scope and non-goals

- The existing `Tencent TokenHub` pay-as-you-go provider is unchanged.
- No Auto model option is added.
- Accepted model aliases are not duplicated in the picker; each model uses the first documented ID.
- No live catalog refresh, dependency, database migration, or renderer API surface is added.
- Existing settings upgrade behavior is unchanged. New records persist the new `vendorId` values and encrypted keys. Older app versions do not recognize those vendor IDs and may discard the new provider records on downgrade.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Provider catalogs and endpoints -> `npm test -- src/shared/provider-registry.test.ts src/main/settings/provider-runtime-projection.test.ts src/main/settings/record-codec.test.ts src/renderer/src/pages/settings/provider-form-value.test.ts src/renderer/src/pages/settings/provider-icons.render.test.tsx` -> 5 files / 105 tests passed.
- Provider account owner, contracts, and representative consumers -> `npm run test:module -- settings_provider_accounts` -> 21 files / 416 tests passed.
- Claude Code, OpenCode, Codex Chat bridge, and CodeBuddy routing -> covered by `provider-runtime-projection.test.ts` in both commands -> passed.
- Settings persistence for both new vendor IDs -> covered by `record-codec.test.ts` -> passed.
- Renderer provider picker and Tencent icon -> covered by the targeted renderer tests -> passed.
- Node types -> `npm run typecheck:node` -> passed.
- Web types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.

The complete local `npm test` suite was intentionally not run; PR Gate remains authoritative for the full portable and platform lanes. Local platform-specific and E2E checks were excluded because the change is registry data plus existing renderer wiring and does not alter OS, filesystem, IPC, or interaction behavior.

Uncovered risk: validation used deterministic configuration tests rather than live Tencent subscription credentials, so upstream availability and future catalog changes remain external risks.

## Review focus

- Confirm the two plans remain separate from pay-as-you-go Tencent TokenHub.
- Confirm the mainland and international endpoint/model mappings match the linked Tencent documentation.
- Confirm omitting aliases and Auto produces the intended picker catalog.
