### PR TITLE
fix(compute): recover detached jobs after restart

### DIFF
--- a/src/main/compute/compute-job-lifecycle.ts
+++ b/src/main/compute/compute-job-lifecycle.ts
@@ -39,12 +39,14 @@ export class ComputeJobLifecycle {
   async dispatchRunning(
     jobId: string,
     remoteHandle: string,
-    startedAt = new Date()
+    startedAt = new Date(),
+    remoteWorkdir?: string
   ): Promise<ComputeJobTransitionResult> {
     return this.apply(jobId, ['submitted'], {
       status: 'running',
       remoteHandle,
-      startedAt
+      startedAt,
+      ...(remoteWorkdir === undefined ? {} : { remoteWorkdir })
     })
   }
 

--- a/src/main/compute/compute-job-lifecycle.ts
+++ b/src/main/compute/compute-job-lifecycle.ts
@@ -36,11 +36,15 @@ export class ComputeJobLifecycle {
     })
   }
 
-  async dispatchRunning(jobId: string, remoteHandle: string): Promise<ComputeJobTransitionResult> {
+  async dispatchRunning(
+    jobId: string,
+    remoteHandle: string,
+    startedAt = new Date()
+  ): Promise<ComputeJobTransitionResult> {
     return this.apply(jobId, ['submitted'], {
       status: 'running',
       remoteHandle,
-      startedAt: new Date()
+      startedAt
     })
   }
 

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -38,6 +38,8 @@ vi.mock('./ssh-runner', async (importOriginal) => {
 // Fixed nonce injected into the poller under test so fixtures can mirror the marker format the
 // poller emits. Production uses a random per-tick nonce (see JobPoller#makeNonce default).
 const NONCE = 'NONCE123_'
+const RECOVERED_STARTED_AT_SECONDS = 1_700_000_000
+const RECOVERED_STARTED_AT = new Date(RECOVERED_STARTED_AT_SECONDS * 1000)
 
 // Prefixes structural marker lines with the fixed nonce, mirroring what the poller emits/parses.
 const withNonce = (lines: string[]): string =>
@@ -1079,7 +1081,7 @@ describe('JobPoller', () => {
     } as unknown as ComputeJobRepository
     const runner = makeSshRunner({
       exitCode: 0,
-      stdout: '1234\n',
+      stdout: `1234\n${RECOVERED_STARTED_AT_SECONDS}\n`,
       stderr: '',
       truncated: false,
       timedOut: false
@@ -1096,19 +1098,70 @@ describe('JobPoller', () => {
 
     expect(runner.run).toHaveBeenCalledWith(
       expect.anything(),
-      expect.stringContaining('job.pid'),
+      expect.stringContaining('process_owned_by_workdir "$pid" "$workdir" || exit 2'),
+      expect.anything()
+    )
+    expect(runner.run).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('/exit_code'),
       expect.anything()
     )
     expect(update).toHaveBeenCalledWith(
       'job-1',
       expect.objectContaining({
         status: 'running',
-        remoteHandle: expect.stringContaining('"pid":1234')
+        remoteHandle: expect.stringContaining('"pid":1234'),
+        startedAt: RECOVERED_STARTED_AT
       })
     )
     expect(update).not.toHaveBeenCalledWith(
       'job-1',
       expect.objectContaining({ status: 'error', errorCode: 'dispatch_failed' })
+    )
+  })
+
+  it('recovers a legacy submitted job by deriving its workdir from the host', async () => {
+    const job = makeJob({
+      status: 'submitted',
+      remote_workdir: undefined,
+      remote_handle: undefined
+    })
+    const update = vi.fn((_id: string, updates: unknown) =>
+      Promise.resolve({ ...job, ...(updates as object) })
+    )
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([job])),
+      update,
+      updateIfStatus: guardStatusUpdate(update)
+    } as unknown as ComputeJobRepository
+    const runner = makeSshRunner({
+      exitCode: 0,
+      stdout: `1234\n${RECOVERED_STARTED_AT_SECONDS}\n`,
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+
+    await new JobPoller({
+      connectionBroker: brokerFromRunner(runner),
+      hostRepository: {
+        get: vi.fn(() => Promise.resolve({ ...sampleHost(), scratchRoot: '/scratch' }))
+      } as unknown as ComputeHostRepository,
+      jobRepository: jobRepo,
+      dispatchTracker: new DispatchTracker()
+    }).tick()
+
+    expect(runner.run).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('/scratch/.openscience/jobs/job-1/job.pid'),
+      expect.anything()
+    )
+    expect(update).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({
+        status: 'running',
+        remoteHandle: expect.stringContaining('/scratch/.openscience/jobs/job-1')
+      })
     )
   })
 
@@ -1139,7 +1192,7 @@ describe('JobPoller', () => {
       .fn()
       .mockResolvedValueOnce({
         exitCode: 0,
-        stdout: '1234\n',
+        stdout: `1234\n${RECOVERED_STARTED_AT_SECONDS}\n`,
         stderr: '',
         truncated: false,
         timedOut: false
@@ -1177,7 +1230,11 @@ describe('JobPoller', () => {
       1,
       'job-1',
       ['submitted'],
-      expect.objectContaining({ status: 'running', remoteHandle: expect.any(String) })
+      expect.objectContaining({
+        status: 'running',
+        remoteHandle: expect.any(String),
+        startedAt: RECOVERED_STARTED_AT
+      })
     )
     expect(updateIfStatus).toHaveBeenNthCalledWith(
       2,

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -1160,7 +1160,8 @@ describe('JobPoller', () => {
       'job-1',
       expect.objectContaining({
         status: 'running',
-        remoteHandle: expect.stringContaining('/scratch/.openscience/jobs/job-1')
+        remoteHandle: expect.stringContaining('/scratch/.openscience/jobs/job-1'),
+        remoteWorkdir: '/scratch/.openscience/jobs/job-1'
       })
     )
   })

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -1043,6 +1043,19 @@ describe('JobPoller', () => {
 
       await poller.tick()
 
+      expect(runner.run).toHaveBeenCalledTimes(2)
+      expect(runner.run).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.stringContaining('job.pid'),
+        expect.anything()
+      )
+      expect(runner.run).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        expect.stringContaining('process_owned_by_workdir'),
+        expect.anything()
+      )
       expect(update).toHaveBeenCalledWith(
         'job-1',
         expect.objectContaining({
@@ -1053,6 +1066,127 @@ describe('JobPoller', () => {
       )
     }
   )
+
+  it('recovers a detached submitted job from job.pid after restart', async () => {
+    const job = makeJob({ status: 'submitted', remote_handle: undefined })
+    const update = vi.fn((_id: string, updates: unknown) =>
+      Promise.resolve({ ...job, ...(updates as object) })
+    )
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([job])),
+      update,
+      updateIfStatus: guardStatusUpdate(update)
+    } as unknown as ComputeJobRepository
+    const runner = makeSshRunner({
+      exitCode: 0,
+      stdout: '1234\n',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+
+    await new JobPoller({
+      connectionBroker: brokerFromRunner(runner),
+      hostRepository: {
+        get: vi.fn(() => Promise.resolve(sampleHost()))
+      } as unknown as ComputeHostRepository,
+      jobRepository: jobRepo,
+      dispatchTracker: new DispatchTracker()
+    }).tick()
+
+    expect(runner.run).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('job.pid'),
+      expect.anything()
+    )
+    expect(update).toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({
+        status: 'running',
+        remoteHandle: expect.stringContaining('"pid":1234')
+      })
+    )
+    expect(update).not.toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({ status: 'error', errorCode: 'dispatch_failed' })
+    )
+  })
+
+  it('polls and harvests an already-finished job after recovering its pid', async () => {
+    let current = makeJob({
+      status: 'submitted',
+      remote_handle: undefined,
+      started_at: undefined
+    })
+    const updateIfStatus = vi.fn(
+      async (_id: string, _expectedStatuses: unknown, updates: Record<string, unknown>) => {
+        current = {
+          ...current,
+          ...(updates.status === undefined ? {} : { status: updates.status }),
+          ...(updates.remoteHandle === undefined ? {} : { remote_handle: updates.remoteHandle }),
+          ...(updates.startedAt instanceof Date ? { started_at: updates.startedAt.getTime() } : {}),
+          ...(updates.exitCode === undefined ? {} : { exit_code: updates.exitCode })
+        } as ComputeJob
+        return current
+      }
+    )
+    const jobRepo = {
+      findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
+      findNonTerminal: vi.fn(() => Promise.resolve([current])),
+      updateIfStatus
+    } as unknown as ComputeJobRepository
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: '1234\n',
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: withNonce([
+          'JOB_START:job-1',
+          'alive:0',
+          '0',
+          'finished output',
+          'STDOUT_END:job-1',
+          '',
+          'STDERR_END:job-1'
+        ]),
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      })
+    const harvestFn = vi.fn(() => Promise.resolve())
+
+    await new JobPoller({
+      connectionBroker: brokerFromRunner({ run } as SshRunner),
+      hostRepository: {
+        get: vi.fn(() => Promise.resolve(sampleHost()))
+      } as unknown as ComputeHostRepository,
+      jobRepository: jobRepo,
+      dispatchTracker: new DispatchTracker(),
+      harvestFn,
+      makeNonce: () => NONCE
+    }).tick()
+
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(updateIfStatus).toHaveBeenNthCalledWith(
+      1,
+      'job-1',
+      ['submitted'],
+      expect.objectContaining({ status: 'running', remoteHandle: expect.any(String) })
+    )
+    expect(updateIfStatus).toHaveBeenNthCalledWith(
+      2,
+      'job-1',
+      ['submitted', 'running'],
+      expect.objectContaining({ status: 'success', exitCode: 0 })
+    )
+    expect(harvestFn).toHaveBeenCalledOnce()
+  })
 
   it('does NOT flag a submitted+no-handle job whose dispatch is still in flight', async () => {
     // A job staging large inputs sits in submitted+no-handle across many ticks. Because its dispatch

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -455,7 +455,8 @@ export class JobPoller {
       const transition = await this.lifecycle.dispatchRunning(
         job.job_id,
         JSON.stringify(remoteHandle),
-        startedAt
+        startedAt,
+        job.remote_workdir ? undefined : workdir
       )
       return transition.kind === 'applied' ? transition.job : undefined
     }

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -19,6 +19,7 @@ import { parsePollOutput } from './job-poll-output'
 import { sharedDispatchTracker, type DispatchTracker } from './dispatch-tracker'
 import { emitJobNotification } from './job-notifier'
 import { ComputeJobLifecycle } from './compute-job-lifecycle'
+import { cleanupCommand, validatedRemoteWorkdir } from './job-deletion-owner'
 
 // Polling interval: 15 seconds (design.md §8).
 export const POLL_INTERVAL_MS = 15_000
@@ -51,6 +52,29 @@ const POLLER_KILL_GRACE_SECONDS = 60
 
 // Maximum concurrent harvest operations (design.md §3: concurrency limit 2).
 const HARVEST_CONCURRENCY_LIMIT = 2
+
+const buildDispatchRecoveryCommand = (workdir: string): string => {
+  const marker = '/.openscience/jobs/'
+  const markerIndex = workdir.lastIndexOf(marker)
+  if (markerIndex < 0) throw new Error('Unsafe remote Compute Job recovery path.')
+  const scratchRoot = markerIndex === 0 ? '/' : workdir.slice(0, markerIndex)
+  const workdirSuffix = workdir.slice(markerIndex + 1)
+  const quotedScratchRoot = quoteRemotePath(scratchRoot)
+  const quotedWorkdirSuffix = quoteRemotePath(workdirSuffix)
+  const quotedWorkdir = quoteRemotePath(workdir)
+  const quotedPidFile = quoteRemotePath(`${workdir}/job.pid`)
+
+  return [
+    `[ ! -L ${quotedWorkdir} ] || exit 3`,
+    `scratch_root=$(cd -- ${quotedScratchRoot} 2>/dev/null && pwd -P || true)`,
+    `workdir=$(cd -- ${quotedWorkdir} 2>/dev/null && pwd -P || true)`,
+    'expected_workdir=${scratch_root%/}/' + quotedWorkdirSuffix,
+    '[ -n "$workdir" ] && [ -n "$scratch_root" ] && [ "$workdir" = "$expected_workdir" ] || exit 3',
+    `pid=$(cat ${quotedPidFile} 2>/dev/null || true)`,
+    `case "$pid" in ''|*[!0-9]*) exit 2 ;; esac`,
+    `printf '%s\n' "$pid"`
+  ].join('\n')
+}
 
 /** Injectable harvest operation. Production supplies `harvestJob` from harvest-engine.ts. */
 export type HarvestFn = (job: ComputeJob, signal?: AbortSignal) => Promise<void>
@@ -319,27 +343,7 @@ export class JobPoller {
       }
     }
 
-    for (const job of noHandle) {
-      if (signal.aborted) return
-      const transition = await this.lifecycle.recoverInterruptedDispatch(job.job_id)
-      if (transition.kind === 'ignored') continue
-      const updated = transition.job
-      // Emit compute_done notification for execution-error jobs (design §8: error is a final
-      // resting state). Fire-and-forget: notification failure must not break the poller tick.
-      if (this.deps.broadcast && this.deps.storageRoot) {
-        const task = emitJobNotification(updated, {
-          jobRepository: this.deps.jobRepository,
-          hostRepository: this.deps.hostRepository,
-          storageRoot: this.deps.storageRoot,
-          broadcast: this.deps.broadcast
-        }).catch(() => {
-          // Non-fatal: job status is already persisted.
-        })
-        this.trackBackground(task)
-      }
-    }
-
-    if (withHandle.length === 0) return
+    if (withHandle.length === 0 && noHandle.length === 0) return
 
     let connection: ComputeConnectionLease
     try {
@@ -350,9 +354,17 @@ export class JobPoller {
     } catch (error) {
       if (signal.aborted) return
       const errorCode = error instanceof ComputeConnectionError ? error.code : 'host_unreachable'
-      await this._recordPollError(withHandle, errorCode, signal)
+      await this._recordPollError([...withHandle, ...noHandle], errorCode, signal)
       return
     }
+
+    for (const job of noHandle) {
+      if (signal.aborted) return
+      const recovered = await this._recoverSubmittedJob(job, connection, signal)
+      if (recovered) withHandle.push(recovered)
+    }
+
+    if (withHandle.length === 0) return
 
     // Poll bounded sub-batches sequentially over one provider connection.
     for (let i = 0; i < withHandle.length; i += POLL_BATCH_MAX_JOBS) {
@@ -360,6 +372,100 @@ export class JobPoller {
       const batch = withHandle.slice(i, i + POLL_BATCH_MAX_JOBS)
       await this._pollBatch(batch, connection, signal)
     }
+  }
+
+  private async _recoverSubmittedJob(
+    job: ComputeJob,
+    connection: ComputeConnectionLease,
+    signal: AbortSignal
+  ): Promise<ComputeJob | undefined> {
+    let workdir: string
+    try {
+      workdir = validatedRemoteWorkdir(job)
+    } catch {
+      await this._recordPollError([job], 'dispatch_recovery_required', signal)
+      return undefined
+    }
+
+    let recoveryResult
+    try {
+      recoveryResult = await connection.run(buildDispatchRecoveryCommand(workdir), {
+        timeoutMs: POLL_TIMEOUT_MS,
+        loginShell: false,
+        maxOutputBytes: 64,
+        signal
+      })
+    } catch (error) {
+      if (signal.aborted) return undefined
+      const errorCode = error instanceof ComputeConnectionError ? error.code : 'host_unreachable'
+      await this._recordPollError([job], errorCode, signal)
+      return undefined
+    }
+
+    if (signal.aborted) return undefined
+    const connectionFailure = classifyConnectionFailure(recoveryResult, false)
+    if (connectionFailure) {
+      await this._recordPollError([job], connectionFailure.code, signal)
+      return undefined
+    }
+
+    const pidText = recoveryResult.stdout.trim()
+    const pid = /^[1-9][0-9]*$/.test(pidText) ? Number(pidText) : Number.NaN
+    if (recoveryResult.exitCode === 0 && Number.isSafeInteger(pid)) {
+      const remoteHandle: RemoteHandle = {
+        pid,
+        exit_code_path: `${workdir}/exit_code`,
+        stdout_path: `${workdir}/stdout`,
+        stderr_path: `${workdir}/stderr`,
+        workdir
+      }
+      const transition = await this.lifecycle.dispatchRunning(
+        job.job_id,
+        JSON.stringify(remoteHandle)
+      )
+      return transition.kind === 'applied' ? transition.job : undefined
+    }
+
+    // The exact workdir was reachable but did not contain a valid launch receipt. Reuse the
+    // deletion owner's fail-closed cleanup: it only signals a PID whose cwd proves ownership, then
+    // removes the exact validated Job directory. Do not terminalize the row unless cleanup succeeds.
+    let cleanupResult
+    try {
+      cleanupResult = await connection.run(cleanupCommand(workdir, undefined), {
+        timeoutMs: POLL_TIMEOUT_MS,
+        loginShell: false,
+        maxOutputBytes: 64,
+        signal
+      })
+    } catch {
+      if (signal.aborted) return undefined
+      await this._recordPollError([job], 'dispatch_recovery_required', signal)
+      return undefined
+    }
+
+    if (signal.aborted) return undefined
+    if (classifyConnectionFailure(cleanupResult, false) || cleanupResult.exitCode !== 0) {
+      await this._recordPollError([job], 'dispatch_recovery_required', signal)
+      return undefined
+    }
+
+    const transition = await this.lifecycle.recoverInterruptedDispatch(job.job_id)
+    if (transition.kind === 'ignored') return undefined
+    this._notifyExecutionError(transition.job)
+    return undefined
+  }
+
+  private _notifyExecutionError(job: ComputeJob): void {
+    if (!this.deps.broadcast || !this.deps.storageRoot) return
+    const task = emitJobNotification(job, {
+      jobRepository: this.deps.jobRepository,
+      hostRepository: this.deps.hostRepository,
+      storageRoot: this.deps.storageRoot,
+      broadcast: this.deps.broadcast
+    }).catch(() => {
+      // Non-fatal: job status is already persisted.
+    })
+    this.trackBackground(task)
   }
 
   // Polls one sub-batch of jobs (all with handles) in a single SSH round-trip, sizing the output cap

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -11,6 +11,7 @@ import {
   type ComputeConnectionLease
 } from './connection-broker'
 import {
+  computeRemoteWorkdir,
   quoteRemotePath,
   REMOTE_PROCESS_OWNERSHIP_FUNCTION,
   type RemoteHandle
@@ -63,6 +64,7 @@ const buildDispatchRecoveryCommand = (workdir: string): string => {
   const quotedWorkdirSuffix = quoteRemotePath(workdirSuffix)
   const quotedWorkdir = quoteRemotePath(workdir)
   const quotedPidFile = quoteRemotePath(`${workdir}/job.pid`)
+  const quotedExitCodeFile = quoteRemotePath(`${workdir}/exit_code`)
 
   return [
     `[ ! -L ${quotedWorkdir} ] || exit 3`,
@@ -72,7 +74,11 @@ const buildDispatchRecoveryCommand = (workdir: string): string => {
     '[ -n "$workdir" ] && [ -n "$scratch_root" ] && [ "$workdir" = "$expected_workdir" ] || exit 3',
     `pid=$(cat ${quotedPidFile} 2>/dev/null || true)`,
     `case "$pid" in ''|*[!0-9]*) exit 2 ;; esac`,
-    `printf '%s\n' "$pid"`
+    REMOTE_PROCESS_OWNERSHIP_FUNCTION,
+    `if [ ! -f ${quotedExitCodeFile} ]; then process_owned_by_workdir "$pid" "$workdir" || exit 2; fi`,
+    `started_at=$(stat -c %Y ${quotedPidFile} 2>/dev/null || stat -f %m ${quotedPidFile} 2>/dev/null || true)`,
+    `case "$started_at" in ''|*[!0-9]*) exit 2 ;; esac`,
+    `printf '%s\n%s\n' "$pid" "$started_at"`
   ].join('\n')
 }
 
@@ -345,6 +351,17 @@ export class JobPoller {
 
     if (withHandle.length === 0 && noHandle.length === 0) return
 
+    let recoveryFallbackRoot: string | undefined
+    let hasRecoveryFallback = false
+    if (noHandle.some((job) => !job.remote_workdir)) {
+      const host = await this.deps.hostRepository.get(providerId)
+      if (signal.aborted) return
+      if (host) {
+        recoveryFallbackRoot = host.scratchRoot
+        hasRecoveryFallback = true
+      }
+    }
+
     let connection: ComputeConnectionLease
     try {
       connection = await this.deps.connectionBroker.acquire(providerId, {
@@ -360,7 +377,11 @@ export class JobPoller {
 
     for (const job of noHandle) {
       if (signal.aborted) return
-      const recovered = await this._recoverSubmittedJob(job, connection, signal)
+      const fallbackWorkdir =
+        !job.remote_workdir && hasRecoveryFallback
+          ? computeRemoteWorkdir(recoveryFallbackRoot, job.job_id)
+          : undefined
+      const recovered = await this._recoverSubmittedJob(job, connection, signal, fallbackWorkdir)
       if (recovered) withHandle.push(recovered)
     }
 
@@ -377,11 +398,12 @@ export class JobPoller {
   private async _recoverSubmittedJob(
     job: ComputeJob,
     connection: ComputeConnectionLease,
-    signal: AbortSignal
+    signal: AbortSignal,
+    fallbackWorkdir?: string
   ): Promise<ComputeJob | undefined> {
     let workdir: string
     try {
-      workdir = validatedRemoteWorkdir(job)
+      workdir = validatedRemoteWorkdir(job, fallbackWorkdir)
     } catch {
       await this._recordPollError([job], 'dispatch_recovery_required', signal)
       return undefined
@@ -409,9 +431,20 @@ export class JobPoller {
       return undefined
     }
 
-    const pidText = recoveryResult.stdout.trim()
+    const recoveryLines = recoveryResult.stdout.trim().split(/\r?\n/)
+    const [pidText = '', startedAtText = ''] = recoveryLines
     const pid = /^[1-9][0-9]*$/.test(pidText) ? Number(pidText) : Number.NaN
-    if (recoveryResult.exitCode === 0 && Number.isSafeInteger(pid)) {
+    const startedAtSeconds = /^[1-9][0-9]*$/.test(startedAtText)
+      ? Number(startedAtText)
+      : Number.NaN
+    const startedAt = new Date(startedAtSeconds * 1000)
+    if (
+      recoveryResult.exitCode === 0 &&
+      recoveryLines.length === 2 &&
+      Number.isSafeInteger(pid) &&
+      Number.isSafeInteger(startedAtSeconds) &&
+      Number.isFinite(startedAt.getTime())
+    ) {
       const remoteHandle: RemoteHandle = {
         pid,
         exit_code_path: `${workdir}/exit_code`,
@@ -421,7 +454,8 @@ export class JobPoller {
       }
       const transition = await this.lifecycle.dispatchRunning(
         job.job_id,
-        JSON.stringify(remoteHandle)
+        JSON.stringify(remoteHandle),
+        startedAt
       )
       return transition.kind === 'applied' ? transition.job : undefined
     }

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -135,10 +135,12 @@ describe('ComputeJob repository (SQLite integration)', () => {
     const updated = await repo.update('test-job-1', {
       status: 'running',
       remoteHandle: JSON.stringify({ pid: 1234, workdir: '~/.openscience/jobs/test-job-1' }),
+      remoteWorkdir: '/scratch/.openscience/jobs/test-job-1',
       startedAt: new Date()
     })
     expect(updated.status).toBe('running')
     expect(updated.started_at).toBeGreaterThan(0)
+    expect(updated.remote_workdir).toBe('/scratch/.openscience/jobs/test-job-1')
 
     // update to terminal.
     await repo.update('test-job-1', {

--- a/src/main/compute/job-repository.ts
+++ b/src/main/compute/job-repository.ts
@@ -86,6 +86,7 @@ export type CreateJobRequest = {
 export type UpdateJobRequest = {
   status?: ComputeJobStatus
   remoteHandle?: string
+  remoteWorkdir?: string
   exitCode?: number | null
   stdoutTail?: string | null
   stderrTail?: string | null
@@ -609,6 +610,8 @@ export class ComputeJobRepository {
     if (updates.status !== undefined) data.status = updates.status
     if (updates.remoteHandle !== undefined)
       data.remoteHandle = this.protectJson(updates.remoteHandle, 'object', sensitiveDataEncrypted)
+    if (updates.remoteWorkdir !== undefined)
+      data.remoteWorkdir = this.protectOptional(updates.remoteWorkdir, sensitiveDataEncrypted)
     if ('exitCode' in updates) data.exitCode = updates.exitCode
     if ('stdoutTail' in updates)
       data.stdoutTail =


### PR DESCRIPTION
## Problem

The detached SSH launcher writes `job.pid` before the local `submitted` row is updated with `remote_handle` and `running`. If the app exits in that window, the remote workload survives but the restarted poller has an empty `DispatchTracker`. The poller previously treated that as proof of an interrupted launch, wrote `error/dispatch_failed`, and stopped polling or harvesting a process that could continue consuming remote resources.

## Proposed change

- Reconcile an untracked `submitted` job against its persisted `remote_workdir` before terminalizing it.
- Validate the exact Open Science job directory, reject symlink/canonical-path mismatches, and read the existing `job.pid` receipt.
- Require an active recovered PID to have a cwd equal to the validated workdir; an existing `exit_code` is accepted as completion evidence when the process has already exited.
- Rebuild the existing `remote_handle` and continue the normal poll/harvest path in the same tick when the receipt is valid.
- Preserve the launch time from the `job.pid` mtime so restart recovery does not extend timeout enforcement.
- Reuse the deletion owner's ownership-checked cleanup when the exact directory has no valid receipt; only write `dispatch_failed` after cleanup succeeds.
- Keep the job non-terminal and persist `last_poll_error` when connection or safe cleanup cannot be confirmed.
- Add public `JobPoller.tick` regression coverage for the post-launch/pre-persistence crash window, completed-result recovery, legacy workdir recovery, timeout preservation, and ownership-checked missing-PID cleanup.

## Scope and non-goals

- No new remote file protocol: recovery uses `remote_workdir`, `job.pid` and its existing filesystem metadata, `exit_code`, `stdout`, and `stderr`.
- No database schema, migration, status-enum, public API, or UI/interaction change.
- The internal `UpdateJobRequest` gains an optional `remoteWorkdir` member so a resolved legacy path can be written to the existing column during the recovery transition.
- No remote process scanning or adoption by name.

Historical compatibility: existing `submitted` rows with a valid persisted `remote_workdir` and `job.pid` are recoverable after upgrade. Rows without `remote_workdir` derive the same exact path from the configured Host `scratchRoot`, validate it, and persist that resolved path before normal polling and harvesting continue. A valid owned directory without a usable PID is cleaned and retains the previous `dispatch_failed` terminal outcome. Missing Host data or unsafe paths remain non-terminal with `dispatch_recovery_required` in the existing `last_poll_error` field; there is no migration.

Persistence impact: the change writes existing `remoteHandle`, `remoteWorkdir`, `status`, `startedAt`, and `lastPollError` fields through `ComputeJobRepository`. `remoteWorkdir` follows the repository's existing sensitive-data encryption path. It adds no persisted field or format.

## Acceptance criteria and validation

- Post-launch/pre-handle crash recovery -> targeted regression was run three times before the fix and failed each time because no SSH probe occurred; it passes after the fix.
- Review findings for PID ownership, legacy workdirs, timeout preservation, and persisted legacy workdirs -> targeted poller, lifecycle, and SQLite repository tests -> 74 passed.
- Compute owner, contracts, representative consumers, and Windows-sensitive overlay -> `npm run test:module -- compute_service` -> 33 files passed, 1 skipped; 924 tests passed, 15 skipped.
- Main-process types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed with no warnings.

The module test, typecheck, and lint results above reflect the final material implementation. Full `npm test` was intentionally not run locally; PR Gate is authoritative for the complete portable and platform matrix. A real-host process crash injection was not run locally.

## Review focus

- The remote workdir and process ownership checks remain fail-closed.
- Completed jobs remain recoverable after their process exits because `exit_code` is authoritative.
- No terminal transition occurs when SSH connectivity or ownership-checked cleanup is uncertain.
- Legacy workdir recovery persists the validated path, and recovered launch timestamps do not require migration or a new status.
