### PR TITLE
fix(acp): bind restored sessions to persisted projects

### DIFF
--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -69,6 +69,20 @@ const createDependencies = (): AcpApplicationCommandDependencies => ({
   }
 })
 
+const ownerResolvingArchiveAvailability = (
+  projectId: string
+): NonNullable<AcpApplicationCommandDependencies['archiveAvailability']> => ({
+  withSessionAvailable: async <Result>(
+    _projectId: string,
+    _sessionId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> => operation(),
+  withSessionAvailableById: async <Result>(
+    _sessionId: string,
+    operation: (ownerProjectId: string) => Promise<Result>
+  ): Promise<Result> => operation(projectId)
+})
+
 const invocation = <Args extends readonly unknown[]>(
   args: Args,
   callerContext: CallerContext = createElectronCallerContext(7)
@@ -500,6 +514,55 @@ describe('ACP application commands', () => {
     expect(dependencies.runtime.compactSession).not.toHaveBeenCalled()
   })
 
+  it('binds Web reset requests to the persisted Project owner', async () => {
+    const persistedProjectId = 'persisted-project'
+    const dependencies: AcpApplicationCommandDependencies = {
+      ...createDependencies(),
+      archiveAvailability: ownerResolvingArchiveAvailability(persistedProjectId)
+    }
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+    const request = { sessionId: 'session-1', cwd: '/workspace' }
+
+    await router.dispatcher.invoke(
+      acpCommands.resetSessionContext,
+      invocation([request], createWebCallerContext('local-web'))
+    )
+
+    expect(dependencies.runtime.resetSessionContext).toHaveBeenCalledWith({
+      ...request,
+      projectId: persistedProjectId
+    })
+  })
+
+  it('rejects a Web reset request whose projectId disagrees with the persisted owner', async () => {
+    const persistedProjectId = 'persisted-project'
+    const dependencies: AcpApplicationCommandDependencies = {
+      ...createDependencies(),
+      archiveAvailability: ownerResolvingArchiveAvailability(persistedProjectId)
+    }
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.resetSessionContext,
+        invocation(
+          [
+            {
+              sessionId: 'session-1',
+              cwd: '/workspace',
+              projectId: 'forged-project'
+            }
+          ],
+          createWebCallerContext('local-web')
+        )
+      )
+    ).rejects.toThrow('Session does not belong to the requested Project.')
+
+    expect(dependencies.runtime.resetSessionContext).not.toHaveBeenCalled()
+  })
+
   it('does not nest Session admission around the coordinator follow-up guard', async () => {
     let archiveQueue: Promise<void> = Promise.resolve()
     const enqueueArchive = <Result>(operation: () => Promise<Result>): Promise<Result> => {
@@ -513,8 +576,8 @@ describe('ACP application commands', () => {
     const base = createDependencies()
     const withSessionAvailableById = <Result>(
       _sessionId: string,
-      operation: () => Promise<Result>
-    ): Promise<Result> => enqueueArchive(operation)
+      operation: (projectId: string) => Promise<Result>
+    ): Promise<Result> => enqueueArchive(() => operation('project-1'))
     const dependencies: AcpApplicationCommandDependencies = {
       ...base,
       runtime: {
@@ -629,7 +692,8 @@ describe('ACP application commands', () => {
           sessionId: string,
           operation: () => Promise<Result>
         ): Promise<Result> => withinAdmission(sessionId, operation),
-        withSessionAvailableById: withinAdmission
+        withSessionAvailableById: (sessionId, operation) =>
+          withinAdmission(sessionId, () => operation('project-1'))
       },
       respondDelegatedQuestion
     }
@@ -747,10 +811,10 @@ describe('ACP application commands', () => {
     const admitted: string[] = []
     const withSessionAvailableById = <Result>(
       sessionId: string,
-      operation: () => Promise<Result>
+      operation: (projectId: string) => Promise<Result>
     ): Promise<Result> => {
       admitted.push(sessionId)
-      return operation()
+      return operation('project-1')
     }
     const respondDelegatedQuestion = vi.fn(async () => undefined)
     const dependencies: AcpApplicationCommandDependencies = {

--- a/src/main/acp/application-commands.ts
+++ b/src/main/acp/application-commands.ts
@@ -29,6 +29,7 @@ import {
   resolveElicitationResponseSessionId,
   resolvePermissionResponseSessionId
 } from './response-session-admission'
+import { bindResumeRequestToProject } from './session-project-binding'
 import type { AcpRuntimeCoordinator } from './runtime-coordinator'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 
@@ -177,7 +178,7 @@ type AcpApplicationCommandDependencies = Readonly<{
     ): Promise<Result>
     withSessionAvailableById<Result>(
       sessionId: string,
-      operation: () => Promise<Result>
+      operation: (projectId: string) => Promise<Result>
     ): Promise<Result>
   }>
   respondDelegatedQuestion?: (
@@ -218,7 +219,10 @@ const registerAcpCommands = (
         dependencies.archiveAvailability
           ? dependencies.archiveAvailability.withSessionAvailableById(
               invocation.args[0].sessionId,
-              () => dependencies.runtime.resetSessionContext(invocation.args[0])
+              (projectId) =>
+                dependencies.runtime.resetSessionContext(
+                  bindResumeRequestToProject(invocation.args[0], projectId)
+                )
             )
           : dependencies.runtime.resetSessionContext(invocation.args[0]),
       'acp:compact-session': (invocation) =>

--- a/src/main/acp/handler-workflows.test.ts
+++ b/src/main/acp/handler-workflows.test.ts
@@ -86,6 +86,7 @@ const createHarness = (
   startContinuationWhenDispatchAdmitted: ReturnType<typeof vi.fn>
   hasLiveSession: ReturnType<typeof vi.fn>
   captureSessionBackend: ReturnType<typeof vi.fn>
+  resumeSession: ReturnType<typeof vi.fn>
   session: PersistedChatSession
   request: {
     projectId: string
@@ -100,6 +101,10 @@ const createHarness = (
   prepareControlTurn(session)
   const startPrompt = vi.fn(async (request: unknown) => void request)
   const startContinuation = vi.fn(async (request: unknown) => void request)
+  const resumeSession = vi.fn(async (request: { sessionId: string; cwd: string }) => ({
+    sessionId: request.sessionId,
+    cwd: request.cwd
+  }))
   const hasLiveSession = vi.fn(() => true)
   const captureSessionBackend = vi.fn(
     () =>
@@ -127,7 +132,7 @@ const createHarness = (
       getSnapshot: () => snapshot,
       hasLiveSession,
       captureSessionBackend,
-      resumeSession: vi.fn(),
+      resumeSession,
       startPrompt,
       getLatestUserPrompt: vi.fn(),
       startContinuation,
@@ -148,6 +153,7 @@ const createHarness = (
     startContinuationWhenDispatchAdmitted,
     hasLiveSession,
     captureSessionBackend,
+    resumeSession,
     session,
     request: {
       projectId: session.projectId,
@@ -158,6 +164,47 @@ const createHarness = (
     }
   }
 }
+
+describe('ACP resume Session workflow', () => {
+  const persistedProjectId = 'persisted-project'
+  const archiveAvailability = {
+    withSessionAvailable: async <Result>(
+      _projectId: string,
+      _sessionId: string,
+      operation: () => Promise<Result>
+    ): Promise<Result> => operation(),
+    withSessionAvailableById: async <Result>(
+      _sessionId: string,
+      operation: (projectId: string) => Promise<Result>
+    ): Promise<Result> => operation(persistedProjectId)
+  }
+
+  it('injects the persisted Project owner when the request omits projectId', async () => {
+    const harness = createHarness(undefined, archiveAvailability)
+    const request = { sessionId: 'session-1', cwd: '/workspace' }
+
+    await harness.workflows.resumeSession(request)
+
+    expect(harness.resumeSession).toHaveBeenCalledWith({
+      ...request,
+      projectId: persistedProjectId
+    })
+  })
+
+  it('rejects a request whose projectId disagrees with the persisted owner', async () => {
+    const harness = createHarness(undefined, archiveAvailability)
+
+    await expect(
+      harness.workflows.resumeSession({
+        sessionId: 'session-1',
+        cwd: '/workspace',
+        projectId: 'forged-project'
+      })
+    ).rejects.toThrow('Session does not belong to the requested Project.')
+
+    expect(harness.resumeSession).not.toHaveBeenCalled()
+  })
+})
 
 describe('ACP interrupted turn workflow', () => {
   it('does not re-enter archive admission while continuing an interrupted turn', async () => {
@@ -172,7 +219,8 @@ describe('ACP interrupted turn workflow', () => {
     }
     const harness = createHarness(undefined, {
       withSessionAvailable: (_projectId, _sessionId, operation) => enqueueArchive(operation),
-      withSessionAvailableById: (_sessionId, operation) => enqueueArchive(operation)
+      withSessionAvailableById: (_sessionId, operation) =>
+        enqueueArchive(() => operation('project-1'))
     })
     harness.session.status = 'error'
     harness.session.activeRun = undefined

--- a/src/main/acp/handler-workflows.ts
+++ b/src/main/acp/handler-workflows.ts
@@ -13,6 +13,7 @@ import type {
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import type { TaskNotificationService } from '../notifications/task-notifications'
 import type { AcpCreateSessionWorkflow } from './create-session-workflow'
+import { bindResumeRequestToProject } from './session-project-binding'
 import { continueInterruptedTurn, SAVE_AS_SKILL_PROMPT } from './interrupted-turn-continuation'
 import { isHiddenControlMessage, type PersistedChatSession } from '../../shared/session-persistence'
 import {
@@ -62,7 +63,7 @@ type SessionArchiveAvailability = {
   ): Promise<Result>
   withSessionAvailableById<Result>(
     sessionId: string,
-    operation: () => Promise<Result>
+    operation: (projectId: string) => Promise<Result>
   ): Promise<Result>
 }
 
@@ -295,16 +296,11 @@ const createAcpHandlerWorkflows = (
     logResumeDiagnostic('info', 'acp:resume-session started', context)
 
     try {
-      const resume = (): Promise<AcpCreateSessionResponse> => runtime.resumeSession(request)
+      const resume = (projectId: string): Promise<AcpCreateSessionResponse> =>
+        runtime.resumeSession(bindResumeRequestToProject(request, projectId))
       const result = archiveAvailability
-        ? request.projectId
-          ? await archiveAvailability.withSessionAvailable(
-              request.projectId,
-              request.sessionId,
-              resume
-            )
-          : await archiveAvailability.withSessionAvailableById(request.sessionId, resume)
-        : await resume()
+        ? await archiveAvailability.withSessionAvailableById(request.sessionId, resume)
+        : await runtime.resumeSession(request)
       logResumeDiagnostic('info', 'acp:resume-session completed', {
         ...context,
         durationMs: Math.max(0, Date.now() - startedAt),

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -153,8 +153,8 @@ type AcpTestOptions = Parameters<typeof createAcpRuntime>[0]
 const passThroughSessionAdmission = {
   withSessionAvailableById: <Result>(
     _sessionId: string,
-    operation: () => Promise<Result>
-  ): Promise<Result> => operation()
+    operation: (projectId: string) => Promise<Result>
+  ): Promise<Result> => operation('project-1')
 }
 
 // Minimal options — createRuntime just forwards them into the mocked AcpRuntime constructor.
@@ -296,7 +296,7 @@ it('rejects ACP response mutations before runtime work when Session admission is
   const sessionAdmission = {
     withSessionAvailableById: async <Result>(
       sessionId: string,
-      operation: () => Promise<Result>
+      operation: (projectId: string) => Promise<Result>
     ): Promise<Result> => {
       void operation
       admitted.push(sessionId)
@@ -392,10 +392,10 @@ it('rejects forged and unknown ACP response authority before Session admission',
   const admitted: string[] = []
   const withSessionAvailableById = <Result>(
     sessionId: string,
-    operation: () => Promise<Result>
+    operation: (projectId: string) => Promise<Result>
   ): Promise<Result> => {
     admitted.push(sessionId)
-    return operation()
+    return operation('project-1')
   }
   const responseRuntime = {
     getSnapshot: vi.fn(() => ({
@@ -551,8 +551,8 @@ describe('ACP module transport seam', () => {
         },
         withSessionAvailableById: async <Result>(
           _sessionId: string,
-          operation: () => Promise<Result>
-        ): Promise<Result> => operation()
+          operation: (projectId: string) => Promise<Result>
+        ): Promise<Result> => operation('project-1')
       },
       interruptedTurnSessions: { loadSession: vi.fn(async () => session) }
     })
@@ -1108,6 +1108,19 @@ describe('installAcpIpcHandlers — managed session workspace', () => {
 })
 
 describe('installAcpIpcHandlers — reset-session-context bridge', () => {
+  const persistedProjectId = 'persisted-project'
+  const ownerResolvingArchiveAvailability = {
+    withSessionAvailable: async <Result>(
+      _projectId: string,
+      _sessionId: string,
+      operation: () => Promise<Result>
+    ): Promise<Result> => operation(),
+    withSessionAvailableById: async <Result>(
+      _sessionId: string,
+      operation: (projectId: string) => Promise<Result>
+    ): Promise<Result> => operation(persistedProjectId)
+  }
+
   it('registers the acp:reset-session-context channel', () => {
     registerWithFakes()
     expect(handlers.has('acp:reset-session-context')).toBe(true)
@@ -1120,10 +1133,35 @@ describe('installAcpIpcHandlers — reset-session-context bridge', () => {
     const result = await handlers.get('acp:reset-session-context')?.({}, request)
 
     expect(resetSessionContext).toHaveBeenCalledTimes(1)
-    expect(resetSessionContext).toHaveBeenCalledWith(request)
+    expect(resetSessionContext).toHaveBeenCalledWith({ ...request, projectId: 'project-1' })
     // The distinct resume channel must not be driven by the reset call.
     expect(resumeSession).not.toHaveBeenCalled()
     expect(result).toEqual({ sessionId: 's-1', cwd: '/workspace', contextReset: true })
+  })
+
+  it('injects the persisted Project owner when the request omits projectId', async () => {
+    registerWithFakes({ archiveAvailability: ownerResolvingArchiveAvailability })
+    const request: AcpResumeSessionRequest = { sessionId: 's-1', cwd: '/workspace' }
+
+    await handlers.get('acp:reset-session-context')?.({}, request)
+
+    expect(resetSessionContext).toHaveBeenCalledWith({
+      ...request,
+      projectId: persistedProjectId
+    })
+  })
+
+  it('rejects a request whose projectId disagrees with the persisted owner', async () => {
+    registerWithFakes({ archiveAvailability: ownerResolvingArchiveAvailability })
+
+    await expect(
+      handlers.get('acp:reset-session-context')?.(
+        {},
+        { sessionId: 's-1', cwd: '/workspace', projectId: 'forged-project' }
+      )
+    ).rejects.toThrow('Session does not belong to the requested Project.')
+
+    expect(resetSessionContext).not.toHaveBeenCalled()
   })
 
   it('uses the durable Memory preference for renderer resume and reset requests', async () => {
@@ -1142,6 +1180,8 @@ describe('installAcpIpcHandlers — reset-session-context bridge', () => {
     expect(resumeSession).toHaveBeenCalledWith({ ...request, memoryEnabled: false })
     expect(resetSessionContext).toHaveBeenCalledWith({ ...request, memoryEnabled: false })
     expect(resolveMemoryEnabled).toHaveBeenCalledTimes(2)
+    expect(resolveMemoryEnabled).toHaveBeenNthCalledWith(1, { sessionId: request.sessionId })
+    expect(resolveMemoryEnabled).toHaveBeenNthCalledWith(2, { sessionId: request.sessionId })
   })
 
   it('fails closed when the durable Memory preference is missing', async () => {
@@ -1196,8 +1236,8 @@ describe('installAcpIpcHandlers — reset-session-context bridge', () => {
     const archiveAvailability = {
       withSessionAvailableById: <Result>(
         _sessionId: string,
-        operation: () => Promise<Result>
-      ): Promise<Result> => enqueueArchive(operation)
+        operation: (projectId: string) => Promise<Result>
+      ): Promise<Result> => enqueueArchive(() => operation('project-1'))
     }
     const withSessionAvailableById = vi.spyOn(archiveAvailability, 'withSessionAvailableById')
     const steerFollowUp = vi.fn(() =>
@@ -1237,9 +1277,17 @@ describe('installAcpIpcHandlers — resume-session diagnostics', () => {
         }
       },
       withSessionAvailableById: async <Result>(
-        _sessionId: string,
-        operation: () => Promise<Result>
-      ): Promise<Result> => operation()
+        sessionId: string,
+        operation: (projectId: string) => Promise<Result>
+      ): Promise<Result> => {
+        admitted('project-1', sessionId, operation)
+        admissionActive = true
+        try {
+          return await operation('project-1')
+        } finally {
+          admissionActive = false
+        }
+      }
     }
     registerWithFakes({ archiveAvailability })
     const request: AcpResumeSessionRequest = {

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -29,18 +29,18 @@ import {
   resolveElicitationResponseSessionId,
   resolvePermissionResponseSessionId
 } from './response-session-admission'
+import { bindResumeRequestToProject } from './session-project-binding'
 import { installAgentShutdownGuard } from './shutdown-guard'
 
 type AcpIpcSessionAdmission = {
   withSessionAvailableById<Result>(
     sessionId: string,
-    operation: () => Promise<Result>
+    operation: (projectId: string) => Promise<Result>
   ): Promise<Result>
 }
 
 type AcpSessionMemoryPreferenceResolver = (request: {
   sessionId: string
-  projectId?: string
 }) => Promise<boolean | undefined>
 
 const withDurableMemoryPreference = async (
@@ -48,10 +48,7 @@ const withDurableMemoryPreference = async (
   resolveMemoryEnabled?: AcpSessionMemoryPreferenceResolver
 ): Promise<AcpResumeSessionRequest> => {
   if (!resolveMemoryEnabled) return request
-  const memoryEnabled = await resolveMemoryEnabled({
-    sessionId: request.sessionId,
-    ...(request.projectId ? { projectId: request.projectId } : {})
-  })
+  const memoryEnabled = await resolveMemoryEnabled({ sessionId: request.sessionId })
   return { ...request, memoryEnabled: memoryEnabled ?? false }
 }
 
@@ -86,8 +83,13 @@ const registerAcpIpcHandlerSet = (
       workflows.continueInterruptedTurn(request)
   )
   ipcMainHandle('acp:reset-session-context', (_event, request: AcpResumeSessionRequest) =>
-    sessionAdmission.withSessionAvailableById(request.sessionId, async () =>
-      runtime.resetSessionContext(await withDurableMemoryPreference(request, resolveMemoryEnabled))
+    sessionAdmission.withSessionAvailableById(request.sessionId, async (projectId) =>
+      runtime.resetSessionContext(
+        await withDurableMemoryPreference(
+          bindResumeRequestToProject(request, projectId),
+          resolveMemoryEnabled
+        )
+      )
     )
   )
   ipcMainHandle('acp:compact-session', (_event, request: AcpCompactSessionRequest) =>

--- a/src/main/acp/session-project-binding.ts
+++ b/src/main/acp/session-project-binding.ts
@@ -1,0 +1,14 @@
+import type { AcpResumeSessionRequest } from '../../shared/acp'
+
+const bindResumeRequestToProject = (
+  request: AcpResumeSessionRequest,
+  projectId: string
+): AcpResumeSessionRequest => {
+  const assertedProjectId = request.projectId?.trim()
+  if (assertedProjectId && assertedProjectId !== projectId) {
+    throw new Error('Session does not belong to the requested Project.')
+  }
+  return { ...request, projectId }
+}
+
+export { bindResumeRequestToProject }

--- a/src/main/archive/coordinator.test.ts
+++ b/src/main/archive/coordinator.test.ts
@@ -307,7 +307,7 @@ describe('ArchiveCoordinator', () => {
     )
 
     expect(sessions.assertSessionAvailable).toHaveBeenCalledWith(project.id, session.id)
-    expect(operation).toHaveBeenCalledOnce()
+    expect(operation).toHaveBeenCalledWith(project.id)
   })
 
   it('fails closed when a session owner cannot be resolved', async () => {

--- a/src/main/archive/coordinator.ts
+++ b/src/main/archive/coordinator.ts
@@ -174,16 +174,18 @@ class ArchiveCoordinator {
   }
 
   assertSessionAvailableById(sessionId: string): Promise<void> {
-    return this.enqueue(() => this.assertSessionAvailableByIdNow(sessionId))
+    return this.enqueue(async () => {
+      await this.assertSessionAvailableByIdNow(sessionId)
+    })
   }
 
   withSessionAvailableById<Result>(
     sessionId: string,
-    operation: () => Promise<Result>
+    operation: (projectId: string) => Promise<Result>
   ): Promise<Result> {
     return this.enqueue(async () => {
-      await this.assertSessionAvailableByIdNow(sessionId)
-      return operation()
+      const projectId = await this.assertSessionAvailableByIdNow(sessionId)
+      return operation(projectId)
     })
   }
 
@@ -222,7 +224,7 @@ class ArchiveCoordinator {
     await this.sessions.assertSessionAvailable(ownerProjectId, sessionId)
   }
 
-  private async assertSessionAvailableByIdNow(sessionId: string): Promise<void> {
+  private async assertSessionAvailableByIdNow(sessionId: string): Promise<string> {
     const projectId =
       (await this.sessions.sessionProjectId(sessionId)) ??
       this.runtime.liveSessionProjectId(sessionId)
@@ -231,6 +233,7 @@ class ArchiveCoordinator {
     }
     await this.activeProject(projectId)
     await this.sessions.assertSessionAvailable(projectId, sessionId)
+    return projectId
   }
 
   private assertProjectDeletionAvailable(projectId: string): void {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3747,17 +3747,11 @@ const createApplicationModules = async (
           withSessionAvailableById: (sessionId, operation) =>
             archiveCoordinator.withSessionAvailableById(sessionId, operation)
         },
-        resolveMemoryEnabled: async ({ sessionId, projectId }) => {
-          const sessions = projectId
-            ? [await sessionRepository.loadSession(projectId, sessionId)].filter(
-                (session): session is PersistedChatSession => session !== undefined
-              )
-            : (await sessionRepository.loadAll()).sessions.filter(
-                (session) => session.id === sessionId
-              )
-          if (sessions.length === 0) return undefined
-          if (sessions.length !== 1) return false
-          return sessions[0].memoryEnabled !== false
+        resolveMemoryEnabled: async ({ sessionId }) => {
+          const projectId = await sessionPersistenceCoordinator.sessionProjectId(sessionId)
+          if (!projectId) return undefined
+          const session = await sessionRepository.loadSession(projectId, sessionId)
+          return session ? session.memoryEnabled !== false : undefined
         },
         respondDelegatedQuestion: (input) => {
           if (!delegatedWork.root.respondQuestion) {


### PR DESCRIPTION
## Problem

Session resume and context reset accepted an optional renderer `projectId` as runtime ownership input. Main already resolved the globally unique persisted Session owner during archive admission, but discarded that Project id before ACP runtime dispatch. Missing values therefore fell back to the default Project, while reset could accept a mismatched value.

## Proposed change

- Pass the resolved Session owner through `withSessionAvailableById` while the admission queue is held.
- Bind resume and Electron/Web reset requests to that owner before runtime mutation.
- Treat a supplied `projectId` only as an assertion and reject mismatches.
- Resolve durable Memory preference globally by `sessionId`, without consulting renderer Project input.

## Scope and non-goals

- No database schema, persisted JSON, migration, or backfill change.
- No new field, enum value, or runtime state.
- No renderer interaction or copy change.
- No provider protocol, history replay, lifecycle event, or subscription change.
- The common pre-runtime binding covers claude-code, opencode, codex-response, and codex-bridge.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Persisted owner propagation and archive admission contract -> `vitest` on `src/main/archive/coordinator.test.ts`, `src/main/acp/handler-workflows.test.ts`, `src/main/acp/ipc.test.ts`, and `src/main/acp/application-commands.test.ts` -> passed.
- Shared provider resume/replacement paths -> `vitest` on `src/main/acp/provider-session-resumer.test.ts`, `src/main/acp/session-replacement-workflow.test.ts`, and `src/main/acp/runtime-provider-session-composition.test.ts` -> passed.
- Combined targeted impact set -> 7 files, 180 tests passed.
- Main-process type contracts -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed.
- Formatting and whitespace -> targeted `prettier --check` plus `git diff --check` -> passed.

Per maintainer instruction, the complete `npm test` suite was not run locally; PR CI is authoritative for the complete portable and platform lanes.

## Review focus

- Confirm the archive admission callback remains the single authoritative owner boundary.
- Confirm mismatched request Project assertions fail before provider/runtime mutation.
- Confirm existing persisted Sessions require no compatibility handling.