### PR TITLE
fix(main-lifecycle): handle confirmed quits and renderer load failures

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -1161,6 +1161,44 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
+  it('rechecks delegated work added after the delegated confirmation', async () => {
+    let active: ActiveSessionInfo[] = []
+    let resolveFirst: ((choice: CloseConfirmChoice) => void) | undefined
+    const confirmClose = vi.fn(() => {
+      if (confirmClose.mock.calls.length === 1) {
+        return new Promise<CloseConfirmChoice>((resolve) => {
+          resolveFirst = resolve
+        })
+      }
+      return Promise.resolve<CloseConfirmChoice>(
+        confirmClose.mock.calls.length === 2 ? 'quit' : 'cancel'
+      )
+    })
+    const { app, quit, prepareForQuit, flushSessionPersistence, shutdownBackends } = setup({
+      detectActiveSessions: () => active,
+      confirmClose
+    })
+
+    app.emit('before-quit')
+    active = [{ projectId: 'demo', sessionId: 'child-1', kind: 'delegated' }]
+    resolveFirst?.('quit')
+    await flush()
+
+    expect(confirmClose).toHaveBeenCalledTimes(2)
+    expect(quit).toHaveBeenCalledTimes(1)
+
+    active = [...active, { projectId: 'demo', sessionId: 'child-2', kind: 'delegated' }]
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).toHaveBeenCalledTimes(3)
+    expect(confirmClose).toHaveBeenLastCalledWith('quit', active)
+    expect(prepareForQuit).not.toHaveBeenCalled()
+    expect(flushSessionPersistence).not.toHaveBeenCalled()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+  })
+
   it('rechecks after a saved close preference resolves and safely minimizes for new delegated work', async () => {
     let active: ActiveSessionInfo[] = []
     let resolveSavedPreference: ((choice: CloseConfirmChoice) => void) | undefined

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -1130,6 +1130,37 @@ describe('installAppLifecycle', () => {
     expect(app.exit).not.toHaveBeenCalled()
   })
 
+  it('reissues quit when the delegated work recheck is confirmed', async () => {
+    let active: ActiveSessionInfo[] = []
+    let resolveFirst: ((choice: CloseConfirmChoice) => void) | undefined
+    const confirmClose = vi.fn(() => {
+      if (confirmClose.mock.calls.length === 1) {
+        return new Promise<CloseConfirmChoice>((resolve) => {
+          resolveFirst = resolve
+        })
+      }
+      return Promise.resolve('quit' as const)
+    })
+    const { app, quit, shutdownBackends } = setup({
+      detectActiveSessions: () => active,
+      confirmClose
+    })
+
+    app.emit('before-quit')
+    active = [{ projectId: 'demo', sessionId: 'child-live', kind: 'delegated' }]
+    resolveFirst?.('quit')
+    await flush()
+
+    expect(confirmClose).toHaveBeenCalledTimes(2)
+    expect(quit).toHaveBeenCalledTimes(1)
+
+    app.emit('before-quit')
+    await flush()
+    expect(confirmClose).toHaveBeenCalledTimes(2)
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
   it('rechecks after a saved close preference resolves and safely minimizes for new delegated work', async () => {
     let active: ActiveSessionInfo[] = []
     let resolveSavedPreference: ((choice: CloseConfirmChoice) => void) | undefined
@@ -1182,6 +1213,31 @@ describe('installAppLifecycle', () => {
     expect(flushSessionPersistence).not.toHaveBeenCalled()
     expect(shutdownBackends).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()
+  })
+
+  it('reissues a confirmed Windows titlebar quit after delegated work is confirmed', async () => {
+    const delegated: ActiveSessionInfo[] = [
+      { projectId: 'demo', sessionId: 'child-live', kind: 'delegated' }
+    ]
+    const confirmClose = vi.fn(async (): Promise<CloseConfirmChoice> => 'quit')
+    const { app, closeOpts, quit, shutdownBackends } = setup({
+      platform: 'win32',
+      detectActiveSessions: () => delegated,
+      confirmClose
+    })
+
+    closeOpts[0].requestQuit(true)
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).toHaveBeenCalledWith('quit', delegated)
+    expect(quit).toHaveBeenCalledTimes(2)
+
+    app.emit('before-quit')
+    await flush()
+    expect(confirmClose).toHaveBeenCalledTimes(1)
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
+    expect(app.exit).toHaveBeenCalledWith(0)
   })
 
   it('a titlebar X close-to-tray does not dispatch a second confirm while a quit-confirm is open', async () => {

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -125,6 +125,10 @@ export const installAppLifecycle = (
   // Set once the user has confirmed a quit (via the dialog or a prior 'confirm' close), so a re-issued
   // before-quit skips straight to teardown instead of asking again.
   let quitConfirmed = false
+  // A delegated confirmation authorizes only the Sessions visible in that dialog. The final
+  // before-quit boundary rechecks this snapshot so work admitted between confirmation and the
+  // re-issued quit cannot inherit an unrelated confirmation.
+  let confirmedDelegatedSessionKeys = new Set<string>()
   // Shared across both confirm-dispatching paths (titlebar X and tray/Ctrl+Q quit) so only one
   // confirmation modal is ever open at a time. The renderer holds a single request slot; a second
   // dispatch would silently overwrite the first and strand its promise forever (see app-lifecycle.test.ts).
@@ -163,8 +167,11 @@ export const installAppLifecycle = (
       : confirmClose(variant, sessions)
   const detectDelegatedWork = (): ActiveSessionInfo[] =>
     deps.detectActiveSessions().filter((session) => session.kind === 'delegated')
-  const requestConfirmedQuit = (): void => {
+  const delegatedSessionKey = (session: ActiveSessionInfo): string =>
+    JSON.stringify([session.projectId, session.sessionId])
+  const requestConfirmedQuit = (delegated: readonly ActiveSessionInfo[] = []): void => {
     quitConfirmed = true
+    confirmedDelegatedSessionKeys = new Set(delegated.map(delegatedSessionKey))
     deps.quit()
   }
 
@@ -203,6 +210,7 @@ export const installAppLifecycle = (
       // A caller's earlier confirmation cannot authorize delegated work that is already live at the
       // final boundary. Leave that case unconfirmed so before-quit performs the delegated-work recheck.
       quitConfirmed = confirmed && detectDelegatedWork().length === 0
+      confirmedDelegatedSessionKeys = new Set()
       deps.quit()
     },
     ...(deps.onAppearanceChanged ? { onAppearanceChanged: deps.onAppearanceChanged } : {})
@@ -269,6 +277,7 @@ export const installAppLifecycle = (
       // ordinary quit could bypass its active-session confirmation.
       clearApplicationShutdownTrigger()
       quitConfirmed = false
+      confirmedDelegatedSessionKeys = new Set()
       return
     }
     const trigger = shutdownTrigger()
@@ -284,15 +293,19 @@ export const installAppLifecycle = (
     // quitAndInstall. Once either committed handoff invokes app.quit(), it must continue; cancelling
     // there would strand the already-started installer or a process cached on the old data root.
     const delegatedAtShutdownBoundary = detectDelegatedWork()
-    if (!quitConfirmed && delegatedWorkBlocksShutdown && delegatedAtShutdownBoundary.length > 0) {
+    const hasUnconfirmedDelegatedWork = delegatedAtShutdownBoundary.some(
+      (session) => !confirmedDelegatedSessionKeys.has(delegatedSessionKey(session))
+    )
+    if (delegatedWorkBlocksShutdown && hasUnconfirmedDelegatedWork) {
       event.preventDefault()
       quitConfirmed = false
+      confirmedDelegatedSessionKeys = new Set()
       clearApplicationShutdownTrigger()
       if (confirmInFlight) return
       confirmInFlight = true
       void confirmResearchClose('quit', delegatedAtShutdownBoundary)
         .then((choice) => {
-          if (choice === 'quit') requestConfirmedQuit()
+          if (choice === 'quit') requestConfirmedQuit(delegatedAtShutdownBoundary)
         })
         .finally(() => {
           confirmInFlight = false
@@ -313,7 +326,7 @@ export const installAppLifecycle = (
             if (delegated.length > 0) {
               quitConfirmed = false
               const delegatedChoice = await confirmResearchClose('quit', delegated)
-              if (delegatedChoice === 'quit') requestConfirmedQuit()
+              if (delegatedChoice === 'quit') requestConfirmedQuit(delegated)
               return
             }
             requestConfirmedQuit()

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -163,6 +163,10 @@ export const installAppLifecycle = (
       : confirmClose(variant, sessions)
   const detectDelegatedWork = (): ActiveSessionInfo[] =>
     deps.detectActiveSessions().filter((session) => session.kind === 'delegated')
+  const requestConfirmedQuit = (): void => {
+    quitConfirmed = true
+    deps.quit()
+  }
 
   // Synchronous close classification, evaluated at close time. A mid-quit close is held so the
   // renderer survives persistence flushing; otherwise darwin keeps its dock convention (real close),
@@ -196,7 +200,9 @@ export const installAppLifecycle = (
     classifyClose,
     resolveCloseAction,
     requestQuit: (confirmed = true) => {
-      quitConfirmed = confirmed
+      // A caller's earlier confirmation cannot authorize delegated work that is already live at the
+      // final boundary. Leave that case unconfirmed so before-quit performs the delegated-work recheck.
+      quitConfirmed = confirmed && detectDelegatedWork().length === 0
       deps.quit()
     },
     ...(deps.onAppearanceChanged ? { onAppearanceChanged: deps.onAppearanceChanged } : {})
@@ -278,15 +284,19 @@ export const installAppLifecycle = (
     // quitAndInstall. Once either committed handoff invokes app.quit(), it must continue; cancelling
     // there would strand the already-started installer or a process cached on the old data root.
     const delegatedAtShutdownBoundary = detectDelegatedWork()
-    if (delegatedWorkBlocksShutdown && delegatedAtShutdownBoundary.length > 0) {
+    if (!quitConfirmed && delegatedWorkBlocksShutdown && delegatedAtShutdownBoundary.length > 0) {
       event.preventDefault()
       quitConfirmed = false
       clearApplicationShutdownTrigger()
       if (confirmInFlight) return
       confirmInFlight = true
-      void confirmResearchClose('quit', delegatedAtShutdownBoundary).finally(() => {
-        confirmInFlight = false
-      })
+      void confirmResearchClose('quit', delegatedAtShutdownBoundary)
+        .then((choice) => {
+          if (choice === 'quit') requestConfirmedQuit()
+        })
+        .finally(() => {
+          confirmInFlight = false
+        })
       return
     }
 
@@ -302,11 +312,11 @@ export const installAppLifecycle = (
             const delegated = detectDelegatedWork()
             if (delegated.length > 0) {
               quitConfirmed = false
-              await confirmResearchClose('quit', delegated)
+              const delegatedChoice = await confirmResearchClose('quit', delegated)
+              if (delegatedChoice === 'quit') requestConfirmedQuit()
               return
             }
-            quitConfirmed = true
-            deps.quit()
+            requestConfirmedQuit()
             return
           }
           // Cancel with no tray and no surviving window would strand the app with no UI (no-tray

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1407,6 +1407,43 @@ describe('close chord interception', () => {
     expect(window.destroyMock).not.toHaveBeenCalled()
   })
 
+  it('recovers a newer navigation failure while a stale explicit load is pending', () => {
+    let loadAttempt = 0
+    loadRendererDocument = () => {
+      loadAttempt += 1
+      return loadAttempt === 1 ? new Promise<void>(() => undefined) : Promise.resolve()
+    }
+
+    createMainWindow()
+    const window = currentWindow!
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      ...mainFrameNavigation,
+      url: 'file:///app/index.html',
+      frame: window.mainFrame
+    })
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      ...mainFrameNavigation,
+      url: 'file:///app/reloaded.html',
+      frame: window.mainFrame
+    })
+
+    fireWebContentsEvent(
+      window,
+      'did-fail-load',
+      {},
+      -105,
+      'NAME_NOT_RESOLVED',
+      'file:///app/reloaded.html',
+      true
+    )
+
+    expect(window.loadFileMock).toHaveBeenCalledTimes(2)
+    expect(windowLogSpies.warn).toHaveBeenCalledWith(
+      'reloading renderer after document load failure',
+      { automaticRecoveryAttempt: 1 }
+    )
+  })
+
   it('recovers a main-frame document load failure within the renderer retry budget', async () => {
     showMessageBoxMock.mockReturnValueOnce(new Promise(() => undefined))
     createMainWindow()

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1343,6 +1343,35 @@ describe('close chord interception', () => {
     await vi.waitFor(() => expect(window.destroyMock).toHaveBeenCalledTimes(1))
   })
 
+  it('keeps the window when a stale initial load rejects after crash recovery starts', async () => {
+    let rejectInitial!: (error: Error) => void
+    let loadAttempt = 0
+    loadRendererDocument = () => {
+      loadAttempt += 1
+      if (loadAttempt === 1) {
+        return new Promise<void>((_resolve, reject) => {
+          rejectInitial = reject
+        })
+      }
+      return Promise.resolve()
+    }
+
+    createMainWindow()
+    const window = currentWindow!
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 139 })
+    expect(window.loadFileMock).toHaveBeenCalledTimes(2)
+    await Promise.resolve()
+
+    rejectInitial(new Error('superseded initial load'))
+    await vi.waitFor(() =>
+      expect(windowLogSpies.error).toHaveBeenCalledWith('renderer document load rejected', {
+        errorName: 'Error'
+      })
+    )
+
+    expect(window.destroyMock).not.toHaveBeenCalled()
+  })
+
   it('recovers a main-frame document load failure within the renderer retry budget', async () => {
     showMessageBoxMock.mockReturnValueOnce(new Promise(() => undefined))
     createMainWindow()

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -101,11 +101,12 @@ type CloseEvent = { preventDefault: () => void; defaultPrevented: boolean }
 // currentWindow and lastWindow both point at the latest window; two describe blocks, one shared fake.
 let currentWindow: FakeBrowserWindow | undefined
 let lastWindow: FakeBrowserWindow | undefined
+let loadRendererDocument = (): Promise<void> => Promise.resolve()
 
 class FakeBrowserWindow {
   closeMock = vi.fn()
   destroyMock = vi.fn()
-  loadFileMock = vi.fn(() => Promise.resolve())
+  loadFileMock = vi.fn(() => loadRendererDocument())
   sendMock = vi.fn()
   showMock = vi.fn()
   webContentsHandlers = new Map<string, WebContentsHandler>()
@@ -1020,6 +1021,7 @@ describe('window-open external handler', () => {
 describe('close chord interception', () => {
   beforeEach(() => {
     currentWindow = undefined
+    loadRendererDocument = () => Promise.resolve()
     ipcMainOnMock.mockReset()
     ipcMainRemoveListenerMock.mockReset()
     findOverlayMock.open.mockClear()
@@ -1332,6 +1334,38 @@ describe('close chord interception', () => {
     expect(JSON.stringify(windowLogSpies.error.mock.calls)).not.toContain('session-content')
   })
 
+  it('destroys an unusable window when the initial renderer load promise rejects', async () => {
+    loadRendererDocument = () => Promise.reject(new Error('renderer entry unavailable'))
+
+    createMainWindow()
+    const window = currentWindow!
+
+    await vi.waitFor(() => expect(window.destroyMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('recovers a main-frame document load failure within the renderer retry budget', async () => {
+    showMessageBoxMock.mockReturnValueOnce(new Promise(() => undefined))
+    createMainWindow()
+    const window = currentWindow!
+    await Promise.resolve()
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      fireWebContentsEvent(
+        window,
+        'did-fail-load',
+        {},
+        -105,
+        'NAME_NOT_RESOLVED',
+        'file:///app/index.html',
+        true
+      )
+      await Promise.resolve()
+    }
+
+    expect(window.loadFileMock).toHaveBeenCalledTimes(3)
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1)
+  })
+
   it('records a preload failure without logging its path or error text', () => {
     createMainWindow()
     const window = currentWindow!
@@ -1395,6 +1429,19 @@ describe('close chord interception', () => {
       })
     )
     await vi.waitFor(() => expect(window.loadFileMock).toHaveBeenCalledTimes(4))
+  })
+
+  it('counts rejected renderer recovery loads toward the retry dialog', async () => {
+    createMainWindow()
+    const window = currentWindow!
+    await Promise.resolve()
+    loadRendererDocument = () => Promise.reject(new Error('renderer entry unavailable'))
+    showMessageBoxMock.mockReturnValueOnce(new Promise(() => undefined))
+
+    fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 139 })
+
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1))
+    expect(window.loadFileMock).toHaveBeenCalledTimes(3)
   })
 
   it('destroys the blank window when the user closes a renderer crash-loop prompt', async () => {

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1444,6 +1444,38 @@ describe('close chord interception', () => {
     )
   })
 
+  it('ignores an aborted load failure from a superseded main-frame navigation', async () => {
+    createMainWindow()
+    const window = currentWindow!
+    await Promise.resolve()
+
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      ...mainFrameNavigation,
+      url: 'file:///app/old.html',
+      frame: window.mainFrame
+    })
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      ...mainFrameNavigation,
+      url: 'file:///app/current.html',
+      frame: window.mainFrame
+    })
+    fireWebContentsEvent(
+      window,
+      'did-fail-load',
+      {},
+      -3,
+      'ERR_ABORTED',
+      'file:///app/old.html',
+      true
+    )
+
+    expect(window.loadFileMock).toHaveBeenCalledTimes(1)
+    expect(windowLogSpies.warn).not.toHaveBeenCalledWith(
+      'reloading renderer after document load failure',
+      expect.anything()
+    )
+  })
+
   it('recovers a main-frame document load failure within the renderer retry budget', async () => {
     showMessageBoxMock.mockReturnValueOnce(new Promise(() => undefined))
     createMainWindow()

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1545,6 +1545,50 @@ describe('close chord interception', () => {
     expect(window.loadFileMock).toHaveBeenCalledTimes(3)
   })
 
+  it.each([
+    ['before', false],
+    ['after', true]
+  ])(
+    'counts a renderer crash and its recovery load rejection only once %s navigation starts',
+    async (_timing, navigationStarted) => {
+      let rejectRecoveryLoad!: (error: Error) => void
+      let loadAttempt = 0
+      loadRendererDocument = () => {
+        loadAttempt += 1
+        if (loadAttempt === 2) {
+          return new Promise<void>((_resolve, reject) => {
+            rejectRecoveryLoad = reject
+          })
+        }
+        return Promise.resolve()
+      }
+
+      createMainWindow()
+      const window = currentWindow!
+      await Promise.resolve()
+
+      fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 139 })
+      if (navigationStarted) {
+        fireWebContentsEvent(window, 'did-start-navigation', {
+          ...mainFrameNavigation,
+          url: 'file:///app/index.html',
+          frame: window.mainFrame
+        })
+      }
+      fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 139 })
+
+      rejectRecoveryLoad(new Error('renderer exited during recovery'))
+      await vi.waitFor(() =>
+        expect(windowLogSpies.error).toHaveBeenCalledWith('renderer document load rejected', {
+          errorName: 'Error'
+        })
+      )
+
+      expect(window.loadFileMock).toHaveBeenCalledTimes(3)
+      expect(showMessageBoxMock).not.toHaveBeenCalled()
+    }
+  )
+
   it('destroys the blank window when the user closes a renderer crash-loop prompt', async () => {
     showMessageBoxMock.mockResolvedValueOnce({ response: 1 })
     createMainWindow({

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1339,6 +1339,11 @@ describe('close chord interception', () => {
 
     createMainWindow()
     const window = currentWindow!
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      ...mainFrameNavigation,
+      url: 'file:///app/index.html',
+      frame: window.mainFrame
+    })
 
     await vi.waitFor(() => expect(window.destroyMock).toHaveBeenCalledTimes(1))
   })
@@ -1361,6 +1366,36 @@ describe('close chord interception', () => {
     fireWebContentsEvent(window, 'render-process-gone', {}, { reason: 'crashed', exitCode: 139 })
     expect(window.loadFileMock).toHaveBeenCalledTimes(2)
     await Promise.resolve()
+
+    rejectInitial(new Error('superseded initial load'))
+    await vi.waitFor(() =>
+      expect(windowLogSpies.error).toHaveBeenCalledWith('renderer document load rejected', {
+        errorName: 'Error'
+      })
+    )
+
+    expect(window.destroyMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the window when a newer top-level reload supersedes the initial load', async () => {
+    let rejectInitial!: (error: Error) => void
+    loadRendererDocument = () =>
+      new Promise<void>((_resolve, reject) => {
+        rejectInitial = reject
+      })
+
+    createMainWindow()
+    const window = currentWindow!
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      ...mainFrameNavigation,
+      url: 'file:///app/index.html',
+      frame: window.mainFrame
+    })
+    fireWebContentsEvent(window, 'did-start-navigation', {
+      ...mainFrameNavigation,
+      url: 'file:///app/index.html',
+      frame: window.mainFrame
+    })
 
     rejectInitial(new Error('superseded initial load'))
     await vi.waitFor(() =>

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -301,7 +301,9 @@ const createMainWindow = (
         if (initial) {
           // The startup shell waits for the resulting closed event and then lets the lifecycle create a
           // fresh window. A rejected load Promise is not guaranteed to reach its did-fail-load listener.
-          window.destroy()
+          // If crash recovery has already started, this is a stale rejection from the superseded initial
+          // attempt; leave the recovery-owned window intact.
+          if (rendererRecoveryTimes.length === 0) window.destroy()
           return
         }
         recoverRenderer('load-failed', true)

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -79,13 +79,12 @@ const clearSourcePreviewState = (window: BrowserWindow): void => {
   sourcePreviewNavigationGuards.get(window)?.clearAll()
 }
 
-const loadRenderer = (window: BrowserWindow): void => {
+const loadRenderer = (window: BrowserWindow): Promise<void> => {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    void window.loadURL(process.env['ELECTRON_RENDERER_URL'])
-    return
+    return window.loadURL(process.env['ELECTRON_RENDERER_URL'])
   }
 
-  void window.loadFile(rendererEntry)
+  return window.loadFile(rendererEntry)
 }
 
 const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindow => {
@@ -282,9 +281,95 @@ const createMainWindow = (
   let rendererUnresponsiveAt: number | undefined
   let rendererRecoveryTimes: number[] = []
   let rendererRecoveryDialogOpen = false
+  let rendererLoadsInFlight = 0
   const clearRendererHangState = (): void => {
     rendererResponsive = true
     rendererUnresponsiveAt = undefined
+  }
+  const rendererLoadErrorName = (error: unknown): string =>
+    error instanceof Error ? error.name : 'UnknownError'
+  function observeRendererLoad(initial: boolean): void {
+    rendererLoadsInFlight += 1
+    void loadRenderer(window).then(
+      () => {
+        rendererLoadsInFlight -= 1
+      },
+      (error) => {
+        rendererLoadsInFlight -= 1
+        log.error('renderer document load rejected', { errorName: rendererLoadErrorName(error) })
+        if (window.isDestroyed()) return
+        if (initial) {
+          // The startup shell waits for the resulting closed event and then lets the lifecycle create a
+          // fresh window. A rejected load Promise is not guaranteed to reach its did-fail-load listener.
+          window.destroy()
+          return
+        }
+        recoverRenderer('load-failed', true)
+      }
+    )
+  }
+  function recoverRenderer(reason: string, loadFailed = false): void {
+    if (window.isDestroyed()) return
+
+    const now = Date.now()
+    rendererRecoveryTimes = rendererRecoveryTimes.filter(
+      (recoveryAt) => now - recoveryAt < RENDERER_RECOVERY_WINDOW_MS
+    )
+    if (rendererRecoveryTimes.length < MAX_AUTOMATIC_RENDERER_RECOVERIES) {
+      rendererRecoveryTimes.push(now)
+      if (loadFailed) {
+        log.warn('reloading renderer after document load failure', {
+          automaticRecoveryAttempt: rendererRecoveryTimes.length
+        })
+      } else {
+        log.warn('reloading renderer after process exit', {
+          reason,
+          automaticRecoveryAttempt: rendererRecoveryTimes.length
+        })
+      }
+      observeRendererLoad(false)
+      return
+    }
+
+    if (rendererRecoveryDialogOpen) return
+    rendererRecoveryDialogOpen = true
+    log.error('renderer automatic recovery paused after repeated exits', {
+      reason,
+      automaticRecoveries: rendererRecoveryTimes.length,
+      recoveryWindowMs: RENDERER_RECOVERY_WINDOW_MS
+    })
+    void dialog
+      .showMessageBox(window, {
+        type: 'error',
+        buttons: [translate('Reload', { context: 'window' }), translate('Close window')],
+        defaultId: 0,
+        cancelId: 1,
+        title: 'Open Science',
+        message: translate('The app window stopped responding repeatedly.'),
+        detail: translate(
+          'Automatic recovery has been paused. Reloading returns this window to the home screen; background work may still be running.'
+        )
+      })
+      .then(
+        ({ response }) => {
+          rendererRecoveryDialogOpen = false
+          if (window.isDestroyed()) return
+          if (response === 0) {
+            rendererRecoveryTimes = []
+            log.warn('reloading renderer after user confirmation')
+            observeRendererLoad(false)
+            return
+          }
+          // Bypass the normal Windows close-to-tray interception: the user explicitly chose to close
+          // this unrecoverable blank window, not leave it hidden and alive in the tray.
+          window.destroy()
+        },
+        () => {
+          rendererRecoveryDialogOpen = false
+          log.error('renderer recovery dialog failed')
+          if (!window.isDestroyed()) window.destroy()
+        }
+      )
   }
   const onListenerReady = (event: IpcMainEvent): void => {
     if (event.sender !== window.webContents) return
@@ -382,6 +467,10 @@ const createMainWindow = (
       )
       if (!isMainFrame) return
       log.error('renderer document failed to load', { errorCode, errorDescription })
+      // Explicit loadRenderer attempts are observed through their Promise so one Chromium failure only
+      // consumes one recovery slot. A later top-level navigation has no pending Promise owner, so route
+      // its failure through the same bounded recovery used for renderer process exits.
+      if (rendererLoadsInFlight === 0) recoverRenderer('load-failed', true)
     }
   )
   window.webContents.on('preload-error', (_event, _preloadPath, error) => {
@@ -408,59 +497,7 @@ const createMainWindow = (
 
     if (!RECOVERABLE_RENDERER_EXIT_REASONS.has(details.reason) || window.isDestroyed()) return
 
-    const now = Date.now()
-    rendererRecoveryTimes = rendererRecoveryTimes.filter(
-      (recoveryAt) => now - recoveryAt < RENDERER_RECOVERY_WINDOW_MS
-    )
-    if (rendererRecoveryTimes.length < MAX_AUTOMATIC_RENDERER_RECOVERIES) {
-      rendererRecoveryTimes.push(now)
-      log.warn('reloading renderer after process exit', {
-        reason: details.reason,
-        automaticRecoveryAttempt: rendererRecoveryTimes.length
-      })
-      loadRenderer(window)
-      return
-    }
-
-    if (rendererRecoveryDialogOpen) return
-    rendererRecoveryDialogOpen = true
-    log.error('renderer automatic recovery paused after repeated exits', {
-      reason: details.reason,
-      automaticRecoveries: rendererRecoveryTimes.length,
-      recoveryWindowMs: RENDERER_RECOVERY_WINDOW_MS
-    })
-    void dialog
-      .showMessageBox(window, {
-        type: 'error',
-        buttons: [translate('Reload', { context: 'window' }), translate('Close window')],
-        defaultId: 0,
-        cancelId: 1,
-        title: 'Open Science',
-        message: translate('The app window stopped responding repeatedly.'),
-        detail: translate(
-          'Automatic recovery has been paused. Reloading returns this window to the home screen; background work may still be running.'
-        )
-      })
-      .then(
-        ({ response }) => {
-          rendererRecoveryDialogOpen = false
-          if (window.isDestroyed()) return
-          if (response === 0) {
-            rendererRecoveryTimes = []
-            log.warn('reloading renderer after user confirmation')
-            loadRenderer(window)
-            return
-          }
-          // Bypass the normal Windows close-to-tray interception: the user explicitly chose to close
-          // this unrecoverable blank window, not leave it hidden and alive in the tray.
-          window.destroy()
-        },
-        () => {
-          rendererRecoveryDialogOpen = false
-          log.error('renderer recovery dialog failed')
-          if (!window.isDestroyed()) window.destroy()
-        }
-      )
+    recoverRenderer(details.reason)
   })
   window.webContents.on('unresponsive', () => {
     if (rendererResponsive) {
@@ -591,7 +628,7 @@ const createMainWindow = (
     })
   }
 
-  loadRenderer(window)
+  observeRendererLoad(true)
   return window
 }
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -282,6 +282,7 @@ const createMainWindow = (
   let rendererRecoveryTimes: number[] = []
   let rendererRecoveryDialogOpen = false
   let rendererLoadsInFlight = 0
+  let mainFrameNavigationGeneration = 0
   const clearRendererHangState = (): void => {
     rendererResponsive = true
     rendererUnresponsiveAt = undefined
@@ -289,6 +290,9 @@ const createMainWindow = (
   const rendererLoadErrorName = (error: unknown): string =>
     error instanceof Error ? error.name : 'UnknownError'
   function observeRendererLoad(initial: boolean): void {
+    // The explicit load is expected to start one top-level navigation. Any later generation means a
+    // reload or replacement navigation superseded this Promise before it settled.
+    const ownedNavigationGeneration = mainFrameNavigationGeneration + 1
     rendererLoadsInFlight += 1
     void loadRenderer(window).then(
       () => {
@@ -298,6 +302,7 @@ const createMainWindow = (
         rendererLoadsInFlight -= 1
         log.error('renderer document load rejected', { errorName: rendererLoadErrorName(error) })
         if (window.isDestroyed()) return
+        if (mainFrameNavigationGeneration > ownedNavigationGeneration) return
         if (initial) {
           // The startup shell waits for the resulting closed event and then lets the lifecycle create a
           // fresh window. A rejected load Promise is not guaranteed to reach its did-fail-load listener.
@@ -438,6 +443,7 @@ const createMainWindow = (
       .get(window)
       ?.startNavigation(details.frame, details.url, details.isSameDocument)
     if (details.isMainFrame && !details.isSameDocument) {
+      mainFrameNavigationGeneration += 1
       clearSourcePreviewState(window)
       rendererListenerReady = false
       windowFindListenerReady = false

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -281,7 +281,7 @@ const createMainWindow = (
   let rendererUnresponsiveAt: number | undefined
   let rendererRecoveryTimes: number[] = []
   let rendererRecoveryDialogOpen = false
-  let rendererLoadsInFlight = 0
+  const pendingRendererLoadsByNavigationGeneration = new Map<number, number>()
   let mainFrameNavigationGeneration = 0
   const clearRendererHangState = (): void => {
     rendererResponsive = true
@@ -293,13 +293,21 @@ const createMainWindow = (
     // The explicit load is expected to start one top-level navigation. Any later generation means a
     // reload or replacement navigation superseded this Promise before it settled.
     const ownedNavigationGeneration = mainFrameNavigationGeneration + 1
-    rendererLoadsInFlight += 1
+    pendingRendererLoadsByNavigationGeneration.set(
+      ownedNavigationGeneration,
+      (pendingRendererLoadsByNavigationGeneration.get(ownedNavigationGeneration) ?? 0) + 1
+    )
+    const releasePendingLoad = (): void => {
+      const pending = pendingRendererLoadsByNavigationGeneration.get(ownedNavigationGeneration) ?? 0
+      if (pending <= 1) pendingRendererLoadsByNavigationGeneration.delete(ownedNavigationGeneration)
+      else pendingRendererLoadsByNavigationGeneration.set(ownedNavigationGeneration, pending - 1)
+    }
     void loadRenderer(window).then(
       () => {
-        rendererLoadsInFlight -= 1
+        releasePendingLoad()
       },
       (error) => {
-        rendererLoadsInFlight -= 1
+        releasePendingLoad()
         log.error('renderer document load rejected', { errorName: rendererLoadErrorName(error) })
         if (window.isDestroyed()) return
         if (mainFrameNavigationGeneration > ownedNavigationGeneration) return
@@ -478,7 +486,9 @@ const createMainWindow = (
       // Explicit loadRenderer attempts are observed through their Promise so one Chromium failure only
       // consumes one recovery slot. A later top-level navigation has no pending Promise owner, so route
       // its failure through the same bounded recovery used for renderer process exits.
-      if (rendererLoadsInFlight === 0) recoverRenderer('load-failed', true)
+      if (!pendingRendererLoadsByNavigationGeneration.has(mainFrameNavigationGeneration)) {
+        recoverRenderer('load-failed', true)
+      }
     }
   )
   window.webContents.on('preload-error', (_event, _preloadPath, error) => {

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -57,6 +57,7 @@ const log = createLogger('window')
 const E2E_WINDOW_MODE_ENV = 'OPEN_SCIENCE_E2E_WINDOW_MODE'
 const RENDERER_RECOVERY_WINDOW_MS = 60_000
 const MAX_AUTOMATIC_RENDERER_RECOVERIES = 2
+const CHROMIUM_ERR_ABORTED = -3
 const ALLOWED_RENDERER_PERMISSIONS = new Set(['clipboard-sanitized-write'])
 const RECOVERABLE_RENDERER_EXIT_REASONS = new Set([
   'abnormal-exit',
@@ -488,6 +489,9 @@ const createMainWindow = (
       )
       if (!isMainFrame) return
       log.error('renderer document failed to load', { errorCode, errorDescription })
+      // Chromium reports a superseded navigation as ERR_ABORTED after the replacement navigation may
+      // already be current. Recovering that canceled document would overwrite the valid replacement.
+      if (errorCode === CHROMIUM_ERR_ABORTED) return
       // Explicit loadRenderer attempts are observed through their Promise so one Chromium failure only
       // consumes one recovery slot. A later top-level navigation has no pending Promise owner, so route
       // its failure through the same bounded recovery used for renderer process exits.

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -281,7 +281,8 @@ const createMainWindow = (
   let rendererUnresponsiveAt: number | undefined
   let rendererRecoveryTimes: number[] = []
   let rendererRecoveryDialogOpen = false
-  const pendingRendererLoadsByNavigationGeneration = new Map<number, number>()
+  type PendingRendererLoad = { failureHandledByProcessExit: boolean }
+  const pendingRendererLoadsByNavigationGeneration = new Map<number, Set<PendingRendererLoad>>()
   let mainFrameNavigationGeneration = 0
   const clearRendererHangState = (): void => {
     rendererResponsive = true
@@ -293,14 +294,17 @@ const createMainWindow = (
     // The explicit load is expected to start one top-level navigation. Any later generation means a
     // reload or replacement navigation superseded this Promise before it settled.
     const ownedNavigationGeneration = mainFrameNavigationGeneration + 1
-    pendingRendererLoadsByNavigationGeneration.set(
-      ownedNavigationGeneration,
-      (pendingRendererLoadsByNavigationGeneration.get(ownedNavigationGeneration) ?? 0) + 1
-    )
+    const pendingLoad: PendingRendererLoad = { failureHandledByProcessExit: false }
+    const loadsForGeneration =
+      pendingRendererLoadsByNavigationGeneration.get(ownedNavigationGeneration) ??
+      new Set<PendingRendererLoad>()
+    loadsForGeneration.add(pendingLoad)
+    pendingRendererLoadsByNavigationGeneration.set(ownedNavigationGeneration, loadsForGeneration)
     const releasePendingLoad = (): void => {
-      const pending = pendingRendererLoadsByNavigationGeneration.get(ownedNavigationGeneration) ?? 0
-      if (pending <= 1) pendingRendererLoadsByNavigationGeneration.delete(ownedNavigationGeneration)
-      else pendingRendererLoadsByNavigationGeneration.set(ownedNavigationGeneration, pending - 1)
+      loadsForGeneration.delete(pendingLoad)
+      if (loadsForGeneration.size === 0) {
+        pendingRendererLoadsByNavigationGeneration.delete(ownedNavigationGeneration)
+      }
     }
     void loadRenderer(window).then(
       () => {
@@ -310,6 +314,7 @@ const createMainWindow = (
         releasePendingLoad()
         log.error('renderer document load rejected', { errorName: rendererLoadErrorName(error) })
         if (window.isDestroyed()) return
+        if (pendingLoad.failureHandledByProcessExit) return
         if (mainFrameNavigationGeneration > ownedNavigationGeneration) return
         if (initial) {
           // The startup shell waits for the resulting closed event and then lets the lifecycle create a
@@ -515,6 +520,14 @@ const createMainWindow = (
 
     if (!RECOVERABLE_RENDERER_EXIT_REASONS.has(details.reason) || window.isDestroyed()) return
 
+    // The load can own the current generation (navigation already started) or the next generation
+    // (the process exited before did-start-navigation). In both cases this process-exit path owns the
+    // recovery decision, so a later rejection from that same load must not consume another slot.
+    for (const generation of [mainFrameNavigationGeneration, mainFrameNavigationGeneration + 1]) {
+      for (const pendingLoad of pendingRendererLoadsByNavigationGeneration.get(generation) ?? []) {
+        pendingLoad.failureHandledByProcessExit = true
+      }
+    }
     recoverRenderer(details.reason)
   })
   window.webContents.on('unresponsive', () => {


### PR DESCRIPTION
## Problem

- A delegated-work confirmation at the final quit boundary discarded the user's choice. The ordinary-quit race recheck did the same, so choosing **Quit** never re-issued `app.quit()`.
- `BrowserWindow.loadURL()` / `loadFile()` promises were not observed. A rejected renderer entry load could reach Node's fail-fast unhandled-rejection behavior, while runtime `did-fail-load` events only logged and recovery reload rejections bypassed the existing retry budget.

## Proposed change

- Reuse one confirmed-quit helper for the ordinary and delegated recheck paths, and keep an earlier confirmation untrusted when delegated work is already active at the final boundary.
- Return the renderer load promise, observe initial and recovery attempts, destroy an unusable initial window, and route runtime document failures/rejected recovery loads through the existing two-attempt recovery budget and reload/close dialog.
- Avoid double-counting one Chromium failure when both `did-fail-load` and the explicit load promise report it.

## Scope and non-goals

- No database, settings, session, or shared data-model changes.
- No persistence changes, migrations, historical-data compatibility work, or new enum/state values.
- No new UI copy, options, or dialog. The existing renderer recovery dialog can now appear for repeated document-load failures as well as renderer process exits.
- No dependency or lockfile changes.

## Acceptance criteria and validation

Red reproduction on the unfixed implementation was stable across repeated runs:

- `vitest run src/main/app-lifecycle.test.ts -t "reissues"` -> 2 failures: the second confirmed choices did not call `quit()`.
- `vitest run src/main/windows.test.ts -t "initial renderer load promise rejects|recovers a main-frame document load failure|counts rejected renderer recovery loads"` -> 3 failures: no startup-window destroy, no runtime reloads, and no recovery dialog.

Final evidence after the last material edit:

- delegated quit rechecks and final teardown -> `vitest run src/main/app-lifecycle.test.ts src/main/windows.test.ts src/main/app-startup.test.ts` -> 146/146 passed.
- Main-process TypeScript contracts -> `npm run typecheck:node` -> passed.
- changed source/tests lint -> `npm run lint` -> passed.
- changed-file formatting -> `prettier --check src/main/app-lifecycle.ts src/main/app-lifecycle.test.ts src/main/windows.ts src/main/windows.test.ts` -> passed.

The complete `npm test` suite was intentionally not run per maintainer direction; PR CI remains authoritative for the portable and platform lanes. Local Vitest used the canonical repository dependency tree directly because the isolated worktree has no generated Prisma client and the main checkout has an unrelated dirty `package-lock.json`.

## Review focus

- Whether `quitConfirmed` now authorizes exactly the re-issued quit after the final delegated-work check without weakening the race guard.
- Whether initial-load destruction versus bounded runtime recovery is the right split for renderer load promise failures.
- Whether `rendererLoadsInFlight` correctly prevents a single failure from consuming two recovery slots.