### PR TITLE
fix(storage): preserve artifact metadata and clean upload drafts

### DIFF
--- a/src/main/artifacts/compatibility-owner.ts
+++ b/src/main/artifacts/compatibility-owner.ts
@@ -75,7 +75,7 @@ class ArtifactCompatibilityOwner {
               messageId,
               filename: entry.name,
               filePath: join(messageDir, entry.name),
-              mimeType: metadata.mimeType
+              metadata
             })
           )
         }
@@ -96,7 +96,7 @@ class ArtifactCompatibilityOwner {
               runId,
               filename: entry.name,
               filePath: join(runDir, entry.name),
-              mimeType: metadata.mimeType
+              metadata
             })
           )
         }

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -1581,6 +1581,51 @@ describe('artifact repository', () => {
     expect(files.map((file) => file.sessionId).sort()).toEqual(['session-1', 'session-2'])
   })
 
+  it('projects finalized artifact Version metadata in the project scan', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    const content = 'finalized version bytes'
+    const checksum = sha256(content)
+    const pending = await repository.writePendingFile({
+      projectId: 'default-project',
+      sessionId: 'session-versioned',
+      runId: 'run-finalized',
+      filename: 'result.txt',
+      mimeType: 'text/plain',
+      source: createInlineSource(content)
+    })
+    await repository.ensurePendingVersionRouting({
+      projectId: 'default-project',
+      sessionId: 'session-versioned',
+      runId: 'run-finalized',
+      filename: 'result.txt',
+      sourcePath: pending.path,
+      routing: {
+        artifactId: 'artifact-finalized',
+        versionId: 'version-finalized',
+        versionNumber: 3,
+        artifactRunId: 'run-finalized',
+        checksum,
+        mimeType: 'text/plain'
+      }
+    })
+    await repository.finalizeRunArtifacts({
+      projectId: 'default-project',
+      sessionId: 'session-versioned',
+      runId: 'run-finalized',
+      messageId: 'message-finalized'
+    })
+
+    const [artifact] = await repository.listProjectArtifacts('default-project')
+
+    expect(artifact).toMatchObject({
+      artifactId: 'artifact-finalized',
+      versionId: 'version-finalized',
+      versionNumber: 3,
+      checksum
+    })
+  })
+
   it('surfaces ownerless pending files (crash before attach) as orphaned artifacts', async () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)
@@ -1600,6 +1645,45 @@ describe('artifact repository', () => {
     expect(files.map((file) => file.name)).toEqual(['draft.txt'])
     expect(files[0].runId).toBe('run-orphan')
     expect(files[0].path).toContain('.pending')
+  })
+
+  it('projects orphaned pending artifact Version metadata in the project scan', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+    const content = 'orphaned version bytes'
+    const checksum = sha256(content)
+    const pending = await repository.writePendingFile({
+      projectId: 'default-project',
+      sessionId: 'session-versioned',
+      runId: 'run-orphaned',
+      filename: 'draft.txt',
+      mimeType: 'text/plain',
+      source: createInlineSource(content)
+    })
+    await repository.ensurePendingVersionRouting({
+      projectId: 'default-project',
+      sessionId: 'session-versioned',
+      runId: 'run-orphaned',
+      filename: 'draft.txt',
+      sourcePath: pending.path,
+      routing: {
+        artifactId: 'artifact-orphaned',
+        versionId: 'version-orphaned',
+        versionNumber: 2,
+        artifactRunId: 'run-orphaned',
+        checksum,
+        mimeType: 'text/plain'
+      }
+    })
+
+    const [artifact] = await repository.listProjectArtifacts('default-project')
+
+    expect(artifact).toMatchObject({
+      artifactId: 'artifact-orphaned',
+      versionId: 'version-orphaned',
+      versionNumber: 2,
+      checksum
+    })
   })
 
   it('does not list the current-run handoff file as an artifact', async () => {

--- a/src/main/artifacts/storage-access.ts
+++ b/src/main/artifacts/storage-access.ts
@@ -396,6 +396,7 @@ class ArtifactStorageAccess {
       artifactId: request.metadata?.artifactId,
       versionId: request.metadata?.versionId,
       versionNumber: request.metadata?.versionNumber,
+      checksum: request.metadata?.checksum,
       size: fileStat.size,
       mtimeMs: fileStat.mtimeMs
     }

--- a/src/main/uploads/active-transfer-owner.test.ts
+++ b/src/main/uploads/active-transfer-owner.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
+
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
   return {
@@ -12,6 +14,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 })
 
 import { ActiveTransferOwner } from './active-transfer-owner'
+import { STAGING_UPLOAD_SESSION_ID, getSessionUploadDir } from './storage-helpers'
 
 const actualFsPromises =
   await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
@@ -39,7 +42,21 @@ describe('ActiveTransferOwner staging initialization', () => {
       receivedBytes: 0,
       totalBytes: request.size
     })
-    expect(rm).toHaveBeenCalledTimes(2)
+    expect(rm).toHaveBeenNthCalledWith(
+      1,
+      getSessionUploadDir(storageRoot, STAGING_UPLOAD_SESSION_ID),
+      { recursive: true, force: true }
+    )
+    expect(rm).toHaveBeenNthCalledWith(
+      2,
+      getSessionUploadDir(storageRoot, STAGING_UPLOAD_SESSION_ID),
+      { recursive: true, force: true }
+    )
+    expect(rm).toHaveBeenNthCalledWith(
+      3,
+      getSessionUploadDir(storageRoot, PENDING_UPLOAD_SESSION_ID),
+      { recursive: true, force: true }
+    )
 
     await owner.abortTransfer({ transferId: request.transferId })
   })

--- a/src/main/uploads/active-transfer-owner.ts
+++ b/src/main/uploads/active-transfer-owner.ts
@@ -357,13 +357,21 @@ class ActiveTransferOwner {
     }
   }
 
-  // Transfers cannot survive a main-process restart. Clear crash-orphaned partial files before the
-  // first transfer in this owner instance; concurrent first calls share the cleanup promise.
+  // Upload drafts are intentionally process-local. Startup recovery first promotes every indexed
+  // staging Version, then calls this owner to remove bytes that have no surviving runtime owner.
+  async reconcileCrashOrphanedTransfers(): Promise<void> {
+    await this.ensureStagingDirectory()
+  }
+
+  // Transfers and unfinalized drafts cannot survive a main-process restart. Clear crash-orphaned
+  // bytes before the first transfer in this owner instance; concurrent first calls share the promise.
   private ensureStagingDirectory(): Promise<void> {
     if (!this.stagingReady) {
       const stagingDir = getSessionUploadDir(this.storageRoot, STAGING_UPLOAD_SESSION_ID)
+      const pendingDir = getSessionUploadDir(this.storageRoot, PENDING_UPLOAD_SESSION_ID)
       this.stagingReady = (async () => {
         await rm(stagingDir, { recursive: true, force: true })
+        await rm(pendingDir, { recursive: true, force: true })
         await mkdir(stagingDir, { recursive: true })
       })().catch((error) => {
         this.stagingReady = undefined

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -241,6 +241,26 @@ describe('upload repository', () => {
     await expect(readFile(attachment.path, 'utf8')).resolves.toBe('png-bytes')
   })
 
+  it('removes unindexed pending drafts during restart recovery without touching finalized uploads', async () => {
+    const root = await createStorageRoot()
+    const beforeRestart = new UploadRepository(root)
+    const [finalizedDraft, orphanedDraft] = await stageUploadFixtures(beforeRestart, {
+      files: [
+        { name: 'keep.txt', content: Buffer.from('keep').toString('base64') },
+        { name: 'discard.txt', content: Buffer.from('discard').toString('base64') }
+      ]
+    })
+    const [finalized] = await beforeRestart.finalizePendingSessionUploads('session-1', [
+      finalizedDraft
+    ])
+
+    const afterRestart = new UploadRepository(root)
+    await afterRestart.recoverStagingUploads()
+
+    await expect(stat(orphanedDraft.path)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(finalized.path, 'utf8')).resolves.toBe('keep')
+  })
+
   it('stages pathless files in bounded, offset-checked chunks', async () => {
     const root = await createStorageRoot()
     const repository = new UploadRepository(root)
@@ -490,7 +510,7 @@ describe('upload repository', () => {
     ).rejects.toThrow(/different (?:project or )?session/i)
   })
 
-  it('recovers a staging Upload Version from the original pending bytes', async () => {
+  it('recovers a staging Upload Version from pending bytes before startup draft cleanup', async () => {
     const root = await createStorageRoot()
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
@@ -543,13 +563,8 @@ describe('upload repository', () => {
       }
     })
 
-    const [recovered] = await repository.finalizePendingSessionUploads(
-      'session-1',
-      [pending],
-      'project-1'
-    )
+    await repository.recoverStagingUploads()
 
-    expect(recovered).toMatchObject({ versionId, versionNumber: 1, checksum })
     await expect(
       client.uploadVersion.findUniqueOrThrow({ where: { id: versionId } })
     ).resolves.toMatchObject({ state: 'ready' })
@@ -564,7 +579,10 @@ describe('upload repository', () => {
         }
       })
     ).resolves.toMatchObject({ sourceVersionId: versionId, storageKey })
-    await expect(readFile(recovered.path, 'utf8')).resolves.toBe('sample,value\na,1\n')
+    await expect(readFile(join(root, ...storageKey.split('/')), 'utf8')).resolves.toBe(
+      'sample,value\na,1\n'
+    )
+    await expect(stat(pending.path)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('recovers a post-rename staging Upload Version during startup reconciliation', async () => {

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -116,7 +116,8 @@ class UploadRepository {
   }
 
   async recoverStagingUploads(): Promise<void> {
-    return this.legacyRecoveryOwner.recoverStagingUploads()
+    await this.legacyRecoveryOwner.recoverStagingUploads()
+    await this.transferOwner.reconcileCrashOrphanedTransfers()
   }
 
   async deleteUpload(request: DeleteUploadRequest): Promise<void> {


### PR DESCRIPTION
## Problem

Project-wide Artifact scans read sidecar metadata but projected only the MIME type. Finalized and crash-orphaned native Artifact Versions therefore appeared as legacy files without immutable identity or checksum.

Completed Upload drafts were moved from `.staging` to `.pending`, but startup recovery only handled indexed `UploadVersion(state = staging)` rows. A crash before the draft was attached to a message could leave an unindexed file of up to 10 GB indefinitely.

## Proposed change

- Pass complete Artifact sidecar metadata through both finalized and orphan-pending Project scans, and include the already-defined checksum in `ArtifactFile` projections.
- During Upload startup recovery, first promote every indexed staging Version; only after all recoveries succeed, remove process-local `.staging` files and remaining unindexed `.pending` drafts.
- Add red/green regression coverage for finalized and orphan-pending Artifact metadata, unindexed Upload cleanup, indexed pending-byte recovery ordering, and transient cleanup retries.

## Scope and non-goals

- No database schema, migration, persisted format, shared data-model field, enum state, renderer interaction, or UI copy changes.
- Existing MIME-only legacy Artifact sidecars remain readable without invented Version identity.
- Historical unindexed `.pending` Upload drafts are intentionally deleted on the next successful startup recovery because composer drafts are not persisted. Indexed staging Versions remain recoverable and are promoted before cleanup.
- A persistent draft manifest or draft-restoration interaction is intentionally out of scope.

## Acceptance criteria and validation

- Final regression set: 5 passed across Artifact Project projection, Upload restart cleanup, indexed staging recovery ordering, and cleanup retry behavior.
- `npm --ignore-scripts run test:module -- upload_repository`: 130 passed; 2 Windows symlink cases could not run because this local environment rejects symlink creation with `EPERM`.
- `npm --ignore-scripts run test:module -- artifact_storage`: 130 passed, 1 skipped; 1 unrelated provenance test consistently stopped at Notebook source verification.
- `npm run lint`: passed after the final material edit.
- `npm run typecheck:node`: locally blocked by the shared dependency tree missing the `waitForMcpServers` export expected by `claude-agent-acp-patch.test.ts`.
- Full and platform-authoritative coverage is delegated to PR Gate CI as requested.

## Review focus

- Verify that Project scans now expose the same immutable Version identity regardless of whether the file is reached through a message, Project Files, or orphan recovery.
- Verify startup ordering: indexed staging bytes must be promoted before `.pending` cleanup, and any recovery failure must leave pending bytes available for a later retry.
