### PR TITLE
fix(skills): separate edit loading and catalog migration

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -500,6 +500,8 @@ const createApplicationModules = async (
     }
   }
   const storedSettings = await settingsService.getStoredSettings()
+  await settingsService.migrateAgentHomeSkillIdentities()
+  composition.phase('agent-home-skill-identity-migration')
   const storageLog = createLogger('storage')
   await networkProxyRuntime.apply(storedSettings.networkProxy)
   // Prime the data-root cache from settings before any data repository is constructed below. A change

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -7122,6 +7122,8 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     await rename(original, canonical)
     await symlink(canonical, original)
 
+    await service.migrateAgentHomeSkillIdentities()
+
     expect(await service.listAgentHomeSkills()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -7165,6 +7167,11 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     await rm(join(userClaudeDir, 'skills'), { recursive: true })
     await symlink(join(userAgentsDir, 'skills'), join(userClaudeDir, 'skills'))
 
+    // Startup migration must include inactive framework roots. The old identity is Claude-owned,
+    // while the selected framework exposes only the shared Agent Home root.
+    await repository.setAgentFramework('opencode')
+    await service.migrateAgentHomeSkillIdentities()
+
     expect(await service.listAgentHomeSkills()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -7175,8 +7182,37 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
       ])
     )
 
-    await repository.setAgentFramework('opencode')
-    expect(await service.listAgentHomeSkills()).toEqual(
+    await expect(
+      readFile(join(storageRoot, 'skills', 'imported', 'real-skill', '.source.json'), 'utf8').then(
+        JSON.parse
+      )
+    ).resolves.toMatchObject({ agentHome: { source: 'agents', slug: 'real-skill' } })
+  })
+
+  it('does not rewrite imported metadata while listing Agent Home Skills', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-list-symlink-root-alias-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-list-symlink-root-shared-'))
+    const original = await seedSkill(userClaudeDir, 'real-skill')
+    const service = createService(undefined, { userClaudeDir, userAgentsDir })
+    await repository.setAgentFramework('claude-code')
+
+    expect(
+      (
+        await service.importAgentHomeSkills({
+          skills: [{ source: 'claude', slug: 'real-skill' }]
+        })
+      ).results[0]
+    ).toMatchObject({ status: 'imported', id: 'imported-real-skill' })
+
+    const importedSource = join(storageRoot, 'skills', 'imported', 'real-skill', '.source.json')
+    const metadataBeforeList = await readFile(importedSource, 'utf8')
+    const sharedSkill = join(userAgentsDir, 'skills', 'real-skill')
+    await mkdir(join(userAgentsDir, 'skills'), { recursive: true })
+    await rename(original, sharedSkill)
+    await rm(join(userClaudeDir, 'skills'), { recursive: true })
+    await symlink(join(userAgentsDir, 'skills'), join(userClaudeDir, 'skills'))
+
+    await expect(service.listAgentHomeSkills()).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           source: 'agents',
@@ -7185,6 +7221,20 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
         })
       ])
     )
+
+    await expect(readFile(importedSource, 'utf8')).resolves.toBe(metadataBeforeList)
+  })
+
+  it('keeps startup available when Agent Home identity migration cannot scan its roots', async () => {
+    const invalidHome = join(storageRoot, 'agent-home-file')
+    await writeFile(invalidHome, 'not a directory')
+    const service = createService(undefined, {
+      userAgentsDir: invalidHome,
+      userClaudeDir: invalidHome,
+      userCodexDir: invalidHome
+    })
+
+    await expect(service.migrateAgentHomeSkillIdentities()).resolves.toBeUndefined()
   })
 })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -27,7 +27,7 @@ import type {
   ClaudeIsolatedAuthStatus
 } from './claude-isolated-auth'
 import type { ClaudeSharedAuthControllerPort } from './claude-shared-auth'
-import type { UserSkillRepository } from '../skills/user-skill-repository'
+import type { UserSkillRepository as UserSkillRepositoryType } from '../skills/user-skill-repository'
 import type { SystemProxyEnvironment } from './system-proxy'
 import type { AgentBackendResolutionContext } from './backend-resolver'
 import type { Logger } from '../logger'
@@ -61,6 +61,7 @@ const { SkillRegistry } = await import('../skills/registry')
 const { managedClaudeDir } = await import('./managed-claude')
 const { managedOpencodeDir } = await import('./managed-opencode')
 const { netFetch } = await import('../skills/net-fetch')
+const { UserSkillRepository } = await import('../skills/user-skill-repository')
 const { UserSkillSpecialistPackageAdapter } = await import('../skills/specialist-package-adapter')
 const { opencodeConfigDir, opencodeTransportProviderId } =
   await import('../agent-framework/opencode')
@@ -196,6 +197,7 @@ const createService = (
     userClaudeDir?: string
     userCodexDir?: string
     userAgentsDir?: string
+    userSkills?: UserSkillRepositoryType
     log?: Logger
   } = {}
 ): InstanceType<typeof SettingsService> =>
@@ -208,6 +210,7 @@ const createService = (
     userClaudeDir: options.userClaudeDir ?? join(storageRoot, 'no-user-claude'),
     userCodexDir: options.userCodexDir ?? join(storageRoot, 'no-user-codex'),
     userAgentsDir: options.userAgentsDir ?? join(storageRoot, 'no-user-agents'),
+    userSkills: options.userSkills,
     executeClaudeProbe: options.executeClaudeProbe,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     installManagedClaudeImpl: options.installManagedClaudeImpl as any,
@@ -4402,7 +4405,7 @@ describe('SettingsService: skills', () => {
               sourceDir: join(storageRoot, 'skills', 'imported', 'data-explorer')
             }
           ])
-      } as unknown as UserSkillRepository
+      } as unknown as UserSkillRepositoryType
     })
 
     expect(await service.skillNudgeNamesForIds(['imported-data-explorer'])).toEqual([
@@ -7235,6 +7238,47 @@ describe('SettingsService: importAgentHomeSkills realpath containment', () => {
     })
 
     await expect(service.migrateAgentHomeSkillIdentities()).resolves.toBeUndefined()
+  })
+
+  it('keeps a failed Agent Home identity migration selectable for manual repair', async () => {
+    const userClaudeDir = await mkdtemp(join(tmpdir(), 'os-migration-failure-legacy-'))
+    const userAgentsDir = await mkdtemp(join(tmpdir(), 'os-migration-failure-shared-'))
+    const original = await seedSkill(userClaudeDir, 'real-skill')
+    const userSkills = new UserSkillRepository(storageRoot)
+    const service = createService(undefined, { userClaudeDir, userAgentsDir, userSkills })
+    await repository.setAgentFramework('claude-code')
+    await service.importAgentHomeSkills({
+      skills: [{ source: 'claude', slug: 'real-skill' }]
+    })
+
+    await mkdir(join(userAgentsDir, 'skills'), { recursive: true })
+    await rename(original, join(userAgentsDir, 'skills', 'real-skill'))
+    await rm(join(userClaudeDir, 'skills'), { recursive: true })
+    await symlink(join(userAgentsDir, 'skills'), join(userClaudeDir, 'skills'))
+    vi.spyOn(userSkills, 'importAgentHomeSkill').mockRejectedValueOnce(
+      new Error('simulated migration write failure')
+    )
+
+    await service.migrateAgentHomeSkillIdentities()
+
+    await expect(service.listAgentHomeSkills()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agents',
+          slug: 'real-skill',
+          alreadyImported: false
+        })
+      ])
+    )
+
+    await expect(
+      service.importAgentHomeSkills({ skills: [{ source: 'agents', slug: 'real-skill' }] })
+    ).resolves.toMatchObject({ results: [{ status: 'updated', id: 'imported-real-skill' }] })
+    await expect(service.listAgentHomeSkills()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'agents', slug: 'real-skill', alreadyImported: true })
+      ])
+    )
   })
 })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -708,6 +708,10 @@ class SettingsService {
     return this.skills.listAgentHomeSkills()
   }
 
+  async migrateAgentHomeSkillIdentities(): Promise<void> {
+    await this.skills.migrateAgentHomeSkillIdentities()
+  }
+
   async previewAgentHomeSkill(
     request: PreviewAgentHomeSkillRequest
   ): Promise<SkillImportPreviewContent> {

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -479,7 +479,7 @@ describe('Settings backend ownership architecture', () => {
         isNpmAvailable listAgentHomeSkills listConnectors listHostSkills listSkills listSpecialistSkillCatalog listUserSkills
         loginClaudeShared loginIsolatedClaude loginIsolatedClaudeBrowser loginIsolatedCodex
         logoutClaudeShared logoutIsolatedClaude logoutIsolatedCodex logoutXaiOAuth markOnboardingComplete
-        markPathsNormalized previewAgentHomeSkill previewCustomServerTemplateExport
+        markPathsNormalized migrateAgentHomeSkillIdentities previewAgentHomeSkill previewCustomServerTemplateExport
         previewCustomServerTemplateImport previewGitHubSkill previewSkillArchive previewSkillZip
         provisionedConnectorSkillNames publishHostSkill refreshProviderModels registeredHelperCatalog removeCustomServer removeGitHubToken
         removeManualInterpreter resolveActiveModelChangeTarget resolveActiveReasoningEffort
@@ -751,6 +751,7 @@ describe('Settings backend ownership architecture', () => {
       /registerIpcHandlers\(\{\s+mainEntryPath,\s+settingsStore,\s+translate,/u
     )
     expect(mainIpc).toContain('settingsStore ?? resolveStorageRoot()')
+    expect(mainIpc).toContain('await settingsService.migrateAgentHomeSkillIdentities()')
     expect(mainIpc).toContain(
       'capability: new SettingsService({\n      repository: settingsRepository,\n      skillRuntimeMcpEntryPath: mainEntryPath,\n      openAlexFetch: netFetchStandard,\n      applyNetworkProxy:'
     )

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -121,6 +121,7 @@ class SkillCatalogModule {
   private readonly userSkills: UserSkillRepository
   private readonly githubFetch: FetchLike
   private readonly registeredHelpers: RegisteredSkillHelperCatalog
+  private readonly failedAgentHomeIdentityMigrationPaths = new Set<string>()
   private userSkillCatalogRead: Promise<BundledSkill[]> | undefined
 
   constructor(private readonly options: SkillCatalogModuleOptions) {
@@ -704,12 +705,15 @@ class SkillCatalogModule {
 
     for (const item of discovered) {
       if (!item.identityMigration) continue
+      const pathKey = process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath
       try {
         await this.userSkills.importAgentHomeSkill(item.realPath, item.identityMigration.skill, {
           ...item.identityMigration.options,
           reservedNames
         })
+        this.failedAgentHomeIdentityMigrationPaths.delete(pathKey)
       } catch (error) {
+        this.failedAgentHomeIdentityMigrationPaths.add(pathKey)
         log.warn('Agent Home Skill identity migration failed', {
           source: item.identityMigration.skill.source,
           slug: item.identityMigration.skill.slug,
@@ -826,6 +830,13 @@ class SkillCatalogModule {
       for (const candidate of candidates) {
         candidate.item.skill.alreadyImported = true
         candidate.item.matchedFallbackDirectoryNames.add(fallbackSlug)
+      }
+    }
+    for (const item of discovered) {
+      if (!item.identityMigration) continue
+      const pathKey = process.platform === 'win32' ? item.realPath.toLowerCase() : item.realPath
+      if (this.failedAgentHomeIdentityMigrationPaths.has(pathKey)) {
+        item.skill.alreadyImported = false
       }
     }
     return discovered

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -58,7 +58,7 @@ import {
   UserSkillRepository,
   isReservedSkillName
 } from '../skills/user-skill-repository'
-import { createLogger } from '../logger'
+import { createLogger, diagnosticErrorFields } from '../logger'
 import type { SettingsRepository } from './repository'
 import type { StoredSettings } from './types'
 import { encryptKey, maskKey, tryDecryptKey } from './crypto'
@@ -91,6 +91,10 @@ type DiscoveredAgentHomeSkill = {
   aliases: AgentHomeSkillRef[]
   fallbackAliases: AgentHomeSkillRef[]
   matchedFallbackDirectoryNames: Set<string>
+  identityMigration?: {
+    skill: AgentHomeSkillRef
+    options: NonNullable<Parameters<UserSkillRepository['importAgentHomeSkill']>[2]>
+  }
 }
 
 const log = createLogger('skills')
@@ -685,6 +689,36 @@ class SkillCatalogModule {
     )
   }
 
+  async migrateAgentHomeSkillIdentities(): Promise<void> {
+    let discovered: DiscoveredAgentHomeSkill[]
+    let reservedNames: string[]
+    try {
+      ;[discovered, reservedNames] = await Promise.all([
+        this.discoverAgentHomeSkills(this.allAgentHomeDirs()),
+        this.bundledSkillNames()
+      ])
+    } catch (error) {
+      log.warn('Agent Home Skill identity migration scan failed', diagnosticErrorFields(error))
+      return
+    }
+
+    for (const item of discovered) {
+      if (!item.identityMigration) continue
+      try {
+        await this.userSkills.importAgentHomeSkill(item.realPath, item.identityMigration.skill, {
+          ...item.identityMigration.options,
+          reservedNames
+        })
+      } catch (error) {
+        log.warn('Agent Home Skill identity migration failed', {
+          source: item.identityMigration.skill.source,
+          slug: item.identityMigration.skill.slug,
+          ...diagnosticErrorFields(error)
+        })
+      }
+    }
+  }
+
   private async discoverAgentHomeSkills(
     sources: AgentHomeSkillDir[]
   ): Promise<DiscoveredAgentHomeSkill[]> {
@@ -757,20 +791,18 @@ class SkillCatalogModule {
         if (!item) continue
         item.skill.alreadyImported = match.identityImported
         item.fallbackAliases.push(...match.fallbackAliases)
-        if (match.identityMigrationNeeded) {
-          try {
-            await this.userSkills.importAgentHomeSkill(
-              item.realPath,
-              { source: item.skill.source, slug: item.skill.slug },
-              {
-                aliases: item.aliases,
-                expectedSignature: match.matchedIdentitySignature,
-                expectedImportedIdentity: match.matchedImportedIdentity,
-                reservedNames: await this.bundledSkillNames()
-              }
-            )
-          } catch {
-            item.skill.alreadyImported = false
+        if (
+          match.identityMigrationNeeded &&
+          match.matchedIdentitySignature &&
+          match.matchedImportedIdentity
+        ) {
+          item.identityMigration = {
+            skill: { source: item.skill.source, slug: item.skill.slug },
+            options: {
+              aliases: item.aliases,
+              expectedSignature: match.matchedIdentitySignature,
+              expectedImportedIdentity: match.matchedImportedIdentity
+            }
           }
         }
       }
@@ -796,7 +828,6 @@ class SkillCatalogModule {
         candidate.item.matchedFallbackDirectoryNames.add(fallbackSlug)
       }
     }
-    await this.refreshRegisteredHelpers()
     return discovered
   }
 
@@ -923,24 +954,31 @@ class SkillCatalogModule {
   }
 
   private agentHomeDirs(framework: AgentFrameworkId): AgentHomeSkillDir[] {
-    const sources: AgentHomeSkillDir[] = [
+    const sources = this.allAgentHomeDirs()
+    if (framework === 'claude-code') {
+      return sources.filter(({ source }) => source === 'agents' || source === 'claude')
+    }
+    if (framework === 'codex') {
+      return sources.filter(({ source }) => source === 'agents' || source === 'codex')
+    }
+    return sources.filter(({ source }) => source === 'agents')
+  }
+
+  private allAgentHomeDirs(): AgentHomeSkillDir[] {
+    return [
       {
         source: 'agents',
         dir: join(this.options.userAgentsDir ?? join(homedir(), '.agents'), 'skills')
-      }
-    ]
-    if (framework === 'claude-code') {
-      sources.push({
+      },
+      {
         source: 'claude',
         dir: join(this.options.userClaudeDir ?? join(homedir(), '.claude'), 'skills')
-      })
-    } else if (framework === 'codex') {
-      sources.push({
+      },
+      {
         source: 'codex',
         dir: join(this.options.userCodexDir ?? join(homedir(), '.codex'), 'skills')
-      })
-    }
-    return sources
+      }
+    ]
   }
 
   private async resolveAgentHomeSkillPath(

--- a/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { SkillEditLoader } from './SkillEditor'
+
+let container: HTMLDivElement
+let root: Root
+
+const detail = {
+  id: 'personal-alpha',
+  name: 'alpha',
+  displayName: 'Alpha',
+  description: 'Alpha description.',
+  source: 'personal' as const,
+  updatedAt: '2026-08-30T00:00:00.000Z',
+  enabled: true,
+  body: '# Alpha',
+  metadata: {},
+  references: [],
+  packageFiles: [{ path: 'SKILL.md', sizeBytes: 7 }]
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  useSettingsStore.setState({
+    ...createInitialSettingsState(),
+    skills: [],
+    updateSkill: vi.fn().mockResolvedValue(undefined)
+  })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('SkillEditLoader', () => {
+  it('leaves loading for a retryable error when detail loading rejects', async () => {
+    const getSkillDetail = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('detail unavailable'))
+      .mockResolvedValueOnce(detail)
+    ;(window as unknown as { api: unknown }).api = { settings: { getSkillDetail } }
+
+    await act(async () => {
+      root.render(<SkillEditLoader skillId="personal-alpha" onDone={vi.fn()} />)
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).not.toContain('Loading…')
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Open Science could not load this Skill.'
+    )
+
+    const retry = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Retry'
+    )
+    await act(async () => {
+      retry?.click()
+      await Promise.resolve()
+    })
+
+    expect(getSkillDetail).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('Alpha description.')
+  })
+
+  it('distinguishes a missing Skill and returns to the Skills list', async () => {
+    const onDone = vi.fn()
+    ;(window as unknown as { api: unknown }).api = {
+      settings: {
+        getSkillDetail: vi
+          .fn()
+          .mockRejectedValue(
+            new Error(
+              "Error invoking remote method 'settings:get-skill-detail': Error: Unknown skill: personal-alpha"
+            )
+          )
+      }
+    }
+
+    await act(async () => {
+      root.render(<SkillEditLoader skillId="personal-alpha" onDone={onDone} />)
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'This Skill is no longer available.'
+    )
+    const back = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Back'
+    )
+    act(() => back?.click())
+    expect(onDone).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/pages/settings/SkillEditor.tsx
+++ b/src/renderer/src/pages/settings/SkillEditor.tsx
@@ -2,7 +2,7 @@
 import type { TFunction } from 'i18next'
 import { AlertTriangle, ChevronDown, FileUp, Upload, X } from 'lucide-react'
 import { RadioGroup } from 'radix-ui'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import type { SkillPackageFileInfo, SkillReference } from '../../../../shared/settings'
@@ -12,13 +12,14 @@ import {
   SKILL_IMPORT_LIMITS
 } from '../../../../shared/skill-import-limits'
 import { parseSkillDocument } from '../../../../shared/skill-frontmatter'
+import { ErrorNotice } from '@/components/error-notice'
 import { FileDropOverlay } from '@/components/FileDropOverlay'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { useSettingsStore } from '@/stores/settings-store'
-import { SettingsIconAction } from './SettingsLayout'
+import { SettingsIconAction, SettingsLoadNotice } from './SettingsLayout'
 
 type SkillEditorReference = SkillReference & { sizeBytes?: number }
 
@@ -716,32 +717,75 @@ const SkillEditLoader = ({ skillId, onDone }: SkillEditLoaderProps): React.JSX.E
   const { t } = useTranslation()
   const updateSkill = useSettingsStore((state) => state.updateSkill)
   const [draft, setDraft] = useState<SkillDraft | null>(null)
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error' | 'not-found'>('loading')
+  const loadRequestRef = useRef(0)
+
+  const requestDetail = useCallback(
+    (requestId: number): void => {
+      void window.api.settings.getSkillDetail(skillId).then(
+        (detail) => {
+          if (loadRequestRef.current !== requestId) return
+          setDraft({
+            id: detail.id,
+            name: detail.name,
+            description: detail.description,
+            body: detail.body,
+            metadata: detail.metadata,
+            references: detail.references.map((ref) => ({
+              path: ref.path,
+              sizeBytes: ref.sizeBytes
+            })),
+            packageFiles: detail.packageFiles
+          })
+          setLoadState('ready')
+        },
+        (error) => {
+          if (loadRequestRef.current !== requestId) return
+          const message = error instanceof Error ? error.message : String(error)
+          setLoadState(message.includes(`Unknown skill: ${skillId}`) ? 'not-found' : 'error')
+        }
+      )
+    },
+    [skillId]
+  )
+
+  const loadDetail = useCallback((): void => {
+    const requestId = ++loadRequestRef.current
+    setDraft(null)
+    setLoadState('loading')
+    requestDetail(requestId)
+  }, [requestDetail])
 
   useEffect(() => {
-    let active = true
-    void window.api.settings.getSkillDetail(skillId).then((detail) => {
-      if (active) {
-        setDraft({
-          id: detail.id,
-          name: detail.name,
-          description: detail.description,
-          body: detail.body,
-          metadata: detail.metadata,
-          references: detail.references.map((ref) => ({
-            path: ref.path,
-            sizeBytes: ref.sizeBytes
-          })),
-          packageFiles: detail.packageFiles
-        })
-      }
-    })
+    requestDetail(++loadRequestRef.current)
     return () => {
-      active = false
+      loadRequestRef.current += 1
     }
-  }, [skillId])
+  }, [requestDetail])
 
   if (!draft) {
-    return <div className="p-5 text-sm text-muted-foreground">{t('Loading…')}</div>
+    if (loadState === 'not-found') {
+      return (
+        <div role="alert" className="flex min-h-64 justify-center p-5">
+          <ErrorNotice
+            icon={AlertTriangle}
+            tone="red"
+            title={t('This Skill is no longer available.')}
+            primaryButton={{ label: t('Back'), onClick: onDone }}
+          />
+        </div>
+      )
+    }
+    return (
+      <div className="p-5">
+        <SettingsLoadNotice
+          state={loadState === 'error' ? 'error' : 'loading'}
+          loadingLabel={t('Loading Skill…')}
+          errorMessage={t('Open Science could not load this Skill.')}
+          onRetry={loadDetail}
+        />
+      </div>
+    )
   }
 
   return (

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -298,7 +298,11 @@ const SkillsPanel = ({
           className="px-5 pt-5"
           onOpenTag={onOpenTag}
         />
-        <SkillEditLoader skillId={view.id} onDone={() => onNavigate({ kind: 'list' })} />
+        <SkillEditLoader
+          key={view.id}
+          skillId={view.id}
+          onDone={() => onNavigate({ kind: 'list' })}
+        />
       </div>
     )
   }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -2382,6 +2382,7 @@
     "This Plan is still pending, but its original Agent interaction has ended. Send a normal message to let the Agent decide how to continue.": "Este plan sigue pendiente, pero la interacción original con el agente ha terminado. Envíe un mensaje normal para que el agente decida cómo continuar.",
     "This plan is shown as a saved snapshot. Step progress is unavailable for archived sessions.": "Este plan se muestra como una instantánea guardada. El progreso del paso no está disponible para sesiones archivadas.",
     "This message snapshot was created by a newer version of Open Science. Update the app to view it.": "Esta instantánea del mensaje fue creada por una versión más reciente de Open Science. Actualice la aplicación para verla.",
+    "This Skill is no longer available.": "Esta habilidad ya no está disponible.",
     "This Skill is protected and cannot be deleted.": "Esta habilidad está protegida y no se puede eliminar.",
     "This Specialist can no longer be resolved by name — it was renamed or removed since the request started. Approving will be rejected.": "Este especialista ya no se puede resolver por su nombre; se le cambió el nombre o se lo eliminó desde que comenzó la solicitud. Si lo aprueba, la solicitud será rechazada.",
     "This Specialist is disabled. Approving will be rejected.": "Este especialista está deshabilitado. Si lo aprueba, la solicitud será rechazada.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -2382,6 +2382,7 @@
     "This Plan is still pending, but its original Agent interaction has ended. Send a normal message to let the Agent decide how to continue.": "Ce plan est toujours en attente, mais son interaction d'origine avec l'agent a pris fin. Envoyez un message normal pour laisser l'agent décider comment continuer.",
     "This plan is shown as a saved snapshot. Step progress is unavailable for archived sessions.": "Ce plan est affiché sous forme d'instantané enregistré. La progression des étapes n'est pas disponible pour les sessions archivées.",
     "This message snapshot was created by a newer version of Open Science. Update the app to view it.": "Cet instantané de message a été créé par une version plus récente d'Open Science. Mettez l'application à jour pour l'afficher.",
+    "This Skill is no longer available.": "Cette compétence n’est plus disponible.",
     "This Skill is protected and cannot be deleted.": "Cette compétence est protégée et ne peut pas être supprimée.",
     "This Specialist can no longer be resolved by name — it was renamed or removed since the request started. Approving will be rejected.": "Ce spécialiste ne peut plus être résolu par son nom : il a été renommé ou supprimé depuis le début de la demande. L'approbation sera rejetée.",
     "This Specialist is disabled. Approving will be rejected.": "Ce spécialiste est désactivé. L'approbation sera rejetée.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -2275,6 +2275,7 @@
     "This PDF couldn't be rendered for preview": "この PDF はプレビュー用にレンダリングできませんでした",
     "This Plan is still pending, but its original Agent interaction has ended. Send a normal message to let the Agent decide how to continue.": "このプランはまだ保留中ですが、当初のエージェントインタラクションは終了しました。通常のメッセージを送信して、エージェントに続行方法を決定させます。",
     "This plan is shown as a saved snapshot. Step progress is unavailable for archived sessions.": "このプランは、保存されたスナップショットとして表示されます。ステップの進行状況は、アーカイブされたセッションでは利用できません。",
+    "This Skill is no longer available.": "このスキルは利用できなくなりました。",
     "This Skill is protected and cannot be deleted.": "このスキルは保護されているため、削除できません。",
     "This Specialist can no longer be resolved by name — it was renamed or removed since the request started. Approving will be rejected.": "このスペシャリストは名前で解決できなくなりました。リクエストの開始後に名前が変更または削除されました。承認は拒否されます。",
     "This Specialist is disabled. Approving will be rejected.": "このスペシャリストは無効になっています。承認は拒否されます。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -2285,6 +2285,7 @@
     "This PDF couldn't be rendered for preview": "이 PDF의 미리보기를 렌더링하지 못했습니다.",
     "This Plan is still pending, but its original Agent interaction has ended. Send a normal message to let the Agent decide how to continue.": "이 계획은 아직 보류 중이지만 원래 에이전트 상호작용은 종료되었습니다. 에이전트가 계속 방법을 결정하도록 일반 메시지를 보냅니다.",
     "This plan is shown as a saved snapshot. Step progress is unavailable for archived sessions.": "이 계획은 저장된 스냅샷으로 표시됩니다. 보관된 세션에는 단계 진행을 사용할 수 없습니다.",
+    "This Skill is no longer available.": "이 스킬은 더 이상 사용할 수 없습니다.",
     "This Skill is protected and cannot be deleted.": "이 스킬은 보호되어 있어 삭제할 수 없습니다.",
     "This Specialist can no longer be resolved by name — it was renamed or removed since the request started. Approving will be rejected.": "이 스페셜리스트는 더 이상 이름으로 확인할 수 없습니다. 요청이 시작된 이후 이름이 바뀌거나 삭제되었습니다. 승인이 거부됩니다.",
     "This Specialist is disabled. Approving will be rejected.": "이 스페셜리스트는 비활성화되어 있습니다. 승인이 거부됩니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -2399,6 +2399,7 @@
     "This PDF couldn't be rendered for preview": "Этот PDF не может быть отображен для предпросмотра",
     "This Plan is still pending, but its original Agent interaction has ended. Send a normal message to let the Agent decide how to continue.": "Этот план ещё ожидается, но взаимодействие с агентом было завершено. Отправьте обычное сообщение, чтобы агент определил, как продолжить.",
     "This plan is shown as a saved snapshot. Step progress is unavailable for archived sessions.": "Этот план отображается как сохранённый снимок. Ход выполнения шагов недоступен для архивных сессий.",
+    "This Skill is no longer available.": "Этот навык больше недоступен.",
     "This Skill is protected and cannot be deleted.": "Этот навык защищён и не может быть удалён.",
     "This Specialist can no longer be resolved by name — it was renamed or removed since the request started. Approving will be rejected.": "Этот специалист больше не может быть найден по имени — он был переименован или удалён с момента начала запроса. Подтверждение будет отклонено.",
     "This Specialist is disabled. Approving will be rejected.": "Этот специалист отключён. Подтверждение будет отклонено.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -2349,6 +2349,7 @@
     "This PDF couldn't be rendered for preview": "无法渲染此 PDF 以进行预览",
     "This Plan is still pending, but its original Agent interaction has ended. Send a normal message to let the Agent decide how to continue.": "该计划仍处于待处理状态，但其原始智能体交互已结束。发送一条普通消息，让智能体决定如何继续。",
     "This plan is shown as a saved snapshot. Step progress is unavailable for archived sessions.": "此计划以已保存快照的形式展示。已归档会话的步骤进度不可用。",
+    "This Skill is no longer available.": "此技能已不可用。",
     "This Skill is protected and cannot be deleted.": "此技能受保护，无法删除。",
     "This Specialist can no longer be resolved by name — it was renamed or removed since the request started. Approving will be rejected.": "已无法再按名称解析该专家 — 自请求开始以来它已被重命名或移除。批准将被拒绝。",
     "This Specialist is disabled. Approving will be rejected.": "该专家已停用。批准将被拒绝。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -2346,6 +2346,7 @@
     "This PDF couldn't be rendered for preview": "無法算繪此 PDF 以進行預覽",
     "This Plan is still pending, but its original Agent interaction has ended. Send a normal message to let the Agent decide how to continue.": "該計畫仍處於待處理狀態，但其原始智能體互動已結束。傳送一則普通訊息，讓智能體決定如何繼續。",
     "This plan is shown as a saved snapshot. Step progress is unavailable for archived sessions.": "此計畫以已儲存快照的形式呈現。已封存會話的步驟進度無法使用。",
+    "This Skill is no longer available.": "此技能已無法使用。",
     "This Skill is protected and cannot be deleted.": "此技能受保護，無法刪除。",
     "This Specialist can no longer be resolved by name — it was renamed or removed since the request started. Approving will be rejected.": "已無法再按名稱解析該專家 — 自請求開始以來它已被重新命名或移除。核准將被拒絕。",
     "This Specialist is disabled. Approving will be rejected.": "該專家已停用。核准將被拒絕。",


### PR DESCRIPTION
## Problem

- Skill detail loading handled only the fulfilled IPC path. A rejected request left the editor on `Loading…` indefinitely and produced an unhandled Promise rejection.
- `listAgentHomeSkills()` migrated compatible Agent Home identities while listing. Opening Settings or running a background scan could therefore rewrite imported `.source.json` metadata.

Both regressions were reproduced with public-boundary tests before the fix. The loader test consistently observed the stuck loading state and unhandled rejection; the catalog test consistently observed metadata changing from the legacy `claude` identity to `agents` during a list operation.

## Proposed change

- Give `SkillEditLoader` explicit `loading`, `ready`, `error`, and `not-found` states.
- Show the shared error notice with Retry for transient failures, and a distinct unavailable state with Back when the Skill was removed.
- Ignore stale detail responses when the loader unmounts or retries.
- Keep Agent Home discovery read-only by returning migration intent instead of importing during discovery.
- Run the existing signature-guarded identity rewrite in an explicit, idempotent startup migration across `.agents`, `.claude`, and `.codex` roots.
- Log and continue when a migration root or individual identity cannot be migrated so compatibility work cannot block startup.

## Scope and non-goals

- No database or persisted-format schema change.
- No new persisted field or migration marker.
- A failed identity rewrite is remembered only for the current process so the row stays selectable for manual repair; the next application start retries migration normally.
- Historical compatibility remains enabled: an existing imported Skill with a compatible legacy Agent Home identity can still have its existing `.source.json` identity normalized during startup.
- The new loader state union is renderer-local, not a shared API enum.
- The startup migration method is main-process internal and does not change the renderer contract.
- No generalized IPC error taxonomy is introduced; the existing `Unknown skill: <id>` behavior remains the not-found boundary.

## Acceptance criteria and validation

All listed checks ran after the final material edit in their affected area.

- rejected or missing Skill detail -> `npm test -- src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx src/renderer/src/pages/settings/SkillsPanel.render.test.tsx -t "SkillEditLoader|edit|loads preserved"` -> 2 files passed, 11 tests passed
- read-only listing, explicit compatibility migration, migration failure isolation/manual repair, and settings consumers -> `npm run test:module -- user_skills_repository` -> 19 files passed, 800 tests passed
- Settings facade and startup ownership -> `npm run test:module -- settings_service_facade` -> 28 files passed, 845 tests passed
- translated unavailable-state copy -> `npm test -- src/renderer/src/i18n/resources.test.ts` -> 1 file passed, 743 tests passed
- main-process types -> `npm run typecheck:node` -> passed
- renderer types -> `npm run typecheck:web` -> passed
- source lint -> `npm run lint` -> passed
- final impact explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> selected full fallback because `src/main/ipc.ts` is an unknown module owner

Per maintainer direction, the locally selected full fallback was not executed; exact-head PR CI is authoritative for the complete suite and platform lanes.

## Review focus

- Whether startup is the correct explicit lifecycle boundary for Agent Home identity normalization.
- Whether the signature and expected-identity guards sufficiently preserve concurrent or user-modified imports.
- Whether the renderer's transient-error versus missing-Skill distinction matches the desired interaction.

Uncovered locally: cross-platform symlink behavior, packaged startup, and visual layout. These remain covered by the applicable PR CI lanes and review.
