### PR TITLE
fix(ipc): enforce renderer document boundaries

### DIFF
--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -445,7 +445,7 @@ test('previews and opens an Agent HTTPS source link in the isolated preview tab'
   await page.screenshot({ path: testInfo.outputPath('source-preview-loading.png') })
   await expect(sourceFrame).toHaveAttribute(
     'sandbox',
-    'allow-same-origin allow-scripts allow-forms allow-popups'
+    'allow-same-origin allow-scripts allow-forms'
   )
   await expect(sourceFrame).toHaveAttribute('referrerpolicy', 'no-referrer')
   await expect(sourceFrame).toHaveAttribute('name', 'open-science-source-preview')

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -43,6 +43,49 @@ describe('createIpcHandlerRegistry', () => {
     expect(handler).toHaveBeenCalledOnce()
   })
 
+  it('replaces a native surface lease when a new main-frame document starts navigating', () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const registry = createIpcHandlerRegistry({
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+        nativeHandlers.set(channel, handler)
+    } as never)
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+    const on = (name: string, listener: (...args: unknown[]) => void): void => {
+      const registered = listeners.get(name) ?? new Set()
+      registered.add(listener)
+      listeners.set(name, registered)
+    }
+    const sender = {
+      id: 42,
+      on,
+      once: on,
+      removeListener: (name: string, listener: (...args: unknown[]) => void): void => {
+        listeners.get(name)?.delete(listener)
+      }
+    }
+    const emit = (name: string, ...args: unknown[]): void => {
+      for (const listener of [...(listeners.get(name) ?? [])]) listener(...args)
+    }
+    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
+
+    const first = nativeHandlers.get('projects:list')?.({ sender }) as ApplicationCallerLease
+    const staleNavigationListener = [...(listeners.get('did-start-navigation') ?? [])][0]
+    emit('did-start-navigation', { isMainFrame: false, isSameDocument: false })
+    expect(nativeHandlers.get('projects:list')?.({ sender })).toBe(first)
+    emit('did-start-navigation', { isMainFrame: true, isSameDocument: true })
+    expect(nativeHandlers.get('projects:list')?.({ sender })).toBe(first)
+
+    emit('did-start-navigation', { isMainFrame: true, isSameDocument: false })
+    expect(first.signal.aborted).toBe(true)
+
+    const replacement = nativeHandlers.get('projects:list')?.({ sender }) as ApplicationCallerLease
+    expect(replacement.generation).toBeGreaterThan(first.generation)
+    expect(replacement.signal.aborted).toBe(false)
+
+    staleNavigationListener?.({ isMainFrame: true, isSameDocument: false })
+    expect(replacement.signal.aborted).toBe(false)
+  })
+
   it('renews a crashed WebContents lease but keeps destroyed terminal', () => {
     const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
     const registry = createIpcHandlerRegistry({

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -91,13 +91,33 @@ const createIpcHandlerRegistry = (
     const ownedLease = epoch.registry.acquire(callerContextForEvent(event))
     epoch.nativeCallers.set(sender, ownedLease)
     const lifecycleSender = event.sender as typeof event.sender & {
+      on?: (name: string, listener: (...args: never[]) => void) => unknown
       once?: (name: string, listener: () => void) => unknown
+      removeListener?: (name: string, listener: (...args: never[]) => void) => unknown
     }
+    const releaseCurrentLease = (): void => {
+      if (epoch.nativeCallers.get(sender) !== ownedLease) return
+      epoch.nativeCallers.delete(sender)
+      ownedLease.release()
+    }
+    const releaseOnMainFrameNavigation = (details: {
+      isMainFrame: boolean
+      isSameDocument: boolean
+    }): void => {
+      if (!details.isMainFrame || details.isSameDocument) return
+      releaseCurrentLease()
+    }
+    const removeNavigationBinding = (): void => {
+      lifecycleSender.removeListener?.('did-start-navigation', releaseOnMainFrameNavigation)
+    }
+    lifecycleSender.on?.('did-start-navigation', releaseOnMainFrameNavigation)
+    ownedLease.lease.signal.addEventListener('abort', removeNavigationBinding, { once: true })
     lifecycleSender.once?.('destroyed', () => {
       destroyedNativeCallers.add(sender)
-      ownedLease.release()
+      releaseCurrentLease()
     })
-    lifecycleSender.once?.('render-process-gone', ownedLease.release)
+    lifecycleSender.once?.('render-process-gone', releaseCurrentLease)
+    if (ownedLease.lease.signal.aborted) removeNavigationBinding()
     return ownedLease
   }
 

--- a/src/main/navigation-policy.ts
+++ b/src/main/navigation-policy.ts
@@ -118,8 +118,8 @@ const createFrameNavigationGuard = (
 // gates on the protocol allowlist alone, deliberately NOT on the initiating referrer: app links use
 // rel="noreferrer" and the packaged app runs on a file:// origin (which Chromium strips from
 // cross-origin referrers), so the referrer is reliably empty for legitimate main-frame links.
-// Source-preview popups reach this handler, but are denied in-app and only allowlisted protocols are
-// handed to the OS. In-frame navigations remain confined by the source-preview frame registry.
+// Untrusted Source Preview frames lack the sandbox capability to request popups. In-frame
+// navigations remain confined by the source-preview frame registry.
 const isAllowedExternalNavigation = (url: string): boolean => isAllowedExternalUrl(url)
 
 export { createFrameNavigationGuard, isAllowedExternalNavigation, isAllowedExternalUrl }

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -433,12 +433,24 @@ describe('default upload repository', () => {
     const sender = createIpcEvent()
 
     await begin(sender.event, { transferId: 'transfer-4', name: 'data.csv', size: 10 })
-    sender.emit('did-start-navigation', {}, 'http://localhost/', false, false)
+    sender.emit(
+      'did-start-navigation',
+      { isMainFrame: false, isSameDocument: false },
+      'http://localhost/',
+      false,
+      false
+    )
     expect(repository.abortTransfer).not.toHaveBeenCalled()
 
     beginMigration()
     const drainPromise = waitForDataRootWriters()
-    sender.emit('did-start-navigation', {}, 'http://localhost/', false, true)
+    sender.emit(
+      'did-start-navigation',
+      { isMainFrame: true, isSameDocument: false },
+      'http://localhost/',
+      false,
+      true
+    )
     await drainPromise
     expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-4' })
   })
@@ -517,10 +529,22 @@ describe('default upload repository', () => {
       })
     )
     await Promise.resolve()
-    sender.emit('did-start-navigation', {}, 'http://localhost/', false, false)
+    sender.emit(
+      'did-start-navigation',
+      { isMainFrame: false, isSameDocument: false },
+      'http://localhost/',
+      false,
+      false
+    )
     expect(repository.abortTransfer).not.toHaveBeenCalled()
 
-    sender.emit('did-start-navigation', {}, 'http://localhost/', false, true)
+    sender.emit(
+      'did-start-navigation',
+      { isMainFrame: true, isSameDocument: false },
+      'http://localhost/',
+      false,
+      true
+    )
     finishStage?.(attachment)
 
     await expect(stagePromise).rejects.toThrow(/renderer is no longer available/i)

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -1,6 +1,6 @@
-import { type Event as ElectronEvent, type IpcMainInvokeEvent } from 'electron'
+import { type IpcMainInvokeEvent } from 'electron'
 
-import type { ApplicationCallerLease, ApplicationInvocation } from '../application-command-router'
+import type { ApplicationInvocation } from '../application-command-router'
 import { callerContextForEvent } from '../caller-context'
 import { callerLeaseForEvent } from '../caller-lifecycle'
 import { ipcMainHandle } from '../ipc-handler-registry'
@@ -35,35 +35,6 @@ const registerUploadIpcHandlers = (
     onStandaloneUploadSaved?: (projectId: string, sessionId: string) => void
   } = {}
 ): void => {
-  const navigationBindings = new WeakMap<ApplicationCallerLease, () => void>()
-  const bindElectronNavigationCleanup = (event: IpcMainInvokeEvent): void => {
-    const lease = callerLeaseForEvent(event)
-    if (callerContextForEvent(event).surface !== 'electron' || navigationBindings.has(lease)) return
-
-    const releaseBinding = (): void => {
-      if (navigationBindings.get(lease) !== releaseBinding) return
-      navigationBindings.delete(lease)
-      lease.signal.removeEventListener('abort', releaseBinding)
-      event.sender.removeListener('did-start-navigation', releaseOnMainFrameNavigation)
-    }
-    const releaseOnMainFrameNavigation = (
-      _navigationEvent: ElectronEvent,
-      _url: string,
-      _isInPlace: boolean,
-      isMainFrame: boolean
-    ): void => {
-      if (!isMainFrame) return
-      releaseBinding()
-      owner.releaseCaller(lease)
-    }
-    navigationBindings.set(lease, releaseBinding)
-    lease.signal.addEventListener('abort', releaseBinding, { once: true })
-    event.sender.on('did-start-navigation', releaseOnMainFrameNavigation)
-    if (lease.signal.aborted || !lease.isCurrent()) {
-      releaseBinding()
-      throw new Error('Upload renderer is no longer available.')
-    }
-  }
   const invocationFor = <const Args extends readonly unknown[]>(
     event: IpcMainInvokeEvent,
     args: Args
@@ -72,24 +43,17 @@ const registerUploadIpcHandlers = (
     callerLease: callerLeaseForEvent(event),
     args
   })
-  const ownedInvocationFor = <const Args extends readonly unknown[]>(
-    event: IpcMainInvokeEvent,
-    args: Args
-  ): ApplicationInvocation<Args> => {
-    bindElectronNavigationCleanup(event)
-    return invocationFor(event, args)
-  }
 
   ipcMainHandle('uploads:stage-local-file', (event, request: StageLocalUploadRequest) =>
-    owner.stageLocalFile(ownedInvocationFor(event, [request]), {
+    owner.stageLocalFile(invocationFor(event, [request]), {
       report: (progress) => event.sender.send('uploads:transfer-progress', progress)
     })
   )
   ipcMainHandle('uploads:claim-local-file', (event, request: UploadTransferRequest) =>
-    owner.claimLocalFile(ownedInvocationFor(event, [request]))
+    owner.claimLocalFile(invocationFor(event, [request]))
   )
   ipcMainHandle('uploads:stage-local-path', async (event, request: StageLocalPathUploadRequest) => {
-    const attachment = await owner.stageLocalPath(ownedInvocationFor(event, [request]), {
+    const attachment = await owner.stageLocalPath(invocationFor(event, [request]), {
       report: (progress) => event.sender.send('uploads:transfer-progress', progress)
     })
     const projectId = request.projectId ?? DEFAULT_UPLOAD_PROJECT_ID
@@ -97,19 +61,19 @@ const registerUploadIpcHandlers = (
     return attachment
   })
   ipcMainHandle('uploads:begin-transfer', (event, request: BeginUploadTransferRequest) =>
-    owner.beginTransfer(ownedInvocationFor(event, [request]))
+    owner.beginTransfer(invocationFor(event, [request]))
   )
   ipcMainHandle('uploads:append-transfer', (event, request: AppendUploadTransferRequest) =>
-    owner.appendTransfer(ownedInvocationFor(event, [request]))
+    owner.appendTransfer(invocationFor(event, [request]))
   )
   ipcMainHandle('uploads:transfer-status', (event, request: UploadTransferRequest) =>
-    owner.transferStatus(ownedInvocationFor(event, [request]))
+    owner.transferStatus(invocationFor(event, [request]))
   )
   ipcMainHandle('uploads:finish-transfer', (event, request: UploadTransferRequest) =>
-    owner.finishTransfer(ownedInvocationFor(event, [request]))
+    owner.finishTransfer(invocationFor(event, [request]))
   )
   ipcMainHandle('uploads:abort-transfer', (event, request: UploadTransferRequest) =>
-    owner.abortTransfer(ownedInvocationFor(event, [request]))
+    owner.abortTransfer(invocationFor(event, [request]))
   )
   ipcMainHandle('uploads:delete', (event, request: DeleteUploadRequest) =>
     owner.deleteUpload(invocationFor(event, [request]))

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -329,9 +329,6 @@ describe('PreviewPanel', () => {
     expect(sourceHeaderClose?.className).toContain('hover:text-text-000')
     expect(sourceHeaderExternal?.nextElementSibling).toBe(sourceHeaderClose)
     expect(iframe?.getAttribute('src')).toBe('https://example.com/paper')
-    expect(iframe?.getAttribute('sandbox')).toBe(
-      'allow-same-origin allow-scripts allow-forms allow-popups'
-    )
     expect(iframe?.getAttribute('referrerpolicy')).toBe('no-referrer')
     expect(iframe?.getAttribute('title')).toBe('Source preview: Genome study')
     expect(container.querySelector('[aria-label="Open source in browser"]')).not.toBeNull()
@@ -356,6 +353,19 @@ describe('PreviewPanel', () => {
 
     expect(container.querySelector('[data-source-preview-frame]')).toBe(iframe)
     expect(iframe?.closest<HTMLElement>('[role="tabpanel"]')?.hidden).toBe(false)
+  })
+
+  it('does not grant remote source previews permission to open popup windows', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createSourceItem())
+
+    await renderPanel()
+
+    const iframe = container.querySelector<HTMLIFrameElement>('[data-source-preview-frame]')
+    expect(iframe?.getAttribute('sandbox')?.split(/\s+/u)).toEqual([
+      'allow-same-origin',
+      'allow-scripts',
+      'allow-forms'
+    ])
   })
 
   it('closes a source preview from the header action', async () => {

--- a/src/renderer/src/pages/workspace/previews/SourceWebPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/SourceWebPreview.tsx
@@ -279,7 +279,7 @@ const SourceWebPreviewContent = ({
             name={SOURCE_PREVIEW_FRAME_NAME}
             title={t('Source preview: {{title}}', { title: item.title })}
             src={sourceUrl.href}
-            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+            sandbox="allow-same-origin allow-scripts allow-forms"
             referrerPolicy="no-referrer"
             aria-hidden={loadState.phase === 'failed' || undefined}
             className={cn(


### PR DESCRIPTION
## Problem

A non-same-document main-frame navigation reused the same Electron `WebContents` caller lease, allowing commands and lease-owned resources from the previous renderer document to remain current. Uploads carried a local navigation workaround, but other consumers such as Managed Preview did not.

Remote HTTPS Source Preview frames also received the `allow-popups` sandbox capability. Their popup requests reached the window-global external-open handler, which can only protocol-allowlist URLs and cannot reliably distinguish trusted main-renderer actions from remote frame script.

Both behaviors were reproduced before the fix with focused regression tests. The caller lease remained un-aborted after navigation, and the rendered Source Preview sandbox still contained `allow-popups`; each failure reproduced twice.

## Proposed change

- Bind Electron caller leases to non-same-document main-frame navigation in the shared IPC handler registry.
- Abort and evict the old lease so the next document receives a fresh generation.
- Preserve leases across subframe and same-document navigation, and prevent stale lifecycle callbacks from revoking a replacement generation.
- Remove the Upload IPC adapter's duplicate navigation binding; Upload ownership continues to clean up through the lease `AbortSignal`.
- Remove `allow-popups` from the remote Source Preview iframe while preserving the trusted renderer's explicit **Open source in browser** controls.

## Scope and non-goals

- No new IPC API, dependency, data field, schema, persistence format, enum value, migration, or historical-compatibility path.
- No referrer/origin heuristics in `setWindowOpenHandler`.
- No behavior change for same-document navigation or subframe navigation.
- Source-page-internal popups are intentionally blocked; host-provided external-open buttons remain available.

## Acceptance criteria and validation

All passing checks below ran after the last material edit:

- New renderer document revokes the old lease and receives a fresh generation -> `vitest run src/main/ipc-handler-registry.test.ts` -> passed.
- Lease abort releases Managed Preview owners -> `vitest run src/main/managed-preview-ipc.test.ts` -> passed.
- Upload navigation cleanup remains intact after removing its local binding -> `vitest run src/main/uploads/ipc.test.ts` -> passed.
- Trusted external-open policy remains available -> `vitest run src/main/windows.test.ts` -> passed.
- Remote Source Preview sandbox omits popup permission -> `vitest run src/renderer/src/pages/workspace/PreviewPanel.test.tsx` -> passed.
- Combined exact regression set -> 5 files, 161 tests passed.
- Additional caller/upload consumer set -> 7 files, 142 tests passed.
- Complete PreviewPanel suite -> 39 tests passed.
- `tsc --noEmit -p tsconfig.node.json --composite false` -> passed.
- `tsc --noEmit -p tsconfig.web.json --composite false` -> passed.
- `eslint --cache .` -> passed.

The `upload_repository` module plan ran 133 tests: 131 passed. Two unrelated symlink-fixture tests could not start on this Windows host because `symlink()` returned `EPERM`, even outside the Codex sandbox:

- `src/main/acp/file-reference-resolver.test.ts` — linked-folder escape fixture.
- `src/main/uploads/repository.test.ts` — legacy missing-authority fixture.

The complete portable `npm test` suite was intentionally not run; PR CI is authoritative for the full selected plan and platform coverage.

## Review focus

- Navigation listener cleanup on abort/dispose and identity guards against stale callbacks.
- Correct distinction between main-frame document replacement, same-document navigation, and subframes.
- Preservation of trusted renderer external-open controls after denying remote iframe popups.