### PR TITLE
fix(database): enforce persisted data integrity

### DIFF
--- a/prisma/sqlite-check-constraints.json
+++ b/prisma/sqlite-check-constraints.json
@@ -372,6 +372,21 @@
     },
     {
       "tableName": "ComputeJob",
+      "name": "ComputeJob_analysisState_check",
+      "expression": "\"analysisState\" IS NULL OR \"analysisState\" IN ('dispatched', 'succeeded', 'failed', 'cancelled')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_analysisBundle_check",
+      "expression": "((\"analysisState\" IS NULL AND \"analysisMessageId\" IS NULL AND \"analysisUpdatedAt\" IS NULL) OR (\"analysisState\" IS NOT NULL AND \"analysisMessageId\" IS NOT NULL AND length(trim(\"analysisMessageId\")) > 0 AND \"analysisUpdatedAt\" IS NOT NULL))"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_analysisConsumption_check",
+      "expression": "\"analysisState\" IS NULL OR \"analysisState\" <> 'succeeded' OR \"notificationConsumedAt\" IS NOT NULL"
+    },
+    {
+      "tableName": "ComputeJob",
       "name": "ComputeJob_harvestPayload_check",
       "expression": "(\"harvestError\" IS NULL AND \"leftOnRemote\" IS NULL) OR \"harvestedAt\" IS NOT NULL"
     },
@@ -589,6 +604,13 @@
       "tableName": "MemoryEntry",
       "name": "MemoryEntry_revision_check",
       "expression": "\"revision\" >= 1"
+    }
+  ],
+  "indexes": [
+    {
+      "tableName": "MemoryEntry",
+      "name": "MemoryEntry_global_contentKey_key",
+      "sql": "CREATE UNIQUE INDEX \"MemoryEntry_global_contentKey_key\" ON \"MemoryEntry\"(\"contentKey\") WHERE \"projectId\" IS NULL"
     }
   ]
 }

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -84,6 +84,14 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0020_compute_job_analysis_state',
     checksum: 'b2bc8f9fd195a08a27af0e6ed2c78e0425002341ce1261952014130da1ea1a8d'
+  },
+  {
+    id: '0021_compute_job_analysis_constraints',
+    checksum: 'e842f932594ee6f4e250befc7f2e7966a680f556ca908bea2b61a9c45752f270'
+  },
+  {
+    id: '0022_memory_global_content_unique',
+    checksum: '0f02a6cace6991db4377da8a2f8d52dad221cb2fede595bf11bab90c64737ac8'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -17,11 +17,66 @@ import {
 } from './database-migration-ledger-smoke.mjs'
 import { PrismaClient } from '@prisma/client'
 
+const rebuildComputeJobWithoutAnalysisConstraints = async (
+  client: PrismaClient,
+  dropAnalysisColumns: boolean
+): Promise<void> => {
+  const [{ sql }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
+    `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
+  )
+  const removedLines = [
+    'CONSTRAINT "ComputeJob_analysisState_check"',
+    'CONSTRAINT "ComputeJob_analysisBundle_check"',
+    'CONSTRAINT "ComputeJob_analysisConsumption_check"',
+    ...(dropAnalysisColumns
+      ? ['"analysisState" TEXT', '"analysisMessageId" TEXT', '"analysisUpdatedAt" DATETIME']
+      : [])
+  ]
+  const legacyDdl = sql
+    .split('\n')
+    .filter((line) => removedLines.every((removed) => !line.includes(removed)))
+    .join('\n')
+    .replace(/CREATE TABLE (?:IF NOT EXISTS )?"ComputeJob"/u, 'CREATE TABLE "__legacy_ComputeJob"')
+  const columns = await client.$queryRawUnsafe<Array<{ name: string }>>(
+    `PRAGMA table_info('ComputeJob')`
+  )
+  const copiedColumns = columns
+    .map(({ name }) => name)
+    .filter(
+      (name) =>
+        !dropAnalysisColumns ||
+        !['analysisState', 'analysisMessageId', 'analysisUpdatedAt'].includes(name)
+    )
+    .map((name) => `"${name}"`)
+    .join(', ')
+
+  await client.$executeRawUnsafe(legacyDdl)
+  await client.$executeRawUnsafe(
+    `INSERT INTO "__legacy_ComputeJob" (${copiedColumns}) SELECT ${copiedColumns} FROM "ComputeJob"`
+  )
+  await client.$executeRawUnsafe('DROP TABLE "ComputeJob"')
+  await client.$executeRawUnsafe('ALTER TABLE "__legacy_ComputeJob" RENAME TO "ComputeJob"')
+  await client.$executeRawUnsafe(
+    'CREATE INDEX "ComputeJob_providerId_idx" ON "ComputeJob"("providerId")'
+  )
+  await client.$executeRawUnsafe(
+    'CREATE INDEX "ComputeJob_sessionId_idx" ON "ComputeJob"("sessionId")'
+  )
+  await client.$executeRawUnsafe('CREATE INDEX "ComputeJob_status_idx" ON "ComputeJob"("status")')
+}
+
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
-    expect(MIGRATION_MANIFEST.at(-1)?.checksum).toBe(
-      'b2bc8f9fd195a08a27af0e6ed2c78e0425002341ce1261952014130da1ea1a8d'
-    )
+    expect(MIGRATION_MANIFEST.slice(-2).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
+      {
+        id: '0021_compute_job_analysis_constraints',
+        checksum: 'e842f932594ee6f4e250befc7f2e7966a680f556ca908bea2b61a9c45752f270'
+      },
+      {
+        id: '0022_memory_global_content_unique',
+        checksum: '0f02a6cace6991db4377da8a2f8d52dad221cb2fede595bf11bab90c64737ac8'
+      }
+    ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST.slice(0, -1))).toThrow(
       /expected application database migration ledger/
@@ -55,11 +110,9 @@ describe('packaged database migration ledger smoke', () => {
           }
         })
       }
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisState"')
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisUpdatedAt"')
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisMessageId"')
+      await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" = '0020_compute_job_analysis_state'`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique')`
       )
 
       await migrateApplicationDatabase(client)
@@ -80,6 +133,88 @@ describe('packaged database migration ledger smoke', () => {
         analysisUpdatedAt: null,
         notificationConsumedAt: expect.any(Date)
       })
+    } finally {
+      await client.$disconnect()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('blocks analysis constraints when a historical Compute Job has an invalid state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-ledger-job-analysis-invalid-'))
+    const databasePath = join(root, 'open-science.db').replaceAll('\\', '/')
+    const client = new PrismaClient({ datasources: { db: { url: `file:${databasePath}` } } })
+
+    try {
+      await migrateApplicationDatabase(client)
+      await rebuildComputeJobWithoutAnalysisConstraints(client, false)
+      await client.$executeRawUnsafe(
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique')`
+      )
+      await client.computeJob.create({
+        data: {
+          id: 'invalid-analysis-state',
+          providerId: 'ssh:legacy',
+          shape: 'direct_ssh',
+          sessionId: 'legacy-session',
+          projectId: 'legacy-project',
+          status: 'success',
+          intent: 'invalid analysis state',
+          command: 'true',
+          commandHash: 'invalid-analysis-state',
+          analysisState: 'unknown',
+          analysisMessageId: 'message-1',
+          analysisUpdatedAt: new Date('2026-01-01')
+        }
+      })
+
+      await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+        migrationId: '0021_compute_job_analysis_constraints'
+      })
+      await expect(
+        client.computeJob.findUnique({ where: { id: 'invalid-analysis-state' } })
+      ).resolves.toMatchObject({ analysisState: 'unknown' })
+    } finally {
+      await client.$disconnect()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('blocks the global Memory index without deleting duplicate historical entries', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-ledger-memory-duplicate-'))
+    const databasePath = join(root, 'open-science.db').replaceAll('\\', '/')
+    const client = new PrismaClient({ datasources: { db: { url: `file:${databasePath}` } } })
+
+    try {
+      await migrateApplicationDatabase(client)
+      await client.$executeRawUnsafe('DROP INDEX "MemoryEntry_global_contentKey_key"')
+      await client.$executeRawUnsafe(
+        `DELETE FROM "_open_science_migrations" WHERE "id" = '0022_memory_global_content_unique'`
+      )
+      await client.memoryEntry.createMany({
+        data: [
+          {
+            id: 'duplicate-global-1',
+            categoryId: 'memory-category-about-you',
+            content: 'same global fact',
+            contentKey: 'same global fact',
+            origin: 'user'
+          },
+          {
+            id: 'duplicate-global-2',
+            categoryId: 'memory-category-about-you',
+            content: 'Same global fact',
+            contentKey: 'same global fact',
+            origin: 'user'
+          }
+        ]
+      })
+
+      await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+        migrationId: '0022_memory_global_content_unique'
+      })
+      await expect(
+        client.memoryEntry.count({ where: { contentKey: 'same global fact', projectId: null } })
+      ).resolves.toBe(2)
     } finally {
       await client.$disconnect()
       await rm(root, { force: true, recursive: true })
@@ -151,11 +286,9 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique')`
       )
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisState"')
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisUpdatedAt"')
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisMessageId"')
+      await rebuildComputeJobWithoutAnalysisConstraints(client, true)
 
       await migrateApplicationDatabase(client)
 
@@ -215,11 +348,9 @@ describe('packaged database migration ledger smoke', () => {
       await client.$executeRawUnsafe('DROP INDEX "Review_sessionId_idx"')
       await client.$executeRawUnsafe('DROP INDEX "Finding_reviewId_idx"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique')`
       )
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisState"')
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisUpdatedAt"')
-      await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisMessageId"')
+      await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await client.$executeRawUnsafe(
         'ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"'
       )

--- a/scripts/generate-database-schema.mjs
+++ b/scripts/generate-database-schema.mjs
@@ -86,7 +86,7 @@ const injectCheckConstraints = (ddl, constraints) => {
   return `${ddl.slice(0, -3)},\n${suffix}\n);`
 }
 
-const validateCheckContract = (checkContract, tableNames) => {
+const validateSqliteContract = (checkContract, tableNames) => {
   if (!Array.isArray(checkContract.constraints)) {
     throw new Error('SQLite CHECK contract must declare a constraints array.')
   }
@@ -100,6 +100,21 @@ const validateCheckContract = (checkContract, tableNames) => {
     }
     constraintNames.add(constraint.name)
   }
+  if (!Array.isArray(checkContract.indexes)) {
+    throw new Error('SQLite schema contract must declare an indexes array.')
+  }
+  const indexNames = new Set()
+  for (const index of checkContract.indexes) {
+    if (
+      !tableNames.has(index.tableName) ||
+      indexNameFromDdl(index.sql) !== index.name ||
+      !index.sql.includes(` ON "${index.tableName}"`) ||
+      indexNames.has(index.name)
+    ) {
+      throw new Error(`SQLite schema contract has an invalid or duplicate index ${index.name}.`)
+    }
+    indexNames.add(index.name)
+  }
 }
 
 const renderTemplateArray = (name, values) => `const ${name} = [
@@ -110,13 +125,14 @@ ${values.map((value) => `  \`${value.replaceAll('`', '\\`').replaceAll('${', '\\
 const buildRuntimeSchemaModule = async (prismaSql, checkContract) => {
   const statements = parsePrismaStatements(prismaSql)
   const rawTables = statements.filter((statement) => tableNameFromDdl(statement))
-  const rawIndexes = statements.filter((statement) => indexNameFromDdl(statement))
-  if (rawTables.length === 0 || rawTables.length + rawIndexes.length !== statements.length) {
+  const prismaIndexes = statements.filter((statement) => indexNameFromDdl(statement))
+  if (rawTables.length === 0 || rawTables.length + prismaIndexes.length !== statements.length) {
     throw new Error('Prisma emitted an unsupported database schema statement.')
   }
+  const rawIndexes = [...prismaIndexes, ...checkContract.indexes.map(({ sql }) => sql)]
 
   const tableNames = new Set(rawTables.map(tableNameFromDdl))
-  validateCheckContract(checkContract, tableNames)
+  validateSqliteContract(checkContract, tableNames)
   const tables = rawTables.map((ddl) => {
     const tableName = tableNameFromDdl(ddl)
     const constraints = checkContract.constraints.filter(

--- a/scripts/generate-database-schema.test.ts
+++ b/scripts/generate-database-schema.test.ts
@@ -26,6 +26,13 @@ CREATE UNIQUE INDEX "Probe_value_key" ON "Probe"("value");
           name: 'Probe_value_check',
           expression: 'length(trim("value")) > 0'
         }
+      ],
+      indexes: [
+        {
+          tableName: 'Probe',
+          name: 'Probe_nonempty_value_key',
+          sql: `CREATE UNIQUE INDEX "Probe_nonempty_value_key" ON "Probe"("value") WHERE "value" <> ''`
+        }
       ]
     }
 
@@ -36,6 +43,9 @@ CREATE UNIQUE INDEX "Probe_value_key" ON "Probe"("value");
     expect(first).toContain('CREATE TABLE IF NOT EXISTS "Probe"')
     expect(first).toContain('CONSTRAINT "Probe_value_check" CHECK (length(trim("value")) > 0)')
     expect(first).toContain('CREATE UNIQUE INDEX IF NOT EXISTS "Probe_value_key"')
+    expect(first).toContain(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "Probe_nonempty_value_key" ON "Probe"("value") WHERE "value" <> ''`
+    )
   })
 
   it('keeps the committed runtime schema generated from the current Prisma target', async () => {

--- a/src/main/acp/vision-evidence-repository.test.ts
+++ b/src/main/acp/vision-evidence-repository.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -103,6 +104,62 @@ describe('VisionEvidenceRepository', () => {
     await client.uploadVersion.delete({ where: { id: 'upload-version-1' } })
 
     await expect(client.visionEvidence.count()).resolves.toBe(0)
+  })
+
+  it('does not persist uploaded evidence under a different Project or Session owner', async () => {
+    await client.project.create({ data: { id: 'project-2', name: 'Other project' } })
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-2', sessionId: 'session-2' }
+    })
+
+    await repository.save({
+      identityKey: IDENTITY,
+      projectId: 'project-2',
+      sessionId: 'session-2',
+      source: { kind: 'upload-version', uploadVersionId: 'upload-version-1' },
+      imageChecksum: HASH_A,
+      mimeType: 'image/png',
+      extractorFingerprint: HASH_A,
+      evidenceSchemaVersion: 2,
+      evidenceJson: '{"summary":"chart"}'
+    })
+
+    await expect(client.visionEvidence.count()).resolves.toBe(0)
+  })
+
+  it('does not return historical uploaded evidence with a mismatched owner', async () => {
+    await client.project.create({ data: { id: 'project-2', name: 'Other project' } })
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-2', sessionId: 'session-2' }
+    })
+    await client.visionEvidence.create({
+      data: {
+        id: IDENTITY,
+        projectId: 'project-2',
+        sessionId: 'session-2',
+        sourceKind: 'upload-version',
+        uploadVersionId: 'upload-version-1',
+        imageChecksum: HASH_A,
+        mimeType: 'image/png',
+        extractorFingerprint: HASH_A,
+        evidenceSchemaVersion: 2,
+        evidenceJson: '{"summary":"chart"}',
+        evidenceChecksum: HASH_B
+      }
+    })
+    await client.visionEvidence.update({
+      where: { id: IDENTITY },
+      data: { evidenceChecksum: createHash('sha256').update('{"summary":"chart"}').digest('hex') }
+    })
+
+    await expect(
+      repository.find({
+        identityKey: IDENTITY,
+        imageChecksum: HASH_A,
+        extractorFingerprint: HASH_A,
+        evidenceSchemaVersion: 2
+      })
+    ).resolves.toBeUndefined()
   })
 
   it('cleans message-image evidence by Session id', async () => {

--- a/src/main/acp/vision-evidence-repository.ts
+++ b/src/main/acp/vision-evidence-repository.ts
@@ -27,7 +27,10 @@ type VisionEvidencePersistence = Readonly<{
   save(input: SaveVisionEvidenceInput): Promise<void>
 }>
 
-type VisionEvidenceClient = Pick<PrismaClient, '$transaction' | 'project' | 'visionEvidence'>
+type VisionEvidenceClient = Pick<
+  PrismaClient,
+  '$transaction' | 'project' | 'uploadVersion' | 'visionEvidence'
+>
 type VisionEvidenceClientProvider = () => Promise<VisionEvidenceClient>
 
 const sha256 = (value: string): string => createHash('sha256').update(value).digest('hex')
@@ -37,13 +40,20 @@ class VisionEvidenceRepository implements VisionEvidencePersistence {
 
   async find(input: FindVisionEvidenceInput): Promise<string | undefined> {
     const client = await this.clientProvider()
-    const row = await client.visionEvidence.findUnique({ where: { id: input.identityKey } })
+    const row = await client.visionEvidence.findUnique({
+      where: { id: input.identityKey },
+      include: { uploadVersion: { include: { uploadFile: true } } }
+    })
     if (
       !row ||
       row.imageChecksum !== input.imageChecksum ||
       row.extractorFingerprint !== input.extractorFingerprint ||
       row.evidenceSchemaVersion !== input.evidenceSchemaVersion ||
-      row.evidenceChecksum !== sha256(row.evidenceJson)
+      row.evidenceChecksum !== sha256(row.evidenceJson) ||
+      (row.sourceKind === 'upload-version' &&
+        (row.uploadVersion === null ||
+          row.uploadVersion.uploadFile.projectId !== row.projectId ||
+          row.uploadVersion.uploadFile.sessionId !== row.sessionId))
     ) {
       return undefined
     }
@@ -83,6 +93,16 @@ class VisionEvidenceRepository implements VisionEvidencePersistence {
         select: { id: true }
       })
       if (!owner) return
+      if (input.source.kind === 'upload-version') {
+        const source = await transaction.uploadVersion.findFirst({
+          where: {
+            id: input.source.uploadVersionId,
+            uploadFile: { projectId: input.projectId, sessionId: input.sessionId }
+          },
+          select: { id: true }
+        })
+        if (!source) return
+      }
       await transaction.visionEvidence.upsert({
         where: { id: input.identityKey },
         create: { id: input.identityKey, ...data },

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -12,7 +12,9 @@ import { migrateApplicationDatabase, verifyCurrentApplicationSchema } from './mi
 const CURRENT_AGENT_MEMORY_MIGRATION_ID = '0017_agent_memory_project_scope'
 const SESSION_AUXILIARY_USAGE_MIGRATION_ID = '0018_session_auxiliary_turn_usage'
 const SESSION_USAGE_ATTRIBUTION_MIGRATION_ID = '0019_session_usage_attribution'
-const CURRENT_MIGRATION_ID = '0020_compute_job_analysis_state'
+const COMPUTE_ANALYSIS_STATE_MIGRATION_ID = '0020_compute_job_analysis_state'
+const COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID = '0021_compute_job_analysis_constraints'
+const CURRENT_MIGRATION_ID = '0022_memory_global_content_unique'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -300,10 +302,12 @@ describe('agent memory project scope migration', () => {
   it('replays an unledgered partial memory migration and restores missing triggers', async () => {
     await client.$executeRawUnsafe('DROP TRIGGER "MemoryEntry_fts_update"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
       SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
+      COMPUTE_ANALYSIS_STATE_MIGRATION_ID,
+      COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID,
       CURRENT_MIGRATION_ID
     )
 
@@ -312,6 +316,8 @@ describe('agent memory project scope migration', () => {
         CURRENT_AGENT_MEMORY_MIGRATION_ID,
         SESSION_AUXILIARY_USAGE_MIGRATION_ID,
         SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
+        COMPUTE_ANALYSIS_STATE_MIGRATION_ID,
+        COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID,
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -30,6 +30,47 @@ const removeAgentMemoryTriggers = async (client: PrismaClient): Promise<void> =>
   await client.$executeRawUnsafe('DROP TABLE "MemoryEntryFts"')
 }
 
+const removeComputeAnalysisSchema = async (client: PrismaClient): Promise<void> => {
+  const [{ sql }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
+    `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
+  )
+  const removedLines = [
+    'CONSTRAINT "ComputeJob_analysisState_check"',
+    'CONSTRAINT "ComputeJob_analysisBundle_check"',
+    'CONSTRAINT "ComputeJob_analysisConsumption_check"',
+    '"analysisState" TEXT',
+    '"analysisMessageId" TEXT',
+    '"analysisUpdatedAt" DATETIME'
+  ]
+  const legacyDdl = sql
+    .split('\n')
+    .filter((line) => removedLines.every((removed) => !line.includes(removed)))
+    .join('\n')
+    .replace(/CREATE TABLE (?:IF NOT EXISTS )?"ComputeJob"/u, 'CREATE TABLE "__legacy_ComputeJob"')
+  const columns = await client.$queryRawUnsafe<Array<{ name: string }>>(
+    `PRAGMA table_info('ComputeJob')`
+  )
+  const copiedColumns = columns
+    .map(({ name }) => name)
+    .filter((name) => !['analysisState', 'analysisMessageId', 'analysisUpdatedAt'].includes(name))
+    .map((name) => `"${name}"`)
+    .join(', ')
+
+  await client.$executeRawUnsafe(legacyDdl)
+  await client.$executeRawUnsafe(
+    `INSERT INTO "__legacy_ComputeJob" (${copiedColumns}) SELECT ${copiedColumns} FROM "ComputeJob"`
+  )
+  await client.$executeRawUnsafe('DROP TABLE "ComputeJob"')
+  await client.$executeRawUnsafe('ALTER TABLE "__legacy_ComputeJob" RENAME TO "ComputeJob"')
+  await client.$executeRawUnsafe(
+    'CREATE INDEX "ComputeJob_providerId_idx" ON "ComputeJob"("providerId")'
+  )
+  await client.$executeRawUnsafe(
+    'CREATE INDEX "ComputeJob_sessionId_idx" ON "ComputeJob"("sessionId")'
+  )
+  await client.$executeRawUnsafe('CREATE INDEX "ComputeJob_status_idx" ON "ComputeJob"("status")')
+}
+
 afterEach(async () => {
   await disconnect?.()
   disconnect = undefined
@@ -131,7 +172,9 @@ describe('application database (integration)', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
 
@@ -609,9 +652,7 @@ describe('application database (integration)', () => {
     // Simulate a pre-ledger database: it predates both the migration ledger and Agent Context.
     await client.$executeRawUnsafe('DROP TABLE "_open_science_migrations"')
     await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "agentContext"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisState"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisUpdatedAt"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisMessageId"')
+    await removeComputeAnalysisSchema(client)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
 
     await migrateApplicationDatabase(client)
@@ -695,9 +736,7 @@ describe('application database (integration)', () => {
     // Simulate a pre-ledger database: it predates both the migration ledger and Agent Context.
     await client.$executeRawUnsafe('DROP TABLE "_open_science_migrations"')
     await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "agentContext"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisState"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisUpdatedAt"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisMessageId"')
+    await removeComputeAnalysisSchema(client)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
 
     await migrateApplicationDatabase(client)
@@ -751,7 +790,7 @@ describe('application database (integration)', () => {
   it('backs up legacy data through the shared client on a portable storage path', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open science 数据 legacy backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
-    const backupPath = `${databasePath}.before-0019_session_usage_attribution.backup`
+    const backupPath = `${databasePath}.before-0022_memory_global_content_unique.backup`
     const seedClient = createProjectDbClient(storageRoot)
     try {
       await seedClient.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -791,7 +830,7 @@ describe('application database (integration)', () => {
         backupClient.$queryRaw<Array<{ id: string }>>`
           SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([{ id: '0018_session_auxiliary_turn_usage' }])
+      ).resolves.toEqual([{ id: '0021_compute_job_analysis_constraints' }])
     } finally {
       await backupClient.$disconnect()
     }
@@ -1170,7 +1209,9 @@ describe('application database (integration)', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
 

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -67,10 +67,12 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ],
       from: '0015_session_model_call_usage',
-      to: '0020_compute_job_analysis_state'
+      to: '0022_memory_global_content_unique'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)
@@ -82,10 +84,10 @@ describe('Compute Job sensitive data encryption migration', () => {
       access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
-      access(`${databasePath}.before-0019_session_usage_attribution.backup`)
+      access(`${databasePath}.before-0021_compute_job_analysis_constraints.backup`)
     ).resolves.toBeUndefined()
     await expect(
-      access(`${databasePath}.before-0020_compute_job_analysis_state.backup`)
+      access(`${databasePath}.before-0022_memory_global_content_unique.backup`)
     ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<

--- a/src/main/database/database-domain-constraints.test.ts
+++ b/src/main/database/database-domain-constraints.test.ts
@@ -143,6 +143,22 @@ describe('database domain constraints', () => {
         sql: `UPDATE "ComputeJob" SET "notificationConsumedAt" = CURRENT_TIMESTAMP WHERE "id" = 'base-job'`
       },
       {
+        name: 'ComputeJob analysis state',
+        sql: `UPDATE "ComputeJob" SET "analysisState" = 'unknown' WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob partial analysis identity',
+        sql: `UPDATE "ComputeJob" SET "analysisState" = 'dispatched' WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob blank analysis Message identity',
+        sql: `UPDATE "ComputeJob" SET "analysisState" = 'dispatched', "analysisMessageId" = ' ', "analysisUpdatedAt" = CURRENT_TIMESTAMP WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob succeeded analysis consumption',
+        sql: `UPDATE "ComputeJob" SET "notifiedAt" = CURRENT_TIMESTAMP, "analysisState" = 'succeeded', "analysisMessageId" = 'analysis-message', "analysisUpdatedAt" = CURRENT_TIMESTAMP, "notificationConsumedAt" = NULL WHERE "id" = 'base-job'`
+      },
+      {
         name: 'ComputeJob harvest payload',
         sql: `UPDATE "ComputeJob" SET "harvestError" = 'failed' WHERE "id" = 'base-job'`
       },

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -159,10 +159,12 @@ describe('database JSON constraints migration', () => {
           '0017_agent_memory_project_scope',
           '0018_session_auxiliary_turn_usage',
           '0019_session_usage_attribution',
-          '0020_compute_job_analysis_state'
+          '0020_compute_job_analysis_state',
+          '0021_compute_job_analysis_constraints',
+          '0022_memory_global_content_unique'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0020_compute_job_analysis_state'
+        to: '0022_memory_global_content_unique'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).rejects.toMatchObject({
         code: 'ENOENT'
@@ -194,10 +196,10 @@ describe('database JSON constraints migration', () => {
         access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
       ).rejects.toMatchObject({ code: 'ENOENT' })
       await expect(
-        access(`${databasePath}.before-0019_session_usage_attribution.backup`)
+        access(`${databasePath}.before-0021_compute_job_analysis_constraints.backup`)
       ).resolves.toBeUndefined()
       await expect(
-        access(`${databasePath}.before-0020_compute_job_analysis_state.backup`)
+        access(`${databasePath}.before-0022_memory_global_content_unique.backup`)
       ).resolves.toBeUndefined()
 
       await expect(

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -117,7 +117,9 @@ describe('database startup logging', () => {
               '0017_agent_memory_project_scope',
               '0018_session_auxiliary_turn_usage',
               '0019_session_usage_attribution',
-              '0020_compute_job_analysis_state'
+              '0020_compute_job_analysis_state',
+              '0021_compute_job_analysis_constraints',
+              '0022_memory_global_content_unique'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -518,6 +518,9 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ComputeJob_errorCode_check" CHECK ("errorCode" IS NULL OR "errorCode" IN ('approval_denied', 'credential_required', 'credential_conflict', 'credential_unavailable', 'secure_storage_unavailable', 'authentication_failed', 'host_key_unknown', 'host_key_changed', 'host_unreachable', 'unsupported_auth_configuration', 'dispatch_failed', 'job_failed', 'timeout', 'process_vanished')),
     CONSTRAINT "ComputeJob_timeoutSeconds_check" CHECK ("timeoutSeconds" IS NULL OR "timeoutSeconds" BETWEEN 1 AND 604800),
     CONSTRAINT "ComputeJob_notification_check" CHECK ("notificationConsumedAt" IS NULL OR "notifiedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_analysisState_check" CHECK ("analysisState" IS NULL OR "analysisState" IN ('dispatched', 'succeeded', 'failed', 'cancelled')),
+    CONSTRAINT "ComputeJob_analysisBundle_check" CHECK ((("analysisState" IS NULL AND "analysisMessageId" IS NULL AND "analysisUpdatedAt" IS NULL) OR ("analysisState" IS NOT NULL AND "analysisMessageId" IS NOT NULL AND length(trim("analysisMessageId")) > 0 AND "analysisUpdatedAt" IS NOT NULL))),
+    CONSTRAINT "ComputeJob_analysisConsumption_check" CHECK ("analysisState" IS NULL OR "analysisState" <> 'succeeded' OR "notificationConsumedAt" IS NOT NULL),
     CONSTRAINT "ComputeJob_harvestPayload_check" CHECK (("harvestError" IS NULL AND "leftOnRemote" IS NULL) OR "harvestedAt" IS NOT NULL),
     CONSTRAINT "ComputeJob_harvestState_check" CHECK ("harvestedAt" IS NULL OR "status" IN ('success', 'failed', 'timeout')),
     CONSTRAINT "ComputeJob_errorState_check" CHECK ((("errorCode" IS NULL OR "status" IN ('failed', 'timeout', 'error')) AND ("status" <> 'error' OR "errorCode" IS NOT NULL))),
@@ -734,7 +737,8 @@ const RUNTIME_SCHEMA_INDEX_DDLS = [
   `CREATE UNIQUE INDEX IF NOT EXISTS "MemoryCategory_nameKey_key" ON "MemoryCategory"("nameKey");`,
   `CREATE INDEX IF NOT EXISTS "MemoryEntry_categoryId_updatedAt_idx" ON "MemoryEntry"("categoryId", "updatedAt");`,
   `CREATE INDEX IF NOT EXISTS "MemoryEntry_projectId_updatedAt_idx" ON "MemoryEntry"("projectId", "updatedAt");`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS "MemoryEntry_projectId_contentKey_key" ON "MemoryEntry"("projectId", "contentKey");`
+  `CREATE UNIQUE INDEX IF NOT EXISTS "MemoryEntry_projectId_contentKey_key" ON "MemoryEntry"("projectId", "contentKey");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "MemoryEntry_global_contentKey_key" ON "MemoryEntry"("contentKey") WHERE "projectId" IS NULL`
 ] as const
 
 const RUNTIME_SCHEMA_TARGET_SQL = [

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -20,7 +20,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0021_test_suffix'
+  const id = '0023_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -84,6 +84,54 @@ const removeComputePasswordAuthSchema = async (client: PrismaClient): Promise<vo
   await client.$executeRawUnsafe(
     'CREATE UNIQUE INDEX "ComputeHost_providerId_key" ON "ComputeHost"("providerId")'
   )
+}
+
+const removeComputeAnalysisSchema = async (
+  client: PrismaClient,
+  dropAnalysisColumns: boolean
+): Promise<void> => {
+  const [{ sql }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
+    `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
+  )
+  const removedLines = [
+    'CONSTRAINT "ComputeJob_analysisState_check"',
+    'CONSTRAINT "ComputeJob_analysisBundle_check"',
+    'CONSTRAINT "ComputeJob_analysisConsumption_check"',
+    ...(dropAnalysisColumns
+      ? ['"analysisState" TEXT', '"analysisMessageId" TEXT', '"analysisUpdatedAt" DATETIME']
+      : [])
+  ]
+  const legacyDdl = sql
+    .split('\n')
+    .filter((line) => removedLines.every((removed) => !line.includes(removed)))
+    .join('\n')
+    .replace(/CREATE TABLE (?:IF NOT EXISTS )?"ComputeJob"/u, 'CREATE TABLE "__legacy_ComputeJob"')
+  const columns = await client.$queryRawUnsafe<Array<{ name: string }>>(
+    `PRAGMA table_info('ComputeJob')`
+  )
+  const copiedColumns = columns
+    .map(({ name }) => name)
+    .filter(
+      (name) =>
+        !dropAnalysisColumns ||
+        !['analysisState', 'analysisMessageId', 'analysisUpdatedAt'].includes(name)
+    )
+    .map((name) => `"${name}"`)
+    .join(', ')
+
+  await client.$executeRawUnsafe(legacyDdl)
+  await client.$executeRawUnsafe(
+    `INSERT INTO "__legacy_ComputeJob" (${copiedColumns}) SELECT ${copiedColumns} FROM "ComputeJob"`
+  )
+  await client.$executeRawUnsafe('DROP TABLE "ComputeJob"')
+  await client.$executeRawUnsafe('ALTER TABLE "__legacy_ComputeJob" RENAME TO "ComputeJob"')
+  await client.$executeRawUnsafe(
+    'CREATE INDEX "ComputeJob_providerId_idx" ON "ComputeJob"("providerId")'
+  )
+  await client.$executeRawUnsafe(
+    'CREATE INDEX "ComputeJob_sessionId_idx" ON "ComputeJob"("sessionId")'
+  )
+  await client.$executeRawUnsafe('CREATE INDEX "ComputeJob_status_idx" ON "ComputeJob"("status")')
 }
 
 const removeAgentMemoryTriggers = async (client: PrismaClient): Promise<void> => {
@@ -267,10 +315,12 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ],
       from: null,
-      to: '0020_compute_job_analysis_state'
+      to: '0022_memory_global_content_unique'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -283,8 +333,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0020_compute_job_analysis_state',
-      to: '0020_compute_job_analysis_state'
+      from: '0022_memory_global_content_unique',
+      to: '0022_memory_global_content_unique'
     })
   })
 
@@ -352,11 +402,9 @@ describe('application database migrations', () => {
       'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
     )
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique')`
     )
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisState"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisUpdatedAt"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisMessageId"')
+    await removeComputeAnalysisSchema(client, true)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.project.create({ data: { id: 'project-1', name: 'Project' } })
     await client.$executeRawUnsafe(`INSERT INTO "Session" (
@@ -373,7 +421,9 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
     await expect(
@@ -447,7 +497,9 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -492,7 +544,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0020_compute_job_analysis_state'
+      to: '0022_memory_global_content_unique'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -513,12 +565,10 @@ describe('application database migrations', () => {
     await migrateApplicationDatabase(client)
     await client.$executeRawUnsafe('DROP INDEX "ComputeJob_status_idx"')
     await removeComputePasswordAuthSchema(client)
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisState"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisUpdatedAt"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisMessageId"')
+    await removeComputeAnalysisSchema(client, true)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state')`)
+      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique')`)
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: [
@@ -536,10 +586,12 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0020_compute_job_analysis_state'
+      to: '0022_memory_global_content_unique'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -610,10 +662,12 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0020_compute_job_analysis_state'
+      to: '0022_memory_global_content_unique'
     })
     await expect(
       client.$queryRaw<
@@ -732,7 +786,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0020_compute_job_analysis_state'
+      migrationId: '0022_memory_global_content_unique'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -748,9 +802,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0021_test_suffix'],
-      from: '0020_compute_job_analysis_state',
-      to: '0021_test_suffix'
+      applied: ['0023_test_suffix'],
+      from: '0022_memory_global_content_unique',
+      to: '0023_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -777,7 +831,9 @@ describe('application database migrations', () => {
       { id: '0018_session_auxiliary_turn_usage' },
       { id: '0019_session_usage_attribution' },
       { id: '0020_compute_job_analysis_state' },
-      { id: '0021_test_suffix' }
+      { id: '0021_compute_job_analysis_constraints' },
+      { id: '0022_memory_global_content_unique' },
+      { id: '0023_test_suffix' }
     ])
   })
 
@@ -849,10 +905,12 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0020_compute_job_analysis_state'
+      to: '0022_memory_global_content_unique'
     })
     expect(backupEvents).toEqual([
       {
@@ -949,6 +1007,16 @@ describe('application database migrations', () => {
         migrationId: '0020_compute_job_analysis_state',
         path: `${databasePath}.before-0020_compute_job_analysis_state.backup`,
         reused: false
+      },
+      {
+        migrationId: '0021_compute_job_analysis_constraints',
+        path: `${databasePath}.before-0021_compute_job_analysis_constraints.backup`,
+        reused: false
+      },
+      {
+        migrationId: '0022_memory_global_content_unique',
+        path: `${databasePath}.before-0022_memory_global_content_unique.backup`,
+        reused: false
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -977,10 +1045,10 @@ describe('application database migrations', () => {
       access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
-      access(`${databasePath}.before-0019_session_usage_attribution.backup`)
+      access(`${databasePath}.before-0021_compute_job_analysis_constraints.backup`)
     ).resolves.toBeUndefined()
     await expect(
-      access(`${databasePath}.before-0020_compute_job_analysis_state.backup`)
+      access(`${databasePath}.before-0022_memory_global_content_unique.backup`)
     ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<Array<{ agentContext: string; name: string }>>`
@@ -1011,7 +1079,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0021_test_suffix'
+      migrationId: '0023_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -1043,7 +1111,9 @@ describe('application database migrations', () => {
       { id: '0017_agent_memory_project_scope' },
       { id: '0018_session_auxiliary_turn_usage' },
       { id: '0019_session_usage_attribution' },
-      { id: '0020_compute_job_analysis_state' }
+      { id: '0020_compute_job_analysis_state' },
+      { id: '0021_compute_job_analysis_constraints' },
+      { id: '0022_memory_global_content_unique' }
     ])
   })
 
@@ -1108,7 +1178,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0021_test_suffix'
+      migrationId: '0023_test_suffix'
     })
   })
 
@@ -1154,9 +1224,11 @@ describe('application database migrations', () => {
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
         '0020_compute_job_analysis_state',
-        '0021_test_suffix'
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique',
+        '0023_test_suffix'
       ],
-      to: '0021_test_suffix'
+      to: '0023_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -1271,9 +1343,7 @@ describe('application database migrations', () => {
     `
     await client.$executeRawUnsafe('PRAGMA foreign_keys = ON')
     await removeComputePasswordAuthSchema(client)
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisState"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisUpdatedAt"')
-    await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "analysisMessageId"')
+    await removeComputeAnalysisSchema(client, true)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.$executeRawUnsafe('DROP TABLE "VisionEvidence"')
     await removeAgentMemoryTriggers(client)
@@ -1403,7 +1473,9 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
     await expect(
@@ -1520,7 +1592,9 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1589,7 +1663,9 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
     await expect(
@@ -1661,7 +1737,9 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -1767,7 +1845,9 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
     await expect(
@@ -1838,7 +1918,9 @@ describe('application database migrations', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ]
     })
     expect(backupEvents).toEqual([
@@ -1941,6 +2023,16 @@ describe('application database migrations', () => {
         migrationId: '0020_compute_job_analysis_state',
         path: analysisStateBackupPath,
         reused: false
+      },
+      {
+        migrationId: '0021_compute_job_analysis_constraints',
+        path: `${databasePath}.before-0021_compute_job_analysis_constraints.backup`,
+        reused: false
+      },
+      {
+        migrationId: '0022_memory_global_content_unique',
+        path: `${databasePath}.before-0022_memory_global_content_unique.backup`,
+        reused: false
       }
     ])
     await expect(
@@ -1948,8 +2040,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0019_session_usage_attribution.backup',
-      'open-science.db.before-0020_compute_job_analysis_state.backup'
+      'open-science.db.before-0021_compute_job_analysis_constraints.backup',
+      'open-science.db.before-0022_memory_global_content_unique.backup'
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentContextBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -1963,12 +2055,22 @@ describe('application database migrations', () => {
     await expect(access(computeJobEncryptionBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentMemoryBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(auxiliaryUsageBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(access(usageAttributionBackupPath)).resolves.toBeUndefined()
-    await expect(access(analysisStateBackupPath)).resolves.toBeUndefined()
+    await expect(access(usageAttributionBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(access(analysisStateBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      access(`${databasePath}.before-0021_compute_job_analysis_constraints.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0022_memory_global_content_unique.backup`)
+    ).resolves.toBeUndefined()
     await expect(client.project.count()).resolves.toBe(1)
 
     const backupClient = new PrismaClient({
-      datasources: { db: { url: `file:${usageAttributionBackupPath.replaceAll('\\', '/')}` } }
+      datasources: {
+        db: {
+          url: `file:${`${databasePath}.before-0022_memory_global_content_unique.backup`.replaceAll('\\', '/')}`
+        }
+      }
     })
     try {
       await expect(
@@ -1980,7 +2082,7 @@ describe('application database migrations', () => {
         backupClient.$queryRaw<Array<{ id: string }>>`
           SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([{ id: '0018_session_auxiliary_turn_usage' }])
+      ).resolves.toEqual([{ id: '0021_compute_job_analysis_constraints' }])
     } finally {
       await backupClient.$disconnect()
     }
@@ -2428,6 +2530,16 @@ describe('application database migrations', () => {
         migrationId: '0020_compute_job_analysis_state',
         path: `${databasePath}.before-0020_compute_job_analysis_state.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0021_compute_job_analysis_constraints',
+        path: `${databasePath}.before-0021_compute_job_analysis_constraints.backup`,
+        reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0022_memory_global_content_unique',
+        path: `${databasePath}.before-0022_memory_global_content_unique.backup`,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -2504,6 +2616,14 @@ describe('application database migrations', () => {
       {
         migrationId: '0020_compute_job_analysis_state',
         path: `${databasePath}.before-0020_compute_job_analysis_state.backup`
+      },
+      {
+        migrationId: '0021_compute_job_analysis_constraints',
+        path: `${databasePath}.before-0021_compute_job_analysis_constraints.backup`
+      },
+      {
+        migrationId: '0022_memory_global_content_unique',
+        path: `${databasePath}.before-0022_memory_global_content_unique.backup`
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -2537,8 +2657,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0019_session_usage_attribution.backup',
-      'open-science.db.before-0020_compute_job_analysis_state.backup',
+      'open-science.db.before-0021_compute_job_analysis_constraints.backup',
+      'open-science.db.before-0022_memory_global_content_unique.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -39,6 +39,8 @@ import {
 import { sessionAuxiliaryTurnUsageMigration } from './migrations/0018-session-auxiliary-turn-usage'
 import { sessionUsageAttributionMigration } from './migrations/0019-session-usage-attribution'
 import { computeJobAnalysisStateMigration } from './migrations/0020-compute-job-analysis-state'
+import { computeJobAnalysisConstraintsMigration } from './migrations/0021-compute-job-analysis-constraints'
+import { memoryGlobalContentUniqueMigration } from './migrations/0022-memory-global-content-unique'
 import {
   applySqliteMigrationOperations,
   type SqliteMigrationOperation
@@ -300,6 +302,18 @@ const COMPUTE_JOB_ANALYSIS_STATE_CHECKSUM = checksumMigrationPayload(
   computeJobAnalysisStateMigration.verifiers,
   computeJobAnalysisStateMigration.operations
 )
+const COMPUTE_JOB_ANALYSIS_CONSTRAINTS_CHECKSUM = checksumMigrationPayload(
+  computeJobAnalysisConstraintsMigration.id,
+  computeJobAnalysisConstraintsMigration.statements,
+  computeJobAnalysisConstraintsMigration.verifiers,
+  computeJobAnalysisConstraintsMigration.operations
+)
+const MEMORY_GLOBAL_CONTENT_UNIQUE_CHECKSUM = checksumMigrationPayload(
+  memoryGlobalContentUniqueMigration.id,
+  memoryGlobalContentUniqueMigration.statements,
+  memoryGlobalContentUniqueMigration.verifiers,
+  memoryGlobalContentUniqueMigration.operations
+)
 const COMPUTE_JOB_SENSITIVE_DATA_ENCRYPTION_CHECKSUM = checksumMigrationPayload(
   computeJobSensitiveDataEncryptionMigration.id,
   computeJobSensitiveDataEncryptionMigration.statements,
@@ -508,6 +522,18 @@ const MIGRATION_MANIFEST = [
   {
     ...computeJobAnalysisStateMigration,
     checksum: COMPUTE_JOB_ANALYSIS_STATE_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...computeJobAnalysisConstraintsMigration,
+    checksum: COMPUTE_JOB_ANALYSIS_CONSTRAINTS_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...memoryGlobalContentUniqueMigration,
+    checksum: MEMORY_GLOBAL_CONTENT_UNIQUE_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }
@@ -776,6 +802,8 @@ const verifyCurrentApplicationSchema = async (client: PrismaClient): Promise<voi
   await runMigrationVerifiers(client, sessionAuxiliaryTurnUsageMigration.verifiers)
   await runMigrationVerifiers(client, sessionUsageAttributionMigration.verifiers)
   await runMigrationVerifiers(client, computeJobAnalysisStateMigration.verifiers)
+  await runMigrationVerifiers(client, computeJobAnalysisConstraintsMigration.verifiers)
+  await runMigrationVerifiers(client, memoryGlobalContentUniqueMigration.verifiers)
 }
 
 const readLedger = async (client: PrismaClient): Promise<LedgerRow[]> => {
@@ -1491,6 +1519,8 @@ export {
   TAG_ORDERING_CHECKSUM,
   REVIEW_QUERY_INDEXES_CHECKSUM,
   AGENT_MEMORY_PROJECT_SCOPE_CHECKSUM,
+  COMPUTE_JOB_ANALYSIS_CONSTRAINTS_CHECKSUM,
+  MEMORY_GLOBAL_CONTENT_UNIQUE_CHECKSUM,
   DatabaseMigrationError,
   checksumMigrationPayload,
   classifyDatabaseFailure,

--- a/src/main/database/migrations/0021-compute-job-analysis-constraints.ts
+++ b/src/main/database/migrations/0021-compute-job-analysis-constraints.ts
@@ -1,0 +1,149 @@
+const analysisStateExpression = `"analysisState" IS NULL OR "analysisState" IN ('dispatched', 'succeeded', 'failed', 'cancelled')`
+const analysisBundleExpression = `(("analysisState" IS NULL AND "analysisMessageId" IS NULL AND "analysisUpdatedAt" IS NULL) OR ("analysisState" IS NOT NULL AND "analysisMessageId" IS NOT NULL AND length(trim("analysisMessageId")) > 0 AND "analysisUpdatedAt" IS NOT NULL))`
+const analysisConsumptionExpression = `"analysisState" IS NULL OR "analysisState" <> 'succeeded' OR "notificationConsumedAt" IS NOT NULL`
+
+const computeJobDdl = `CREATE TABLE IF NOT EXISTS "ComputeJob" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "providerId" TEXT NOT NULL,
+    "shape" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'submitted',
+    "intent" TEXT NOT NULL,
+    "command" TEXT NOT NULL,
+    "commandHash" TEXT NOT NULL,
+    "sensitiveDataEncrypted" BOOLEAN,
+    "environment" TEXT,
+    "resourceRequest" TEXT,
+    "inputManifest" TEXT,
+    "outputManifest" TEXT,
+    "harvestConfig" TEXT,
+    "timeoutSeconds" INTEGER,
+    "remoteWorkdir" TEXT,
+    "remoteHandle" TEXT,
+    "exitCode" INTEGER,
+    "stdoutTail" TEXT,
+    "stderrTail" TEXT,
+    "errorCode" TEXT,
+    "lastPollError" TEXT,
+    "harvestError" TEXT,
+    "leftOnRemote" TEXT,
+    "notifiedAt" DATETIME,
+    "notificationConsumedAt" DATETIME,
+    "analysisState" TEXT,
+    "analysisMessageId" TEXT,
+    "analysisUpdatedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "submittedAt" DATETIME,
+    "startedAt" DATETIME,
+    "finishedAt" DATETIME,
+    "harvestedAt" DATETIME,
+    CONSTRAINT "ComputeJob_shape_check" CHECK ("shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')),
+    CONSTRAINT "ComputeJob_status_check" CHECK ("status" IN ('queued', 'submitted', 'running', 'success', 'failed', 'timeout', 'error')),
+    CONSTRAINT "ComputeJob_errorCode_check" CHECK ("errorCode" IS NULL OR "errorCode" IN ('approval_denied', 'credential_required', 'credential_conflict', 'credential_unavailable', 'secure_storage_unavailable', 'authentication_failed', 'host_key_unknown', 'host_key_changed', 'host_unreachable', 'unsupported_auth_configuration', 'dispatch_failed', 'job_failed', 'timeout', 'process_vanished')),
+    CONSTRAINT "ComputeJob_timeoutSeconds_check" CHECK ("timeoutSeconds" IS NULL OR "timeoutSeconds" BETWEEN 1 AND 604800),
+    CONSTRAINT "ComputeJob_notification_check" CHECK ("notificationConsumedAt" IS NULL OR "notifiedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_analysisState_check" CHECK (${analysisStateExpression}),
+    CONSTRAINT "ComputeJob_analysisBundle_check" CHECK (${analysisBundleExpression}),
+    CONSTRAINT "ComputeJob_analysisConsumption_check" CHECK (${analysisConsumptionExpression}),
+    CONSTRAINT "ComputeJob_harvestPayload_check" CHECK (("harvestError" IS NULL AND "leftOnRemote" IS NULL) OR "harvestedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_harvestState_check" CHECK ("harvestedAt" IS NULL OR "status" IN ('success', 'failed', 'timeout')),
+    CONSTRAINT "ComputeJob_errorState_check" CHECK ((("errorCode" IS NULL OR "status" IN ('failed', 'timeout', 'error')) AND ("status" <> 'error' OR "errorCode" IS NOT NULL))),
+    CONSTRAINT "ComputeJob_resourceRequestJson_check" CHECK ("resourceRequest" IS NULL OR (json_valid("resourceRequest") AND json_type("resourceRequest") = 'object')),
+    CONSTRAINT "ComputeJob_inputManifestJson_check" CHECK ("inputManifest" IS NULL OR (json_valid("inputManifest") AND json_type("inputManifest") = 'array')),
+    CONSTRAINT "ComputeJob_outputManifestJson_check" CHECK ("outputManifest" IS NULL OR (json_valid("outputManifest") AND json_type("outputManifest") = 'array')),
+    CONSTRAINT "ComputeJob_harvestConfigJson_check" CHECK ("harvestConfig" IS NULL OR (json_valid("harvestConfig") AND json_type("harvestConfig") = 'object')),
+    CONSTRAINT "ComputeJob_remoteHandleJson_check" CHECK ("remoteHandle" IS NULL OR (json_valid("remoteHandle") AND json_type("remoteHandle") = 'object')),
+    CONSTRAINT "ComputeJob_leftOnRemoteJson_check" CHECK ("leftOnRemote" IS NULL OR (json_valid("leftOnRemote") AND json_type("leftOnRemote") = 'array'))
+)`
+
+const computeJobIndexDdls = [
+  `CREATE INDEX IF NOT EXISTS "ComputeJob_providerId_idx" ON "ComputeJob"("providerId")`,
+  `CREATE INDEX IF NOT EXISTS "ComputeJob_sessionId_idx" ON "ComputeJob"("sessionId")`,
+  `CREATE INDEX IF NOT EXISTS "ComputeJob_status_idx" ON "ComputeJob"("status")`
+] as const
+
+const computeJobAnalysisConstraintsMigration = {
+  id: '0021_compute_job_analysis_constraints',
+  statements: [] as const,
+  operations: [
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'ComputeJob',
+          canonicalTableDdl: computeJobDdl,
+          columns: [
+            'id',
+            'providerId',
+            'shape',
+            'sessionId',
+            'projectId',
+            'status',
+            'intent',
+            'command',
+            'commandHash',
+            'sensitiveDataEncrypted',
+            'environment',
+            'resourceRequest',
+            'inputManifest',
+            'outputManifest',
+            'harvestConfig',
+            'timeoutSeconds',
+            'remoteWorkdir',
+            'remoteHandle',
+            'exitCode',
+            'stdoutTail',
+            'stderrTail',
+            'errorCode',
+            'lastPollError',
+            'harvestError',
+            'leftOnRemote',
+            'notifiedAt',
+            'notificationConsumedAt',
+            'analysisState',
+            'analysisMessageId',
+            'analysisUpdatedAt',
+            'createdAt',
+            'submittedAt',
+            'startedAt',
+            'finishedAt',
+            'harvestedAt'
+          ]
+        }
+      ],
+      dropOrder: ['ComputeJob'],
+      indexes: computeJobIndexDdls
+    }
+  ] as const,
+  verifiers: [
+    {
+      kind: 'check-constraints-exist',
+      version: 1,
+      tables: [
+        {
+          table: 'ComputeJob',
+          constraints: [
+            { name: 'ComputeJob_analysisState_check', expression: analysisStateExpression },
+            { name: 'ComputeJob_analysisBundle_check', expression: analysisBundleExpression },
+            {
+              name: 'ComputeJob_analysisConsumption_check',
+              expression: analysisConsumptionExpression
+            }
+          ]
+        }
+      ]
+    },
+    {
+      kind: 'indexes-exist',
+      version: 1,
+      indexes: computeJobIndexDdls.map((sql) => ({
+        name: sql.match(/INDEX IF NOT EXISTS "([^"]+)"/)![1]!,
+        sql
+      }))
+    }
+  ] as const
+}
+
+export { computeJobAnalysisConstraintsMigration }

--- a/src/main/database/migrations/0022-memory-global-content-unique.ts
+++ b/src/main/database/migrations/0022-memory-global-content-unique.ts
@@ -1,0 +1,21 @@
+const memoryGlobalContentUniqueIndexDdl = `CREATE UNIQUE INDEX IF NOT EXISTS "MemoryEntry_global_contentKey_key" ON "MemoryEntry"("contentKey") WHERE "projectId" IS NULL`
+
+const memoryGlobalContentUniqueMigration = {
+  id: '0022_memory_global_content_unique',
+  statements: [memoryGlobalContentUniqueIndexDdl] as const,
+  operations: [] as const,
+  verifiers: [
+    {
+      kind: 'indexes-exist',
+      version: 1,
+      indexes: [
+        {
+          name: 'MemoryEntry_global_contentKey_key',
+          sql: memoryGlobalContentUniqueIndexDdl
+        }
+      ]
+    }
+  ] as const
+}
+
+export { memoryGlobalContentUniqueMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -79,10 +79,12 @@ describe('notification attention metadata migration', () => {
         '0017_agent_memory_project_scope',
         '0018_session_auxiliary_turn_usage',
         '0019_session_usage_attribution',
-        '0020_compute_job_analysis_state'
+        '0020_compute_job_analysis_state',
+        '0021_compute_job_analysis_constraints',
+        '0022_memory_global_content_unique'
       ],
       from: '0006_database_domain_constraints',
-      to: '0020_compute_job_analysis_state'
+      to: '0022_memory_global_content_unique'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)
@@ -112,10 +114,10 @@ describe('notification attention metadata migration', () => {
       access(`${databasePath}.before-0018_session_auxiliary_turn_usage.backup`)
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
-      access(`${databasePath}.before-0019_session_usage_attribution.backup`)
+      access(`${databasePath}.before-0021_compute_job_analysis_constraints.backup`)
     ).resolves.toBeUndefined()
     await expect(
-      access(`${databasePath}.before-0020_compute_job_analysis_state.backup`)
+      access(`${databasePath}.before-0022_memory_global_content_unique.backup`)
     ).resolves.toBeUndefined()
 
     await expect(

--- a/src/main/memory/service.test.ts
+++ b/src/main/memory/service.test.ts
@@ -90,6 +90,19 @@ describe('MemoryService', () => {
     expect((await service.snapshot()).categories[0]?.entries).toHaveLength(1)
   })
 
+  it('rejects duplicate global Memory content within the same scope', async () => {
+    const service = createService()
+    const request = {
+      categoryId: ABOUT_YOU_MEMORY_CATEGORY_ID,
+      content: 'Prefers concise answers.'
+    }
+
+    await service.createEntry(request)
+
+    await expect(service.createEntry(request)).rejects.toThrow()
+    await expect(client.memoryEntry.count()).resolves.toBe(1)
+  })
+
   it('persists categories and entries across database reopen and hard-deletes category entries', async () => {
     const service = createService()
     const created = await service.createCategory({
@@ -413,6 +426,7 @@ describe('MemoryService', () => {
         {
           id: 'duplicate-cross-category',
           categoryId: duplicateCategory.id,
+          projectId: 'project-1',
           content: '  ALPHA BETA  ',
           contentKey: 'alpha beta',
           origin: 'user'
@@ -432,37 +446,44 @@ describe('MemoryService', () => {
     ).toHaveLength(1)
   })
 
-  it('deduplicates before the five-record recall cap and backfills distinct facts', async () => {
+  it('deduplicates global and project facts before the recall cap', async () => {
     const service = createService()
-    const categoryIds: string[] = [ABOUT_YOU_MEMORY_CATEGORY_ID]
-    for (let index = 0; index < 4; index += 1) {
-      const snapshot = await service.createCategory({
-        name: `Recall ${index}`,
-        guidance: '',
-        autoRecall: true
-      })
-      categoryIds.push(
-        snapshot.categories.find(
-          (category) => 'name' in category && category.name === `Recall ${index}`
-        )!.id
-      )
-    }
-    for (const categoryId of categoryIds) {
-      await service.createEntry({ categoryId, content: 'microscope recall' })
-    }
-    await service.createEntry({
-      categoryId: ABOUT_YOU_MEMORY_CATEGORY_ID,
-      content: 'microscope recall unique calibration detail'
+    await client.memoryEntry.createMany({
+      data: [
+        {
+          id: 'global-duplicate',
+          categoryId: ABOUT_YOU_MEMORY_CATEGORY_ID,
+          content: 'microscope recall',
+          contentKey: 'microscope recall',
+          origin: 'user'
+        },
+        {
+          id: 'project-duplicate',
+          projectId: 'project-1',
+          content: '  MICROSCOPE RECALL  ',
+          contentKey: 'microscope recall',
+          origin: 'user'
+        },
+        ...Array.from({ length: 4 }, (_, index) => ({
+          id: `distinct-${index}`,
+          categoryId: ABOUT_YOU_MEMORY_CATEGORY_ID,
+          content: `microscope recall unique calibration detail ${index}`,
+          contentKey: `microscope recall unique calibration detail ${index}`,
+          origin: 'user' as const
+        }))
+      ]
     })
     await service.setEnabled({ enabled: true })
 
     const recalled = await service.recallForPrompt('microscope recall', agentContext)
     const encodedRecords = recalled?.match(/<memory_records>(.*)<\/memory_records>/u)?.[1]
     const records = JSON.parse(encodedRecords ?? '[]') as Array<{ content: string }>
-    expect(records.filter(({ content }) => content === 'microscope recall')).toHaveLength(1)
+    expect(
+      records.filter(({ content }) => content.trim().toLowerCase() === 'microscope recall')
+    ).toHaveLength(1)
     expect(records).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ content: 'microscope recall unique calibration detail' })
+        expect.objectContaining({ content: 'microscope recall unique calibration detail 0' })
       ])
     )
   })


### PR DESCRIPTION
## Problem

SQLite did not enforce the durable Compute automatic-analysis state bundle, and the nullable composite Memory unique index did not cover global rows. VisionEvidence also accepted an UploadVersion owned by a different Project or Session.

## Changes

- add immutable 0021/0022 migrations for Compute CHECK constraints and the global Memory partial unique index
- extend the generated SQLite schema contract to carry Prisma-inexpressible indexes
- fail migration without rewriting rows when historical Compute state is invalid or global Memory duplicates exist
- verify UploadVersion ownership inside the VisionEvidence save transaction and treat historical owner mismatches as cache misses
- leave ReviewScopeSnapshot and ArtifactVersionInput composite relationship constraints out of scope

## Persisted-data impact

- no new columns
- no new analysis states or enum values
- ComputeJob is rebuilt once to add three named CHECK constraints
- MemoryEntry gains a persistent partial unique index for projectId IS NULL
- incompatible historical rows are not repaired, merged, or deleted; the existing pre-migration backup is retained and startup fails closed
- historical mismatched VisionEvidence rows remain stored but are no longer returned

## Validation

- reproduced all three reports with regression tests that failed before the production fixes
- npm run db:schema:check
- npm run typecheck:node
- npm run lint
- focused ESLint on changed files
- 13 affected Vitest files: 170 tests passed

The change-impact classifier selects the complete Vitest suite because schema/generator files changed. Per project guidance, the full suite is deferred to PR CI.