### PR TITLE
ci(performance): enforce runtime soak invariants

### DIFF
--- a/e2e/runtime-performance.spec.ts
+++ b/e2e/runtime-performance.spec.ts
@@ -107,8 +107,8 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
   ).toBe(1)
   expect(
     recoveryStorage?.notebookRunFileCount.last,
-    'the journey must persist one Notebook run per stress cycle'
-  ).toBe(stressCycles)
+    'the journey must reuse exactly one persisted Notebook run file'
+  ).toBe(1)
   expect(recoveryStorage?.sessionBytes.last).toBeGreaterThan(0)
   expect(recoveryStorage?.notebookRunBytes.last).toBeGreaterThan(0)
   console.log(`Runtime performance summary: ${result.summaryMarkdownPath}`)

--- a/e2e/runtime-performance.spec.ts
+++ b/e2e/runtime-performance.spec.ts
@@ -78,10 +78,38 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
     path: result.summaryMarkdownPath,
     contentType: 'text/markdown'
   })
-  const recoveryStorage = result.summary.phases.recovery?.storage
-  expect(recoveryStorage?.sessionFileCount.last).toBeGreaterThan(0)
+  const summary = result.summary
+  expect(summary.sampleCount, 'the profile must contain resource samples').toBeGreaterThan(0)
+  expect(
+    summary.incompleteSampleCount / summary.sampleCount,
+    'no more than 10% of resource samples may be incomplete'
+  ).toBeLessThanOrEqual(0.1)
+  const idle = summary.phases.idle
+  const recovery = summary.phases.recovery
+  if (!idle || !recovery) throw new Error('The profile must contain idle and recovery phases.')
+  expect(idle.includedSampleCount, 'idle must contain a complete resource sample').toBeGreaterThan(
+    0
+  )
+  expect(
+    recovery.includedSampleCount,
+    'recovery must contain a complete resource sample'
+  ).toBeGreaterThan(0)
+  expect(
+    recovery.processCount.last,
+    'recovery must not retain more processes than the stable idle phase'
+  ).toBeLessThanOrEqual(idle.processCount.last)
+  const recoveryStorage = recovery.storage
+  expect(recoveryStorage?.temporaryFileCount.last, 'recovery must leave no temporary files').toBe(0)
+  expect(recoveryStorage?.temporaryBytes.last, 'recovery must leave no temporary bytes').toBe(0)
+  expect(
+    recoveryStorage?.sessionFileCount.last,
+    'the journey must persist exactly one Session'
+  ).toBe(1)
+  expect(
+    recoveryStorage?.notebookRunFileCount.last,
+    'the journey must persist one Notebook run per stress cycle'
+  ).toBe(stressCycles)
   expect(recoveryStorage?.sessionBytes.last).toBeGreaterThan(0)
-  expect(recoveryStorage?.notebookRunFileCount.last).toBeGreaterThan(0)
   expect(recoveryStorage?.notebookRunBytes.last).toBeGreaterThan(0)
   console.log(`Runtime performance summary: ${result.summaryMarkdownPath}`)
 })

--- a/scripts/performance/run-runtime-profile.mjs
+++ b/scripts/performance/run-runtime-profile.mjs
@@ -75,14 +75,21 @@ for (const argument of process.argv.slice(2)) {
   }
 }
 
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const npmCliPath = process.env.npm_execpath?.trim()
+if (!npmCliPath) {
+  throw new Error('npm_execpath is required. Run this profile through npm run perf:runtime.')
+}
 const run = (args, environment = process.env) =>
   new Promise((resolveRun, rejectRun) => {
-    const child = spawn(npmCommand, args, { env: environment, stdio: 'inherit', windowsHide: true })
+    const child = spawn(process.execPath, [npmCliPath, ...args], {
+      env: environment,
+      stdio: 'inherit',
+      windowsHide: true
+    })
     child.once('error', rejectRun)
     child.once('exit', (code, signal) => {
       if (code === 0) resolveRun()
-      else rejectRun(new Error(`${npmCommand} ${args.join(' ')} exited with ${code ?? signal}.`))
+      else rejectRun(new Error(`npm ${args.join(' ')} exited with ${code ?? signal}.`))
     })
   })
 

--- a/scripts/performance/run-runtime-profile.test.ts
+++ b/scripts/performance/run-runtime-profile.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+describe('runtime profile launcher', () => {
+  it('invokes npm through the current Node executable without relying on a shell command', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-runtime-launcher-'))
+    const npmCliPath = join(root, 'mock-npm-cli.mjs')
+    const invocationLog = join(root, 'npm-invocations.jsonl')
+    await writeFile(
+      npmCliPath,
+      `import { appendFileSync } from 'node:fs'
+appendFileSync(process.env.RUNTIME_PROFILE_INVOCATION_LOG, JSON.stringify(process.argv.slice(2)) + '\\n')
+`,
+      'utf8'
+    )
+
+    try {
+      const environment = Object.fromEntries(
+        Object.entries(process.env).filter(([name]) => name.toLowerCase() !== 'path')
+      )
+      const result = spawnSync(
+        process.execPath,
+        [
+          resolve(process.cwd(), 'scripts/performance/run-runtime-profile.mjs'),
+          '--repeat=1',
+          '--phase-ms=2000',
+          '--interval-ms=500',
+          '--stress-cycles=1',
+          `--output=${join(root, 'output')}`
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8',
+          env: {
+            ...environment,
+            npm_execpath: npmCliPath,
+            RUNTIME_PROFILE_INVOCATION_LOG: invocationLog
+          },
+          timeout: 10_000
+        }
+      )
+
+      expect(result.error).toBeUndefined()
+      expect(result.status, result.stderr).toBe(0)
+      const invocations = (await readFile(invocationLog, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as string[])
+      expect(invocations).toEqual([
+        ['run', 'build:e2e'],
+        [
+          'exec',
+          '--',
+          'playwright',
+          'test',
+          'e2e/runtime-performance.spec.ts',
+          '--workers=1',
+          '--repeat-each=1',
+          '--reporter=list'
+        ]
+      ])
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/scripts/performance/runtime-resource-profiler.test.ts
+++ b/scripts/performance/runtime-resource-profiler.test.ts
@@ -247,7 +247,15 @@ describe('runtime resource profiler', () => {
       }
       return tree([processEntry()])
     })
-    const evaluate = vi.fn().mockResolvedValueOnce('39.0.0').mockResolvedValue([])
+    let retainedElectronMetricsPromise = false
+    const evaluate = vi.fn(
+      async (callback: (electron: { app: { getAppMetrics: () => [] } }) => unknown) => {
+        if (evaluate.mock.calls.length === 1) return '39.0.0'
+        const result = callback({ app: { getAppMetrics: () => [] } })
+        retainedElectronMetricsPromise = result instanceof Promise
+        return result
+      }
+    )
     const application = {
       evaluate,
       off: vi.fn(),
@@ -279,6 +287,7 @@ describe('runtime resource profiler', () => {
       expect(result.summary.phases.recovery.sampleCount).toBe(1)
       expect(result.summary.phases.idle.sampleCount).toBe(1)
       expect(readTree).toHaveBeenCalledTimes(3)
+      expect(retainedElectronMetricsPromise).toBe(true)
     } finally {
       profiler.abort()
       await rm(outputRoot, { force: true, recursive: true })

--- a/scripts/performance/runtime-resource-profiler.ts
+++ b/scripts/performance/runtime-resource-profiler.ts
@@ -831,8 +831,8 @@ class RuntimeResourceProfiler {
     const [tree, electronSnapshot, storage] = await Promise.all([
       this.readTree(rootPid),
       application
-        .evaluate(({ app }) =>
-          app.getAppMetrics().map((metric) => ({
+        .evaluate(({ app }) => {
+          const metrics = app.getAppMetrics().map((metric) => ({
             pid: metric.pid,
             type: metric.type,
             creationTime: metric.creationTime,
@@ -843,7 +843,10 @@ class RuntimeResourceProfiler {
             peakWorkingSetKb: metric.memory.peakWorkingSetSize,
             privateKb: metric.memory.privateBytes
           }))
-        )
+          return new Promise<typeof metrics>((resolveMetrics) => {
+            setImmediate(() => resolveMetrics(metrics))
+          })
+        })
         .then(
           (metrics) => ({ complete: true, metrics }),
           (error) => {

--- a/scripts/performance/runtime-resource-profiler.ts
+++ b/scripts/performance/runtime-resource-profiler.ts
@@ -846,7 +846,12 @@ class RuntimeResourceProfiler {
         )
         .then(
           (metrics) => ({ complete: true, metrics }),
-          () => ({ complete: false, metrics: [] as ElectronProcessMetric[] })
+          (error) => {
+            process.stderr.write(
+              `Runtime resource profiler could not capture Electron metrics: ${error instanceof Error ? error.message : String(error)}\n`
+            )
+            return { complete: false, metrics: [] as ElectronProcessMetric[] }
+          }
         ),
       includeStorage && this.storageRoot
         ? readRuntimeStorageSnapshot(this.storageRoot, this.dataRoot)


### PR DESCRIPTION
## Problem

The scheduled Windows runtime-resource workflow collected CPU, RSS, process, Session, Notebook, and
temporary-file evidence but treated most of it as report-only. A successful scenario therefore did
not prove that samples were sufficiently complete, child processes returned to the stable count,
temporary files were cleaned up, or durable file growth matched the deterministic workload.

The workflow also has not reached sampling on the current Windows/Node 22 runner: direct
`spawn('npm.cmd', ...)` exits with `EINVAL`.

After fixing that launcher, the first hosted smoke exposed a second Node 22/Electron tooling issue:
Playwright's main-process `evaluate()` result Promise was garbage-collected by V8 during the
high-volume Session stream, excluding about 91% of stress samples.

## Proposed change

- launch npm's JavaScript CLI through the current Node executable and `npm_execpath`, avoiding the
  Windows `.cmd` process boundary and shell interpolation;
- add a focused launcher regression test that removes `PATH` and records both nested npm calls;
- retain the idempotent Electron-metrics evaluation through the target event loop, preventing V8
  from collecting Playwright's awaited Promise under stream pressure, and log capture failures to
  CI stderr without adding artifact fields;
- make the deterministic performance E2E fail when:
  - more than 10% of samples are incomplete;
  - idle or recovery has no complete sample;
  - recovery ends with more processes than stable idle;
  - recovery leaves any temporary files or bytes;
  - the workload does not persist exactly one Session and one reused Notebook run file.

The profiler still writes its evidence before these E2E assertions run, so the workflow's
`always()` upload preserves diagnostics for a failed gate.

## Scope and non-goals

- No absolute CPU or RSS threshold is added before successful hosted-runner history exists.
- No cross-commit baseline downloader, trend store, or alert policy is added.
- No production architecture, application data model, user interaction, persisted user-data format,
  or enum/state value changes.
- No profile field or schema-version change; historical schema-v3 reports remain standalone and
  compatible.

## Acceptance criteria and validation

All listed local checks ran after the last material edit using the canonical checkout's dependency
tree; the full `npm test` suite was intentionally left to PR CI.

| Behavior | Check | Result |
| --- | --- | --- |
| profiler summaries and Promise retention, npm launcher contract, and scheduled-workflow topology | Node 22.23.2 `vitest run scripts/performance/runtime-resource-profiler.test.ts scripts/performance/run-runtime-profile.test.ts scripts/ci/release-workflows.test.ts` | 18 passed |
| Node/E2E types | `tsc --noEmit -p tsconfig.node.json --composite false` | final local attempt was environment-blocked by the shared canonical Prisma client missing the new `computeJobOperation` model; no changed-file error was reported, and PR Static checks are authoritative |
| changed source lint | `eslint e2e/runtime-performance.spec.ts scripts/performance/runtime-resource-profiler.ts scripts/performance/runtime-resource-profiler.test.ts scripts/performance/run-runtime-profile.mjs scripts/performance/run-runtime-profile.test.ts` | passed |
| changed source formatting | `prettier --check e2e/runtime-performance.spec.ts scripts/performance/runtime-resource-profiler.ts scripts/performance/runtime-resource-profiler.test.ts scripts/performance/run-runtime-profile.mjs scripts/performance/run-runtime-profile.test.ts` | passed |
| patch hygiene | `git diff --check` | passed |
| hosted Windows smoke | exact-head workflow run `33355609700`, Node 22.23.2 | passed; preceding fix-validation run `33355179353` recorded 51/51 complete samples, idle/recovery processes 8/8, temp files/bytes 0/0, and Session/Notebook files 1/1 |
| pull request CI | PR Gate run `33355288884` after rerunning three unrelated first-attempt failures | passed, including Static checks, both full Module test shards, macOS build/E2E, Windows E2E, Windows core, and the final deterministic gate |

Consumer/platform scope: the changed assertions are owned by the isolated runtime-performance E2E;
the launcher regression test covers the Node-to-npm adapter, and the hosted smoke covers the real
Node 22 runner and complete Electron journey. An exact-head smoke and PR checks are authoritative.

## Review focus

- whether the 10% incomplete-sample cap is strict enough without making hosted sampling flaky;
- whether final recovery process count relative to idle is the right minimal persistent-leak gate;
- whether exact deterministic Session/Notebook file counts correctly reject duplicate durable files;
- whether invoking npm through `process.execPath + npm_execpath` covers supported npm installations.
- whether retaining the read-only Electron metrics result for one target event-loop turn is the
  smallest safe workaround for Playwright/Chromium Promise collection.
