### PR TITLE
fix(connectors): restrict custom lifecycle to local callers

### DIFF
--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -295,6 +295,17 @@ describe('ConnectorSettingsModule', () => {
     await expect(service.getConnectorDetail('nope')).rejects.toThrow(/Unknown connector/)
   })
 
+  it('does not synthesize persisted trust metadata from an ordinary add request', async () => {
+    await addCustomServer({
+      name: 'unverified-trust',
+      transport: 'stdio',
+      command: 'npx'
+    })
+
+    const stored = (await repository.getSettings()).connectors?.customMcpServers?.[0]
+    expect(stored).not.toHaveProperty('trustedAt')
+  })
+
   it('adds, toggles, and removes a local (stdio) custom server', async () => {
     let snapshot = await addCustomServer({
       name: 'my-mem',

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -421,7 +421,6 @@ class ConnectorSettingsModule {
       displayName,
       transport: request.transport,
       enabled: !request.oauth,
-      trustedAt: Date.now(),
       ...(request.description?.trim() ? { description: request.description.trim() } : {}),
       ...(request.command?.trim() ? { command: request.command.trim() } : {}),
       ...(request.args && request.args.length > 0 ? { args: request.args } : {}),

--- a/src/main/settings/integration-application-commands.test.ts
+++ b/src/main/settings/integration-application-commands.test.ts
@@ -189,7 +189,11 @@ describe('Settings integration application commands', () => {
             contract.channel !== 'settings:disconnect-custom-server' &&
             contract.channel !== 'settings:retry-custom-server' &&
             contract.channel !== 'settings:set-openalex-credential' &&
-            contract.channel !== 'settings:validate-openalex-credential'
+            contract.channel !== 'settings:validate-openalex-credential' &&
+            contract.channel !== 'settings:add-custom-server' &&
+            contract.channel !== 'settings:set-custom-server-enabled' &&
+            contract.channel !== 'settings:remove-custom-server' &&
+            contract.channel !== 'settings:update-custom-server'
         )
         .every(
           (contract) =>
@@ -207,7 +211,11 @@ describe('Settings integration application commands', () => {
             contract.channel === 'settings:disconnect-custom-server' ||
             contract.channel === 'settings:retry-custom-server' ||
             contract.channel === 'settings:set-openalex-credential' ||
-            contract.channel === 'settings:validate-openalex-credential'
+            contract.channel === 'settings:validate-openalex-credential' ||
+            contract.channel === 'settings:add-custom-server' ||
+            contract.channel === 'settings:set-custom-server-enabled' ||
+            contract.channel === 'settings:remove-custom-server' ||
+            contract.channel === 'settings:update-custom-server'
         )
         .every(
           (contract) =>
@@ -317,7 +325,7 @@ describe('Settings integration application commands', () => {
     expect(skillMethod('setConversationSkillImportEnabled')).not.toHaveBeenCalled()
   })
 
-  it('delegates all eight remote Connector mutations through the Connector workflow owner', async () => {
+  it('delegates all four remotely available Connector mutations through the workflow owner', async () => {
     const { connectorMethod, dependencies } = createDependencies()
     const router = createApplicationCommandRouter()
     registerIntegrationSettingsApplicationCommands(router.registrar, dependencies)
@@ -338,32 +346,6 @@ describe('Settings integration application commands', () => {
       settingsIntegrationApplicationCommands.setNcbiCredentials,
       invocation([{ contactEmail: 'researcher@example.test', apiKey: 'secret' }] as const)
     )
-    await router.dispatcher.invoke(
-      settingsIntegrationApplicationCommands.addCustomServer,
-      invocation([
-        { name: 'custom', displayName: 'Custom', transport: 'stdio', command: 'custom-mcp' }
-      ] as const)
-    )
-    await router.dispatcher.invoke(
-      settingsIntegrationApplicationCommands.setCustomServerEnabled,
-      invocation([{ id: 'server-1', enabled: false }] as const)
-    )
-    await router.dispatcher.invoke(
-      settingsIntegrationApplicationCommands.removeCustomServer,
-      invocation([{ id: 'server-1' }] as const)
-    )
-    await router.dispatcher.invoke(
-      settingsIntegrationApplicationCommands.updateCustomServer,
-      invocation([
-        {
-          id: 'server-2',
-          description: 'Updated',
-          transport: 'streamable_http',
-          url: 'https://mcp.example.test'
-        }
-      ] as const)
-    )
-
     expect(connectorMethod('setConnectorEnabled')).toHaveBeenCalledWith({
       id: 'pubchem',
       enabled: false
@@ -380,33 +362,101 @@ describe('Settings integration application commands', () => {
       contactEmail: 'researcher@example.test',
       apiKey: 'secret'
     })
+  })
+
+  it('rejects custom Connector lifecycle mutations from remote callers before a workflow can run', async () => {
+    const { connectorMethod, dependencies } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerIntegrationSettingsApplicationCommands(router.registrar, dependencies)
+
+    const attempts = [
+      [
+        settingsIntegrationApplicationCommands.addCustomServer,
+        [{ name: 'custom', displayName: 'Custom', transport: 'stdio', command: 'custom-mcp' }]
+      ],
+      [
+        settingsIntegrationApplicationCommands.setCustomServerEnabled,
+        [{ id: 'server-1', enabled: true }]
+      ],
+      [settingsIntegrationApplicationCommands.removeCustomServer, [{ id: 'server-1' }]],
+      [
+        settingsIntegrationApplicationCommands.updateCustomServer,
+        [{ id: 'server-1', transport: 'stdio', command: 'replacement-mcp' }]
+      ]
+    ] as const
+
+    for (const [command, args] of attempts) {
+      await expect(router.dispatcher.invoke(command, invocation(args))).rejects.toThrow(
+        `Channel only available from the local app: ${command.name}`
+      )
+    }
+
+    expect(connectorMethod('addCustomServer')).not.toHaveBeenCalled()
+    expect(connectorMethod('setCustomServerEnabled')).not.toHaveBeenCalled()
+    expect(connectorMethod('removeCustomServer')).not.toHaveBeenCalled()
+    expect(connectorMethod('updateCustomServer')).not.toHaveBeenCalled()
+  })
+
+  it('allows custom Connector lifecycle, authentication, secrets, and retry only locally', async () => {
+    const { connectorMethod, dependencies } = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerIntegrationSettingsApplicationCommands(router.registrar, dependencies)
+
+    const localCaller = createWebCallerContext('local-human')
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.addCustomServer,
+      invocation(
+        [{ name: 'custom', displayName: 'Custom', transport: 'stdio', command: 'custom-mcp' }],
+        localCaller
+      )
+    )
     expect(connectorMethod('addCustomServer')).toHaveBeenCalledWith({
       name: 'custom',
       displayName: 'Custom',
       transport: 'stdio',
       command: 'custom-mcp'
     })
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.setCustomServerEnabled,
+      invocation([{ id: 'server-1', enabled: false }], localCaller)
+    )
     expect(connectorMethod('setCustomServerEnabled')).toHaveBeenCalledWith({
       id: 'server-1',
       enabled: false
     })
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.removeCustomServer,
+      invocation([{ id: 'server-1' }], localCaller)
+    )
     expect(connectorMethod('removeCustomServer')).toHaveBeenCalledWith({ id: 'server-1' })
+
+    await router.dispatcher.invoke(
+      settingsIntegrationApplicationCommands.updateCustomServer,
+      invocation(
+        [
+          {
+            id: 'server-2',
+            description: 'Updated',
+            transport: 'streamable_http',
+            url: 'https://mcp.example.test'
+          }
+        ],
+        localCaller
+      )
+    )
     expect(connectorMethod('updateCustomServer')).toHaveBeenCalledWith({
       id: 'server-2',
       description: 'Updated',
       transport: 'streamable_http',
       url: 'https://mcp.example.test'
     })
-  })
-
-  it('allows authentication, secret writes, validation, and runtime retry only locally', async () => {
-    const { connectorMethod, dependencies } = createDependencies()
-    const router = createApplicationCommandRouter()
-    registerIntegrationSettingsApplicationCommands(router.registrar, dependencies)
 
     await router.dispatcher.invoke(
       settingsIntegrationApplicationCommands.authenticateCustomServer,
-      invocation([{ id: 'server-1' }] as const, createWebCallerContext('local-human'))
+      invocation([{ id: 'server-1' }] as const, localCaller)
     )
     expect(connectorMethod('authenticateCustomServer')).toHaveBeenCalledWith({ id: 'server-1' })
 

--- a/src/main/settings/integration-application-commands.ts
+++ b/src/main/settings/integration-application-commands.ts
@@ -296,13 +296,22 @@ const registerIntegrationSettingsApplicationCommands = (
         requireLocalCaller(callerContext, 'settings:validate-openalex-credential')
         return dependencies.connectors.validateOpenAlexCredential(args[0])
       },
-      'settings:add-custom-server': ({ args }) => dependencies.connectors.addCustomServer(args[0]),
-      'settings:set-custom-server-enabled': ({ args }) =>
-        dependencies.connectors.setCustomServerEnabled(args[0]),
-      'settings:remove-custom-server': ({ args }) =>
-        dependencies.connectors.removeCustomServer(args[0]),
-      'settings:update-custom-server': ({ args }) =>
-        dependencies.connectors.updateCustomServer(args[0]),
+      'settings:add-custom-server': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:add-custom-server')
+        return dependencies.connectors.addCustomServer(args[0])
+      },
+      'settings:set-custom-server-enabled': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:set-custom-server-enabled')
+        return dependencies.connectors.setCustomServerEnabled(args[0])
+      },
+      'settings:remove-custom-server': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:remove-custom-server')
+        return dependencies.connectors.removeCustomServer(args[0])
+      },
+      'settings:update-custom-server': ({ args, callerContext }) => {
+        requireLocalCaller(callerContext, 'settings:update-custom-server')
+        return dependencies.connectors.updateCustomServer(args[0])
+      },
       'settings:authenticate-custom-server': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:authenticate-custom-server')
         return dependencies.connectors.authenticateCustomServer(args[0])

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -36,6 +36,32 @@ describe('renderer contract catalog', () => {
     ).toBe(true)
   })
 
+  it('keeps custom Connector lifecycle mutations local-only', () => {
+    const publicPaths = [
+      'settings.addCustomServer',
+      'settings.setCustomServerEnabled',
+      'settings.removeCustomServer',
+      'settings.updateCustomServer'
+    ]
+
+    expect(
+      publicPaths.map((publicPath) =>
+        RENDERER_CONTRACT_CATALOG.find((contract) => contract.publicPath === publicPath)
+      )
+    ).toEqual(
+      publicPaths.map((publicPath) =>
+        expect.objectContaining({
+          publicPath,
+          surfaceInstallation: {
+            electron: 'preload',
+            localWeb: 'web-rpc',
+            remoteWeb: 'rejecting-stub'
+          }
+        })
+      )
+    )
+  })
+
   it('publishes remote-access route management only on Electron', () => {
     expect(
       RENDERER_CONTRACT_CATALOG.filter(({ publicPath }) =>

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -1493,7 +1493,7 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   >()('sessions', ['sessions:unlink-pdf-context', WEB, undefined, undefined, RUNTIME_VALIDATED]),
   'settings.addCustomServer': callable<
     (request: AddCustomServerRequest) => Promise<ConnectorsSnapshot>
-  >()('settings', ['settings:add-custom-server']),
+  >()('settings', ['settings:add-custom-server', LOCAL]),
   'settings.authenticateCustomServer': callable<
     (request: DisconnectCustomServerRequest) => Promise<ConnectorsSnapshot>
   >()('settings', ['settings:authenticate-custom-server', LOCAL]),
@@ -1703,7 +1703,7 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   >()('settings', ['settings:refresh-provider-models']),
   'settings.removeCustomServer': callable<
     (request: RemoveCustomServerRequest) => Promise<ConnectorsSnapshot>
-  >()('settings', ['settings:remove-custom-server']),
+  >()('settings', ['settings:remove-custom-server', LOCAL]),
   'settings.removeGitHubToken': callable<() => Promise<GitHubTokenStatus>>()('settings', [
     'settings:remove-github-token',
     LOCAL
@@ -1769,7 +1769,7 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   >()('settings', ['settings:set-conversation-skill-import-enabled']),
   'settings.setCustomServerEnabled': callable<
     (request: SetCustomServerEnabledRequest) => Promise<ConnectorsSnapshot>
-  >()('settings', ['settings:set-custom-server-enabled']),
+  >()('settings', ['settings:set-custom-server-enabled', LOCAL]),
   'settings.setDefaultPermissionProfile': callable<
     (request: SetDefaultPermissionProfileRequest) => Promise<SettingsSnapshot>
   >()('settings', ['settings:set-default-permission-profile', LOCAL]),
@@ -1840,7 +1840,7 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   ]),
   'settings.updateCustomServer': callable<
     (request: UpdateCustomServerRequest) => Promise<ConnectorsSnapshot>
-  >()('settings', ['settings:update-custom-server']),
+  >()('settings', ['settings:update-custom-server', LOCAL]),
   'settings.updateSkill': callable<(request: UpdateSkillRequest) => Promise<SkillView[]>>()(
     'settings',
     ['settings:update-skill']

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -198,6 +198,7 @@ const REMOTE_LOCAL_ONLY_CHANNELS: GroupedInventory = {
     'unregister-interpreter'
   ],
   settings: [
+    'add-custom-server',
     'authenticate-custom-server',
     'begin-xai-oauth-login',
     'cancel-claude-login',
@@ -219,11 +220,13 @@ const REMOTE_LOCAL_ONLY_CHANNELS: GroupedInventory = {
     'logout-isolated-codex',
     'logout-shared-claude',
     'logout-xai-oauth',
+    'remove-custom-server',
     'remove-github-token',
     'retry-custom-server',
     'save-github-token',
     'set-app-icon-variant',
     'set-close-preference',
+    'set-custom-server-enabled',
     'set-default-permission-profile',
     'set-notifications-enabled',
     'set-show-notification-content',
@@ -235,6 +238,7 @@ const REMOTE_LOCAL_ONLY_CHANNELS: GroupedInventory = {
     'uninstall-codebuddy',
     'uninstall-codex',
     'uninstall-opencode',
+    'update-custom-server',
     'validate-openalex-credential',
     'wait-xai-oauth-login'
   ],


### PR DESCRIPTION
## Problem

Paired Remote Web callers could invoke custom Connector lifecycle RPCs that were intended to remain under local host authority. Adding or updating an enabled `stdio` Connector triggers the Connector Skill projection refresh, which calls `listTools()` and connects a `StdioClientTransport` with the caller-supplied command and arguments. Enabling an existing custom Connector exposed the same path.

The Add Connector UI trust checkbox did not cross the renderer contract, while main synthesized `trustedAt` for every ordinary add request. The timestamp is not currently an authorization input, but persisting it implied a confirmation that main could not verify.

## Proposed change

- Mark add, update, enable/disable, and remove custom Connector contracts local-only so Remote Web does not install the RPCs.
- Enforce the same local-caller requirement at the main-process application-command boundary before a Connector workflow can run.
- Stop synthesizing `trustedAt` for ordinary add requests.
- Add regression coverage for the renderer surface contract, main-process rejection boundary, retained local behavior, and persisted trust metadata.

## Scope and non-goals

- Electron and local Web custom Connector management remain available.
- The four ordinary bundled-Connector setting mutations that do not manage a custom server remain remotely available.
- No database schema, request field, data-model enum, migration, or UI layout is added.
- Historical records containing `trustedAt` remain readable and retain the optional field; this change does not rewrite existing settings.
- This PR does not treat a caller-provided trust boolean as proof of a user interaction. Local caller provenance is the enforceable authority boundary.

## Acceptance criteria and validation

The new regression tests were first run against the unfixed implementation and failed deterministically because Remote Web contracts were still `web-rpc`, application commands resolved instead of rejecting, and main synthesized `trustedAt`.

Final checks ran after the last material edit:

- custom Connector remote rejection and retained local behavior -> `src/main/settings/integration-application-commands.test.ts` -> passed
- renderer/local-only surface and Remote Web restriction inventory -> Settings module contract/consumer test set -> passed
- Connector persistence and `trustedAt` behavior -> `src/main/settings/connector-settings.test.ts` -> passed
- Settings facade owner/contract/consumer impact set, excluding the environment-blocked symlink file -> 28 files passed; 656 tests passed, 4 skipped
- Node process typing -> `npm run typecheck:node` -> passed
- Web process typing -> `npm run typecheck:web` -> passed
- lint -> `npm run lint` -> passed

The complete module attempt also ran `src/main/settings/service.test.ts`: 254 tests passed and seven pre-existing symlink tests failed with Windows `EPERM` because the current session cannot create symlinks. The affected behavior does not use those paths; PR CI remains authoritative for that file and the complete portable suite.

## Review focus

- The catalog and application-command checks should remain paired as defense in depth.
- Confirm that all custom Connector lifecycle mutations, including enable/disable, belong on the local side of the authority boundary.
- Confirm that retaining historical `trustedAt` data without generating new values is the desired compatibility behavior.
