### PR TITLE
feat(notebook): dock variables in wide previews

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -774,6 +774,10 @@ colors communicate a successful or failed probe/migration result.
 - Composer: fixed to the bottom of the activity stream and constrained to `max-w-4xl`, with the composer text track aligned to the message content.
 - Right viewer area: `border-l border-border/20`.
 - Right card: `m-2 rounded-lg bg-card shadow-sm`.
+- An open Notebook Variables view shares the Preview with the Notebook and manual kernel terminal
+  when the Notebook surface is at least `55rem` wide, using a fixed 40% right column. Below that
+  container width it collapses to the focused Variables view; resizing back preserves the user's
+  open intent. The outer Preview remains the only horizontal resize control.
 - Conversation panel shell: `bg-bg-10 p-2 pl-4`.
 - Composer area uses a top fade `bg-gradient-to-t from-bg-10 to-bg-10/0`.
 - Message scroller and preview panel both use `bg-bg-10`.

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -567,6 +567,7 @@ describe('NotebookPreview per-kernel tabs', () => {
     )
 
     expect(primaryView).not.toBeNull()
+    expect(primaryView?.className).toContain('flex-col')
     expect(primaryView?.className).toContain('hidden')
     expect(primaryView?.className).toContain('@min-[55rem]/notebook:flex')
     expect(primaryView?.querySelector('[data-testid="notebook-cells"]')).toBe(cellsBeforeOpen)

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -549,6 +549,45 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(input.disabled).toBe(true)
   })
 
+  it('keeps notebook controls mounted for the responsive variables layout', async () => {
+    await mountWithRuns([makeRun({ runId: 'p1', kernelKind: 'python' })])
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Inspect variables' }))
+    })
+
+    const primaryView = container.querySelector<HTMLElement>(
+      '[data-testid="notebook-primary-view"]'
+    )
+    const variablesView = container.querySelector<HTMLElement>(
+      '[data-testid="notebook-variables-view"]'
+    )
+
+    expect(primaryView).not.toBeNull()
+    expect(primaryView?.className).toContain('hidden')
+    expect(primaryView?.className).toContain('@min-[55rem]/notebook:flex')
+    expect(primaryView?.querySelector('[data-testid="notebook-cells"]')).not.toBeNull()
+    expect(primaryView?.querySelector('[data-testid="kernel-terminal-input"]')).not.toBeNull()
+    expect(variablesView?.className).toContain('@min-[55rem]/notebook:basis-[40%]')
+    expect(variablesView?.className).toContain('@min-[55rem]/notebook:border-l')
+
+    const variablesButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="notebook-variables-button"]'
+    )
+    expect(variablesButton?.getAttribute('aria-pressed')).toBe('true')
+
+    await act(async () => {
+      fireEvent.click(variablesButton as HTMLButtonElement)
+    })
+
+    expect(container.querySelector('[data-testid="notebook-variables-view"]')).toBeNull()
+    expect(
+      container
+        .querySelector('[data-testid="notebook-variables-button"]')
+        ?.getAttribute('aria-pressed')
+    ).toBe('false')
+  })
+
   it('clears a live namespace snapshot when its kernel terminates', async () => {
     await mountWithRuns([makeRun({ runId: 'p1', kernelKind: 'python' })])
 

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -552,6 +552,9 @@ describe('NotebookPreview per-kernel tabs', () => {
   it('keeps notebook controls mounted for the responsive variables layout', async () => {
     await mountWithRuns([makeRun({ runId: 'p1', kernelKind: 'python' })])
 
+    const cellsBeforeOpen = container.querySelector('[data-testid="notebook-cells"]')
+    const terminalBeforeOpen = container.querySelector('[data-testid="kernel-terminal-input"]')
+
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Inspect variables' }))
     })
@@ -566,10 +569,21 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(primaryView).not.toBeNull()
     expect(primaryView?.className).toContain('hidden')
     expect(primaryView?.className).toContain('@min-[55rem]/notebook:flex')
-    expect(primaryView?.querySelector('[data-testid="notebook-cells"]')).not.toBeNull()
-    expect(primaryView?.querySelector('[data-testid="kernel-terminal-input"]')).not.toBeNull()
+    expect(primaryView?.querySelector('[data-testid="notebook-cells"]')).toBe(cellsBeforeOpen)
+    expect(primaryView?.querySelector('[data-testid="kernel-terminal-input"]')).toBe(
+      terminalBeforeOpen
+    )
     expect(variablesView?.className).toContain('@min-[55rem]/notebook:basis-[40%]')
     expect(variablesView?.className).toContain('@min-[55rem]/notebook:border-l')
+
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="notebook-variables-close"]'
+    )
+    fireEvent.focus(closeButton as HTMLButtonElement)
+    await screen.findByRole('tooltip')
+    expect(
+      document.body.querySelector<HTMLElement>('[data-slot="tooltip-content"]')?.className
+    ).toContain('z-[70]')
 
     const variablesButton = container.querySelector<HTMLButtonElement>(
       '[data-testid="notebook-variables-button"]'
@@ -581,6 +595,10 @@ describe('NotebookPreview per-kernel tabs', () => {
     })
 
     expect(container.querySelector('[data-testid="notebook-variables-view"]')).toBeNull()
+    expect(container.querySelector('[data-testid="notebook-cells"]')).toBe(cellsBeforeOpen)
+    expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBe(
+      terminalBeforeOpen
+    )
     expect(
       container
         .querySelector('[data-testid="notebook-variables-button"]')

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -1016,7 +1016,9 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
                 <X className="size-4" aria-hidden="true" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">{t('Close')}</TooltipContent>
+            <TooltipContent side="bottom" className="z-[70]">
+              {t('Close')}
+            </TooltipContent>
           </Tooltip>
         </TooltipProvider>
         <div className="mr-auto min-w-0">
@@ -1399,19 +1401,23 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         </div>
       ) : null}
 
-      {showVariables && activeDataLanguage ? (
-        <div className="flex min-h-0 flex-1" data-testid="notebook-responsive-variables-layout">
-          <div
-            className="hidden min-h-0 min-w-0 flex-1 overflow-hidden @min-[55rem]/notebook:flex"
-            data-testid="notebook-primary-view"
-          >
-            {notebookView}
-          </div>
-          {namespaceView}
+      <div
+        className="flex min-h-0 flex-1"
+        data-testid={
+          showVariables && activeDataLanguage ? 'notebook-responsive-variables-layout' : undefined
+        }
+      >
+        <div
+          className={cn(
+            'min-h-0 min-w-0 flex-1 overflow-hidden',
+            showVariables && activeDataLanguage ? 'hidden @min-[55rem]/notebook:flex' : 'flex'
+          )}
+          data-testid="notebook-primary-view"
+        >
+          {notebookView}
         </div>
-      ) : (
-        notebookView
-      )}
+        {showVariables && activeDataLanguage ? namespaceView : null}
+      </div>
 
       {!showVariables && (isNamespaceLost || isHistoricalEnvironmentView) ? (
         <footer

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -8,7 +8,7 @@ import {
   type RefObject
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ArrowLeft, RefreshCw, Variable } from 'lucide-react'
+import { RefreshCw, Variable, X } from 'lucide-react'
 
 import { usePreviewWorkbenchStore, type PreviewToolItem } from '@/stores/preview-workbench-store'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
@@ -998,17 +998,27 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     </div>
   )
   const namespaceView = (
-    <div className="flex min-h-0 flex-1 flex-col" data-testid="notebook-variables-view">
+    <div
+      className="flex min-h-0 min-w-0 flex-1 flex-col @min-[55rem]/notebook:basis-[40%] @min-[55rem]/notebook:grow-0 @min-[55rem]/notebook:border-l @min-[55rem]/notebook:border-border-200"
+      data-testid="notebook-variables-view"
+    >
       <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border-100 px-3 py-2">
-        <button
-          type="button"
-          aria-label={t('Back to Notebook')}
-          onClick={() => setShowVariables(false)}
-          className="inline-flex size-7 items-center justify-center rounded-md text-text-300 transition-colors hover:bg-bg-200 hover:text-text-100"
-          data-testid="notebook-variables-back"
-        >
-          <ArrowLeft className="size-4" aria-hidden="true" />
-        </button>
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={t('Close')}
+                onClick={() => setShowVariables(false)}
+                className="inline-flex size-7 items-center justify-center rounded-md text-text-300 transition-colors hover:bg-bg-200 hover:text-text-100"
+                data-testid="notebook-variables-close"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{t('Close')}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <div className="mr-auto min-w-0">
           <div className="text-xs font-medium text-text-100">{t('Variables')}</div>
           <div className="text-[11px] text-text-300">
@@ -1129,10 +1139,73 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       </div>
     </div>
   )
+  const notebookView =
+    !activeDataLanguage || isNamespaceLost || isHistoricalEnvironmentView ? (
+      <div className="min-h-0 flex-1 overflow-hidden">{notebookCells}</div>
+    ) : (
+      <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 flex-col">
+        <ResizablePanel
+          id="notebook-cells-panel"
+          defaultSize="80%"
+          minSize="35%"
+          className="min-h-0 overflow-hidden"
+        >
+          {notebookCells}
+        </ResizablePanel>
+
+        <ResizableHandle
+          aria-label={t('Resize notebook and terminal')}
+          className="z-10 shrink-0 border-y border-border-200 bg-bg-200/70 aria-[orientation=horizontal]:h-7 aria-[orientation=horizontal]:before:h-1 aria-[orientation=horizontal]:before:w-10 before:opacity-60 hover:before:opacity-100 focus-visible:before:opacity-100 data-[separator=active]:before:opacity-100"
+        >
+          <div
+            className="pointer-events-none absolute inset-0 flex items-center justify-between gap-2 px-3 text-[11px] text-text-300"
+            data-testid="notebook-terminal-header"
+          >
+            <span>
+              {activeDataLanguage === 'r'
+                ? t('R kernel · shared with the agent')
+                : t('Python kernel · shared with the agent')}
+            </span>
+            <span>{isSelectedKernelRunning ? t('running') : t('idle')}</span>
+          </div>
+        </ResizableHandle>
+
+        <ResizablePanel
+          id="notebook-terminal-panel"
+          defaultSize="20%"
+          minSize="15%"
+          className="min-h-0 overflow-hidden"
+        >
+          <div className="flex h-full min-h-0 flex-col bg-bg-000" data-testid="kernel-terminal">
+            {actionError ? (
+              <div className="border-b border-border-100/60 px-3 py-2 font-mono text-xs text-danger-000">
+                {actionError}
+              </div>
+            ) : null}
+            <TerminalScrollback
+              runs={visibleRuns}
+              language={activeDataLanguage}
+              viewportRef={terminalViewportRef}
+            />
+            <TerminalInput
+              code={terminalCode}
+              disabled={isTerminalLocked}
+              language={activeDataLanguage}
+              variables={suggestionVariables}
+              onChange={setTerminalCode}
+              onFocusChange={setTerminalInputFocused}
+              onSubmit={() => {
+                void submitTerminalCode()
+              }}
+            />
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    )
 
   return (
     <section
-      className="relative flex h-full min-w-0 flex-col overflow-hidden bg-bg-000"
+      className="@container/notebook relative flex h-full min-w-0 flex-col overflow-hidden bg-bg-000"
       data-testid="kernel-notebook-pane"
     >
       {gated ? (
@@ -1228,9 +1301,10 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
                 <button
                   type="button"
                   aria-label={t('Inspect variables')}
+                  aria-pressed={showVariables}
                   aria-disabled={namespaceButtonDisabled}
                   onClick={() => {
-                    if (!namespaceButtonDisabled) setShowVariables(true)
+                    if (!namespaceButtonDisabled) setShowVariables((current) => !current)
                   }}
                   className={cn(
                     'ml-2 inline-flex size-7 shrink-0 items-center justify-center rounded-md text-text-300 transition-colors',
@@ -1326,68 +1400,17 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       ) : null}
 
       {showVariables && activeDataLanguage ? (
-        namespaceView
-      ) : !activeDataLanguage || isNamespaceLost || isHistoricalEnvironmentView ? (
-        <div className="min-h-0 flex-1 overflow-hidden">{notebookCells}</div>
+        <div className="flex min-h-0 flex-1" data-testid="notebook-responsive-variables-layout">
+          <div
+            className="hidden min-h-0 min-w-0 flex-1 overflow-hidden @min-[55rem]/notebook:flex"
+            data-testid="notebook-primary-view"
+          >
+            {notebookView}
+          </div>
+          {namespaceView}
+        </div>
       ) : (
-        <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 flex-col">
-          <ResizablePanel
-            id="notebook-cells-panel"
-            defaultSize="80%"
-            minSize="35%"
-            className="min-h-0 overflow-hidden"
-          >
-            {notebookCells}
-          </ResizablePanel>
-
-          <ResizableHandle
-            aria-label={t('Resize notebook and terminal')}
-            className="z-10 shrink-0 border-y border-border-200 bg-bg-200/70 aria-[orientation=horizontal]:h-7 aria-[orientation=horizontal]:before:h-1 aria-[orientation=horizontal]:before:w-10 before:opacity-60 hover:before:opacity-100 focus-visible:before:opacity-100 data-[separator=active]:before:opacity-100"
-          >
-            <div
-              className="pointer-events-none absolute inset-0 flex items-center justify-between gap-2 px-3 text-[11px] text-text-300"
-              data-testid="notebook-terminal-header"
-            >
-              <span>
-                {activeDataLanguage === 'r'
-                  ? t('R kernel · shared with the agent')
-                  : t('Python kernel · shared with the agent')}
-              </span>
-              <span>{isSelectedKernelRunning ? t('running') : t('idle')}</span>
-            </div>
-          </ResizableHandle>
-
-          <ResizablePanel
-            id="notebook-terminal-panel"
-            defaultSize="20%"
-            minSize="15%"
-            className="min-h-0 overflow-hidden"
-          >
-            <div className="flex h-full min-h-0 flex-col bg-bg-000" data-testid="kernel-terminal">
-              {actionError ? (
-                <div className="border-b border-border-100/60 px-3 py-2 font-mono text-xs text-danger-000">
-                  {actionError}
-                </div>
-              ) : null}
-              <TerminalScrollback
-                runs={visibleRuns}
-                language={activeDataLanguage}
-                viewportRef={terminalViewportRef}
-              />
-              <TerminalInput
-                code={terminalCode}
-                disabled={isTerminalLocked}
-                language={activeDataLanguage}
-                variables={suggestionVariables}
-                onChange={setTerminalCode}
-                onFocusChange={setTerminalInputFocused}
-                onSubmit={() => {
-                  void submitTerminalCode()
-                }}
-              />
-            </div>
-          </ResizablePanel>
-        </ResizablePanelGroup>
+        notebookView
       )}
 
       {!showVariables && (isNamespaceLost || isHistoricalEnvironmentView) ? (

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -1409,7 +1409,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       >
         <div
           className={cn(
-            'min-h-0 min-w-0 flex-1 overflow-hidden',
+            'min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
             showVariables && activeDataLanguage ? 'hidden @min-[55rem]/notebook:flex' : 'flex'
           )}
           data-testid="notebook-primary-view"

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1681,7 +1681,6 @@
     "Proxy settings saved.": "Configuración de proxy guardada.",
     "Publish": "Publicar",
     "Publish skill": "Publicar habilidad",
-    "Back to Notebook": "Volver a Notebook",
     "Variables": "Variables",
     "Variables: {{count}}_one": "{{count}} variable",
     "Variables: {{count}}_many": "{{count}} variables",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1725,7 +1725,6 @@
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_one": "Références : {{count}}/{{limit}} ; paquet : {{size}} / {{total}}",
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_other": "Références : {{count}}/{{limit}} ; paquet : {{size}} / {{total}}",
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_many": "Références : {{count}}/{{limit}} ; paquet : {{size}} / {{total}}",
-    "Back to Notebook": "Retour au Notebook",
     "Could not inspect variables.": "Impossible d’inspecter les variables.",
     "Filter variables": "Filtrer les variables",
     "Filter variables...": "Filtrer les variables...",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1663,7 +1663,6 @@
     "Ref:": "参照：",
     "References": "参考文献",
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_other": "参照：{{count}} / {{limit}}、パッケージ：{{size}} / {{total}}",
-    "Back to Notebook": "Notebook に戻る",
     "Could not inspect variables.": "変数を検査できませんでした。",
     "Filter variables": "変数を絞り込む",
     "Filter variables...": "変数を絞り込む…",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1673,7 +1673,6 @@
     "Ref:": "참조:",
     "References": "참고자료",
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_other": "참고문헌: {{count}} / {{limit}}; 패키지: {{size}} / {{total}}",
-    "Back to Notebook": "Notebook으로 돌아가기",
     "Could not inspect variables.": "변수를 검사할 수 없습니다.",
     "Filter variables": "변수 필터링",
     "Filter variables...": "변수 필터링...",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1725,7 +1725,6 @@
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_few": "Ссылки: {{count}} / {{limit}}; пакет: {{size}} / {{total}}",
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_many": "Ссылки: {{count}} / {{limit}}; пакет: {{size}} / {{total}}",
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_other": "Ссылки: {{count}} / {{limit}}; пакет: {{size}} / {{total}}",
-    "Back to Notebook": "Вернуться к Notebook",
     "Could not inspect variables.": "Не удалось проверить переменные.",
     "Filter variables": "Фильтровать переменные",
     "Filter variables...": "Фильтровать переменные...",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1734,7 +1734,6 @@
     "Ref:": "引用：",
     "References": "参考文件",
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_other": "参考文件：{{count}} / {{limit}}；包大小：{{size}} / {{total}}",
-    "Back to Notebook": "返回 Notebook",
     "Could not inspect variables.": "无法检查变量。",
     "Filter variables": "筛选变量",
     "Filter variables...": "筛选变量...",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1731,7 +1731,6 @@
     "Ref:": "參照：",
     "References": "參考檔案",
     "References: {{count}} / {{limit}}; package: {{size}} / {{total}}_other": "參考檔案：{{count}} / {{limit}}；套件大小：{{size}} / {{total}}",
-    "Back to Notebook": "返回 Notebook",
     "Could not inspect variables.": "無法檢查變數。",
     "Filter variables": "篩選變數",
     "Filter variables...": "篩選變數...",


### PR DESCRIPTION
## Problem

Opening live Variables currently replaces Notebook history and the manual kernel terminal. That makes variable inspection less useful during hands-on coding, especially after the user has widened the resizable Preview panel enough to show both surfaces.

## Proposed change

- Make Notebook Preview a named CSS container.
- At `55rem` or wider, keep Notebook cells and the manual terminal visible while docking live Variables in a fixed 40% right column.
- Below `55rem`, retain the existing focused Variables view and preserve the user's open intent so the dock returns automatically when space becomes available.
- Make the existing Variables toolbar button toggle the view, and provide a labeled/tooltiped close control inside Variables.
- Keep the primary Notebook wrapper mounted as a bounded flex column so toggling Variables preserves divider/scroll state and read-only history remains scrollable.
- Preserve the live kernel variable suggestions introduced on the latest `main` while rebasing the responsive layout.
- Cover the responsive structure and toggle behavior with the Notebook render gate; document the interaction in the design guide.

## Scope and non-goals

- Renderer-only UI behavior.
- No second horizontal resize control; users continue resizing the outer Preview panel.
- No backend, runtime, protocol, dependency, or schema changes.
- No historical-data compatibility or migration requirement.
- No enum/state-value additions.
- No persistence changes.

## Acceptance criteria and validation

- Responsive Notebook/Variables layout and toggle behavior: `npm test -- src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx` — 46/46 passed.
- Workspace module consumers: `npm run test:module -- workspace_page` — 25 files, 593/593 passed.
- Renderer types: `npm run typecheck:web` — passed.
- Repository lint: `npm run lint` — passed.
- Production Web bundle and generated container-query CSS: `npx vite build --config vite.web.config.ts` — passed (existing optimizer/chunk warnings only).
- Browser drag verification against the local app: at a 985.6 px Notebook pane the wide layout resolves to `display: flex`; at 563.6 px it resolves to `display: none`, restoring the focused Variables fallback.
- `npm run test:affected:explain -- --base origin/main --head HEAD` conservatively selected the full suite because `docs/design.md` has no module owner. Per maintainer direction, the full local `npm test` was intentionally deferred; PR Gate is the authoritative full-suite result.

## Review focus

- Whether `55rem` and the fixed 40% Variables column provide the right working balance.
- Whether the narrow focused fallback and preserved open intent feel natural while dragging the outer Preview splitter.
