### PR TITLE
fix(artifacts): preserve Version identity on finalize retry

### DIFF
--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -3,7 +3,10 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createArtifactVersionLocator } from '../../shared/artifact-provenance'
+import {
+  createArtifactVersionLocator,
+  type ArtifactVersionFile
+} from '../../shared/artifact-provenance'
 import {
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile,
@@ -177,6 +180,51 @@ describe('artifact IPC handlers', () => {
       [finalizedArtifact]
     ])
     expect(repository.listMessageFiles).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves provenance Version identity when a finalized claim is retried', async () => {
+    const compatibilityArtifact = createFinalizedArtifact()
+    const provenanceArtifact = {
+      ...compatibilityArtifact,
+      id: 'version-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1',
+      versionNumber: 1,
+      checksum: 'a'.repeat(64),
+      createdAt: '2026-08-30T00:00:00.000Z'
+    } satisfies ArtifactVersionFile
+    const repository = {
+      finalizeRunArtifacts: vi.fn().mockResolvedValue([compatibilityArtifact]),
+      listMessageFiles: vi.fn().mockResolvedValue([compatibilityArtifact])
+    } as unknown as ArtifactRepository
+    const provenance = {
+      finalizeRun: vi.fn().mockResolvedValue([provenanceArtifact]),
+      listRunVersions: vi.fn().mockResolvedValue([provenanceArtifact])
+    }
+    const runRegistry = new ArtifactRunRegistry()
+    const claimId = runRegistry.register({
+      projectId: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-1',
+      promptMessageId: 'prompt-1',
+      artifactVersionIds: ['version-1']
+    })
+    const handlers = createArtifactHandlers(repository, runRegistry, {
+      provenance: provenance as never
+    })
+
+    const firstResult = await handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
+    const retryResult = await handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
+
+    const identityOf = (artifacts: ArtifactFile[]): Array<Pick<ArtifactFile, 'id' | 'versionId'>> =>
+      artifacts.map(({ id, versionId }) => ({ id, versionId }))
+    expect(identityOf(firstResult)).toEqual([{ id: 'version-1', versionId: 'version-1' }])
+    expect(identityOf(retryResult)).toEqual(identityOf(firstResult))
   })
 
   it('finalizes compatibility files and provenance inside the shared Session mutation', async () => {

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -91,6 +91,7 @@ type ArtifactHandlerDependencies = {
   provenance?: Pick<
     ArtifactProvenanceRepository,
     | 'finalizeRun'
+    | 'listRunVersions'
     | 'getLineage'
     | 'getVersionProvenance'
     | 'getVersionCore'
@@ -252,7 +253,7 @@ const finalizeRunArtifacts = async (
   repository: ArtifactRepository,
   runRegistry: ArtifactRunRegistry,
   request: FinalizeRunArtifactsRequest,
-  provenance?: Pick<ArtifactProvenanceRepository, 'finalizeRun'>,
+  provenance?: Pick<ArtifactProvenanceRepository, 'finalizeRun' | 'listRunVersions'>,
   logger: Pick<Logger, 'error'> = log
 ): Promise<ArtifactFile[]> => {
   const claim = runRegistry.resolve(request.claimId)
@@ -265,11 +266,17 @@ const finalizeRunArtifacts = async (
       )
     }
 
-    return repository.listMessageFiles({
-      projectId: claim.projectId,
-      sessionId: claim.sessionId,
-      messageId: request.messageId
-    })
+    return provenance
+      ? provenance.listRunVersions({
+          projectId: claim.projectId,
+          appSessionId: claim.sessionId,
+          artifactRunId: claim.runId
+        })
+      : repository.listMessageFiles({
+          projectId: claim.projectId,
+          sessionId: claim.sessionId,
+          messageId: request.messageId
+        })
   }
 
   let durableFinalizationCompleted = false
@@ -389,6 +396,7 @@ const registerArtifactIpcHandlers = (
   provenance?: Pick<
     ArtifactProvenanceRepository,
     | 'finalizeRun'
+    | 'listRunVersions'
     | 'getLineage'
     | 'getVersionProvenance'
     | 'getVersionCore'


### PR DESCRIPTION
## Problem

With Artifact Provenance enabled, the first successful run finalization returns native `ArtifactVersionFile` values whose `id` equals `versionId`. Replaying the same claim and message after the claim is marked finalized instead returned a compatibility-directory scan, whose `id` is the compatibility path identity (`sessionId:messageId:filename`).

The renderer persists the returned `id` in the message-to-artifact relationship, so duplicate finalization could replace the immutable Version identity with the compatibility identity. The existing concurrent test did not expose this because both mocked projections returned the same object.

The bug reproduces when provenance is enabled, one finalization completes and marks the claim finalized, and the same claim/message is finalized again (including a concurrent duplicate serialized behind the claim lock).

## Proposed change

- Read finalized provenance retries through the existing `listRunVersions()` read model.
- Keep the compatibility-directory retry path unchanged when provenance is not configured.
- Add a handler-boundary regression test whose native Version and compatibility file have distinct identities, asserting that first and retry results preserve the same `id` and `versionId`.

## Scope and non-goals

- No new data fields, database schema, migration, persisted format, or enum state.
- No renderer interaction or UI change.
- No architecture or domain-model change; this reuses an existing repository method.
- Historical compatibility: no migration is required. Provenance-disabled legacy/compatibility finalization keeps its existing path.
- Persistence impact: the retry now reads existing `ArtifactVersion` records; it does not add or modify persisted writes.

## Acceptance criteria and validation

The final regression assertion was run against the unmodified production branch and failed with `id: session-1:message-1:result.txt` / `versionId: undefined` instead of `id === versionId === version-1`. It passes after the fix.

Final evidence after the last material edit:

- Finalize retry representation identity -> `npm test -- src/main/artifacts/ipc.test.ts -t 'preserves provenance Version identity when a finalized claim is retried'` -> pass (and verified red before the fix).
- Artifact storage owner/contract/consumer slice -> `npm run test:module -- artifact_storage` -> 4 files, 131 tests passed.
- Artifact provenance owner/contract/consumer slice -> `npm run test:module -- artifact_provenance` -> 26 files, 1,419 tests passed.
- Main-process TypeScript surface -> `npm run typecheck:node` -> pass.
- Source and test lint -> `npm run lint` -> pass.

`npm run test:affected -- --base origin/main --head HEAD --explain` fails closed to the full plan because `src/main/artifacts/ipc.ts` is not registered as a module owner. Per maintainer request, the complete local `npm test` suite was not run; PR CI remains authoritative for the complete portable and platform-sensitive lanes. The module plan identifies the change as Windows-sensitive, which is not exercised locally.

## Review focus

- Confirm that finalized provenance retries should project the run through `listRunVersions()` rather than the compatibility directory.
- Confirm the regression test represents the distinct identities returned by the two storage projections.
- Confirm the selected storage and provenance module checks cover the final two-file diff while PR CI supplies the full/platform lanes.
