### PR TITLE
fix(connectors): enforce MCP credential integrity

### DIFF
--- a/src/main/agents/agents-service.test.ts
+++ b/src/main/agents/agents-service.test.ts
@@ -305,6 +305,46 @@ describe('AgentsService connector runtime availability', () => {
     ).rejects.toThrow(/host\.agents\.attach_connector:.*unavailable/)
     expect(attachConnector).not.toHaveBeenCalled()
   })
+
+  it('reports unresolved custom credentials and rejects a new attachment', async () => {
+    const stored: StoredConnectors = {
+      enabledIds: [],
+      autoAllowIds: [],
+      customMcpServers: [
+        {
+          id: 'credential-missing',
+          name: 'credential-missing',
+          displayName: 'Credential Missing',
+          transport: 'stdio',
+          enabled: true,
+          command: 'run',
+          envRefs: { API_TOKEN: 'enc:unavailable' }
+        }
+      ]
+    }
+    const profiles = mutatingSpecialistService([profile()])
+    const attachConnector = vi.fn(async () => profile())
+    profiles.attachConnector = attachConnector
+    const service = new AgentsService({
+      specialistService: profiles,
+      catalog: catalog({ getConnectors: vi.fn(async () => stored) })
+    })
+
+    const connector = (await service.listConnectors({})).find(
+      (item) => item.id === 'credential-missing'
+    )
+    expect(connector).toMatchObject({
+      availability: 'credential_unavailable',
+      mainEnabled: false
+    })
+    await expect(
+      service.dispatch({
+        op: 'attach_connector',
+        params: { name: 'Bio Expert', connector_ref: 'credential-missing', revision: 3 }
+      })
+    ).rejects.toThrow(/host\.agents\.attach_connector:.*credential_unavailable/)
+    expect(attachConnector).not.toHaveBeenCalled()
+  })
 })
 
 describe('AgentsService privileged dispatch — trusted session threading', () => {

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -14,6 +14,7 @@
 
 import { CONNECTOR_CATALOG, type ConnectorMeta } from '../connectors/catalog'
 import {
+  hasUsableCustomMcpCredentials,
   isCustomMcpServerRouteSafe,
   type CustomMcpFailureAvailability
 } from '../connectors/custom-mcp-bootstrap'
@@ -140,8 +141,9 @@ export type ConnectorReadModel = {
   description: string
   mainEnabled: boolean
   // Authentication/availability state, projected without secret detail. Custom connectors report
-  // 'unavailable'/'unauthenticated' from their stored shape; bundled connectors are 'available'.
-  availability: 'available' | 'unavailable' | 'unauthenticated'
+  // 'unavailable'/'unauthenticated'/'credential_unavailable' from their stored shape; bundled
+  // connectors are 'available'.
+  availability: 'available' | 'unavailable' | 'unauthenticated' | 'credential_unavailable'
   source: 'bundled' | 'custom'
   tools: ConnectorToolReadModel[]
 }
@@ -440,6 +442,7 @@ export const projectConnectorsFromStored = (
       const unreachable =
         (server.transport === 'stdio' && !server.command) ||
         (server.transport !== 'stdio' && !server.url)
+      const credentialUnavailable = !hasUsableCustomMcpCredentials(server)
       const unauthenticated = Boolean(server.oauth && !server.oauthState?.tokens?.access_token)
       return {
         // Local Specialist references use the UUID; name remains the immutable public route.
@@ -447,15 +450,17 @@ export const projectConnectorsFromStored = (
         name: server.name,
         displayName: server.displayName,
         description: server.description ?? '',
-        mainEnabled: server.enabled && !unauthenticated,
+        mainEnabled: server.enabled && !credentialUnavailable && !unauthenticated,
         // Custom MCP servers expose their tools dynamically; we do not enumerate them here (the
         // milestone decides whole-Connector inclusion only). An empty tools list keeps the shape
         // consistent without leaking transport/command details.
         availability: unreachable
           ? 'unavailable'
-          : unauthenticated
-            ? 'unauthenticated'
-            : (runtimeAvailability ?? 'available'),
+          : credentialUnavailable
+            ? 'credential_unavailable'
+            : unauthenticated
+              ? 'unauthenticated'
+              : (runtimeAvailability ?? 'available'),
         source: 'custom',
         tools: []
       }

--- a/src/main/connectors/application.test.ts
+++ b/src/main/connectors/application.test.ts
@@ -109,6 +109,36 @@ describe('Connector application composition', () => {
     expect(mcpClientManager.closeAll).toHaveBeenCalledOnce()
   })
 
+  it('fails closed before OAuth authentication when the client secret cannot be decrypted', async () => {
+    const { settings, mcpClientManager, deps } = createHarness()
+    settings.getConnectors.mockResolvedValue({
+      customMcpServers: [
+        {
+          id: 'oauth-incomplete',
+          name: 'oauth-incomplete',
+          displayName: 'OAuth incomplete',
+          transport: 'streamable_http',
+          url: 'https://mcp.example.test',
+          enabled: false,
+          oauth: {
+            authorizationServerUrl: 'https://auth.example.test',
+            clientId: 'registered-client'
+          },
+          oauthClientSecretRef: 'enc:unavailable'
+        }
+      ]
+    })
+    const module = await createConnectorApplicationModule(deps)
+    const authenticate = settings.setCustomServerAuthenticator.mock.calls[0][0] as (
+      serverId: string
+    ) => Promise<void>
+
+    await expect(authenticate('oauth-incomplete')).rejects.toThrow(/credential_unavailable/)
+    expect(mcpClientManager.authenticate).not.toHaveBeenCalled()
+
+    await module.dispose?.()
+  })
+
   it('forwards the conversation cancellation signal to GitHub scanning', async () => {
     const { settings, skillImportApprovals, deps } = createHarness()
     const controller = new AbortController()

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -15,7 +15,7 @@ import { ApprovalBroker } from './approval-broker'
 import { CredentialRequestBroker } from './credential-request-broker'
 import { ParserEngine } from './engine'
 import { McpClientManager } from './mcp-client-manager'
-import { toCustomMcpConfig } from './custom-mcp-bootstrap'
+import { hasUsableCustomMcpCredentials, toCustomMcpConfig } from './custom-mcp-bootstrap'
 import { ConnectorRuntimeSettingsProjection } from './runtime-settings-projection'
 import { ConnectorService, type ConnectorCallContext } from './service'
 
@@ -99,6 +99,7 @@ const createConnectorApplication = (
         (candidate) => candidate.id === serverId
       )
       if (!server) throw new Error(`Unknown custom connector: ${serverId}`)
+      if (!hasUsableCustomMcpCredentials(server)) throw new Error('credential_unavailable')
       await mcpClientManager.authenticate(toCustomMcpConfig(server))
     },
     (serverId) => mcpClientManager.cancelAuthentication(serverId)

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -243,12 +243,19 @@ describe('selectEnabledCustomServers', () => {
       },
       headers: { Authorization: 'Bearer resolved-value' }
     }
+    const partialOAuthClient: StoredCustomMcpServer = {
+      ...authenticatedOAuthServer,
+      id: 'partial-oauth-client',
+      name: 'partial-oauth-client',
+      displayName: 'Partial OAuth client',
+      oauthClientSecretRef: 'enc:unavailable'
+    }
 
     expect(
       selectEnabledCustomServers({
         enabledIds: [],
         autoAllowIds: [],
-        customMcpServers: [partialEnvironment, partialHeaders]
+        customMcpServers: [partialEnvironment, partialHeaders, partialOAuthClient]
       })
     ).toEqual([])
   })

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -219,4 +219,62 @@ describe('selectEnabledCustomServers', () => {
       })
     ).toEqual([])
   })
+
+  it('fails closed when encrypted credential records are only partially resolved', () => {
+    const partialEnvironment: StoredCustomMcpServer = {
+      ...stdioServer,
+      id: 'partial-environment',
+      name: 'partial-environment',
+      displayName: 'Partial environment',
+      envRefs: {
+        API_TOKEN: 'enc:resolved',
+        OPTIONAL_HOST_TOKEN: 'enc:unavailable'
+      },
+      env: { API_TOKEN: 'resolved-value' }
+    }
+    const partialHeaders: StoredCustomMcpServer = {
+      ...remoteServer,
+      id: 'partial-headers',
+      name: 'partial-headers',
+      displayName: 'Partial headers',
+      headerRefs: {
+        Authorization: 'enc:resolved',
+        'X-API-Key': 'enc:unavailable'
+      },
+      headers: { Authorization: 'Bearer resolved-value' }
+    }
+
+    expect(
+      selectEnabledCustomServers({
+        enabledIds: [],
+        autoAllowIds: [],
+        customMcpServers: [partialEnvironment, partialHeaders]
+      })
+    ).toEqual([])
+  })
+
+  it('fails closed for historical servers with credentials embedded in args or URLs', () => {
+    const unsafeArguments: StoredCustomMcpServer = {
+      ...stdioServer,
+      id: 'unsafe-arguments',
+      name: 'unsafe-arguments',
+      displayName: 'Unsafe arguments',
+      args: ['--api-key=legacy-plaintext-secret']
+    }
+    const unsafeUrl: StoredCustomMcpServer = {
+      ...remoteServer,
+      id: 'unsafe-url',
+      name: 'unsafe-url',
+      displayName: 'Unsafe URL',
+      url: 'https://mcp.example.test?token=legacy-plaintext-secret'
+    }
+
+    expect(
+      selectEnabledCustomServers({
+        enabledIds: [],
+        autoAllowIds: [],
+        customMcpServers: [unsafeArguments, unsafeUrl]
+      })
+    ).toEqual([])
+  })
 })

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -260,6 +260,31 @@ describe('selectEnabledCustomServers', () => {
     ).toEqual([])
   })
 
+  it('ignores unresolved credential maps that are unused by the active transport', () => {
+    const stdioWithStaleHeaders: StoredCustomMcpServer = {
+      ...stdioServer,
+      id: 'stdio-stale-headers',
+      name: 'stdio-stale-headers',
+      displayName: 'Stdio stale headers',
+      headerRefs: { Authorization: 'enc:unavailable' }
+    }
+    const remoteWithStaleEnvironment: StoredCustomMcpServer = {
+      ...remoteServer,
+      id: 'remote-stale-environment',
+      name: 'remote-stale-environment',
+      displayName: 'Remote stale environment',
+      envRefs: { API_TOKEN: 'enc:unavailable' }
+    }
+
+    expect(
+      selectEnabledCustomServers({
+        enabledIds: [],
+        autoAllowIds: [],
+        customMcpServers: [stdioWithStaleHeaders, remoteWithStaleEnvironment]
+      })
+    ).toEqual([stdioWithStaleHeaders, remoteWithStaleEnvironment])
+  })
+
   it('fails closed for historical servers with credentials embedded in args or URLs', () => {
     const unsafeArguments: StoredCustomMcpServer = {
       ...stdioServer,

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -1,5 +1,6 @@
 import type { CustomMcpServerConfig } from './mcp-client-manager'
 import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
+import { hasEmbeddedConnectorCredentials } from '../settings/connector-template'
 import { ALL_CONNECTOR_IDS } from './registry'
 
 export type CustomMcpFailureAvailability = 'unavailable' | 'unauthenticated'
@@ -62,6 +63,18 @@ export const isCustomMcpServerRouteSafe = (
   return allServers.every((candidate) => candidate === server || candidate.name !== server.name)
 }
 
+const hasResolvedSecretRecord = (
+  refs: Record<string, string> | undefined,
+  values: Record<string, string> | undefined
+): boolean => !refs || Object.keys(refs).every((name) => Object.hasOwn(values ?? {}, name))
+
+const hasCompleteCustomMcpCredentials = (server: StoredCustomMcpServer): boolean =>
+  hasResolvedSecretRecord(server.envRefs, server.env) &&
+  hasResolvedSecretRecord(server.headerRefs, server.headers)
+
+export const hasUsableCustomMcpCredentials = (server: StoredCustomMcpServer): boolean =>
+  hasCompleteCustomMcpCredentials(server) && !hasEmbeddedConnectorCredentials(server)
+
 // Selects runnable custom servers for discovery and skill-doc sync. OAuth Connectors remain absent
 // until sign-in has produced an access token, even if an older settings record says enabled.
 export function selectEnabledCustomServers(
@@ -72,6 +85,7 @@ export function selectEnabledCustomServers(
     (server) =>
       server.enabled &&
       isCustomMcpServerRouteSafe(server, servers) &&
+      hasUsableCustomMcpCredentials(server) &&
       SUPPORTED_CUSTOM_MCP_TRANSPORTS.has(server.transport) &&
       (!server.oauth || Boolean(server.oauthState?.tokens?.access_token))
   )

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -69,9 +69,10 @@ const hasResolvedSecretRecord = (
 ): boolean => !refs || Object.keys(refs).every((name) => Object.hasOwn(values ?? {}, name))
 
 const hasCompleteCustomMcpCredentials = (server: StoredCustomMcpServer): boolean =>
-  hasResolvedSecretRecord(server.envRefs, server.env) &&
-  hasResolvedSecretRecord(server.headerRefs, server.headers) &&
-  (!server.oauthClientSecretRef || server.oauthClientSecret !== undefined)
+  server.transport === 'stdio'
+    ? hasResolvedSecretRecord(server.envRefs, server.env)
+    : hasResolvedSecretRecord(server.headerRefs, server.headers) &&
+      (!server.oauthClientSecretRef || server.oauthClientSecret !== undefined)
 
 export const hasUsableCustomMcpCredentials = (server: StoredCustomMcpServer): boolean =>
   hasCompleteCustomMcpCredentials(server) && !hasEmbeddedConnectorCredentials(server)

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -70,7 +70,8 @@ const hasResolvedSecretRecord = (
 
 const hasCompleteCustomMcpCredentials = (server: StoredCustomMcpServer): boolean =>
   hasResolvedSecretRecord(server.envRefs, server.env) &&
-  hasResolvedSecretRecord(server.headerRefs, server.headers)
+  hasResolvedSecretRecord(server.headerRefs, server.headers) &&
+  (!server.oauthClientSecretRef || server.oauthClientSecret !== undefined)
 
 export const hasUsableCustomMcpCredentials = (server: StoredCustomMcpServer): boolean =>
   hasCompleteCustomMcpCredentials(server) && !hasEmbeddedConnectorCredentials(server)

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -1350,10 +1350,15 @@ describe('ConnectorService', () => {
           clientId: 'registered-client'
         },
         oauthClientSecretRef: 'enc:old-secret',
+        oauthClientSecret: 'old-secret',
         oauthState: { tokens: { access_token: 'access', token_type: 'Bearer' as const } },
         enabled: true
       }
-      const replacement = { ...original, oauthClientSecretRef: 'enc:new-secret' }
+      const replacement = {
+        ...original,
+        oauthClientSecretRef: 'enc:new-secret',
+        oauthClientSecret: 'new-secret'
+      }
       let current = original
       let approve: ((decision: 'once') => void) | undefined
       const requestApproval = vi.fn(

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -844,6 +844,39 @@ describe('ConnectorService', () => {
       expect(call).not.toHaveBeenCalled()
     })
 
+    it('rejects a historical custom server with credentials embedded in an OAuth URL', async () => {
+      const call = vi.fn()
+      const mcpClientManager = manager(call)
+      const svc = new ConnectorService({
+        mcpClientManager,
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'srv-oauth-url-credential',
+              name: 'oauth-url-credential',
+              displayName: 'OAuth URL credential',
+              transport: 'streamable_http',
+              url: 'https://mcp.example.test',
+              oauth: {
+                authorizationServerUrl: 'https://auth.example.test?api_key=legacy-plaintext-secret'
+              },
+              oauthState: { tokens: { access_token: 'access', token_type: 'Bearer' } },
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+
+      await expect(svc.call('oauth-url-credential', 'do_thing', {}, internal)).rejects.toThrow(
+        /credential_unavailable/
+      )
+      expect(mcpClientManager.listTools).not.toHaveBeenCalled()
+      expect(call).not.toHaveBeenCalled()
+    })
+
     it('rejects a historical custom server with curl-style user credentials', async () => {
       const call = vi.fn()
       const mcpClientManager = manager(call)

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -874,6 +874,36 @@ describe('ConnectorService', () => {
       expect(call).not.toHaveBeenCalled()
     })
 
+    it('rejects a historical custom server with a credential-like custom header argument', async () => {
+      const call = vi.fn()
+      const mcpClientManager = manager(call)
+      const svc = new ConnectorService({
+        mcpClientManager,
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'srv-custom-header-credential',
+              name: 'custom-header-credential',
+              displayName: 'Custom header credential',
+              transport: 'stdio',
+              command: 'example-mcp',
+              args: ['--header', 'X-API-Token: legacy-plaintext-secret'],
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+
+      await expect(svc.call('custom-header-credential', 'do_thing', {}, internal)).rejects.toThrow(
+        /credential_unavailable/
+      )
+      expect(mcpClientManager.listTools).not.toHaveBeenCalled()
+      expect(call).not.toHaveBeenCalled()
+    })
+
     it('does not dispatch a custom name that collides with a bundled connector', async () => {
       const call = vi.fn()
       const mcpClientManager = manager(call)

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -844,6 +844,36 @@ describe('ConnectorService', () => {
       expect(call).not.toHaveBeenCalled()
     })
 
+    it('rejects a historical custom server with curl-style user credentials', async () => {
+      const call = vi.fn()
+      const mcpClientManager = manager(call)
+      const svc = new ConnectorService({
+        mcpClientManager,
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'srv-user-credential',
+              name: 'user-credential',
+              displayName: 'User credential',
+              transport: 'stdio',
+              command: 'example-mcp',
+              args: ['-u', 'legacy-user:legacy-password'],
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+
+      await expect(svc.call('user-credential', 'do_thing', {}, internal)).rejects.toThrow(
+        /credential_unavailable/
+      )
+      expect(mcpClientManager.listTools).not.toHaveBeenCalled()
+      expect(call).not.toHaveBeenCalled()
+    })
+
     it('does not dispatch a custom name that collides with a bundled connector', async () => {
       const call = vi.fn()
       const mcpClientManager = manager(call)

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -781,6 +781,69 @@ describe('ConnectorService', () => {
       )
     })
 
+    it('rejects a custom server when encrypted credentials are only partially resolved', async () => {
+      const call = vi.fn()
+      const mcpClientManager = manager(call)
+      const svc = new ConnectorService({
+        mcpClientManager,
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'srv-partial-credentials',
+              name: 'partial-credentials',
+              displayName: 'Partial credentials',
+              transport: 'stdio',
+              command: 'example-mcp',
+              envRefs: {
+                API_TOKEN: 'enc:resolved',
+                OPTIONAL_HOST_TOKEN: 'enc:unavailable'
+              },
+              env: { API_TOKEN: 'resolved-value' },
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+
+      await expect(svc.call('partial-credentials', 'do_thing', {}, internal)).rejects.toThrow(
+        /credential_unavailable/
+      )
+      expect(mcpClientManager.listTools).not.toHaveBeenCalled()
+      expect(call).not.toHaveBeenCalled()
+    })
+
+    it('rejects a historical custom server with credentials embedded in its URL', async () => {
+      const call = vi.fn()
+      const mcpClientManager = manager(call)
+      const svc = new ConnectorService({
+        mcpClientManager,
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'srv-embedded-credential',
+              name: 'embedded-credential',
+              displayName: 'Embedded credential',
+              transport: 'streamable_http',
+              url: 'https://mcp.example.test?api_key=legacy-plaintext-secret',
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+
+      await expect(svc.call('embedded-credential', 'do_thing', {}, internal)).rejects.toThrow(
+        /credential_unavailable/
+      )
+      expect(mcpClientManager.listTools).not.toHaveBeenCalled()
+      expect(call).not.toHaveBeenCalled()
+    })
+
     it('does not dispatch a custom name that collides with a bundled connector', async () => {
       const call = vi.fn()
       const mcpClientManager = manager(call)

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -4,6 +4,7 @@ import { ParserEngine } from './engine'
 import { ALL_CONNECTOR_IDS, getDescriptor, validateToolArguments } from './registry'
 import {
   classifyCustomMcpFailure,
+  hasUsableCustomMcpCredentials,
   isCustomMcpServerRouteSafe,
   toCustomMcpConfig,
   type CustomMcpFailureAvailability
@@ -186,6 +187,8 @@ const connectorGateGuidance: Readonly<Record<string, string>> = {
     'The Connector runtime is unavailable. Wait briefly and retry the same call once. If it fails again, ask the user to restart Open Science before retrying.',
   connector_configuration_changed:
     'The Connector configuration changed before the external tool was called. Retry the exact same call once.',
+  credential_unavailable:
+    'One or more encrypted Connector credentials could not be read. Do not retry until the user re-enters them in Settings > Connectors.',
   credential_required:
     'A required credential was not configured. Do not retry until the user adds it in Settings > Credentials.'
 }
@@ -452,6 +455,9 @@ export class ConnectorService {
         disabledConnectorMessage(custom.displayName)
       )
     }
+    if (!hasUsableCustomMcpCredentials(custom)) {
+      throw new ConnectorGateError('credential_unavailable')
+    }
     if (!this.isCustomConfigRunnable(custom, customServers)) {
       throw new ConnectorGateError('connector_unavailable')
     }
@@ -710,6 +716,9 @@ export class ConnectorService {
           'connector_disabled',
           disabledConnectorMessage(current.displayName)
         )
+      }
+      if (!hasUsableCustomMcpCredentials(current)) {
+        throw new ConnectorGateError('credential_unavailable')
       }
       if (!this.isCustomConfigRunnable(current, customServers)) {
         throw new ConnectorGateError('connector_unavailable')

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -176,7 +176,7 @@ describe('ConnectorSettingsModule', () => {
     })
     expect(
       (await service.listConnectors()).customServers.find(({ name }) => name === 'local-secrets')
-    ).toMatchObject({ hasEnv: false, enabled: false, availability: 'credential_unavailable' })
+    ).toMatchObject({ hasEnv: false, enabled: true, availability: 'credential_unavailable' })
 
     keychain.available = false
     const snapshot = await service.listConnectors()
@@ -687,7 +687,7 @@ describe('ConnectorSettingsModule', () => {
     expect(snapshot.customServers[0]).toMatchObject({
       name: 'chemistry',
       displayName: 'Chemistry!',
-      enabled: false,
+      enabled: true,
       availability: 'unavailable'
     })
   })
@@ -712,8 +712,8 @@ describe('ConnectorSettingsModule', () => {
     expect(snapshot.customServers).toHaveLength(2)
     expect(snapshot.customServers).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ enabled: false, availability: 'unavailable' }),
-        expect.objectContaining({ enabled: false, availability: 'unavailable' })
+        expect.objectContaining({ enabled: true, availability: 'unavailable' }),
+        expect.objectContaining({ enabled: true, availability: 'unavailable' })
       ])
     )
   })
@@ -1211,13 +1211,13 @@ describe('ConnectorSettingsModule', () => {
       expect.objectContaining({
         name: 'legacy-args-secret',
         args: undefined,
-        enabled: false,
+        enabled: true,
         availability: 'credential_unavailable'
       }),
       expect.objectContaining({
         name: 'legacy-url-secret',
         url: undefined,
-        enabled: false,
+        enabled: true,
         availability: 'credential_unavailable'
       })
     ])
@@ -1246,7 +1246,7 @@ describe('ConnectorSettingsModule', () => {
     const [server] = (await service.listConnectors()).customServers
     expect(server).toMatchObject({
       name: 'legacy-oauth-url-secret',
-      enabled: false,
+      enabled: true,
       availability: 'credential_unavailable'
     })
     expect(server.oauth).not.toHaveProperty('clientMetadataUrl')
@@ -1273,7 +1273,7 @@ describe('ConnectorSettingsModule', () => {
     expect(server).toMatchObject({
       name: 'legacy-user-credentials',
       args: undefined,
-      enabled: false,
+      enabled: true,
       availability: 'credential_unavailable'
     })
     expect(JSON.stringify(server)).not.toContain('legacy-password')

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -1022,6 +1022,36 @@ describe('ConnectorSettingsModule', () => {
     expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
   })
 
+  it.each([
+    [
+      'client metadata URL',
+      { clientMetadataUrl: 'https://oauth-user:oauth-secret@client.example.test/metadata' }
+    ],
+    [
+      'authorization server URL',
+      { authorizationServerUrl: 'https://auth.example.test?api_key=oauth-secret' }
+    ],
+    [
+      'redirect URI',
+      {
+        authorizationServerUrl: 'https://auth.example.test',
+        clientId: 'registered-client',
+        redirectUri: 'http://127.0.0.1/callback?access_token=oauth-secret'
+      }
+    ]
+  ])('rejects credentials embedded in an OAuth %s', async (_description, oauth) => {
+    await expect(
+      addCustomServer({
+        name: 'unsafe-oauth-url',
+        transport: 'streamable_http',
+        url: 'https://mcp.example.test',
+        oauth
+      })
+    ).rejects.toThrow(/encrypted environment or header fields/i)
+
+    expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
+  })
+
   it('rejects a credential-bearing header argument after renderer whitespace tokenization', async () => {
     await expect(
       addCustomServer({
@@ -1079,6 +1109,29 @@ describe('ConnectorSettingsModule', () => {
     expect((await repository.getSettings()).connectors?.customMcpServers?.[0]?.url).toBe(
       'https://mcp.example.test'
     )
+  })
+
+  it('rejects a credential-bearing OAuth URL when updating a custom server', async () => {
+    const added = await addCustomServer({
+      name: 'unsafe-oauth-url-update',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test',
+      oauth: { authorizationServerUrl: 'https://auth.example.test' }
+    })
+
+    await expect(
+      service.updateCustomServer({
+        id: added.customServers[0].id,
+        transport: 'streamable_http',
+        url: 'https://mcp.example.test',
+        oauth: { authorizationServerUrl: 'https://auth.example.test?api_key=oauth-secret' }
+      })
+    ).rejects.toThrow(/encrypted environment or header fields/i)
+
+    expect(
+      (await repository.getSettings()).connectors?.customMcpServers?.[0]?.oauth
+        ?.authorizationServerUrl
+    ).toBe('https://auth.example.test')
   })
 
   it('rejects an invalid custom server (stdio without a command)', async () => {
@@ -1139,6 +1192,37 @@ describe('ConnectorSettingsModule', () => {
 
     const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
     expect(storedJson).toContain('legacy-plaintext-secret')
+  })
+
+  it('redacts credential-bearing OAuth URLs from historical custom-server views', async () => {
+    await repository.addCustomServer({
+      id: 'legacy-oauth-url-secret',
+      name: 'legacy-oauth-url-secret',
+      displayName: 'Legacy OAuth URL secret',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test',
+      oauth: {
+        clientMetadataUrl: 'https://oauth-user:client-secret@client.example.test/metadata',
+        authorizationServerUrl: 'https://auth.example.test?api_key=issuer-secret',
+        clientId: 'registered-client',
+        redirectUri: 'http://127.0.0.1/callback?access_token=redirect-secret'
+      },
+      enabled: true
+    })
+
+    const [server] = (await service.listConnectors()).customServers
+    expect(server).toMatchObject({
+      name: 'legacy-oauth-url-secret',
+      enabled: false,
+      availability: 'credential_unavailable'
+    })
+    expect(server.oauth).not.toHaveProperty('clientMetadataUrl')
+    expect(server.oauth).not.toHaveProperty('authorizationServerUrl')
+    expect(server.oauth).not.toHaveProperty('redirectUri')
+    expect(JSON.stringify(server)).not.toMatch(/client-secret|issuer-secret|redirect-secret/)
+
+    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
+    expect(storedJson).toMatch(/client-secret|issuer-secret|redirect-secret/)
   })
 
   it('redacts curl-style user credentials from historical custom-server views', async () => {

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -333,6 +333,39 @@ describe('ConnectorSettingsModule', () => {
     expect(afterRemoval?.pendingCustomServerDeletionIds).toBeUndefined()
   })
 
+  it('clears inactive credential maps when the custom-server transport changes', async () => {
+    const added = await addCustomServer({
+      name: 'transport-secret-cleanup',
+      transport: 'stdio',
+      command: 'python3',
+      env: { API_TOKEN: 'stdio-secret' }
+    })
+    const id = added.customServers[0].id
+
+    await service.updateCustomServer({
+      id,
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test',
+      headers: { Authorization: 'Bearer remote-secret' }
+    })
+    let stored = (await repository.getSettings()).connectors?.customMcpServers?.[0]
+    expect(stored?.envRefs).toBeUndefined()
+    expect(stored?.env).toBeUndefined()
+    expect(stored?.headerRefs).toBeDefined()
+
+    await service.updateCustomServer({
+      id,
+      transport: 'stdio',
+      command: 'python3',
+      args: ['-u', 'server.py'],
+      env: { API_TOKEN: 'next-stdio-secret' }
+    })
+    stored = (await repository.getSettings()).connectors?.customMcpServers?.[0]
+    expect(stored?.headerRefs).toBeUndefined()
+    expect(stored?.headers).toBeUndefined()
+    expect(stored?.envRefs).toBeDefined()
+  })
+
   it('retains a deletion journal and reserves its ID when permission pruning fails', async () => {
     const added = await addCustomServer({
       name: 'recoverable-delete',

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -1024,6 +1024,9 @@ describe('ConnectorSettingsModule', () => {
 
   it.each([
     ['split credential flag', ['--auth-token', 'plaintext-secret']],
+    ['split curl user credentials', ['--user', 'researcher:plaintext-secret']],
+    ['inline curl user credentials', ['--user=researcher:plaintext-secret']],
+    ['short curl user credentials', ['-uresearcher:plaintext-secret']],
     [
       'credential-bearing URL argument',
       ['--endpoint', 'https://mcp.example.test?auth_token=plaintext-secret']
@@ -1123,6 +1126,30 @@ describe('ConnectorSettingsModule', () => {
 
     const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
     expect(storedJson).toContain('legacy-plaintext-secret')
+  })
+
+  it('redacts curl-style user credentials from historical custom-server views', async () => {
+    await repository.addCustomServer({
+      id: 'legacy-user-credentials',
+      name: 'legacy-user-credentials',
+      displayName: 'Legacy user credentials',
+      transport: 'stdio',
+      command: 'example-mcp',
+      args: ['--user', 'legacy-user:legacy-password'],
+      enabled: true
+    })
+
+    const [server] = (await service.listConnectors()).customServers
+    expect(server).toMatchObject({
+      name: 'legacy-user-credentials',
+      args: undefined,
+      enabled: false,
+      availability: 'credential_unavailable'
+    })
+    expect(JSON.stringify(server)).not.toContain('legacy-password')
+
+    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
+    expect(storedJson).toContain('legacy-password')
   })
 
   it('migrates legacy plaintext custom-server secrets when secure storage is available', async () => {

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -176,8 +176,7 @@ describe('ConnectorSettingsModule', () => {
     })
     expect(
       (await service.listConnectors()).customServers.find(({ name }) => name === 'local-secrets')
-        ?.hasEnv
-    ).toBe(false)
+    ).toMatchObject({ hasEnv: false, enabled: false, availability: 'credential_unavailable' })
 
     keychain.available = false
     const snapshot = await service.listConnectors()
@@ -960,6 +959,42 @@ describe('ConnectorSettingsModule', () => {
     expect(stored?.headerRefs).toBeUndefined()
   })
 
+  it('rejects credential-bearing arguments when adding a custom server', async () => {
+    await expect(
+      addCustomServer({
+        name: 'unsafe-arguments',
+        transport: 'stdio',
+        command: 'example-mcp',
+        args: ['--token=plaintext-secret']
+      })
+    ).rejects.toThrow(/encrypted environment or header fields/i)
+
+    expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
+  })
+
+  it.each([
+    'https://user:plaintext-secret@mcp.example.test',
+    'https://mcp.example.test?api_key=plaintext-secret'
+  ])('rejects a credential-bearing URL when updating a custom server', async (url) => {
+    const added = await addCustomServer({
+      name: 'unsafe-url-update',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test'
+    })
+
+    await expect(
+      service.updateCustomServer({
+        id: added.customServers[0].id,
+        transport: 'streamable_http',
+        url
+      })
+    ).rejects.toThrow(/encrypted environment or header fields/i)
+
+    expect((await repository.getSettings()).connectors?.customMcpServers?.[0]?.url).toBe(
+      'https://mcp.example.test'
+    )
+  })
+
   it('rejects an invalid custom server (stdio without a command)', async () => {
     await expect(addCustomServer({ name: 'bad', transport: 'stdio' })).rejects.toThrow(
       /Invalid custom connector/
@@ -978,6 +1013,46 @@ describe('ConnectorSettingsModule', () => {
     expect(storedJson).not.toContain('super-secret')
     expect(storedJson).toContain('envRefs')
     expect(storedJson).toContain('enc:')
+  })
+
+  it('redacts credential-bearing fields from historical custom-server views', async () => {
+    await repository.addCustomServer({
+      id: 'legacy-args-secret',
+      name: 'legacy-args-secret',
+      displayName: 'Legacy args secret',
+      transport: 'stdio',
+      command: 'example-mcp',
+      args: ['--token=legacy-plaintext-secret'],
+      enabled: true
+    })
+    await repository.addCustomServer({
+      id: 'legacy-url-secret',
+      name: 'legacy-url-secret',
+      displayName: 'Legacy URL secret',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test?api_key=legacy-plaintext-secret',
+      enabled: true
+    })
+
+    const snapshot = await service.listConnectors()
+    expect(snapshot.customServers).toEqual([
+      expect.objectContaining({
+        name: 'legacy-args-secret',
+        args: undefined,
+        enabled: false,
+        availability: 'credential_unavailable'
+      }),
+      expect.objectContaining({
+        name: 'legacy-url-secret',
+        url: undefined,
+        enabled: false,
+        availability: 'credential_unavailable'
+      })
+    ])
+    expect(JSON.stringify(snapshot)).not.toContain('legacy-plaintext-secret')
+
+    const storedJson = await readFile(join(dir, 'settings.json'), 'utf8')
+    expect(storedJson).toContain('legacy-plaintext-secret')
   })
 
   it('migrates legacy plaintext custom-server secrets when secure storage is available', async () => {

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -201,6 +201,27 @@ describe('ConnectorSettingsModule', () => {
     })
   })
 
+  it('refuses to persist enabled state when custom credentials are unavailable', async () => {
+    await repository.addCustomServer({
+      id: 'credential-unavailable-enable',
+      name: 'credential-unavailable-enable',
+      displayName: 'Credential unavailable enable',
+      transport: 'stdio',
+      enabled: false,
+      command: 'example-mcp',
+      envRefs: { API_TOKEN: 'not-a-key-ref' }
+    })
+
+    await expect(
+      service.setCustomServerEnabled({ id: 'credential-unavailable-enable', enabled: true })
+    ).rejects.toThrow('credential_unavailable')
+
+    const stored = (await repository.getSettings()).connectors?.customMcpServers?.find(
+      ({ id }) => id === 'credential-unavailable-enable'
+    )
+    expect(stored?.enabled).toBe(false)
+  })
+
   it('encrypts OpenAlex at rest and exposes only configured state', async () => {
     let snapshot = await service.setOpenAlexCredential({ apiKey: 'openalex-secret' })
     expect(snapshot.openAlex).toEqual({ hasApiKey: true })

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -989,8 +989,28 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it.each([
+    ['split credential flag', ['--auth-token', 'plaintext-secret']],
+    [
+      'credential-bearing URL argument',
+      ['--endpoint', 'https://mcp.example.test?auth_token=plaintext-secret']
+    ]
+  ])('rejects a %s when adding a custom server', async (_description, args) => {
+    await expect(
+      addCustomServer({
+        name: 'unsafe-argument-form',
+        transport: 'stdio',
+        command: 'example-mcp',
+        args
+      })
+    ).rejects.toThrow(/encrypted environment or header fields/i)
+
+    expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
+  })
+
+  it.each([
     'https://user:plaintext-secret@mcp.example.test',
-    'https://mcp.example.test?api_key=plaintext-secret'
+    'https://mcp.example.test?api_key=plaintext-secret',
+    'https://mcp.example.test?auth_token=plaintext-secret'
   ])('rejects a credential-bearing URL when updating a custom server', async (url) => {
     const added = await addCustomServer({
       name: 'unsafe-url-update',

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -1009,6 +1009,19 @@ describe('ConnectorSettingsModule', () => {
     expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
   })
 
+  it('rejects a credential-bearing custom header argument when adding a custom server', async () => {
+    await expect(
+      addCustomServer({
+        name: 'unsafe-custom-header-argument',
+        transport: 'stdio',
+        command: 'example-mcp',
+        args: ['--header', 'X-API-Token: plaintext-secret']
+      })
+    ).rejects.toThrow(/encrypted environment or header fields/i)
+
+    expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
+  })
+
   it('rejects a credential-bearing header argument after renderer whitespace tokenization', async () => {
     await expect(
       addCustomServer({

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -988,6 +988,19 @@ describe('ConnectorSettingsModule', () => {
     expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
   })
 
+  it('rejects a credential-bearing header argument after renderer whitespace tokenization', async () => {
+    await expect(
+      addCustomServer({
+        name: 'unsafe-tokenized-header-argument',
+        transport: 'stdio',
+        command: 'example-mcp',
+        args: ['--header', 'Authorization:', 'Bearer', 'plaintext-secret']
+      })
+    ).rejects.toThrow(/encrypted environment or header fields/i)
+
+    expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
+  })
+
   it.each([
     ['split credential flag', ['--auth-token', 'plaintext-secret']],
     [

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -188,13 +188,16 @@ describe('ConnectorSettingsModule', () => {
       remoteHeaders: snapshot.customServers.find(({ name }) => name === 'remote-secrets')
         ?.hasHeaders,
       oauthClientSecret: snapshot.customServers.find(({ name }) => name === 'oauth-secrets')?.oauth
-        ?.hasClientSecret
+        ?.hasClientSecret,
+      oauthAvailability: snapshot.customServers.find(({ name }) => name === 'oauth-secrets')
+        ?.availability
     }).toEqual({
       ncbi: false,
       openAlex: false,
       localEnv: false,
       remoteHeaders: false,
-      oauthClientSecret: false
+      oauthClientSecret: false,
+      oauthAvailability: 'credential_unavailable'
     })
   })
 
@@ -966,6 +969,19 @@ describe('ConnectorSettingsModule', () => {
         transport: 'stdio',
         command: 'example-mcp',
         args: ['--token=plaintext-secret']
+      })
+    ).rejects.toThrow(/encrypted environment or header fields/i)
+
+    expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
+  })
+
+  it('rejects a credential-bearing header argument when adding a custom server', async () => {
+    await expect(
+      addCustomServer({
+        name: 'unsafe-header-argument',
+        transport: 'stdio',
+        command: 'example-mcp',
+        args: ['--header', 'Authorization: Bearer plaintext-secret']
       })
     ).rejects.toThrow(/encrypted environment or header fields/i)
 

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -500,10 +500,16 @@ class ConnectorSettingsModule {
     const displayName = request.displayName?.trim() ?? existing.displayName
     if (!displayName) throw new Error('Display name is required')
 
-    const envRefs = request.env ? this.encryptSecretRecord(request.env) : existing.envRefs
+    const envRefs =
+      request.transport === 'stdio'
+        ? request.env
+          ? this.encryptSecretRecord(request.env)
+          : existing.envRefs
+        : undefined
     // Preserve legacy plaintext only when the caller leaves it untouched and safeStorage is still
     // unavailable. A later getConnectors() call migrates it as soon as encryption becomes available.
-    const legacyEnv = request.env === undefined ? existing.env : undefined
+    const legacyEnv =
+      request.transport === 'stdio' && request.env === undefined ? existing.env : undefined
     const nextOAuth =
       request.transport === 'stdio' && request.oauth === undefined
         ? undefined
@@ -530,14 +536,14 @@ class ConnectorSettingsModule {
           ? undefined
           : existing.oauthClientSecretRef
     validateOAuthRegistration(nextOAuth ?? {}, Boolean(oauthClientSecretRef))
-    const headerRefs = nextOAuth
-      ? undefined
-      : request.headers
-        ? this.encryptSecretRecord(request.headers)
-        : existing.headerRefs
-    const legacyHeaders = nextOAuth
-      ? undefined
-      : request.headers === undefined
+    const headerRefs =
+      request.transport !== 'stdio' && !nextOAuth
+        ? request.headers
+          ? this.encryptSecretRecord(request.headers)
+          : existing.headerRefs
+        : undefined
+    const legacyHeaders =
+      request.transport !== 'stdio' && !nextOAuth && request.headers === undefined
         ? existing.headers
         : undefined
     const oauthChanged = !isDeepStrictEqual(existing.oauth ?? undefined, nextOAuth ?? undefined)

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -721,7 +721,7 @@ class ConnectorSettingsModule {
           displayName: server.displayName,
           description: server.description,
           transport: server.transport,
-          enabled: server.enabled && !configurationAvailability,
+          enabled: server.enabled,
           command: server.command,
           args: argsContainCredentials ? undefined : server.args,
           url: urlContainsCredentials ? undefined : server.url,

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -448,6 +448,11 @@ class ConnectorSettingsModule {
         (candidate) => candidate.id === request.id
       )
       if (!server) throw new Error(`Unknown custom connector: ${request.id}`)
+      if (!hasUsableCustomMcpCredentials(server)) {
+        throw new Error(
+          `credential_unavailable: Re-enter credentials for "${server.displayName}" before enabling it`
+        )
+      }
       if (server.oauth && !server.oauthState?.tokens?.access_token) {
         throw new Error(`Sign in to "${server.displayName}" before enabling it`)
       }

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -30,12 +30,19 @@ import {
   isCustomConnectorName
 } from '../../shared/custom-connector'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
-import { isCustomMcpServerRouteSafe } from '../connectors/custom-mcp-bootstrap'
+import {
+  hasUsableCustomMcpCredentials,
+  isCustomMcpServerRouteSafe
+} from '../connectors/custom-mcp-bootstrap'
 import { getConnectorTools } from '../connectors/registry'
 import { encryptKey, isEncryptionAvailable, tryDecryptKey } from './crypto'
 import { sanitizeCustomMcpServer, type SettingsRepository } from './repository'
 import type { StoredConnectors, StoredCustomMcpOAuthState, StoredCustomMcpServer } from './types'
-import { buildConnectorTemplateExport, parseConnectorTemplate } from './connector-template'
+import {
+  buildConnectorTemplateExport,
+  hasEmbeddedConnectorCredentials,
+  parseConnectorTemplate
+} from './connector-template'
 import { CustomServerIdConflictError } from './custom-server-identity'
 
 type CustomServerSecurityChangeGuard = {
@@ -91,6 +98,17 @@ const hasResolvedSecretRecord = (
 ): boolean => {
   const names = Object.keys(refs ?? values ?? {})
   return names.length > 0 && names.every((name) => Object.hasOwn(values ?? {}, name))
+}
+
+const assertCredentialFieldsAreEncrypted = (fields: {
+  args?: readonly string[]
+  url?: string
+}): void => {
+  if (hasEmbeddedConnectorCredentials(fields)) {
+    throw new Error(
+      'Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.'
+    )
+  }
 }
 
 // Owns durable Connector policy, secret migration/projection, and custom-server mutation. Live MCP
@@ -348,6 +366,7 @@ class ConnectorSettingsModule {
   }
 
   async addCustomServer(request: AddCustomServerRequest): Promise<ConnectorsSnapshot> {
+    assertCredentialFieldsAreEncrypted(request)
     const name = request.name.trim()
     const displayName = request.displayName.trim()
     const connectors = (await this.repository.getSettings()).connectors
@@ -462,6 +481,7 @@ class ConnectorSettingsModule {
       serverId: string
     ) => Promise<CustomServerSecurityChangeGuard | void>
   ): Promise<ConnectorsSnapshot> {
+    assertCredentialFieldsAreEncrypted(request)
     const existing = (await this.getConnectors())?.customMcpServers?.find(
       (server) => server.id === request.id
     )
@@ -645,6 +665,9 @@ class ConnectorSettingsModule {
     return customServers
       .map((server) => {
         const routeUnavailable = !isCustomMcpServerRouteSafe(server, customServers)
+        const argsContainCredentials = hasEmbeddedConnectorCredentials({ args: server.args })
+        const urlContainsCredentials = hasEmbeddedConnectorCredentials({ url: server.url })
+        const credentialUnavailable = !hasUsableCustomMcpCredentials(server)
         const unavailable =
           routeUnavailable ||
           (server.transport === 'stdio' && !server.command) ||
@@ -652,9 +675,11 @@ class ConnectorSettingsModule {
         const unauthenticated = Boolean(server.oauth && !server.oauthState?.tokens?.access_token)
         const configurationAvailability = unavailable
           ? ('unavailable' as const)
-          : unauthenticated
-            ? ('unauthenticated' as const)
-            : undefined
+          : credentialUnavailable
+            ? ('credential_unavailable' as const)
+            : unauthenticated
+              ? ('unauthenticated' as const)
+              : undefined
         const runtimeAvailability = server.enabled
           ? this.customServerRuntimeProjectionProvider.availability(server.id)
           : undefined
@@ -671,10 +696,10 @@ class ConnectorSettingsModule {
           displayName: server.displayName,
           description: server.description,
           transport: server.transport,
-          enabled: server.enabled && !unavailable && !unauthenticated,
+          enabled: server.enabled && !configurationAvailability,
           command: server.command,
-          args: server.args,
-          url: server.url,
+          args: argsContainCredentials ? undefined : server.args,
+          url: urlContainsCredentials ? undefined : server.url,
           ...(server.transport !== 'stdio'
             ? {
                 hasHeaders: hasResolvedSecretRecord(server.headerRefs, server.headers)

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -103,6 +103,11 @@ const hasResolvedSecretRecord = (
 const assertCredentialFieldsAreEncrypted = (fields: {
   args?: readonly string[]
   url?: string
+  oauth?: {
+    clientMetadataUrl?: string
+    authorizationServerUrl?: string
+    redirectUri?: string
+  } | null
 }): void => {
   if (hasEmbeddedConnectorCredentials(fields)) {
     throw new Error(
@@ -672,6 +677,15 @@ class ConnectorSettingsModule {
         const routeUnavailable = !isCustomMcpServerRouteSafe(server, customServers)
         const argsContainCredentials = hasEmbeddedConnectorCredentials({ args: server.args })
         const urlContainsCredentials = hasEmbeddedConnectorCredentials({ url: server.url })
+        const clientMetadataUrlContainsCredentials = hasEmbeddedConnectorCredentials({
+          url: server.oauth?.clientMetadataUrl
+        })
+        const authorizationServerUrlContainsCredentials = hasEmbeddedConnectorCredentials({
+          url: server.oauth?.authorizationServerUrl
+        })
+        const redirectUriContainsCredentials = hasEmbeddedConnectorCredentials({
+          url: server.oauth?.redirectUri
+        })
         const credentialUnavailable = !hasUsableCustomMcpCredentials(server)
         const unavailable =
           routeUnavailable ||
@@ -716,15 +730,18 @@ class ConnectorSettingsModule {
           ...(server.oauth
             ? {
                 oauth: {
-                  ...(server.oauth.clientMetadataUrl
+                  ...(server.oauth.clientMetadataUrl && !clientMetadataUrlContainsCredentials
                     ? { clientMetadataUrl: server.oauth.clientMetadataUrl }
                     : {}),
-                  ...(server.oauth.authorizationServerUrl
+                  ...(server.oauth.authorizationServerUrl &&
+                  !authorizationServerUrlContainsCredentials
                     ? { authorizationServerUrl: server.oauth.authorizationServerUrl }
                     : {}),
                   ...(server.oauth.scopes ? { scopes: server.oauth.scopes } : {}),
                   ...(server.oauth.clientId ? { clientId: server.oauth.clientId } : {}),
-                  ...(server.oauth.redirectUri ? { redirectUri: server.oauth.redirectUri } : {}),
+                  ...(server.oauth.redirectUri && !redirectUriContainsCredentials
+                    ? { redirectUri: server.oauth.redirectUri }
+                    : {}),
                   hasTokens: Boolean(server.oauthState?.tokens?.access_token),
                   hasClientSecret: server.oauthClientSecret !== undefined
                 }

--- a/src/main/settings/connector-template.test.ts
+++ b/src/main/settings/connector-template.test.ts
@@ -210,6 +210,7 @@ describe('Connector configuration templates', () => {
     [{ env: { API_TOKEN: 'secret' } }, 'Unknown field "env"'],
     [{ headers: { Authorization: 'Bearer secret' } }, 'Unknown field "headers"'],
     [{ args: ['--api-key=secret'] }, 'appears to contain a credential'],
+    [{ args: ['--header', 'Authorization: Bearer secret'] }, 'appears to contain a credential'],
     [{ url: 'https://mcp.example.test/mcp?token=secret' }, 'credential-like query parameter']
   ])('rejects secret-bearing or unknown fields', (extra, message) => {
     const preview = parseConnectorTemplate(

--- a/src/main/settings/connector-template.test.ts
+++ b/src/main/settings/connector-template.test.ts
@@ -215,6 +215,9 @@ describe('Connector configuration templates', () => {
       { args: ['--header', 'Authorization:', 'Bearer', 'secret'] },
       'appears to contain a credential'
     ],
+    [{ args: ['--user=researcher:secret'] }, 'appears to contain a credential'],
+    [{ args: ['-u', 'researcher:secret'] }, 'appears to contain a credential'],
+    [{ args: ['-uresearcher:secret'] }, 'appears to contain a credential'],
     [{ args: ['--auth-token', 'secret'] }, 'appears to contain a credential'],
     [
       { args: ['--endpoint', 'https://mcp.example.test/mcp?auth_token=secret'] },
@@ -414,14 +417,17 @@ describe('Connector configuration templates', () => {
     expect(result.preview.mcpClientSuggestedFileName).toBe('mcp-example-server.json')
   })
 
-  it('withholds both export formats when historical arguments contain split credentials', () => {
+  it.each([
+    ['split header credentials', ['--header', 'Authorization:', 'Bearer', 'plaintext-secret']],
+    ['curl-style user credentials', ['--user', 'researcher:plaintext-secret']]
+  ])('withholds both export formats for historical %s', (_description, args) => {
     const result = buildConnectorTemplateExport({
       id: 'unsafe-id',
       name: 'unsafe-server',
       displayName: 'Unsafe Server',
       transport: 'stdio',
       command: 'example-mcp',
-      args: ['--header', 'Authorization:', 'Bearer', 'plaintext-secret']
+      args
     })
 
     expect(result.preview).toMatchObject({

--- a/src/main/settings/connector-template.test.ts
+++ b/src/main/settings/connector-template.test.ts
@@ -291,6 +291,22 @@ describe('Connector configuration templates', () => {
     expect(preview.ready).toBe(true)
   })
 
+  it('accepts Python unbuffered mode without treating bare -u as a credential flag', () => {
+    const preview = parseConnectorTemplate(
+      JSON.stringify({
+        schema_version: 1,
+        kind: 'open-science.connector',
+        name: 'python-server',
+        display_name: 'Python Server',
+        transport: 'stdio',
+        command: 'python3',
+        args: ['-u', 'server.py']
+      })
+    )
+
+    expect(preview.ready).toBe(true)
+  })
+
   it('accepts local paths with portability warnings', () => {
     const local = parseConnectorTemplate(
       JSON.stringify({

--- a/src/main/settings/connector-template.test.ts
+++ b/src/main/settings/connector-template.test.ts
@@ -211,6 +211,10 @@ describe('Connector configuration templates', () => {
     [{ headers: { Authorization: 'Bearer secret' } }, 'Unknown field "headers"'],
     [{ args: ['--api-key=secret'] }, 'appears to contain a credential'],
     [{ args: ['--header', 'Authorization: Bearer secret'] }, 'appears to contain a credential'],
+    [
+      { args: ['--header', 'Authorization:', 'Bearer', 'secret'] },
+      'appears to contain a credential'
+    ],
     [{ args: ['--auth-token', 'secret'] }, 'appears to contain a credential'],
     [
       { args: ['--endpoint', 'https://mcp.example.test/mcp?auth_token=secret'] },
@@ -408,6 +412,29 @@ describe('Connector configuration templates', () => {
     })
     expect(result.preview.mcpClientDigest).toMatch(/^[a-f0-9]{64}$/)
     expect(result.preview.mcpClientSuggestedFileName).toBe('mcp-example-server.json')
+  })
+
+  it('withholds both export formats when historical arguments contain split credentials', () => {
+    const result = buildConnectorTemplateExport({
+      id: 'unsafe-id',
+      name: 'unsafe-server',
+      displayName: 'Unsafe Server',
+      transport: 'stdio',
+      command: 'example-mcp',
+      args: ['--header', 'Authorization:', 'Bearer', 'plaintext-secret']
+    })
+
+    expect(result.preview).toMatchObject({
+      ready: false,
+      connectorId: 'unsafe-id',
+      diagnostics: [expect.objectContaining({ code: 'connector-template.argument-secret' })]
+    })
+    expect(result.preview.digest).toBeUndefined()
+    expect(result.preview.suggestedFileName).toBeUndefined()
+    expect(result.preview.mcpClientDigest).toBeUndefined()
+    expect(result.preview.mcpClientSuggestedFileName).toBeUndefined()
+    expect(result.contents).toBeUndefined()
+    expect(result.mcpClientContents).toBeUndefined()
   })
 
   it('exports remote MCP client transport labels and excludes OAuth state', () => {

--- a/src/main/settings/connector-template.test.ts
+++ b/src/main/settings/connector-template.test.ts
@@ -211,6 +211,7 @@ describe('Connector configuration templates', () => {
     [{ headers: { Authorization: 'Bearer secret' } }, 'Unknown field "headers"'],
     [{ args: ['--api-key=secret'] }, 'appears to contain a credential'],
     [{ args: ['--header', 'Authorization: Bearer secret'] }, 'appears to contain a credential'],
+    [{ args: ['--header', 'X-API-Token: secret'] }, 'appears to contain a credential'],
     [
       { args: ['--header', 'Authorization:', 'Bearer', 'secret'] },
       'appears to contain a credential'
@@ -267,6 +268,27 @@ describe('Connector configuration templates', () => {
       })
     )
     expect(ordinary.ready).toBe(true)
+  })
+
+  it('accepts ordinary custom header arguments', () => {
+    const preview = parseConnectorTemplate(
+      JSON.stringify({
+        schema_version: 1,
+        kind: 'open-science.connector',
+        name: 'ordinary-header',
+        display_name: 'Ordinary Header',
+        transport: 'stdio',
+        command: 'example-mcp',
+        args: [
+          '--header',
+          'X-Request-ID: request-123',
+          '--header',
+          'Idempotency-Key: operation-123'
+        ]
+      })
+    )
+
+    expect(preview.ready).toBe(true)
   })
 
   it('accepts local paths with portability warnings', () => {
@@ -419,6 +441,7 @@ describe('Connector configuration templates', () => {
 
   it.each([
     ['split header credentials', ['--header', 'Authorization:', 'Bearer', 'plaintext-secret']],
+    ['custom token header credentials', ['--header', 'X-API-Token:', 'plaintext-secret']],
     ['curl-style user credentials', ['--user', 'researcher:plaintext-secret']]
   ])('withholds both export formats for historical %s', (_description, args) => {
     const result = buildConnectorTemplateExport({

--- a/src/main/settings/connector-template.test.ts
+++ b/src/main/settings/connector-template.test.ts
@@ -211,6 +211,11 @@ describe('Connector configuration templates', () => {
     [{ headers: { Authorization: 'Bearer secret' } }, 'Unknown field "headers"'],
     [{ args: ['--api-key=secret'] }, 'appears to contain a credential'],
     [{ args: ['--header', 'Authorization: Bearer secret'] }, 'appears to contain a credential'],
+    [{ args: ['--auth-token', 'secret'] }, 'appears to contain a credential'],
+    [
+      { args: ['--endpoint', 'https://mcp.example.test/mcp?auth_token=secret'] },
+      'appears to contain a credential'
+    ],
     [{ url: 'https://mcp.example.test/mcp?token=secret' }, 'credential-like query parameter']
   ])('rejects secret-bearing or unknown fields', (extra, message) => {
     const preview = parseConnectorTemplate(

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -87,6 +87,30 @@ const SECRET_FLAG = /^--?(?:api[-_]?key|token|secret|password|credential|authori
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
 const SAFE_HEADER_NAME = /^[A-Za-z0-9][A-Za-z0-9-]*$/
 const CONNECTOR_TEMPLATE_DIGEST_CACHE_LIMIT = 64
+
+const argumentContainsCredential = (argument: string): boolean =>
+  JWT.test(argument) || /^Bearer\s+/i.test(argument) || SECRET_FLAG.test(argument)
+
+const hasSuspiciousQueryKey = (url: URL): boolean =>
+  [...url.searchParams.keys()].some((key) =>
+    SUSPICIOUS_QUERY_KEYS.has(key.toLowerCase().replace(/[^a-z0-9]/g, ''))
+  )
+
+export const hasEmbeddedConnectorCredentials = (fields: {
+  args?: readonly string[]
+  url?: string
+}): boolean => {
+  if (fields.args?.some(argumentContainsCredential)) return true
+  if (!fields.url) return false
+
+  try {
+    const url = new URL(fields.url)
+    return Boolean(url.username || url.password || hasSuspiciousQueryKey(url))
+  } catch {
+    return false
+  }
+}
+
 // Keeps preview digests opaque to the renderer without persisting exported connector metadata.
 const connectorTemplateDigests = new Map<string, string>()
 
@@ -243,18 +267,14 @@ const readHttpUrl = (
       path
     )
   }
-  for (const key of url.searchParams.keys()) {
-    const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, '')
-    if (SUSPICIOUS_QUERY_KEYS.has(normalizedKey)) {
-      diagnostic(
-        diagnostics,
-        'error',
-        'connector-template.url-secret',
-        `${path} contains a credential-like query parameter.`,
-        path
-      )
-      break
-    }
+  if (hasSuspiciousQueryKey(url)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      'connector-template.url-secret',
+      `${path} contains a credential-like query parameter.`,
+      path
+    )
   }
   return raw
 }
@@ -399,7 +419,7 @@ const validateArgs = (
         `args[${index}]`
       )
     }
-    if (JWT.test(arg) || /^Bearer\s+/i.test(arg) || SECRET_FLAG.test(arg)) {
+    if (argumentContainsCredential(arg)) {
       diagnostic(
         diagnostics,
         'error',

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -84,12 +84,26 @@ const SUSPICIOUS_QUERY_KEYS = new Set([
 ])
 const JWT = /(?:^|[=:\s])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:$|\s)/
 const SECRET_FLAG = /^--?(?:api[-_]?key|token|secret|password|credential|authorization)(?:=|$)/i
+const CREDENTIAL_HEADER =
+  /^(?:authorization|proxy-authorization|cookie|x-api-key|api-key|x-auth-token|x-access-token)\s*:\s*\S/i
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
 const SAFE_HEADER_NAME = /^[A-Za-z0-9][A-Za-z0-9-]*$/
 const CONNECTOR_TEMPLATE_DIGEST_CACHE_LIMIT = 64
 
+const headerArgumentValue = (argument: string): string => {
+  const trimmed = argument.trim()
+  const longOption = /^--header(?:=|\s+)(.+)$/i.exec(trimmed)
+  if (longOption) return longOption[1].trim()
+
+  const shortOption = /^-H(?:=|\s+)?(.+)$/i.exec(trimmed)
+  return shortOption ? shortOption[1].trim() : trimmed
+}
+
 const argumentContainsCredential = (argument: string): boolean =>
-  JWT.test(argument) || /^Bearer\s+/i.test(argument) || SECRET_FLAG.test(argument)
+  JWT.test(argument) ||
+  /^Bearer\s+/i.test(argument) ||
+  SECRET_FLAG.test(argument) ||
+  CREDENTIAL_HEADER.test(headerArgumentValue(argument))
 
 const hasSuspiciousQueryKey = (url: URL): boolean =>
   [...url.searchParams.keys()].some((key) =>

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -65,8 +65,11 @@ const TRANSPORTS = new Set<CustomServerTransport>(['stdio', 'streamable_http', '
 const SUSPICIOUS_QUERY_KEYS = new Set([
   'accesstoken',
   'apikey',
+  'apitoken',
   'auth',
+  'authtoken',
   'authorization',
+  'bearertoken',
   'clientassertion',
   'clientsecret',
   'code',
@@ -77,18 +80,46 @@ const SUSPICIOUS_QUERY_KEYS = new Set([
   'key',
   'passwd',
   'password',
+  'privatekey',
   'refreshtoken',
+  'securitytoken',
   'secret',
+  'sessiontoken',
+  'signature',
   'token',
-  'tokenkey'
+  'tokenkey',
+  'xapikey'
 ])
 const JWT = /(?:^|[=:\s])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:$|\s)/
-const SECRET_FLAG = /^--?(?:api[-_]?key|token|secret|password|credential|authorization)(?:=|$)/i
+const SECRET_FLAG =
+  /^--?(?:[a-z0-9]+[-_])*(?:access[-_]?(?:key|token)|api[-_]?(?:key|token)|auth(?:entication)?[-_]?(?:key|token)|authorization|bearer(?:[-_]?token)?|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|refresh[-_]?token|secret(?:[-_]?access[-_]?key)?|security[-_]?token|session[-_]?token|tokens?)(?:[-_]?(?:file|path))?(?:=|:|$)/i
 const CREDENTIAL_HEADER =
   /^(?:authorization|proxy-authorization|cookie|x-api-key|api-key|x-auth-token|x-access-token)\s*:\s*\S/i
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
 const SAFE_HEADER_NAME = /^[A-Za-z0-9][A-Za-z0-9-]*$/
 const CONNECTOR_TEMPLATE_DIGEST_CACHE_LIMIT = 64
+
+const hasSuspiciousQueryKey = (url: URL): boolean =>
+  [...url.searchParams.keys()].some((key) =>
+    SUSPICIOUS_QUERY_KEYS.has(key.toLowerCase().replace(/[^a-z0-9]/g, ''))
+  )
+
+const urlContainsCredential = (value: string): boolean => {
+  try {
+    const url = new URL(value)
+    return Boolean(url.username || url.password || hasSuspiciousQueryKey(url))
+  } catch {
+    return false
+  }
+}
+
+const argumentUrlContainsCredential = (argument: string): boolean => {
+  const trimmed = argument.trim()
+  if (urlContainsCredential(trimmed)) return true
+
+  const separator = trimmed.indexOf('=')
+  return separator >= 0 && urlContainsCredential(trimmed.slice(separator + 1))
+}
 
 const headerArgumentValue = (argument: string): string => {
   const trimmed = argument.trim()
@@ -103,12 +134,8 @@ const argumentContainsCredential = (argument: string): boolean =>
   JWT.test(argument) ||
   /^Bearer\s+/i.test(argument) ||
   SECRET_FLAG.test(argument) ||
-  CREDENTIAL_HEADER.test(headerArgumentValue(argument))
-
-const hasSuspiciousQueryKey = (url: URL): boolean =>
-  [...url.searchParams.keys()].some((key) =>
-    SUSPICIOUS_QUERY_KEYS.has(key.toLowerCase().replace(/[^a-z0-9]/g, ''))
-  )
+  CREDENTIAL_HEADER.test(headerArgumentValue(argument)) ||
+  argumentUrlContainsCredential(argument)
 
 export const hasEmbeddedConnectorCredentials = (fields: {
   args?: readonly string[]
@@ -117,12 +144,7 @@ export const hasEmbeddedConnectorCredentials = (fields: {
   if (fields.args?.some(argumentContainsCredential)) return true
   if (!fields.url) return false
 
-  try {
-    const url = new URL(fields.url)
-    return Boolean(url.username || url.password || hasSuspiciousQueryKey(url))
-  } catch {
-    return false
-  }
+  return urlContainsCredential(fields.url)
 }
 
 // Keeps preview digests opaque to the renderer without persisting exported connector metadata.

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -443,6 +443,7 @@ const validateArgs = (
   args: string[] | undefined,
   diagnostics: ConnectorTemplateDiagnostic[]
 ): void => {
+  let credentialReported = false
   for (const [index, arg] of (args ?? []).entries()) {
     if (isLocalPath(arg)) {
       diagnostic(
@@ -463,6 +464,7 @@ const validateArgs = (
       )
     }
     if (argumentContainsCredential(arg)) {
+      credentialReported = true
       diagnostic(
         diagnostics,
         'error',
@@ -471,6 +473,15 @@ const validateArgs = (
         `args[${index}]`
       )
     }
+  }
+  if (args && !credentialReported && argumentsContainCredential(args)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      'connector-template.argument-secret',
+      'args appears to contain a credential.',
+      'args'
+    )
   }
 }
 
@@ -1011,7 +1022,16 @@ export const buildConnectorTemplateExport = (
   }
   const contents = templateJson(definition)
   const parsed = parseConnectorTemplate(contents)
-  const digest = parsed.ready ? connectorTemplateDigest(contents) : undefined
+  if (!parsed.ready) {
+    return {
+      preview: {
+        ...parsed,
+        connectorId: source.id
+      }
+    }
+  }
+
+  const digest = connectorTemplateDigest(contents)
   const mcpClientContents = mcpClientJson(definition)
   const mcpClientDigest = connectorTemplateDigest(mcpClientContents)
   const mcpClientDiagnostics: ConnectorTemplateDiagnostic[] = source.oauth
@@ -1028,14 +1048,14 @@ export const buildConnectorTemplateExport = (
     preview: {
       ...parsed,
       connectorId: source.id,
-      ...(digest
-        ? { digest, suggestedFileName: `open-science-connector-${source.name}.json` }
-        : {}),
+      digest,
+      suggestedFileName: `open-science-connector-${source.name}.json`,
       mcpClientDigest,
       mcpClientSuggestedFileName: `mcp-${source.name}.json`,
       ...(mcpClientDiagnostics.length ? { mcpClientDiagnostics } : {})
     },
-    ...(parsed.ready ? { contents, mcpClientContents } : {})
+    contents,
+    mcpClientContents
   }
 }
 

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -94,8 +94,8 @@ const JWT = /(?:^|[=:\s])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:$|\
 const SECRET_FLAG =
   /^--?(?:[a-z0-9]+[-_])*(?:access[-_]?(?:key|token)|api[-_]?(?:key|token)|auth(?:entication)?[-_]?(?:key|token)|authorization|bearer(?:[-_]?token)?|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|refresh[-_]?token|secret(?:[-_]?access[-_]?key)?|security[-_]?token|session[-_]?token|tokens?|user)(?:[-_]?(?:file|path))?(?:=|:|$)/i
 const CREDENTIAL_USER_FLAG = /^-[uU](?:$|[=:]|[^-]*:)/
-const CREDENTIAL_HEADER =
-  /^(?:authorization|proxy-authorization|cookie|x-api-key|api-key|x-auth-token|x-access-token)\s*:\s*\S/i
+const CREDENTIAL_HEADER_NAME =
+  /(?:^|[-_])(?:auth(?:entication|orization)?|bearer|cookie|credentials?|passphrase|passwd|password|pat|secret|signature|token|(?:access|api|client|private|refresh|security|session)[-_]?(?:key|secret|token))(?:$|[-_])/i
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
 const SAFE_HEADER_NAME = /^[A-Za-z0-9][A-Za-z0-9-]*$/
 const CONNECTOR_TEMPLATE_DIGEST_CACHE_LIMIT = 64
@@ -131,12 +131,22 @@ const headerArgumentValue = (argument: string): string => {
   return shortOption ? shortOption[1].trim() : trimmed
 }
 
+const headerArgumentContainsCredential = (argument: string): boolean => {
+  const value = headerArgumentValue(argument)
+  const separator = value.indexOf(':')
+  return (
+    separator > 0 &&
+    CREDENTIAL_HEADER_NAME.test(value.slice(0, separator).trim()) &&
+    /\S/.test(value.slice(separator + 1))
+  )
+}
+
 const argumentContainsCredential = (argument: string): boolean =>
   JWT.test(argument) ||
   /^Bearer\s+/i.test(argument) ||
   SECRET_FLAG.test(argument) ||
   CREDENTIAL_USER_FLAG.test(argument) ||
-  CREDENTIAL_HEADER.test(headerArgumentValue(argument)) ||
+  headerArgumentContainsCredential(argument) ||
   argumentUrlContainsCredential(argument)
 
 const argumentsContainCredential = (args: readonly string[]): boolean =>

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -92,7 +92,8 @@ const SUSPICIOUS_QUERY_KEYS = new Set([
 ])
 const JWT = /(?:^|[=:\s])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:$|\s)/
 const SECRET_FLAG =
-  /^--?(?:[a-z0-9]+[-_])*(?:access[-_]?(?:key|token)|api[-_]?(?:key|token)|auth(?:entication)?[-_]?(?:key|token)|authorization|bearer(?:[-_]?token)?|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|refresh[-_]?token|secret(?:[-_]?access[-_]?key)?|security[-_]?token|session[-_]?token|tokens?)(?:[-_]?(?:file|path))?(?:=|:|$)/i
+  /^--?(?:[a-z0-9]+[-_])*(?:access[-_]?(?:key|token)|api[-_]?(?:key|token)|auth(?:entication)?[-_]?(?:key|token)|authorization|bearer(?:[-_]?token)?|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|refresh[-_]?token|secret(?:[-_]?access[-_]?key)?|security[-_]?token|session[-_]?token|tokens?|user)(?:[-_]?(?:file|path))?(?:=|:|$)/i
+const CREDENTIAL_USER_FLAG = /^-[uU](?:$|[=:]|[^-]*:)/
 const CREDENTIAL_HEADER =
   /^(?:authorization|proxy-authorization|cookie|x-api-key|api-key|x-auth-token|x-access-token)\s*:\s*\S/i
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
@@ -134,6 +135,7 @@ const argumentContainsCredential = (argument: string): boolean =>
   JWT.test(argument) ||
   /^Bearer\s+/i.test(argument) ||
   SECRET_FLAG.test(argument) ||
+  CREDENTIAL_USER_FLAG.test(argument) ||
   CREDENTIAL_HEADER.test(headerArgumentValue(argument)) ||
   argumentUrlContainsCredential(argument)
 

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -137,11 +137,18 @@ const argumentContainsCredential = (argument: string): boolean =>
   CREDENTIAL_HEADER.test(headerArgumentValue(argument)) ||
   argumentUrlContainsCredential(argument)
 
+const argumentsContainCredential = (args: readonly string[]): boolean =>
+  args.some(argumentContainsCredential) ||
+  args.some((argument, index) => {
+    if (!/^(?:--header|-H)(?:=.+)?$/i.test(argument.trim())) return false
+    return argumentContainsCredential(args.slice(index).join(' '))
+  })
+
 export const hasEmbeddedConnectorCredentials = (fields: {
   args?: readonly string[]
   url?: string
 }): boolean => {
-  if (fields.args?.some(argumentContainsCredential)) return true
+  if (fields.args && argumentsContainCredential(fields.args)) return true
   if (!fields.url) return false
 
   return urlContainsCredential(fields.url)

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -159,11 +159,19 @@ const argumentsContainCredential = (args: readonly string[]): boolean =>
 export const hasEmbeddedConnectorCredentials = (fields: {
   args?: readonly string[]
   url?: string
+  oauth?: {
+    clientMetadataUrl?: string
+    authorizationServerUrl?: string
+    redirectUri?: string
+  } | null
 }): boolean => {
   if (fields.args && argumentsContainCredential(fields.args)) return true
-  if (!fields.url) return false
-
-  return urlContainsCredential(fields.url)
+  return [
+    fields.url,
+    fields.oauth?.clientMetadataUrl,
+    fields.oauth?.authorizationServerUrl,
+    fields.oauth?.redirectUri
+  ].some((url) => Boolean(url && urlContainsCredential(url)))
 }
 
 // Keeps preview digests opaque to the renderer without persisting exported connector metadata.

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -93,7 +93,7 @@ const SUSPICIOUS_QUERY_KEYS = new Set([
 const JWT = /(?:^|[=:\s])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:$|\s)/
 const SECRET_FLAG =
   /^--?(?:[a-z0-9]+[-_])*(?:access[-_]?(?:key|token)|api[-_]?(?:key|token)|auth(?:entication)?[-_]?(?:key|token)|authorization|bearer(?:[-_]?token)?|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|refresh[-_]?token|secret(?:[-_]?access[-_]?key)?|security[-_]?token|session[-_]?token|tokens?|user)(?:[-_]?(?:file|path))?(?:=|:|$)/i
-const CREDENTIAL_USER_FLAG = /^-[uU](?:$|[=:]|[^-]*:)/
+const CREDENTIAL_USER_FLAG = /^-[uU](?:[=:]|[^-]*:)/
 const CREDENTIAL_HEADER_NAME =
   /(?:^|[-_])(?:auth(?:entication|orization)?|bearer|cookie|credentials?|passphrase|passwd|password|pat|secret|signature|token|(?:access|api|client|private|refresh|security|session)[-_]?(?:key|secret|token))(?:$|[-_])/i
 const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
@@ -149,8 +149,19 @@ const argumentContainsCredential = (argument: string): boolean =>
   headerArgumentContainsCredential(argument) ||
   argumentUrlContainsCredential(argument)
 
+const splitUserValueContainsCredential = (argument: string): boolean => {
+  const value = argument.trim()
+  if (/^[A-Za-z]:[\\/]/.test(value) || /^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return false
+  const separator = value.indexOf(':')
+  return separator >= 0 && /\S/.test(value.replace(':', ''))
+}
+
 const argumentsContainCredential = (args: readonly string[]): boolean =>
   args.some(argumentContainsCredential) ||
+  args.some(
+    (argument, index) =>
+      /^-[uU]$/.test(argument.trim()) && splitUserValueContainsCredential(args[index + 1] ?? '')
+  ) ||
   args.some((argument, index) => {
     if (!/^(?:--header|-H)(?:=.+)?$/i.test(argument.trim())) return false
     return argumentContainsCredential(args.slice(index).join(' '))

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -149,6 +149,25 @@ describe('ConnectorAddForm (local command)', () => {
     expect(onDone).toHaveBeenCalled()
   })
 
+  it('submits whitespace-separated header input as separate arguments', async () => {
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+
+    setValue('Display name', 'Header Server')
+    openAdvancedSettings()
+    setValue('Arguments', '--header Authorization: Bearer plaintext-secret')
+    checkTrust()
+
+    await act(async () => addButton()?.click())
+
+    expect(useSettingsStore.getState().addCustomServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: ['--header', 'Authorization:', 'Bearer', 'plaintext-secret']
+      })
+    )
+  })
+
   it('previews an ID from the name and submits a valid user override', async () => {
     act(() => {
       root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -737,6 +737,32 @@ describe('ConnectorsPanel (groups)', () => {
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'edit', id: 'invalid-mcp' })
   })
 
+  it('directs custom Connectors with unavailable credentials to Edit', () => {
+    const onNavigate = vi.fn()
+    useSettingsStore.setState({
+      customServers: [
+        {
+          id: 'credential-unavailable-mcp',
+          name: 'credential-unavailable-mcp',
+          displayName: 'Credential unavailable MCP',
+          transport: 'stdio',
+          enabled: false,
+          availability: 'credential_unavailable'
+        }
+      ]
+    })
+    act(() => root.render(<ConnectorsPanel onNavigate={onNavigate} />))
+
+    expect(document.body.textContent).toContain('Credentials unavailable')
+    expect(
+      document.body
+        .querySelector<HTMLButtonElement>('[aria-label="Toggle Credential unavailable MCP"]')
+        ?.getAttribute('aria-disabled')
+    ).toBe('true')
+    act(() => clickButtonByText('Configure'))
+    expect(onNavigate).toHaveBeenCalledWith({ kind: 'edit', id: 'credential-unavailable-mcp' })
+  })
+
   it('shows checking while background discovery is still pending', () => {
     useSettingsStore.setState({
       customServers: [

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -763,6 +763,33 @@ describe('ConnectorsPanel (groups)', () => {
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'edit', id: 'credential-unavailable-mcp' })
   })
 
+  it('allows a durably enabled Connector with unavailable credentials to be disabled', () => {
+    useSettingsStore.setState({
+      customServers: [
+        {
+          id: 'enabled-credential-unavailable-mcp',
+          name: 'enabled-credential-unavailable-mcp',
+          displayName: 'Enabled credential unavailable MCP',
+          transport: 'stdio',
+          enabled: true,
+          availability: 'credential_unavailable'
+        }
+      ]
+    })
+    act(() => root.render(<ConnectorsPanel onNavigate={vi.fn()} />))
+
+    const toggle = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Toggle Enabled credential unavailable MCP"]'
+    )
+    expect(toggle?.getAttribute('data-state')).toBe('checked')
+    expect(toggle?.getAttribute('aria-disabled')).toBeNull()
+    act(() => toggle?.click())
+    expect(useSettingsStore.getState().setCustomServerEnabled).toHaveBeenCalledWith(
+      'enabled-credential-unavailable-mcp',
+      false
+    )
+  })
+
   it('shows checking while background discovery is still pending', () => {
     useSettingsStore.setState({
       customServers: [

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -105,6 +105,9 @@ const requiresSignInBeforeEnable = (server: CustomServerView): boolean =>
     !server.enabled
   )
 
+const cannotEnableCustomServer = (server: CustomServerView): boolean =>
+  requiresSignInBeforeEnable(server) || server.availability === 'credential_unavailable'
+
 type ConnectorsPanelProps = {
   onNavigate: (view: ConnectorsView) => void
   onOpenTag?: (tagId: string) => void
@@ -684,11 +687,13 @@ export function ConnectorsPanel({
                                   ? t('Checking…')
                                   : server.availability === 'unavailable'
                                     ? t('Unavailable')
-                                    : server.availability === 'unauthenticated'
-                                      ? t('Sign-in required')
-                                      : server.enabled
-                                        ? t('Connected')
-                                        : t('Disabled')}
+                                    : server.availability === 'credential_unavailable'
+                                      ? t('Credentials unavailable')
+                                      : server.availability === 'unauthenticated'
+                                        ? t('Sign-in required')
+                                        : server.enabled
+                                          ? t('Connected')
+                                          : t('Disabled')}
                             </span>
                             {server.enabled || usages.length > 0 ? (
                               <span className="inline-flex shrink-0 items-center gap-1">
@@ -726,7 +731,8 @@ export function ConnectorsPanel({
                             {retryingIds.has(server.id) ? t('Checking…') : t('Retry')}
                           </Button>
                         ) : null}
-                        {server.availability === 'unauthenticated' && !server.oauth ? (
+                        {(server.availability === 'unauthenticated' && !server.oauth) ||
+                        server.availability === 'credential_unavailable' ? (
                           <Button
                             type="button"
                             size="sm"
@@ -736,7 +742,7 @@ export function ConnectorsPanel({
                             {t('Configure')}
                           </Button>
                         ) : null}
-                        {server.oauth ? (
+                        {server.oauth && server.availability !== 'credential_unavailable' ? (
                           <Button
                             type="button"
                             size="sm"
@@ -800,9 +806,9 @@ export function ConnectorsPanel({
                           <SettingsToggle
                             enabled={server.enabled}
                             aria-label={t('Toggle {{name}}', { name: server.displayName })}
-                            aria-disabled={requiresSignInBeforeEnable(server) || undefined}
+                            aria-disabled={cannotEnableCustomServer(server) || undefined}
                             className={
-                              requiresSignInBeforeEnable(server)
+                              cannotEnableCustomServer(server)
                                 ? 'cursor-not-allowed opacity-50'
                                 : undefined
                             }
@@ -814,7 +820,7 @@ export function ConnectorsPanel({
                                   : t('Unavailable to Main Agent')
                             }
                             onToggle={() => {
-                              if (requiresSignInBeforeEnable(server)) return
+                              if (cannotEnableCustomServer(server)) return
                               void saveToggle(async () => {
                                 await setCustomServerEnabled(server.id, !server.enabled)
                               })

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -106,7 +106,8 @@ const requiresSignInBeforeEnable = (server: CustomServerView): boolean =>
   )
 
 const cannotEnableCustomServer = (server: CustomServerView): boolean =>
-  requiresSignInBeforeEnable(server) || server.availability === 'credential_unavailable'
+  requiresSignInBeforeEnable(server) ||
+  (!server.enabled && server.availability === 'credential_unavailable')
 
 type ConnectorsPanelProps = {
   onNavigate: (view: ConnectorsView) => void

--- a/src/renderer/src/pages/settings/SpecialistCapabilitiesSection.tsx
+++ b/src/renderer/src/pages/settings/SpecialistCapabilitiesSection.tsx
@@ -17,7 +17,7 @@ type ConnectorRow = {
   description?: string
   mainEnabled: boolean
   available: boolean
-  availability?: 'unavailable' | 'unauthenticated'
+  availability?: 'unavailable' | 'unauthenticated' | 'credential_unavailable'
 }
 
 type SkillRow = {

--- a/src/renderer/src/pages/settings/connector-error-message.test.ts
+++ b/src/renderer/src/pages/settings/connector-error-message.test.ts
@@ -1,0 +1,15 @@
+import type { TFunction } from 'i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+import { localizeConnectorError } from './connector-error-message'
+
+describe('localizeConnectorError', () => {
+  it('localizes the aggregate credential argument diagnostic', () => {
+    const t = vi.fn((key: string) => `translated:${key}`) as unknown as TFunction
+
+    expect(localizeConnectorError('args appears to contain a credential.', t)).toBe(
+      'translated:args appears to contain a credential.'
+    )
+    expect(t).toHaveBeenCalledWith('args appears to contain a credential.')
+  })
+})

--- a/src/renderer/src/pages/settings/connector-error-message.ts
+++ b/src/renderer/src/pages/settings/connector-error-message.ts
@@ -48,6 +48,8 @@ export const localizeConnectorError = (message: string, t: TFunction): string =>
       return t(
         'Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.'
       )
+    case 'args appears to contain a credential.':
+      return t('args appears to contain a credential.')
     default:
       return message
   }

--- a/src/renderer/src/pages/settings/connector-error-message.ts
+++ b/src/renderer/src/pages/settings/connector-error-message.ts
@@ -44,6 +44,10 @@ export const localizeConnectorError = (message: string, t: TFunction): string =>
       return t('OAuth redirect URI requires a pre-registered client ID.')
     case 'Secure credential storage is unavailable. Unlock the system keychain and retry.':
       return t('Secure credential storage is unavailable. Unlock the system keychain and retry.')
+    case 'Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.':
+      return t(
+        'Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.'
+      )
     default:
       return message
   }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -3534,6 +3534,7 @@
     "The saved credential is unavailable on this device.": "La credencial guardada no está disponible en este dispositivo.",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "El almacenamiento seguro de credenciales no está disponible. Desbloquee el llavero del sistema y vuelva a intentarlo.",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "No se permiten credenciales en argumentos ni URL. Use en su lugar campos de entorno o encabezado cifrados.",
+    "args appears to contain a credential.": "Parece que args contiene una credencial.",
     "Credentials unavailable": "Credenciales no disponibles",
     "Authentication failed. Verify the username and password.": "Error de autenticación. Verifique el nombre de usuario y la contraseña.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "Se desconoce la clave del host SSH. Verifíquela en una terminal antes de conectarse.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -3533,6 +3533,8 @@
     "A password must be configured before this Compute Host can connect.": "Debe configurar una contraseña antes de que este host de cálculo pueda conectarse.",
     "The saved credential is unavailable on this device.": "La credencial guardada no está disponible en este dispositivo.",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "El almacenamiento seguro de credenciales no está disponible. Desbloquee el llavero del sistema y vuelva a intentarlo.",
+    "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "No se permiten credenciales en argumentos ni URL. Use en su lugar campos de entorno o encabezado cifrados.",
+    "Credentials unavailable": "Credenciales no disponibles",
     "Authentication failed. Verify the username and password.": "Error de autenticación. Verifique el nombre de usuario y la contraseña.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "Se desconoce la clave del host SSH. Verifíquela en una terminal antes de conectarse.",
     "The SSH host key changed. Verify known hosts in a terminal before connecting.": "La clave del host SSH cambió. Verifique los hosts conocidos en una terminal antes de conectarse.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -3533,6 +3533,8 @@
     "A password must be configured before this Compute Host can connect.": "Un mot de passe doit être configuré avant que cet hôte de calcul puisse se connecter.",
     "The saved credential is unavailable on this device.": "Les informations d'identification enregistrées ne sont pas disponibles sur cet appareil.",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "Le stockage sécurisé des informations d’identification n’est pas disponible. Déverrouillez le trousseau du système et réessayez.",
+    "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "Les identifiants ne sont pas autorisés dans les arguments ni les URL. Utilisez plutôt des champs d’environnement ou d’en-tête chiffrés.",
+    "Credentials unavailable": "Identifiants indisponibles",
     "Authentication failed. Verify the username and password.": "L'authentification a échoué. Vérifiez le nom d'utilisateur et le mot de passe.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "La clé d'hôte SSH est inconnue. Vérifiez-le dans un terminal avant de vous connecter.",
     "The SSH host key changed. Verify known hosts in a terminal before connecting.": "La clé d'hôte SSH a été modifiée. Vérifiez les hôtes connus dans un terminal avant de vous connecter.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -3534,6 +3534,7 @@
     "The saved credential is unavailable on this device.": "Les informations d'identification enregistrées ne sont pas disponibles sur cet appareil.",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "Le stockage sécurisé des informations d’identification n’est pas disponible. Déverrouillez le trousseau du système et réessayez.",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "Les identifiants ne sont pas autorisés dans les arguments ni les URL. Utilisez plutôt des champs d’environnement ou d’en-tête chiffrés.",
+    "args appears to contain a credential.": "args semble contenir un identifiant.",
     "Credentials unavailable": "Identifiants indisponibles",
     "Authentication failed. Verify the username and password.": "L'authentification a échoué. Vérifiez le nom d'utilisateur et le mot de passe.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "La clé d'hôte SSH est inconnue. Vérifiez-le dans un terminal avant de vous connecter.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3268,6 +3268,7 @@
     "The saved credential is unavailable on this device.": "保存済みの認証情報はこのデバイスでは利用できません。",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全な認証情報ストレージを利用できません。システムキーチェーンのロックを解除して、もう一度お試しください。",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "引数や URL に認証情報を含めることはできません。代わりに暗号化された環境変数またはヘッダーフィールドを使用してください。",
+    "args appears to contain a credential.": "args に認証情報が含まれている可能性があります。",
     "Credentials unavailable": "認証情報を利用できません",
     "Authentication failed. Verify the username and password.": "認証に失敗しました。ユーザー名とパスワードを確認してください。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH ホスト鍵が不明です。接続する前にターミナルで確認してください。",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3267,6 +3267,8 @@
     "A password must be configured before this Compute Host can connect.": "この Compute Host が接続するには、先にパスワードを設定する必要があります。",
     "The saved credential is unavailable on this device.": "保存済みの認証情報はこのデバイスでは利用できません。",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全な認証情報ストレージを利用できません。システムキーチェーンのロックを解除して、もう一度お試しください。",
+    "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "引数や URL に認証情報を含めることはできません。代わりに暗号化された環境変数またはヘッダーフィールドを使用してください。",
+    "Credentials unavailable": "認証情報を利用できません",
     "Authentication failed. Verify the username and password.": "認証に失敗しました。ユーザー名とパスワードを確認してください。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH ホスト鍵が不明です。接続する前にターミナルで確認してください。",
     "The SSH host key changed. Verify known hosts in a terminal before connecting.": "SSH ホスト鍵が変更されました。接続する前にターミナルで known hosts を確認してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3268,6 +3268,7 @@
     "The saved credential is unavailable on this device.": "저장된 자격 증명을 이 기기에서 사용할 수 없습니다.",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "보안 자격 증명 저장소를 사용할 수 없습니다. 시스템 키체인의 잠금을 해제한 후 다시 시도하세요.",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "인수 또는 URL에는 자격 증명을 포함할 수 없습니다. 대신 암호화된 환경 변수 또는 헤더 필드를 사용하세요.",
+    "args appears to contain a credential.": "args에 자격 증명이 포함된 것으로 보입니다.",
     "Credentials unavailable": "자격 증명을 사용할 수 없음",
     "Authentication failed. Verify the username and password.": "인증에 실패했습니다. 사용자 이름과 비밀번호를 확인하세요.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 호스트 키를 알 수 없습니다. 연결하기 전에 터미널에서 확인하세요.",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3267,6 +3267,8 @@
     "A password must be configured before this Compute Host can connect.": "이 컴퓨팅 호스트를 연결하려면 먼저 비밀번호를 구성해야 합니다.",
     "The saved credential is unavailable on this device.": "저장된 자격 증명을 이 기기에서 사용할 수 없습니다.",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "보안 자격 증명 저장소를 사용할 수 없습니다. 시스템 키체인의 잠금을 해제한 후 다시 시도하세요.",
+    "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "인수 또는 URL에는 자격 증명을 포함할 수 없습니다. 대신 암호화된 환경 변수 또는 헤더 필드를 사용하세요.",
+    "Credentials unavailable": "자격 증명을 사용할 수 없음",
     "Authentication failed. Verify the username and password.": "인증에 실패했습니다. 사용자 이름과 비밀번호를 확인하세요.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 호스트 키를 알 수 없습니다. 연결하기 전에 터미널에서 확인하세요.",
     "The SSH host key changed. Verify known hosts in a terminal before connecting.": "SSH 호스트 키가 변경되었습니다. 연결하기 전에 터미널에서 알려진 호스트를 확인하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -3637,6 +3637,8 @@
     "A password must be configured before this Compute Host can connect.": "Перед подключением этого вычислительного узла настройте пароль.",
     "The saved credential is unavailable on this device.": "Сохранённые учётные данные недоступны на данном устройстве.",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "Защищённое хранилище учётных данных недоступно. Разблокируйте системную связку ключей и повторите попытку.",
+    "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "Учётные данные нельзя указывать в аргументах или URL. Используйте зашифрованные поля переменных окружения или заголовков.",
+    "Credentials unavailable": "Учётные данные недоступны",
     "Authentication failed. Verify the username and password.": "Ошибка аутентификации. Убедитесь, что имя пользователя и пароль верны.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "Ключ узла SSH неизвестен. Перед подключением подтвердите его в командной строке.",
     "The SSH host key changed. Verify known hosts in a terminal before connecting.": "Ключ узла SSH изменился. Перед подключением проверьте запись в known_hosts из командной строки.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -3638,6 +3638,7 @@
     "The saved credential is unavailable on this device.": "Сохранённые учётные данные недоступны на данном устройстве.",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "Защищённое хранилище учётных данных недоступно. Разблокируйте системную связку ключей и повторите попытку.",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "Учётные данные нельзя указывать в аргументах или URL. Используйте зашифрованные поля переменных окружения или заголовков.",
+    "args appears to contain a credential.": "Похоже, args содержит учётные данные.",
     "Credentials unavailable": "Учётные данные недоступны",
     "Authentication failed. Verify the username and password.": "Ошибка аутентификации. Убедитесь, что имя пользователя и пароль верны.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "Ключ узла SSH неизвестен. Перед подключением подтвердите его в командной строке.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -425,6 +425,7 @@
     "The saved credential is unavailable on this device.": "保存的凭据在此设备上不可用。",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全凭据存储不可用。请解锁系统密钥环后重试。",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "参数或 URL 中不允许包含凭据。请改用加密的环境变量或请求头字段。",
+    "args appears to contain a credential.": "args 似乎包含凭据。",
     "Credentials unavailable": "凭据不可用",
     "Authentication failed. Verify the username and password.": "认证失败。请确认用户名和密码。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 主机密钥未知。请先在终端中验证，再进行连接。",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -424,6 +424,8 @@
     "A password must be configured before this Compute Host can connect.": "必须先为此计算主机配置密码，才能连接。",
     "The saved credential is unavailable on this device.": "保存的凭据在此设备上不可用。",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全凭据存储不可用。请解锁系统密钥环后重试。",
+    "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "参数或 URL 中不允许包含凭据。请改用加密的环境变量或请求头字段。",
+    "Credentials unavailable": "凭据不可用",
     "Authentication failed. Verify the username and password.": "认证失败。请确认用户名和密码。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 主机密钥未知。请先在终端中验证，再进行连接。",
     "The SSH host key changed. Verify known hosts in a terminal before connecting.": "SSH 主机密钥已更改。请先在终端中验证已知主机记录，再进行连接。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -424,6 +424,8 @@
     "A password must be configured before this Compute Host can connect.": "必須先為此運算主機設定密碼，才能連線。",
     "The saved credential is unavailable on this device.": "儲存的憑證在此裝置上無法使用。",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全憑證儲存無法使用。請解鎖系統鑰匙圈後重試。",
+    "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "參數或 URL 中不允許包含憑證。請改用加密的環境變數或標頭欄位。",
+    "Credentials unavailable": "憑證無法使用",
     "Authentication failed. Verify the username and password.": "認證失敗。請確認使用者名稱和密碼。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 主機金鑰未知。請先在終端機中驗證，再進行連線。",
     "The SSH host key changed. Verify known hosts in a terminal before connecting.": "SSH 主機金鑰已變更。請先在終端機中驗證已知主機記錄，再進行連線。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -425,6 +425,7 @@
     "The saved credential is unavailable on this device.": "儲存的憑證在此裝置上無法使用。",
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全憑證儲存無法使用。請解鎖系統鑰匙圈後重試。",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "參數或 URL 中不允許包含憑證。請改用加密的環境變數或標頭欄位。",
+    "args appears to contain a credential.": "args 似乎包含憑證。",
     "Credentials unavailable": "憑證無法使用",
     "Authentication failed. Verify the username and password.": "認證失敗。請確認使用者名稱和密碼。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 主機金鑰未知。請先在終端機中驗證，再進行連線。",

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1346,7 +1346,7 @@ export type CustomServerView = {
   enabled: boolean
   // Physical availability is independent of Main's enabled toggle. An invalid persisted server may
   // remain visible to a Specialist but can never be selected or dispatched.
-  availability?: 'unavailable' | 'unauthenticated'
+  availability?: 'unavailable' | 'unauthenticated' | 'credential_unavailable'
   // Background discovery is transient and does not make the Connector unavailable by itself.
   checking?: boolean
   // Display-only config summary (the command that runs, its args, or the remote URL). env/headers


### PR DESCRIPTION
## Problem

Manual custom MCP Connector add/update accepted credentials embedded in `args` or `url`. Those values were persisted as plaintext settings and returned in renderer snapshots even though template import already rejected the same credential patterns.

Separately, encrypted `envRefs`, `headerRefs`, or a pre-registered OAuth `oauthClientSecretRef` could resolve only partially. Runtime discovery, direct calls, and direct OAuth authentication checked enablement and transport fields but still passed the incomplete configuration to the MCP client, where stdio environment construction could fall back to a same-named host variable.

## Proposed change

- Reuse the Connector-template credential rules for manual add/update and reject URL userinfo, sensitive query keys, JWT/Bearer arguments, split or inline secret flags, curl-style `--user`/`-u` credentials, semantically credential-like header names (including custom names such as `X-API-Token` and values split into multiple argv entries by the form), credential-bearing URLs passed through argv, and credentials embedded in OAuth client-metadata, authorization-server, or redirect URLs before persistence.
- Compare every persisted env/header ref and OAuth client-secret ref with its decrypted main-process projection before custom MCP discovery, dispatch, or OAuth authentication.
- Make env/header completeness transport-aware, preserving fail-closed checks for active credentials while ignoring inactive historical maps; remove inactive env/header refs when an edit changes transport.
- Return the stable `credential_unavailable` call category and expose the same non-persisted availability state to Settings.
- Keep the renderer-safe `enabled` value as the durable Main-Agent preference and use `availability` independently for current runtime eligibility, allowing a durably enabled but unavailable Connector to be explicitly disabled.
- Project unresolved credentials as `credential_unavailable` through `host.agents`, mark the Connector unavailable to Main, and reject Specialist attachment before mutation.
- Reject direct/stale `enabled=true` mutations while credentials are unavailable, so durable enablement cannot contradict the fail-closed projection or reactivate unexpectedly after later repair.
- Keep historical records on disk, but fail them closed and redact credential-bearing `args`, endpoint URLs, and OAuth URLs from renderer snapshots until the user repairs the Connector.
- Withhold both Open Science and MCP-client export contents/digests when a historical record contains embedded credentials, including header values split across argv entries.
- Direct affected users to the existing encrypted environment/header fields.

## Scope and non-goals

- No settings, database, or schema version change.
- No new persisted fields.
- No automatic migration of credential-bearing args/URLs: their server-specific env/header mapping cannot be inferred safely.
- No changes to template schema v1 or MCP transport protocols.

### Historical compatibility

Historical records remain parseable and are not rewritten or deleted. Records with embedded credentials or undecryptable refs remain visible but non-runnable; users must edit them and re-enter credentials through encrypted fields.

Inactive env/header maps on historical records no longer block the transport that does not consume them. They remain unchanged until the Connector is edited; a later transport-changing edit removes the inactive map from durable settings.

### State impact

`CustomServerView.availability` and the agent-facing `ConnectorReadModel.availability` gain `credential_unavailable`. Both are transient read/runtime projections and are never persisted.

## Acceptance criteria and validation

All checks below ran after the last relevant material edit:

- manual add/update rejects credential-bearing fields and preserves durable state -> `connector-settings.test.ts`
- historical snapshots redact unsafe args/URLs and mark unavailable -> `connector-settings.test.ts`
- template parsing and both export formats reject standard and custom credential-like headers while accepting ordinary request/idempotency headers -> `connector-template.test.ts`
- discovery excludes partial env/header/OAuth and historical unsafe credential configurations -> `custom-mcp-bootstrap.test.ts`
- direct OAuth authentication fails before the MCP manager when its client secret cannot be decrypted -> `application.test.ts`
- direct calls fail before `listTools` or `call` with `credential_unavailable` -> `service.test.ts`
- main-process enablement rejects `credential_unavailable` and leaves durable `enabled=false` -> `connector-settings.test.ts`
- curl-style user credentials are rejected before persistence and fail closed in projection, export, and runtime dispatch -> `connector-settings.test.ts`, `connector-template.test.ts`, `service.test.ts`
- custom sensitive header names fail closed in manual persistence, template import/export, and runtime dispatch -> `connector-settings.test.ts`, `connector-template.test.ts`, `service.test.ts`
- OAuth client-metadata, authorization-server, and redirect URLs reject credentials on add/update; historical values are redacted and direct runtime calls fail closed -> `connector-settings.test.ts`, `service.test.ts`
- Python's bare `-u` unbuffered flag remains valid while existing curl `-u user:secret` cases still reject -> `connector-template.test.ts`, `connector-settings.test.ts`
- unresolved inactive credential maps do not block the other transport, and transport changes durably clear those inactive refs -> `custom-mcp-bootstrap.test.ts`, `connector-settings.test.ts`
- Settings displays Credentials unavailable, blocks unavailable enable attempts, and routes to Configure -> `ConnectorsPanel.render.test.tsx`
- Settings blocks enabling unavailable credentials but still lets an already-enabled Connector be disabled, preventing automatic reactivation after credential recovery -> `ConnectorsPanel.render.test.tsx`, `connector-settings.test.ts`
- aggregate argument validation guidance is localized through the existing Settings error helper in all seven translated locales -> `connector-error-message.test.ts`, `resources.test.ts`
- the add form's whitespace tokenization is covered through a real form submission -> `ConnectorAddForm.render.test.tsx`
- `host.agents` reports unresolved credentials and rejects Specialist attachment -> `agents-service.test.ts`, `agents-mutations.test.ts`
- template rules and all locale contracts remain intact -> `connector-template.test.ts`, `resources.test.ts`

Final focused test command:

```
node D:\projects\aipoch\open-science\node_modules\vitest\vitest.mjs run src/main/settings/connector-template.test.ts src/main/settings/connector-settings.test.ts src/main/connectors/custom-mcp-bootstrap.test.ts src/main/connectors/application.test.ts src/main/connectors/service.test.ts src/main/agents/agents-service.test.ts src/main/agents/agents-mutations.test.ts src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx src/renderer/src/pages/settings/connector-error-message.test.ts src/renderer/src/i18n/resources.test.ts
```

Result: 11 files passed, 1037 tests passed.

The related `SettingsService: custom MCP OAuth` module also passed (1 test; 258 unrelated tests skipped). Running that entire file on this Windows host reached seven unrelated symlink-containment tests that require symlink privileges and failed with `EPERM`; PR CI remains authoritative for those platform checks.

Additional checks:

- `npm run typecheck:node` — passed
- `npm run typecheck:web` — passed
- `npm run lint -- --no-cache` — passed
- `git diff --check` — passed

The full `npm test` suite was intentionally not run; PR CI remains authoritative for the complete portable and platform suites.

## Review focus

- Whether the shared credential detector exactly preserves the existing template rejection policy.
- Whether both runtime entry points fail closed before any MCP connection or approval side effect.
- Whether the agent-facing catalog and attachment gate should share the same unavailable projection.
- Whether preserving historical bytes while redacting renderer projections is the right compatibility boundary.
