### PR TITLE
fix(acp): reclaim Session cancellation tombstones

### DIFF
--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -41,6 +41,11 @@ const shellRequest = (sessionId: string): RequestPermissionRequest => ({
   ]
 })
 
+const retainedSessionCancellationKeys = (owner: object): unknown[] =>
+  Object.entries(owner).flatMap(([name, value]) =>
+    name.includes('sessionCancellation') && value instanceof Map ? Array.from(value.keys()) : []
+  )
+
 const registeredToolRequest = (toolName: string): RequestPermissionRequest => ({
   sessionId: 'session-registered',
   toolCall: {
@@ -240,7 +245,7 @@ describe('ACP permission broker with durable grants', () => {
     }
   )
 
-  it('cancels a request while its durable grant lookup is still pending', async () => {
+  it('releases cleared Session cancellation state after a durable grant lookup settles', async () => {
     let finishResolve: (() => void) | undefined
     const registry = {
       resolve: vi.fn(
@@ -266,12 +271,13 @@ describe('ACP permission broker with durable grants', () => {
       profile: 'ask',
       projectId: 'project-1'
     })
-    broker.cancelForSession('session-1')
+    broker.clearSession('session-1')
     finishResolve?.()
 
     await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
     expect(emitted).toEqual([])
     expect(broker.hasPendingForSession('session-1')).toBe(false)
+    expect(retainedSessionCancellationKeys(broker)).not.toContain('session-1')
   })
 
   it('re-evaluates a request when grant lookup crosses a live profile change', async () => {

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -70,6 +70,8 @@ type PermissionWaitHooks = Readonly<{
   settleLive: (candidate: DurablePermissionWaitCandidate) => Promise<void>
 }>
 
+type SessionCancellationToken = { cancelled: boolean }
+
 class ConversationPermissionGrantStore {
   private readonly categoriesBySession = new Map<string, Set<string>>()
 
@@ -729,7 +731,7 @@ class AcpPermissionBroker {
   private readonly durableRequestQueues = new Map<string, string[]>()
   private readonly activeDurableRequestBySession = new Map<string, string>()
   private cancellationGeneration = 0
-  private readonly sessionCancellationGenerations = new Map<string, number>()
+  private readonly sessionCancellationTokens = new Map<string, Set<SessionCancellationToken>>()
   private readonly livePermissionProfiles = new Map<
     string,
     {
@@ -909,8 +911,6 @@ class AcpPermissionBroker {
     policyContext?: PermissionPolicyContext
   ): Promise<RequestPermissionResponse> {
     const cancellationGeneration = this.cancellationGeneration
-    const sessionCancellationGeneration =
-      this.sessionCancellationGenerations.get(params.sessionId) ?? 0
     const requestId = randomUUID()
     const mcpServerNames = policyContext?.mcpServerNames ?? []
     const isMcp = isMcpPermission(params, mcpServerNames)
@@ -1036,6 +1036,7 @@ class AcpPermissionBroker {
     }
 
     if (this.permissionGrantRegistry && capability) {
+      const sessionCancellationToken = this.trackSessionCancellation(params.sessionId)
       return this.permissionGrantRegistry
         .resolve(capability, {
           projectId: policyContext?.projectId,
@@ -1044,8 +1045,7 @@ class AcpPermissionBroker {
         .then((match) => {
           if (
             cancellationGeneration !== this.cancellationGeneration ||
-            sessionCancellationGeneration !==
-              (this.sessionCancellationGenerations.get(params.sessionId) ?? 0)
+            sessionCancellationToken.cancelled
           ) {
             return { outcome: { outcome: 'cancelled' as const } }
           }
@@ -1065,6 +1065,9 @@ class AcpPermissionBroker {
             providerAllowOnceOptionId: providerAllowOnceOption?.optionId,
             durableCandidate
           })
+        })
+        .finally(() => {
+          this.releaseSessionCancellation(params.sessionId, sessionCancellationToken)
         })
     }
 
@@ -1478,6 +1481,7 @@ class AcpPermissionBroker {
   // Cancels every pending request while preserving conversation grants across Agent reconnects.
   cancelAllPending(): void {
     this.cancellationGeneration += 1
+    this.sessionCancellationTokens.clear()
     this.livePermissionProfiles.clear()
     this.restoredAllowOnceBySession.clear()
     const pendingRequests = Array.from(this.pendingRequests.keys())
@@ -1489,10 +1493,9 @@ class AcpPermissionBroker {
 
   // Cancels pending requests for one session while leaving other sessions intact.
   cancelForSession(sessionId: string): void {
-    this.sessionCancellationGenerations.set(
-      sessionId,
-      (this.sessionCancellationGenerations.get(sessionId) ?? 0) + 1
-    )
+    const cancellationTokens = this.sessionCancellationTokens.get(sessionId)
+    this.sessionCancellationTokens.delete(sessionId)
+    for (const token of cancellationTokens ?? []) token.cancelled = true
     this.restoredAllowOnceBySession.delete(sessionId)
     const pendingRequests = Array.from(this.pendingRequests.values())
 
@@ -1501,6 +1504,20 @@ class AcpPermissionBroker {
         void this.respond({ requestId: request.requestId, cancelled: true }).catch(() => undefined)
       }
     }
+  }
+
+  private trackSessionCancellation(sessionId: string): SessionCancellationToken {
+    const token = { cancelled: false }
+    const tokens = this.sessionCancellationTokens.get(sessionId) ?? new Set()
+    tokens.add(token)
+    this.sessionCancellationTokens.set(sessionId, tokens)
+    return token
+  }
+
+  private releaseSessionCancellation(sessionId: string, token: SessionCancellationToken): void {
+    const tokens = this.sessionCancellationTokens.get(sessionId)
+    tokens?.delete(token)
+    if (tokens?.size === 0) this.sessionCancellationTokens.delete(sessionId)
   }
 
   // Ends one Agent session: cancel its outstanding prompts and discard its non-persistent grants.

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -46,6 +46,11 @@ const emptySnapshot = (): AcpStateSnapshot => ({
 const runtimeEventId = (runtimeSequence: number, eventId: string): RegExp =>
   new RegExp(`^runtime-${runtimeSequence}-[0-9a-f-]{36}:${eventId}$`, 'u')
 
+const retainedSessionCancellationKeys = (owner: object): unknown[] =>
+  Object.entries(owner).flatMap(([name, value]) =>
+    name.includes('sessionCancellation') && value instanceof Map ? Array.from(value.keys()) : []
+  )
+
 const createFakeRuntime = (options: {
   frameworkId: AgentFrameworkId
   sessionIds: string[]
@@ -1501,7 +1506,7 @@ describe('AcpRuntimeCoordinator', () => {
     expect(rootTurnStarted).toHaveBeenCalledTimes(3)
   })
 
-  it.each(['cancel', 'handoff'] as const)(
+  it.each(['cancel', 'handoff', 'delete'] as const)(
     'does not dispatch a root turn superseded by %s while its settlement baseline loads',
     async (supersede) => {
       const settlementStart = createDeferred<string | undefined>()
@@ -1548,8 +1553,10 @@ describe('AcpRuntimeCoordinator', () => {
 
       if (supersede === 'cancel') {
         await coordinator.cancelPrompt({ sessionId: session.sessionId })
-      } else {
+      } else if (supersede === 'handoff') {
         await coordinator.stopPromptForHandoff(session.sessionId)
+      } else {
+        await coordinator.deleteSession({ sessionId: session.sessionId })
       }
       await coordinator.waitForSessionInteractionRelease(session.sessionId)
       settlementStart.resolve('settlement-lease-1')
@@ -1563,6 +1570,9 @@ describe('AcpRuntimeCoordinator', () => {
         clean: false,
         leaseId: 'settlement-lease-1'
       })
+      if (supersede === 'delete') {
+        expect(retainedSessionCancellationKeys(coordinator)).not.toContain(session.sessionId)
+      }
     }
   )
 

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -75,7 +75,7 @@ type PermissionGrantSnapshotProvider = () => AcpStateSnapshot['permissionGrants'
 type PendingPromptStart = {
   id: string
   runtime: AcpRuntime
-  sessionCancellationGeneration: number
+  cancelled: boolean
   globalCancellationGeneration: number
 }
 
@@ -157,7 +157,6 @@ class AcpRuntimeCoordinator {
   private globalCancellationGeneration = 0
   private delegatedWorkRevision = 0
   private promptAttemptSequence = 0
-  private readonly sessionCancellationGenerations = new Map<string, number>()
   private readonly pendingPromptStarts = new Map<string, PendingPromptStart[]>()
   private readonly activePromptRequests = new Map<string, ActivePromptRequest>()
   private readonly activePromptCounts = new Map<string, number>()
@@ -1044,8 +1043,7 @@ class AcpRuntimeCoordinator {
     const attempt: PendingPromptStart = {
       id: `prompt-attempt-${++this.promptAttemptSequence}`,
       runtime,
-      sessionCancellationGeneration:
-        this.sessionCancellationGenerations.get(request.sessionId) ?? 0,
+      cancelled: false,
       globalCancellationGeneration: this.globalCancellationGeneration
     }
     const pending = this.pendingPromptStarts.get(request.sessionId) ?? []
@@ -1093,8 +1091,7 @@ class AcpRuntimeCoordinator {
       settlementLeaseId = leaseId
       if (
         attempt.globalCancellationGeneration !== this.globalCancellationGeneration ||
-        attempt.sessionCancellationGeneration !==
-          (this.sessionCancellationGenerations.get(request.sessionId) ?? 0) ||
+        attempt.cancelled ||
         this.activePromptRequests.get(request.sessionId) !== activePrompt
       ) {
         throw new DelegateMessagePreAcceptanceError(
@@ -1534,10 +1531,7 @@ class AcpRuntimeCoordinator {
   }
 
   private invalidateSessionTurn(sessionId: string, notifyCancellation = true): void {
-    this.sessionCancellationGenerations.set(
-      sessionId,
-      (this.sessionCancellationGenerations.get(sessionId) ?? 0) + 1
-    )
+    for (const attempt of this.pendingPromptStarts.get(sessionId) ?? []) attempt.cancelled = true
     this.pendingPromptStarts.delete(sessionId)
     const activePrompt = this.activePromptRequests.get(sessionId)
     if (activePrompt && activePrompt.turnToken === undefined) {
@@ -1659,9 +1653,8 @@ class AcpRuntimeCoordinator {
           this.activePromptCounts.set(sessionId, (this.activePromptCounts.get(sessionId) ?? 0) + 1)
           if (
             attempt &&
-            attempt.globalCancellationGeneration === this.globalCancellationGeneration &&
-            attempt.sessionCancellationGeneration ===
-              (this.sessionCancellationGenerations.get(sessionId) ?? 0)
+            !attempt.cancelled &&
+            attempt.globalCancellationGeneration === this.globalCancellationGeneration
           ) {
             this.teardownCallbacks.onSessionTurnStarted?.(sessionId, turnToken)
           }


### PR DESCRIPTION
## Problem

Session-scoped cancellation generations in the ACP runtime coordinator and permission broker were retained after Session deletion. Long-lived processes that repeatedly created and deleted Sessions therefore accumulated cancellation tombstones in proportion to historical Session count.

The entries could not simply be deleted at teardown because an older prompt settlement or permission-grant lookup could still complete later and revive work for the deleted Session.

## Proposed change

- mark the coordinator's existing pending prompt attempts as cancelled, so the in-flight closure carries its own non-revivable token without a historical per-Session generation map;
- track permission-broker cancellation tokens only while durable grant lookups are in flight, invalidate and detach them during Session cleanup, and release them when the lookup settles;
- extend the existing delayed prompt and registry-lookup tests to assert both fail-closed behavior and cancellation-state reclamation.

## Scope and non-goals

- No renderer or user-interaction changes.
- No public API, ACP wire shape, provider adapter, or launcher changes.
- No persistence, migration, data-model, historical-data compatibility, or new enum/state impact.
- No attempt to refactor the broader Session lifecycle or unrelated retained state.

## ACP compatibility matrix

The changed barriers live in the shared coordinator and permission broker used by `claude-code`, `opencode`, `codex-response`, and `codex-bridge`. The regression fixtures exercise the shared pre-provider prompt dispatch and durable permission-registry boundaries. Framework adapters, transport translation, history replay, model-specific request shapes, subscriptions, and platform process behavior are excluded because this patch does not change those interfaces or wire-level paths.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- deleted prompt remains rejected before provider dispatch and releases cancellation state -> `vitest run --config vitest.worktree.config.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/permission-broker-registry.test.ts` -> passed, 206/206 tests;
- cleared permission lookup remains cancelled, emits no request, and releases cancellation state -> same owner-test command -> passed;
- main-process types -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed;
- repository lint -> `eslint --no-cache .` -> passed;
- changed-file formatting -> `prettier --check ...` -> passed.

The dependency-aware selector fails closed to the complete Vitest plan because core ACP is not registered as a module owner. The complete local `npm test` suite was intentionally not run; exact-head PR Gate and its selected platform lanes remain the final authority.

## Review focus

- Verify that operation-local tokens preserve the existing fail-closed cancellation barrier.
- Verify that settling an older lookup cannot delete or revive cancellation state belonging to later work for the same live Session.
- Confirm that the final PR Gate matrix covers the shared ACP behavior and that no adapter-specific lane is required.
