### PR TITLE
fix(acp): preserve loopback model call details

### DIFF
--- a/src/main/acp/claude-turn-adapter.test.ts
+++ b/src/main/acp/claude-turn-adapter.test.ts
@@ -182,6 +182,95 @@ describe('Claude Code turn adapter', () => {
     })
   })
 
+  it('publishes exact calls from repeated provider messages that omit the parent tool id', async () => {
+    const probe = await claudeCodeTurnAdapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+
+    for (let index = 1; index <= 7; index += 1) {
+      const observation = {
+        sessionId: 'provider-session-1',
+        message: {
+          type: 'assistant',
+          message: {
+            id: `provider-call-${index}`,
+            usage: {
+              input_tokens: index,
+              cache_read_input_tokens: index,
+              cache_creation_input_tokens: 0,
+              output_tokens: index
+            }
+          }
+        }
+      }
+      probe.observe?.(observation)
+      probe.observe?.(observation)
+    }
+    probe.observe?.({
+      sessionId: 'provider-session-1',
+      message: { type: 'result', num_turns: 7, origin: { kind: 'human' } }
+    })
+
+    const result = await probe.finalize({
+      response: {
+        stopReason: 'end_turn',
+        usage: {
+          inputTokens: 28,
+          cachedReadTokens: 28,
+          cachedWriteTokens: 0,
+          outputTokens: 28
+        }
+      } as PromptResponse
+    })
+
+    expect(result.modelTurnCount).toBe(7)
+    expect(result.modelCalls).toHaveLength(7)
+    expect(result.modelCalls?.map((call) => call.sourceInvocationId)).toEqual(
+      Array.from({ length: 7 }, (_, index) => `provider-call-${index + 1}`)
+    )
+  })
+
+  it('rejects conflicting usage replayed under the same provider call id', async () => {
+    const probe = await claudeCodeTurnAdapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const observeAssistant = (inputTokens: number): void =>
+      probe.observe?.({
+        sessionId: 'provider-session-1',
+        message: {
+          type: 'assistant',
+          message: {
+            id: 'provider-call-1',
+            usage: {
+              input_tokens: inputTokens,
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+              output_tokens: 1
+            }
+          }
+        }
+      })
+
+    observeAssistant(1)
+    observeAssistant(2)
+    probe.observe?.({
+      sessionId: 'provider-session-1',
+      message: { type: 'result', num_turns: 1, origin: { kind: 'human' } }
+    })
+
+    const result = await probe.finalize({
+      response: {
+        stopReason: 'end_turn',
+        usage: { inputTokens: 1, outputTokens: 1 }
+      } as PromptResponse
+    })
+
+    expect(result.modelTurnCount).toBe(1)
+    expect(result.modelCalls).toBeUndefined()
+  })
+
   it('sums user-driven results while excluding every autonomous Claude origin', async () => {
     const probe = await claudeCodeTurnAdapter.begin({
       providerSessionId: 'provider-session-1',

--- a/src/main/acp/claude-turn-adapter.ts
+++ b/src/main/acp/claude-turn-adapter.ts
@@ -20,7 +20,7 @@ const toClaudeModelStepUsage = (
   message: Record<string, unknown>
 ): AcpProviderModelCallUsage | undefined => {
   if (
-    message.parent_tool_use_id !== null ||
+    (message.parent_tool_use_id !== undefined && message.parent_tool_use_id !== null) ||
     typeof message.message !== 'object' ||
     message.message === null ||
     Array.isArray(message.message)
@@ -44,6 +44,16 @@ const toClaudeModelStepUsage = (
     ...(typeof inner.id === 'string' && inner.id.length > 0 ? { sourceInvocationId: inner.id } : {})
   }
 }
+
+const sameClaudeModelCallUsage = (
+  left: AcpProviderModelCallUsage,
+  right: AcpProviderModelCallUsage
+): boolean =>
+  left.inputTokens === right.inputTokens &&
+  left.cacheTokens === right.cacheTokens &&
+  left.cachedReadTokens === right.cachedReadTokens &&
+  left.cachedWriteTokens === right.cachedWriteTokens &&
+  left.outputTokens === right.outputTokens
 
 const hasExactClaudeCallCoverage = (
   calls: readonly AcpProviderModelCallUsage[],
@@ -91,12 +101,16 @@ export const claudeCodeTurnAdapter: AcpProviderTurnAdapter = {
     let modelTurnCount = 0
     let lastModelStepUsage: AcpModelStepTokenUsage | undefined
     let modelCalls: AcpProviderModelCallUsage[] = []
+    let modelCallIndexes = new Map<string, number>()
+    let modelCallsTrusted = true
     let closed = false
     const close = (): void => {
       closed = true
       modelTurnCount = 0
       lastModelStepUsage = undefined
       modelCalls = []
+      modelCallIndexes = new Map()
+      modelCallsTrusted = true
     }
 
     return {
@@ -118,7 +132,16 @@ export const claudeCodeTurnAdapter: AcpProviderTurnAdapter = {
           const modelCall = toClaudeModelStepUsage(message)
           if (modelCall) {
             lastModelStepUsage = modelCall
-            modelCalls.push(modelCall)
+            const sourceInvocationId = modelCall.sourceInvocationId
+            const existingIndex = sourceInvocationId
+              ? modelCallIndexes.get(sourceInvocationId)
+              : undefined
+            if (existingIndex === undefined) {
+              if (sourceInvocationId) modelCallIndexes.set(sourceInvocationId, modelCalls.length)
+              modelCalls.push(modelCall)
+            } else if (!sameClaudeModelCallUsage(modelCalls[existingIndex], modelCall)) {
+              modelCallsTrusted = false
+            }
           }
           return
         }
@@ -138,13 +161,15 @@ export const claudeCodeTurnAdapter: AcpProviderTurnAdapter = {
         const finalModelTurnCount = modelTurnCount
         const finalLastModelStepUsage = lastModelStepUsage
         const finalModelCalls = modelCalls
+        const finalModelCallsTrusted = modelCallsTrusted
         close()
         const turnUsage = toAcpTurnTokenUsage(response.usage)
         const result: AcpProviderTurnResult = {
           ...(turnUsage ? { turnUsage } : {}),
           ...(finalModelTurnCount > 0 ? { modelTurnCount: finalModelTurnCount } : {}),
           ...(finalLastModelStepUsage ? { lastModelStepUsage: finalLastModelStepUsage } : {}),
-          ...(hasExactClaudeCallCoverage(finalModelCalls, finalModelTurnCount, turnUsage)
+          ...(finalModelCallsTrusted &&
+          hasExactClaudeCallCoverage(finalModelCalls, finalModelTurnCount, turnUsage)
             ? { modelCalls: finalModelCalls }
             : {})
         }


### PR DESCRIPTION
## Problem

Claude-compatible provider loopbacks can emit top-level assistant messages without `parent_tool_use_id` and can replay the same assistant message ID more than once. The Claude turn adapter rejected the omitted parent field and would count identical replays more than once.

As a result, terminal `num_turns` remained available while exact `modelCallUsage` was dropped. Context Window then reported messages such as `Showing 0 of 7 reported calls`, especially after Literature MCP tool loops created multiple model turns.

## Proposed change

- Treat omitted and `null` Claude parent-tool metadata as top-level assistant calls while continuing to exclude explicit subagent parent IDs.
- Collapse identical replayed assistant messages by stable provider call ID.
- Keep conflicting usage under one provider call ID fail-closed.

## Scope and non-goals

- This is limited to the Claude Code provider turn adapter; Literature retrieval, renderer behavior, and shared ACP contracts are unchanged.
- Existing aggregate-only Session history is not backfilled. Historical `0 of 7` records remain aggregate-only.
- No state or enum value is added.
- No persistence schema or migration changes. Future turns populate the existing optional `modelCallUsage` field when exact coverage is proven.
- `opencode`, `codex-response`, and `codex-bridge` use separate adapters and are excluded because this change does not alter their protocol path.

## Acceptance criteria and validation

- Captured seven-call loopback shape with omitted parent metadata and duplicate messages -> `npm test -- src/main/acp/claude-turn-adapter.test.ts` -> 8 tests passed.
- Claude adapter behavior, ACP lifecycle, Literature MCP host, and representative framework contracts -> `npm test -- src/main/acp` -> 100 files and 2,125 tests passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting -> `npx prettier --check src/main/acp/claude-turn-adapter.ts src/main/acp/claude-turn-adapter.test.ts` -> passed.
- `npm run test:affected -- --base origin/main --head HEAD --explain` selected the complete suite because the test file has no module owner. The full local suite was intentionally not run; exact-head PR CI is the final validation authority.

Platform-specific lanes are left to CI because the change has no path, process-launch, or OS-specific behavior.

## Review focus

- Whether omitted parent metadata is safely classified without admitting explicit subagent calls.
- Whether duplicate provider IDs preserve exact usage only when every replay agrees.
- Whether retaining aggregate-only historical Sessions without backfill is the correct compatibility boundary.