### PR TITLE
fix(onboarding): preserve data-drive default after startup

### DIFF
--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -1,4 +1,5 @@
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readdir } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 
@@ -58,6 +59,7 @@ import { toErrorMessage } from '../error-message'
 import type { RendererSessionPersistenceTarget } from '../session-persistence/renderer-flush'
 import type { SessionPersistenceFlushResponse } from '../../shared/session-persistence-flush'
 import { DataRootCleanupJournal } from './data-root-cleanup'
+import { DEFAULT_UPLOAD_PROJECT_ID } from '../../shared/uploads'
 
 type LegacySessionSource = { projectId: string; sessionId: string }
 type NotebookSessionSource = { projectId: string; sessionId: string }
@@ -120,6 +122,49 @@ type StorageCommandOwnerDeps = {
 
 type StorageParentRequest = Readonly<{ parent: string }>
 type StorageRootRequest = Readonly<{ parent: string; markOnboarding?: boolean }>
+
+const NON_UPLOAD_DATA_ROOT_DIRS = DATA_ROOT_DIRS.filter((dir) => dir !== 'uploads')
+
+const readDirectoryIfPresent = async (path: string): Promise<Dirent[] | undefined> => {
+  try {
+    return await readdir(path, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  }
+}
+
+// Uploads initializes this empty directory chain before onboarding asks for storage information.
+// It is infrastructure, not user data, so it must not pin a fresh install to the system drive. Any
+// additional entry (including an in-flight staged file or a symlink) still fails closed as data.
+const hasUploadDataBeyondStartupScaffold = async (dataRoot: string): Promise<boolean> => {
+  const uploads = await readDirectoryIfPresent(join(dataRoot, 'uploads'))
+  if (!uploads || uploads.length === 0) return false
+  if (
+    uploads.length !== 1 ||
+    uploads[0].name !== DEFAULT_UPLOAD_PROJECT_ID ||
+    !uploads[0].isDirectory()
+  ) {
+    return true
+  }
+
+  const defaultProject = await readDirectoryIfPresent(
+    join(dataRoot, 'uploads', DEFAULT_UPLOAD_PROJECT_ID)
+  )
+  if (!defaultProject || defaultProject.length === 0) return false
+  if (
+    defaultProject.length !== 1 ||
+    defaultProject[0].name !== '.staging' ||
+    !defaultProject[0].isDirectory()
+  ) {
+    return true
+  }
+
+  const staging = await readDirectoryIfPresent(
+    join(dataRoot, 'uploads', DEFAULT_UPLOAD_PROJECT_ID, '.staging')
+  )
+  return Boolean(staging?.length)
+}
 
 // Pushes migration progress to every live window, mirroring the acp/update broadcast pattern.
 const defaultBroadcast = (progress: MigrationProgress): void => {
@@ -222,9 +267,10 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
         legacyInPlace && hasUserData && storedSettings.legacyDataMovePromptDismissedAt === undefined
       // Include runtime/: unlike legacy detection, onboarding must not pointer-switch away from a
       // managed environment that was prepared before an interrupted setup resumed.
-      const currentRootHasData = await (deps.hasAnyExistingPath ?? hasAnyExistingPath)(
-        DATA_ROOT_DIRS.map((dir) => join(dataRoot, dir))
-      )
+      const currentRootHasData =
+        (await (deps.hasAnyExistingPath ?? hasAnyExistingPath)(
+          NON_UPLOAD_DATA_ROOT_DIRS.map((dir) => join(dataRoot, dir))
+        )) || (await hasUploadDataBeyondStartupScaffold(dataRoot))
       canAutoSelectDataDrive = !storedSettings.dataRoot && !currentRootHasData && !dataRootMissing
     } catch (err) {
       logger.warn('data root status detection failed', diagnosticErrorFields(err))

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -60,6 +60,7 @@ import type { RendererSessionPersistenceTarget } from '../session-persistence/re
 import type { SessionPersistenceFlushResponse } from '../../shared/session-persistence-flush'
 import { DataRootCleanupJournal } from './data-root-cleanup'
 import { DEFAULT_UPLOAD_PROJECT_ID } from '../../shared/uploads'
+import { STAGING_UPLOAD_SESSION_ID, UPLOADS_DIR } from '../uploads/storage-helpers'
 
 type LegacySessionSource = { projectId: string; sessionId: string }
 type NotebookSessionSource = { projectId: string; sessionId: string }
@@ -123,7 +124,7 @@ type StorageCommandOwnerDeps = {
 type StorageParentRequest = Readonly<{ parent: string }>
 type StorageRootRequest = Readonly<{ parent: string; markOnboarding?: boolean }>
 
-const NON_UPLOAD_DATA_ROOT_DIRS = DATA_ROOT_DIRS.filter((dir) => dir !== 'uploads')
+const NON_UPLOAD_DATA_ROOT_DIRS = DATA_ROOT_DIRS.filter((dir) => dir !== UPLOADS_DIR)
 
 const readDirectoryIfPresent = async (path: string): Promise<Dirent[] | undefined> => {
   try {
@@ -138,7 +139,7 @@ const readDirectoryIfPresent = async (path: string): Promise<Dirent[] | undefine
 // It is infrastructure, not user data, so it must not pin a fresh install to the system drive. Any
 // additional entry (including an in-flight staged file or a symlink) still fails closed as data.
 const hasUploadDataBeyondStartupScaffold = async (dataRoot: string): Promise<boolean> => {
-  const uploads = await readDirectoryIfPresent(join(dataRoot, 'uploads'))
+  const uploads = await readDirectoryIfPresent(join(dataRoot, UPLOADS_DIR))
   if (!uploads || uploads.length === 0) return false
   if (
     uploads.length !== 1 ||
@@ -149,19 +150,19 @@ const hasUploadDataBeyondStartupScaffold = async (dataRoot: string): Promise<boo
   }
 
   const defaultProject = await readDirectoryIfPresent(
-    join(dataRoot, 'uploads', DEFAULT_UPLOAD_PROJECT_ID)
+    join(dataRoot, UPLOADS_DIR, DEFAULT_UPLOAD_PROJECT_ID)
   )
   if (!defaultProject || defaultProject.length === 0) return false
   if (
     defaultProject.length !== 1 ||
-    defaultProject[0].name !== '.staging' ||
+    defaultProject[0].name !== STAGING_UPLOAD_SESSION_ID ||
     !defaultProject[0].isDirectory()
   ) {
     return true
   }
 
   const staging = await readDirectoryIfPresent(
-    join(dataRoot, 'uploads', DEFAULT_UPLOAD_PROJECT_ID, '.staging')
+    join(dataRoot, UPLOADS_DIR, DEFAULT_UPLOAD_PROJECT_ID, STAGING_UPLOAD_SESSION_ID)
   )
   return Boolean(staging?.length)
 }

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 import type { Logger } from '../logger'
+import { DEFAULT_UPLOAD_PROJECT_ID } from '../../shared/uploads'
+import { STAGING_UPLOAD_SESSION_ID, UPLOADS_DIR } from '../uploads/storage-helpers'
 
 // Capture ipcMain.handle registrations; stub dialog/BrowserWindow/app so handlers can be invoked
 // directly without a real Electron runtime. isPackaged: true means dataFolderName() === 'OpenScience'.
@@ -414,9 +416,16 @@ describe('storage IPC handlers', () => {
     const home = await mkdtemp(join(tmpdir(), 'ds-upload-scaffold-home-'))
     electronHome.path = home
     try {
-      await mkdir(join(home, 'OpenScience', 'uploads', 'default-project', '.staging'), {
-        recursive: true
-      })
+      await mkdir(
+        join(
+          home,
+          'OpenScience',
+          UPLOADS_DIR,
+          DEFAULT_UPLOAD_PROJECT_ID,
+          STAGING_UPLOAD_SESSION_ID
+        ),
+        { recursive: true }
+      )
       initDataRoot(undefined)
       registerStorageIpcHandlers(fakeDeps())
 
@@ -434,7 +443,13 @@ describe('storage IPC handlers', () => {
     const home = await mkdtemp(join(tmpdir(), 'ds-staged-upload-home-'))
     electronHome.path = home
     try {
-      const staging = join(home, 'OpenScience', 'uploads', 'default-project', '.staging')
+      const staging = join(
+        home,
+        'OpenScience',
+        UPLOADS_DIR,
+        DEFAULT_UPLOAD_PROJECT_ID,
+        STAGING_UPLOAD_SESSION_ID
+      )
       await mkdir(staging, { recursive: true })
       await writeFile(join(staging, 'transfer.part'), 'pending upload')
       initDataRoot(undefined)

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -410,6 +410,46 @@ describe('storage IPC handlers', () => {
     expect(info.canAutoSelectDataDrive).toBe(true)
   })
 
+  it('get-info permits auto-selection when startup created only the empty upload scaffold', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'ds-upload-scaffold-home-'))
+    electronHome.path = home
+    try {
+      await mkdir(join(home, 'OpenScience', 'uploads', 'default-project', '.staging'), {
+        recursive: true
+      })
+      initDataRoot(undefined)
+      registerStorageIpcHandlers(fakeDeps())
+
+      const info = (await invoke('storage:get-info')) as { canAutoSelectDataDrive: boolean }
+
+      expect(info.canAutoSelectDataDrive).toBe(true)
+    } finally {
+      electronHome.path = '/home/user'
+      initDataRoot(undefined)
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('get-info suppresses auto-selection when the upload scaffold contains a staged file', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'ds-staged-upload-home-'))
+    electronHome.path = home
+    try {
+      const staging = join(home, 'OpenScience', 'uploads', 'default-project', '.staging')
+      await mkdir(staging, { recursive: true })
+      await writeFile(join(staging, 'transfer.part'), 'pending upload')
+      initDataRoot(undefined)
+      registerStorageIpcHandlers(fakeDeps())
+
+      const info = (await invoke('storage:get-info')) as { canAutoSelectDataDrive: boolean }
+
+      expect(info.canAutoSelectDataDrive).toBe(false)
+    } finally {
+      electronHome.path = '/home/user'
+      initDataRoot(undefined)
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   it('get-info fails closed when default-root emptiness cannot be proven', async () => {
     initDataRoot(undefined)
     const logger = fakeDiagnosticLogger()


### PR DESCRIPTION
## Problem

On fresh Windows startup, the upload service creates an empty `uploads/default-project/.staging` scaffold before onboarding requests storage information. That scaffold was treated as existing user data, which suppressed automatic selection of an available non-system drive and left onboarding on C:.

A separate local-development issue could also reject a valid NTFS folder when the native safe-file-publisher addon had not been compiled. The installed Visual Studio C++ Desktop toolchain now allows that addon to rebuild successfully; official Windows CI already compiles and smoke-tests it.

## Proposed change

- Ignore only the exact empty startup upload scaffold when determining whether a fresh data root is eligible for automatic drive selection.
- Continue treating staged files, any other upload content, symlinks/non-directories, and inspection errors as existing or inconclusive data.
- Reuse the upload module's existing directory and staging constants.

## Scope and non-goals

- No architecture, data model, data relationship, enum/state, persistence, or new UI changes.
- No bundled native binary is added; local development uses the existing native rebuild path, while Windows CI packages the addon.

## Acceptance criteria and validation

- Empty startup scaffold permits non-C drive selection; staged content blocks it: targeted Vitest suite, 247 passed and 4 skipped.
- Main-process types: Node TypeScript check passed.
- Changed source quality: targeted ESLint and Prettier checks passed.
- Renderer/main packaging inputs: `electron-vite build` passed.
- Fresh Windows onboarding: isolated Electron run displayed `D:\OpenScience-DEV` and classified `D:\os-tmp` as a usable move target.
- Local development native path: `npm rebuild @aipoch/safe-file-publisher-native` succeeded and the main `npm run dev` application startup completed.
- Packaged native path: the existing successful Windows CI job compiled the addon and passed installer smoke; this PR's exact-head CI remains authoritative for the final package.

All checks above were run after the last material edit. Per request, the full local `npm test` suite was not run; PR CI provides the complete test run.

## Compatibility and persistence

Existing incomplete onboarding profiles whose default data root contains only the exact empty upload scaffold become eligible for non-system-drive auto-selection. No migration is required. Any real or staged data continues to block auto-selection.

No new persisted data and no new status or enum values are introduced.

## Review focus

Please confirm that the exact empty scaffold is the only ignored path and that staged or inconclusive data remains fail-closed.