### PR TITLE
fix(lifecycle): explain blocked quit and stale notification clicks

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -123,7 +123,9 @@ type Harness = {
   trayHandlers: TrayHandlers | undefined
   shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
-  abortQuitPreparation: () => Promise<void> | void
+  abortQuitPreparation: (
+    reason: import('../shared/session-persistence-flush').SessionPersistenceFlushAbortReason
+  ) => Promise<void> | void
   flushSessionPersistence: (
     timeoutMs?: number
   ) => Promise<RendererSessionPersistenceFlushOutcome | void>
@@ -632,7 +634,7 @@ describe('installAppLifecycle', () => {
 
     expect(flushSessionPersistence).toHaveBeenCalledOnce()
     expect(prepareForQuit).not.toHaveBeenCalled()
-    expect(abortQuitPreparation).toHaveBeenCalledOnce()
+    expect(abortQuitPreparation).toHaveBeenCalledWith('conflict')
     expect(shutdownBackends).not.toHaveBeenCalled()
     expect(tray?.destroy).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()
@@ -658,7 +660,7 @@ describe('installAppLifecycle', () => {
 
     expect(flushSessionPersistence).toHaveBeenCalledOnce()
     expect(prepareForQuit).not.toHaveBeenCalled()
-    expect(abortQuitPreparation).toHaveBeenCalledOnce()
+    expect(abortQuitPreparation).toHaveBeenCalledWith('renderer-failed')
     expect(shutdownBackends).not.toHaveBeenCalled()
     expect(tray?.destroy).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()
@@ -707,7 +709,7 @@ describe('installAppLifecycle', () => {
 
     expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
     expect(prepareForQuit).toHaveBeenCalledOnce()
-    expect(abortQuitPreparation).toHaveBeenCalledOnce()
+    expect(abortQuitPreparation).toHaveBeenCalledWith('conflict')
     expect(shutdownBackends).not.toHaveBeenCalled()
     expect(tray?.destroy).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()
@@ -736,7 +738,7 @@ describe('installAppLifecycle', () => {
 
     expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
     expect(prepareForQuit).toHaveBeenCalledOnce()
-    expect(abortQuitPreparation).toHaveBeenCalledOnce()
+    expect(abortQuitPreparation).toHaveBeenCalledWith('renderer-failed')
     expect(shutdownBackends).not.toHaveBeenCalled()
     expect(tray?.destroy).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -1,10 +1,8 @@
 import type { App, BrowserWindow, Tray } from 'electron'
 
 import type { ActiveSessionInfo } from '../shared/storage'
-import {
-  rendererSessionPersistenceFlushBlocksShutdown,
-  type RendererSessionPersistenceFlushOutcome
-} from './session-persistence/renderer-flush'
+import type { SessionPersistenceFlushAbortReason } from '../shared/session-persistence-flush'
+import { type RendererSessionPersistenceFlushOutcome } from './session-persistence/renderer-flush'
 import type { ShutdownStepOutcome } from './lifecycle-shutdown'
 import { flushDiagnosticsWithTimeout } from './diagnostics/flush'
 import { diagnosticErrorFields, type Logger } from './logger'
@@ -59,7 +57,7 @@ export type AppLifecycleDeps = {
   // Requests active ACP turns to cancel, then waits a bounded interval for terminal usage events.
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
   // Reopens Main/renderer admission when persistence prevents an orderly quit from committing.
-  abortQuitPreparation: () => Promise<void> | void
+  abortQuitPreparation: (reason: SessionPersistenceFlushAbortReason) => Promise<void> | void
   // Drains renderer runtime events and its ordered Session write queue before the window disappears.
   flushSessionPersistence: (
     timeoutMs?: number
@@ -143,6 +141,10 @@ export const installAppLifecycle = (
     if (outcome === 'renderer-gone') return 'degraded'
     return 'completed'
   }
+  const rendererPersistenceAbortReason = (
+    outcome: RendererSessionPersistenceFlushOutcome
+  ): SessionPersistenceFlushAbortReason | undefined =>
+    outcome === 'conflict' || outcome === 'renderer-failed' ? outcome : undefined
   const shutdownTrigger = (): ApplicationShutdownTrigger => {
     try {
       return deps.shutdownTrigger?.() ?? currentApplicationShutdownTrigger()
@@ -339,7 +341,7 @@ export const installAppLifecycle = (
       let rendererFlushOutcome: RendererSessionPersistenceFlushOutcome
       let rendererFlushResult: ShutdownStepOutcome
       let backendTeardownResult: ShutdownStepOutcome
-      let shutdownAbortedForRendererPersistence = false
+      let shutdownAbortReason: SessionPersistenceFlushAbortReason | undefined
       const flushRendererSessionPersistence = async (
         phase: 'renderer-session-preflight' | 'renderer-session-flush',
         timeoutMs: number
@@ -365,11 +367,9 @@ export const installAppLifecycle = (
         )
         rendererPreflightOutcome = preflight.outcome
         rendererPreflightResult = preflight.result
-        if (
-          ordinaryQuit &&
-          rendererSessionPersistenceFlushBlocksShutdown(rendererPreflightOutcome)
-        ) {
-          shutdownAbortedForRendererPersistence = true
+        const preflightAbortReason = rendererPersistenceAbortReason(rendererPreflightOutcome)
+        if (ordinaryQuit && preflightAbortReason) {
+          shutdownAbortReason = preflightAbortReason
           diagnostics?.complete({
             degraded: true,
             rendererPreflightOutcome,
@@ -402,8 +402,9 @@ export const installAppLifecycle = (
         )
         rendererFlushOutcome = finalFlush.outcome
         rendererFlushResult = finalFlush.result
-        if (ordinaryQuit && rendererSessionPersistenceFlushBlocksShutdown(rendererFlushOutcome)) {
-          shutdownAbortedForRendererPersistence = true
+        const finalAbortReason = rendererPersistenceAbortReason(rendererFlushOutcome)
+        if (ordinaryQuit && finalAbortReason) {
+          shutdownAbortReason = finalAbortReason
           diagnostics?.complete({
             degraded: true,
             rendererPreflightResult,
@@ -449,9 +450,9 @@ export const installAppLifecycle = (
           if (result === 'timeout') deps.log?.warn('final log flush timed out')
         }
       } finally {
-        if (shutdownAbortedForRendererPersistence) {
+        if (shutdownAbortReason) {
           try {
-            await deps.abortQuitPreparation()
+            await deps.abortQuitPreparation(shutdownAbortReason)
           } catch (error) {
             try {
               deps.log?.error('quit preparation rollback failed', diagnosticErrorFields(error))

--- a/src/main/application-events.ts
+++ b/src/main/application-events.ts
@@ -37,7 +37,10 @@ import type { UpdateStatus } from '../shared/update'
 import type { LocalePreferenceSnapshot } from '../shared/locale'
 import type { TagsChangedEvent } from '../shared/tags'
 import type { MemoryChangedEvent } from '../shared/memory'
-import type { SessionPersistenceFlushRequest } from '../shared/session-persistence-flush'
+import type {
+  SessionPersistenceFlushAbortedEvent,
+  SessionPersistenceFlushRequest
+} from '../shared/session-persistence-flush'
 import { createLogger, errorLogFields } from './logger'
 
 const log = createLogger('application-events')
@@ -62,7 +65,7 @@ export type ApplicationEventMap = {
   'session:created': SessionUpsertEvent
   'session:updated': SessionUpsertEvent
   'session:deleted': SessionDeletedEvent
-  'sessions:flush-aborted': undefined
+  'sessions:flush-aborted': SessionPersistenceFlushAbortedEvent | undefined
   'sessions:flush-request': SessionPersistenceFlushRequest
   'project-files:changed': ProjectFilesChangedEvent
   'permissions:changed': PermissionGrantsChangedEvent

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -614,8 +614,9 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
                 getWindow: () => InstanceType<typeof BrowserWindow> | undefined
               ) => createElectronSessionPersistenceFlush(getWindow),
               notifySessionPersistenceFlushAborted: (
-                getWindow: () => InstanceType<typeof BrowserWindow> | undefined
-              ) => notifyRendererSessionPersistenceFlushAborted(getWindow),
+                getWindow: () => InstanceType<typeof BrowserWindow> | undefined,
+                reason?: Parameters<typeof notifyRendererSessionPersistenceFlushAborted>[1]
+              ) => notifyRendererSessionPersistenceFlushAborted(getWindow, reason),
               createConfirmClose: (
                 getWindow: () => InstanceType<typeof BrowserWindow> | undefined
               ) =>
@@ -720,9 +721,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             detectActiveSessions: ctx.detectActiveSessions,
             hasActiveReviewerWork: ctx.hasActiveReviewerWork,
             prepareForQuit: ctx.prepareForQuit,
-            abortQuitPreparation: () => {
+            abortQuitPreparation: (reason) => {
               ctx.abortQuitPreparation()
-              ctx.notifySessionPersistenceFlushAborted(() => ctx.mainWindowGetterBox.current?.())
+              ctx.notifySessionPersistenceFlushAborted(
+                () => ctx.mainWindowGetterBox.current?.(),
+                reason
+              )
             },
             flushSessionPersistence: ctx.createSessionPersistenceFlush(() =>
               ctx.mainWindowGetterBox.current?.()

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -187,6 +187,23 @@ describe('createElectronSessionPersistenceFlush', () => {
       webContents
     }
 
+    notifyRendererSessionPersistenceFlushAborted(() => window as never, 'conflict')
+
+    expect(webContents.send).toHaveBeenCalledWith(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL, {
+      reason: 'conflict'
+    })
+  })
+
+  it('preserves the payload-free durability-abort notification', () => {
+    const webContents = {
+      isDestroyed: vi.fn(() => false),
+      send: vi.fn()
+    }
+    const window = {
+      isDestroyed: vi.fn(() => false),
+      webContents
+    }
+
     notifyRendererSessionPersistenceFlushAborted(() => window as never)
 
     expect(webContents.send).toHaveBeenCalledWith(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL)
@@ -342,6 +359,17 @@ describe('createWebSessionPersistenceFlush', () => {
   })
 
   it('notifies Web when a refused handoff must resume renderer activity', () => {
+    const publish = vi.fn()
+    const coordinator = createWebSessionPersistenceFlush({ publish })
+
+    coordinator.notifyAborted('renderer-failed')
+
+    expect(publish).toHaveBeenCalledWith(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL, {
+      reason: 'renderer-failed'
+    })
+  })
+
+  it('preserves the payload-free Web durability-abort notification', () => {
     const publish = vi.fn()
     const coordinator = createWebSessionPersistenceFlush({ publish })
 

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -5,6 +5,8 @@ import {
   SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL,
   SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL,
   SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL,
+  type SessionPersistenceFlushAbortReason,
+  type SessionPersistenceFlushAbortedEvent,
   type SessionPersistenceFlushRequest,
   type SessionPersistenceFlushResponse
 } from '../../shared/session-persistence-flush'
@@ -52,7 +54,7 @@ export const createWebSessionPersistenceFlush = (
 ): Readonly<{
   flush: (targetLifecycleClientId: string) => Promise<RendererSessionPersistenceFlushOutcome>
   acknowledge: (response: SessionPersistenceFlushResponse, lifecycleClientId: string) => void
-  notifyAborted: () => void
+  notifyAborted: (reason?: SessionPersistenceFlushAbortReason) => void
 }> => {
   const responseListeners = new Set<
     (response: SessionPersistenceFlushResponse, lifecycleClientId: string) => void
@@ -86,7 +88,8 @@ export const createWebSessionPersistenceFlush = (
     acknowledge: (response, lifecycleClientId) => {
       for (const listener of responseListeners) listener(response, lifecycleClientId)
     },
-    notifyAborted: () => events.publish(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL, undefined)
+    notifyAborted: (reason) =>
+      events.publish(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL, reason ? { reason } : undefined)
   })
 }
 
@@ -163,10 +166,17 @@ export const createElectronSessionPersistenceFlush = (
 }
 
 export const notifyRendererSessionPersistenceFlushAborted = (
-  getWindow: () => BrowserWindow | undefined
+  getWindow: () => BrowserWindow | undefined,
+  reason?: SessionPersistenceFlushAbortedEvent['reason']
 ): void => {
   const window = getWindow()
   const webContents = window?.webContents
   if (!window || window.isDestroyed() || !webContents || webContents.isDestroyed()) return
+  if (reason) {
+    webContents.send(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL, {
+      reason
+    } satisfies SessionPersistenceFlushAbortedEvent)
+    return
+  }
   webContents.send(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL)
 }

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -62,7 +62,9 @@ type PreloadApi = {
     deleteSession: (request: unknown) => unknown
     saveManifest: (request: unknown) => unknown
     exportConversation: (request: unknown) => unknown
-    onFlushAborted: (listener: () => void) => unknown
+    onFlushAborted: (
+      listener: (event?: { reason: 'conflict' | 'renderer-failed' }) => void
+    ) => unknown
     onFlushRequest: (listener: (request: { requestId: string }) => void) => unknown
     sendFlushResponse: (response: { requestId: string }) => void
   }
@@ -1492,9 +1494,9 @@ describe('preload bridge — sessions + agent-framework IPC channels', () => {
     api.sessions.onFlushAborted(abortedListener)
     expect(onMock).toHaveBeenCalledWith('sessions:flush-aborted', expect.any(Function))
     const wrappedAbortedListener = onMock.mock.calls.at(-1)?.[1] as
-      ((_event: unknown) => void) | undefined
-    wrappedAbortedListener?.({})
-    expect(abortedListener).toHaveBeenCalledOnce()
+      ((_event: unknown, payload: { reason: 'conflict' }) => void) | undefined
+    wrappedAbortedListener?.({}, { reason: 'conflict' })
+    expect(abortedListener).toHaveBeenCalledWith({ reason: 'conflict' })
 
     api.sessions.onFlushRequest(listener)
     expect(onMock).toHaveBeenCalledWith('sessions:flush-request', expect.any(Function))

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1698,6 +1698,7 @@ describe('App startup routing', () => {
     expect(alert?.textContent).toContain('Quit was canceled')
     expect(alert?.closest('[inert]')).toBeNull()
     expect(alert?.closest('[aria-hidden="true"]')).toBeNull()
+    expect(alert?.classList.contains('z-toast')).toBe(true)
   })
 
   it('does not let a later notification peek override navigation while an earlier peek is pending', async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1670,6 +1670,36 @@ describe('App startup routing', () => {
     expect(container.textContent).not.toContain('Quit was canceled')
   })
 
+  it('keeps quit recovery controls interactive while Settings covers the base presentation', async () => {
+    let notifyFlushAborted: (event: { reason: 'renderer-failed' }) => void = () => undefined
+    ;(
+      window.api as unknown as {
+        sessions: {
+          onFlushAborted: (listener: typeof notifyFlushAborted) => () => void
+          onFlushRequest: (listener: (request: { requestId: string }) => void) => () => void
+          sendFlushResponse: (response: { requestId: string; status: string }) => void
+        }
+      }
+    ).sessions = {
+      onFlushAborted: (listener) => {
+        notifyFlushAborted = listener
+        return () => undefined
+      },
+      onFlushRequest: () => () => undefined,
+      sendFlushResponse: vi.fn()
+    }
+    mocks.settings.isLoaded = true
+    mocks.settings.isSettingsOpen = true
+
+    await render()
+    act(() => notifyFlushAborted({ reason: 'renderer-failed' }))
+
+    const alert = container.querySelector('[data-testid="session-persistence-alert"]')
+    expect(alert?.textContent).toContain('Quit was canceled')
+    expect(alert?.closest('[inert]')).toBeNull()
+    expect(alert?.closest('[aria-hidden="true"]')).toBeNull()
+  })
+
   it('does not let a later notification peek override navigation while an earlier peek is pending', async () => {
     const target = { sessionId: 's-3', token: 3 }
     let pending: typeof target | null = target

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1619,6 +1619,57 @@ describe('App startup routing', () => {
     expect(mocks.openSessionById).toHaveBeenCalledWith('s-3', 'notification')
   })
 
+  it('explains when a desktop-notification target is no longer available', async () => {
+    mocks.settings.isLoaded = true
+    mocks.notifications.peekPendingOpenSession.mockResolvedValue({ sessionId: 's-gone', token: 4 })
+    mocks.notifications.takePendingOpenSession.mockResolvedValue({ sessionId: 's-gone', token: 4 })
+
+    await render()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mocks.notifications.takePendingOpenSession).toHaveBeenCalledWith(4)
+    expect(mocks.openSessionById).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('This session was deleted or is unavailable.')
+  })
+
+  it('explains a quit canceled by a Session persistence conflict and offers retry', async () => {
+    let notifyFlushAborted: (event: { reason: 'conflict' }) => void = () => undefined
+    ;(
+      window.api as unknown as {
+        sessions: {
+          onFlushAborted: (listener: typeof notifyFlushAborted) => () => void
+          onFlushRequest: (listener: (request: { requestId: string }) => void) => () => void
+          sendFlushResponse: (response: { requestId: string; status: string }) => void
+        }
+      }
+    ).sessions = {
+      onFlushAborted: (listener) => {
+        notifyFlushAborted = listener
+        return () => undefined
+      },
+      onFlushRequest: () => () => undefined,
+      sendFlushResponse: vi.fn()
+    }
+    mocks.settings.isLoaded = true
+
+    await render()
+    act(() => notifyFlushAborted({ reason: 'conflict' }))
+
+    expect(container.textContent).toContain('Quit was canceled')
+    expect(container.textContent).toContain(
+      'A conversation changed elsewhere and could not be saved safely.'
+    )
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-persistence-retry"]'
+    )
+    act(() => retry?.click())
+    expect(mocks.sessionPersistence.retryWrites).toHaveBeenCalledOnce()
+    expect(container.textContent).not.toContain('Quit was canceled')
+  })
+
   it('does not let a later notification peek override navigation while an earlier peek is pending', async () => {
     const target = { sessionId: 's-3', token: 3 }
     let pending: typeof target | null = target

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1690,11 +1690,14 @@ describe('App startup routing', () => {
     }
     mocks.settings.isLoaded = true
     mocks.settings.isSettingsOpen = true
+    mocks.sessionPersistence.loadError = 'selected conversation unavailable'
 
     await render()
     act(() => notifyFlushAborted({ reason: 'renderer-failed' }))
 
-    const alert = container.querySelector('[data-testid="session-persistence-alert"]')
+    const alert = Array.from(
+      container.querySelectorAll('[data-testid="session-persistence-alert"]')
+    ).find((candidate) => candidate.textContent?.includes('Quit was canceled'))
     expect(alert?.textContent).toContain('Quit was canceled')
     expect(alert?.closest('[inert]')).toBeNull()
     expect(alert?.closest('[aria-hidden="true"]')).toBeNull()

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -237,9 +237,7 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
           />
         ) : null}
       </div>
-      {sessions.catalogRecovery.kind === 'ready' && sessions.loadError
-        ? null
-        : quitPersistenceAlert}
+      {quitPersistenceAlert}
       <WebEventRecoveryDialog
         active={activePresentation === 'webEventRecovery'}
         phase={events.webEventConnectionPhase}

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -149,8 +149,12 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
       }
       onDismiss={startup.quitPersistence.dismissNotice}
       onRetry={() => {
-        startup.quitPersistence.dismissNotice()
         sessions.retryWrites()
+        if (startup.quitPersistence.notice?.reason === 'conflict') {
+          startup.quitPersistence.dismissNotice()
+          return
+        }
+        void startup.quitPersistence.retryPersistence().catch(() => undefined)
       }}
     />
   ) : null

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { CloseConfirmModal } from '@/components/CloseConfirmModal'
+import { ActionToast } from '@/components/ActionToast'
 import { ConnectorAuthToast } from '@/components/ConnectorAuthToast'
 import { DataRootMissingDialog } from '@/components/DataRootMissingDialog'
 import { ErrorNotice } from '@/components/error-notice'
@@ -138,6 +139,21 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
       onRetry={sessions.retryWrites}
     />
   ) : null
+  const quitPersistenceAlert = startup.quitPersistence.notice ? (
+    <SessionPersistenceAlert
+      title={t('Quit was canceled')}
+      message={
+        startup.quitPersistence.notice.reason === 'conflict'
+          ? t('A conversation changed elsewhere and could not be saved safely.')
+          : t('One or more conversations could not be saved.')
+      }
+      onDismiss={startup.quitPersistence.dismissNotice}
+      onRetry={() => {
+        startup.quitPersistence.dismissNotice()
+        sessions.retryWrites()
+      }}
+    />
+  ) : null
 
   return (
     <>
@@ -162,6 +178,8 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
             message={sessions.loadError}
             onRetry={sessions.retryLoad}
           />
+        ) : quitPersistenceAlert ? (
+          quitPersistenceAlert
         ) : writeErrorAlert ? (
           writeErrorAlert
         ) : sessions.loadWarning ? (
@@ -172,7 +190,9 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
             onDismiss={sessions.dismissLoadWarning}
           />
         ) : null}
-        {sessions.catalogRecovery.kind !== 'ready' ? writeErrorAlert : null}
+        {sessions.catalogRecovery.kind !== 'ready'
+          ? (quitPersistenceAlert ?? writeErrorAlert)
+          : null}
         <WorkspaceAgentRuntimeProvider>
           <JobAnalysisRuntimeBridge enabled={sessions.isReady} />
           <WorkspaceMessageQueueProvider>
@@ -203,6 +223,17 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
         <StorageCleanupToast />
         <NotificationLiveToast />
         <PermissionUndoSnackbar allowsArchiveShortcut={events.allowsArchiveUndoShortcut} />
+        {events.notification.unavailableToken !== undefined ? (
+          <ActionToast
+            key={events.notification.unavailableToken}
+            title={t('This session was deleted or is unavailable.')}
+            dismissLabel={t('Close')}
+            onDismiss={events.notification.dismissUnavailable}
+            autoDismissMs={6000}
+            className="top-44"
+            testId="notification-target-unavailable-toast"
+          />
+        ) : null}
       </div>
       <WebEventRecoveryDialog
         active={activePresentation === 'webEventRecovery'}

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -182,9 +182,7 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
             message={sessions.loadError}
             onRetry={sessions.retryLoad}
           />
-        ) : quitPersistenceAlert ? (
-          quitPersistenceAlert
-        ) : writeErrorAlert ? (
+        ) : startup.quitPersistence.notice ? null : writeErrorAlert ? (
           writeErrorAlert
         ) : sessions.loadWarning ? (
           <SessionPersistenceAlert
@@ -194,8 +192,8 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
             onDismiss={sessions.dismissLoadWarning}
           />
         ) : null}
-        {sessions.catalogRecovery.kind !== 'ready'
-          ? (quitPersistenceAlert ?? writeErrorAlert)
+        {sessions.catalogRecovery.kind !== 'ready' && !startup.quitPersistence.notice
+          ? writeErrorAlert
           : null}
         <WorkspaceAgentRuntimeProvider>
           <JobAnalysisRuntimeBridge enabled={sessions.isReady} />
@@ -239,6 +237,9 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
           />
         ) : null}
       </div>
+      {sessions.catalogRecovery.kind === 'ready' && sessions.loadError
+        ? null
+        : quitPersistenceAlert}
       <WebEventRecoveryDialog
         active={activePresentation === 'webEventRecovery'}
         phase={events.webEventConnectionPhase}

--- a/src/renderer/src/components/ActionToast.test.tsx
+++ b/src/renderer/src/components/ActionToast.test.tsx
@@ -83,4 +83,21 @@ describe('ActionToast', () => {
 
     expect(onDismiss).toHaveBeenCalledOnce()
   })
+
+  it('renders a dismiss-only status without an action button', async () => {
+    await act(async () =>
+      root.render(
+        <ActionToast
+          title="This session is unavailable"
+          dismissLabel="Dismiss"
+          onDismiss={vi.fn()}
+        />
+      )
+    )
+
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      'This session is unavailable'
+    )
+    expect(container.querySelectorAll('button')).toHaveLength(1)
+  })
 })

--- a/src/renderer/src/components/ActionToast.tsx
+++ b/src/renderer/src/components/ActionToast.tsx
@@ -8,9 +8,9 @@ import { cn } from '@/lib/utils'
 type ActionToastProps = {
   title: string
   detail?: string
-  actionLabel: string
+  actionLabel?: string
   dismissLabel: string
-  onAction: () => void
+  onAction?: () => void
   onDismiss: () => void
   autoDismissMs?: number
   className?: string
@@ -62,13 +62,15 @@ const ActionToast = ({
           </span>
         ) : null}
       </span>
-      <button
-        type="button"
-        onClick={onAction}
-        className="inline-flex h-7 shrink-0 items-center rounded px-2 text-xs font-medium whitespace-nowrap text-primary hover:bg-bg-300 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
-      >
-        {actionLabel}
-      </button>
+      {actionLabel && onAction ? (
+        <button
+          type="button"
+          onClick={onAction}
+          className="inline-flex h-7 shrink-0 items-center rounded px-2 text-xs font-medium whitespace-nowrap text-primary hover:bg-bg-300 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+        >
+          {actionLabel}
+        </button>
+      ) : null}
       <button
         type="button"
         aria-label={dismissLabel}

--- a/src/renderer/src/components/SessionPersistenceAlert.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.tsx
@@ -36,7 +36,8 @@ const SessionPersistenceAlert = ({
     <div
       role="alert"
       data-testid="session-persistence-alert"
-      className={`${inline ? 'w-full max-w-md' : 'fixed bottom-3 right-3 z-50 w-[min(420px,calc(100vw-24px))]'} rounded-xl border bg-card p-4 text-sm text-muted-foreground shadow-sm ${
+      // z-toast resolves to 70, above the standard portaled modal layer (z-50 / z-modal).
+      className={`${inline ? 'w-full max-w-md' : 'fixed bottom-3 right-3 z-toast w-[min(420px,calc(100vw-24px))]'} rounded-xl border bg-card p-4 text-sm text-muted-foreground shadow-sm ${
         variant === 'warning' ? 'border-border' : 'border-destructive/40'
       }`}
     >

--- a/src/renderer/src/hooks/useApplicationEventBindings.ts
+++ b/src/renderer/src/hooks/useApplicationEventBindings.ts
@@ -49,6 +49,10 @@ type ApplicationEventProjection = Readonly<{
   webEventConnectionPhase: WebEventConnectionPhase
   blockedApprovalSessionIds: ReadonlySet<string>
   lifecycle: ReturnType<typeof useLifecycleSync>
+  notification: Readonly<{
+    unavailableToken: number | undefined
+    dismissUnavailable: () => void
+  }>
   allowsArchiveUndoShortcut: () => boolean
   navigation: Readonly<{
     view: NavigationView
@@ -116,6 +120,7 @@ const useApplicationEventBindings = ({
   const listenForNotificationChanges = useNotificationInboxStore((state) => state.listen)
   const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false)
   const [isGlobalSearchOpen, setIsGlobalSearchOpen] = useState(false)
+  const [unavailableNotificationToken, setUnavailableNotificationToken] = useState<number>()
   const deferredNotification = useRef<OpenSessionFromNotificationRequest | undefined>(undefined)
   const pendingNotificationOpenQueue = useRef<Promise<void>>(Promise.resolve())
   const notificationOpenIntent = useRef<NotificationOpenIntent>({
@@ -354,11 +359,15 @@ const useApplicationEventBindings = ({
         }
         if (
           intent.generation !== notificationOpenIntent.current.generation ||
-          !sessionExists ||
           useNavigationStore.getState().userNavigationRevision !== intent.userNavigationRevision
         ) {
           return
         }
+        if (!sessionExists) {
+          setUnavailableNotificationToken(consumed.token)
+          return
+        }
+        setUnavailableNotificationToken(undefined)
         useNavigationStore.getState().openSessionById(consumed.sessionId, 'notification')
       }
 
@@ -431,6 +440,10 @@ const useApplicationEventBindings = ({
     webEventConnectionPhase,
     blockedApprovalSessionIds: openSideChatParentSessionIds,
     lifecycle,
+    notification: {
+      unavailableToken: unavailableNotificationToken,
+      dismissUnavailable: () => setUnavailableNotificationToken(undefined)
+    },
     allowsArchiveUndoShortcut,
     navigation: { view },
     globalSearch: { open: openGlobalSearch, setOpen: setGlobalSearchOpen },

--- a/src/renderer/src/hooks/useApplicationStartup.ts
+++ b/src/renderer/src/hooks/useApplicationStartup.ts
@@ -8,7 +8,10 @@ import {
 } from '@/lib/session-persistence/session-persistence'
 import { resolveStartupView, type StartupView } from '@/pages/onboarding/startup-gate'
 import type { ProvisionUiState } from '@/pages/workspace/provisioning-view'
-import { useQuitPersistenceFlush } from '@/hooks/useQuitPersistenceFlush'
+import {
+  useQuitPersistenceFlush,
+  type QuitPersistenceFlushProjection
+} from '@/hooks/useQuitPersistenceFlush'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -29,6 +32,7 @@ type ApplicationStartupProjection = Readonly<{
     retry: () => Promise<void>
   }>
   sessions: SessionPersistenceState
+  quitPersistence: QuitPersistenceFlushProjection
   environment: Readonly<{
     ui: ProvisionUiState
     retry: () => Promise<void>
@@ -46,7 +50,7 @@ type ApplicationStartupProjection = Readonly<{
 // presentation and event-binding modules need.
 const useApplicationStartup = (): ApplicationStartupProjection => {
   const sessions = useSessionPersistence()
-  useQuitPersistenceFlush()
+  const quitPersistence = useQuitPersistenceFlush()
   useDeepLinkNavigation({ isHydrated: sessions.isHydrated, isReady: sessions.isReady })
 
   const loadProjects = useProjectStore((state) => state.loadProjects)
@@ -133,6 +137,7 @@ const useApplicationStartup = (): ApplicationStartupProjection => {
       retry: retrySettings
     },
     sessions,
+    quitPersistence,
     environment: { ui: environmentUi, retry: retryEnvironment },
     storageRecovery: {
       missingDataRoot,

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
@@ -3,12 +3,17 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { flushPreviewPersistence, flushSessionPersistence, resumeAutoReviewsAfterQuitAbort } =
-  vi.hoisted(() => ({
-    flushPreviewPersistence: vi.fn(async () => undefined),
-    flushSessionPersistence: vi.fn(async () => undefined),
-    resumeAutoReviewsAfterQuitAbort: vi.fn()
-  }))
+const {
+  drainWorkspaceRuntimeEventsForPersistence,
+  flushPreviewPersistence,
+  flushSessionPersistence,
+  resumeAutoReviewsAfterQuitAbort
+} = vi.hoisted(() => ({
+  drainWorkspaceRuntimeEventsForPersistence: vi.fn(async () => undefined),
+  flushPreviewPersistence: vi.fn(async () => undefined),
+  flushSessionPersistence: vi.fn(async () => undefined),
+  resumeAutoReviewsAfterQuitAbort: vi.fn()
+}))
 
 vi.mock('../lib/preview-persistence/preview-persistence', () => ({
   flushPreviewPersistence
@@ -19,7 +24,7 @@ vi.mock('../lib/acp/workspace-events', () => ({
   suppressAutoReviewsForQuit: vi.fn()
 }))
 vi.mock('../lib/acp/useWorkspaceAgentRuntime', () => ({
-  drainWorkspaceRuntimeEventsForPersistence: vi.fn(async () => undefined)
+  drainWorkspaceRuntimeEventsForPersistence
 }))
 vi.mock('../lib/session-persistence/session-persistence', () => ({
   flushSessionPersistence
@@ -29,6 +34,7 @@ import { completeQuitPersistenceFlush, useQuitPersistenceFlush } from './useQuit
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  drainWorkspaceRuntimeEventsForPersistence.mockClear()
   flushPreviewPersistence.mockClear()
   flushSessionPersistence.mockClear()
   resumeAutoReviewsAfterQuitAbort.mockClear()
@@ -82,6 +88,54 @@ describe('completeQuitPersistenceFlush', () => {
 
     expect(resumeAutoReviewsAfterQuitAbort).toHaveBeenCalledOnce()
     expect(result.current.notice).toBeUndefined()
+  })
+
+  it('retries every renderer persistence phase after a failed quit flush', async () => {
+    let notifyAborted: (event: { reason: 'renderer-failed' }) => void = () => undefined
+    vi.stubGlobal('window', {
+      api: {
+        sessions: {
+          onFlushAborted: (listener: typeof notifyAborted) => {
+            notifyAborted = listener
+            return vi.fn()
+          },
+          onFlushRequest: () => vi.fn(),
+          sendFlushResponse: vi.fn()
+        }
+      }
+    })
+
+    const { result } = renderHook(() => useQuitPersistenceFlush())
+    act(() => notifyAborted({ reason: 'renderer-failed' }))
+    await act(() => result.current.retryPersistence())
+
+    expect(drainWorkspaceRuntimeEventsForPersistence).toHaveBeenCalledOnce()
+    expect(flushSessionPersistence).toHaveBeenCalledOnce()
+    expect(flushPreviewPersistence).toHaveBeenCalledOnce()
+    expect(result.current.notice).toBeUndefined()
+  })
+
+  it('keeps the failed quit notice when a complete persistence retry still fails', async () => {
+    let notifyAborted: (event: { reason: 'renderer-failed' }) => void = () => undefined
+    flushPreviewPersistence.mockRejectedValueOnce(new Error('preview write failed'))
+    vi.stubGlobal('window', {
+      api: {
+        sessions: {
+          onFlushAborted: (listener: typeof notifyAborted) => {
+            notifyAborted = listener
+            return vi.fn()
+          },
+          onFlushRequest: () => vi.fn(),
+          sendFlushResponse: vi.fn()
+        }
+      }
+    })
+
+    const { result } = renderHook(() => useQuitPersistenceFlush())
+    act(() => notifyAborted({ reason: 'renderer-failed' }))
+    await expect(result.current.retryPersistence()).rejects.toThrow('preview write failed')
+
+    expect(result.current.notice).toEqual({ reason: 'renderer-failed' })
   })
 
   it('flushes Preview persistence before acknowledging quit', async () => {

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const { flushPreviewPersistence, flushSessionPersistence, resumeAutoReviewsAfterQuitAbort } =
@@ -35,14 +35,14 @@ afterEach(() => {
 })
 
 describe('completeQuitPersistenceFlush', () => {
-  it('resumes renderer quit preparation when Main aborts shutdown', () => {
-    let notifyAborted = (): void => undefined
+  it('resumes renderer quit preparation and exposes the blocking conflict', () => {
+    let notifyAborted: (event: { reason: 'conflict' }) => void = () => undefined
     const removeAborted = vi.fn()
     const removeRequest = vi.fn()
     vi.stubGlobal('window', {
       api: {
         sessions: {
-          onFlushAborted: (listener: () => void) => {
+          onFlushAborted: (listener: typeof notifyAborted) => {
             notifyAborted = listener
             return removeAborted
           },
@@ -52,13 +52,36 @@ describe('completeQuitPersistenceFlush', () => {
       }
     })
 
-    const { unmount } = renderHook(() => useQuitPersistenceFlush())
-    notifyAborted()
+    const { result, unmount } = renderHook(() => useQuitPersistenceFlush())
+    act(() => notifyAborted({ reason: 'conflict' }))
 
     expect(resumeAutoReviewsAfterQuitAbort).toHaveBeenCalledOnce()
+    expect(result.current).toMatchObject({ notice: { reason: 'conflict' } })
     unmount()
     expect(removeAborted).toHaveBeenCalledOnce()
     expect(removeRequest).toHaveBeenCalledOnce()
+  })
+
+  it('resumes renderer activity without a quit notice for a durability handoff abort', () => {
+    let notifyAborted: (event?: { reason: 'conflict' }) => void = () => undefined
+    vi.stubGlobal('window', {
+      api: {
+        sessions: {
+          onFlushAborted: (listener: typeof notifyAborted) => {
+            notifyAborted = listener
+            return vi.fn()
+          },
+          onFlushRequest: () => vi.fn(),
+          sendFlushResponse: vi.fn()
+        }
+      }
+    })
+
+    const { result } = renderHook(() => useQuitPersistenceFlush())
+    act(() => notifyAborted())
+
+    expect(resumeAutoReviewsAfterQuitAbort).toHaveBeenCalledOnce()
+    expect(result.current.notice).toBeUndefined()
   })
 
   it('flushes Preview persistence before acknowledging quit', async () => {

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -1,6 +1,7 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import type {
+  SessionPersistenceFlushAbortedEvent,
   SessionPersistenceFlushRequest,
   SessionPersistenceFlushResponse
 } from '../../../shared/session-persistence-flush'
@@ -20,6 +21,11 @@ type QuitPersistenceFlushDeps = {
   flushPreviewPersistence: () => Promise<void>
   acknowledge: (response: SessionPersistenceFlushResponse) => void
 }
+
+type QuitPersistenceFlushProjection = Readonly<{
+  notice: SessionPersistenceFlushAbortedEvent | undefined
+  dismissNotice: () => void
+}>
 
 export const completeQuitPersistenceFlush = async (
   request: SessionPersistenceFlushRequest,
@@ -41,7 +47,10 @@ export const completeQuitPersistenceFlush = async (
   if (failure !== undefined) throw failure
 }
 
-export const useQuitPersistenceFlush = (): void => {
+export const useQuitPersistenceFlush = (): QuitPersistenceFlushProjection => {
+  const [notice, setNotice] = useState<SessionPersistenceFlushAbortedEvent>()
+  const dismissNotice = useCallback(() => setNotice(undefined), [])
+
   useEffect(() => {
     const onFlushAborted = window.api.sessions?.onFlushAborted
     const onFlushRequest = window.api.sessions?.onFlushRequest
@@ -49,7 +58,10 @@ export const useQuitPersistenceFlush = (): void => {
       window.api.sessions?.sendFlushResponse ?? window.api.storage?.ackDataRootHandoffFlush
     if (!onFlushRequest || !sendFlushResponse) return
 
-    const removeFlushAborted = onFlushAborted?.(resumeAutoReviewsAfterQuitAbort)
+    const removeFlushAborted = onFlushAborted?.((event) => {
+      resumeAutoReviewsAfterQuitAbort()
+      if (event) setNotice(event)
+    })
     const removeFlushRequest = onFlushRequest((request) => {
       void (async () => {
         if (request.targetLifecycleClientId) {
@@ -70,4 +82,8 @@ export const useQuitPersistenceFlush = (): void => {
       removeFlushRequest()
     }
   }, [])
+
+  return { notice, dismissNotice }
 }
+
+export type { QuitPersistenceFlushProjection }

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -25,6 +25,7 @@ type QuitPersistenceFlushDeps = {
 type QuitPersistenceFlushProjection = Readonly<{
   notice: SessionPersistenceFlushAbortedEvent | undefined
   dismissNotice: () => void
+  retryPersistence: () => Promise<void>
 }>
 
 export const completeQuitPersistenceFlush = async (
@@ -50,6 +51,12 @@ export const completeQuitPersistenceFlush = async (
 export const useQuitPersistenceFlush = (): QuitPersistenceFlushProjection => {
   const [notice, setNotice] = useState<SessionPersistenceFlushAbortedEvent>()
   const dismissNotice = useCallback(() => setNotice(undefined), [])
+  const retryPersistence = useCallback(async (): Promise<void> => {
+    await drainWorkspaceRuntimeEventsForPersistence()
+    await flushSessionPersistence()
+    await flushPreviewPersistence()
+    setNotice(undefined)
+  }, [])
 
   useEffect(() => {
     const onFlushAborted = window.api.sessions?.onFlushAborted
@@ -83,7 +90,7 @@ export const useQuitPersistenceFlush = (): QuitPersistenceFlushProjection => {
     }
   }, [])
 
-  return { notice, dismissNotice }
+  return { notice, dismissNotice, retryPersistence }
 }
 
 export type { QuitPersistenceFlushProjection }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -58,6 +58,10 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "A conversation changed elsewhere and could not be saved safely.": "Una conversación cambió en otro lugar y no se pudo guardar de forma segura.",
+    "One or more conversations could not be saved.": "No se pudieron guardar una o más conversaciones.",
+    "Quit was canceled": "Se canceló la salida",
+    "This session was deleted or is unavailable.": "Esta sesión se eliminó o no está disponible.",
     "Architect": "Arquitecto",
     "Archivist": "Archivero",
     "Builder": "Constructor",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -58,6 +58,10 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "A conversation changed elsewhere and could not be saved safely.": "Une conversation a été modifiée ailleurs et n’a pas pu être enregistrée en toute sécurité.",
+    "One or more conversations could not be saved.": "Une ou plusieurs conversations n’ont pas pu être enregistrées.",
+    "Quit was canceled": "La fermeture a été annulée",
+    "This session was deleted or is unavailable.": "Cette session a été supprimée ou n’est pas disponible.",
     "Add context for the Agent": "Ajouter du contexte pour l’Agent",
     "Agent Message": "Message de l’Agent",
     "An annotated image is no longer available. Restore access to its fixed version or remove the annotation, then try again.": "Une image annotée n’est plus disponible. Restaurez l’accès à sa version fixe ou supprimez l’annotation, puis réessayez.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -56,6 +56,10 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "A conversation changed elsewhere and could not be saved safely.": "別の場所で会話が変更されたため、安全に保存できませんでした。",
+    "One or more conversations could not be saved.": "1件以上の会話を保存できませんでした。",
+    "Quit was canceled": "終了はキャンセルされました",
+    "This session was deleted or is unavailable.": "このセッションは削除されたか、利用できません。",
     "Add context for the Agent": "エージェント向けの補足を追加",
     "Agent Message": "エージェントのメッセージ",
     "An annotated image is no longer available. Restore access to its fixed version or remove the annotation, then try again.": "注釈付き画像を利用できなくなりました。固定バージョンへのアクセスを復元するか、注釈を削除してから再試行してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -56,6 +56,10 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "A conversation changed elsewhere and could not be saved safely.": "다른 곳에서 대화가 변경되어 안전하게 저장할 수 없습니다.",
+    "One or more conversations could not be saved.": "하나 이상의 대화를 저장할 수 없습니다.",
+    "Quit was canceled": "종료가 취소되었습니다",
+    "This session was deleted or is unavailable.": "이 세션은 삭제되었거나 사용할 수 없습니다.",
     "Add context for the Agent": "에이전트에게 전달할 컨텍스트 추가",
     "Agent Message": "에이전트 메시지",
     "An annotated image is no longer available. Restore access to its fixed version or remove the annotation, then try again.": "주석이 추가된 이미지를 더 이상 사용할 수 없습니다. 고정 버전에 대한 액세스를 복원하거나 주석을 제거한 후 다시 시도하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -59,6 +59,10 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "A conversation changed elsewhere and could not be saved safely.": "Диалог был изменён в другом месте, поэтому его не удалось безопасно сохранить.",
+    "One or more conversations could not be saved.": "Не удалось сохранить один или несколько диалогов.",
+    "Quit was canceled": "Выход отменён",
+    "This session was deleted or is unavailable.": "Эта сессия удалена или недоступна.",
     "Add context for the Agent": "Добавить контекст для Агента",
     "Agent Message": "Сообщение Агента",
     "An annotated image is no longer available. Restore access to its fixed version or remove the annotation, then try again.": "Аннотированное изображение больше недоступно. Восстановите доступ к зафиксированной версии или удалите аннотацию и повторите попытку.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -56,6 +56,10 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "A conversation changed elsewhere and could not be saved safely.": "会话已在其他位置更改，无法安全保存。",
+    "One or more conversations could not be saved.": "一个或多个会话无法保存。",
+    "Quit was canceled": "已取消退出",
+    "This session was deleted or is unavailable.": "该会话已被删除或不可用。",
     "Add context for the Agent": "为智能体添加上下文",
     "Agent Message": "智能体消息",
     "An annotated image is no longer available. Restore access to its fixed version or remove the annotation, then try again.": "某个已标注的图片已不可用。请恢复对其固定版本的访问权限，或移除该标注，然后重试。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -56,6 +56,10 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "A conversation changed elsewhere and could not be saved safely.": "會話已在其他位置變更，無法安全儲存。",
+    "One or more conversations could not be saved.": "一個或多個會話無法儲存。",
+    "Quit was canceled": "已取消結束",
+    "This session was deleted or is unavailable.": "此會話已刪除或無法使用。",
     "Add context for the Agent": "為智能體新增上下文",
     "Agent Message": "智能體訊息",
     "An annotated image is no longer available. Restore access to its fixed version or remove the annotation, then try again.": "某個已標註的圖片已無法使用。請恢復其固定版本的存取權限，或移除該標註，然後再試一次。",

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -240,6 +240,7 @@ import type {
   UpdateSessionArchiveRequest
 } from './session-persistence'
 import type {
+  SessionPersistenceFlushAbortedEvent,
   SessionPersistenceFlushRequest,
   SessionPersistenceFlushResponse
 } from './session-persistence-flush'
@@ -1416,11 +1417,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     'sessions',
     ['session:deleted', EVENT]
   ),
-  'sessions.onFlushAborted': callable<(listener: () => void) => RemoveListener>()(
-    'sessions',
-    ['sessions:flush-aborted', EVENT],
-    { optionalMember: true }
-  ),
+  'sessions.onFlushAborted': callable<
+    (listener: AcpListener<SessionPersistenceFlushAbortedEvent | undefined>) => RemoveListener
+  >()('sessions', ['sessions:flush-aborted', EVENT], { optionalMember: true }),
   'sessions.onFlushRequest': callable<
     (listener: AcpListener<SessionPersistenceFlushRequest>) => RemoveListener
   >()('sessions', ['sessions:flush-request', EVENT], { optionalMember: true }),

--- a/src/shared/session-persistence-flush.ts
+++ b/src/shared/session-persistence-flush.ts
@@ -9,6 +9,10 @@ export type SessionPersistenceFlushRequest = {
   targetLifecycleClientId?: string
 }
 export type SessionPersistenceFlushStatus = 'completed' | 'conflict' | 'failed'
+export type SessionPersistenceFlushAbortReason = 'conflict' | 'renderer-failed'
+export type SessionPersistenceFlushAbortedEvent = {
+  reason: SessionPersistenceFlushAbortReason
+}
 export type SessionPersistenceFlushResponse = {
   requestId: string
   status: SessionPersistenceFlushStatus


### PR DESCRIPTION
## Problem

An ordinary quit blocked by a Session persistence conflict or renderer write failure reopened the
window without explaining why. The existing abort event only resumed renderer activity and discarded
the blocking flush outcome.

Clicking a desktop notification for a Session that had since been deleted consumed the click target
and activated the app, but returned without navigation or feedback.

## Proposed change

- Carry `conflict` / `renderer-failed` through the existing `sessions:flush-aborted` event for blocked
  ordinary quits.
- Keep payload-free durability-abort events compatible for update and data-root handoff recovery.
- Show a transient, retryable Session persistence alert after a blocked quit.
- Show a dismissible, auto-expiring status toast after consuming an unavailable notification target.
- Reuse the existing persistence alert and toast primitives; do not add a global notice store.
- Add all new renderer copy to the seven translated locale catalogs.

## Scope and non-goals

- No Prisma, database, Session, Project, or notification data-model changes.
- No new persisted fields, files, migrations, or write paths.
- No historical stored-data compatibility work is required.
- The only new state union is the transient abort reason `conflict | renderer-failed`.
- Deleted Sessions are not restored, re-queried, or recreated; notification targets remain
  consume-once.

## Acceptance criteria and validation

Regression tests were added before the production fix. On the unchanged implementation, the focused
command failed deterministically twice with the reported symptoms: abort callbacks received no reason,
Electron/Web events had no payload, the renderer hook exposed no notice, and the consumed missing
notification target rendered no explanation (8 failed, 233 passed).

All listed passing checks ran after the last material edit:

- blocked quit outcome and renderer feedback -> `npm test -- src/main/app-lifecycle.test.ts src/main/session-persistence/renderer-flush.test.ts src/main/application-event-flow.test.ts src/main/web-service/application-event-projections.test.ts src/shared/renderer-contract-catalog.test.ts src/preload/index.test.ts src/preload/electron-renderer-contract-adapter.test.ts src/renderer/web/api-installer.test.ts src/renderer/src/hooks/useQuitPersistenceFlush.test.ts src/renderer/src/components/ActionToast.test.tsx src/renderer/src/components/SessionPersistenceAlert.render.test.tsx src/renderer/src/App.test.tsx` -> 303 passed
- translated user-visible copy and catalog contracts -> `npm test -- src/renderer/src/i18n/resources.test.ts` -> 743 passed
- renderer and shared contract typing -> `npm run typecheck:web` -> passed
- linted source and tests -> `npm run lint` -> passed
- Node typing -> `npm run typecheck:node` -> blocked by the existing unrelated
  `src/main/acp/claude-agent-acp-patch.test.ts` import of `waitForMcpServers`, which the installed
  `@agentclientprotocol/claude-agent-acp` declarations do not export; no errors remain in changed files

The complete portable and platform suites are left to PR CI as requested.

## Review focus

- Confirm the abort reason is emitted only for ordinary quit blockers while payload-free durability
  aborts continue to resume renderer activity without a quit alert.
- Confirm a stale notification notice appears only after full Session readiness, successful target
  consumption, and no superseding user navigation.
- Confirm the transient UI projections do not become persisted domain state.
