### PR TITLE
fix(connectors): enforce custom connector integrity

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -121,6 +121,7 @@
         "src/main/app-lifecycle.ts",
         "src/main/artifacts/durability.ts",
         "src/main/cli-install/launcher.ts",
+        "src/main/connectors/custom-mcp-bootstrap.ts",
         "src/main/compute/connection-adapters.ts",
         "src/main/compute/credential-vault.ts",
         "src/main/compute/scp-runner.ts",

--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -121,7 +121,6 @@
         "src/main/app-lifecycle.ts",
         "src/main/artifacts/durability.ts",
         "src/main/cli-install/launcher.ts",
-        "src/main/connectors/custom-mcp-bootstrap.ts",
         "src/main/compute/connection-adapters.ts",
         "src/main/compute/credential-vault.ts",
         "src/main/compute/scp-runner.ts",

--- a/src/main/connectors/application.test.ts
+++ b/src/main/connectors/application.test.ts
@@ -164,12 +164,9 @@ describe('Connector application composition', () => {
     await module.capability.runtimeSettings.refresh()
     const args = { query: 'x'.repeat(400) }
 
-    await module.capability.connectorService.call(
-      'stable-server',
-      'lookup',
-      args,
-      { origin: 'internal' }
-    )
+    await module.capability.connectorService.call('stable-server', 'lookup', args, {
+      origin: 'internal'
+    })
 
     expect(connectorApprovals.request).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/main/connectors/application.test.ts
+++ b/src/main/connectors/application.test.ts
@@ -139,6 +139,52 @@ describe('Connector application composition', () => {
     await module.dispose?.()
   })
 
+  it('captures the immutable custom Connector target and full arguments for approval', async () => {
+    const { settings, mcpClientManager, connectorApprovals, deps } = createHarness()
+    settings.getConnectors.mockResolvedValue({
+      enabledIds: [],
+      autoAllowIds: [],
+      askToolIds: ['stable-server/lookup'],
+      customMcpServers: [
+        {
+          id: 'server-id',
+          name: 'stable-server',
+          displayName: 'Duplicate label',
+          transport: 'streamable_http',
+          url: 'https://mcp.example.test/path',
+          enabled: true
+        }
+      ]
+    })
+    mcpClientManager.listTools.mockResolvedValue([
+      { name: 'lookup', description: 'Look up a record', inputSchema: { type: 'object' } }
+    ])
+    mcpClientManager.call.mockResolvedValue({ ok: true })
+    const module = await createConnectorApplicationModule(deps)
+    await module.capability.runtimeSettings.refresh()
+    const args = { query: 'x'.repeat(400) }
+
+    await module.capability.connectorService.call(
+      'stable-server',
+      'lookup',
+      args,
+      { origin: 'internal' }
+    )
+
+    expect(connectorApprovals.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectorId: 'server-id',
+        connectorName: 'stable-server',
+        displayName: 'Duplicate label',
+        transport: 'streamable_http',
+        target: 'https://mcp.example.test',
+        argsJson: JSON.stringify(args)
+      }),
+      undefined
+    )
+    await module.dispose?.()
+  })
+
   it('forwards the conversation cancellation signal to GitHub scanning', async () => {
     const { settings, skillImportApprovals, deps } = createHarness()
     const controller = new AbortController()

--- a/src/main/connectors/application.test.ts
+++ b/src/main/connectors/application.test.ts
@@ -182,6 +182,41 @@ describe('Connector application composition', () => {
     await module.dispose?.()
   })
 
+  it('bounds oversized approval arguments before broadcasting them', async () => {
+    const { settings, mcpClientManager, connectorApprovals, deps } = createHarness()
+    settings.getConnectors.mockResolvedValue({
+      enabledIds: [],
+      autoAllowIds: [],
+      askToolIds: ['stable-server/lookup'],
+      customMcpServers: [
+        {
+          id: 'server-id',
+          name: 'stable-server',
+          displayName: 'Stable server',
+          transport: 'streamable_http',
+          url: 'https://mcp.example.test/path',
+          enabled: true
+        }
+      ]
+    })
+    mcpClientManager.listTools.mockResolvedValue([
+      { name: 'lookup', description: 'Look up a record', inputSchema: { type: 'object' } }
+    ])
+    mcpClientManager.call.mockResolvedValue({ ok: true })
+    const module = await createConnectorApplicationModule(deps)
+    await module.capability.runtimeSettings.refresh()
+    const args = { query: 'x'.repeat(70_000) }
+
+    await module.capability.connectorService.call('stable-server', 'lookup', args, {
+      origin: 'internal'
+    })
+
+    const request = connectorApprovals.request.mock.calls[0][0]
+    expect(request.argsJson?.length).toBeLessThan(JSON.stringify(args).length)
+    expect(request.argsJsonTruncated).toBe(true)
+    await module.dispose?.()
+  })
+
   it('forwards the conversation cancellation signal to GitHub scanning', async () => {
     const { settings, skillImportApprovals, deps } = createHarness()
     const controller = new AbortController()

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -192,7 +192,12 @@ export const createConnectorApplicationModule = async (
     deps.mcpClientManager ??
     new McpClientManager({
       openExternal: deps.openExternal,
-      saveOAuthState: (serverId, state) => deps.settings.saveCustomServerOAuthState(serverId, state)
+      saveOAuthState: (serverId, state, expectedConfigurationFingerprint) =>
+        deps.settings.saveCustomServerOAuthState(
+          serverId,
+          state,
+          expectedConfigurationFingerprint
+        )
     })
 
   try {

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -209,8 +209,18 @@ export const createConnectorApplicationModule = async (
     deps.mcpClientManager ??
     new McpClientManager({
       openExternal: deps.openExternal,
-      saveOAuthState: (serverId, state, expectedConfigurationFingerprint) =>
-        deps.settings.saveCustomServerOAuthState(serverId, state, expectedConfigurationFingerprint)
+      saveOAuthState: (
+        serverId,
+        state,
+        expectedConfigurationFingerprint,
+        expectedOAuthClientSecretRef
+      ) =>
+        deps.settings.saveCustomServerOAuthState(
+          serverId,
+          state,
+          expectedConfigurationFingerprint,
+          expectedOAuthClientSecretRef
+        )
     })
 
   try {

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -67,14 +67,23 @@ type ConnectorApplication = {
   skillImportApprovals: SkillImportApprovalBroker
 }
 
-const serializeArgs = (args: Record<string, unknown>): { preview: string; json: string } => {
+const MAX_APPROVAL_ARGS_JSON_CHARS = 64_000
+
+const serializeArgs = (
+  args: Record<string, unknown>
+): { preview: string; json: string; truncated: boolean } => {
   let json: string
   try {
     json = JSON.stringify(args)
   } catch {
     json = '{…}'
   }
-  return { preview: json.length > 300 ? `${json.slice(0, 300)}…` : json, json }
+  const truncated = json.length > MAX_APPROVAL_ARGS_JSON_CHARS
+  return {
+    preview: json.length > 300 ? `${json.slice(0, 300)}…` : json,
+    json: truncated ? `${json.slice(0, MAX_APPROVAL_ARGS_JSON_CHARS)}…` : json,
+    truncated
+  }
 }
 
 const createConnectorApplication = (
@@ -165,6 +174,7 @@ const createConnectorApplication = (
           method,
           argsPreview: serializedArgs.preview,
           argsJson: serializedArgs.json,
+          ...(serializedArgs.truncated ? { argsJsonTruncated: true } : {}),
           ...(sessionId ? { sessionId } : {}),
           availableScopes
         },

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -67,14 +67,14 @@ type ConnectorApplication = {
   skillImportApprovals: SkillImportApprovalBroker
 }
 
-const previewArgs = (args: Record<string, unknown>): string => {
+const serializeArgs = (args: Record<string, unknown>): { preview: string; json: string } => {
   let json: string
   try {
     json = JSON.stringify(args)
   } catch {
     json = '{…}'
   }
-  return json.length > 300 ? `${json.slice(0, 300)}…` : json
+  return { preview: json.length > 300 ? `${json.slice(0, 300)}…` : json, json }
 }
 
 const createConnectorApplication = (
@@ -153,17 +153,24 @@ const createConnectorApplication = (
     resolveApiKey: deps.resolveApiKey,
     mcpClientManager,
     permissionGrantRegistry: deps.permissionGrantRegistry,
-    requestApproval: ({ connector, method, args, sessionId, availableScopes }, signal) =>
-      connectorApprovals.request(
+    requestApproval: (
+      { connector, method, args, sessionId, availableScopes, approvalTarget },
+      signal
+    ) => {
+      const serializedArgs = serializeArgs(args)
+      return connectorApprovals.request(
         {
           connector,
+          ...(approvalTarget ?? {}),
           method,
-          argsPreview: previewArgs(args),
+          argsPreview: serializedArgs.preview,
+          argsJson: serializedArgs.json,
           ...(sessionId ? { sessionId } : {}),
           availableScopes
         },
         signal
-      ),
+      )
+    },
     requestCredential: (request, signal) =>
       deps.canRequestCredential()
         ? credentialRequests.request(request, signal)
@@ -193,11 +200,7 @@ export const createConnectorApplicationModule = async (
     new McpClientManager({
       openExternal: deps.openExternal,
       saveOAuthState: (serverId, state, expectedConfigurationFingerprint) =>
-        deps.settings.saveCustomServerOAuthState(
-          serverId,
-          state,
-          expectedConfigurationFingerprint
-        )
+        deps.settings.saveCustomServerOAuthState(serverId, state, expectedConfigurationFingerprint)
     })
 
   try {

--- a/src/main/connectors/approval-broker.ts
+++ b/src/main/connectors/approval-broker.ts
@@ -1,18 +1,6 @@
-import type {
-  ApprovalDecision,
-  ConnectorApprovalRequest,
-  ConnectorApprovalScope
-} from '../../shared/settings'
+import type { ApprovalDecision, ConnectorApprovalRequest } from '../../shared/settings'
 
-export type ApprovalInfo = {
-  connector: string
-  method: string
-  argsPreview: string
-  // The session that triggered the connector call, when one is known, so the desktop notification
-  // can open that conversation.
-  sessionId?: string
-  availableScopes?: ConnectorApprovalScope[]
-}
+export type ApprovalInfo = Omit<ConnectorApprovalRequest, 'id'>
 
 type ApprovalBrokerDeps = {
   // Pushes a pending request to the renderer(s) that show the approval card.

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -200,6 +200,22 @@ describe('selectEnabledCustomServers', () => {
     expect(selectEnabledCustomServers({ enabledIds: [], autoAllowIds: [] })).toEqual([])
   })
 
+  it('keeps a persisted non-loopback HTTP server out of runtime discovery', () => {
+    const insecureRemote: StoredCustomMcpServer = {
+      ...remoteServer,
+      url: 'http://example.com/mcp',
+      headers: { Authorization: 'Bearer secret' }
+    }
+
+    expect(
+      selectEnabledCustomServers({
+        enabledIds: [],
+        autoAllowIds: [],
+        customMcpServers: [insecureRemote]
+      })
+    ).toEqual([])
+  })
+
   it('fails closed when custom Connectors have duplicate names', () => {
     const first: StoredCustomMcpServer = {
       ...stdioServer,

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -76,6 +76,7 @@ describe('toCustomMcpConfig', () => {
         authorizationServerUrl: 'https://auth.example.test',
         clientId: 'registered-client'
       },
+      oauthClientSecretRef: 'enc:registered-secret',
       oauthClientSecret: 'registered-secret',
       oauthState: { tokens: { access_token: 'access', token_type: 'Bearer' } },
       enabled: true
@@ -85,6 +86,7 @@ describe('toCustomMcpConfig', () => {
       id: 'srv-oauth',
       name: 'oauth-server',
       configurationFingerprint: expect.any(String),
+      oauthClientSecretRef: 'enc:registered-secret',
       transport: 'streamable_http',
       command: '',
       args: undefined,

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -279,6 +279,64 @@ describe('selectEnabledCustomServers', () => {
     ).toEqual([])
   })
 
+  it('fails closed for historical credential names that collide on the active platform', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      const ambiguousEnvironment: StoredCustomMcpServer = {
+        ...stdioServer,
+        id: 'ambiguous-environment',
+        name: 'ambiguous-environment',
+        env: { API_TOKEN: 'first', api_token: 'second' }
+      }
+      const ambiguousHeaders: StoredCustomMcpServer = {
+        ...remoteServer,
+        id: 'ambiguous-headers',
+        name: 'ambiguous-headers',
+        headers: { Authorization: 'first', authorization: 'second' }
+      }
+
+      expect(
+        selectEnabledCustomServers({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [ambiguousEnvironment, ambiguousHeaders]
+        })
+      ).toEqual([])
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
+  it('keeps case-distinct historical environment variables runnable on Unix', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    try {
+      const caseDistinctEnvironment: StoredCustomMcpServer = {
+        ...stdioServer,
+        id: 'case-distinct-environment',
+        name: 'case-distinct-environment',
+        env: { API_TOKEN: 'first', api_token: 'second' }
+      }
+
+      expect(
+        selectEnabledCustomServers({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [caseDistinctEnvironment]
+        })
+      ).toEqual([caseDistinctEnvironment])
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
   it('ignores unresolved credential maps that are unused by the active transport', () => {
     const stdioWithStaleHeaders: StoredCustomMcpServer = {
       ...stdioServer,

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -18,6 +18,7 @@ describe('toCustomMcpConfig', () => {
     expect(toCustomMcpConfig(server)).toEqual({
       id: 'srv-1',
       name: 'my-server',
+      configurationFingerprint: expect.any(String),
       transport: 'stdio',
       command: 'npx',
       args: ['-y', 'some-mcp-server'],
@@ -53,6 +54,7 @@ describe('toCustomMcpConfig', () => {
     expect(toCustomMcpConfig(server)).toEqual({
       id: 'srv-remote',
       name: 'remote-server',
+      configurationFingerprint: expect.any(String),
       transport: 'streamable_http',
       command: '',
       args: undefined,
@@ -82,6 +84,7 @@ describe('toCustomMcpConfig', () => {
     expect(toCustomMcpConfig(server)).toEqual({
       id: 'srv-oauth',
       name: 'oauth-server',
+      configurationFingerprint: expect.any(String),
       transport: 'streamable_http',
       command: '',
       args: undefined,

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -30,6 +30,7 @@ export function toCustomMcpConfig(server: StoredCustomMcpServer): CustomMcpServe
     id: server.id,
     name: server.name,
     configurationFingerprint: customServerSecurityFingerprint(server),
+    ...(server.oauthClientSecretRef ? { oauthClientSecretRef: server.oauthClientSecretRef } : {}),
     transport: server.transport,
     command: server.command ?? '',
     args: server.args,

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -56,6 +56,22 @@ const SUPPORTED_CUSTOM_MCP_TRANSPORTS = new Set<StoredCustomMcpServer['transport
   'sse'
 ])
 
+const hasCaseInsensitiveNameCollision = (values: Record<string, string> | undefined): boolean => {
+  const names = Object.keys(values ?? {})
+  return new Set(names.map((name) => name.toLowerCase())).size !== names.length
+}
+
+export const hasAmbiguousCustomMcpCredentialNames = (
+  fields: Pick<StoredCustomMcpServer, 'transport' | 'env' | 'envRefs' | 'headers' | 'headerRefs'>,
+  platform = process.platform
+): boolean =>
+  fields.transport === 'stdio'
+    ? platform === 'win32' &&
+      (hasCaseInsensitiveNameCollision(fields.envRefs) ||
+        hasCaseInsensitiveNameCollision(fields.env))
+    : hasCaseInsensitiveNameCollision(fields.headerRefs) ||
+      hasCaseInsensitiveNameCollision(fields.headers)
+
 // A name already owned by a bundled Connector or another custom record remains visible in Settings
 // but cannot be exposed or dispatched.
 export const isCustomMcpServerRouteSafe = (
@@ -66,6 +82,7 @@ export const isCustomMcpServerRouteSafe = (
     validateResourceId(server.id) ||
     ALL_CONNECTOR_IDS.includes(server.id) ||
     ALL_CONNECTOR_IDS.includes(server.name) ||
+    hasAmbiguousCustomMcpCredentialNames(server) ||
     (server.transport !== 'stdio' && (!server.url || !isSecureCustomMcpUrl(server.url)))
   ) {
     return false

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -4,6 +4,7 @@ import { hasEmbeddedConnectorCredentials } from '../settings/connector-template'
 import { ALL_CONNECTOR_IDS } from './registry'
 import { validateResourceId } from '../../shared/resource-id'
 import { customServerSecurityFingerprint } from '../settings/custom-server-identity'
+import { isSecureCustomMcpUrl } from './custom-mcp-url'
 
 export type CustomMcpFailureAvailability = 'unavailable' | 'unauthenticated'
 
@@ -64,7 +65,8 @@ export const isCustomMcpServerRouteSafe = (
   if (
     validateResourceId(server.id) ||
     ALL_CONNECTOR_IDS.includes(server.id) ||
-    ALL_CONNECTOR_IDS.includes(server.name)
+    ALL_CONNECTOR_IDS.includes(server.name) ||
+    (server.transport !== 'stdio' && (!server.url || !isSecureCustomMcpUrl(server.url)))
   ) {
     return false
   }

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -5,6 +5,7 @@ import { ALL_CONNECTOR_IDS } from './registry'
 import { validateResourceId } from '../../shared/resource-id'
 import { customServerSecurityFingerprint } from '../settings/custom-server-identity'
 import { isSecureCustomMcpUrl } from './custom-mcp-url'
+import { hasAmbiguousCustomMcpCredentialNames } from './custom-mcp-windows-credential-names'
 
 export type CustomMcpFailureAvailability = 'unavailable' | 'unauthenticated'
 
@@ -55,22 +56,6 @@ const SUPPORTED_CUSTOM_MCP_TRANSPORTS = new Set<StoredCustomMcpServer['transport
   'streamable_http',
   'sse'
 ])
-
-const hasCaseInsensitiveNameCollision = (values: Record<string, string> | undefined): boolean => {
-  const names = Object.keys(values ?? {})
-  return new Set(names.map((name) => name.toLowerCase())).size !== names.length
-}
-
-export const hasAmbiguousCustomMcpCredentialNames = (
-  fields: Pick<StoredCustomMcpServer, 'transport' | 'env' | 'envRefs' | 'headers' | 'headerRefs'>,
-  platform = process.platform
-): boolean =>
-  fields.transport === 'stdio'
-    ? platform === 'win32' &&
-      (hasCaseInsensitiveNameCollision(fields.envRefs) ||
-        hasCaseInsensitiveNameCollision(fields.env))
-    : hasCaseInsensitiveNameCollision(fields.headerRefs) ||
-      hasCaseInsensitiveNameCollision(fields.headers)
 
 // A name already owned by a bundled Connector or another custom record remains visible in Settings
 // but cannot be exposed or dispatched.

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -2,6 +2,7 @@ import type { CustomMcpServerConfig } from './mcp-client-manager'
 import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
 import { hasEmbeddedConnectorCredentials } from '../settings/connector-template'
 import { ALL_CONNECTOR_IDS } from './registry'
+import { validateResourceId } from '../../shared/resource-id'
 
 export type CustomMcpFailureAvailability = 'unavailable' | 'unauthenticated'
 
@@ -58,9 +59,22 @@ export const isCustomMcpServerRouteSafe = (
   server: StoredCustomMcpServer,
   allServers: readonly StoredCustomMcpServer[]
 ): boolean => {
-  if (ALL_CONNECTOR_IDS.includes(server.name)) return false
+  if (
+    validateResourceId(server.id) ||
+    ALL_CONNECTOR_IDS.includes(server.id) ||
+    ALL_CONNECTOR_IDS.includes(server.name)
+  ) {
+    return false
+  }
 
-  return allServers.every((candidate) => candidate === server || candidate.name !== server.name)
+  return allServers.every(
+    (candidate) =>
+      candidate === server ||
+      (candidate.id !== server.id &&
+        candidate.name !== server.name &&
+        candidate.id !== server.name &&
+        candidate.name !== server.id)
+  )
 }
 
 const hasResolvedSecretRecord = (

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -3,6 +3,7 @@ import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
 import { hasEmbeddedConnectorCredentials } from '../settings/connector-template'
 import { ALL_CONNECTOR_IDS } from './registry'
 import { validateResourceId } from '../../shared/resource-id'
+import { customServerSecurityFingerprint } from '../settings/custom-server-identity'
 
 export type CustomMcpFailureAvailability = 'unavailable' | 'unauthenticated'
 
@@ -26,6 +27,7 @@ export function toCustomMcpConfig(server: StoredCustomMcpServer): CustomMcpServe
   return {
     id: server.id,
     name: server.name,
+    configurationFingerprint: customServerSecurityFingerprint(server),
     transport: server.transport,
     command: server.command ?? '',
     args: server.args,

--- a/src/main/connectors/custom-mcp-url.ts
+++ b/src/main/connectors/custom-mcp-url.ts
@@ -1,0 +1,24 @@
+import { isIP } from 'node:net'
+
+const isLoopbackHost = (hostname: string): boolean => {
+  const unbracketed =
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+
+  if (unbracketed.toLowerCase() === 'localhost' || unbracketed === '::1') return true
+  return isIP(unbracketed) === 4 && unbracketed.split('.')[0] === '127'
+}
+
+export const isSecureCustomMcpUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' || (url.protocol === 'http:' && isLoopbackHost(url.hostname))
+  } catch {
+    return false
+  }
+}
+
+export const assertSecureCustomMcpUrl = (value: string): void => {
+  if (!isSecureCustomMcpUrl(value)) {
+    throw new Error('Remote MCP server URL must use HTTPS or loopback HTTP.')
+  }
+}

--- a/src/main/connectors/custom-mcp-windows-credential-names.ts
+++ b/src/main/connectors/custom-mcp-windows-credential-names.ts
@@ -1,0 +1,17 @@
+import type { StoredCustomMcpServer } from '../settings/types'
+
+const hasCaseInsensitiveNameCollision = (values: Record<string, string> | undefined): boolean => {
+  const names = Object.keys(values ?? {})
+  return new Set(names.map((name) => name.toLowerCase())).size !== names.length
+}
+
+export const hasAmbiguousCustomMcpCredentialNames = (
+  fields: Pick<StoredCustomMcpServer, 'transport' | 'env' | 'envRefs' | 'headers' | 'headerRefs'>,
+  platform = process.platform
+): boolean =>
+  fields.transport === 'stdio'
+    ? platform === 'win32' &&
+      (hasCaseInsensitiveNameCollision(fields.envRefs) ||
+        hasCaseInsensitiveNameCollision(fields.env))
+    : hasCaseInsensitiveNameCollision(fields.headerRefs) ||
+      hasCaseInsensitiveNameCollision(fields.headers)

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -809,6 +809,7 @@ describe('buildTransport', () => {
   })
 
   it('does not forward static headers across an insecure transport redirect', async () => {
+    netFetch.mockReset()
     const redirectedHeaders: Headers[] = []
     netFetch.mockImplementation(async (input, init) => {
       const url = new URL(String(input))
@@ -836,6 +837,38 @@ describe('buildTransport', () => {
       .catch(() => undefined)
 
     expect(redirectedHeaders).toEqual([])
+    await transport.close()
+  })
+
+  it('keeps static headers on a secure same-origin transport redirect', async () => {
+    netFetch.mockReset()
+    netFetch
+      .mockResolvedValueOnce(
+        new Response(null, { status: 307, headers: { location: '/redirected-mcp' } })
+      )
+      .mockResolvedValue(new Response(null, { status: 202 }))
+    const transport = buildTransport({
+      id: 'srv-http-same-origin-redirect',
+      name: 'http-same-origin-redirect-server',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test',
+      headers: { 'X-API-Key': 'secret' }
+    })
+
+    await transport.start()
+    await transport.send({ jsonrpc: '2.0', method: 'notifications/initialized' })
+
+    expect(netFetch).toHaveBeenNthCalledWith(
+      2,
+      new URL('https://mcp.example.test/redirected-mcp'),
+      expect.objectContaining({
+        headers: expect.any(Headers),
+        method: 'POST',
+        redirect: 'manual'
+      })
+    )
+    const redirectedInit = netFetch.mock.calls[1]?.[1]
+    expect(new Headers(redirectedInit?.headers).get('X-API-Key')).toBe('secret')
     await transport.close()
   })
 

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -589,6 +589,18 @@ describe('McpClientManager', () => {
 })
 
 describe('buildTransport', () => {
+  it('rejects a non-loopback HTTP transport before creating a client', () => {
+    expect(() =>
+      buildTransport({
+        id: 'srv-http-cleartext',
+        name: 'http-cleartext',
+        transport: 'streamable_http',
+        url: 'http://example.com/mcp',
+        headers: { Authorization: 'Bearer secret' }
+      })
+    ).toThrow(/HTTPS|loopback/)
+  })
+
   const stdioTransportEnvironment = (env?: Record<string, string>): Record<string, string> => {
     const transport = buildTransport({
       id: 'srv-stdio',

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -11,7 +11,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { z } from 'zod'
 import { McpClientManager, McpToolCallError, buildTransport } from './mcp-client-manager'
 import type { CustomMcpServerConfig } from './mcp-client-manager'
-import { OAuthCallbackServer, type PersistentOAuthClientProvider } from './oauth-client'
+import { OAuthCallbackServer, PersistentOAuthClientProvider } from './oauth-client'
 import { EXTRA_PATH_DIRS } from '../settings/shell-path'
 
 const { netFetch, stderrWarn } = vi.hoisted(() => ({
@@ -809,6 +809,73 @@ describe('buildTransport', () => {
       expect.objectContaining({ method: 'POST' })
     )
     expect(directFetch).not.toHaveBeenCalled()
+    await transport.close()
+  })
+
+  it('allows OAuth discovery on a different secure origin from the MCP server', async () => {
+    netFetch.mockReset()
+    const authorizationServerHeaders: Headers[] = []
+    netFetch.mockImplementation(async (input, init) => {
+      const url = new URL(String(input))
+      if (url.origin === 'https://mcp.example.test' && url.pathname === '/mcp') {
+        return new Response(null, { status: 401 })
+      }
+      if (
+        url.origin === 'https://mcp.example.test' &&
+        url.pathname.startsWith('/.well-known/oauth-protected-resource')
+      ) {
+        return new Response(null, { status: 404 })
+      }
+      if (
+        url.origin === 'https://auth.example.test' &&
+        url.pathname === '/.well-known/oauth-authorization-server'
+      ) {
+        authorizationServerHeaders.push(new Headers(init?.headers))
+        return Response.json({
+          issuer: 'https://auth.example.test',
+          authorization_endpoint: 'https://auth.example.test/authorize',
+          token_endpoint: 'https://auth.example.test/token',
+          response_types_supported: ['code'],
+          code_challenge_methods_supported: ['S256']
+        })
+      }
+      throw new Error(`unexpected request to ${url}`)
+    })
+    const openExternal = vi.fn(async () => undefined)
+    const provider = new PersistentOAuthClientProvider({
+      serverId: 'srv-cross-origin-oauth',
+      redirectUrl: 'http://127.0.0.1:4000/oauth/callback',
+      config: {
+        authorizationServerUrl: 'https://auth.example.test',
+        clientId: 'registered-client'
+      },
+      openExternal
+    })
+    const transport = buildTransport(
+      {
+        id: 'srv-cross-origin-oauth',
+        name: 'cross-origin-oauth-server',
+        transport: 'streamable_http',
+        url: 'https://mcp.example.test/mcp',
+        headers: { 'X-API-Key': 'mcp-static-secret' },
+        oauth: {
+          authorizationServerUrl: 'https://auth.example.test',
+          clientId: 'registered-client'
+        }
+      },
+      provider
+    )
+
+    await transport.start()
+    await expect(
+      transport.send({ jsonrpc: '2.0', method: 'notifications/initialized' })
+    ).rejects.toBeInstanceOf(UnauthorizedError)
+
+    expect(openExternal).toHaveBeenCalledWith(
+      expect.stringMatching(/^https:\/\/auth\.example\.test\/authorize\?/)
+    )
+    expect(authorizationServerHeaders).toHaveLength(1)
+    expect(authorizationServerHeaders[0]?.get('X-API-Key')).toBeNull()
     await transport.close()
   })
 

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -808,6 +808,37 @@ describe('buildTransport', () => {
     await transport.close()
   })
 
+  it('does not forward static headers across an insecure transport redirect', async () => {
+    const redirectedHeaders: Headers[] = []
+    netFetch.mockImplementation(async (input, init) => {
+      const url = new URL(String(input))
+      if (url.hostname === 'redirect.example.test') {
+        redirectedHeaders.push(new Headers(init?.headers))
+        return new Response(null, { status: 202 })
+      }
+      const location = 'http://redirect.example.test/mcp'
+      if (init?.redirect === 'manual') {
+        return new Response(null, { status: 302, headers: { location } })
+      }
+      return netFetch(new URL(location), init)
+    })
+    const transport = buildTransport({
+      id: 'srv-http-redirect',
+      name: 'http-redirect-server',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test',
+      headers: { 'X-API-Key': 'secret' }
+    })
+
+    await transport.start()
+    await transport
+      .send({ jsonrpc: '2.0', method: 'notifications/initialized' })
+      .catch(() => undefined)
+
+    expect(redirectedHeaders).toEqual([])
+    await transport.close()
+  })
+
   it('throws when a streamable_http config is missing a url', () => {
     expect(() =>
       buildTransport({ id: 'srv-http', name: 'http-server', transport: 'streamable_http' })

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -287,6 +287,8 @@ describe('McpClientManager', () => {
       await manager.authenticate({
         id: 'oauth-1',
         name: 'OAuth server',
+        configurationFingerprint: 'security-fingerprint',
+        oauthClientSecretRef: 'enc:client-secret',
         transport: 'streamable_http',
         url: 'https://mcp.example.test',
         oauth: { redirectUri: 'http://127.0.0.1:8080/callback' }
@@ -299,7 +301,9 @@ describe('McpClientManager', () => {
         'oauth-1',
         expect.objectContaining({
           tokens: { access_token: 'access-1', token_type: 'Bearer' }
-        })
+        }),
+        'security-fingerprint',
+        'enc:client-secret'
       )
     } finally {
       await manager.closeAll()

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -65,15 +65,26 @@ export class McpToolCallError extends Error {
   }
 }
 
-const createCustomMcpFetch = (configuredUrl: URL): typeof fetch =>
+const createCustomMcpFetch = (
+  configuredUrl: URL,
+  configuredHeaders?: Record<string, string>
+): typeof fetch =>
   async function customMcpFetch(input, init): Promise<Response> {
     const inputRequest = typeof input === 'string' || input instanceof URL ? undefined : input
     let target = new URL(inputRequest?.url ?? input.toString())
+    const requestOrigin = target.origin
     let requestInit = init
+
+    if (target.origin === configuredUrl.origin && configuredHeaders) {
+      const headers = new Headers(inputRequest?.headers)
+      new Headers(init?.headers).forEach((value, name) => headers.set(name, value))
+      new Headers(configuredHeaders).forEach((value, name) => headers.set(name, value))
+      requestInit = { ...init, headers }
+    }
 
     for (let redirects = 0; ; redirects += 1) {
       assertSecureCustomMcpUrl(target.toString())
-      if (target.origin !== configuredUrl.origin) {
+      if (target.origin !== requestOrigin) {
         throw new Error('Remote MCP server redirects must stay on the configured origin.')
       }
 
@@ -88,7 +99,7 @@ const createCustomMcpFetch = (configuredUrl: URL): typeof fetch =>
 
       const next = new URL(location, target)
       assertSecureCustomMcpUrl(next.toString())
-      if (next.origin !== configuredUrl.origin) {
+      if (next.origin !== requestOrigin) {
         await response.body?.cancel()
         throw new Error('Remote MCP server redirects must stay on the configured origin.')
       }
@@ -370,9 +381,8 @@ export function buildTransport(
       assertSecureCustomMcpUrl(config.url)
       const url = new URL(config.url)
       return new StreamableHTTPClientTransport(url, {
-        fetch: createCustomMcpFetch(url),
-        ...(authProvider ? { authProvider } : {}),
-        ...(config.headers ? { requestInit: { headers: config.headers } } : {})
+        fetch: createCustomMcpFetch(url, config.headers),
+        ...(authProvider ? { authProvider } : {})
       })
     }
     case 'sse': {
@@ -382,9 +392,8 @@ export function buildTransport(
       assertSecureCustomMcpUrl(config.url)
       const url = new URL(config.url)
       return new SSEClientTransport(url, {
-        fetch: createCustomMcpFetch(url),
-        ...(authProvider ? { authProvider } : {}),
-        ...(config.headers ? { requestInit: { headers: config.headers } } : {})
+        fetch: createCustomMcpFetch(url, config.headers),
+        ...(authProvider ? { authProvider } : {})
       })
     }
   }

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -14,6 +14,7 @@ import { augmentedPathEnv } from '../settings/shell-path'
 import { netFetchStandard } from '../skills/net-fetch'
 import { redactSensitiveText } from '../diagnostic-redaction'
 import { createLogger } from '../logger'
+import { assertSecureCustomMcpUrl } from './custom-mcp-url'
 
 const log = createLogger('connectors:mcp-client')
 const STDERR_LINE_LIMIT = 4 * 1024
@@ -316,6 +317,7 @@ export function buildTransport(
       if (!config.url) {
         throw new Error(`custom MCP server "${config.name}" is missing a url for streamable_http`)
       }
+      assertSecureCustomMcpUrl(config.url)
       return new StreamableHTTPClientTransport(new URL(config.url), {
         fetch: netFetchStandard,
         ...(authProvider ? { authProvider } : {}),
@@ -326,6 +328,7 @@ export function buildTransport(
       if (!config.url) {
         throw new Error(`custom MCP server "${config.name}" is missing a url for sse`)
       }
+      assertSecureCustomMcpUrl(config.url)
       return new SSEClientTransport(new URL(config.url), {
         fetch: netFetchStandard,
         ...(authProvider ? { authProvider } : {}),

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -30,6 +30,7 @@ export type CustomMcpServerConfig = {
   id: string
   name: string
   configurationFingerprint?: string
+  oauthClientSecretRef?: string
   transport: 'stdio' | 'streamable_http' | 'sse'
   // stdio (local command):
   command?: string
@@ -120,7 +121,8 @@ type McpClientManagerDeps = {
   saveOAuthState?: (
     serverId: string,
     state: StoredCustomMcpOAuthState,
-    expectedConfigurationFingerprint?: string
+    expectedConfigurationFingerprint?: string,
+    expectedOAuthClientSecretRef?: string
   ) => Promise<void>
 }
 
@@ -418,7 +420,8 @@ export class McpClientManager {
   private readonly saveOAuthState?: (
     serverId: string,
     state: StoredCustomMcpOAuthState,
-    expectedConfigurationFingerprint?: string
+    expectedConfigurationFingerprint?: string,
+    expectedOAuthClientSecretRef?: string
   ) => Promise<void>
 
   constructor(deps?: McpClientManagerDeps) {
@@ -657,7 +660,12 @@ export class McpClientManager {
         ? (state) =>
             generation === this.generation(config.id)
               ? config.configurationFingerprint
-                ? this.saveOAuthState!(config.id, state, config.configurationFingerprint)
+                ? this.saveOAuthState!(
+                    config.id,
+                    state,
+                    config.configurationFingerprint,
+                    config.oauthClientSecretRef
+                  )
                 : this.saveOAuthState!(config.id, state)
               : Promise.resolve()
         : undefined

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -21,6 +21,8 @@ const STDERR_LINE_LIMIT = 4 * 1024
 const STDERR_TOTAL_LIMIT = 64 * 1024
 const STDERR_REDACTION_COMPARISON_LIMIT = 4 * 1024 * 1024
 const STDERR_TRUNCATION_MARKER = '…[truncated]'
+const MAX_MCP_REDIRECTS = 5
+const MCP_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
 
 // Config for a user-added custom MCP server. OAuth state is a transient main-process projection;
 // stdio remains non-OAuth and remote servers can use OAuth, static headers, or neither.
@@ -61,6 +63,52 @@ export class McpToolCallError extends Error {
     this.name = 'McpToolCallError'
   }
 }
+
+const createCustomMcpFetch = (configuredUrl: URL): typeof fetch =>
+  async function customMcpFetch(input, init): Promise<Response> {
+    const inputRequest = typeof input === 'string' || input instanceof URL ? undefined : input
+    let target = new URL(inputRequest?.url ?? input.toString())
+    let requestInit = init
+
+    for (let redirects = 0; ; redirects += 1) {
+      assertSecureCustomMcpUrl(target.toString())
+      if (target.origin !== configuredUrl.origin) {
+        throw new Error('Remote MCP server redirects must stay on the configured origin.')
+      }
+
+      const response = await netFetchStandard(target, { ...requestInit, redirect: 'manual' })
+      if (!MCP_REDIRECT_STATUSES.has(response.status)) return response
+
+      const location = response.headers.get('location')
+      if (!location || redirects >= MAX_MCP_REDIRECTS) {
+        await response.body?.cancel()
+        throw new Error('Remote MCP server redirect is invalid.')
+      }
+
+      const next = new URL(location, target)
+      assertSecureCustomMcpUrl(next.toString())
+      if (next.origin !== configuredUrl.origin) {
+        await response.body?.cancel()
+        throw new Error('Remote MCP server redirects must stay on the configured origin.')
+      }
+
+      const method = (requestInit?.method ?? inputRequest?.method ?? 'GET').toUpperCase()
+      if (
+        response.status === 303 ||
+        ((response.status === 301 || response.status === 302) && method === 'POST')
+      ) {
+        const headers = new Headers(requestInit?.headers ?? inputRequest?.headers)
+        headers.delete('content-encoding')
+        headers.delete('content-language')
+        headers.delete('content-location')
+        headers.delete('content-type')
+        requestInit = { ...requestInit, body: undefined, headers, method: 'GET' }
+      }
+
+      await response.body?.cancel()
+      target = next
+    }
+  }
 
 type McpClientManagerDeps = {
   createClient?: (
@@ -318,8 +366,9 @@ export function buildTransport(
         throw new Error(`custom MCP server "${config.name}" is missing a url for streamable_http`)
       }
       assertSecureCustomMcpUrl(config.url)
-      return new StreamableHTTPClientTransport(new URL(config.url), {
-        fetch: netFetchStandard,
+      const url = new URL(config.url)
+      return new StreamableHTTPClientTransport(url, {
+        fetch: createCustomMcpFetch(url),
         ...(authProvider ? { authProvider } : {}),
         ...(config.headers ? { requestInit: { headers: config.headers } } : {})
       })
@@ -329,8 +378,9 @@ export function buildTransport(
         throw new Error(`custom MCP server "${config.name}" is missing a url for sse`)
       }
       assertSecureCustomMcpUrl(config.url)
-      return new SSEClientTransport(new URL(config.url), {
-        fetch: netFetchStandard,
+      const url = new URL(config.url)
+      return new SSEClientTransport(url, {
+        fetch: createCustomMcpFetch(url),
         ...(authProvider ? { authProvider } : {}),
         ...(config.headers ? { requestInit: { headers: config.headers } } : {})
       })

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -26,6 +26,7 @@ const STDERR_TRUNCATION_MARKER = '…[truncated]'
 export type CustomMcpServerConfig = {
   id: string
   name: string
+  configurationFingerprint?: string
   transport: 'stdio' | 'streamable_http' | 'sse'
   // stdio (local command):
   command?: string
@@ -67,7 +68,11 @@ type McpClientManagerDeps = {
     signal?: AbortSignal
   ) => Promise<Client>
   openExternal?: (url: string) => Promise<void> | void
-  saveOAuthState?: (serverId: string, state: StoredCustomMcpOAuthState) => Promise<void>
+  saveOAuthState?: (
+    serverId: string,
+    state: StoredCustomMcpOAuthState,
+    expectedConfigurationFingerprint?: string
+  ) => Promise<void>
 }
 
 type ConnectionAttempt = {
@@ -359,7 +364,8 @@ export class McpClientManager {
   private readonly openExternal: (url: string) => Promise<void> | void
   private readonly saveOAuthState?: (
     serverId: string,
-    state: StoredCustomMcpOAuthState
+    state: StoredCustomMcpOAuthState,
+    expectedConfigurationFingerprint?: string
   ) => Promise<void>
 
   constructor(deps?: McpClientManagerDeps) {
@@ -597,7 +603,9 @@ export class McpClientManager {
       saveState: this.saveOAuthState
         ? (state) =>
             generation === this.generation(config.id)
-              ? this.saveOAuthState!(config.id, state)
+              ? config.configurationFingerprint
+                ? this.saveOAuthState!(config.id, state, config.configurationFingerprint)
+                : this.saveOAuthState!(config.id, state)
               : Promise.resolve()
         : undefined
     })

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -769,6 +769,7 @@ describe('ConnectorService', () => {
         {
           id: 'srv-1',
           name: 'example-oauth-e2e',
+          configurationFingerprint: expect.any(String),
           transport: 'stdio',
           command: 'npx',
           args: ['-y', '@example/server'],
@@ -1144,6 +1145,7 @@ describe('ConnectorService', () => {
         {
           id: 'srv-remote',
           name: 'remoteserver',
+          configurationFingerprint: expect.any(String),
           transport: 'streamable_http',
           command: '',
           args: undefined,
@@ -1264,6 +1266,13 @@ describe('ConnectorService', () => {
 
       expect(requestApproval).toHaveBeenCalledWith({
         connector: 'My server',
+        approvalTarget: {
+          connectorId: 'srv-1',
+          connectorName: 'myserver',
+          displayName: 'My server',
+          transport: 'stdio',
+          target: 'npx'
+        },
         method: 'do_thing',
         args: { x: 1 },
         sessionId: 'session-99',

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -1,5 +1,3 @@
-import { createHmac, randomBytes } from 'node:crypto'
-
 import { ParserEngine } from './engine'
 import { ALL_CONNECTOR_IDS, getDescriptor, validateToolArguments } from './registry'
 import {
@@ -12,6 +10,7 @@ import {
 import { McpToolCallError, type CustomMcpServerConfig } from './mcp-client-manager'
 import type { ConnectorCredentialId, ConnectorCredentials, ToolDescriptor } from './types'
 import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
+import { customServerSecurityFingerprint } from '../settings/custom-server-identity'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { ConnectorPermissionBroker } from '../permission-grants/connector-broker'
 import type { ConnectorPermissionRequest } from '../permission-grants/connector-broker'
@@ -158,32 +157,6 @@ type CustomMcpFailureState = {
   retryAt?: number
   probing: boolean
 }
-
-const stableRecordEntries = (record: Record<string, string> | undefined): [string, string][] =>
-  Object.entries(record ?? {}).sort(([left], [right]) => left.localeCompare(right))
-
-const customServerSecurityFingerprintKey = randomBytes(32)
-
-// Authenticates fields that can contain credentials. The process-local key lets the barrier compare
-// a configuration generation without retaining another plaintext copy or exposing an enumerable
-// digest. OAuth configuration contains only public metadata, so it remains outside the keyed digest.
-const customServerCredentialFingerprint = (server: StoredCustomMcpServer): string =>
-  createHmac('sha256', customServerSecurityFingerprintKey)
-    .update(
-      JSON.stringify([
-        server.transport,
-        server.command ?? null,
-        server.args ?? [],
-        server.url ?? null,
-        stableRecordEntries(server.envRefs ?? server.env),
-        stableRecordEntries(server.headerRefs ?? server.headers),
-        server.oauthClientSecretRef ?? null
-      ])
-    )
-    .digest('hex')
-
-const customServerSecurityFingerprint = (server: StoredCustomMcpServer): string =>
-  JSON.stringify([server.oauth ?? null, customServerCredentialFingerprint(server)])
 
 const unavailableConnectorMessage = (connector: string): string =>
   `Connector ${JSON.stringify(connector)} is unavailable. ` +

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -230,7 +230,11 @@ export class ConnectorService {
   private readonly customServerGenerations = new Map<string, number>()
   private readonly customServerBarriers = new Map<
     string,
-    { generation: number; expectedFingerprint?: string }
+    {
+      generation: number
+      expectedFingerprint?: string
+      expectedOAuthClientSecretRef?: string
+    }
   >()
   constructor(private readonly deps: ConnectorServiceDeps) {
     this.engine = deps.engine ?? new ParserEngine()
@@ -262,7 +266,8 @@ export class ConnectorService {
         if (barrier?.generation !== generation) return
         this.customServerBarriers.set(serverId, {
           generation,
-          expectedFingerprint: customServerSecurityFingerprint(server)
+          expectedFingerprint: customServerSecurityFingerprint(server),
+          expectedOAuthClientSecretRef: server.oauthClientSecretRef
         })
       },
       rollback: () => {
@@ -662,7 +667,8 @@ export class ConnectorService {
     if (!barrier) return generation
     if (
       barrier.expectedFingerprint === undefined ||
-      barrier.expectedFingerprint !== customServerSecurityFingerprint(custom)
+      barrier.expectedFingerprint !== customServerSecurityFingerprint(custom) ||
+      barrier.expectedOAuthClientSecretRef !== custom.oauthClientSecretRef
     ) {
       throw new ConnectorGateError('connector_configuration_changed')
     }

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -53,6 +53,7 @@ type ConnectorServiceDeps = {
       // open the right conversation.
       sessionId?: string
       availableScopes: ConnectorApprovalScope[]
+      approvalTarget?: NonNullable<ConnectorPermissionRequest['approvalTarget']>
     },
     signal?: AbortSignal
   ) => Promise<ApprovalDecision>
@@ -770,7 +771,17 @@ export class ConnectorService {
         method,
         args,
         context,
-        connectors
+        connectors,
+        {
+          connectorId: current.id,
+          connectorName: current.name,
+          displayName: current.displayName,
+          transport: current.transport,
+          target:
+            current.transport === 'stdio'
+              ? (current.command ?? '')
+              : new URL(current.url ?? '').origin
+        }
       )
       if (access.bypassMainPolicy) {
         return { custom: current, request, requireApprovalSatisfied }
@@ -846,7 +857,8 @@ export class ConnectorService {
     method: string,
     args: Record<string, unknown>,
     context: ConnectorCallContext,
-    connectors: StoredConnectors | undefined = this.deps.getConnectors()
+    connectors: StoredConnectors | undefined = this.deps.getConnectors(),
+    approvalTarget?: ConnectorPermissionRequest['approvalTarget']
   ): ConnectorPermissionRequest {
     return {
       capability: { kind: 'mcp_tool', key: `mcp:${capabilityServerId}/${method}` },
@@ -854,6 +866,7 @@ export class ConnectorService {
       connector: connectorLabel,
       method,
       args,
+      ...(approvalTarget ? { approvalTarget } : {}),
       policy: {
         aliases: policyIds,
         autoAllowIds: connectors?.autoAllowIds,

--- a/src/main/permission-grants/connector-broker.ts
+++ b/src/main/permission-grants/connector-broker.ts
@@ -13,9 +13,18 @@ type ConnectorPermissionPrompt = (
     args: Record<string, unknown>
     sessionId?: string
     availableScopes: ConnectorApprovalScope[]
+    approvalTarget?: ConnectorApprovalTarget
   },
   signal?: AbortSignal
 ) => Promise<ApprovalDecision>
+
+type ConnectorApprovalTarget = {
+  connectorId: string
+  connectorName: string
+  displayName: string
+  transport: 'stdio' | 'streamable_http' | 'sse'
+  target: string
+}
 
 type ConnectorPolicyInput = {
   aliases: readonly string[]
@@ -30,6 +39,7 @@ type ConnectorPermissionRequest = {
   connector: string
   method: string
   args: Record<string, unknown>
+  approvalTarget?: ConnectorApprovalTarget
   policy: ConnectorPolicyInput
 }
 
@@ -86,7 +96,8 @@ class ConnectorPermissionBroker {
       method: request.method,
       args: request.args,
       ...(request.context.sessionId ? { sessionId: request.context.sessionId } : {}),
-      availableScopes
+      availableScopes,
+      ...(request.approvalTarget ? { approvalTarget: request.approvalTarget } : {})
     }
     const decision = options.signal
       ? await this.prompt(prompt, options.signal)

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -108,6 +108,15 @@ describe('ConnectorSettingsModule', () => {
     const c = await service.getConnectors()
     expect(c?.askToolIds ?? []).not.toContain(toolId)
     expect(c?.blockedToolIds ?? []).toContain(toolId)
+  })
+
+  it('does not persist policy for an unknown connector tool', async () => {
+    await expect(
+      service.setToolPermission({ toolId: 'chemistry/not-a-real-tool', permission: 'ask' })
+    ).rejects.toThrow('Unknown')
+
+    const connectors = await service.getConnectors()
+    expect(connectors?.askToolIds ?? []).not.toContain('chemistry/not-a-real-tool')
   })
 
   it('treats block as stronger than ask when reading inconsistent stored policy', async () => {
@@ -816,6 +825,78 @@ describe('ConnectorSettingsModule', () => {
     )
   })
 
+  it('keeps persisted identity conflicts visible but unavailable', async () => {
+    const baseline = await repository.getSettings()
+    await writeFile(
+      join(dir, 'settings.json'),
+      JSON.stringify({
+        ...baseline,
+        connectors: {
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'duplicate-id',
+              name: 'duplicate-one',
+              displayName: 'Duplicate one',
+              transport: 'stdio',
+              command: 'first-command',
+              enabled: true
+            },
+            {
+              id: 'duplicate-id',
+              name: 'duplicate-two',
+              displayName: 'Duplicate two',
+              transport: 'stdio',
+              command: 'second-command',
+              enabled: true
+            },
+            {
+              id: 'chemistry',
+              name: 'built-in-id-collision',
+              displayName: 'Built-in ID collision',
+              transport: 'stdio',
+              command: 'third-command',
+              enabled: true
+            },
+            {
+              id: 'cross-id',
+              name: 'cross-name',
+              displayName: 'Cross one',
+              transport: 'stdio',
+              command: 'fourth-command',
+              enabled: true
+            },
+            {
+              id: 'cross-name',
+              name: 'cross-other',
+              displayName: 'Cross two',
+              transport: 'stdio',
+              command: 'fifth-command',
+              enabled: true
+            },
+            {
+              id: 'Invalid ID',
+              name: 'invalid-id-format',
+              displayName: 'Invalid ID format',
+              transport: 'stdio',
+              command: 'sixth-command',
+              enabled: true
+            }
+          ]
+        }
+      })
+    )
+    service = new ConnectorSettingsModule(new SettingsRepository(dir))
+
+    const snapshot = await service.listConnectors()
+
+    expect(snapshot.customServers).toHaveLength(6)
+    expect(snapshot.customServers.every((server) => server.availability === 'unavailable')).toBe(
+      true
+    )
+  })
+
   it('exports only credential names and validates imports against installed connectors', async () => {
     const snapshot = await addCustomServer({
       id: 'internal-export-id',
@@ -851,6 +932,19 @@ describe('ConnectorSettingsModule', () => {
       transport: 'streamable_http',
       url: 'https://example.com/mcp'
     })
+  })
+
+  it('rejects credentials over non-loopback HTTP before persistence', async () => {
+    await expect(
+      addCustomServer({
+        name: 'remote-http-credentials',
+        transport: 'streamable_http',
+        url: 'http://example.com/mcp',
+        headers: { Authorization: 'Bearer secret' }
+      })
+    ).rejects.toThrow(/HTTPS|loopback/)
+
+    expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
   })
 
   it('stores OAuth configuration publicly and OAuth state encrypted', async () => {
@@ -890,6 +984,54 @@ describe('ConnectorSettingsModule', () => {
 
     const enabled = await service.setCustomServerEnabled({ id, enabled: true })
     expect(enabled.customServers[0].enabled).toBe(true)
+  })
+
+  it('does not let a stale OAuth save replace a concurrent configuration edit', async () => {
+    const added = await addCustomServer({
+      name: 'oauth-config-race',
+      transport: 'streamable_http',
+      url: 'https://old.example/mcp',
+      oauth: { authorizationServerUrl: 'https://old.example/oauth' }
+    })
+    const id = added.customServers[0].id
+    const updateCustomServer = repository.updateCustomServer.bind(repository)
+    let releaseStaleSave!: () => void
+    const staleSaveReleased = new Promise<void>((resolve) => {
+      releaseStaleSave = resolve
+    })
+    let markStaleSaveStarted!: () => void
+    const staleSaveStarted = new Promise<void>((resolve) => {
+      markStaleSaveStarted = resolve
+    })
+    let intercepted = false
+    vi.spyOn(repository, 'updateCustomServer').mockImplementation(
+      async (serverId, server, allowMissing) => {
+        if (!intercepted && server.oauthRef) {
+          intercepted = true
+          markStaleSaveStarted()
+          await staleSaveReleased
+        }
+        return updateCustomServer(serverId, server, allowMissing)
+      }
+    )
+
+    const staleSave = service.saveCustomServerOAuthState(id, {
+      tokens: { access_token: 'stale-token', token_type: 'Bearer' }
+    })
+    await staleSaveStarted
+    await service.updateCustomServer({
+      id,
+      transport: 'streamable_http',
+      url: 'https://new.example/mcp',
+      oauth: { authorizationServerUrl: 'https://new.example/oauth' }
+    })
+    releaseStaleSave()
+    await staleSave
+
+    const stored = (await repository.getSettings()).connectors?.customMcpServers?.[0]
+    expect(stored?.url).toBe('https://new.example/mcp')
+    expect(stored?.oauth?.authorizationServerUrl).toBe('https://new.example/oauth')
+    expect(stored?.oauthRef).toBeUndefined()
   })
 
   it('stores a pre-registered client secret as an encrypted ref and applies explicit edit semantics', async () => {

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -1086,13 +1086,18 @@ describe('ConnectorSettingsModule', () => {
     })
     let intercepted = false
     vi.spyOn(repository, 'updateCustomServerOAuthState').mockImplementation(
-      async (serverId, expectedFingerprint, oauthRef) => {
+      async (serverId, expectedFingerprint, expectedClientSecretRef, oauthRef) => {
         if (!intercepted && oauthRef) {
           intercepted = true
           markStaleSaveStarted()
           await staleSaveReleased
         }
-        return updateCustomServerOAuthState(serverId, expectedFingerprint, oauthRef)
+        return updateCustomServerOAuthState(
+          serverId,
+          expectedFingerprint,
+          expectedClientSecretRef,
+          oauthRef
+        )
       }
     )
 
@@ -1113,6 +1118,66 @@ describe('ConnectorSettingsModule', () => {
     expect(stored?.url).toBe('https://new.example/mcp')
     expect(stored?.oauth?.authorizationServerUrl).toBe('https://new.example/oauth')
     expect(stored?.oauthRef).toBeUndefined()
+  })
+
+  it('discards a stale OAuth save when only the client secret changed', async () => {
+    const added = await addCustomServer({
+      name: 'oauth-client-secret-race',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test',
+      oauth: {
+        authorizationServerUrl: 'https://auth.example.test',
+        clientId: 'registered-client',
+        clientSecret: 'old-client-secret'
+      }
+    })
+    const id = added.customServers[0].id
+    const updateCustomServerOAuthState = repository.updateCustomServerOAuthState.bind(repository)
+    let releaseStaleSave!: () => void
+    const staleSaveReleased = new Promise<void>((resolve) => {
+      releaseStaleSave = resolve
+    })
+    let markStaleSaveStarted!: () => void
+    const staleSaveStarted = new Promise<void>((resolve) => {
+      markStaleSaveStarted = resolve
+    })
+    vi.spyOn(repository, 'updateCustomServerOAuthState').mockImplementation(
+      async (serverId, expectedFingerprint, expectedClientSecretRef, oauthRef) => {
+        if (oauthRef) {
+          markStaleSaveStarted()
+          await staleSaveReleased
+        }
+        return updateCustomServerOAuthState(
+          serverId,
+          expectedFingerprint,
+          expectedClientSecretRef,
+          oauthRef
+        )
+      }
+    )
+
+    const staleSave = service.saveCustomServerOAuthState(id, {
+      tokens: { access_token: 'stale-token', token_type: 'Bearer' }
+    })
+    await staleSaveStarted
+    await service.updateCustomServer({
+      id,
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test',
+      oauth: {
+        authorizationServerUrl: 'https://auth.example.test',
+        clientId: 'registered-client',
+        clientSecret: 'new-client-secret'
+      }
+    })
+    releaseStaleSave()
+    await staleSave
+
+    const stored = (await repository.getSettings()).connectors?.customMcpServers?.[0]
+    expect(stored?.oauthRef).toBeUndefined()
+    expect((await service.getConnectors())?.customMcpServers?.[0].oauthClientSecret).toBe(
+      'new-client-secret'
+    )
   })
 
   it('stores a pre-registered client secret as an encrypted ref and applies explicit edit semantics', async () => {

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -375,6 +375,87 @@ describe('ConnectorSettingsModule', () => {
     expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
   })
 
+  it.each([
+    {
+      label: 'Windows environment variables',
+      platform: 'win32',
+      request: {
+        name: 'ambiguous-add-env',
+        transport: 'stdio' as const,
+        command: 'npx',
+        env: { API_TOKEN: 'first', api_token: 'second' }
+      }
+    },
+    {
+      label: 'HTTP headers',
+      platform: 'darwin',
+      request: {
+        name: 'ambiguous-add-headers',
+        transport: 'streamable_http' as const,
+        url: 'https://mcp.example.test',
+        headers: { Authorization: 'first', authorization: 'second' }
+      }
+    }
+  ])('rejects case-colliding $label before add persistence', async ({ platform, request }) => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+    try {
+      await expect(addCustomServer(request)).rejects.toThrow(/duplicate credential name/i)
+      expect(keychain.encryptedValues).toEqual([])
+      expect((await repository.getSettings()).connectors?.customMcpServers ?? []).toEqual([])
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
+  it.each([
+    {
+      label: 'Windows environment variables',
+      platform: 'win32',
+      transport: 'stdio' as const,
+      replacement: { env: { API_TOKEN: 'first', api_token: 'second' } }
+    },
+    {
+      label: 'HTTP headers',
+      platform: 'darwin',
+      transport: 'streamable_http' as const,
+      replacement: { headers: { Authorization: 'first', authorization: 'second' } }
+    }
+  ])('rejects case-colliding $label before update persistence', async (testCase) => {
+    const added = await addCustomServer({
+      name: `ambiguous-update-${testCase.transport.replaceAll('_', '-')}`,
+      transport: testCase.transport,
+      ...(testCase.transport === 'stdio' ? { command: 'npx' } : { url: 'https://mcp.example.test' })
+    })
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: testCase.platform
+    })
+    keychain.encryptedValues.length = 0
+    try {
+      await expect(
+        service.updateCustomServer({
+          id: added.customServers[0].id,
+          transport: testCase.transport,
+          ...(testCase.transport === 'stdio'
+            ? { command: 'npx' }
+            : { url: 'https://mcp.example.test' }),
+          ...testCase.replacement
+        })
+      ).rejects.toThrow(/duplicate credential name/i)
+      expect(keychain.encryptedValues).toEqual([])
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
   it('includes retained secrets when validating an updated Connector total', async () => {
     const retainedEnvironment = Object.fromEntries(
       Array.from({ length: 15 }, (_, index) => [`TOKEN_${index}`, 'x'.repeat(16_384)])

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -994,7 +994,7 @@ describe('ConnectorSettingsModule', () => {
       oauth: { authorizationServerUrl: 'https://old.example/oauth' }
     })
     const id = added.customServers[0].id
-    const updateCustomServer = repository.updateCustomServer.bind(repository)
+    const updateCustomServerOAuthState = repository.updateCustomServerOAuthState.bind(repository)
     let releaseStaleSave!: () => void
     const staleSaveReleased = new Promise<void>((resolve) => {
       releaseStaleSave = resolve
@@ -1004,14 +1004,14 @@ describe('ConnectorSettingsModule', () => {
       markStaleSaveStarted = resolve
     })
     let intercepted = false
-    vi.spyOn(repository, 'updateCustomServer').mockImplementation(
-      async (serverId, server, allowMissing) => {
-        if (!intercepted && server.oauthRef) {
+    vi.spyOn(repository, 'updateCustomServerOAuthState').mockImplementation(
+      async (serverId, expectedFingerprint, oauthRef) => {
+        if (!intercepted && oauthRef) {
           intercepted = true
           markStaleSaveStarted()
           await staleSaveReleased
         }
-        return updateCustomServer(serverId, server, allowMissing)
+        return updateCustomServerOAuthState(serverId, expectedFingerprint, oauthRef)
       }
     )
 

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -52,6 +52,7 @@ import {
   CustomServerIdConflictError,
   customServerSecurityFingerprint
 } from './custom-server-identity'
+import { assertSecureCustomMcpUrl } from '../connectors/custom-mcp-url'
 
 type CustomServerSecurityChangeGuard = {
   commit(server: StoredCustomMcpServer): void
@@ -330,7 +331,6 @@ class ConnectorSettingsModule {
       request.permission === 'block'
     )
     const connectorId = request.toolId.split('/')[0]
-
     return this.getConnectorDetail(connectorId)
   }
 
@@ -380,6 +380,9 @@ class ConnectorSettingsModule {
 
   async addCustomServer(request: AddCustomServerRequest): Promise<ConnectorsSnapshot> {
     assertCredentialFieldsAreEncrypted(request)
+    if (request.transport !== 'stdio' && request.url) {
+      assertSecureCustomMcpUrl(request.url.trim())
+    }
     const name = request.name.trim()
     const displayName = request.displayName.trim()
     const connectors = (await this.repository.getSettings()).connectors
@@ -502,6 +505,9 @@ class ConnectorSettingsModule {
     ) => Promise<CustomServerSecurityChangeGuard | void>
   ): Promise<ConnectorsSnapshot> {
     assertCredentialFieldsAreEncrypted(request)
+    if (request.transport !== 'stdio' && request.url) {
+      assertSecureCustomMcpUrl(request.url.trim())
+    }
     const existing = (await this.getConnectors())?.customMcpServers?.find(
       (server) => server.id === request.id
     )

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -36,6 +36,7 @@ import {
 } from '../../shared/custom-connector'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import {
+  hasAmbiguousCustomMcpCredentialNames,
   hasUsableCustomMcpCredentials,
   isCustomMcpServerRouteSafe
 } from '../connectors/custom-mcp-bootstrap'
@@ -391,6 +392,9 @@ class ConnectorSettingsModule {
 
   async addCustomServer(request: AddCustomServerRequest): Promise<ConnectorsSnapshot> {
     assertCredentialFieldsAreEncrypted(request)
+    if (hasAmbiguousCustomMcpCredentialNames(request)) {
+      throw new Error('Duplicate credential names are not allowed on this platform.')
+    }
     if (request.transport !== 'stdio' && request.url) {
       assertSecureCustomMcpUrl(request.url.trim())
     }
@@ -516,6 +520,9 @@ class ConnectorSettingsModule {
     ) => Promise<CustomServerSecurityChangeGuard | void>
   ): Promise<ConnectorsSnapshot> {
     assertCredentialFieldsAreEncrypted(request)
+    if (hasAmbiguousCustomMcpCredentialNames(request)) {
+      throw new Error('Duplicate credential names are not allowed on this platform.')
+    }
     if (request.transport !== 'stdio' && request.url) {
       assertSecureCustomMcpUrl(request.url.trim())
     }

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -48,7 +48,10 @@ import {
   hasEmbeddedConnectorCredentials,
   parseConnectorTemplate
 } from './connector-template'
-import { CustomServerIdConflictError } from './custom-server-identity'
+import {
+  CustomServerIdConflictError,
+  customServerSecurityFingerprint
+} from './custom-server-identity'
 
 type CustomServerSecurityChangeGuard = {
   commit(server: StoredCustomMcpServer): void
@@ -629,7 +632,8 @@ class ConnectorSettingsModule {
 
   async saveCustomServerOAuthState(
     serverId: string,
-    state: StoredCustomMcpOAuthState | undefined
+    state: StoredCustomMcpOAuthState | undefined,
+    expectedConfigurationFingerprint?: string
   ): Promise<void> {
     const stored = (await this.repository.getSettings()).connectors?.customMcpServers?.find(
       (server) => server.id === serverId
@@ -637,10 +641,11 @@ class ConnectorSettingsModule {
     if (!stored) throw new Error(`Unknown custom connector: ${serverId}`)
     if (!stored.oauth) throw new Error(`Custom connector "${serverId}" is not configured for OAuth`)
 
-    await this.repository.updateCustomServer(serverId, {
-      ...stored,
-      ...(state ? { oauthRef: encryptKey(JSON.stringify(state)) } : { oauthRef: undefined })
-    })
+    await this.repository.updateCustomServerOAuthState(
+      serverId,
+      expectedConfigurationFingerprint ?? customServerSecurityFingerprint(stored),
+      state ? encryptKey(JSON.stringify(state)) : undefined
+    )
   }
 
   async disconnectCustomServer(serverId: string): Promise<ConnectorsSnapshot> {

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -36,10 +36,10 @@ import {
 } from '../../shared/custom-connector'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import {
-  hasAmbiguousCustomMcpCredentialNames,
   hasUsableCustomMcpCredentials,
   isCustomMcpServerRouteSafe
 } from '../connectors/custom-mcp-bootstrap'
+import { hasAmbiguousCustomMcpCredentialNames } from '../connectors/custom-mcp-windows-credential-names'
 import { getConnectorTools } from '../connectors/registry'
 import { encryptKey, isEncryptionAvailable, tryDecryptKey } from './crypto'
 import { sanitizeCustomMcpServer, type SettingsRepository } from './repository'

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -657,7 +657,8 @@ class ConnectorSettingsModule {
   async saveCustomServerOAuthState(
     serverId: string,
     state: StoredCustomMcpOAuthState | undefined,
-    expectedConfigurationFingerprint?: string
+    expectedConfigurationFingerprint?: string,
+    expectedOAuthClientSecretRef?: string
   ): Promise<void> {
     const stored = (await this.repository.getSettings()).connectors?.customMcpServers?.find(
       (server) => server.id === serverId
@@ -668,6 +669,9 @@ class ConnectorSettingsModule {
     await this.repository.updateCustomServerOAuthState(
       serverId,
       expectedConfigurationFingerprint ?? customServerSecurityFingerprint(stored),
+      expectedConfigurationFingerprint === undefined
+        ? stored.oauthClientSecretRef
+        : expectedOAuthClientSecretRef,
       state ? encryptKey(JSON.stringify(state)) : undefined
     )
   }

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -325,12 +325,23 @@ class ConnectorSettingsModule {
   }
 
   async setToolPermission(request: SetToolPermissionRequest): Promise<ConnectorDetailView> {
+    const separator = request.toolId.indexOf('/')
+    const connectorId = separator > 0 ? request.toolId.slice(0, separator) : ''
+    const method = separator > 0 ? request.toolId.slice(separator + 1) : ''
+    const connector = CONNECTOR_CATALOG.find((candidate) => candidate.id === connectorId)
+    if (
+      !connector ||
+      !method ||
+      !getConnectorTools(connectorId).some((tool) => tool.id === method)
+    ) {
+      throw new Error(`Unknown connector tool: ${request.toolId}`)
+    }
+
     await this.repository.setToolPolicy(
       request.toolId,
       request.permission === 'ask',
       request.permission === 'block'
     )
-    const connectorId = request.toolId.split('/')[0]
     return this.getConnectorDetail(connectorId)
   }
 

--- a/src/main/settings/custom-server-identity.ts
+++ b/src/main/settings/custom-server-identity.ts
@@ -1,4 +1,31 @@
+import { createHmac, randomBytes } from 'node:crypto'
+
 import type { StoredConnectors, StoredCustomMcpServer } from './types'
+
+const stableRecordEntries = (record: Record<string, string> | undefined): [string, string][] =>
+  Object.entries(record ?? {}).sort(([left], [right]) => left.localeCompare(right))
+
+const customServerSecurityFingerprintKey = randomBytes(32)
+
+const customServerCredentialFingerprint = (server: StoredCustomMcpServer): string =>
+  createHmac('sha256', customServerSecurityFingerprintKey)
+    .update(
+      JSON.stringify([
+        server.transport,
+        server.command ?? null,
+        server.args ?? [],
+        server.url ?? null,
+        stableRecordEntries(server.envRefs ?? server.env),
+        stableRecordEntries(server.headerRefs ?? server.headers),
+        server.oauthClientSecretRef ?? null
+      ])
+    )
+    .digest('hex')
+
+// Process-local fingerprint for compare-and-set writes and live dispatch generations. Secret values
+// are authenticated with an ephemeral key instead of being retained in an enumerable digest.
+export const customServerSecurityFingerprint = (server: StoredCustomMcpServer): string =>
+  JSON.stringify([server.oauth ?? null, customServerCredentialFingerprint(server)])
 
 export class CustomServerIdConflictError extends Error {
   constructor() {

--- a/src/main/settings/custom-server-identity.ts
+++ b/src/main/settings/custom-server-identity.ts
@@ -17,6 +17,8 @@ const customServerCredentialFingerprint = (server: StoredCustomMcpServer): strin
         server.url ?? null,
         stableRecordEntries(server.envRefs ?? server.env),
         stableRecordEntries(server.headerRefs ?? server.headers),
+        // codeql[js/insufficient-password-hash] -- this is an encrypted reference authenticated
+        // with a random process-local HMAC key for CAS equality, not a stored password verifier.
         server.oauthClientSecretRef ?? null
       ])
     )

--- a/src/main/settings/custom-server-identity.ts
+++ b/src/main/settings/custom-server-identity.ts
@@ -16,10 +16,7 @@ const customServerCredentialFingerprint = (server: StoredCustomMcpServer): strin
         server.args ?? [],
         server.url ?? null,
         stableRecordEntries(server.envRefs ?? server.env),
-        stableRecordEntries(server.headerRefs ?? server.headers),
-        // codeql[js/insufficient-password-hash] -- this is an encrypted reference authenticated
-        // with a random process-local HMAC key for CAS equality, not a stored password verifier.
-        server.oauthClientSecretRef ?? null
+        stableRecordEntries(server.headerRefs ?? server.headers)
       ])
     )
     .digest('hex')

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -686,13 +686,18 @@ class SettingsRepository {
   async updateCustomServerOAuthState(
     id: string,
     expectedConfigurationFingerprint: string,
+    expectedOAuthClientSecretRef: string | undefined,
     oauthRef: string | undefined
   ): Promise<boolean> {
     let updated = false
     await this.mutateConnectors((connectors) => {
       const server = connectors.customMcpServers?.find((candidate) => candidate.id === id)
       if (!server) throw new Error(`Unknown custom connector: ${id}`)
-      if (customServerSecurityFingerprint(server) !== expectedConfigurationFingerprint) return
+      if (
+        customServerSecurityFingerprint(server) !== expectedConfigurationFingerprint ||
+        server.oauthClientSecretRef !== expectedOAuthClientSecretRef
+      )
+        return
       server.oauthRef = oauthRef
       updated = true
     })

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -40,7 +40,8 @@ import { assertCustomServerCapacity } from './connector-resource-limits'
 import {
   appendCustomServer,
   beginCustomServerDeletion,
-  completeCustomServerDeletion
+  completeCustomServerDeletion,
+  customServerSecurityFingerprint
 } from './custom-server-identity'
 import {
   buildReviewerModelMutation,
@@ -680,6 +681,22 @@ class SettingsRepository {
         throw new Error(`Unknown custom connector: ${id}`)
       connectors.customMcpServers = servers?.map((stored) => (stored.id === id ? server : stored))
     })
+  }
+
+  async updateCustomServerOAuthState(
+    id: string,
+    expectedConfigurationFingerprint: string,
+    oauthRef: string | undefined
+  ): Promise<boolean> {
+    let updated = false
+    await this.mutateConnectors((connectors) => {
+      const server = connectors.customMcpServers?.find((candidate) => candidate.id === id)
+      if (!server) throw new Error(`Unknown custom connector: ${id}`)
+      if (customServerSecurityFingerprint(server) !== expectedConfigurationFingerprint) return
+      server.oauthRef = oauthRef
+      updated = true
+    })
+    return updated
   }
 
   // Sets the bookmark folders for a provider_id in settings.computeBookmarks. Replaces the full

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1015,12 +1015,14 @@ class SettingsService {
   async saveCustomServerOAuthState(
     serverId: string,
     state: StoredCustomMcpOAuthState | undefined,
-    expectedConfigurationFingerprint?: string
+    expectedConfigurationFingerprint?: string,
+    expectedOAuthClientSecretRef?: string
   ): Promise<void> {
     return this.connectors.saveCustomServerOAuthState(
       serverId,
       state,
-      expectedConfigurationFingerprint
+      expectedConfigurationFingerprint,
+      expectedOAuthClientSecretRef
     )
   }
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1014,9 +1014,14 @@ class SettingsService {
   // intentionally main-process-only; renderer settings never receive the token-bearing state.
   async saveCustomServerOAuthState(
     serverId: string,
-    state: StoredCustomMcpOAuthState | undefined
+    state: StoredCustomMcpOAuthState | undefined,
+    expectedConfigurationFingerprint?: string
   ): Promise<void> {
-    return this.connectors.saveCustomServerOAuthState(serverId, state)
+    return this.connectors.saveCustomServerOAuthState(
+      serverId,
+      state,
+      expectedConfigurationFingerprint
+    )
   }
 
   setCustomServerAuthenticator(

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -395,6 +395,7 @@ describe('Settings backend ownership architecture', () => {
       'updateClaudeIsolatedValidationIfKeyMatches',
       'updateClaudeSharedValidationIfUnchanged',
       'updateCustomServer',
+      'updateCustomServerOAuthState',
       'updateProviderModelCatalogIfTargetMatches',
       'upsertClaudeIsolatedProvider',
       'upsertProvider'

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -892,6 +892,33 @@ describe('ConnectorAddForm (edit)', () => {
     expect(addButton()?.disabled).toBe(true)
   })
 
+  it('reports duplicate environment and header names instead of overwriting them', () => {
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+
+    setValue('Display name', 'Memory')
+    openAdvancedSettings()
+    setValue('Environment variables', 'API_TOKEN=first\nAPI_TOKEN=second')
+    checkTrust()
+
+    expect(document.body.textContent).toContain('Line 2: API_TOKEN is duplicated.')
+    expect(addButton()?.disabled).toBe(true)
+
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+    setValue('Display name', 'Remote memory')
+    setValue('Server URL', 'https://mcp.example.test')
+    openAdvancedSettings()
+    selectOption('Authentication', 'Static headers')
+    setValue('Headers', 'Authorization: first\nAuthorization: second')
+    checkTrust()
+
+    expect(document.body.textContent).toContain('Line 2: Authorization is duplicated.')
+    expect(addButton()?.disabled).toBe(true)
+  })
+
   it('requires secure storage before submitting static credentials', () => {
     useSettingsStore.setState({ encryptionAvailable: false })
     act(() => {
@@ -901,6 +928,23 @@ describe('ConnectorAddForm (edit)', () => {
     setValue('Display name', 'Local memory')
     openAdvancedSettings()
     setValue('Environment variables', 'API_TOKEN=secret')
+    checkTrust()
+
+    expect(document.body.textContent).toContain('Secure credential storage is unavailable')
+    expect(addButton()?.disabled).toBe(true)
+  })
+
+  it('requires secure storage before submitting static remote headers', () => {
+    useSettingsStore.setState({ encryptionAvailable: false })
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+
+    setValue('Display name', 'Remote memory')
+    setValue('Server URL', 'https://mcp.example.test')
+    openAdvancedSettings()
+    selectOption('Authentication', 'Static headers')
+    setValue('Headers', 'Authorization: Bearer secret')
     checkTrust()
 
     expect(document.body.textContent).toContain('Secure credential storage is unavailable')

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -878,7 +878,9 @@ describe('ConnectorAddForm (edit)', () => {
 
   it('reports malformed header lines instead of silently dropping them', () => {
     act(() => {
-      root.render(<ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />)
+      root.render(
+        <ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />
+      )
     })
 
     setValue('Display name', 'Remote memory')
@@ -892,7 +894,7 @@ describe('ConnectorAddForm (edit)', () => {
     expect(addButton()?.disabled).toBe(true)
   })
 
-  it('reports duplicate environment and header names instead of overwriting them', () => {
+  it('reports duplicate environment names instead of overwriting them', () => {
     act(() => {
       root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
     })
@@ -904,9 +906,13 @@ describe('ConnectorAddForm (edit)', () => {
 
     expect(document.body.textContent).toContain('Line 2: API_TOKEN is duplicated.')
     expect(addButton()?.disabled).toBe(true)
+  })
 
+  it('reports duplicate header names instead of overwriting them', () => {
     act(() => {
-      root.render(<ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />)
+      root.render(
+        <ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />
+      )
     })
     setValue('Display name', 'Remote memory')
     setValue('Server URL', 'https://mcp.example.test')
@@ -937,7 +943,9 @@ describe('ConnectorAddForm (edit)', () => {
   it('requires secure storage before submitting static remote headers', () => {
     useSettingsStore.setState({ encryptionAvailable: false })
     act(() => {
-      root.render(<ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />)
+      root.render(
+        <ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />
+      )
     })
 
     setValue('Display name', 'Remote memory')

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -909,6 +909,8 @@ describe('ConnectorAddForm (edit)', () => {
   })
 
   it('reports environment names that collide case-insensitively on Windows', () => {
+    const originalApi = window.api
+    window.api = { ...originalApi, platform: 'win32' } as Window['api']
     act(() => {
       root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
     })
@@ -920,6 +922,24 @@ describe('ConnectorAddForm (edit)', () => {
 
     expect(document.body.textContent).toContain('Line 2: api_token is duplicated.')
     expect(addButton()?.disabled).toBe(true)
+    window.api = originalApi
+  })
+
+  it('keeps case-distinct environment names valid on Unix', () => {
+    const originalApi = window.api
+    window.api = { ...originalApi, platform: 'darwin' } as Window['api']
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+
+    setValue('Display name', 'Memory')
+    openAdvancedSettings()
+    setValue('Environment variables', 'API_TOKEN=first\napi_token=second')
+    checkTrust()
+
+    expect(document.body.textContent).not.toContain('Line 2: api_token is duplicated.')
+    expect(addButton()?.disabled).toBe(false)
+    window.api = originalApi
   })
 
   it('reports duplicate header names instead of overwriting them', () => {

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -876,6 +876,37 @@ describe('ConnectorAddForm (edit)', () => {
     expect(addButton()?.disabled).toBe(true)
   })
 
+  it('reports malformed header lines instead of silently dropping them', () => {
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+
+    setValue('Display name', 'Remote memory')
+    setValue('Server URL', 'https://mcp.example.test')
+    openAdvancedSettings()
+    selectOption('Authentication', 'Static headers')
+    setValue('Headers', 'Authorization: Bearer secret\nBROKEN')
+    checkTrust()
+
+    expect(document.body.textContent).toContain('Line 2: use Name: Value.')
+    expect(addButton()?.disabled).toBe(true)
+  })
+
+  it('requires secure storage before submitting static credentials', () => {
+    useSettingsStore.setState({ encryptionAvailable: false })
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+
+    setValue('Display name', 'Local memory')
+    openAdvancedSettings()
+    setValue('Environment variables', 'API_TOKEN=secret')
+    checkTrust()
+
+    expect(document.body.textContent).toContain('Secure credential storage is unavailable')
+    expect(addButton()?.disabled).toBe(true)
+  })
+
   it('keeps a legacy Connector editable when its name matches another stored ID', () => {
     useSettingsStore.setState({
       ...createInitialSettingsState(),

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -1052,7 +1052,11 @@ describe('ConnectorAddForm (edit)', () => {
 
   it('clears OAuth state when switching a remote server to static headers', async () => {
     const updateCustomServer = vi.fn().mockResolvedValue(undefined)
-    useSettingsStore.setState({ ...createInitialSettingsState(), updateCustomServer })
+    useSettingsStore.setState({
+      ...createInitialSettingsState(),
+      encryptionAvailable: true,
+      updateCustomServer
+    })
     act(() => {
       root.render(
         <ConnectorAddForm

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -908,6 +908,20 @@ describe('ConnectorAddForm (edit)', () => {
     expect(addButton()?.disabled).toBe(true)
   })
 
+  it('reports environment names that collide case-insensitively on Windows', () => {
+    act(() => {
+      root.render(<ConnectorAddForm initialTransport="local" onDone={vi.fn()} onCancel={vi.fn()} />)
+    })
+
+    setValue('Display name', 'Memory')
+    openAdvancedSettings()
+    setValue('Environment variables', 'API_TOKEN=first\napi_token=second')
+    checkTrust()
+
+    expect(document.body.textContent).toContain('Line 2: api_token is duplicated.')
+    expect(addButton()?.disabled).toBe(true)
+  })
+
   it('reports duplicate header names instead of overwriting them', () => {
     act(() => {
       root.render(

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -43,13 +43,18 @@ const parseArgs = (raw: string, onePerLine = false): string[] =>
     .map((token) => token.trim())
     .filter((token) => token.length > 0)
 
-type ParsedEnvironment = { values: Record<string, string>; invalidLines: number[] }
+type ParsedNamedValues = {
+  values: Record<string, string>
+  invalidLines: number[]
+  duplicateLines: Array<{ line: number; name: string }>
+}
 type EnvironmentUpdateMode = 'keep' | 'replace' | 'clear'
 
 // Parses one KEY=VALUE per line and preserves line numbers for actionable validation feedback.
-const parseEnv = (raw: string): ParsedEnvironment => {
+const parseEnv = (raw: string): ParsedNamedValues => {
   const env: Record<string, string> = {}
   const invalidLines: number[] = []
+  const duplicateLines: ParsedNamedValues['duplicateLines'] = []
   for (const [index, line] of raw.split('\n').entries()) {
     const trimmed = line.trim()
     if (!trimmed) continue
@@ -58,22 +63,35 @@ const parseEnv = (raw: string): ParsedEnvironment => {
       invalidLines.push(index + 1)
       continue
     }
-    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim()
+    const name = trimmed.slice(0, eq).trim()
+    if (Object.hasOwn(env, name)) duplicateLines.push({ line: index + 1, name })
+    env[name] = trimmed.slice(eq + 1).trim()
   }
-  return { values: env, invalidLines }
+  return { values: env, invalidLines, duplicateLines }
 }
 
-// Parses one "Name: Value" per line into a headers record; blank/invalid lines are ignored.
-const parseHeaders = (raw: string): Record<string, string> => {
+// Parses one "Name: Value" per line and preserves validation errors instead of dropping input.
+const parseHeaders = (raw: string): ParsedNamedValues => {
   const headers: Record<string, string> = {}
-  for (const line of raw.split('\n')) {
+  const invalidLines: number[] = []
+  const duplicateLines: ParsedNamedValues['duplicateLines'] = []
+  const headerNames = new Map<string, string>()
+  for (const [index, line] of raw.split('\n').entries()) {
     const trimmed = line.trim()
     if (!trimmed) continue
     const colon = trimmed.indexOf(':')
-    if (colon <= 0) continue
-    headers[trimmed.slice(0, colon).trim()] = trimmed.slice(colon + 1).trim()
+    if (colon <= 0) {
+      invalidLines.push(index + 1)
+      continue
+    }
+    const name = trimmed.slice(0, colon).trim()
+    const normalizedName = name.toLowerCase()
+    const previousName = headerNames.get(normalizedName)
+    if (previousName) duplicateLines.push({ line: index + 1, name })
+    else headerNames.set(normalizedName, name)
+    headers[previousName ?? name] = trimmed.slice(colon + 1).trim()
   }
-  return headers
+  return { values: headers, invalidLines, duplicateLines }
 }
 
 // A required-field marker next to a label. Purely visual; the real guard is the disabled Add button.
@@ -307,6 +325,8 @@ export function ConnectorAddForm({
   const parsedEnv = parsedEnvironment.values
   const environmentErrors =
     environmentUpdateMode === 'replace' ? parsedEnvironment.invalidLines : []
+  const environmentDuplicateErrors =
+    environmentUpdateMode === 'replace' ? parsedEnvironment.duplicateLines : []
   const parsedHeaders = parseHeaders(headersText)
   const commandPreview = [command.trim(), ...parsedArgs].filter((part) => part.length > 0).join(' ')
   const requiredEnvironment = initialTemplate?.requiredSecrets?.environment ?? []
@@ -337,12 +357,20 @@ export function ConnectorAddForm({
     (requiredHeaders.length === 0 ||
       (mode === 'remote' &&
         remoteAuth === 'headers' &&
-        requiredHeaders.every((header) => (parsedHeaders[header] ?? '').trim().length > 0))) &&
+        requiredHeaders.every(
+          (header) => (parsedHeaders.values[header] ?? '').trim().length > 0
+        ))) &&
     (!requiresOAuthClientSecret ||
       (mode === 'remote' &&
         remoteAuth === 'oauth' &&
         encryptionAvailable &&
         clientSecret.trim().length > 0))
+
+  const hasUnsavedStaticCredentials =
+    (mode === 'local' &&
+      environmentUpdateMode === 'replace' &&
+      Object.keys(parsedEnv).length > 0) ||
+    (mode === 'remote' && remoteAuth === 'headers' && Object.keys(parsedHeaders.values).length > 0)
 
   const requiredFilled =
     displayName.trim().length > 0 &&
@@ -351,7 +379,12 @@ export function ConnectorAddForm({
     (mode === 'local' ? command.trim().length > 0 : url.trim().length > 0) &&
     oauthRegistrationValid &&
     requiredSecretValuesFilled &&
-    (mode !== 'local' || environmentErrors.length === 0)
+    (mode !== 'local' ||
+      (environmentErrors.length === 0 && environmentDuplicateErrors.length === 0)) &&
+    (mode !== 'remote' ||
+      remoteAuth !== 'headers' ||
+      (parsedHeaders.invalidLines.length === 0 && parsedHeaders.duplicateLines.length === 0)) &&
+    (!hasUnsavedStaticCredentials || encryptionAvailable)
   const canSubmit = requiredFilled && trusted && !submitting && !editTargetMissing
 
   const switchMode = (next: ConnectorMode): void => {
@@ -365,7 +398,7 @@ export function ConnectorAddForm({
     setError(null)
     try {
       const env = parsedEnv
-      const headers = parsedHeaders
+      const headers = parsedHeaders.values
       const oauthScopes = oauthScopesText
         .split(/[\s,]+/)
         .map((scope) => scope.trim())
@@ -764,6 +797,18 @@ export function ConnectorAddForm({
                         {t('Line {{line}}: use KEY=VALUE.', { line })}
                       </p>
                     ))}
+                    {environmentDuplicateErrors.map(({ line, name }) => (
+                      <p key={`${line}-${name}`} className="text-xs text-status-failure">
+                        {t('Line {{line}}: {{name}} is duplicated.', { line, name })}
+                      </p>
+                    ))}
+                    {!encryptionAvailable && Object.keys(parsedEnv).length > 0 ? (
+                      <p className="text-xs leading-5 text-destructive">
+                        {t(
+                          'Secure credential storage is unavailable. Unlock the system keychain and retry.'
+                        )}
+                      </p>
+                    ) : null}
                   </div>
                 </>
               ) : (
@@ -1110,6 +1155,11 @@ export function ConnectorAddForm({
                         id="connector-headers"
                         aria-label={t('Headers')}
                         aria-required={requiredHeaders.length > 0 || undefined}
+                        aria-invalid={
+                          parsedHeaders.invalidLines.length > 0 ||
+                          parsedHeaders.duplicateLines.length > 0 ||
+                          undefined
+                        }
                         aria-describedby="connector-headers-help"
                         value={headersText}
                         rows={3}
@@ -1130,6 +1180,23 @@ export function ConnectorAddForm({
                           : ''}
                         {isEdit ? ' ' + t('Leave blank to keep the current values.') : ''}
                       </p>
+                      {parsedHeaders.invalidLines.map((line) => (
+                        <p key={line} className="text-xs text-status-failure">
+                          {t('Line {{line}}: use Name: Value.', { line })}
+                        </p>
+                      ))}
+                      {parsedHeaders.duplicateLines.map(({ line, name }) => (
+                        <p key={`${line}-${name}`} className="text-xs text-status-failure">
+                          {t('Line {{line}}: {{name}} is duplicated.', { line, name })}
+                        </p>
+                      ))}
+                      {!encryptionAvailable && Object.keys(parsedHeaders.values).length > 0 ? (
+                        <p className="text-xs leading-5 text-destructive">
+                          {t(
+                            'Secure credential storage is unavailable. Unlock the system keychain and retry.'
+                          )}
+                        </p>
+                      ) : null}
                     </div>
                   ) : null}
                 </>

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -55,6 +55,7 @@ const parseEnv = (raw: string): ParsedNamedValues => {
   const env: Record<string, string> = {}
   const invalidLines: number[] = []
   const duplicateLines: ParsedNamedValues['duplicateLines'] = []
+  const environmentNames = new Set<string>()
   for (const [index, line] of raw.split('\n').entries()) {
     const trimmed = line.trim()
     if (!trimmed) continue
@@ -64,7 +65,9 @@ const parseEnv = (raw: string): ParsedNamedValues => {
       continue
     }
     const name = trimmed.slice(0, eq).trim()
-    if (Object.hasOwn(env, name)) duplicateLines.push({ line: index + 1, name })
+    const normalizedName = name.toLowerCase()
+    if (environmentNames.has(normalizedName)) duplicateLines.push({ line: index + 1, name })
+    else environmentNames.add(normalizedName)
     env[name] = trimmed.slice(eq + 1).trim()
   }
   return { values: env, invalidLines, duplicateLines }

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -51,7 +51,7 @@ type ParsedNamedValues = {
 type EnvironmentUpdateMode = 'keep' | 'replace' | 'clear'
 
 // Parses one KEY=VALUE per line and preserves line numbers for actionable validation feedback.
-const parseEnv = (raw: string): ParsedNamedValues => {
+const parseEnv = (raw: string, caseInsensitiveNames: boolean): ParsedNamedValues => {
   const env: Record<string, string> = {}
   const invalidLines: number[] = []
   const duplicateLines: ParsedNamedValues['duplicateLines'] = []
@@ -65,7 +65,7 @@ const parseEnv = (raw: string): ParsedNamedValues => {
       continue
     }
     const name = trimmed.slice(0, eq).trim()
-    const normalizedName = name.toLowerCase()
+    const normalizedName = caseInsensitiveNames ? name.toLowerCase() : name
     if (environmentNames.has(normalizedName)) duplicateLines.push({ line: index + 1, name })
     else environmentNames.add(normalizedName)
     env[name] = trimmed.slice(eq + 1).trim()
@@ -324,7 +324,7 @@ export function ConnectorAddForm({
     advancedOpen || Boolean(displayName.trim() && nameError) || Boolean(idError)
 
   const parsedArgs = parseArgs(argsText, initialTemplate !== undefined)
-  const parsedEnvironment = parseEnv(envText)
+  const parsedEnvironment = parseEnv(envText, window.api?.platform === 'win32')
   const parsedEnv = parsedEnvironment.values
   const environmentErrors =
     environmentUpdateMode === 'replace' ? parsedEnvironment.invalidLines : []

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
@@ -169,6 +169,35 @@ describe('ConnectorApprovalDialog', () => {
     expect(document.body.textContent).toContain(argsJson)
   })
 
+  it('keeps oversized expanded arguments scrollable without displacing approval actions', () => {
+    const argsJson = JSON.stringify({ query: 'x'.repeat(64_000) })
+    useSettingsStore.setState({
+      pendingApprovals: [
+        {
+          id: 'r-large-args',
+          connector: 'biomart',
+          method: 'get_data',
+          argsPreview: `${argsJson.slice(0, 300)}…`,
+          argsJson,
+          argsJsonTruncated: true,
+          availableScopes: ['once']
+        } as never
+      ]
+    })
+
+    act(() => root.render(<ConnectorApprovalDialog />))
+    act(() => button('Show full arguments')?.click())
+
+    const args = Array.from(document.body.querySelectorAll<HTMLElement>('span')).find(
+      (element) => element.textContent === argsJson
+    )
+    expect(args?.className).toContain('max-h-48')
+    expect(args?.className).toContain('overflow-y-auto')
+    expect(document.body.textContent).toContain('Arguments were truncated for display.')
+    expect(button('Deny')).toBeDefined()
+    expect(button('Allow once')).toBeDefined()
+  })
+
   it('Allow once responds with one-call scope without changing Connector policy', () => {
     useSettingsStore.setState({
       pendingApprovals: [

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
@@ -138,6 +138,37 @@ describe('ConnectorApprovalDialog', () => {
     )
   })
 
+  it('disambiguates a custom Connector target and exposes its full arguments', () => {
+    const argsJson = JSON.stringify({ query: 'x'.repeat(400) })
+    useSettingsStore.setState({
+      pendingApprovals: [
+        {
+          id: 'r-custom',
+          connector: 'Duplicate label',
+          connectorId: 'server-id',
+          connectorName: 'stable-server',
+          displayName: 'Duplicate label',
+          transport: 'streamable_http',
+          target: 'https://mcp.example.test',
+          method: 'lookup',
+          argsPreview: `${argsJson.slice(0, 300)}…`,
+          argsJson,
+          availableScopes: ['once', 'project', 'global']
+        } as never
+      ]
+    })
+
+    act(() => root.render(<ConnectorApprovalDialog />))
+
+    expect(document.body.textContent).toContain('stable-server')
+    expect(document.body.textContent).toContain('server-id')
+    expect(document.body.textContent).toContain('Streamable HTTP')
+    expect(document.body.textContent).toContain('https://mcp.example.test')
+    expect(document.body.textContent).toContain('Show full arguments')
+    act(() => button('Show full arguments')?.click())
+    expect(document.body.textContent).toContain(argsJson)
+  })
+
   it('Allow once responds with one-call scope without changing Connector policy', () => {
     useSettingsStore.setState({
       pendingApprovals: [

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
@@ -162,10 +162,21 @@ export function ConnectorApprovalDialog({
               </div>
               <div className="flex gap-2">
                 <span className="w-16 shrink-0 text-muted-foreground">{t('Args')}</span>
-                <span className="min-w-0 break-all font-mono text-muted-foreground">
+                <span
+                  className={cn(
+                    'min-w-0 break-all font-mono text-muted-foreground',
+                    argsExpanded &&
+                      'max-h-48 flex-1 overflow-y-auto overscroll-contain whitespace-pre-wrap'
+                  )}
+                >
                   {argsExpanded ? request.argsJson : request.argsPreview}
                 </span>
               </div>
+              {argsExpanded && request.argsJsonTruncated ? (
+                <p className="text-xs text-muted-foreground">
+                  {t('Arguments were truncated for display.')}
+                </p>
+              ) : null}
               {request.argsJson && request.argsJson !== request.argsPreview ? (
                 <Button
                   type="button"

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
@@ -47,14 +47,25 @@ export function ConnectorApprovalDialog({
   const [pendingBroadScope, setPendingBroadScope] = useState<PendingBroadScope>()
   const [responding, setResponding] = useState(false)
   const [responseErrorRequestId, setResponseErrorRequestId] = useState<string>()
+  const [expandedArgsRequestId, setExpandedArgsRequestId] = useState<string>()
 
   if (!request) return null
   const availableScopes = request.availableScopes ?? ['once']
 
   const displayName =
+    request.displayName ??
     connectors.find((c) => c.id === request.connector)?.displayName ??
     customServers.find((s) => s.name === request.connector)?.name ??
     request.connector
+  const transportLabel =
+    request.transport === 'streamable_http'
+      ? t('Streamable HTTP')
+      : request.transport === 'sse'
+        ? t('SSE')
+        : request.transport === 'stdio'
+          ? t('Local command')
+          : undefined
+  const argsExpanded = expandedArgsRequestId === request.id
 
   const submitResponse = (decision: 'once' | 'session' | 'project' | 'global' | 'deny'): void => {
     if (responding) return
@@ -115,6 +126,36 @@ export function ConnectorApprovalDialog({
                 <span className="w-16 shrink-0 text-muted-foreground">{t('Connector')}</span>
                 <span className="min-w-0 truncate font-medium text-foreground">{displayName}</span>
               </div>
+              {request.connectorName ? (
+                <div className="flex gap-2">
+                  <span className="w-24 shrink-0 text-muted-foreground">{t('Connector name')}</span>
+                  <span className="min-w-0 break-all font-mono text-foreground">
+                    {request.connectorName}
+                  </span>
+                </div>
+              ) : null}
+              {request.connectorId ? (
+                <div className="flex gap-2">
+                  <span className="w-24 shrink-0 text-muted-foreground">{t('Connector ID')}</span>
+                  <span className="min-w-0 break-all font-mono text-foreground">
+                    {request.connectorId}
+                  </span>
+                </div>
+              ) : null}
+              {transportLabel ? (
+                <div className="flex gap-2">
+                  <span className="w-24 shrink-0 text-muted-foreground">{t('Transport')}</span>
+                  <span className="min-w-0 text-foreground">{transportLabel}</span>
+                </div>
+              ) : null}
+              {request.target ? (
+                <div className="flex gap-2">
+                  <span className="w-24 shrink-0 text-muted-foreground">{t('Target')}</span>
+                  <span className="min-w-0 break-all font-mono text-foreground">
+                    {request.target}
+                  </span>
+                </div>
+              ) : null}
               <div className="flex gap-2">
                 <span className="w-16 shrink-0 text-muted-foreground">{t('Tool')}</span>
                 <span className="min-w-0 truncate font-mono text-foreground">{request.method}</span>
@@ -122,9 +163,20 @@ export function ConnectorApprovalDialog({
               <div className="flex gap-2">
                 <span className="w-16 shrink-0 text-muted-foreground">{t('Args')}</span>
                 <span className="min-w-0 break-all font-mono text-muted-foreground">
-                  {request.argsPreview}
+                  {argsExpanded ? request.argsJson : request.argsPreview}
                 </span>
               </div>
+              {request.argsJson && request.argsJson !== request.argsPreview ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto justify-start px-0 py-1 text-xs"
+                  onClick={() => setExpandedArgsRequestId(argsExpanded ? undefined : request.id)}
+                >
+                  {argsExpanded ? t('Hide full arguments') : t('Show full arguments')}
+                </Button>
+              ) : null}
             </div>
             {responseErrorRequestId === request.id ? (
               <div
@@ -182,7 +234,7 @@ export function ConnectorApprovalDialog({
           active && pendingBroadScope && request.id === pendingBroadScope.requestId
             ? {
                 scope: pendingBroadScope.scope,
-                subject: `${displayName} ${request.method}`,
+                subject: `${displayName} (${request.connectorName ?? request.connector}${request.target ? ` · ${request.target}` : ''}) ${request.method}`,
                 codeExecution: false
               }
             : undefined

--- a/src/renderer/src/pages/settings/connector-error-message.test.ts
+++ b/src/renderer/src/pages/settings/connector-error-message.test.ts
@@ -12,4 +12,14 @@ describe('localizeConnectorError', () => {
     )
     expect(t).toHaveBeenCalledWith('args appears to contain a credential.')
   })
+
+  it.each([
+    'Duplicate credential names are not allowed on this platform.',
+    'Remote MCP server URL must use HTTPS or loopback HTTP.'
+  ])('localizes custom Connector security validation errors: %s', (message) => {
+    const t = vi.fn((key: string) => `translated:${key}`) as unknown as TFunction
+
+    expect(localizeConnectorError(message, t)).toBe(`translated:${message}`)
+    expect(t).toHaveBeenCalledWith(message)
+  })
 })

--- a/src/renderer/src/pages/settings/connector-error-message.ts
+++ b/src/renderer/src/pages/settings/connector-error-message.ts
@@ -50,6 +50,10 @@ export const localizeConnectorError = (message: string, t: TFunction): string =>
       )
     case 'args appears to contain a credential.':
       return t('args appears to contain a credential.')
+    case 'Duplicate credential names are not allowed on this platform.':
+      return t('Duplicate credential names are not allowed on this platform.')
+    case 'Remote MCP server URL must use HTTPS or loopback HTTP.':
+      return t('Remote MCP server URL must use HTTPS or loopback HTTP.')
     default:
       if (
         /^(?:Connector|OAuth).+ must not exceed \d+ (?:characters|entries|bytes)\.$/u.test(message)

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -3635,6 +3635,8 @@
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "El almacenamiento seguro de credenciales no está disponible. Desbloquee el llavero del sistema y vuelva a intentarlo.",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "No se permiten credenciales en argumentos ni URL. Use en su lugar campos de entorno o encabezado cifrados.",
     "args appears to contain a credential.": "Parece que args contiene una credencial.",
+    "Duplicate credential names are not allowed on this platform.": "No se permiten nombres de credenciales duplicados en esta plataforma.",
+    "Remote MCP server URL must use HTTPS or loopback HTTP.": "La URL del servidor MCP remoto debe usar HTTPS o HTTP de loopback.",
     "Credentials unavailable": "Credenciales no disponibles",
     "Authentication failed. Verify the username and password.": "Error de autenticación. Verifique el nombre de usuario y la contraseña.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "Se desconoce la clave del host SSH. Verifíquela en una terminal antes de conectarse.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -356,6 +356,7 @@
     "Archiving…": "Archivando…",
     "Args": "Argumentos",
     "Arguments": "Argumentos",
+    "Arguments were truncated for display.": "Los argumentos se truncaron para mostrarlos.",
     "Artifact content is {{reason}}; captured provenance remains available.": "El contenido del artefacto es {{reason}}; la procedencia capturada sigue estando disponible.",
     "Artifact file input": "Entrada de archivo de artefacto",
     "Artifact suggestions": "Sugerencias de artefactos",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -863,6 +863,8 @@
     "The maximum number of custom Connectors has been reached.": "Se ha alcanzado el número máximo de Conectores personalizados.",
     "Keep saved variables": "Conservar variables guardadas",
     "Line {{line}}: use KEY=VALUE.": "Línea {{line}}: use KEY=VALUE.",
+    "Line {{line}}: use Name: Value.": "Línea {{line}}: use Name: Value.",
+    "Line {{line}}: {{name}} is duplicated.": "Línea {{line}}: {{name}} está duplicado.",
     "Manage “{{name}}” connection": "Gestionar la conexión «{{name}}»",
     "Reauthenticate": "Volver a autenticar",
     "Replace saved variables": "Reemplazar variables guardadas",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -865,6 +865,8 @@
     "Line {{line}}: use KEY=VALUE.": "Línea {{line}}: use KEY=VALUE.",
     "Line {{line}}: use Name: Value.": "Línea {{line}}: use Name: Value.",
     "Line {{line}}: {{name}} is duplicated.": "Línea {{line}}: {{name}} está duplicado.",
+    "Show full arguments": "Mostrar todos los argumentos",
+    "Hide full arguments": "Ocultar todos los argumentos",
     "Manage “{{name}}” connection": "Gestionar la conexión «{{name}}»",
     "Reauthenticate": "Volver a autenticar",
     "Replace saved variables": "Reemplazar variables guardadas",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -865,6 +865,8 @@
     "Line {{line}}: use KEY=VALUE.": "Ligne {{line}} : utilisez KEY=VALUE.",
     "Line {{line}}: use Name: Value.": "Ligne {{line}} : utilisez Name: Value.",
     "Line {{line}}: {{name}} is duplicated.": "Ligne {{line}} : {{name}} est dupliqué.",
+    "Show full arguments": "Afficher tous les arguments",
+    "Hide full arguments": "Masquer tous les arguments",
     "Manage “{{name}}” connection": "Gérer la connexion « {{name}} »",
     "Reauthenticate": "S’authentifier de nouveau",
     "Replace saved variables": "Remplacer les variables enregistrées",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -3635,6 +3635,8 @@
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "Le stockage sécurisé des informations d’identification n’est pas disponible. Déverrouillez le trousseau du système et réessayez.",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "Les identifiants ne sont pas autorisés dans les arguments ni les URL. Utilisez plutôt des champs d’environnement ou d’en-tête chiffrés.",
     "args appears to contain a credential.": "args semble contenir un identifiant.",
+    "Duplicate credential names are not allowed on this platform.": "Les noms d’identifiants en double ne sont pas autorisés sur cette plateforme.",
+    "Remote MCP server URL must use HTTPS or loopback HTTP.": "L’URL du serveur MCP distant doit utiliser HTTPS ou HTTP en boucle locale.",
     "Credentials unavailable": "Identifiants indisponibles",
     "Authentication failed. Verify the username and password.": "L'authentification a échoué. Vérifiez le nom d'utilisateur et le mot de passe.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "La clé d'hôte SSH est inconnue. Vérifiez-le dans un terminal avant de vous connecter.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -356,6 +356,7 @@
     "Archiving…": "Archivage…",
     "Args": "Args",
     "Arguments": "Arguments",
+    "Arguments were truncated for display.": "Les arguments ont été tronqués pour l’affichage.",
     "Artifact content is {{reason}}; captured provenance remains available.": "Le contenu de l'artefact est {{reason}} ; la provenance capturée reste disponible.",
     "Artifact file input": "Entrée du fichier d'artefact",
     "Artifact suggestions": "Suggestions d'artefacts",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -863,6 +863,8 @@
     "The maximum number of custom Connectors has been reached.": "Le nombre maximal de Connecteurs personnalisés a été atteint.",
     "Keep saved variables": "Conserver les variables enregistrées",
     "Line {{line}}: use KEY=VALUE.": "Ligne {{line}} : utilisez KEY=VALUE.",
+    "Line {{line}}: use Name: Value.": "Ligne {{line}} : utilisez Name: Value.",
+    "Line {{line}}: {{name}} is duplicated.": "Ligne {{line}} : {{name}} est dupliqué.",
     "Manage “{{name}}” connection": "Gérer la connexion « {{name}} »",
     "Reauthenticate": "S’authentifier de nouveau",
     "Replace saved variables": "Remplacer les variables enregistrées",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -824,6 +824,8 @@
     "Line {{line}}: use KEY=VALUE.": "{{line}} 行目: KEY=VALUE 形式を使用してください。",
     "Line {{line}}: use Name: Value.": "{{line}} 行目: Name: Value 形式を使用してください。",
     "Line {{line}}: {{name}} is duplicated.": "{{line}} 行目: {{name}} が重複しています。",
+    "Show full arguments": "引数の全体を表示",
+    "Hide full arguments": "引数の全体を隠す",
     "Manage “{{name}}” connection": "「{{name}}」の接続を管理",
     "Reauthenticate": "再認証",
     "Replace saved variables": "保存済みの変数を置換",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3363,6 +3363,8 @@
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全な認証情報ストレージを利用できません。システムキーチェーンのロックを解除して、もう一度お試しください。",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "引数や URL に認証情報を含めることはできません。代わりに暗号化された環境変数またはヘッダーフィールドを使用してください。",
     "args appears to contain a credential.": "args に認証情報が含まれている可能性があります。",
+    "Duplicate credential names are not allowed on this platform.": "このプラットフォームでは認証情報名の重複は許可されていません。",
+    "Remote MCP server URL must use HTTPS or loopback HTTP.": "リモート MCP サーバーの URL は HTTPS またはループバック HTTP を使用する必要があります。",
     "Credentials unavailable": "認証情報を利用できません",
     "Authentication failed. Verify the username and password.": "認証に失敗しました。ユーザー名とパスワードを確認してください。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH ホスト鍵が不明です。接続する前にターミナルで確認してください。",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -344,6 +344,7 @@
     "Archiving…": "アーカイブ中…",
     "Args": "引数",
     "Arguments": "引数",
+    "Arguments were truncated for display.": "表示用に引数が切り詰められています。",
     "Artifact content is {{reason}}; captured provenance remains available.": "アーティファクトの内容は {{reason}} です。キャプチャされた来歴情報は引き続き利用できます。",
     "Artifact file input": "アーティファクトファイルの入力",
     "Artifact suggestions": "アーティファクトの提案",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -822,6 +822,8 @@
     "The maximum number of custom Connectors has been reached.": "カスタムコネクタの上限に達しました。",
     "Keep saved variables": "保存済みの変数を保持",
     "Line {{line}}: use KEY=VALUE.": "{{line}} 行目: KEY=VALUE 形式を使用してください。",
+    "Line {{line}}: use Name: Value.": "{{line}} 行目: Name: Value 形式を使用してください。",
+    "Line {{line}}: {{name}} is duplicated.": "{{line}} 行目: {{name}} が重複しています。",
     "Manage “{{name}}” connection": "「{{name}}」の接続を管理",
     "Reauthenticate": "再認証",
     "Replace saved variables": "保存済みの変数を置換",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -843,6 +843,8 @@
     "Line {{line}}: use KEY=VALUE.": "{{line}}번 줄: KEY=VALUE 형식을 사용하세요.",
     "Line {{line}}: use Name: Value.": "{{line}}번 줄: Name: Value 형식을 사용하세요.",
     "Line {{line}}: {{name}} is duplicated.": "{{line}}번 줄: {{name}}이(가) 중복되었습니다.",
+    "Show full arguments": "전체 인수 표시",
+    "Hide full arguments": "전체 인수 숨기기",
     "Manage “{{name}}” connection": "‘{{name}}’ 연결 관리",
     "Reauthenticate": "다시 인증",
     "Replace saved variables": "저장된 변수 바꾸기",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -841,6 +841,8 @@
     "The maximum number of custom Connectors has been reached.": "사용자 지정 커넥터의 최대 개수에 도달했습니다.",
     "Keep saved variables": "저장된 변수 유지",
     "Line {{line}}: use KEY=VALUE.": "{{line}}번 줄: KEY=VALUE 형식을 사용하세요.",
+    "Line {{line}}: use Name: Value.": "{{line}}번 줄: Name: Value 형식을 사용하세요.",
+    "Line {{line}}: {{name}} is duplicated.": "{{line}}번 줄: {{name}}이(가) 중복되었습니다.",
     "Manage “{{name}}” connection": "‘{{name}}’ 연결 관리",
     "Reauthenticate": "다시 인증",
     "Replace saved variables": "저장된 변수 바꾸기",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -344,6 +344,7 @@
     "Archiving…": "보관 중…",
     "Args": "인수",
     "Arguments": "인수",
+    "Arguments were truncated for display.": "표시를 위해 인수를 잘랐습니다.",
     "Artifact content is {{reason}}; captured provenance remains available.": "아티팩트 내용은 {{reason}}입니다. 캡처된 출처는 계속 사용 가능합니다.",
     "Artifact file input": "아티팩트 파일 입력",
     "Artifact suggestions": "아티팩트 제안",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3363,6 +3363,8 @@
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "보안 자격 증명 저장소를 사용할 수 없습니다. 시스템 키체인의 잠금을 해제한 후 다시 시도하세요.",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "인수 또는 URL에는 자격 증명을 포함할 수 없습니다. 대신 암호화된 환경 변수 또는 헤더 필드를 사용하세요.",
     "args appears to contain a credential.": "args에 자격 증명이 포함된 것으로 보입니다.",
+    "Duplicate credential names are not allowed on this platform.": "이 플랫폼에서는 자격 증명 이름을 중복해서 사용할 수 없습니다.",
+    "Remote MCP server URL must use HTTPS or loopback HTTP.": "원격 MCP 서버 URL은 HTTPS 또는 루프백 HTTP를 사용해야 합니다.",
     "Credentials unavailable": "자격 증명을 사용할 수 없음",
     "Authentication failed. Verify the username and password.": "인증에 실패했습니다. 사용자 이름과 비밀번호를 확인하세요.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 호스트 키를 알 수 없습니다. 연결하기 전에 터미널에서 확인하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -854,6 +854,8 @@
     "The maximum number of custom Connectors has been reached.": "Достигнуто максимальное число пользовательских Коннекторов.",
     "Keep saved variables": "Сохранить текущие переменные",
     "Line {{line}}: use KEY=VALUE.": "Строка {{line}}: используйте KEY=VALUE.",
+    "Line {{line}}: use Name: Value.": "Строка {{line}}: используйте Name: Value.",
+    "Line {{line}}: {{name}} is duplicated.": "Строка {{line}}: {{name}} дублируется.",
     "Manage “{{name}}” connection": "Управление подключением «{{name}}»",
     "Reauthenticate": "Повторно войти",
     "Replace saved variables": "Заменить сохранённые переменные",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -3742,6 +3742,8 @@
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "Защищённое хранилище учётных данных недоступно. Разблокируйте системную связку ключей и повторите попытку.",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "Учётные данные нельзя указывать в аргументах или URL. Используйте зашифрованные поля переменных окружения или заголовков.",
     "args appears to contain a credential.": "Похоже, args содержит учётные данные.",
+    "Duplicate credential names are not allowed on this platform.": "Повторяющиеся имена учётных данных не допускаются на этой платформе.",
+    "Remote MCP server URL must use HTTPS or loopback HTTP.": "URL удалённого сервера MCP должен использовать HTTPS или HTTP с обратной петлёй.",
     "Credentials unavailable": "Учётные данные недоступны",
     "Authentication failed. Verify the username and password.": "Ошибка аутентификации. Убедитесь, что имя пользователя и пароль верны.",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "Ключ узла SSH неизвестен. Перед подключением подтвердите его в командной строке.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -856,6 +856,8 @@
     "Line {{line}}: use KEY=VALUE.": "Строка {{line}}: используйте KEY=VALUE.",
     "Line {{line}}: use Name: Value.": "Строка {{line}}: используйте Name: Value.",
     "Line {{line}}: {{name}} is duplicated.": "Строка {{line}}: {{name}} дублируется.",
+    "Show full arguments": "Показать аргументы полностью",
+    "Hide full arguments": "Скрыть аргументы полностью",
     "Manage “{{name}}” connection": "Управление подключением «{{name}}»",
     "Reauthenticate": "Повторно войти",
     "Replace saved variables": "Заменить сохранённые переменные",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -360,6 +360,7 @@
     "Archiving…": "Архивирование…",
     "Args": "Параметры",
     "Arguments": "Аргументы",
+    "Arguments were truncated for display.": "Аргументы обрезаны для отображения.",
     "Artifact content is {{reason}}; captured provenance remains available.": "Содержимое артефакта — {{reason}}; информация о происхождении сохранена.",
     "Artifact file input": "Ввод файла артефакта",
     "Artifact suggestions": "Рекомендации по артефактам",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -896,6 +896,8 @@
     "The maximum number of custom Connectors has been reached.": "自定义连接器数量已达到上限。",
     "Keep saved variables": "保留已保存的变量",
     "Line {{line}}: use KEY=VALUE.": "第 {{line}} 行：请使用 KEY=VALUE 格式。",
+    "Line {{line}}: use Name: Value.": "第 {{line}} 行：请使用 Name: Value 格式。",
+    "Line {{line}}: {{name}} is duplicated.": "第 {{line}} 行：{{name}} 重复。",
     "Manage “{{name}}” connection": "管理“{{name}}”连接",
     "Reauthenticate": "重新认证",
     "Replace saved variables": "替换已保存的变量",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -898,6 +898,8 @@
     "Line {{line}}: use KEY=VALUE.": "第 {{line}} 行：请使用 KEY=VALUE 格式。",
     "Line {{line}}: use Name: Value.": "第 {{line}} 行：请使用 Name: Value 格式。",
     "Line {{line}}: {{name}} is duplicated.": "第 {{line}} 行：{{name}} 重复。",
+    "Show full arguments": "显示完整参数",
+    "Hide full arguments": "隐藏完整参数",
     "Manage “{{name}}” connection": "管理“{{name}}”连接",
     "Reauthenticate": "重新认证",
     "Replace saved variables": "替换已保存的变量",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -444,6 +444,8 @@
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全凭据存储不可用。请解锁系统密钥环后重试。",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "参数或 URL 中不允许包含凭据。请改用加密的环境变量或请求头字段。",
     "args appears to contain a credential.": "args 似乎包含凭据。",
+    "Duplicate credential names are not allowed on this platform.": "此平台不允许重复的凭据名称。",
+    "Remote MCP server URL must use HTTPS or loopback HTTP.": "远程 MCP 服务器 URL 必须使用 HTTPS 或回环 HTTP。",
     "Credentials unavailable": "凭据不可用",
     "Authentication failed. Verify the username and password.": "认证失败。请确认用户名和密码。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 主机密钥未知。请先在终端中验证，再进行连接。",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -397,6 +397,7 @@
     "Archiving…": "正在归档…",
     "Args": "参数",
     "Arguments": "参数",
+    "Arguments were truncated for display.": "参数已截断以便显示。",
     "Artifact content is {{reason}}; captured provenance remains available.": "工件内容{{reason}}；已捕获的溯源信息仍可用。",
     "Artifact file input": "写入 Artifact 文件",
     "Artifact suggestions": "Artifact 建议",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -444,6 +444,8 @@
     "Secure credential storage is unavailable. Unlock the system keychain and retry.": "安全憑證儲存無法使用。請解鎖系統鑰匙圈後重試。",
     "Credentials in arguments or URLs are not allowed. Use encrypted environment or header fields instead.": "參數或 URL 中不允許包含憑證。請改用加密的環境變數或標頭欄位。",
     "args appears to contain a credential.": "args 似乎包含憑證。",
+    "Duplicate credential names are not allowed on this platform.": "此平台不允許重複的憑證名稱。",
+    "Remote MCP server URL must use HTTPS or loopback HTTP.": "遠端 MCP 伺服器 URL 必須使用 HTTPS 或迴路 HTTP。",
     "Credentials unavailable": "憑證無法使用",
     "Authentication failed. Verify the username and password.": "認證失敗。請確認使用者名稱和密碼。",
     "The SSH host key is unknown. Verify it in a terminal before connecting.": "SSH 主機金鑰未知。請先在終端機中驗證，再進行連線。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -895,6 +895,8 @@
     "The maximum number of custom Connectors has been reached.": "自訂連接器數量已達上限。",
     "Keep saved variables": "保留已儲存的變數",
     "Line {{line}}: use KEY=VALUE.": "第 {{line}} 行：請使用 KEY=VALUE 格式。",
+    "Line {{line}}: use Name: Value.": "第 {{line}} 行：請使用 Name: Value 格式。",
+    "Line {{line}}: {{name}} is duplicated.": "第 {{line}} 行：{{name}} 重複。",
     "Manage “{{name}}” connection": "管理「{{name}}」連線",
     "Reauthenticate": "重新驗證",
     "Replace saved variables": "取代已儲存的變數",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -397,6 +397,7 @@
     "Archiving…": "正在封存…",
     "Args": "參數",
     "Arguments": "參數",
+    "Arguments were truncated for display.": "參數已截斷以供顯示。",
     "Artifact content is {{reason}}; captured provenance remains available.": "成品內容{{reason}}；已擷取的來源資訊仍可用。",
     "Artifact file input": "寫入 Artifact 檔案",
     "Artifact suggestions": "Artifact 建議",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -897,6 +897,8 @@
     "Line {{line}}: use KEY=VALUE.": "第 {{line}} 行：請使用 KEY=VALUE 格式。",
     "Line {{line}}: use Name: Value.": "第 {{line}} 行：請使用 Name: Value 格式。",
     "Line {{line}}: {{name}} is duplicated.": "第 {{line}} 行：{{name}} 重複。",
+    "Show full arguments": "顯示完整參數",
+    "Hide full arguments": "隱藏完整參數",
     "Manage “{{name}}” connection": "管理「{{name}}」連線",
     "Reauthenticate": "重新驗證",
     "Replace saved variables": "取代已儲存的變數",

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1523,8 +1523,16 @@ export type UpdateCustomServerRequest = {
 export type ConnectorApprovalRequest = {
   id: string
   connector: string // bundled connector id or custom server name
+  // Custom Connector identity/route metadata. Optional for bundled requests and compatibility with
+  // an older main process during development.
+  connectorId?: string
+  connectorName?: string
+  displayName?: string
+  transport?: CustomServerTransport
+  target?: string
   method: string
   argsPreview: string // truncated JSON preview of the call arguments
+  argsJson?: string // complete serialized arguments, expandable in the approval dialog
   // The session that triggered the connector call, so a desktop notification can surface and open
   // that conversation. Absent for call paths that don't carry one.
   sessionId?: string

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1532,7 +1532,8 @@ export type ConnectorApprovalRequest = {
   target?: string
   method: string
   argsPreview: string // truncated JSON preview of the call arguments
-  argsJson?: string // complete serialized arguments, expandable in the approval dialog
+  argsJson?: string // bounded serialized arguments, expandable in the approval dialog
+  argsJsonTruncated?: boolean
   // The session that triggered the connector call, so a desktop notification can surface and open
   // that conversation. Absent for call paths that don't carry one.
   sessionId?: string


### PR DESCRIPTION
## Problem

Persisted Custom Connector records and several settings/runtime boundaries allowed ambiguous identity, stale OAuth writes, cleartext remote HTTP, insufficient approval context, invalid tool-policy writes, and silently discarded credential input.

Each reported behavior was first exercised through a public boundary. Only reports that produced a stable failing regression test were included in this PR.

## Proposed change

| Report | Reproduction and impact | Change |
| --- | --- | --- |
| 1. Persisted identity uniqueness | Duplicate/invalid IDs and ID/name cross-collisions loaded from `settings.json` could route different records through the same MCP client or grant identity. | Build a global route-safety index over all persisted Custom Connectors. Conflicting records remain visible in Settings but are unavailable to discovery, authorization, and dispatch. |
| 2. Stale OAuth state overwrite | A delayed token save could replace a concurrently edited URL/issuer/client configuration with an old full-record snapshot. | Save only `oauthRef` inside the repository mutation queue and compare the expected process-local configuration fingerprint plus the opaque encrypted client-secret reference in the same critical section. A stale write is discarded. |
| 5. Cleartext remote HTTP | A non-loopback `http://` MCP URL could carry static headers or OAuth credentials. A later red test confirmed that an initially valid HTTPS endpoint could redirect static headers to an insecure, unrelated origin. | Require HTTPS, except for `localhost`, IPv4 `127.0.0.0/8`, and IPv6 `::1`. Enforce on add/edit, historical route projection, transport construction, and every redirect hop. Follow at most five same-origin redirects; reject cross-origin and insecure redirects before sending the next request. |
| 7. Ambiguous approval target | Duplicate display names and a 300-character argument preview did not identify the actual Custom Connector target. A later red test also confirmed that expanded arguments were unbounded in IPC and could overflow the approval dialog. | Add transient approval metadata for immutable name, ID, transport, remote origin/local command, and expandable arguments. Bound expanded disclosure to 64,000 characters, mark truncation, and keep it in an independently scrollable region. Broad-scope confirmation repeats the disambiguated subject. |
| 8. Tool-policy write ordering | An unknown bundled `toolId` was persisted before connector detail validation. | Validate the bundled Connector and registered method before any policy write. |
| 9. Credential text parsing | Malformed lines were dropped, duplicate names were overwritten, and static env/header secrets were accepted in the UI before secure-storage availability was known. | Report malformed and duplicate lines, block submission, and surface the existing keychain recovery message before static secrets can be saved. Enforce header-name collisions case-insensitively on every platform and environment-name collisions case-insensitively on Windows at renderer, main command, and historical runtime boundaries. |

Review follow-ups were also admitted through the same red-test gate:

- The new secure-URL and duplicate-credential validation errors bypassed the renderer's localization mapping. They now use the existing localized error boundary in all seven renderer locales.
- The MCP data-plane same-origin fetch wrapper also handled OAuth discovery and token requests, so a secure authorization server on a different origin failed before browser authorization. OAuth control-plane requests may now use their own secure origin without receiving static MCP headers; every individual request still rejects cross-origin or insecure redirects.

## Scope and non-goals

- Report 3 is not changed: the current security-update workflow already clears dispatch failure state only after durable commit and re-probes; its recovery/rollback tests were green before this work.
- Report 4 (Custom Connector tool-level permission UI and default-new-tool policy) is a product feature gap. There is no existing public behavior contract to make red, so it is intentionally deferred.
- Report 8 is limited to the reproduced write-before-validation defect. This PR does not introduce a new command-wide Zod framework without failing behavior to justify it.
- `enabledIds`, `trustedAt`, and the broader `enabled` state-model cleanup are unrelated refactors and remain unchanged.

## Historical compatibility, persistence, and state

- Existing conflicting-identity and non-loopback HTTP records are preserved in `settings.json` and remain editable, but project as unavailable and cannot be discovered, authorized, or called. There is no destructive migration.
- Existing header-name collisions fail closed on every platform. Existing environment-name collisions fail closed on Windows, while Unix keeps case-sensitive environment names such as `FOO` and `foo` distinct.
- Existing valid HTTPS, loopback HTTP, and stdio records keep their current behavior.
- Existing same-origin remote MCP data-plane redirects remain supported. Cross-origin data-plane redirects now fail closed, including HTTPS-to-HTTP downgrade redirects. OAuth control-plane endpoints may use a different secure origin from the MCP server, but redirects for each OAuth request remain same-origin. This is a runtime compatibility change, not a stored-data migration.
- OAuth persistence keeps the same `oauthRef` and client-secret reference formats; only the mutation changes from full-record replacement to field-level compare-and-set. The encrypted client-secret reference is compared separately instead of being included in a hash.
- Approval metadata, including the new optional `argsJsonTruncated` flag, is transient IPC data. Fields are optional so an older main process still renders through the existing fallback.
- No persisted field, database schema, migration, or enum value is added.

## Acceptance criteria and validation

The following checks ran after the final material source edit:

- Localized Custom Connector security errors and complete locale catalogs:
  - `npx vitest run src/renderer/src/pages/settings/connector-error-message.test.ts`
  - **1 file, 3 tests passed**
  - `npx vitest run src/renderer/src/i18n/resources.test.ts`
  - **1 file, 743 tests passed**

- Bounded approval payload, scrollable expanded arguments, and complete locale catalogs:
  - `npx vitest run src/main/connectors/application.test.ts src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx src/renderer/src/i18n/resources.test.ts`
  - **3 files, 764 tests passed**
- Platform-aware credential collision behavior across renderer, main command, and historical runtime projection:
  - `npx vitest run src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx src/main/settings/connector-settings.test.ts src/main/connectors/custom-mcp-bootstrap.test.ts`
  - **3 files, 134 tests passed**
- Identity, OAuth CAS, secure URL, tool-policy validation, existing failure recovery, settings/UI forms, approval broker/dialog, and i18n contracts before the final credential-boundary extension:
  - `npx vitest run src/main/settings/connector-settings.test.ts src/main/connectors/custom-mcp-bootstrap.test.ts src/main/connectors/application.test.ts src/main/connectors/approval-broker.test.ts src/main/permission-grants/connector-broker.test.ts src/main/connectors/service.test.ts src/main/settings/workflows.test.ts src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx src/renderer/src/i18n/resources.test.ts`
  - **10 files, 1011 tests passed**
- MCP transport and OAuth callback behavior:
  - `npx vitest run src/main/connectors/mcp-client-manager.test.ts`
  - **1 file, 39 tests passed**, including cross-origin OAuth discovery without static MCP-header disclosure
- Shared approval interface consumers:
  - `npx vitest run src/renderer/src/stores/settings-connectors-slice.test.ts src/main/notifications/electron-wiring.test.ts src/main/notifications/task-notifications.test.ts`
  - **3 files, 127 tests passed**
- `npm run typecheck` — passed
- `npm run lint` — passed with no errors; final changed files were formatted and rechecked with targeted ESLint
- `npx vitest run scripts/ci/classify-pr-changes.test.ts` — **1 file, 63 tests passed**
- `npx vitest run src/main/settings/connector-settings.test.ts` — **1 file, 85 tests passed**, including a client-secret-only stale OAuth save race
- `npx vitest run src/main/connectors/custom-mcp-bootstrap.test.ts src/main/connectors/service.test.ts` — **2 files, 91 tests passed**
- `npx vitest run src/main/connectors/mcp-client-manager.test.ts src/main/connectors/application.test.ts src/main/settings/service.test.ts` — **3 files, 306 tests passed**
- `git diff --check origin/main...HEAD` — passed

`test:affected --explain` falls back to the complete suite because `src/main/connectors/application.test.ts` has no module owner. Per maintainer direction, the full local suite was not run; exact-head PR CI is the authority for the fallback and platform lanes.

## Review focus

- Confirm the repository compare-and-set boundary covers every OAuth state writer without changing the stored format.
- Confirm historical invalid identities, insecure HTTP records, and platform-ambiguous credentials remain visible but fail closed at every runtime projection.
- Confirm the added approval metadata is display-only and does not alter durable permission capability keys.
- Confirm the deliberately deferred feature/model work remains outside this focused integrity fix.
