### PR TITLE
feat(tags): align Settings panel interactions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -826,14 +826,19 @@ colors communicate a successful or failed probe/migration result.
 
 - Settings -> Capabilities -> Tags is the shared organization surface for catalog resources. V1
   adapters cover Skills, Connectors, and runnable Specialists; the Reviewer placeholder is excluded.
-  The left column manages Tags and the right column aggregates assigned resources with resource-type
-  and text filters. Selecting a result navigates through the existing Settings history to that
-  resource's detail or editor.
+  The bordered master-detail frame owns the available content height: its independently scrolling
+  left column uses the shared muted panel background, while the right detail column uses the shared
+  card background. The left column manages Tags and the right column aggregates assigned resources
+  with resource-type and text filters. Selecting a result navigates through the existing Settings
+  history to that resource's detail or editor.
 - The Tag list is a single-action selector: every row keeps its resource count in one right-aligned
   trailing column. Persistent edit and delete icon actions belong to the selected custom Tag's detail
   header instead of individual list rows; the protected Favorites Tag exposes neither action. A
   leading handle reorders custom Tags by pointer or keyboard. Favorites instead shows a fixed lock
-  affordance and always remains first.
+  affordance and always remains first. **New Tag** is the final left-column action. Create and edit
+  open as breadcrumb-backed Settings second-level pages with the same stacked form rhythm and
+  bottom-aligned Cancel / Create or Save actions used by other Settings editors; Back and Forward
+  restore the corresponding list or form history entry.
 - A Tag may belong to any number of resources and a resource may have any number of Tags. The same
   Tag filter is available in the three catalog panels and in the Specialist capability picker, but
   Specialist persistence continues to store concrete Skill and Connector IDs rather than a dynamic

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -634,6 +634,40 @@ describe('SettingsPage layout', () => {
     )
   })
 
+  it('opens Tag creation as a breadcrumb-backed Settings sub-view', async () => {
+    vi.mocked(window.api.tags.snapshot).mockResolvedValue({
+      revision: 1,
+      tags: [{ id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 }],
+      assignments: []
+    })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () => navButton('Tags')?.click())
+    await waitFor(() =>
+      expect(document.body.querySelector('[data-slot="tags-panel"]')).not.toBeNull()
+    )
+
+    const panel = document.body.querySelector<HTMLElement>('[data-slot="tags-panel"]')
+    expect(panel?.parentElement?.className.split(/\s+/)).toContain('h-full')
+
+    const newTag = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'New Tag'
+    )
+    await act(async () => newTag?.click())
+
+    expect(document.body.querySelector('[data-slot="tag-form"]')).not.toBeNull()
+    expect(
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back to tags"]')
+    ).not.toBeNull()
+    expect(document.body.textContent).toContain('New Tag')
+
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    )
+    expect(document.body.querySelector('[data-slot="tags-panel"]')).not.toBeNull()
+    expect(document.body.querySelector('[data-slot="tag-form"]')).toBeNull()
+  })
+
   it('restores the Tag selected by a Settings history entry', async () => {
     vi.mocked(window.api.tags.snapshot).mockResolvedValue({
       revision: 2,

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -76,6 +76,7 @@ import { ConnectorsNavIcon } from './connector-icons'
 import type { ComputeView } from './ComputePanel'
 import type { ArchivedView } from './ArchivedPanel'
 import type { MemoryView } from './MemoryPanel'
+import type { TagsView } from './TagsPanel'
 import type { CredentialsView } from './CredentialsPanel'
 import { resolveVendorModelsUrl } from '../../../../shared/provider-registry'
 import { ProviderForm } from './ProviderForm'
@@ -281,6 +282,7 @@ const PANEL_NAME_LOWER = {
   Compute: 'compute',
   Specialists: 'specialists',
   Memory: 'memory',
+  Tags: 'tags',
   Credentials: 'credentials',
   Archived: 'archived'
 } as const
@@ -556,9 +558,15 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     currentRoute.panel === 'archived' ? currentRoute.view : { kind: 'list' }
   const memoryView: MemoryView =
     currentRoute.panel === 'memory' ? currentRoute.view : { kind: 'list' }
+  const tagsView: TagsView = currentRoute.panel === 'tags' ? currentRoute.view : { kind: 'list' }
   const credentialsView: CredentialsView =
     currentRoute.panel === 'credentials' ? currentRoute.view : { kind: 'list' }
-  const activeTagId = currentRoute.panel === 'tags' ? currentRoute.tagId : undefined
+  const activeTagId =
+    tagsView.kind === 'list'
+      ? tagsView.tagId
+      : tagsView.kind === 'edit'
+        ? tagsView.tagId
+        : undefined
   const canGoBack = historyIndex > 0
   const canGoForward = historyIndex < history.length - 1
 
@@ -578,7 +586,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   // entry point, so Back returns to the recovery panel the user just completed.
   const navigatePanel = (panel: SettingsPanelId): void => {
     if (panel === 'tags') {
-      navigate({ panel, tagId: browserSelectedTagId })
+      navigate({ panel, view: { kind: 'list', tagId: browserSelectedTagId } })
       return
     }
     navigate(settingsPanelRoute(panel))
@@ -586,16 +594,20 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
 
   const navigateTag = (tagId: string): void => {
     setSelectedTagId(tagId)
-    navigate({ panel: 'tags', tagId })
+    navigate({ panel: 'tags', view: { kind: 'list', tagId } })
   }
 
   const recordSelectedTag = useCallback(
     (tagId: string): void => {
       setHistory((entries) => {
         const entry = entries[historyIndex]
-        if (entry?.panel !== 'tags' || entry.tagId === tagId) return entries
+        if (entry?.panel !== 'tags' || entry.view.kind !== 'list' || entry.view.tagId === tagId) {
+          return entries
+        }
         return entries.map((candidate, index) =>
-          index === historyIndex ? { ...candidate, tagId } : candidate
+          index === historyIndex && candidate.panel === 'tags' && candidate.view.kind === 'list'
+            ? { ...candidate, view: { ...candidate.view, tagId } }
+            : candidate
         )
       })
     },
@@ -626,6 +638,8 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     navigate({ panel: 'archived', view: archived })
 
   const navigateMemory = (memory: MemoryView): void => navigate({ panel: 'memory', view: memory })
+
+  const navigateTags = (tags: TagsView): void => navigate({ panel: 'tags', view: tags })
 
   const navigateCredentials = (credentials: CredentialsView): void =>
     navigate({ panel: 'credentials', view: credentials })
@@ -762,6 +776,19 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
         rootLabelKey: 'Memory',
         rootTo: { panel: 'memory', view: { kind: 'list' } },
         leaf: memoryView.kind === 'create' ? t('New category') : t('Edit category')
+      }
+    }
+    if (activePanel === 'tags' && tagsView.kind !== 'list') {
+      return {
+        rootLabelKey: 'Tags',
+        rootTo: {
+          panel: 'tags',
+          view: {
+            kind: 'list',
+            tagId: tagsView.kind === 'edit' ? tagsView.tagId : browserSelectedTagId
+          }
+        },
+        leaf: tagsView.kind === 'create' ? t('New Tag') : t('Edit Tag')
       }
     }
     if (activePanel === 'credentials' && credentialsView.kind === 'service') {
@@ -1293,7 +1320,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
               <div
                 className={cn(
                   'mx-auto w-full max-w-[880px]',
-                  activePanel === 'memory' ? 'h-full' : 'min-h-full'
+                  activePanel === 'memory' || activePanel === 'tags' ? 'h-full' : 'min-h-full'
                 )}
               >
                 <SettingsPanelLoadingBoundary
@@ -1344,6 +1371,8 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                     />
                   ) : activePanel === 'tags' ? (
                     <TagsPanel
+                      view={tagsView}
+                      onNavigate={navigateTags}
                       onSelectedTagChange={recordSelectedTag}
                       onOpenResource={(reference) => {
                         if (reference.resourceType === 'catalog.skill') {

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -73,7 +73,9 @@ describe('TagsPanel', () => {
   it('aggregates tagged resources and opens their owning Settings detail', async () => {
     const onOpenResource = vi.fn()
     await act(async () => {
-      root.render(<TagsPanel onOpenResource={onOpenResource} />)
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={onOpenResource} />
+      )
     })
 
     expect(container.textContent).toContain('Favorites')
@@ -90,13 +92,112 @@ describe('TagsPanel', () => {
     })
   })
 
+  it('opens create as a Settings sub-view and returns to the created Tag', async () => {
+    const onNavigate = vi.fn()
+    const createTag = vi.fn().mockResolvedValue('tag-research')
+    useTagStore.setState({ create: createTag })
+
+    await act(async () => {
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={onNavigate} onOpenResource={vi.fn()} />
+      )
+    })
+
+    const newTag = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'New Tag'
+    )
+    act(() => newTag?.click())
+    expect(onNavigate).toHaveBeenCalledWith({ kind: 'create' })
+
+    await act(async () => {
+      root.render(
+        <TagsPanel view={{ kind: 'create' }} onNavigate={onNavigate} onOpenResource={vi.fn()} />
+      )
+    })
+    const name = container.querySelector<HTMLInputElement>('#tag-form-name')
+    act(() => {
+      if (!name) return
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
+        name,
+        'Research'
+      )
+      name.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      container.querySelector<HTMLFormElement>('[data-slot="tag-form"]')?.requestSubmit()
+    })
+
+    expect(createTag).toHaveBeenCalledWith({
+      name: 'Research',
+      iconKey: 'tag',
+      colorKey: 'blue'
+    })
+    expect(onNavigate).toHaveBeenLastCalledWith({ kind: 'list', tagId: 'tag-research' })
+  })
+
+  it('edits a custom Tag in the Settings sub-view', async () => {
+    const onNavigate = vi.fn()
+    const updateTag = vi.fn().mockResolvedValue(undefined)
+    useTagStore.setState({
+      update: updateTag,
+      tags: [
+        {
+          id: 'tag-research',
+          name: 'Research',
+          iconKey: 'book-open',
+          colorKey: 'purple',
+          createdAt: 1,
+          updatedAt: 2
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(
+        <TagsPanel
+          view={{ kind: 'edit', tagId: 'tag-research' }}
+          onNavigate={onNavigate}
+          onOpenResource={vi.fn()}
+        />
+      )
+    })
+
+    const name = container.querySelector<HTMLInputElement>('#tag-form-name')
+    expect(name?.value).toBe('Research')
+    expect(container.querySelector('[aria-label="Book"][aria-pressed="true"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Purple"][aria-pressed="true"]')).not.toBeNull()
+
+    act(() => {
+      if (!name) return
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
+        name,
+        'Literature'
+      )
+      name.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      container.querySelector<HTMLFormElement>('[data-slot="tag-form"]')?.requestSubmit()
+    })
+
+    expect(updateTag).toHaveBeenCalledWith({
+      id: 'tag-research',
+      expectedUpdatedAt: 2,
+      name: 'Literature',
+      iconKey: 'book-open',
+      colorKey: 'purple'
+    })
+    expect(onNavigate).toHaveBeenCalledWith({ kind: 'list', tagId: 'tag-research' })
+  })
+
   it('omits the secondary line when a resource has no description', async () => {
     useSettingsStore.setState((state) => ({
       skills: state.skills.map((skill) => ({ ...skill, description: '' }))
     }))
 
     await act(async () => {
-      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
     })
 
     const resourceRow = container.querySelector('[data-slot="tag-resource-row"]')
@@ -135,7 +236,9 @@ describe('TagsPanel', () => {
     })
 
     await act(async () => {
-      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
     })
 
     expect(
@@ -321,7 +424,9 @@ describe('TagsPanel', () => {
     useTagStore.setState({ setAssignment })
 
     await act(async () => {
-      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
     })
 
     const removeResource = container.querySelector<HTMLButtonElement>(
@@ -400,7 +505,9 @@ describe('TagsPanel', () => {
     })
 
     await act(async () => {
-      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
     })
 
     const groupButtons = Array.from(
@@ -465,7 +572,9 @@ describe('TagsPanel', () => {
     })
 
     await act(async () => {
-      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
     })
 
     const tagRows = Array.from(
@@ -477,8 +586,10 @@ describe('TagsPanel', () => {
 
     expect(tagRows).toHaveLength(2)
     expect(masterDetail?.classList.contains('grid-cols-1')).toBe(true)
-    expect(masterDetail?.classList.contains('md:grid-cols-[15rem_minmax(0,1fr)]')).toBe(true)
+    expect(masterDetail?.classList.contains('md:grid-cols-[220px_minmax(0,1fr)]')).toBe(true)
+    expect(masterDetail?.classList.contains('min-h-0')).toBe(true)
     expect(tagList?.classList.contains('border-b')).toBe(true)
+    expect(tagList?.classList.contains('bg-muted/20')).toBe(true)
     expect(tagList?.classList.contains('md:border-b-0')).toBe(true)
     expect(tagList?.classList.contains('md:border-r')).toBe(true)
     expect(tagRows.every((row) => row.classList.contains('flex-1'))).toBe(true)
@@ -524,7 +635,9 @@ describe('TagsPanel', () => {
     })
 
     await act(async () => {
-      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
     })
 
     expect(container.querySelector('[aria-label="System Tags stay first"]')).not.toBeNull()
@@ -564,7 +677,9 @@ describe('TagsPanel', () => {
       ]
     })
     await act(async () => {
-      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
     })
 
     const rows = Array.from(container.querySelectorAll<HTMLElement>('[data-reorderable-tag-id]'))

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -3,7 +3,7 @@
  * states: default · hover · focus · active · disabled · loading · error · success
  * theme: project tokens · contrast: pass · slop: pass
  */
-import { AlertDialog, Dialog } from 'radix-ui'
+import { AlertDialog } from 'radix-ui'
 import {
   ChevronDown,
   GripVertical,
@@ -39,12 +39,8 @@ import { Button } from '@/components/ui/button'
 import {
   dialogBodyClassName,
   dialogCancelButtonClassName,
-  dialogCloseButtonClassName,
   dialogDescriptionClassName,
   dialogFooterClassName,
-  dialogFormInputClassName,
-  dialogFormLabelClassName,
-  dialogHeaderClassName,
   dialogOverlayClassName,
   dialogPanelClassName,
   dialogTitleClassName
@@ -68,6 +64,8 @@ type TagResourceRow = TagResourceRef & {
 
 type TagDraft = { name: string; iconKey: TagIconKey; colorKey: TagColorKey }
 type CustomTagView = Extract<TagView, { name: string }>
+export type TagsView =
+  { kind: 'list'; tagId?: string } | { kind: 'create' } | { kind: 'edit'; tagId: string }
 type TagDropTarget = { tagId: string; edge: 'before' | 'after' }
 type TagDropZone = { tagId: string; top: number; bottom: number }
 type TagPointerDrag = {
@@ -79,6 +77,12 @@ type TagPointerDrag = {
   target?: TagDropTarget
 }
 const EMPTY_DRAFT: TagDraft = { name: '', iconKey: 'tag', colorKey: 'blue' }
+
+const RequiredMark = (): React.JSX.Element => (
+  <span aria-hidden="true" className="ml-0.5 text-destructive">
+    *
+  </span>
+)
 
 const resourceTypeLabel = (
   t: ReturnType<typeof useTranslation>['t'],
@@ -112,20 +116,149 @@ const colorLabel = (t: ReturnType<typeof useTranslation>['t'], key: TagColorKey)
   return t('Pink')
 }
 
-const TagsPanel = ({
+const TagForm = ({
+  tag,
+  onCancel,
+  onSaved
+}: {
+  tag?: CustomTagView
+  onCancel(): void
+  onSaved(tagId: string): void
+}): React.JSX.Element => {
+  const { t } = useTranslation()
+  const createTag = useTagStore((state) => state.create)
+  const updateTag = useTagStore((state) => state.update)
+  const [draft, setDraft] = useState<TagDraft>(
+    tag ? { name: tag.name, iconKey: tag.iconKey, colorKey: tag.colorKey } : EMPTY_DRAFT
+  )
+  const [saving, setSaving] = useState(false)
+  const [formError, setFormError] = useState<string>()
+  const canSubmit = Boolean(draft.name.trim()) && !saving
+
+  const save = async (): Promise<void> => {
+    if (!canSubmit) return
+    setSaving(true)
+    setFormError(undefined)
+    try {
+      if (tag) {
+        await updateTag({ id: tag.id, expectedUpdatedAt: tag.updatedAt, ...draft })
+        onSaved(tag.id)
+      } else {
+        onSaved(await createTag(draft))
+      }
+    } catch {
+      setFormError(t('Could not save Tag.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <form
+      data-slot="tag-form"
+      className="mx-auto flex h-full min-h-0 w-full max-w-3xl flex-col gap-5 px-4 py-4 md:px-6"
+      onSubmit={(event) => {
+        event.preventDefault()
+        void save()
+      }}
+    >
+      <p className="text-sm text-muted-foreground">
+        {t('Choose a name, icon, and color. Names are unique regardless of case.')}
+      </p>
+      <label className="space-y-1.5 text-sm font-medium" htmlFor="tag-form-name">
+        <span>
+          {t('Name')}
+          <RequiredMark />
+        </span>
+        <Input
+          id="tag-form-name"
+          name="tag-name"
+          autoFocus
+          required
+          value={draft.name}
+          maxLength={64}
+          aria-invalid={formError ? true : undefined}
+          onChange={(event) => setDraft((value) => ({ ...value, name: event.target.value }))}
+        />
+      </label>
+      <fieldset className="space-y-1.5">
+        <legend className="text-sm font-medium">{t('Icon')}</legend>
+        <div className="flex flex-wrap gap-2">
+          {TAG_ICON_KEYS.map((key) => {
+            const Icon = TAG_ICONS[key]
+            return (
+              <Button
+                key={key}
+                type="button"
+                variant="outline"
+                size="icon-lg"
+                aria-label={iconLabel(t, key)}
+                aria-pressed={draft.iconKey === key}
+                onClick={() => setDraft((value) => ({ ...value, iconKey: key }))}
+                className={cn(
+                  'active:translate-y-px [@media(pointer:coarse)]:size-11',
+                  draft.iconKey === key &&
+                    'border-primary bg-primary/10 text-primary hover:bg-primary/10'
+                )}
+              >
+                <Icon className="size-4" aria-hidden="true" />
+              </Button>
+            )
+          })}
+        </div>
+      </fieldset>
+      <fieldset className="space-y-1.5">
+        <legend className="text-sm font-medium">{t('Color')}</legend>
+        <div className="flex flex-wrap gap-2">
+          {TAG_COLOR_KEYS.map((key) => (
+            <button
+              key={key}
+              type="button"
+              aria-label={colorLabel(t, key)}
+              aria-pressed={draft.colorKey === key}
+              onClick={() => setDraft((value) => ({ ...value, colorKey: key }))}
+              className={cn(
+                'size-8 rounded-full border-2 outline-none transition-transform active:translate-y-px focus-visible:ring-3 focus-visible:ring-ring/50 motion-reduce:transition-none [@media(pointer:coarse)]:size-11',
+                TAG_COLORS[key],
+                draft.colorKey === key ? 'ring-2 ring-primary ring-offset-2' : 'border-transparent'
+              )}
+            />
+          ))}
+        </div>
+      </fieldset>
+      {formError ? (
+        <p role="alert" className="text-xs text-destructive">
+          {formError}
+        </p>
+      ) : null}
+      <div className="mt-auto flex justify-end gap-2 pt-2">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          {t('Cancel')}
+        </Button>
+        <Button type="submit" disabled={!canSubmit}>
+          {saving ? t('Saving…') : tag ? t('Save') : t('Create')}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+const TagsList = ({
   onOpenResource,
-  onSelectedTagChange
+  onSelectedTagChange,
+  onCreate,
+  onEdit
 }: {
   onOpenResource(reference: TagResourceRef): void
   onSelectedTagChange?(tagId: string): void
+  onCreate(): void
+  onEdit(tag: CustomTagView): void
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const tags = useTagStore((state) => state.tags)
   const assignments = useTagStore((state) => state.assignments)
   const status = useTagStore((state) => state.status)
   const error = useTagStore((state) => state.error)
-  const createTag = useTagStore((state) => state.create)
-  const updateTag = useTagStore((state) => state.update)
   const deleteTag = useTagStore((state) => state.delete)
   const reorderTags = useTagStore((state) => state.reorder)
   const setAssignment = useTagStore((state) => state.setAssignment)
@@ -146,10 +279,6 @@ const TagsPanel = ({
   const scrollTop = useTagStore((state) => state.browserScrollTop)
   const setScrollTop = useTagStore((state) => state.setBrowserScrollTop)
   const resourceListRef = useRef<HTMLElement>(null)
-  const [editing, setEditing] = useState<TagView | 'new'>()
-  const [draft, setDraft] = useState<TagDraft>(EMPTY_DRAFT)
-  const [saving, setSaving] = useState(false)
-  const [formError, setFormError] = useState<string>()
   const [deleting, setDeleting] = useState<TagView>()
   const [deleteBusy, setDeleteBusy] = useState(false)
   const [deleteError, setDeleteError] = useState<string>()
@@ -253,29 +382,6 @@ const TagsPanel = ({
     }))
     .filter(({ resources }) => resources.length > 0)
 
-  const openEditor = (tag?: TagView): void => {
-    setFormError(undefined)
-    setEditing(tag ?? 'new')
-    setDraft(
-      tag && !('systemKey' in tag)
-        ? { name: tag.name, iconKey: tag.iconKey, colorKey: tag.colorKey }
-        : EMPTY_DRAFT
-    )
-  }
-  const save = async (): Promise<void> => {
-    if (!editing || saving) return
-    setSaving(true)
-    setFormError(undefined)
-    try {
-      if (editing === 'new') await createTag(draft)
-      else await updateTag({ id: editing.id, expectedUpdatedAt: editing.updatedAt, ...draft })
-      setEditing(undefined)
-    } catch {
-      setFormError(t('Could not save Tag.'))
-    } finally {
-      setSaving(false)
-    }
-  }
   const confirmDelete = async (): Promise<void> => {
     if (!deleting || deleteBusy) return
     setDeleteBusy(true)
@@ -396,20 +502,7 @@ const TagsPanel = ({
   }
 
   return (
-    <div className="flex min-h-full flex-col p-5">
-      <div className="mb-4 flex items-start justify-between gap-4">
-        <div>
-          <h3 className="text-base font-semibold">{t('Tags')}</h3>
-          <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
-            {t('Organize Skills, Connectors, and Specialists across one shared catalog.')}
-          </p>
-        </div>
-        <Button type="button" variant="outline" onClick={() => openEditor()}>
-          <Plus data-icon="inline-start" aria-hidden="true" />
-          {t('New Tag')}
-        </Button>
-      </div>
-
+    <div data-slot="tags-panel" className="flex h-full min-h-0 flex-col px-3 py-3 md:px-4">
       {error ? (
         <p role="alert" className="mb-3 text-xs text-destructive">
           {t('Tags could not be loaded.')}
@@ -417,10 +510,10 @@ const TagsPanel = ({
       ) : null}
       <div
         data-slot="tag-master-detail"
-        className="grid min-h-[420px] flex-1 grid-cols-1 overflow-hidden rounded-lg border border-border md:grid-cols-[15rem_minmax(0,1fr)]"
+        className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden rounded-lg border border-border md:grid-cols-[220px_minmax(0,1fr)]"
       >
         <aside
-          className="border-b border-border bg-background p-2 md:border-r md:border-b-0"
+          className="min-h-0 overflow-y-auto border-b border-border bg-muted/20 p-2 md:border-r md:border-b-0"
           aria-busy={reorderBusy || undefined}
         >
           {reorderError ? (
@@ -431,7 +524,7 @@ const TagsPanel = ({
           <p className="sr-only" aria-live="polite" aria-atomic="true">
             {reorderAnnouncement}
           </p>
-          <ol>
+          <ol className="space-y-1">
             {tags.map((tag) => {
               const customIndex = customTags.findIndex((candidate) => candidate.id === tag.id)
               const dropBefore = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'before'
@@ -538,12 +631,22 @@ const TagsPanel = ({
                 </li>
               )
             })}
+            <li>
+              <button
+                type="button"
+                onClick={onCreate}
+                className="flex h-9 w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-left text-sm text-muted-foreground hover:bg-muted hover:text-foreground active:bg-muted/80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [@media(pointer:coarse)]:min-h-11"
+              >
+                <Plus className="size-4 shrink-0" aria-hidden="true" />
+                <span className="truncate">{t('New Tag')}</span>
+              </button>
+            </li>
           </ol>
         </aside>
 
         <section
           ref={resourceListRef}
-          className="min-w-0 overflow-y-auto p-4"
+          className="min-h-0 min-w-0 overflow-y-auto bg-card p-4"
           onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
         >
           {selectedTag ? (
@@ -566,7 +669,7 @@ const TagsPanel = ({
                     <SettingsIconAction
                       label={t('Edit Tag')}
                       icon={Pencil}
-                      onClick={() => openEditor(selectedTag)}
+                      onClick={() => onEdit(selectedTag)}
                     />
                     <SettingsIconAction
                       label={t('Delete Tag')}
@@ -719,125 +822,6 @@ const TagsPanel = ({
         </section>
       </div>
 
-      <Dialog.Root
-        open={editing !== undefined}
-        onOpenChange={(open) => !open && setEditing(undefined)}
-      >
-        <Dialog.Portal>
-          <Dialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
-          <Dialog.Content
-            className={dialogPanelClassName('z-[60] w-[min(460px,calc(100vw-2rem))] p-0')}
-          >
-            <div>
-              <div className={dialogHeaderClassName}>
-                <Dialog.Title className={dialogTitleClassName}>
-                  {editing === 'new' ? t('New Tag') : t('Edit Tag')}
-                </Dialog.Title>
-                <Dialog.Close asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    className={dialogCloseButtonClassName}
-                    aria-label={t('Close')}
-                  >
-                    <X className="size-4" aria-hidden="true" />
-                  </Button>
-                </Dialog.Close>
-              </div>
-              <div className={`${dialogBodyClassName} space-y-4`}>
-                <Dialog.Description className={dialogDescriptionClassName}>
-                  {t('Choose a name, icon, and color. Names are unique regardless of case.')}
-                </Dialog.Description>
-                <div>
-                  <label className={dialogFormLabelClassName} htmlFor="tag-form-name">
-                    {t('Name')}
-                  </label>
-                  <Input
-                    id="tag-form-name"
-                    autoFocus
-                    value={draft.name}
-                    maxLength={64}
-                    className={`${dialogFormInputClassName} h-9 px-3 text-sm`}
-                    onChange={(event) =>
-                      setDraft((value) => ({ ...value, name: event.target.value }))
-                    }
-                  />
-                </div>
-                <fieldset>
-                  <legend className={dialogFormLabelClassName}>{t('Icon')}</legend>
-                  <div className="flex flex-wrap gap-2">
-                    {TAG_ICON_KEYS.map((key) => {
-                      const Icon = TAG_ICONS[key]
-                      return (
-                        <Button
-                          key={key}
-                          type="button"
-                          variant="outline"
-                          size="icon-lg"
-                          aria-label={iconLabel(t, key)}
-                          aria-pressed={draft.iconKey === key}
-                          onClick={() => setDraft((value) => ({ ...value, iconKey: key }))}
-                          className={cn(
-                            draft.iconKey === key &&
-                              'border-primary bg-primary/10 text-primary hover:bg-primary/10'
-                          )}
-                        >
-                          <Icon className="size-4" aria-hidden="true" />
-                        </Button>
-                      )
-                    })}
-                  </div>
-                </fieldset>
-                <fieldset>
-                  <legend className={dialogFormLabelClassName}>{t('Color')}</legend>
-                  <div className="flex flex-wrap gap-2">
-                    {TAG_COLOR_KEYS.map((key) => (
-                      <button
-                        key={key}
-                        type="button"
-                        aria-label={colorLabel(t, key)}
-                        aria-pressed={draft.colorKey === key}
-                        onClick={() => setDraft((value) => ({ ...value, colorKey: key }))}
-                        className={cn(
-                          'size-8 rounded-full border-2 outline-none focus-visible:ring-3 focus-visible:ring-ring/50',
-                          TAG_COLORS[key],
-                          draft.colorKey === key
-                            ? 'ring-2 ring-primary ring-offset-2'
-                            : 'border-transparent'
-                        )}
-                      />
-                    ))}
-                  </div>
-                </fieldset>
-                {formError ? (
-                  <p role="alert" className="text-xs text-destructive">
-                    {formError}
-                  </p>
-                ) : null}
-              </div>
-              <div className={dialogFooterClassName}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className={dialogCancelButtonClassName}
-                  onClick={() => setEditing(undefined)}
-                >
-                  {t('Cancel')}
-                </Button>
-                <Button
-                  type="button"
-                  disabled={saving || !draft.name.trim()}
-                  onClick={() => void save()}
-                >
-                  {saving ? t('Saving…') : t('Save')}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
-
       <AlertDialog.Root
         open={deleting !== undefined}
         onOpenChange={(open) => !open && !deleteBusy && setDeleting(undefined)}
@@ -892,6 +876,62 @@ const TagsPanel = ({
         </AlertDialog.Portal>
       </AlertDialog.Root>
     </div>
+  )
+}
+
+const TagsPanel = ({
+  view,
+  onNavigate,
+  onOpenResource,
+  onSelectedTagChange
+}: {
+  view: TagsView
+  onNavigate(view: TagsView): void
+  onOpenResource(reference: TagResourceRef): void
+  onSelectedTagChange?(tagId: string): void
+}): React.JSX.Element => {
+  const tags = useTagStore((state) => state.tags)
+  const status = useTagStore((state) => state.status)
+  const editTag =
+    view.kind === 'edit'
+      ? tags.find((tag): tag is CustomTagView => tag.id === view.tagId && !('systemKey' in tag))
+      : undefined
+
+  useEffect(() => {
+    if (view.kind === 'edit' && status === 'ready' && !editTag) {
+      onNavigate({ kind: 'list' })
+    }
+  }, [editTag, onNavigate, status, view.kind])
+
+  if (view.kind === 'create') {
+    return (
+      <TagForm
+        onCancel={() => onNavigate({ kind: 'list' })}
+        onSaved={(tagId) => onNavigate({ kind: 'list', tagId })}
+      />
+    )
+  }
+
+  if (view.kind === 'edit' && editTag) {
+    return (
+      <TagForm
+        key={`${editTag.id}:${editTag.updatedAt}`}
+        tag={editTag}
+        onCancel={() => onNavigate({ kind: 'list', tagId: editTag.id })}
+        onSaved={(tagId) => onNavigate({ kind: 'list', tagId })}
+      />
+    )
+  }
+
+  if (view.kind === 'edit') return <div className="h-full" />
+
+  return (
+    <TagsList
+      onCreate={() => onNavigate({ kind: 'create' })}
+      onEdit={(tag) => onNavigate({ kind: 'edit', tagId: tag.id })}
+      onOpenResource={onOpenResource}
+      onSelectedTagChange={onSelectedTagChange}
+    />
   )
 }
 

--- a/src/renderer/src/pages/settings/settings-navigation.ts
+++ b/src/renderer/src/pages/settings/settings-navigation.ts
@@ -6,6 +6,7 @@ import type { ConnectorsView } from './ConnectorsPanel'
 import type { MemoryView } from './MemoryPanel'
 import type { SkillsView } from './SkillsPanel'
 import type { SpecialistsView } from './SpecialistsPanel'
+import type { TagsView } from './TagsPanel'
 
 export type SettingsPanelId =
   | 'model'
@@ -52,7 +53,7 @@ export type SettingsRoute = {
                   : Panel extends 'memory'
                     ? { panel: Panel; view: MemoryView }
                     : Panel extends 'tags'
-                      ? { panel: Panel; tagId?: string }
+                      ? { panel: Panel; view: TagsView }
                       : { panel: Panel }
 }[SettingsPanelId]
 
@@ -72,6 +73,7 @@ export const settingsPanelRoute = (panel: SettingsPanelId): SettingsRoute => {
     case 'specialists':
     case 'archived':
     case 'memory':
+    case 'tags':
       return { panel, view: { kind: 'list' } }
     default:
       return { panel }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -3684,7 +3684,7 @@
     "All resources": "Todos los recursos",
     "Could not save Tag.": "No se pudo guardar la etiqueta.",
     "Tags": "Etiquetas",
-    "Organize Skills, Connectors, and Specialists across one shared catalog.": "Organice habilidades, conectores y especialistas en un catálogo compartido.",
+    "tags": "etiquetas",
     "New Tag": "Nueva etiqueta",
     "Edit Tag": "Editar etiqueta",
     "Delete Tag": "Eliminar etiqueta",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -3684,7 +3684,7 @@
     "All resources": "Toutes les ressources",
     "Could not save Tag.": "Impossible d'enregistrer la balise.",
     "Tags": "Balises",
-    "Organize Skills, Connectors, and Specialists across one shared catalog.": "Organisez les compétences, les connecteurs et les spécialistes dans un catalogue partagé.",
+    "tags": "balises",
     "New Tag": "Nouvelle balise",
     "Edit Tag": "Modifier la balise",
     "Delete Tag": "Supprimer la balise",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3412,7 +3412,7 @@
     "All resources": "すべてのリソース",
     "Could not save Tag.": "タグを保存できませんでした。",
     "Tags": "タグ",
-    "Organize Skills, Connectors, and Specialists across one shared catalog.": "スキル、コネクタ、スペシャリストを 1 つの共有カタログで整理します。",
+    "tags": "タグ",
     "New Tag": "新しいタグ",
     "Edit Tag": "タグを編集",
     "Delete Tag": "タグを削除",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3412,7 +3412,7 @@
     "All resources": "모든 리소스",
     "Could not save Tag.": "태그를 저장할 수 없습니다.",
     "Tags": "태그",
-    "Organize Skills, Connectors, and Specialists across one shared catalog.": "하나의 공유 카탈로그에서 스킬, 커넥터 및 스페셜리스트를 구성합니다.",
+    "tags": "태그",
     "New Tag": "새 태그",
     "Edit Tag": "태그 편집",
     "Delete Tag": "태그 삭제",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -3791,7 +3791,7 @@
     "All resources": "Все ресурсы",
     "Could not save Tag.": "Не удалось сохранить тег.",
     "Tags": "Теги",
-    "Organize Skills, Connectors, and Specialists across one shared catalog.": "Организация навыков, коннекторов и специалистов в одном общем каталоге.",
+    "tags": "теги",
     "New Tag": "Новый тег",
     "Edit Tag": "Редактировать тег",
     "Delete Tag": "Удалить тег",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -3412,7 +3412,7 @@
     "All resources": "所有资源",
     "Could not save Tag.": "无法保存标签。",
     "Tags": "标签",
-    "Organize Skills, Connectors, and Specialists across one shared catalog.": "在一个共享目录中整理技能、连接器和专家。",
+    "tags": "标签",
     "New Tag": "新建标签",
     "Edit Tag": "编辑标签",
     "Delete Tag": "删除标签",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -3412,7 +3412,7 @@
     "All resources": "所有資源",
     "Could not save Tag.": "無法儲存標籤。",
     "Tags": "標籤",
-    "Organize Skills, Connectors, and Specialists across one shared catalog.": "在一個共用目錄中整理技能、連接器和專家。",
+    "tags": "標籤",
     "New Tag": "新增標籤",
     "Edit Tag": "編輯標籤",
     "Delete Tag": "刪除標籤",


### PR DESCRIPTION
## Problem

Settings > Tags used a modal create/edit flow and a different master-detail surface treatment from Settings > Memory. This made panel navigation, Back/Forward behavior, background hierarchy, and the placement of the create action feel inconsistent.

## Proposed change

- Move Tag creation and editing into breadcrumb-backed Settings secondary pages.
- Keep Tag selection, filtering, reordering, assignment removal, and delete confirmation in the existing master-detail flow.
- Place **New Tag** at the bottom of the Tag list and align the panel shell with Memory's internal-scroll layout: muted master column and card detail column.
- Preserve the selected Tag in Settings history when navigating to resources or returning from forms.
- Update focused render coverage, locale catalogs, and the Settings design specification.

## Scope and non-goals

- `MemoryPanel` is unchanged.
- No backend, IPC, database, migration, or durable persistence path changes.
- No historical data compatibility work is required because persisted Tag definitions and assignments keep their existing schema and APIs.
- The only new state variants are renderer-local `TagsView` navigation discriminants (`list`, `create`, and `edit`); no persisted or domain enum is added.
- No new dependencies, themes, design tokens, or preview surfaces.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Tag list/create/edit, Settings history, and locale contracts -> `npx vitest run src/renderer/src/i18n/resources.test.ts src/renderer/src/pages/settings/TagsPanel.render.test.tsx src/renderer/src/pages/settings/SettingsPage.render.test.tsx` -> 3 files, 856 tests passed.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Repository lint contract -> `npm run lint` -> passed.
- Patch whitespace -> `git diff --check` -> passed.
- Desktop visual/interaction smoke -> verified the Tags list layout and accessibility tree in the current worktree development app; create/edit route and form states are covered by focused render tests.

The final Test Impact Set classifier selected the full fallback because `docs/design.md` has no module owner in `module-impact.json`. Per maintainer instruction, the complete local `npm test` suite was not run; PR Gate remains authoritative for the full portable and platform lanes.

Uncovered local risk: cross-platform visual rendering is not reproduced locally and is left to PR CI/visual lanes.

## Review focus

- `TagsView` history transitions and selected-Tag restoration.
- Create/edit form behavior after replacing the modal.
- Master-detail height ownership, scrolling, and responsive behavior.
