### PR TITLE
fix(tags): serialize snapshots with mutations

### DIFF
--- a/src/main/tags/service.test.ts
+++ b/src/main/tags/service.test.ts
@@ -94,6 +94,62 @@ describe('TagService', () => {
     expect(events.publish).toHaveBeenNthCalledWith(2, 'tags:changed', { revision: 2 })
   })
 
+  it('keeps a snapshot revision consistent with following mutations', async () => {
+    let releaseInitialSnapshot: (() => void) | undefined
+    let initialSnapshotStarted: (() => void) | undefined
+    const initialSnapshotGate = new Promise<void>((resolve) => {
+      releaseInitialSnapshot = resolve
+    })
+    const initialSnapshotCall = new Promise<void>((resolve) => {
+      initialSnapshotStarted = resolve
+    })
+    const tags: TagSnapshot['tags'] = []
+    const repository = {
+      create: vi.fn(async (request: { name: string; iconKey: 'tag'; colorKey: 'blue' }) => {
+        tags.push({
+          id: 'tag-created',
+          ...request,
+          createdAt: 1,
+          updatedAt: 1
+        })
+      }),
+      pruneStaleAssignments: vi.fn().mockResolvedValue(0),
+      snapshot: vi.fn(async (revision: number) => {
+        if (revision === 0) {
+          initialSnapshotStarted?.()
+          await initialSnapshotGate
+        }
+        return { revision, tags: [...tags], assignments: [] }
+      })
+    }
+    const service = new TagService(
+      repository as unknown as TagRepository,
+      { snapshot: vi.fn().mockResolvedValue({}) } as unknown as TagResourceCatalog,
+      { publish: vi.fn() }
+    )
+
+    const beforeMutation = service.snapshot()
+    await initialSnapshotCall
+    const mutation = service.create({ name: 'Created', iconKey: 'tag', colorKey: 'blue' })
+    releaseInitialSnapshot?.()
+
+    await expect(beforeMutation).resolves.toEqual(snapshot(0))
+    await expect(mutation).resolves.toEqual({
+      revision: 1,
+      tags: [
+        {
+          id: 'tag-created',
+          name: 'Created',
+          iconKey: 'tag',
+          colorKey: 'blue',
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      assignments: []
+    })
+  })
+
   it('rejects assigning a stale resource without writing', async () => {
     const repository = { setAssignment: vi.fn() }
     const service = new TagService(

--- a/src/main/tags/service.ts
+++ b/src/main/tags/service.ts
@@ -22,10 +22,6 @@ class TagService {
     private readonly events: Pick<ApplicationEventPublisher, 'publish'>
   ) {}
 
-  private async afterMutations(): Promise<void> {
-    await this.mutationQueue
-  }
-
   private mutate(operation: () => Promise<void>): Promise<TagSnapshot> {
     const result = this.mutationQueue.then(async () => {
       await operation()
@@ -40,25 +36,31 @@ class TagService {
     return result
   }
 
-  async snapshot(): Promise<TagSnapshot> {
-    await this.afterMutations()
-    const pending = [...this.pendingResourceDeletions.values()]
-    if (pending.length > 0) {
-      const removed = await this.repository.removeResourceAssignments(pending)
-      for (const reference of pending)
-        this.pendingResourceDeletions.delete(this.resourceKey(reference))
-      if (removed > 0) {
+  snapshot(): Promise<TagSnapshot> {
+    const result = this.mutationQueue.then(async () => {
+      const pending = [...this.pendingResourceDeletions.values()]
+      if (pending.length > 0) {
+        const removed = await this.repository.removeResourceAssignments(pending)
+        for (const reference of pending)
+          this.pendingResourceDeletions.delete(this.resourceKey(reference))
+        if (removed > 0) {
+          this.revision += 1
+          this.events.publish('tags:changed', { revision: this.revision })
+        }
+      }
+      const resources = await this.resources.snapshot()
+      const pruned = await this.repository.pruneStaleAssignments(resources)
+      if (pruned > 0) {
         this.revision += 1
         this.events.publish('tags:changed', { revision: this.revision })
       }
-    }
-    const resources = await this.resources.snapshot()
-    const pruned = await this.repository.pruneStaleAssignments(resources)
-    if (pruned > 0) {
-      this.revision += 1
-      this.events.publish('tags:changed', { revision: this.revision })
-    }
-    return this.repository.snapshot(this.revision)
+      return this.repository.snapshot(this.revision)
+    })
+    this.mutationQueue = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
   }
 
   create(request: CreateTagRequest): Promise<TagSnapshot> {


### PR DESCRIPTION
## Problem

`TagService.snapshot()` waited for the existing mutation queue only at entry. Resource reconciliation and the final repository read then ran outside that queue, so a later mutation could overlap the snapshot. A deterministic regression reproduced a snapshot containing the later Tag while still carrying revision `0`.

## Proposed change

Queue the complete snapshot operation on the existing `mutationQueue`, including pending-resource cleanup, resource catalog scanning, stale-assignment pruning, revision/event updates, and the final repository snapshot read.

The regression test uses the public `TagService` behavior boundary and controlled repository promises. It failed consistently before the fix with newer Tag data under the older revision and passes after the fix.

## Scope and non-goals

- Reuses the existing queue; no new coordinator, dependency, or test-only production seam.
- No public API, renderer interaction, or application-command contract change.
- No data-model, relationship, schema, persisted-format, or migration change.
- No new state or enum value.
- No historical-data compatibility work is required.
- The intended scheduling change is that mutations invoked after a snapshot wait for its reconciliation and final read to finish.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Snapshot/revision consistency across a following mutation -> `npm test -- src/main/tags/service.test.ts -t 'keeps a snapshot revision consistent with following mutations'` -> passed after failing deterministically on the unfixed code.
- Tag owner, persistence, shared contract, and renderer consumer -> `npm test -- src/main/tags/service.test.ts src/main/tags/repository.test.ts src/shared/tags.test.ts src/renderer/src/stores/tag-store.test.ts` -> 33 tests passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Changed-file lint -> `npx eslint src/main/tags/service.ts src/main/tags/service.test.ts` -> passed.
- Changed-file formatting -> `npx prettier --check src/main/tags/service.ts src/main/tags/service.test.ts` -> passed.
- Patch whitespace -> `git diff --check` -> passed.

The complete portable suite and platform lanes were not run locally; PR CI remains authoritative. A repeated local full-lint process produced no output for several minutes and was stopped, while changed-file lint passed.

## Review focus

- Confirm the full snapshot lifecycle now shares one serial boundary with all Tag mutations.
- Confirm queue recovery remains intact when a snapshot rejects.
- Confirm the regression exercises the reported old-revision/new-data interleaving without adding a production seam.
