### PR TITLE
test(storage): pin confirmed handoff wiring

### DIFF
--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -184,6 +184,7 @@ describe('storage IPC handlers', () => {
     expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
     expect(deps.runtime.disconnect).toHaveBeenCalledOnce()
     expect(deps.notebook.shutdownAll).toHaveBeenCalledOnce()
+    expect(deps.prepareDataRootHandoff).toHaveBeenCalledWith({ surface: 'electron-renderer' }, true)
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
   })
 
@@ -647,6 +648,22 @@ describe('storage IPC handlers', () => {
     // clicks "Restart now" (storage:commit-and-relaunch).
     expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
     expect(deps.relaunch).not.toHaveBeenCalled()
+  })
+
+  it('marks migration handoff preparation as user-confirmed', async () => {
+    initDataRoot(dataRoot)
+    const prepareDataRootHandoff = vi.fn().mockResolvedValue(true)
+    const runDataRootMigration = vi.fn().mockResolvedValue({ ok: true })
+    const deps = fakeDeps({
+      prepareDataRootHandoff,
+      runDataRootMigration,
+      validateNewDataRoot: vi.fn().mockResolvedValue({ ok: true })
+    })
+    registerStorageIpcHandlers(deps)
+
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+
+    expect(prepareDataRootHandoff).toHaveBeenCalledWith({ surface: 'electron-renderer' }, true)
   })
 
   it('rejects a stale migration request while delegated work is running without interrupting it', async () => {


### PR DESCRIPTION
## Problem

PR #1882's final actionable AI review reported that confirmed migration and recovery were blocked like an unconfirmed direct root switch. The production fix merged, but its public command wiring was not asserted directly and the follow-up review was skipped after the review quota was reached.

## Proposed change

Assert at the storage IPC boundary that both migration copy and recovered commit pass confirmedInterruption=true to data-root durability preparation. The existing direct-adoption test continues to assert false.

## Scope and non-goals

Test-only. No production logic, schema, persisted field, enum, interaction, or historical-data compatibility change. The separate review claim that recovered cancellation latched migration flags was reproduced on the reviewed pre-fix commit and did not fail, so this PR intentionally adds no production state handling for it.

## Acceptance criteria and validation

Final Test Impact Set after the last material edit:
- targeted Vitest: 7 passed, 110 skipped across storage IPC and update strategy
- recovered writer-pause cancellation: 6 consecutive passes; in-progress and pending clear while the verified marker remains
- red check: the new migration wiring test fails on 09c9ae8ef because the gate receives no true argument
- Prettier check: passed
- ESLint: passed
- git diff --check: passed

Uncovered risk: the full storage IPC file has unrelated Windows hard-link capability failures locally; exact-head CI remains authoritative. Full npm test was not run because this only changes testFiles in the existing storage Module.

## Review focus

Confirm the assertions cover the owner-to-durability-gate policy wiring without duplicating production behavior.

Related: #1882
