### PR TITLE
fix(uploads): validate session finalization requests

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -141,12 +141,10 @@ const launchEnvironment = (
   }
 
   environment.OPEN_SCIENCE_STORAGE_ROOT = storageRoot
+  environment.OPEN_SCIENCE_E2E_STORAGE_ROOT = storageRoot
   environment.OPEN_SCIENCE_E2E_HANDOFF_CAPTURE_ROOT = join(storageRoot, 'e2e-handoff-captures')
   environment.OPEN_SCIENCE_E2E_WINDOW_MODE = windowMode
   if (sessionPerformanceTrace) environment.OPEN_SCIENCE_PERF_SESSION_TRACE = '1'
-  if (environment.OPEN_SCIENCE_E2E_EXECUTABLE) {
-    environment.OPEN_SCIENCE_E2E_STORAGE_ROOT = storageRoot
-  }
   if (fakeRemoteItRoot) {
     environment.OPEN_SCIENCE_FAKE_REMOTEIT_STATE = join(storageRoot, 'fake-remoteit-state.json')
     environment.OPEN_SCIENCE_REMOTEIT_BIN = process.execPath

--- a/e2e/launch-environment.spec.ts
+++ b/e2e/launch-environment.spec.ts
@@ -11,9 +11,16 @@ test('normalizes a Windows-style Path before injecting the fake Agent directory'
   expect(environment.PATH).toBe(`fake-agent-bin${delimiter}system-bin`)
   expect(environment.Path).toBeUndefined()
   expect(environment.ELECTRON_RENDERER_URL).toBeUndefined()
-  expect(environment.OPEN_SCIENCE_E2E_STORAGE_ROOT).toBeUndefined()
   expect(environment.OPEN_SCIENCE_STORAGE_ROOT).toBe('storage-root')
   expect(environment.OPEN_SCIENCE_E2E_WINDOW_MODE).toBe('hidden')
+})
+
+test('isolates source E2E data storage without changing the process home', () => {
+  const environment = launchEnvironment('storage-root', undefined, { HOME: 'host-home' })
+
+  expect(environment.OPEN_SCIENCE_E2E_STORAGE_ROOT).toBe('storage-root')
+  expect(environment.OPEN_SCIENCE_STORAGE_ROOT).toBe('storage-root')
+  expect(environment.HOME).toBe('host-home')
 })
 
 test('isolates packaged certification storage without changing the process home', () => {

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -212,7 +212,8 @@ describe('application command composition', () => {
       'tags:reorder',
       'tags:set-assignment',
       'tags:snapshot',
-      'tags:update'
+      'tags:update',
+      'uploads:finalize-session'
     ])
   })
 

--- a/src/main/application-command-electron-adapter.test.ts
+++ b/src/main/application-command-electron-adapter.test.ts
@@ -40,7 +40,8 @@ const validatedChannels = [
   'tags:reorder',
   'tags:set-assignment',
   'tags:snapshot',
-  'tags:update'
+  'tags:update',
+  'uploads:finalize-session'
 ] as const
 
 const eventWithLease = (): IpcMainInvokeEvent => {

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -172,7 +172,7 @@ const createDependencies = () => {
     finishTransfer: vi.fn(),
     abortTransfer: vi.fn(),
     deleteUpload: vi.fn(),
-    finalizeSession: vi.fn(),
+    finalizeSession: vi.fn(async () => []),
     readPreview: vi.fn()
   }
   const electron = {
@@ -485,7 +485,7 @@ describe('Data and content application commands', () => {
       },
       {
         key: 'uploadFinalizeSession',
-        args: [request('upload-finalize')],
+        args: [{ projectId: 'project-1', sessionId: 'session-1', attachments: [] }],
         owner: deps.uploads.finalizeSession,
         passInvocation: true
       },
@@ -531,6 +531,107 @@ describe('Data and content application commands', () => {
         .sort()
     )
   })
+
+  it.each([
+    {
+      label: 'malformed attachment',
+      request: {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        attachments: [
+          {
+            id: 'upload-1',
+            sessionId: '.pending',
+            name: 'report.txt',
+            path: 'upload-version:version-1',
+            size: 10
+          }
+        ]
+      }
+    },
+    {
+      label: 'more than ten attachments',
+      request: {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        attachments: Array.from({ length: 11 }, (_, index) => ({
+          id: `upload-${index}`,
+          sessionId: '.pending',
+          name: `report-${index}.txt`,
+          originalName: `report-${index}.txt`,
+          path: `upload-version:version-${index}`,
+          size: 10
+        }))
+      }
+    },
+    {
+      label: 'duplicate attachment ids',
+      request: {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        attachments: [
+          {
+            id: 'upload-1',
+            sessionId: '.pending',
+            name: 'report-1.txt',
+            originalName: 'report-1.txt',
+            path: 'upload-version:version-1',
+            size: 10
+          },
+          {
+            id: 'upload-1',
+            sessionId: '.pending',
+            name: 'report-2.txt',
+            originalName: 'report-2.txt',
+            path: 'upload-version:version-2',
+            size: 10
+          }
+        ]
+      }
+    },
+    {
+      label: 'duplicate attachment paths',
+      request: {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        attachments: [
+          {
+            id: 'upload-1',
+            sessionId: '.pending',
+            name: 'report-1.txt',
+            originalName: 'report-1.txt',
+            path: 'upload-version:version-1',
+            size: 10
+          },
+          {
+            id: 'upload-2',
+            sessionId: '.pending',
+            name: 'report-2.txt',
+            originalName: 'report-2.txt',
+            path: 'upload-version:version-1',
+            size: 10
+          }
+        ]
+      }
+    }
+  ])(
+    'rejects an invalid finalize upload request ($label) before reaching the owner',
+    async ({ request }) => {
+      const router = createApplicationCommandRouter()
+      const deps = createDependencies()
+      registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+      const { result: dispatched } = dispatchCommand(
+        router,
+        'uploadFinalizeSession',
+        [request],
+        remoteCaller
+      )
+
+      await expect(dispatched).rejects.toMatchObject({ code: 'invalid-command-arguments' })
+      expect(deps.uploads.finalizeSession).not.toHaveBeenCalled()
+    }
+  )
 
   it('routes existing owner seams and passes the exact caller lease to owned resources', async () => {
     const router = createApplicationCommandRouter()

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -60,13 +60,17 @@ type InvocationArgs<Owner, Method extends keyof Owner> = Owner[Method] extends (
 
 const invocationCommandFor =
   <Owner>() =>
-  <const Name extends string, Method extends keyof Owner>(name: Name, method: Method) => {
+  <const Name extends string, Method extends keyof Owner>(
+    name: Name,
+    method: Method,
+    contract?: ApplicationCommandContract<InvocationArgs<Owner, Method>, OwnerResult<Owner, Method>>
+  ) => {
     void method
     return defineApplicationCommand<
       Name,
       InvocationArgs<Owner, Method>,
       OwnerResult<Owner, Method>
-    >(name)
+    >(name, contract)
   }
 
 type PreviewApplicationCommandOwner = Readonly<{
@@ -292,7 +296,11 @@ const dataContentApplicationCommands = Object.freeze({
   uploadBeginTransfer: uploadCommand('uploads:begin-transfer', 'beginTransfer'),
   uploadClaimLocalFile: uploadCommand('uploads:claim-local-file', 'claimLocalFile'),
   uploadDelete: uploadCommand('uploads:delete', 'deleteUpload'),
-  uploadFinalizeSession: uploadCommand('uploads:finalize-session', 'finalizeSession'),
+  uploadFinalizeSession: uploadCommand(
+    'uploads:finalize-session',
+    'finalizeSession',
+    Uploads.uploadApplicationCommandContracts.finalizeSession
+  ),
   uploadFinishTransfer: uploadCommand('uploads:finish-transfer', 'finishTransfer'),
   uploadReadPreview: uploadCommand('uploads:read-preview', 'readPreview'),
   uploadStageLocalFile: electronCommand('uploads:stage-local-file', 'stageLocalFileWithProgress'),

--- a/src/main/uploads/command-owner.test.ts
+++ b/src/main/uploads/command-owner.test.ts
@@ -8,6 +8,7 @@ import type { ApplicationInvocation } from '../application-command-router'
 import { createElectronCallerContext } from '../caller-context'
 import { ApplicationCallerLeaseRegistry } from '../caller-lifecycle'
 import type { DataContentApplicationCommandDependencies } from '../data-content-application-commands'
+import { DEFAULT_UPLOAD_PROJECT_ID } from '../../shared/uploads'
 import {
   beginMigration,
   clearMigrationPending,
@@ -447,6 +448,37 @@ describe('upload command owner', () => {
 
     expect(mutationScopes).toEqual([{ projectId: 'project-1', sessionId: 'session-1' }])
     expect(order).toEqual(['lock', 'unlock'])
+  })
+
+  it('uses the default Project session mutation when finalization omits projectId', async () => {
+    const repository = {
+      finalizePendingSessionUploads: vi.fn(async () => [])
+    } as unknown as UploadRepository
+    const mutationScopes: Array<{ projectId: string; sessionId: string }> = []
+    const withSessionMutation = async <Result>(
+      projectId: string,
+      sessionId: string,
+      mutation: () => Promise<Result>
+    ): Promise<Result> => {
+      mutationScopes.push({ projectId, sessionId })
+      return mutation()
+    }
+    const owner = createUploadCommandOwner(repository, { withSessionMutation })
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 16)
+
+    await owner.finalizeSession(
+      invocationFor(caller, [{ sessionId: 'session-1', attachments: [] }] as const)
+    )
+
+    expect(mutationScopes).toEqual([
+      { projectId: DEFAULT_UPLOAD_PROJECT_ID, sessionId: 'session-1' }
+    ])
+    expect(repository.finalizePendingSessionUploads).toHaveBeenCalledWith(
+      'session-1',
+      [],
+      DEFAULT_UPLOAD_PROJECT_ID
+    )
   })
 
   it('exposes the exact staged data-command owner interface', () => {

--- a/src/main/uploads/command-owner.ts
+++ b/src/main/uploads/command-owner.ts
@@ -382,14 +382,15 @@ const createUploadCommandOwner = (
       withDataRootWrite(() => repository.deleteUpload(request)),
     finalizeSession: ({ args: [request] }) =>
       withDataRootWrite(() => {
+        const projectId = request.projectId?.trim() || DEFAULT_UPLOAD_PROJECT_ID
         const finalize = (): Promise<UploadedAttachment[]> =>
           repository.finalizePendingSessionUploads(
             request.sessionId,
             request.attachments,
-            request.projectId
+            projectId
           )
-        return options.withSessionMutation && request.projectId
-          ? options.withSessionMutation(request.projectId, request.sessionId, finalize)
+        return options.withSessionMutation
+          ? options.withSessionMutation(projectId, request.sessionId, finalize)
           : finalize()
       }),
     readPreview: ({ args: [request] }) => repository.readManagedUploadPreview(request)

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -81,17 +81,10 @@ const createIpcEvent = (
 const registerUploadIpcHandlers = (
   repository: UploadRepository,
   options: {
-    withSessionMutation?: <Result>(
-      projectId: string,
-      sessionId: string,
-      mutation: () => Promise<Result>
-    ) => Promise<Result>
     onStandaloneUploadSaved?: (projectId: string, sessionId: string) => void
   } = {}
 ): void => {
-  const owner = createUploadCommandOwner(repository, {
-    withSessionMutation: options.withSessionMutation
-  })
+  const owner = createUploadCommandOwner(repository)
   registerUploadOwnerIpcHandlers(owner, {
     onStandaloneUploadSaved: options.onStandaloneUploadSaved
   })
@@ -224,35 +217,10 @@ describe('default upload repository', () => {
     await finish(caller.event, { transferId: 'shared-ipc-transfer' })
   })
 
-  it('finalizes Upload Versions inside the shared Session mutation boundary', async () => {
-    const repository = {
-      finalizePendingSessionUploads: vi.fn(async () => ['finalized'])
-    } as unknown as UploadRepository
-    const order: string[] = []
-    const mutationScopes: Array<{ projectId: string; sessionId: string }> = []
-    const withSessionMutation = async <Result>(
-      projectId: string,
-      sessionId: string,
-      mutation: () => Promise<Result>
-    ): Promise<Result> => {
-      mutationScopes.push({ projectId, sessionId })
-      order.push('lock')
-      const result = await mutation()
-      order.push('unlock')
-      return result
-    }
-    registerUploadIpcHandlers(repository, { withSessionMutation })
-    const finalize = ipcHandlers.get('uploads:finalize-session')!
+  it('leaves finalize Session ownership to the runtime-validated command adapter', () => {
+    registerUploadIpcHandlers({} as UploadRepository)
 
-    await expect(
-      finalize(createIpcEvent().event, {
-        projectId: 'project-1',
-        sessionId: 'session-1',
-        attachments: []
-      })
-    ).resolves.toEqual(['finalized'])
-    expect(mutationScopes).toEqual([{ projectId: 'project-1', sessionId: 'session-1' }])
-    expect(order).toEqual(['lock', 'unlock'])
+    expect(ipcHandlers.has('uploads:finalize-session')).toBe(false)
   })
 
   it('waits for begin before aborting and releases the transfer during migration', async () => {

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -10,7 +10,6 @@ import type {
   AppendUploadTransferRequest,
   BeginUploadTransferRequest,
   DeleteUploadRequest,
-  FinalizeUploadSessionRequest,
   StageLocalPathUploadRequest,
   StageLocalUploadRequest,
   UploadTransferRequest
@@ -114,9 +113,6 @@ const registerUploadIpcHandlers = (
   )
   ipcMainHandle('uploads:delete', (event, request: DeleteUploadRequest) =>
     owner.deleteUpload(invocationFor(event, [request]))
-  )
-  ipcMainHandle('uploads:finalize-session', (event, request: FinalizeUploadSessionRequest) =>
-    owner.finalizeSession(invocationFor(event, [request]))
   )
   ipcMainHandle('uploads:read-preview', (event, request: ReadArtifactPreviewRequest) =>
     owner.readPreview(invocationFor(event, [request]))

--- a/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.test.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.test.ts
@@ -1,11 +1,28 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
-import { branchWorkspaceSessionFromMessage } from './workspace-runtime-session-branch-owner'
+import {
+  MAX_COMPOSER_ATTACHMENTS,
+  uploadApplicationCommandContracts,
+  type FinalizeUploadSessionRequest,
+  type UploadedAttachment
+} from '../../../../shared/uploads'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatMessage
+} from '../../stores/session-store'
+import {
+  branchWorkspaceSessionFromMessage,
+  reconcileBranchedAttachments
+} from './workspace-runtime-session-branch-owner'
 
 describe('branchWorkspaceSessionFromMessage', () => {
   beforeEach(() => {
     useSessionStore.setState(createInitialSessionState())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('creates a fresh provider branch from replay-pending persisted history', async () => {
@@ -53,5 +70,59 @@ describe('branchWorkspaceSessionFromMessage', () => {
       undefined,
       false
     )
+  })
+
+  it('finalizes legacy branch history in bounded requests', async () => {
+    const uploads = Array.from({ length: MAX_COMPOSER_ATTACHMENTS + 1 }, (_, index) => ({
+      id: `legacy-upload-${index}`,
+      sessionId: 'source-session',
+      name: `legacy-${index}.txt`,
+      originalName: `legacy-${index}.txt`,
+      path: `/legacy/uploads/legacy-${index}.txt`,
+      mimeType: 'text/plain',
+      size: index + 1
+    }))
+    const messages: ChatMessage[] = [
+      {
+        id: 'message-1',
+        role: 'user',
+        content: 'Review the first legacy upload batch',
+        status: 'complete',
+        eventIds: [],
+        uploads: uploads.slice(0, MAX_COMPOSER_ATTACHMENTS),
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        id: 'message-2',
+        role: 'user',
+        content: 'Review one more legacy upload',
+        status: 'complete',
+        eventIds: [],
+        uploads: uploads.slice(MAX_COMPOSER_ATTACHMENTS),
+        createdAt: 2,
+        updatedAt: 2
+      }
+    ]
+    const finalizeSession = vi.fn(
+      async (request: FinalizeUploadSessionRequest): Promise<UploadedAttachment[]> => {
+        const [parsed] = uploadApplicationCommandContracts.finalizeSession.args.parse([request])
+        return parsed.attachments.map((attachment) => ({
+          ...attachment,
+          versionId: `version-${attachment.id}`,
+          versionNumber: 1,
+          path: `upload-version:project-1/source-session/version-${attachment.id}`
+        }))
+      }
+    )
+    vi.stubGlobal('window', { api: { uploads: { finalizeSession } } })
+
+    await reconcileBranchedAttachments('source-session', 'child-session', messages, 'project-1')
+
+    expect(finalizeSession).toHaveBeenCalledTimes(2)
+    expect(finalizeSession.mock.calls.map(([request]) => request.attachments.length)).toEqual([
+      MAX_COMPOSER_ATTACHMENTS,
+      1
+    ])
   })
 })

--- a/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_PERMISSION_PROFILE } from '../../../../shared/permission-profiles'
 import {
+  MAX_COMPOSER_ATTACHMENTS,
   toPersistedUploadedAttachment,
   toRuntimeUploadedAttachment,
   type UploadedAttachment
@@ -44,11 +45,16 @@ export const reconcileBranchedAttachments = async (
   }
   if (stagedById.size === 0) return
 
-  const finalized = await window.api.uploads.finalizeSession({
-    projectId,
-    sessionId: sourceSessionId,
-    attachments: [...stagedById.values()]
-  })
+  const staged = [...stagedById.values()]
+  const finalized: UploadedAttachment[] = []
+  for (let offset = 0; offset < staged.length; offset += MAX_COMPOSER_ATTACHMENTS) {
+    const batch = await window.api.uploads.finalizeSession({
+      projectId,
+      sessionId: sourceSessionId,
+      attachments: staged.slice(offset, offset + MAX_COMPOSER_ATTACHMENTS)
+    })
+    finalized.push(...batch)
+  }
   const finalizedById = new Map(finalized.map((upload) => [upload.id, upload]))
   for (const stagedId of stagedById.keys()) {
     if (!finalizedById.has(stagedId)) {

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -307,7 +307,8 @@ describe('renderer contract catalog', () => {
       'tags.reorder',
       'tags.setAssignment',
       'tags.snapshot',
-      'tags.update'
+      'tags.update',
+      'uploads.finalizeSession'
     ])
     expect(ELECTRON_APPLICATION_COMMAND_CHANNELS).toEqual([
       'memory:clear-all',
@@ -331,7 +332,8 @@ describe('renderer contract catalog', () => {
       'tags:reorder',
       'tags:set-assignment',
       'tags:snapshot',
-      'tags:update'
+      'tags:update',
+      'uploads:finalize-session'
     ])
   })
 })

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -2060,7 +2060,7 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   ]),
   'uploads.finalizeSession': callable<
     (request: FinalizeUploadSessionRequest) => Promise<UploadedAttachment[]>
-  >()('uploads', ['uploads:finalize-session']),
+  >()('uploads', ['uploads:finalize-session', WEB, undefined, undefined, RUNTIME_VALIDATED]),
   'uploads.finishTransfer': callable<
     (request: UploadTransferRequest) => Promise<UploadedAttachment>
   >()('uploads', ['uploads:finish-transfer']),

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -1,3 +1,6 @@
+import { z } from 'zod'
+
+import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
 import { DEFAULT_ARTIFACT_PROJECT_ID } from './artifacts'
 
 // Uploads share the default project bucket so they live beside the matching session data.
@@ -11,7 +14,7 @@ export const STANDALONE_UPLOAD_SESSION_ID = 'standalone-uploads'
 export const MAX_UPLOAD_FILE_BYTES = 10 * 1024 * 1024 * 1024
 // Keeps both Electron IPC and the Web JSON/base64 fallback comfortably below their body limits.
 export const MAX_UPLOAD_CHUNK_BYTES = 8 * 1024 * 1024
-// Composer total attachment cap; enforced renderer-side since main is stateless about composer state.
+// Shared composer/finalization cap, enforced in both Renderer intake and the main command contract.
 export const MAX_COMPOSER_ATTACHMENTS = 10
 
 const GENERIC_UPLOAD_MIME_TYPES = new Set(['application/octet-stream', 'binary/octet-stream'])
@@ -105,6 +108,22 @@ export type UploadedAttachment = {
   checksum?: string
   createdAt?: string
 }
+
+export const uploadedAttachmentSchema = z
+  .object({
+    id: z.string(),
+    versionId: z.string().optional(),
+    versionNumber: z.number().finite().optional(),
+    sessionId: z.string(),
+    name: z.string(),
+    originalName: z.string(),
+    path: z.string(),
+    mimeType: z.string().optional(),
+    size: z.number().finite().nonnegative(),
+    checksum: z.string().optional(),
+    createdAt: z.string().optional()
+  })
+  .strict() satisfies z.ZodType<UploadedAttachment>
 
 // Path-free projection stored on a Message. Native finalization always supplies the immutable
 // Version fields; they remain optional in the reader type only so legacy Session JSON can be
@@ -217,6 +236,33 @@ export type FinalizeUploadSessionRequest = {
   sessionId: string
   attachments: UploadedAttachment[]
 }
+
+const finalizeUploadAttachmentsSchema = z
+  .array(uploadedAttachmentSchema)
+  .max(MAX_COMPOSER_ATTACHMENTS)
+  .refine(
+    (attachments) => new Set(attachments.map(({ id }) => id)).size === attachments.length,
+    'Upload attachment ids must be unique.'
+  )
+  .refine(
+    (attachments) => new Set(attachments.map(({ path }) => path)).size === attachments.length,
+    'Upload attachment paths must be unique.'
+  )
+
+export const finalizeUploadSessionRequestSchema = z
+  .object({
+    projectId: z.string().optional(),
+    sessionId: z.string(),
+    attachments: finalizeUploadAttachmentsSchema
+  })
+  .strict() satisfies z.ZodType<FinalizeUploadSessionRequest>
+
+export const uploadApplicationCommandContracts = Object.freeze({
+  finalizeSession: defineApplicationCommandContract(
+    validationCodec(z.tuple([finalizeUploadSessionRequestSchema])),
+    validationCodec(finalizeUploadAttachmentsSchema)
+  )
+})
 
 // Chooses the user-facing name while tolerating older records that only have the safe filename.
 export const getUploadedAttachmentName = (

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -109,7 +109,7 @@ export type UploadedAttachment = {
   createdAt?: string
 }
 
-export const uploadedAttachmentSchema = z
+const uploadedAttachmentSchema = z
   .object({
     id: z.string(),
     versionId: z.string().optional(),
@@ -249,7 +249,7 @@ const finalizeUploadAttachmentsSchema = z
     'Upload attachment paths must be unique.'
   )
 
-export const finalizeUploadSessionRequestSchema = z
+const finalizeUploadSessionRequestSchema = z
   .object({
     projectId: z.string().optional(),
     sessionId: z.string(),


### PR DESCRIPTION
## Problem

`uploads:finalize-session` accepted unvalidated renderer payloads. A remote or abnormal renderer could submit malformed, oversized, or duplicate attachment batches, which the upload repository processed concurrently. Compatibility calls that omitted `projectId` also finalized into the default Project without entering that Project and Session's mutation lane.

## Proposed change

- add a strict runtime contract for finalize requests and results;
- cap finalize batches at the existing 10-attachment composer limit;
- reject duplicate attachment IDs and exact duplicate path strings before the upload owner runs;
- route Electron and Web finalization through the existing runtime-validated application command;
- leave the Electron channel exclusively owned by that application-command adapter instead of also registering it in legacy upload IPC;
- resolve the default Project once and use the same ID for the Session mutation lane and repository call;
- isolate source Electron E2E data roots so parallel workers cannot clean another test's pending uploads.

## Scope and non-goals

- no new limiter, queue, or concurrency subsystem;
- no UI or normal interaction change;
- no new data fields, enum values, database schema, persistence format, or migration;
- `projectId` remains optional for compatibility, and omitted or blank values retain the existing default-Project behavior;
- historical Session upload recovery continues through its existing internal repository path and is not migrated by this command contract;
- the E2E-only storage override reuses the existing disposable-root mechanism and does not change production storage selection.

## Acceptance criteria and validation

The request and mutation-lane regression tests were added before the fix. On the unmodified implementation, the same command failed deterministically twice with four invalid batches resolving successfully and the default mutation scope remaining empty. The IPC ownership regression also failed before its fix because the legacy adapter still registered `uploads:finalize-session`.

Windows PR CI then exposed a test-harness race twice: parallel source Electron workers shared `OpenScience-DEV`, so another worker's startup cleanup could remove `research-notes.md` from `.pending`; the failed attempt reported `ENOENT` and its isolated retry passed. The new source-E2E isolation expectation failed before the harness fix because `OPEN_SCIENCE_E2E_STORAGE_ROOT` was `undefined`, then passed after the fix.

- invalid finalize requests are rejected before owner execution -> `src/main/data-content-application-commands.test.ts` -> passed (4 cases);
- omitted `projectId` uses the default Project mutation lane and repository scope -> `src/main/uploads/command-owner.test.ts` -> passed;
- legacy upload IPC does not duplicate the runtime-validated Electron channel -> `src/main/uploads/ipc.test.ts` -> passed;
- Electron/Application Command inventories and Renderer catalog remain consistent -> composition, adapter, catalog, and wiring tests passed;
- final focused behavior set -> 8 files, 92 tests passed;
- source E2E launch isolation -> 7 tests passed;
- isolated workspace file upload and preview -> 2 E2E tests passed;
- `npm run build` -> passed;
- `npm run check:web-api-map` -> passed;
- changed-file ESLint, Prettier, and `git diff --check` -> passed;
- full `npm run lint -- --no-cache` -> passed before the final E2E-only edit; the affected files passed changed-file ESLint afterward;
- `npm run test:affected:explain -- --base origin/main --head HEAD` selected the full CI plan because `src/main/data-content-application-commands.ts` is not mapped to a module owner. Per maintainer direction, the full portable and platform suites remain authoritative in PR CI.

## Review focus

- the strict `UploadedAttachment` wire shape and duplicate-ID/path rules;
- the Renderer catalog's runtime-validated routing marker and exclusive Electron channel ownership;
- the single default-Project resolution shared by the mutation lane and repository;
- source E2E use of the existing disposable storage-root override.
