### PR TITLE
fix(logs): enforce bounded local diagnostics

### DIFF
--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -75,9 +75,15 @@ const createDependencies = (): HostApplicationCommandDependencies => ({
     setGrantedRootAccess: vi.fn(async () => [])
   },
   logs: {
-    getPath: vi.fn(() => '/logs/main.log'),
+    getStatus: vi.fn(async () => ({
+      configured: true,
+      path: '/logs/main.log',
+      existing: true,
+      lastWriteSucceeded: true,
+      lastFailureCategory: null
+    })),
     openFile: vi.fn(async () => ({ opened: true })),
-    revealInFolder: vi.fn(() => ({ revealed: true }))
+    revealInFolder: vi.fn(async () => ({ revealed: true }))
   },
   notifications: {
     getSnapshot: vi.fn(async () => ({
@@ -263,7 +269,7 @@ describe('Host application commands', () => {
       hostApplicationCommands.localFs.setGrantedRootAccess,
       invocation([{ id: 'root-1', access: 'rw' }])
     )
-    await router.dispatcher.invoke(hostApplicationCommands.logs.getPath, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.logs.getStatus, invocation([]))
     await router.dispatcher.invoke(hostApplicationCommands.logs.openFile, invocation([]))
     await router.dispatcher.invoke(hostApplicationCommands.logs.revealInFolder, invocation([]))
     await router.dispatcher.invoke(
@@ -480,7 +486,7 @@ describe('Host application commands', () => {
         .filter((channel): channel is string => channel !== null)
     )
 
-    expect(localOnlyChannels).toHaveLength(27)
+    expect(localOnlyChannels).toHaveLength(28)
     for (const channel of localOnlyChannels) {
       await expect(
         router.dispatcher.invoke(
@@ -494,6 +500,28 @@ describe('Host application commands', () => {
     expect(
       ownerMethods.filter(vi.isMockFunction).every((method) => method.mock.calls.length === 0)
     ).toBe(true)
+  })
+
+  it('rejects every logs command from a remote Web caller before entering the owner', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerHostApplicationCommands(router.registrar, dependencies)
+    const remoteCaller = createWebCallerContext('remote-browser', { location: 'remote' })
+    const channels =
+      RENDERER_CONTRACT_GROUPS.find(({ capability }) => capability === 'logs')?.contracts.flatMap(
+        ({ channel }) => (channel === null ? [] : [channel])
+      ) ?? []
+
+    expect(channels.length).toBeGreaterThan(0)
+    for (const channel of channels) {
+      await expect(
+        router.dispatcher.invoke(commandByName(channel), invocation([], remoteCaller))
+      ).rejects.toThrow(`Channel only available from the local app: ${channel}`)
+    }
+
+    expect(dependencies.logs.getStatus).not.toHaveBeenCalled()
+    expect(dependencies.logs.openFile).not.toHaveBeenCalled()
+    expect(dependencies.logs.revealInFolder).not.toHaveBeenCalled()
   })
 
   it('preserves the five-state Remote Access authority and freshness matrix', async () => {

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -9,7 +9,7 @@ import type {
   RemoveGrantedLocalRootRequest,
   SetGrantedLocalRootAccessRequest
 } from '../shared/local-fs'
-import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
+import type { LogFileStatus, OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 import type {
   NotificationInboxSnapshot,
   NotificationMarkAllReadRequest,
@@ -138,7 +138,9 @@ const localFsCommands = Object.freeze({
 })
 
 const logsCommands = Object.freeze({
-  getPath: defineApplicationCommand<'logs:get-path', readonly [], string | null>('logs:get-path'),
+  getStatus: defineApplicationCommand<'logs:get-status', readonly [], LogFileStatus>(
+    'logs:get-status'
+  ),
   openFile: defineApplicationCommand<'logs:open-file', readonly [], OpenLogFileResult>(
     'logs:open-file'
   ),
@@ -485,7 +487,8 @@ const registerHostApplicationCommands = (
         )
     })
     scope.registerGroup(hostApplicationCommandGroups[3], {
-      'logs:get-path': () => dependencies.logs.getPath(),
+      'logs:get-status': ({ callerContext }) =>
+        localCommand(callerContext, 'logs:get-status', () => dependencies.logs.getStatus()),
       'logs:open-file': ({ callerContext }) =>
         localCommand(callerContext, 'logs:open-file', () => dependencies.logs.openFile()),
       'logs:reveal-in-folder': ({ callerContext }) =>

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -4,12 +4,21 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const renameFile = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs/promises')>()
+  renameFile.mockImplementation(original.rename)
+  return { ...original, rename: renameFile }
+})
+
 import {
   createLogger,
   diagnosticErrorFields,
   errorLogFields,
   flushLogs,
   formatLine,
+  getLogFileStatus,
   initLogger,
   runWithDiagnosticCorrelation,
   writeFatalLogSync
@@ -1339,6 +1348,28 @@ describe('logger: fatal process diagnostics', () => {
 })
 
 describe('logger: rotation (auto-cleanup)', () => {
+  it('reports file existence and the most recent successful write', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-'))
+    initLogger({ logDir, fileName: 'main.log', mirrorToConsole: false })
+
+    await expect(getLogFileStatus()).resolves.toMatchObject({
+      configured: true,
+      path: join(logDir, 'main.log'),
+      existing: false,
+      lastWriteSucceeded: null,
+      lastFailureCategory: null
+    })
+
+    createLogger('test').info('created')
+    await flushLogs()
+
+    await expect(getLogFileStatus()).resolves.toMatchObject({
+      existing: true,
+      lastWriteSucceeded: true,
+      lastFailureCategory: null
+    })
+  })
+
   it('caps total files, rotating oldest out so logs never grow unbounded', async () => {
     logDir = await mkdtemp(join(tmpdir(), 'os-logger-'))
 
@@ -1372,5 +1403,42 @@ describe('logger: rotation (auto-cleanup)', () => {
     const files = (await readdir(logDir)).filter((name) => name.startsWith('main'))
 
     expect(files).toEqual(['main.log'])
+  })
+
+  it('does not append past the cap while replacing the live file keeps failing', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-'))
+    const runId = 'rotation-failure-run'
+    const firstLineBytes =
+      Buffer.byteLength(formatLine('info', 'test', 'seed', undefined, runId)) + 1
+
+    initLogger({
+      logDir,
+      fileName: 'main.log',
+      maxBytes: firstLineBytes + 1,
+      maxFiles: 2,
+      mirrorToConsole: false,
+      runId
+    })
+    const log = createLogger('test')
+    log.info('seed')
+    await flushLogs()
+
+    renameFile.mockClear()
+    renameFile.mockRejectedValue(new Error('simulated Windows file lock'))
+
+    log.info('blocked-1')
+    log.info('blocked-2')
+    log.info('blocked-3')
+    await flushLogs()
+
+    const records = (await readFile(join(logDir, 'main.log'), 'utf8')).trim().split('\n')
+    expect(renameFile).toHaveBeenCalledTimes(3)
+    expect(records).toHaveLength(1)
+    expect(JSON.parse(records[0]!) as { msg: string }).toMatchObject({ msg: 'seed' })
+    await expect(getLogFileStatus()).resolves.toMatchObject({
+      existing: true,
+      lastWriteSucceeded: false,
+      lastFailureCategory: 'rotation'
+    })
   })
 })

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -4,6 +4,8 @@ import { randomUUID } from 'node:crypto'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { extname, join } from 'node:path'
 
+import type { LogFileStatus, LogWriteFailureCategory } from '../shared/logs'
+
 // Lightweight structured file logger for the main process. Kept free of Electron imports so it stays
 // unit-testable and usable from the MCP-server entry modes; the caller resolves the log directory
 // (e.g. Electron's `app.getPath('logs')`) and passes it to `initLogger`. Every record is one JSON line
@@ -38,6 +40,8 @@ let config: LoggerConfig | undefined
 let writeChain: Promise<void> = Promise.resolve()
 // Running size of the live file; undefined until seeded from disk on the first write after init.
 let currentBytes: number | undefined
+let lastWriteSucceeded: boolean | null = null
+let lastFailureCategory: LogWriteFailureCategory | null = null
 const diagnosticCorrelation = new AsyncLocalStorage<string>()
 
 const runWithDiagnosticCorrelation = <Result>(operation: () => Result): Result => {
@@ -743,24 +747,30 @@ const rotatedName = (fileName: string, index: number): string => {
   return `${base}.${index}${ext}`
 }
 
+const isMissingFileError = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+
 const fileSize = async (path: string): Promise<number> => {
   try {
     return (await stat(path)).size
-  } catch {
-    return 0
+  } catch (error) {
+    if (isMissingFileError(error)) return 0
+    throw error
   }
 }
 
 // Shifts the live file into backups, dropping any beyond `maxFiles`. Best-effort: a missing file at
 // any step is ignored so logging never fails because of rotation.
-const rotate = async (logDir: string, fileName: string, maxFiles: number): Promise<void> => {
+const rotate = async (logDir: string, fileName: string, maxFiles: number): Promise<boolean> => {
   const path = (name: string): string => join(logDir, name)
   const backups = Math.max(0, maxFiles - 1)
 
   if (backups === 0) {
     // No backups kept: just drop the live file so a fresh one starts.
-    await rm(path(fileName), { force: true }).catch(() => undefined)
-    return
+    return rm(path(fileName), { force: true }).then(
+      () => true,
+      () => false
+    )
   }
 
   // Delete the oldest backup, then shift each backup up one slot, then the live file becomes .1.
@@ -772,7 +782,10 @@ const rotate = async (logDir: string, fileName: string, maxFiles: number): Promi
     )
   }
 
-  await rename(path(fileName), path(rotatedName(fileName, 1))).catch(() => undefined)
+  return rename(path(fileName), path(rotatedName(fileName, 1))).then(
+    () => true,
+    () => false
+  )
 }
 
 const appendLine = (line: string): void => {
@@ -782,12 +795,14 @@ const appendLine = (line: string): void => {
 
   writeChain = writeChain.then(
     async () => {
+      let failureCategory: LogWriteFailureCategory = 'directory'
       try {
         await mkdir(logDir, { recursive: true })
 
         const filePath = join(logDir, fileName)
 
         if (currentBytes === undefined) {
+          failureCategory = 'inspect'
           currentBytes = await fileSize(filePath)
         }
 
@@ -795,13 +810,33 @@ const appendLine = (line: string): void => {
 
         // Rotate before writing when the next line would exceed the cap (but never rotate an empty file).
         if (currentBytes > 0 && currentBytes + lineBytes > maxBytes) {
-          await rotate(logDir, fileName, maxFiles)
-          currentBytes = 0
+          failureCategory = 'rotation'
+          const rotated = await rotate(logDir, fileName, maxFiles)
+          if (rotated) {
+            currentBytes = 0
+          } else {
+            // The live file may still have changed despite the failed operation (for example, another
+            // process removed it). Re-read the real size, and drop this line if it remains over cap.
+            currentBytes = await fileSize(filePath)
+            if (currentBytes > 0 && currentBytes + lineBytes > maxBytes) {
+              lastWriteSucceeded = false
+              lastFailureCategory = 'rotation'
+              return
+            }
+          }
         }
 
+        failureCategory = 'append'
         await appendFile(filePath, `${line}\n`, 'utf8')
         currentBytes += lineBytes
+        lastWriteSucceeded = true
+        lastFailureCategory = null
       } catch {
+        // An append can fail after a partial filesystem write. Re-seed from disk before the next
+        // attempt so the bounded-size decision never relies on a possibly stale byte count.
+        currentBytes = undefined
+        lastWriteSucceeded = false
+        lastFailureCategory = failureCategory
         // Logging must never throw or reject into the app; a failed write is silently dropped.
       }
     },
@@ -821,11 +856,48 @@ const initLogger = (options: { logDir: string } & Partial<Omit<LoggerConfig, 'lo
     ...options
   }
   currentBytes = undefined
+  lastWriteSucceeded = null
+  lastFailureCategory = null
 }
 
-// Absolute path of the active log file, or undefined before init. Used to reveal logs from the UI.
+// Absolute path of the configured log file, or undefined before init.
 const getLogFilePath = (): string | undefined =>
   config ? join(config.logDir, config.fileName) : undefined
+
+const getLogFileStatus = async (): Promise<LogFileStatus> => {
+  const activeConfig = config
+  if (!activeConfig) {
+    return {
+      configured: false,
+      path: null,
+      existing: false,
+      lastWriteSucceeded,
+      lastFailureCategory
+    }
+  }
+
+  await writeChain
+  const path = join(activeConfig.logDir, activeConfig.fileName)
+
+  try {
+    await stat(path)
+    return {
+      configured: true,
+      path,
+      existing: true,
+      lastWriteSucceeded,
+      lastFailureCategory
+    }
+  } catch (error) {
+    return {
+      configured: true,
+      path,
+      existing: false,
+      lastWriteSucceeded,
+      lastFailureCategory: isMissingFileError(error) ? lastFailureCategory : 'inspect'
+    }
+  }
+}
 
 // Resolves once all queued writes have flushed. Useful for tests and orderly shutdown.
 const flushLogs = (): Promise<void> => writeChain
@@ -904,6 +976,7 @@ export {
   flushLogs,
   formatLine,
   getLogFilePath,
+  getLogFileStatus,
   initLogger,
   runWithDiagnosticCorrelation,
   writeFatalLogSync

--- a/src/main/logs-ipc.test.ts
+++ b/src/main/logs-ipc.test.ts
@@ -1,7 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Hoisted so the mock factory can mutate `logPath` per test.
-const logPath = vi.hoisted(() => ({ value: '/logs/main.log' as string | null }))
+// Hoisted so the mock factory can mutate the observed log state per test.
+const logStatus = vi.hoisted(() => ({
+  value: {
+    configured: true,
+    path: '/logs/main.log' as string | null,
+    existing: true,
+    lastWriteSucceeded: true as boolean | null,
+    lastFailureCategory: null as 'directory' | 'inspect' | 'rotation' | 'append' | null
+  }
+}))
 
 // Capture ipcMain.handle registrations and stub shell.showItemInFolder / shell.openPath so handlers
 // can be invoked directly from tests.
@@ -22,7 +30,7 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('./logger', () => ({
-  getLogFilePath: () => logPath.value
+  getLogFileStatus: async () => logStatus.value
 }))
 
 const { registerLogsIpcHandlers } = await import('./logs-ipc')
@@ -35,36 +43,48 @@ describe('logs IPC handlers', () => {
     handlers.clear()
     openPath.mockClear()
     showItemInFolder.mockClear()
-    logPath.value = '/logs/main.log'
+    logStatus.value = {
+      configured: true,
+      path: '/logs/main.log',
+      existing: true,
+      lastWriteSucceeded: true,
+      lastFailureCategory: null
+    }
   })
 
   it('delegates every channel to one injected command owner', async () => {
     const owner: LogsCommandOwner = {
-      getPath: vi.fn(() => '/injected/main.log'),
+      getStatus: vi.fn(async () => ({
+        configured: true,
+        path: '/injected/main.log',
+        existing: true,
+        lastWriteSucceeded: true,
+        lastFailureCategory: null
+      })),
       openFile: vi.fn().mockResolvedValue({ opened: true }),
-      revealInFolder: vi.fn(() => ({ revealed: true }))
+      revealInFolder: vi.fn(async () => ({ revealed: true }))
     }
 
     expect(registerLogsIpcHandlers(owner)).toBe(owner)
-    expect(invoke('logs:get-path')).toBe('/injected/main.log')
+    await expect(invoke('logs:get-status')).resolves.toMatchObject({ path: '/injected/main.log' })
     await expect(invoke('logs:open-file')).resolves.toEqual({ opened: true })
-    expect(invoke('logs:reveal-in-folder')).toEqual({ revealed: true })
+    await expect(invoke('logs:reveal-in-folder')).resolves.toEqual({ revealed: true })
   })
 
   it('registers the diagnostics channels', () => {
     handlers.clear()
     registerLogsIpcHandlers()
 
-    expect(handlers.has('logs:get-path')).toBe(true)
+    expect(handlers.has('logs:get-status')).toBe(true)
     expect(handlers.has('logs:open-file')).toBe(true)
     expect(handlers.has('logs:reveal-in-folder')).toBe(true)
   })
 
-  it('returns the log file path', () => {
+  it('returns the observed log file status', async () => {
     handlers.clear()
     registerLogsIpcHandlers()
 
-    expect(invoke('logs:get-path')).toBe('/logs/main.log')
+    await expect(invoke('logs:get-status')).resolves.toEqual(logStatus.value)
   })
 
   it('opens the log file (not its folder) and reports success', async () => {
@@ -87,19 +107,42 @@ describe('logs IPC handlers', () => {
     })
   })
 
-  it('reveals the log file in its containing folder when a path is available', () => {
+  it('does not ask the OS to open a configured log file that does not exist', async () => {
+    logStatus.value = {
+      configured: true,
+      path: '/logs/main.log',
+      existing: false,
+      lastWriteSucceeded: null,
+      lastFailureCategory: null
+    }
     registerLogsIpcHandlers()
 
-    expect(invoke('logs:reveal-in-folder')).toEqual({ revealed: true })
+    await expect(invoke('logs:open-file')).resolves.toEqual({
+      opened: false,
+      error: 'No log file is available yet.'
+    })
+    expect(openPath).not.toHaveBeenCalled()
+  })
+
+  it('reveals the log file in its containing folder when a path is available', async () => {
+    registerLogsIpcHandlers()
+
+    await expect(invoke('logs:reveal-in-folder')).resolves.toEqual({ revealed: true })
     expect(showItemInFolder).toHaveBeenCalledTimes(1)
     expect(showItemInFolder).toHaveBeenCalledWith('/logs/main.log')
   })
 
-  it('reports a missing log file when reveal is requested before one is written', () => {
-    logPath.value = null
+  it('reports a missing log file when reveal is requested before one is written', async () => {
+    logStatus.value = {
+      configured: true,
+      path: '/logs/main.log',
+      existing: false,
+      lastWriteSucceeded: null,
+      lastFailureCategory: null
+    }
     registerLogsIpcHandlers()
 
-    expect(invoke('logs:reveal-in-folder')).toEqual({
+    expect(await invoke('logs:reveal-in-folder')).toEqual({
       revealed: false,
       error: 'No log file is available yet.'
     })

--- a/src/main/logs-ipc.ts
+++ b/src/main/logs-ipc.ts
@@ -2,34 +2,39 @@ import { shell } from 'electron'
 
 import { ipcMainHandle } from './ipc-handler-registry'
 
-import { getLogFilePath } from './logger'
-import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
+import { getLogFileStatus } from './logger'
+import type { LogFileStatus, OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 
 type LogsCommandOwner = Readonly<{
-  getPath: () => string | null
+  getStatus: () => Promise<LogFileStatus>
   openFile: () => Promise<OpenLogFileResult>
-  revealInFolder: () => RevealLogFileResult
+  revealInFolder: () => Promise<RevealLogFileResult>
 }>
 
 const createLogsCommandOwner = (): LogsCommandOwner => ({
-  getPath: () => getLogFilePath() ?? null,
+  getStatus: () => getLogFileStatus(),
   openFile: async (): Promise<OpenLogFileResult> => {
-    const path = getLogFilePath()
+    const status = await getLogFileStatus()
 
-    if (!path) return { opened: false, error: 'No log file is available yet.' }
+    if (!status.path || !status.existing) {
+      return { opened: false, error: 'No log file is available yet.' }
+    }
 
     // shell.openPath resolves to '' on success or an error string on failure.
-    const error = await shell.openPath(path)
+    const error = await shell.openPath(status.path)
 
     return error ? { opened: false, error } : { opened: true }
   },
-  revealInFolder: (): RevealLogFileResult => {
-    const path = getLogFilePath()
+  revealInFolder: async (): Promise<RevealLogFileResult> => {
+    const status = await getLogFileStatus()
 
-    if (!path) return { revealed: false, error: 'No log file is available yet.' }
+    if (!status.path || !status.existing) {
+      return { revealed: false, error: 'No log file is available yet.' }
+    }
 
-    // Opens the containing folder with the log file selected; returns void, so success is assumed.
-    shell.showItemInFolder(path)
+    // Electron returns void here, so the only observable guarantee is that the file existed
+    // immediately before the shell request.
+    shell.showItemInFolder(status.path)
 
     return { revealed: true }
   }
@@ -40,7 +45,7 @@ const createLogsCommandOwner = (): LogsCommandOwner => ({
 const registerLogsIpcHandlers = (
   owner: LogsCommandOwner = createLogsCommandOwner()
 ): LogsCommandOwner => {
-  ipcMainHandle('logs:get-path', () => owner.getPath())
+  ipcMainHandle('logs:get-status', () => owner.getStatus())
   ipcMainHandle('logs:open-file', () => owner.openFile())
   ipcMainHandle('logs:reveal-in-folder', () => owner.revealInFolder())
   return owner

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -344,7 +344,7 @@ describe('preload bridge — public surface inventory', () => {
       'locale.initialize',
       'locale.onChanged',
       'locale.setPreference',
-      'logs.getPath',
+      'logs.getStatus',
       'logs.openFile',
       'logs.revealInFolder',
       'memory.clearAll',

--- a/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
@@ -113,7 +113,13 @@ beforeEach(() => {
   })
   ;(window as unknown as { api: unknown }).api = {
     logs: {
-      getPath: vi.fn().mockResolvedValue('/logs/main.log'),
+      getStatus: vi.fn().mockResolvedValue({
+        configured: true,
+        path: '/logs/main.log',
+        existing: true,
+        lastWriteSucceeded: true,
+        lastFailureCategory: null
+      }),
       openFile: vi.fn().mockResolvedValue({ opened: true }),
       revealInFolder: vi.fn().mockResolvedValue({ revealed: true })
     },
@@ -315,6 +321,30 @@ describe('GeneralPanel close behavior', () => {
 
     expect(settingsApi.setClosePreference).toHaveBeenCalledWith({ preference: 'quit' })
     expect(useSettingsStore.getState().closePreference).toBe('quit')
+  })
+})
+
+describe('GeneralPanel diagnostics', () => {
+  it('shows a recent write failure without hiding an existing log file', async () => {
+    const getStatus = (
+      window as unknown as { api: { logs: { getStatus: ReturnType<typeof vi.fn> } } }
+    ).api.logs.getStatus
+    getStatus.mockResolvedValueOnce({
+      configured: true,
+      path: '/logs/main.log',
+      existing: true,
+      lastWriteSucceeded: false,
+      lastFailureCategory: 'append'
+    })
+
+    await act(async () => root.render(<GeneralPanel />))
+    await flush()
+
+    expect(container.textContent).toContain(
+      'The app could not write to the log file during its most recent attempt.'
+    )
+    expect(findButton(/^open$/i)?.disabled).toBe(false)
+    expect(findButton(/^reveal$/i)?.disabled).toBe(false)
   })
 })
 

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -14,6 +14,7 @@ import { errorDetail } from '@/lib/error-detail'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { CloseActionPreference } from '../../../../shared/window-controls'
 import type { CliLauncherStatus } from '../../../../shared/cli'
+import type { LogFileStatus } from '../../../../shared/logs'
 import { APP } from '../../../../shared/app-config'
 import { AppIconSection } from './AppIconSection'
 import { AppVersionSection } from './AppVersionSection'
@@ -59,7 +60,7 @@ const XMark = ({ className }: { className?: string }): React.JSX.Element => (
 const GeneralPanel = (): React.JSX.Element => {
   const { t } = useTranslation()
   const isMac = window.api.platform === 'darwin'
-  const [logPath, setLogPath] = useState<string | null>(null)
+  const [logStatus, setLogStatus] = useState<LogFileStatus | null>(null)
   const [message, setMessage] = useState<GeneralActionError | undefined>(undefined)
   const [isOpening, setIsOpening] = useState(false)
   const [cli, setCli] = useState<CliLauncherStatus | null>(null)
@@ -71,9 +72,12 @@ const GeneralPanel = (): React.JSX.Element => {
   const setClosePreference = useSettingsStore((state) => state.setClosePreference)
 
   useEffect(() => {
-    void window.api.logs.getPath().then(setLogPath)
+    void window.api.logs.getStatus().then(setLogStatus, () => setLogStatus(null))
     void window.api.cli.getStatus().then(setCli)
   }, [])
+
+  const logPath = logStatus?.path ?? null
+  const logExists = logStatus?.existing === true
 
   const handleCli = async (action: 'install' | 'uninstall'): Promise<void> => {
     setIsUpdatingCli(true)
@@ -259,7 +263,7 @@ const GeneralPanel = (): React.JSX.Element => {
               type="button"
               variant="outline"
               onClick={() => void handleReveal()}
-              disabled={!logPath}
+              disabled={!logExists}
             >
               <FolderOpen className="size-4" aria-hidden="true" />
               {t('Reveal')}
@@ -268,7 +272,7 @@ const GeneralPanel = (): React.JSX.Element => {
               type="button"
               variant="outline"
               onClick={() => void handleOpenLog()}
-              disabled={isOpening || !logPath}
+              disabled={isOpening || !logExists}
             >
               <ExternalLink className="size-4" aria-hidden="true" />
               {isOpening ? t('Opening…') : t('Open')}
@@ -282,6 +286,12 @@ const GeneralPanel = (): React.JSX.Element => {
         >
           {logPath ?? t('Not available yet.')}
         </pre>
+
+        {logStatus?.lastWriteSucceeded === false ? (
+          <p className="mt-2 text-xs text-destructive" role="status">
+            {t('The app could not write to the log file during its most recent attempt.')}
+          </p>
+        ) : null}
 
         {message ? (
           <div className="mt-2">

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -181,7 +181,13 @@ const installApi = (): void => {
       onChanged: vi.fn().mockReturnValue(() => undefined)
     },
     logs: {
-      getPath: vi.fn().mockResolvedValue('/Users/x/Library/Logs/Open Science/main.log'),
+      getStatus: vi.fn().mockResolvedValue({
+        configured: true,
+        path: '/Users/x/Library/Logs/Open Science/main.log',
+        existing: true,
+        lastWriteSucceeded: true,
+        lastFailureCategory: null
+      }),
       openFile: vi.fn().mockResolvedValue({ opened: true }),
       revealInFolder: vi.fn().mockResolvedValue({ revealed: true })
     },
@@ -1949,6 +1955,38 @@ describe('SettingsPage layout', () => {
       (window as unknown as { api: { logs: { revealInFolder: ReturnType<typeof vi.fn> } } }).api
         .logs.revealInFolder
     ).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not enable log actions for a configured path whose file does not exist', async () => {
+    const logs = (
+      window as unknown as {
+        api: {
+          logs: {
+            getStatus: ReturnType<typeof vi.fn>
+          }
+        }
+      }
+    ).api.logs
+    logs.getStatus.mockResolvedValueOnce({
+      configured: true,
+      path: '/Users/x/Library/Logs/Open Science/main.log',
+      existing: false,
+      lastWriteSucceeded: null,
+      lastFailureCategory: null
+    })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => navButton('General')?.click())
+
+    const buttons = Array.from(document.body.querySelectorAll('button'))
+    const openButton = buttons.find((button) => /^open$/i.test((button.textContent ?? '').trim()))
+    const revealButton = buttons.find((button) =>
+      /^reveal$/i.test((button.textContent ?? '').trim())
+    )
+    expect(openButton?.disabled).toBe(true)
+    expect(revealButton?.disabled).toBe(true)
   })
 
   it('opens the Remote panel with three scenario-based access modes', async () => {

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1399,6 +1399,7 @@
     "Node v": "Node v",
     "None": "Ninguno",
     "Not available yet.": "Aún no disponible.",
+    "The app could not write to the log file during its most recent attempt.": "La aplicación no pudo escribir en el archivo de registro durante el intento más reciente.",
     "Not compatible with the active agent framework.": "No es compatible con el framework de agentes activo.",
     "Not configured": "No configurado",
     "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "No configurado: los paquetes provienen de hosts públicos (conda.anaconda.org, pypi.org)",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1398,6 +1398,7 @@
     "Node v": "Nœud v",
     "None": "Aucun",
     "Not available yet.": "Pas encore disponible.",
+    "The app could not write to the log file during its most recent attempt.": "L’application n’a pas pu écrire dans le fichier journal lors de sa dernière tentative.",
     "Not compatible with the active agent framework.": "Non compatible avec le framework d'agents actif.",
     "Not configured": "Non configuré",
     "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "Non configuré — les paquets proviennent des hôtes publics (conda.anaconda.org, pypi.org)",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1335,6 +1335,7 @@
     "Node v": "Node v",
     "None": "なし",
     "Not available yet.": "まだ利用できません。",
+    "The app could not write to the log file during its most recent attempt.": "直近の試行で、アプリはログファイルに書き込めませんでした。",
     "Not compatible with the active agent framework.": "アクティブなエージェントフレームワークと互換性がありません。",
     "Not configured": "未設定",
     "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "未設定 — パッケージはパブリックホスト (conda.anaconda.org、pypi.org) から取得されます。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1350,6 +1350,7 @@
     "Node v": "Node v",
     "None": "없음",
     "Not available yet.": "아직 사용할 수 없습니다.",
+    "The app could not write to the log file during its most recent attempt.": "최근 시도에서 앱이 로그 파일에 쓰지 못했습니다.",
     "Not compatible with the active agent framework.": "활성 에이전트 프레임워크와 호환되지 않습니다.",
     "Not configured": "구성되지 않음",
     "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "구성되지 않음 - 패키지가 공개 호스트(conda.anaconda.org, pypi.org)에서 제공됩니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1395,6 +1395,7 @@
     "Node v": "Node v",
     "None": "Нет",
     "Not available yet.": "Еще недоступно.",
+    "The app could not write to the log file during its most recent attempt.": "При последней попытке приложению не удалось записать данные в файл журнала.",
     "Not compatible with the active agent framework.": "Несовместимо с активным фреймворком агента.",
     "Not configured": "Не настроен",
     "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "Не настроен — пакеты поступают с публичных хостов (conda.anaconda.org, pypi.org)",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1406,6 +1406,7 @@
     "Node v": "Node 版本 ",
     "None": "无",
     "Not available yet.": "暂不可用。",
+    "The app could not write to the log file during its most recent attempt.": "应用在最近一次尝试中无法写入日志文件。",
     "Not compatible with the active agent framework.": "与当前智能体框架不兼容。",
     "Not configured": "未配置",
     "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "未配置 —— 软件包来自公共源（conda.anaconda.org、pypi.org）",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1404,6 +1404,7 @@
     "Node v": "Node 版本 ",
     "None": "無",
     "Not available yet.": "尚不可用。",
+    "The app could not write to the log file during its most recent attempt.": "應用程式在最近一次嘗試中無法寫入日誌檔案。",
     "Not compatible with the active agent framework.": "與目前的智能體框架不相容。",
     "Not configured": "未設定",
     "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "未設定 —— 套件來自公共來源（conda.anaconda.org、pypi.org）",

--- a/src/shared/logs.ts
+++ b/src/shared/logs.ts
@@ -1,5 +1,17 @@
 // Shared types for the diagnostics/logs IPC surface.
 
+export type LogWriteFailureCategory = 'directory' | 'inspect' | 'rotation' | 'append'
+
+// Observed state of the active log file. `lastWriteSucceeded` is null until the first queued write
+// completes; `existing` is refreshed from disk whenever this status is requested.
+export type LogFileStatus = {
+  configured: boolean
+  path: string | null
+  existing: boolean
+  lastWriteSucceeded: boolean | null
+  lastFailureCategory: LogWriteFailureCategory | null
+}
+
 // Result of asking the OS to open the log file.
 export type OpenLogFileResult = {
   opened: boolean

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -13,6 +13,17 @@ const paths = (
 ): string[] => RENDERER_CONTRACT_CATALOG.filter(predicate).map(({ publicPath }) => publicPath)
 
 describe('renderer contract catalog', () => {
+  it('keeps every logs command local-only', () => {
+    const logs = RENDERER_CONTRACT_GROUPS.find(({ capability }) => capability === 'logs')
+
+    expect(logs?.contracts.length).toBeGreaterThan(0)
+    expect(
+      logs?.contracts.every(
+        ({ surfaceInstallation }) => surfaceInstallation.remoteWeb === 'rejecting-stub'
+      )
+    ).toBe(true)
+  })
+
   it('pins the complete capability-owned inventory and legacy map projection', () => {
     const projection = projectRendererContractMaps(RENDERER_CONTRACT_CATALOG)
 

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -106,7 +106,7 @@ import type {
   SetGrantedLocalRootAccessRequest
 } from './local-fs'
 import type { RendererFailureReport } from './diagnostics'
-import type { OpenLogFileResult, RevealLogFileResult } from './logs'
+import type { LogFileStatus, OpenLogFileResult, RevealLogFileResult } from './logs'
 import type {
   NotificationInboxChanged,
   NotificationInboxSnapshot,
@@ -987,7 +987,7 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'localFs.setGrantedRootAccess': callable<
     (request: SetGrantedLocalRootAccessRequest) => Promise<GrantedLocalRoot[]>
   >()('local-fs', ['local-fs:granted-roots:set-access', LOCAL]),
-  'logs.getPath': callable<() => Promise<string | null>>()('logs', ['logs:get-path']),
+  'logs.getStatus': callable<() => Promise<LogFileStatus>>()('logs', ['logs:get-status', LOCAL]),
   'logs.openFile': callable<() => Promise<OpenLogFileResult>>()('logs', ['logs:open-file', LOCAL]),
   'logs.revealInFolder': callable<() => Promise<RevealLogFileResult>>()('logs', [
     'logs:reveal-in-folder',

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -179,7 +179,7 @@ const REMOTE_LOCAL_ONLY_CHANNELS: GroupedInventory = {
     'read-preview',
     'reveal'
   ],
-  logs: ['open-file', 'reveal-in-folder'],
+  logs: ['get-status', 'open-file', 'reveal-in-folder'],
   'notebook-env': ['cancel', 'provision', 'repair'],
   notebook: ['export-ipynb', 'export-ipynb-all'],
   runtime: [

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -77,7 +77,7 @@ export const WEB_INVOKE_CHANNELS = {
   'localFs.removeGrantedRoot': 'local-fs:granted-roots:remove',
   'localFs.reveal': 'local-fs:reveal',
   'localFs.setGrantedRootAccess': 'local-fs:granted-roots:set-access',
-  'logs.getPath': 'logs:get-path',
+  'logs.getStatus': 'logs:get-status',
   'logs.openFile': 'logs:open-file',
   'logs.revealInFolder': 'logs:reveal-in-folder',
   'memory.clearAll': 'memory:clear-all',


### PR DESCRIPTION
## Problem

- A failed live-log rename/remove was suppressed and `currentBytes` was reset to zero anyway. Repeated
  Windows file-lock or permission failures therefore allowed the live file to grow without bound.
- `logs:get-path` was remotely callable, exposing the host's absolute log path to authenticated remote
  Web clients even though Open and Reveal were local-only.
- Settings treated a configured path as proof that a usable log file existed, and Reveal reported
  success without checking the file.

## Proposed change

- Make rotation report whether the live file was actually replaced or removed. On failure, re-stat the
  file and drop the queued line while it remains over the cap; later writes retry rotation.
- Track the most recent write result in memory and expose a compact `LogFileStatus` through
  `logs.getStatus`.
- Mark the status command `LOCAL` in the renderer contract and enforce the same boundary with
  `localCommand` in the Host router.
- Verify observed file existence before Open or Reveal. Settings disables those actions for a missing
  file and displays a warning after a failed write.

## Scope and non-goals

- New transient fields: `configured`, `path`, `existing`, `lastWriteSucceeded`, and
  `lastFailureCategory`.
- New failure-category values: `directory`, `inspect`, `rotation`, and `append`.
- No `writable` field: a preflight access check cannot reliably predict disk-full, file-lock,
  antivirus, or later transient failures.
- No database, settings-document, migration, or other persistence changes.
- No historical-data compatibility work is required. The internal renderer/main method changes from
  `logs.getPath` to `logs.getStatus` in lockstep; no legacy alias is retained.
- Electron's Reveal API returns void. The implementation verifies that the file exists immediately
  before the shell request but cannot prove that the file manager displayed it.

## Acceptance criteria and validation

All listed checks ran after the last material code edit.

- Bounded rotation, filesystem status, IPC actions, Host authorization, renderer contracts,
  preload/Web adapters, Settings behavior, and translations:
  `npm test -- src/main/logger.test.ts src/main/logs-ipc.test.ts src/main/host-application-commands.test.ts src/shared/renderer-contract-catalog.test.ts src/shared/renderer-surface-inventory.test.ts src/shared/renderer-surface-matrix.test.ts src/shared/web-rpc-contract.test.ts src/renderer/web/api-installer.test.ts src/preload/index.test.ts src/renderer/src/pages/settings/GeneralPanel.render.test.tsx src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/i18n/resources.test.ts`
  — 12 files and 1,061 tests passed.
- Main/preload/shared types: `npm run typecheck:node` — passed.
- Renderer/shared types: `npm run typecheck:web` — passed.
- Source and tests: `npm run lint` — passed.
- Patch hygiene: `git diff --check` — passed.

The full portable suite was intentionally not run locally; PR Gate is authoritative for complete and
cross-platform coverage. The local environment also lacks the Visual Studio C++ toolchain needed to
build the unrelated native publisher package, so dependencies were installed with scripts disabled,
then the repository patches, Prisma client, and Electron test binary were prepared separately.

## Review focus

- Confirm that dropping a line while rotation remains blocked is the intended tradeoff for preserving
  the documented disk bound.
- Confirm that every logs command is remote-restricted at both catalog and Host-router layers.
- Confirm that the transient status fields communicate observed facts without implying future
  writability.
