### PR TITLE
fix(delegation): propagate Codex subscription auth

### DIFF
--- a/src/main/acp/restricted-inference-runner.test.ts
+++ b/src/main/acp/restricted-inference-runner.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { CODEX_SHARED_PROVIDER_ID } from '../../shared/settings'
+import { CODEX_SHARED_PROVIDER_ID, CODEX_SUBSCRIPTION_PROVIDER_ID } from '../../shared/settings'
 import type { AcpRuntimeEvent, AcpTurnTokenUsage } from '../../shared/acp'
 import type { ResolvedAgentBackend } from '../agent-framework'
 import { claudeCodeFramework } from '../agent-framework/claude-code'
@@ -178,6 +178,7 @@ describe('RestrictedInferenceRunner', () => {
 
     const prepared = await prepareRestrictedBackend(
       backend(codexFramework, {
+        providerId: CODEX_SUBSCRIPTION_PROVIDER_ID,
         backendId: `codex:${CODEX_SHARED_PROVIDER_ID}`,
         env: {
           CODEX_HOME: sourceHome,

--- a/src/main/acp/restricted-runtime-profile.ts
+++ b/src/main/acp/restricted-runtime-profile.ts
@@ -1,9 +1,10 @@
-import { chmod, copyFile, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { ResolvedAgentBackend } from '../agent-framework'
 import { isolateCodeBuddyEnvironment } from '../agent-framework/codebuddy'
-import { projectSafeCodexProviderRoute } from '../settings/codex-auth'
+import { CODEX_SUBSCRIPTION_PROVIDER_ID } from '../../shared/settings'
+import { prepareCodexRuntimeHomeAuthentication } from '../settings/codex-auth'
 import { OPEN_SCIENCE_SKILL_RUNTIME_SESSION_OPTION } from '../skills/runtime-mcp-server'
 
 type RestrictedRuntimeProfile = Readonly<{
@@ -45,34 +46,6 @@ const RESTRICTED_CODEX_FEATURES = Object.freeze({
   default_mode_request_user_input: false,
   plugin_sharing: false
 })
-
-const copyCodexAuthentication = async (
-  sourceHome: string | undefined,
-  targetHome: string
-): Promise<boolean> => {
-  if (!sourceHome || sourceHome === targetHome) return false
-  try {
-    const target = join(targetHome, 'auth.json')
-    await copyFile(join(sourceHome, 'auth.json'), target)
-    await chmod(target, 0o600)
-    return true
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
-    throw error
-  }
-}
-
-const readCodexProviderRoute = async (
-  sourceHome: string | undefined
-): Promise<string | undefined> => {
-  if (!sourceHome) return undefined
-  try {
-    return projectSafeCodexProviderRoute(await readFile(join(sourceHome, 'config.toml'), 'utf8'))
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
-    throw error
-  }
-}
 
 const removeSkillRuntimeCapability = (
   source: Readonly<Record<string, unknown>> | undefined
@@ -157,16 +130,11 @@ const prepareCodexBackend = async (
   profile: RestrictedRuntimeProfile
 ): Promise<ResolvedAgentBackend> => {
   const codexHome = join(profileRoot, 'codex')
-  await mkdir(codexHome, { recursive: true })
-  const [hasFileAuthentication, providerRoute] = await Promise.all([
-    copyCodexAuthentication(backend.env.CODEX_HOME, codexHome),
-    readCodexProviderRoute(backend.env.CODEX_HOME)
-  ])
-  await writeFile(
-    join(codexHome, 'config.toml'),
-    `cli_auth_credentials_store = "${hasFileAuthentication ? 'file' : 'ephemeral'}"\n${providerRoute ? `\n${providerRoute}` : ''}`,
-    { encoding: 'utf8', mode: 0o600 }
-  )
+  await prepareCodexRuntimeHomeAuthentication({
+    sourceHome: backend.env.CODEX_HOME,
+    runtimeHome: codexHome,
+    useSubscriptionAuthentication: backend.providerId === CODEX_SUBSCRIPTION_PROVIDER_ID
+  })
   const codexConfig = record(JSON.parse(backend.env.CODEX_CONFIG ?? '{}'))
   delete codexConfig.developer_instructions
   codexConfig.experimental_use_unified_exec_tool = false
@@ -181,7 +149,7 @@ const prepareCodexBackend = async (
       ...backend.env,
       CODEX_HOME: codexHome,
       HOME: codexHome,
-      ...(backend.env.USERPROFILE === undefined ? {} : { USERPROFILE: codexHome }),
+      USERPROFILE: codexHome,
       CODEX_CONFIG: JSON.stringify(codexConfig)
     },
     systemPromptAppends: [profile.systemPrompt],

--- a/src/main/acp/restricted-runtime-profile.ts
+++ b/src/main/acp/restricted-runtime-profile.ts
@@ -133,7 +133,8 @@ const prepareCodexBackend = async (
   await prepareCodexRuntimeHomeAuthentication({
     sourceHome: backend.env.CODEX_HOME,
     runtimeHome: codexHome,
-    useSubscriptionAuthentication: backend.providerId === CODEX_SUBSCRIPTION_PROVIDER_ID
+    useSubscriptionAuthentication: backend.providerId === CODEX_SUBSCRIPTION_PROVIDER_ID,
+    subscriptionTransport: backend.codexSubscriptionTransport
   })
   const codexConfig = record(JSON.parse(backend.env.CODEX_CONFIG ?? '{}'))
   delete codexConfig.developer_instructions

--- a/src/main/agent-framework/codebuddy.ts
+++ b/src/main/agent-framework/codebuddy.ts
@@ -26,6 +26,7 @@ import type {
   AgentModelConfig,
   AgentSpawnInput,
   ModelConfigContext,
+  ResolvedAgentBackend,
   SessionSetup,
   SessionSetupContext
 } from './types'
@@ -121,6 +122,18 @@ export const createCodeBuddyFramework = ({
         shell: needsShell
       }
     )
+  },
+
+  async prepareDelegatedSpawn(
+    backend: ResolvedAgentBackend,
+    runtimeHome: string
+  ): Promise<AgentSpawnInput> {
+    return {
+      executablePath: backend.executablePath,
+      args: [...(backend.args ?? [])],
+      env: await isolateCodeBuddyEnvironment(backend.env, join(runtimeHome, 'codebuddy')),
+      proxyEnvironmentMode: backend.proxyEnvironmentMode
+    }
   },
 
   async beforePromptDispatch({

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -190,6 +190,57 @@ describe('codexFramework', () => {
     }
   })
 
+  it.each([
+    ['https', 'open-science-chatgpt-https', false],
+    ['websocket', 'open-science-chatgpt-websocket', true]
+  ] as const)(
+    'projects the resolved %s subscription transport into a delegated runtime home',
+    async (codexSubscriptionTransport, providerId, supportsWebsockets) => {
+      const root = await mkdtemp(join(tmpdir(), 'codex-delegated-transport-'))
+      const sourceHome = join(root, 'subscription')
+      const runtimeHome = join(root, 'runtime')
+      await mkdir(sourceHome, { recursive: true })
+      await writeFile(join(sourceHome, 'auth.json'), '{"tokens":{"access_token":"secret"}}\n')
+      // This is the app-owned non-loopback route used by subscription sessions. It is deliberately
+      // not imported as an arbitrary provider route; the trusted resolved transport below owns it.
+      await writeFile(
+        join(sourceHome, 'config.toml'),
+        [
+          'model_provider = "open-science-chatgpt-https"',
+          '',
+          '[model_providers."open-science-chatgpt-https"]',
+          'name = "OpenAI HTTPS"',
+          'base_url = "https://chatgpt.com/backend-api/codex"',
+          'wire_api = "responses"',
+          'requires_openai_auth = true',
+          'supports_websockets = false',
+          ''
+        ].join('\n')
+      )
+
+      try {
+        const framework = createCodexFramework({ platform: 'darwin' })
+        await framework.prepareDelegatedSpawn!(
+          {
+            framework,
+            providerId: CODEX_SUBSCRIPTION_PROVIDER_ID,
+            codexSubscriptionTransport,
+            executablePath: '/runtime/codex-acp',
+            env: { CODEX_HOME: sourceHome }
+          },
+          runtimeHome
+        )
+
+        const configToml = await readFile(join(runtimeHome, 'config.toml'), 'utf8')
+        expect(configToml).toContain(`model_provider = "${providerId}"`)
+        expect(configToml).toContain('base_url = "https://chatgpt.com/backend-api/codex"')
+        expect(configToml).toContain(`supports_websockets = ${String(supportsWebsockets)}`)
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('does not copy stale subscription authentication for an API-key delegated backend', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codex-delegated-api-key-'))
     const sourceHome = join(root, 'shared-codex-home')

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -1,5 +1,8 @@
 import { execFileSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { once } from 'node:events'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
@@ -14,6 +17,7 @@ import {
 import codexNativeModelInstructions from './codex-native-model-instructions.md?raw'
 import { terminateProcessTree } from '../process-tree'
 import { CODEX_VERSION } from '../settings/managed-codex'
+import { CODEX_SUBSCRIPTION_PROVIDER_ID } from '../../shared/settings'
 
 const fakeChild = {} as ChildProcessWithoutNullStreams
 
@@ -134,6 +138,99 @@ describe('codexFramework', () => {
       }
     }
   )
+
+  it('projects subscription authentication into a Windows delegated runtime home', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-delegated-subscription-'))
+    const sourceHome = join(root, 'subscription')
+    const runtimeHome = join(root, 'runtime')
+    await mkdir(sourceHome, { recursive: true })
+    await writeFile(join(sourceHome, 'auth.json'), '{"tokens":{"access_token":"secret"}}\n')
+    await writeFile(
+      join(sourceHome, 'config.toml'),
+      [
+        'model_provider = "subscription-route"',
+        '',
+        '[model_providers."subscription-route"]',
+        'name = "Subscription route"',
+        'base_url = "http://127.0.0.1:43123/v1"',
+        'wire_api = "responses"',
+        'requires_openai_auth = true',
+        '',
+        '[mcp_servers.persisted-tool]',
+        'command = "unsafe-tool"',
+        ''
+      ].join('\n')
+    )
+
+    try {
+      const framework = createCodexFramework({ platform: 'win32' })
+      const prepared = await framework.prepareDelegatedSpawn!(
+        {
+          framework,
+          providerId: CODEX_SUBSCRIPTION_PROVIDER_ID,
+          executablePath: '/runtime/codex-acp.exe',
+          env: { CODEX_HOME: sourceHome }
+        },
+        runtimeHome
+      )
+
+      expect(prepared.env).toMatchObject({
+        HOME: runtimeHome,
+        USERPROFILE: runtimeHome,
+        CODEX_HOME: runtimeHome
+      })
+      expect(await readFile(join(runtimeHome, 'auth.json'), 'utf8')).toContain('secret')
+      const configToml = await readFile(join(runtimeHome, 'config.toml'), 'utf8')
+      expect(configToml).toContain('cli_auth_credentials_store = "file"')
+      expect(configToml).toContain('model_provider = "subscription-route"')
+      expect(configToml).not.toContain('mcp_servers')
+      expect(configToml).not.toContain('unsafe-tool')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not copy stale subscription authentication for an API-key delegated backend', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-delegated-api-key-'))
+    const sourceHome = join(root, 'shared-codex-home')
+    const runtimeHome = join(root, 'runtime')
+    await mkdir(sourceHome, { recursive: true })
+    await writeFile(join(sourceHome, 'auth.json'), '{"tokens":{"access_token":"stale"}}\n')
+    await writeFile(
+      join(sourceHome, 'config.toml'),
+      [
+        'model_provider = "stale-subscription-route"',
+        '',
+        '[model_providers."stale-subscription-route"]',
+        'name = "Stale route"',
+        'base_url = "http://127.0.0.1:43123/v1"',
+        'wire_api = "responses"',
+        'requires_openai_auth = true',
+        ''
+      ].join('\n')
+    )
+
+    try {
+      const framework = createCodexFramework({ platform: 'darwin' })
+      const prepared = await framework.prepareDelegatedSpawn!(
+        {
+          framework,
+          providerId: 'api-key-provider',
+          executablePath: '/runtime/codex-acp',
+          env: { CODEX_HOME: sourceHome, CODEX_CONFIG: '{"model":"gpt-5.4"}' }
+        },
+        runtimeHome
+      )
+
+      expect(prepared.env.CODEX_HOME).toBe(runtimeHome)
+      expect(existsSync(join(runtimeHome, 'auth.json'))).toBe(false)
+      expect(await readFile(join(runtimeHome, 'config.toml'), 'utf8')).toBe(
+        'cli_auth_credentials_store = "ephemeral"\n'
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
 
   it('describes the base role as a general agent instead of narrowing every task to coding', () => {
     expect(codexNativeModelInstructions).toContain('You are an agent')

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -430,7 +430,8 @@ export const createCodexFramework = ({
     await prepareCodexRuntimeHomeAuthentication({
       sourceHome: backend.env.CODEX_HOME,
       runtimeHome,
-      useSubscriptionAuthentication: backend.providerId === CODEX_SUBSCRIPTION_PROVIDER_ID
+      useSubscriptionAuthentication: backend.providerId === CODEX_SUBSCRIPTION_PROVIDER_ID,
+      subscriptionTransport: backend.codexSubscriptionTransport
     })
     return {
       executablePath: backend.executablePath,

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -24,11 +24,14 @@ import {
   type AgentModelConfig,
   type AgentSpawnInput,
   type ModelConfigContext,
+  type ResolvedAgentBackend,
   type SessionSetup,
   type SessionSetupContext
 } from './types'
 import { isProductionDelegatedWorkFramework } from '../delegation/production-readiness'
-import { isCodexSubscriptionProvider } from '../../shared/settings'
+import { CODEX_SUBSCRIPTION_PROVIDER_ID, isCodexSubscriptionProvider } from '../../shared/settings'
+import { prepareCodexRuntimeHomeAuthentication } from '../settings/codex-auth'
+import { codexStorageDir, codexSubscriptionStorageDir } from '../settings/codex-paths'
 import { CODEX_VERSION } from '../settings/managed-codex'
 import { clearSystemProxyEnvironment } from '../settings/system-proxy'
 import { registerOwnedPosixProcessGroup } from '../process-tree'
@@ -102,10 +105,6 @@ type CodexFrameworkDeps = {
   sourceEnv?: NodeJS.ProcessEnv
   spawnProcess?: SpawnProcess
 }
-
-export const codexStorageDir = (storageRoot: string): string => join(storageRoot, 'codex')
-export const codexSubscriptionStorageDir = (storageRoot: string): string =>
-  join(storageRoot, 'codex-subscription')
 
 const isolatedCodexHomeEnv = (codexHome: string, platform: NodeJS.Platform): NodeJS.ProcessEnv => ({
   // Codex discovers user-installed Skills under $HOME/.agents/skills in addition to
@@ -424,6 +423,28 @@ export const createCodexFramework = ({
     return child
   },
 
+  async prepareDelegatedSpawn(
+    backend: ResolvedAgentBackend,
+    runtimeHome: string
+  ): Promise<AgentSpawnInput> {
+    await prepareCodexRuntimeHomeAuthentication({
+      sourceHome: backend.env.CODEX_HOME,
+      runtimeHome,
+      useSubscriptionAuthentication: backend.providerId === CODEX_SUBSCRIPTION_PROVIDER_ID
+    })
+    return {
+      executablePath: backend.executablePath,
+      args: [...(backend.args ?? [])],
+      env: {
+        ...backend.env,
+        HOME: runtimeHome,
+        CODEX_HOME: runtimeHome,
+        ...(platform === 'win32' ? { USERPROFILE: runtimeHome } : {})
+      },
+      proxyEnvironmentMode: backend.proxyEnvironmentMode
+    }
+  },
+
   prepareModelConfig(provider, ctx: ModelConfigContext): AgentModelConfig {
     const persistentSystemPrompt =
       ctx.systemPromptAppends?.filter(Boolean).join('\n\n') || undefined
@@ -571,6 +592,8 @@ export const codexFramework = createCodexFramework()
 
 export {
   buildCodexConfig,
+  codexStorageDir,
+  codexSubscriptionStorageDir,
   isOfficialOpenAiResponsesBase,
   mapCodexPermissionProfile,
   normalizeResponsesBaseUrl

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -3,7 +3,11 @@ import type { ClientConnection, McpServer, SessionModeState } from '@agentclient
 
 import type { PermissionProfileApplication } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
-import type { AgentFrameworkId, ChatApiEndpoint } from '../../shared/settings'
+import type {
+  AgentFrameworkId,
+  ChatApiEndpoint,
+  CodexSubscriptionTransport
+} from '../../shared/settings'
 import type {
   CustomReasoningEffortTransport,
   ModelReasoningEffort,
@@ -310,6 +314,10 @@ export type ResolvedAgentBackend = {
   // Stable app provider/account identity used for usage attribution. This remains separate from
   // backendId because a framework may normalize provider selections onto one session store.
   providerId?: string
+  // Effective transport for an app-owned Codex subscription profile. Settings resolves Auto and
+  // its learned HTTPS fallback once; disposable child/restricted homes project this exact choice
+  // instead of re-reading or guessing it from a sanitized config snapshot.
+  codexSubscriptionTransport?: CodexSubscriptionTransport
   // Stable identity of the framework/provider storage boundary. Two providers can use the same
   // framework while keeping incompatible session stores (for example Codex shared vs isolated login).
   backendId?: string

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -241,6 +241,14 @@ export interface AgentFramework {
   // Launch the ACP agent subprocess (stdio JSON-RPC), wrapping the per-framework binary + args.
   spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams
 
+  // Materialize a framework-owned, isolated spawn profile for one delegated Attempt. Generic
+  // orchestration supplies the admitted backend and runtime home without knowing credential or
+  // configuration details for the framework.
+  prepareDelegatedSpawn?(
+    backend: ResolvedAgentBackend,
+    runtimeHome: string
+  ): Promise<AgentSpawnInput>
+
   // Some ACP servers keep process-global current-session state. When present, the prompt workflow
   // calls this immediately before session.prompt() for the target provider session.
   beforePromptDispatch?(input: {

--- a/src/main/delegation/production-framework-runtime.test.ts
+++ b/src/main/delegation/production-framework-runtime.test.ts
@@ -1,21 +1,23 @@
 import { describe, expect, it, vi } from 'vitest'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
-import type { AgentFrameworkId } from '../../shared/settings'
+import { CODEX_SUBSCRIPTION_PROVIDER_ID, type AgentFrameworkId } from '../../shared/settings'
 import {
   claudeCodeFramework,
   codeBuddyFramework,
   codexFramework,
   opencodeFramework,
+  type AgentSpawnInput,
   type ResolvedAgentBackend
 } from '../agent-framework'
 import {
   createProductionDelegatedFrameworkRuntime,
   DELEGATED_CHILD_SYSTEM_PROMPT_APPEND,
-  prepareCodeBuddyDelegateSpawn,
   withDelegatedChildContext
 } from './production-framework-runtime'
 
@@ -166,7 +168,7 @@ describe('production delegated framework runtime bridge', () => {
     await writeFile(join(sourceConfigDir, 'models.json'), '{"models":[]}\n')
 
     try {
-      const spawn = await prepareCodeBuddyDelegateSpawn(
+      const spawn = await codeBuddyFramework.prepareDelegatedSpawn!(
         {
           ...backend('codebuddy'),
           env: {
@@ -185,6 +187,116 @@ describe('production delegated framework runtime bridge', () => {
       )
     } finally {
       await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('copies app-owned Codex subscription authentication before spawning a delegated Attempt', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'delegated-codex-auth-'))
+    const workspaceCwd = await mkdtemp(join(tmpdir(), 'delegated-codex-workspace-'))
+    const sourceHome = join(dataRoot, 'codex-subscription')
+    await mkdir(sourceHome, { recursive: true })
+    await writeFile(join(sourceHome, 'auth.json'), '{"tokens":{"access_token":"secret"}}\n', {
+      mode: 0o600
+    })
+    await writeFile(
+      join(sourceHome, 'config.toml'),
+      [
+        'cli_auth_credentials_store = "file"',
+        'model_provider = "subscription-route"',
+        '',
+        '[model_providers."subscription-route"]',
+        'name = "Subscription route"',
+        'base_url = "http://127.0.0.1:43123/v1"',
+        'wire_api = "responses"',
+        'requires_openai_auth = true',
+        '',
+        '[mcp_servers.persisted-tool]',
+        'command = "unsafe-tool"',
+        ''
+      ].join('\n'),
+      { mode: 0o600 }
+    )
+    const issueDelegatedNotebookConnection = vi.fn(async () => ({
+      endpoint: 'http://127.0.0.1:1',
+      token: 'attempt-token',
+      release: () => undefined,
+      revoke: async () => undefined
+    }))
+    const admittedBackend: ResolvedAgentBackend = {
+      ...backend('codex'),
+      providerId: CODEX_SUBSCRIPTION_PROVIDER_ID,
+      env: {
+        ...backend('codex').env,
+        HOME: sourceHome,
+        CODEX_HOME: sourceHome
+      }
+    }
+    let spawnedInput: AgentSpawnInput | undefined
+    let spawnedAuthJson: string | undefined
+    let spawnedConfigToml: string | undefined
+    let child: ChildProcessWithoutNullStreams | undefined
+    const spawnSpy = vi.spyOn(codexFramework, 'spawn').mockImplementation((input) => {
+      spawnedInput = input
+      spawnedAuthJson = readFileSync(join(input.env.CODEX_HOME!, 'auth.json'), 'utf8')
+      spawnedConfigToml = readFileSync(join(input.env.CODEX_HOME!, 'config.toml'), 'utf8')
+      child = spawn(process.execPath, ['-e', 'process.stdin.resume()'], {
+        stdio: 'pipe'
+      })
+      return child
+    })
+    const frameworks = createProductionDelegatedFrameworkRuntime({
+      capacity: 1,
+      dataRoot,
+      runtime: { settingsService: {} } as never,
+      notebookRpcServer: () => ({ issueDelegatedNotebookConnection }) as never,
+      readSession: async () => delegatedSession('codex')
+    })
+
+    try {
+      const selected = await frameworks.forSession(session('codex'))
+      const reservation = await selected.execution.reserve(1)
+      const running = selected.execution.run(
+        {
+          session: { projectId: 'project-1', sessionId: 'session-codex' },
+          frameId: 'child-frame',
+          attemptId: 'attempt-1',
+          runtimeSegmentId: 'runtime-1',
+          executionModel: {
+            frameworkId: 'codex',
+            providerId: CODEX_SUBSCRIPTION_PROVIDER_ID,
+            backendId: `codex:${CODEX_SUBSCRIPTION_PROVIDER_ID}`,
+            modelRoute: 'codex-responses',
+            model: 'gpt-5.4',
+            reasoningEffort: 'medium'
+          },
+          executionBackend: admittedBackend,
+          task: 'Investigate',
+          inputs: [],
+          workspaceCwd,
+          continuation: false
+        },
+        reservation.slotIds[0]
+      )
+
+      await vi.waitFor(() => expect(spawnedInput).toBeDefined())
+      const childHome = spawnedInput!.env.CODEX_HOME!
+      expect(childHome).not.toBe(sourceHome)
+      expect(spawnedAuthJson).toContain('secret')
+      expect(spawnedConfigToml).toContain('cli_auth_credentials_store = "file"')
+      expect(spawnedConfigToml).toContain('model_provider = "subscription-route"')
+      expect(spawnedConfigToml).toContain('base_url = "http://127.0.0.1:43123/v1"')
+      expect(spawnedConfigToml).not.toContain('mcp_servers')
+      expect(spawnedConfigToml).not.toContain('unsafe-tool')
+
+      child?.kill()
+      await expect(running.completion).rejects.toBeDefined()
+    } finally {
+      child?.kill()
+      spawnSpy.mockRestore()
+      await Promise.all([
+        rm(dataRoot, { recursive: true, force: true }),
+        rm(workspaceCwd, { recursive: true, force: true })
+      ])
     }
   })
 

--- a/src/main/delegation/production-framework-runtime.ts
+++ b/src/main/delegation/production-framework-runtime.ts
@@ -13,11 +13,9 @@ import {
 import {
   releaseResolvedAgentBackendLeases,
   type AgentModelConfig,
-  type AgentSpawnInput,
   type ResolvedAgentBackend,
   type SessionSetup
 } from '../agent-framework'
-import { isolateCodeBuddyEnvironment } from '../agent-framework/codebuddy'
 import { createAcpRuntime, type AcpRuntimeCompositionOptions } from '../acp/runtime-composition'
 import type { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
 import type { NotebookRpcConnection } from '../notebook/mcp-server'
@@ -82,16 +80,6 @@ const sessionSetup = (backend: ResolvedAgentBackend): SessionSetup =>
     ],
     ...(backend.sessionOptions ? { sessionOptions: backend.sessionOptions } : {})
   })
-
-const prepareCodeBuddyDelegateSpawn = async (
-  backend: ResolvedAgentBackend,
-  runtimeHome: string
-): Promise<AgentSpawnInput> => ({
-  executablePath: backend.executablePath,
-  args: [...(backend.args ?? [])],
-  env: await isolateCodeBuddyEnvironment(backend.env, join(runtimeHome, 'codebuddy')),
-  proxyEnvironmentMode: backend.proxyEnvironmentMode
-})
 
 const createProductionDelegatedFrameworkRuntime = (
   options: ProductionFrameworkRuntimeOptions
@@ -202,35 +190,20 @@ const createProductionDelegatedFrameworkRuntime = (
               await rm(runtimeHome, { recursive: true, force: true }).catch(() => undefined)
             }
           }
+          const delegatedSpawn = await backend.framework.prepareDelegatedSpawn?.(
+            backend,
+            runtimeHome
+          )
+          if (delegatedSpawn) return { ...base, spawn: delegatedSpawn }
           if (frameworkId === 'claude-code') {
             return { ...base, sessionSetup: sessionSetup(backend) }
           }
           if (frameworkId === 'opencode') {
             return { ...base, modelConfig: openCodeModelConfig(backend) }
           }
-          if (frameworkId === 'codex') {
-            return {
-              ...base,
-              spawn: {
-                executablePath: backend.executablePath,
-                args: [...(backend.args ?? [])],
-                env: {
-                  ...backend.env,
-                  HOME: runtimeHome,
-                  CODEX_HOME: runtimeHome
-                },
-                proxyEnvironmentMode: backend.proxyEnvironmentMode
-              }
-            }
-          }
-          if (frameworkId === 'codebuddy') {
-            return {
-              ...base,
-              spawn: await prepareCodeBuddyDelegateSpawn(backend, runtimeHome)
-            }
-          }
-          const unsupported: never = frameworkId
-          throw new Error(`Unsupported delegated-work framework: ${String(unsupported)}`)
+          throw new Error(
+            `Delegated-work framework ${frameworkId} does not prepare an execution scope.`
+          )
         } catch (error) {
           preparedAttempts.delete(input.attemptId)
           if (releaseResolvedBackend) await releaseResolvedAgentBackendLeases(backend)
@@ -280,7 +253,6 @@ const createProductionDelegatedFrameworkRuntime = (
 export {
   createProductionDelegatedFrameworkRuntime,
   DELEGATED_CHILD_SYSTEM_PROMPT_APPEND,
-  prepareCodeBuddyDelegateSpawn,
   withDelegatedChildContext
 }
 export type { ProductionFrameworkRuntimeOptions }

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -544,7 +544,7 @@ describe('AgentBackendResolver configured and explicit targets', () => {
       })
     })
 
-    await harness.resolver.resolveExplicitTarget({
+    const backend = await harness.resolver.resolveExplicitTarget({
       frameworkId: 'codex',
       providerId: provider.id,
       model: { kind: 'required', id: 'gpt-5.4' },
@@ -552,6 +552,7 @@ describe('AgentBackendResolver configured and explicit targets', () => {
     })
 
     expect(harness.ensureCodexSubscriptionHome).toHaveBeenCalledWith('https')
+    expect(backend.codexSubscriptionTransport).toBe('https')
   })
 
   it.each(['https', 'websocket'] as const)(
@@ -585,7 +586,7 @@ describe('AgentBackendResolver configured and explicit targets', () => {
         })
       })
 
-      await harness.resolver.resolveExplicitTarget({
+      const backend = await harness.resolver.resolveExplicitTarget({
         frameworkId: 'codex',
         providerId: provider.id,
         model: { kind: 'required', id: 'gpt-5.4' },
@@ -593,6 +594,7 @@ describe('AgentBackendResolver configured and explicit targets', () => {
       })
 
       expect(harness.ensureCodexSubscriptionHome).toHaveBeenCalledWith(codexTransport)
+      expect(backend.codexSubscriptionTransport).toBe(codexTransport)
     }
   )
 

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -396,10 +396,12 @@ export class AgentBackendResolver {
       }
     }
 
-    if (framework.id === 'codex' && isCodexSubscriptionProvider(target.provider.type)) {
-      await this.ensureCodexSubscriptionHome(
-        resolveEffectiveCodexSubscriptionTransport(target.provider)
-      )
+    const codexSubscriptionTransport =
+      framework.id === 'codex' && isCodexSubscriptionProvider(target.provider.type)
+        ? resolveEffectiveCodexSubscriptionTransport(target.provider)
+        : undefined
+    if (codexSubscriptionTransport) {
+      await this.ensureCodexSubscriptionHome(codexSubscriptionTransport)
     }
     const backendProviderId = plan.backendProviderId
     if (framework.supportsSkills || framework.id === 'codebuddy') {
@@ -466,6 +468,7 @@ export class AgentBackendResolver {
       return {
         framework,
         providerId: target.providerId,
+        ...(codexSubscriptionTransport ? { codexSubscriptionTransport } : {}),
         backendId: `${framework.id}:${backendProviderId}`,
         modelRoute,
         ...(modelRoute === 'codex-bridge' && responsesBridge?.continuityToken

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -8,8 +8,8 @@ import { Readable, Writable } from 'node:stream'
 import * as acp from '@agentclientprotocol/sdk'
 
 import type { CodexSubscriptionTransport } from '../../shared/settings'
-import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { terminateProcessTree } from '../process-tree'
+import { codexSubscriptionStorageDir } from './codex-paths'
 import { augmentedPathEnv } from './shell-path'
 import { clearSystemProxyEnvironment, type SystemProxyEnvironment } from './system-proxy'
 
@@ -303,7 +303,10 @@ const isCodexCredentialStoreAssignment = (line: string): boolean =>
 // CODEX_HOME isolates file-backed auth.json, but the default/auto store can still select the
 // process-wide OS keyring. Pin subscription profiles to file storage so status, login, and logout
 // cannot observe or mutate the user's global Codex CLI credential.
-const serializeCodexFileCredentialStore = (existingConfigToml: string): string => {
+const serializeCodexCredentialStore = (
+  existingConfigToml: string,
+  credentialStore: 'file' | 'ephemeral'
+): string => {
   const lines = existingConfigToml.split(/\r?\n/)
   const result: string[] = []
   let inTopLevel = true
@@ -326,11 +329,20 @@ const serializeCodexFileCredentialStore = (existingConfigToml: string): string =
   const insertionCandidates = [firstOwnedMarkerIndex, firstTableIndex].filter((index) => index >= 0)
   const insertionIndex =
     insertionCandidates.length > 0 ? Math.min(...insertionCandidates) : result.length
-  result.splice(insertionIndex, 0, CODEX_FILE_CREDENTIAL_STORE)
+  result.splice(
+    insertionIndex,
+    0,
+    credentialStore === 'file'
+      ? CODEX_FILE_CREDENTIAL_STORE
+      : 'cli_auth_credentials_store = "ephemeral"'
+  )
   result.push('')
 
   return result.join('\n')
 }
+
+const serializeCodexFileCredentialStore = (existingConfigToml: string): string =>
+  serializeCodexCredentialStore(existingConfigToml, 'file')
 
 const restoreCompleteMarkedBlock = (lines: string[], begin: string, end: string): string[] => {
   const result = [...lines]
@@ -610,24 +622,25 @@ export const createCodexAuthEnvironment = (
   }
 }
 
-// Provider setup imports an existing login plus the safe, non-secret subset of its active provider
-// route. Global model defaults, MCP servers, Skills, sessions, memories, hooks, and tokens embedded in
-// provider config remain outside Open Science.
-export const importCodexAuthentication = async (
+type CodexAuthenticationSnapshot = Readonly<{
+  content: string
+  providerRoute?: ImportedCodexProviderRoute
+}>
+
+const readCodexAuthenticationSnapshot = async (
   sourceHome: string,
-  destinationHome: string
-): Promise<void> => {
+  required: boolean
+): Promise<CodexAuthenticationSnapshot | undefined> => {
   const sourcePath = join(sourceHome, 'auth.json')
-  const destinationPath = join(destinationHome, 'auth.json')
   const sourceConfigPath = join(sourceHome, 'config.toml')
-  const destinationConfigPath = join(destinationHome, 'config.toml')
   let content: string
 
   try {
     content = await readFile(sourcePath, 'utf8')
     const parsed = JSON.parse(content) as unknown
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error()
-  } catch {
+  } catch (error) {
+    if (!required && (error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
     throw new Error('The selected Codex profile does not contain importable authentication.')
   }
 
@@ -638,23 +651,74 @@ export const importCodexAuthentication = async (
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
   }
 
+  return { content, ...(providerRoute ? { providerRoute } : {}) }
+}
+
+const writeCodexAuthenticationSnapshot = async (
+  snapshot: CodexAuthenticationSnapshot | undefined,
+  destinationHome: string,
+  credentialStore?: 'file' | 'ephemeral'
+): Promise<void> => {
+  const destinationPath = join(destinationHome, 'auth.json')
+  const destinationConfigPath = join(destinationHome, 'config.toml')
   await mkdir(destinationHome, { recursive: true })
-  await writePrivateFileAtomically(destinationPath, content)
-  if (providerRoute) {
-    let existingConfigToml = ''
-    try {
-      existingConfigToml = await readFile(destinationConfigPath, 'utf8')
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-    }
-    await writePrivateFileAtomically(
-      destinationConfigPath,
-      serializeImportedCodexProviderRoute(providerRoute, existingConfigToml)
-    )
-  } else {
-    await clearImportedCodexProviderRoute(destinationHome)
+
+  let existingConfigToml = ''
+  try {
+    existingConfigToml = await readFile(destinationConfigPath, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
   }
-  await ensureCodexAuthConfigHome(destinationHome, 'auto')
+  let nextConfigToml = snapshot?.providerRoute
+    ? serializeImportedCodexProviderRoute(snapshot.providerRoute, existingConfigToml)
+    : removeImportedCodexProviderRoute(existingConfigToml)
+  // Imported routes stay authoritative; aligning on 'auto' only removes a stale owned transport
+  // route left behind in a reused runtime home (subscription transport stays a runtime decision).
+  nextConfigToml = serializeCodexSubscriptionTransport(nextConfigToml, 'auto')
+  if (credentialStore) {
+    nextConfigToml = serializeCodexCredentialStore(nextConfigToml, credentialStore)
+  }
+
+  if (snapshot) await writePrivateFileAtomically(destinationPath, snapshot.content)
+  else await rm(destinationPath, { force: true })
+
+  if (nextConfigToml === existingConfigToml) return
+  if (nextConfigToml.trim()) {
+    await writePrivateFileAtomically(destinationConfigPath, nextConfigToml)
+  } else {
+    await rm(destinationConfigPath, { force: true })
+  }
+}
+
+// Provider setup imports an existing login plus the safe, non-secret subset of its active provider
+// route. Global model defaults, MCP servers, Skills, sessions, memories, hooks, and tokens embedded in
+// provider config remain outside Open Science.
+export const importCodexAuthentication = async (
+  sourceHome: string,
+  destinationHome: string
+): Promise<void> => {
+  const snapshot = await readCodexAuthenticationSnapshot(sourceHome, true)
+  await writeCodexAuthenticationSnapshot(snapshot, destinationHome, 'file')
+}
+
+// Runtime profiles start from a fresh app-owned home. Subscription backends receive one sanitized
+// authentication snapshot; every other backend is pinned to ephemeral ACP authentication and clears
+// any stale file credential or imported route already present in a reused runtime home.
+export const prepareCodexRuntimeHomeAuthentication = async ({
+  sourceHome,
+  runtimeHome,
+  useSubscriptionAuthentication
+}: Readonly<{
+  sourceHome?: string
+  runtimeHome: string
+  useSubscriptionAuthentication: boolean
+}>): Promise<void> => {
+  const snapshot =
+    useSubscriptionAuthentication && sourceHome
+      ? await readCodexAuthenticationSnapshot(sourceHome, false)
+      : undefined
+
+  await writeCodexAuthenticationSnapshot(snapshot, runtimeHome, snapshot ? 'file' : 'ephemeral')
 }
 
 export const clearImportedCodexProviderRoute = async (destinationHome: string): Promise<void> => {

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -657,7 +657,8 @@ const readCodexAuthenticationSnapshot = async (
 const writeCodexAuthenticationSnapshot = async (
   snapshot: CodexAuthenticationSnapshot | undefined,
   destinationHome: string,
-  credentialStore?: 'file' | 'ephemeral'
+  credentialStore?: 'file' | 'ephemeral',
+  subscriptionTransport: CodexSubscriptionTransport = 'auto'
 ): Promise<void> => {
   const destinationPath = join(destinationHome, 'auth.json')
   const destinationConfigPath = join(destinationHome, 'config.toml')
@@ -672,9 +673,9 @@ const writeCodexAuthenticationSnapshot = async (
   let nextConfigToml = snapshot?.providerRoute
     ? serializeImportedCodexProviderRoute(snapshot.providerRoute, existingConfigToml)
     : removeImportedCodexProviderRoute(existingConfigToml)
-  // Imported routes stay authoritative; aligning on 'auto' only removes a stale owned transport
-  // route left behind in a reused runtime home (subscription transport stays a runtime decision).
-  nextConfigToml = serializeCodexSubscriptionTransport(nextConfigToml, 'auto')
+  // Imported loopback routes stay authoritative. Otherwise project the effective app-owned
+  // subscription transport selected by Settings into this disposable runtime home.
+  nextConfigToml = serializeCodexSubscriptionTransport(nextConfigToml, subscriptionTransport)
   if (credentialStore) {
     nextConfigToml = serializeCodexCredentialStore(nextConfigToml, credentialStore)
   }
@@ -702,23 +703,31 @@ export const importCodexAuthentication = async (
 }
 
 // Runtime profiles start from a fresh app-owned home. Subscription backends receive one sanitized
-// authentication snapshot; every other backend is pinned to ephemeral ACP authentication and clears
-// any stale file credential or imported route already present in a reused runtime home.
+// authentication snapshot plus the transport already resolved by Settings; every other backend is
+// pinned to ephemeral ACP authentication and clears any stale file credential or imported route
+// already present in a reused runtime home.
 export const prepareCodexRuntimeHomeAuthentication = async ({
   sourceHome,
   runtimeHome,
-  useSubscriptionAuthentication
+  useSubscriptionAuthentication,
+  subscriptionTransport
 }: Readonly<{
   sourceHome?: string
   runtimeHome: string
   useSubscriptionAuthentication: boolean
+  subscriptionTransport?: CodexSubscriptionTransport
 }>): Promise<void> => {
   const snapshot =
     useSubscriptionAuthentication && sourceHome
       ? await readCodexAuthenticationSnapshot(sourceHome, false)
       : undefined
 
-  await writeCodexAuthenticationSnapshot(snapshot, runtimeHome, snapshot ? 'file' : 'ephemeral')
+  await writeCodexAuthenticationSnapshot(
+    snapshot,
+    runtimeHome,
+    snapshot ? 'file' : 'ephemeral',
+    useSubscriptionAuthentication ? subscriptionTransport : undefined
+  )
 }
 
 export const clearImportedCodexProviderRoute = async (destinationHome: string): Promise<void> => {

--- a/src/main/settings/codex-paths.ts
+++ b/src/main/settings/codex-paths.ts
@@ -1,0 +1,7 @@
+import { join } from 'node:path'
+
+const codexStorageDir = (storageRoot: string): string => join(storageRoot, 'codex')
+const codexSubscriptionStorageDir = (storageRoot: string): string =>
+  join(storageRoot, 'codex-subscription')
+
+export { codexStorageDir, codexSubscriptionStorageDir }


### PR DESCRIPTION
## Problem

Delegated Codex Attempts run in an isolated runtime home, but the production delegation path did not prepare that home with the user's Codex subscription authentication. A broad credential copy would also be unsafe: API-key providers could inherit stale subscription credentials or unrelated route configuration.

## Proposed change

- Add a framework-owned delegated-spawn preparation seam so Codex and CodeBuddy can prepare their own runtimes without provider-specific logic in generic delegation.
- Project Codex authentication only for the built-in Codex subscription provider.
- Read and validate one authentication snapshot, write it atomically with private permissions, and preserve only a safe loopback provider route.
- Remove stale auth and import routes for non-subscription providers.
- Keep `HOME`, `CODEX_HOME`, and Windows `USERPROFILE` aligned with the isolated runtime home.
- Reuse the same authentication projection in restricted inference and extract path ownership to avoid a settings/framework import cycle.

## Scope and non-goals

This PR covers Codex delegated runtime authentication and the framework spawn-preparation boundary. It does not change OpenCode, ACP signal handling, provider login UX, or how credentials are initially acquired.

## Acceptance criteria and validation

- Subscription auth reaches an isolated delegated Codex runtime: covered by Codex framework and production runtime tests.
- API-key providers do not inherit stale subscription auth or routes: covered by negative provider tests.
- Safe route fields are preserved while unrelated configuration/MCP entries are omitted: covered by auth projection tests.
- Windows runtime-home environment consistency: covered by unit tests.
- Targeted changed-area suite — 144/144 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm test` — 1290 files / 21705 tests passed; 16 files / 238 tests skipped.
- A real Electron Figure Composer run using the combined local branches completed three rounds and 12 delegated frames without authentication failures.
- Independent Standards and Spec review after fixes: no remaining P1/P2 findings.

Uncovered risk: Windows behavior is unit-tested but was not exercised on a local Windows host. The live application validation used macOS and the built-in Codex subscription provider.

## Review focus

- Ownership of provider-specific spawn preparation at the framework boundary.
- Fail-closed provider gating and the reduced route projection.
- Atomic/private credential handling and cleanup of stale non-subscription state.
