### PR TITLE
fix(connectors): enforce Specialist tool permissions

### DIFF
--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -2006,6 +2006,96 @@ describe('ConnectorService specialist capability gate', () => {
     expect(localHandler).toHaveBeenCalledTimes(3)
   })
 
+  it.each([
+    {
+      name: 'method outside include list',
+      connectorTools: [{ connectorId: 'molecule', includedMethods: ['render_molecule'] }],
+      method: 'preview_molecule',
+      allowed: false
+    },
+    {
+      name: 'method in include and exclude lists',
+      connectorTools: [
+        {
+          connectorId: 'molecule',
+          includedMethods: ['preview_molecule'],
+          excludedMethods: ['preview_molecule']
+        }
+      ],
+      method: 'preview_molecule',
+      allowed: false
+    },
+    {
+      name: 'method matching anchored include glob',
+      connectorTools: [{ connectorId: 'molecule', includeToolsPattern: 'preview_*' }],
+      method: 'preview_molecule',
+      allowed: true
+    },
+    {
+      name: 'method outside anchored include glob',
+      connectorTools: [{ connectorId: 'molecule', includeToolsPattern: 'preview_*' }],
+      method: 'render_molecule',
+      allowed: false
+    },
+    {
+      name: 'method matching include and exclude globs',
+      connectorTools: [
+        {
+          connectorId: 'molecule',
+          includeToolsPattern: '*',
+          excludeToolsPattern: 'preview_*'
+        }
+      ],
+      method: 'preview_molecule',
+      allowed: false
+    },
+    {
+      name: 'overlong persisted glob',
+      connectorTools: [{ connectorId: 'molecule', excludeToolsPattern: 'x'.repeat(129) }],
+      method: 'preview_molecule',
+      allowed: false
+    },
+    {
+      name: 'too many persisted rules',
+      connectorTools: Array.from({ length: 129 }, () => ({ connectorId: 'molecule' })),
+      method: 'preview_molecule',
+      allowed: false
+    }
+  ])(
+    'enforces Specialist Connector tool rules: $name',
+    async ({ connectorTools, method, allowed }) => {
+      const localHandler = vi.fn().mockResolvedValue({ ok: true })
+      const current = specialist({
+        capabilityMode: 'selected',
+        selectedCapabilities: {
+          skillIds: [],
+          connectorIds: ['molecule'],
+          connectorTools
+        }
+      })
+      const svc = new ConnectorService({
+        engine: { call: vi.fn() } as unknown as ParserEngine,
+        getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+        resolveApiKey: () => undefined,
+        resolveSpecialistProfile: async () => current,
+        localToolHandlers: {
+          'molecule/preview_molecule': localHandler,
+          'molecule/render_molecule': localHandler
+        }
+      })
+      const call = svc.call(
+        'molecule',
+        method,
+        { smiles: 'CCO' },
+        { origin: 'agent', sessionId: `tool-rule-${method}`, specialistId: current.id }
+      )
+
+      if (allowed) await expect(call).resolves.toEqual({ ok: true })
+      else await expect(call).rejects.toThrow('specialist_capability_denied')
+      expect(localHandler).toHaveBeenCalledTimes(allowed ? 1 : 0)
+    }
+  )
+
   it('accepts a custom Connector local UUID or legacy public name as a capability reference', async () => {
     const call = vi.fn().mockResolvedValue({ ok: true })
     const listTools = vi.fn().mockResolvedValue([{ name: 'do_thing' }])
@@ -2066,6 +2156,74 @@ describe('ConnectorService specialist capability gate', () => {
       'specialist_capability_denied'
     )
     expect(call).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not dispatch a custom Connector method restricted during tool discovery', async () => {
+    const call = vi.fn().mockResolvedValue({ ok: true })
+    let settleTools: ((tools: Array<{ name: string }>) => void) | undefined
+    const listTools = vi.fn(
+      () =>
+        new Promise<Array<{ name: string }>>((resolve) => {
+          settleTools = resolve
+        })
+    )
+    let current = specialist({
+      capabilityMode: 'selected',
+      selectedCapabilities: {
+        skillIds: [],
+        connectorIds: ['custom-server-id'],
+        connectorTools: [
+          {
+            connectorId: 'custom-server-id',
+            includedMethods: ['lookup']
+          }
+        ]
+      }
+    })
+    const svc = new ConnectorService({
+      mcpClientManager: { call, listTools },
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: [],
+        customMcpServers: [
+          {
+            id: 'custom-server-id',
+            name: 'custom-server',
+            displayName: 'Custom server',
+            transport: 'stdio',
+            command: 'custom-server',
+            enabled: true
+          }
+        ]
+      }),
+      resolveApiKey: () => undefined,
+      resolveSpecialistProfile: async () => current
+    })
+    const pending = svc.call(
+      'custom-server',
+      'lookup',
+      {},
+      { origin: 'agent', sessionId: 'custom-restriction', specialistId: current.id }
+    )
+
+    await vi.waitFor(() => expect(listTools).toHaveBeenCalledOnce())
+    current = specialist({
+      capabilityMode: 'selected',
+      selectedCapabilities: {
+        skillIds: [],
+        connectorIds: ['custom-server-id'],
+        connectorTools: [
+          {
+            connectorId: 'custom-server-id',
+            includedMethods: ['read_only']
+          }
+        ]
+      }
+    })
+    settleTools?.([{ name: 'lookup' }])
+
+    await expect(pending).rejects.toThrow('specialist_capability_denied')
+    expect(call).not.toHaveBeenCalled()
   })
 
   it('fails closed for missing agent session/profile/connector without exposing call data', async () => {

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -16,7 +16,11 @@ import { ConnectorPermissionBroker } from '../permission-grants/connector-broker
 import type { ConnectorPermissionRequest } from '../permission-grants/connector-broker'
 import type { PermissionGrantScope } from '../../shared/permission-grants'
 import type { ApprovalDecision, ConnectorApprovalScope } from '../../shared/settings'
-import type { SpecialistView } from '../../shared/specialist'
+import {
+  CONNECTOR_TOOL_PATTERN_MAX_LENGTH,
+  CONNECTOR_TOOL_RULE_MAX_COUNT,
+  type SpecialistView
+} from '../../shared/specialist'
 
 type McpClientManagerLike = {
   listTools(config: CustomMcpServerConfig, signal?: AbortSignal): Promise<Array<{ name: string }>>
@@ -119,6 +123,33 @@ const customMcpFailureCategory = (
 
 const CUSTOM_MCP_RETRY_BASE_MS = 1_000
 const CUSTOM_MCP_RETRY_MAX_MS = 30_000
+
+const matchesToolGlob = (method: string, pattern: string): boolean => {
+  let methodIndex = 0
+  let patternIndex = 0
+  let starIndex = -1
+  let starMethodIndex = 0
+
+  while (methodIndex < method.length) {
+    if (pattern[patternIndex] === '?' || pattern[patternIndex] === method[methodIndex]) {
+      methodIndex += 1
+      patternIndex += 1
+    } else if (pattern[patternIndex] === '*') {
+      starIndex = patternIndex
+      starMethodIndex = methodIndex
+      patternIndex += 1
+    } else if (starIndex >= 0) {
+      patternIndex = starIndex + 1
+      starMethodIndex += 1
+      methodIndex = starMethodIndex
+    } else {
+      return false
+    }
+  }
+
+  while (pattern[patternIndex] === '*') patternIndex += 1
+  return patternIndex === pattern.length
+}
 
 type CustomMcpFailureState = {
   category: 'connector_unavailable' | 'connector_unauthenticated'
@@ -286,7 +317,7 @@ export class ConnectorService {
     const descriptor = getDescriptor(connector, method)
     const isBundled = descriptor !== undefined || ALL_CONNECTOR_IDS.includes(connector)
     if (isBundled) {
-      const access = await this.resolveAccess(connector, context, [connector], signal)
+      const access = await this.resolveAccess(connector, method, context, [connector], signal)
       return this.callBundled(connector, method, args, descriptor, context, access, signal)
     }
 
@@ -295,6 +326,7 @@ export class ConnectorService {
     const custom = customServers.find((server) => server.name === connector)
     const access = await this.resolveAccess(
       connector,
+      method,
       context,
       custom ? [custom.id, custom.name] : [connector],
       signal
@@ -310,6 +342,7 @@ export class ConnectorService {
 
   private async resolveAccess(
     connector: string,
+    method: string,
     context: ConnectorCallContext,
     aliases: readonly string[] = [connector],
     signal?: AbortSignal
@@ -330,11 +363,41 @@ export class ConnectorService {
     signal?.throwIfAborted()
     if (!profile || !profile.enabled) throw new ConnectorGateError('specialist_unavailable')
 
-    const allowed =
+    const capabilities =
+      profile.capabilityMode === 'full' ? profile.fullAccess : profile.selectedCapabilities
+    if (capabilities.connectorTools.length > CONNECTOR_TOOL_RULE_MAX_COUNT) {
+      throw new ConnectorGateError('specialist_capability_denied')
+    }
+    const connectorAllowed =
       profile.capabilityMode === 'full'
         ? !aliases.some((alias) => profile.fullAccess.excludedConnectorIds.includes(alias))
         : aliases.some((alias) => profile.selectedCapabilities.connectorIds.includes(alias))
-    if (!allowed) throw new ConnectorGateError('specialist_capability_denied')
+    const toolRules = capabilities.connectorTools.filter((rule) =>
+      aliases.includes(rule.connectorId)
+    )
+    const includedMethods = toolRules.flatMap((rule) => rule.includedMethods ?? [])
+    const excludedMethods = toolRules.flatMap((rule) => rule.excludedMethods ?? [])
+    const includePatterns = toolRules.flatMap((rule) =>
+      rule.includeToolsPattern === undefined ? [] : [rule.includeToolsPattern]
+    )
+    const excludePatterns = toolRules.flatMap((rule) =>
+      rule.excludeToolsPattern === undefined ? [] : [rule.excludeToolsPattern]
+    )
+    const invalidPattern = [...includePatterns, ...excludePatterns].some(
+      (pattern) => pattern.length === 0 || pattern.length > CONNECTOR_TOOL_PATTERN_MAX_LENGTH
+    )
+    const included =
+      includedMethods.includes(method) ||
+      includePatterns.some((pattern) => matchesToolGlob(method, pattern))
+    if (
+      !connectorAllowed ||
+      invalidPattern ||
+      ((includedMethods.length > 0 || includePatterns.length > 0) && !included) ||
+      excludedMethods.includes(method) ||
+      excludePatterns.some((pattern) => matchesToolGlob(method, pattern))
+    ) {
+      throw new ConnectorGateError('specialist_capability_denied')
+    }
 
     // A Specialist's configuration is independent from Main's enabled and Allow/Ask/Block settings.
     // Physical availability is still checked by the actual bundled/custom dispatch path below.
@@ -396,7 +459,7 @@ export class ConnectorService {
     // or Main enablement and policy, so a concurrent access revocation wins while retaining a Once
     // approval already granted to this exact Main call.
     if (credentialResult.prompted && access.specialistScoped) {
-      await this.resolveAccess(connector, context, [connector], signal)
+      await this.resolveAccess(connector, method, context, [connector], signal)
       credentials = this.credentials(await this.currentConnectors())
       signal?.throwIfAborted()
       if (
@@ -713,6 +776,9 @@ export class ConnectorService {
       }
       if (!this.isCustomConfigRunnable(current, customServers)) {
         throw new ConnectorGateError('connector_unavailable')
+      }
+      if (access.specialistScoped) {
+        await this.resolveAccess(current.name, method, context, [current.id, current.name], signal)
       }
 
       const request = this.authorizationRequest(

--- a/src/main/specialist/service.test.ts
+++ b/src/main/specialist/service.test.ts
@@ -244,6 +244,27 @@ describe('SpecialistService.create', () => {
     expect(await service.list()).toEqual([])
   })
 
+  it('rejects an overlong Connector tool glob before persisting the profile', async () => {
+    await expect(
+      service.create({
+        name: 'My Bot',
+        capabilityMode: 'full',
+        fullAccess: {
+          excludedSkillIds: [],
+          excludedConnectorIds: [],
+          connectorTools: [
+            {
+              connectorId: 'molecule',
+              excludeToolsPattern: 'x'.repeat(129)
+            }
+          ]
+        }
+      })
+    ).rejects.toThrow(/capability configuration is invalid/i)
+
+    expect(await service.list()).toEqual([])
+  })
+
   it('rejects non-string optional identity fields before persisting the profile', async () => {
     await expect(service.create({ name: 'My Bot', description: 42 } as never)).rejects.toThrow(
       /description must be a string/i

--- a/src/main/specialist/service.ts
+++ b/src/main/specialist/service.ts
@@ -20,6 +20,8 @@ import type {
   SpecialistSelectedConfig
 } from '../../shared/specialist'
 import {
+  CONNECTOR_TOOL_PATTERN_MAX_LENGTH,
+  CONNECTOR_TOOL_RULE_MAX_COUNT,
   inferSpecialistId,
   validateCreateSpecialistInput,
   validateUpdateSpecialistInput,
@@ -33,6 +35,7 @@ const isStringArray = (value: unknown): value is string[] =>
 
 const isConnectorToolRuleArray = (value: unknown): boolean =>
   Array.isArray(value) &&
+  value.length <= CONNECTOR_TOOL_RULE_MAX_COUNT &&
   value.every(
     (rule) =>
       rule &&
@@ -47,7 +50,13 @@ const isConnectorToolRuleArray = (value: unknown): boolean =>
       [
         (rule as { includeToolsPattern?: unknown }).includeToolsPattern,
         (rule as { excludeToolsPattern?: unknown }).excludeToolsPattern
-      ].every((pattern) => pattern === undefined || typeof pattern === 'string')
+      ].every(
+        (pattern) =>
+          pattern === undefined ||
+          (typeof pattern === 'string' &&
+            pattern.length > 0 &&
+            pattern.length <= CONNECTOR_TOOL_PATTERN_MAX_LENGTH)
+      )
   )
 
 const assertCapabilityConfigShape = (

--- a/src/shared/specialist.ts
+++ b/src/shared/specialist.ts
@@ -108,7 +108,11 @@ export type ResolveSessionSpecialistRequest = {
 // The capability scope mode for a specialist.
 export type SpecialistCapabilityMode = 'full' | 'selected'
 
-// Per-connector tool-level rules. Uses bare method names (no connector prefix).
+export const CONNECTOR_TOOL_RULE_MAX_COUNT = 128
+export const CONNECTOR_TOOL_PATTERN_MAX_LENGTH = 128
+
+// Per-connector tool-level rules. Uses bare method names (no connector prefix). Patterns are
+// anchored globs where `*` matches any characters and `?` matches one character.
 export type ConnectorToolRule = {
   connectorId: string
   includedMethods?: string[]


### PR DESCRIPTION
## Problem

Specialist capability profiles persist Connector tool rules, but `ConnectorService` only enforced the Connector-level grant. A Specialist restricted to `read`-style methods could therefore dispatch any method exposed by that Connector.

The bypass of Main Agent Connector enablement and Allow/Ask/Block policy remains intentional: Specialist capability configuration is an independent scope. This change only closes the missing tool-level check inside that scope.

## Proposed change

- Enforce exact `includedMethods` / `excludedMethods` rules at the shared `ConnectorService.call()` authorization boundary.
- Interpret include/exclude patterns as anchored globs (`*` and `?`), with exclusions taking precedence over inclusions.
- Bound persisted rule count and pattern length; invalid historical rule sets fail closed at runtime.
- Recheck Specialist tool access immediately before custom MCP dispatch so a restriction applied during tool discovery wins.
- Reject newly created or updated Specialist profiles with unsafe rule counts or pattern lengths before persistence.

## Scope and non-goals

- No new data fields, schema migrations, database changes, UI changes, or enum values.
- The existing `connectorTools` JSON shape is unchanged.
- Existing profiles with empty tool rules retain Connector-wide behavior.
- Existing non-empty rules now become effective. Historical over-limit or empty patterns remain on disk but calls fail closed until the profile is corrected; no data is silently rewritten or deleted.
- Official Specialist package import/export is unchanged. Package import already rejects capability fields and export does not emit `connectorTools`.

## Acceptance criteria and validation

- Reproduced before the fix through the public `ConnectorService.call()` boundary: a method outside `includedMethods` was dispatched and the regression test failed with a resolved result instead of `specialist_capability_denied`.
- The same regression passes after the fix.
- Exact inclusion/exclusion, anchored include/exclude globs, exclusion precedence, custom Connector aliases/recheck, and fail-closed historical limits are covered.

Validation after the final edit:

- `vitest run` on 6 focused Connector, Specialist, repository, and Notebook RPC files: 219 passed, 5 skipped.
- `tsc --noEmit -p tsconfig.node.json --composite false`
- `eslint --cache .`
- Prettier check on all 5 changed files.

The module-impact classifier conservatively selects the full suite because `src/main/connectors/service.test.ts` has no registered module owner. Per project guidance, the complete suite is left to PR CI; no local full `npm test` was run.

## Review focus

- Include union and exclude-wins precedence in `resolveAccess()`.
- Anchored glob semantics and the 128-rule / 128-character safety limits.
- Compatibility choice for historical invalid persisted rules: retain data, fail calls closed.
