### PR TITLE
fix(concurrency): fence stale operations and terminal races

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -617,6 +617,7 @@
       "ownerPaths": [
         "src/main/settings/service.ts",
         "src/main/settings/network-proxy-settings-owner.ts",
+        "src/main/settings/settings-snapshot-commit-owner.ts",
         "src/main/settings/reviewer-model-owner.ts",
         "src/main/settings/subagent-model-owner.ts",
         "src/main/settings/vision-model-owner.ts"
@@ -632,6 +633,7 @@
       "testFiles": {
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
+          "src/main/settings/settings-snapshot-commit-owner.test.ts",
           "src/main/settings/service.test.ts",
           "src/main/settings/service.providers.test.ts",
           "src/main/settings/service.connectors.test.ts"

--- a/src/main/agents/completion-handoff-lifecycle.test.ts
+++ b/src/main/agents/completion-handoff-lifecycle.test.ts
@@ -275,6 +275,27 @@ describe('CompletionHandoffLifecycle', () => {
     expect(await repository.get(context)).toMatchObject({ stage: 'continued' })
   })
 
+  it('joins concurrent retries so handoff side effects run exactly once', async () => {
+    const repository = new InMemoryCompletionHandoffRepository()
+    const { runtime } = createRuntime({
+      reconfigure: vi.fn().mockRejectedValueOnce(new Error('target unavailable'))
+    })
+    const lifecycle = new CompletionHandoffLifecycle(repository, runtime)
+
+    await lifecycle.approve({ context, targetName: 'Approved Specialist', generation: 1 })
+    await lifecycle.capture(context, { kind: 'returned', value: 'captured' })
+    await expect(lifecycle.run(context)).resolves.toMatchObject({ stage: 'failed' })
+
+    await expect(
+      Promise.all([lifecycle.retry(context), lifecycle.retry(context)])
+    ).resolves.toEqual([
+      expect.objectContaining({ stage: 'continued' }),
+      expect.objectContaining({ stage: 'continued' })
+    ])
+    expect(runtime.reconfigure).toHaveBeenCalledTimes(2)
+    expect(runtime.continueAsApproved).toHaveBeenCalledOnce()
+  })
+
   it('does not create a binding when cancellation happens before approval, and cancellation after approval never permits the old identity to resume', async () => {
     const repository = new InMemoryCompletionHandoffRepository()
     const { runtime, requests } = createRuntime()

--- a/src/main/agents/completion-handoff-lifecycle.ts
+++ b/src/main/agents/completion-handoff-lifecycle.ts
@@ -288,6 +288,8 @@ export type ApprovedSpecialistIdentity = {
 }
 
 export class CompletionHandoffLifecycle {
+  private readonly retryLifecycles = new Map<string, Promise<DurableCompletionHandoff>>()
+
   constructor(
     private readonly repository: CompletionHandoffRepository,
     private readonly runtime: CompletionHandoffRuntime,
@@ -444,7 +446,21 @@ export class CompletionHandoffLifecycle {
   // Retrying never asks the user to approve the same committed binding again. It resumes at the
   // earliest safe stage recorded by the failed attempt: reconfigure after ownership was released,
   // otherwise the approved continuation start.
-  async retry(context: TrustedToolCompletionContext): Promise<DurableCompletionHandoff> {
+  retry(context: TrustedToolCompletionContext): Promise<DurableCompletionHandoff> {
+    const key = completionHandoffKey(context)
+    const existing = this.retryLifecycles.get(key)
+    if (existing) return existing
+
+    const retry = this.retryOnce(context).finally(() => {
+      if (this.retryLifecycles.get(key) === retry) this.retryLifecycles.delete(key)
+    })
+    this.retryLifecycles.set(key, retry)
+    return retry
+  }
+
+  private async retryOnce(
+    context: TrustedToolCompletionContext
+  ): Promise<DurableCompletionHandoff> {
     const handoff = await this.require(context)
     if (handoff.stage !== 'failed' || !handoff.retryFrom) return handoff
     const resumed = await this.repository.update(context, (current) => {

--- a/src/main/compute/compute-job-workflow-owner.test.ts
+++ b/src/main/compute/compute-job-workflow-owner.test.ts
@@ -237,6 +237,42 @@ const makeJobRepo = (
 }
 
 describe('ComputeJobWorkflowOwner.submitJob', () => {
+  it('does not create a job when cancellation wins after approval', async () => {
+    const controller = new AbortController()
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '123',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo, createCalls } = makeJobRepo()
+    const { repo: hostRepo } = makeRepo()
+    const broker = {
+      request: vi.fn(),
+      requestWithContext: vi.fn(async () => {
+        controller.abort()
+        return 'once' as const
+      }),
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+
+    const service = makeOwner(runner, hostRepo, broker, jobRepo)
+
+    await expect(
+      service.submitJob(
+        'ssh:biowulf',
+        'cancelled submission',
+        'echo hi',
+        {},
+        { sessionId: 's1', projectId: 'p1' },
+        controller.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(createCalls).not.toHaveBeenCalled()
+    expect(runner.run).not.toHaveBeenCalled()
+  })
+
   it('keeps an unexpected live dispatch failure recoverable when launch state is unknown', async () => {
     const jobs = new Map<string, import('../../shared/compute').ComputeJob>()
     const runner: SshRunner = { run: vi.fn(() => Promise.reject(new Error('transport crashed'))) }

--- a/src/main/compute/compute-job-workflow-owner.ts
+++ b/src/main/compute/compute-job-workflow-owner.ts
@@ -327,12 +327,14 @@ export class ComputeJobWorkflowOwner {
 
     let allowUnencryptedPersistence = !this.jobRepository.isFieldProtectionAvailable()
     await requestApproval(allowUnencryptedPersistence)
+    signal?.throwIfAborted()
 
     const commandHash = hashCommand(command)
     const inputManifest = stagedEntries.length > 0 ? JSON.stringify(stagedEntries) : undefined
     const jobRepository = this.jobRepository
     let dispatchHandoffHeld = false
     const createRow = async (initialStatus: 'submitted' | 'queued'): Promise<void> => {
+      signal?.throwIfAborted()
       if (initialStatus === 'submitted') {
         sharedDispatchTracker.begin(jobId)
         dispatchHandoffHeld = true

--- a/src/main/index-startup-order.test.ts
+++ b/src/main/index-startup-order.test.ts
@@ -36,4 +36,9 @@ describe('main startup ordering', () => {
     expect(createCloseConfirm).toBeGreaterThan(bindTranslator)
     expect(closeConfirmTranslation).toBeGreaterThan(createCloseConfirm)
   })
+
+  it('routes native close-preference writes through the settings commit owner', () => {
+    expect(mainSource).toContain('await commitClosePreference(preference)')
+    expect(mainSource).not.toContain('await settingsService.setClosePreference(preference)')
+  })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -484,6 +484,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               taskNotifications,
               notificationInbox,
               settingsService,
+              commitClosePreference,
               taskAgent,
               taskControls,
               computePreferences,
@@ -631,7 +632,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
                   {
                     get: () => settingsService.getClosePreference(),
                     set: async (preference) => {
-                      await settingsService.setClosePreference(preference)
+                      await commitClosePreference(preference)
                     }
                   },
                   translate

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -249,6 +249,7 @@ import { GrantedLocalRootsRepository } from './local-fs/granted-roots-repository
 import { LocalFsService } from './local-fs/service'
 import { SettingsService } from './settings/service'
 import { SettingsRepository } from './settings/repository'
+import { SettingsSnapshotCommitOwner } from './settings/settings-snapshot-commit-owner'
 import type { SettingsDocumentStore } from './settings/document-store'
 import { NetworkProxyRuntime } from './settings/network-proxy-runtime'
 import type { NotebookRuntimeSettings } from './settings/capabilities'
@@ -419,6 +420,9 @@ export type ApplicationRuntimeInterfaces = {
     'configureDesktop' | 'syncViewState' | 'handleAppFocus' | 'handleWindowCreated' | 'refreshBadge'
   >
   settingsService: WindowSettingsCapabilities
+  commitClosePreference: (
+    preference: Parameters<WindowSettingsCapabilities['setClosePreference']>[0]
+  ) => Promise<void>
   taskAgent: TaskAgentPort
   taskControls: TaskControlPorts
   computePreferences: Pick<SessionEnabledComputeHostsOwner, 'withReservation' | 'set'>
@@ -613,6 +617,10 @@ const createApplicationModules = async (
     })
   }))
   settingsServiceRef.current = settingsService
+  const settingsSnapshotCommits = new SettingsSnapshotCommitOwner(
+    settingsService,
+    applicationEvents
+  )
   const resolveSessionAgentTarget: SessionAgentTargetResolver = async (source) =>
     resolveValidatedSessionAgentTarget(source, await settingsService.getSettingsView())
   const resolveDefaultSessionAgentTarget = async (): Promise<AcpSessionAgentTarget> => {
@@ -3049,6 +3057,7 @@ const createApplicationModules = async (
     registerSettingsIpcHandlers({
       service: settingsService,
       workflows: settingsWorkflows,
+      snapshotCommits: settingsSnapshotCommits,
       listAppIconPreviews,
       connectorTemplateFiles: {
         select: async () => {
@@ -3731,16 +3740,21 @@ const createApplicationModules = async (
     settingsCore: {
       service: settingsService,
       appearance: settingsWorkflows.appearance,
+      snapshotCommits: settingsSnapshotCommits,
       emitInstallEvent: (event) => broadcastToRenderers(SETTINGS_INSTALL_LOG_CHANNEL, event),
       listAppIconPreviews
     },
     settingsIntegration: {
       skills: settingsWorkflows.skills,
       connectors: settingsWorkflows.connectors,
+      snapshotCommits: settingsSnapshotCommits,
       connectorApprovals: approvalBroker,
       skillImportApprovals: skillImportApprovalBroker
     },
-    settingsRuntime: { workflows: settingsWorkflows.runtime },
+    settingsRuntime: {
+      workflows: settingsWorkflows.runtime,
+      snapshotCommits: settingsSnapshotCommits
+    },
     compute: {
       compute: computeIpcModule.handlers,
       bookmarks: {
@@ -3907,6 +3921,11 @@ const createApplicationModules = async (
     taskNotifications,
     notificationInbox,
     settingsService,
+    commitClosePreference: async (preference) => {
+      await settingsSnapshotCommits.currentSnapshotAfter(
+        settingsService.setClosePreference(preference)
+      )
+    },
     taskAgent,
     taskControls: {
       specialists: {

--- a/src/main/notebook/session-aggregate.test.ts
+++ b/src/main/notebook/session-aggregate.test.ts
@@ -150,6 +150,67 @@ describe('NotebookSessionAggregate', () => {
     expect(queuedTask).not.toHaveBeenCalled()
   })
 
+  it('tracks concurrent kernel runs and lets only the latest starter publish cwd', () => {
+    const session = new NotebookSessionAggregate({
+      sessionId: 'session-1',
+      projectId: 'default-project',
+      lane: createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1'),
+      cwd: '/workspace/data',
+      notebookSessionRoot: '/workspace',
+      dataRoot: '/workspace/data',
+      runtimeRoot: '/runtime',
+      runJsonPath: '/workspace/run.json',
+      executionCount: 0,
+      executorGeneration: Symbol('executor-1'),
+      executor: {
+        execute: async () => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: '/workspace/data',
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      }
+    })
+    for (const [cellId, language] of [
+      ['cell-python', 'python'],
+      ['cell-r', 'r']
+    ] as const) {
+      session.beginCellWrite({
+        cellId,
+        language,
+        writeId: `write-${cellId}`,
+        source: 'agent',
+        startedAt: 1
+      })
+      session.finishCellWrite(cellId, `write-${cellId}`)
+    }
+
+    session.markCellRunning('cell-python', 'run-python-1', 1)
+    session.markCellRunning('cell-r', 'run-r-1', 2)
+    session.completeCellRun('cell-python', 'completed', '/workspace/python-first')
+
+    expect(session.hasActiveRun()).toBe(true)
+    expect(session.snapshot()).toMatchObject({
+      activeRunId: 'run-r-1',
+      cwd: '/workspace/data'
+    })
+
+    session.completeCellRun('cell-r', 'completed', '/workspace/r-latest')
+    expect(session.hasActiveRun()).toBe(false)
+    expect(session.cwd).toBe('/workspace/r-latest')
+
+    session.markCellRunning('cell-python', 'run-python-2', 3)
+    session.markCellRunning('cell-r', 'run-r-2', 4)
+    session.completeCellRun('cell-r', 'completed', '/workspace/r-newer')
+    session.completeCellRun('cell-python', 'completed', '/workspace/python-stale')
+
+    expect(session.hasActiveRun()).toBe(false)
+    expect(session.cwd).toBe('/workspace/r-newer')
+  })
+
   it('returns snapshots that cannot mutate owned cell or kernel state', () => {
     const session = new NotebookSessionAggregate({
       sessionId: 'session-1',

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -229,7 +229,9 @@ export class NotebookSessionAggregate<
   private cwdValue: string
   private readonly cells = new Map<string, NotebookCell>()
   private activeWriteValue: NotebookWriteLock | undefined
+  private readonly activeRunIds = new Set<string>()
   private activeRunIdValue: string | undefined
+  private cwdOwnerRunId: string | undefined
   private executionCountValue: number
   private executorValue: NotebookSessionExecutor<Request, Result>
   private executorGenerationValue: NotebookSessionExecutorGeneration
@@ -364,7 +366,9 @@ export class NotebookSessionAggregate<
 
   markCellRunning(cellId: string, runId: string, executionCount: number): void {
     const cell = this.requireCell(cellId)
+    this.activeRunIds.add(runId)
     this.activeRunIdValue = runId
+    this.cwdOwnerRunId = runId
     cell.status = 'running'
     cell.executionCount = executionCount
     cell.latestRunId = runId
@@ -376,13 +380,19 @@ export class NotebookSessionAggregate<
     cwdAfter: string
   ): void {
     const cell = this.requireCell(cellId)
-    this.cwdValue = cwdAfter
-    this.activeRunIdValue = undefined
+    const runId = cell.latestRunId
+    if (runId) {
+      this.activeRunIds.delete(runId)
+      if (this.cwdOwnerRunId === runId) this.cwdValue = cwdAfter
+      if (this.activeRunIdValue === runId) {
+        this.activeRunIdValue = Array.from(this.activeRunIds).at(-1)
+      }
+    }
     cell.status = status
   }
 
   hasActiveRun(): boolean {
-    return this.activeRunIdValue !== undefined
+    return this.activeRunIds.size > 0
   }
 
   enqueueExecution<T>(

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -774,6 +774,59 @@ describe('reviewer IPC handlers', () => {
       // Settle the original review promise so the mock's pending state is released.
       await expect(promise).resolves.toEqual({ started: true })
     })
+
+    it('serializes fix loops that target the same Main session', async () => {
+      type CapturedRun = {
+        onStarted?: () => void
+        onFixLoopStart?: () => void | Promise<void>
+        onFixLoopEnd?: () => void
+        fixLoopAbortSignal?: AbortSignal
+      }
+      const captured: CapturedRun[] = []
+      const finishRuns: Array<() => void> = []
+      runReview.mockImplementation((options?: CapturedRun) => {
+        if (options) captured.push(options)
+        options?.onStarted?.()
+        return new Promise<void>((resolve) => finishRuns.push(resolve))
+      })
+      const owner = createReviewerCommandOwner({ acpRuntime })
+
+      await owner.run({
+        ...createRequest(),
+        sessionId: 'reviewer-a',
+        turnMessageId: 'turn-a',
+        mainSessionId: 'main-session'
+      })
+      await owner.run({
+        ...createRequest(),
+        sessionId: 'reviewer-b',
+        turnMessageId: 'turn-b',
+        mainSessionId: 'main-session'
+      })
+      expect(captured).toHaveLength(2)
+
+      await captured[0].onFixLoopStart?.()
+      const secondStart = Promise.resolve(captured[1].onFixLoopStart?.())
+      await Promise.resolve()
+      expect(
+        broadcastToRenderers.mock.calls.filter(
+          ([channel]) => channel === REVIEWER_IPC.FIX_LOOP_START
+        )
+      ).toHaveLength(1)
+
+      captured[0].onFixLoopEnd?.()
+      await secondStart
+      expect(
+        broadcastToRenderers.mock.calls.filter(
+          ([channel]) => channel === REVIEWER_IPC.FIX_LOOP_START
+        )
+      ).toHaveLength(2)
+
+      owner.abortFixLoop({ projectId: 'project-1', appSessionId: 'main-session' })
+      expect(captured[1].fixLoopAbortSignal?.aborted).toBe(true)
+      captured[1].onFixLoopEnd?.()
+      for (const finish of finishRuns) finish()
+    })
   })
 
   describe('Task review-chain cancellation', () => {

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -827,6 +827,57 @@ describe('reviewer IPC handlers', () => {
       captured[1].onFixLoopEnd?.()
       for (const finish of finishRuns) finish()
     })
+
+    it('aborts queued fix loops before they can start after the active loop ends', async () => {
+      type CapturedRun = {
+        onStarted?: () => void
+        onFixLoopStart?: () => void | Promise<void>
+        onFixLoopEnd?: () => void
+        fixLoopAbortSignal?: AbortSignal
+      }
+      const captured: CapturedRun[] = []
+      const finishRuns: Array<() => void> = []
+      runReview.mockImplementation((options?: CapturedRun) => {
+        if (options) captured.push(options)
+        options?.onStarted?.()
+        return new Promise<void>((resolve) => finishRuns.push(resolve))
+      })
+      const owner = createReviewerCommandOwner({ acpRuntime })
+
+      await owner.run({
+        ...createRequest(),
+        sessionId: 'reviewer-a',
+        turnMessageId: 'turn-a',
+        mainSessionId: 'main-session'
+      })
+      await owner.run({
+        ...createRequest(),
+        sessionId: 'reviewer-b',
+        turnMessageId: 'turn-b',
+        mainSessionId: 'main-session'
+      })
+      await captured[0].onFixLoopStart?.()
+      const secondStart = Promise.resolve(captured[1].onFixLoopStart?.())
+      await Promise.resolve()
+
+      owner.abortFixLoop({ projectId: 'project-1', appSessionId: 'main-session' })
+      expect(captured[0].fixLoopAbortSignal?.aborted).toBe(true)
+      expect(captured[1].fixLoopAbortSignal?.aborted).toBe(true)
+
+      captured[0].onFixLoopEnd?.()
+      await secondStart
+      captured[1].onFixLoopEnd?.()
+      expect(
+        broadcastToRenderers.mock.calls.filter(
+          ([channel]) => channel === REVIEWER_IPC.FIX_LOOP_START
+        )
+      ).toHaveLength(1)
+      expect(
+        broadcastToRenderers.mock.calls.filter(([channel]) => channel === REVIEWER_IPC.FIX_LOOP_END)
+      ).toHaveLength(1)
+
+      for (const finish of finishRuns) finish()
+    })
   })
 
   describe('Task review-chain cancellation', () => {

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -188,10 +188,10 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
         sessionRepository.loadSession(projectId, appSessionId)
     })
   const projectRuntime = options.projectRuntime ?? new ReviewerProjectRuntimeOwner()
-  // Per-session abort capabilities for active fix loops. Keyed by the main session id (not the
-  // reviewer session id). Project deletion owns the same signal, so user cancellation and Project
-  // quiescence converge on one operation without maintaining competing AbortControllers.
-  const fixLoopAbortControllers = new Map<string, () => void>()
+  // Per-session abort capabilities for active and queued fix loops. Keyed by the main session id
+  // (not the reviewer session id). Project deletion owns the same signal, so user cancellation and
+  // Project quiescence converge on one operation without maintaining competing AbortControllers.
+  const fixLoopAbortControllers = new Map<string, Set<() => void>>()
   const fixLoopLifecycles = new Map<string, Promise<void>>()
   // Task cancellation targets the whole admitted Review chain, including the initial assessment.
   // Keep this separate from the renderer's fix-loop-only affordance and allow concurrent manual
@@ -226,10 +226,10 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
 
   const abortFixLoop = (request: ReviewSessionRequest): void => {
     const key = `${request.projectId}\0${request.appSessionId}`
-    const controller = fixLoopAbortControllers.get(key)
-    if (controller) {
+    const controllers = fixLoopAbortControllers.get(key)
+    if (controllers && controllers.size > 0) {
       log.info('fix loop abort requested', request)
-      controller()
+      for (const controller of controllers) controller()
     } else {
       log.warn('abort-fix-loop: no active fix loop found for session', request)
     }
@@ -427,6 +427,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
       activeControllers.add(projectAdmission.abort)
       activeReviewAbortControllers.set(effectiveMainSessionKey, activeControllers)
       let releaseFixLoop: (() => void) | undefined
+      let fixLoopBroadcastStarted = false
 
       void runReview({
         sessionId,
@@ -490,6 +491,10 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
           })
           const lifecycle = previous ? previous.catch(() => undefined).then(() => hold) : hold
           fixLoopLifecycles.set(effectiveMainSessionKey, lifecycle)
+          const controllers =
+            fixLoopAbortControllers.get(effectiveMainSessionKey) ?? new Set<() => void>()
+          controllers.add(projectAdmission.abort)
+          fixLoopAbortControllers.set(effectiveMainSessionKey, controllers)
           if (previous) await previous.catch(() => undefined)
 
           let released = false
@@ -503,12 +508,18 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
               }
             })
           }
-          fixLoopAbortControllers.set(effectiveMainSessionKey, projectAdmission.abort)
+          if (projectAdmission.signal.aborted) {
+            releaseFixLoop()
+            return
+          }
+          fixLoopBroadcastStarted = true
           broadcastFixLoopStart(projectId, effectiveMainSessionId)
         },
         onFixLoopEnd: () => {
-          fixLoopAbortControllers.delete(effectiveMainSessionKey)
-          broadcastFixLoopEnd(projectId, effectiveMainSessionId)
+          const controllers = fixLoopAbortControllers.get(effectiveMainSessionKey)
+          controllers?.delete(projectAdmission.abort)
+          if (controllers?.size === 0) fixLoopAbortControllers.delete(effectiveMainSessionKey)
+          if (fixLoopBroadcastStarted) broadcastFixLoopEnd(projectId, effectiveMainSessionId)
           releaseFixLoop?.()
         },
         fixLoopAbortSignal: projectAdmission.signal,

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -192,6 +192,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
   // reviewer session id). Project deletion owns the same signal, so user cancellation and Project
   // quiescence converge on one operation without maintaining competing AbortControllers.
   const fixLoopAbortControllers = new Map<string, () => void>()
+  const fixLoopLifecycles = new Map<string, Promise<void>>()
   // Task cancellation targets the whole admitted Review chain, including the initial assessment.
   // Keep this separate from the renderer's fix-loop-only affordance and allow concurrent manual
   // Reviews for different turns in one Session to be cancelled together.
@@ -425,6 +426,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
         activeReviewAbortControllers.get(effectiveMainSessionKey) ?? new Set<() => void>()
       activeControllers.add(projectAdmission.abort)
       activeReviewAbortControllers.set(effectiveMainSessionKey, activeControllers)
+      let releaseFixLoop: (() => void) | undefined
 
       void runReview({
         sessionId,
@@ -480,13 +482,34 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
           }
         },
         // Broadcast fix-loop lifecycle events and register/deregister the admitted abort capability.
-        onFixLoopStart: () => {
+        onFixLoopStart: async () => {
+          const previous = fixLoopLifecycles.get(effectiveMainSessionKey)
+          let release!: () => void
+          const hold = new Promise<void>((resolve) => {
+            release = resolve
+          })
+          const lifecycle = previous ? previous.catch(() => undefined).then(() => hold) : hold
+          fixLoopLifecycles.set(effectiveMainSessionKey, lifecycle)
+          if (previous) await previous.catch(() => undefined)
+
+          let released = false
+          releaseFixLoop = () => {
+            if (released) return
+            released = true
+            release()
+            void lifecycle.then(() => {
+              if (fixLoopLifecycles.get(effectiveMainSessionKey) === lifecycle) {
+                fixLoopLifecycles.delete(effectiveMainSessionKey)
+              }
+            })
+          }
           fixLoopAbortControllers.set(effectiveMainSessionKey, projectAdmission.abort)
           broadcastFixLoopStart(projectId, effectiveMainSessionId)
         },
         onFixLoopEnd: () => {
           fixLoopAbortControllers.delete(effectiveMainSessionKey)
           broadcastFixLoopEnd(projectId, effectiveMainSessionId)
+          releaseFixLoop?.()
         },
         fixLoopAbortSignal: projectAdmission.signal,
         recordUsage: options.recordUsage

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -100,7 +100,7 @@ export type RunReviewOptions = {
   fixLoopMaxRounds?: number
   // Called just before the fix loop starts (after initial review finds warn/fail). Used to lock
   // the session composer in the renderer.
-  onFixLoopStart?: () => void
+  onFixLoopStart?: () => void | Promise<void>
   // Called when the fix loop ends (all pass, cap reached, or aborted). Used to unlock the session
   // composer in the renderer.
   onFixLoopEnd?: () => void
@@ -190,7 +190,7 @@ const runReviewWithSession = async (
   const hasWarnOrFail = finalReview.checks.some((c) => c.status === 'warn' || c.status === 'fail')
 
   if (mainSessionId && hasWarnOrFail) {
-    onFixLoopStart?.()
+    await onFixLoopStart?.()
     try {
       await runReviewerFixLoop({
         sessionId,

--- a/src/main/settings/application-commands.test.ts
+++ b/src/main/settings/application-commands.test.ts
@@ -186,6 +186,40 @@ describe('Settings core application commands', () => {
     expect(published).toEqual([currentSnapshot, currentSnapshot])
   })
 
+  it('commits notebook network writes through the authoritative snapshot owner', async () => {
+    const currentSnapshot = {
+      claude: {},
+      providers: [],
+      notebookNetwork: {
+        allowedDomains: ['pypi.org'],
+        disabledOpenScienceDomainGroups: [],
+        disabledOpenScienceDomains: []
+      }
+    }
+    const savedNetwork = currentSnapshot.notebookNetwork
+    const published: unknown[] = []
+    const snapshotCommits = new SettingsSnapshotCommitOwner(
+      { getSettingsView: vi.fn().mockResolvedValue(currentSnapshot) },
+      {
+        publish: (channel, payload) => {
+          if (channel === 'settings:changed') published.push(payload)
+        }
+      }
+    )
+    const { dependencies, serviceMethod } = createDependencies(snapshotCommits)
+    serviceMethod('setNotebookNetwork').mockResolvedValue(savedNetwork)
+    const router = createApplicationCommandRouter()
+    registerCoreSettingsApplicationCommands(router.registrar, dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        settingsCoreApplicationCommands.setNotebookNetwork,
+        invocation([savedNetwork] as const)
+      )
+    ).resolves.toBe(savedNetwork)
+    expect(published).toEqual([currentSnapshot])
+  })
+
   it('installs the exact command inventory and dispatches a remote-safe preflight query', async () => {
     const { dependencies, serviceMethod } = createDependencies()
     const preflight = { agentReady: true }

--- a/src/main/settings/application-commands.test.ts
+++ b/src/main/settings/application-commands.test.ts
@@ -14,6 +14,21 @@ import {
   settingsCoreApplicationCommands,
   type CoreSettingsApplicationCommandDependencies
 } from './application-commands'
+import { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
+
+const passThroughSnapshotCommits = {
+  currentSnapshotAfter: (pending: Promise<unknown>) => pending,
+  projectAfter: (pending: Promise<unknown>) => pending,
+  readCurrentSnapshot: () => Promise.resolve(undefined)
+} as unknown as SettingsSnapshotCommitOwner
+
+const deferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
 
 const expectedChannels = [
   'settings:cancel-claude-login',
@@ -87,7 +102,9 @@ const invocation = <Args extends readonly unknown[]>(
     args
   })
 
-const createDependencies = (): Readonly<{
+const createDependencies = (
+  snapshotCommits: SettingsSnapshotCommitOwner = passThroughSnapshotCommits
+): Readonly<{
   appearance: ReturnType<typeof vi.fn>
   dependencies: CoreSettingsApplicationCommandDependencies
   emitInstallEvent: ReturnType<typeof vi.fn>
@@ -117,6 +134,7 @@ const createDependencies = (): Readonly<{
     dependencies: {
       service,
       appearance: { setAppIconVariant: appearance },
+      snapshotCommits,
       emitInstallEvent,
       listAppIconPreviews: vi.fn(() => [])
     },
@@ -126,6 +144,48 @@ const createDependencies = (): Readonly<{
 }
 
 describe('Settings core application commands', () => {
+  it('returns and publishes current snapshots when an older command result resolves late', async () => {
+    const currentSnapshot = {
+      claude: {},
+      providers: [],
+      notificationsEnabled: false,
+      showNotificationContent: false
+    }
+    const staleSnapshot = { claude: {}, providers: [], notificationsEnabled: false }
+    const staleMutation = deferred<typeof staleSnapshot>()
+    const published: unknown[] = []
+    const snapshotCommits = new SettingsSnapshotCommitOwner(
+      { getSettingsView: vi.fn().mockResolvedValue(currentSnapshot) },
+      {
+        publish: (channel, payload) => {
+          if (channel === 'settings:changed') published.push(payload)
+        }
+      }
+    )
+    const { dependencies, serviceMethod } = createDependencies(snapshotCommits)
+    serviceMethod('setNotificationsEnabled').mockReturnValueOnce(staleMutation.promise)
+    serviceMethod('setShowNotificationContent').mockResolvedValueOnce({
+      ...currentSnapshot,
+      notificationsEnabled: true
+    })
+    const router = createApplicationCommandRouter()
+    registerCoreSettingsApplicationCommands(router.registrar, dependencies)
+
+    const older = router.dispatcher.invoke(
+      settingsCoreApplicationCommands.setNotificationsEnabled,
+      invocation([{ enabled: false }] as const)
+    )
+    const newer = router.dispatcher.invoke(
+      settingsCoreApplicationCommands.setShowNotificationContent,
+      invocation([{ enabled: false }] as const)
+    )
+
+    await expect(newer).resolves.toBe(currentSnapshot)
+    staleMutation.resolve(staleSnapshot)
+    await expect(older).resolves.toBe(currentSnapshot)
+    expect(published).toEqual([currentSnapshot, currentSnapshot])
+  })
+
   it('installs the exact command inventory and dispatches a remote-safe preflight query', async () => {
     const { dependencies, serviceMethod } = createDependencies()
     const preflight = { agentReady: true }

--- a/src/main/settings/application-commands.ts
+++ b/src/main/settings/application-commands.ts
@@ -34,6 +34,7 @@ import {
 } from '../application-command-router'
 import type { CallerContext } from '../caller-context'
 import type { SettingsService } from './service'
+import type { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
 import {
   readAppIconVariant,
   readClosePreference,
@@ -400,6 +401,7 @@ const settingsCoreApplicationCommandGroup = defineApplicationCommandGroup('setti
 type CoreSettingsApplicationCommandDependencies = Readonly<{
   service: CoreSettingsCommandStore
   appearance: Pick<AppearanceSettingsWorkflows, 'setAppIconVariant'>
+  snapshotCommits: SettingsSnapshotCommitOwner
   emitInstallEvent: (event: ClaudeInstallEvent) => void
   listAppIconPreviews?: () => AppIconPreview[]
 }>
@@ -430,11 +432,16 @@ const registerCoreSettingsApplicationCommands = (
         requireLocalCaller(callerContext, 'settings:cancel-isolated-claude-login')
         return dependencies.service.cancelClaudeIsolatedLogin()
       },
-      'settings:check-environment': () => dependencies.service.checkEnvironment(),
-      'settings:detect-claude': () => dependencies.service.detectClaude(),
-      'settings:detect-codebuddy': () => dependencies.service.detectCodeBuddy(),
-      'settings:detect-codex': () => dependencies.service.detectCodex(),
-      'settings:detect-opencode': () => dependencies.service.detectOpencode(),
+      'settings:check-environment': () =>
+        dependencies.snapshotCommits.projectAfter(dependencies.service.checkEnvironment()),
+      'settings:detect-claude': () =>
+        dependencies.snapshotCommits.projectAfter(dependencies.service.detectClaude()),
+      'settings:detect-codebuddy': () =>
+        dependencies.snapshotCommits.currentSnapshotAfter(dependencies.service.detectCodeBuddy()),
+      'settings:detect-codex': () =>
+        dependencies.snapshotCommits.currentSnapshotAfter(dependencies.service.detectCodex()),
+      'settings:detect-opencode': () =>
+        dependencies.snapshotCommits.currentSnapshotAfter(dependencies.service.detectOpencode()),
       'settings:get-connector-detail': ({ args }) =>
         dependencies.service.getConnectorDetail(args[0]),
       'settings:get-github-token-status': ({ callerContext }) => {
@@ -444,23 +451,31 @@ const registerCoreSettingsApplicationCommands = (
       'settings:get-package-mirror': () => dependencies.service.getPackageMirror(),
       'settings:get-notebook-network-status': () => dependencies.service.getNotebookNetworkStatus(),
       'settings:get-preflight': () => dependencies.service.getPreflight(),
-      'settings:get-settings': () => dependencies.service.getSettingsView(),
+      'settings:get-settings': () => dependencies.snapshotCommits.readCurrentSnapshot(),
       'settings:get-skill-detail': ({ args }) => dependencies.service.getSkillDetail(args[0]),
       'settings:install-claude': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:install-claude')
-        return dependencies.service.installClaude(args[0], dependencies.emitInstallEvent)
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.service.installClaude(args[0], dependencies.emitInstallEvent)
+        )
       },
       'settings:install-codebuddy': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:install-codebuddy')
-        return dependencies.service.installCodeBuddy(args[0], dependencies.emitInstallEvent)
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.service.installCodeBuddy(args[0], dependencies.emitInstallEvent)
+        )
       },
       'settings:install-codex': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:install-codex')
-        return dependencies.service.installCodex(args[0], dependencies.emitInstallEvent)
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.service.installCodex(args[0], dependencies.emitInstallEvent)
+        )
       },
       'settings:install-opencode': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:install-opencode')
-        return dependencies.service.installOpencode(args[0], dependencies.emitInstallEvent)
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.service.installOpencode(args[0], dependencies.emitInstallEvent)
+        )
       },
       'settings:install-notebook-network': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:install-notebook-network')
@@ -475,14 +490,19 @@ const registerCoreSettingsApplicationCommands = (
       'settings:list-app-icons': () => dependencies.listAppIconPreviews?.() ?? [],
       'settings:list-connectors': () => dependencies.service.listConnectors(),
       'settings:list-skills': () => dependencies.service.listSkills(),
-      'settings:mark-onboarding-complete': () => dependencies.service.markOnboardingComplete(),
+      'settings:mark-onboarding-complete': () =>
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.markOnboardingComplete()
+        ),
       'settings:preview-agent-home-skill': ({ args }) =>
         dependencies.service.previewAgentHomeSkill(args[0]),
       'settings:preview-github-skill': ({ args }) =>
         dependencies.service.previewGitHubSkill(args[0]),
       'settings:preview-skill-zip': ({ args }) => dependencies.service.previewSkillZip(args[0]),
       'settings:refresh-provider-models': ({ args }) =>
-        dependencies.service.refreshProviderModels(args[0]),
+        dependencies.snapshotCommits.projectAfter(
+          dependencies.service.refreshProviderModels(args[0])
+        ),
       'settings:scan-repo-skills': ({ args }) => dependencies.service.scanRepoSkills(args[0]),
       'settings:save-github-token': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:save-github-token')
@@ -494,33 +514,45 @@ const registerCoreSettingsApplicationCommands = (
       },
       'settings:set-app-icon-variant': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-app-icon-variant')
-        return dependencies.appearance.setAppIconVariant(readAppIconVariant(args[0]))
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.appearance.setAppIconVariant(readAppIconVariant(args[0]))
+        )
       },
       'settings:set-close-preference': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-close-preference')
-        return dependencies.service.setClosePreference(readClosePreference(args[0]))
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setClosePreference(readClosePreference(args[0]))
+        )
       },
       'settings:set-default-permission-profile': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-default-permission-profile')
-        return dependencies.service.setDefaultPermissionProfile(
-          readDefaultPermissionProfile(args[0])
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setDefaultPermissionProfile(readDefaultPermissionProfile(args[0]))
         )
       },
       'settings:set-notifications-enabled': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-notifications-enabled')
-        return dependencies.service.setNotificationsEnabled(readNotificationsEnabled(args[0]))
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setNotificationsEnabled(readNotificationsEnabled(args[0]))
+        )
       },
       'settings:set-show-notification-content': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-show-notification-content')
-        return dependencies.service.setShowNotificationContent(readShowNotificationContent(args[0]))
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setShowNotificationContent(readShowNotificationContent(args[0]))
+        )
       },
       'settings:set-package-mirror': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-package-mirror')
-        return dependencies.service.setPackageMirror(args[0])
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.service.setPackageMirror(args[0])
+        )
       },
       'settings:set-network-proxy': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-network-proxy')
-        return dependencies.service.setNetworkProxy(args[0])
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.service.setNetworkProxy(args[0])
+        )
       },
       'settings:set-notebook-network': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-notebook-network')
@@ -528,17 +560,28 @@ const registerCoreSettingsApplicationCommands = (
       },
       'settings:set-project-files-filter': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-project-files-filter')
-        return dependencies.service.setProjectFilesFilter(readProjectFilesFilter(args[0]))
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setProjectFilesFilter(readProjectFilesFilter(args[0]))
+        )
       },
       'settings:set-reviewer-model': ({ args }) =>
-        dependencies.service.setReviewerModel(readReviewerModel(args[0])),
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setReviewerModel(readReviewerModel(args[0]))
+        ),
       'settings:set-session-details-model': ({ args }) =>
-        dependencies.service.setSessionDetailsModel(readSessionDetailsModel(args[0])),
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setSessionDetailsModel(readSessionDetailsModel(args[0]))
+        ),
       'settings:set-subagent-model': ({ args }) =>
-        dependencies.service.setSubagentModel(readSubagentModel(args[0])),
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setSubagentModel(readSubagentModel(args[0]))
+        ),
       'settings:set-vision-model': ({ args }) =>
-        dependencies.service.setVisionModel(readVisionModel(args[0])),
-      'settings:validate-provider': ({ args }) => dependencies.service.validateProvider(args[0])
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.service.setVisionModel(readVisionModel(args[0]))
+        ),
+      'settings:validate-provider': ({ args }) =>
+        dependencies.snapshotCommits.projectAfter(dependencies.service.validateProvider(args[0]))
     })
     return scope.complete()
   } catch (error) {

--- a/src/main/settings/application-commands.ts
+++ b/src/main/settings/application-commands.ts
@@ -556,7 +556,9 @@ const registerCoreSettingsApplicationCommands = (
       },
       'settings:set-notebook-network': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-notebook-network')
-        return dependencies.service.setNotebookNetwork(args[0])
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.service.setNotebookNetwork(args[0])
+        )
       },
       'settings:set-project-files-filter': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:set-project-files-filter')

--- a/src/main/settings/integration-application-commands.test.ts
+++ b/src/main/settings/integration-application-commands.test.ts
@@ -26,6 +26,12 @@ import {
   settingsSkillApplicationCommandGroup,
   type IntegrationSettingsApplicationCommandDependencies
 } from './integration-application-commands'
+import type { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
+
+const passThroughSnapshotCommits = {
+  currentSnapshotAfter: (pending: Promise<unknown>) => pending,
+  projectAfter: (pending: Promise<unknown>) => pending
+} as unknown as SettingsSnapshotCommitOwner
 
 const expectedSkillChannels = [
   'settings:set-conversation-skill-import-enabled',
@@ -130,6 +136,7 @@ const createDependencies = (): Readonly<{
     dependencies: {
       skills: skills.port,
       connectors: connectors.port,
+      snapshotCommits: passThroughSnapshotCommits,
       connectorApprovals: {
         getPending: vi.fn(() => null),
         replayPending: vi.fn(),

--- a/src/main/settings/integration-application-commands.ts
+++ b/src/main/settings/integration-application-commands.ts
@@ -12,6 +12,7 @@ import { canSatisfyHumanApproval, type CallerContext } from '../caller-context'
 import type { ApprovalBroker } from '../connectors/approval-broker'
 import type { SkillImportApprovalBroker } from '../skills/conversation-import'
 import { readConversationSkillImportEnabled } from './transport-validation'
+import type { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
 import type { ConnectorSettingsWorkflows } from './workflows/connectors'
 import type { SkillSettingsWorkflows } from './workflows/skills'
 
@@ -302,6 +303,7 @@ const settingsApprovalApplicationCommandGroup = defineApplicationCommandGroup(
 type IntegrationSettingsApplicationCommandDependencies = Readonly<{
   skills: SkillIntegrationWorkflows
   connectors: ConnectorIntegrationWorkflows
+  snapshotCommits: SettingsSnapshotCommitOwner
   connectorApprovals: Pick<ApprovalBroker, 'getPending' | 'replayPending' | 'respond'>
   skillImportApprovals: Pick<SkillImportApprovalBroker, 'respond' | 'replayPending'>
 }>
@@ -315,9 +317,11 @@ const registerIntegrationSettingsApplicationCommands = (
   try {
     scope.registerGroup(settingsSkillApplicationCommandGroup, {
       'settings:set-conversation-skill-import-enabled': ({ args }) =>
-        dependencies.skills.setConversationSkillImportEnabled({
-          enabled: readConversationSkillImportEnabled(args[0])
-        }),
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.skills.setConversationSkillImportEnabled({
+            enabled: readConversationSkillImportEnabled(args[0])
+          })
+        ),
       'settings:set-skill-enabled': ({ args }) => dependencies.skills.setSkillEnabled(args[0]),
       'settings:set-skills-enabled': ({ args }) => dependencies.skills.setSkillsEnabled(args[0]),
       'settings:create-skill': ({ args }) => dependencies.skills.createSkill(args[0]),

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -23,6 +23,16 @@ vi.mock('electron', () => ({
 
 const { registerSettingsIpcHandlers } = await import('./ipc')
 const { createSettingsWorkflows } = await import('./workflows')
+const { addRendererBroadcastSink, broadcastToRenderers } = await import('../renderer-broadcast')
+const { SettingsSnapshotCommitOwner } = await import('./settings-snapshot-commit-owner')
+
+const deferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
 
 // A fake service whose methods are all spies; cast to SettingsService only when registering handlers.
 type FakeSettingsService = Record<
@@ -32,9 +42,11 @@ type FakeSettingsService = Record<
   | 'isNpmAvailable'
   | 'checkEnvironment'
   | 'detectClaude'
+  | 'detectCodeBuddy'
   | 'detectOpencode'
   | 'detectCodex'
   | 'installClaude'
+  | 'installCodeBuddy'
   | 'installOpencode'
   | 'installCodex'
   | 'uninstallClaude'
@@ -70,7 +82,15 @@ type FakeSettingsService = Record<
   | 'loginIsolatedClaudeBrowser'
   | 'cancelClaudeIsolatedLogin'
   | 'logoutIsolatedClaude'
+  | 'beginXaiOAuthLogin'
+  | 'waitXaiOAuthLogin'
+  | 'cancelXaiOAuthLogin'
+  | 'logoutXaiOAuth'
+  | 'refreshProviderModels'
   | 'markOnboardingComplete'
+  | 'getPackageMirror'
+  | 'setPackageMirror'
+  | 'setNetworkProxy'
   | 'listSkills'
   | 'getSkillDetail'
   | 'buildSkillExport'
@@ -89,7 +109,8 @@ type FakeSettingsService = Record<
   | 'previewCustomServerTemplateImport'
   | 'setConnectorEnabled'
   | 'updateCustomServer'
-  | 'cancelCustomServerAuthentication',
+  | 'cancelCustomServerAuthentication'
+  | 'setComputeBookmarks',
   ReturnType<typeof vi.fn>
 >
 
@@ -100,11 +121,15 @@ const createFakeService = (): FakeSettingsService => ({
   isNpmAvailable: vi.fn().mockResolvedValue(true),
   checkEnvironment: vi.fn().mockResolvedValue({ ready: true, checks: [] }),
   detectClaude: vi.fn().mockResolvedValue({ found: false }),
+  detectCodeBuddy: vi
+    .fn()
+    .mockResolvedValue({ claude: {}, providers: [], agentFrameworkId: 'codebuddy' }),
   detectOpencode: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], agentFrameworkId: 'opencode' }),
   detectCodex: vi.fn().mockResolvedValue({ codex: {}, providers: [], agentFrameworkId: 'codex' }),
   installClaude: vi.fn().mockResolvedValue({ installId: 'i', ok: true }),
+  installCodeBuddy: vi.fn().mockResolvedValue({ installId: 'cb', ok: true }),
   installOpencode: vi.fn().mockResolvedValue({ installId: 'oc', ok: true }),
   installCodex: vi.fn().mockResolvedValue({ installId: 'cx', ok: true }),
   uninstallClaude: vi.fn().mockResolvedValue({
@@ -183,7 +208,15 @@ const createFakeService = (): FakeSettingsService => ({
   loginIsolatedClaudeBrowser: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
   cancelClaudeIsolatedLogin: vi.fn(),
   logoutIsolatedClaude: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  beginXaiOAuthLogin: vi.fn().mockResolvedValue({ userCode: 'XAI-1234' }),
+  waitXaiOAuthLogin: vi.fn().mockResolvedValue({ accountEmail: 'user@example.com' }),
+  cancelXaiOAuthLogin: vi.fn(),
+  logoutXaiOAuth: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
+  refreshProviderModels: vi.fn().mockResolvedValue({ ok: true, models: [] }),
   markOnboardingComplete: vi.fn().mockResolvedValue({ claude: {}, providers: [] }),
+  getPackageMirror: vi.fn().mockResolvedValue({}),
+  setPackageMirror: vi.fn().mockResolvedValue({}),
+  setNetworkProxy: vi.fn().mockResolvedValue({ mode: 'system' }),
   listSkills: vi.fn().mockResolvedValue([]),
   getSkillDetail: vi.fn().mockResolvedValue({
     id: 'demo',
@@ -242,7 +275,8 @@ const createFakeService = (): FakeSettingsService => ({
   }),
   setConnectorEnabled: vi.fn().mockResolvedValue({ connectors: [] }),
   updateCustomServer: vi.fn().mockResolvedValue({ connectors: [], customServers: [] }),
-  cancelCustomServerAuthentication: vi.fn().mockResolvedValue(undefined)
+  cancelCustomServerAuthentication: vi.fn().mockResolvedValue(undefined),
+  setComputeBookmarks: vi.fn().mockResolvedValue([])
 })
 
 // Adapts the spy bag into the SettingsService shape the registration function expects.
@@ -278,6 +312,9 @@ const registerTestSettingsIpcHandlers = ({
 }: TestSettingsIpcOptions): void => {
   registerSettingsIpcHandlers({
     service,
+    snapshotCommits: new SettingsSnapshotCommitOwner(service, {
+      publish: (channel, payload) => broadcastToRenderers(channel, payload)
+    }),
     workflows: createSettingsWorkflows(service, {
       runtime: {
         requestProviderReconnect: onActiveProviderChanged ?? (() => undefined),
@@ -1020,6 +1057,7 @@ describe('settings IPC handlers', () => {
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], agentFrameworkId: 'opencode' }
     service.detectOpencode.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     registerTestSettingsIpcHandlers({ service: asService(service) })
 
     const result = await invoke('settings:detect-opencode')
@@ -1061,6 +1099,7 @@ describe('settings IPC handlers', () => {
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], agentFrameworkId: 'opencode' }
     service.setAgentFramework.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     const onActiveProviderChanged = vi.fn()
     const onAgentFrameworkChanged = vi.fn()
     registerTestSettingsIpcHandlers({
@@ -1084,6 +1123,7 @@ describe('settings IPC handlers', () => {
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], reasoningEffort: 'high' }
     service.setReasoningEffort.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     const onActiveProviderChanged = vi.fn()
     registerTestSettingsIpcHandlers({
       service: asService(service),
@@ -1096,6 +1136,169 @@ describe('settings IPC handlers', () => {
     expect(service.resolveActiveReasoningEffort).not.toHaveBeenCalled()
     expect(onActiveProviderChanged).not.toHaveBeenCalled()
     expect(result).toBe(snapshot)
+  })
+
+  it('broadcasts every committed optimistic preference snapshot', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    registerTestSettingsIpcHandlers({ service: asService(service) })
+    const changed: unknown[] = []
+    const removeSink = addRendererBroadcastSink((channel, payload) => {
+      if (channel === 'settings:changed') changed.push(payload)
+    })
+
+    try {
+      const expected = await Promise.all([
+        invoke('settings:set-reasoning-effort', { effort: 'high' }),
+        invoke('settings:set-session-details-model', {
+          configuration: { mode: 'inherit', reasoningEffort: 'low' }
+        }),
+        invoke('settings:set-notifications-enabled', { enabled: false }),
+        invoke('settings:set-show-notification-content', { enabled: false }),
+        invoke('settings:set-conversation-skill-import-enabled', { enabled: false }),
+        invoke('settings:set-close-preference', { preference: 'quit' }),
+        invoke('settings:set-app-icon-variant', { variant: 'dark' }),
+        invoke('settings:set-project-files-filter', { filter: { sourceMode: 'local' } }),
+        invoke('settings:set-default-permission-profile', { profile: 'auto' })
+      ])
+
+      expect(changed).toEqual(expect.arrayContaining(expected))
+      expect(changed).toHaveLength(expected.length)
+    } finally {
+      removeSink()
+    }
+  })
+
+  it('returns and broadcasts a current snapshot when an older mutation snapshot resolves late', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const staleSnapshot = { claude: {}, providers: [], notificationsEnabled: false }
+    const newerMutationSnapshot = {
+      claude: {},
+      providers: [],
+      notificationsEnabled: true,
+      showNotificationContent: false
+    }
+    const currentSnapshot = {
+      claude: {},
+      providers: [],
+      notificationsEnabled: false,
+      showNotificationContent: false
+    }
+    const staleMutation = deferred<typeof staleSnapshot>()
+    service.setNotificationsEnabled.mockReturnValueOnce(staleMutation.promise)
+    service.setShowNotificationContent.mockResolvedValueOnce(newerMutationSnapshot)
+    service.getSettingsView.mockResolvedValue(currentSnapshot)
+    registerTestSettingsIpcHandlers({ service: asService(service) })
+    const changed: unknown[] = []
+    const removeSink = addRendererBroadcastSink((channel, payload) => {
+      if (channel === 'settings:changed') changed.push(payload)
+    })
+
+    try {
+      const older = invoke('settings:set-notifications-enabled', { enabled: false })
+      const newer = invoke('settings:set-show-notification-content', { enabled: false })
+      await expect(newer).resolves.toBe(currentSnapshot)
+      staleMutation.resolve(staleSnapshot)
+      await expect(older).resolves.toBe(currentSnapshot)
+      expect(changed).toEqual([currentSnapshot, currentSnapshot])
+    } finally {
+      removeSink()
+    }
+  })
+
+  it('serializes current snapshot reads and broadcasts in mutation-completion order', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const firstSnapshot = { claude: {}, providers: [], notificationsEnabled: false }
+    const secondSnapshot = {
+      claude: {},
+      providers: [],
+      notificationsEnabled: false,
+      showNotificationContent: false
+    }
+    const firstRead = deferred<typeof firstSnapshot>()
+    service.getSettingsView
+      .mockReturnValueOnce(firstRead.promise)
+      .mockResolvedValueOnce(secondSnapshot)
+    registerTestSettingsIpcHandlers({ service: asService(service) })
+    const changed: unknown[] = []
+    const removeSink = addRendererBroadcastSink((channel, payload) => {
+      if (channel === 'settings:changed') changed.push(payload)
+    })
+
+    try {
+      const first = invoke('settings:set-notifications-enabled', { enabled: false })
+      await vi.waitFor(() => expect(service.getSettingsView).toHaveBeenCalledOnce())
+      const second = invoke('settings:set-show-notification-content', { enabled: false })
+      await Promise.resolve()
+      expect(service.getSettingsView).toHaveBeenCalledOnce()
+
+      firstRead.resolve(firstSnapshot)
+      await expect(first).resolves.toBe(firstSnapshot)
+      await expect(second).resolves.toBe(secondSnapshot)
+      expect(changed).toEqual([firstSnapshot, secondSnapshot])
+    } finally {
+      removeSink()
+    }
+  })
+
+  it.each([
+    ['settings:check-environment', undefined],
+    ['settings:detect-codebuddy', undefined],
+    ['settings:install-codebuddy', { source: 'managed' }],
+    ['settings:uninstall-codex', undefined],
+    ['settings:upsert-provider', { type: 'custom', name: 'Lab' }],
+    ['settings:set-agent-framework', { id: 'opencode' }],
+    ['settings:validate-provider', { providerId: 'p1' }],
+    ['settings:login-isolated-codex', undefined],
+    ['settings:wait-xai-oauth-login', undefined],
+    ['settings:refresh-provider-models', { providerId: 'p1' }],
+    ['settings:mark-onboarding-complete', undefined],
+    ['settings:set-package-mirror', {}],
+    ['settings:set-network-proxy', { mode: 'system' }]
+  ])('broadcasts the current SettingsSnapshot after %s', async (channel, payload) => {
+    handlers.clear()
+    const service = createFakeService()
+    const currentSnapshot = { claude: {}, providers: [], notificationsEnabled: true }
+    service.getSettingsView.mockResolvedValue(currentSnapshot)
+    registerTestSettingsIpcHandlers({ service: asService(service) })
+    const changed: unknown[] = []
+    const removeSink = addRendererBroadcastSink((broadcastChannel, broadcastPayload) => {
+      if (broadcastChannel === 'settings:changed') changed.push(broadcastPayload)
+    })
+
+    try {
+      await invoke(channel, payload)
+      expect(changed).toEqual([currentSnapshot])
+    } finally {
+      removeSink()
+    }
+  })
+
+  it('does not broadcast SettingsSnapshot for Skill, Connector, or Bookmark directory changes', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    registerTestSettingsIpcHandlers({ service: asService(service) })
+    const changed: unknown[] = []
+    const removeSink = addRendererBroadcastSink((channel, payload) => {
+      if (channel === 'settings:changed') changed.push(payload)
+    })
+
+    try {
+      await invoke('settings:set-skill-enabled', { id: 'skill-a', enabled: false })
+      await invoke('settings:set-connector-enabled', { id: 'connector-a', enabled: false })
+      await (
+        handlers.get('compute:bookmarks:set') as unknown as (
+          event: unknown,
+          providerId: string,
+          folders: string[]
+        ) => Promise<unknown>
+      )({ sender: ipcSender }, 'compute-a', ['/work'])
+      expect(changed).toEqual([])
+    } finally {
+      removeSink()
+    }
   })
 
   it('rejects an unknown reasoning effort without touching the service or the agent', async () => {
@@ -1129,6 +1332,7 @@ describe('settings IPC handlers', () => {
     }
     const snapshot = { claude: {}, providers: [], subagentModel: configuration }
     service.setSubagentModel.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     registerTestSettingsIpcHandlers({ service: asService(service) })
 
     await expect(invoke('settings:set-subagent-model', { configuration })).resolves.toBe(snapshot)
@@ -1153,6 +1357,7 @@ describe('settings IPC handlers', () => {
     }
     const snapshot = { claude: {}, providers: [], reviewerModel: configuration }
     service.setReviewerModel.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     registerTestSettingsIpcHandlers({ service: asService(service) })
 
     await expect(invoke('settings:set-reviewer-model', { configuration })).resolves.toBe(snapshot)
@@ -1172,6 +1377,7 @@ describe('settings IPC handlers', () => {
     const configuration = { mode: 'inherit' as const, reasoningEffort: 'low' as const }
     const snapshot = { claude: {}, providers: [], sessionDetailsModel: configuration }
     service.setSessionDetailsModel.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     registerTestSettingsIpcHandlers({ service: asService(service) })
 
     await expect(invoke('settings:set-session-details-model', { configuration })).resolves.toBe(
@@ -1193,6 +1399,7 @@ describe('settings IPC handlers', () => {
     }
     const snapshot = { claude: {}, providers: [], visionModel: configuration }
     service.setVisionModel.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     registerTestSettingsIpcHandlers({ service: asService(service) })
 
     await expect(invoke('settings:set-vision-model', { configuration })).resolves.toBe(snapshot)
@@ -1211,6 +1418,7 @@ describe('settings IPC handlers', () => {
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], notificationsEnabled: false }
     service.setNotificationsEnabled.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     registerTestSettingsIpcHandlers({ service: asService(service) })
 
     const result = await invoke('settings:set-notifications-enabled', { enabled: false })
@@ -1240,6 +1448,7 @@ describe('settings IPC handlers', () => {
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], showNotificationContent: true }
     service.setShowNotificationContent.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     registerTestSettingsIpcHandlers({ service: asService(service) })
 
     const result = await invoke('settings:set-show-notification-content', { enabled: true })
@@ -1267,6 +1476,7 @@ describe('settings IPC handlers', () => {
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], conversationSkillImportEnabled: false }
     service.setConversationSkillImportEnabled.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     const onSkillsChanged = vi.fn()
     registerTestSettingsIpcHandlers({ service: asService(service), onSkillsChanged })
 
@@ -1335,6 +1545,7 @@ describe('settings IPC handlers', () => {
     const service = createFakeService()
     const snapshot = { claude: {}, providers: [], appIconVariant: 'dark' }
     service.setAppIconVariant.mockResolvedValue(snapshot)
+    service.getSettingsView.mockResolvedValue(snapshot)
     const onAppIconVariantChanged = vi.fn()
     registerTestSettingsIpcHandlers({ service: asService(service), onAppIconVariantChanged })
 
@@ -1349,6 +1560,11 @@ describe('settings IPC handlers', () => {
   it('persists valid default permission profiles and rejects unknown values', async () => {
     handlers.clear()
     const service = createFakeService()
+    service.getSettingsView.mockResolvedValue({
+      claude: {},
+      providers: [],
+      defaultPermissionProfile: 'auto'
+    })
     registerTestSettingsIpcHandlers({ service: asService(service) })
 
     const result = await invoke('settings:set-default-permission-profile', { profile: 'auto' })

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -91,6 +91,7 @@ type FakeSettingsService = Record<
   | 'getPackageMirror'
   | 'setPackageMirror'
   | 'setNetworkProxy'
+  | 'setNotebookNetwork'
   | 'listSkills'
   | 'getSkillDetail'
   | 'buildSkillExport'
@@ -217,6 +218,11 @@ const createFakeService = (): FakeSettingsService => ({
   getPackageMirror: vi.fn().mockResolvedValue({}),
   setPackageMirror: vi.fn().mockResolvedValue({}),
   setNetworkProxy: vi.fn().mockResolvedValue({ mode: 'system' }),
+  setNotebookNetwork: vi.fn().mockResolvedValue({
+    allowedDomains: [],
+    disabledOpenScienceDomainGroups: [],
+    disabledOpenScienceDomains: []
+  }),
   listSkills: vi.fn().mockResolvedValue([]),
   getSkillDetail: vi.fn().mockResolvedValue({
     id: 'demo',
@@ -1256,7 +1262,15 @@ describe('settings IPC handlers', () => {
     ['settings:refresh-provider-models', { providerId: 'p1' }],
     ['settings:mark-onboarding-complete', undefined],
     ['settings:set-package-mirror', {}],
-    ['settings:set-network-proxy', { mode: 'system' }]
+    ['settings:set-network-proxy', { mode: 'system' }],
+    [
+      'settings:set-notebook-network',
+      {
+        allowedDomains: [],
+        disabledOpenScienceDomainGroups: [],
+        disabledOpenScienceDomains: []
+      }
+    ]
   ])('broadcasts the current SettingsSnapshot after %s', async (channel, payload) => {
     handlers.clear()
     const service = createFakeService()

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -345,7 +345,7 @@ const registerSettingsIpcHandlers = ({
     snapshotCommits.projectAfter(service.setNetworkProxy(request))
   )
   ipcMainHandle('settings:set-notebook-network', (_event, request: SetNotebookNetworkRequest) =>
-    service.setNotebookNetwork(request)
+    snapshotCommits.projectAfter(service.setNotebookNetwork(request))
   )
   ipcMainHandle('settings:install-notebook-network', () => service.installNotebookNetwork())
   ipcMainHandle('settings:remove-notebook-network', () => service.removeNotebookNetwork())

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -72,6 +72,7 @@ import type { SettingsWorkflows } from './workflows'
 import { createLogger } from '../logger'
 import type { SkillExportArchive } from '../skills/export'
 import { broadcastToRenderers } from '../renderer-broadcast'
+import type { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
 import {
   readAppIconVariant,
   readClosePreference,
@@ -98,6 +99,7 @@ const SETTINGS_INSTALL_LOG_CHANNEL = 'settings:install-log'
 export type SettingsIpcOptions = {
   service: SettingsService
   workflows: SettingsWorkflows
+  snapshotCommits: SettingsSnapshotCommitOwner
   // Renders the built-in icon variants to preview data URLs for the Appearance picker. Absent means
   // the picker gets an empty list (no bundled assets available, e.g. an environment without them).
   listAppIconPreviews?: () => AppIconPreview[]
@@ -122,63 +124,82 @@ const broadcastInstallEvent = (event: ClaudeInstallEvent): void => {
 const registerSettingsIpcHandlers = ({
   service,
   workflows,
+  snapshotCommits,
   listAppIconPreviews,
   connectorTemplateFiles,
   skillExportFiles
 }: SettingsIpcOptions): void => {
   ipcMainHandle('settings:get-preflight', () => service.getPreflight())
-  ipcMainHandle('settings:get-settings', () => service.getSettingsView())
+  ipcMainHandle('settings:get-settings', () => snapshotCommits.readCurrentSnapshot())
   ipcMainHandle('settings:encryption-available', () => service.isEncryptionAvailable())
   ipcMainHandle('settings:npm-available', () => service.isNpmAvailable())
-  ipcMainHandle('settings:check-environment', () => service.checkEnvironment())
-  ipcMainHandle('settings:detect-claude', () => service.detectClaude())
-  ipcMainHandle('settings:detect-codebuddy', () => service.detectCodeBuddy())
-  ipcMainHandle('settings:detect-opencode', () => service.detectOpencode())
-  ipcMainHandle('settings:detect-codex', () => service.detectCodex())
+  ipcMainHandle('settings:check-environment', () =>
+    snapshotCommits.projectAfter(service.checkEnvironment())
+  )
+  ipcMainHandle('settings:detect-claude', () =>
+    snapshotCommits.projectAfter(service.detectClaude())
+  )
+  ipcMainHandle('settings:detect-codebuddy', () =>
+    snapshotCommits.currentSnapshotAfter(service.detectCodeBuddy())
+  )
+  ipcMainHandle('settings:detect-opencode', () =>
+    snapshotCommits.currentSnapshotAfter(service.detectOpencode())
+  )
+  ipcMainHandle('settings:detect-codex', () =>
+    snapshotCommits.currentSnapshotAfter(service.detectCodex())
+  )
   ipcMainHandle('settings:install-opencode', (_event, request: InstallOpencodeRequest) =>
-    service.installOpencode(request, broadcastInstallEvent)
+    snapshotCommits.projectAfter(service.installOpencode(request, broadcastInstallEvent))
   )
   ipcMainHandle('settings:install-codebuddy', (_event, request: InstallCodeBuddyRequest) =>
-    service.installCodeBuddy(request, broadcastInstallEvent)
+    snapshotCommits.projectAfter(service.installCodeBuddy(request, broadcastInstallEvent))
   )
   ipcMainHandle('settings:install-codex', (_event, request: InstallCodexRequest) =>
-    service.installCodex(request, broadcastInstallEvent)
+    snapshotCommits.projectAfter(service.installCodex(request, broadcastInstallEvent))
   )
 
   ipcMainHandle('settings:install-claude', (_event, request: InstallClaudeRequest) =>
-    service.installClaude(request, broadcastInstallEvent)
+    snapshotCommits.projectAfter(service.installClaude(request, broadcastInstallEvent))
   )
 
   ipcMainHandle('settings:uninstall-claude', () =>
-    workflows.runtime.uninstallRuntime('uninstallClaude', 'claude-code')
+    snapshotCommits.currentSnapshotAfter(
+      workflows.runtime.uninstallRuntime('uninstallClaude', 'claude-code')
+    )
   )
 
   ipcMainHandle('settings:uninstall-opencode', () =>
-    workflows.runtime.uninstallRuntime('uninstallOpencode', 'opencode')
+    snapshotCommits.currentSnapshotAfter(
+      workflows.runtime.uninstallRuntime('uninstallOpencode', 'opencode')
+    )
   )
 
   ipcMainHandle('settings:uninstall-codebuddy', () =>
-    workflows.runtime.uninstallRuntime('uninstallCodeBuddy', 'codebuddy')
+    snapshotCommits.currentSnapshotAfter(
+      workflows.runtime.uninstallRuntime('uninstallCodeBuddy', 'codebuddy')
+    )
   )
 
   ipcMainHandle('settings:uninstall-codex', () =>
-    workflows.runtime.uninstallRuntime('uninstallCodex', 'codex')
+    snapshotCommits.currentSnapshotAfter(
+      workflows.runtime.uninstallRuntime('uninstallCodex', 'codex')
+    )
   )
 
   ipcMainHandle('settings:upsert-provider', (_event, request: UpsertProviderRequest) =>
-    workflows.runtime.upsertProvider(request)
+    snapshotCommits.currentSnapshotAfter(workflows.runtime.upsertProvider(request))
   )
   ipcMainHandle('settings:delete-provider', (_event, request: DeleteProviderRequest) =>
-    workflows.runtime.deleteProvider(request.id)
+    snapshotCommits.currentSnapshotAfter(workflows.runtime.deleteProvider(request.id))
   )
   ipcMainHandle('settings:set-active-provider', (_event, request: SetActiveProviderRequest) =>
-    workflows.runtime.setActiveProvider(request)
+    snapshotCommits.currentSnapshotAfter(workflows.runtime.setActiveProvider(request))
   )
   ipcMainHandle(
     'settings:set-agent-framework',
     async (_event, request: SetAgentFrameworkRequest) => {
       log.info('set agent framework requested', { id: request.id })
-      return workflows.runtime.setAgentFramework(request)
+      return snapshotCommits.currentSnapshotAfter(workflows.runtime.setAgentFramework(request))
     }
   )
   ipcMainHandle(
@@ -186,42 +207,34 @@ const registerSettingsIpcHandlers = ({
     async (_event, request: SetReasoningEffortRequest) => {
       const effort = readReasoningEffort(request)
       log.info('set reasoning effort requested', { effort })
-      return workflows.runtime.setReasoningEffort({ effort })
+      return snapshotCommits.currentSnapshotAfter(workflows.runtime.setReasoningEffort({ effort }))
     }
   )
   ipcMainHandle('settings:set-subagent-model', async (_event, request: SetSubagentModelRequest) => {
     const configuration = readSubagentModel(request)
-    const snapshot = await service.setSubagentModel(configuration)
-    broadcastToRenderers('settings:changed', snapshot)
-    return snapshot
+    return snapshotCommits.currentSnapshotAfter(service.setSubagentModel(configuration))
   })
   ipcMainHandle('settings:set-reviewer-model', async (_event, request: SetReviewerModelRequest) => {
     const configuration = readReviewerModel(request)
-    const snapshot = await service.setReviewerModel(configuration)
-    broadcastToRenderers('settings:changed', snapshot)
-    return snapshot
+    return snapshotCommits.currentSnapshotAfter(service.setReviewerModel(configuration))
   })
   ipcMainHandle(
     'settings:set-session-details-model',
     async (_event, request: SetSessionDetailsModelRequest) => {
       const configuration = readSessionDetailsModel(request)
-      const snapshot = await service.setSessionDetailsModel(configuration)
-      broadcastToRenderers('settings:changed', snapshot)
-      return snapshot
+      return snapshotCommits.currentSnapshotAfter(service.setSessionDetailsModel(configuration))
     }
   )
   ipcMainHandle('settings:set-vision-model', async (_event, request: SetVisionModelRequest) => {
     const configuration = readVisionModel(request)
-    const snapshot = await service.setVisionModel(configuration)
-    broadcastToRenderers('settings:changed', snapshot)
-    return snapshot
+    return snapshotCommits.currentSnapshotAfter(service.setVisionModel(configuration))
   })
   ipcMainHandle(
     'settings:set-notifications-enabled',
     async (_event, request: SetNotificationsEnabledRequest) => {
       const enabled = readNotificationsEnabled(request)
       log.info('set notifications enabled requested', { enabled })
-      return service.setNotificationsEnabled(enabled)
+      return snapshotCommits.currentSnapshotAfter(service.setNotificationsEnabled(enabled))
     }
   )
   ipcMainHandle(
@@ -229,7 +242,7 @@ const registerSettingsIpcHandlers = ({
     async (_event, request: SetShowNotificationContentRequest) => {
       const enabled = readShowNotificationContent(request)
       log.info('set show notification content requested', { enabled })
-      return service.setShowNotificationContent(enabled)
+      return snapshotCommits.currentSnapshotAfter(service.setShowNotificationContent(enabled))
     }
   )
   ipcMainHandle(
@@ -237,7 +250,9 @@ const registerSettingsIpcHandlers = ({
     async (_event, request: SetConversationSkillImportEnabledRequest) => {
       const enabled = readConversationSkillImportEnabled(request)
       log.info('set conversation Skill import enabled requested', { enabled })
-      return workflows.skills.setConversationSkillImportEnabled({ enabled })
+      return snapshotCommits.currentSnapshotAfter(
+        workflows.skills.setConversationSkillImportEnabled({ enabled })
+      )
     }
   )
   ipcMainHandle(
@@ -245,7 +260,7 @@ const registerSettingsIpcHandlers = ({
     async (_event, request: SetClosePreferenceRequest) => {
       const preference = readClosePreference(request)
       log.info('set close preference requested', { preference: preference ?? 'ask' })
-      return service.setClosePreference(preference)
+      return snapshotCommits.currentSnapshotAfter(service.setClosePreference(preference))
     }
   )
   ipcMainHandle(
@@ -253,7 +268,7 @@ const registerSettingsIpcHandlers = ({
     async (_event, request: SetProjectFilesFilterRequest) => {
       const filter = readProjectFilesFilter(request)
       log.info('set project files filter requested', { filter: filter ?? 'default' })
-      return service.setProjectFilesFilter(filter)
+      return snapshotCommits.currentSnapshotAfter(service.setProjectFilesFilter(filter))
     }
   )
   ipcMainHandle(
@@ -261,7 +276,7 @@ const registerSettingsIpcHandlers = ({
     async (_event, request: SetDefaultPermissionProfileRequest) => {
       const profile = readDefaultPermissionProfile(request)
       log.info('set default permission profile requested', { profile })
-      return service.setDefaultPermissionProfile(profile)
+      return snapshotCommits.currentSnapshotAfter(service.setDefaultPermissionProfile(profile))
     }
   )
   ipcMainHandle('settings:list-app-icons', (): AppIconPreview[] => listAppIconPreviews?.() ?? [])
@@ -270,45 +285,64 @@ const registerSettingsIpcHandlers = ({
     async (_event, request: SetAppIconVariantRequest) => {
       const variant = readAppIconVariant(request)
       log.info('set app icon variant requested', { variant })
-      return workflows.appearance.setAppIconVariant(variant)
+      return snapshotCommits.currentSnapshotAfter(workflows.appearance.setAppIconVariant(variant))
     }
   )
   ipcMainHandle('settings:validate-provider', (_event, request: ValidateProviderRequest) =>
-    service.validateProvider(request)
+    snapshotCommits.projectAfter(service.validateProvider(request))
   )
   ipcMainHandle('settings:cancel-codex-login', () => service.cancelCodexLogin())
   ipcMainHandle('settings:cancel-claude-login', () => service.cancelClaudeLogin())
-  ipcMainHandle('settings:login-shared-claude', () => workflows.runtime.loginClaudeShared())
-  ipcMainHandle('settings:logout-shared-claude', () => workflows.runtime.logoutClaudeShared())
+  ipcMainHandle('settings:login-shared-claude', () =>
+    snapshotCommits.projectAfter(workflows.runtime.loginClaudeShared())
+  )
+  ipcMainHandle('settings:logout-shared-claude', () =>
+    snapshotCommits.projectAfter(workflows.runtime.logoutClaudeShared())
+  )
   ipcMainHandle('settings:login-isolated-claude', (_event, token: string) =>
-    workflows.runtime.loginIsolatedClaude(readIsolatedClaudeToken(token))
+    snapshotCommits.projectAfter(
+      workflows.runtime.loginIsolatedClaude(readIsolatedClaudeToken(token))
+    )
   )
   ipcMainHandle('settings:login-isolated-claude-browser', () =>
-    workflows.runtime.loginIsolatedClaudeBrowser()
+    snapshotCommits.projectAfter(workflows.runtime.loginIsolatedClaudeBrowser())
   )
   ipcMainHandle('settings:cancel-isolated-claude-login', async () => {
     await service.cancelClaudeIsolatedLogin()
   })
-  ipcMainHandle('settings:logout-isolated-claude', () => workflows.runtime.logoutIsolatedClaude())
-  ipcMainHandle('settings:login-isolated-codex', () => workflows.runtime.loginIsolatedCodex())
-  ipcMainHandle('settings:logout-isolated-codex', () => workflows.runtime.logoutIsolatedCodex())
+  ipcMainHandle('settings:logout-isolated-claude', () =>
+    snapshotCommits.projectAfter(workflows.runtime.logoutIsolatedClaude())
+  )
+  ipcMainHandle('settings:login-isolated-codex', () =>
+    snapshotCommits.projectAfter(workflows.runtime.loginIsolatedCodex())
+  )
+  ipcMainHandle('settings:logout-isolated-codex', () =>
+    snapshotCommits.projectAfter(workflows.runtime.logoutIsolatedCodex())
+  )
   ipcMainHandle('settings:begin-xai-oauth-login', () => workflows.runtime.beginXaiOAuthLogin())
-  ipcMainHandle('settings:wait-xai-oauth-login', () => workflows.runtime.waitXaiOAuthLogin())
+  ipcMainHandle('settings:wait-xai-oauth-login', () =>
+    snapshotCommits.projectAfter(workflows.runtime.waitXaiOAuthLogin())
+  )
   ipcMainHandle('settings:cancel-xai-oauth-login', () => workflows.runtime.cancelXaiOAuthLogin())
-  ipcMainHandle('settings:logout-xai-oauth', () => workflows.runtime.logoutXaiOAuth())
+  ipcMainHandle('settings:logout-xai-oauth', () =>
+    snapshotCommits.currentSnapshotAfter(workflows.runtime.logoutXaiOAuth())
+  )
   ipcMainHandle(
     'settings:refresh-provider-models',
-    (_event, request: RefreshProviderModelsRequest) => service.refreshProviderModels(request)
+    (_event, request: RefreshProviderModelsRequest) =>
+      snapshotCommits.projectAfter(service.refreshProviderModels(request))
   )
-  ipcMainHandle('settings:mark-onboarding-complete', () => service.markOnboardingComplete())
+  ipcMainHandle('settings:mark-onboarding-complete', () =>
+    snapshotCommits.currentSnapshotAfter(service.markOnboardingComplete())
+  )
 
   ipcMainHandle('settings:get-package-mirror', () => service.getPackageMirror())
   ipcMainHandle('settings:get-notebook-network-status', () => service.getNotebookNetworkStatus())
   ipcMainHandle('settings:set-package-mirror', (_event, request: SetPackageMirrorRequest) =>
-    service.setPackageMirror(request)
+    snapshotCommits.projectAfter(service.setPackageMirror(request))
   )
   ipcMainHandle('settings:set-network-proxy', (_event, request: SetNetworkProxyRequest) =>
-    service.setNetworkProxy(request)
+    snapshotCommits.projectAfter(service.setNetworkProxy(request))
   )
   ipcMainHandle('settings:set-notebook-network', (_event, request: SetNotebookNetworkRequest) =>
     service.setNotebookNetwork(request)

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -292,6 +292,108 @@ describe('ProviderAccountsModule', () => {
     expect((await repository.getSettings()).providers).toEqual([])
   })
 
+  it('serializes isolated Codex logout with a concurrent authentication-mode edit', async () => {
+    const userCodexDir = join(dir, 'user-codex')
+    await mkdir(userCodexDir, { recursive: true })
+    await writeFile(join(userCodexDir, 'auth.json'), JSON.stringify({ tokens: { access: 'user' } }))
+    await module.upsertProvider({ type: 'codex-isolated' })
+
+    const logoutCancellation = deferred<void>()
+    const editCancellation = deferred<void>()
+    const editEntered = deferred<void>()
+    vi.mocked(codexAuth.cancelLogin)
+      .mockImplementationOnce(() => logoutCancellation.promise)
+      .mockImplementationOnce(() => {
+        editEntered.resolve()
+        return editCancellation.promise
+      })
+
+    const logout = module.logoutIsolatedCodex()
+    await vi.waitFor(() => expect(codexAuth.cancelLogin).toHaveBeenCalledOnce())
+    const originalGetSettings = repository.getSettings.bind(repository)
+    const editRead = deferred<StoredSettings>()
+    const getSettings = vi.spyOn(repository, 'getSettings').mockImplementation(async () => {
+      const settings = await originalGetSettings()
+      editRead.resolve(settings)
+      return settings
+    })
+    const edit = module.upsertProvider({
+      id: 'builtin-codex-subscription',
+      type: 'codex-shared',
+      requireExisting: true,
+      reimportCodexAuthentication: true
+    })
+
+    const editEnteredDuringLogout = await Promise.race([
+      editRead.promise.then(() => true),
+      new Promise<false>((resolve) => setImmediate(() => resolve(false)))
+    ])
+    if (editEnteredDuringLogout) {
+      editCancellation.resolve()
+      await edit
+      logoutCancellation.resolve()
+    } else {
+      logoutCancellation.resolve()
+      await editEntered.promise
+      editCancellation.resolve()
+    }
+    await Promise.all([logout, edit])
+    getSettings.mockRestore()
+
+    expect(editEnteredDuringLogout).toBe(false)
+    expect((await repository.getSettings()).providers[0]).toMatchObject({
+      id: 'builtin-codex-subscription',
+      codexAuthMode: 'imported'
+    })
+    await expect(
+      readFile(join(codexSubscriptionStorageDir(dir), 'auth.json'), 'utf8')
+    ).resolves.toContain('user')
+  })
+
+  it('does not restore isolated Codex validation after a concurrent logout', async () => {
+    await module.upsertProvider({ type: 'codex-isolated' })
+    const staleSettings = await repository.getSettings()
+    const staleRead = deferred<StoredSettings>()
+    vi.spyOn(repository, 'getSettings').mockImplementationOnce(() => staleRead.promise)
+
+    const login = module.loginIsolatedCodex()
+    await vi.waitFor(() => expect(codexAuth.loginIsolated).toHaveBeenCalledOnce())
+    await module.logoutIsolatedCodex()
+    staleRead.resolve(staleSettings)
+
+    await expect(login).resolves.toMatchObject({ ok: true, applied: false })
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.codexAuthMode).toBe('isolated')
+    expect(stored.lastValidatedAt).toBeUndefined()
+    expect(stored.lastValidationFailure).toBeUndefined()
+  })
+
+  it('does not restore isolated Codex mode after a concurrent shared-mode edit', async () => {
+    const userCodexDir = join(dir, 'user-codex')
+    await mkdir(userCodexDir, { recursive: true })
+    await writeFile(join(userCodexDir, 'auth.json'), JSON.stringify({ tokens: { access: 'user' } }))
+    await module.upsertProvider({ type: 'codex-isolated' })
+    const staleSettings = await repository.getSettings()
+    const staleRead = deferred<StoredSettings>()
+    vi.spyOn(repository, 'getSettings').mockImplementationOnce(() => staleRead.promise)
+
+    const login = module.loginIsolatedCodex()
+    await vi.waitFor(() => expect(codexAuth.loginIsolated).toHaveBeenCalledOnce())
+    await module.upsertProvider({
+      id: 'builtin-codex-subscription',
+      type: 'codex-shared',
+      requireExisting: true,
+      reimportCodexAuthentication: true
+    })
+    staleRead.resolve(staleSettings)
+
+    await expect(login).resolves.toMatchObject({ ok: true, applied: false })
+    expect((await repository.getSettings()).providers[0]).toMatchObject({
+      id: 'builtin-codex-subscription',
+      codexAuthMode: 'imported'
+    })
+  })
+
   it.each([
     {
       sourceType: 'claude-isolated',

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -312,7 +312,7 @@ class ProviderAccountsModule {
   }
 
   async logoutIsolatedCodex(): Promise<ValidateProviderResult> {
-    return this.auth.logoutIsolatedCodex()
+    return this.auth.serializeAccountMutation(() => this.auth.logoutIsolatedCodex())
   }
 
   async loginIsolatedClaude(token: string): Promise<ValidateProviderResult> {

--- a/src/main/settings/provider-auth-lifecycle.ts
+++ b/src/main/settings/provider-auth-lifecycle.ts
@@ -68,6 +68,7 @@ class ProviderAuthLifecycleOwner {
   private readonly claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
   private readonly claudeSharedAuth: ClaudeSharedAuthControllerPort
   private accountMutationTail: Promise<void> = Promise.resolve()
+  private codexIsolatedLoginGeneration = 0
   private claudeSharedAuthStatusCache: { authenticated: boolean; checkedAt: number } | undefined
   private claudeSharedAuthStatusGeneration = 0
   private claudeSharedAuthStatusPromise:
@@ -155,6 +156,7 @@ class ProviderAuthLifecycleOwner {
     existing: StoredProvider | undefined,
     onAuthenticationReimported: () => void
   ): Promise<void> {
+    if (isCodexSubscriptionProvider(request.type)) this.codexIsolatedLoginGeneration += 1
     const reimport = request.type === 'codex-shared' && request.reimportCodexAuthentication === true
     if (request.type === 'codex-shared' && (existing?.codexAuthMode !== 'imported' || reimport)) {
       await this.codexAuth.cancelLogin()
@@ -179,6 +181,7 @@ class ProviderAuthLifecycleOwner {
 
   async cleanupProviderBeforeDelete(id: string): Promise<void> {
     if (isCodexSubscriptionProviderId(id)) {
+      this.codexIsolatedLoginGeneration += 1
       await this.codexAuth.cancelLogin()
       const codexHome = codexSubscriptionStorageDir(this.options.storageRoot)
       await clearImportedCodexProviderRoute(codexHome)
@@ -191,6 +194,7 @@ class ProviderAuthLifecycleOwner {
   }
 
   cancelCodexLogin(): void {
+    this.codexIsolatedLoginGeneration += 1
     void this.codexAuth.cancelLogin()
   }
 
@@ -199,6 +203,7 @@ class ProviderAuthLifecycleOwner {
   }
 
   async loginIsolatedCodex(): Promise<ValidateProviderResult> {
+    const loginGeneration = ++this.codexIsolatedLoginGeneration
     const result = this.codexAuthValidationResult(await this.codexAuth.loginIsolated())
     const settings = await this.repository.getSettings()
     const provider = settings.providers.find(
@@ -208,24 +213,28 @@ class ProviderAuthLifecycleOwner {
       return { ...result, applied: false }
     }
 
-    await this.repository.upsertProvider(
-      result.ok
-        ? { ...provider, lastValidatedAt: Date.now(), lastValidationFailure: undefined }
-        : {
-            ...provider,
-            lastValidatedAt: undefined,
-            lastValidationFailure: {
-              at: Date.now(),
-              category: result.category,
-              status: result.status,
-              message: result.message
+    const applied = await this.serializeAccountMutation(() => {
+      if (this.codexIsolatedLoginGeneration !== loginGeneration) return Promise.resolve(false)
+      return this.repository.updateCodexIsolatedValidationIfIdentityMatches(
+        provider,
+        result.ok
+          ? { lastValidatedAt: Date.now(), lastValidationFailure: undefined }
+          : {
+              lastValidatedAt: undefined,
+              lastValidationFailure: {
+                at: Date.now(),
+                category: result.category,
+                status: result.status,
+                message: result.message
+              }
             }
-          }
-    )
-    return { ...result, applied: true }
+      )
+    })
+    return { ...result, applied }
   }
 
   async logoutIsolatedCodex(): Promise<ValidateProviderResult> {
+    this.codexIsolatedLoginGeneration += 1
     const settings = await this.repository.getSettings()
     const provider = settings.providers.find(
       (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
@@ -250,11 +259,7 @@ class ProviderAuthLifecycleOwner {
       }
     }
 
-    await this.repository.upsertProvider({
-      ...provider,
-      lastValidatedAt: undefined,
-      lastValidationFailure: undefined
-    })
+    await this.repository.clearCodexIsolatedValidationIfExists()
     return { ok: true, category: 'ok' }
   }
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -10,6 +10,7 @@ import type {
 import {
   CLAUDE_ISOLATED_PROVIDER_ID,
   CLAUDE_SHARED_PROVIDER_ID,
+  CODEX_SUBSCRIPTION_PROVIDER_ID,
   claudeIsolatedProviderIdentity,
   isClaudeSubscriptionProvider,
   isClaudeSubscriptionProviderId
@@ -120,6 +121,55 @@ class SettingsRepository {
 
       const providers = [...settings.providers]
       providers[index] = { ...currentProvider, fetchedModels }
+      applied = true
+      return { ...settings, providers }
+    })
+
+    return applied
+  }
+
+  async clearCodexIsolatedValidationIfExists(): Promise<boolean> {
+    let applied = false
+
+    await this.mutate((settings) => {
+      const index = settings.providers.findIndex(
+        (provider) => provider.id === CODEX_SUBSCRIPTION_PROVIDER_ID
+      )
+      const current = settings.providers[index]
+      if (current?.type !== 'codex-isolated' || current.codexAuthMode !== 'isolated') {
+        return settings
+      }
+
+      const provider = { ...current }
+      delete provider.lastValidatedAt
+      delete provider.lastValidationFailure
+      const providers = [...settings.providers]
+      providers[index] = provider
+      applied = true
+      return { ...settings, providers }
+    })
+
+    return applied
+  }
+
+  async updateCodexIsolatedValidationIfIdentityMatches(
+    expectedProvider: Pick<StoredProvider, 'id' | 'type' | 'codexAuthMode'>,
+    patch: Pick<StoredProvider, 'lastValidatedAt' | 'lastValidationFailure'>
+  ): Promise<boolean> {
+    let applied = false
+
+    await this.mutate((settings) => {
+      const index = settings.providers.findIndex((provider) => provider.id === expectedProvider.id)
+      const current = settings.providers[index]
+      if (
+        current?.type !== expectedProvider.type ||
+        current.codexAuthMode !== expectedProvider.codexAuthMode
+      ) {
+        return settings
+      }
+
+      const providers = [...settings.providers]
+      providers[index] = { ...current, ...patch }
       applied = true
       return { ...settings, providers }
     })

--- a/src/main/settings/runtime-application-commands.test.ts
+++ b/src/main/settings/runtime-application-commands.test.ts
@@ -13,6 +13,12 @@ import {
   settingsRuntimeApplicationCommands,
   type RuntimeSettingsApplicationCommandDependencies
 } from './runtime-application-commands'
+import type { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
+
+const passThroughSnapshotCommits = {
+  currentSnapshotAfter: (pending: Promise<unknown>) => pending,
+  projectAfter: (pending: Promise<unknown>) => pending
+} as unknown as SettingsSnapshotCommitOwner
 
 const expectedChannels = [
   'settings:uninstall-claude',
@@ -77,7 +83,7 @@ const createDependencies = (): Readonly<{
   ) as RuntimeSettingsApplicationCommandDependencies['workflows']
 
   return {
-    dependencies: { workflows },
+    dependencies: { workflows, snapshotCommits: passThroughSnapshotCommits },
     workflowMethod: (name) => workflows[name] as ReturnType<typeof vi.fn>
   }
 }

--- a/src/main/settings/runtime-application-commands.ts
+++ b/src/main/settings/runtime-application-commands.ts
@@ -7,6 +7,7 @@ import {
 } from '../application-command-router'
 import type { CallerContext } from '../caller-context'
 import { readIsolatedClaudeToken, readReasoningEffort } from './transport-validation'
+import type { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
 import type { RuntimeSettingsWorkflows } from './workflows/runtime'
 
 type RuntimeSettingsCommandWorkflows = Pick<
@@ -168,6 +169,7 @@ const settingsRuntimeApplicationCommandGroup = defineApplicationCommandGroup('se
 
 type RuntimeSettingsApplicationCommandDependencies = Readonly<{
   workflows: RuntimeSettingsCommandWorkflows
+  snapshotCommits: SettingsSnapshotCommitOwner
 }>
 
 const requireLocalCaller = (context: CallerContext, channel: string): void => {
@@ -186,55 +188,87 @@ const registerRuntimeSettingsApplicationCommands = (
     scope.registerGroup(settingsRuntimeApplicationCommandGroup, {
       'settings:uninstall-claude': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:uninstall-claude')
-        return dependencies.workflows.uninstallRuntime('uninstallClaude', 'claude-code')
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.uninstallRuntime('uninstallClaude', 'claude-code')
+        )
       },
       'settings:uninstall-codex': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:uninstall-codex')
-        return dependencies.workflows.uninstallRuntime('uninstallCodex', 'codex')
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.uninstallRuntime('uninstallCodex', 'codex')
+        )
       },
       'settings:uninstall-codebuddy': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:uninstall-codebuddy')
-        return dependencies.workflows.uninstallRuntime('uninstallCodeBuddy', 'codebuddy')
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.uninstallRuntime('uninstallCodeBuddy', 'codebuddy')
+        )
       },
       'settings:uninstall-opencode': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:uninstall-opencode')
-        return dependencies.workflows.uninstallRuntime('uninstallOpencode', 'opencode')
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.uninstallRuntime('uninstallOpencode', 'opencode')
+        )
       },
-      'settings:upsert-provider': ({ args }) => dependencies.workflows.upsertProvider(args[0]),
-      'settings:delete-provider': ({ args }) => dependencies.workflows.deleteProvider(args[0].id),
+      'settings:upsert-provider': ({ args }) =>
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.upsertProvider(args[0])
+        ),
+      'settings:delete-provider': ({ args }) =>
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.deleteProvider(args[0].id)
+        ),
       'settings:set-active-provider': ({ args }) =>
-        dependencies.workflows.setActiveProvider(args[0]),
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.setActiveProvider(args[0])
+        ),
       'settings:set-agent-framework': ({ args }) =>
-        dependencies.workflows.setAgentFramework(args[0]),
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.setAgentFramework(args[0])
+        ),
       'settings:set-reasoning-effort': ({ args }) =>
-        dependencies.workflows.setReasoningEffort({ effort: readReasoningEffort(args[0]) }),
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.setReasoningEffort({ effort: readReasoningEffort(args[0]) })
+        ),
       'settings:login-shared-claude': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:login-shared-claude')
-        return dependencies.workflows.loginClaudeShared()
+        return dependencies.snapshotCommits.projectAfter(dependencies.workflows.loginClaudeShared())
       },
       'settings:logout-shared-claude': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:logout-shared-claude')
-        return dependencies.workflows.logoutClaudeShared()
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.workflows.logoutClaudeShared()
+        )
       },
       'settings:login-isolated-claude': ({ args, callerContext }) => {
         requireLocalCaller(callerContext, 'settings:login-isolated-claude')
-        return dependencies.workflows.loginIsolatedClaude(readIsolatedClaudeToken(args[0]))
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.workflows.loginIsolatedClaude(readIsolatedClaudeToken(args[0]))
+        )
       },
       'settings:login-isolated-claude-browser': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:login-isolated-claude-browser')
-        return dependencies.workflows.loginIsolatedClaudeBrowser()
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.workflows.loginIsolatedClaudeBrowser()
+        )
       },
       'settings:logout-isolated-claude': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:logout-isolated-claude')
-        return dependencies.workflows.logoutIsolatedClaude()
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.workflows.logoutIsolatedClaude()
+        )
       },
       'settings:login-isolated-codex': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:login-isolated-codex')
-        return dependencies.workflows.loginIsolatedCodex()
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.workflows.loginIsolatedCodex()
+        )
       },
       'settings:logout-isolated-codex': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:logout-isolated-codex')
-        return dependencies.workflows.logoutIsolatedCodex()
+        return dependencies.snapshotCommits.projectAfter(
+          dependencies.workflows.logoutIsolatedCodex()
+        )
       },
       'settings:begin-xai-oauth-login': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:begin-xai-oauth-login')
@@ -242,7 +276,7 @@ const registerRuntimeSettingsApplicationCommands = (
       },
       'settings:wait-xai-oauth-login': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:wait-xai-oauth-login')
-        return dependencies.workflows.waitXaiOAuthLogin()
+        return dependencies.snapshotCommits.projectAfter(dependencies.workflows.waitXaiOAuthLogin())
       },
       'settings:cancel-xai-oauth-login': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:cancel-xai-oauth-login')
@@ -250,7 +284,9 @@ const registerRuntimeSettingsApplicationCommands = (
       },
       'settings:logout-xai-oauth': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:logout-xai-oauth')
-        return dependencies.workflows.logoutXaiOAuth()
+        return dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.logoutXaiOAuth()
+        )
       }
     })
     return scope.complete()

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -343,6 +343,7 @@ describe('Settings backend ownership architecture', () => {
       'addCustomServer',
       'clearCodeBuddyInfo',
       'clearCodexInfo',
+      'clearCodexIsolatedValidationIfExists',
       'clearComputeGrants',
       'clearGrantedLocalRoots',
       'clearOpencodeInfo',
@@ -396,6 +397,7 @@ describe('Settings backend ownership architecture', () => {
       'updateClaudeIsolatedCredentialsIfExists',
       'updateClaudeIsolatedValidationIfKeyMatches',
       'updateClaudeSharedValidationIfUnchanged',
+      'updateCodexIsolatedValidationIfIdentityMatches',
       'updateCustomServer',
       'updateCustomServerOAuthState',
       'updateProviderModelCatalogIfTargetMatches',
@@ -821,6 +823,7 @@ describe('Settings backend ownership architecture', () => {
     expect(manifest.modules.settings_service_facade.ownerPaths).toEqual([
       'src/main/settings/service.ts',
       'src/main/settings/network-proxy-settings-owner.ts',
+      'src/main/settings/settings-snapshot-commit-owner.ts',
       'src/main/settings/reviewer-model-owner.ts',
       'src/main/settings/subagent-model-owner.ts',
       'src/main/settings/vision-model-owner.ts'

--- a/src/main/settings/settings-snapshot-commit-owner.test.ts
+++ b/src/main/settings/settings-snapshot-commit-owner.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SettingsSnapshot } from '../../shared/settings'
+import { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
+
+const snapshot = (): SettingsSnapshot => ({
+  claude: {},
+  activeProviderId: undefined,
+  providers: [],
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [],
+  opencode: {},
+  codex: {},
+  codebuddy: {},
+  claudeManaged: false,
+  opencodeManaged: false,
+  codexManaged: false,
+  codebuddyManaged: false,
+  reasoningEffort: 'default',
+  notificationsEnabled: true,
+  conversationSkillImportEnabled: true,
+  appIconVariant: 'light'
+})
+
+describe('SettingsSnapshotCommitOwner', () => {
+  it('assigns monotonic revisions to distinct committed projections', async () => {
+    const first = snapshot()
+    const second = snapshot()
+    const publish = vi.fn()
+    const owner = new SettingsSnapshotCommitOwner(
+      { getSettingsView: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second) },
+      { publish }
+    )
+
+    await expect(owner.currentSnapshotAfter(Promise.resolve())).resolves.toBe(first)
+    await expect(owner.currentSnapshotAfter(Promise.resolve())).resolves.toBe(second)
+
+    expect(first.revision).toBe(1)
+    expect(second.revision).toBe(2)
+    expect(publish).toHaveBeenNthCalledWith(1, 'settings:changed', first)
+    expect(publish).toHaveBeenNthCalledWith(2, 'settings:changed', second)
+  })
+
+  it('returns the current revision without publishing a new commit', async () => {
+    const initial = snapshot()
+    const committed = snapshot()
+    const current = snapshot()
+    const publish = vi.fn()
+    const owner = new SettingsSnapshotCommitOwner(
+      {
+        getSettingsView: vi
+          .fn()
+          .mockResolvedValueOnce(initial)
+          .mockResolvedValueOnce(committed)
+          .mockResolvedValueOnce(current)
+      },
+      { publish }
+    )
+
+    await expect(owner.readCurrentSnapshot()).resolves.toBe(initial)
+    await owner.currentSnapshotAfter(Promise.resolve())
+    await expect(owner.readCurrentSnapshot()).resolves.toBe(current)
+
+    expect(initial.revision).toBe(0)
+    expect(committed.revision).toBe(1)
+    expect(current.revision).toBe(1)
+    expect(publish).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/settings/settings-snapshot-commit-owner.ts
+++ b/src/main/settings/settings-snapshot-commit-owner.ts
@@ -1,0 +1,49 @@
+import type { SettingsSnapshot } from '../../shared/settings'
+import type { ApplicationEventPublisher } from '../application-events'
+
+type SettingsSnapshotStore = {
+  getSettingsView(): Promise<SettingsSnapshot>
+}
+
+class SettingsSnapshotCommitOwner {
+  private tail = Promise.resolve()
+  private revision = 0
+
+  constructor(
+    private readonly settings: SettingsSnapshotStore,
+    private readonly events: ApplicationEventPublisher
+  ) {}
+
+  async currentSnapshotAfter(pending: Promise<unknown>): Promise<SettingsSnapshot> {
+    await pending
+    return this.enqueueCurrentSnapshot(true)
+  }
+
+  async projectAfter<Result>(pending: Promise<Result>): Promise<Result> {
+    const result = await pending
+    await this.enqueueCurrentSnapshot(true)
+    return result
+  }
+
+  readCurrentSnapshot(): Promise<SettingsSnapshot> {
+    return this.enqueueCurrentSnapshot(false)
+  }
+
+  private enqueueCurrentSnapshot(publish: boolean): Promise<SettingsSnapshot> {
+    const current = this.tail.then(async () => {
+      const snapshot = await this.settings.getSettingsView()
+      if (publish) this.revision += 1
+      snapshot.revision = this.revision
+      if (publish) this.events.publish('settings:changed', snapshot)
+      return snapshot
+    })
+    this.tail = current.then(
+      () => undefined,
+      () => undefined
+    )
+    return current
+  }
+}
+
+export { SettingsSnapshotCommitOwner }
+export type { SettingsSnapshotStore }

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -1228,6 +1228,7 @@ describe('UpdateService.apply', () => {
   const downloadedService = async (
     target: string,
     overrides: {
+      fetchImpl?: typeof fetch
       openPath?: () => Promise<string>
       fileExists?: (path: string) => boolean
       log?: Logger
@@ -1275,6 +1276,73 @@ describe('UpdateService.apply', () => {
 
     expect(openPath).toHaveBeenCalledWith(target)
     expect(status.state).toBe('ready')
+  })
+
+  it('admits only one installer open while apply is in flight', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'open-once-'))
+    const target = join(dir, 'installer.dmg')
+    let resolveOpen!: (error: string) => void
+    const openPath = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveOpen = resolve
+        })
+    )
+    const service = await downloadedService(target, { openPath })
+
+    const first = service.apply()
+    const second = service.apply()
+
+    expect(openPath).toHaveBeenCalledTimes(1)
+    resolveOpen('')
+    await expect(Promise.all([first, second])).resolves.toMatchObject([
+      { state: 'ready' },
+      { state: 'ready' }
+    ])
+    expect(openPath).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let an older apply overwrite a newer manifest check', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'apply-refresh-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    let manifestChecks = 0
+    const fetchImpl = ((input: unknown) => {
+      if (!String(input).endsWith('version.json')) {
+        return Promise.resolve(installerResponse(body))
+      }
+      manifestChecks += 1
+      return Promise.resolve(
+        jsonResponse({
+          version: manifestChecks === 1 ? '0.3.0' : '0.4.0',
+          releaseDate: '',
+          notes: '',
+          downloads: {
+            'mac-arm64': {
+              url: 'https://statics.aipoch.com/releases/0.3.0/installer.dmg',
+              size: body.byteLength,
+              sha256: createHash('sha256').update(body).digest('hex')
+            }
+          }
+        } satisfies UpdateManifest)
+      )
+    }) as unknown as typeof fetch
+    let resolveOpen!: (error: string) => void
+    const openPath = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveOpen = resolve
+        })
+    )
+    const service = await downloadedService(target, { fetchImpl, openPath })
+
+    const applying = service.apply()
+    await expect(service.check()).resolves.toMatchObject({ state: 'available', latest: '0.4.0' })
+    resolveOpen('No application is associated with this file')
+    await applying
+
+    expect(service.getStatus()).toMatchObject({ state: 'available', latest: '0.4.0' })
+    expect(service.getStatus().error).toBeUndefined()
   })
 
   it('records a completed installer apply without its local path', async () => {

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -88,6 +88,9 @@ export class UpdateService implements UpdateStrategy {
   // In-flight check() promise. Overlapping check()/download() await this instead of returning a
   // snapshot taken while the startup scheduler still owns the manifest fetch.
   private checkLifecycle?: Promise<UpdateStatus>
+  // Coalesces concurrent apply requests from multiple windows and keeps the admitted status identity
+  // available until the operating-system open request settles.
+  private applyLifecycle?: Promise<UpdateStatus>
   private readonly fetchImpl?: typeof fetch
   private readonly platform: NodeJS.Platform
   private readonly arch: string
@@ -407,26 +410,42 @@ export class UpdateService implements UpdateStrategy {
   // Opens the downloaded installer. A missing file drops back to 'available' for re-download. When
   // the file still exists but the OS cannot open it, keep the ready artifact and surface the reason so
   // the user can retry without another transfer. With no artifact, open the public download page.
-  async apply(): Promise<UpdateStatus> {
+  apply(): Promise<UpdateStatus> {
+    if (this.applyLifecycle) return this.applyLifecycle
+
+    const admittedStatus = this.status
+    const lifecycle = this.applyAdmitted(admittedStatus)
+    this.applyLifecycle = lifecycle
+    const clearLifecycle = (): void => {
+      if (this.applyLifecycle === lifecycle) this.applyLifecycle = undefined
+    }
+    void lifecycle.then(clearLifecycle, clearLifecycle)
+    return lifecycle
+  }
+
+  private async applyAdmitted(admittedStatus: UpdateStatus): Promise<UpdateStatus> {
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-apply',
       fields: { strategy: 'manifest' }
     })
     try {
-      const { localPath, download } = this.status
+      const { localPath, download } = admittedStatus
       if (localPath) {
         operation.phase('verify-installer')
         if (this.fileExists(localPath)) {
           operation.phase('open-installer')
           const error = await this.openPath(localPath)
           if (!error) {
-            if (this.status.error) this.setStatus({ ...this.status, error: undefined })
+            if (this.status === admittedStatus && admittedStatus.error) {
+              this.setStatus({ ...admittedStatus, error: undefined })
+            }
             operation.complete({ result: 'installer-opened' })
             return this.status
           }
           operation.fail(new Error('Installer open failed'), { reason: 'open-failed' })
+          if (this.status !== admittedStatus) return this.status
           this.setStatus({
-            ...this.status,
+            ...admittedStatus,
             state: 'ready',
             error: this.translate('Could not open the update installer: {{error}}', { error })
           })
@@ -440,7 +459,7 @@ export class UpdateService implements UpdateStrategy {
 
       if (download) {
         this.setStatus({
-          ...this.status,
+          ...admittedStatus,
           state: 'available',
           localPath: undefined,
           progress: undefined,

--- a/src/main/uploads/command-owner.test.ts
+++ b/src/main/uploads/command-owner.test.ts
@@ -36,6 +36,14 @@ const invocationFor = <Args extends readonly unknown[]>(
   args
 })
 
+const deferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
 describe('upload command owner', () => {
   const temporaryRoots: string[] = []
 
@@ -300,6 +308,43 @@ describe('upload command owner', () => {
     await append
     await drain
     expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'in-flight-transfer' })
+  })
+
+  it('rejects abort after finish wins terminal settlement', async () => {
+    const finishing = deferred<undefined>()
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'settling-transfer',
+        name: 'data.csv',
+        receivedBytes: 10,
+        totalBytes: 10
+      })),
+      finishTransfer: vi.fn(() => finishing.promise),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 17)
+
+    await owner.beginTransfer(
+      invocationFor(caller, [
+        { transferId: 'settling-transfer', name: 'data.csv', size: 10 }
+      ] as const)
+    )
+    const finish = owner.finishTransfer(
+      invocationFor(caller, [{ transferId: 'settling-transfer' }] as const)
+    )
+    await vi.waitFor(() => expect(repository.finishTransfer).toHaveBeenCalledOnce())
+
+    try {
+      await expect(
+        owner.abortTransfer(invocationFor(caller, [{ transferId: 'settling-transfer' }] as const))
+      ).rejects.toThrow('Upload transfer is already finishing')
+      expect(repository.abortTransfer).not.toHaveBeenCalled()
+    } finally {
+      finishing.resolve(undefined)
+      await finish
+    }
   })
 
   it('deletes a staged native upload when its caller releases before claim', async () => {

--- a/src/main/uploads/command-owner.ts
+++ b/src/main/uploads/command-owner.ts
@@ -355,11 +355,20 @@ const createUploadCommandOwner = (
 
       try {
         await writer.ready
-        if (writer.cancelled) {
-          await writer.cleanup
-          throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
-        }
-        writer.settling = true
+      } catch (error) {
+        await abortChunkWriter(request.transferId, writer)
+        throw error
+      }
+      if (writer.cancelled) {
+        await writer.cleanup
+        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+      }
+      if (writer.settling) {
+        throw new Error(`Upload transfer is already finishing: ${request.transferId}`)
+      }
+      writer.settling = true
+
+      try {
         await Promise.allSettled([...writer.inFlight])
         return await repository.finishTransfer(request)
       } catch (error) {
@@ -375,6 +384,9 @@ const createUploadCommandOwner = (
 
       const writer = getOwnedChunkWriter(callerLease, request.transferId)
       if (!writer) return withDataRootWrite(() => repository.abortTransfer(request))
+      if (writer.settling) {
+        throw new Error(`Upload transfer is already finishing: ${request.transferId}`)
+      }
 
       await abortChunkWriter(request.transferId, writer)
     },

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -697,4 +697,54 @@ describe('useAcpRuntime pending lifecycle', () => {
     expect(result.current.isConnecting).toBe(false)
     expect(result.current.state.cwd).toBe('/connected')
   })
+
+  it('keeps the connecting flag raised until all overlapping actions settle', async () => {
+    const first = createDeferred<{ sessionId: string }>()
+    const second = createDeferred<{ sessionId: string }>()
+    acpApi.createSession.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    const { result } = await mountRuntime()
+
+    let firstAction!: Promise<{ sessionId: string }>
+    let secondAction!: Promise<{ sessionId: string }>
+    act(() => {
+      firstAction = result.current.createSession('/first')
+      secondAction = result.current.createSession('/second')
+    })
+    await act(async () => {
+      first.resolve({ sessionId: 'first' })
+      await firstAction
+    })
+
+    expect(result.current.isConnecting).toBe(true)
+
+    await act(async () => {
+      second.resolve({ sessionId: 'second' })
+      await secondAction
+    })
+    expect(result.current.isConnecting).toBe(false)
+  })
+
+  it('does not surface an older action failure after a newer action succeeds', async () => {
+    const older = createDeferred<{ sessionId: string }>()
+    const latest = createDeferred<{ sessionId: string }>()
+    acpApi.createSession.mockReturnValueOnce(older.promise).mockReturnValueOnce(latest.promise)
+    const { result } = await mountRuntime()
+
+    let olderAction!: Promise<{ sessionId: string }>
+    let latestAction!: Promise<{ sessionId: string }>
+    act(() => {
+      olderAction = result.current.createSession('/older')
+      latestAction = result.current.createSession('/latest')
+    })
+    await act(async () => {
+      latest.resolve({ sessionId: 'latest' })
+      await latestAction
+    })
+    await act(async () => {
+      older.reject(new Error('older failed'))
+      await olderAction.catch(() => undefined)
+    })
+
+    expect(result.current.actionError).toBeNull()
+  })
 })

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -14,7 +14,7 @@ import type {
   AcpStateSnapshot
 } from '../../../../shared/acp'
 import type { PermissionProfileId } from '../../../../shared/permission-profiles'
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react'
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { acceptAcpRuntimeSnapshotRevision } from './runtime-snapshot-revision-owner'
 import {
   createRuntimeEventSubscriptionOwner,
@@ -133,6 +133,8 @@ const useAcpRuntime = (): {
   const [actionError, setActionError] = useState<string | null>(null)
   const [isConnecting, setIsConnecting] = useState(false)
   const [isDisconnecting, setIsDisconnecting] = useState(false)
+  const actionGenerationRef = useRef(0)
+  const pendingActionCountsRef = useRef(new Map<PendingSetter, number>())
   const [runtimeEventOwner] = useState(createRuntimeEventSubscriptionOwner)
   const onRuntimeEvent = (window.api.acp as Partial<Pick<typeof window.api.acp, 'onEvent'>>).onEvent
   const subscribeRuntimeEvents = onRuntimeEvent ? runtimeEventOwner.subscribe : undefined
@@ -200,27 +202,47 @@ const useAcpRuntime = (): {
     }
   }, [applyInitialSnapshot, applySnapshot, onRuntimeEvent, runtimeEventOwner])
 
+  const beginAction = useCallback((setPending?: PendingSetter): number => {
+    const generation = ++actionGenerationRef.current
+    setActionError(null)
+    if (setPending) {
+      const count = (pendingActionCountsRef.current.get(setPending) ?? 0) + 1
+      pendingActionCountsRef.current.set(setPending, count)
+      if (count === 1) setPending(true)
+    }
+    return generation
+  }, [])
+
+  const finishPendingAction = useCallback((setPending?: PendingSetter): void => {
+    if (!setPending) return
+    const remaining = (pendingActionCountsRef.current.get(setPending) ?? 1) - 1
+    if (remaining > 0) pendingActionCountsRef.current.set(setPending, remaining)
+    else {
+      pendingActionCountsRef.current.delete(setPending)
+      setPending(false)
+    }
+  }, [])
+
   // Runs an IPC action that returns a full runtime snapshot.
   const runSnapshotAction = useCallback(
     async (
       setPending: PendingSetter | undefined,
       action: SnapshotAction
     ): Promise<AcpStateSnapshot | undefined> => {
-      setActionError(null)
-      setPending?.(true)
+      const generation = beginAction(setPending)
 
       try {
         const snapshot = await action()
         applySnapshot(snapshot)
         return snapshot
       } catch (error) {
-        setActionError(getErrorMessage(error))
+        if (generation === actionGenerationRef.current) setActionError(getErrorMessage(error))
         return undefined
       } finally {
-        setPending?.(false)
+        finishPendingAction(setPending)
       }
     },
-    [applySnapshot]
+    [applySnapshot, beginAction, finishPendingAction]
   )
 
   // Runs an IPC action that returns a non-snapshot value such as a new session id.
@@ -232,19 +254,18 @@ const useAcpRuntime = (): {
       setPending: PendingSetter | undefined,
       action: ValueAction<Value>
     ): Promise<Value> => {
-      setActionError(null)
-      setPending?.(true)
+      const generation = beginAction(setPending)
 
       try {
         return await action()
       } catch (error) {
-        setActionError(getErrorMessage(error))
+        if (generation === actionGenerationRef.current) setActionError(getErrorMessage(error))
         throw error
       } finally {
-        setPending?.(false)
+        finishPendingAction(setPending)
       }
     },
-    []
+    [beginAction, finishPendingAction]
   )
 
   // Specialized helper for sendPrompt: rethrows errors (like runValueAction) but does NOT
@@ -254,7 +275,7 @@ const useAcpRuntime = (): {
     async (action: () => Promise<AcpStateSnapshot>): Promise<AcpStateSnapshot> => {
       // Clear on entry so the helper is self-consistent with the other action helpers and does
       // not rely on WorkspacePage's active-session visibility gate to hide a stale actionError.
-      setActionError(null)
+      beginAction()
       const snapshot = await action()
       // Apply state-sync side-effect before returning, matching runSnapshotAction's contract.
       // Without this, callers that do `void runtime.sendPrompt(...)` would discard the snapshot
@@ -262,7 +283,7 @@ const useAcpRuntime = (): {
       applySnapshot(snapshot)
       return snapshot
     },
-    [applySnapshot]
+    [applySnapshot, beginAction]
   )
 
   // Keep all renderer ACP IPC calls in one hook so the future conversation UI can reuse it.
@@ -452,32 +473,32 @@ const useAcpRuntime = (): {
         cancelled: !optionId,
         ...(restored ? { restored } : {})
       }
-      setActionError(null)
+      const generation = beginAction()
       try {
         const snapshot = await window.api.acp.respondToPermission(response)
         applySnapshot(snapshot)
         return snapshot
       } catch (error) {
-        setActionError(getErrorMessage(error))
+        if (generation === actionGenerationRef.current) setActionError(getErrorMessage(error))
         throw error
       }
     },
-    [applySnapshot]
+    [applySnapshot, beginAction]
   )
 
   const respondToElicitation = useCallback(
     async (response: ElicitationResponse): Promise<AcpStateSnapshot> => {
-      setActionError(null)
+      const generation = beginAction()
       try {
         const snapshot = await window.api.acp.respondToElicitation(response)
         applySnapshot(snapshot)
         return snapshot
       } catch (error) {
-        setActionError(getErrorMessage(error))
+        if (generation === actionGenerationRef.current) setActionError(getErrorMessage(error))
         throw error
       }
     },
-    [applySnapshot]
+    [applySnapshot, beginAction]
   )
 
   const setPermissionProfile = useCallback(

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.test.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.test.tsx
@@ -4,7 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import type { PropsWithChildren } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { LocalDirListing } from '../../../../shared/local-fs'
+import type { LocalDirListing, LocalRoots } from '../../../../shared/local-fs'
 import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
@@ -35,6 +35,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 
 const HOME = '/Users/roxi'
 const GRANTED = `${HOME}/data`
+const OTHER_GRANTED = `${HOME}/results`
 
 let container: HTMLElement
 let root: Root
@@ -45,6 +46,14 @@ const flush = async (): Promise<void> => {
     await Promise.resolve()
     await Promise.resolve()
   })
+}
+
+const deferred = <T,>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
 }
 
 beforeEach(() => {
@@ -140,6 +149,57 @@ describe('LocalFileBrowser requestedPath', () => {
     expect(listDir).toHaveBeenCalledWith(GRANTED)
     expect(listDir).not.toHaveBeenCalledWith(HOME)
     expect(addressInput()?.value).toBe(GRANTED)
+  })
+
+  it('does not let the bootstrap Home navigation replace a request received while roots load', async () => {
+    const roots = deferred<LocalRoots>()
+    window.api.localFs.getRoots = vi.fn().mockReturnValue(roots.promise)
+
+    act(() => root.render(<LocalFileBrowser />))
+    await flush()
+    act(() => root.render(<LocalFileBrowser requestedPath={{ path: GRANTED, nonce: 1 }} />))
+    await flush()
+    expect(addressInput()?.value).toBe(GRANTED)
+
+    await act(async () => {
+      roots.resolve({ home: HOME, machineName: 'Test Mac' })
+      await roots.promise
+    })
+    await flush()
+
+    expect(listDir).not.toHaveBeenCalledWith(HOME)
+    expect(addressInput()?.value).toBe(GRANTED)
+  })
+
+  it('does not let an older navigation response replace the latest requested path', async () => {
+    await act(async () => {
+      root.render(<LocalFileBrowser />)
+    })
+    await flush()
+
+    const older = deferred<LocalDirListing>()
+    const latest = deferred<LocalDirListing>()
+    listDir.mockImplementation((path: string) => {
+      if (path === GRANTED) return older.promise
+      if (path === OTHER_GRANTED) return latest.promise
+      return Promise.resolve({ entries: [], truncated: false, resolvedPath: path })
+    })
+
+    act(() => root.render(<LocalFileBrowser requestedPath={{ path: GRANTED, nonce: 1 }} />))
+    act(() => root.render(<LocalFileBrowser requestedPath={{ path: OTHER_GRANTED, nonce: 2 }} />))
+
+    await act(async () => {
+      latest.resolve({ entries: [], truncated: false, resolvedPath: OTHER_GRANTED })
+      await latest.promise
+    })
+    expect(addressInput()?.value).toBe(OTHER_GRANTED)
+
+    await act(async () => {
+      older.resolve({ entries: [], truncated: false, resolvedPath: GRANTED })
+      await older.promise
+    })
+
+    expect(addressInput()?.value).toBe(OTHER_GRANTED)
   })
 })
 

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
@@ -485,10 +485,12 @@ export const LocalFileBrowser = ({
   // A request already pending when the browser mounts replaces the initial Home landing instead
   // of racing it.
   const initialRequestedPathRef = useRef(requestedPath)
+  const navigationRequestRef = useRef(0)
 
   // Clear the reported count when this container goes away, so the header stops showing a stale one.
   useEffect(
     () => () => {
+      navigationRequestRef.current += 1
       onEntryCountChangeRef.current?.(undefined)
     },
     []
@@ -497,9 +499,11 @@ export const LocalFileBrowser = ({
   // Loads one directory into the listing. Navigation is a single axis (parent arrow, address bar,
   // Go-to, entry double-click), so there is no history stack to maintain.
   const navigate = useCallback(async (target: string): Promise<void> => {
+    const request = ++navigationRequestRef.current
     setState({ kind: 'loading' })
     try {
       const listing = await window.api.localFs.listDir(target)
+      if (request !== navigationRequestRef.current) return
       setState({
         kind: 'ok',
         entries: listing.entries,
@@ -511,6 +515,7 @@ export const LocalFileBrowser = ({
       setAddressInput(listing.resolvedPath)
       onEntryCountChangeRef.current?.(listing.entries.length)
     } catch (err) {
+      if (request !== navigationRequestRef.current) return
       setState({
         kind: 'error',
         problem: describeLocalListingError((err as Error).message ?? '', target)
@@ -523,6 +528,7 @@ export const LocalFileBrowser = ({
   // before the browser mounted (its nonce is marked handled so the effect below doesn't
   // re-navigate).
   useEffect(() => {
+    const navigationIntent = navigationRequestRef.current
     void (async () => {
       const [fetchedRoots, fetchedDrives, fetchedBookmarks] = await Promise.all([
         window.api.localFs.getRoots(),
@@ -533,6 +539,7 @@ export const LocalFileBrowser = ({
       setRoots(fetchedRoots)
       setDrives(fetchedDrives)
       setBookmarks(fetchedBookmarks)
+      if (navigationIntent !== navigationRequestRef.current) return
       const pendingRequest = initialRequestedPathRef.current
       await navigate(pendingRequest?.path ?? fetchedRoots.home)
     })()

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -96,12 +96,18 @@ const sessionWithRunningChild = (): ChatSession => {
 const specialist = (id: string, name: string): SpecialistListItem =>
   ({ kind: 'custom', id, name, enabled: true }) as SpecialistListItem
 
-const deferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+} => {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise
+    reject = rejectPromise
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 type Options = Parameters<typeof useWorkspaceSessionController>[0]
@@ -204,6 +210,35 @@ describe('workspace session controller', () => {
     })
   })
 
+  it('keeps the latest Edit-session intent when an older lazy load finishes last', async () => {
+    const first = session({ id: 'session-a', contentLoaded: false })
+    const second = session({ id: 'session-b', title: 'Second title', contentLoaded: false })
+    const firstLoad = deferred<PersistedChatSession | undefined>()
+    const secondLoad = deferred<PersistedChatSession | undefined>()
+    const loadOne = vi.fn(({ sessionId }: { sessionId: string }) =>
+      sessionId === first.id ? firstLoad.promise : secondLoad.promise
+    )
+    window.api = { sessions: { loadOne } } as unknown as Window['api']
+    useSessionStore.setState({ sessions: [first, second], selectedSessionId: first.id })
+    const hook = renderController({ activeSession: first })
+    mounted.push(hook)
+
+    act(() => {
+      hook.result.current.actions.openEdit(first)
+      hook.result.current.actions.openEdit(second)
+    })
+    await act(async () => {
+      secondLoad.resolve({ ...second, revision: 1, messages: [] })
+      await secondLoad.promise
+    })
+    await act(async () => {
+      firstLoad.resolve({ ...first, revision: 1, messages: [] })
+      await firstLoad.promise
+    })
+
+    expect(hook.result.current.view.dialogs.edit?.session.id).toBe(second.id)
+  })
+
   it('submits title and description through the dedicated edit command and applies its authority', async () => {
     const active = session({ revision: 2, description: 'Before' })
     const edited: PersistedChatSession = {
@@ -244,6 +279,76 @@ describe('workspace session controller', () => {
       revision: 3
     })
     expect(hook.result.current.view.dialogs.edit).toBeNull()
+  })
+
+  it('does not close a newly opened Edit dialog when the previous save succeeds', async () => {
+    const first = session({ id: 'session-a', title: 'First' })
+    const second = session({ id: 'session-b', title: 'Second' })
+    const firstSave = deferred<PersistedChatSession>()
+    window.api = {
+      sessions: { editDetails: vi.fn().mockReturnValue(firstSave.promise) }
+    } as unknown as Window['api']
+    useSessionStore.setState({ sessions: [first, second], selectedSessionId: first.id })
+    const hook = renderController({ activeSession: first })
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.openEdit(first))
+    act(() => hook.result.current.actions.confirmEdit({ preventDefault: vi.fn() } as never))
+    act(() => hook.result.current.actions.openEdit(second))
+
+    await act(async () => {
+      firstSave.resolve({ ...first, revision: 2 })
+      await firstSave.promise
+    })
+
+    expect(hook.result.current.view.dialogs.edit).toMatchObject({
+      session: { id: second.id },
+      titleDraft: second.title,
+      isSaving: false
+    })
+  })
+
+  it('does not clear a new Edit save state when the previous save fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const first = session({ id: 'session-a', title: 'First' })
+    const second = session({ id: 'session-b', title: 'Second' })
+    const firstSave = deferred<PersistedChatSession>()
+    const secondSave = deferred<PersistedChatSession>()
+    window.api = {
+      sessions: {
+        editDetails: vi
+          .fn()
+          .mockReturnValueOnce(firstSave.promise)
+          .mockReturnValueOnce(secondSave.promise)
+      }
+    } as unknown as Window['api']
+    useSessionStore.setState({ sessions: [first, second], selectedSessionId: first.id })
+    const hook = renderController({ activeSession: first })
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.openEdit(first))
+    act(() => hook.result.current.actions.confirmEdit({ preventDefault: vi.fn() } as never))
+    act(() => hook.result.current.actions.openEdit(second))
+    act(() => hook.result.current.actions.confirmEdit({ preventDefault: vi.fn() } as never))
+
+    try {
+      await act(async () => {
+        firstSave.reject(new Error('first save failed'))
+        await firstSave.promise.catch(() => undefined)
+      })
+
+      expect(hook.result.current.view.dialogs.edit).toMatchObject({
+        session: { id: second.id },
+        isSaving: true
+      })
+    } finally {
+      await act(async () => {
+        secondSave.resolve({ ...second, revision: 2 })
+        await secondSave.promise
+        await Promise.resolve()
+      })
+      warn.mockRestore()
+    }
   })
 
   it('renames a Session title inline through the session-details mutation', async () => {
@@ -415,6 +520,28 @@ describe('workspace session controller', () => {
     })
 
     expect(useSessionStore.getState().sessions).toEqual([])
+    expect(hook.result.current.view.dialogs.exportConversation).toBeNull()
+  })
+
+  it('does not open conversation export after its lazy-load intent is closed', async () => {
+    const summary = session({ contentLoaded: false, activeMessageCount: 1 })
+    const load = deferred<PersistedChatSession | undefined>()
+    window.api = {
+      sessions: { loadOne: vi.fn().mockReturnValue(load.promise) }
+    } as unknown as Window['api']
+    useSessionStore.setState({ sessions: [summary], selectedSessionId: summary.id })
+    const hook = renderController({ activeSession: summary })
+    mounted.push(hook)
+
+    act(() => {
+      hook.result.current.actions.openExportConversation(summary)
+      hook.result.current.actions.closeExportConversation()
+    })
+    await act(async () => {
+      load.resolve({ ...summary, revision: 1, messages: [] })
+      await load.promise
+    })
+
     expect(hook.result.current.view.dialogs.exportConversation).toBeNull()
   })
 

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -185,6 +185,7 @@ const useWorkspaceSessionController = ({
   const [downloadArtifactsDialog, setDownloadArtifactsDialog] = useState<ChatSession | null>(null)
   const [notebookDialog, setNotebookDialog] = useState<ChatSession | null>(null)
   const [exportConversationDialog, setExportConversationDialog] = useState<ChatSession | null>(null)
+  const exportConversationIntentRef = useRef(0)
   const [jobListDialog, setJobListDialog] = useState({ open: false, sessionId: '' })
   const [deletingIds, setDeletingIds] = useState<ReadonlySet<string>>(new Set())
   const deletingIdsRef = useRef(new Set<string>())
@@ -645,21 +646,28 @@ const useWorkspaceSessionController = ({
       },
       archive,
       openExportConversation: (session: ChatSession) => {
+        const intent = ++exportConversationIntentRef.current
         setExportError(null)
         if (session.contentLoaded === false) {
           void loadPersistedSession({ projectId: session.projectId, sessionId: session.id })
             .then((persisted) => {
               if (!persisted) throw new Error('Selected Session JSON is missing.')
               const hydrated = hydratePersistedSessionIfPresent(persisted)
-              if (!hydrated) return
+              if (!hydrated || intent !== exportConversationIntentRef.current) return
               setExportConversationDialog(hydrated)
             })
-            .catch(() => setExportError(t('Could not load this session for export.')))
+            .catch(() => {
+              if (intent === exportConversationIntentRef.current)
+                setExportError(t('Could not load this session for export.'))
+            })
           return
         }
         setExportConversationDialog(session)
       },
-      closeExportConversation: () => setExportConversationDialog(null),
+      closeExportConversation: () => {
+        exportConversationIntentRef.current += 1
+        setExportConversationDialog(null)
+      },
       openDelete,
       closeDelete: () => setDeleteDialog((current) => (current?.isDeleting ? current : null)),
       confirmDelete,

--- a/src/renderer/src/pages/workspace/workspace-session-details-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-details-controller.ts
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useRef, useState, type FormEvent } from 'react'
 
 import type { EditSessionDetailsRequest } from '../../../../shared/session-persistence'
 import { useSessionStore, type ChatSession } from '@/stores/session-store'
@@ -29,7 +29,9 @@ const useWorkspaceSessionDetailsController = (
   onLoadFailure: () => void
 ): WorkspaceSessionDetailsController => {
   const [dialog, setDialog] = useState<SessionDetailsDialog | null>(null)
+  const dialogIntentRef = useRef(0)
   const open = (session: ChatSession): void => {
+    const intent = ++dialogIntentRef.current
     if (!isPersistenceReady) return
     const show = (authoritative: ChatSession): void =>
       setDialog({
@@ -46,16 +48,20 @@ const useWorkspaceSessionDetailsController = (
       .then((persisted) => {
         if (!persisted) throw new Error('Selected Session JSON is missing.')
         const hydrated = hydratePersistedSessionIfPresent(persisted)
-        if (hydrated) show(hydrated)
+        if (hydrated && intent === dialogIntentRef.current) show(hydrated)
       })
-      .catch(onLoadFailure)
+      .catch(() => {
+        if (intent === dialogIntentRef.current) onLoadFailure()
+      })
   }
   const confirm = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault()
     if (!isPersistenceReady || !dialog || dialog.isSaving || !dialog.titleDraft.trim()) return
+    const intent = dialogIntentRef.current
+    const sessionId = dialog.session.id
     const request: EditSessionDetailsRequest = {
       projectId: dialog.session.projectId,
-      sessionId: dialog.session.id,
+      sessionId,
       title: dialog.titleDraft,
       description: dialog.descriptionDraft
     }
@@ -64,11 +70,17 @@ const useWorkspaceSessionDetailsController = (
       .editDetails(request)
       .then((persisted) => {
         useSessionStore.getState().upsertPersistedSession(persisted)
-        setDialog(null)
+        setDialog((current) =>
+          intent === dialogIntentRef.current && current?.session.id === sessionId ? null : current
+        )
       })
       .catch((error: unknown) => {
         console.warn('editSessionDetails failed', error)
-        setDialog((current) => (current ? { ...current, isSaving: false } : current))
+        setDialog((current) =>
+          intent === dialogIntentRef.current && current?.session.id === sessionId
+            ? { ...current, isSaving: false }
+            : current
+        )
       })
   }
   // Title-only rename (sidebar hover card inline editor). Routes through the session-details
@@ -109,7 +121,11 @@ const useWorkspaceSessionDetailsController = (
   return {
     dialog,
     open,
-    close: () => setDialog((current) => (current?.isSaving ? current : null)),
+    close: () => {
+      if (dialog?.isSaving) return
+      dialogIntentRef.current += 1
+      setDialog(null)
+    },
     changeTitle: (titleDraft) =>
       setDialog((current) => (current ? { ...current, titleDraft } : current)),
     changeDescription: (descriptionDraft) =>

--- a/src/renderer/src/stores/compute-store.test.ts
+++ b/src/renderer/src/stores/compute-store.test.ts
@@ -34,6 +34,17 @@ const setComputeApi = (api: Partial<Window['api']['compute']>): void => {
   } as never
 }
 
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 beforeEach(() => {
   useComputeStore.setState(createInitialComputeState())
 })
@@ -123,6 +134,58 @@ describe('compute store', () => {
       'ssh:lab-gpu',
       'ssh:old'
     ])
+  })
+
+  it('does not let a stale host load erase a host created while it was in flight', async () => {
+    const staleLoad = deferred<ComputeHost[]>()
+    const created = createHost({ providerId: 'ssh:new', createdAt: 50 })
+    setComputeApi({
+      list: vi.fn().mockReturnValue(staleLoad.promise),
+      create: vi.fn().mockResolvedValue(created)
+    })
+
+    const load = useComputeStore.getState().loadHosts()
+    await useComputeStore.getState().createHost({ sshAlias: 'new' })
+    staleLoad.resolve([])
+    await load
+
+    expect(useComputeStore.getState().hosts).toEqual([created])
+  })
+
+  it('keeps an in-flight host load when an overlapping probe fails', async () => {
+    const hostLoad = deferred<ComputeHost[]>()
+    const loaded = createHost({ providerId: 'ssh:loaded' })
+    setComputeApi({
+      list: vi.fn().mockReturnValue(hostLoad.promise),
+      probe: vi.fn().mockRejectedValue(new Error('probe failed'))
+    })
+
+    const load = useComputeStore.getState().loadHosts()
+    await expect(useComputeStore.getState().probeHost('ssh:biowulf')).rejects.toThrow(
+      'probe failed'
+    )
+    hostLoad.resolve([loaded])
+    await load
+
+    expect(useComputeStore.getState().hosts).toEqual([loaded])
+  })
+
+  it('keeps an in-flight host load when an overlapping details save fails', async () => {
+    const hostLoad = deferred<ComputeHost[]>()
+    const loaded = createHost({ providerId: 'ssh:loaded' })
+    setComputeApi({
+      list: vi.fn().mockReturnValue(hostLoad.promise),
+      detailsSave: vi.fn().mockRejectedValue(new Error('old_text mismatch'))
+    })
+
+    const load = useComputeStore.getState().loadHosts()
+    await expect(
+      useComputeStore.getState().saveDetails('ssh:biowulf', 'new', 'stale')
+    ).rejects.toThrow('old_text mismatch')
+    hostLoad.resolve([loaded])
+    await load
+
+    expect(useComputeStore.getState().hosts).toEqual([loaded])
   })
 
   it('propagates a create rejection (e.g. duplicate alias)', async () => {
@@ -438,6 +501,94 @@ describe('compute store — details', () => {
     await expect(
       useComputeStore.getState().saveDetails('ssh:biowulf', 'new', 'wrong old')
     ).rejects.toThrow(/old_text|mismatch/i)
+  })
+
+  it('keeps the latest post-write host projection when an older re-fetch finishes last', async () => {
+    const olderGet = deferred<ComputeHost | null>()
+    const latestGet = deferred<ComputeHost | null>()
+    setComputeApi({
+      detailsSave: vi.fn().mockResolvedValue(undefined),
+      concurrencySet: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn().mockReturnValueOnce(olderGet.promise).mockReturnValueOnce(latestGet.promise)
+    })
+    useComputeStore.setState({ hosts: [createHost()] })
+
+    const olderWrite = useComputeStore.getState().saveDetails('ssh:biowulf', 'older', '')
+    await Promise.resolve()
+    const latestWrite = useComputeStore.getState().setConcurrency('ssh:biowulf', 20)
+    await Promise.resolve()
+
+    const latest = createHost({ detailsDoc: 'older', concurrencyLimit: 20, updatedAt: 3 })
+    latestGet.resolve(latest)
+    await latestWrite
+    olderGet.resolve(createHost({ detailsDoc: 'older', updatedAt: 2 }))
+    await olderWrite
+
+    expect(useComputeStore.getState().hosts).toEqual([latest])
+  })
+
+  it('keeps the later-started write when its mutation finishes before the older one', async () => {
+    const olderMutation = deferred<void>()
+    const latestMutation = deferred<void>()
+    const latestGet = deferred<ComputeHost | null>()
+    const olderGet = deferred<ComputeHost | null>()
+    setComputeApi({
+      detailsSave: vi.fn().mockReturnValue(olderMutation.promise),
+      concurrencySet: vi.fn().mockReturnValue(latestMutation.promise),
+      get: vi.fn().mockReturnValueOnce(latestGet.promise).mockReturnValueOnce(olderGet.promise)
+    })
+    useComputeStore.setState({ hosts: [createHost()] })
+
+    const olderWrite = useComputeStore.getState().saveDetails('ssh:biowulf', 'older', '')
+    const latestWrite = useComputeStore.getState().setConcurrency('ssh:biowulf', 20)
+
+    latestMutation.resolve(undefined)
+    await Promise.resolve()
+    const latest = createHost({ concurrencyLimit: 20, updatedAt: 3 })
+    latestGet.resolve(latest)
+    await latestWrite
+
+    olderMutation.resolve(undefined)
+    await Promise.resolve()
+    olderGet.resolve(createHost({ detailsDoc: 'older', updatedAt: 2 }))
+    await olderWrite
+
+    expect(useComputeStore.getState().hosts).toEqual([latest])
+  })
+})
+
+describe('compute store — probing', () => {
+  it('keeps probing state and the latest projection across overlapping probes', async () => {
+    const firstProbe = deferred<ProbeResult>()
+    const secondProbe = deferred<ProbeResult>()
+    const latestGet = deferred<ComputeHost | null>()
+    const olderGet = deferred<ComputeHost | null>()
+    setComputeApi({
+      probe: vi
+        .fn()
+        .mockReturnValueOnce(firstProbe.promise)
+        .mockReturnValueOnce(secondProbe.promise),
+      get: vi.fn().mockReturnValueOnce(latestGet.promise).mockReturnValueOnce(olderGet.promise)
+    })
+    useComputeStore.setState({ hosts: [createHost()] })
+
+    const first = useComputeStore.getState().probeHost('ssh:biowulf')
+    const second = useComputeStore.getState().probeHost('ssh:biowulf')
+    secondProbe.resolve({ ok: true, probedAt: 'second', exitCode: 0, errorTail: null })
+    await Promise.resolve()
+
+    const latest = createHost({ updatedAt: 3 })
+    latestGet.resolve(latest)
+    await second
+    expect(useComputeStore.getState().probingIds.has('ssh:biowulf')).toBe(true)
+
+    firstProbe.resolve({ ok: true, probedAt: 'first', exitCode: 0, errorTail: null })
+    await Promise.resolve()
+    olderGet.resolve(createHost({ updatedAt: 2 }))
+    await first
+
+    expect(useComputeStore.getState().hosts).toEqual([latest])
+    expect(useComputeStore.getState().probingIds.has('ssh:biowulf')).toBe(false)
   })
 })
 

--- a/src/renderer/src/stores/compute-store.test.ts
+++ b/src/renderer/src/stores/compute-store.test.ts
@@ -555,6 +555,26 @@ describe('compute store — details', () => {
 
     expect(useComputeStore.getState().hosts).toEqual([latest])
   })
+
+  it('projects an older committed write when a later-started mutation fails', async () => {
+    const olderMutation = deferred<void>()
+    const committed = createHost({ detailsDoc: 'committed', updatedAt: 2 })
+    setComputeApi({
+      detailsSave: vi.fn().mockReturnValue(olderMutation.promise),
+      concurrencySet: vi.fn().mockRejectedValue(new Error('newer mutation failed')),
+      get: vi.fn().mockResolvedValue(committed)
+    })
+    useComputeStore.setState({ hosts: [createHost()] })
+
+    const olderWrite = useComputeStore.getState().saveDetails('ssh:biowulf', 'committed', '')
+    await expect(useComputeStore.getState().setConcurrency('ssh:biowulf', 20)).rejects.toThrow(
+      'newer mutation failed'
+    )
+    olderMutation.resolve(undefined)
+    await olderWrite
+
+    expect(useComputeStore.getState().hosts).toEqual([committed])
+  })
 })
 
 describe('compute store — probing', () => {

--- a/src/renderer/src/stores/compute-store.ts
+++ b/src/renderer/src/stores/compute-store.ts
@@ -123,14 +123,17 @@ let hostProjectionGeneration = 0
 const hostProjectionGenerations = new Map<string, number>()
 const hostProbeRequestCounts = new Map<string, number>()
 
-const beginHostProjection = (providerId: string): number => {
-  const generation = ++hostProjectionGeneration
+const beginHostProjection = (): number => ++hostProjectionGeneration
+
+const commitHostProjection = (providerId: string, generation: number): boolean => {
+  if (generation < (hostProjectionGenerations.get(providerId) ?? 0)) return false
   hostProjectionGenerations.set(providerId, generation)
-  return generation
+  return true
 }
 
-const isCurrentHostProjection = (providerId: string, generation: number): boolean =>
-  hostProjectionGenerations.get(providerId) === generation
+const supersedeHostProjection = (providerId: string): void => {
+  hostProjectionGenerations.set(providerId, beginHostProjection())
+}
 
 export const createInitialComputeState = (): ComputeStoreData => ({
   hosts: [],
@@ -191,7 +194,7 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
     const host = await window.api.compute.create(request)
 
     hostMutationSequence += 1
-    beginHostProjection(host.providerId)
+    supersedeHostProjection(host.providerId)
     set((state) => ({
       hosts: sortByCreatedDesc([
         host,
@@ -210,7 +213,7 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
     }
     const host = result.host
     hostMutationSequence += 1
-    beginHostProjection(host.providerId)
+    supersedeHostProjection(host.providerId)
     set((state) => ({
       hosts: sortByCreatedDesc([
         host,
@@ -222,13 +225,14 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   },
 
   resetPassword: async (request) => {
-    const generation = beginHostProjection(request.providerId)
+    const generation = beginHostProjection()
     const result = await window.api.compute.resetPassword(request)
     if (!result.ok) {
       throw Object.assign(new Error(result.errorCode), { code: result.errorCode })
     }
     hostMutationSequence += 1
-    if (isCurrentHostProjection(result.host.providerId, generation)) {
+    const ownsProjection = commitHostProjection(result.host.providerId, generation)
+    if (ownsProjection) {
       set((state) => ({
         hosts: state.hosts.map((host) =>
           host.providerId === result.host.providerId ? result.host : host
@@ -239,7 +243,7 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
     // belongs to the previous credential revision). Re-probe so the Host's status refreshes on its
     // own instead of sitting at "Not probed". Fire-and-forget, like the Add form's post-create
     // probe: failures become probeResult.ok=false and surface in the detail UI.
-    if (isCurrentHostProjection(result.host.providerId, generation)) {
+    if (ownsProjection) {
       void get()
         .probeHost(result.host.providerId)
         .catch(() => undefined)
@@ -248,12 +252,13 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   },
 
   changeAuthentication: async (request) => {
-    const generation = beginHostProjection(request.providerId)
+    const generation = beginHostProjection()
     const result = await window.api.compute.changeAuthentication(request)
     if (!result.ok) throw Object.assign(new Error(result.errorCode), { code: result.errorCode })
     const host = result.host
     hostMutationSequence += 1
-    if (isCurrentHostProjection(host.providerId, generation)) {
+    const ownsProjection = commitHostProjection(host.providerId, generation)
+    if (ownsProjection) {
       set((state) => ({
         hosts: state.hosts.map((candidate) =>
           candidate.providerId === host.providerId ? host : candidate
@@ -264,7 +269,7 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
     // Same as resetPassword: the commit clears the persisted probe snapshot, so re-probe in the
     // background. Without this, a successful "Test and save" leaves the Host looking disconnected
     // ("Not probed") even though the candidate connection was just verified.
-    if (isCurrentHostProjection(host.providerId, generation)) {
+    if (ownsProjection) {
       void get()
         .probeHost(host.providerId)
         .catch(() => undefined)
@@ -274,7 +279,7 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
 
   // Removes a host by provider id and drops it from the cache.
   deleteHost: async (providerId) => {
-    const generation = beginHostProjection(providerId)
+    const generation = beginHostProjection()
     const request: DeleteComputeHostRequest = { providerId }
     try {
       await window.api.compute.delete(request)
@@ -289,7 +294,7 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
     }
 
     hostMutationSequence += 1
-    if (isCurrentHostProjection(providerId, generation)) {
+    if (commitHostProjection(providerId, generation)) {
       set((state) => ({ hosts: state.hosts.filter((host) => host.providerId !== providerId) }))
     }
   },
@@ -298,7 +303,7 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   // the returned probeResult back into the cached host. Propagates errors so the UI can show the
   // failed banner; probeResult itself already carries the structured failure.
   probeHost: async (providerId) => {
-    const generation = beginHostProjection(providerId)
+    const generation = beginHostProjection()
     hostProbeRequestCounts.set(providerId, (hostProbeRequestCounts.get(providerId) ?? 0) + 1)
     set((state) => ({
       probingIds: new Set([...state.probingIds, providerId])
@@ -309,7 +314,7 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
       // Merge the returned probeResult into the cached host. Re-fetch the full host to pick up
       // shape / scratchRoot changes the probe may have written.
       const updatedHost = await window.api.compute.get(providerId)
-      if (isCurrentHostProjection(providerId, generation)) {
+      if (commitHostProjection(providerId, generation)) {
         set((state) => ({
           hosts: state.hosts.map((h) =>
             h.providerId === providerId ? (updatedHost ?? { ...h, probeResult }) : h
@@ -332,12 +337,12 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   // Saves the details document via full replace (old_text guard prevents concurrent collisions).
   // The UI always writes with author='user'; issue 06 agent paths will call the same IPC directly.
   saveDetails: async (providerId, text, oldText) => {
-    const generation = beginHostProjection(providerId)
+    const generation = beginHostProjection()
     await window.api.compute.detailsSave(providerId, text, oldText, 'user')
     hostMutationSequence += 1
     // Re-fetch so detailsUpdatedAt/detailsUpdatedBy are reflected in the cache.
     const updatedHost = await window.api.compute.get(providerId)
-    if (updatedHost && isCurrentHostProjection(providerId, generation)) {
+    if (commitHostProjection(providerId, generation) && updatedHost) {
       set((state) => ({
         hosts: state.hosts.map((h) => (h.providerId === providerId ? updatedHost : h))
       }))
@@ -346,11 +351,11 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
 
   // Sets the scratch root path and marks the host as pinned. Merges the updated host into cache.
   setScratch: async (providerId, path) => {
-    const generation = beginHostProjection(providerId)
+    const generation = beginHostProjection()
     await window.api.compute.scratchSet(providerId, path)
     hostMutationSequence += 1
     const updatedHost = await window.api.compute.get(providerId)
-    if (updatedHost && isCurrentHostProjection(providerId, generation)) {
+    if (commitHostProjection(providerId, generation) && updatedHost) {
       set((state) => ({
         hosts: state.hosts.map((h) => (h.providerId === providerId ? updatedHost : h))
       }))
@@ -358,11 +363,11 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   },
 
   clearScratch: async (providerId) => {
-    const generation = beginHostProjection(providerId)
+    const generation = beginHostProjection()
     await window.api.compute.scratchClear(providerId)
     hostMutationSequence += 1
     const updatedHost = await window.api.compute.get(providerId)
-    if (updatedHost && isCurrentHostProjection(providerId, generation)) {
+    if (commitHostProjection(providerId, generation) && updatedHost) {
       set((state) => ({
         hosts: state.hosts.map((h) => (h.providerId === providerId ? updatedHost : h))
       }))
@@ -371,11 +376,11 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
 
   // Updates the concurrent job limit. Merges the updated host into cache.
   setConcurrency: async (providerId, limit) => {
-    const generation = beginHostProjection(providerId)
+    const generation = beginHostProjection()
     await window.api.compute.concurrencySet(providerId, limit)
     hostMutationSequence += 1
     const updatedHost = await window.api.compute.get(providerId)
-    if (updatedHost && isCurrentHostProjection(providerId, generation)) {
+    if (commitHostProjection(providerId, generation) && updatedHost) {
       set((state) => ({
         hosts: state.hosts.map((h) => (h.providerId === providerId ? updatedHost : h))
       }))

--- a/src/renderer/src/stores/compute-store.ts
+++ b/src/renderer/src/stores/compute-store.ts
@@ -118,6 +118,19 @@ const sortByCreatedDesc = (hosts: ComputeHost[]): ComputeHost[] =>
 
 let loadHostsRequest: Promise<void> | undefined
 let computePanelPreloadReady = false
+let hostMutationSequence = 0
+let hostProjectionGeneration = 0
+const hostProjectionGenerations = new Map<string, number>()
+const hostProbeRequestCounts = new Map<string, number>()
+
+const beginHostProjection = (providerId: string): number => {
+  const generation = ++hostProjectionGeneration
+  hostProjectionGenerations.set(providerId, generation)
+  return generation
+}
+
+const isCurrentHostProjection = (providerId: string, generation: number): boolean =>
+  hostProjectionGenerations.get(providerId) === generation
 
 export const createInitialComputeState = (): ComputeStoreData => ({
   hosts: [],
@@ -136,11 +149,20 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   // error instead of a silent empty list.
   loadHosts: () => {
     if (loadHostsRequest) return loadHostsRequest
+    const mutationSequence = hostMutationSequence
     const request = window.api.compute.list().then(
       (hosts) => {
+        if (mutationSequence !== hostMutationSequence) {
+          set({ isLoaded: true })
+          return
+        }
         set({ hosts: sortByCreatedDesc(hosts), isLoaded: true, loadError: undefined })
       },
       (error: unknown) => {
+        if (mutationSequence !== hostMutationSequence) {
+          set({ isLoaded: true })
+          return
+        }
         set({ isLoaded: true, loadError: describeError(error) })
       }
     )
@@ -168,6 +190,8 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   createHost: async (request) => {
     const host = await window.api.compute.create(request)
 
+    hostMutationSequence += 1
+    beginHostProjection(host.providerId)
     set((state) => ({
       hosts: sortByCreatedDesc([
         host,
@@ -185,6 +209,8 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
       throw Object.assign(new Error(result.errorCode), { code: result.errorCode })
     }
     const host = result.host
+    hostMutationSequence += 1
+    beginHostProjection(host.providerId)
     set((state) => ({
       hosts: sortByCreatedDesc([
         host,
@@ -196,46 +222,59 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   },
 
   resetPassword: async (request) => {
+    const generation = beginHostProjection(request.providerId)
     const result = await window.api.compute.resetPassword(request)
     if (!result.ok) {
       throw Object.assign(new Error(result.errorCode), { code: result.errorCode })
     }
-    set((state) => ({
-      hosts: state.hosts.map((host) =>
-        host.providerId === result.host.providerId ? result.host : host
-      )
-    }))
+    hostMutationSequence += 1
+    if (isCurrentHostProjection(result.host.providerId, generation)) {
+      set((state) => ({
+        hosts: state.hosts.map((host) =>
+          host.providerId === result.host.providerId ? result.host : host
+        )
+      }))
+    }
     // The committed reset clears the persisted probe snapshot (main nulls it because the result
     // belongs to the previous credential revision). Re-probe so the Host's status refreshes on its
     // own instead of sitting at "Not probed". Fire-and-forget, like the Add form's post-create
     // probe: failures become probeResult.ok=false and surface in the detail UI.
-    void get()
-      .probeHost(result.host.providerId)
-      .catch(() => undefined)
+    if (isCurrentHostProjection(result.host.providerId, generation)) {
+      void get()
+        .probeHost(result.host.providerId)
+        .catch(() => undefined)
+    }
     return result.host
   },
 
   changeAuthentication: async (request) => {
+    const generation = beginHostProjection(request.providerId)
     const result = await window.api.compute.changeAuthentication(request)
     if (!result.ok) throw Object.assign(new Error(result.errorCode), { code: result.errorCode })
     const host = result.host
-    set((state) => ({
-      hosts: state.hosts.map((candidate) =>
-        candidate.providerId === host.providerId ? host : candidate
-      ),
-      loadError: undefined
-    }))
+    hostMutationSequence += 1
+    if (isCurrentHostProjection(host.providerId, generation)) {
+      set((state) => ({
+        hosts: state.hosts.map((candidate) =>
+          candidate.providerId === host.providerId ? host : candidate
+        ),
+        loadError: undefined
+      }))
+    }
     // Same as resetPassword: the commit clears the persisted probe snapshot, so re-probe in the
     // background. Without this, a successful "Test and save" leaves the Host looking disconnected
     // ("Not probed") even though the candidate connection was just verified.
-    void get()
-      .probeHost(host.providerId)
-      .catch(() => undefined)
+    if (isCurrentHostProjection(host.providerId, generation)) {
+      void get()
+        .probeHost(host.providerId)
+        .catch(() => undefined)
+    }
     return host
   },
 
   // Removes a host by provider id and drops it from the cache.
   deleteHost: async (providerId) => {
+    const generation = beginHostProjection(providerId)
     const request: DeleteComputeHostRequest = { providerId }
     try {
       await window.api.compute.delete(request)
@@ -249,31 +288,42 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
       if (host) throw error
     }
 
-    set((state) => ({ hosts: state.hosts.filter((host) => host.providerId !== providerId) }))
+    hostMutationSequence += 1
+    if (isCurrentHostProjection(providerId, generation)) {
+      set((state) => ({ hosts: state.hosts.filter((host) => host.providerId !== providerId) }))
+    }
   },
 
   // Triggers a probe for the given host. Marks the host as probing during the call, then merges
   // the returned probeResult back into the cached host. Propagates errors so the UI can show the
   // failed banner; probeResult itself already carries the structured failure.
   probeHost: async (providerId) => {
+    const generation = beginHostProjection(providerId)
+    hostProbeRequestCounts.set(providerId, (hostProbeRequestCounts.get(providerId) ?? 0) + 1)
     set((state) => ({
       probingIds: new Set([...state.probingIds, providerId])
     }))
     try {
       const probeResult = await window.api.compute.probe(providerId)
+      hostMutationSequence += 1
       // Merge the returned probeResult into the cached host. Re-fetch the full host to pick up
       // shape / scratchRoot changes the probe may have written.
       const updatedHost = await window.api.compute.get(providerId)
-      set((state) => ({
-        hosts: state.hosts.map((h) =>
-          h.providerId === providerId ? (updatedHost ?? { ...h, probeResult }) : h
-        )
-      }))
+      if (isCurrentHostProjection(providerId, generation)) {
+        set((state) => ({
+          hosts: state.hosts.map((h) =>
+            h.providerId === providerId ? (updatedHost ?? { ...h, probeResult }) : h
+          )
+        }))
+      }
       return probeResult
     } finally {
+      const remaining = (hostProbeRequestCounts.get(providerId) ?? 1) - 1
+      if (remaining > 0) hostProbeRequestCounts.set(providerId, remaining)
+      else hostProbeRequestCounts.delete(providerId)
       set((state) => {
         const next = new Set(state.probingIds)
-        next.delete(providerId)
+        if (remaining === 0) next.delete(providerId)
         return { probingIds: next }
       })
     }
@@ -282,10 +332,12 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   // Saves the details document via full replace (old_text guard prevents concurrent collisions).
   // The UI always writes with author='user'; issue 06 agent paths will call the same IPC directly.
   saveDetails: async (providerId, text, oldText) => {
+    const generation = beginHostProjection(providerId)
     await window.api.compute.detailsSave(providerId, text, oldText, 'user')
+    hostMutationSequence += 1
     // Re-fetch so detailsUpdatedAt/detailsUpdatedBy are reflected in the cache.
     const updatedHost = await window.api.compute.get(providerId)
-    if (updatedHost) {
+    if (updatedHost && isCurrentHostProjection(providerId, generation)) {
       set((state) => ({
         hosts: state.hosts.map((h) => (h.providerId === providerId ? updatedHost : h))
       }))
@@ -294,9 +346,11 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
 
   // Sets the scratch root path and marks the host as pinned. Merges the updated host into cache.
   setScratch: async (providerId, path) => {
+    const generation = beginHostProjection(providerId)
     await window.api.compute.scratchSet(providerId, path)
+    hostMutationSequence += 1
     const updatedHost = await window.api.compute.get(providerId)
-    if (updatedHost) {
+    if (updatedHost && isCurrentHostProjection(providerId, generation)) {
       set((state) => ({
         hosts: state.hosts.map((h) => (h.providerId === providerId ? updatedHost : h))
       }))
@@ -304,9 +358,11 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
   },
 
   clearScratch: async (providerId) => {
+    const generation = beginHostProjection(providerId)
     await window.api.compute.scratchClear(providerId)
+    hostMutationSequence += 1
     const updatedHost = await window.api.compute.get(providerId)
-    if (updatedHost) {
+    if (updatedHost && isCurrentHostProjection(providerId, generation)) {
       set((state) => ({
         hosts: state.hosts.map((h) => (h.providerId === providerId ? updatedHost : h))
       }))
@@ -315,9 +371,11 @@ export const useComputeStore = create<ComputeStore>((set, get) => ({
 
   // Updates the concurrent job limit. Merges the updated host into cache.
   setConcurrency: async (providerId, limit) => {
+    const generation = beginHostProjection(providerId)
     await window.api.compute.concurrencySet(providerId, limit)
+    hostMutationSequence += 1
     const updatedHost = await window.api.compute.get(providerId)
-    if (updatedHost) {
+    if (updatedHost && isCurrentHostProjection(providerId, generation)) {
       set((state) => ({
         hosts: state.hosts.map((h) => (h.providerId === providerId ? updatedHost : h))
       }))

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -107,6 +107,49 @@ describe('project store', () => {
     expect(useProjectStore.getState().projects[0]).toEqual(created)
   })
 
+  it('does not let a late update result replace a newer lifecycle projection', async () => {
+    const original = createProject({ name: 'Original', updatedAt: 1 })
+    const command = createDeferred<Project>()
+    setProjectsApi({ update: vi.fn().mockReturnValue(command.promise) })
+    useProjectStore.setState({ projects: [original], isLoaded: true })
+
+    const update = useProjectStore
+      .getState()
+      .updateProject({ id: original.id, expectedUpdatedAt: 1, name: 'Command' })
+    const lifecycle = createProject({ name: 'Lifecycle', updatedAt: 3 })
+    useProjectStore.getState().upsertProject(lifecycle)
+    command.resolve(createProject({ name: 'Command', updatedAt: 2 }))
+
+    await update
+
+    expect(useProjectStore.getState().projects).toEqual([lifecycle])
+  })
+
+  it('lets the later-started update win when both commands begin from the same projection', async () => {
+    const original = createProject({ name: 'Original', updatedAt: 1 })
+    const first = createDeferred<Project>()
+    const second = createDeferred<Project>()
+    setProjectsApi({
+      update: vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    })
+    useProjectStore.setState({ projects: [original], isLoaded: true })
+
+    const firstUpdate = useProjectStore
+      .getState()
+      .updateProject({ id: original.id, expectedUpdatedAt: 1, name: 'First' })
+    const secondUpdate = useProjectStore
+      .getState()
+      .updateProject({ id: original.id, expectedUpdatedAt: 1, name: 'Second' })
+    first.resolve(createProject({ name: 'First', updatedAt: 2 }))
+    await firstUpdate
+    second.resolve(createProject({ name: 'Second', updatedAt: 3 }))
+    await secondUpdate
+
+    expect(useProjectStore.getState().projects).toEqual([
+      createProject({ name: 'Second', updatedAt: 3 })
+    ])
+  })
+
   it('returns cleanup-pending while dropping a committed Project deletion from the cache', async () => {
     useProjectStore.setState({
       projects: [createProject({ id: 'keep' }), createProject({ id: 'drop' })],

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -150,6 +150,32 @@ describe('project store', () => {
     ])
   })
 
+  it('projects an older committed update when a later-started update fails', async () => {
+    const original = createProject({ name: 'Original', updatedAt: 1 })
+    const first = createDeferred<Project>()
+    setProjectsApi({
+      update: vi
+        .fn()
+        .mockReturnValueOnce(first.promise)
+        .mockRejectedValueOnce(new Error('newer update failed'))
+    })
+    useProjectStore.setState({ projects: [original], isLoaded: true })
+
+    const firstUpdate = useProjectStore
+      .getState()
+      .updateProject({ id: original.id, expectedUpdatedAt: 1, name: 'Committed' })
+    await expect(
+      useProjectStore
+        .getState()
+        .updateProject({ id: original.id, expectedUpdatedAt: 1, name: 'Failed' })
+    ).rejects.toThrow('newer update failed')
+    const committed = createProject({ name: 'Committed', updatedAt: 2 })
+    first.resolve(committed)
+    await firstUpdate
+
+    expect(useProjectStore.getState().projects).toEqual([committed])
+  })
+
   it('returns cleanup-pending while dropping a committed Project deletion from the cache', async () => {
     useProjectStore.setState({
       projects: [createProject({ id: 'keep' }), createProject({ id: 'drop' })],

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -50,6 +50,16 @@ const upsertProjectList = (projects: Project[], project: Project): Project[] => 
 let projectLoadSequence = 0
 let projectMutationSequence = 0
 let projectDeletionRequestGeneration = 0
+const projectProjectionGenerations = new Map<string, number>()
+
+const beginProjectProjection = (id: string): number => {
+  const generation = (projectProjectionGenerations.get(id) ?? 0) + 1
+  projectProjectionGenerations.set(id, generation)
+  return generation
+}
+
+const isCurrentProjectProjection = (id: string, generation: number): boolean =>
+  projectProjectionGenerations.get(id) === generation
 
 export const createInitialProjectState = (): ProjectStoreData => ({
   projects: [],
@@ -95,31 +105,46 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     const project = await window.api.projects.create(request)
 
     projectMutationSequence += 1
-    set((state) => ({ projects: upsertProjectList(state.projects, project), loadError: undefined }))
+    if (get().projects.some((current) => current.id === project.id)) {
+      set({ loadError: undefined })
+    } else {
+      beginProjectProjection(project.id)
+      set((state) => ({
+        projects: upsertProjectList(state.projects, project),
+        loadError: undefined
+      }))
+    }
 
     return project
   },
 
   // Applies an editable Project patch and merges the updated row into the cache.
   updateProject: async (request) => {
+    const generation = beginProjectProjection(request.id)
     const project = await window.api.projects.update(request)
 
     projectMutationSequence += 1
-    set((state) => ({ projects: upsertProjectList(state.projects, project) }))
+    if (isCurrentProjectProjection(project.id, generation)) {
+      set((state) => ({ projects: upsertProjectList(state.projects, project) }))
+    }
 
     return project
   },
 
   updateProjectArchive: async (request) => {
+    const generation = beginProjectProjection(request.id)
     const project = await window.api.projects.updateArchive(request)
 
     projectMutationSequence += 1
-    set((state) => ({ projects: upsertProjectList(state.projects, project) }))
+    if (isCurrentProjectProjection(project.id, generation)) {
+      set((state) => ({ projects: upsertProjectList(state.projects, project) }))
+    }
     return project
   },
 
   // Drops committed Project deletion from the cache. Session cascade is handled by the session store.
   deleteProject: async (id) => {
+    const projectionGeneration = beginProjectProjection(id)
     const generation = ++projectDeletionRequestGeneration
     set((state) => {
       const projectDeletionRequests = new Map(state.projectDeletionRequests)
@@ -150,7 +175,11 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
       // Lifecycle events are the authoritative cross-window ordering stream. If one arrived while
       // this command was in flight, its newer pending/terminal projection must win over the RPC result.
-      if (!isCurrentRequest || request.lifecycleStatus !== undefined) {
+      if (
+        !isCurrentRequest ||
+        request.lifecycleStatus !== undefined ||
+        !isCurrentProjectProjection(id, projectionGeneration)
+      ) {
         return { projectDeletionRequests }
       }
 
@@ -168,11 +197,13 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   },
 
   upsertProject: (project) => {
+    beginProjectProjection(project.id)
     projectMutationSequence += 1
     set((state) => ({ projects: upsertProjectList(state.projects, project) }))
   },
 
   removeProject: (id, outcome = { status: 'deleted' }) => {
+    beginProjectProjection(id)
     projectMutationSequence += 1
     set((state) => {
       const pendingDeletionCleanupProjectIds = new Set(state.pendingDeletionCleanupProjectIds)

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -49,17 +49,20 @@ const upsertProjectList = (projects: Project[], project: Project): Project[] => 
 
 let projectLoadSequence = 0
 let projectMutationSequence = 0
-let projectDeletionRequestGeneration = 0
+let projectOperationGeneration = 0
 const projectProjectionGenerations = new Map<string, number>()
 
-const beginProjectProjection = (id: string): number => {
-  const generation = (projectProjectionGenerations.get(id) ?? 0) + 1
+const beginProjectProjection = (): number => ++projectOperationGeneration
+
+const commitProjectProjection = (id: string, generation: number): boolean => {
+  if (generation < (projectProjectionGenerations.get(id) ?? 0)) return false
   projectProjectionGenerations.set(id, generation)
-  return generation
+  return true
 }
 
-const isCurrentProjectProjection = (id: string, generation: number): boolean =>
-  projectProjectionGenerations.get(id) === generation
+const supersedeProjectProjection = (id: string): void => {
+  projectProjectionGenerations.set(id, beginProjectProjection())
+}
 
 export const createInitialProjectState = (): ProjectStoreData => ({
   projects: [],
@@ -108,7 +111,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     if (get().projects.some((current) => current.id === project.id)) {
       set({ loadError: undefined })
     } else {
-      beginProjectProjection(project.id)
+      supersedeProjectProjection(project.id)
       set((state) => ({
         projects: upsertProjectList(state.projects, project),
         loadError: undefined
@@ -120,11 +123,11 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
   // Applies an editable Project patch and merges the updated row into the cache.
   updateProject: async (request) => {
-    const generation = beginProjectProjection(request.id)
+    const generation = beginProjectProjection()
     const project = await window.api.projects.update(request)
 
     projectMutationSequence += 1
-    if (isCurrentProjectProjection(project.id, generation)) {
+    if (commitProjectProjection(project.id, generation)) {
       set((state) => ({ projects: upsertProjectList(state.projects, project) }))
     }
 
@@ -132,11 +135,11 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   },
 
   updateProjectArchive: async (request) => {
-    const generation = beginProjectProjection(request.id)
+    const generation = beginProjectProjection()
     const project = await window.api.projects.updateArchive(request)
 
     projectMutationSequence += 1
-    if (isCurrentProjectProjection(project.id, generation)) {
+    if (commitProjectProjection(project.id, generation)) {
       set((state) => ({ projects: upsertProjectList(state.projects, project) }))
     }
     return project
@@ -144,8 +147,8 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
   // Drops committed Project deletion from the cache. Session cascade is handled by the session store.
   deleteProject: async (id) => {
-    const projectionGeneration = beginProjectProjection(id)
-    const generation = ++projectDeletionRequestGeneration
+    const projectionGeneration = beginProjectProjection()
+    const generation = ++projectOperationGeneration
     set((state) => {
       const projectDeletionRequests = new Map(state.projectDeletionRequests)
       projectDeletionRequests.set(id, { generation })
@@ -167,6 +170,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     }
 
     projectMutationSequence += 1
+    const ownsProjection = commitProjectProjection(id, projectionGeneration)
     set((state) => {
       const projectDeletionRequests = new Map(state.projectDeletionRequests)
       const request = projectDeletionRequests.get(id)
@@ -175,11 +179,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
       // Lifecycle events are the authoritative cross-window ordering stream. If one arrived while
       // this command was in flight, its newer pending/terminal projection must win over the RPC result.
-      if (
-        !isCurrentRequest ||
-        request.lifecycleStatus !== undefined ||
-        !isCurrentProjectProjection(id, projectionGeneration)
-      ) {
+      if (!isCurrentRequest || request.lifecycleStatus !== undefined || !ownsProjection) {
         return { projectDeletionRequests }
       }
 
@@ -197,13 +197,13 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   },
 
   upsertProject: (project) => {
-    beginProjectProjection(project.id)
+    supersedeProjectProjection(project.id)
     projectMutationSequence += 1
     set((state) => ({ projects: upsertProjectList(state.projects, project) }))
   },
 
   removeProject: (id, outcome = { status: 'deleted' }) => {
-    beginProjectProjection(id)
+    supersedeProjectProjection(id)
     projectMutationSequence += 1
     set((state) => {
       const pendingDeletionCleanupProjectIds = new Set(state.pendingDeletionCleanupProjectIds)

--- a/src/renderer/src/stores/settings-preferences-slice.test.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.test.ts
@@ -135,16 +135,27 @@ const createCommands = (persisted: Partial<SettingsSnapshot>): CommandMocks => {
     setAppIconVariant: vi.fn(({ variant }) => save('appIconVariant', variant)),
     setProjectFilesFilter: vi.fn(({ filter }) => save('projectFilesFilter', filter)),
     setDefaultPermissionProfile: vi.fn(({ profile }) => save('defaultPermissionProfile', profile)),
-    markOnboardingComplete: vi.fn().mockResolvedValue(snapshot({ onboardingCompletedAt: 42 })),
-    setPackageMirror: vi.fn((mirror) => Promise.resolve(mirror)),
-    setNetworkProxy: vi.fn((settings) => Promise.resolve(settings)),
-    setNotebookNetwork: vi.fn((settings) =>
-      Promise.resolve({
+    markOnboardingComplete: vi.fn(() => {
+      persisted.onboardingCompletedAt = 42
+      return Promise.resolve(snapshot(persisted))
+    }),
+    setPackageMirror: vi.fn((mirror) => {
+      persisted.packageMirror = mirror
+      return Promise.resolve(mirror)
+    }),
+    setNetworkProxy: vi.fn((settings) => {
+      persisted.networkProxy = settings
+      return Promise.resolve(settings)
+    }),
+    setNotebookNetwork: vi.fn((settings) => {
+      const saved = {
         allowedDomains: settings.allowedDomains,
         disabledOpenScienceDomainGroups: settings.disabledOpenScienceDomainGroups,
         disabledOpenScienceDomains: settings.disabledOpenScienceDomains
-      })
-    )
+      }
+      persisted.notebookNetwork = saved
+      return Promise.resolve(saved)
+    })
   }
 }
 
@@ -289,6 +300,7 @@ describe('settings preferences slice', () => {
     })
 
     commands.setPackageMirror.mockResolvedValueOnce({})
+    commands.getSettings.mockResolvedValueOnce(snapshot({ onboardingCompletedAt: 42 }))
     await store.getState().setPackageMirror({})
     expect(store.getState().packageMirror).toBeUndefined()
   })

--- a/src/renderer/src/stores/settings-preferences-slice.test.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.test.ts
@@ -417,6 +417,8 @@ describe('settings preferences slice', () => {
     await store.getState().setNetworkProxy(proxy)
 
     expect(commands.setNetworkProxy).toHaveBeenCalledWith(proxy)
+    expect(commands.getSettings).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).toHaveBeenCalledOnce()
     expect(store.getState().networkProxy).toEqual(proxy)
 
     commands.setNetworkProxy = undefined as unknown as Mock
@@ -440,6 +442,8 @@ describe('settings preferences slice', () => {
       ...notebookNetwork,
       baseAllowedDomains: ['baseline.example.org']
     })
+    expect(commands.getSettings).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).toHaveBeenCalledOnce()
     expect(store.getState().notebookNetwork).toEqual(notebookNetwork)
 
     commands.setNotebookNetwork = undefined as unknown as Mock

--- a/src/renderer/src/stores/settings-preferences-slice.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.ts
@@ -107,7 +107,8 @@ type SettingsPreferencesSliceOptions = {
   getState: () => SettingsPreferencesState
   setState: (patch: Partial<SettingsPreferencesState>) => void
   getCommands: () => SettingsPreferencesCommands
-  reconcileSnapshot: (snapshot: SettingsSnapshot) => void
+  // False means a newer cross-transport snapshot is already authoritative.
+  reconcileSnapshot: (snapshot: SettingsSnapshot) => boolean | void
   writeCoordinator: SettingsWriteCoordinator
 }
 
@@ -125,11 +126,15 @@ const OPTIMISTIC_PREFERENCE_WRITES = [
 
 export const omitInFlightOptimisticPreferences = <Patch extends Partial<SettingsPreferencesState>>(
   patch: Patch,
-  hasPending: (key: OptimisticSettingsWriteKey) => boolean
+  hasPending: (key: OptimisticSettingsWriteKey) => boolean,
+  acceptCommitted: (key: OptimisticSettingsWriteKey, value: unknown) => void
 ): Patch => {
   const next = { ...patch }
   for (const [field, key] of OPTIMISTIC_PREFERENCE_WRITES) {
-    if (hasPending(key)) delete next[field]
+    if (hasPending(key)) {
+      acceptCommitted(key, next[field])
+      delete next[field]
+    }
   }
   return next
 }
@@ -168,9 +173,17 @@ export const createSettingsPreferencesSlice = ({
 
     try {
       const snapshot = await write.run(command)
-      write.complete({ value: snapshot[field] as unknown as SettingsPreferencesState[Field] })
-      if (!write.isCurrent()) return
-      reconcileSnapshot(snapshot)
+      const isCurrent = write.isCurrent()
+      const accepted = reconcileSnapshot(snapshot) !== false
+      const confirmedValue = write.complete(
+        accepted
+          ? { value: snapshot[field] as unknown as SettingsPreferencesState[Field] }
+          : undefined
+      )
+      if (!isCurrent) return
+      if (!accepted) {
+        setState({ [field]: confirmedValue } as Partial<SettingsPreferencesState>)
+      }
       write.succeed()
     } catch (error) {
       const confirmedValue = write.complete()
@@ -350,14 +363,18 @@ export const createSettingsPreferencesSlice = ({
 
     setPackageMirror: async (mirror) => {
       const saved = await getCommands().setPackageMirror(mirror)
-      setState({ packageMirror: isMirrorConfigured(saved) ? saved : undefined })
+      const refresh = getCommands().getSettings
+      if (refresh) reconcileSnapshot(await refresh())
+      else setState({ packageMirror: isMirrorConfigured(saved) ? saved : undefined })
     },
 
     setNetworkProxy: async (networkProxy) => {
       const setNetworkProxy = getCommands().setNetworkProxy
       if (!setNetworkProxy) throw new Error('Network proxy settings are unavailable.')
       const saved = await setNetworkProxy(networkProxy)
-      setState({ networkProxy: saved })
+      const refresh = getCommands().getSettings
+      if (refresh) reconcileSnapshot(await refresh())
+      else setState({ networkProxy: saved })
     },
 
     setNotebookNetwork: async (notebookNetwork, baseAllowedDomains) => {
@@ -368,7 +385,9 @@ export const createSettingsPreferencesSlice = ({
         ...(baseAllowedDomains === undefined ? {} : { baseAllowedDomains })
       }
       const saved = await command(request)
-      setState({ notebookNetwork: saved })
+      const refresh = getCommands().getSettings
+      if (refresh) reconcileSnapshot(await refresh())
+      else setState({ notebookNetwork: saved })
       return saved
     }
   }

--- a/src/renderer/src/stores/settings-runtime-slice.test.ts
+++ b/src/renderer/src/stores/settings-runtime-slice.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 import type {
   AgentFrameworkId,
-  ClaudeDetectResult,
   ClaudeInfo,
   ClaudeInstallEvent,
   ClaudeInstallResult,
@@ -54,7 +53,7 @@ type EnvironmentReconcilePatch = Partial<
   Pick<RuntimeSetupSlice, 'environmentCheck' | 'preflight' | 'npmAvailable'>
 >
 
-const snapshot = (): SettingsSnapshot => ({
+const snapshot = (patch: Partial<SettingsSnapshot> = {}): SettingsSnapshot => ({
   claude: {},
   activeProviderId: undefined,
   providers: [],
@@ -70,7 +69,8 @@ const snapshot = (): SettingsSnapshot => ({
   reasoningEffort: 'default',
   notificationsEnabled: true,
   conversationSkillImportEnabled: true,
-  appIconVariant: 'light'
+  appIconVariant: 'light',
+  ...patch
 })
 
 const preflight = (): Preflight => ({
@@ -136,22 +136,18 @@ const createHarness = (): {
   reconcileSnapshot: Mock<
     (snapshot: SettingsSnapshot, runtimePatch?: EnvironmentReconcilePatch) => void
   >
-  reconcileClaudeDetection: Mock<(result: ClaudeDetectResult, npmAvailable: boolean) => void>
   store: StoreApi<TestStore>
 } => {
   const commands = createCommands()
   const reconcileSnapshot = vi.fn(
     (nextSnapshot: SettingsSnapshot, runtimePatch: EnvironmentReconcilePatch = {}) => {
-      store.setState({ agentFrameworkId: nextSnapshot.agentFrameworkId, ...runtimePatch })
+      store.setState({
+        agentFrameworkId: nextSnapshot.agentFrameworkId,
+        claude: nextSnapshot.claude,
+        ...runtimePatch
+      })
     }
   )
-  const reconcileClaudeDetection = vi.fn((result: ClaudeDetectResult, npmAvailable: boolean) => {
-    store.setState(
-      result.found && result.path
-        ? { npmAvailable, claude: { resolvedPath: result.path, version: result.version } }
-        : { npmAvailable }
-    )
-  })
 
   const store = createStore<TestStore>((set, get) => ({
     agentFrameworkId: 'claude-code',
@@ -160,12 +156,11 @@ const createHarness = (): {
       set,
       get,
       getCommands: () => commands as RuntimeCommands,
-      reconcileSnapshot,
-      reconcileClaudeDetection
+      reconcileSnapshot
     })
   }))
 
-  return { commands, reconcileSnapshot, reconcileClaudeDetection, store }
+  return { commands, reconcileSnapshot, store }
 }
 
 describe('runtime setup slice: install lifecycle', () => {
@@ -418,14 +413,12 @@ describe('runtime setup slice: install lifecycle', () => {
 describe('runtime setup slice: discovery lifecycle', () => {
   let commands: RuntimeCommandMocks
   let reconcileSnapshot: ReturnType<typeof createHarness>['reconcileSnapshot']
-  let reconcileClaudeDetection: ReturnType<typeof createHarness>['reconcileClaudeDetection']
   let store: StoreApi<TestStore>
 
   beforeEach(() => {
     const harness = createHarness()
     commands = harness.commands
     reconcileSnapshot = harness.reconcileSnapshot
-    reconcileClaudeDetection = harness.reconcileClaudeDetection
     store = harness.store
   })
 
@@ -587,11 +580,14 @@ describe('runtime setup slice: discovery lifecycle', () => {
   })
 
   it('reconciles Claude and npm, refreshes preflight, and keeps the old Claude on not-found', async () => {
+    commands.getSettings.mockResolvedValueOnce(
+      snapshot({ claude: { resolvedPath: '/bin/claude', version: '1.0.0' } })
+    )
     await store.getState().detectClaude()
 
-    expect(reconcileClaudeDetection).toHaveBeenCalledWith(
-      { found: true, path: '/bin/claude', version: '1.0.0' },
-      true
+    expect(reconcileSnapshot).toHaveBeenCalledWith(
+      snapshot({ claude: { resolvedPath: '/bin/claude', version: '1.0.0' } }),
+      { npmAvailable: true }
     )
     expect(store.getState()).toMatchObject({
       claude: { resolvedPath: '/bin/claude', version: '1.0.0' },
@@ -602,6 +598,9 @@ describe('runtime setup slice: discovery lifecycle', () => {
 
     commands.detectClaude.mockResolvedValueOnce({ found: false })
     commands.isNpmAvailable.mockResolvedValueOnce(false)
+    commands.getSettings.mockResolvedValueOnce(
+      snapshot({ claude: { resolvedPath: '/bin/claude', version: '1.0.0' } })
+    )
     await store.getState().detectClaude()
 
     expect(store.getState()).toMatchObject({
@@ -613,6 +612,9 @@ describe('runtime setup slice: discovery lifecycle', () => {
 
   it('propagates Claude preflight failure after applying detection and clears the flag', async () => {
     const failure = new Error('preflight unavailable')
+    commands.getSettings.mockResolvedValueOnce(
+      snapshot({ claude: { resolvedPath: '/bin/claude', version: '1.0.0' } })
+    )
     commands.getPreflight.mockRejectedValue(failure)
 
     await expect(store.getState().detectClaude()).rejects.toBe(failure)

--- a/src/renderer/src/stores/settings-runtime-slice.ts
+++ b/src/renderer/src/stores/settings-runtime-slice.ts
@@ -111,7 +111,6 @@ type RuntimeSetupSliceOptions<Store extends RuntimeSetupHost> = {
     snapshot: SettingsSnapshot,
     runtimePatch?: Partial<EnvironmentReconcilePatch>
   ) => void
-  reconcileClaudeDetection: (result: ClaudeDetectResult, npmAvailable: boolean) => void
 }
 
 const createInitialRuntimeInstallState = (): RuntimeInstallState => ({
@@ -308,8 +307,7 @@ export const createRuntimeSetupSlice = <Store extends RuntimeSetupHost>({
   set,
   get,
   getCommands,
-  reconcileSnapshot,
-  reconcileClaudeDetection
+  reconcileSnapshot
 }: RuntimeSetupSliceOptions<Store>): RuntimeSetupSlice => ({
   ...createInitialRuntimeSetupState(),
 
@@ -388,8 +386,9 @@ export const createRuntimeSetupSlice = <Store extends RuntimeSetupHost>({
         commands.isNpmAvailable()
       ])
 
-      // Core retains the stable Claude projection; a not-found result intentionally leaves it intact.
-      reconcileClaudeDetection(result, npmAvailable)
+      // The result is informational. Reconcile from Main's revisioned current snapshot so a slow
+      // probe cannot replace a newer install/uninstall or another window's write.
+      reconcileSnapshot(await commands.getSettings(), { npmAvailable })
       await get().refreshPreflight()
       return result
     } finally {

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -37,6 +37,7 @@ type SettingsApi = {
   onInstallLog: ReturnType<typeof vi.fn>
   setAgentFramework: ReturnType<typeof vi.fn>
   setReasoningEffort: ReturnType<typeof vi.fn>
+  setReviewerModel: ReturnType<typeof vi.fn>
   setSessionDetailsModel: ReturnType<typeof vi.fn>
   setNotificationsEnabled: ReturnType<typeof vi.fn>
   setConversationSkillImportEnabled: ReturnType<typeof vi.fn>
@@ -191,6 +192,11 @@ beforeEach(() => {
       .fn()
       .mockImplementation((request: { effort: string }) =>
         Promise.resolve({ ...snapshot([]), reasoningEffort: request.effort })
+      ),
+    setReviewerModel: vi
+      .fn()
+      .mockImplementation((request: { configuration: SettingsSnapshot['reviewerModel'] }) =>
+        Promise.resolve({ ...snapshot([]), reviewerModel: request.configuration })
       ),
     setSessionDetailsModel: vi
       .fn()
@@ -502,6 +508,36 @@ describe('settings store: detectClaude refreshes npm', () => {
 
     expect(api.isNpmAvailable).toHaveBeenCalledTimes(1)
     expect(useSettingsStore.getState().npmAvailable).toBe(true)
+  })
+
+  it('does not let an older probe result replace a newer committed runtime snapshot', async () => {
+    let resolveDetect: (value: { found: true; path: string; version: string }) => void = () =>
+      undefined
+    api.detectClaude.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDetect = resolve
+        })
+    )
+    api.getSettings.mockResolvedValue({
+      ...snapshot([]),
+      revision: 2,
+      claude: { resolvedPath: '/bin/claude-new', version: '2.0.0' }
+    })
+
+    const pending = useSettingsStore.getState().detectClaude()
+    useSettingsStore.getState().acceptCommittedSnapshot({
+      ...snapshot([]),
+      revision: 2,
+      claude: { resolvedPath: '/bin/claude-new', version: '2.0.0' }
+    })
+    resolveDetect({ found: true, path: '/bin/claude-old', version: '1.0.0' })
+    await pending
+
+    expect(useSettingsStore.getState().claude).toEqual({
+      resolvedPath: '/bin/claude-new',
+      version: '2.0.0'
+    })
   })
 })
 
@@ -2079,6 +2115,110 @@ describe('settings store: setNotificationsEnabled', () => {
 })
 
 describe('settings store: acceptCommittedSnapshot vs in-flight optimistic preference', () => {
+  it('keeps a newer event as rollback baseline across queued same-field writes', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let resolveOlder: (value: SettingsSnapshot) => void = () => undefined
+    api.setReasoningEffort
+      .mockImplementationOnce(
+        () =>
+          new Promise<SettingsSnapshot>((resolve) => {
+            resolveOlder = resolve
+          })
+      )
+      .mockRejectedValueOnce(new Error('newer write failed'))
+
+    const older = useSettingsStore.getState().setReasoningEffort('high')
+    const newer = useSettingsStore.getState().setReasoningEffort('max')
+    useSettingsStore.getState().acceptCommittedSnapshot({
+      ...snapshot([]),
+      revision: 2,
+      reasoningEffort: 'low'
+    })
+
+    resolveOlder({ ...snapshot([]), revision: 1, reasoningEffort: 'high' })
+    await Promise.all([older, newer])
+
+    expect(useSettingsStore.getState().reasoningEffort).toBe('low')
+    expect(useSettingsStore.getState().settingsSnapshotRevision).toBe(2)
+  })
+
+  it('rejects an older preference response that arrives after a newer committed event', async () => {
+    let resolveNotifications: (value: SettingsSnapshot) => void = () => undefined
+    api.setNotificationsEnabled.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((resolve) => {
+          resolveNotifications = resolve
+        })
+    )
+
+    const pending = useSettingsStore.getState().setNotificationsEnabled(false)
+    useSettingsStore.getState().acceptCommittedSnapshot({
+      ...snapshot([]),
+      revision: 2,
+      notificationsEnabled: true,
+      appIconVariant: 'dark'
+    })
+
+    resolveNotifications({
+      ...snapshot([]),
+      revision: 1,
+      notificationsEnabled: false,
+      appIconVariant: 'light'
+    })
+    await pending
+
+    expect(useSettingsStore.getState().notificationsEnabled).toBe(true)
+    expect(useSettingsStore.getState().appIconVariant).toBe('dark')
+    expect(useSettingsStore.getState().settingsSnapshotRevision).toBe(2)
+  })
+
+  it('rejects an older non-optimistic response that arrives after a newer committed event', async () => {
+    let resolveReviewer: (value: SettingsSnapshot) => void = () => undefined
+    api.setReviewerModel.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((resolve) => {
+          resolveReviewer = resolve
+        })
+    )
+
+    const pending = useSettingsStore.getState().setReviewerModel({
+      mode: 'fixed',
+      providerId: 'provider-old',
+      model: 'model-old',
+      reasoningEffort: 'high'
+    })
+    useSettingsStore.getState().acceptCommittedSnapshot({
+      ...snapshot([]),
+      revision: 2,
+      reviewerModel: {
+        mode: 'fixed',
+        providerId: 'provider-new',
+        model: 'model-new',
+        reasoningEffort: 'high'
+      }
+    })
+
+    resolveReviewer({
+      ...snapshot([]),
+      revision: 1,
+      reviewerModel: {
+        mode: 'fixed',
+        providerId: 'provider-old',
+        model: 'model-old',
+        reasoningEffort: 'high'
+      }
+    })
+    await pending
+
+    expect(useSettingsStore.getState().reviewerModel).toEqual({
+      mode: 'fixed',
+      providerId: 'provider-new',
+      model: 'model-new',
+      reasoningEffort: 'high'
+    })
+    expect(useSettingsStore.getState().settingsSnapshotRevision).toBe(2)
+  })
+
   it('does not let a foreign committed snapshot clobber an in-flight optimistic preference', async () => {
     let resolveNotifications: (value: SettingsSnapshot) => void = () => undefined
     api.setNotificationsEnabled.mockImplementation(
@@ -2112,7 +2252,7 @@ describe('settings store: acceptCommittedSnapshot vs in-flight optimistic prefer
     expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
   })
 
-  it('rolls back a failed optimistic preference to the last confirmed value after a foreign snapshot', async () => {
+  it('rolls back a failed optimistic preference to the committed value received while pending', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     let rejectNotifications: (reason?: unknown) => void = () => undefined
     api.setNotificationsEnabled.mockImplementation(
@@ -2134,7 +2274,7 @@ describe('settings store: acceptCommittedSnapshot vs in-flight optimistic prefer
     rejectNotifications(new Error('ipc down'))
     await pending
 
-    expect(useSettingsStore.getState().notificationsEnabled).toBe(true)
+    expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
     expect(useSettingsStore.getState().appIconVariant).toBe('dark')
     expect(useSettingsStore.getState().settingsWriteError).toBe(
       'Could not save notification preference. Try again.'

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -102,6 +102,7 @@ type SettingsStoreData = RuntimeSetupState &
     // Latest failed Settings write, shown by the dialog until dismissed or another write starts.
     settingsWriteError: string | undefined
     settingsLoadGeneration: number
+    settingsSnapshotRevision: number
     claude: ClaudeInfo
     activeProviderId: string | undefined
     claudeSubscriptionProviderId: ClaudeSubscriptionProviderId | undefined
@@ -179,6 +180,7 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   loadError: undefined,
   settingsWriteError: undefined,
   settingsLoadGeneration: 0,
+  settingsSnapshotRevision: 0,
   claude: {},
   activeProviderId: undefined,
   claudeSubscriptionProviderId: undefined,
@@ -253,6 +255,24 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   codexManaged: snapshot.codexManaged ?? false,
   codebuddyManaged: snapshot.codebuddyManaged ?? false
 })
+
+const canApplySnapshot = (state: SettingsStoreData, snapshot: SettingsSnapshot): boolean =>
+  snapshot.revision === undefined
+    ? state.settingsSnapshotRevision === 0
+    : snapshot.revision >= state.settingsSnapshotRevision
+
+const mergeSnapshot = (
+  state: SettingsStoreData,
+  snapshot: SettingsSnapshot,
+  extra: Partial<SettingsStoreData> = {}
+): Partial<SettingsStoreData> =>
+  canApplySnapshot(state, snapshot)
+    ? {
+        ...applySnapshot(snapshot),
+        ...(snapshot.revision === undefined ? {} : { settingsSnapshotRevision: snapshot.revision }),
+        ...extra
+      }
+    : extra
 
 // Stable fallback reference so the selector returns the same array identity across renders
 // (a fresh literal would make useSettingsStore re-render every tick and loop).
@@ -337,18 +357,12 @@ const createSettingsStoreState = (
     // Resolve browser globals only when an action runs; node-based renderer tests import this store.
     getCommands: () => window.api.settings,
     reconcileSnapshot: (snapshot, runtimePatch = {}) =>
-      set({ ...applySnapshot(snapshot), ...runtimePatch }),
-    reconcileClaudeDetection: (result, npmAvailable) =>
-      set(
-        result.found && result.path
-          ? { npmAvailable, claude: { resolvedPath: result.path, version: result.version } }
-          : { npmAvailable }
-      )
+      set((state) => mergeSnapshot(state, snapshot, runtimePatch))
   }),
   ...createProviderAuthSlice({
     get,
     getCommands: () => window.api.settings,
-    reconcileSnapshot: (snapshot) => set(applySnapshot(snapshot)),
+    reconcileSnapshot: (snapshot) => set((state) => mergeSnapshot(state, snapshot)),
     refreshPreflight: () => get().refreshPreflight(),
     refreshFrameworkStatus: async (id) => {
       if (id === 'opencode') {
@@ -368,7 +382,17 @@ const createSettingsStoreState = (
     getState: get,
     setState: (patch) => set(patch),
     getCommands: () => window.api.settings,
-    reconcileSnapshot: (snapshot) => set(applySnapshot(snapshot)),
+    reconcileSnapshot: (snapshot) => {
+      if (!canApplySnapshot(get(), snapshot)) return false
+      set((state) =>
+        omitInFlightOptimisticPreferences(
+          mergeSnapshot(state, snapshot),
+          writeCoordinator.hasPending,
+          writeCoordinator.acceptCommitted
+        )
+      )
+      return true
+    },
     writeCoordinator
   }),
   ...createSettingsNavigationSlice({
@@ -425,11 +449,12 @@ const createSettingsStoreState = (
 
         // The persisted Settings authority is enough for an existing user to enter Home. Capability
         // probes continue in this same deduplicated pass; first-run onboarding still waits in App.
-        set({
-          ...applySnapshot(snapshot),
-          ...(shouldInitializeRuntime ? { isLoaded: true } : {}),
-          loadError: undefined
-        })
+        set((state) =>
+          mergeSnapshot(state, snapshot, {
+            ...(shouldInitializeRuntime ? { isLoaded: true } : {}),
+            loadError: undefined
+          })
+        )
 
         const [[encryptionResult], runtimeResults] = await Promise.all([
           encryptionAvailability,
@@ -493,9 +518,14 @@ const createSettingsStoreState = (
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),
   acceptCommittedSnapshot: (snapshot) =>
-    set(() =>
-      omitInFlightOptimisticPreferences(applySnapshot(snapshot), writeCoordinator.hasPending)
-    )
+    set((state) => {
+      if (!canApplySnapshot(state, snapshot)) return {}
+      return omitInFlightOptimisticPreferences(
+        mergeSnapshot(state, snapshot),
+        writeCoordinator.hasPending,
+        writeCoordinator.acceptCommitted
+      )
+    })
 })
 
 export const useSettingsStore = create<SettingsStore>((set, get) =>

--- a/src/renderer/src/stores/settings-write-coordinator.ts
+++ b/src/renderer/src/stores/settings-write-coordinator.ts
@@ -58,6 +58,7 @@ export type SettingsWriteCoordinator = {
     key: OptimisticSettingsWriteKey,
     confirmedValue: T
   ) => OptimisticSettingsWrite<T>
+  acceptCommitted: (key: OptimisticSettingsWriteKey, value: unknown) => void
   hasPending: (key: OptimisticSettingsWriteKey) => boolean
   clearFailures: () => void
 }
@@ -170,6 +171,10 @@ export const createSettingsWriteCoordinator = (
         run: (write) => runQueued(key, write),
         complete: (value) => completeOptimistic(key, state, value)
       }
+    },
+    acceptCommitted: (key, value) => {
+      const state = optimisticStates.get(key)
+      if (state) state.confirmedValue = value
     },
     hasPending: (key) => (optimisticStates.get(key)?.pendingCount ?? 0) > 0,
     clearFailures: () => {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -480,6 +480,9 @@ export type AgentFrameworkView = {
 
 // Full renderer snapshot of settings state.
 export type SettingsSnapshot = {
+  // Volatile Main-authority projection order. It is not persisted; older peers may omit it.
+  // Renderer stores use it to reject an RPC response that arrives after a newer settings event.
+  revision?: number
   claude: ClaudeInfo
   // Detected opencode executable, for the framework-aware detection card.
   opencode: OpencodeInfo

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -7,6 +7,7 @@ import vitestConfig, {
   coverageThresholdsEnabled,
   coverageThresholdsFor,
   FULL_COVERAGE_THRESHOLDS,
+  fullSuiteShardAllowsEmptyProjects,
   resolveVitestMaxWorkers,
   VITEST_ARCHITECTURE_TEST_GLOBS,
   VITEST_COVERAGE_EXCLUDE_PATTERNS,
@@ -37,6 +38,13 @@ it('defers coverage thresholds only for explicit shard collection', () => {
       VITEST_DEFER_COVERAGE_THRESHOLDS: '1'
     })
   ).toBeUndefined()
+})
+
+it('allows an empty Vitest project only during explicit shard collection', () => {
+  expect(fullSuiteShardAllowsEmptyProjects(['vitest', 'run', '--shard=1/2'])).toBe(true)
+  expect(fullSuiteShardAllowsEmptyProjects(['vitest', 'run', '--shard', '2/2'])).toBe(true)
+  expect(fullSuiteShardAllowsEmptyProjects(['vitest', 'run'])).toBe(false)
+  expect(vitestConfig.test?.passWithNoTests).toBe(fullSuiteShardAllowsEmptyProjects(process.argv))
 })
 
 it('ratchets full coverage without raising selective changed-source thresholds', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,10 @@ function coverageThresholdsEnabled(env: NodeJS.ProcessEnv): boolean {
   return env.VITEST_DEFER_COVERAGE_THRESHOLDS !== '1'
 }
 
+function fullSuiteShardAllowsEmptyProjects(argv: readonly string[]): boolean {
+  return argv.some((argument) => argument === '--shard' || argument.startsWith('--shard='))
+}
+
 const FULL_COVERAGE_THRESHOLDS = {
   lines: 90,
   functions: 88,
@@ -119,6 +123,9 @@ export default defineConfig({
     }
   },
   test: {
+    // Vitest shards each project independently. A valid full-suite shard can therefore contain no
+    // files for one project even though its other projects execute tests.
+    passWithNoTests: fullSuiteShardAllowsEmptyProjects(process.argv),
     // Keep successful suites quiet while retaining their captured console output on failure.
     silent: 'passed-only',
     server: {
@@ -206,6 +213,7 @@ export {
   coverageThresholdsEnabled,
   coverageThresholdsFor,
   FULL_COVERAGE_THRESHOLDS,
+  fullSuiteShardAllowsEmptyProjects,
   VITEST_COVERAGE_EXCLUDE_PATTERNS,
   VITEST_EXCLUDE_PATTERNS
 }


### PR DESCRIPTION
## Problem

The repository-wide concurrency audit found 20 reachable race classes across Main owners, renderer projections, authentication, updates, uploads, Notebook, Reviewer, Compute, Projects, and multi-client transports. This PR implements the first migration-free batch: issues where a stale completion, duplicate live request, or cancel/finish race could be fixed without choosing a durable idempotency or historical-data policy.

## Proposed change

- Serialize or coalesce duplicate live side effects for completion handoff retries, Reviewer fix loops, update apply, and upload terminalization.
- Add post-approval cancellation fencing to Compute submission and preserve all concurrently active Notebook runs with deterministic cwd ownership.
- Make Settings mutations publish through one ordered Main snapshot owner across Electron IPC, application commands, Web RPC, and native close confirmation. Add an optional volatile snapshot revision so older RPC responses cannot overwrite newer events.
- Serialize isolated Codex logout with account mutations and reject stale login finalization after edit, delete, logout, or cancellation. Apply targeted validation patches instead of replacing a stale provider record.
- Add per-resource/per-intent generations for Project and Compute stores, local-file navigation, Session details/export, and ACP action metadata.
- Add deterministic regression tests for every changed race. These tests reproduced the pre-fix interleavings during the red/green inner loop.
- Let explicit Vitest shards tolerate an empty per-project partition while preserving the normal no-tests failure outside `--shard` runs.

## Scope and non-goals

This first batch intentionally defers changes that need a product decision, durable identity, CAS contract, or historical compatibility policy:

- Web RPC mutation idempotency and restart-safe receipts.
- End-to-end durable Compute submit identity.
- Granted-folder access CAS and cross-client events.
- Crash-safe upload completion replay.
- Project pin CAS, Tags revision admission, atomic bookmark commands, and User Skill edit conflicts.
- Stable operation identity for app-generated Artifacts and Project creation.

Existing protections were confirmed for Session autosave/revision rebase, Project Files/preview queues, ordinary ACP prompts across all four framework paths, permission/plan/elicitation/delegation owners, Compute cancel/finish, remote access/OAuth generation fencing, and Artifact MCP writes.

Compatibility and state impact:

- Historical data: no migration and no stored-format change. Older snapshots may omit `revision`; the renderer accepts them until it has observed a revisioned Main snapshot.
- New state: no enum values. New state is process-local only: promise owners, generations, refcounts, active-run sets, and `SettingsSnapshot.revision`.
- Persistence: no database schema, migration, or new persisted field. Existing Settings provider records are updated through targeted serialized mutations; upload/update arbitration remains process-local.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

- Rebased direct race contracts outside the full Settings module -> focused Vitest set -> 16 files, 430 tests passed.
- Settings owner, repository, IPC, application-command, and consumer coverage -> `npx vitest run src/main/settings` with loopback enabled -> 93 files passed, 1 skipped; 1720 tests passed, 4 skipped.
- Module ownership and trusted CI contracts -> focused CI suite -> 4 files, 80 tests passed.
- Vitest shard/config contract -> red test reproduced the empty-project exit; rebased direct suite passed; latest-base CI Integrity check passed.
- Node and renderer interfaces -> `npm run typecheck` -> passed.
- Source quality -> `npm run lint`, Prettier check, and `git diff --check` -> passed.
- Independent read-only review -> confirmed final fixes and found no remaining regression in this batch.

The final impact classifier selects the full PR Gate because `scripts/ci/module-impact.json` is a global gate input. Per maintainer direction, the complete local `npm test` was not run; exact-head PR CI is the authority for the full suite and platform lanes.

## Review focus

- Ordering and failure recovery in `SettingsSnapshotCommitOwner`, especially event-versus-RPC settlement.
- The non-persisted optional revision compatibility rule.
- Terminal claims/coalescing in completion handoff, update apply, and upload finish/abort.
- Per-resource generations in renderer stores and intent fencing in Session/local-file flows.
- Provider login/logout identity checks and preservation of concurrent provider edits.
