### PR TITLE
fix(startup): redact public diagnostic reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,12 +209,12 @@ should compose `ErrorNotice` instead of rolling their own layout.
 
 ### Startup issue draft helpers (`src/renderer/src/lib/startup-issue.ts`)
 
-- `buildStartupIssueUrl(error)` — GitHub `issues/new` URL with a prefilled title and body
+- `buildStartupIssueUrl(error, diagnostics?)` — GitHub `issues/new` URL with a prefilled title and body
   (What happened / Environment / Steps to reproduce / Error stack). Oversized stacks are trimmed
   by binary search against the real percent-encoded URL length (~7800-char budget).
-- `openStartupIssueDraft(error)` — opens that URL in a new browser window. This is a stateless
-  side effect, so it stays a plain function: don't wrap it in a hook unless React state or
-  lifecycle actually gets involved.
+- `StartupIssueDialog` owns the editable diagnostics preview and exact-payload consent. Keep the
+  external GitHub link disabled until the user has reviewed the current URL; editing diagnostics
+  invalidates prior consent.
 
 ## Known patterns
 

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -131,8 +131,10 @@ describe('buildStartupDiagnostics', () => {
   it('reuses the diagnostic credential policy before diagnostics cross IPC', () => {
     const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdGFydHVwIn0.signaturevalue123'
     const signedUrlSecret = 'signed-url-opaque-7319'
+    const quotedSecretParts = ['quoted-left-opaque-7319', 'quoted-right-opaque-7319']
+    const quotedSecret = quotedSecretParts.join(' ')
     const error = new Error(
-      `request failed: Bearer bearer-opaque-7319; apiKey=key-opaque-7319; jwt=${jwt}; ` +
+      `request failed: Bearer bearer-opaque-7319; apiKey=key-opaque-7319; password="${quotedSecret}"; jwt=${jwt}; ` +
         'https://alice:password-opaque-7319@example.test/v1?token=query-opaque-7319&ok=1; ' +
         `https://bucket.example.test/private?X-Amz-Signature=${signedUrlSecret}&version=7`
     )
@@ -146,7 +148,8 @@ describe('buildStartupDiagnostics', () => {
       'alice',
       'password-opaque-7319',
       'query-opaque-7319',
-      signedUrlSecret
+      signedUrlSecret,
+      ...quotedSecretParts
     ]) {
       expect(result).not.toContain(secret)
     }

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -104,6 +104,27 @@ describe('buildStartupDiagnostics', () => {
   })
 
   it.each([
+    ['POSIX', 'relative.db,/srv/customer/secret.db', '/srv/customer/secret.db'],
+    [
+      'drive-letter',
+      String.raw`relative.db,D:\Clients\Acme\secret.db`,
+      String.raw`D:\Clients\Acme\secret.db`
+    ],
+    [
+      'forward-slash UNC',
+      'relative.db,//fileserver/research-share/secret.db',
+      '//fileserver/research-share/secret.db'
+    ]
+  ])('redacts a comma-delimited %s path', (_kind, message, path) => {
+    const result = buildStartupDiagnostics(new Error(`cannot open ${message}`), {
+      home: '/Users/alice'
+    })
+
+    expect(result).toContain('cannot open relative.db,<absolute-path>')
+    expect(result).not.toContain(path)
+  })
+
+  it.each([
     '/srv/customer/Private Study/patient.db',
     String.raw`D:\Clients\Private Study\patient.db`,
     String.raw`\\fileserver\Private Study\patient.db`,

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -46,7 +46,8 @@ describe('buildStartupDiagnostics', () => {
 
     expect(result).toContain('<config-root>/open-science.db')
     expect(result).toContain('<data-root>/notebook/run.json')
-    expect(result).toContain('<absolute-path>/private.db')
+    expect(result).toContain('other=<absolute-path>')
+    expect(result).not.toContain('<absolute-path><absolute-path>')
     expect(result).not.toContain('/Volumes/Config Space')
     expect(result).not.toContain('/mnt/research')
     expect(result).not.toContain('/srv/customer')
@@ -54,6 +55,33 @@ describe('buildStartupDiagnostics', () => {
     expect(result).not.toContain('D:\\Clients')
     expect(result).not.toContain('fileserver')
     expect(result).not.toContain('research-share')
+  })
+
+  it.each([
+    '/srv/customer/Private Study/patient.db',
+    String.raw`D:\Clients\Private Study\patient.db`,
+    String.raw`\\fileserver\Private Study\patient.db`,
+    'file://fileserver/Private%20Study/patient.db'
+  ])('fully redacts an unquoted path containing spaces: %s', (path) => {
+    const error = new Error(`cannot open ${path} because the file is locked`)
+
+    const result = buildStartupDiagnostics(error, { home: '/Users/alice' })
+
+    expect(result).toContain('<absolute-path>')
+    expect(result).not.toContain('Private Study')
+    expect(result).not.toContain('Private%20Study')
+    expect(result).not.toContain('patient.db')
+    expect(result).not.toContain('fileserver')
+  })
+
+  it('keeps a useful file suffix for a delimited stack path containing spaces', () => {
+    const error = new Error('failed')
+    error.stack = 'Error: failed\n    at open (/srv/customer/Private Study/patient.db:10:5)'
+
+    const result = buildStartupDiagnostics(error, { home: '/Users/alice' })
+
+    expect(result).toContain('at open (<absolute-path>/patient.db:10:5)')
+    expect(result).not.toContain('Private Study')
   })
 
   it('reuses the diagnostic credential policy before diagnostics cross IPC', () => {

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -90,6 +90,18 @@ describe('buildStartupDiagnostics', () => {
   )
 
   it.each([
+    ['POSIX', '[/srv/customer/secret.db]', '/srv/customer/secret.db'],
+    ['drive-letter', String.raw`[D:\Clients\Acme\secret.db]`, String.raw`D:\Clients\Acme\secret.db`]
+  ])('redacts a bracket-delimited %s path', (_kind, message, path) => {
+    const result = buildStartupDiagnostics(new Error(`cannot open ${message}`), {
+      home: '/Users/alice'
+    })
+
+    expect(result).toContain('cannot open [<absolute-path>]')
+    expect(result).not.toContain(path)
+  })
+
+  it.each([
     '/srv/customer/Private Study/patient.db',
     String.raw`D:\Clients\Private Study\patient.db`,
     String.raw`\\fileserver\Private Study\patient.db`,

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -12,7 +12,7 @@ describe('buildStartupDiagnostics', () => {
     const result = buildStartupDiagnostics(error)
 
     expect(result).toContain('Error: database is locked')
-    expect(result).toContain('at open (/app/dist/main.js:10:5)')
+    expect(result).toContain('at open (<absolute-path>/main.js:10:5)')
   })
 
   it('redacts the home directory from messages and stack frames', () => {
@@ -26,6 +26,58 @@ describe('buildStartupDiagnostics', () => {
     expect(result).not.toContain(home)
   })
 
+  it('redacts configured roots and remaining cross-platform absolute paths', () => {
+    const error = new Error(
+      [
+        'config=/Volumes/Config Space/.open-science/open-science.db',
+        'data=/mnt/research/OpenScience/notebook/run.json',
+        'other=/srv/customer/private.db',
+        'file=file:///Volumes/External/private.db',
+        String.raw`windows=D:\Clients\Acme\private.db`,
+        String.raw`network=\\fileserver\research-share\private.db`
+      ].join(' ')
+    )
+
+    const result = buildStartupDiagnostics(error, {
+      home: '/Users/alice',
+      configRoot: '/Volumes/Config Space/.open-science',
+      dataRoot: '/mnt/research/OpenScience'
+    })
+
+    expect(result).toContain('<config-root>/open-science.db')
+    expect(result).toContain('<data-root>/notebook/run.json')
+    expect(result).toContain('<absolute-path>/private.db')
+    expect(result).not.toContain('/Volumes/Config Space')
+    expect(result).not.toContain('/mnt/research')
+    expect(result).not.toContain('/srv/customer')
+    expect(result).not.toContain('/Volumes/External')
+    expect(result).not.toContain('D:\\Clients')
+    expect(result).not.toContain('fileserver')
+    expect(result).not.toContain('research-share')
+  })
+
+  it('reuses the diagnostic credential policy before diagnostics cross IPC', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdGFydHVwIn0.signaturevalue123'
+    const error = new Error(
+      `request failed: Bearer bearer-opaque-7319; apiKey=key-opaque-7319; jwt=${jwt}; ` +
+        'https://alice:password-opaque-7319@example.test/v1?token=query-opaque-7319&ok=1'
+    )
+
+    const result = buildStartupDiagnostics(error, { home: '/Users/alice' })
+
+    for (const secret of [
+      'bearer-opaque-7319',
+      'key-opaque-7319',
+      jwt,
+      'alice',
+      'password-opaque-7319',
+      'query-opaque-7319'
+    ]) {
+      expect(result).not.toContain(secret)
+    }
+    expect(result).toContain('[redacted]')
+  })
+
   it('walks the cause chain with Caused by separators', () => {
     const root = new Error('disk I/O error')
     root.stack = 'Error: disk I/O error\n    at write (/x.js:1:1)'
@@ -36,7 +88,7 @@ describe('buildStartupDiagnostics', () => {
 
     expect(result).toContain('Error: migration failed')
     expect(result).toContain('Caused by: Error: disk I/O error')
-    expect(result).toContain('at write (/x.js:1:1)')
+    expect(result).toContain('at write (<absolute-path>/x.js:1:1)')
   })
 
   it('returns undefined when nothing describable was thrown', () => {
@@ -63,7 +115,7 @@ describe('buildStartupDiagnostics', () => {
     const result = buildStartupDiagnostics(outer)
 
     expect(result).toContain('Caused by: Error: root cause')
-    expect(result).toContain('at f19 (/f.js:19:1)')
+    expect(result).toContain('at f19 (<absolute-path>/f.js:19:1)')
   })
 
   it('marks frames dropped by the frame budget instead of hiding them', () => {
@@ -73,8 +125,8 @@ describe('buildStartupDiagnostics', () => {
 
     const result = buildStartupDiagnostics(error)
 
-    expect(result).toContain('at f31 (/f.js:31:1)')
-    expect(result).not.toContain('at f32 (/f.js:32:1)')
+    expect(result).toContain('at f31 (<absolute-path>/f.js:31:1)')
+    expect(result).not.toContain('at f32 (<absolute-path>/f.js:32:1)')
     expect(result).toContain('… 8 more frames')
   })
 

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -34,7 +34,8 @@ describe('buildStartupDiagnostics', () => {
         'other=/srv/customer/private.db',
         'file=file:///Volumes/External/private.db',
         String.raw`windows=D:\Clients\Acme\private.db`,
-        String.raw`network=\\fileserver\research-share\private.db`
+        String.raw`network=\\fileserver\research-share\private.db`,
+        'forwardNetwork=//forward-fileserver/research-share/private.db'
       ].join(' ')
     )
 
@@ -54,6 +55,7 @@ describe('buildStartupDiagnostics', () => {
     expect(result).not.toContain('/Volumes/External')
     expect(result).not.toContain('D:\\Clients')
     expect(result).not.toContain('fileserver')
+    expect(result).not.toContain('forward-fileserver')
     expect(result).not.toContain('research-share')
   })
 

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -128,13 +128,25 @@ describe('buildStartupDiagnostics', () => {
     expect(result).not.toContain('Private Study')
   })
 
+  it('does not end a stack path at a parenthesis inside a directory name', () => {
+    const error = new Error('failed')
+    error.stack = 'Error: failed\n    at open (/srv/Research (2026)/patient.db:10:5)'
+
+    const result = buildStartupDiagnostics(error, { home: '/Users/alice' })
+
+    expect(result).toContain('at open (<absolute-path>/patient.db:10:5)')
+    expect(result).not.toContain('Research (2026)')
+  })
+
   it('reuses the diagnostic credential policy before diagnostics cross IPC', () => {
     const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdGFydHVwIn0.signaturevalue123'
     const signedUrlSecret = 'signed-url-opaque-7319'
     const quotedSecretParts = ['quoted-left-opaque-7319', 'quoted-right-opaque-7319']
     const quotedSecret = quotedSecretParts.join(' ')
+    const unquotedSecretParts = ['unquoted-left-opaque-7319', 'unquoted-right-opaque-7319']
+    const unquotedSecret = unquotedSecretParts.join(' ')
     const error = new Error(
-      `request failed: Bearer bearer-opaque-7319; apiKey=key-opaque-7319; password="${quotedSecret}"; jwt=${jwt}; ` +
+      `request failed: Bearer bearer-opaque-7319; apiKey=key-opaque-7319; password="${quotedSecret}"; credential=${unquotedSecret}; status=denied; jwt=${jwt}; ` +
         'https://alice:password-opaque-7319@example.test/v1?token=query-opaque-7319&ok=1; ' +
         `https://bucket.example.test/private?X-Amz-Signature=${signedUrlSecret}&version=7`
     )
@@ -149,11 +161,13 @@ describe('buildStartupDiagnostics', () => {
       'password-opaque-7319',
       'query-opaque-7319',
       signedUrlSecret,
-      ...quotedSecretParts
+      ...quotedSecretParts,
+      ...unquotedSecretParts
     ]) {
       expect(result).not.toContain(secret)
     }
     expect(result).toContain('[redacted]')
+    expect(result).toContain('status=denied')
     expect(result).toContain('version=7')
   })
 

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -40,8 +40,8 @@ describe('buildStartupDiagnostics', () => {
 
     const result = buildStartupDiagnostics(error, {
       home: '/Users/alice',
-      configRoot: '/Volumes/Config Space/.open-science',
-      dataRoot: '/mnt/research/OpenScience'
+      configRoot: '/Volumes/Config Space/.open-science/',
+      dataRoot: '/mnt/research/OpenScience/'
     })
 
     expect(result).toContain('<config-root>/open-science.db')
@@ -56,6 +56,38 @@ describe('buildStartupDiagnostics', () => {
     expect(result).not.toContain('fileserver')
     expect(result).not.toContain('research-share')
   })
+
+  it('does not apply a configured-root marker to a sibling path prefix', () => {
+    const error = new Error('cannot open /data/project-old/secret.db')
+
+    const result = buildStartupDiagnostics(error, {
+      home: '/Users/alice',
+      dataRoot: '/data/project/'
+    })
+
+    expect(result).toContain('<absolute-path>')
+    expect(result).not.toContain('<data-root>-old')
+    expect(result).not.toContain('project-old')
+    expect(result).not.toContain('secret.db')
+  })
+
+  it.each([
+    ['POSIX', 'endpoint:https://example.test/public path:/srv/private.db', '/srv/private.db'],
+    [
+      'drive-letter',
+      String.raw`endpoint:https://example.test/public path:D:\Clients\private.db`,
+      String.raw`D:\Clients\private.db`
+    ]
+  ])(
+    'redacts a colon-prefixed %s path without treating a URL as a path',
+    (_kind, message, path) => {
+      const result = buildStartupDiagnostics(new Error(message), { home: '/Users/alice' })
+
+      expect(result).toContain('endpoint:https://example.test/public')
+      expect(result).toContain('path:<absolute-path>')
+      expect(result).not.toContain(path)
+    }
+  )
 
   it.each([
     '/srv/customer/Private Study/patient.db',

--- a/src/main/database/startup-diagnostics.test.ts
+++ b/src/main/database/startup-diagnostics.test.ts
@@ -86,9 +86,11 @@ describe('buildStartupDiagnostics', () => {
 
   it('reuses the diagnostic credential policy before diagnostics cross IPC', () => {
     const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdGFydHVwIn0.signaturevalue123'
+    const signedUrlSecret = 'signed-url-opaque-7319'
     const error = new Error(
       `request failed: Bearer bearer-opaque-7319; apiKey=key-opaque-7319; jwt=${jwt}; ` +
-        'https://alice:password-opaque-7319@example.test/v1?token=query-opaque-7319&ok=1'
+        'https://alice:password-opaque-7319@example.test/v1?token=query-opaque-7319&ok=1; ' +
+        `https://bucket.example.test/private?X-Amz-Signature=${signedUrlSecret}&version=7`
     )
 
     const result = buildStartupDiagnostics(error, { home: '/Users/alice' })
@@ -99,11 +101,13 @@ describe('buildStartupDiagnostics', () => {
       jwt,
       'alice',
       'password-opaque-7319',
-      'query-opaque-7319'
+      'query-opaque-7319',
+      signedUrlSecret
     ]) {
       expect(result).not.toContain(secret)
     }
     expect(result).toContain('[redacted]')
+    expect(result).toContain('version=7')
   })
 
   it('walks the cause chain with Caused by separators', () => {

--- a/src/main/database/startup-diagnostics.ts
+++ b/src/main/database/startup-diagnostics.ts
@@ -26,12 +26,16 @@ type StartupDiagnosticsOptions = {
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 const replaceRoot = (text: string, root: string | undefined, marker: string): string => {
-  if (!root || root === '/' || /^[A-Za-z]:[\\/]?$/.test(root)) return text
-  const variants = new Set([root, root.replace(/\\/g, '/')])
+  if (!root || /^[\\/]+$/.test(root) || /^[A-Za-z]:[\\/]*$/.test(root)) return text
+  const normalizedRoot = root.replace(/[\\/]+$/, '')
+  const variants = new Set([normalizedRoot, normalizedRoot.replace(/\\/g, '/')])
   let redacted = text
   for (const variant of variants) {
-    const flags = /^[A-Za-z]:[\\/]/.test(variant) || variant.startsWith('\\\\') ? 'gi' : 'g'
-    redacted = redacted.replace(new RegExp(escapeRegExp(variant), flags), marker)
+    const flags =
+      /^[A-Za-z]:[\\/]/.test(variant) || variant.startsWith('\\\\') || variant.startsWith('//')
+        ? 'gi'
+        : 'g'
+    redacted = redacted.replace(new RegExp(`${escapeRegExp(variant)}(?=$|[\\\\/])`, flags), marker)
   }
   return redacted
 }
@@ -58,12 +62,13 @@ const redactRemainingAbsolutePaths = (text: string): string =>
     .replace(/\bfile:\/\/[^\r\n"'<>()[\]{}]+/gi, '<absolute-path>')
     .replace(/\\\\[^\r\n"'<>()[\]{}]+/g, '<absolute-path>')
     .replace(
-      /(^|[\s("'=])([A-Za-z]:[\\/][^\r\n"'<>()[\]{}]*)/gm,
+      /(^|[\s("'=:])([A-Za-z]:[\\/][^\r\n"'<>()[\]{}]*)/gm,
       (_match, boundary: string) => `${boundary}<absolute-path>`
     )
-    // A leading boundary avoids URL paths, `I/O`, and suffixes below already-redacted named roots.
+    // The double-slash guard excludes URL schemes even when ':' is accepted as a path boundary.
+    // Other leading boundaries avoid `I/O` and suffixes below already-redacted named roots.
     .replace(
-      /(^|[\s("'=])\/(?!\/)([^\r\n"'<>()[\]{}]*)/gm,
+      /(^|[\s("'=:])\/(?!\/)([^\r\n"'<>()[\]{}]*)/gm,
       (_match, boundary: string) => `${boundary}<absolute-path>`
     )
     // Multiple unquoted paths on one line can leave adjacent markers as each conservative matcher

--- a/src/main/database/startup-diagnostics.ts
+++ b/src/main/database/startup-diagnostics.ts
@@ -63,17 +63,17 @@ const redactRemainingAbsolutePaths = (text: string): string =>
     .replace(/\\\\[^\r\n"'<>()[\]{}]+/g, '<absolute-path>')
     // Excluding ':' from the boundary keeps URI schemes such as https:// intact.
     .replace(
-      /(^|[\s("'=[{])\/\/(?!\/)[^\r\n"'<>()[\]{}]*/gm,
+      /(^|[\s("'=,[{])\/\/(?!\/)[^\r\n"'<>()[\]{}]*/gm,
       (_match, boundary: string) => `${boundary}<absolute-path>`
     )
     .replace(
-      /(^|[\s("'=:[{])([A-Za-z]:[\\/][^\r\n"'<>()[\]{}]*)/gm,
+      /(^|[\s("'=:,[{])([A-Za-z]:[\\/][^\r\n"'<>()[\]{}]*)/gm,
       (_match, boundary: string) => `${boundary}<absolute-path>`
     )
     // The double-slash guard excludes URL schemes even when ':' is accepted as a path boundary.
     // Other leading boundaries avoid `I/O` and suffixes below already-redacted named roots.
     .replace(
-      /(^|[\s("'=:[{])\/(?!\/)([^\r\n"'<>()[\]{}]*)/gm,
+      /(^|[\s("'=:,[{])\/(?!\/)([^\r\n"'<>()[\]{}]*)/gm,
       (_match, boundary: string) => `${boundary}<absolute-path>`
     )
     // Multiple unquoted paths on one line can leave adjacent markers as each conservative matcher

--- a/src/main/database/startup-diagnostics.ts
+++ b/src/main/database/startup-diagnostics.ts
@@ -62,13 +62,13 @@ const redactRemainingAbsolutePaths = (text: string): string =>
     .replace(/\bfile:\/\/[^\r\n"'<>()[\]{}]+/gi, '<absolute-path>')
     .replace(/\\\\[^\r\n"'<>()[\]{}]+/g, '<absolute-path>')
     .replace(
-      /(^|[\s("'=:])([A-Za-z]:[\\/][^\r\n"'<>()[\]{}]*)/gm,
+      /(^|[\s("'=:[{])([A-Za-z]:[\\/][^\r\n"'<>()[\]{}]*)/gm,
       (_match, boundary: string) => `${boundary}<absolute-path>`
     )
     // The double-slash guard excludes URL schemes even when ':' is accepted as a path boundary.
     // Other leading boundaries avoid `I/O` and suffixes below already-redacted named roots.
     .replace(
-      /(^|[\s("'=:])\/(?!\/)([^\r\n"'<>()[\]{}]*)/gm,
+      /(^|[\s("'=:[{])\/(?!\/)([^\r\n"'<>()[\]{}]*)/gm,
       (_match, boundary: string) => `${boundary}<absolute-path>`
     )
     // Multiple unquoted paths on one line can leave adjacent markers as each conservative matcher

--- a/src/main/database/startup-diagnostics.ts
+++ b/src/main/database/startup-diagnostics.ts
@@ -61,6 +61,11 @@ const redactRemainingAbsolutePaths = (text: string): string =>
     // conservatively rather than keeping a suffix that may still contain a mount/share/folder name.
     .replace(/\bfile:\/\/[^\r\n"'<>()[\]{}]+/gi, '<absolute-path>')
     .replace(/\\\\[^\r\n"'<>()[\]{}]+/g, '<absolute-path>')
+    // Excluding ':' from the boundary keeps URI schemes such as https:// intact.
+    .replace(
+      /(^|[\s("'=[{])\/\/(?!\/)[^\r\n"'<>()[\]{}]*/gm,
+      (_match, boundary: string) => `${boundary}<absolute-path>`
+    )
     .replace(
       /(^|[\s("'=:[{])([A-Za-z]:[\\/][^\r\n"'<>()[\]{}]*)/gm,
       (_match, boundary: string) => `${boundary}<absolute-path>`

--- a/src/main/database/startup-diagnostics.ts
+++ b/src/main/database/startup-diagnostics.ts
@@ -54,7 +54,7 @@ const redactRemainingAbsolutePaths = (text: string): string =>
       (_match, quote: string, path: string) => `${quote}${absolutePathMarker(path)}${quote}`
     )
     .replace(
-      /\(((?:file:\/\/|[A-Za-z]:[\\/]|\\\\|\/)[^)\r\n]+)\)/g,
+      /\(((?:file:\/\/|[A-Za-z]:[\\/]|\\\\|\/)[^\r\n]+)\)/g,
       (_match, path: string) => `(${absolutePathMarker(path)})`
     )
     // Unquoted paths have no reliable end when a segment contains spaces. Redact the remaining line

--- a/src/main/database/startup-diagnostics.ts
+++ b/src/main/database/startup-diagnostics.ts
@@ -37,21 +37,38 @@ const replaceRoot = (text: string, root: string | undefined, marker: string): st
 }
 
 const absolutePathMarker = (path: string): string => {
-  const withoutFileScheme = path.replace(/^file:\/\/\//i, '')
+  const withoutFileScheme = path.replace(/^file:\/\//i, '')
   const tail = withoutFileScheme.split(/[\\/]/).at(-1)
   return tail ? `<absolute-path>/${tail}` : '<absolute-path>'
 }
 
 const redactRemainingAbsolutePaths = (text: string): string =>
   text
-    .replace(/\bfile:\/\/\/[^\s"'<>()[\]{}]+/gi, absolutePathMarker)
-    .replace(/\\\\[^\s"'<>()[\]{}]+(?:[\\/][^\s"'<>()[\]{}]+)+/g, absolutePathMarker)
-    .replace(/\b[A-Za-z]:[\\/][^\s"'<>()[\]{}]+/g, absolutePathMarker)
+    // Delimiters let us retain a useful filename/line suffix even when the path contains spaces.
+    .replace(
+      /(["'`])((?:file:\/\/|[A-Za-z]:[\\/]|\\\\|\/)[^\r\n]*?)\1/g,
+      (_match, quote: string, path: string) => `${quote}${absolutePathMarker(path)}${quote}`
+    )
+    .replace(
+      /\(((?:file:\/\/|[A-Za-z]:[\\/]|\\\\|\/)[^)\r\n]+)\)/g,
+      (_match, path: string) => `(${absolutePathMarker(path)})`
+    )
+    // Unquoted paths have no reliable end when a segment contains spaces. Redact the remaining line
+    // conservatively rather than keeping a suffix that may still contain a mount/share/folder name.
+    .replace(/\bfile:\/\/[^\r\n"'<>()[\]{}]+/gi, '<absolute-path>')
+    .replace(/\\\\[^\r\n"'<>()[\]{}]+/g, '<absolute-path>')
+    .replace(
+      /(^|[\s("'=])([A-Za-z]:[\\/][^\r\n"'<>()[\]{}]*)/gm,
+      (_match, boundary: string) => `${boundary}<absolute-path>`
+    )
     // A leading boundary avoids URL paths, `I/O`, and suffixes below already-redacted named roots.
     .replace(
-      /(^|[\s("'=])\/(?!\/)([^\s"'<>()[\]{}]+)/gm,
-      (_match, boundary: string, path: string) => `${boundary}${absolutePathMarker(`/${path}`)}`
+      /(^|[\s("'=])\/(?!\/)([^\r\n"'<>()[\]{}]*)/gm,
+      (_match, boundary: string) => `${boundary}<absolute-path>`
     )
+    // Multiple unquoted paths on one line can leave adjacent markers as each conservative matcher
+    // stops at an earlier replacement. One marker communicates the same redaction more clearly.
+    .replace(/(?:<absolute-path>){2,}/g, '<absolute-path>')
 
 const redactPublicDiagnostics = (text: string, options: StartupDiagnosticsOptions): string => {
   const roots = [

--- a/src/main/database/startup-diagnostics.ts
+++ b/src/main/database/startup-diagnostics.ts
@@ -1,11 +1,13 @@
 import { homedir } from 'node:os'
 
+import { redactSensitiveText } from '../diagnostic-redaction'
+
 // Composes the pre-redacted stack block attached to a blocked database startup state. The block is
-// user-shareable by design: it feeds the GitHub issue draft opened from the startup failure page,
-// so every absolute path under the user's home directory is collapsed to `~`. The budgets below are
-// a generous IPC-safety ceiling; the precise fit to the GitHub issue-URL length limit happens at
-// link-build time (startup-issue.ts). Environment facts travel separately in the typed
-// `environment` field (see shared/database-startup.ts).
+// user-shareable by design: credentials and absolute paths are removed before it crosses IPC, with
+// known config/data/home roots replaced by useful stable markers. The budgets below are a generous
+// IPC-safety ceiling; the precise fit to the GitHub issue-URL length limit happens at link-build time
+// (startup-issue.ts). Environment facts travel separately in the typed `environment` field (see
+// shared/database-startup.ts).
 
 const MAX_CAUSE_DEPTH = 8
 const MAX_STACK_FRAMES = 32
@@ -15,10 +17,53 @@ const TRUNCATION_MARKER = '… (truncated)'
 const FURTHER_CAUSES_MARKER = '… (further causes omitted)'
 const NON_ERROR_CAUSE_MARKER = '… (a non-error cause was omitted)'
 
-const redactPaths = (text: string, home: string): string => {
-  if (!home || home === '/') return text
-  // Windows paths may surface with either separator in stack traces.
-  return text.split(home).join('~').split(home.replace(/\\/g, '/')).join('~')
+type StartupDiagnosticsOptions = {
+  configRoot?: string
+  dataRoot?: string
+  home?: string
+}
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const replaceRoot = (text: string, root: string | undefined, marker: string): string => {
+  if (!root || root === '/' || /^[A-Za-z]:[\\/]?$/.test(root)) return text
+  const variants = new Set([root, root.replace(/\\/g, '/')])
+  let redacted = text
+  for (const variant of variants) {
+    const flags = /^[A-Za-z]:[\\/]/.test(variant) || variant.startsWith('\\\\') ? 'gi' : 'g'
+    redacted = redacted.replace(new RegExp(escapeRegExp(variant), flags), marker)
+  }
+  return redacted
+}
+
+const absolutePathMarker = (path: string): string => {
+  const withoutFileScheme = path.replace(/^file:\/\/\//i, '')
+  const tail = withoutFileScheme.split(/[\\/]/).at(-1)
+  return tail ? `<absolute-path>/${tail}` : '<absolute-path>'
+}
+
+const redactRemainingAbsolutePaths = (text: string): string =>
+  text
+    .replace(/\bfile:\/\/\/[^\s"'<>()[\]{}]+/gi, absolutePathMarker)
+    .replace(/\\\\[^\s"'<>()[\]{}]+(?:[\\/][^\s"'<>()[\]{}]+)+/g, absolutePathMarker)
+    .replace(/\b[A-Za-z]:[\\/][^\s"'<>()[\]{}]+/g, absolutePathMarker)
+    // A leading boundary avoids URL paths, `I/O`, and suffixes below already-redacted named roots.
+    .replace(
+      /(^|[\s("'=])\/(?!\/)([^\s"'<>()[\]{}]+)/gm,
+      (_match, boundary: string, path: string) => `${boundary}${absolutePathMarker(`/${path}`)}`
+    )
+
+const redactPublicDiagnostics = (text: string, options: StartupDiagnosticsOptions): string => {
+  const roots = [
+    [options.configRoot, '<config-root>'],
+    [options.dataRoot, '<data-root>'],
+    [options.home ?? homedir(), '~']
+  ] as const
+  // Replace the most specific root first when roots are nested (the normal data-root/home case).
+  const withNamedRoots = [...roots]
+    .sort(([a], [b]) => (b?.length ?? 0) - (a?.length ?? 0))
+    .reduce((value, [root, marker]) => replaceRoot(value, root, marker), text)
+  return redactRemainingAbsolutePaths(redactSensitiveText(withNamedRoots))
 }
 
 const describeError = (error: unknown): { heading: string; frames: string[] } | undefined => {
@@ -33,7 +78,10 @@ const describeError = (error: unknown): { heading: string; frames: string[] } | 
   return undefined
 }
 
-const buildStartupDiagnostics = (error: unknown): string | undefined => {
+const buildStartupDiagnostics = (
+  error: unknown,
+  options: StartupDiagnosticsOptions = {}
+): string | undefined => {
   const sections: string[] = []
   let remainingFrames = MAX_STACK_FRAMES
   let current: unknown = error
@@ -61,7 +109,7 @@ const buildStartupDiagnostics = (error: unknown): string | undefined => {
     sections.push(describeError(current) ? FURTHER_CAUSES_MARKER : NON_ERROR_CAUSE_MARKER)
   }
 
-  const body = redactPaths(sections.join('\nCaused by: '), homedir())
+  const body = redactPublicDiagnostics(sections.join('\nCaused by: '), options)
   if (body.length <= MAX_DIAGNOSTICS_LENGTH) return body
   // Slice by code points, not UTF-16 code units, so a multibyte character astride the cut never
   // leaves a lone surrogate in user-shared text.
@@ -70,3 +118,4 @@ const buildStartupDiagnostics = (error: unknown): string | undefined => {
 }
 
 export { buildStartupDiagnostics }
+export type { StartupDiagnosticsOptions }

--- a/src/main/diagnostic-redaction.ts
+++ b/src/main/diagnostic-redaction.ts
@@ -38,6 +38,8 @@ const TOKEN_METRIC_WORDS = new Set([
   'usage'
 ])
 
+const SIGNED_URL_QUERY_WORDS = new Set(['sig', 'signature'])
+
 const diagnosticKeyWords = (key: string): string[] =>
   key
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
@@ -75,6 +77,11 @@ const isSensitiveDiagnosticKey = (key: string): boolean => {
   ].some((suffix) => normalized.endsWith(suffix))
 }
 
+const isSensitiveUrlQueryKey = (key: string): boolean =>
+  key.toLowerCase() === 'key' ||
+  isSensitiveDiagnosticKey(key) ||
+  diagnosticKeyWords(key).some((word) => SIGNED_URL_QUERY_WORDS.has(word))
+
 const redactUrlCredentials = (rawUrl: string): string => {
   try {
     const url = new URL(rawUrl)
@@ -86,7 +93,7 @@ const redactUrlCredentials = (rawUrl: string): string => {
       changed = true
     }
     for (const key of [...url.searchParams.keys()]) {
-      if (!isSensitiveDiagnosticKey(key) && key.toLowerCase() !== 'key') continue
+      if (!isSensitiveUrlQueryKey(key)) continue
       url.searchParams.set(key, REDACTED_MARKER)
       changed = true
     }

--- a/src/main/diagnostic-redaction.ts
+++ b/src/main/diagnostic-redaction.ts
@@ -123,7 +123,7 @@ const redactSensitiveText = (value: string): string =>
       `$1$2$3${REDACTED_MARKER}$3`
     )
     .replace(
-      /\b(api[_-]?key|access[_-]?token|auth[_-]?token|authorization|bearer[_-]?token|client[_-]?secret|cookie|credential|password|passphrase|passwd|private[_-]?key|refresh[_-]?token|secret|secret[_-]?access[_-]?key|security[_-]?token|session[_-]?token|token)\b(\s*["']?\s*[:=]\s*["']?)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;}]+/gi,
+      /\b(api[_-]?key|access[_-]?token|auth[_-]?token|authorization|bearer[_-]?token|client[_-]?secret|cookie|credential|password|passphrase|passwd|private[_-]?key|refresh[_-]?token|secret|secret[_-]?access[_-]?key|security[_-]?token|session[_-]?token|token)\b(\s*["']?\s*[:=]\s*["']?)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^"'&;}\r\n]+/gi,
       `$1$2${REDACTED_MARKER}`
     )
     .replace(
@@ -134,7 +134,7 @@ const redactSensitiveText = (value: string): string =>
           : match
     )
     .replace(
-      /\b([a-z][a-z0-9_-]*)(\s*=\s*)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;}]+/gi,
+      /\b([a-z][a-z0-9_-]*)(\s*=\s*)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^"'&;}\r\n]+/gi,
       (match, key: string, separator: string) =>
         isSensitiveDiagnosticKey(key) ? `${key}${separator}${REDACTED_MARKER}` : match
     )

--- a/src/main/diagnostic-redaction.ts
+++ b/src/main/diagnostic-redaction.ts
@@ -1,0 +1,134 @@
+const REDACTED_MARKER = '[redacted]'
+
+const SENSITIVE_KEY_WORDS = new Set([
+  'auth',
+  'authentication',
+  'authorization',
+  'authorizations',
+  'bearer',
+  'cookie',
+  'cookies',
+  'credential',
+  'credentials',
+  'password',
+  'passwords',
+  'passphrase',
+  'passphrases',
+  'passwd',
+  'pat',
+  'pats',
+  'secret',
+  'secrets',
+  'token',
+  'tokens'
+])
+
+const TOKEN_METRIC_WORDS = new Set([
+  'budget',
+  'cached',
+  'count',
+  'counts',
+  'input',
+  'limit',
+  'max',
+  'output',
+  'reasoning',
+  'remaining',
+  'total',
+  'usage'
+])
+
+const diagnosticKeyWords = (key: string): string[] =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+
+const isTokenMetricKey = (words: string[]): boolean =>
+  words.some((word) => word === 'token' || word === 'tokens') &&
+  words.some((word) => TOKEN_METRIC_WORDS.has(word)) &&
+  words.every((word) => word === 'token' || word === 'tokens' || TOKEN_METRIC_WORDS.has(word))
+
+const isSensitiveDiagnosticKey = (key: string): boolean => {
+  const words = diagnosticKeyWords(key)
+  const normalized = words.join('')
+
+  if (isTokenMetricKey(words)) return false
+  if (words.some((word) => SENSITIVE_KEY_WORDS.has(word))) return true
+
+  return [
+    'accesstoken',
+    'apikey',
+    'apikeys',
+    'authtoken',
+    'bearertoken',
+    'clientsecret',
+    'clientsecrets',
+    'privatekey',
+    'privatekeys',
+    'refreshtoken',
+    'secretaccesskey',
+    'securitytoken',
+    'sessiontoken',
+    'xapikey'
+  ].some((suffix) => normalized.endsWith(suffix))
+}
+
+const redactUrlCredentials = (rawUrl: string): string => {
+  try {
+    const url = new URL(rawUrl)
+    let changed = false
+
+    if (url.username || url.password) {
+      url.username = REDACTED_MARKER
+      url.password = ''
+      changed = true
+    }
+    for (const key of [...url.searchParams.keys()]) {
+      if (!isSensitiveDiagnosticKey(key) && key.toLowerCase() !== 'key') continue
+      url.searchParams.set(key, REDACTED_MARKER)
+      changed = true
+    }
+    if (url.hash) {
+      url.hash = ''
+      changed = true
+    }
+
+    return changed ? url.toString().replaceAll('%5Bredacted%5D', REDACTED_MARKER) : rawUrl
+  } catch {
+    return REDACTED_MARKER
+  }
+}
+
+// Shared credential-text policy for diagnostic sinks and user-reviewed public reports. Keep this
+// helper unbounded: each caller owns its own output budget, while the credential patterns stay
+// identical at both boundaries.
+const redactSensitiveText = (value: string): string =>
+  value
+    .replace(/\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi, redactUrlCredentials)
+    .replace(
+      /\b(authorization|proxy-authorization|x-api-key|api-key|x-auth-token|x-amz-security-token|cookie|set-cookie)\b(\s*["']?\s*:\s*["']?)[^"'\r\n}]*/gi,
+      `$1$2${REDACTED_MARKER}`
+    )
+    .replace(
+      /\b(api[_-]?key|access[_-]?token|auth[_-]?token|authorization|bearer[_-]?token|client[_-]?secret|cookie|credential|password|passphrase|passwd|private[_-]?key|refresh[_-]?token|secret|secret[_-]?access[_-]?key|security[_-]?token|session[_-]?token|token)\b(\s*["']?\s*[:=]\s*["']?)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;}]+/gi,
+      `$1$2${REDACTED_MARKER}`
+    )
+    .replace(
+      /\b([a-z][a-z0-9_-]*)(\s*=\s*)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;}]+/gi,
+      (match, key: string, separator: string) =>
+        isSensitiveDiagnosticKey(key) ? `${key}${separator}${REDACTED_MARKER}` : match
+    )
+    .replace(
+      /(--?(?:access[-_]?token|api[-_]?key|auth[-_]?token|authorization|bearer[-_]?token|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|secret|token))(\s+|=)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;]+/gi,
+      `$1$2${REDACTED_MARKER}`
+    )
+    .replace(/\bBearer\s+[^\s"']+/gi, `Bearer ${REDACTED_MARKER}`)
+    .replace(/\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g, REDACTED_MARKER)
+    .replace(
+      /\b(?:AKIA[0-9A-Z]{16}|gh[pousr]_[A-Za-z0-9_]{8,}|github_pat_[A-Za-z0-9_]{8,}|sk-[A-Za-z0-9_-]{8,})\b/g,
+      REDACTED_MARKER
+    )
+
+export { REDACTED_MARKER, diagnosticKeyWords, isSensitiveDiagnosticKey, redactSensitiveText }

--- a/src/main/diagnostic-redaction.ts
+++ b/src/main/diagnostic-redaction.ts
@@ -119,13 +119,28 @@ const redactSensitiveText = (value: string): string =>
       `$1$2${REDACTED_MARKER}`
     )
     .replace(
+      /\b(api[_-]?key|access[_-]?token|auth[_-]?token|authorization|bearer[_-]?token|client[_-]?secret|cookie|credential|password|passphrase|passwd|private[_-]?key|refresh[_-]?token|secret|secret[_-]?access[_-]?key|security[_-]?token|session[_-]?token|token)\b(\s*["']?\s*[:=]\s*)(["'])(?:\\.|(?!\3)[^\\\r\n])*\3/gi,
+      `$1$2$3${REDACTED_MARKER}$3`
+    )
+    .replace(
       /\b(api[_-]?key|access[_-]?token|auth[_-]?token|authorization|bearer[_-]?token|client[_-]?secret|cookie|credential|password|passphrase|passwd|private[_-]?key|refresh[_-]?token|secret|secret[_-]?access[_-]?key|security[_-]?token|session[_-]?token|token)\b(\s*["']?\s*[:=]\s*["']?)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;}]+/gi,
       `$1$2${REDACTED_MARKER}`
+    )
+    .replace(
+      /\b([a-z][a-z0-9_-]*)(\s*=\s*)(["'])(?:\\.|(?!\3)[^\\\r\n])*\3/gi,
+      (match, key: string, separator: string, quote: string) =>
+        isSensitiveDiagnosticKey(key)
+          ? `${key}${separator}${quote}${REDACTED_MARKER}${quote}`
+          : match
     )
     .replace(
       /\b([a-z][a-z0-9_-]*)(\s*=\s*)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;}]+/gi,
       (match, key: string, separator: string) =>
         isSensitiveDiagnosticKey(key) ? `${key}${separator}${REDACTED_MARKER}` : match
+    )
+    .replace(
+      /(--?(?:access[-_]?token|api[-_]?key|auth[-_]?token|authorization|bearer[-_]?token|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|secret|token))(\s+|=)(["'])(?:\\.|(?!\3)[^\\\r\n])*\3/gi,
+      `$1$2$3${REDACTED_MARKER}$3`
     )
     .replace(
       /(--?(?:access[-_]?token|api[-_]?key|auth[-_]?token|authorization|bearer[-_]?token|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|secret|token))(\s+|=)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;]+/gi,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -327,7 +327,11 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const databaseStartupLogging = createDatabaseStartupLogging(log, app.getVersion())
       const databaseStartupOwner = createDatabaseStartupOwner({
         reportBlocked: databaseStartupLogging.reportBlocked,
-        buildDiagnostics: (error) => buildStartupDiagnostics(error),
+        buildDiagnostics: (error) =>
+          buildStartupDiagnostics(error, {
+            configRoot: resolveStorageRoot(),
+            dataRoot: startupSettings.dataRoot
+          }),
         environment: {
           appVersion: app.getVersion(),
           platform: process.platform,

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -201,6 +201,14 @@ describe('logger: formatLine', () => {
         text: 'https://alice:malformed-url-opaque-7319@example.test:99999/path',
         secrets: ['alice', 'malformed-url-opaque-7319']
       },
+      {
+        text: 'https://bucket.example.test/private?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=aws-signature-opaque-7319&version=7',
+        secrets: ['aws-signature-opaque-7319']
+      },
+      {
+        text: 'https://storage.example.test/private?sv=2024-11-04&sig=azure-signature-opaque-7319&version=7',
+        secrets: ['azure-signature-opaque-7319']
+      },
       { text: 'sk-1234567890abcdef', secrets: ['sk-1234567890abcdef'] },
       { text: 'github_pat_1234567890abcdef', secrets: ['github_pat_1234567890abcdef'] },
       { text: 'AKIA1234567890ABCDEF', secrets: ['AKIA1234567890ABCDEF'] }

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -170,6 +170,10 @@ describe('logger: formatLine', () => {
         secrets: ['quoted-left-opaque-7319', 'quoted-right-opaque-7319']
       },
       {
+        text: 'password=unquoted-left-opaque-7319 unquoted-right-opaque-7319; status=denied',
+        secrets: ['unquoted-left-opaque-7319', 'unquoted-right-opaque-7319']
+      },
+      {
         text: 'token=comma-token-opaque-7319,remaining-token-opaque-7319',
         secrets: ['comma-token-opaque-7319', 'remaining-token-opaque-7319']
       },
@@ -183,6 +187,10 @@ describe('logger: formatLine', () => {
       },
       {
         text: "providerApiKey='compound-left-opaque-7319 compound-right-opaque-7319'",
+        secrets: ['compound-left-opaque-7319', 'compound-right-opaque-7319']
+      },
+      {
+        text: 'providerApiKey=compound-left-opaque-7319 compound-right-opaque-7319; status=denied',
         secrets: ['compound-left-opaque-7319', 'compound-right-opaque-7319']
       },
       {

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -166,6 +166,10 @@ describe('logger: formatLine', () => {
       { text: 'Cookie: session=cookie-opaque-7319; Path=/', secrets: ['cookie-opaque-7319'] },
       { text: 'apiKey="json-opaque-7319"', secrets: ['json-opaque-7319'] },
       {
+        text: 'apiKey="quoted-left-opaque-7319 quoted-right-opaque-7319"',
+        secrets: ['quoted-left-opaque-7319', 'quoted-right-opaque-7319']
+      },
+      {
         text: 'token=comma-token-opaque-7319,remaining-token-opaque-7319',
         secrets: ['comma-token-opaque-7319', 'remaining-token-opaque-7319']
       },
@@ -178,11 +182,19 @@ describe('logger: formatLine', () => {
         secrets: ['compound-camel-opaque-7319']
       },
       {
+        text: "providerApiKey='compound-left-opaque-7319 compound-right-opaque-7319'",
+        secrets: ['compound-left-opaque-7319', 'compound-right-opaque-7319']
+      },
+      {
         text: 'openai_api_key=compound-lower-opaque-7319',
         secrets: ['compound-lower-opaque-7319']
       },
       { text: 'OPENAI_API_KEY=env-opaque-7319', secrets: ['env-opaque-7319'] },
       { text: '--api-key cli-opaque-7319', secrets: ['cli-opaque-7319'] },
+      {
+        text: '--api-key "cli-left-opaque-7319 cli-right-opaque-7319"',
+        secrets: ['cli-left-opaque-7319', 'cli-right-opaque-7319']
+      },
       {
         text: '--authorization Bearer cli-scheme-opaque-7319',
         secrets: ['cli-scheme-opaque-7319']

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -5,6 +5,12 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 import { extname, join } from 'node:path'
 
 import type { LogFileStatus, LogWriteFailureCategory } from '../shared/logs'
+import {
+  REDACTED_MARKER,
+  diagnosticKeyWords,
+  isSensitiveDiagnosticKey,
+  redactSensitiveText
+} from './diagnostic-redaction'
 
 // Lightweight structured file logger for the main process. Kept free of Electron imports so it stays
 // unit-testable and usable from the MCP-server entry modes; the caller resolves the log directory
@@ -97,7 +103,6 @@ const MAX_TOTAL_NODES = 10000
 const MAX_TOTAL_CHARS = 256 * 1024
 
 // One mandatory policy for every logger sink. Callers may still pre-sanitize, but cannot opt out here.
-const REDACTED_MARKER = '[redacted]'
 const OVERSIZED_TEXT_MARKER = '[redacted: oversized text]'
 const CONTENT_BEARING_KEYS = new Set([
   'body',
@@ -107,42 +112,6 @@ const CONTENT_BEARING_KEYS = new Set([
   'requestpayload',
   'responsebody',
   'responsepayload'
-])
-const SENSITIVE_KEY_WORDS = new Set([
-  'auth',
-  'authentication',
-  'authorization',
-  'authorizations',
-  'bearer',
-  'cookie',
-  'cookies',
-  'credential',
-  'credentials',
-  'password',
-  'passwords',
-  'passphrase',
-  'passphrases',
-  'passwd',
-  'pat',
-  'pats',
-  'secret',
-  'secrets',
-  'token',
-  'tokens'
-])
-const TOKEN_METRIC_WORDS = new Set([
-  'budget',
-  'cached',
-  'count',
-  'counts',
-  'input',
-  'limit',
-  'max',
-  'output',
-  'reasoning',
-  'remaining',
-  'total',
-  'usage'
 ])
 
 // Mutable budget shared across one errorLogFields call: `nodes` bounds how many values are emitted,
@@ -156,107 +125,21 @@ const truncate = (value: string): string =>
     ? value
     : `${value.slice(0, MAX_STRING_LENGTH)}…[+${value.length - MAX_STRING_LENGTH} chars]`
 
-const logKeyWords = (key: string): string[] =>
-  key
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter(Boolean)
-
-const isTokenMetricKey = (words: string[]): boolean =>
-  words.some((word) => word === 'token' || word === 'tokens') &&
-  words.some((word) => TOKEN_METRIC_WORDS.has(word)) &&
-  words.every((word) => word === 'token' || word === 'tokens' || TOKEN_METRIC_WORDS.has(word))
-
-const isSensitiveLogKey = (key: string): boolean => {
-  const words = logKeyWords(key)
-  const normalized = words.join('')
-
-  if (isTokenMetricKey(words)) return false
-  if (words.some((word) => SENSITIVE_KEY_WORDS.has(word))) return true
-
-  return [
-    'accesstoken',
-    'apikey',
-    'apikeys',
-    'authtoken',
-    'bearertoken',
-    'clientsecret',
-    'clientsecrets',
-    'privatekey',
-    'privatekeys',
-    'refreshtoken',
-    'secretaccesskey',
-    'securitytoken',
-    'sessiontoken',
-    'xapikey'
-  ].some((suffix) => normalized.endsWith(suffix))
-}
-
 const isContentBearingLogKey = (key: string): boolean =>
-  CONTENT_BEARING_KEYS.has(logKeyWords(key).join(''))
-
-const redactUrlCredentials = (rawUrl: string): string => {
-  try {
-    const url = new URL(rawUrl)
-    let changed = false
-
-    if (url.username || url.password) {
-      url.username = REDACTED_MARKER
-      url.password = ''
-      changed = true
-    }
-    for (const key of [...url.searchParams.keys()]) {
-      if (!isSensitiveLogKey(key) && key.toLowerCase() !== 'key') continue
-      url.searchParams.set(key, REDACTED_MARKER)
-      changed = true
-    }
-    if (url.hash) {
-      url.hash = ''
-      changed = true
-    }
-
-    return changed ? url.toString().replaceAll('%5Bredacted%5D', REDACTED_MARKER) : rawUrl
-  } catch {
-    return REDACTED_MARKER
-  }
-}
+  CONTENT_BEARING_KEYS.has(diagnosticKeyWords(key).join(''))
 
 const redactLogText = (value: string): string => {
   if (value.length > MAX_STRING_LENGTH) return OVERSIZED_TEXT_MARKER
-
-  return value
-    .replace(/\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi, redactUrlCredentials)
-    .replace(
-      /\b(authorization|proxy-authorization|x-api-key|api-key|x-auth-token|x-amz-security-token|cookie|set-cookie)\b(\s*["']?\s*:\s*["']?)[^"'\r\n}]*/gi,
-      `$1$2${REDACTED_MARKER}`
-    )
-    .replace(
-      /\b(api[_-]?key|access[_-]?token|auth[_-]?token|authorization|bearer[_-]?token|client[_-]?secret|cookie|credential|password|passphrase|passwd|private[_-]?key|refresh[_-]?token|secret|secret[_-]?access[_-]?key|security[_-]?token|session[_-]?token|token)\b(\s*["']?\s*[:=]\s*["']?)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;}]+/gi,
-      `$1$2${REDACTED_MARKER}`
-    )
-    .replace(
-      /\b([a-z][a-z0-9_-]*)(\s*=\s*)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;}]+/gi,
-      (match, key: string, separator: string) =>
-        isSensitiveLogKey(key) ? `${key}${separator}${REDACTED_MARKER}` : match
-    )
-    .replace(
-      /(--?(?:access[-_]?token|api[-_]?key|auth[-_]?token|authorization|bearer[-_]?token|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|secret|token))(\s+|=)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^\s"'&;]+/gi,
-      `$1$2${REDACTED_MARKER}`
-    )
-    .replace(/\bBearer\s+[^\s"']+/gi, `Bearer ${REDACTED_MARKER}`)
-    .replace(/\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g, REDACTED_MARKER)
-    .replace(
-      /\b(?:AKIA[0-9A-Z]{16}|gh[pousr]_[A-Za-z0-9_]{8,}|github_pat_[A-Za-z0-9_]{8,}|sk-[A-Za-z0-9_-]{8,})\b/g,
-      REDACTED_MARKER
-    )
+  return redactSensitiveText(value)
 }
 
 const stringifyLogRecord = (record: Record<string, unknown>): string =>
   // JSON's replacer recursively covers every serializable descendant and prunes sensitive subtrees
   // before they can reach the file or the console mirror.
   JSON.stringify(record, (key, value: unknown) => {
-    if (key && (isSensitiveLogKey(key) || isContentBearingLogKey(key))) return REDACTED_MARKER
+    if (key && (isSensitiveDiagnosticKey(key) || isContentBearingLogKey(key))) {
+      return REDACTED_MARKER
+    }
     const serializable = toSerializable(value)
     return typeof serializable === 'string' ? redactLogText(serializable) : serializable
   })

--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -299,6 +299,16 @@ describe('DatabaseStartupGate', () => {
     expect(decodeURIComponent(url)).toContain('Startup blocked: database_newer_than_app')
     expect(decodeURIComponent(url)).toContain('Error: reviewed and edited')
 
+    fireEvent.change(details, { target: { value: '' } })
+    expect(issueLink.getAttribute('aria-disabled')).toBe('true')
+    expect(issueLink.getAttribute('href')).toBeNull()
+
+    await act(async () => screen.getByRole('checkbox').click())
+    const clearedUrl = issueLink.getAttribute('href') ?? ''
+    expect(issueLink.getAttribute('aria-disabled')).toBe('false')
+    expect(decodeURIComponent(clearedUrl)).not.toContain('Error: boom')
+    expect(decodeURIComponent(clearedUrl)).not.toContain('## Error stack')
+
     fireEvent.change(details, { target: { value: 'Error: edited again' } })
     expect(issueLink.getAttribute('aria-disabled')).toBe('true')
     expect(issueLink.getAttribute('href')).toBeNull()

--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18next } from '@/i18n'
@@ -253,7 +253,7 @@ describe('DatabaseStartupGate', () => {
     expect(retry).toHaveBeenCalledOnce()
   })
 
-  it('renders per-error guidance and opens a pre-filled GitHub issue draft', async () => {
+  it('renders per-error guidance and requires review before exposing the GitHub issue URL', async () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null)
     render(
       <DatabaseStartupGate>
@@ -281,11 +281,26 @@ describe('DatabaseStartupGate', () => {
 
     await act(async () => screen.getByRole('button', { name: /Create an issue for help/ }).click())
 
-    expect(open).toHaveBeenCalledOnce()
-    const [url, target] = open.mock.calls[0] as unknown as [string, string]
+    expect(open).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    const details = screen.getByLabelText('Error details') as HTMLTextAreaElement
+    expect(details.value).toContain('Error: boom')
+    const issueLink = document.body.querySelector<HTMLAnchorElement>('a[aria-disabled]')!
+    expect(issueLink.textContent).toContain('Open GitHub issue')
+    expect(issueLink.getAttribute('aria-disabled')).toBe('true')
+    expect(issueLink.getAttribute('href')).toBeNull()
+
+    fireEvent.change(details, { target: { value: 'Error: reviewed and edited' } })
+    await act(async () => screen.getByRole('checkbox').click())
+
+    expect(issueLink.getAttribute('aria-disabled')).toBe('false')
+    const url = issueLink.getAttribute('href') ?? ''
     expect(url).toContain('https://github.com/aipoch/open-science/issues/new?title=')
     expect(decodeURIComponent(url)).toContain('Startup blocked: database_newer_than_app')
-    expect(decodeURIComponent(url)).toContain('Error: boom')
-    expect(target).toBe('_blank')
+    expect(decodeURIComponent(url)).toContain('Error: reviewed and edited')
+
+    fireEvent.change(details, { target: { value: 'Error: edited again' } })
+    expect(issueLink.getAttribute('aria-disabled')).toBe('true')
+    expect(issueLink.getAttribute('href')).toBeNull()
   })
 })

--- a/src/renderer/src/components/database-startup-gate.tsx
+++ b/src/renderer/src/components/database-startup-gate.tsx
@@ -13,7 +13,7 @@ import {
 
 import { ErrorNotice, type ErrorNoticeTone } from '@/components/error-notice'
 import { OpenScienceLogoLoader } from '@/components/OpenScienceLogoLoader'
-import { openStartupIssueDraft } from '@/lib/startup-issue'
+import { StartupIssueDialog } from '@/components/startup-issue-dialog'
 import type {
   DatabaseStartupErrorCode,
   DatabaseStartupState
@@ -99,6 +99,7 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
     databaseStartup ? { phase: 'checking' } : { phase: 'ready' }
   )
   const [retrying, setRetrying] = useState(false)
+  const [issueDraftOpen, setIssueDraftOpen] = useState(false)
 
   useEffect(() => {
     if (!databaseStartup) return
@@ -138,7 +139,7 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
 
   const openIssueDraft = (): void => {
     if (state.phase !== 'blocked') return
-    openStartupIssueDraft(state.error)
+    setIssueDraftOpen(true)
   }
 
   if (state.phase !== 'blocked') {
@@ -196,9 +197,7 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
         }
         issueLink={{
           label: t('Still stuck? Create an issue for help'),
-          tooltip: t(
-            'Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.'
-          ),
+          tooltip: t('Review and edit the redacted report in Open Science before opening GitHub.'),
           onClick: openIssueDraft
         }}
         secondaryButton={{
@@ -215,6 +214,9 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
             : undefined
         }
       />
+      {issueDraftOpen ? (
+        <StartupIssueDialog error={error} onClose={() => setIssueDraftOpen(false)} />
+      ) : null}
     </main>
   )
 }

--- a/src/renderer/src/components/startup-issue-dialog.tsx
+++ b/src/renderer/src/components/startup-issue-dialog.tsx
@@ -26,10 +26,7 @@ type StartupIssueDialogProps = {
 const StartupIssueDialog = ({ error, onClose }: StartupIssueDialogProps): React.JSX.Element => {
   const { t } = useTranslation()
   const [diagnostics, setDiagnostics] = useState(error.diagnostics ?? '')
-  const issueUrl = useMemo(
-    () => buildStartupIssueUrl(error, diagnostics.trim() ? diagnostics : undefined),
-    [diagnostics, error]
-  )
+  const issueUrl = useMemo(() => buildStartupIssueUrl(error, diagnostics), [diagnostics, error])
   const issuePreview = useMemo(() => {
     const body = new URL(issueUrl).searchParams.get('body') ?? ''
     return `${buildStartupIssueTitle(error)}\n\n${body}`

--- a/src/renderer/src/components/startup-issue-dialog.tsx
+++ b/src/renderer/src/components/startup-issue-dialog.tsx
@@ -1,0 +1,144 @@
+import { Dialog } from 'radix-ui'
+import { ExternalLink, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import {
+  dialogBodyClassName,
+  dialogCloseButtonClassName,
+  dialogDescriptionClassName,
+  dialogFooterClassName,
+  dialogHeaderClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName,
+  dialogTitleClassName
+} from '@/components/ui/dialog-chrome'
+import { buildStartupIssueTitle, buildStartupIssueUrl } from '@/lib/startup-issue'
+import { cn } from '@/lib/utils'
+import type { DatabaseStartupError } from '../../../shared/database-startup'
+
+type StartupIssueDialogProps = {
+  error: DatabaseStartupError
+  onClose: () => void
+}
+
+const StartupIssueDialog = ({ error, onClose }: StartupIssueDialogProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const [diagnostics, setDiagnostics] = useState(error.diagnostics ?? '')
+  const issueUrl = useMemo(
+    () => buildStartupIssueUrl(error, diagnostics.trim() ? diagnostics : undefined),
+    [diagnostics, error]
+  )
+  const issuePreview = useMemo(() => {
+    const body = new URL(issueUrl).searchParams.get('body') ?? ''
+    return `${buildStartupIssueTitle(error)}\n\n${body}`
+  }, [error, issueUrl])
+  const [consentedUrl, setConsentedUrl] = useState<string | null>(null)
+  const consented = consentedUrl === issueUrl
+
+  return (
+    <Dialog.Root open onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={dialogOverlayClassName} />
+        <Dialog.Content
+          onInteractOutside={(event) => event.preventDefault()}
+          className={dialogPanelClassName(
+            'flex max-h-[min(680px,calc(100vh-2rem))] w-[min(620px,calc(100vw-2rem))] flex-col p-0'
+          )}
+        >
+          <div className={dialogHeaderClassName}>
+            <div className="min-w-0">
+              <Dialog.Title className={dialogTitleClassName}>{t('Report this error')}</Dialog.Title>
+              <Dialog.Description className={dialogDescriptionClassName}>
+                {t(
+                  'This report is posted publicly on GitHub. Edit the error text below to remove anything sensitive before sharing. Your runtime log stays on this device and is never attached automatically.'
+                )}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className={dialogCloseButtonClassName}
+                aria-label={t('Close')}
+              >
+                <X className="size-4" aria-hidden="true" />
+              </Button>
+            </Dialog.Close>
+          </div>
+
+          <div className={cn(dialogBodyClassName, 'min-h-0 flex-1 overflow-auto')}>
+            <label className="text-[11px] font-medium uppercase tracking-wide text-text-300">
+              {t('Error details')}
+            </label>
+            <textarea
+              className="mt-1 min-h-32 w-full resize-y rounded-lg border border-input bg-bg-100 px-3 py-2.5 font-mono text-[12px] leading-5 text-text-100 focus:outline-none focus:ring-1 focus:ring-primary/50"
+              aria-label={t('Error details')}
+              value={diagnostics}
+              onChange={(event) => setDiagnostics(event.target.value)}
+            />
+
+            <p className="mt-3 text-[11px] font-medium uppercase tracking-wide text-text-300">
+              {t('GitHub issue prefill')}
+            </p>
+            <pre
+              className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap rounded-lg border border-border-200 bg-bg-100 px-3 py-2 font-mono text-[11px] leading-5 text-text-200"
+              aria-label={t('GitHub issue prefill')}
+            >
+              {issuePreview}
+            </pre>
+
+            <label className="mt-4 flex items-start gap-2 text-[13px] leading-5 text-text-100">
+              <input
+                type="checkbox"
+                className="mt-0.5 size-4 shrink-0 accent-primary"
+                checked={consented}
+                onChange={(event) => setConsentedUrl(event.target.checked ? issueUrl : null)}
+              />
+              <span>
+                <Trans
+                  i18nKey="I've reviewed the details above and agree to share them in a public GitHub issue, subject to GitHub's <privacyLink>Privacy Statement</privacyLink>."
+                  components={{
+                    privacyLink: (
+                      <a
+                        href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="underline hover:text-text-000"
+                        onClick={(event) => event.stopPropagation()}
+                      />
+                    )
+                  }}
+                />
+              </span>
+            </label>
+          </div>
+
+          <div className={dialogFooterClassName}>
+            <a
+              href={consented ? issueUrl : undefined}
+              target="_blank"
+              rel="noreferrer"
+              aria-disabled={!consented}
+              tabIndex={consented ? undefined : -1}
+              onClick={(event) => {
+                if (!consented) event.preventDefault()
+                else onClose()
+              }}
+              className={`inline-flex h-8 items-center gap-1.5 rounded-lg border border-transparent bg-primary px-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/80 ${
+                consented ? '' : 'pointer-events-none opacity-50'
+              }`}
+            >
+              <ExternalLink className="size-4" aria-hidden="true" />
+              {t('Open GitHub issue')}
+            </a>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+export { StartupIssueDialog }

--- a/src/renderer/src/i18n/resources.test.ts
+++ b/src/renderer/src/i18n/resources.test.ts
@@ -2044,8 +2044,8 @@ describe('Russian catalog quality', () => {
     ['How to fix', 'Как исправить'],
     ['Still stuck? Create an issue for help', 'Проблема не решена? Создать обращение'],
     [
-      'Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.',
-      'На GitHub откроется заранее заполненное обращение с кодом ошибки, версией приложения и стеком вызовов. Личные пути в файловой системе будут скрыты (домашняя папка заменена на ~). Проверьте содержимое перед отправкой. При желании раздел со стеком вызовов можно удалить.'
+      'Review and edit the redacted report in Open Science before opening GitHub.',
+      'Просмотрите и отредактируйте обезличенный отчёт в Open Science перед открытием GitHub.'
     ],
     ['Skill import menu — 8 states', 'Меню импорта навыков — 8 состояний'],
     ['Import', 'Импортировать'],

--- a/src/renderer/src/lib/startup-issue.test.ts
+++ b/src/renderer/src/lib/startup-issue.test.ts
@@ -1,14 +1,13 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type { DatabaseStartupError } from '../../../shared/database-startup'
 import {
   ISSUE_BASE_URL,
   buildStartupIssueBody,
   buildStartupIssueTitle,
-  buildStartupIssueUrl,
-  openStartupIssueDraft
+  buildStartupIssueUrl
 } from './startup-issue'
 
 const baseError: DatabaseStartupError = {
@@ -110,19 +109,11 @@ describe('buildStartupIssueUrl', () => {
     expect(decodeURIComponent(url)).toContain('at f (/f.js:1:1)')
     expect(decodeURIComponent(url)).not.toContain('stack truncated')
   })
-})
 
-describe('openStartupIssueDraft', () => {
-  it('opens the pre-filled issue URL in a new window', () => {
-    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+  it('uses edited diagnostics in the bounded public draft', () => {
+    const url = buildStartupIssueUrl(baseError, 'Error: edited by the user')
 
-    openStartupIssueDraft({ ...baseError, diagnostics: 'Error: boom' })
-
-    expect(open).toHaveBeenCalledOnce()
-    const [url, target, features] = open.mock.calls[0] as unknown as [string, string, string]
-    expect(url).toContain(`${ISSUE_BASE_URL}?title=`)
-    expect(decodeURIComponent(url)).toContain('Error: boom')
-    expect(target).toBe('_blank')
-    expect(features).toBe('noreferrer')
+    expect(decodeURIComponent(url)).toContain('Error: edited by the user')
+    expect(decodeURIComponent(url)).not.toContain('Error: boom')
   })
 })

--- a/src/renderer/src/lib/startup-issue.test.ts
+++ b/src/renderer/src/lib/startup-issue.test.ts
@@ -116,4 +116,12 @@ describe('buildStartupIssueUrl', () => {
     expect(decodeURIComponent(url)).toContain('Error: edited by the user')
     expect(decodeURIComponent(url)).not.toContain('Error: boom')
   })
+
+  it('truncates long emoji diagnostics without splitting a surrogate pair', () => {
+    const url = buildStartupIssueUrl(baseError, `Error: boom\n${'🚀'.repeat(5000)}`)
+
+    expect(url.length).toBeLessThanOrEqual(7800)
+    expect(decodeURIComponent(url)).toContain('stack truncated')
+    expect(() => new URL(url)).not.toThrow()
+  })
 })

--- a/src/renderer/src/lib/startup-issue.ts
+++ b/src/renderer/src/lib/startup-issue.ts
@@ -50,8 +50,8 @@ const buildStartupIssueBody = (
 const toIssueUrl = (error: DatabaseStartupError, diagnostics: string | undefined): string =>
   `${ISSUE_BASE_URL}?title=${encodeURIComponent(buildStartupIssueTitle(error))}&body=${encodeURIComponent(buildStartupIssueBody(error, diagnostics))}`
 
-const withTruncationNote = (diagnostics: string, end: number): string =>
-  `${diagnostics.slice(0, end).trimEnd()}\n${STACK_TRUNCATION_NOTE}`
+const withTruncationNote = (diagnostics: readonly string[], end: number): string =>
+  `${diagnostics.slice(0, end).join('').trimEnd()}\n${STACK_TRUNCATION_NOTE}`
 
 const fitDiagnosticsToUrl = (
   error: DatabaseStartupError,
@@ -59,19 +59,21 @@ const fitDiagnosticsToUrl = (
 ): string | undefined => {
   if (!diagnostics) return undefined
   if (toIssueUrl(error, diagnostics).length <= MAX_URL_LENGTH) return diagnostics
+  const codePoints = [...diagnostics]
   // Binary search the longest prefix whose encoded URL still fits. Encoded length is not linear in
-  // the raw length (multibyte characters expand), so measure the real URL at each step.
+  // the raw length (multibyte characters expand), so measure the real URL at each step. Search code
+  // points rather than UTF-16 indexes so an edited emoji can never be sliced into a lone surrogate.
   let low = 0
-  let high = diagnostics.length
+  let high = codePoints.length
   while (low < high) {
     const mid = Math.ceil((low + high) / 2)
-    if (toIssueUrl(error, withTruncationNote(diagnostics, mid)).length <= MAX_URL_LENGTH) {
+    if (toIssueUrl(error, withTruncationNote(codePoints, mid)).length <= MAX_URL_LENGTH) {
       low = mid
     } else {
       high = mid - 1
     }
   }
-  return low > 0 ? withTruncationNote(diagnostics, low) : undefined
+  return low > 0 ? withTruncationNote(codePoints, low) : undefined
 }
 
 const buildStartupIssueUrl = (

--- a/src/renderer/src/lib/startup-issue.ts
+++ b/src/renderer/src/lib/startup-issue.ts
@@ -39,8 +39,8 @@ const buildStartupIssueBody = (
   if (diagnostics) {
     sections.push(
       '## Error stack\n\n' +
-        '_Automatically attached and lightly redacted (personal paths are replaced with ~). ' +
-        'Review before submitting — feel free to delete this section if you have any concerns._\n\n' +
+        '_Automatically attached and redacted for credentials and local paths. ' +
+        'Review before submitting — feel free to edit or delete this section._\n\n' +
         `\`\`\`text\n${diagnostics}\n\`\`\``
     )
   }
@@ -53,8 +53,10 @@ const toIssueUrl = (error: DatabaseStartupError, diagnostics: string | undefined
 const withTruncationNote = (diagnostics: string, end: number): string =>
   `${diagnostics.slice(0, end).trimEnd()}\n${STACK_TRUNCATION_NOTE}`
 
-const fitDiagnosticsToUrl = (error: DatabaseStartupError): string | undefined => {
-  const diagnostics = error.diagnostics
+const fitDiagnosticsToUrl = (
+  error: DatabaseStartupError,
+  diagnostics: string | undefined
+): string | undefined => {
   if (!diagnostics) return undefined
   if (toIssueUrl(error, diagnostics).length <= MAX_URL_LENGTH) return diagnostics
   // Binary search the longest prefix whose encoded URL still fits. Encoded length is not linear in
@@ -72,19 +74,9 @@ const fitDiagnosticsToUrl = (error: DatabaseStartupError): string | undefined =>
   return low > 0 ? withTruncationNote(diagnostics, low) : undefined
 }
 
-const buildStartupIssueUrl = (error: DatabaseStartupError): string =>
-  toIssueUrl(error, fitDiagnosticsToUrl(error))
+const buildStartupIssueUrl = (
+  error: DatabaseStartupError,
+  diagnostics: string | undefined = error.diagnostics
+): string => toIssueUrl(error, fitDiagnosticsToUrl(error, diagnostics))
 
-// Opening the draft is a stateless side effect, so it stays a plain function rather than a hook —
-// there is no React state or lifecycle for a hook to manage.
-const openStartupIssueDraft = (error: DatabaseStartupError): void => {
-  window.open(buildStartupIssueUrl(error), '_blank', 'noreferrer')
-}
-
-export {
-  ISSUE_BASE_URL,
-  buildStartupIssueBody,
-  buildStartupIssueTitle,
-  buildStartupIssueUrl,
-  openStartupIssueDraft
-}
+export { ISSUE_BASE_URL, buildStartupIssueBody, buildStartupIssueTitle, buildStartupIssueUrl }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -641,7 +641,7 @@
     "Notes": "Notas",
     "Open Science could not open its database.": "Open Science no pudo abrir su base de datos.",
     "Open Science could not update its database. Existing data was not reset.": "Open Science no pudo actualizar su base de datos. Los datos existentes no se restablecieron.",
-    "Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.": "Abre GitHub con una incidencia prellenada: el código de error, la versión de la aplicación y la pila de errores. Las rutas personales se ocultan (su carpeta de inicio se convierte en ~). Revise los datos antes de enviarlos; puede eliminar la sección de la pila si lo prefiere.",
+    "Review and edit the redacted report in Open Science before opening GitHub.": "Revise y edite el informe anonimizado en Open Science antes de abrir GitHub.",
     "Part of the stored data doesn't match the structure this version requires — usually left behind by an interrupted update.": "Parte de los datos almacenados no coincide con la estructura que exige esta versión; suele ser un resto de una actualización interrumpida.",
     "Petri dish": "Placa de Petri",
     "Quill": "Pluma",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -641,7 +641,7 @@
     "Notes": "Remarques",
     "Open Science could not open its database.": "Open Science n'a pas pu ouvrir sa base de données.",
     "Open Science could not update its database. Existing data was not reset.": "Open Science n'a pas pu mettre à jour sa base de données. Les données existantes n'ont pas été réinitialisées.",
-    "Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.": "Ouvre GitHub avec un ticket pré-rempli : code d'erreur, version de l'application et pile d'erreurs. Les chemins personnels sont masqués (votre dossier personnel devient ~). Vérifiez le contenu avant de l'envoyer — vous pouvez supprimer la section de la pile si vous préférez.",
+    "Review and edit the redacted report in Open Science before opening GitHub.": "Examinez et modifiez le rapport expurgé dans Open Science avant d’ouvrir GitHub.",
     "Part of the stored data doesn't match the structure this version requires — usually left behind by an interrupted update.": "Une partie des données enregistrées ne correspond pas à la structure requise par cette version — il s'agit généralement d'un reliquat d'une mise à jour interrompue.",
     "Petri dish": "Boîte de Pétri",
     "Quill": "Plume",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1427,7 +1427,7 @@
     "Open Science could not finish checking its database.": "Open Science はデータベースの確認を完了できませんでした。",
     "Open Science could not open its database.": "Open Science はデータベースを開けませんでした。",
     "Open Science could not update its database. Existing data was not reset.": "Open Science はデータベースを更新できませんでした。既存のデータはリセットされていません。",
-    "Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.": "GitHub で事前入力済みの Issue が開きます。エラーコード、アプリのバージョン、エラースタックが含まれます。個人のパスは秘匿されています (ホームフォルダーは ~ と表示されます)。送信前に内容を確認してください。必要に応じてスタックセクションを削除できます。",
+    "Review and edit the redacted report in Open Science before opening GitHub.": "GitHub を開く前に、Open Science で秘匿処理済みのレポートを確認して編集します。",
     "Open Science couldn't start": "Open Science を開始できませんでした",
     "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically.": "Open Science はバックグラウンドタスクを停止しているため、インストールを完了するために終了します。更新には少し時間がかかる場合があります。このステップ中にアプリを再度開かないでください。更新されたアプリは自動的に再度開きます。",
     "Open Science needs write access to its private configuration directory.": "Open Science には、プライベート構成ディレクトリへの書き込みアクセスが必要です。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -621,7 +621,7 @@
     "Notes": "메모",
     "Open Science could not open its database.": "Open Science가 데이터베이스를 열지 못했습니다.",
     "Open Science could not update its database. Existing data was not reset.": "Open Science가 데이터베이스를 업데이트하지 못했습니다. 기존 데이터는 초기화되지 않았습니다.",
-    "Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.": "오류 코드, 앱 버전, 오류 스택이 미리 채워진 이슈로 GitHub를 엽니다. 개인 경로는 가려집니다(홈 폴더는 ~로 표시). 제출 전에 내용을 확인하세요. 원하면 스택 섹션은 삭제할 수 있습니다.",
+    "Review and edit the redacted report in Open Science before opening GitHub.": "GitHub를 열기 전에 Open Science에서 민감 정보가 가려진 보고서를 검토하고 편집하세요.",
     "Part of the stored data doesn't match the structure this version requires — usually left behind by an interrupted update.": "저장된 데이터 일부가 이 버전에서 요구하는 구조와 일치하지 않습니다. 보통 중단된 업데이트가 남긴 것입니다.",
     "Petri dish": "페트리 접시",
     "Quill": "퀼",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1465,7 +1465,7 @@
     "Only this computer can open the workspace.": "Рабочее пространство можно открыть только на этом компьютере.",
     "Open": "Открыть",
     "Open GitHub issue": "Создать обращение на GitHub",
-    "Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.": "На GitHub откроется заранее заполненное обращение с кодом ошибки, версией приложения и стеком вызовов. Личные пути в файловой системе будут скрыты (домашняя папка заменена на ~). Проверьте содержимое перед отправкой. При желании раздел со стеком вызовов можно удалить.",
+    "Review and edit the redacted report in Open Science before opening GitHub.": "Просмотрите и отредактируйте обезличенный отчёт в Open Science перед открытием GitHub.",
     "Open Open Science from the signed-in mobile app with two-step verification.": "Откройте Open Science из мобильного приложения, в котором выполнен вход, и пройдите двухэтапную проверку.",
     "Open Provenance for {{title}}": "Открыть сведения о происхождении для {{title}}",
     "Open Science confirms its core requirements before your first research session.": "Перед первой исследовательской сессией Open Science проверяет выполнение основных требований.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1498,7 +1498,7 @@
     "Open Science could not finish checking its database.": "Open Science 无法完成数据库检查。",
     "Open Science could not open its database.": "Open Science 无法打开数据库。",
     "Open Science could not update its database. Existing data was not reset.": "Open Science 无法更新数据库。现有数据未被重置。",
-    "Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.": "将打开 GitHub 并预填一条 Issue：包含错误代码、应用版本和错误堆栈。个人路径已脱敏（你的主目录会显示为 ~）。提交前请检查内容，如有顾虑可以删除堆栈部分。",
+    "Review and edit the redacted report in Open Science before opening GitHub.": "在打开 GitHub 前，先在 Open Science 中查看并编辑已脱敏的报告。",
     "Open Science couldn't start": "Open Science 无法启动",
     "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically.": "Open Science 正在停止后台任务，并将关闭以完成安装。更新可能需要一些时间，请勿在此期间重新打开应用。更新完成后应用会自动重新打开。",
     "Open Science needs write access to its private configuration directory.": "Open Science 需要对其私有配置目录的写入权限。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1496,7 +1496,7 @@
     "Open Science could not finish checking its database.": "Open Science 無法完成資料庫檢查。",
     "Open Science could not open its database.": "Open Science 無法開啟資料庫。",
     "Open Science could not update its database. Existing data was not reset.": "Open Science 無法更新資料庫。現有資料未被重置。",
-    "Opens GitHub with a pre-filled issue: the error code, app version, and error stack. Personal paths are redacted (your home folder becomes ~). Please review before submitting — you can delete the stack section if you prefer.": "將開啟 GitHub 並預填一則 Issue：包含錯誤代碼、應用程式版本與錯誤堆疊。個人路徑已脫敏（你的主目錄會顯示為 ~）。提交前請檢查內容，如有顧慮可以刪除堆疊段落。",
+    "Review and edit the redacted report in Open Science before opening GitHub.": "在開啟 GitHub 前，先在 Open Science 中檢視並編輯已脫敏的報告。",
     "Open Science couldn't start": "Open Science 無法啟動",
     "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically.": "Open Science 正在停止背景工作，並將關閉以完成安裝。更新可能需要一些時間，請勿在此期間重新開啟應用程式。更新完成後應用程式會自動重新開啟。",
     "Open Science needs write access to its private configuration directory.": "Open Science 需要對其私有設定目錄的寫入權限。",


### PR DESCRIPTION
## Problem

Database startup diagnostics only replaced the current home directory before the renderer embedded the diagnostics in a GitHub issues/new URL. Paths outside the home directory and credential-shaped error text could therefore reach GitHub as soon as the help action opened the external URL.

## Proposed change

- Share the tested diagnostic credential redaction policy between logger sinks and startup reports.
- Replace configured config/data/home roots and redact remaining POSIX, Windows drive-letter, file URL, and UNC absolute paths before diagnostics cross IPC.
- Replace the direct external open with an editable startup report dialog. The dialog shows the exact bounded GitHub prefill and enables the link only after consent for the current URL; editing revokes consent.
- Update all seven renderer locales and the startup-report owner notes.

## Scope and non-goals

- No database schema, persisted format, renderer API, IPC channel, data relationship, or startup-state enum changes.
- No historical-data compatibility or migration work is required.
- No automatic log upload, issue submission, configurable redaction rules, or persisted redaction preferences.

## Acceptance criteria and validation

All listed checks ran against the final material implementation:

- Credential and cross-platform path cleaning -> npm test -- src/main/logger.test.ts src/main/database/startup-diagnostics.test.ts -> passed.
- Bounded draft generation, editable preview, exact-payload consent, and locale coverage -> npm test -- src/renderer/src/lib/startup-issue.test.ts src/renderer/src/components/database-startup-gate.test.tsx src/renderer/src/i18n/resources.test.ts -> passed.
- Combined targeted suite -> 5 files, 844 tests passed.
- Main-process types -> npm run typecheck:node -> passed.
- Renderer types -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed.

The full npm test suite was intentionally not run locally. Exact-head PR CI remains authoritative for the complete portable and platform lanes.

## Review focus

- Public-boundary completeness of the credential and absolute-path patterns.
- Diagnostic usefulness of the stable root/path markers.
- Consent invalidation when the editable diagnostics change.

Uncovered local risk: representative Windows and UNC strings are unit tested on macOS, while packaged cross-platform behavior is left to PR CI.