### PR TITLE
fix(compute): validate SSH aliases and scratch paths

### DIFF
--- a/src/main/compute/compute-auth-owner.test.ts
+++ b/src/main/compute/compute-auth-owner.test.ts
@@ -408,6 +408,24 @@ describe('Compute password-host application handler', () => {
     })
   })
 
+  it('rejects an option-like alias before password validation or persistence', async () => {
+    const { owner, createPasswordHost, acquireWithPassword, encrypt } = setup()
+
+    await expect(
+      owner.createPassword({
+        sshAlias: '-oProxyCommand=touch /tmp/not-approved',
+        authenticationMode: 'password',
+        username: 'researcher',
+        port: 22,
+        password: 'secret',
+        operationId: 'operation-unsafe-alias'
+      })
+    ).rejects.toThrow(/alias/i)
+    expect(encrypt).not.toHaveBeenCalled()
+    expect(acquireWithPassword).not.toHaveBeenCalled()
+    expect(createPasswordHost).not.toHaveBeenCalled()
+  })
+
   it('replays a committed password-host creation without contacting the SSH transport', async () => {
     const committed = {
       ...publicHost(),

--- a/src/main/compute/compute-auth-owner.test.ts
+++ b/src/main/compute/compute-auth-owner.test.ts
@@ -420,7 +420,7 @@ describe('Compute password-host application handler', () => {
         password: 'secret',
         operationId: 'operation-unsafe-alias'
       })
-    ).rejects.toThrow(/alias/i)
+    ).rejects.toMatchObject({ code: 'unsupported_auth_configuration' })
     expect(encrypt).not.toHaveBeenCalled()
     expect(acquireWithPassword).not.toHaveBeenCalled()
     expect(createPasswordHost).not.toHaveBeenCalled()

--- a/src/main/compute/compute-auth-owner.ts
+++ b/src/main/compute/compute-auth-owner.ts
@@ -96,6 +96,18 @@ const requireValidTrimmedField = (value: string, label: string): string => {
   return result
 }
 
+const requireSafeSshAlias = (value: string): string => {
+  const alias = requireValidTrimmedField(value, 'SSH alias')
+  try {
+    return assertSafeSshAlias(alias)
+  } catch (error) {
+    throw new ComputeConnectionError(
+      'unsupported_auth_configuration',
+      error instanceof Error ? error.message : undefined
+    )
+  }
+}
+
 class ComputeAuthOwner {
   private readonly mutationTails = new Map<string, Promise<void>>()
 
@@ -145,7 +157,7 @@ class ComputeAuthOwner {
     if (request.authenticationMode !== 'password') {
       throw new ComputeConnectionError('unsupported_auth_configuration')
     }
-    const alias = assertSafeSshAlias(requireValidTrimmedField(request.sshAlias, 'SSH alias'))
+    const alias = requireSafeSshAlias(request.sshAlias)
     const username = requireValidTrimmedField(request.username, 'Username')
     const operationId = requireValidTrimmedField(
       request.operationId,

--- a/src/main/compute/compute-auth-owner.ts
+++ b/src/main/compute/compute-auth-owner.ts
@@ -9,6 +9,7 @@ import { computeProviderId, DETAILS_DOC_MAX_LENGTH } from '../../shared/compute'
 import type { PasswordSshAdapter } from './connection-adapters'
 import { ComputeConnectionError } from './connection-broker'
 import type { CredentialVault } from './credential-vault'
+import { assertSafeSshAlias } from './remote-path-security'
 
 type CreatePasswordHostPersistence = Readonly<{
   operationId: string
@@ -144,7 +145,7 @@ class ComputeAuthOwner {
     if (request.authenticationMode !== 'password') {
       throw new ComputeConnectionError('unsupported_auth_configuration')
     }
-    const alias = requireValidTrimmedField(request.sshAlias, 'SSH alias')
+    const alias = assertSafeSshAlias(requireValidTrimmedField(request.sshAlias, 'SSH alias'))
     const username = requireValidTrimmedField(request.username, 'Username')
     const operationId = requireValidTrimmedField(
       request.operationId,

--- a/src/main/compute/compute-host-profile-owner.test.ts
+++ b/src/main/compute/compute-host-profile-owner.test.ts
@@ -510,6 +510,31 @@ describe('ComputeHostProfileOwner.probe', () => {
     expect(updateScratchRoot).not.toHaveBeenCalled()
   })
 
+  it('does NOT persist an invalid $SCRATCH value from a successful probe', async () => {
+    const stdout = [
+      'os=Linux',
+      'cpus=8',
+      'mem_mib=16000',
+      'gpus=',
+      'sbatch=no',
+      'qsub=no',
+      'bsub=no',
+      'scratch=../../$(touch /tmp/not-approved)'
+    ].join('\n')
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout,
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateScratchRoot } = makeRepo()
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await expect(service.probe('ssh:biowulf')).resolves.toMatchObject({ ok: true })
+    expect(updateScratchRoot).not.toHaveBeenCalled()
+  })
+
   it('does NOT write detailsDoc', async () => {
     const runner = makeFakeRunner({
       exitCode: 0,
@@ -698,6 +723,31 @@ describe('ComputeHostProfileOwner.setScratchRoot', () => {
     const service = new ComputeHostProfileOwner(fakeRunner, repo)
     await service.setScratchRoot('ssh:biowulf', '/my/scratch')
     expect(updateScratchPinned).toHaveBeenCalledWith('ssh:biowulf', '/my/scratch')
+  })
+
+  it('accepts a canonical home-relative scratch root', async () => {
+    const { repo, updateScratchPinned } = makeRepo()
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+
+    await service.setScratchRoot('ssh:biowulf', '~/scratch path/$literal')
+
+    expect(updateScratchPinned).toHaveBeenCalledWith('ssh:biowulf', '~/scratch path/$literal')
+  })
+
+  it.each([
+    'relative/path',
+    '/scratch/../other',
+    '/scratch/./other',
+    '/scratch//other',
+    '/scratch/other/',
+    '/scratch\nother',
+    `/${'a'.repeat(4096)}`
+  ])('rejects an invalid scratch root before persistence: %j', async (path) => {
+    const { repo, updateScratchPinned } = makeRepo()
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+
+    await expect(service.setScratchRoot('ssh:biowulf', path)).rejects.toThrow(/scratch root/i)
+    expect(updateScratchPinned).not.toHaveBeenCalled()
   })
 
   it('throws when the host does not exist', async () => {

--- a/src/main/compute/compute-host-profile-owner.ts
+++ b/src/main/compute/compute-host-profile-owner.ts
@@ -6,6 +6,7 @@ import {
   type ComputeConnectionBrokerAcquirer
 } from './connection-broker'
 import type { ComputeHostRepository } from './repository'
+import { assertSafeScratchRoot } from './remote-path-security'
 
 const PROBE_TIMEOUT_MS = 30_000
 const PROBE_MAX_OUTPUT_BYTES = 4 * 1024
@@ -228,7 +229,15 @@ export class ComputeHostProfileOwner {
 
     await this.repository.updateProbeResult(providerId, result, shape)
     if (!host.scratchPinned && parsed.scratchEnv) {
-      await this.repository.updateScratchRoot(providerId, parsed.scratchEnv)
+      let safeScratchRoot: string | undefined
+      try {
+        safeScratchRoot = assertSafeScratchRoot(parsed.scratchEnv)
+      } catch {
+        // Ignore an unusable remote value without hiding persistence failures for valid paths.
+      }
+      if (safeScratchRoot !== undefined) {
+        await this.repository.updateScratchRoot(providerId, safeScratchRoot)
+      }
     }
     return result
   }
@@ -285,7 +294,7 @@ export class ComputeHostProfileOwner {
 
   async setScratchRoot(providerId: string, path: string): Promise<void> {
     if (!(await this.repository.get(providerId))) throw hostNotFound(providerId)
-    await this.repository.updateScratchPinned(providerId, path)
+    await this.repository.updateScratchPinned(providerId, assertSafeScratchRoot(path))
   }
 
   async setConcurrencyLimit(providerId: string, limit: number): Promise<void> {

--- a/src/main/compute/compute-remote-operation-owner.test.ts
+++ b/src/main/compute/compute-remote-operation-owner.test.ts
@@ -213,6 +213,29 @@ describe('ComputeRemoteOperationOwner.callCommand', () => {
     expect(calledCmd).toContain('ls')
   })
 
+  it('quotes scratchRoot so shell expansions cannot add unapproved commands', async () => {
+    const runMock = vi.fn(() =>
+      Promise.resolve({ exitCode: 0, stdout: '', stderr: '', truncated: false, timedOut: false })
+    )
+    const runner: SshRunner = { run: runMock }
+    const host = sampleHost({ scratchRoot: '/scratch/$(touch /tmp/not-approved)' })
+    const { repo } = makeRepo(host)
+    const approvalBroker = makeApprovalBroker('once')
+    const service = makeOwner(runner, repo, approvalBroker)
+
+    await service.callCommand('ssh:biowulf', 'printf approved', 'test approval')
+
+    expect(approvalBroker.request).toHaveBeenCalledWith(
+      expect.objectContaining({ command_full: 'printf approved' }),
+      undefined,
+      undefined
+    )
+    const calledCmd = (runMock.mock.calls[0] as unknown as [unknown, string])?.[1]
+    expect(calledCmd).toBe(
+      "cd '/scratch/$(touch /tmp/not-approved)' 2>/dev/null || cd ~; printf approved"
+    )
+  })
+
   it('falls back to cd ~ when no scratchRoot is configured', async () => {
     const runMock = vi.fn(() =>
       Promise.resolve({ exitCode: 0, stdout: '', stderr: '', truncated: false, timedOut: false })
@@ -392,6 +415,27 @@ const buildListDirStdout = (resolvedPath: string, home: string, findOutput: stri
   `${resolvedPath}\n${home}\n${findOutput}`
 
 describe('ComputeRemoteOperationOwner.listDir', () => {
+  it('quotes a ~/ suffix so shell expansions cannot run while browsing', async () => {
+    const runMock = vi.fn(() =>
+      Promise.resolve({
+        exitCode: 0,
+        stdout: '/home/user/$(touch /tmp/not-approved)\n/home/user\n',
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      })
+    )
+    const runner: SshRunner = { run: runMock }
+    const { repo } = makeRepo()
+    const service = makeOwner(runner, repo)
+
+    await service.listDir('ssh:biowulf', '~/$(touch /tmp/not-approved)')
+
+    const calledCmd = (runMock.mock.calls[0] as unknown as [unknown, string])?.[1]
+    expect(calledCmd).toContain("realpath ~/'$(touch /tmp/not-approved)'")
+    expect(calledCmd).toContain("cd ~/'$(touch /tmp/not-approved)' || exit 1")
+  })
+
   it('preserves a stable sanitized password-authentication error code', async () => {
     const runner: SshRunner = {
       run: vi.fn(async () => {

--- a/src/main/compute/compute-remote-operation-owner.ts
+++ b/src/main/compute/compute-remote-operation-owner.ts
@@ -14,6 +14,7 @@ import {
   type ComputeConnectionLease
 } from './connection-broker'
 import type { ComputeHostRepository } from './repository'
+import { quoteRemotePath } from './remote-path-security'
 import {
   MAX_DOWNLOAD_BYTES,
   MAX_IMPORT_BYTES,
@@ -92,11 +93,7 @@ export class ComputeRemoteOperationOwner {
       throw remoteConnectionError(error)
     }
 
-    const expandedPath =
-      path === '~' ? '$HOME' : path.startsWith('~/') ? `$HOME/${path.slice(2)}` : path
-    const quotedPath = expandedPath.startsWith('$HOME')
-      ? expandedPath
-      : shellSingleQuote(expandedPath)
+    const quotedPath = quoteRemotePath(path)
     const remoteCommand = [
       `realpath ${quotedPath} 2>/dev/null || echo ${quotedPath}`,
       `cd ${quotedPath} || exit 1`,
@@ -227,7 +224,7 @@ export class ComputeRemoteOperationOwner {
     }
 
     const cwdExpression = host.scratchRoot
-      ? `cd ${JSON.stringify(host.scratchRoot)} 2>/dev/null || cd ~`
+      ? `cd ${quoteRemotePath(host.scratchRoot)} 2>/dev/null || cd ~`
       : 'cd ~'
     const wrappedCommand = `${cwdExpression}; ${cmd}`
     const timeoutMs =

--- a/src/main/compute/remote-path-security.ts
+++ b/src/main/compute/remote-path-security.ts
@@ -1,6 +1,48 @@
 // Transport-neutral remote path policy shared by Compute Job command and transfer workflows.
 export const GLOB_CHARS = /[*?[\]{}\\]/
 
+export const SSH_ALIAS_MAX_LENGTH = 255
+export const SCRATCH_ROOT_MAX_LENGTH = 4096
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/
+
+export const assertSafeSshAlias = (value: string): string => {
+  const alias = value.trim()
+  if (
+    !alias ||
+    alias.length > SSH_ALIAS_MAX_LENGTH ||
+    alias.startsWith('-') ||
+    alias === '.' ||
+    alias === '..' ||
+    CONTROL_CHARS.test(value) ||
+    /[\s/\\%]/u.test(alias)
+  ) {
+    throw new Error(
+      `SSH host alias must contain 1–${SSH_ALIAS_MAX_LENGTH} characters and cannot start with "-" or contain whitespace, path separators, or "%".`
+    )
+  }
+  return alias
+}
+
+export const assertSafeScratchRoot = (value: string): string => {
+  const invalidMessage = `Scratch root must be a canonical absolute or ~/ path of at most ${SCRATCH_ROOT_MAX_LENGTH} characters.`
+  if (!value || value.length > SCRATCH_ROOT_MAX_LENGTH || CONTROL_CHARS.test(value)) {
+    throw new Error(invalidMessage)
+  }
+  if (value === '/' || value === '~') return value
+
+  const suffix = value.startsWith('/')
+    ? value.slice(1)
+    : value.startsWith('~/')
+      ? value.slice(2)
+      : ''
+  if (!suffix || suffix.split('/').some((part) => !part || part === '.' || part === '..')) {
+    throw new Error(invalidMessage)
+  }
+  return value
+}
+
 // eslint-disable-next-line no-control-regex
 export const SHELL_UNSAFE_CHARS = /[$`;|&<>()"'\x00-\x1f\x7f]/
 

--- a/src/main/compute/repository.test.ts
+++ b/src/main/compute/repository.test.ts
@@ -26,12 +26,13 @@ const createRow = (overrides: Record<string, unknown> = {}): Record<string, unkn
 
 // Builds a mock computeHost delegate; each method is a spy the tests can assert against.
 const createMockClient = (
-  methods: Partial<Record<'findMany' | 'findUnique' | 'create' | 'delete', unknown>>
+  methods: Partial<Record<'findMany' | 'findUnique' | 'create' | 'update' | 'delete', unknown>>
 ): { client: ComputeHostClient; computeHost: Record<string, ReturnType<typeof vi.fn>> } => {
   const computeHost = {
     findMany: vi.fn(methods.findMany as never),
     findUnique: vi.fn(methods.findUnique as never),
     create: vi.fn(methods.create as never),
+    update: vi.fn(methods.update as never),
     delete: vi.fn(methods.delete as never)
   }
 
@@ -180,6 +181,27 @@ describe('compute host repository', () => {
     expect(computeHost.findUnique).toHaveBeenCalledWith({ where: { providerId: 'ssh:missing' } })
   })
 
+  it('keeps historical aliases and scratch roots readable without rewriting them', async () => {
+    const { client } = createMockClient({
+      findUnique: () =>
+        Promise.resolve(
+          createRow({
+            providerId: 'ssh:-legacy-option',
+            sshAlias: '-legacy-option',
+            scratchRoot: 'relative/legacy-scratch',
+            scratchPinned: true
+          })
+        )
+    })
+    const repository = new ComputeHostRepository(() => Promise.resolve(client))
+
+    await expect(repository.get('ssh:-legacy-option')).resolves.toMatchObject({
+      sshAlias: '-legacy-option',
+      scratchRoot: 'relative/legacy-scratch',
+      scratchPinned: true
+    })
+  })
+
   it('creates a host: derives provider_id, defaults display name to alias, seeds details as user', async () => {
     const { client, computeHost } = createMockClient({
       // No existing host with this providerId → create proceeds.
@@ -245,6 +267,40 @@ describe('compute host repository', () => {
 
     await expect(repository.create({ sshAlias: '   ' })).rejects.toThrow(/alias/i)
     expect(computeHost.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects an option-like alias without touching the database', async () => {
+    const { client, computeHost } = createMockClient({})
+    const repository = new ComputeHostRepository(() => Promise.resolve(client))
+
+    await expect(
+      repository.create({ sshAlias: '-oProxyCommand=touch /tmp/not-approved' })
+    ).rejects.toThrow(/alias/i)
+    expect(computeHost.findUnique).not.toHaveBeenCalled()
+    expect(computeHost.create).not.toHaveBeenCalled()
+  })
+
+  it.each(['relative/path', '/scratch/../other', '/scratch\nother'])(
+    'rejects an invalid discovered scratch root before writing: %j',
+    async (scratchRoot) => {
+      const { client, computeHost } = createMockClient({})
+      const repository = new ComputeHostRepository(() => Promise.resolve(client))
+
+      await expect(repository.updateScratchRoot('ssh:biowulf', scratchRoot)).rejects.toThrow(
+        /scratch root/i
+      )
+      expect(computeHost.update).not.toHaveBeenCalled()
+    }
+  )
+
+  it('rejects an invalid pinned scratch root before writing', async () => {
+    const { client, computeHost } = createMockClient({})
+    const repository = new ComputeHostRepository(() => Promise.resolve(client))
+
+    await expect(repository.updateScratchPinned('ssh:biowulf', '~/scratch//other')).rejects.toThrow(
+      /scratch root/i
+    )
+    expect(computeHost.update).not.toHaveBeenCalled()
   })
 
   it('rejects a duplicate alias with a readable error before inserting', async () => {

--- a/src/main/compute/repository.ts
+++ b/src/main/compute/repository.ts
@@ -21,6 +21,7 @@ import type {
 import { computeProviderId, DETAILS_DOC_MAX_LENGTH } from '../../shared/compute'
 import { decodeVersionedJson } from '../storage/versioned-json-decoder'
 import { ComputeConnectionError } from './connection-broker'
+import { assertSafeScratchRoot, assertSafeSshAlias } from './remote-path-security'
 
 // Only the computeHost delegate is needed; typing to this subset keeps the repository unit-testable
 // with a lightweight mock instead of a real (engine-backed) PrismaClient (aligns with the reviewer and
@@ -270,7 +271,7 @@ class ComputeHostRepository {
   async preparePasswordCreate(
     request: PreparePasswordCreateRequest
   ): Promise<PasswordCreatePreparation> {
-    const providerId = computeProviderId(request.sshAlias)
+    const providerId = computeProviderId(assertSafeSshAlias(request.sshAlias))
     const client = await this.getClient()
     const replay = await client.computeAuthOperation.findUnique({
       where: { id: request.operationId }
@@ -313,10 +314,7 @@ class ComputeHostRepository {
   // Creates a host record. Validates the alias, the 32 KiB details cap, and rejects a duplicate
   // provider_id with a readable error before inserting. No SSH connection is made in Phase 1.
   async create(request: CreateComputeHostRequest): Promise<ComputeHost> {
-    const alias = request.sshAlias.trim()
-    if (!alias) {
-      throw new Error('An SSH host alias is required.')
-    }
+    const alias = assertSafeSshAlias(request.sshAlias)
 
     const detailsDoc = request.detailsDoc ?? ''
     if (detailsDoc.length > DETAILS_DOC_MAX_LENGTH) {
@@ -358,13 +356,14 @@ class ComputeHostRepository {
   // Validated password Hosts and their encrypted credential are committed together. The operation
   // row makes a retried local command return the original result without creating a duplicate.
   async createPasswordHost(request: CreatePasswordHostPersistence): Promise<ComputeHost> {
+    const alias = assertSafeSshAlias(request.sshAlias)
     const detailsDoc = request.detailsDoc ?? ''
     if (detailsDoc.length > DETAILS_DOC_MAX_LENGTH) {
       throw new Error(
         `Details must be ${DETAILS_DOC_MAX_LENGTH} characters or fewer (got ${detailsDoc.length}).`
       )
     }
-    const providerId = computeProviderId(request.sshAlias)
+    const providerId = computeProviderId(alias)
     const client = await this.getClient()
     const row = await client.$transaction(async (transaction) => {
       const replay = await transaction.computeAuthOperation.findUnique({
@@ -380,13 +379,13 @@ class ComputeHostRepository {
       }
       const duplicate = await transaction.computeHost.findUnique({ where: { providerId } })
       if (duplicate) {
-        throw new Error(`A host with alias "${request.sshAlias}" is already registered.`)
+        throw new Error(`A host with alias "${alias}" is already registered.`)
       }
       const host = await transaction.computeHost.create({
         data: {
           providerId,
-          displayName: request.displayName?.trim() || request.sshAlias,
-          sshAlias: request.sshAlias,
+          displayName: request.displayName?.trim() || alias,
+          sshAlias: alias,
           sshOverrides: serializeOverrides({ user: request.username, port: request.port }),
           authenticationMode: 'password',
           authenticationRevision: 1,
@@ -743,11 +742,12 @@ class ComputeHostRepository {
   // Updates scratchRoot when the probe reads $SCRATCH and scratchPinned is false. Probe callers
   // must check scratchPinned before calling (ComputeService.probe does this).
   async updateScratchRoot(providerId: string, scratchRoot: string): Promise<void> {
+    const safeScratchRoot = assertSafeScratchRoot(scratchRoot)
     const client = await this.getClient()
 
     await client.computeHost.update({
       where: { providerId },
-      data: { scratchRoot }
+      data: { scratchRoot: safeScratchRoot }
     })
   }
 
@@ -773,11 +773,12 @@ class ComputeHostRepository {
   // Updates scratchRoot and sets scratchPinned=true. Called when the user explicitly sets a
   // scratch path in the UI — pinned hosts are never overwritten by probe.
   async updateScratchPinned(providerId: string, scratchRoot: string): Promise<void> {
+    const safeScratchRoot = assertSafeScratchRoot(scratchRoot)
     const client = await this.getClient()
 
     await client.computeHost.update({
       where: { providerId },
-      data: { scratchRoot, scratchPinned: true }
+      data: { scratchRoot: safeScratchRoot, scratchPinned: true }
     })
   }
 

--- a/src/main/compute/ssh-config.test.ts
+++ b/src/main/compute/ssh-config.test.ts
@@ -85,6 +85,16 @@ describe('parseSshConfigHostAliases', () => {
     expect(parseSshConfigHostAliases(config)).toEqual(['real-host'])
   })
 
+  it('excludes aliases that cannot pass the compute Host creation boundary', () => {
+    const config = [
+      'Host safe-host -legacy-option foo%bar path/alias path\\alias',
+      'Host . ..',
+      'Host another-safe-host'
+    ].join('\n')
+
+    expect(parseSshConfigHostAliases(config)).toEqual(['safe-host', 'another-safe-host'])
+  })
+
   it('excludes aliases declared inside a Match block', () => {
     const config = [
       'Host keep-me',

--- a/src/main/compute/ssh-config.ts
+++ b/src/main/compute/ssh-config.ts
@@ -2,6 +2,8 @@ import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { assertSafeSshAlias } from './remote-path-security'
+
 // Pure parser: turns the text of a ~/.ssh/config into the list of concrete Host aliases a user can
 // register as a compute provider. It intentionally does NOT resolve HostName/User/etc. — the real
 // connection details are resolved later via `ssh -G <alias>` (see design.md §1). Keeping this a pure
@@ -19,6 +21,15 @@ import { join } from 'node:path'
 // True when a token is an OpenSSH pattern rather than a concrete, connectable alias.
 const isPatternToken = (token: string): boolean =>
   token.includes('*') || token.includes('?') || token.startsWith('!')
+
+const isSafeAlias = (token: string): boolean => {
+  try {
+    assertSafeSshAlias(token)
+    return true
+  } catch {
+    return false
+  }
+}
 
 // Strips a trailing `# ...` comment and surrounding whitespace from a raw config line.
 const stripComment = (line: string): string => {
@@ -47,7 +58,7 @@ export const parseSshConfigHostAliases = (configText: string): string[] => {
     if (keyword !== 'host') continue
 
     for (const token of rest.split(/\s+/)) {
-      if (token === '' || isPatternToken(token)) continue
+      if (token === '' || isPatternToken(token) || !isSafeAlias(token)) continue
       if (seen.has(token)) continue
       seen.add(token)
       aliases.push(token)

--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -12,6 +12,7 @@ import {
   CappedOutput,
   SystemSshRunner,
   controlMasterArgs,
+  readEffectiveConfig,
   resolveSshBinary,
   resolveSshTarget
 } from './ssh-runner'
@@ -297,6 +298,48 @@ describe('resolveSshTarget', () => {
     hostname: '47.98.96.100',
     port: '22',
     identityfile: '~/.ssh/aliyun-xt-test.pem'
+  })
+
+  it('rejects an option-like alias before consulting ssh -G', async () => {
+    const readConfig = vi.fn(async () => fakeSshG())
+
+    await expect(
+      resolveSshTarget('-oProxyCommand=touch /tmp/not-approved', undefined, readConfig)
+    ).rejects.toThrow(/alias/i)
+    expect(readConfig).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'host/name',
+    '../host',
+    'host\\name',
+    'host%h',
+    'host name',
+    '\ncluster',
+    'host\nname',
+    'host\x00name',
+    'a'.repeat(256)
+  ])('rejects an alias that cannot be passed to OpenSSH safely: %j', async (alias) => {
+    const readConfig = vi.fn(async () => fakeSshG())
+
+    await expect(resolveSshTarget(alias, undefined, readConfig)).rejects.toThrow(/alias/i)
+    expect(readConfig).not.toHaveBeenCalled()
+  })
+
+  it('accepts and trims a 255-character alias', async () => {
+    const alias = 'a'.repeat(255)
+    const target = await resolveSshTarget(` ${alias} `, undefined, async () => ({}))
+
+    expect(target.host).toBe(alias)
+  })
+
+  it('rejects an option-like alias before spawning ssh -G directly', async () => {
+    execFileMock.mockClear()
+
+    await expect(
+      readEffectiveConfig('-oProxyCommand=touch /tmp/not-approved', 'ssh')
+    ).rejects.toThrow(/alias/i)
+    expect(execFileMock).not.toHaveBeenCalled()
   })
 
   it('returns the alias as host, NOT the resolved hostname', async () => {

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { promisify } from 'node:util'
 
 import type { SshOverrides } from '../../shared/compute'
+import { assertSafeSshAlias, shellSingleQuote } from './remote-path-security'
 
 // Maximum bytes captured per stream before we truncate. Caller can pass a smaller cap.
 const DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024
@@ -13,12 +14,6 @@ const DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024
 // window lets Node deliver the exit/close events after SIGKILL while still bounding every run.
 const TERMINATION_GRACE_MS = 2_000
 const FORCE_KILL_EVENT_GRACE_MS = 1_000
-
-// Wraps a string in POSIX single quotes, escaping embedded single quotes via the '\'' idiom. Inside
-// single quotes the shell expands nothing, so this is the only safe way to hand an arbitrary command
-// string to an outer `bash -lc` layer. (scp-runner exports an identical helper; duplicated here to keep
-// ssh-runner free of a dependency on the scp path.)
-const shellSingleQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`
 
 // Short connect timeout used for probe calls; SSH itself honors ConnectTimeout from config but we
 // add it explicitly to override any large value from ~/.ssh/config (design.md §1).
@@ -61,6 +56,7 @@ export interface SshRunner {
 // bundle. Windows does not support ControlMaster so this returns an empty array there.
 export const controlMasterArgs = (alias: string): string[] => {
   if (platform() === 'win32') return []
+  const safeAlias = assertSafeSshAlias(alias)
   // Use a per-alias socket under ~/.ssh/ctrl/ so multiple hosts don't share a socket. ssh does not
   // create the ControlPath parent directory itself, so ensure it exists (mode 0700 like ~/.ssh) —
   // otherwise the control socket bind fails with "unix_listener: cannot bind ... No such file".
@@ -70,7 +66,7 @@ export const controlMasterArgs = (alias: string): string[] => {
   } catch {
     // Best-effort: if we can't create it, ssh will surface the bind error as before.
   }
-  const socketPath = join(ctrlDir, `%r@%h:%p.${alias}`)
+  const socketPath = join(ctrlDir, `%r@%h:%p.${safeAlias}`)
   return ['-o', `ControlMaster=auto`, '-o', `ControlPath=${socketPath}`, '-o', `ControlPersist=60`]
 }
 
@@ -120,9 +116,10 @@ export const readEffectiveConfig = async (
   alias: string,
   sshBinary: string
 ): Promise<Record<string, string>> => {
+  const safeAlias = assertSafeSshAlias(alias)
   const execFileAsync = promisify(execFile)
   try {
-    const { stdout } = await execFileAsync(sshBinary, ['-G', alias], { timeout: 5000 })
+    const { stdout } = await execFileAsync(sshBinary, ['-G', safeAlias], { timeout: 5000 })
     return parseSshG(stdout)
   } catch {
     return {}
@@ -150,6 +147,7 @@ export const resolveSshTarget = async (
     sshBinary: string
   ) => Promise<Record<string, string>> = readEffectiveConfig
 ): Promise<ResolvedSshTarget> => {
+  const safeAlias = assertSafeSshAlias(alias)
   const sshBinary = resolveSshBinary()
 
   // Read the effective connection config from ~/.ssh/config for this alias. Wrapped in try/catch so
@@ -157,7 +155,7 @@ export const resolveSshTarget = async (
   // caller falls back to the bare alias + defaults.
   let sshGConfig: Record<string, string> = {}
   try {
-    sshGConfig = await readConfig(alias, sshBinary)
+    sshGConfig = await readConfig(safeAlias, sshBinary)
   } catch {
     // readConfig failed — proceed with overrides and defaults only.
   }
@@ -169,7 +167,7 @@ export const resolveSshTarget = async (
   // when no override is set — but harmless (values match) and kept for clarity. IdentityFile, by
   // contrast, is override-only because ssh picks it up from config via the alias.
   const resolvedUser = overrides?.user?.trim() ?? sshGConfig['user']
-  if (resolvedUser && resolvedUser !== alias) {
+  if (resolvedUser && resolvedUser !== safeAlias) {
     extraArgs.push('-o', `User=${resolvedUser}`)
   }
 
@@ -195,12 +193,12 @@ export const resolveSshTarget = async (
   extraArgs.push('-o', `ConnectTimeout=${DEFAULT_CONNECT_TIMEOUT_SECS}`)
 
   // ControlMaster on mac/linux for connection reuse across the probe bundle.
-  extraArgs.push(...controlMasterArgs(alias))
+  extraArgs.push(...controlMasterArgs(safeAlias))
 
   // Pass the alias — NOT the resolved hostname — as the connection target (see the function
   // docstring above). ControlMaster's ControlPath uses %h, which ssh expands to the real HostName,
   // so the mux socket is identical whether the alias or the IP is the target.
-  const host = alias
+  const host = safeAlias
 
   return { sshBinary, host, extraArgs }
 }


### PR DESCRIPTION
## Problem

Compute Host aliases were forwarded as positional arguments to `ssh -G`, `ssh`, and `scp` after only an empty-value check. An alias beginning with `-` could therefore be interpreted as an OpenSSH option even though the process is launched with `execFile`.

Scratch Root and `~/...` browser paths also used double-quoted or unquoted remote-shell interpolation. Shell expansions in those values could add behavior beyond the command shown in the approval prompt.

## Proposed change

- validate SSH aliases at SSH-config discovery, repository, authentication, config-resolution, and OpenSSH argument boundaries;
- reject option-like aliases, control/whitespace characters, path separators, `%` expansion markers, traversal forms, and aliases over 255 characters;
- preserve the existing `unsupported_auth_configuration` error contract when password-host creation rejects an alias;
- accept only canonical absolute, `~`, or `~/...` Scratch Root values up to 4096 characters at manual and probe persistence boundaries;
- route Scratch Root and remote browser paths through the existing `quoteRemotePath()` helper;
- keep invalid remote `$SCRATCH` values from replacing a valid host profile while preserving a successful probe result.

## Scope and non-goals

- No database field, Prisma schema, migration, IPC shape, enum, state, dependency, or UI-layout change.
- Historical rows remain readable and are not rewritten. Historical aliases fail closed before OpenSSH execution; historical Scratch Root values remain usable through literal path quoting.
- No automatic cleanup or normalization of persisted user data.

## Acceptance criteria and validation

Regression tests were added before each implementation step. On the unfixed code, the original four focused assertions failed for the reported behaviors: option-like aliases reached repository/SSH resolution, Scratch Root used expandable double quotes, and `~/...` browser suffixes were unquoted. Two follow-up assertions also failed before the review fixes: SSH-config discovery returned aliases rejected by creation, and password-host creation returned a generic error instead of `unsupported_auth_configuration`.

All listed checks ran after the last material edit:

- alias and Scratch Root validation/quoting -> `npm test -- src/main/compute/ssh-config.test.ts src/main/compute/ssh-runner.test.ts src/main/compute/repository.test.ts src/main/compute/compute-auth-owner.test.ts src/main/compute/compute-host-profile-owner.test.ts src/main/compute/compute-remote-operation-owner.test.ts` -> 229 passed;
- Compute owner, contract, and representative consumer coverage -> `npm run test:module -- compute_service` -> 848 passed, 6 skipped;
- main-process types -> `npm run typecheck:node` -> passed;
- linted source and tests -> `npm run lint` -> passed.

`test:affected --explain` selects the complete CI suite because `remote-path-security.ts` has no declared module owner. The PR Gate remains the final authority for the complete portable and platform lanes.

## Review focus

- Alias validation occurs before every affected OpenSSH argument boundary, including password-host setup, and discovery only offers aliases accepted by creation.
- Remote path quoting keeps leading `~` expansion while making the suffix literal.
- Invalid historical values remain visible without being migrated or silently rewritten.
