### PR TITLE
fix(skills): preserve UTF-8 helper validation input

### DIFF
--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
-import { findPythonCommand, isPython3Version, resolvePythonCommand } from './python-command'
+import {
+  findPythonCommand,
+  isPython3Version,
+  resolvePythonCommand,
+  validateNotebookHelperExports
+} from './python-command'
 
 describe('resolvePythonCommand', () => {
   it('accepts Python 3 versions and rejects Python 2', () => {
@@ -137,5 +142,28 @@ describe('resolvePythonCommand', () => {
 
     expect(win).toEqual({ command: 'py', baseArgs: ['-3'] })
     expect(nix).toEqual({ command: 'python3', baseArgs: [] })
+  })
+})
+
+describe('validateNotebookHelperExports', () => {
+  it('validates UTF-8 helper source when the interpreter defaults stdin to a legacy encoding', async () => {
+    const python = await resolvePythonCommand()
+
+    await expect(
+      validateNotebookHelperExports(
+        'utf8-helper',
+        'def public_value():\n    return "a — b"\n',
+        ['public_value'],
+        {
+          python: { ...python, baseArgs: [...python.baseArgs, '-X', 'utf8=0'] },
+          env: {
+            LC_ALL: 'C',
+            PATH: process.env.PATH,
+            SystemRoot: process.env.SystemRoot,
+            WINDIR: process.env.WINDIR
+          }
+        }
+      )
+    ).resolves.toBeUndefined()
   })
 })

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -146,7 +146,7 @@ export const resolvePythonCommand = async (
 }
 
 const CALLABLE_HELPER_VALIDATOR = String.raw`
-import builtins, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics, sys
+import base64, builtins, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics, sys
 
 allowed_modules = {
     module.__name__: module
@@ -165,7 +165,7 @@ def deny(event, args):
         raise PermissionError("host access is unavailable during helper validation")
 
 sys.addaudithook(deny)
-request = json.loads(sys.stdin.read())
+request = json.loads(base64.b64decode(sys.stdin.read()).decode("utf-8"))
 safe_names = (
     "__build_class__", "abs", "all", "any", "bool", "bytes", "callable", "dict", "enumerate",
     "Exception", "float", "int", "isinstance", "len", "list", "map", "max", "min", "object",
@@ -183,18 +183,20 @@ if missing:
 export const validateNotebookHelperExports = async (
   helperId: string,
   source: string,
-  exports: readonly string[]
+  exports: readonly string[],
+  deps: { python?: PythonCommand; env?: NodeJS.ProcessEnv } = {}
 ): Promise<void> => {
-  const python = await resolvePythonCommand()
+  const python = deps.python ?? (await resolvePythonCommand())
   await new Promise<void>((resolveValidation, rejectValidation) => {
     const child = spawn(
       python.command,
       [...python.baseArgs, '-I', '-S', '-c', CALLABLE_HELPER_VALIDATOR],
       {
         env:
-          process.platform === 'win32'
+          deps.env ??
+          (process.platform === 'win32'
             ? { SystemRoot: process.env.SystemRoot, WINDIR: process.env.WINDIR }
-            : {},
+            : {}),
         stdio: ['pipe', 'ignore', 'pipe'],
         windowsHide: true
       }
@@ -224,6 +226,6 @@ export const validateNotebookHelperExports = async (
         )
       )
     })
-    child.stdin.end(JSON.stringify({ source, exports }))
+    child.stdin.end(Buffer.from(JSON.stringify({ source, exports }), 'utf8').toString('base64'))
   })
 }


### PR DESCRIPTION
## Problem

Skill imports can fail while validating the bundled `figure-composer` helper when Python reads the validator's UTF-8 JSON through a legacy stdin encoding. Non-ASCII source bytes can be decoded with `surrogateescape`, and `compile()` then raises `UnicodeEncodeError: surrogates not allowed`. Because installed helpers are revalidated during import, unrelated Skill packages report the same application-side failure.

## Proposed change

- Encode the validator request as UTF-8 Base64 before sending it through Python text stdin, then decode it explicitly as UTF-8 inside the isolated validator.
- Add a regression test that forces legacy stdin behavior and exercises the existing callable-export validation boundary with non-ASCII Python source.

The callable checks, restricted imports, audit hook, source limits, and package validation policy are unchanged.

The shared boundary also covers registered helpers installed inside Specialist packages: bundled Skills are committed to the user Skill catalog, whose observer refreshes `RegisteredSkillHelperCatalog` through this validator. Connector template imports are not affected because they remain in the JSON parser/settings repository path and never start Python or refresh the helper catalog.

## Scope and non-goals

- No Skill archive parsing or installation policy changes.
- No persisted format, migration, historical-data compatibility, or new state/enum values.
- No user-visible copy changes.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Legacy stdin preserves UTF-8 helper source -> `vitest run src/main/notebook/python-command.test.ts ...` -> regression failed before the fix with the reported `UnicodeEncodeError` and passes after the fix.
- Callable-export restrictions and staged package validation remain intact -> focused `python-command.test.ts` + `registered-helper-catalog.test.ts` run -> 43 passed, 1 unrelated real Notebook-loop test excluded because local Python 3.14 exits after validation.
- Specialist bundled-Skill propagation -> focused Specialist package transaction test + complete user Skill catalog observer tests -> 13 passed.
- Connector import boundary -> complete `connector-template.test.ts` -> 34 passed; confirms this path has no helper-validator transport.
- Node types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed.
- PR Gate impact explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> fail-closed full plan because `python-command.test.ts` has no module owner; complete portable/platform coverage is delegated to required PR CI per maintainer request.

Uncovered local risk: the fix targets a platform-sensitive locale boundary. Required Windows CI is the final authority for the affected environment.

## Review focus

- Confirm the ASCII-only transport removes locale dependence without weakening isolated helper validation.
- Confirm the injected interpreter/environment options are the minimum test seam needed to reproduce legacy stdin behavior deterministically.
