### PR TITLE
fix(reviewer): preserve correction responses and model identity

### DIFF
--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -615,7 +615,7 @@ describe('AcpPromptTurnWorkflow', () => {
     expect(harness.onProviderPromptAccepted).toHaveBeenCalledWith('s1', 'attempt-2')
   })
 
-  it('publishes an attributed application turn without claiming side chat or routing user notifications', async () => {
+  it('publishes an attributed application turn and routes its provider response', async () => {
     const claim = vi.fn(() => ({
       historyPreamble: 'Queued human side chat.',
       commit: vi.fn(),
@@ -654,7 +654,15 @@ describe('AcpPromptTurnWorkflow', () => {
       attribution
     })
     expect(claim).not.toHaveBeenCalled()
-    expect(harness.routeNotification).not.toHaveBeenCalled()
+    expect(harness.routeNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'Internal reviewer turn' }
+        })
+      }),
+      's1'
+    )
   })
 
   it('cannot let delayed admission clear a newer active interaction', async () => {

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -457,9 +457,12 @@ class AcpPromptTurnWorkflow {
               skillFinalized = true
             }
           },
-          routeNotification: (notification) => {
-            if (turn.mode.kind !== 'application') env.routeNotification(notification, sessionId)
-          },
+          // Application turns are app-authored prompts, but their provider output is still the
+          // Session's authoritative assistant turn. Route it through the normal event projection so
+          // the response, tools, stop metadata, and durable transcript all settle. Dropping these
+          // notifications left Reviewer Corrections with only the [Auditor] prompt persisted, so the
+          // fix loop could never observe the completed correction and refused its scoped re-review.
+          routeNotification: (notification) => env.routeNotification(notification, sessionId),
           reportBestEffortFailure: (stage, error) =>
             log.warn('provider prompt observation failed', {
               sessionId,

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -540,15 +540,17 @@ describe('review assessment owner', () => {
 
   it('records the upstream model instead of the Codex bridge catalog alias', async () => {
     const reviewRepository = makeRepository()
+    const upstreamModel = 'upstream-reviewer-model'
+    const bridgeCatalogAlias = 'bridge-catalog-alias'
 
     await runReviewAssessment({
       ...commonOptions(reviewRepository),
-      acpRuntime: runtime('glm-5.3', 'gpt-5.4', 'codex-bridge'),
+      acpRuntime: runtime(upstreamModel, bridgeCatalogAlias, 'codex-bridge'),
       mode: 'initial'
     })
 
     expect(reviewRepository.updateReview).toHaveBeenCalledWith('assessment-review', {
-      model: 'glm-5.3'
+      model: upstreamModel
     })
   })
 

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PrismaClient } from '@prisma/client'
 
 import type { AcpRuntime } from '../acp/runtime'
+import type { AcpBackendGenerationView } from '../acp/backend-generation-owner'
 import { getAgentFramework } from '../agent-framework'
 import type {
   NewCheck,
@@ -233,13 +234,18 @@ const makeRepository = (): ReviewRepository =>
     })
   }) as unknown as ReviewRepository
 
-const runtime = (contextModel?: string, sessionModel?: string): AcpRuntime =>
+const runtime = (
+  contextModel?: string,
+  sessionModel?: string,
+  modelRoute?: AcpBackendGenerationView['modelRoute']
+): AcpRuntime =>
   ({
-    ...(contextModel || sessionModel
+    ...(contextModel || sessionModel || modelRoute
       ? {
           captureBackend: () => ({
             framework: getAgentFramework('codex'),
             providerId: 'reviewer-provider',
+            ...(modelRoute ? { modelRoute } : {}),
             context: {
               ...(contextModel ? { model: contextModel } : {}),
               supportsImageInput: false
@@ -529,6 +535,20 @@ describe('review assessment owner', () => {
 
     expect(reviewRepository.updateReview).toHaveBeenCalledWith('assessment-review', {
       model: 'selected-runtime-model'
+    })
+  })
+
+  it('records the upstream model instead of the Codex bridge catalog alias', async () => {
+    const reviewRepository = makeRepository()
+
+    await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      acpRuntime: runtime('glm-5.3', 'gpt-5.4', 'codex-bridge'),
+      mode: 'initial'
+    })
+
+    expect(reviewRepository.updateReview).toHaveBeenCalledWith('assessment-review', {
+      model: 'glm-5.3'
     })
   })
 

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -346,7 +346,14 @@ export const runReviewAssessment = async (
     })
     reviewerSession = built.session
     const backend = acpRuntime.captureBackend?.()
-    const runtimeModel = backend?.session.model ?? backend?.context.model
+    // Codex bridge Sessions intentionally advertise a catalog-only model (currently gpt-5.4) so
+    // Codex enables classic function tools. The bridge rewrites requests to the configured upstream
+    // model, which is retained as the context model. Persisting the catalog alias here makes Review
+    // attribution claim GPT ran the audit even when the actual Reviewer was GLM or another provider.
+    const runtimeModel =
+      backend?.modelRoute === 'codex-bridge'
+        ? (backend.context.model ?? model)
+        : (backend?.session.model ?? backend?.context.model)
     if (runtimeModel && runtimeModel !== review.model) {
       review = await runReviewMutation(runSessionMutation, () =>
         reviewRepository.updateReview(review.id, { model: runtimeModel })

--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -1024,6 +1024,7 @@ describe('ReviewerCard — fix limit reached hint', () => {
 
     expect(container.textContent).toContain('correction failed')
     expect(container.textContent).not.toContain('fix limit reached')
+    expect(container.textContent).not.toContain('self-corrects')
   })
 
   it('does NOT show "fix limit reached" for a normal (non-capped) flagged card', async () => {

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -429,7 +429,7 @@ export const ReviewerCard = ({
           ))}
 
           {/* Self-correct footer note — shown only for warn/fail (flagged) expansions. */}
-          {hasWarnOrFail && (
+          {hasWarnOrFail && !isCapReached && !isCorrectionFailed && (
             <p className="mt-1 text-[11px] italic text-text-400">
               {t('The agent reads these findings and self-corrects in its next message.')}
             </p>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -79,7 +79,7 @@ const renderItem = async (
       onPrevious?: () => void
       onNext?: () => void
     }
-    reviewerCorrectionActive?: boolean
+    reviewerCorrectionState?: 'waiting' | 'responding' | 'completed' | 'failed'
     activeTextAnnotations?: TextAnnotation[]
     onAddTextAnnotation?: (annotation: TextAnnotation) => undefined
   } = {}
@@ -101,7 +101,7 @@ const renderItem = async (
         onBranchInNewSession={options.onBranchInNewSession}
         subsequentTurns={options.subsequentTurns ?? 0}
         revisionNavigation={options.revisionNavigation}
-        reviewerCorrectionActive={options.reviewerCorrectionActive}
+        reviewerCorrectionState={options.reviewerCorrectionState}
         annotationPort={
           options.onAddTextAnnotation
             ? {
@@ -563,13 +563,14 @@ describe('WorkspaceMessageItem user message actions', () => {
       }),
       {
         canEditMessage: true,
-        revisionNavigation: { index: 0, total: 2, onNext: noop }
+        revisionNavigation: { index: 0, total: 2, onNext: noop },
+        reviewerCorrectionState: 'completed'
       }
     )
 
     expect(container.querySelector('[data-testid="reviewer-correction-message"]')).not.toBeNull()
     expect(container.textContent).toContain('Corrections requested')
-    expect(container.textContent).toContain('Handed off to the Agent · response started')
+    expect(container.textContent).toContain('Response completed.')
     expect(container.textContent).not.toContain('[Auditor] Correct the unsupported claim.')
     expect(container.querySelector('[data-slot="user-message-bubble"]')).toBeNull()
     expect(container.querySelector('[aria-label="Edit message"]')).toBeNull()
@@ -592,7 +593,7 @@ describe('WorkspaceMessageItem user message actions', () => {
           causeReviewId: 'review-1'
         }
       }),
-      { reviewerCorrectionActive: true }
+      { reviewerCorrectionState: 'waiting' }
     )
 
     expect(container.textContent).toContain('Reviewer requested corrections')

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -19,6 +19,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronUp,
+  CircleAlert,
   CircleGauge,
   Copy,
   FileText,
@@ -111,6 +112,7 @@ type WorkspaceAssistantTurnCompletionProps = {
   canBranchInNewSession?: boolean
   onBranchInNewSession?: (messageId: string) => void
 }
+type ReviewerCorrectionState = 'waiting' | 'responding' | 'completed' | 'failed'
 type WorkspaceMessageItemProps = {
   message: ChatMessage
   projectId?: string
@@ -161,9 +163,9 @@ type WorkspaceMessageItemProps = {
   // A trailing buffered reply can reserve the loading-row geometry it replaces. When another
   // live row remains below it, the message keeps only its natural text-line height.
   reserveLoadingRowHeight?: boolean
-  // True only while this application-authored correction is the current live Agent prompt and no
-  // Agent response has appeared. Historical/reloaded rows stay settled and motionless.
-  reviewerCorrectionActive?: boolean
+  // Durable lifecycle of an application-authored correction request. Keeping the response state
+  // explicit prevents a missing historical response from looking like a successfully started one.
+  reviewerCorrectionState?: ReviewerCorrectionState
 }
 
 const ARTIFACT_GALLERY_VISIBLE_COUNT = 5
@@ -1245,11 +1247,13 @@ const WorkspaceMessageItemImpl = ({
   presentationSourceOpen,
   presentationAnimateOnMount = true,
   reserveLoadingRowHeight = true,
-  reviewerCorrectionActive = false
+  reviewerCorrectionState = 'failed'
 }: WorkspaceMessageItemProps): React.JSX.Element => {
   const { t } = useTranslation()
   const isUserMessage = message.role === 'user'
   const isHumanUser = isHumanUserMessage(message)
+  const reviewerCorrectionActive =
+    reviewerCorrectionState === 'waiting' || reviewerCorrectionState === 'responding'
   const isReviewerCorrection = isReviewerCorrectionAttribution(message.attribution)
   const isComputeJobCompletion =
     isComputeJobCompletionAttribution(message.attribution) ||
@@ -1468,26 +1472,38 @@ const WorkspaceMessageItemImpl = ({
                 className="mt-0.5 size-3.5 shrink-0 animate-spin text-text-300 motion-reduce:animate-none"
                 aria-hidden="true"
               />
-            ) : (
+            ) : reviewerCorrectionState === 'completed' ? (
               <Check
                 data-testid="reviewer-correction-settled-icon"
                 className="mt-0.5 size-3.5 shrink-0 text-text-300"
                 aria-hidden="true"
               />
+            ) : (
+              <CircleAlert
+                data-testid="reviewer-correction-failed-icon"
+                className="mt-0.5 size-3.5 shrink-0 text-status-warning-foreground dark:text-status-warning-dark-foreground"
+                aria-hidden="true"
+              />
             )}
             <div className="flex min-w-0 flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2">
               <span className="font-medium text-text-200">
-                {reviewerCorrectionActive
+                {reviewerCorrectionState === 'waiting'
                   ? t('Reviewer requested corrections')
                   : t('Corrections requested')}
               </span>
-              {reviewerCorrectionActive && (
+              {reviewerCorrectionState === 'waiting' && (
                 <span className="text-text-300">{t('Agent is addressing the feedback')}</span>
               )}
-              {!reviewerCorrectionActive && (
+              {reviewerCorrectionState === 'responding' && (
                 <span className="text-text-300">
                   {t('Handed off to the Agent · response started')}
                 </span>
+              )}
+              {reviewerCorrectionState === 'completed' && (
+                <span className="text-text-300">{t('Response completed.')}</span>
+              )}
+              {reviewerCorrectionState === 'failed' && (
+                <span className="text-text-300">{t('Response failed.')}</span>
               )}
             </div>
           </div>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -350,19 +350,69 @@ describe('WorkspaceMessageScroller Reviewer Correction lifecycle', () => {
     )
     expect(responded).toContain('Corrections requested')
     expect(responded).toContain('Handed off to the Agent · response started')
-    expect(responded).not.toContain('data-active="true"')
+    expect(responded).toContain('data-active="true"')
     expect(responded).not.toContain('Agent is addressing the feedback')
     expect(responded).not.toContain(correction.content)
   })
 
-  it('keeps a reloaded historical correction settled', async () => {
+  it('marks a reloaded historical correction without a durable response as failed', async () => {
     const html = await renderScroller(
       createSession({ status: 'idle', activeRun: undefined, messages: [correction] })
     )
     expect(html).toContain('Corrections requested')
-    expect(html).toContain('Handed off to the Agent · response started')
+    expect(html).toContain('Response failed.')
+    expect(html).toContain('reviewer-correction-failed-icon')
     expect(html).not.toContain('animate-spin')
     expect(html).not.toContain(correction.content)
+  })
+
+  it('marks a correction with a durable Agent response as completed', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        activeRun: undefined,
+        messages: [
+          correction,
+          createMessage({
+            id: 'correction-response',
+            role: 'agent',
+            content: 'Correction complete.',
+            responseToMessageId: correction.id,
+            createdAt: correction.createdAt + 1,
+            updatedAt: correction.updatedAt + 1
+          })
+        ]
+      })
+    )
+    expect(html).toContain('Corrections requested')
+    expect(html).toContain('Response completed.')
+    expect(html).toContain('reviewer-correction-settled-icon')
+    expect(html).not.toContain('animate-spin')
+  })
+
+  it('marks an inactive correction with a dangling streaming response as failed', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        activeRun: undefined,
+        messages: [
+          correction,
+          createMessage({
+            id: 'dangling-correction-response',
+            role: 'agent',
+            content: 'Partial correction.',
+            status: 'streaming',
+            responseToMessageId: correction.id,
+            createdAt: correction.createdAt + 1,
+            updatedAt: correction.updatedAt + 1
+          })
+        ]
+      })
+    )
+    expect(html).toContain('Corrections requested')
+    expect(html).toContain('Response failed.')
+    expect(html).toContain('reviewer-correction-failed-icon')
+    expect(html).not.toContain('animate-spin')
   })
 
   it('keeps a reloaded Compute completion as a system event', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -784,14 +784,14 @@ const WorkspaceMessageScrollerImpl = ({
       ),
     [conversationItems]
   )
-  const respondedPromptMessageIds = useMemo(
+  const responseByPromptMessageId = useMemo(
     () =>
-      new Set(
+      new Map(
         conversationItems.flatMap((item) =>
           item.type === 'message' &&
           item.message.role === 'agent' &&
           item.message.responseToMessageId
-            ? [item.message.responseToMessageId]
+            ? [[item.message.responseToMessageId, item.message] as const]
             : []
         )
       ),
@@ -1421,11 +1421,18 @@ const WorkspaceMessageScrollerImpl = ({
                           }
                         : undefined,
                     artifacts,
-                    reviewerCorrectionActive:
-                      activeSession?.activeRun?.promptMessageId === item.message.id &&
-                      activeSession.status !== 'idle' &&
-                      activeSession.status !== 'error' &&
-                      !respondedPromptMessageIds.has(item.message.id)
+                    reviewerCorrectionState: (() => {
+                      const response = responseByPromptMessageId.get(item.message.id)
+                      if (response?.status === 'complete') return 'completed'
+                      if (response?.status === 'error') return 'failed'
+
+                      const runIsActive =
+                        activeSession?.activeRun?.promptMessageId === item.message.id &&
+                        activeSession.status !== 'idle' &&
+                        activeSession.status !== 'error'
+                      if (runIsActive) return response ? 'responding' : 'waiting'
+                      return 'failed'
+                    })()
                   }
                   if (item.message.role === 'agent') {
                     const nextConversationItem = conversationItems[itemIndex + 1]


### PR DESCRIPTION
## Problem

Reviewer runs routed through the Codex bridge can persist the bridge's catalog model alias instead of the configured upstream model, so review attribution displays the wrong model.

Application-authored correction turns also discard provider notifications. The provider can finish the correction, but the assistant response never reaches durable Session state, which prevents the scoped re-review from observing completion.

The transcript then collapses every non-waiting correction into a generic "response started" status, including completed, failed, and incomplete historical responses. A failed correction can also retain copy that promises a future self-correction.

## Proposed change

- Persist the bridge context model for Reviewer attribution while preserving the existing session-model precedence for other routes.
- Route application-turn provider notifications through the normal Session projection so correction responses, tools, and terminal metadata settle durably.
- Represent correction transcript state explicitly as waiting, responding, completed, or failed.
- Treat inactive dangling streaming responses as failed instead of leaving a permanent spinner.
- Hide the self-correction footer when correction delivery has failed.
- Add regression coverage for model attribution, application-turn notification routing, and correction lifecycle presentation.

## Scope and non-goals

- No persisted schema or migration changes.
- Existing historical corrections without a durable response are not reconstructed; they are presented as failed.
- Reviewer reasoning-log visibility is unchanged.
- Recovery when provider continuity is lost before correction prompt admission is outside this change.

## Acceptance criteria and validation

All checks below ran after the final material edit.

- Reviewer model attribution -> `npx vitest run src/main/reviewer/review-assessment-owner.test.ts` -> passed as part of the 210-test focused suite.
- Correction response routing -> `npx vitest run src/main/acp/prompt-turn-workflow.test.ts` -> passed as part of the 210-test focused suite.
- Correction transcript and failure copy -> focused Renderer tests for `WorkspaceMessageItem`, `WorkspaceMessageScroller`, and `ReviewerCard` -> passed as part of the 210-test focused suite.
- Node and Renderer contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed.
- Translation/resource contracts -> `npx vitest run src/renderer/src/i18n/resources.test.ts` -> 743 passed.
- Final impact plan -> `npm run test:affected -- --base origin/main --head HEAD` -> selected the full portable suite because the ACP test file has no module owner; 1,303 files passed, 16 skipped; 21,894 tests passed, 238 skipped.

No platform-specific E2E lane was run because the change does not alter platform adapters, packaging, native resources, or persisted formats. Exact-head CI remains authoritative for repository-selected platform lanes.

An independent review found no P0/P1 issues. Its dangling-streaming P2 finding was addressed and covered by a reload regression test.

## Review focus

- Confirm that routing provider notifications for application turns cannot duplicate already-projected prompt or stop events.
- Confirm the model identity precedence remains correct for non-bridge backends.
- Confirm failed and historical correction rows communicate durable state without reviving transient activity.
