### PR TITLE
fix(renderer): recover CLI status and tooltip focus

### DIFF
--- a/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
@@ -155,6 +155,37 @@ afterEach(() => {
 })
 
 describe('GeneralPanel command line tool', () => {
+  it('recovers when the initial command status check fails', async () => {
+    cliApi.getStatus
+      .mockRejectedValueOnce(new Error('command status unavailable'))
+      .mockResolvedValueOnce({
+        installed: false,
+        target: '/home/u/.local/bin/open-science',
+        onPath: true
+      })
+
+    await act(async () => {
+      root.render(<GeneralPanel />)
+    })
+    await flush()
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Could not check the command-line tool.'
+    )
+    const retryButton = findButton(/check again/i)
+    expect(retryButton).toBeDefined()
+    expect(findButton(/install command/i)?.disabled).toBe(true)
+
+    await act(async () => {
+      retryButton?.click()
+    })
+    await flush()
+
+    expect(cliApi.getStatus).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(findButton(/install command/i)?.disabled).toBe(false)
+  })
+
   it('installs the command and surfaces the returned path + PATH hint', async () => {
     await act(async () => {
       root.render(<GeneralPanel />)

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -30,7 +30,7 @@ const socialLinkClassName =
   'inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-card px-2 text-xs font-medium text-muted-foreground transition-colors duration-150 motion-reduce:transition-none hover:bg-muted hover:text-foreground'
 
 type GeneralActionError = {
-  action: 'cli' | 'open-log' | 'reveal-log'
+  action: 'cli' | 'cli-status' | 'open-log' | 'reveal-log'
   detail?: string
 }
 
@@ -38,6 +38,8 @@ const generalActionErrorCopy = (error: GeneralActionError, t: TFunction): string
   switch (error.action) {
     case 'cli':
       return t('Could not update the command-line tool.')
+    case 'cli-status':
+      return t('Could not check the command-line tool.')
     case 'open-log':
       return t('Could not open the log file.')
     case 'reveal-log':
@@ -81,9 +83,24 @@ const GeneralPanel = (): React.JSX.Element => {
   const closePreference = useSettingsStore((state) => state.closePreference)
   const setClosePreference = useSettingsStore((state) => state.setClosePreference)
 
+  const checkCliStatus = async (): Promise<void> => {
+    setIsUpdatingCli(true)
+
+    try {
+      setCli(await window.api.cli.getStatus())
+      setCliError(undefined)
+    } catch (error) {
+      setCliError({ action: 'cli-status', detail: errorDetail(error) })
+    } finally {
+      setIsUpdatingCli(false)
+    }
+  }
+
   useEffect(() => {
     void window.api.logs.getStatus().then(setLogStatus, () => setLogStatus(null))
-    void window.api.cli.getStatus().then(setCli)
+    void window.api.cli.getStatus().then(setCli, (error) => {
+      setCliError({ action: 'cli-status', detail: errorDetail(error) })
+    })
     const getAvailability = window.api.notifications.getDesktopAvailability
     if (getAvailability) {
       void getAvailability()
@@ -447,6 +464,18 @@ const GeneralPanel = (): React.JSX.Element => {
               {generalActionErrorCopy(cliError, t)}
             </p>
             <DiagnosticDetails detail={cliError.detail} />
+            {cliError.action === 'cli-status' ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                disabled={isUpdatingCli}
+                onClick={() => void checkCliStatus()}
+              >
+                {isUpdatingCli ? t('Checking…') : t('Check again')}
+              </Button>
+            ) : null}
           </div>
         ) : null}
 

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -150,6 +150,24 @@ afterEach(() => {
 })
 
 describe('SpecialistsPanel', () => {
+  it('does not reopen an action tooltip when a menu returns focus to its trigger', async () => {
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    const actions = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Actions for RNA Reviewer"]'
+    )
+    expect(actions).not.toBeNull()
+
+    fireEvent.focus(actions!)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    })
+
+    expect(document.body.querySelector('[role="tooltip"]')).toBeNull()
+  })
+
   it('renders safely when the web surface omits the specialist API', async () => {
     const specialistApi = window.api.specialist
     delete (window.api as { specialist?: Window['api']['specialist'] }).specialist

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -1884,7 +1884,14 @@ const InstalledSpecialistsPanel = ({
                       <DropdownMenu>
                         <TooltipProvider delayDuration={200}>
                           <Tooltip>
-                            <TooltipTrigger asChild>
+                            <TooltipTrigger
+                              asChild
+                              onFocus={(event) => {
+                                if (!event.currentTarget.matches(':focus-visible')) {
+                                  event.preventDefault()
+                                }
+                              }}
+                            >
                               <DropdownMenuTrigger asChild>
                                 <Button
                                   variant="ghost"

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -74,7 +74,12 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 vi.mock('@/components/ui/tooltip', () => ({
   TooltipProvider: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>,
   Tooltip: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>,
-  TooltipTrigger: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    onFocus
+  }: PropsWithChildren<{
+    onFocus?: (event: React.FocusEvent<HTMLElement>) => void
+  }>): React.JSX.Element => (onFocus ? <span onFocus={onFocus}>{children}</span> : <>{children}</>),
   TooltipContent: ({ children }: PropsWithChildren): React.JSX.Element => (
     <span data-testid="tooltip-content">{children}</span>
   )
@@ -2506,7 +2511,7 @@ describe('ConversationPanel composer intake', () => {
     expect(onStartSideChat).toHaveBeenCalledOnce()
   })
 
-  it('keeps Side chat available while the main Session is running', () => {
+  it('keeps Side chat available while running without reopening its tooltip', () => {
     const onStartSideChat = vi.fn()
     renderPanel({
       view: {
@@ -2545,6 +2550,9 @@ describe('ConversationPanel composer intake', () => {
     const item = container.querySelector('[data-testid="menu-side-chat"]') as HTMLButtonElement
     expect(trigger.disabled).toBe(false)
     expect(item.disabled).toBe(false)
+    const focusReturn = new FocusEvent('focusin', { bubbles: true, cancelable: true })
+    act(() => trigger.dispatchEvent(focusReturn))
+    expect(focusReturn.defaultPrevented).toBe(true)
     act(() => item.click())
     expect(onStartSideChat).toHaveBeenCalledOnce()
   })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -2236,7 +2236,17 @@ const ConversationPanel = ({
                             <DropdownMenu>
                               <TooltipProvider delayDuration={200}>
                                 <Tooltip>
-                                  <TooltipTrigger asChild>
+                                  <TooltipTrigger
+                                    asChild
+                                    onFocus={(event) => {
+                                      if (
+                                        !(event.target instanceof Element) ||
+                                        !event.target.matches(':focus-visible')
+                                      ) {
+                                        event.preventDefault()
+                                      }
+                                    }}
+                                  >
                                     <span className="inline-flex">
                                       <DropdownMenuTrigger asChild>
                                         <button

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -795,6 +795,7 @@
     "Could not test the provider connection.": "No se pudo probar la conexión del proveedor.",
     "Could not update project pin.": "No se pudo actualizar el pin del proyecto.",
     "Could not update the command-line tool.": "No se pudo actualizar la herramienta de línea de comandos.",
+    "Could not check the command-line tool.": "No se pudo comprobar la herramienta de línea de comandos.",
     "Couldn't fetch models: {{reason}}. Using the bundled list.": "No se pudieron obtener los modelos: {{reason}}. Se usará la lista incluida.",
     "Couldn't load hosts.": "No se pudieron cargar los hosts.",
     "Create a project to search sessions and artifacts.": "Cree un proyecto para buscar sesiones y artefactos.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -795,6 +795,7 @@
     "Could not test the provider connection.": "Impossible de tester la connexion du fournisseur.",
     "Could not update project pin.": "Impossible de mettre à jour le code PIN du projet.",
     "Could not update the command-line tool.": "Impossible de mettre à jour l'outil de ligne de commande.",
+    "Could not check the command-line tool.": "Impossible de vérifier l'outil de ligne de commande.",
     "Couldn't fetch models: {{reason}}. Using the bundled list.": "Impossible de récupérer les modèles : {{reason}}. Utilisation de la liste groupée.",
     "Couldn't load hosts.": "Impossible de charger les hôtes.",
     "Create a project to search sessions and artifacts.": "Créez un projet pour rechercher des sessions et des artefacts.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -752,6 +752,7 @@
     "Could not test the provider connection.": "プロバイダー接続をテストできませんでした。",
     "Could not update project pin.": "プロジェクトピンを更新できませんでした。",
     "Could not update the command-line tool.": "コマンドラインツールを更新できませんでした。",
+    "Could not check the command-line tool.": "コマンドラインツールを確認できませんでした。",
     "Couldn't fetch models: {{reason}}. Using the bundled list.": "モデルを取得できませんでした：{{reason}}。バンドルリストを使用します。",
     "Couldn't load hosts.": "ホストを読み込めませんでした。",
     "Create a project to search sessions and artifacts.": "セッションとアーティファクトを検索するには、プロジェクトを作成してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -771,6 +771,7 @@
     "Could not test the provider connection.": "모델 제공업체 연결을 테스트할 수 없습니다.",
     "Could not update project pin.": "프로젝트 고정을 업데이트할 수 없습니다.",
     "Could not update the command-line tool.": "명령줄 도구를 업데이트할 수 없습니다.",
+    "Could not check the command-line tool.": "명령줄 도구를 확인할 수 없습니다.",
     "Couldn't fetch models: {{reason}}. Using the bundled list.": "모델을 가져올 수 없습니다: {{reason}}. 번들 목록을 사용합니다.",
     "Couldn't load hosts.": "호스트를 로드할 수 없습니다.",
     "Create a project to search sessions and artifacts.": "프로젝트를 만들어 세션 및 아티팩트를 검색하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -787,6 +787,7 @@
     "Could not test the provider connection.": "Не удалось протестировать соединение с поставщиком.",
     "Could not update project pin.": "Не удалось изменить закрепление проекта.",
     "Could not update the command-line tool.": "Не удалось обновить инструмент командной строки.",
+    "Could not check the command-line tool.": "Не удалось проверить инструмент командной строки.",
     "Couldn't fetch models: {{reason}}. Using the bundled list.": "Не удалось загрузить модели: {{reason}}. Используется встроенный список.",
     "Couldn't load hosts.": "Не удалось загрузить хосты.",
     "Create a project to search sessions and artifacts.": "Создайте проект, чтобы искать сессии и артефакты.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -826,6 +826,7 @@
     "Could not test the provider connection.": "无法测试模型服务商连接。",
     "Could not update project pin.": "无法更新项目置顶状态。",
     "Could not update the command-line tool.": "无法更新命令行工具。",
+    "Could not check the command-line tool.": "无法检查命令行工具。",
     "Couldn't fetch models: {{reason}}. Using the bundled list.": "无法获取模型：{{reason}}。将使用内置列表。",
     "Couldn't load hosts.": "无法加载主机。",
     "Create a project to search sessions and artifacts.": "新建一个项目，即可搜索会话和产物。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -825,6 +825,7 @@
     "Could not test the provider connection.": "無法測試模型服務商連線。",
     "Could not update project pin.": "無法更新專案置頂狀態。",
     "Could not update the command-line tool.": "無法更新命令列工具。",
+    "Could not check the command-line tool.": "無法檢查命令列工具。",
     "Couldn't fetch models: {{reason}}. Using the bundled list.": "無法取得模型：{{reason}}。將使用內建清單。",
     "Couldn't load hosts.": "無法載入主機。",
     "Create a project to search sessions and artifacts.": "新增一個專案，即可搜尋會話和產物。",


### PR DESCRIPTION
## Problem

The General settings panel did not handle a rejected CLI status read. The status stayed unknown, the install or uninstall control stayed disabled for the panel lifetime, and the UI offered neither an explanation nor a retry.

Two Tooltip plus DropdownMenu triggers also lacked the repository's focus-visible guard. Radix could reopen their tooltips when a closing menu returned focus programmatically.

## Proposed change

- Handle rejected CLI status reads through the existing CLI error surface, include collapsed diagnostic detail, and provide a retry that restores the command control after a successful check.
- Add a local `cli-status` General action-error discriminant so status-read copy remains distinct from install or uninstall failures.
- Suppress non-focus-visible focus on the Specialist actions trigger.
- Suppress bubbled non-focus-visible focus on the running Side chat trigger while preserving keyboard focus through the actual focused event target.
- Add regression coverage that failed on the original implementation for all three behaviors.

## Scope and non-goals

- No IPC or renderer contract changes.
- No architecture or data-model changes.
- No persisted fields, migrations, historical-data compatibility behavior, or durable state changes.
- No controlled Tooltip state and no new dependencies.
- The only added state value is the component-local, in-memory `cli-status` error discriminant.

## Acceptance criteria and validation

Final checks ran after the last material edit:

- CLI status rejection and recovery; Specialist real-Radix focus return; running Side chat focus return; renderer i18n catalogs -> `npx vitest run src/renderer/src/pages/settings/GeneralPanel.render.test.tsx src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/i18n/resources.test.ts` -> 4 files and 942 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Source and test lint -> `npm run lint` -> passed without warnings.
- Patch whitespace -> `git diff --check` -> passed.

The regression tests were run before the production fix and failed with the reported symptoms: an unhandled CLI status rejection with no recovery UI, a real Radix Specialist tooltip reopening on programmatic focus, and an uncancelled running Side chat focus return.

The complete local `npm test` suite was intentionally not run per maintainer direction. These large renderer page files have no explicit module ownership entry, so exact-head PR Gate remains authoritative and may fail closed to the complete CI plan. No local Electron E2E run was included; the focused DOM coverage exercises the affected public interaction boundaries, with the Specialist test using the real Radix Tooltip implementation.

## Review focus

- Confirm that keeping the CLI error visible as `Checking…` during retry is the desired recovery interaction.
- Confirm that the wrapped Side chat trigger checks `event.target` rather than the non-focusable wrapper so keyboard `:focus-visible` behavior remains available.
