### PR TITLE
fix(lifecycle): warn before interrupting Reviewer on quit

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -158,9 +158,11 @@ const setup = (
   > & {
     trayHost?: boolean
     detectActiveSessions?: () => ActiveSessionInfo[]
+    hasActiveReviewerWork?: () => boolean
     confirmClose?: (
       variant: CloseConfirmVariant,
-      sessions: ActiveSessionInfo[]
+      sessions: ActiveSessionInfo[],
+      reviewerActive?: boolean
     ) => Promise<CloseConfirmChoice>
   } = {}
 ): Harness => {
@@ -211,6 +213,7 @@ const setup = (
     onAppearanceChanged: overrides.onAppearanceChanged,
     platform: overrides.platform ?? 'linux',
     detectActiveSessions,
+    hasActiveReviewerWork: overrides.hasActiveReviewerWork ?? (() => false),
     createConfirmClose: () => confirmClose
   })
   return {
@@ -371,6 +374,7 @@ describe('installAppLifecycle', () => {
       countWindows: (): number => 1,
       platform: 'linux',
       detectActiveSessions: (): ActiveSessionInfo[] => [],
+      hasActiveReviewerWork: () => false,
       createConfirmClose: () => (): Promise<CloseConfirmChoice> => Promise.resolve('quit')
     })
 
@@ -894,6 +898,29 @@ describe('installAppLifecycle', () => {
     expect(shutdownBackends).toHaveBeenCalledTimes(1)
     expect(tray?.destroy).toHaveBeenCalledTimes(1)
     expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('warns before ordinary quit when only Reviewer work is active', async () => {
+    const confirmClose = vi.fn(
+      (
+        _variant: CloseConfirmVariant,
+        sessions: ActiveSessionInfo[],
+        reviewerActive = false
+      ): Promise<CloseConfirmChoice> =>
+        Promise.resolve(sessions.length === 0 && !reviewerActive ? 'quit' : 'cancel')
+    )
+    const { app, quit, shutdownBackends } = setup({
+      hasActiveReviewerWork: () => true,
+      confirmClose
+    })
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).toHaveBeenCalledWith('quit', [], true)
+    expect(quit).not.toHaveBeenCalled()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
   })
 
   it('before-quit with delegated work + blocked choice keeps the app alive without interruption', async () => {

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -86,10 +86,16 @@ export type AppLifecycleDeps = {
   // Snapshot of sessions with running work (in-flight agent prompt or a notebook cell mid-execution),
   // used to populate the confirmation list and to skip the quit dialog when nothing is running.
   detectActiveSessions: () => ActiveSessionInfo[]
+  // Reviewer activity has no ActiveSessionInfo row, but still requires the ordinary-quit warning.
+  hasActiveReviewerWork: () => boolean
   // Builds the close-confirm coordinator bound to the current main window (recreated on demand).
   createConfirmClose: (
     getWindow: () => BrowserWindow | undefined
-  ) => (variant: CloseConfirmVariant, sessions: ActiveSessionInfo[]) => Promise<CloseConfirmChoice>
+  ) => (
+    variant: CloseConfirmVariant,
+    sessions: ActiveSessionInfo[],
+    reviewerActive?: boolean
+  ) => Promise<CloseConfirmChoice>
 }
 
 // Installs the tray, the first window, and the quit/activate/window-all-closed handlers. Returns
@@ -146,6 +152,13 @@ export const installAppLifecycle = (
   }
 
   const confirmClose = deps.createConfirmClose(() => mainWindow)
+  const confirmResearchClose = (
+    variant: CloseConfirmVariant,
+    sessions: ActiveSessionInfo[]
+  ): Promise<CloseConfirmChoice> =>
+    deps.hasActiveReviewerWork()
+      ? confirmClose(variant, sessions, true)
+      : confirmClose(variant, sessions)
   const detectDelegatedWork = (): ActiveSessionInfo[] =>
     deps.detectActiveSessions().filter((session) => session.kind === 'delegated')
 
@@ -168,10 +181,10 @@ export const installAppLifecycle = (
     if (confirmInFlight) return 'cancel'
     confirmInFlight = true
     try {
-      const choice = await confirmClose('close-to-tray', deps.detectActiveSessions())
+      const choice = await confirmResearchClose('close-to-tray', deps.detectActiveSessions())
       if (choice !== 'quit') return choice
       const delegated = detectDelegatedWork()
-      return delegated.length > 0 ? await confirmClose('close-to-tray', delegated) : choice
+      return delegated.length > 0 ? await confirmResearchClose('close-to-tray', delegated) : choice
     } finally {
       confirmInFlight = false
     }
@@ -269,25 +282,25 @@ export const installAppLifecycle = (
       clearApplicationShutdownTrigger()
       if (confirmInFlight) return
       confirmInFlight = true
-      void confirmClose('quit', delegatedAtShutdownBoundary).finally(() => {
+      void confirmResearchClose('quit', delegatedAtShutdownBoundary).finally(() => {
         confirmInFlight = false
       })
       return
     }
 
     // Confirmation gate: unless the user already confirmed (e.g. Windows X -> Quit), confirm the
-    // quit. An empty active-session list makes confirmClose('quit', []) resolve 'quit' with no modal.
+    // quit. An empty active-session list with no Reviewer work resolves 'quit' with no modal.
     if (!quitConfirmed && ordinaryQuit) {
       event.preventDefault()
       if (confirmInFlight) return
       confirmInFlight = true
-      void confirmClose('quit', deps.detectActiveSessions())
+      void confirmResearchClose('quit', deps.detectActiveSessions())
         .then(async (choice) => {
           if (choice === 'quit') {
             const delegated = detectDelegatedWork()
             if (delegated.length > 0) {
               quitConfirmed = false
-              await confirmClose('quit', delegated)
+              await confirmResearchClose('quit', delegated)
               return
             }
             quitConfirmed = true

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -483,6 +483,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               taskControls,
               computePreferences,
               detectActiveSessions,
+              hasActiveReviewerWork,
               prepareForQuit,
               abortQuitPreparation,
               dispose: disposeApplicationRuntime
@@ -606,6 +607,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               getAppIconVariant: () => appIconControllerBox.current?.getVariant() ?? initialVariant,
               disposeApplicationRuntime,
               detectActiveSessions,
+              hasActiveReviewerWork,
               prepareForQuit,
               abortQuitPreparation,
               createSessionPersistenceFlush: (
@@ -716,6 +718,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             countWindows: () => BrowserWindow.getAllWindows().length,
             createInitialWindow: !ctx.webMode.headless,
             detectActiveSessions: ctx.detectActiveSessions,
+            hasActiveReviewerWork: ctx.hasActiveReviewerWork,
             prepareForQuit: ctx.prepareForQuit,
             abortQuitPreparation: () => {
               ctx.abortQuitPreparation()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -404,6 +404,7 @@ export type ApplicationRuntimeInterfaces = {
   sessionDeletionCapability: Pick<SessionPersistenceCoordinator, 'setSessionDeletionHandlers'>
   archiveCapability: Pick<ArchiveCoordinator, 'isSessionAvailableById' | 'setMarkReadSessions'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
+  hasActiveReviewerWork: () => boolean
   prepareForQuit: () => Promise<Extract<ShutdownStepOutcome, 'completed' | 'timeout' | 'failed'>>
   abortQuitPreparation: () => void
 }
@@ -3594,6 +3595,7 @@ const createApplicationModules = async (
         delegated: { getActiveDelegatedSessions },
         notebook: notebookService
       }),
+    hasActiveReviewerWork: () => reviewerModelRuntimeShutdown?.hasActiveWork() ?? false,
     prepareForQuit: () => runtime.prepareForQuit(),
     abortQuitPreparation: () => runtime.abortQuitPreparation(),
     electronAdapters: {

--- a/src/main/window-close-confirm.test.ts
+++ b/src/main/window-close-confirm.test.ts
@@ -113,6 +113,18 @@ describe('createCloseConfirm', () => {
     expect(h.sent).toHaveLength(0)
   })
 
+  it('confirms quit when only Reviewer work is active', async () => {
+    const h = makeHarness()
+    const pending = h.confirm('quit', [], true)
+    h.ack()
+    h.choose('cancel')
+
+    await expect(pending).resolves.toBe('cancel')
+    expect(h.sent).toEqual([
+      { requestId: 'req-1', variant: 'quit', sessions: [], reviewerActive: true }
+    ])
+  })
+
   it('sends a request and resolves the renderer choice', async () => {
     const h = makeHarness()
     const pending = h.confirm('close-to-tray', [session])

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -59,20 +59,21 @@ export type ClosePreferenceAccess = {
 const DEFAULT_ACK_TIMEOUT_MS = 500
 const DEFAULT_HANG_GRACE_MS = 10_000
 
-// Coordinates a close/quit confirmation. Main computes `sessions`, so the quit variant with an empty
-// list resolves without any IPC; otherwise the renderer renders the modal and replies the choice,
-// with a native/proceed fallback if it can't.
+// Coordinates a close/quit confirmation. Main computes `sessions` plus Reviewer activity, so the quit
+// variant resolves without IPC only when both are idle; otherwise the renderer renders the modal and
+// replies with the choice, with a native/proceed fallback if it can't.
 export const createCloseConfirm = (
   deps: CloseConfirmDeps
 ): ((
   variant: CloseConfirmVariant,
-  sessions: ActiveSessionInfo[]
+  sessions: ActiveSessionInfo[],
+  reviewerActive?: boolean
 ) => Promise<CloseConfirmChoice>) => {
   const ackTimeoutMs = deps.ackTimeoutMs ?? DEFAULT_ACK_TIMEOUT_MS
   const hangGraceMs = deps.hangGraceMs ?? DEFAULT_HANG_GRACE_MS
 
-  return async (variant, sessions) => {
-    if (variant === 'quit' && sessions.length === 0) return 'quit'
+  return async (variant, sessions, reviewerActive = false) => {
+    if (variant === 'quit' && sessions.length === 0 && !reviewerActive) return 'quit'
     const hasDelegatedWork = hasDelegatedActiveSession(sessions)
     const enforceDelegatedBlock = (choice: CloseConfirmChoice): CloseConfirmChoice =>
       hasDelegatedWork && choice === 'quit' ? (variant === 'quit' ? 'cancel' : 'minimize') : choice
@@ -169,7 +170,7 @@ export const createCloseConfirm = (
         if (!acked) startFallback()
       }, ackTimeoutMs)
 
-      deps.send({ requestId, variant, sessions })
+      deps.send({ requestId, variant, sessions, reviewerActive })
     })
   }
 }
@@ -240,7 +241,11 @@ export const createElectronCloseConfirm = (
   getWindow: () => BrowserWindow | undefined,
   preferences: ClosePreferenceAccess,
   translate: NativeTranslator = englishNativeTranslator
-): ((variant: CloseConfirmVariant, sessions: ActiveSessionInfo[]) => Promise<CloseConfirmChoice>) =>
+): ((
+  variant: CloseConfirmVariant,
+  sessions: ActiveSessionInfo[],
+  reviewerActive?: boolean
+) => Promise<CloseConfirmChoice>) =>
   createCloseConfirm({
     // Reveal the window before asking: a tray/Ctrl+Q quit can arrive while the window is hidden
     // (minimized to tray), and a modal sent to a hidden window would never be seen — leaving the

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -179,6 +179,8 @@ export type CloseConfirmRequest = {
   requestId: string
   variant: CloseConfirmVariant
   sessions: ActiveSessionInfo[]
+  // Reviewer runtime activity has no session row but still requires the ordinary-quit warning.
+  reviewerActive?: boolean
 }
 
 // ack:true when the modal mounts (proves the renderer is alive); choice set when the user decides.


### PR DESCRIPTION
## Problem

Ordinary quit projected active agents, delegated work, and notebooks, but omitted Reviewer runtime activity. Backend teardown still shuts Reviewer runtimes down, so a Reviewer-only workload could take the no-work fast path and be interrupted without a warning.

The regression was reproduced before the fix with the lifecycle test added here: the close coordinator received `confirmClose('quit', [])` instead of the Reviewer-aware call and the test failed consistently on two runs.

## Proposed change

- expose the existing `ReviewerModelRuntimeOwner.hasActiveWork()` state through the application runtime;
- include that state when the application lifecycle requests close confirmation;
- prevent an empty Session list from bypassing confirmation while Reviewer work is active; and
- carry the transient Reviewer flag on the main-to-renderer close-confirm request.

## Scope and non-goals

- No database, persisted setting, migration, or historical-data compatibility change.
- No new `ActiveSessionInfo.kind` enum value.
- No Reviewer-specific row or new UI copy; the existing generic running-work warning is used.
- No new `ActiveResearchWork` abstraction. The fix reuses the existing Reviewer runtime activity owner and keeps update/data-root behavior unchanged.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Reviewer-only ordinary quit warns and cancellation prevents teardown -> `vitest run src/main/app-lifecycle.test.ts` -> passed.
- Reviewer activity bypasses the empty-Session fast path and reaches renderer confirmation -> `vitest run src/main/window-close-confirm.test.ts` -> passed.
- Existing activity detection, renderer modal, and renderer contract remain compatible -> targeted five-file Vitest run -> 123 tests passed.
- Main-process wiring and shared contract types -> `npm run typecheck:node` -> passed.
- Renderer consumption of the optional request field -> `npm run typecheck:web` -> passed.
- Source and test style -> `npm run lint` -> passed with no warnings.
- Exact-head impact plan -> full suite selected because `src/main/app-lifecycle.test.ts` has no declared module owner. Per maintainer direction, the local complete `npm test` run was intentionally omitted; PR Gate is the final complete and platform validation authority.

Uncovered local risk: no live Electron UI run was performed. The relevant Electron-specific before-quit and close-confirm behavior is dependency-injected and covered by the focused tests above.

## Review focus

- Verify ordinary quit consults the same Reviewer activity owner already used by update and data-root safeguards.
- Verify confirmed/update/data-root shutdown behavior remains unchanged.
