### PR TITLE
fix(remote-access): enforce browser authorization lifecycle

### DIFF
--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -309,6 +309,7 @@ describe('application command composition', () => {
     const firstSnapshot = vi.fn(() => snapshot)
     const firstOwner = {
       snapshot: firstSnapshot,
+      probe: vi.fn(),
       detect: vi.fn(),
       setMode: vi.fn(),
       disable: vi.fn(),

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -241,6 +241,7 @@ const createRemoteAccessSlot = (): Readonly<{
   }
   const owner: RemoteAccessOwner = Object.freeze({
     snapshot: (...args) => current().snapshot(...args),
+    probe: (...args) => current().probe(...args),
     detect: (...args) => current().detect(...args),
     setMode: (...args) => current().setMode(...args),
     disable: (...args) => current().disable(...args),

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -492,7 +492,7 @@ describe('Host application commands', () => {
         .filter((channel): channel is string => channel !== null)
     )
 
-    expect(localOnlyChannels).toHaveLength(28)
+    expect(localOnlyChannels).toHaveLength(29)
     for (const channel of localOnlyChannels) {
       await expect(
         router.dispatcher.invoke(
@@ -528,6 +528,28 @@ describe('Host application commands', () => {
     expect(dependencies.logs.getStatus).not.toHaveBeenCalled()
     expect(dependencies.logs.openFile).not.toHaveBeenCalled()
     expect(dependencies.logs.revealInFolder).not.toHaveBeenCalled()
+  })
+
+  it('keeps the read-only Remote Access probe available only to local callers', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerHostApplicationCommands(router.registrar, dependencies)
+    const localCaller = createWebCallerContext('local-browser')
+    const remoteCaller = createWebCallerContext('remote-browser', { location: 'remote' })
+
+    await expect(
+      router.dispatcher.invoke(
+        hostApplicationCommands.remoteAccess.probe,
+        invocation([], localCaller)
+      )
+    ).resolves.toBe(remoteSnapshot)
+    await expect(
+      router.dispatcher.invoke(
+        hostApplicationCommands.remoteAccess.probe,
+        invocation([], remoteCaller)
+      )
+    ).rejects.toThrow('Channel only available from the local app: remote-access:probe')
+    expect(dependencies.remoteAccess.probe).toHaveBeenCalledOnce()
   })
 
   it('preserves the five-state Remote Access authority and freshness matrix', async () => {
@@ -593,7 +615,7 @@ describe('Host application commands', () => {
         hostApplicationCommands.remoteAccess.probe,
         invocation([], currentManager)
       )
-    ).rejects.toThrow('This action must be approved from the Open Science desktop app.')
+    ).rejects.toThrow('Channel only available from the local app: remote-access:probe')
     expect(dependencies.remoteAccess.detect).not.toHaveBeenCalled()
     expect(dependencies.remoteAccess.probe).not.toHaveBeenCalled()
   })

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -101,6 +101,7 @@ const createDependencies = (): HostApplicationCommandDependencies => ({
   remoteAccess: {
     snapshot: vi.fn(() => remoteSnapshot),
     detect: vi.fn(async () => remoteSnapshot),
+    probe: vi.fn(async () => remoteSnapshot),
     setMode: vi.fn(async () => remoteSnapshot),
     disable: vi.fn(async () => remoteSnapshot),
     approve: vi.fn(async () => remoteSnapshot),
@@ -184,7 +185,7 @@ const commandByName = (name: string): ApplicationCommand<string, readonly unknow
 }
 
 describe('Host application commands', () => {
-  it('defines the exact 54 request channels in their existing capability groups', () => {
+  it('defines the exact 55 request channels in their existing capability groups', () => {
     const expected = RENDERER_CONTRACT_GROUPS.filter(({ capability }) =>
       HOST_CAPABILITIES.includes(capability as (typeof HOST_CAPABILITIES)[number])
     ).map(({ capability, contracts }) => {
@@ -202,7 +203,7 @@ describe('Host application commands', () => {
       }
     })
 
-    expect(expected.flatMap(({ channels }) => channels)).toHaveLength(54)
+    expect(expected.flatMap(({ channels }) => channels)).toHaveLength(55)
     expect(
       hostApplicationCommandGroups.map(({ name, commands }) => ({
         capability: name,
@@ -218,7 +219,7 @@ describe('Host application commands', () => {
       {} as HostApplicationCommandDependencies
     )
 
-    expect(router.dispatcher.commandNames()).toHaveLength(54)
+    expect(router.dispatcher.commandNames()).toHaveLength(55)
     installation.uninstall()
     expect(router.dispatcher.commandNames()).toEqual([])
   })
@@ -303,6 +304,7 @@ describe('Host application commands', () => {
       invocation([{ requestId: 'pair-1', decision: 'once' }])
     )
     await router.dispatcher.invoke(hostApplicationCommands.remoteAccess.detect, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.remoteAccess.probe, invocation([]))
     await router.dispatcher.invoke(hostApplicationCommands.remoteAccess.disable, invocation([]))
     await router.dispatcher.invoke(hostApplicationCommands.remoteAccess.getSnapshot, invocation([]))
     await router.dispatcher.invoke(
@@ -391,6 +393,8 @@ describe('Host application commands', () => {
       true,
       true
     )
+    expect(dependencies.remoteAccess.detect).toHaveBeenCalledOnce()
+    expect(dependencies.remoteAccess.probe).toHaveBeenCalledOnce()
     expect(dependencies.remoteAccess.reject).toHaveBeenCalledWith('pair-2', true, true)
     expect(dependencies.remoteAccess.revoke).toHaveBeenCalledWith('browser-1', true, true)
     expect(dependencies.remoteAccess.setMode).toHaveBeenCalledWith('remoteit')
@@ -584,7 +588,14 @@ describe('Host application commands', () => {
         invocation([], currentManager)
       )
     ).rejects.toThrow('This action must be approved from the Open Science desktop app.')
+    await expect(
+      router.dispatcher.invoke(
+        hostApplicationCommands.remoteAccess.probe,
+        invocation([], currentManager)
+      )
+    ).rejects.toThrow('This action must be approved from the Open Science desktop app.')
     expect(dependencies.remoteAccess.detect).not.toHaveBeenCalled()
+    expect(dependencies.remoteAccess.probe).not.toHaveBeenCalled()
   })
 
   it('rejects malformed Remote Access arguments before entering an owner', async () => {
@@ -594,6 +605,7 @@ describe('Host application commands', () => {
     const cases: Array<readonly [string, readonly unknown[]]> = [
       ['remote-access:approve', [undefined]],
       ['remote-access:detect', [{}]],
+      ['remote-access:probe', [{}]],
       ['remote-access:disable', [{}]],
       ['remote-access:get-snapshot', [{}]],
       ['remote-access:reject', [undefined]],
@@ -609,6 +621,7 @@ describe('Host application commands', () => {
 
     expect(dependencies.remoteAccess.approve).not.toHaveBeenCalled()
     expect(dependencies.remoteAccess.detect).not.toHaveBeenCalled()
+    expect(dependencies.remoteAccess.probe).not.toHaveBeenCalled()
     expect(dependencies.remoteAccess.disable).not.toHaveBeenCalled()
     expect(dependencies.remoteAccess.snapshot).not.toHaveBeenCalled()
     expect(dependencies.remoteAccess.reject).not.toHaveBeenCalled()

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -527,10 +527,8 @@ const registerHostApplicationCommands = (
         requireDesktopCaller(callerContext)
         return dependencies.remoteAccess.detect()
       },
-      'remote-access:probe': ({ callerContext }) => {
-        requireDesktopCaller(callerContext)
-        return dependencies.remoteAccess.probe()
-      },
+      'remote-access:probe': ({ callerContext }) =>
+        localCommand(callerContext, 'remote-access:probe', () => dependencies.remoteAccess.probe()),
       'remote-access:disable': ({ callerContext }) => {
         requireDesktopCaller(callerContext)
         return dependencies.remoteAccess.disable()

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -194,6 +194,10 @@ const remoteAccessCommands = Object.freeze({
     'remote-access:detect',
     remoteAccessApplicationCommandContracts.detect
   ),
+  probe: defineApplicationCommand<'remote-access:probe', readonly [], RemoteAccessSnapshot>(
+    'remote-access:probe',
+    remoteAccessApplicationCommandContracts.probe
+  ),
   disable: defineApplicationCommand<'remote-access:disable', readonly [], RemoteAccessSnapshot>(
     'remote-access:disable',
     remoteAccessApplicationCommandContracts.disable
@@ -378,7 +382,7 @@ type HostApplicationCommandDependencies = Readonly<{
   }>
   remoteAccess: Pick<
     RemoteAccessService,
-    'snapshot' | 'detect' | 'setMode' | 'disable' | 'approve' | 'reject' | 'revoke'
+    'snapshot' | 'probe' | 'detect' | 'setMode' | 'disable' | 'approve' | 'reject' | 'revoke'
   >
   reviewer: Pick<ReviewerCommandOwner, 'run' | 'getForSession' | 'abort' | 'abortFixLoop'>
   storage: Readonly<{
@@ -522,6 +526,10 @@ const registerHostApplicationCommands = (
       'remote-access:detect': ({ callerContext }) => {
         requireDesktopCaller(callerContext)
         return dependencies.remoteAccess.detect()
+      },
+      'remote-access:probe': ({ callerContext }) => {
+        requireDesktopCaller(callerContext)
+        return dependencies.remoteAccess.probe()
       },
       'remote-access:disable': ({ callerContext }) => {
         requireDesktopCaller(callerContext)

--- a/src/main/remote-access/ipc.test.ts
+++ b/src/main/remote-access/ipc.test.ts
@@ -88,6 +88,7 @@ describe('remote access IPC authorization', () => {
     const service = {
       approve: vi.fn(),
       detect: vi.fn(),
+      probe: vi.fn(),
       disable: vi.fn(),
       snapshot: vi.fn(),
       reject: vi.fn(),
@@ -99,6 +100,7 @@ describe('remote access IPC authorization', () => {
     const cases: Array<readonly [string, unknown]> = [
       ['remote-access:get-snapshot', { unexpected: true }],
       ['remote-access:detect', { unexpected: true }],
+      ['remote-access:probe', { unexpected: true }],
       ['remote-access:disable', { unexpected: true }],
       ['remote-access:approve', undefined],
       ['remote-access:reject', undefined],
@@ -114,6 +116,7 @@ describe('remote access IPC authorization', () => {
 
     expect(service.approve).not.toHaveBeenCalled()
     expect(service.detect).not.toHaveBeenCalled()
+    expect(service.probe).not.toHaveBeenCalled()
     expect(service.disable).not.toHaveBeenCalled()
     expect(service.snapshot).not.toHaveBeenCalled()
     expect(service.reject).not.toHaveBeenCalled()

--- a/src/main/remote-access/ipc.ts
+++ b/src/main/remote-access/ipc.ts
@@ -37,6 +37,11 @@ export const registerRemoteAccessIpcHandlers = (service: RemoteAccessService): v
     requireDesktopCaller(callerContextForEvent(event))
     return service.detect()
   })
+  ipcMainHandle('remote-access:probe', async (event, ...args) => {
+    remoteAccessApplicationCommandContracts.probe.args.parse(args)
+    requireDesktopCaller(callerContextForEvent(event))
+    return service.probe()
+  })
   ipcMainHandle('remote-access:set-mode', async (event, ...args) => {
     const [request] = remoteAccessApplicationCommandContracts.setMode.args.parse(args)
     requireDesktopCaller(callerContextForEvent(event))

--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -135,7 +135,10 @@ describe('RemoteSessionPairingManager', () => {
         }),
         new URL('https://home.example.ts.net/api/v1/events')
       )
-    ).resolves.toMatchObject({ sessionId: expect.any(String) })
+    ).resolves.toMatchObject({
+      principalId: expect.any(String),
+      isCurrent: expect.any(Function)
+    })
     expect(manager.trustedViews()).toHaveLength(0)
     expect(changed).toHaveBeenCalled()
   })
@@ -793,6 +796,74 @@ describe('RemoteSessionPairingManager', () => {
         expect((await repository.load()).trustedBrowsers).toHaveLength(0)
       })
       expect(onChanged).toHaveBeenCalledOnce()
+    } finally {
+      manager?.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('reports each naturally expired authorization by stable principal ID', async () => {
+    vi.useFakeTimers()
+    let manager: RemoteSessionPairingManager | undefined
+    try {
+      vi.setSystemTime(0)
+      const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+      roots.push(root)
+      const onAuthorizationExpired = vi.fn()
+      const options = {
+        repository: new RemoteAccessRepository(root),
+        isAllowedRemoteHost: (hostname: string) => hostname === 'home.example.ts.net',
+        isEnabled: () => true,
+        onChanged: vi.fn(),
+        onAuthorizationExpired
+      }
+      manager = await RemoteSessionPairingManager.create(options)
+
+      const grant = async (
+        decision: RemotePairingDecision
+      ): Promise<{ principalId: string; isCurrent: () => boolean }> => {
+        const pairingResponse = response()
+        await manager!.webAccess.authorizeHttp(
+          request('/'),
+          pairingResponse.response,
+          new URL('https://home.example.ts.net/')
+        )
+        const pendingCookie = cookiePair(pairingResponse.headers.get('set-cookie') as string)
+        await manager!.approve(manager!.pendingViews()[0].id, decision)
+        const statusResponse = response()
+        await manager!.webAccess.authorizeHttp(
+          request('/__open_science_remote/pair/status', { cookie: pendingCookie }),
+          statusResponse.response,
+          new URL('https://home.example.ts.net/__open_science_remote/pair/status')
+        )
+        const sessionCookie = cookiePair((statusResponse.headers.get('set-cookie') as string[])[0])
+        const authorization = await manager!.webAccess.authorizeWebSocket(
+          request('/api/v1/events', {
+            cookie: sessionCookie,
+            origin: 'https://home.example.ts.net'
+          }),
+          new URL('https://home.example.ts.net/api/v1/events')
+        )
+        return authorization!
+      }
+
+      const oneTimeAuthorization = await grant('once')
+      const trustedAuthorization = await grant('always')
+      expect(oneTimeAuthorization.isCurrent()).toBe(true)
+      expect(trustedAuthorization.isCurrent()).toBe(true)
+      onAuthorizationExpired.mockClear()
+
+      const oneTimeTtlMs = 12 * 60 * 60 * 1_000
+      await vi.advanceTimersByTimeAsync(oneTimeTtlMs + 1)
+      expect(onAuthorizationExpired).toHaveBeenCalledOnce()
+      expect(onAuthorizationExpired).toHaveBeenLastCalledWith(oneTimeAuthorization.principalId)
+      expect(oneTimeAuthorization.isCurrent()).toBe(false)
+      expect(trustedAuthorization.isCurrent()).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(TRUSTED_BROWSER_TTL_MS - oneTimeTtlMs)
+      expect(onAuthorizationExpired).toHaveBeenCalledTimes(2)
+      expect(onAuthorizationExpired).toHaveBeenLastCalledWith(trustedAuthorization.principalId)
+      expect(trustedAuthorization.isCurrent()).toBe(false)
     } finally {
       manager?.dispose()
       vi.useRealTimers()

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -62,6 +62,7 @@ type PairingManagerOptions = {
   isEnabled: () => boolean
   authorizationGeneration?: () => number
   onChanged: () => void
+  onAuthorizationExpired?: (principalId: string) => void
   now?: () => number
 }
 
@@ -478,6 +479,7 @@ export class RemoteSessionPairingManager {
     url: URL
   ): ReturnType<ExternalWebAccess['authorizeWebSocket']> {
     const authorizationGeneration = this.options.authorizationGeneration?.() ?? 0
+    const pairingAuthorizationGeneration = this.authorizationGeneration
     if (
       !['/events', '/api/v1/events'].includes(url.pathname) ||
       !this.isExpectedRemoteRequest(request, true)
@@ -487,11 +489,37 @@ export class RemoteSessionPairingManager {
     const sessionAccess = await this.getSessionAccess(request)
     if (
       authorizationGeneration !== (this.options.authorizationGeneration?.() ?? 0) ||
+      pairingAuthorizationGeneration !== this.authorizationGeneration ||
       !this.isExpectedRemoteRequest(request, true)
     ) {
       return undefined
     }
-    return sessionAccess ? { sessionId: sessionAccess.sessionId } : undefined
+    return sessionAccess
+      ? {
+          principalId: sessionAccess.sessionId,
+          isCurrent: () =>
+            authorizationGeneration === (this.options.authorizationGeneration?.() ?? 0) &&
+            pairingAuthorizationGeneration === this.authorizationGeneration &&
+            this.isExpectedRemoteRequest(request, true) &&
+            this.isSessionAccessCurrent(sessionAccess)
+        }
+      : undefined
+  }
+
+  private isSessionAccessCurrent(access: Exclude<RemoteSessionAccess, undefined>): boolean {
+    const now = this.now()
+    if (access.kind === 'once') {
+      const session = this.oneTimeSessions.get(access.sessionId)
+      return Boolean(session && session.expiresAt > now)
+    }
+    if (
+      this.pendingRevocations.has(access.sessionId) ||
+      this.unclaimedTrustedBrowserCleanup.has(access.sessionId)
+    ) {
+      return false
+    }
+    const browser = this.stored.trustedBrowsers.find(({ id }) => id === access.sessionId)
+    return Boolean(browser && browser.expiresAt > now)
   }
 
   private ensurePending(
@@ -692,23 +720,35 @@ export class RemoteSessionPairingManager {
   private pruneExpired(): void {
     const now = this.now()
     let pendingViewsChanged = false
+    const expiredPrincipalIds = new Set<string>()
     for (const [id, request] of this.pending) {
       if (request.expiresAt > now) continue
       if (request.status === 'pending' || request.status === 'approving') {
         pendingViewsChanged = true
       }
       if (request.grant?.decision === 'always') {
+        expiredPrincipalIds.add(request.grant.sessionId)
         this.unclaimedTrustedBrowserCleanup.add(request.grant.sessionId)
       } else if (request.grant?.decision === 'once') {
+        expiredPrincipalIds.add(request.grant.sessionId)
         this.oneTimeSessions.delete(request.grant.sessionId)
       }
       this.pending.delete(id)
     }
     for (const [id, session] of this.oneTimeSessions) {
-      if (session.expiresAt <= now) this.oneTimeSessions.delete(id)
+      if (session.expiresAt <= now) {
+        this.oneTimeSessions.delete(id)
+        expiredPrincipalIds.add(id)
+      }
     }
     for (const browser of this.stored.trustedBrowsers) {
-      if (browser.expiresAt <= now) this.unclaimedTrustedBrowserCleanup.add(browser.id)
+      if (browser.expiresAt <= now && !this.unclaimedTrustedBrowserCleanup.has(browser.id)) {
+        this.unclaimedTrustedBrowserCleanup.add(browser.id)
+        expiredPrincipalIds.add(browser.id)
+      }
+    }
+    for (const principalId of expiredPrincipalIds) {
+      this.options.onAuthorizationExpired?.(principalId)
     }
     this.scheduleUnclaimedTrustedBrowserCleanup()
     this.scheduleExpirationTimer()

--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -43,6 +43,27 @@ const remoteResponse = (): ServerResponse =>
     end: vi.fn().mockReturnThis()
   }) as unknown as ServerResponse
 
+const capturedRemoteResponse = (): {
+  response: ServerResponse
+  header: (name: string) => string | string[] | undefined
+} => {
+  const headers = new Map<string, string | string[]>()
+  const response = {
+    setHeader: (name: string, value: string | string[]) => {
+      headers.set(name.toLowerCase(), value)
+      return response
+    },
+    writeHead: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis()
+  }
+  return {
+    response: response as unknown as ServerResponse,
+    header: (name) => headers.get(name.toLowerCase())
+  }
+}
+
+const cookiePair = (header: string): string => header.split(';', 1)[0]
+
 const webController = (port = 4180): WebServiceController => ({
   ensureStarted: vi.fn().mockResolvedValue({
     port,
@@ -226,6 +247,63 @@ describe('RemoteAccessService', () => {
       remoteItBrowserServiceId: 'browser-service-1',
       remoteItPublicUrl: 'https://open-science.connect.remote.it/'
     })
+  })
+
+  it('probes Browser access without closing or invalidating a one-time session', async () => {
+    const repository = await createRepository()
+    const deps = createReadyDeps()
+    const controller = webController()
+    const service = await RemoteAccessService.create({
+      repository,
+      ...deps,
+      broadcast: vi.fn()
+    })
+    service.attachWebController(controller)
+    await service.setMode('remoteit-public')
+
+    const host = 'open-science.connect.remote.it'
+    const pairingResponse = capturedRemoteResponse()
+    await service.webAccess.authorizeHttp(
+      remoteRequest(host),
+      pairingResponse.response,
+      new URL(`https://${host}/`)
+    )
+    const pairingCookie = cookiePair(pairingResponse.header('set-cookie') as string)
+    const [pending] = service.snapshot(true).pendingRequests
+    await service.approve({ requestId: pending.id, decision: 'once' })
+
+    const statusResponse = capturedRemoteResponse()
+    await service.webAccess.authorizeHttp(
+      {
+        ...remoteRequest(host),
+        url: '/__open_science_remote/pair/status',
+        headers: { host, cookie: pairingCookie }
+      } as IncomingMessage,
+      statusResponse.response,
+      new URL(`https://${host}/__open_science_remote/pair/status`)
+    )
+    const sessionCookie = cookiePair((statusResponse.header('set-cookie') as string[])[0])
+    const websocketRequest = {
+      ...remoteRequest(host),
+      url: '/api/v1/events',
+      headers: { host, cookie: sessionCookie, origin: `https://${host}` }
+    } as IncomingMessage
+
+    const authorization = await service.webAccess.authorizeWebSocket(
+      websocketRequest,
+      new URL(`https://${host}/api/v1/events`)
+    )
+    expect(authorization?.isCurrent()).toBe(true)
+
+    await service.probe()
+
+    expect(controller.closeExternalConnections).not.toHaveBeenCalled()
+    expect(authorization?.isCurrent()).toBe(true)
+    const repeatedAuthorization = await service.webAccess.authorizeWebSocket(
+      websocketRequest,
+      new URL(`https://${host}/api/v1/events`)
+    )
+    expect(repeatedAuthorization?.isCurrent()).toBe(true)
   })
 
   it('keeps separate service IDs while switching between App and Browser access', async () => {

--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -306,6 +306,22 @@ describe('RemoteAccessService', () => {
     expect(repeatedAuthorization?.isCurrent()).toBe(true)
   })
 
+  it('keeps provider observations from a probe current without persisting configuration', async () => {
+    const repository = await createRepository()
+    const before = await repository.load()
+    const deps = createReadyDeps()
+    const observed = readyInstallation('observed-service')
+    deps.detectRemoteIt.mockResolvedValueOnce(observed)
+    const broadcast = vi.fn()
+    const service = await RemoteAccessService.create({ repository, ...deps, broadcast })
+
+    await expect(service.probe()).resolves.toMatchObject({ remoteIt: observed })
+
+    expect(service.snapshot(true).remoteIt).toEqual(observed)
+    expect(await repository.load()).toEqual(before)
+    expect(broadcast).not.toHaveBeenCalled()
+  })
+
   it('keeps separate service IDs while switching between App and Browser access', async () => {
     const repository = await createRepository()
     const deps = createReadyDeps()

--- a/src/main/remote-access/service.ts
+++ b/src/main/remote-access/service.ts
@@ -123,7 +123,9 @@ export class RemoteAccessService {
       isAllowedRemoteHost: (hostname) => context.service?.isAllowedRemoteHost(hostname) === true,
       isEnabled: () => context.service?.runtimeEnabled === true,
       authorizationGeneration: () => context.service?.authorizationGeneration ?? 0,
-      onChanged: () => context.service?.notifyChanged()
+      onChanged: () => context.service?.notifyChanged(),
+      onAuthorizationExpired: (principalId) =>
+        context.service?.webController?.closeExternalConnections(principalId)
     }
     let configurationError: Error | undefined
     let loadFailure: unknown
@@ -204,6 +206,21 @@ export class RemoteAccessService {
 
   detect(): Promise<RemoteAccessSnapshot> {
     return this.serialize(() => this.detectSerialized())
+  }
+
+  probe(): Promise<RemoteAccessSnapshot> {
+    return this.serialize(async () => {
+      if (this.shutdownStarted || this.configurationError) return this.snapshot(true)
+      try {
+        const remoteIt = await this.deps.detectRemoteIt(this.preferredServiceId())
+        return { ...this.snapshot(true), remoteIt }
+      } catch (error) {
+        return {
+          ...this.snapshot(true),
+          remoteIt: { ...this.remoteIt, error: toErrorMessage(error) }
+        }
+      }
+    })
   }
 
   private async detectSerialized(): Promise<RemoteAccessSnapshot> {

--- a/src/main/remote-access/service.ts
+++ b/src/main/remote-access/service.ts
@@ -212,14 +212,11 @@ export class RemoteAccessService {
     return this.serialize(async () => {
       if (this.shutdownStarted || this.configurationError) return this.snapshot(true)
       try {
-        const remoteIt = await this.deps.detectRemoteIt(this.preferredServiceId())
-        return { ...this.snapshot(true), remoteIt }
+        this.remoteIt = await this.deps.detectRemoteIt(this.preferredServiceId())
       } catch (error) {
-        return {
-          ...this.snapshot(true),
-          remoteIt: { ...this.remoteIt, error: toErrorMessage(error) }
-        }
+        this.remoteIt = { ...this.remoteIt, error: toErrorMessage(error) }
       }
+      return this.snapshot(true)
     })
   }
 

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -143,6 +143,197 @@ afterEach(async () => {
 })
 
 describe('startWebHttpServer', () => {
+  it('closes stale external event sockets before an application event can leak', async () => {
+    let authorizationCurrent = true
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      externalAccess: {
+        authorizeHttp: vi.fn().mockResolvedValue('denied'),
+        authorizeWebSocket: vi.fn().mockResolvedValue({
+          principalId: 'remote-principal-1',
+          isCurrent: () => authorizationCurrent
+        })
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const socket = new WebSocket(`ws://127.0.0.1:${server.port}/events`)
+    await new Promise<void>((resolve) => socket.once('open', resolve))
+    authorizationCurrent = false
+
+    const outcome = new Promise<'closed' | 'leaked'>((resolve) => {
+      socket.once('close', () => resolve('closed'))
+      socket.once('message', () => resolve('leaked'))
+    })
+    applicationEvents.publish('project:created', {
+      id: 'private-project',
+      name: 'Private project',
+      description: '',
+      isExample: false,
+      createdAt: 1,
+      updatedAt: 1
+    })
+
+    await expect(
+      Promise.race([
+        outcome,
+        new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 250))
+      ])
+    ).resolves.toBe('closed')
+  })
+
+  it('closes stale idle external sockets before heartbeat traffic is sent', async () => {
+    let authorizationCurrent = true
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      eventHeartbeatIntervalMs: 10,
+      rpc: { channels: () => [], invoke: vi.fn() },
+      externalAccess: {
+        authorizeHttp: vi.fn().mockResolvedValue('denied'),
+        authorizeWebSocket: vi.fn().mockResolvedValue({
+          principalId: 'remote-principal-1',
+          isCurrent: () => authorizationCurrent
+        })
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const socket = new WebSocket(`ws://127.0.0.1:${server.port}/events?liveness=1`)
+    await new Promise<void>((resolve) => socket.once('open', resolve))
+    authorizationCurrent = false
+
+    const outcome = new Promise<'closed' | 'heartbeat'>((resolve) => {
+      socket.once('close', () => resolve('closed'))
+      socket.once('message', () => resolve('heartbeat'))
+    })
+    await expect(
+      Promise.race([
+        outcome,
+        new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 250))
+      ])
+    ).resolves.toBe('closed')
+  })
+
+  it('closes stale external sockets before replay frames are sent', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      externalAccess: {
+        authorizeHttp: vi.fn().mockResolvedValue('denied'),
+        authorizeWebSocket: vi.fn().mockResolvedValue({
+          principalId: 'remote-principal-1',
+          isCurrent: () => false
+        })
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const url = new URL(`ws://127.0.0.1:${server.port}/events`)
+    url.searchParams.set('eventProtocol', String(WEB_EVENT_STREAM_PROTOCOL_VERSION))
+    url.searchParams.set('stream', 'stale-stream')
+    url.searchParams.set('after', '0')
+    const socket = new WebSocket(url)
+    const outcome = new Promise<'closed' | 'replayed'>((resolve) => {
+      socket.once('close', () => resolve('closed'))
+      socket.once('message', () => resolve('replayed'))
+    })
+
+    await expect(
+      Promise.race([
+        outcome,
+        new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 250))
+      ])
+    ).resolves.toBe('closed')
+  })
+
+  it('closes stale external sockets before Task progress is sent', async () => {
+    let authorizationCurrent = true
+    let publishProgress:
+      ((event: import('../../shared/task-api').TaskRunProgressEvent) => void) | undefined
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      tasks: {
+        subscribeProgress: (listener) => {
+          publishProgress = listener
+          return () => {
+            publishProgress = undefined
+          }
+        }
+      } as never,
+      externalAccess: {
+        authorizeHttp: vi.fn().mockResolvedValue('denied'),
+        authorizeWebSocket: vi.fn().mockResolvedValue({
+          principalId: 'remote-principal-1',
+          isCurrent: () => authorizationCurrent
+        })
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const socket = new WebSocket(`ws://127.0.0.1:${server.port}/api/v1/events`)
+    await new Promise<void>((resolve) => socket.once('open', resolve))
+    authorizationCurrent = false
+
+    const outcome = new Promise<'closed' | 'leaked'>((resolve) => {
+      socket.once('close', () => resolve('closed'))
+      socket.once('message', () => resolve('leaked'))
+    })
+    publishProgress?.({
+      runId: 'run-1',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      phase: 'provider-accepted',
+      timestamp: 250,
+      elapsedMs: 249,
+      heartbeat: false
+    })
+
+    await expect(
+      Promise.race([
+        outcome,
+        new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 250))
+      ])
+    ).resolves.toBe('closed')
+  })
+
   it('rejects malformed URL encoding at the public HTTP boundary', async () => {
     const server = await startTestWebHttpServer({
       host: '127.0.0.1',
@@ -2197,7 +2388,10 @@ describe('startWebHttpServer', () => {
       },
       externalAccess: {
         authorizeHttp: vi.fn().mockResolvedValue(authorizedExternalAccess()),
-        authorizeWebSocket: vi.fn().mockResolvedValue({ sessionId: 'trusted-browser' })
+        authorizeWebSocket: vi.fn().mockResolvedValue({
+          principalId: 'trusted-browser',
+          isCurrent: () => true
+        })
       },
       bootstrap: {
         appName: 'Open Science',

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -272,7 +272,8 @@ export type ExternalWebAccessAuthorization = {
 export type ExternalWebAccessDecision = ExternalWebAccessAuthorization | 'handled' | 'denied'
 
 export type ExternalWebSocketAccess = {
-  sessionId?: string
+  principalId: string
+  isCurrent: () => boolean
 }
 
 // Optional authentication boundary for a loopback reverse proxy. The normal localhost token path
@@ -910,7 +911,7 @@ const serveStatic = async (
 
 const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWebServer> => {
   const sockets = new Set<WebSocket>()
-  const externalSockets = new Map<WebSocket, string | undefined>()
+  const externalSockets = new Map<WebSocket, ExternalWebSocketAccess>()
   const publicEventSockets = new Map<WebSocket, 'legacy' | 'replay'>()
   const internalEventSockets = new Map<WebSocket, 'legacy' | 'replay'>()
   const livenessSockets = new Set<WebSocket>()
@@ -930,6 +931,21 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     commandClient.releaseClient('web', clientId)
   })
   const wsServer = new WebSocketServer({ noServer: true })
+
+  const isWebSocketAuthorizationCurrent = (socket: WebSocket): boolean => {
+    const authorization = externalSockets.get(socket)
+    if (!authorization) return true
+    try {
+      if (authorization.isCurrent()) return true
+    } catch {
+      // A failed runtime authorization check is stale by default.
+    }
+    socket.close(1008, 'Remote access expired')
+    return false
+  }
+
+  const sendCurrentWebSocketMessage = (socket: WebSocket, message: string): boolean =>
+    isWebSocketAuthorizationCurrent(socket) && sendWebSocketMessage(socket, message)
 
   const handleRequest = async (
     request: IncomingMessage,
@@ -1186,7 +1202,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         }
         wsServer.handleUpgrade(request, socket, head, (webSocket) => {
           if (externalAuthorization) {
-            externalSockets.set(webSocket, externalAuthorization.sessionId)
+            externalSockets.set(webSocket, externalAuthorization)
           }
           wsServer.emit('connection', webSocket, request)
         })
@@ -1230,7 +1246,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
                 after: afterValue === null ? Number.NaN : Number(afterValue)
               })
         for (const message of messages) {
-          if (!sendWebSocketMessage(socket, message)) break
+          if (!sendCurrentWebSocketMessage(socket, message)) break
         }
       }
     } else {
@@ -1248,7 +1264,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         const afterValue = url.searchParams.get('after')
         const after = afterValue === null ? Number.NaN : Number(afterValue)
         for (const message of internalEventStream.resume({ streamId, after })) {
-          if (!sendWebSocketMessage(socket, message)) break
+          if (!sendCurrentWebSocketMessage(socket, message)) break
         }
       }
     }
@@ -1269,19 +1285,19 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     for (const socket of sockets) {
       if (publicEventSockets.has(socket)) {
         for (const publicMessage of publicMessages) {
-          if (!sendWebSocketMessage(socket, publicMessage)) break
+          if (!sendCurrentWebSocketMessage(socket, publicMessage)) break
         }
       } else if (internalEventSockets.get(socket) === 'replay') {
-        if (replayInternalMessage) sendWebSocketMessage(socket, replayInternalMessage)
+        if (replayInternalMessage) sendCurrentWebSocketMessage(socket, replayInternalMessage)
       } else if (legacyInternalMessage) {
-        sendWebSocketMessage(socket, legacyInternalMessage)
+        sendCurrentWebSocketMessage(socket, legacyInternalMessage)
       }
     }
   })
   const removeTaskProgressSink = options.tasks?.subscribeProgress((event) => {
     const message = publicTaskEventStream.publish(projectPublicTaskProgressEvent(event))
     for (const socket of publicEventSockets.keys()) {
-      sendWebSocketMessage(socket, message)
+      sendCurrentWebSocketMessage(socket, message)
     }
   })
 
@@ -1315,22 +1331,25 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     const internalHeartbeat = internalEventStream.heartbeat()
     for (const socket of livenessSockets) {
       if (socket.readyState !== WebSocket.OPEN) continue
+      if (!isWebSocketAuthorizationCurrent(socket)) continue
       if (awaitingPong.has(socket)) {
         socket.terminate()
         continue
       }
       awaitingPong.add(socket)
       socket.ping()
-      if (publicEventSockets.has(socket)) sendWebSocketMessage(socket, publicHeartbeat)
-      else if (internalEventSockets.has(socket)) sendWebSocketMessage(socket, internalHeartbeat)
+      if (publicEventSockets.has(socket)) sendCurrentWebSocketMessage(socket, publicHeartbeat)
+      else if (internalEventSockets.has(socket)) {
+        sendCurrentWebSocketMessage(socket, internalHeartbeat)
+      }
     }
   }, options.eventHeartbeatIntervalMs ?? DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS)
 
   return {
     port,
-    closeExternalConnections: (sessionId) => {
-      for (const [socket, externalSessionId] of externalSockets) {
-        if (sessionId === undefined || externalSessionId === sessionId) {
+    closeExternalConnections: (principalId) => {
+      for (const [socket, authorization] of externalSockets) {
+        if (principalId === undefined || authorization.principalId === principalId) {
           socket.close(1008, 'Remote access revoked')
         }
       }

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -425,6 +425,7 @@ describe('preload bridge — public surface inventory', () => {
       'remoteAccess.disable',
       'remoteAccess.getSnapshot',
       'remoteAccess.onChanged',
+      'remoteAccess.probe',
       'remoteAccess.reject',
       'remoteAccess.revokeBrowser',
       'remoteAccess.setMode',

--- a/src/renderer/src/pages/settings/RemoteControlPanel.tsx
+++ b/src/renderer/src/pages/settings/RemoteControlPanel.tsx
@@ -169,8 +169,8 @@ const loadRemoteAccessSnapshot = async (
     if (!isActive()) return initial
     onInitial(initial)
     if (!initial.canManage) return initial
-    const detected = await window.api.remoteAccess.detect()
-    return cacheRemoteAccessSnapshot(detected, generation)
+    const probed = await window.api.remoteAccess.probe()
+    return cacheRemoteAccessSnapshot(probed, generation)
   })
   const trackedRequest = request.finally(() => {
     if (remoteAccessLoadInFlight === trackedRequest) remoteAccessLoadInFlight = undefined

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -234,6 +234,16 @@ const installApi = (): void => {
         pendingRequests: [],
         trustedBrowsers: []
       }),
+      probe: vi.fn().mockResolvedValue({
+        canManage: true,
+        canManagePairing: true,
+        mode: 'off',
+        enabled: false,
+        lifecycle: 'disabled',
+        remoteIt: { installed: false, loggedIn: false, registered: false },
+        pendingRequests: [],
+        trustedBrowsers: []
+      }),
       detect: vi.fn().mockResolvedValue({
         canManage: true,
         canManagePairing: true,
@@ -2044,10 +2054,18 @@ describe('SettingsPage layout', () => {
     expect(modeGrid?.className).toContain('sm:grid-cols-3')
     expect(document.body.textContent).not.toContain('route on exit')
     expect(document.body.textContent).not.toContain('service on exit')
-    expect(
-      (window as unknown as { api: { remoteAccess: { detect: ReturnType<typeof vi.fn> } } }).api
-        .remoteAccess.detect
-    ).toHaveBeenCalledOnce()
+    const remoteAccess = (
+      window as unknown as {
+        api: {
+          remoteAccess: {
+            probe: ReturnType<typeof vi.fn>
+            detect: ReturnType<typeof vi.fn>
+          }
+        }
+      }
+    ).api.remoteAccess
+    expect(remoteAccess.probe).toHaveBeenCalledOnce()
+    expect(remoteAccess.detect).not.toHaveBeenCalled()
   })
 
   it('exits loading when the initial remote access snapshot fails', async () => {
@@ -2113,13 +2131,13 @@ describe('SettingsPage layout', () => {
     )
   })
 
-  it('does not detect after leaving the Remote panel during the initial snapshot load', async () => {
+  it('does not probe after leaving the Remote panel during the initial snapshot load', async () => {
     const remoteAccess = (
       window as unknown as {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2153,16 +2171,16 @@ describe('SettingsPage layout', () => {
       await Promise.resolve()
     })
 
-    expect(remoteAccess.detect).not.toHaveBeenCalled()
+    expect(remoteAccess.probe).not.toHaveBeenCalled()
   })
 
-  it('does not detect after leaving the Remote panel during an initial-load retry', async () => {
+  it('does not probe after leaving the Remote panel during an initial-load retry', async () => {
     const remoteAccess = (
       window as unknown as {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2201,7 +2219,7 @@ describe('SettingsPage layout', () => {
       await Promise.resolve()
     })
 
-    expect(remoteAccess.detect).not.toHaveBeenCalled()
+    expect(remoteAccess.probe).not.toHaveBeenCalled()
   })
 
   it('reuses the remote access snapshot when the panel is reopened within 60 seconds', async () => {
@@ -2210,7 +2228,7 @@ describe('SettingsPage layout', () => {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2226,7 +2244,7 @@ describe('SettingsPage layout', () => {
       trustedBrowsers: []
     }
     remoteAccess.getSnapshot.mockResolvedValue(manageableSnapshot)
-    remoteAccess.detect.mockResolvedValue(manageableSnapshot)
+    remoteAccess.probe.mockResolvedValue(manageableSnapshot)
 
     await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
     await act(async () => navButton('Remote')?.click())
@@ -2234,7 +2252,7 @@ describe('SettingsPage layout', () => {
     await act(async () => navButton('Remote')?.click())
 
     expect(remoteAccess.getSnapshot).toHaveBeenCalledOnce()
-    expect(remoteAccess.detect).toHaveBeenCalledOnce()
+    expect(remoteAccess.probe).toHaveBeenCalledOnce()
   })
 
   it('invalidates the remote access cache when a pairing request arrives while the panel is closed', async () => {
@@ -2288,13 +2306,13 @@ describe('SettingsPage layout', () => {
     expect(document.body.textContent).toContain('654321')
   })
 
-  it('does not let an older initial detection overwrite a newer lifecycle snapshot', async () => {
+  it('does not let an older initial probe overwrite a newer lifecycle snapshot', async () => {
     const remoteAccess = (
       window as unknown as {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
             onChanged: ReturnType<typeof vi.fn>
           }
         }
@@ -2317,20 +2335,20 @@ describe('SettingsPage layout', () => {
       lifecycle: 'running',
       remoteIt: { installed: true, loggedIn: true, registered: true }
     }
-    let finishInitialDetection!: (snapshot: typeof initialSnapshot) => void
+    let finishInitialProbe!: (snapshot: typeof initialSnapshot) => void
     remoteAccess.getSnapshot
       .mockResolvedValueOnce(initialSnapshot)
       .mockResolvedValueOnce(eventSnapshot)
-    remoteAccess.detect.mockImplementationOnce(
+    remoteAccess.probe.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
-          finishInitialDetection = resolve
+          finishInitialProbe = resolve
         })
     )
 
     await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
     await act(async () => navButton('Remote')?.click())
-    expect(remoteAccess.detect).toHaveBeenCalledOnce()
+    expect(remoteAccess.probe).toHaveBeenCalledOnce()
 
     const lifecycleListener = remoteAccess.onChanged.mock.calls[0]?.[0] as (() => void) | undefined
     await act(async () => {
@@ -2343,7 +2361,7 @@ describe('SettingsPage layout', () => {
     )
 
     await act(async () => {
-      finishInitialDetection(initialSnapshot)
+      finishInitialProbe(initialSnapshot)
       await Promise.resolve()
       await Promise.resolve()
     })
@@ -2360,6 +2378,7 @@ describe('SettingsPage layout', () => {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
             setMode: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
             detect: ReturnType<typeof vi.fn>
             onChanged: ReturnType<typeof vi.fn>
           }
@@ -2487,7 +2506,7 @@ describe('SettingsPage layout', () => {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2504,7 +2523,7 @@ describe('SettingsPage layout', () => {
       trustedBrowsers: []
     }
     remoteAccess.getSnapshot.mockResolvedValue(staleOffSnapshot)
-    remoteAccess.detect.mockResolvedValue(staleOffSnapshot)
+    remoteAccess.probe.mockResolvedValue(staleOffSnapshot)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2523,7 +2542,7 @@ describe('SettingsPage layout', () => {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2540,7 +2559,7 @@ describe('SettingsPage layout', () => {
       trustedBrowsers: []
     }
     remoteAccess.getSnapshot.mockResolvedValue(appErrorSnapshot)
-    remoteAccess.detect.mockResolvedValue(appErrorSnapshot)
+    remoteAccess.probe.mockResolvedValue(appErrorSnapshot)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2583,7 +2602,7 @@ describe('SettingsPage layout', () => {
           api: {
             remoteAccess: {
               getSnapshot: ReturnType<typeof vi.fn>
-              detect: ReturnType<typeof vi.fn>
+              probe: ReturnType<typeof vi.fn>
             }
           }
         }
@@ -2636,7 +2655,7 @@ describe('SettingsPage layout', () => {
       ).toBe(true)
       expect(settingsSection(currentSection)).not.toBeUndefined()
       expect(settingsSection(otherSection)).toBeUndefined()
-      expect(remoteAccess.detect).not.toHaveBeenCalled()
+      expect(remoteAccess.probe).not.toHaveBeenCalled()
     }
   )
 
@@ -2646,7 +2665,7 @@ describe('SettingsPage layout', () => {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2674,7 +2693,7 @@ describe('SettingsPage layout', () => {
       trustedBrowsers: []
     }
     remoteAccess.getSnapshot.mockResolvedValue(remoteItSnapshot)
-    remoteAccess.detect.mockResolvedValue(remoteItSnapshot)
+    remoteAccess.probe.mockResolvedValue(remoteItSnapshot)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2713,7 +2732,7 @@ describe('SettingsPage layout', () => {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2740,7 +2759,7 @@ describe('SettingsPage layout', () => {
       trustedBrowsers: []
     }
     remoteAccess.getSnapshot.mockResolvedValue(readySnapshot)
-    remoteAccess.detect.mockResolvedValue(readySnapshot)
+    remoteAccess.probe.mockResolvedValue(readySnapshot)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2762,7 +2781,7 @@ describe('SettingsPage layout', () => {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2792,7 +2811,7 @@ describe('SettingsPage layout', () => {
       trustedBrowsers: []
     }
     remoteAccess.getSnapshot.mockResolvedValue(publicSnapshot)
-    remoteAccess.detect.mockResolvedValue(publicSnapshot)
+    remoteAccess.probe.mockResolvedValue(publicSnapshot)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2829,7 +2848,7 @@ describe('SettingsPage layout', () => {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2852,7 +2871,7 @@ describe('SettingsPage layout', () => {
       trustedBrowsers: []
     }
     remoteAccess.getSnapshot.mockResolvedValue(publicSnapshot)
-    remoteAccess.detect.mockResolvedValue(publicSnapshot)
+    remoteAccess.probe.mockResolvedValue(publicSnapshot)
     const writeText = vi.fn().mockRejectedValue(new Error('Clipboard permission denied'))
     vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
 
@@ -2881,7 +2900,7 @@ describe('SettingsPage layout', () => {
         api: {
           remoteAccess: {
             getSnapshot: ReturnType<typeof vi.fn>
-            detect: ReturnType<typeof vi.fn>
+            probe: ReturnType<typeof vi.fn>
           }
         }
       }
@@ -2903,7 +2922,7 @@ describe('SettingsPage layout', () => {
       trustedBrowsers: []
     }
     remoteAccess.getSnapshot.mockResolvedValue(setupSnapshot)
-    remoteAccess.detect.mockResolvedValue(setupSnapshot)
+    remoteAccess.probe.mockResolvedValue(setupSnapshot)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)

--- a/src/shared/remote-access.ts
+++ b/src/shared/remote-access.ts
@@ -181,6 +181,7 @@ export const remoteAccessApplicationCommandContracts = Object.freeze({
     validationCodec(z.tuple([])),
     remoteAccessSnapshotResult
   ),
+  probe: defineApplicationCommandContract(validationCodec(z.tuple([])), remoteAccessSnapshotResult),
   disable: defineApplicationCommandContract(
     validationCodec(z.tuple([])),
     remoteAccessSnapshotResult

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -13,6 +13,18 @@ const paths = (
 ): string[] => RENDERER_CONTRACT_CATALOG.filter(predicate).map(({ publicPath }) => publicPath)
 
 describe('renderer contract catalog', () => {
+  it('keeps the Remote Access probe local-only', () => {
+    expect(
+      RENDERER_CONTRACT_CATALOG.find(({ publicPath }) => publicPath === 'remoteAccess.probe')
+    ).toMatchObject({
+      surfaceInstallation: {
+        electron: 'preload',
+        localWeb: 'web-rpc',
+        remoteWeb: 'rejecting-stub'
+      }
+    })
+  })
+
   it('keeps every logs command local-only', () => {
     const logs = RENDERER_CONTRACT_GROUPS.find(({ capability }) => capability === 'logs')
 

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -1287,6 +1287,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'remoteAccess.detect': callable<() => Promise<RemoteAccessSnapshot>>()('remote-access', [
     'remote-access:detect'
   ]),
+  'remoteAccess.probe': callable<() => Promise<RemoteAccessSnapshot>>()('remote-access', [
+    'remote-access:probe'
+  ]),
   'remoteAccess.disable': callable<() => Promise<RemoteAccessSnapshot>>()('remote-access', [
     'remote-access:disable'
   ]),

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -1288,7 +1288,8 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     'remote-access:detect'
   ]),
   'remoteAccess.probe': callable<() => Promise<RemoteAccessSnapshot>>()('remote-access', [
-    'remote-access:probe'
+    'remote-access:probe',
+    LOCAL
   ]),
   'remoteAccess.disable': callable<() => Promise<RemoteAccessSnapshot>>()('remote-access', [
     'remote-access:disable'

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -183,6 +183,7 @@ const REMOTE_LOCAL_ONLY_CHANNELS: GroupedInventory = {
   logs: ['get-status', 'open-file', 'reveal-in-folder'],
   'notebook-env': ['cancel', 'provision', 'repair'],
   notebook: ['export-ipynb', 'export-ipynb-all'],
+  'remote-access': ['probe'],
   runtime: [
     'pick-interpreter',
     'register-interpreter',

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -137,6 +137,7 @@ export const WEB_INVOKE_CHANNELS = {
   'remoteAccess.detect': 'remote-access:detect',
   'remoteAccess.disable': 'remote-access:disable',
   'remoteAccess.getSnapshot': 'remote-access:get-snapshot',
+  'remoteAccess.probe': 'remote-access:probe',
   'remoteAccess.reject': 'remote-access:reject',
   'remoteAccess.revokeBrowser': 'remote-access:revoke-browser',
   'remoteAccess.setMode': 'remote-access:set-mode',


### PR DESCRIPTION
## Problem

- Opening Remote settings for the first time or after the renderer cache expired called the mutating `remoteAccess.detect()` path. In Browser mode that forced reconciliation, advanced the authorization generation, closed every remote WebSocket, and cleared pending and time-limited browser access.
- One-time and trusted-browser authorization was only checked during WebSocket upgrade. A socket that outlived its authorization could continue receiving replay, application, Task progress, and heartbeat traffic.

## Proposed change

- Add a read-only `remoteAccess.probe()` command across the service, IPC/host command, preload contract, and generated Web API map. Automatic Remote settings loads use `probe`; the existing explicit Detect action still uses `detect` for repair and public-link refresh. Probe retains its provider observation in memory so later snapshots stay current, without broadcasting or persisting it.
- Keep `probe` available to Electron and local Web callers while installing a rejecting stub on the remote Web surface.
- Represent accepted external WebSockets with a stable `principalId` and runtime `isCurrent()` check. Pairing expiration reports the expired principal so its sockets close immediately, and every outbound WebSocket path closes stale sockets before sending.

## Scope and non-goals

- No database or `remote-access.json` fields, migrations, or persisted authorization-principal model.
- No historical-data compatibility work is needed because no persisted shape changes.
- No new `RemoteAccessMode`, `RemoteAccessLifecycle`, pairing-decision, or other persisted enum values.
- No new UI interaction, copy, or i18n changes.
- No unrelated idempotency, caller-identity, or Remote Access refactor.

## Acceptance criteria and validation

| Behavior | Command | Result |
| --- | --- | --- |
| Remote settings automatic load uses read-only probe, not mutating detect | `rtk npm test -- src/renderer/src/pages/settings/SettingsPage.render.test.tsx -t "opens the Remote panel with three scenario-based access modes"` | Red twice before production change (`probe` called 0 times); green after implementation |
| Browser probe preserves a real one-time cookie and connection | `rtk npm test -- src/main/remote-access/service.test.ts -t "probes Browser access without closing or invalidating a one-time session"` | Red twice before production change (`closeExternalConnections` called once); green after implementation |
| Probe observations remain current without persistence or broadcast | `rtk npm test -- src/main/remote-access/service.test.ts -t "keeps provider observations from a probe current without persisting configuration"` | Red twice before production change (later snapshot remained stale); green after implementation |
| Natural expiry reports stable principal IDs and invalidates runtime authorization | `rtk npm test -- src/main/remote-access/pairing.test.ts -t "reports each naturally expired authorization by stable principal ID"` | Red twice before production change (expiry callback called 0 times); green after implementation |
| Stale real WebSockets close before application, replay, Task progress, or heartbeat traffic | `rtk npm test -- src/main/web-service/http-server.test.ts -t "closes stale"` | Red twice before production change (`leaked`, `replayed`, or `heartbeat`); final: 4 passed |
| Probe is absent from the remote Web RPC surface and remains callable only from local callers | `rtk npm test -- src/shared/renderer-contract-catalog.test.ts -t "keeps the Remote Access probe local-only"`; `rtk npm test -- src/main/host-application-commands.test.ts -t "keeps the read-only Remote Access probe available only to local callers"` | Each regression was red twice before its production change; both green after implementation |
| Remote Access, Web Service, Settings, IPC/host/preload, and contract impact set | `rtk npm test -- <29 targeted test files>` | 29 files passed; 481 passed, 3 skipped |
| Node types | `rtk npm run typecheck:node` | Passed |
| Web types | `rtk npm run typecheck:web` | Passed |
| Lint | `rtk npm run lint` | Passed |
| Generated Web API map | `rtk npm run check:web-api-map` | Passed |
| Changed-file formatting | `rtk npx prettier --check <5 changed files>` | Passed |
| Patch hygiene | `rtk git diff --check` | Passed |

Per contribution guidance, the full repository test suite was not run; validation used the final targeted Test Impact Set above.

## Review focus

- Confirm `probe()` only observes provider state and updates its in-memory observation; it never reconciles routing, advances authorization generation, closes connections, changes pairing/session state, broadcasts, or persists configuration.
- Confirm `probe` is callable from Electron/local Web but represented by a rejecting stub for remote Web, while explicit Detect retains its desktop-only repair and public-link refresh behavior.
- Confirm principal-scoped expiry closure and the defensive `isCurrent()` gate cover replay, application broadcasts (legacy and replay), Task progress, and heartbeat frames without affecting local WebSockets.
