### PR TITLE
fix(web-service): bound client caller retention

### DIFF
--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1796,6 +1796,246 @@ describe('startWebHttpServer', () => {
     expect(directSignals[0]?.aborted).toBe(true)
   })
 
+  it('bounds retained caller leases when one principal rotates HTTP client nonces', async () => {
+    const callerSignals: AbortSignal[] = []
+    const remoteInvoke = vi.fn(async (_channel, invocation) => {
+      callerSignals.push(invocation.callerLease.signal)
+      return []
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'local-token',
+      staticRoot: '/unused',
+      rpc: {
+        channels: () => ['projects:list'],
+        invoke: vi.fn(),
+        dispose: vi.fn()
+      },
+      applicationCommands: {
+        localWeb: { commandNames: () => [], invoke: vi.fn() },
+        remoteWeb: {
+          commandNames: () => ['projects:list'],
+          rejectedCommandNames: () => [],
+          invoke: remoteInvoke
+        }
+      },
+      externalAccess: {
+        authorizeHttp: vi.fn().mockResolvedValue(accessOnlyExternalAccess('shared-principal')),
+        authorizeWebSocket: vi.fn().mockResolvedValue(undefined)
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const responses: Response[] = []
+    for (let index = 0; index < 65; index += 1) {
+      responses.push(
+        await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-open-science-client': `rotated-client-${index}`
+          },
+          body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+        })
+      )
+    }
+
+    expect(responses.every((response) => response.status === 200)).toBe(true)
+    expect(callerSignals).toHaveLength(65)
+    expect(callerSignals.some((signal) => signal.aborted)).toBe(true)
+  })
+
+  it('rejects malformed or repeated HTTP client nonces before invoking a command', async () => {
+    const invoke = vi.fn().mockResolvedValue([])
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => ['projects:list'], invoke },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const body = JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+    const postWithClientHeader = (clientHeader: string | string[]): Promise<number> =>
+      new Promise<number>((resolve, reject) => {
+        const request = httpRequest(
+          {
+            host: '127.0.0.1',
+            port: server.port,
+            path: '/rpc/projects%3Alist',
+            method: 'POST',
+            headers: {
+              authorization: 'Bearer test-token',
+              'content-type': 'application/json',
+              'content-length': String(Buffer.byteLength(body)),
+              'x-open-science-client': clientHeader
+            }
+          },
+          (response) => {
+            response.resume()
+            response.once('end', () => resolve(response.statusCode ?? 0))
+          }
+        )
+        request.once('error', reject)
+        request.end(body)
+      })
+
+    expect(
+      await Promise.all([
+        postWithClientHeader('x'.repeat(65)),
+        postWithClientHeader('client with spaces'),
+        postWithClientHeader(['first-client', 'second-client'])
+      ])
+    ).toEqual([400, 400, 400])
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed WebSocket client nonces during the HTTP upgrade', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    await new Promise<void>((resolve, reject) => {
+      const socket = new WebSocket(
+        `ws://127.0.0.1:${server.port}/events?token=test-token&client=invalid%20client`
+      )
+      socket.once('open', () => {
+        socket.close()
+        reject(new Error('WebSocket with malformed client nonce opened.'))
+      })
+      socket.once('error', () => undefined)
+      socket.once('unexpected-response', (_request, response) => {
+        expect(response.statusCode).toBe(400)
+        response.resume()
+        resolve()
+      })
+    })
+  })
+
+  it('releases an HTTP-only caller when its connection closes during command execution', async () => {
+    let markInvocationStarted: (() => void) | undefined
+    const invocationStarted = new Promise<void>((resolve) => {
+      markInvocationStarted = resolve
+    })
+    let finishInvocation: (() => void) | undefined
+    const invocationGate = new Promise<void>((resolve) => {
+      finishInvocation = resolve
+    })
+    let callerSignal: AbortSignal | undefined
+    const directInvoke = vi.fn(async (_channel, invocation) => {
+      callerSignal = invocation.callerLease.signal
+      markInvocationStarted?.()
+      await invocationGate
+      return []
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => ['projects:list'], invoke: vi.fn() },
+      applicationCommands: {
+        localWeb: { commandNames: () => ['projects:list'], invoke: directInvoke },
+        remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() }
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const request = httpRequest({
+      host: '127.0.0.1',
+      port: server.port,
+      path: '/rpc/projects%3Alist',
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+        'x-open-science-client': 'http-only-client'
+      }
+    })
+    request.once('error', () => undefined)
+    request.end(JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] }))
+    await invocationStarted
+
+    request.destroy()
+    await vi.waitFor(() => expect(callerSignal?.aborted).toBe(true))
+    finishInvocation?.()
+  })
+
+  it('releases an HTTP-only caller after its idle retention window', async () => {
+    let callerSignal: AbortSignal | undefined
+    const directInvoke = vi.fn(async (_channel, invocation) => {
+      callerSignal = invocation.callerLease.signal
+      return []
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      webClientRetention: { httpIdleTtlMs: 20 },
+      rpc: { channels: () => ['projects:list'], invoke: vi.fn() },
+      applicationCommands: {
+        localWeb: { commandNames: () => ['projects:list'], invoke: directInvoke },
+        remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() }
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+        'x-open-science-client': 'http-only-client'
+      },
+      body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+    })
+
+    expect(response.status).toBe(200)
+    expect(callerSignal?.aborted).toBe(false)
+    await vi.waitFor(() => expect(callerSignal?.aborted).toBe(true))
+  })
+
   it('bounds close when an active HTTP request does not finish', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1939,6 +1939,52 @@ describe('startWebHttpServer', () => {
     })
   })
 
+  it('does not retain external socket metadata after client capacity rejects an upgrade', async () => {
+    const close = vi.spyOn(WebSocket.prototype, 'close')
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'local-token',
+      staticRoot: '/unused',
+      webClientRetention: { maxClientsPerPrincipal: 1 },
+      rpc: { channels: () => [], invoke: vi.fn() },
+      externalAccess: {
+        authorizeHttp: vi.fn().mockResolvedValue('denied'),
+        authorizeWebSocket: vi.fn().mockResolvedValue({
+          principalId: 'shared-principal',
+          isCurrent: () => true
+        })
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const retained = new WebSocket(`ws://127.0.0.1:${server.port}/events?client=retained-client`)
+    await new Promise<void>((resolve) => retained.once('open', resolve))
+    const rejected = new WebSocket(`ws://127.0.0.1:${server.port}/events?client=rejected-client`)
+
+    await new Promise<void>((resolve) => {
+      rejected.once('close', (code) => {
+        expect(code).toBe(1013)
+        resolve()
+      })
+    })
+    const retainedClosed = new Promise<void>((resolve) => retained.once('close', () => resolve()))
+    server.closeExternalConnections('shared-principal')
+    await retainedClosed
+
+    expect(
+      close.mock.calls.filter(
+        ([code, reason]) => code === 1008 && reason === 'Remote access revoked'
+      )
+    ).toHaveLength(1)
+  })
+
   it('releases an HTTP-only caller when its connection closes during command execution', async () => {
     let markInvocationStarted: (() => void) | undefined
     const invocationStarted = new Promise<void>((resolve) => {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -18,7 +18,6 @@ import {
 import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { WebRpcErrorCode } from '../../shared/web-rpc-contract'
 import {
-  ClientLeaseRegistry,
   createTaskCallerContext,
   createWebCallerContext,
   type CallerContext
@@ -68,6 +67,10 @@ const MAX_TASK_IDEMPOTENCY_BYTES = 64 * 1024 * 1024
 const MIN_TASK_IDEMPOTENCY_ENTRY_BYTES = 16 * 1024
 const MAX_IDEMPOTENCY_KEY_LENGTH = 255
 const MAX_CACHED_TASK_ERROR_MESSAGE_LENGTH = 4_096
+const MAX_WEB_CLIENTS_PER_PRINCIPAL = 64
+const MAX_WEB_CLIENT_NONCE_LENGTH = 64
+const DEFAULT_HTTP_CLIENT_IDLE_TTL_MS = 5 * 60_000
+const WEB_CLIENT_NONCE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u
 const gzipAsync = promisify(gzip)
 const log = createLogger('web-service')
 const STATIC_RESPONSE_SECURITY_HEADERS = {
@@ -113,6 +116,10 @@ type WebServerOptions = {
   applicationEvents: ApplicationEventSource
   eventHeartbeatIntervalMs?: number
   requestBodyBudgets?: RequestBodyBudgets
+  webClientRetention?: Readonly<{
+    maxClientsPerPrincipal?: number
+    httpIdleTtlMs?: number
+  }>
   externalAccess?: ExternalWebAccess
   tasks?: Pick<
     HeadlessTaskApi,
@@ -224,6 +231,148 @@ class RequestBodyBudgetRegistry {
     const clientBytes = (this.clientInFlightBytes.get(lease.clientId) ?? 0) - lease.reservedBytes
     if (clientBytes === 0) this.clientInFlightBytes.delete(lease.clientId)
     else this.clientInFlightBytes.set(lease.clientId, clientBytes)
+  }
+}
+
+class WebClientCapacityExceededError extends Error {
+  readonly name = 'WebClientCapacityExceededError'
+
+  constructor() {
+    super('Too many active Web clients for this authenticated principal.')
+  }
+}
+
+class InvalidWebClientNonceError extends Error {
+  readonly name = 'InvalidWebClientNonceError'
+
+  constructor() {
+    super('Web client identifier must be one ASCII token of at most 64 characters.')
+  }
+}
+
+type RetainedWebClient = {
+  clientId: string
+  httpRequests: number
+  sockets: number
+  idleTimer?: ReturnType<typeof setTimeout>
+}
+
+type WebClientLease = Readonly<{ release: (disconnected?: boolean) => void }>
+
+class WebClientLeaseRegistry {
+  private readonly clientsByPrincipal = new Map<string, Map<string, RetainedWebClient>>()
+  private disposed = false
+
+  constructor(
+    private readonly releaseClient: (clientId: string) => void,
+    private readonly maxClientsPerPrincipal = MAX_WEB_CLIENTS_PER_PRINCIPAL,
+    private readonly httpIdleTtlMs = DEFAULT_HTTP_CLIENT_IDLE_TTL_MS
+  ) {
+    if (!Number.isSafeInteger(maxClientsPerPrincipal) || maxClientsPerPrincipal <= 0) {
+      throw new TypeError('maxClientsPerPrincipal must be a positive safe integer.')
+    }
+    if (!Number.isSafeInteger(httpIdleTtlMs) || httpIdleTtlMs <= 0) {
+      throw new TypeError('httpIdleTtlMs must be a positive safe integer.')
+    }
+  }
+
+  acquireHttp(principalId: string, clientNonce: string, clientId: string): WebClientLease {
+    return this.acquire(principalId, clientNonce, clientId, 'httpRequests')
+  }
+
+  acquireSocket(principalId: string, clientNonce: string, clientId: string): WebClientLease {
+    return this.acquire(principalId, clientNonce, clientId, 'sockets')
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    const principalClients = [...this.clientsByPrincipal.values()]
+    const clients = principalClients.flatMap((clients) => [...clients.values()])
+    for (const clients of principalClients) clients.clear()
+    this.clientsByPrincipal.clear()
+    const failures: unknown[] = []
+    for (const client of clients) {
+      if (client.idleTimer) clearTimeout(client.idleTimer)
+      try {
+        this.releaseClient(client.clientId)
+      } catch (error) {
+        failures.push(error)
+      }
+    }
+    if (failures.length > 0) throw new AggregateError(failures, 'Web client cleanup failed.')
+  }
+
+  private acquire(
+    principalId: string,
+    clientNonce: string,
+    clientId: string,
+    kind: 'httpRequests' | 'sockets'
+  ): WebClientLease {
+    if (this.disposed) throw new Error('Web client lease registry is disposed.')
+    const clients = this.clientsByPrincipal.get(principalId) ?? new Map<string, RetainedWebClient>()
+    let client = clients.get(clientNonce)
+    if (!client) {
+      if (clients.size >= this.maxClientsPerPrincipal) {
+        const idle = [...clients].find(
+          ([, candidate]) => candidate.httpRequests === 0 && candidate.sockets === 0
+        )
+        if (!idle) throw new WebClientCapacityExceededError()
+        clients.delete(idle[0])
+        if (idle[1].idleTimer) clearTimeout(idle[1].idleTimer)
+        this.releaseClient(idle[1].clientId)
+      }
+      client = { clientId, httpRequests: 0, sockets: 0 }
+    } else if (client.clientId !== clientId) {
+      throw new Error('Web client identity changed within one principal scope.')
+    }
+    if (client.idleTimer) {
+      clearTimeout(client.idleTimer)
+      delete client.idleTimer
+    }
+    clients.delete(clientNonce)
+    clients.set(clientNonce, client)
+    this.clientsByPrincipal.set(principalId, clients)
+    client[kind] += 1
+    let released = false
+
+    return Object.freeze({
+      release: (disconnected = false) => {
+        if (released) return
+        released = true
+        if (clients.get(clientNonce) !== client) return
+        client[kind] -= 1
+        if (
+          (kind === 'sockets' || disconnected) &&
+          client.sockets === 0 &&
+          client.httpRequests === 0
+        ) {
+          clients.delete(clientNonce)
+          if (clients.size === 0) this.clientsByPrincipal.delete(principalId)
+          if (client.idleTimer) clearTimeout(client.idleTimer)
+          this.releaseClient(client.clientId)
+          return
+        }
+        clients.delete(clientNonce)
+        clients.set(clientNonce, client)
+        if (client.httpRequests === 0 && client.sockets === 0) {
+          client.idleTimer = setTimeout(() => {
+            if (
+              clients.get(clientNonce) !== client ||
+              client.httpRequests !== 0 ||
+              client.sockets !== 0
+            ) {
+              return
+            }
+            clients.delete(clientNonce)
+            if (clients.size === 0) this.clientsByPrincipal.delete(principalId)
+            delete client.idleTimer
+            this.releaseClient(client.clientId)
+          }, this.httpIdleTtlMs)
+          client.idleTimer.unref()
+        }
+      }
+    })
   }
 }
 
@@ -357,8 +506,21 @@ const closeRequestAfterResponse = (request: IncomingMessage, response: ServerRes
   else response.once('finish', () => request.destroy())
 }
 
+const parseClientNonce = (values: readonly string[]): string => {
+  if (values.length === 0) return 'web'
+  const value = values[0]
+  if (
+    values.length !== 1 ||
+    value.length > MAX_WEB_CLIENT_NONCE_LENGTH ||
+    !WEB_CLIENT_NONCE_PATTERN.test(value)
+  ) {
+    throw new InvalidWebClientNonceError()
+  }
+  return value
+}
+
 const requestClientNonce = (request: IncomingMessage): string =>
-  String(request.headers['x-open-science-client'] ?? 'web')
+  parseClientNonce(request.headersDistinct['x-open-science-client'] ?? [])
 
 const authorizedClientId = (principalId: string, clientNonce: string): string =>
   `${principalId}:${clientNonce}`
@@ -945,9 +1107,13 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       serverInFlightBytes: MAX_SERVER_IN_FLIGHT_RPC_BODY_BYTES
     }
   )
-  const clientLeases = new ClientLeaseRegistry((clientId) => {
-    commandClient.releaseClient('web', clientId)
-  })
+  const webClientLeases = new WebClientLeaseRegistry(
+    (clientId) => {
+      commandClient.releaseClient('web', clientId)
+    },
+    options.webClientRetention?.maxClientsPerPrincipal,
+    options.webClientRetention?.httpIdleTtlMs
+  )
   const wsServer = new WebSocketServer({ noServer: true })
 
   const isWebSocketAuthorizationCurrent = (socket: WebSocket): boolean => {
@@ -987,10 +1153,22 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         response.end('Unauthorized')
         return
       }
-      const clientNonce = requestClientNonce(request)
+      let clientNonce: string
+      try {
+        clientNonce = requestClientNonce(request)
+      } catch (error) {
+        if (error instanceof InvalidWebClientNonceError) {
+          json(response, 400, { error: error.message })
+          return
+        }
+        throw error
+      }
       const clientId = externalAuthorization
         ? authorizedClientId(externalAuthorization.principalId, clientNonce)
         : clientNonce
+      const clientPrincipalId = externalAuthorization
+        ? `remote:${externalAuthorization.principalId}`
+        : 'local'
       const requestBodyClientId = externalAuthorization?.principalId ?? clientId
       if (!hasValidUrlPathEncoding(url.pathname)) {
         json(response, 400, { error: 'Malformed URL encoding.' })
@@ -1153,6 +1331,19 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
               }
             : {})
         })
+        let clientLease: WebClientLease
+        try {
+          clientLease = webClientLeases.acquireHttp(clientPrincipalId, clientNonce, clientId)
+        } catch (error) {
+          if (error instanceof WebClientCapacityExceededError) {
+            webRpcError(response, 429, 'handler_error', error.message)
+            return
+          }
+          throw error
+        }
+        const releaseDisconnectedClient = (): void => clientLease.release(true)
+        request.once('aborted', releaseDisconnectedClient)
+        response.once('close', releaseDisconnectedClient)
         try {
           assertExternalAuthorizationCurrent(externalAuthorization)
           const dispatcher = auth.ok
@@ -1182,6 +1373,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
           }
           const publicError = publicApplicationCommandError(error)
           webRpcError(response, 500, publicError.code, publicError.message)
+        } finally {
+          request.off('aborted', releaseDisconnectedClient)
+          response.off('close', releaseDisconnectedClient)
+          clientLease.release()
         }
         return
       }
@@ -1229,6 +1424,14 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
           socket.destroy()
           return
         }
+        try {
+          parseClientNonce(url.searchParams.getAll('client'))
+        } catch (error) {
+          if (!(error instanceof InvalidWebClientNonceError)) throw error
+          socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n')
+          socket.destroy()
+          return
+        }
         wsServer.handleUpgrade(request, socket, head, (webSocket) => {
           if (externalAuthorization) {
             externalSockets.set(webSocket, externalAuthorization)
@@ -1244,7 +1447,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
 
   wsServer.on('connection', (socket, request) => {
     const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`)
-    const clientNonce = url.searchParams.get('client') ?? 'web'
+    const clientNonce = parseClientNonce(url.searchParams.getAll('client'))
     const externalAuthorization = externalSockets.get(socket)
     if (externalAuthorization && !externalAuthorization.isCurrent()) {
       externalSockets.delete(socket)
@@ -1255,7 +1458,18 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       externalAuthorization === undefined
         ? clientNonce
         : authorizedClientId(externalAuthorization.principalId, clientNonce)
-    const lease = clientLeases.acquire(clientId)
+    const clientPrincipalId =
+      externalAuthorization === undefined ? 'local' : `remote:${externalAuthorization.principalId}`
+    let lease: WebClientLease
+    try {
+      lease = webClientLeases.acquireSocket(clientPrincipalId, clientNonce, clientId)
+    } catch (error) {
+      if (error instanceof WebClientCapacityExceededError) {
+        socket.close(1013, 'Too many active Web clients')
+        return
+      }
+      throw error
+    }
     socket.on('close', () => {
       sockets.delete(socket)
       externalSockets.delete(socket)
@@ -1353,7 +1567,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     removeBroadcastSink()
     removeTaskProgressSink?.()
     try {
-      clientLeases.dispose()
+      webClientLeases.dispose()
     } finally {
       commandClient.dispose()
     }
@@ -1404,7 +1618,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       const closePromise = new Promise<void>((resolveClose) => server.close(() => resolveClose()))
       let cleanupError: unknown
       try {
-        clientLeases.dispose()
+        webClientLeases.dispose()
       } catch (error) {
         cleanupError = error
       } finally {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -1465,6 +1465,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       lease = webClientLeases.acquireSocket(clientPrincipalId, clientNonce, clientId)
     } catch (error) {
       if (error instanceof WebClientCapacityExceededError) {
+        externalSockets.delete(socket)
         socket.close(1013, 'Too many active Web clients')
         return
       }


### PR DESCRIPTION
## Summary

- validate Web client nonces as one ASCII token of at most 64 characters on both HTTP and WebSocket boundaries
- cap retained clients at 64 per authenticated principal, evict idle callers by LRU, and release HTTP-only callers after a five-minute idle TTL
- bind HTTP abort/connection-close events to scoped caller leases while preserving callers that still have concurrent requests or WebSockets
- keep the change inside the Web transport adapter; no database fields, migrations, renderer models, or persistent configuration are added

## Reproduction

The regression test sends 65 successful RPC requests for one authenticated principal while rotating valid client nonces. Before the fix, all 65 caller signals remained active, demonstrating that the caller/lease maps grew with every nonce until server shutdown. The test failed consistently on the unmodified implementation and passes after the bounded retention change.

Additional public-boundary tests confirm that the old implementation accepted oversized, malformed, and repeated HTTP client headers, allowed malformed WebSocket client identifiers to upgrade, and retained HTTP-only callers after disconnect or idle expiry.

## Behavior changes

- malformed or repeated HTTP client identifiers return `400`
- malformed WebSocket client identifiers are rejected during upgrade with `400`
- if all 64 client slots for a principal are actively leased, new HTTP RPC calls return `429` and new WebSockets close with `1013`
- disconnected HTTP-only callers are cancelled through the existing caller `AbortSignal`; successful HTTP-only clients retain cross-request ownership for five idle minutes

## Testing

- `npx vitest run src/main/web-service/http-server.test.ts src/main/application-command-client.test.ts src/main/caller-lifecycle.test.ts src/main/caller-context.test.ts` — 63 passed
- `npm run typecheck:node` — passed
- `npx eslint src/main/web-service/http-server.ts src/main/web-service/http-server.test.ts` — passed
- full `npm test` reached 21,246 passing tests; 153 unrelated Windows-environment tests failed because this host lacks symlink privileges/Python and the worktree path exceeds existing path-budget fixtures