### PR TITLE
fix(logging): route main diagnostics through central logger

### DIFF
--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -433,7 +433,7 @@ export const installAppLifecycle = (
 
         if (deps.flushLogs) {
           const result = await flushDiagnosticsWithTimeout(deps.flushLogs, logFlushTimeoutMs)
-          if (result === 'timeout') console.warn('[shutdown] final log flush timed out')
+          if (result === 'timeout') deps.log?.warn('final log flush timed out')
         }
       } finally {
         if (shutdownAbortedForRendererPersistence) {

--- a/src/main/artifacts/mcp-server.test.ts
+++ b/src/main/artifacts/mcp-server.test.ts
@@ -3,6 +3,15 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const { log } = vi.hoisted(() => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('../logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../logger')>()),
+  createLogger: () => log
+}))
+
 import { createPngBytes, createPngInlineSource } from './artifact-test-fixtures'
 import { ArtifactRepository } from './repository'
 import {
@@ -51,8 +60,6 @@ describe('artifact MCP server', () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)
     const environment = await createEnvironment(root)
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-
     const artifact = await writeArtifactFileForCurrentRun(repository, environment, {
       filename: 'plot.svg',
       mimeType: 'image/svg+xml',
@@ -72,8 +79,8 @@ describe('artifact MCP server', () => {
       join(root, 'artifacts', 'default-project', 'session-1', '.pending', 'run-1', 'plot.svg')
     )
     await expect(readFile(artifact.path, 'utf8')).resolves.toBe('<svg />')
-    expect(warn).toHaveBeenCalledWith(
-      '[artifacts:mcp] writing a legacy pending file without durable Provenance',
+    expect(log.warn).toHaveBeenCalledWith(
+      'writing a legacy pending file without durable Provenance',
       {
         artifactRunId: 'run-1',
         missingContext: [

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -22,10 +22,12 @@ import { resolveProjectId } from '../../shared/project-scope'
 import type { ProjectIdScope } from '../../shared/project-scope'
 import { ARTIFACT_MCP_SERVER_ARG } from '../mcp-server-args'
 import { fetchLocalRpc } from '../local-rpc-transport'
+import { createLogger } from '../logger'
 import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
 import { ArtifactRepository } from './repository'
 
 const ARTIFACT_MCP_SERVER_NAME = 'open-science-artifacts'
+const log = createLogger('artifacts:mcp')
 
 type ArtifactMcpEnvironment = ProjectIdScope & {
   storageRoot: string
@@ -442,7 +444,7 @@ const writeArtifactFileForCurrentRun = async (
     !context.promptMessageId ? 'promptMessageId' : undefined
   ].filter((field): field is string => field !== undefined)
   if (missingProvenanceContext.length > 0) {
-    console.warn('[artifacts:mcp] writing a legacy pending file without durable Provenance', {
+    log.warn('writing a legacy pending file without durable Provenance', {
       artifactRunId: context.artifactRunId,
       missingContext: missingProvenanceContext
     })

--- a/src/main/connectors/runtime-settings-projection.ts
+++ b/src/main/connectors/runtime-settings-projection.ts
@@ -8,7 +8,10 @@ import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './provision'
 import { ALL_CONNECTOR_IDS } from './registry'
 import { customConnectorSkillName } from '../../shared/custom-connector'
 import type { McpClientManager } from './mcp-client-manager'
+import { createLogger, errorLogFields } from '../logger'
 import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
+
+const log = createLogger('connectors:runtime-settings')
 
 type ConnectorRuntimeSettingsProjectionOptions = {
   readConnectors: () => Promise<StoredConnectors | undefined>
@@ -41,7 +44,7 @@ class ConnectorRuntimeSettingsProjection {
     this.reportError =
       options.reportError ??
       ((error) => {
-        console.error('Failed to sync connector skill docs:', error)
+        log.error('failed to sync connector skill docs', errorLogFields(error))
       })
   }
 

--- a/src/main/index-fatal-errors.test.ts
+++ b/src/main/index-fatal-errors.test.ts
@@ -152,6 +152,7 @@ const bootUntilFailureHandlersAreInstalled = async (): Promise<
 
   await import('./index')
   await vi.waitFor(() => expect(mocks.registerRendererDiagnosticsIpc).toHaveBeenCalledOnce())
+  mocks.log.error.mockClear()
 
   return listeners
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ const shouldRunReviewerMcpProxy = process.argv.includes(REVIEWER_MCP_PROXY_ARG)
 const shouldRunSkillImportMcpServer = process.argv.includes(SKILL_IMPORT_MCP_SERVER_ARG)
 const shouldRunSkillRuntimeMcpServer = process.argv.includes(SKILL_RUNTIME_MCP_SERVER_ARG)
 const shouldRunPlanMcpServer = process.argv.includes(PLAN_MCP_SERVER_ARG)
+const bootstrapLog = createLogger('bootstrap')
 let startupDiagnostics: DiagnosticOperation | undefined
 let startupFlush = flushLogs
 
@@ -43,7 +44,7 @@ if (shouldRunArtifactMcpServer) {
   void import('./artifacts/mcp-server')
     .then(({ runArtifactMcpServer }) => runArtifactMcpServer())
     .catch((error: unknown) => {
-      console.error(error)
+      bootstrapLog.error('artifact MCP server failed', error)
       process.exitCode = 1
     })
 } else if (shouldRunNotebookMcpServer) {
@@ -51,35 +52,35 @@ if (shouldRunArtifactMcpServer) {
   void import('./notebook/mcp-server')
     .then(({ runNotebookMcpServer }) => runNotebookMcpServer())
     .catch((error: unknown) => {
-      console.error(error)
+      bootstrapLog.error('notebook MCP server failed', error)
       process.exitCode = 1
     })
 } else if (shouldRunReviewerMcpProxy) {
   void import('./reviewer/mcp-stdio-proxy')
     .then(({ runReviewerMcpStdioProxy }) => runReviewerMcpStdioProxy())
     .catch((error: unknown) => {
-      console.error(error)
+      bootstrapLog.error('reviewer MCP proxy failed', error)
       process.exitCode = 1
     })
 } else if (shouldRunSkillImportMcpServer) {
   void import('./skills/mcp-server')
     .then(({ runSkillImportMcpServer }) => runSkillImportMcpServer())
     .catch((error: unknown) => {
-      console.error(error)
+      bootstrapLog.error('skill import MCP server failed', error)
       process.exitCode = 1
     })
 } else if (shouldRunSkillRuntimeMcpServer) {
   void import('./skills/runtime-mcp-server')
     .then(({ runSkillRuntimeMcpServer }) => runSkillRuntimeMcpServer())
     .catch((error: unknown) => {
-      console.error(error)
+      bootstrapLog.error('skill runtime MCP server failed', error)
       process.exitCode = 1
     })
 } else if (shouldRunPlanMcpServer) {
   void import('./session-plan/plan-mcp-server')
     .then(({ runPlanMcpServer }) => runPlanMcpServer())
     .catch((error: unknown) => {
-      console.error(error)
+      bootstrapLog.error('plan MCP server failed', error)
       process.exitCode = 1
     })
 } else {
@@ -89,7 +90,7 @@ if (shouldRunArtifactMcpServer) {
       error,
       flush: startupFlush
     })
-    console.error(error)
+    bootstrapLog.error('application startup failed', diagnosticErrorFields(error))
     process.exitCode = 1
   })
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -357,6 +357,7 @@ import type { TaskAgentPort } from './tasks/task-runner'
 import { englishNativeTranslator, type NativeTranslator } from './locale/main-process-messages'
 
 const permissionGrantsLog = createLogger('permission-grants')
+const notebookStartupLog = createLogger('notebook:startup')
 
 type IpcRegistrationOptions = {
   mainEntryPath: string
@@ -3149,7 +3150,7 @@ const createApplicationModules = async (
     // Warm the process-local mirror cache after provisioner construction succeeds. This stays outside
     // the startup critical path; a later named-env create awaits the same memoized probe if necessary.
     void effectiveMirror().catch((error) =>
-      console.error('Notebook package mirror warmup failed:', error)
+      notebookStartupLog.error('package mirror warmup failed', errorLogFields(error))
     )
     // One serialized wrapper shared by the startup gate and the notebook service's on-demand default
     // provisioning, so a concurrent build of the same default env (UI R-tab + an agent R run) can't
@@ -3158,7 +3159,7 @@ const createApplicationModules = async (
   } catch (error) {
     // micromamba missing (e.g. dev without a staged binary): the notebook env stays unprovisioned and
     // the UI surfaces "runtime unavailable" rather than crashing startup or dropping the IPC handlers.
-    console.error('Notebook environment provisioning unavailable:', error)
+    notebookStartupLog.error('environment provisioning unavailable', errorLogFields(error))
   }
   // Crash recovery (WS13): reconcile any runtime operation the previous process left in flight (orphan
   // download staging, a half-built prefix, an interrupted install). Kicked off HERE — before the env
@@ -3169,7 +3170,7 @@ const createApplicationModules = async (
   // actually orders the prefix work.
   void notebookService
     .recoverInterruptedOperations()
-    .catch((error) => console.error('Notebook operation recovery failed:', error))
+    .catch((error) => notebookStartupLog.error('operation recovery failed', errorLogFields(error)))
   const waitForRecovery = (): Promise<void> => notebookService.ensureRecovered()
   // Lets UI provision/repair refuse when recovery left the default env's prefix blocked (an
   // unknown-liveness orphan may still be writing it) — throws with an actionable message.

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -1,6 +1,7 @@
+import { readdirSync, readFileSync } from 'node:fs'
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -27,6 +28,26 @@ afterEach(async () => {
     await rm(logDir, { recursive: true, force: true })
     logDir = undefined
   }
+})
+
+const productionTypeScriptFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) return productionTypeScriptFiles(path)
+    if (!entry.isFile() || !/\.tsx?$/.test(entry.name)) return []
+    if (/\.(?:test|integration|certification)\.tsx?$/.test(entry.name)) return []
+    return path.endsWith(`${join('src', 'main', 'logger.ts')}`) ? [] : [path]
+  })
+
+describe('logger: main-process boundary', () => {
+  it('keeps the central logger as the only production console adapter', () => {
+    const directConsoleCalls = productionTypeScriptFiles(__dirname).flatMap((path) => {
+      const source = readFileSync(path, 'utf8')
+      return /\bconsole\s*(?:\.|\[)/.test(source) ? [path.slice(__dirname.length + 1)] : []
+    })
+
+    expect(directConsoleCalls).toEqual([])
+  })
 })
 
 describe('logger: formatLine', () => {

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { DiscoveredInterpreter, EnvProvenance } from '../../shared/notebook-runtime'
+import { createLogger } from '../logger'
 import { isMacOSDeveloperToolsPythonStub, probeInterpreterVersion } from './python-command'
 import { parseRVersion, rHasJsonlite } from './r-command'
 import {
@@ -22,6 +23,7 @@ import {
 export type { DiscoveredInterpreter, EnvProvenance }
 
 const execFileAsync = promisify(execFile)
+const log = createLogger('notebook:environment-discovery')
 
 // Shared options for every discovery subprocess: a hard timeout so a wedged tool (a hung conda, a
 // stuck interpreter, an unresponsive `which`) can NEVER hang environment discovery, and windowsHide so
@@ -275,7 +277,9 @@ export const defaultCandidatePaths =
           // observability but do not reject the entire Promise.all that would block Python discovery too.
           const code = (err as NodeJS.ErrnoException).code
           if (code !== 'ENOENT' && code !== 'EACCES' && code !== 'EPERM') {
-            console.warn('[cran-r] unexpected error scanning', rRoot, code)
+            log.warn('unexpected error scanning standard R installation root', {
+              errorCode: code ?? 'unknown'
+            })
           }
           continue
         }

--- a/src/main/notebook/environment-operations.ts
+++ b/src/main/notebook/environment-operations.ts
@@ -4,6 +4,7 @@ import type { NotebookSessionRuntimeBinding } from './session-aggregate'
 import type { NotebookLaneIdentity } from './lane-identity'
 import { EnvironmentLeaseManager, type EnvironmentLeaseMode } from './environment-lease-manager'
 import type { NotebookRecoveryCoordinator } from './recovery-coordinator'
+import { errorLogFields } from '../logger'
 import {
   boundedRuntimeDiagnostic,
   redactRuntimeDiagnosticValue,
@@ -278,7 +279,10 @@ export class NotebookEnvironmentOperations {
               session.clearProcessState(revokedProcessKey)
               this.options.notifyChanged(session)
             } catch (error) {
-              console.error('[notebook] Failed to drain/close a revoked runtime', error)
+              this.options.logger?.error('failed to drain or close a revoked runtime', {
+                ...errorLogFields(error),
+                environment
+              })
             }
           })
           this.revocationDrains.add(drain)

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -14,6 +14,7 @@ import type {
   NotebookWorkingFile,
   RunNotebookCellRequest
 } from '../../shared/notebook'
+import type { Logger } from '../logger'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import { NotebookDataExecutionAdmissionOwner } from './data-execution-admission'
 import {
@@ -117,6 +118,7 @@ type NotebookExecutionOwnerOptions = {
     NotebookHelperModuleHost,
     'preflight' | 'plan' | 'commitInitialized' | 'loadedEvidence'
   >
+  logger: Pick<Logger, 'error'>
   platform?: NodeJS.Platform
   shellProcess?: NotebookShellProcess
 }
@@ -245,9 +247,9 @@ class NotebookExecutionOwner {
       inputFiles: request.provenanceContext ? (request.registeredInputFiles ?? []) : []
     }
     if (!existsSync(cwdBefore)) {
-      console.error(
-        `[notebook] Session cwd is missing before execution, the kernel may run in an unexpected directory: ${cwdBefore}`
-      )
+      this.options.logger.error('session working directory is missing before execution', {
+        sessionId: session.sessionId
+      })
     }
     const kernelMarkedRunning = admission.rejection === undefined
     if (kernelMarkedRunning) {

--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -2,8 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NotebookRuntimeService } from './runtime-service'
 
-const { ipcHandlers } = vi.hoisted(() => ({
-  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
+const { ipcHandlers, log } = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('../logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../logger')>()),
+  createLogger: () => log
 }))
 
 vi.mock('electron', () => ({
@@ -19,6 +25,7 @@ import { beginMigration, clearMigrationPending } from '../storage/migration-stat
 
 beforeEach(() => {
   ipcHandlers.clear()
+  log.error.mockClear()
 })
 afterEach(() => clearMigrationPending())
 
@@ -222,7 +229,6 @@ describe('notebook IPC handlers', () => {
       .mockResolvedValueOnce(executionFailure)
       .mockRejectedValueOnce(submissionFailure)
     const service = { execute } as unknown as NotebookRuntimeService
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     registerNotebookIpcHandlers(createNotebookCommandWorkflows(service))
     const request = {
       sessionId: 'session-1',
@@ -238,22 +244,24 @@ describe('notebook IPC handlers', () => {
     await expect(handler?.(undefined, request)).resolves.toBe(executionFailure)
     await expect(handler?.(undefined, request)).rejects.toBe(submissionFailure)
 
-    expect(errorSpy).toHaveBeenNthCalledWith(1, '[notebook] User terminal execution failed', {
+    expect(log.error).toHaveBeenNthCalledWith(1, 'user terminal execution failed', {
       sessionId: 'session-1',
       projectId: 'project-1',
       language: 'python',
       environment: 'default-python',
       runId: 'run-failed',
-      status: 'failed',
-      error: 'ValueError: diagnostic detail'
+      status: 'failed'
     })
-    expect(errorSpy).toHaveBeenNthCalledWith(2, '[notebook] User terminal submission failed', {
+    expect(log.error).toHaveBeenNthCalledWith(2, 'user terminal submission failed', {
       sessionId: 'session-1',
       projectId: 'project-1',
       language: 'python',
       codeLength: 11,
-      error: submissionFailure
+      errorCategory: 'error'
     })
-    expect(errorSpy.mock.calls.flat().join(' ')).not.toContain('secret = 42')
+    const logged = JSON.stringify(log.error.mock.calls)
+    expect(logged).not.toContain('secret = 42')
+    expect(logged).not.toContain('diagnostic detail')
+    expect(logged).not.toContain('kernel connection closed')
   })
 })

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -1,4 +1,5 @@
 import { ipcMainHandle } from '../ipc-handler-registry'
+import { createLogger, diagnosticErrorFields } from '../logger'
 
 import type {
   AppendNotebookCodeCellRequest,
@@ -14,12 +15,7 @@ import type {
 } from '../../shared/notebook'
 import type { NotebookCommandWorkflows } from './notebook-workflows'
 
-const lastNonEmptyLine = (value: string): string | undefined =>
-  value
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .at(-1)
+const log = createLogger('notebook:ipc')
 
 // Registers renderer-callable notebook commands on the main-process IPC bus.
 const registerNotebookIpcHandlers = (handlers: NotebookCommandWorkflows): void => {
@@ -52,28 +48,24 @@ const registerNotebookIpcHandlers = (handlers: NotebookCommandWorkflows): void =
         request.inputKind === 'terminal' &&
         result.status !== 'completed'
       ) {
-        console.error('[notebook] User terminal execution failed', {
+        log.error('user terminal execution failed', {
           sessionId: request.sessionId,
           projectId: request.projectId,
           language: request.language ?? 'python',
           environment: result.environment,
           runId: result.runId,
-          status: result.status,
-          error:
-            lastNonEmptyLine(result.text.traceback) ??
-            lastNonEmptyLine(result.text.stderr) ??
-            'unknown'
+          status: result.status
         })
       }
       return result
     } catch (error) {
       if (request.source === 'user' && request.inputKind === 'terminal') {
-        console.error('[notebook] User terminal submission failed', {
+        log.error('user terminal submission failed', {
           sessionId: request.sessionId,
           projectId: request.projectId,
           language: request.language ?? 'python',
           codeLength: request.code.length,
-          error
+          ...diagnosticErrorFields(error)
         })
       }
       throw error

--- a/src/main/notebook/operation-recovery.ts
+++ b/src/main/notebook/operation-recovery.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs'
 
+import { createLogger, errorLogFields } from '../logger'
 import type { RuntimeOperationJournal, RuntimeOperationRecord } from './operation-journal'
+
+const log = createLogger('notebook:recovery')
 
 // Injected side-effects for reconciling ONE interrupted runtime operation, so the startup-recovery
 // orchestration is unit-tested without real processes, filesystem, or provisioner. See
@@ -140,17 +143,17 @@ export const reconcileInterruptedOperations = async (
         try {
           await deps.blockUnknownChildTarget(raw)
         } catch (blockError) {
-          console.error(
-            `[notebook] could not block cache publication recovery for ${raw.operationId}`,
-            blockError
-          )
+          log.error('could not block cache publication recovery', {
+            operationId: raw.operationId,
+            ...errorLogFields(blockError)
+          })
         }
       }
       deps.onRetained?.(raw)
-      console.error(
-        `[notebook] operation recovery failed for ${raw.operationId}; leaving journal entry`,
-        error
-      )
+      log.error('operation recovery failed; leaving journal entry', {
+        operationId: raw.operationId,
+        ...errorLogFields(error)
+      })
     }
   }
 

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -3,6 +3,7 @@ import { lstat, realpath, rm } from 'node:fs/promises'
 import { isAbsolute, join, relative, sep } from 'node:path'
 
 import { isCurrentInFlight } from '../../shared/in-flight-promise'
+import { createLogger } from '../logger'
 import {
   operationJournalPath,
   readOperationChild,
@@ -20,6 +21,8 @@ import { defaultOperationChildLiveness, reconcileInterruptedOperations } from '.
 import { verifyExecutable } from './provisioner-runtime'
 import { addRepairRequired, DEFAULT_PY_ENV, DEFAULT_R_ENV, pythonBin, rBin } from './runtime-paths'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
+
+const log = createLogger('notebook:recovery')
 
 const isPathInside = (root: string, candidate: string): boolean => {
   const nested = relative(root, candidate)
@@ -192,9 +195,7 @@ export class NotebookRecoveryCoordinator {
     )
     const journal = RuntimeOperationJournal.forPath(operationJournalPath(this.runtimeRoot))
     if ((await journal.readState()) === 'corrupt') {
-      console.error(
-        '[notebook] operation journal is unreadable; blocking all runtime writes until recovery'
-      )
+      log.error('operation journal is unreadable; blocking all runtime writes until recovery')
       this.recoveryCorrupt = true
       return
     }

--- a/src/main/notebook/runtime-application-commands.test.ts
+++ b/src/main/notebook/runtime-application-commands.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
+const { log } = vi.hoisted(() => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('../logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../logger')>()),
+  createLogger: () => log
+}))
+
 import type { NotebookLanguage } from '../../shared/notebook'
 import type {
   RuntimeReadiness,
@@ -230,7 +239,7 @@ describe('runtime application commands', () => {
       .fn<() => Promise<string | null>>()
       .mockResolvedValueOnce(null)
       .mockRejectedValueOnce(pickerFailure)
-    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    log.error.mockClear()
     const { router } = install(createWorkflows(), pickInterpreter)
 
     await expect(
@@ -239,8 +248,9 @@ describe('runtime application commands', () => {
     await expect(
       router.dispatcher.invoke(runtimeApplicationCommands.pickInterpreter, invocation([] as const))
     ).resolves.toBeNull()
-    expect(log).toHaveBeenCalledWith('[runtime-commands] pick-interpreter failed', pickerFailure)
-    log.mockRestore()
+    expect(log.error).toHaveBeenCalledWith('pick interpreter failed', {
+      errorCategory: 'error'
+    })
   })
 
   it('uninstalls only the Runtime command group', async () => {

--- a/src/main/notebook/runtime-application-commands.ts
+++ b/src/main/notebook/runtime-application-commands.ts
@@ -14,7 +14,10 @@ import {
   type ApplicationCommandRegistrar
 } from '../application-command-router'
 import type { CallerContext } from '../caller-context'
+import { createLogger, diagnosticErrorFields } from '../logger'
 import type { RuntimeSelectionWorkflows } from './runtime-selection-workflows'
+
+const log = createLogger('notebook:runtime-commands')
 
 type RuntimeLanguageRequest = Readonly<{ language: NotebookLanguage }>
 type RuntimeEnvironmentRequest = Readonly<{ language: NotebookLanguage; envId: string }>
@@ -155,7 +158,7 @@ const registerRuntimeApplicationCommands = (
         try {
           return await dependencies.pickInterpreter()
         } catch (error) {
-          console.error('[runtime-commands] pick-interpreter failed', error)
+          log.error('pick interpreter failed', diagnosticErrorFields(error))
           return null
         }
       },

--- a/src/main/notebook/runtime-binding.ts
+++ b/src/main/notebook/runtime-binding.ts
@@ -10,6 +10,7 @@ import {
   type RuntimeTargetReceipt
 } from '../../shared/notebook-runtime'
 import type { NotebookRuntimeSettings } from '../settings/capabilities'
+import { createLogger, diagnosticErrorFields } from '../logger'
 import {
   defaultDiscoveryDeps,
   discoverInterpreters,
@@ -25,6 +26,8 @@ import type {
   NotebookSessionResolvedInterpreter,
   NotebookSessionRuntimeBinding
 } from './session-aggregate'
+
+const log = createLogger('notebook:runtime-binding')
 
 type RuntimeBindingSession = Pick<
   NotebookSessionAggregate,
@@ -353,7 +356,10 @@ export class NotebookRuntimeBindingOwner {
         session.lane
       )
     } catch (error) {
-      console.error('[notebook] Failed to persist runtime bindings', error)
+      log.error('failed to persist runtime bindings', {
+        sessionId: session.sessionId,
+        ...diagnosticErrorFields(error)
+      })
     }
   }
 

--- a/src/main/notebook/runtime-ipc.test.ts
+++ b/src/main/notebook/runtime-ipc.test.ts
@@ -15,6 +15,12 @@ import {
 
 const handlers = new Map<string, (event: unknown, payload?: unknown) => unknown>()
 const showOpenDialog = vi.fn()
+const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+vi.mock('../logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../logger')>()),
+  createLogger: () => log
+}))
 
 vi.mock('electron', () => ({
   ipcMain: {
@@ -243,7 +249,7 @@ describe('runtime IPC adapter', () => {
   })
 
   it('returns null when the picker is cancelled or fails', async () => {
-    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    log.error.mockClear()
     registerRuntime(fakeDeps(), { showOpenDialog: async () => null })
     await expect(invoke('runtime:pick-interpreter')).resolves.toBeNull()
 
@@ -254,8 +260,9 @@ describe('runtime IPC adapter', () => {
     })
 
     await expect(invoke('runtime:pick-interpreter')).resolves.toBeNull()
-    expect(log).toHaveBeenCalled()
-    log.mockRestore()
+    expect(log.error).toHaveBeenCalledWith('pick interpreter failed', {
+      errorCategory: 'error'
+    })
   })
 
   it('uses the Electron open-file picker when no override is injected', async () => {

--- a/src/main/notebook/runtime-ipc.ts
+++ b/src/main/notebook/runtime-ipc.ts
@@ -1,10 +1,13 @@
 import { dialog } from 'electron'
 
 import { ipcMainHandle } from '../ipc-handler-registry'
+import { createLogger, diagnosticErrorFields } from '../logger'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeSelection } from '../../shared/notebook-runtime'
 import type { RuntimeSelectionWorkflows } from './runtime-selection-workflows'
+
+const log = createLogger('notebook:runtime-ipc')
 
 export type RuntimeIpcOptions = {
   // Injectable for tests; production defaults to the Electron native open-file dialog.
@@ -69,7 +72,7 @@ const registerRuntimeIpcHandlers = (
     } catch (err) {
       // Never let a picker failure surface as a raw rejection to the renderer; the choose action
       // becomes a no-op instead.
-      console.error('[runtime-ipc] pick-interpreter failed', err)
+      log.error('pick interpreter failed', diagnosticErrorFields(err))
       return null
     }
   })

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -5603,12 +5603,13 @@ describe('notebook runtime service', () => {
     // A cell can os.chdir() to a directory outside the repository-managed session tree (whose
     // sub-directories are recreated on every write); simulate that, then delete it.
     const changedCwd = await mkdtemp(join(tmpdir(), 'open-science-notebook-chdir-'))
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const error = vi.fn()
     const service = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
       projectId: 'default-project',
       repository: new NotebookRunRepository(root),
+      logger: { info: vi.fn(), warn: vi.fn(), error },
       executorFactory: () => ({
         execute: async (): Promise<NotebookExecutionResult> => ({
           status: 'completed',
@@ -5632,9 +5633,9 @@ describe('notebook runtime service', () => {
     const second = await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '2' })
 
     expect(second.status).toBe('completed')
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Session cwd is missing'))
-
-    errorSpy.mockRestore()
+    expect(error).toHaveBeenCalledWith('session working directory is missing before execution', {
+      sessionId: 'session-1'
+    })
   })
 
   describe('inspectPackages', () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -93,7 +93,7 @@ import {
   type NotebookSessionRuntimeBinding
 } from './session-aggregate'
 import { NotebookSessionRegistry } from './session-registry'
-import { createLogger, errorLogFields, getLogFilePath } from '../logger'
+import { createLogger, errorLogFields } from '../logger'
 import { EnvironmentStateTracker, type EnvironmentCaptureTarget } from './environment-state-tracker'
 import { NotebookRuntimeBindingOwner } from './runtime-binding'
 import type { RuntimeDiagnosticLogger } from './runtime-diagnostics'
@@ -282,7 +282,10 @@ const resolveLoopScript = (envOverride: string | undefined, fileName: string): s
   if (!resolved) {
     // Surface the miss instead of silently handing the executor a path that only fails once the loop
     // actually tries to spawn.
-    console.error(`[notebook] Could not resolve ${fileName}; tried:`, candidates)
+    createLogger('notebook:runtime').error('could not resolve loop script', {
+      fileName,
+      candidateCount: candidates.length
+    })
     return candidates[candidates.length - 1]
   }
 
@@ -343,7 +346,7 @@ class NotebookRuntimeService {
     ((language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>) | undefined
   private readonly runtimeBindingOwner: NotebookRuntimeBindingOwner
   private readonly recoveryCoordinator: NotebookRecoveryCoordinator
-  private readonly runtimeLogger?: RuntimeDiagnosticLogger
+  private readonly runtimeLogger: RuntimeDiagnosticLogger
   private readonly environmentStateTracker: Pick<
     EnvironmentStateTracker,
     | 'prepareRun'
@@ -398,8 +401,7 @@ class NotebookRuntimeService {
             ? this.runtimeBindingOwner.dependencyInterpreter(run.kernelKind, run.runtimeId)
             : Promise.resolve(undefined)
       })
-    this.runtimeLogger =
-      options.logger ?? (getLogFilePath() ? createLogger('notebook:runtime') : undefined)
+    this.runtimeLogger = options.logger ?? createLogger('notebook:runtime')
     this.environmentOperations = new NotebookEnvironmentOperations({
       recovery: this.recoveryCoordinator,
       bindings: this.runtimeBindingOwner,
@@ -444,8 +446,7 @@ class NotebookRuntimeService {
           kind,
           environment: env
         }
-        if (this.runtimeLogger) this.runtimeLogger.error(message, fields)
-        else console.error(`[notebook] ${message}`, fields)
+        this.runtimeLogger.error(message, fields)
       }
     })
     this.runtimeRepair = new NotebookRuntimeRepairOwner({
@@ -530,6 +531,7 @@ class NotebookRuntimeService {
           ...(interpreter ? { interpreter } : {})
         }),
       helperModules: this.helperModules,
+      logger: this.runtimeLogger,
       platform: options.platform,
       shellProcess: options.shellProcess
     })

--- a/src/main/office-preview/office-preview-electron.ts
+++ b/src/main/office-preview/office-preview-electron.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../logger'
+
+const log = createLogger('office-preview')
+
 type OfficePreviewFrame = {
   url: string
   osProcessId: number
@@ -31,7 +35,7 @@ const createOfficePreviewFrameProcessResolver = (contents: OfficePreviewWebConte
     // A frame may disappear before React's close IPC reaches the main process during replacement.
     if (!runtimeFrame) return undefined
     if (runtimeFrame.osProcessId === mainFrame.osProcessId) {
-      console.warn('[office-preview] runtime frame did not receive an isolated process', {
+      log.warn('runtime frame did not receive an isolated process', {
         parentOwnerId,
         osProcessId: runtimeFrame.osProcessId
       })

--- a/src/main/office-preview/office-preview-ipc.test.ts
+++ b/src/main/office-preview/office-preview-ipc.test.ts
@@ -10,6 +10,12 @@ type TestHandler = (event: TestEvent, ...args: unknown[]) => unknown
 
 const handlers = new Map<string, TestHandler>()
 const listeners = new Map<string, TestHandler>()
+const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+vi.mock('../logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../logger')>()),
+  createLogger: () => log
+}))
 
 vi.mock('electron', () => ({
   ipcMain: {
@@ -41,6 +47,7 @@ describe('registerOfficePreviewIpcHandlers', () => {
   beforeEach(() => {
     handlers.clear()
     listeners.clear()
+    log.error.mockClear()
   })
 
   it('derives ownership from the sender for open, attach, state, and close', async () => {
@@ -123,7 +130,6 @@ describe('registerOfficePreviewIpcHandlers', () => {
     supervisor.reportState.mockImplementation(() => {
       throw new Error('state failure')
     })
-    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     registerOfficePreviewIpcHandlers(supervisor as never)
     const event = { sender: { id: 7, once: vi.fn() } }
 
@@ -133,8 +139,9 @@ describe('registerOfficePreviewIpcHandlers', () => {
         phase: 'ready'
       })
     ).not.toThrow()
-    expect(error).toHaveBeenCalled()
-    error.mockRestore()
+    expect(log.error).toHaveBeenCalledWith('failed to report runtime state', {
+      errorCategory: 'error'
+    })
   })
 
   it('returns cancellation when a development remount supersedes an open', async () => {

--- a/src/main/office-preview/office-preview-ipc.ts
+++ b/src/main/office-preview/office-preview-ipc.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 
 import { ipcMainHandle } from '../ipc-handler-registry'
+import { createLogger, diagnosticErrorFields } from '../logger'
 
 import type { OfficePreviewOpenRequest } from '../../shared/office-preview'
 import {
@@ -12,6 +13,8 @@ import {
 } from '../../shared/office-preview'
 import type { OfficePreviewSupervisor } from './office-preview-supervisor'
 import { OfficePreviewOpenSupersededError } from './office-preview-supervisor'
+
+const log = createLogger('office-preview:ipc')
 
 type OfficePreviewSupervisorPort = Pick<
   OfficePreviewSupervisor,
@@ -61,7 +64,7 @@ const registerOfficePreviewIpcHandlers = (supervisor: OfficePreviewSupervisorPor
     try {
       supervisor.reportState(event.sender.id, sessionId, state)
     } catch (error) {
-      console.error('Failed to report Office preview runtime state', error)
+      log.error('failed to report runtime state', diagnosticErrorFields(error))
     }
   })
 

--- a/src/main/office-preview/office-preview-runtime-protocol.ts
+++ b/src/main/office-preview/office-preview-runtime-protocol.ts
@@ -1,11 +1,14 @@
 import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { createLogger, diagnosticErrorFields } from '../logger'
 import {
   OFFICE_PREVIEW_RUNTIME_HOST,
   OFFICE_PREVIEW_RUNTIME_ORIGIN,
   OFFICE_PREVIEW_RUNTIME_SCHEME
 } from '../../shared/office-preview'
+
+const log = createLogger('office-preview:protocol')
 
 const OFFICE_PREVIEW_RUNTIME_SCHEME_CONFIG = {
   scheme: OFFICE_PREVIEW_RUNTIME_SCHEME,
@@ -132,10 +135,10 @@ const createOfficePreviewRuntimeProtocolHandler = (
       })
     } catch (error) {
       const failedUrl = new URL(request.url)
-      console.warn('[office-preview] runtime asset request failed', {
+      log.warn('runtime asset request failed', {
         method: request.method,
         resource: failedUrl.pathname.endsWith('.html') ? 'document' : 'asset',
-        error
+        ...diagnosticErrorFields(error)
       })
       return new Response('Office preview runtime is unavailable.', {
         status: 404,

--- a/src/main/project-files/mutation-owner.ts
+++ b/src/main/project-files/mutation-owner.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { ProjectFileSource } from '../../shared/project-files'
+import { createLogger } from '../logger'
 import {
   buildProjectCollisionFilters,
   describeError,
@@ -15,6 +16,8 @@ import {
   type ProjectFilesClient,
   type ProjectFilesClientProvider
 } from './mutation-projection'
+
+const log = createLogger('project-files')
 
 // Valid persisted revisions are non-negative. A collision loser stores this sentinel so it cannot
 // take the revision fast path and can claim the canonical row after its current owner is deleted.
@@ -95,7 +98,7 @@ class ProjectFilesMutationOwner {
           // a legacy duplicate reference, but it must not steal ownership or make migration unretryable.
           if (activeOtherSessionRow) {
             hasActiveCollision = true
-            console.warn('Skipping duplicate file reference owned by another active session', {
+            log.warn('skipping duplicate file reference owned by another active session', {
               projectId: file.projectId,
               sessionId: file.sessionId,
               canonicalSessionId: activeOtherSessionRow.sessionId,

--- a/src/main/project-files/mutation-projection.ts
+++ b/src/main/project-files/mutation-projection.ts
@@ -5,6 +5,7 @@ import { Prisma, type ManagedFile, type PrismaClient } from '@prisma/client'
 
 import type { ProjectFileSource } from '../../shared/project-files'
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createLogger } from '../logger'
 import {
   DEFAULT_UPLOAD_PROJECT_ID,
   getUploadedAttachmentName,
@@ -14,6 +15,7 @@ import {
 const ARTIFACTS_DIR = 'artifacts'
 const UPLOADS_DIR = 'uploads'
 const PENDING_ARTIFACT_DIR = '.pending'
+const log = createLogger('project-files')
 
 type ProjectFilesClient = Pick<
   PrismaClient,
@@ -391,7 +393,7 @@ const toIndexedFile = async (
   const requestedPath = resolve(input.path)
 
   if (!isPathInsideRoot(managedRoot, requestedPath)) {
-    console.warn('Skipping file outside managed storage', {
+    log.warn('skipping file outside managed storage', {
       projectId: input.projectId,
       sessionId: input.sessionId,
       source: input.source
@@ -413,7 +415,7 @@ const toIndexedFile = async (
   }
 
   if (!isPathInsideRoot(canonicalRoot, canonicalPath)) {
-    console.warn('Skipping file whose canonical path leaves managed storage', {
+    log.warn('skipping file whose canonical path leaves managed storage', {
       projectId: input.projectId,
       sessionId: input.sessionId,
       source: input.source

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
+const { log } = vi.hoisted(() => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+vi.mock('../logger', () => ({ createLogger: () => log }))
+
 import { ApplicationEventHub } from '../application-events'
 import type { ApplicationEventSource } from '../application-events'
 import type { ApplicationCommandComposition } from '../application-command-composition'
@@ -194,18 +200,18 @@ describe('createWebServiceController', () => {
   })
 
   it('keeps the bearer token out of daemon stdout when the service starts', async () => {
-    const stdout = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     const h = makeController()
+    log.info.mockClear()
 
-    try {
-      const result = await h.controller.ensureStarted(44100, { attached: false })
+    const result = await h.controller.ensureStarted(44100, { attached: false })
 
-      expect(result.url).toBe('http://127.0.0.1:44100/?token=tok-123')
-      expect(stdout).toHaveBeenCalledWith('Open Science Web: http://127.0.0.1:44100/')
-      expect(stdout.mock.calls.flat().join(' ')).not.toContain('tok-123')
-    } finally {
-      stdout.mockRestore()
-    }
+    expect(result.url).toBe('http://127.0.0.1:44100/?token=tok-123')
+    expect(log.info).toHaveBeenCalledWith('Open Science Web: http://127.0.0.1:44100/', {
+      host: '127.0.0.1',
+      port: 44100,
+      attached: false
+    })
+    expect(JSON.stringify(log.info.mock.calls)).not.toContain('tok-123')
   })
 
   it('is idempotent: a second ensureStarted while running reuses the server (no second start)', async () => {

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -14,6 +14,8 @@ import { projectTaskRuntimeEvents } from './application-event-projections'
 import { HeadlessTaskApi } from './task-api'
 import { removeWebServiceState, writeWebServiceState, type WebServiceState } from './state-file'
 
+const log = createLogger('web-service')
+
 // A single-instance web service that can be started at launch (--serve) or later, on demand, when a
 // second launch forwards a --serve request to the already-running instance. Starting is idempotent: a
 // second ensureStarted while one is running (or in flight) reuses it rather than binding a new port.
@@ -222,12 +224,11 @@ const createWebServiceController = (
     }
 
     const url = authUrl(token, server.port)
-    createLogger('web-service').info('local web service started', {
+    log.info(`Open Science Web: http://127.0.0.1:${server.port}/`, {
       host: '127.0.0.1',
       port: server.port,
       attached
     })
-    console.log(`Open Science Web: http://127.0.0.1:${server.port}/`)
     return { port: server.port, url }
   }
 


### PR DESCRIPTION
## Problem

The Electron main process had 33 production `console.*` calls outside the central logger. They occur when terminal submissions or executions fail, Notebook environment initialization or crash recovery fails, MCP stdio entry points reject, and several best-effort recovery or projection paths report diagnostics.

Those calls bypass the logger boundary that performs recursive credential and URL redaction, bounds records, rotates `main.log`, and mirrors sanitized records to the console. In development they could expose raw exception, stderr, traceback, URL, or local-path content to the launching terminal. In packaged builds the same recovery diagnostics might never reach persistent logs. The terminal IPC path was the highest-risk example because it copied the last traceback or stderr line directly.

## Proposed change

- Route all 33 production main-process console calls through the existing central logger.
- Keep MCP stdio failures visible on stderr through the logger console adapter, so output is redacted before emission.
- Stop copying terminal traceback, stderr, and exception messages into diagnostics; retain only identifiers, execution status, code length, and a coarse error category.
- Preserve the token-free `Open Science Web:` startup line through the logger console mirror.
- Add a regression test that makes the central logger the only production console adapter under `src/main`.

## Scope and non-goals

- No new dependency or logging framework.
- No database, persisted domain-data, migration, historical-compatibility, enum, or state-machine change.
- No renderer/API contract, UI, or user-interaction change.
- Existing rotating `main.log` persistence is reused; this change only sends previously console-only diagnostics into that existing sink.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Logger redaction, persistence, and no-direct-console boundary -> `npm test -- src/main/logger.test.ts ...` as part of the 22-file focused suite -> 568 tests passed.
- Main bootstrap, shutdown, Notebook runtime/recovery, MCP, Connector, Office Preview, Project Files, and Web service behavior -> same focused suite -> 22 files passed.
- Project Files owner, IPC contract, and Session persistence consumers -> `npm run test:module -- project_files_repository` -> 6 files / 234 tests passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Source lint and formatting rules -> `npm run lint` -> passed.
- Patch whitespace -> `git diff --check` -> passed.

Renderer, Web typecheck, UI E2E, and local package certification were excluded because no renderer code, renderer-facing contract, interaction, build configuration, or packaged resource changed. Exact-head PR CI remains authoritative for portable and platform/package coverage.

## Review focus

- Confirm that diagnostics keep enough structured context for recovery triage without persisting terminal output or raw submission errors.
- Confirm that the Web startup marker and MCP stderr behavior remain observable through the logger mirror.