### PR TITLE
fix(acp): isolate provider resume timeouts

### DIFF
--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -68,6 +68,7 @@ type HarnessOptions = {
   ensureConnected?: () => Promise<ClientConnection>
   foreignIdentityCollision?: (sessionIds: readonly string[]) => Error | undefined
   initialBackend?: AcpBackendGenerationView
+  invalidatePendingOnTimeout?: boolean
   invalidateDuringResume?: boolean
   observerError?: Error
   projectAgentContext?: string
@@ -203,7 +204,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
   )
   const disconnectTimedOutConnection = vi.fn(async () => {
     order.push('disconnect')
-    registry.invalidatePending()
+    if (options.invalidatePendingOnTimeout !== false) registry.invalidatePending()
   })
   const configure = vi.fn(async (input: { backend: AcpBackendGenerationView }) => {
     order.push('configure')
@@ -409,7 +410,8 @@ describe('AcpProviderSessionResumer', () => {
 
     expect(harness.request).toHaveBeenCalledWith(
       acp.methods.agent.session.resume,
-      expect.objectContaining({ mcpServers: [capabilityServer, skillServer] })
+      expect.objectContaining({ mcpServers: [capabilityServer, skillServer] }),
+      expect.objectContaining({ cancellationSignal: expect.any(AbortSignal) })
     )
   })
 
@@ -629,19 +631,57 @@ describe('AcpProviderSessionResumer', () => {
     expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
   })
 
-  it('starts a fresh timeout budget after reconnecting before provider resume stalls', async () => {
-    const harness = createHarness()
-    harness.request.mockImplementationOnce(() => new Promise<never>(() => undefined))
+  it.each([
+    ['claude-code', backend, {}],
+    ['opencode', opencodeBackend, {}],
+    ['codex-response', codexResponsesBackend, {}],
+    [
+      'codex-bridge',
+      { ...codexBridgeBackend, providerContinuityToken: 'bridge-token' },
+      { providerContinuityToken: 'bridge-token' }
+    ]
+  ] as const)(
+    'starts a fresh timeout budget and cancels the stalled %s provider resume request',
+    async (_route, initialBackend, request) => {
+      const harness = createHarness({ initialBackend })
+      harness.request.mockImplementationOnce(() => new Promise<never>(() => undefined))
 
-    const resumed = harness.resume()
+      const resumed = harness.resume({
+        providerSessionId: '019fb8c8-6c66-7f22-9653-17b5b287dbbb',
+        previousFrameworkId: initialBackend.framework.id,
+        previousBackendId: initialBackend.backendId,
+        ...request
+      })
+      await vi.waitFor(() => expect(harness.request).toHaveBeenCalledOnce())
+      const requestOptions = harness.request.mock.calls[0]?.[2] as
+        { cancellationSignal?: AbortSignal } | undefined
+      expect(requestOptions?.cancellationSignal?.aborted).toBe(false)
+      harness.fireTimeout()
+
+      await expect(resumed).rejects.toThrow('ACP session resume timed out.')
+      expect(requestOptions?.cancellationSignal?.aborted).toBe(true)
+      expect(harness.setTimer).toHaveBeenCalledTimes(2)
+      expect(harness.setTimer).toHaveBeenNthCalledWith(1, expect.any(Function), 60_000)
+      expect(harness.setTimer).toHaveBeenNthCalledWith(2, expect.any(Function), 60_000)
+      expect(harness.disconnectTimedOutConnection).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('discards a provider resume response that arrives after a preserved-connection timeout', async () => {
+    const harness = createHarness({ invalidatePendingOnTimeout: false })
+    const finishResume = Promise.withResolvers<{ sessionId: string }>()
+    harness.request.mockImplementationOnce(() => finishResume.promise)
+
+    const resumed = harness.resume({ providerSessionId: 'provider-session' })
     await vi.waitFor(() => expect(harness.request).toHaveBeenCalledOnce())
     harness.fireTimeout()
-
     await expect(resumed).rejects.toThrow('ACP session resume timed out.')
-    expect(harness.setTimer).toHaveBeenCalledTimes(2)
-    expect(harness.setTimer).toHaveBeenNthCalledWith(1, expect.any(Function), 60_000)
-    expect(harness.setTimer).toHaveBeenNthCalledWith(2, expect.any(Function), 60_000)
-    expect(harness.disconnectTimedOutConnection).toHaveBeenCalledOnce()
+
+    finishResume.resolve({ sessionId: 'provider-session' })
+    await vi.waitFor(() => expect(harness.providerSession.dispose).toHaveBeenCalledOnce())
+
+    expect(harness.registry.lookup('stable-app-session')?.attachment).toBeUndefined()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: false })
   })
 
   it('renews only the matching provider resume inactivity budget', async () => {
@@ -775,7 +815,8 @@ describe('AcpProviderSessionResumer', () => {
 
     expect(harness.request).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ sessionId: providerSessionId })
+      expect.objectContaining({ sessionId: providerSessionId }),
+      expect.objectContaining({ cancellationSignal: expect.any(AbortSignal) })
     )
     expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
     expect(harness.adopt).toHaveBeenCalledOnce()
@@ -798,7 +839,8 @@ describe('AcpProviderSessionResumer', () => {
 
     expect(harness.request).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ sessionId: providerSessionId })
+      expect.objectContaining({ sessionId: providerSessionId }),
+      expect.objectContaining({ cancellationSignal: expect.any(AbortSignal) })
     )
     expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
     expect(harness.adopt).toHaveBeenCalledOnce()
@@ -826,7 +868,8 @@ describe('AcpProviderSessionResumer', () => {
 
       expect(harness.request).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ sessionId: providerSessionId })
+        expect.objectContaining({ sessionId: providerSessionId }),
+        expect.objectContaining({ cancellationSignal: expect.any(AbortSignal) })
       )
       expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
       expect(harness.adopt).toHaveBeenCalledOnce()

--- a/src/main/acp/provider-session-resumer.ts
+++ b/src/main/acp/provider-session-resumer.ts
@@ -176,7 +176,16 @@ export class AcpProviderSessionResumer {
       this.deps.assertCurrentConnection(connection)
       identity.renew()
       return await this.withTimeout(
-        () => this.resumeConnected(request, connection, cwd, projectId, identity, compatibleOnly),
+        (cancellationSignal) =>
+          this.resumeConnected(
+            request,
+            connection,
+            cwd,
+            projectId,
+            identity,
+            compatibleOnly,
+            cancellationSignal
+          ),
         this.progressSessionIds(request)
       )
     } finally {
@@ -241,9 +250,10 @@ export class AcpProviderSessionResumer {
   }
 
   private async withTimeout<Result>(
-    operation: () => Promise<Result>,
+    operation: (cancellationSignal: AbortSignal) => Promise<Result>,
     progressSessionIds: readonly string[] = []
   ): Promise<Result> {
+    const cancellation = new AbortController()
     let timer: ReturnType<typeof setTimeout> | undefined
     let timedOut = false
     let settled = false
@@ -256,14 +266,16 @@ export class AcpProviderSessionResumer {
       if (timer !== undefined) this.deps.clearTimer(timer)
       timer = this.deps.setTimer(() => {
         timedOut = true
-        rejectTimeout(new Error('ACP session resume timed out.'))
+        const error = new Error('ACP session resume timed out.')
+        cancellation.abort(error)
+        rejectTimeout(error)
       }, this.deps.resumeTimeoutMs)
     }
     const unsubscribe = this.subscribeToProgress(progressSessionIds, renewTimeout)
     renewTimeout()
 
     try {
-      return await Promise.race([operation(), timeout])
+      return await Promise.race([operation(cancellation.signal), timeout])
     } catch (error) {
       if (timedOut) await this.deps.disconnectTimedOutConnection()
       throw error
@@ -306,7 +318,8 @@ export class AcpProviderSessionResumer {
     cwd: string,
     projectId: string,
     identity: AcpPrimarySessionIdentityReservation,
-    compatibleOnly: boolean
+    compatibleOnly: boolean,
+    cancellationSignal: AbortSignal
   ): Promise<AcpCreateSessionResponse> {
     const affinity = this.deps.registry.lookup(request.sessionId)?.aggregate.snapshot()
     const persistedProviderSessionId = affinity?.providerSessionId ?? request.providerSessionId
@@ -330,7 +343,8 @@ export class AcpProviderSessionResumer {
         identity,
         persistedProviderSessionId,
         true,
-        true
+        true,
+        cancellationSignal
       )
     }
     const decision = this.policy.decide({
@@ -367,7 +381,8 @@ export class AcpProviderSessionResumer {
       identity,
       decision.providerSessionId,
       persistedProviderSessionId !== undefined,
-      compatibleOnly
+      compatibleOnly,
+      cancellationSignal
     )
   }
 
@@ -379,7 +394,8 @@ export class AcpProviderSessionResumer {
     identity: AcpPrimarySessionIdentityReservation,
     providerSessionId: string,
     providerSessionIdPersisted: boolean,
-    compatibleOnly: boolean
+    compatibleOnly: boolean,
+    cancellationSignal: AbortSignal
   ): Promise<AcpCreateSessionResponse> {
     let capability: SessionCapabilityProvision | undefined
     let provisionalSession: ActiveSession | undefined
@@ -438,12 +454,16 @@ export class AcpProviderSessionResumer {
 
       let resumeResponse: unknown
       try {
-        resumeResponse = await connection.agent.request(acp.methods.agent.session.resume, {
-          sessionId: providerSessionId,
-          cwd,
-          mcpServers: sessionCapabilities.mcpServers,
-          ...specialistProjection.setup.metaArg
-        })
+        resumeResponse = await connection.agent.request(
+          acp.methods.agent.session.resume,
+          {
+            sessionId: providerSessionId,
+            cwd,
+            mcpServers: sessionCapabilities.mcpServers,
+            ...specialistProjection.setup.metaArg
+          },
+          { cancellationSignal }
+        )
       } catch (error) {
         const failure = this.policy.classifyFailure(error, {
           currentFrameworkId: backend.framework.id,

--- a/src/main/acp/runtime-provider-session-composition.ts
+++ b/src/main/acp/runtime-provider-session-composition.ts
@@ -157,7 +157,9 @@ const composeAcpRuntimeProviderSessionOwners = (
     ensureConnected,
     assertCurrentConnection,
     disconnectTimedOutConnection: async () => {
-      await lifecycle.connectionClose.disconnect(false)
+      if (session.sessionRegistry.entries(true).length === 0) {
+        await lifecycle.connectionClose.disconnect(false)
+      }
     },
     resumeCapabilityAdvertised: () => base.connectionResources.capabilities.resume,
     currentBackend: () => base.backendGeneration.current,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -226,7 +226,11 @@ const startFakeAgent = (
     rejectModeChange?: boolean
     newSessionError?: unknown
     onNewSession?: (context: { sessionId: string; index: number }) => Promise<void> | void
-    onResumeRequest?: (context: { sessionId: string; index: number }) => Promise<void> | void
+    onResumeRequest?: (context: {
+      sessionId: string
+      index: number
+      signal: AbortSignal
+    }) => Promise<void> | void
     onResume?: (sessionId: string) => Promise<void> | void
     onSetMode?: (context: { sessionId: string; modeId: string }) => Promise<void> | void
     onClose?: (sessionId: string) => Promise<void> | void
@@ -337,7 +341,11 @@ const startFakeAgent = (
     .onRequest(acp.methods.agent.session.resume, async (ctx) => {
       const index = resumeIndex
       resumeIndex += 1
-      await options.onResumeRequest?.({ sessionId: ctx.params.sessionId, index })
+      await options.onResumeRequest?.({
+        sessionId: ctx.params.sessionId,
+        index,
+        signal: ctx.signal
+      })
 
       if (options.resumeNotFound) {
         throw acp.RequestError.resourceNotFound(ctx.params.sessionId)
@@ -16559,6 +16567,48 @@ describe('ACP runtime session management', () => {
     await expect(resume).rejects.toThrow(/timed out/i)
     // The half-open connection is torn down so a retry reconnects cleanly.
     expect(process.killed).toBe(true)
+  })
+
+  it('keeps other Sessions on a shared connection alive when one resume times out', async () => {
+    const process = new FakeAgentProcess()
+    const resumeReceived = createDeferred()
+    const resumeCancelled = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['active-session'], {
+      onResumeRequest: ({ signal }) => {
+        resumeReceived.resolve(undefined)
+        signal.addEventListener('abort', () => resumeCancelled.resolve(undefined), { once: true })
+        return new Promise<never>(() => {})
+      }
+    })
+
+    let fireResumeTimeout: (() => void) | undefined
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      resumeTimeoutMs: 1000,
+      setTimer: (fn) => {
+        fireResumeTimeout = fn
+        return 0 as unknown as ReturnType<typeof setTimeout>
+      },
+      clearTimer: () => {}
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    const resume = runtime.resumeSession({ sessionId: 'stuck-session', cwd: '/workspace' })
+    await resumeReceived.promise
+    fireResumeTimeout?.()
+
+    await expect(resume).rejects.toThrow(/timed out/i)
+    await resumeCancelled.promise
+    await expect(
+      runtime.sendPrompt({ sessionId: 'active-session', text: 'keep working' })
+    ).resolves.toMatchObject({ stopReason: 'end_turn' })
+    expect(fakeAgent.prompts).toContainEqual({
+      sessionId: 'active-session',
+      text: 'keep working'
+    })
+    expect(process.killed).toBe(false)
   })
 
   it.each(['session-update', 'claude-sdk-message'] as const)(


### PR DESCRIPTION
## Problem

A stalled `session/resume` hit the inactivity timeout and unconditionally called the connection-level `disconnect(false)`. Because one ACP connection can host multiple Sessions, timing out one provider Session removed unrelated active Session attachments and stopped their prompts, permission waits, or streamed output.

The regression was reproduced first at the public `AcpRuntime` boundary: Session A was attached, Session B's provider resume was held open, and firing B's timeout made a later prompt to A fail with `ACP session not found: active-session`. The test failed deterministically three times before the production change.

## Proposed change

- pass an `AbortSignal` to the target `session/resume` request so the ACP SDK emits `$/cancel_request` for that request only;
- keep the shared connection when another provider Session remains attached;
- retain the existing full disconnect when no active Session remains, so a lone half-open reconnect is still replaced;
- rely on the existing identity reservation to discard a provider resume response that arrives after timeout.

## Scope and non-goals

- No renderer or user-interaction changes.
- No database, persistence format, historical-data compatibility, or migration changes.
- No new fields, enum values, or durable/transient data-model state.
- No connection-migration or connection-pending-replacement state machine. The installed ACP SDK already supports request-scoped cancellation, and the regression proves the same connection can continue serving another Session while the timed-out request is pending.

## ACP compatibility matrix

| Behavior | Framework/path | Command | Result |
| --- | --- | --- | --- |
| timed-out provider resume receives a request-scoped cancellation signal | `claude-code`, `opencode`, `codex-response`, `codex-bridge` through the shared provider resumer | `vitest run src/main/acp/provider-session-resumer.test.ts src/main/acp/runtime-provider-session-composition.test.ts` | passed, 54/54 |
| lone half-open resume still tears down its connection | shared runtime/ACP SDK transport | `vitest run src/main/acp/runtime.test.ts -t 'times out and tears down a reconnect\|keeps other Sessions on a shared connection alive'` | passed, 2/2 |
| unrelated attached Session remains prompt-capable after another resume times out | shared runtime/ACP SDK transport | same targeted runtime command | passed |
| late provider response cannot publish the timed-out Session | shared provider resumer identity reservation | provider resumer command above | passed |

The change is transport-neutral and does not modify framework adapters, model payload translation, subscription timing, launcher behavior, or platform-specific process handling. Therefore no model-specific or OS-specific local lane was added; PR CI remains authoritative for those lanes.

## Acceptance criteria and validation

Checks listed below ran after the last material edit:

- Node typecheck: passed.
- ESLint for all changed files: passed. A full-project ESLint run also passed before the final test-only refinement.
- Prettier check for all changed files: passed.
- Provider resumer and provider-session composition tests: passed, 54/54.
- Focused public runtime timeout regression: passed, 2/2.

One final full `runtime.test.ts` attempt reached 581/585 and failed four unrelated Artifact tests because the shared generated Prisma Client expected `ArtifactVersion.contentBlobId` while this worktree's schema and migrations do not contain that field. The worktree schema matches `main`; the shared generated-client schema hash does not. An earlier run before that shared generated client changed passed 585/585. This PR does not touch Prisma or Artifact code; exact-head PR CI will run with a freshly generated matching client.

## Review focus

- Confirm the active-Session guard is the correct ownership boundary for preserving a shared connection.
- Confirm request-scoped ACP cancellation plus the existing reservation invalidation is sufficient for uncooperative/late provider responses.
- Review the deliberate non-goal of automatic connection migration; repeated retries against a provider that ignores cancellation can leave provider-side requests pending until that connection is eventually retired.
