### PR TITLE
fix(memory): honor global gate in conversation controls

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -327,6 +327,32 @@ describe('ComposerAgentControlsMenu', () => {
     expect(selectEvents.at(-1)?.prevented).toBe(true)
   })
 
+  it('shows why Memory is unavailable when the global setting is off', () => {
+    const onMemoryChange = vi.fn()
+    const reason = 'Memory is off in Settings. Turn it on to use Memory in this conversation.'
+
+    act(() => {
+      root.render(
+        <ComposerAgentControlsMenu
+          profile="ask"
+          autoReviewEnabled={false}
+          memoryEnabled={false}
+          memoryReadOnly
+          memoryDisabledReason={reason}
+          onProfileChange={vi.fn()}
+          onAutoReviewChange={vi.fn()}
+          onMemoryChange={onMemoryChange}
+        />
+      )
+    })
+
+    const memoryRow = findButton(`Memory${reason}`)
+    expect(memoryRow.disabled).toBe(true)
+    expect(container.querySelector('[data-testid="controls-nondefault-dot"]')).toBeNull()
+    act(() => memoryRow.click())
+    expect(onMemoryChange).not.toHaveBeenCalled()
+  })
+
   it('opens permission choices inside the same menu on mobile and can return', () => {
     mediaState.mobile = true
 

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -83,6 +83,7 @@ type ComposerAgentControlsMenuProps = {
   readOnly?: boolean
   // Memory may be reconfigured again after context replacement while transcript replay is pending.
   memoryReadOnly?: boolean
+  memoryDisabledReason?: string
   // Auto-review is a durable preference and does not depend on the provider transcript state.
   autoReviewReadOnly?: boolean
   // Permission mode remains independently editable during a running prompt.
@@ -161,6 +162,7 @@ const ComposerAgentControlsMenu = ({
   memoryEnabled = true,
   readOnly = false,
   memoryReadOnly = readOnly,
+  memoryDisabledReason,
   autoReviewReadOnly = readOnly,
   permissionProfileReadOnly = readOnly,
   grantActionsReadOnly = readOnly,
@@ -195,8 +197,11 @@ const ComposerAgentControlsMenu = ({
   const fullAccessUnavailable = profileState?.fullAccessAvailable === false
   // Ask grants stay visible across profile switches so changing Auto/Full never appears to lose them.
   const hasGrants = (grants?.length ?? 0) > 0
-  // Anything other than the defaults (ask + auto-review off) gets a dot on the trigger.
-  const isNonDefault = profile !== DEFAULT_PERMISSION_PROFILE || autoReviewEnabled || !memoryEnabled
+  // A globally unavailable Memory capability is not a per-conversation customization.
+  const isNonDefault =
+    profile !== DEFAULT_PERMISSION_PROFILE ||
+    autoReviewEnabled ||
+    (!memoryEnabled && !memoryDisabledReason)
 
   useEffect(() => {
     if (openRequest === undefined || openRequest === previousOpenRequest.current) return
@@ -518,7 +523,8 @@ const ComposerAgentControlsMenu = ({
                 <span className="min-w-0 flex-1">
                   <span className="block text-[13px] font-medium leading-5">{t('Memory')}</span>
                   <span className="block text-[11px] leading-4 text-text-300">
-                    {t('Let the agent recall and save memory in this conversation.')}
+                    {memoryDisabledReason ??
+                      t('Let the agent recall and save memory in this conversation.')}
                   </span>
                 </span>
                 <Switch

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -332,6 +332,7 @@ type ConversationPanelAgentControls = {
   changeModelConfiguration?: (configuration: SessionAgentConfiguration) => void
   autoReviewEnabled: boolean
   memoryEnabled?: boolean
+  memoryDisabledReason?: string
   enabledComputeHosts: string[]
   selectedComputeHosts?: string[]
   toggleAutoReview: (enabled: boolean) => void
@@ -537,6 +538,7 @@ const ConversationPanel = ({
     changeModelConfiguration = () => undefined,
     autoReviewEnabled,
     memoryEnabled = true,
+    memoryDisabledReason,
     enabledComputeHosts,
     selectedComputeHosts = [],
     toggleAutoReview: onAutoReviewToggle,
@@ -1382,6 +1384,7 @@ const ConversationPanel = ({
                               grants={permissionGrants}
                               autoReviewEnabled={autoReviewEnabled}
                               memoryEnabled={memoryEnabled}
+                              memoryDisabledReason={memoryDisabledReason}
                               readOnly
                               permissionProfileReadOnly
                               grantActionsReadOnly
@@ -2111,6 +2114,7 @@ const ConversationPanel = ({
                           grants={permissionGrants}
                           autoReviewEnabled={autoReviewEnabled}
                           memoryEnabled={memoryEnabled}
+                          memoryDisabledReason={memoryDisabledReason}
                           readOnly={!canChangeAgentControls}
                           autoReviewReadOnly={!canChangeAutoReview}
                           memoryReadOnly={!canChangeMemory}

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as React from 'react'
 
 import { useNavigationStore } from '@/stores/navigation-store'
+import { createInitialMemoryState, useMemoryStore } from '@/stores/memory-store'
 import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
@@ -176,6 +177,7 @@ describe('WorkspacePage send gate while compacting', () => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useProjectStore.setState({ projects: [] })
     useReviewStore.setState(createInitialReviewState())
+    useMemoryStore.setState(createInitialMemoryState())
     useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
     useSessionStore.setState({
       ...createInitialSessionState(),
@@ -210,7 +212,13 @@ describe('WorkspacePage send gate while compacting', () => {
         onFixLoopEnd: vi.fn(() => vi.fn()),
         abortFixLoop: vi.fn(() => Promise.resolve())
       },
-      compute: { enabledHostsSet: vi.fn(() => Promise.resolve()) }
+      compute: { enabledHostsSet: vi.fn(() => Promise.resolve()) },
+      memory: {
+        snapshot: vi.fn(() =>
+          Promise.resolve({ revision: 1, enabled: true, categories: [], projects: [] })
+        ),
+        onChanged: vi.fn(() => vi.fn())
+      }
     } as never
 
     container = document.createElement('div')
@@ -260,6 +268,43 @@ describe('WorkspacePage send gate while compacting', () => {
       useSessionStore.getState().finishRun('sess-a')
     })
     expect(conversationProps.conversation.availability.submit).toBe(true)
+  })
+
+  it('defaults Memory off and explains the global gate when Memory is off in Settings', async () => {
+    vi.mocked(window.api.memory.snapshot).mockResolvedValue({
+      revision: 1,
+      enabled: false,
+      categories: [],
+      projects: []
+    })
+
+    await renderPage()
+
+    expect(conversationProps.agentControls).toMatchObject({
+      canChangeMemory: false,
+      memoryEnabled: false,
+      memoryDisabledReason:
+        'Memory is off in Settings. Turn it on to use Memory in this conversation.'
+    })
+
+    conversationProps.agentControls.toggleMemory?.(true)
+    expect(runtime.setMemoryEnabled).not.toHaveBeenCalled()
+
+    await act(async () => useSessionStore.getState().clearSelection())
+    expect(conversationProps.agentControls).toMatchObject({
+      canChangeMemory: false,
+      memoryEnabled: false
+    })
+
+    runtime.sendMessage.mockResolvedValueOnce({ sessionId: 'new-session', messageId: 'message-1' })
+    await act(async () => conversationProps.composer.actions.changeDoc(textDoc('start safely')))
+    await act(async () => {
+      conversationProps.conversation.actions.submit.draft({ forcedSkillIds: [] })
+      await Promise.resolve()
+    })
+    expect(runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ memoryEnabled: false, text: 'start safely' })
+    )
   })
 
   it.each(['running', 'waiting-permission'] as const)(

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/acp/useWorkspaceElicitation'
 import { usePreviewPersistence } from '@/lib/preview-persistence/preview-persistence'
 import { deleteSession } from '@/lib/session-persistence/session-persistence'
+import { useMemoryStore } from '@/stores/memory-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -129,6 +130,11 @@ const WorkspacePage = ({
   const catalogSkills = useSettingsStore((state) => state.skills)
   const loadSkills = useSettingsStore((state) => state.loadSkills)
   const pendingCredentialRequests = useSettingsStore((state) => state.pendingCredentialRequests)
+  const memoryGloballyEnabled = useMemoryStore((state) => state.enabled)
+  const loadMemory = useMemoryStore((state) => state.load)
+  const listenForMemoryChanges = useMemoryStore((state) => state.listen)
+  // The store starts disabled, so new conversations fail closed until the global setting loads.
+  const isGlobalMemoryEnabled = memoryGloballyEnabled
   const scopedProjectId = activeProjectId ?? ''
   const activeProject = useProjectStore((state) =>
     state.projects.find((project) => project.id === scopedProjectId)
@@ -232,7 +238,11 @@ const WorkspacePage = ({
   // conversation starts disabled; the user can toggle it on before sending. On send it is stamped
   // onto the created session through the Conversation submit transaction.
   const [newConversationAutoReviewEnabled, setNewConversationAutoReviewEnabled] = useState(false)
-  const [newConversationMemoryEnabled, setNewConversationMemoryEnabled] = useState(true)
+  const [newConversationMemoryPreference, setNewConversationMemoryPreference] = useState<
+    boolean | undefined
+  >()
+  const newConversationMemoryEnabled =
+    isGlobalMemoryEnabled && (newConversationMemoryPreference ?? true)
   // Draft compute hosts for a not-yet-created conversation. Cleared when a new conversation draft
   // is started, and stamped onto the session by the Conversation submit transaction.
   const [newConversationEnabledComputeHosts, setNewConversationEnabledComputeHosts] = useState<
@@ -244,6 +254,11 @@ const WorkspacePage = ({
   const [notebookReferences, setNotebookReferences] = useState<
     Record<string, NotebookSessionReference>
   >({})
+
+  useEffect(() => {
+    void loadMemory()
+    return listenForMemoryChanges()
+  }, [listenForMemoryChanges, loadMemory])
 
   // The selected session is the only conversation rendered in the center panel. Selecting it by
   // id (instead of deriving it from the full list) keeps chunk commits for other sessions from
@@ -466,7 +481,7 @@ const WorkspacePage = ({
     ? activeSession.autoReviewEnabled === true
     : newConversationAutoReviewEnabled
   const activeMemoryEnabled = activeSession
-    ? activeSession.memoryEnabled !== false
+    ? isGlobalMemoryEnabled && activeSession.memoryEnabled !== false
     : newConversationMemoryEnabled
   const computeHostAccess = createWorkspaceComputeHostAccessController({
     activeSession,
@@ -519,7 +534,7 @@ const WorkspacePage = ({
     setAutoReviewEnabled,
     resetNewConversationSettings: () => {
       setNewConversationAutoReviewEnabled(false)
-      setNewConversationMemoryEnabled(true)
+      setNewConversationMemoryPreference(undefined)
       setNewConversationEnabledComputeHosts([])
       setNewConversationSelectedComputeHosts([])
       resetNewConversationConfiguration()
@@ -807,7 +822,7 @@ const WorkspacePage = ({
     setAttachmentError(null)
     setNewConversationPermissionProfile(defaultPermissionProfile)
     setNewConversationAutoReviewEnabled(false)
-    setNewConversationMemoryEnabled(true)
+    setNewConversationMemoryPreference(undefined)
     setNewConversationEnabledComputeHosts([])
     setNewConversationSelectedComputeHosts([])
     resetNewConversationConfiguration()
@@ -888,7 +903,8 @@ const WorkspacePage = ({
   }
 
   const changeMemoryEnabled = (enabled: boolean): void => {
-    if (!activeSession) return setNewConversationMemoryEnabled(enabled)
+    if (!isGlobalMemoryEnabled) return
+    if (!activeSession) return setNewConversationMemoryPreference(enabled)
 
     setAttachmentError(null)
     void runtime.setMemoryEnabled(activeSession.id, enabled).catch((error: unknown) => {
@@ -1180,11 +1196,15 @@ const WorkspacePage = ({
             }}
             agentControls={{
               ...agentControlAvailability,
+              canChangeMemory: agentControlAvailability.canChangeMemory && isGlobalMemoryEnabled,
               modelConfiguration: activeAgentConfiguration,
               modelUnavailable: agentConfigurationUnavailable,
               changeModelConfiguration: changeAgentConfiguration,
               autoReviewEnabled: activeAutoReviewEnabled,
               memoryEnabled: activeMemoryEnabled,
+              memoryDisabledReason: isGlobalMemoryEnabled
+                ? undefined
+                : t('Memory is off in Settings. Turn it on to use Memory in this conversation.'),
               enabledComputeHosts: computeHostAccess.enabledProviderIds,
               selectedComputeHosts: computeHostAccess.selectedProviderIds,
               toggleAutoReview: changeAutoReviewEnabled,

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -3934,6 +3934,7 @@
     "The vendor returned a model ID longer than {{limit}} characters.": "El proveedor devolvió un ID de modelo de más de {{limit}} caracteres.",
     "Claude token must not exceed {{limit}} bytes.": "El token de Claude no debe superar {{limit}} bytes.",
     "Let the agent recall and save memory in this conversation.": "Permitir que el agente recuerde y guarde memoria en esta conversación.",
+    "Memory is off in Settings. Turn it on to use Memory in this conversation.": "La memoria está desactivada en Configuración. Actívela para usar la memoria en esta conversación.",
     "A memory category with this name already exists.": "Ya existe una categoría de memoria con este nombre.",
     "You can create up to {{limit}} memory categories.": "Puede crear hasta {{limit}} categorías de memoria.",
     "Memory category changed. Refresh and try again.": "La categoría de memoria ha cambiado. Actualice y vuelva a intentarlo.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -3934,6 +3934,7 @@
     "The vendor returned a model ID longer than {{limit}} characters.": "Le fournisseur a renvoyé un identifiant de modèle de plus de {{limit}} caractères.",
     "Claude token must not exceed {{limit}} bytes.": "Le jeton Claude ne doit pas dépasser {{limit}} octets.",
     "Let the agent recall and save memory in this conversation.": "Autoriser l’agent à rappeler et enregistrer des souvenirs dans cette session.",
+    "Memory is off in Settings. Turn it on to use Memory in this conversation.": "La mémoire est désactivée dans les réglages. Activez-la pour l’utiliser dans cette session.",
     "A memory category with this name already exists.": "Une catégorie de mémoire portant ce nom existe déjà.",
     "You can create up to {{limit}} memory categories.": "Vous pouvez créer jusqu’à {{limit}} catégories de mémoire.",
     "Memory category changed. Refresh and try again.": "La catégorie de mémoire a été modifiée. Actualisez la page et réessayez.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3636,6 +3636,7 @@
     "The vendor returned a model ID longer than {{limit}} characters.": "ベンダーから {{limit}} 文字を超えるモデル ID が返されました。",
     "Claude token must not exceed {{limit}} bytes.": "Claude トークンは {{limit}} バイト以内である必要があります。",
     "Let the agent recall and save memory in this conversation.": "このセッションでエージェントがメモリを呼び出して保存できるようにします。",
+    "Memory is off in Settings. Turn it on to use Memory in this conversation.": "設定でメモリがオフになっています。このセッションでメモリを使用するにはオンにしてください。",
     "A memory category with this name already exists.": "同じ名前のメモリカテゴリがすでに存在します。",
     "You can create up to {{limit}} memory categories.": "メモリカテゴリは最大 {{limit}} 件まで作成できます。",
     "Memory category changed. Refresh and try again.": "メモリカテゴリが変更されました。更新してから再試行してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3634,6 +3634,7 @@
     "The vendor returned a model ID longer than {{limit}} characters.": "공급업체에서 {{limit}}자보다 긴 모델 ID를 반환했습니다.",
     "Claude token must not exceed {{limit}} bytes.": "Claude 토큰은 {{limit}}바이트를 초과할 수 없습니다.",
     "Let the agent recall and save memory in this conversation.": "이 대화에서 에이전트가 메모리를 불러오고 저장하도록 허용합니다.",
+    "Memory is off in Settings. Turn it on to use Memory in this conversation.": "설정에서 메모리가 꺼져 있습니다. 이 대화에서 메모리를 사용하려면 켜세요.",
     "A memory category with this name already exists.": "같은 이름의 메모리 카테고리가 이미 있습니다.",
     "You can create up to {{limit}} memory categories.": "메모리 카테고리는 최대 {{limit}}개까지 만들 수 있습니다.",
     "Memory category changed. Refresh and try again.": "메모리 카테고리가 변경되었습니다. 새로 고친 후 다시 시도하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4058,6 +4058,7 @@
     "The vendor returned a model ID longer than {{limit}} characters.": "Поставщик вернул идентификатор модели длиннее {{limit}} символов.",
     "Claude token must not exceed {{limit}} bytes.": "Токен Claude не должен превышать {{limit}} байт.",
     "Let the agent recall and save memory in this conversation.": "Разрешить агенту использовать и сохранять память в этом диалоге.",
+    "Memory is off in Settings. Turn it on to use Memory in this conversation.": "Память отключена в настройках. Включите её, чтобы использовать память в этом диалоге.",
     "A memory category with this name already exists.": "Категория памяти с таким названием уже существует.",
     "You can create up to {{limit}} memory categories.": "Можно создать не более {{limit}} категорий памяти.",
     "Memory category changed. Refresh and try again.": "Категория памяти была изменена. Обновите страницу и повторите попытку.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -3636,6 +3636,7 @@
     "The vendor returned a model ID longer than {{limit}} characters.": "服务商返回了长度超过 {{limit}} 个字符的模型 ID。",
     "Claude token must not exceed {{limit}} bytes.": "Claude 令牌不得超过 {{limit}} 字节。",
     "Let the agent recall and save memory in this conversation.": "允许智能体在此会话中调用和保存记忆。",
+    "Memory is off in Settings. Turn it on to use Memory in this conversation.": "设置中的记忆已关闭。开启后才能在此会话中使用记忆。",
     "A memory category with this name already exists.": "已存在同名的记忆分类。",
     "You can create up to {{limit}} memory categories.": "最多可以创建 {{limit}} 个记忆分类。",
     "Memory category changed. Refresh and try again.": "记忆分类已更改。请刷新后重试。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -3636,6 +3636,7 @@
     "The vendor returned a model ID longer than {{limit}} characters.": "服務商傳回了長度超過 {{limit}} 個字元的模型 ID。",
     "Claude token must not exceed {{limit}} bytes.": "Claude 權杖不得超過 {{limit}} 位元組。",
     "Let the agent recall and save memory in this conversation.": "允許智能體在此工作階段中調用和儲存記憶。",
+    "Memory is off in Settings. Turn it on to use Memory in this conversation.": "設定中的記憶已關閉。開啟後才能在此工作階段中使用記憶。",
     "A memory category with this name already exists.": "已存在同名的記憶分類。",
     "You can create up to {{limit}} memory categories.": "最多可以建立 {{limit}} 個記憶分類。",
     "Memory category changed. Refresh and try again.": "記憶分類已變更。請重新整理後再試。",


### PR DESCRIPTION
## Problem

Turning global Memory off already prevents built-in recall and writes in Main, but the per-conversation Memory control still defaults to and displays On. That presents an effective state the runtime cannot honor, and a new conversation can persist an enabled preference while the global capability is unavailable.

## Proposed change

- Load and observe the global Memory setting from the Workspace.
- Derive the conversation's effective Memory state from both the global gate and its local preference.
- Fail closed while the global setting is loading.
- Disable the conversation control and show a localized explanation while global Memory is off.
- Submit new conversations with `memoryEnabled: false` while globally disabled.
- Keep existing Session preferences intact instead of forcing context resets across Sessions.
- Avoid marking the Agent controls trigger as customized solely because Memory is globally unavailable.

## Scope and non-goals

- This changes the built-in Open Science Memory control only; custom Connectors with memory-like behavior are unchanged.
- It does not delete Memory data, migrate Session files, or bulk-reconfigure live provider contexts.
- Re-enabling global Memory can restore an existing Session's retained preference; changing that persistence model is outside this fix.

## Acceptance criteria and validation

All checks below ran after the final material edit on top of `origin/main` (`1f238ca0`). The final Test Impact Set selected the full fallback because the changed interaction test is not currently owned by `scripts/ci/module-impact.json`.

- Global-off effective state, disabled explanation, no reconfiguration call, and new-Session `memoryEnabled: false` submission → `npm test -- src/renderer/src/pages/workspace/WorkspacePage*.test.tsx src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx src/renderer/src/i18n/resources.test.ts` → 11 files and 928 tests passed.
- Node and renderer type contracts → `npm run typecheck` → passed.
- Repository lint policy → `npm run lint` → passed.
- Fail-closed full fallback → `npm test` → 1,302 files and 21,888 tests passed; 16 files and 238 tests skipped by their existing conditions.

Uncovered risks: no Electron E2E or visual-regression lane was run locally. The UI change reuses the existing dropdown and Switch primitives and is covered by renderer interaction tests. Independent human review was not performed locally; PR review and the authoritative PR Gate remain required.

## Review focus

- Whether retaining the underlying per-Session preference while presenting the globally gated effective state matches the intended resume behavior.
- Whether loading/listening to the Memory snapshot at Workspace lifetime is the right ownership seam.
- Whether the disabled explanatory copy is sufficiently clear across desktop and mobile composer surfaces.
