### PR TITLE
fix(lifecycle): harden system shutdown and recovery

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -190,6 +190,7 @@
         "src/main/settings/skill-catalog.ts",
         "src/main/storage-root.ts",
         "src/main/storage/**",
+        "src/main/system-lifecycle-adapters.ts",
         "src/main/tray.ts",
         "src/main/update/create-strategy.ts",
         "src/main/update/electron-updater-strategy.ts",

--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -190,7 +190,6 @@
         "src/main/settings/skill-catalog.ts",
         "src/main/storage-root.ts",
         "src/main/storage/**",
-        "src/main/system-lifecycle-adapters.ts",
         "src/main/tray.ts",
         "src/main/update/create-strategy.ts",
         "src/main/update/electron-updater-strategy.ts",

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -56,25 +56,6 @@ const makeFakeApp = (): FakeApp => {
   }
 }
 
-const makeFakeSignalSource = (): NonNullable<AppLifecycleDeps['headlessSignalSource']> & {
-  emit: (signal: 'SIGTERM' | 'SIGINT') => void
-} => {
-  const listeners = new Map<'SIGTERM' | 'SIGINT', () => void>()
-  return {
-    once(signal, listener): void {
-      listeners.set(signal, listener)
-    },
-    removeListener(signal, listener): void {
-      if (listeners.get(signal) === listener) listeners.delete(signal)
-    },
-    emit(signal): void {
-      const listener = listeners.get(signal)
-      listeners.delete(signal)
-      listener?.()
-    }
-  }
-}
-
 type FakeWindow = {
   destroyed: boolean
   minimized: boolean
@@ -163,6 +144,7 @@ type Harness = {
   showMainWindow: () => void
   getMainWindow: () => import('electron').BrowserWindow | undefined
   isMainWindowHidden: () => boolean
+  onSystemShutdown: () => void
   closeOpts: CapturedCloseOpts[]
   confirmClose: ReturnType<typeof vi.fn>
 }
@@ -183,8 +165,6 @@ const setup = (
       | 'isMigrationInProgress'
       | 'platform'
       | 'createInitialWindow'
-      | 'headlessSignalSource'
-      | 'subscribePowerShutdown'
       | 'onAppearanceChanged'
       | 'initialWindow'
       | 'configureMainWindow'
@@ -217,41 +197,40 @@ const setup = (
   )
   const detectActiveSessions = overrides.detectActiveSessions ?? ((): ActiveSessionInfo[] => [])
 
-  const { showMainWindow, getMainWindow, isMainWindowHidden } = installAppLifecycle({
-    app: app as unknown as AppLifecycleDeps['app'],
-    createMainWindow: (opts) => {
-      closeOpts.push(opts)
-      const w = makeFakeWindow()
-      windows.push(w)
-      return asWindow(w)
-    },
-    initialWindow: overrides.initialWindow,
-    configureMainWindow: overrides.configureMainWindow,
-    createTray: (handlers) => {
-      trayHandlers = handlers
-      return tray as unknown as import('electron').Tray | undefined
-    },
-    shutdownBackends,
-    prepareForQuit,
-    abortQuitPreparation,
-    flushSessionPersistence,
-    log: overrides.log,
-    flushLogs: overrides.flushLogs,
-    logFlushTimeoutMs: overrides.logFlushTimeoutMs,
-    rendererFlushTimeoutMs: overrides.rendererFlushTimeoutMs,
-    shutdownTrigger: overrides.shutdownTrigger,
-    isMigrationInProgress: overrides.isMigrationInProgress ?? ((): boolean => false),
-    quit,
-    countWindows: () => windows.filter((w) => !w.destroyed).length,
-    createInitialWindow: overrides.createInitialWindow,
-    headlessSignalSource: overrides.headlessSignalSource,
-    subscribePowerShutdown: overrides.subscribePowerShutdown,
-    onAppearanceChanged: overrides.onAppearanceChanged,
-    platform: overrides.platform ?? 'linux',
-    detectActiveSessions,
-    hasActiveReviewerWork: overrides.hasActiveReviewerWork ?? (() => false),
-    createConfirmClose: () => confirmClose
-  })
+  const { showMainWindow, getMainWindow, isMainWindowHidden, onSystemShutdown } =
+    installAppLifecycle({
+      app: app as unknown as AppLifecycleDeps['app'],
+      createMainWindow: (opts) => {
+        closeOpts.push(opts)
+        const w = makeFakeWindow()
+        windows.push(w)
+        return asWindow(w)
+      },
+      initialWindow: overrides.initialWindow,
+      configureMainWindow: overrides.configureMainWindow,
+      createTray: (handlers) => {
+        trayHandlers = handlers
+        return tray as unknown as import('electron').Tray | undefined
+      },
+      shutdownBackends,
+      prepareForQuit,
+      abortQuitPreparation,
+      flushSessionPersistence,
+      log: overrides.log,
+      flushLogs: overrides.flushLogs,
+      logFlushTimeoutMs: overrides.logFlushTimeoutMs,
+      rendererFlushTimeoutMs: overrides.rendererFlushTimeoutMs,
+      shutdownTrigger: overrides.shutdownTrigger,
+      isMigrationInProgress: overrides.isMigrationInProgress ?? ((): boolean => false),
+      quit,
+      countWindows: () => windows.filter((w) => !w.destroyed).length,
+      createInitialWindow: overrides.createInitialWindow,
+      onAppearanceChanged: overrides.onAppearanceChanged,
+      platform: overrides.platform ?? 'linux',
+      detectActiveSessions,
+      hasActiveReviewerWork: overrides.hasActiveReviewerWork ?? (() => false),
+      createConfirmClose: () => confirmClose
+    })
   return {
     app,
     windows,
@@ -265,6 +244,7 @@ const setup = (
     showMainWindow,
     getMainWindow,
     isMainWindowHidden,
+    onSystemShutdown,
     closeOpts,
     confirmClose
   }
@@ -381,14 +361,11 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
-  it('respects Windows session end while routing best-effort cleanup through the shutdown owner', async () => {
-    const { app, windows, shutdownBackends, flushSessionPersistence, quit, confirmClose } = setup({
-      platform: 'win32'
-    })
+  it('routes a system request through the existing shutdown owner', async () => {
+    const { app, onSystemShutdown, shutdownBackends, flushSessionPersistence, quit, confirmClose } =
+      setup()
 
-    const event = windows[0].emit('query-session-end')
-
-    expect(event.defaultPrevented).toBe(false)
+    onSystemShutdown()
     expect(quit).toHaveBeenCalledTimes(1)
 
     app.emit('before-quit')
@@ -400,26 +377,16 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
-  it('uses Windows session-end as a best-effort fallback when the query event was missed', () => {
-    const { windows, quit } = setup({ platform: 'win32' })
-
-    const event = windows[0].emit('session-end')
-
-    expect(event.defaultPrevented).toBe(false)
-    expect(quit).toHaveBeenCalledTimes(1)
-  })
-
   it('does not block a system shutdown on active work or renderer persistence conflicts', async () => {
     const flushSessionPersistence = vi.fn(async () => 'conflict' as const)
-    const { app, windows, shutdownBackends, confirmClose } = setup({
-      platform: 'win32',
+    const { app, onSystemShutdown, shutdownBackends, confirmClose } = setup({
       detectActiveSessions: () => [
         { projectId: 'project-1', sessionId: 'session-1', kind: 'delegated' }
       ],
       flushSessionPersistence
     })
 
-    windows[0].emit('query-session-end')
+    onSystemShutdown()
     app.emit('before-quit')
     await flush()
 
@@ -440,8 +407,7 @@ describe('installAppLifecycle', () => {
           })
       )
       .mockResolvedValue('conflict' as const)
-    const { app, closeOpts, windows, quit, confirmClose, shutdownBackends } = setup({
-      platform: 'win32',
+    const { app, closeOpts, onSystemShutdown, quit, confirmClose, shutdownBackends } = setup({
       flushSessionPersistence
     })
 
@@ -449,7 +415,7 @@ describe('installAppLifecycle', () => {
     app.emit('before-quit')
     expect(flushSessionPersistence).toHaveBeenCalledOnce()
 
-    windows[0].emit('query-session-end')
+    onSystemShutdown()
     resolvePreflight?.('conflict')
     await flush()
 
@@ -459,49 +425,6 @@ describe('installAppLifecycle', () => {
 
     expect(confirmClose).not.toHaveBeenCalled()
     expect(shutdownBackends).toHaveBeenCalledOnce()
-    expect(app.exit).toHaveBeenCalledWith(0)
-  })
-
-  it.each(['SIGTERM', 'SIGINT'] as const)(
-    'routes headless %s through the existing shutdown owner',
-    async (signal) => {
-      const headlessSignalSource = makeFakeSignalSource()
-      const { app, shutdownBackends, quit, confirmClose } = setup({
-        createInitialWindow: false,
-        headlessSignalSource
-      })
-
-      headlessSignalSource.emit(signal)
-      expect(quit).toHaveBeenCalledTimes(1)
-
-      app.emit('before-quit')
-      await flush()
-
-      expect(confirmClose).not.toHaveBeenCalled()
-      expect(shutdownBackends).toHaveBeenCalledTimes(1)
-      expect(app.exit).toHaveBeenCalledWith(0)
-    }
-  )
-
-  it('routes a preventable power shutdown through the existing shutdown owner', async () => {
-    let onPowerShutdown: ((event: QuitEvent) => void) | undefined
-    const { app, shutdownBackends, quit, confirmClose } = setup({
-      subscribePowerShutdown: (listener) => {
-        onPowerShutdown = listener
-      }
-    })
-    const event = makeQuitEvent()
-
-    onPowerShutdown?.(event)
-
-    expect(event.defaultPrevented).toBe(true)
-    expect(quit).toHaveBeenCalledTimes(1)
-
-    app.emit('before-quit')
-    await flush()
-
-    expect(confirmClose).not.toHaveBeenCalled()
-    expect(shutdownBackends).toHaveBeenCalledTimes(1)
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
@@ -516,12 +439,11 @@ describe('installAppLifecycle', () => {
 
   it('preserves system shutdown intent until the migration guard reissues quit', async () => {
     let migrationInProgress = true
-    const { app, windows, shutdownBackends, confirmClose } = setup({
-      platform: 'win32',
+    const { app, onSystemShutdown, shutdownBackends, confirmClose } = setup({
       isMigrationInProgress: () => migrationInProgress
     })
 
-    windows[0].emit('query-session-end')
+    onSystemShutdown()
     app.emit('before-quit')
     expect(shutdownBackends).not.toHaveBeenCalled()
 

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -381,14 +381,14 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
-  it('routes a preventable Windows session end through the existing shutdown owner', async () => {
+  it('respects Windows session end while routing best-effort cleanup through the shutdown owner', async () => {
     const { app, windows, shutdownBackends, flushSessionPersistence, quit, confirmClose } = setup({
       platform: 'win32'
     })
 
     const event = windows[0].emit('query-session-end')
 
-    expect(event.defaultPrevented).toBe(true)
+    expect(event.defaultPrevented).toBe(false)
     expect(quit).toHaveBeenCalledTimes(1)
 
     app.emit('before-quit')
@@ -400,7 +400,7 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
-  it('uses Windows session-end as a best-effort fallback when the preventable event was missed', () => {
+  it('uses Windows session-end as a best-effort fallback when the query event was missed', () => {
     const { windows, quit } = setup({ platform: 'win32' })
 
     const event = windows[0].emit('session-end')

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -429,6 +429,39 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
+  it('replays a system shutdown that arrives while an ordinary quit is aborting', async () => {
+    let resolvePreflight: ((outcome: 'conflict') => void) | undefined
+    const flushSessionPersistence = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<'conflict'>((resolve) => {
+            resolvePreflight = resolve
+          })
+      )
+      .mockResolvedValue('conflict' as const)
+    const { app, closeOpts, windows, quit, confirmClose, shutdownBackends } = setup({
+      platform: 'win32',
+      flushSessionPersistence
+    })
+
+    closeOpts[0].requestQuit()
+    app.emit('before-quit')
+    expect(flushSessionPersistence).toHaveBeenCalledOnce()
+
+    windows[0].emit('query-session-end')
+    resolvePreflight?.('conflict')
+    await flush()
+
+    expect(quit).toHaveBeenCalledTimes(2)
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).not.toHaveBeenCalled()
+    expect(shutdownBackends).toHaveBeenCalledOnce()
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
   it.each(['SIGTERM', 'SIGINT'] as const)(
     'routes headless %s through the existing shutdown owner',
     async (signal) => {
@@ -479,6 +512,26 @@ describe('installAppLifecycle', () => {
     await flush()
     expect(shutdownBackends).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()
+  })
+
+  it('preserves system shutdown intent until the migration guard reissues quit', async () => {
+    let migrationInProgress = true
+    const { app, windows, shutdownBackends, confirmClose } = setup({
+      platform: 'win32',
+      isMigrationInProgress: () => migrationInProgress
+    })
+
+    windows[0].emit('query-session-end')
+    app.emit('before-quit')
+    expect(shutdownBackends).not.toHaveBeenCalled()
+
+    migrationInProgress = false
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).not.toHaveBeenCalled()
+    expect(shutdownBackends).toHaveBeenCalledOnce()
+    expect(app.exit).toHaveBeenCalledWith(0)
   })
 
   it('respects a quit an earlier handler already cancelled (defaultPrevented)', async () => {

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -19,6 +19,16 @@ import type {
 type QuitEvent = { preventDefault: () => void; defaultPrevented: boolean }
 type Handler = (event: QuitEvent) => void
 
+const makeQuitEvent = (): QuitEvent => {
+  const event: QuitEvent = {
+    defaultPrevented: false,
+    preventDefault(): void {
+      event.defaultPrevented = true
+    }
+  }
+  return event
+}
+
 afterEach(() => clearApplicationShutdownTrigger())
 
 type FakeApp = {
@@ -39,14 +49,28 @@ const makeFakeApp = (): FakeApp => {
     },
     exit: vi.fn(),
     emit(event): QuitEvent {
-      const evt: QuitEvent = {
-        defaultPrevented: false,
-        preventDefault(): void {
-          evt.defaultPrevented = true
-        }
-      }
+      const evt = makeQuitEvent()
       for (const handler of handlers.get(event) ?? []) handler(evt)
       return evt
+    }
+  }
+}
+
+const makeFakeSignalSource = (): NonNullable<AppLifecycleDeps['headlessSignalSource']> & {
+  emit: (signal: 'SIGTERM' | 'SIGINT') => void
+} => {
+  const listeners = new Map<'SIGTERM' | 'SIGINT', () => void>()
+  return {
+    once(signal, listener): void {
+      listeners.set(signal, listener)
+    },
+    removeListener(signal, listener): void {
+      if (listeners.get(signal) === listener) listeners.delete(signal)
+    },
+    emit(signal): void {
+      const listener = listeners.get(signal)
+      listeners.delete(signal)
+      listener?.()
     }
   }
 }
@@ -63,12 +87,13 @@ type FakeWindow = {
   show: () => void
   hide: () => void
   focus: () => void
-  on: (event: 'hide' | 'show', handler: () => void) => void
+  on: (event: string, handler: Handler) => void
+  emit: (event: string) => QuitEvent
 }
 
 // A fake BrowserWindow tracking visibility/focus/destroyed state.
 const makeFakeWindow = (): FakeWindow => {
-  const handlers = new Map<'hide' | 'show', Array<() => void>>()
+  const handlers = new Map<string, Handler[]>()
 
   return {
     destroyed: false,
@@ -89,17 +114,22 @@ const makeFakeWindow = (): FakeWindow => {
     },
     show(): void {
       this.visible = true
-      for (const handler of handlers.get('show') ?? []) handler()
+      for (const handler of handlers.get('show') ?? []) handler(makeQuitEvent())
     },
     hide(): void {
       this.visible = false
-      for (const handler of handlers.get('hide') ?? []) handler()
+      for (const handler of handlers.get('hide') ?? []) handler(makeQuitEvent())
     },
     focus(): void {
       this.focused = true
     },
     on(event, handler): void {
       handlers.set(event, [...(handlers.get(event) ?? []), handler])
+    },
+    emit(event): QuitEvent {
+      const evt = makeQuitEvent()
+      for (const handler of handlers.get(event) ?? []) handler(evt)
+      return evt
     }
   }
 }
@@ -153,6 +183,8 @@ const setup = (
       | 'isMigrationInProgress'
       | 'platform'
       | 'createInitialWindow'
+      | 'headlessSignalSource'
+      | 'subscribePowerShutdown'
       | 'onAppearanceChanged'
       | 'initialWindow'
       | 'configureMainWindow'
@@ -212,6 +244,8 @@ const setup = (
     quit,
     countWindows: () => windows.filter((w) => !w.destroyed).length,
     createInitialWindow: overrides.createInitialWindow,
+    headlessSignalSource: overrides.headlessSignalSource,
+    subscribePowerShutdown: overrides.subscribePowerShutdown,
     onAppearanceChanged: overrides.onAppearanceChanged,
     platform: overrides.platform ?? 'linux',
     detectActiveSessions,
@@ -344,6 +378,97 @@ describe('installAppLifecycle', () => {
     await flush()
     expect(shutdownBackends).toHaveBeenCalledTimes(1)
     expect(tray?.destroy).toHaveBeenCalledTimes(1)
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('routes a preventable Windows session end through the existing shutdown owner', async () => {
+    const { app, windows, shutdownBackends, flushSessionPersistence, quit, confirmClose } = setup({
+      platform: 'win32'
+    })
+
+    const event = windows[0].emit('query-session-end')
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(quit).toHaveBeenCalledTimes(1)
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).not.toHaveBeenCalled()
+    expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('uses Windows session-end as a best-effort fallback when the preventable event was missed', () => {
+    const { windows, quit } = setup({ platform: 'win32' })
+
+    const event = windows[0].emit('session-end')
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(quit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not block a system shutdown on active work or renderer persistence conflicts', async () => {
+    const flushSessionPersistence = vi.fn(async () => 'conflict' as const)
+    const { app, windows, shutdownBackends, confirmClose } = setup({
+      platform: 'win32',
+      detectActiveSessions: () => [
+        { projectId: 'project-1', sessionId: 'session-1', kind: 'delegated' }
+      ],
+      flushSessionPersistence
+    })
+
+    windows[0].emit('query-session-end')
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).not.toHaveBeenCalled()
+    expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it.each(['SIGTERM', 'SIGINT'] as const)(
+    'routes headless %s through the existing shutdown owner',
+    async (signal) => {
+      const headlessSignalSource = makeFakeSignalSource()
+      const { app, shutdownBackends, quit, confirmClose } = setup({
+        createInitialWindow: false,
+        headlessSignalSource
+      })
+
+      headlessSignalSource.emit(signal)
+      expect(quit).toHaveBeenCalledTimes(1)
+
+      app.emit('before-quit')
+      await flush()
+
+      expect(confirmClose).not.toHaveBeenCalled()
+      expect(shutdownBackends).toHaveBeenCalledTimes(1)
+      expect(app.exit).toHaveBeenCalledWith(0)
+    }
+  )
+
+  it('routes a preventable power shutdown through the existing shutdown owner', async () => {
+    let onPowerShutdown: ((event: QuitEvent) => void) | undefined
+    const { app, shutdownBackends, quit, confirmClose } = setup({
+      subscribePowerShutdown: (listener) => {
+        onPowerShutdown = listener
+      }
+    })
+    const event = makeQuitEvent()
+
+    onPowerShutdown?.(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(quit).toHaveBeenCalledTimes(1)
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(confirmClose).not.toHaveBeenCalled()
+    expect(shutdownBackends).toHaveBeenCalledTimes(1)
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -89,6 +89,9 @@ export type AppLifecycleDeps = {
   // Native process/power sources are injected so their global event bridges remain unit-testable.
   headlessSignalSource?: HeadlessSignalSource
   subscribePowerShutdown?: (listener: (event: PreventableSystemShutdownEvent) => void) => void
+  // Production binds the startup window before runtime composition and reuses the same idempotent
+  // binder here for later windows. Tests may omit it and exercise the built-in Windows bridge.
+  bindSystemShutdownWindow?: (window: BrowserWindow) => void
   // Overridable for tests; defaults to the host platform.
   platform?: NodeJS.Platform
   // Snapshot of sessions with running work (in-flight agent prompt or a notebook cell mid-execution),
@@ -117,6 +120,7 @@ export const installAppLifecycle = (
   showMainWindow: () => BrowserWindow
   getMainWindow: () => BrowserWindow | undefined
   isMainWindowHidden: () => boolean
+  onSystemShutdown: () => void
 } => {
   const platform = deps.platform ?? process.platform
   const logFlushTimeoutMs = deps.logFlushTimeoutMs ?? 1_000
@@ -246,7 +250,9 @@ export const installAppLifecycle = (
     // taskbar attention can distinguish a legitimate minimized window from one hidden to the tray.
     window.on('hide', () => hiddenWindows.add(window))
     window.on('show', () => hiddenWindows.delete(window))
-    if (platform === 'win32') {
+    if (deps.bindSystemShutdownWindow) {
+      deps.bindSystemShutdownWindow(window)
+    } else if (platform === 'win32') {
       window.on('query-session-end', (event) => {
         event.preventDefault()
         requestSystemShutdown()
@@ -568,6 +574,7 @@ export const installAppLifecycle = (
     showMainWindow,
     // Attention effects may inspect the current window, but must never surface it as a side effect.
     getMainWindow: () => mainWindow,
-    isMainWindowHidden: () => Boolean(mainWindow && hiddenWindows.has(mainWindow))
+    isMainWindowHidden: () => Boolean(mainWindow && hiddenWindows.has(mainWindow)),
+    onSystemShutdown: requestSystemShutdown
   }
 }

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -10,6 +10,7 @@ import { startDiagnosticOperation } from './diagnostics/operation'
 import {
   clearApplicationShutdownTrigger,
   currentApplicationShutdownTrigger,
+  markApplicationShutdownTrigger,
   type ApplicationShutdownTrigger
 } from './application-shutdown-trigger'
 import type {
@@ -21,6 +22,12 @@ import type {
 
 // Menu action callbacks the tray is wired to.
 export type TrayHandlers = { onShow: () => void; onHide: () => void; onQuit: () => void }
+
+type PreventableSystemShutdownEvent = { preventDefault: () => void }
+type HeadlessSignalSource = {
+  once: (signal: 'SIGTERM' | 'SIGINT', listener: () => void) => unknown
+  removeListener: (signal: 'SIGTERM' | 'SIGINT', listener: () => void) => unknown
+}
 
 // Wires the window/tray/quit lifecycle for the UI process. Kept as a dependency-injected unit (no direct
 // electron imports beyond types) so the event ordering, migration-guard interaction, tray-quit cleanup,
@@ -79,6 +86,9 @@ export type AppLifecycleDeps = {
   countWindows: () => number
   // Headless web mode starts the backend and tray without opening a renderer window.
   createInitialWindow?: boolean
+  // Native process/power sources are injected so their global event bridges remain unit-testable.
+  headlessSignalSource?: HeadlessSignalSource
+  subscribePowerShutdown?: (listener: (event: PreventableSystemShutdownEvent) => void) => void
   // Overridable for tests; defaults to the host platform.
   platform?: NodeJS.Platform
   // Snapshot of sessions with running work (in-flight agent prompt or a notebook cell mid-execution),
@@ -122,6 +132,7 @@ export const installAppLifecycle = (
   // Latches make the async quit cleanup idempotent: once started, further quits are held until exit.
   let shutdownStarted = false
   let shutdownFinished = false
+  let systemShutdownRequested = false
   // Set once the user has confirmed a quit (via the dialog or a prior 'confirm' close), so a re-issued
   // before-quit skips straight to teardown instead of asking again.
   let quitConfirmed = false
@@ -174,6 +185,18 @@ export const installAppLifecycle = (
     confirmedDelegatedSessionKeys = new Set(delegated.map(delegatedSessionKey))
     deps.quit()
   }
+  const requestSystemShutdown = (): void => {
+    if (systemShutdownRequested || shutdownStarted || shutdownFinished) return
+    systemShutdownRequested = true
+    const rollbackTrigger = markApplicationShutdownTrigger('system')
+    try {
+      deps.quit()
+    } catch (error) {
+      systemShutdownRequested = false
+      rollbackTrigger()
+      throw error
+    }
+  }
 
   // Synchronous close classification, evaluated at close time. A mid-quit close is held so the
   // renderer survives persistence flushing; otherwise darwin keeps its dock convention (real close),
@@ -223,6 +246,16 @@ export const installAppLifecycle = (
     // taskbar attention can distinguish a legitimate minimized window from one hidden to the tray.
     window.on('hide', () => hiddenWindows.add(window))
     window.on('show', () => hiddenWindows.delete(window))
+    if (platform === 'win32') {
+      window.on('query-session-end', (event) => {
+        event.preventDefault()
+        requestSystemShutdown()
+      })
+      // This notification can no longer delay Windows logoff/shutdown. It is only a best-effort
+      // fallback for a host that did not deliver query-session-end; the preventable event above owns
+      // the bounded, awaited path.
+      window.on('session-end', requestSystemShutdown)
+    }
     return window
   }
 
@@ -258,6 +291,22 @@ export const installAppLifecycle = (
     onQuit: () => deps.quit()
   })
 
+  if (deps.createInitialWindow === false && deps.headlessSignalSource) {
+    const source = deps.headlessSignalSource
+    const onSignal = (): void => {
+      source.removeListener('SIGTERM', onSignal)
+      source.removeListener('SIGINT', onSignal)
+      requestSystemShutdown()
+    }
+    source.once('SIGTERM', onSignal)
+    source.once('SIGINT', onSignal)
+  }
+
+  deps.subscribePowerShutdown?.((event) => {
+    event.preventDefault()
+    requestSystemShutdown()
+  })
+
   // Authoritative quit cleanup: stop the agent process tree (awaited, so Windows taskkill /T finishes)
   // and every notebook kernel before exiting. app.on (not once) plus latches: a re-issued quit while
   // cleanup runs is held until app.exit(0), which itself skips before-quit/will-quit. Gated on the
@@ -276,6 +325,7 @@ export const installAppLifecycle = (
       // confirmation and shutdown trigger so neither leaks into a later close: otherwise a later
       // ordinary quit could bypass its active-session confirmation.
       clearApplicationShutdownTrigger()
+      systemShutdownRequested = false
       quitConfirmed = false
       confirmedDelegatedSessionKeys = new Set()
       return

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -23,12 +23,6 @@ import type {
 // Menu action callbacks the tray is wired to.
 export type TrayHandlers = { onShow: () => void; onHide: () => void; onQuit: () => void }
 
-type PreventableSystemShutdownEvent = { preventDefault: () => void }
-type HeadlessSignalSource = {
-  once: (signal: 'SIGTERM' | 'SIGINT', listener: () => void) => unknown
-  removeListener: (signal: 'SIGTERM' | 'SIGINT', listener: () => void) => unknown
-}
-
 // Wires the window/tray/quit lifecycle for the UI process. Kept as a dependency-injected unit (no direct
 // electron imports beyond types) so the event ordering, migration-guard interaction, tray-quit cleanup,
 // and window recreation are unit-testable without a real Electron runtime.
@@ -86,11 +80,8 @@ export type AppLifecycleDeps = {
   countWindows: () => number
   // Headless web mode starts the backend and tray without opening a renderer window.
   createInitialWindow?: boolean
-  // Native process/power sources are injected so their global event bridges remain unit-testable.
-  headlessSignalSource?: HeadlessSignalSource
-  subscribePowerShutdown?: (listener: (event: PreventableSystemShutdownEvent) => void) => void
-  // Production binds the startup window before runtime composition and reuses the same idempotent
-  // binder here for later windows. Tests may omit it and exercise the built-in Windows bridge.
+  // Production binds the startup window before runtime composition and reuses the same tested,
+  // idempotent adapter here for later windows.
   bindSystemShutdownWindow?: (window: BrowserWindow) => void
   // Overridable for tests; defaults to the host platform.
   platform?: NodeJS.Platform
@@ -253,16 +244,7 @@ export const installAppLifecycle = (
     // taskbar attention can distinguish a legitimate minimized window from one hidden to the tray.
     window.on('hide', () => hiddenWindows.add(window))
     window.on('show', () => hiddenWindows.delete(window))
-    if (deps.bindSystemShutdownWindow) {
-      deps.bindSystemShutdownWindow(window)
-    } else if (platform === 'win32') {
-      // Respect the OS-owned session end while giving the existing shutdown owner an early,
-      // best-effort opportunity to clean up before Windows terminates the process.
-      window.on('query-session-end', requestSystemShutdown)
-      // This notification can no longer delay Windows logoff/shutdown. Retain it as a fallback for
-      // hosts that did not deliver query-session-end.
-      window.on('session-end', requestSystemShutdown)
-    }
+    deps.bindSystemShutdownWindow?.(window)
     return window
   }
 
@@ -296,22 +278,6 @@ export const installAppLifecycle = (
     onShow: showMainWindow,
     onHide: hideMainWindow,
     onQuit: () => deps.quit()
-  })
-
-  if (deps.createInitialWindow === false && deps.headlessSignalSource) {
-    const source = deps.headlessSignalSource
-    const onSignal = (): void => {
-      source.removeListener('SIGTERM', onSignal)
-      source.removeListener('SIGINT', onSignal)
-      requestSystemShutdown()
-    }
-    source.once('SIGTERM', onSignal)
-    source.once('SIGINT', onSignal)
-  }
-
-  deps.subscribePowerShutdown?.((event) => {
-    event.preventDefault()
-    requestSystemShutdown()
   })
 
   // Authoritative quit cleanup: stop the agent process tree (awaited, so Windows taskkill /T finishes)

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -256,13 +256,11 @@ export const installAppLifecycle = (
     if (deps.bindSystemShutdownWindow) {
       deps.bindSystemShutdownWindow(window)
     } else if (platform === 'win32') {
-      window.on('query-session-end', (event) => {
-        event.preventDefault()
-        requestSystemShutdown()
-      })
-      // This notification can no longer delay Windows logoff/shutdown. It is only a best-effort
-      // fallback for a host that did not deliver query-session-end; the preventable event above owns
-      // the bounded, awaited path.
+      // Respect the OS-owned session end while giving the existing shutdown owner an early,
+      // best-effort opportunity to clean up before Windows terminates the process.
+      window.on('query-session-end', requestSystemShutdown)
+      // This notification can no longer delay Windows logoff/shutdown. Retain it as a fallback for
+      // hosts that did not deliver query-session-end.
       window.on('session-end', requestSystemShutdown)
     }
     return window

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -190,9 +190,12 @@ export const installAppLifecycle = (
     deps.quit()
   }
   const requestSystemShutdown = (): void => {
-    if (systemShutdownRequested || shutdownStarted || shutdownFinished) return
+    if (systemShutdownRequested || shutdownFinished) return
     systemShutdownRequested = true
     const rollbackTrigger = markApplicationShutdownTrigger('system')
+    // An ordinary quit may already be inside its abortable Renderer preflight. Keep the stronger
+    // system intent latched; its abort path will reissue quit through the same lifecycle owner.
+    if (shutdownStarted) return
     try {
       deps.quit()
     } catch (error) {
@@ -326,17 +329,20 @@ export const installAppLifecycle = (
       event.preventDefault()
       return
     }
+    const trigger = shutdownTrigger()
     if (event.defaultPrevented || deps.isMigrationInProgress()) {
       // This quit is being aborted (e.g. the migration guard cancelled it). Clear any prior
       // confirmation and shutdown trigger so neither leaks into a later close: otherwise a later
-      // ordinary quit could bypass its active-session confirmation.
-      clearApplicationShutdownTrigger()
-      systemShutdownRequested = false
+      // ordinary quit could bypass its active-session confirmation. A system request remains latched
+      // because the migration guard owns cancelling/joining the move and then reissues app.quit().
+      if (trigger !== 'system') {
+        clearApplicationShutdownTrigger()
+        systemShutdownRequested = false
+      }
       quitConfirmed = false
       confirmedDelegatedSessionKeys = new Set()
       return
     }
-    const trigger = shutdownTrigger()
     // Renderer persistence may cancel only an ordinary quit. Update and data-root relaunches pass a
     // producer-teardown + renderer-durability gate before committing their handoff; once app.quit()
     // runs, cancellation would leave the old process alive after the external pointer changed.
@@ -541,8 +547,15 @@ export const installAppLifecycle = (
           }
           shutdownStarted = false
           quitConfirmed = false
-          clearApplicationShutdownTrigger()
-          showMainWindow()
+          if (systemShutdownRequested) {
+            // A preventable OS shutdown arrived after this ordinary attempt began. Do not restore an
+            // interactive app: replay it with the already-latched system trigger so persistence is
+            // best-effort and cannot cancel the OS-owned exit.
+            deps.quit()
+          } else {
+            clearApplicationShutdownTrigger()
+            showMainWindow()
+          }
         } else {
           trayBox.current?.destroy()
           shutdownFinished = true

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -139,6 +139,37 @@ describe('orchestrateAppStartup', () => {
     expect(markReady).toHaveBeenCalledWith({ tag: 'ctx' })
   })
 
+  it('queues a system shutdown requested during prepare until the lifecycle owner is installed', async () => {
+    const events: string[] = []
+    const onSystemShutdown = vi.fn(() => events.push('shutdown'))
+    const onSecondInstance = vi.fn()
+    let requestSystemShutdown = (): void => {}
+    const installSystemShutdownListeners = vi.fn((request: () => void) => {
+      requestSystemShutdown = request
+    })
+    const deps = {
+      ...makeDeps({
+        prepare: vi.fn(async () => {
+          requestSystemShutdown()
+          expect(onSystemShutdown).not.toHaveBeenCalled()
+          return { tag: 'ctx' }
+        }),
+        installAppLifecycle: vi.fn(() => ({ onSecondInstance, onSystemShutdown })),
+        markReady: vi.fn(() => events.push('ready'))
+      }),
+      installSystemShutdownListeners
+    } as Parameters<typeof orchestrateAppStartup<{ tag: string }>>[0]
+
+    await orchestrateAppStartup(deps)
+
+    expect(installSystemShutdownListeners).toHaveBeenCalledOnce()
+    expect(onSystemShutdown).toHaveBeenCalledOnce()
+    expect(events).toEqual(['ready', 'shutdown'])
+    const listenersOrder = installSystemShutdownListeners.mock.invocationCallOrder[0]
+    const prepareOrder = vi.mocked(deps.prepare).mock.invocationCallOrder[0]
+    expect(listenersOrder).toBeLessThan(prepareOrder)
+  })
+
   it('drains a second instance that arrives during startup, forwarding its argv', async () => {
     const onSecondInstance = vi.fn()
     let signalDuringStartup: (argv: string[]) => void = () => {}

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -170,6 +170,31 @@ describe('orchestrateAppStartup', () => {
     expect(listenersOrder).toBeLessThan(prepareOrder)
   })
 
+  it('forces exit when system shutdown is requested while prepare remains blocked', async () => {
+    vi.useFakeTimers()
+    try {
+      const preparation = deferred<{ tag: string }>()
+      const forceExit = vi.fn()
+      let requestSystemShutdown = (): void => {}
+      const deps = {
+        ...makeDeps({ prepare: vi.fn(() => preparation.promise) }),
+        installSystemShutdownListeners: (request: () => void) => {
+          requestSystemShutdown = request
+        },
+        forceExit,
+        startupSystemShutdownTimeoutMs: 25
+      } as Parameters<typeof orchestrateAppStartup<{ tag: string }>>[0]
+
+      void orchestrateAppStartup(deps)
+      requestSystemShutdown()
+      await vi.advanceTimersByTimeAsync(25)
+
+      expect(forceExit).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('drains a second instance that arrives during startup, forwarding its argv', async () => {
     const onSecondInstance = vi.fn()
     let signalDuringStartup: (argv: string[]) => void = () => {}

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -25,6 +25,8 @@ type SystemShutdownRelay = {
   bind: (handler: () => void) => void
 }
 
+const STARTUP_SYSTEM_SHUTDOWN_TIMEOUT_MS = 5_000
+
 type StartupWindowSurface = {
   focus: () => void
   isDestroyed: () => boolean
@@ -78,17 +80,30 @@ export const createSecondInstanceRelay = (): SecondInstanceRelay => {
   }
 }
 
-const createSystemShutdownRelay = (): SystemShutdownRelay => {
+const createSystemShutdownRelay = (
+  forceExit?: () => void,
+  timeoutMs = STARTUP_SYSTEM_SHUTDOWN_TIMEOUT_MS
+): SystemShutdownRelay => {
   let pending = false
   let handler: (() => void) | undefined
+  let forceExitTimer: ReturnType<typeof setTimeout> | undefined
 
   return {
     signal: () => {
       if (handler) handler()
-      else pending = true
+      else {
+        pending = true
+        // Startup preparation can block indefinitely before the bounded lifecycle owner exists.
+        // Preserve a short handoff window, then stop delaying the OS rather than hanging shutdown.
+        if (forceExit && !forceExitTimer) forceExitTimer = setTimeout(forceExit, timeoutMs)
+      }
     },
     bind: (next) => {
       handler = next
+      if (forceExitTimer) {
+        clearTimeout(forceExitTimer)
+        forceExitTimer = undefined
+      }
       if (!pending) return
       pending = false
       handler()
@@ -102,6 +117,9 @@ export type AppStartupDeps<Context> = {
   acquireSingleInstanceLock: (opts: { onSecondInstance: (argv: string[]) => void }) => boolean
   // Quits this launch when it is a secondary instance.
   quit: () => void
+  // Last-resort startup exit used only when preparation never reaches the bounded lifecycle owner.
+  forceExit?: () => void
+  startupSystemShutdownTimeoutMs?: number
   // Installs signal/native shutdown sources immediately after the primary-instance lock. The supplied
   // callback queues a request until the lifecycle's bounded shutdown owner exists.
   installSystemShutdownListeners?: (requestSystemShutdown: () => void) => void
@@ -199,7 +217,10 @@ export const orchestrateAppStartup = async <Context>(
   deps: AppStartupDeps<Context>
 ): Promise<void> => {
   const relay = createSecondInstanceRelay()
-  const systemShutdownRelay = createSystemShutdownRelay()
+  const systemShutdownRelay = createSystemShutdownRelay(
+    deps.forceExit,
+    deps.startupSystemShutdownTimeoutMs
+  )
 
   try {
     deps.diagnostics?.phase('single-instance-lock')

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -20,6 +20,11 @@ export type SecondInstanceRelay = {
   bind: (handler: (argv: string[]) => void) => void
 }
 
+type SystemShutdownRelay = {
+  signal: () => void
+  bind: (handler: () => void) => void
+}
+
 type StartupWindowSurface = {
   focus: () => void
   isDestroyed: () => boolean
@@ -73,12 +78,33 @@ export const createSecondInstanceRelay = (): SecondInstanceRelay => {
   }
 }
 
+const createSystemShutdownRelay = (): SystemShutdownRelay => {
+  let pending = false
+  let handler: (() => void) | undefined
+
+  return {
+    signal: () => {
+      if (handler) handler()
+      else pending = true
+    },
+    bind: (next) => {
+      handler = next
+      if (!pending) return
+      pending = false
+      handler()
+    }
+  }
+}
+
 export type AppStartupDeps<Context> = {
   // Acquires the OS single-instance lock, wiring the relay's signal as the second-instance handler.
   // Returns false for a secondary launch (the caller must quit) and true for the primary.
   acquireSingleInstanceLock: (opts: { onSecondInstance: (argv: string[]) => void }) => boolean
   // Quits this launch when it is a secondary instance.
   quit: () => void
+  // Installs signal/native shutdown sources immediately after the primary-instance lock. The supplied
+  // callback queues a request until the lifecycle's bounded shutdown owner exists.
+  installSystemShutdownListeners?: (requestSystemShutdown: () => void) => void
   // Heavy post-lock preparation (backend module imports, app.whenReady, logger, IPC registration). Runs
   // ONLY after the lock is held so a doomed secondary instance never imports the backend or spawns a
   // duplicate process tree. Returns the context the guard/lifecycle installers need.
@@ -88,7 +114,10 @@ export type AppStartupDeps<Context> = {
   installMigrationQuitGuard: (context: Context) => void
   // Installs the tray/window/quit lifecycle; returns the second-instance handler for the relay to drain.
   // The handler decides per forwarded argv whether to surface the window or start the web service.
-  installAppLifecycle: (context: Context) => { onSecondInstance: (argv: string[]) => void }
+  installAppLifecycle: (context: Context) => {
+    onSecondInstance: (argv: string[]) => void
+    onSystemShutdown?: () => void
+  }
   // Publishes renderer readiness only after lifecycle installation and adapter wiring complete.
   markReady?: (context: Context) => void
   diagnostics?: DiagnosticOperation
@@ -170,6 +199,7 @@ export const orchestrateAppStartup = async <Context>(
   deps: AppStartupDeps<Context>
 ): Promise<void> => {
   const relay = createSecondInstanceRelay()
+  const systemShutdownRelay = createSystemShutdownRelay()
 
   try {
     deps.diagnostics?.phase('single-instance-lock')
@@ -179,12 +209,14 @@ export const orchestrateAppStartup = async <Context>(
       return
     }
 
+    deps.installSystemShutdownListeners?.(systemShutdownRelay.signal)
     deps.diagnostics?.phase('prepare-runtime')
     const context = await deps.prepare()
     deps.diagnostics?.phase('install-lifecycle')
     deps.installMigrationQuitGuard(context)
-    const { onSecondInstance } = deps.installAppLifecycle(context)
+    const { onSecondInstance, onSystemShutdown } = deps.installAppLifecycle(context)
     deps.markReady?.(context)
+    if (onSystemShutdown) systemShutdownRelay.bind(onSystemShutdown)
     relay.bind(onSecondInstance)
     deps.diagnostics?.complete({ instance: 'primary' })
   } catch (error) {

--- a/src/main/application-shutdown-trigger.ts
+++ b/src/main/application-shutdown-trigger.ts
@@ -1,4 +1,4 @@
-export type ApplicationShutdownTrigger = 'quit' | 'update' | 'migration-relaunch'
+export type ApplicationShutdownTrigger = 'quit' | 'update' | 'migration-relaunch' | 'system'
 
 let requestedTrigger: ApplicationShutdownTrigger = 'quit'
 

--- a/src/main/index-startup-order.test.ts
+++ b/src/main/index-startup-order.test.ts
@@ -6,6 +6,18 @@ import { describe, expect, it } from 'vitest'
 const mainSource = readFileSync(resolve(__dirname, 'index.ts'), 'utf8')
 
 describe('main startup ordering', () => {
+  it('installs power-monitor listeners before loading startup shell modules', () => {
+    const electronReady = mainSource.indexOf('await app.whenReady()')
+    const installPowerMonitor = mainSource.indexOf('installPowerMonitorListeners()')
+    const loadStartupModules = mainSource.indexOf(
+      "startupDiagnostics?.phase('load-startup-shell-modules')"
+    )
+
+    expect(electronReady).toBeGreaterThan(-1)
+    expect(installPowerMonitor).toBeGreaterThan(electronReady)
+    expect(loadStartupModules).toBeGreaterThan(installPowerMonitor)
+  })
+
   it('registers the managed-preview protocol bridge before creating the first window', () => {
     const registerBridge = mainSource.indexOf(
       'const managedPreviewProtocolBridge = createManagedPreviewProtocolBridge(protocol)'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -270,6 +270,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       return true
     },
     quit: () => app.quit(),
+    forceExit: () => app.exit(0),
     installSystemShutdownListeners: (requestSystemShutdown) => {
       signalSystemShutdown = requestSystemShutdown
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -142,11 +142,13 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       prepareVisibleStartupRuntime,
       waitForStartupShell
     },
-    { parseWebModeOptions }
+    { parseWebModeOptions },
+    { installSystemLifecycleAdapters }
   ] = await Promise.all([
     import('./single-instance'),
     import('./app-startup'),
-    import('./web-service/options')
+    import('./web-service/options'),
+    import('./system-lifecycle-adapters')
   ])
   const preStartupSecondInstanceRelay = createSecondInstanceRelay()
   if (
@@ -159,18 +161,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     return
   }
   const webMode = parseWebModeOptions(process.argv)
-  let signalSystemShutdown = (): void => {}
-  const systemShutdownWindows = new WeakSet<InstanceType<typeof BrowserWindow>>()
-  const bindSystemShutdownWindow = (window: InstanceType<typeof BrowserWindow>): void => {
-    if (process.platform !== 'win32' || systemShutdownWindows.has(window)) return
-    systemShutdownWindows.add(window)
-    // Respect the OS-owned session end while giving the existing shutdown owner an early,
-    // best-effort opportunity to clean up before Windows terminates the process.
-    window.on('query-session-end', signalSystemShutdown)
-    // Windows no longer permits delaying shutdown at this point; retain a fallback for hosts that
-    // skipped query-session-end.
-    window.on('session-end', signalSystemShutdown)
+  let bindSystemShutdownWindow = (window: InstanceType<typeof BrowserWindow>): void => {
+    void window
   }
+  let installPowerMonitorListeners = (): void => {}
 
   // Initialize the file sink after the primary lock but before assets, the backend graph, and
   // app.whenReady so packaged startup failures remain locally diagnosable.
@@ -271,17 +265,16 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     quit: () => app.quit(),
     forceExit: () => app.exit(0),
     installSystemShutdownListeners: (requestSystemShutdown) => {
-      signalSystemShutdown = requestSystemShutdown
-
-      if (webMode.headless) {
-        const onSignal = (): void => {
-          process.removeListener('SIGTERM', onSignal)
-          process.removeListener('SIGINT', onSignal)
-          signalSystemShutdown()
-        }
-        process.once('SIGTERM', onSignal)
-        process.once('SIGINT', onSignal)
-      }
+      const adapters = installSystemLifecycleAdapters({
+        platform: process.platform,
+        headless: webMode.headless,
+        signalSource: process,
+        powerMonitor,
+        getWindows: () => BrowserWindow.getAllWindows(),
+        requestSystemShutdown
+      })
+      bindSystemShutdownWindow = adapters.bindWindow
+      installPowerMonitorListeners = adapters.installPowerMonitorListeners
     },
     prepare: async () => {
       // Start local-only Crashpad after the single-instance lock but before any BrowserWindow can
@@ -332,14 +325,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
 
       startupDiagnostics?.phase('electron-ready')
       await app.whenReady()
-      if (process.platform !== 'win32') {
-        powerMonitor.on('shutdown', ((event?: { preventDefault?: () => void }) => {
-          // Electron's generated v39 type omits this documented event argument. Keep the bridge safe
-          // if a host also omits it at runtime.
-          event?.preventDefault?.()
-          signalSystemShutdown()
-        }) as () => void)
-      }
+      installPowerMonitorListeners()
       startupDiagnostics?.phase('prepare-shell')
       // The bridge is lightweight, but its protocol handler must exist before the first BrowserWindow
       // creates the default session. macOS otherwise treats later managed-preview requests as an

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -164,12 +164,11 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   const bindSystemShutdownWindow = (window: InstanceType<typeof BrowserWindow>): void => {
     if (process.platform !== 'win32' || systemShutdownWindows.has(window)) return
     systemShutdownWindows.add(window)
-    window.on('query-session-end', (event) => {
-      event.preventDefault()
-      signalSystemShutdown()
-    })
-    // Windows no longer permits delaying shutdown at this point; retain a best-effort fallback for
-    // hosts that skipped query-session-end.
+    // Respect the OS-owned session end while giving the existing shutdown owner an early,
+    // best-effort opportunity to clean up before Windows terminates the process.
+    window.on('query-session-end', signalSystemShutdown)
+    // Windows no longer permits delaying shutdown at this point; retain a fallback for hosts that
+    // skipped query-session-end.
     window.on('session-end', signalSystemShutdown)
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -266,7 +266,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     forceExit: () => app.exit(0),
     installSystemShutdownListeners: (requestSystemShutdown) => {
       const adapters = installSystemLifecycleAdapters({
-        platform: process.platform,
+        windowSessionEndEvents: process.platform === 'win32',
+        powerShutdownEvent: process.platform !== 'win32',
         headless: webMode.headless,
         signalSource: process,
         powerMonitor,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -283,19 +283,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         process.once('SIGTERM', onSignal)
         process.once('SIGINT', onSignal)
       }
-
-      if (process.platform !== 'win32') {
-        // powerMonitor is available only after app ready. Register this continuation before prepare()
-        // awaits the same barrier, so shutdown is covered before database verification/composition.
-        void app.whenReady().then(() => {
-          powerMonitor.on('shutdown', ((event?: { preventDefault?: () => void }) => {
-            // Electron's generated v39 type omits this documented event argument. Keep the bridge
-            // safe if a host also omits it at runtime.
-            event?.preventDefault?.()
-            signalSystemShutdown()
-          }) as () => void)
-        })
-      }
     },
     prepare: async () => {
       // Start local-only Crashpad after the single-instance lock but before any BrowserWindow can
@@ -346,6 +333,14 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
 
       startupDiagnostics?.phase('electron-ready')
       await app.whenReady()
+      if (process.platform !== 'win32') {
+        powerMonitor.on('shutdown', ((event?: { preventDefault?: () => void }) => {
+          // Electron's generated v39 type omits this documented event argument. Keep the bridge safe
+          // if a host also omits it at runtime.
+          event?.preventDefault?.()
+          signalSystemShutdown()
+        }) as () => void)
+      }
       startupDiagnostics?.phase('prepare-shell')
       // The bridge is lightweight, but its protocol handler must exist before the first BrowserWindow
       // creates the default session. macOS otherwise treats later managed-preview requests as an

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -141,8 +141,13 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       orchestrateAppStartup,
       prepareVisibleStartupRuntime,
       waitForStartupShell
-    }
-  ] = await Promise.all([import('./single-instance'), import('./app-startup')])
+    },
+    { parseWebModeOptions }
+  ] = await Promise.all([
+    import('./single-instance'),
+    import('./app-startup'),
+    import('./web-service/options')
+  ])
   const preStartupSecondInstanceRelay = createSecondInstanceRelay()
   if (
     !allowMultiInstance &&
@@ -152,6 +157,20 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   ) {
     app.quit()
     return
+  }
+  const webMode = parseWebModeOptions(process.argv)
+  let signalSystemShutdown = (): void => {}
+  const systemShutdownWindows = new WeakSet<InstanceType<typeof BrowserWindow>>()
+  const bindSystemShutdownWindow = (window: InstanceType<typeof BrowserWindow>): void => {
+    if (process.platform !== 'win32' || systemShutdownWindows.has(window)) return
+    systemShutdownWindows.add(window)
+    window.on('query-session-end', (event) => {
+      event.preventDefault()
+      signalSystemShutdown()
+    })
+    // Windows no longer permits delaying shutdown at this point; retain a best-effort fallback for
+    // hosts that skipped query-session-end.
+    window.on('session-end', signalSystemShutdown)
   }
 
   // Initialize the file sink after the primary lock but before assets, the backend graph, and
@@ -251,6 +270,32 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       return true
     },
     quit: () => app.quit(),
+    installSystemShutdownListeners: (requestSystemShutdown) => {
+      signalSystemShutdown = requestSystemShutdown
+
+      if (webMode.headless) {
+        const onSignal = (): void => {
+          process.removeListener('SIGTERM', onSignal)
+          process.removeListener('SIGINT', onSignal)
+          signalSystemShutdown()
+        }
+        process.once('SIGTERM', onSignal)
+        process.once('SIGINT', onSignal)
+      }
+
+      if (process.platform !== 'win32') {
+        // powerMonitor is available only after app ready. Register this continuation before prepare()
+        // awaits the same barrier, so shutdown is covered before database verification/composition.
+        void app.whenReady().then(() => {
+          powerMonitor.on('shutdown', ((event?: { preventDefault?: () => void }) => {
+            // Electron's generated v39 type omits this documented event argument. Keep the bridge
+            // safe if a host also omits it at runtime.
+            event?.preventDefault?.()
+            signalSystemShutdown()
+          }) as () => void)
+        })
+      }
+    },
     prepare: async () => {
       // Start local-only Crashpad after the single-instance lock but before any BrowserWindow can
       // create a renderer. Upload stays disabled: dumps remain local for explicit support collection.
@@ -280,8 +325,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { getProjectDbClient },
         { resolveStorageRoot },
         { SettingsDocumentStore },
-        { SettingsRepository },
-        { parseWebModeOptions }
+        { SettingsRepository }
       ] = await Promise.all([
         import('./managed-preview-protocol'),
         import('./windows'),
@@ -296,8 +340,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./projects/prisma-client'),
         import('./storage-root'),
         import('./settings/document-store'),
-        import('./settings/repository'),
-        import('./web-service/options')
+        import('./settings/repository')
       ])
 
       startupDiagnostics?.phase('electron-ready')
@@ -331,7 +374,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // preventDefault() on Cmd+- and Cmd+= and silently disables zoom out / reset (issue #336).
       installWindowShortcuts(app)
 
-      const webMode = parseWebModeOptions(process.argv)
       const databaseStartupLogging = createDatabaseStartupLogging(log, app.getVersion())
       const databaseStartupOwner = createDatabaseStartupOwner({
         reportBlocked: databaseStartupLogging.reportBlocked,
@@ -372,6 +414,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const startupWindow = webMode.headless
         ? undefined
         : createMainWindow(startupWindowCloseOptions, translate)
+      if (startupWindow) bindSystemShutdownWindow(startupWindow)
       // Yield the main-process event loop until Chromium has painted the startup shell. Evaluating the
       // 5 MB backend chunk immediately after BrowserWindow construction can otherwise delay
       // ready-to-show even though the window no longer depends on that chunk.
@@ -693,7 +736,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     // is bound with the live backend handles; the agent teardown latches shutting-down and awaits the
     // process tree so a Windows taskkill /T completes before app.exit.
     installAppLifecycle: (ctx) => {
-      const { showMainWindow, getMainWindow, isMainWindowHidden } = ctx.installAppLifecycle(
+      const lifecycle = ctx.installAppLifecycle(
         withApplicationRuntimeShutdown(
           {
             app,
@@ -732,17 +775,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             quit: () => app.quit(),
             countWindows: () => BrowserWindow.getAllWindows().length,
             createInitialWindow: !ctx.webMode.headless,
-            headlessSignalSource: ctx.webMode.headless ? process : undefined,
-            subscribePowerShutdown:
-              process.platform === 'win32'
-                ? undefined
-                : (listener) =>
-                    powerMonitor.on('shutdown', ((event?: { preventDefault?: () => void }) =>
-                      listener({
-                        // Electron's generated v39 type omits this documented event argument.
-                        // Keep the bridge safe if a host also omits it at runtime.
-                        preventDefault: () => event?.preventDefault?.()
-                      })) as () => void),
+            bindSystemShutdownWindow,
             detectActiveSessions: ctx.detectActiveSessions,
             hasActiveReviewerWork: ctx.hasActiveReviewerWork,
             prepareForQuit: ctx.prepareForQuit,
@@ -773,6 +806,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           }
         )
       )
+      const { showMainWindow, getMainWindow, isMainWindowHidden, onSystemShutdown } = lifecycle
 
       // Window lifecycle now exists: expose it to the restored controller, reapply any Windows
       // overlay to the first window, then attach completion/focus/window-recreation events.
@@ -821,7 +855,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           onError: (error) => ctx.log.error('on-demand web service start failed', error)
         })
       preStartupSecondInstanceRelay.bind(onSecondInstance)
-      return { onSecondInstance }
+      return { onSecondInstance, onSystemShutdown }
     },
     markReady: (ctx) => {
       ctx.databaseStartupOwner.complete()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -97,8 +97,16 @@ if (shouldRunArtifactMcpServer) {
 
 // Boots the Electron app only in normal UI mode, keeping artifact MCP mode free of Electron imports.
 async function startElectronApp(mainEntryPath: string): Promise<void> {
-  const { app, BrowserWindow, crashReporter, ipcMain, nativeImage, nativeTheme, protocol } =
-    createRequire(import.meta.url)('electron') as typeof import('electron')
+  const {
+    app,
+    BrowserWindow,
+    crashReporter,
+    ipcMain,
+    nativeImage,
+    nativeTheme,
+    powerMonitor,
+    protocol
+  } = createRequire(import.meta.url)('electron') as typeof import('electron')
 
   // Electron accepts privileged schemes only before app ready. Keep this in the synchronous UI
   // bootstrap before any awaited import can yield to the ready event.
@@ -724,6 +732,17 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             quit: () => app.quit(),
             countWindows: () => BrowserWindow.getAllWindows().length,
             createInitialWindow: !ctx.webMode.headless,
+            headlessSignalSource: ctx.webMode.headless ? process : undefined,
+            subscribePowerShutdown:
+              process.platform === 'win32'
+                ? undefined
+                : (listener) =>
+                    powerMonitor.on('shutdown', ((event?: { preventDefault?: () => void }) =>
+                      listener({
+                        // Electron's generated v39 type omits this documented event argument.
+                        // Keep the bridge safe if a host also omits it at runtime.
+                        preventDefault: () => event?.preventDefault?.()
+                      })) as () => void),
             detectActiveSessions: ctx.detectActiveSessions,
             hasActiveReviewerWork: ctx.hasActiveReviewerWork,
             prepareForQuit: ctx.prepareForQuit,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -291,6 +291,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       })
       startupDiagnostics?.phase('crash-reporting', { enabled: crashReporting.enabled })
 
+      startupDiagnostics?.phase('electron-ready')
+      await app.whenReady()
+      installPowerMonitorListeners()
+
       startupDiagnostics?.phase('load-startup-shell-modules')
       const [
         { createManagedPreviewProtocolBridge },
@@ -324,9 +328,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./settings/repository')
       ])
 
-      startupDiagnostics?.phase('electron-ready')
-      await app.whenReady()
-      installPowerMonitorListeners()
       startupDiagnostics?.phase('prepare-shell')
       // The bridge is lightweight, but its protocol handler must exist before the first BrowserWindow
       // creates the default session. macOS otherwise treats later managed-preview requests as an

--- a/src/main/storage/migration-state.test.ts
+++ b/src/main/storage/migration-state.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  clearApplicationShutdownTrigger,
+  markApplicationShutdownTrigger
+} from '../application-shutdown-trigger'
+
 vi.mock('electron', () => ({ dialog: { showMessageBoxSync: vi.fn() } }))
 
 const {
@@ -35,6 +40,7 @@ const makeApp = (): GuardApp & { fireBeforeQuit: () => { prevented: boolean } } 
 
 afterEach(() => {
   endMigration()
+  clearApplicationShutdownTrigger()
   vi.clearAllMocks()
 })
 
@@ -172,6 +178,25 @@ describe('migration-state', () => {
     expect(confirmQuit).toHaveBeenCalledTimes(1)
     expect(app.quit).not.toHaveBeenCalled()
     expect(isMigrationInProgress()).toBe(true)
+  })
+
+  it('cancels a migration without prompting when system shutdown owns the quit', async () => {
+    const app = makeApp()
+    const confirmQuit = vi.fn().mockReturnValue(false)
+    installMigrationQuitGuard(app, confirmQuit)
+    beginMigration()
+    markApplicationShutdownTrigger('system')
+
+    const { prevented } = app.fireBeforeQuit()
+
+    expect(prevented).toBe(true)
+    expect(confirmQuit).not.toHaveBeenCalled()
+    expect(app.quit).not.toHaveBeenCalled()
+
+    await Promise.resolve()
+
+    expect(isMigrationInProgress()).toBe(false)
+    await vi.waitFor(() => expect(app.quit).toHaveBeenCalledTimes(1))
   })
 
   it('quit guard clears the flag before asynchronously re-issuing a confirmed quit', async () => {

--- a/src/main/storage/migration-state.ts
+++ b/src/main/storage/migration-state.ts
@@ -1,6 +1,7 @@
 import { dialog, type App } from 'electron'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { englishNativeTranslator, type NativeTranslator } from '../locale/main-process-messages'
+import { currentApplicationShutdownTrigger } from '../application-shutdown-trigger'
 
 // Module-level state (not parameters) because the quit guard, the migrate IPC handler, and the
 // ACP/notebook write paths live in different modules but must agree on a single truth. The three
@@ -186,10 +187,11 @@ const defaultConfirmQuit = (translate: NativeTranslator): boolean =>
 // Installs a before-quit guard so an in-flight migration is not silently torn down by Cmd+Q / the
 // window close button. The move itself is crash-safe (copy → verify → commit → delete leaves either
 // the old or the new root fully intact), so this is about not making the user redo a move by
-// accident, not about preventing data loss. On confirmation the active command is aborted and
-// awaited before quit is re-issued. Pre-commit cancellation clears the flags; a command that commits
-// while being joined keeps the write gate and performs its mandatory relaunch. `confirmQuit` is
-// injectable for tests.
+// accident, not about preventing data loss. A system-owned shutdown skips the interactive choice and
+// uses the same safe cancel/join path because the OS request must not leave a latent shutdown trigger.
+// On confirmation/cancellation the active command is aborted and awaited before quit is re-issued.
+// Pre-commit cancellation clears the flags; a command that commits while being joined keeps the write
+// gate and performs its mandatory relaunch. `confirmQuit` is injectable for tests.
 export const installMigrationQuitGuard = (
   app: Pick<App, 'on' | 'quit'>,
   confirmQuit?: () => boolean,
@@ -200,7 +202,8 @@ export const installMigrationQuitGuard = (
     if (!isMigrationInProgress()) return
     event.preventDefault()
     if (quitCancellationPending) return
-    if ((confirmQuit ?? (() => defaultConfirmQuit(translate)))()) {
+    const systemShutdown = currentApplicationShutdownTrigger() === 'system'
+    if (systemShutdown || (confirmQuit ?? (() => defaultConfirmQuit(translate)))()) {
       quitCancellationPending = true
       void cancelMigrationForQuit().then(() => {
         quitCancellationPending = false

--- a/src/main/system-lifecycle-adapters.test.ts
+++ b/src/main/system-lifecycle-adapters.test.ts
@@ -1,0 +1,114 @@
+import { EventEmitter } from 'node:events'
+
+import type { BrowserWindow, PowerMonitor } from 'electron'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  installSystemLifecycleAdapters,
+  type ShutdownSignalSource,
+  type SystemLifecycleWindow
+} from './system-lifecycle-adapters'
+
+const setup = (
+  options: { platform?: NodeJS.Platform; headless?: boolean } = {}
+): {
+  adapters: ReturnType<typeof installSystemLifecycleAdapters>
+  signalSource: EventEmitter
+  powerMonitor: EventEmitter
+  requestSystemShutdown: () => void
+  windows: SystemLifecycleWindow[]
+} => {
+  const signalSource = new EventEmitter()
+  const powerMonitor = new EventEmitter()
+  const requestSystemShutdown = vi.fn()
+  const windows: SystemLifecycleWindow[] = []
+  const adapters = installSystemLifecycleAdapters({
+    platform: options.platform ?? 'linux',
+    headless: options.headless ?? false,
+    signalSource: signalSource as ShutdownSignalSource,
+    powerMonitor: powerMonitor as unknown as Pick<PowerMonitor, 'on'>,
+    getWindows: () => windows,
+    requestSystemShutdown
+  })
+  return { adapters, signalSource, powerMonitor, requestSystemShutdown, windows }
+}
+
+const makeWindow = (): {
+  window: SystemLifecycleWindow
+  emit: (event: 'query-session-end' | 'session-end', payload?: unknown) => void
+  send: ReturnType<typeof vi.fn>
+} => {
+  const emitter = new EventEmitter()
+  const send = vi.fn()
+  return {
+    window: {
+      isDestroyed: () => false,
+      on: emitter.on.bind(emitter),
+      webContents: { send }
+    } as unknown as Pick<BrowserWindow, 'isDestroyed' | 'on' | 'webContents'>,
+    emit: (event, payload) => emitter.emit(event, payload),
+    send
+  }
+}
+
+describe('installSystemLifecycleAdapters', () => {
+  it.each(['query-session-end', 'session-end'] as const)(
+    'routes Windows %s without vetoing the OS event',
+    (eventName) => {
+      const { adapters, requestSystemShutdown } = setup({ platform: 'win32' })
+      const { window, emit } = makeWindow()
+      const event = { preventDefault: vi.fn() }
+
+      adapters.bindWindow(window)
+      adapters.bindWindow(window)
+      emit(eventName, event)
+
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(requestSystemShutdown).toHaveBeenCalledOnce()
+    }
+  )
+
+  it.each(['SIGTERM', 'SIGINT'] as const)(
+    'routes Headless %s once and removes the sibling signal listener',
+    (signal) => {
+      const { signalSource, requestSystemShutdown } = setup({ headless: true })
+      const sibling = signal === 'SIGTERM' ? 'SIGINT' : 'SIGTERM'
+
+      signalSource.emit(signal)
+      signalSource.emit(sibling)
+
+      expect(requestSystemShutdown).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('routes a preventable non-Windows power shutdown', () => {
+    const { adapters, powerMonitor, requestSystemShutdown } = setup({ platform: 'darwin' })
+    const event = { preventDefault: vi.fn() }
+
+    adapters.installPowerMonitorListeners()
+    powerMonitor.emit('shutdown', event)
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(requestSystemShutdown).toHaveBeenCalledOnce()
+  })
+
+  it('does not install unsupported Windows power shutdown handling', () => {
+    const { adapters, powerMonitor, requestSystemShutdown } = setup({ platform: 'win32' })
+
+    adapters.installPowerMonitorListeners()
+    powerMonitor.emit('shutdown', { preventDefault: vi.fn() })
+
+    expect(requestSystemShutdown).not.toHaveBeenCalled()
+  })
+
+  it('notifies every live Renderer to revalidate network state after resume', () => {
+    const { adapters, powerMonitor, windows } = setup({ platform: 'win32' })
+    const live = makeWindow()
+    windows.push(live.window)
+
+    adapters.installPowerMonitorListeners()
+    powerMonitor.emit('resume')
+
+    expect(live.send).toHaveBeenCalledWith('network:system-resumed')
+  })
+})

--- a/src/main/system-lifecycle-adapters.test.ts
+++ b/src/main/system-lifecycle-adapters.test.ts
@@ -22,8 +22,10 @@ const setup = (
   const powerMonitor = new EventEmitter()
   const requestSystemShutdown = vi.fn()
   const windows: SystemLifecycleWindow[] = []
+  const platform = options.platform ?? 'linux'
   const adapters = installSystemLifecycleAdapters({
-    platform: options.platform ?? 'linux',
+    windowSessionEndEvents: platform === 'win32',
+    powerShutdownEvent: platform !== 'win32',
     headless: options.headless ?? false,
     signalSource: signalSource as ShutdownSignalSource,
     powerMonitor: powerMonitor as unknown as Pick<PowerMonitor, 'on'>,

--- a/src/main/system-lifecycle-adapters.ts
+++ b/src/main/system-lifecycle-adapters.ts
@@ -1,0 +1,74 @@
+import type { BrowserWindow, PowerMonitor } from 'electron'
+
+import { NETWORK_SYSTEM_RESUMED_CHANNEL } from '../shared/network'
+
+type ShutdownSignal = 'SIGTERM' | 'SIGINT'
+
+type ShutdownSignalSource = {
+  once: (signal: ShutdownSignal, listener: () => void) => unknown
+  removeListener: (signal: ShutdownSignal, listener: () => void) => unknown
+}
+
+type SystemLifecycleWindow = Pick<BrowserWindow, 'isDestroyed' | 'on' | 'webContents'>
+
+type SystemLifecycleAdapterDeps = {
+  platform: NodeJS.Platform
+  headless: boolean
+  signalSource: ShutdownSignalSource
+  powerMonitor: Pick<PowerMonitor, 'on'>
+  getWindows: () => readonly SystemLifecycleWindow[]
+  requestSystemShutdown: () => void
+}
+
+type SystemLifecycleAdapters = {
+  bindWindow: (window: SystemLifecycleWindow) => void
+  installPowerMonitorListeners: () => void
+}
+
+// Owns the Electron/Node event adapters that feed the startup shutdown relay. Window listeners are
+// installed early enough to cover the startup shell; powerMonitor is installed only after app ready.
+export const installSystemLifecycleAdapters = (
+  deps: SystemLifecycleAdapterDeps
+): SystemLifecycleAdapters => {
+  const boundWindows = new WeakSet<SystemLifecycleWindow>()
+
+  if (deps.headless) {
+    const onSignal = (): void => {
+      deps.signalSource.removeListener('SIGTERM', onSignal)
+      deps.signalSource.removeListener('SIGINT', onSignal)
+      deps.requestSystemShutdown()
+    }
+    deps.signalSource.once('SIGTERM', onSignal)
+    deps.signalSource.once('SIGINT', onSignal)
+  }
+
+  return {
+    bindWindow: (window) => {
+      if (deps.platform !== 'win32' || boundWindows.has(window)) return
+      boundWindows.add(window)
+      // Respect the OS-owned session end while giving the shutdown owner an early best-effort start.
+      window.on('query-session-end', deps.requestSystemShutdown)
+      // session-end can no longer delay Windows logoff/shutdown; retain it as a fallback.
+      window.on('session-end', deps.requestSystemShutdown)
+    },
+    installPowerMonitorListeners: () => {
+      deps.powerMonitor.on('resume', () => {
+        for (const window of deps.getWindows()) {
+          if (!window.isDestroyed()) {
+            window.webContents.send(NETWORK_SYSTEM_RESUMED_CHANNEL)
+          }
+        }
+      })
+
+      if (deps.platform === 'win32') return
+      deps.powerMonitor.on('shutdown', ((event?: { preventDefault?: () => void }) => {
+        // Electron's generated v39 type omits this documented event argument. Keep the bridge safe
+        // if a host also omits it at runtime.
+        event?.preventDefault?.()
+        deps.requestSystemShutdown()
+      }) as () => void)
+    }
+  }
+}
+
+export type { ShutdownSignalSource, SystemLifecycleAdapterDeps, SystemLifecycleWindow }

--- a/src/main/system-lifecycle-adapters.ts
+++ b/src/main/system-lifecycle-adapters.ts
@@ -12,7 +12,8 @@ type ShutdownSignalSource = {
 type SystemLifecycleWindow = Pick<BrowserWindow, 'isDestroyed' | 'on' | 'webContents'>
 
 type SystemLifecycleAdapterDeps = {
-  platform: NodeJS.Platform
+  windowSessionEndEvents: boolean
+  powerShutdownEvent: boolean
   headless: boolean
   signalSource: ShutdownSignalSource
   powerMonitor: Pick<PowerMonitor, 'on'>
@@ -44,7 +45,7 @@ export const installSystemLifecycleAdapters = (
 
   return {
     bindWindow: (window) => {
-      if (deps.platform !== 'win32' || boundWindows.has(window)) return
+      if (!deps.windowSessionEndEvents || boundWindows.has(window)) return
       boundWindows.add(window)
       // Respect the OS-owned session end while giving the shutdown owner an early best-effort start.
       window.on('query-session-end', deps.requestSystemShutdown)
@@ -60,7 +61,7 @@ export const installSystemLifecycleAdapters = (
         }
       })
 
-      if (deps.platform === 'win32') return
+      if (!deps.powerShutdownEvent) return
       deps.powerMonitor.on('shutdown', ((event?: { preventDefault?: () => void }) => {
         // Electron's generated v39 type omits this documented event argument. Keep the bridge safe
         // if a host also omits it at runtime.

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -21,7 +21,7 @@ const {
   showMessageBoxMock,
   webFrameMainFromIdMock
 } = vi.hoisted(() => ({
-  openExternalMock: vi.fn(),
+  openExternalMock: vi.fn(async () => undefined),
   ipcMainOnMock: vi.fn(),
   ipcMainRemoveListenerMock: vi.fn(),
   showMessageBoxMock: vi.fn(),
@@ -37,7 +37,8 @@ const { windowLogSpies } = vi.hoisted(() => ({
 }))
 
 vi.mock('./logger', () => ({
-  createLogger: () => windowLogSpies
+  createLogger: () => windowLogSpies,
+  diagnosticErrorFields: () => ({ errorCategory: 'error' })
 }))
 
 // The overlay manager is a collaborator with its own deep test suite; here we only need to observe
@@ -995,6 +996,7 @@ describe('window-open external handler', () => {
   beforeEach(() => {
     windowOpenHandler = undefined
     openExternalMock.mockClear()
+    windowLogSpies.warn.mockClear()
   })
 
   // Regression: app links use rel="noreferrer" and the packaged app runs on a file:// origin, so the
@@ -1015,6 +1017,20 @@ describe('window-open external handler', () => {
     windowOpenHandler!({ url: 'javascript:alert(1)', referrer: { url: '' } })
 
     expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('records a rejected operating-system open without leaving an unhandled rejection', async () => {
+    openExternalMock.mockRejectedValueOnce(new Error('no protocol handler'))
+    createMainWindow()
+
+    windowOpenHandler!({ url: 'https://example.com/report', referrer: { url: '' } })
+
+    await vi.waitFor(() =>
+      expect(windowLogSpies.warn).toHaveBeenCalledWith(
+        'external link open failed',
+        expect.objectContaining({ errorCategory: 'error' })
+      )
+    )
   })
 })
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -18,7 +18,7 @@ import iconWindows from '../../resources/icon-light.ico?asset'
 import { createFrameNavigationGuard, isAllowedExternalNavigation } from './navigation-policy'
 import { createFindOverlayManager, type FindOverlayDeps } from './find-overlay'
 import { registerFindOverlayOwner } from './find-overlay-registry'
-import { createLogger } from './logger'
+import { createLogger, diagnosticErrorFields } from './logger'
 import { createSourcePreviewLoadMonitor } from './source-preview-load-monitor'
 import { createSourcePreviewEmbedPolicy } from './source-preview-embed-policy'
 import { registerSourcePreviewWebRequestOwner } from './source-preview-web-request-owner'
@@ -111,7 +111,9 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
 
   window.webContents.setWindowOpenHandler((details) => {
     if (isAllowedExternalNavigation(details.url)) {
-      void shell.openExternal(details.url)
+      void shell.openExternal(details.url).catch((error) => {
+        log.warn('external link open failed', diagnosticErrorFields(error))
+      })
     }
     return { action: 'deny' }
   })

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -369,6 +369,7 @@ describe('preload bridge — public surface inventory', () => {
       'memory.updateEntry',
       'network.checkConnectivity',
       'network.getInfo',
+      'network.onSystemResume',
       'notebook.appendCodeCell',
       'notebook.beginCodeCell',
       'notebook.execute',

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -237,9 +237,10 @@ describe('startNetworkMonitor silent recovery', () => {
   })
 
   it('does not re-probe on focus while already reachable', async () => {
-    const checkConnectivity = vi.fn().mockResolvedValue(false)
+    const checkConnectivity = vi.fn().mockResolvedValue(true)
     stubCheckConnectivity(checkConnectivity)
-    useNetworkStore.setState({ isOnline: true, connectivity: 'reachable' })
+    await useNetworkStore.getState().probeConnectivity()
+    checkConnectivity.mockClear()
 
     window.dispatchEvent(new Event('focus'))
     await Promise.resolve()
@@ -247,6 +248,29 @@ describe('startNetworkMonitor silent recovery', () => {
 
     expect(checkConnectivity).not.toHaveBeenCalled()
     expect(useNetworkStore.getState().connectivity).toBe('reachable')
+  })
+
+  it('silently re-probes a reachable result that is stale when the window regains focus', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-08-30T00:00:00.000Z'))
+      const checkConnectivity = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+      stubCheckConnectivity(checkConnectivity)
+
+      await useNetworkStore.getState().probeConnectivity()
+      expect(useNetworkStore.getState().connectivity).toBe('reachable')
+
+      await vi.advanceTimersByTimeAsync(60_001)
+      window.dispatchEvent(new Event('focus'))
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(checkConnectivity).toHaveBeenCalledTimes(2)
+      expect(useNetworkStore.getState().connectivity).toBe('unreachable')
+    } finally {
+      vi.useRealTimers()
+      stubCheckConnectivity(vi.fn().mockResolvedValue(true))
+      await useNetworkStore.getState().probeConnectivity()
+    }
   })
 
   it('does not re-probe on focus while the link is down', async () => {

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -355,4 +355,81 @@ describe('startNetworkMonitor silent recovery', () => {
     })
     expect(checkConnectivity).toHaveBeenCalledTimes(2)
   })
+
+  it('refreshes a cached offline state before re-probing after system resume', async () => {
+    vi.resetModules()
+    let notifySystemResume: (() => void) | undefined
+    const checkConnectivity = vi.fn().mockResolvedValue(true)
+    ;(window as unknown as { api: unknown }).api = {
+      network: {
+        checkConnectivity,
+        onSystemResume: (listener: () => void) => {
+          notifySystemResume = listener
+          return vi.fn()
+        }
+      }
+    }
+    setNavigatorOnline(false)
+
+    const freshNetworkStore = await import('./network-store')
+    freshNetworkStore.startNetworkMonitor()
+    expect(freshNetworkStore.useNetworkStore.getState()).toMatchObject({
+      isOnline: false,
+      connectivity: 'unreachable'
+    })
+
+    setNavigatorOnline(true)
+    notifySystemResume?.()
+
+    await vi.waitFor(() => {
+      expect(freshNetworkStore.useNetworkStore.getState()).toMatchObject({
+        isOnline: true,
+        connectivity: 'reachable'
+      })
+    })
+    expect(checkConnectivity).toHaveBeenCalledOnce()
+  })
+
+  it('runs a pending forced resume recheck after a silent probe finishes', async () => {
+    vi.resetModules()
+    let notifySystemResume: (() => void) | undefined
+    let resolveInFlight!: (reachable: boolean) => void
+    const inFlightResult = new Promise<boolean>((resolve) => {
+      resolveInFlight = resolve
+    })
+    const checkConnectivity = vi
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockReturnValueOnce(inFlightResult)
+      .mockResolvedValueOnce(false)
+    ;(window as unknown as { api: unknown }).api = {
+      network: {
+        checkConnectivity,
+        onSystemResume: (listener: () => void) => {
+          notifySystemResume = listener
+          return vi.fn()
+        }
+      }
+    }
+    setNavigatorOnline(true)
+
+    const freshNetworkStore = await import('./network-store')
+    freshNetworkStore.startNetworkMonitor()
+    await vi.waitFor(() => {
+      expect(freshNetworkStore.useNetworkStore.getState().connectivity).toBe('reachable')
+    })
+
+    notifySystemResume?.()
+    await vi.waitFor(() => {
+      expect(checkConnectivity).toHaveBeenCalledTimes(2)
+    })
+    notifySystemResume?.()
+    await Promise.resolve()
+    resolveInFlight(true)
+
+    await vi.waitFor(() => {
+      expect(checkConnectivity).toHaveBeenCalledTimes(3)
+    })
+    expect(freshNetworkStore.useNetworkStore.getState().connectivity).toBe('unreachable')
+  })
 })

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -325,4 +325,34 @@ describe('startNetworkMonitor silent recovery', () => {
     expect(checkConnectivity).not.toHaveBeenCalled()
     expect(useNetworkStore.getState().connectivity).toBe('unreachable')
   })
+
+  it('silently re-probes a fresh reachable result after system resume', async () => {
+    vi.resetModules()
+    let notifySystemResume: (() => void) | undefined
+    const checkConnectivity = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    ;(window as unknown as { api: unknown }).api = {
+      network: {
+        checkConnectivity,
+        onSystemResume: (listener: () => void) => {
+          notifySystemResume = listener
+          return vi.fn()
+        }
+      }
+    }
+    setNavigatorOnline(true)
+
+    const freshNetworkStore = await import('./network-store')
+    freshNetworkStore.startNetworkMonitor()
+    await vi.waitFor(() => {
+      expect(freshNetworkStore.useNetworkStore.getState().connectivity).toBe('reachable')
+    })
+
+    expect(notifySystemResume).toBeTypeOf('function')
+    notifySystemResume?.()
+
+    await vi.waitFor(() => {
+      expect(freshNetworkStore.useNetworkStore.getState().connectivity).toBe('unreachable')
+    })
+    expect(checkConnectivity).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -100,9 +100,9 @@ export const useNetworkStore = create<NetworkStore>((set, get) => {
 // Installs the window listeners and runs the first probe. Called once from the app entry
 // (main.tsx) — deliberately NOT at module scope, so importing the store in tests stays free
 // of side effects. Probing happens on startup, on every link recovery, on window focus /
-// becoming visible while a previous probe is failing or its known result has expired, and on demand
-// (Retry). There is no background polling: a changed path out (Wi-Fi, VPN, proxy, DNS) is picked up
-// when the user returns to the window, not on a timer.
+// becoming visible while a previous probe is failing or its known result has expired, after system
+// resume, and on demand (Retry). There is no background polling: a changed path out (Wi-Fi, VPN,
+// proxy, DNS) is picked up when the user returns to the window, not on a timer.
 let monitorStarted = false
 
 export const startNetworkMonitor = (): void => {
@@ -119,14 +119,16 @@ export const startNetworkMonitor = (): void => {
   })
 
   let silentRecheckQueued = false
+  let forcedSilentRecheckQueued = false
   let silentProbeInFlight = false
-  const silentlyRecheckIfStale = (): void => {
+  const silentlyRecheckIfStale = (force = false): void => {
     const { isOnline, connectivity } = useNetworkStore.getState()
     if (!isOnline) return
     const now = Date.now()
     const resultExpired =
       lastProbedAt === 0 || now < lastProbedAt || now - lastProbedAt >= REACHABILITY_RECHECK_TTL_MS
     if (
+      !force &&
       connectivity !== 'unreachable' &&
       connectivity !== 'probe-failed' &&
       !(connectivity === 'reachable' && resultExpired)
@@ -141,19 +143,23 @@ export const startNetworkMonitor = (): void => {
         silentProbeInFlight = false
       })
   }
-  const scheduleSilentRecheck = (): void => {
+  const scheduleSilentRecheck = (force = false): void => {
+    forcedSilentRecheckQueued ||= force
     if (silentRecheckQueued) return
     silentRecheckQueued = true
     queueMicrotask(() => {
       silentRecheckQueued = false
-      silentlyRecheckIfStale()
+      const shouldForce = forcedSilentRecheckQueued
+      forcedSilentRecheckQueued = false
+      silentlyRecheckIfStale(shouldForce)
     })
   }
 
-  window.addEventListener('focus', scheduleSilentRecheck)
+  window.addEventListener('focus', () => scheduleSilentRecheck())
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') scheduleSilentRecheck()
   })
+  window.api?.network?.onSystemResume?.(() => scheduleSilentRecheck(true))
 
   if (navigator.onLine) {
     void useNetworkStore.getState().probeConnectivity()

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -120,6 +120,7 @@ export const startNetworkMonitor = (): void => {
 
   let silentRecheckQueued = false
   let forcedSilentRecheckQueued = false
+  let forcedSilentRecheckPending = false
   let silentProbeInFlight = false
   const silentlyRecheckIfStale = (force = false): void => {
     const { isOnline, connectivity } = useNetworkStore.getState()
@@ -134,13 +135,20 @@ export const startNetworkMonitor = (): void => {
       !(connectivity === 'reachable' && resultExpired)
     )
       return
-    if (silentProbeInFlight) return
+    if (silentProbeInFlight) {
+      forcedSilentRecheckPending ||= force
+      return
+    }
     silentProbeInFlight = true
     void useNetworkStore
       .getState()
       .probeConnectivity()
       .finally(() => {
         silentProbeInFlight = false
+        if (forcedSilentRecheckPending) {
+          forcedSilentRecheckPending = false
+          scheduleSilentRecheck(true)
+        }
       })
   }
   const scheduleSilentRecheck = (force = false): void => {
@@ -159,7 +167,10 @@ export const startNetworkMonitor = (): void => {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') scheduleSilentRecheck()
   })
-  window.api?.network?.onSystemResume?.(() => scheduleSilentRecheck(true))
+  window.api?.network?.onSystemResume?.(() => {
+    useNetworkStore.getState().recheckOnline()
+    scheduleSilentRecheck(true)
+  })
 
   if (navigator.onLine) {
     void useNetworkStore.getState().probeConnectivity()

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -26,6 +26,8 @@ type NetworkStore = {
 // Minimum time an announced probe's Checking… presentation stays visible, so a clicked
 // re-check reads as a deliberate check instead of a flash.
 const MIN_CHECKING_MS = 500
+const REACHABILITY_RECHECK_TTL_MS = 60_000
+let lastProbedAt = 0
 
 export const useNetworkStore = create<NetworkStore>((set, get) => {
   let probeGeneration = 0
@@ -82,6 +84,7 @@ export const useNetworkStore = create<NetworkStore>((set, get) => {
     if (probeGeneration === generation && (get().isOnline || !reachable)) {
       const connectivity = reachable ? 'reachable' : 'unreachable'
       lastKnownConnectivity = connectivity
+      lastProbedAt = Date.now()
       set({ connectivity })
     }
   }
@@ -97,8 +100,8 @@ export const useNetworkStore = create<NetworkStore>((set, get) => {
 // Installs the window listeners and runs the first probe. Called once from the app entry
 // (main.tsx) — deliberately NOT at module scope, so importing the store in tests stays free
 // of side effects. Probing happens on startup, on every link recovery, on window focus /
-// becoming visible while a previous probe is still failing, and on demand (Retry). There is
-// no background polling: a live link with a recovered path out (proxy, DNS) is picked up
+// becoming visible while a previous probe is failing or its known result has expired, and on demand
+// (Retry). There is no background polling: a changed path out (Wi-Fi, VPN, proxy, DNS) is picked up
 // when the user returns to the window, not on a timer.
 let monitorStarted = false
 
@@ -120,7 +123,15 @@ export const startNetworkMonitor = (): void => {
   const silentlyRecheckIfStale = (): void => {
     const { isOnline, connectivity } = useNetworkStore.getState()
     if (!isOnline) return
-    if (connectivity !== 'unreachable' && connectivity !== 'probe-failed') return
+    const now = Date.now()
+    const resultExpired =
+      lastProbedAt === 0 || now < lastProbedAt || now - lastProbedAt >= REACHABILITY_RECHECK_TTL_MS
+    if (
+      connectivity !== 'unreachable' &&
+      connectivity !== 'probe-failed' &&
+      !(connectivity === 'reachable' && resultExpired)
+    )
+      return
     if (silentProbeInFlight) return
     silentProbeInFlight = true
     void useNetworkStore

--- a/src/shared/network.ts
+++ b/src/shared/network.ts
@@ -7,3 +7,5 @@ export type NetworkInfo = {
   connectionType: NetworkConnectionType
   ipAddress: string | null
 }
+
+export const NETWORK_SYSTEM_RESUMED_CHANNEL = 'network:system-resumed'

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -354,7 +354,7 @@ import type {
 import type { PackageMirror } from './mirror'
 import type { NetworkProxySettings } from './network-proxy'
 import type { NotebookNetworkSettings, NotebookNetworkStatus } from './notebook-network'
-import type { NetworkInfo } from './network'
+import { NETWORK_SYSTEM_RESUMED_CHANNEL, type NetworkInfo } from './network'
 import type {
   ActiveSessionInfo,
   DataRootInspection,
@@ -1076,6 +1076,10 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'network.getInfo': callable<() => Promise<NetworkInfo>>()('network', [
     'network:get-info',
     ELECTRON
+  ]),
+  'network.onSystemResume': callable<(listener: () => void) => RemoveListener>()('network', [
+    NETWORK_SYSTEM_RESUMED_CHANNEL,
+    ELECTRON_EVENT
   ]),
   'notebook.appendCodeCell': callable<
     (request: AppendNotebookCodeCellRequest) => Promise<{

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -64,6 +64,7 @@ const GENERATED_SOURCE_OMISSIONS = [
   'locale.setPreference',
   'network.checkConnectivity',
   'network.getInfo',
+  'network.onSystemResume',
   'notifications.getDesktopAvailability',
   'notifications.onOpenSession',
   'notifications.onViewProbe',


### PR DESCRIPTION
## Problem

Three P3 lifecycle/recovery paths lacked an observed owner boundary:

- OS shutdown events and headless `SIGTERM`/`SIGINT` could bypass the only bounded application
  shutdown sequence, so Renderer persistence, ACP/Notebook disposal, Web state removal, Remote Access
  invalidation, and log flushing were not attempted consistently.
- A `reachable` renderer network result had no freshness boundary, so focus/visibility recovery could
  keep showing stale green status after Wi-Fi, VPN, proxy, or DNS changes.
- The main-window external navigation handler discarded a rejected `shell.openExternal()` Promise,
  allowing an OS open failure to reach the main process's intentional fail-fast rejection policy.

## Proposed change

- Add a transient `system` shutdown trigger and route Windows `query-session-end`, Linux/macOS
  `powerMonitor.shutdown`, and dedicated-headless `SIGTERM`/`SIGINT` through the existing
  `app.quit()` -> bounded lifecycle owner. Windows `session-end` remains an explicitly best-effort
  fallback because it cannot delay session termination.
- Install those native sources immediately after the primary-instance lock. A one-bit startup relay
  coalesces any request received during database verification/runtime composition and forwards it only
  after the existing migration guard and shutdown owner are ready. If preparation never finishes, a
  five-second startup-only budget falls back to `app.exit(0)` rather than indefinitely delaying OS
  shutdown; the timer is cancelled as soon as the normal owner is available.
- Track the last completed reachability probe time in memory and silently re-probe an aged
  `reachable` result when the renderer regains focus or becomes visible. The TTL is 60 seconds and
  adds no polling timer.
- Catch `shell.openExternal()` rejection at the existing call site and emit only the existing
  fixed-vocabulary diagnostic category.

## Scope and non-goals

- No hidden `BaseWindow` is created for Windows headless mode. Service-manager signals are covered;
  a pure Windows logoff/shutdown of a headless daemon still has no preventable window callback.
- No generic `suspend`/`resume` framework is added. Suspend is not exit, so ACP/Notebook work is not
  destroyed; visible renderer recovery is covered by the focus/visibility TTL.
- No background network polling, UI, copy, or user-flow changes.
- No database, Settings, Session, shared wire-model, data-relationship, or migration changes.
- Historical compatibility: none required. No serialized format is changed.
- New state: `ApplicationShutdownTrigger` gains transient `system`; the probe timestamp is also
  process-memory-only.
- Persistence: no new field or file. Existing Renderer flush and Web state-file removal now run on
  more graceful exit paths.

## Acceptance criteria and validation

Each regression was first run twice on the unfixed implementation and failed for the reported reason:

- Windows session end: event was not prevented and shutdown was not requested.
- Stale reachable result: focus produced one probe call instead of the expected second call.
- Rejected external open: no warning was recorded and the Promise had no observed rejection path.
- Headless signals / power shutdown: fake native sources had no registered bridge to `app.quit()`.
- Startup delivery (run twice after review feedback): the startup orchestrator installed the native
  listener callback zero times, so a request during `prepare()` was never queued for the lifecycle owner.
- Blocked startup (run twice after review feedback): after the startup budget elapsed, the force-exit
  callback had been called zero times, confirming that a queued request could hang indefinitely.
- Electron readiness chain (CI plus two local reproductions): `app-branding.test.ts` rejected the
  detached `app.whenReady().then` continuation. The power listener now registers immediately after the
  existing awaited readiness barrier and still precedes database verification/runtime composition.

Final evidence below was collected after the last material edit:

- System/session/signal/power shutdown policy ->
  `vitest run src/main/app-lifecycle.test.ts` -> 67 passed.
- External navigation failure handling -> `vitest run src/main/windows.test.ts` -> 65 passed.
- Reachability TTL/coalescing -> `vitest run src/renderer/src/stores/network-store.test.ts` ->
  21 passed.
- Startup/composition consumers -> `vitest run src/main/application-command-wiring.test.ts
  src/main/app-startup.test.ts` -> 25 passed.
- Electron readiness policy -> `vitest run src/main/app-branding.test.ts` -> 4 passed.
- Combined final targeted run of the six files above -> 182 passed.
- Main process types -> `npm run typecheck:node` -> passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.
- `npm run test:affected -- --base origin/main --head HEAD --explain` classified the lifecycle files
  as an unknown Module owner and therefore selected the full suite. Per maintainer direction, the
  complete local `npm test` was not run; PR Gate and platform lanes are authoritative.

Local delivery-event coverage remains bounded to the documented Electron API boundary; unit tests do
not simulate a real OS shutdown, service manager deadline, or unpreventable forced termination.

## Review focus

- The native handlers should only select the `system` policy and delegate to the existing shutdown
  owner; teardown ordering must remain single-owned.
- System shutdown intentionally bypasses interactive confirmation and conflict cancellation because
  those paths have no reliable interaction budget.
- `session-end` is not described as guaranteed cleanup, and Windows headless does not add a hidden
  native resource.
- Network focus/visibility stays silent, coalesced, and timer-free.
- External-open diagnostics must not retain URLs, OS error text, stacks, or local paths.
