### PR TITLE
fix(acp): isolate Codex child process signals

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4887,6 +4887,30 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().sessionId).toBeUndefined()
   })
 
+  it('does not report an in-flight prompt as a connection failure once quit teardown starts', async () => {
+    const process = new FakeAgentProcess()
+    const promptGate = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['quit-active-prompt-session'], {
+      onPrompt: () => promptGate.promise
+    })
+    const events: AcpRuntimeEvent[] = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: session.sessionId, text: 'stay pending' })
+    void prompt.catch(() => undefined)
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+
+    await runtime.shutdownForQuit()
+
+    expect(events).not.toContainEqual(expect.objectContaining({ text: 'ACP connection closed' }))
+    promptGate.resolve()
+  })
+
   it('shutdownForQuit propagates a degraded reaped:false from the agent tree teardown', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['degraded-reap-session'])

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -1,4 +1,5 @@
-import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { execFileSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { once } from 'node:events'
 import { join } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
@@ -11,11 +12,129 @@ import {
   normalizeResponsesBaseUrl
 } from './codex'
 import codexNativeModelInstructions from './codex-native-model-instructions.md?raw'
+import { terminateProcessTree } from '../process-tree'
 import { CODEX_VERSION } from '../settings/managed-codex'
 
 const fakeChild = {} as ChildProcessWithoutNullStreams
 
 describe('codexFramework', () => {
+  it.runIf(process.platform !== 'win32')(
+    'reaps a descendant that leaves the owned ACP process group while its leader is alive',
+    async () => {
+      const framework = createCodexFramework()
+      const child = framework.spawn({
+        executablePath: process.execPath,
+        env: {},
+        args: [
+          '-e',
+          [
+            "const { spawn } = require('node:child_process')",
+            "const descendant = spawn(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)'], { detached: true, stdio: 'ignore' })",
+            'process.stdout.write(`${descendant.pid}\\n`)',
+            'setInterval(() => undefined, 1_000)'
+          ].join('\n')
+        ]
+      })
+      let descendantPid: number | undefined
+
+      try {
+        expect(child.pid).toBeTypeOf('number')
+        descendantPid = Number((await once(child.stdout, 'data'))[0].toString().trim())
+        expect(descendantPid).toBeGreaterThan(0)
+
+        const childProcessGroup = Number(
+          execFileSync('ps', ['-o', 'pgid=', '-p', String(child.pid)], { encoding: 'utf8' }).trim()
+        )
+        const descendantProcessGroup = Number(
+          execFileSync('ps', ['-o', 'pgid=', '-p', String(descendantPid)], {
+            encoding: 'utf8'
+          }).trim()
+        )
+        expect(descendantProcessGroup).toBe(descendantPid)
+        expect(descendantProcessGroup).not.toBe(childProcessGroup)
+
+        await expect(terminateProcessTree(child)).resolves.toEqual({ reaped: true })
+        expect(() => process.kill(descendantPid as number, 0)).toThrow(
+          expect.objectContaining({ code: 'ESRCH' })
+        )
+      } finally {
+        if (child.exitCode === null && child.signalCode === null) {
+          const exited = once(child, 'exit')
+          child.kill('SIGKILL')
+          await exited
+        }
+        if (descendantPid !== undefined) {
+          try {
+            process.kill(descendantPid, 'SIGKILL')
+          } catch {
+            // The process-tree teardown already reaped it.
+          }
+        }
+      }
+    }
+  )
+
+  it.runIf(process.platform !== 'win32')(
+    'reaps the owned ACP process group after its leader exits and its grandchild is reparented',
+    async () => {
+      const framework = createCodexFramework()
+      const child = framework.spawn({
+        executablePath: process.execPath,
+        env: {},
+        args: [
+          '-e',
+          [
+            "const { spawn } = require('node:child_process')",
+            "const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)'], { stdio: 'ignore' })",
+            'process.stdout.write(`${grandchild.pid}\\n`, () => process.exit(0))'
+          ].join('\n')
+        ]
+      })
+      let grandchildPid: number | undefined
+
+      try {
+        expect(child.pid).toBeTypeOf('number')
+        const childProcessGroup = Number(
+          execFileSync('ps', ['-o', 'pgid=', '-p', String(child.pid)], {
+            encoding: 'utf8'
+          }).trim()
+        )
+        const applicationProcessGroup = Number(
+          execFileSync('ps', ['-o', 'pgid=', '-p', String(process.pid)], {
+            encoding: 'utf8'
+          }).trim()
+        )
+
+        expect(childProcessGroup).not.toBe(applicationProcessGroup)
+        expect(childProcessGroup).toBe(child.pid)
+
+        const leaderExited = once(child, 'exit')
+        grandchildPid = Number((await once(child.stdout, 'data'))[0].toString().trim())
+        expect(grandchildPid).toBeGreaterThan(0)
+        await leaderExited
+        expect(() => process.kill(grandchildPid as number, 0)).not.toThrow()
+
+        await expect(terminateProcessTree(child)).resolves.toEqual({ reaped: true })
+        expect(() => process.kill(grandchildPid as number, 0)).toThrow(
+          expect.objectContaining({ code: 'ESRCH' })
+        )
+      } finally {
+        if (child.exitCode === null && child.signalCode === null) {
+          const exited = once(child, 'exit')
+          child.kill('SIGKILL')
+          await exited
+        }
+        if (grandchildPid !== undefined) {
+          try {
+            process.kill(grandchildPid, 'SIGKILL')
+          } catch {
+            // The owned process-group teardown already reaped it.
+          }
+        }
+      }
+    }
+  )
+
   it('describes the base role as a general agent instead of narrowing every task to coding', () => {
     expect(codexNativeModelInstructions).toContain('You are an agent')
     expect(codexNativeModelInstructions).not.toContain('coding agent')
@@ -793,10 +912,24 @@ describe('codexFramework', () => {
           CODEX_HOME: '/data/codex',
           ELECTRON_RUN_AS_NODE: '1'
         }),
+        detached: true,
         shell: false,
         stdio: 'pipe',
         windowsHide: true
       })
+    )
+  })
+
+  it('does not request a detached Windows console for the ACP process', () => {
+    const spawnProcess = vi.fn().mockReturnValue(fakeChild)
+    const framework = createCodexFramework({ platform: 'win32', spawnProcess })
+
+    framework.spawn({ executablePath: 'C:\\codex-acp.exe', env: {}, args: [] })
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'C:\\codex-acp.exe',
+      [],
+      expect.objectContaining({ detached: false })
     )
   })
 

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -31,6 +31,7 @@ import { isProductionDelegatedWorkFramework } from '../delegation/production-rea
 import { isCodexSubscriptionProvider } from '../../shared/settings'
 import { CODEX_VERSION } from '../settings/managed-codex'
 import { clearSystemProxyEnvironment } from '../settings/system-proxy'
+import { registerOwnedPosixProcessGroup } from '../process-tree'
 import codexNativeModelInstructions from './codex-native-model-instructions.md?raw'
 
 const CODEX_PROVIDER_ID = 'open-science'
@@ -404,12 +405,20 @@ export const createCodexFramework = ({
         : input.executablePath
     const args = isJavaScript ? [input.executablePath, ...input.args] : input.args
 
-    return spawnProcess(command, args, {
+    const child = spawnProcess(command, args, {
       env: buildSpawnEnvironment(input, sourceEnv),
       stdio: 'pipe',
+      // Keep a terminal/dev-runner SIGINT aimed at the Electron application's foreground process
+      // group from killing Codex before the app's awaited ACP teardown can mark and reap it. Piped
+      // stdio remains referenced (we never unref the child), and the resource owner still performs
+      // explicit cross-platform tree teardown. Node's detached process-group behavior is POSIX-only;
+      // creating an independent Windows console/process group here would change packaged startup.
+      detached: platform !== 'win32',
       windowsHide: true,
       shell: needsShell
     })
+    if (platform !== 'win32') registerOwnedPosixProcessGroup(child)
+    return child
   },
 
   prepareModelConfig(provider, ctx: ModelConfigContext): AgentModelConfig {

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -9,7 +9,7 @@ const { spawnMock } = vi.hoisted(() => ({
 
 vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 
-const { terminateProcessTree } = await import('./process-tree')
+const { registerOwnedPosixProcessGroup, terminateProcessTree } = await import('./process-tree')
 
 // Minimal ChildProcess stand-in: an EventEmitter (so waitForExit's once('exit') resolves) exposing the
 // pid/kill/killed/exitCode surface the code under test touches. kill() flips killed like Node does.
@@ -172,6 +172,47 @@ describe('terminateProcessTree (win32)', () => {
 })
 
 describe('terminateProcessTree (posix)', () => {
+  it('escalates an explicitly owned process group after snapshotting its descendants', async () => {
+    vi.useFakeTimers()
+    setPlatform('linux')
+    const ps = new FakePs()
+    spawnMock.mockReturnValueOnce(ps)
+    let groupAlive = true
+    let detachedDescendantAlive = true
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (pid === -1000) {
+        if (signal === 0 && !groupAlive) throw esrch()
+        if (signal === 'SIGKILL') groupAlive = false
+        return true
+      }
+      expect(pid).toBe(1001)
+      if (signal === 0 && !detachedDescendantAlive) throw esrch()
+      if (signal === 'SIGKILL') detachedDescendantAlive = false
+      return true
+    })
+    const child = new FakeChild(1000)
+    registerOwnedPosixProcessGroup(child as never)
+
+    const pending = terminateProcessTree(child as never)
+
+    ps.stdout.emit('data', Buffer.from('1000 1\n1001 1000\n'))
+    ps.emit('close', 0)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(killSpy).toHaveBeenCalledWith(-1000, 'SIGTERM')
+    expect(killSpy).toHaveBeenCalledWith(1001, 'SIGTERM')
+    await vi.advanceTimersByTimeAsync(3_000)
+    await expect(pending).resolves.toEqual({ reaped: true })
+    expect(killSpy).toHaveBeenCalledWith(-1000, 'SIGKILL')
+    expect(killSpy).toHaveBeenCalledWith(1001, 'SIGKILL')
+    expect(child.kill).not.toHaveBeenCalled()
+    expect(spawnMock).toHaveBeenCalledWith(
+      'ps',
+      ['-A', '-o', 'pid=,ppid='],
+      expect.objectContaining({ windowsHide: true })
+    )
+  })
+
   it('signals descendants and the child, and returns without escalating when everything exits', async () => {
     setPlatform('linux')
     const ps = new FakePs()

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -11,6 +11,22 @@ export type ProcessTreeLogger = { error: (message: string, error?: unknown) => v
 // caller that must guarantee released file handles (the update-install gate) can refuse to proceed.
 export type ProcessTreeKillResult = { reaped: boolean }
 
+type OwnedPosixProcessGroup = Readonly<{
+  kind: 'owned-posix-process-group'
+  id: number
+}>
+
+// A detached POSIX child is the leader of a private process group whose stable id is its spawn pid.
+// Keep that ownership receipt on the child handle so teardown can still address the group after the
+// leader exits and its descendants are reparented. Unregistered children retain PPID-tree teardown.
+const ownedPosixProcessGroups = new WeakMap<ChildProcess, OwnedPosixProcessGroup>()
+
+export const registerOwnedPosixProcessGroup = (child: ChildProcess): void => {
+  const groupId = child.pid
+  if (groupId === undefined || !Number.isSafeInteger(groupId) || groupId <= 0) return
+  ownedPosixProcessGroups.set(child, { kind: 'owned-posix-process-group', id: groupId })
+}
+
 // Upper bound for awaiting a direct child's real exit (POSIX) or taskkill's own completion (Windows).
 // Bounded so a wedged process can never hang app teardown; the caller (before-quit) also time-bounds
 // the whole shutdown, this is a second, tighter guard scoped to a single tree.
@@ -19,6 +35,7 @@ const TERMINATE_GRACE_MS = 3_000
 // Shorter wait after escalating to SIGKILL: SIGKILL is uncatchable, so a process that survives it is a
 // kernel-level unkillable (uninterruptible sleep) we cannot do anything about — don't wait the full grace.
 const SIGKILL_GRACE_MS = 1_000
+const PROCESS_GROUP_POLL_MS = 25
 
 // Signals the direct child, tolerating an already-exited process or a handle with no pid. Skips a child
 // already signaled so a first, graceful pass is a no-op on retry; escalation uses forceKillChild instead.
@@ -63,6 +80,50 @@ const signalPids = (pids: number[], signal: NodeJS.Signals): void => {
     }
   }
 }
+
+// Negative POSIX pids address a process group. Treat every error except ESRCH as potentially alive so
+// permission or platform failures fail closed instead of claiming an owned group was reaped.
+const isProcessGroupAlive = (groupId: number): boolean => {
+  try {
+    process.kill(-groupId, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+const signalProcessGroup = (groupId: number, signal: NodeJS.Signals): void => {
+  try {
+    process.kill(-groupId, signal)
+  } catch {
+    // The group may already be gone or inaccessible. The subsequent liveness wait decides reaped.
+  }
+}
+
+const waitUntil = (condition: () => boolean, ms: number): Promise<boolean> =>
+  new Promise<boolean>((resolve) => {
+    const deadline = Date.now() + ms
+    const poll = (): void => {
+      if (condition()) {
+        resolve(true)
+        return
+      }
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) {
+        resolve(false)
+        return
+      }
+      const timer = setTimeout(poll, Math.min(PROCESS_GROUP_POLL_MS, remaining))
+      timer.unref?.()
+    }
+    poll()
+  })
+
+const waitForProcessGroupExit = (groupId: number, ms: number): Promise<boolean> =>
+  waitUntil(() => !isProcessGroupAlive(groupId), ms)
+
+const waitForPidsExit = (pids: number[], ms: number): Promise<boolean> =>
+  waitUntil(() => pids.every((pid) => !isProcessAlive(pid)), ms)
 
 // Resolves true once the child actually exits, or false once the grace elapses without an exit — so the
 // caller can decide whether to escalate. The timer is cleared on exit (and unref'd) so a settled wait
@@ -276,6 +337,47 @@ const terminatePosixTree = async (
   }
 }
 
+// An explicitly owned detached group is stronger identity than a live PPID relationship: it remains
+// addressable after the leader exits and descendants are reparented. Signal only the recorded private
+// group, never infer a group from an arbitrary child or from the application's own process state.
+const terminateOwnedPosixProcessGroup = async (
+  group: OwnedPosixProcessGroup,
+  signal: NodeJS.Signals | undefined,
+  log: ProcessTreeLogger | undefined
+): Promise<ProcessTreeKillResult> => {
+  const gracefulSignal = signal ?? 'SIGTERM'
+  // Snapshot before signaling the leader so descendants that created their own process group/session
+  // remain addressable even if the leader exits immediately. The owned group independently covers
+  // same-group descendants after reparenting, when PPID discovery can no longer find them.
+  const snapshot = await collectDescendantPids(group.id)
+  signalProcessGroup(group.id, gracefulSignal)
+  signalPids(snapshot.pids, gracefulSignal)
+  const gracefulExit = await Promise.all([
+    waitForProcessGroupExit(group.id, TERMINATE_GRACE_MS),
+    waitForPidsExit(snapshot.pids, TERMINATE_GRACE_MS)
+  ])
+  if (gracefulExit.every(Boolean)) return { reaped: snapshot.complete }
+
+  const survivors = snapshot.pids.filter(isProcessAlive)
+  if (isProcessGroupAlive(group.id)) {
+    log?.error(
+      `owned process group ${group.id} did not exit after ${gracefulSignal}; escalating to SIGKILL`
+    )
+  }
+  if (survivors.length > 0) {
+    log?.error(
+      `owned process tree left ${survivors.length} detached descendant(s) alive after ${gracefulSignal}; escalating to SIGKILL`
+    )
+  }
+  signalProcessGroup(group.id, 'SIGKILL')
+  signalPids(survivors, 'SIGKILL')
+  const forcedExit = await Promise.all([
+    waitForProcessGroupExit(group.id, SIGKILL_GRACE_MS),
+    waitForPidsExit(snapshot.pids, SIGKILL_GRACE_MS)
+  ])
+  return { reaped: snapshot.complete && forcedExit.every(Boolean) }
+}
+
 // Terminates a child process and every descendant it spawned, then waits for the direct child to actually
 // exit — escalating to SIGKILL anything still alive. On Windows the tree is reaped with taskkill /T /F
 // (with a direct-kill fallback); on POSIX descendants are found via `ps`, signaled, and SIGKILL-escalated.
@@ -290,5 +392,7 @@ export const terminateProcessTree = async (
   if (process.platform === 'win32') {
     return terminateWindowsTree(child, signal, log)
   }
+  const ownedGroup = ownedPosixProcessGroups.get(child)
+  if (ownedGroup) return terminateOwnedPosixProcessGroup(ownedGroup, signal, log)
   return terminatePosixTree(child, signal, log)
 }


### PR DESCRIPTION
## Problem

The captured failures showed externally signaled Codex child processes closing their ACP connection while delegated work was still active. Normal tree termination could also miss descendants that outlived or escaped the immediate child, while broad process-group signaling would risk affecting processes the application did not explicitly own.

## Proposed change

- Launch POSIX Codex adapter processes in a detached process group while retaining their stdio pipes.
- Register an explicit owned-process-group receipt only for those Codex children.
- During owned shutdown, snapshot PPID descendants, signal the process group and snapshot PIDs with TERM, wait for both scopes, then escalate to KILL if needed.
- Fail closed when the descendant snapshot cannot be established.
- Keep Windows and OpenCode on the existing ordinary process-tree path.
- Treat expected application shutdown separately from an unexpected ACP close in runtime tests.

## Scope and non-goals

This PR is limited to POSIX Codex child-process ownership and expected ACP shutdown handling. It does not change OpenCode behavior, Windows termination, generic authentication, or Figure Composer orchestration.

## Acceptance criteria and validation

- Owned Codex group termination covers a live leader, a reparented same-group grandchild, and a descendant that creates a separate session: targeted process-tree/framework tests passed.
- Ordinary unregistered process trees retain their previous behavior: covered by negative ownership tests.
- Expected shutdown suppresses the expected ACP-close error while a real unexpected close is still reported: covered by ACP runtime tests.
- Targeted final changed-area suite — 72/72 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- Full `npm test` under high parallel load completed 21692 passing tests and reported 15 failures across 12 unrelated timeout/async-flaky files. All 12 files passed when immediately rerun in isolation: 12/12 files, 1448/1448 tests. The changed-area tests were green before and after that run.
- A 40-minute real Electron Figure Composer run on the companion local branches completed 12 delegated frames without `acp connection closed`.
- Independent Standards and Spec review after fixes: no remaining P1/P2 findings.

Uncovered risk: the owned process-group path is POSIX-only by design; Windows remains on the existing termination implementation and was not live-tested here. The full-suite high-load flakiness should be rechecked by CI on the exact branch head.

## Review focus

- Whether explicit process-group ownership is scoped narrowly enough.
- Whether combining the PGID signal with a pre-signal PPID snapshot safely covers escaped descendants.
- Whether fail-closed behavior and TERM-to-KILL escalation preserve existing shutdown guarantees.
