### PR TITLE
fix(notebook): correct kernel Skill import errors

### DIFF
--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1948,6 +1948,89 @@ describe('compactNotebookExecutionResult', () => {
     expect(compact.traceback).toBe(traceback)
   })
 
+  it('corrects imports of injected figure Skill helpers without suggesting package installation', () => {
+    const kernelSkillIds = ['figure-style', 'figure-composer', 'paper-narrative']
+
+    for (const [skillId, moduleName] of [
+      ['figure-style', 'figure_style'],
+      ['figure-composer', 'figure_composer'],
+      ['paper-narrative', 'paper_narrative']
+    ] as const) {
+      const traceback = [
+        'Traceback (most recent call last):',
+        '  File "<cell>", line 3, in <module>',
+        `ModuleNotFoundError: No module named '${moduleName}'`
+      ].join('\n')
+
+      const compact = compactNotebookExecutionResult(
+        {
+          ...runSummary({ traceback }),
+          kernelKind: 'python',
+          status: 'failed'
+        },
+        { kernelSkillIds }
+      ) as { hint?: string; traceback: string }
+
+      expect(compact.traceback).toBe(traceback)
+      expect(compact.hint).toContain(`Kernel Skill "${skillId}"`)
+      expect(compact.hint).toContain('not a Python package')
+      expect(compact.hint).toContain(
+        'kernelSkillIds: ["figure-style","figure-composer","paper-narrative"]'
+      )
+      expect(compact.hint).toContain('call its exported functions directly')
+      expect(compact.hint).toContain(`Do not install ${moduleName}`)
+    }
+
+    const ordinaryMissingPackage = compactNotebookExecutionResult(
+      {
+        ...runSummary({
+          traceback: [
+            'Traceback (most recent call last):',
+            '  File "<cell>", line 1, in <module>',
+            "ModuleNotFoundError: No module named 'pandas'"
+          ].join('\n')
+        }),
+        kernelKind: 'python',
+        status: 'failed'
+      },
+      { kernelSkillIds }
+    ) as { hint?: string }
+    expect(ordinaryMissingPackage.hint).toBeUndefined()
+
+    const helperInternalFailure = compactNotebookExecutionResult(
+      {
+        ...runSummary({
+          traceback: [
+            'Traceback (most recent call last):',
+            '  File "<cell>", line 1, in <module>',
+            '  File "<open-science-helper:figure-style>", line 2, in apply_figure_style',
+            "ModuleNotFoundError: No module named 'figure_style'"
+          ].join('\n')
+        }),
+        kernelKind: 'python',
+        status: 'failed'
+      },
+      { kernelSkillIds }
+    ) as { hint?: string }
+    expect(helperInternalFailure.hint).toBeUndefined()
+
+    const unverifiedCustomHelper = compactNotebookExecutionResult(
+      {
+        ...runSummary({
+          traceback: [
+            'Traceback (most recent call last):',
+            '  File "<cell>", line 1, in <module>',
+            "ModuleNotFoundError: No module named 'foo_bar'"
+          ].join('\n')
+        }),
+        kernelKind: 'python',
+        status: 'failed'
+      },
+      { kernelSkillIds: ['foo-bar'] }
+    ) as { hint?: string }
+    expect(unverifiedCustomHelper.hint).toBeUndefined()
+  })
+
   it('preserves producer truncation when no additional MCP clipping is needed', () => {
     const compact = compactNotebookExecutionResult({
       ...runSummary({ stdout: 'retained prefix' }),

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -613,11 +613,18 @@ const compactExecutionOutputs = (
   return { outputs, truncated, omitted }
 }
 
+const BUNDLED_KERNEL_SKILL_PSEUDO_MODULES = new Map([
+  ['figure_style', 'figure-style'],
+  ['figure_composer', 'figure-composer'],
+  ['paper_narrative', 'paper-narrative']
+])
+
 // Projects one immediate execution result for the next model step. Code, roots, provenance, and
 // duplicated stream outputs remain durable but are not echoed into every later inference.
-const compactNotebookExecutionResult = (raw: unknown): unknown => {
+const compactNotebookExecutionResult = (raw: unknown, input: unknown = {}): unknown => {
   const record = asRecord(raw)
   if (!record) return raw
+  const request = asRecord(input)
   const text = asRecord(record.text)
   const stream = (field: 'stdout' | 'stderr' | 'traceback'): string => {
     const value = record[field] ?? text?.[field]
@@ -642,6 +649,25 @@ const compactNotebookExecutionResult = (raw: unknown): unknown => {
     staleness.truncated
   const captureTruncated = record.truncated === true
   const truncated = captureTruncated || resultCompacted
+  const rawTraceback = stream('traceback')
+  const pythonFrames = [...rawTraceback.matchAll(/^\s*File "([^"]+)", line \d+/gmu)]
+  const missingModule =
+    record.status === 'failed' && pythonFrames.at(-1)?.[1] === '<cell>'
+      ? rawTraceback.match(
+          /ModuleNotFoundError:\s+No module named ['"]([A-Za-z_][A-Za-z0-9_]*)['"]/u
+        )?.[1]
+      : undefined
+  const requestedKernelSkillIds = Array.isArray(request?.kernelSkillIds)
+    ? request.kernelSkillIds.filter((id): id is string => typeof id === 'string')
+    : []
+  const importedKernelSkillId =
+    missingModule && requestedKernelSkillIds.length
+      ? BUNDLED_KERNEL_SKILL_PSEUDO_MODULES.get(missingModule)
+      : undefined
+  const hint =
+    importedKernelSkillId && requestedKernelSkillIds.includes(importedKernelSkillId)
+      ? `Kernel Skill "${importedKernelSkillId}" is injected by kernelSkillIds and is not a Python package. Remove the "${missingModule}" import, keep kernelSkillIds: ${JSON.stringify(requestedKernelSkillIds)}, call its exported functions directly, and retry. Do not install ${missingModule}.`
+      : undefined
   const invalidatedRuns = Array.isArray(record.invalidatedRuns)
     ? record.invalidatedRuns.slice(0, 50).flatMap((value) => {
         const invalidated = asRecord(value)
@@ -675,6 +701,7 @@ const compactNotebookExecutionResult = (raw: unknown): unknown => {
     ...(stdout.text ? { stdout: stdout.text } : {}),
     ...(stderr.text ? { stderr: stderr.text } : {}),
     ...(traceback.text ? { traceback: traceback.text } : {}),
+    ...(hint ? { hint } : {}),
     ...(compactOutputs.outputs.length ? { outputs: compactOutputs.outputs } : {}),
     ...(compactOutputs.omitted > 0 ? { omittedOutputCount: compactOutputs.omitted } : {}),
     ...(workingFiles.length ? { workingFiles } : {}),


### PR DESCRIPTION
## Problem

Notebook code generated from a registered Kernel Skill can incorrectly treat the Skill ID as a Python package. For example, `from figure_style import apply_figure_style` fails with `ModuleNotFoundError` even when `kernelSkillIds: ["figure-style"]` is present, because registered helper exports are injected into the kernel namespace rather than installed into conda.

## Proposed change

- when a failed Python traceback ends at the user `<cell>` frame with a missing pseudo-module for a requested bundled figure Skill, return an actionable hint to remove the import, retain the complete requested `kernelSkillIds` list, call the injected exports directly, and avoid package installation;
- cover the verified mappings for `figure-style` / `figure_style`, `figure-composer` / `figure_composer`, and `paper-narrative` / `paper_narrative`;
- leave ordinary missing-package errors, helper-internal failures, and unverified custom helpers unchanged.

## Scope and non-goals

- error parser and its regression test only; no Skill description, Notebook prompt, or tool-schema changes;
- no conda bundle or package-set change;
- no virtual Python modules or import compatibility layer;
- no persisted-format, historical-data compatibility, migration, new enum, or new durable state impact;
- existing direct calls to injected helper exports remain unchanged.

## Acceptance criteria and validation

Final evidence mapping; all listed checks ran after the last material edit:

- direct user-cell imports of `figure_style`, `figure_composer`, and `paper_narrative` produce corrective guidance and retain all requested Kernel Skill IDs -> `src/main/notebook/mcp-server.test.ts` -> passed;
- ordinary third-party package failures, helper-internal failures, and an unverified custom helper do not produce this hint -> `src/main/notebook/mcp-server.test.ts` -> passed;
- Notebook MCP module regression suite -> `vitest run src/main/notebook/mcp-server.test.ts` -> 93/93 passed;
- Node process types -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed;
- changed TypeScript lint -> `eslint --cache src/main/notebook/mcp-server.ts src/main/notebook/mcp-server.test.ts` -> passed;
- changed-file formatting and diff whitespace -> Prettier check and `git diff --check` -> passed.

Full portable and platform coverage is left to PR CI as requested.

## Review focus

- confirm the hint is limited to the three verified bundled mappings and a final `<cell>` traceback frame;
- confirm the hint retains every requested `kernelSkillIds` entry when multiple helpers are active;
- confirm helper-internal and genuine third-party package failures remain unchanged.
