### PR TITLE
feat(notifications): add mark-as-unread session action

### DIFF
--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -174,10 +174,12 @@ describe('production application command wiring', () => {
     expect(notificationIpcSource).toContain(
       "ipcMainHandle('notifications:mark-session-completions-read'"
     )
+    expect(notificationIpcSource).toContain("ipcMainHandle('notifications:mark-session-unread'")
     expect(notificationIpcSource).toContain('owner.getSnapshot()')
     expect(notificationIpcSource).toContain('owner.markRead(')
     expect(notificationIpcSource).toContain('owner.markAllRead(')
     expect(notificationIpcSource).toContain('owner.markSessionCompletionsRead(')
+    expect(notificationIpcSource).toContain('owner.markSessionUnread(')
   })
 
   it('adds transport adapters after composition and disposes the router before its owners', () => {

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -89,6 +89,7 @@ const createDependencies = (): HostApplicationCommandDependencies => ({
     getSnapshot: vi.fn(async () => ({
       revision: 1,
       unreadCount: 0,
+      unreadSessionIds: [],
       latestSequence: 0,
       items: []
     })),

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -95,6 +95,7 @@ const createDependencies = (): HostApplicationCommandDependencies => ({
     markAllRead: vi.fn(async () => undefined),
     markRead: vi.fn(async () => undefined),
     markSessionCompletionsRead: vi.fn(async () => undefined),
+    markSessionUnread: vi.fn(async () => undefined),
     peekPendingOpenSession: vi.fn(() => ({ sessionId: 'session-1', token: 7 })),
     takePendingOpenSession: vi.fn(() => ({ sessionId: 'session-1', token: 7 }))
   },
@@ -186,7 +187,7 @@ const commandByName = (name: string): ApplicationCommand<string, readonly unknow
 }
 
 describe('Host application commands', () => {
-  it('defines the exact 55 Electron request channels in their existing capability groups', () => {
+  it('defines the exact 56 Electron request channels in their existing capability groups', () => {
     const expected = RENDERER_CONTRACT_GROUPS.filter(({ capability }) =>
       HOST_CAPABILITIES.includes(capability as (typeof HOST_CAPABILITIES)[number])
     ).map(({ capability, contracts }) => {
@@ -206,7 +207,7 @@ describe('Host application commands', () => {
       }
     })
 
-    expect(expected.flatMap(({ channels }) => channels)).toHaveLength(55)
+    expect(expected.flatMap(({ channels }) => channels)).toHaveLength(56)
     expect(
       hostApplicationCommandGroups.map(({ name, commands }) => ({
         capability: name,
@@ -222,7 +223,7 @@ describe('Host application commands', () => {
       {} as HostApplicationCommandDependencies
     )
 
-    expect(router.dispatcher.commandNames()).toHaveLength(55)
+    expect(router.dispatcher.commandNames()).toHaveLength(56)
     installation.uninstall()
     expect(router.dispatcher.commandNames()).toEqual([])
   })
@@ -245,6 +246,7 @@ describe('Host application commands', () => {
     const markReadRequest = { ids: ['message-1'] }
     const markAllReadRequest = { throughSequence: 7 }
     const markSessionCompletionsReadRequest = { sessionIds: ['session-1'] }
+    const markSessionUnreadRequest = { sessionIds: ['session-2'] }
 
     await router.dispatcher.invoke(hostApplicationCommands.cli.getStatus, invocation([]))
     await router.dispatcher.invoke(hostApplicationCommands.cli.install, invocation([]))
@@ -293,6 +295,10 @@ describe('Host application commands', () => {
     await router.dispatcher.invoke(
       hostApplicationCommands.notifications.markSessionCompletionsRead,
       invocation([markSessionCompletionsReadRequest])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.notifications.markSessionUnread,
+      invocation([markSessionUnreadRequest])
     )
     await router.dispatcher.invoke(
       hostApplicationCommands.notifications.peekPendingOpenSession,
@@ -390,6 +396,9 @@ describe('Host application commands', () => {
     expect(dependencies.notifications.markRead).toHaveBeenCalledWith(markReadRequest)
     expect(dependencies.notifications.markSessionCompletionsRead).toHaveBeenCalledWith(
       markSessionCompletionsReadRequest
+    )
+    expect(dependencies.notifications.markSessionUnread).toHaveBeenCalledWith(
+      markSessionUnreadRequest
     )
     expect(dependencies.remoteAccess.approve).toHaveBeenCalledWith(
       { requestId: 'pair-1', decision: 'once' },
@@ -719,9 +728,24 @@ describe('Host application commands', () => {
         )
       ).rejects.toThrow('Invalid notifications:mark-session-completions-read request.')
     }
+    for (const invalidRequest of [
+      undefined,
+      null,
+      {},
+      { sessionIds: 'session-1' },
+      { sessionIds: [1] }
+    ]) {
+      await expect(
+        router.dispatcher.invoke(
+          commandByName('notifications:mark-session-unread'),
+          invocation([invalidRequest])
+        )
+      ).rejects.toThrow('Invalid notifications:mark-session-unread request.')
+    }
 
     expect(dependencies.notifications.markRead).not.toHaveBeenCalled()
     expect(dependencies.notifications.markAllRead).not.toHaveBeenCalled()
     expect(dependencies.notifications.markSessionCompletionsRead).not.toHaveBeenCalled()
+    expect(dependencies.notifications.markSessionUnread).not.toHaveBeenCalled()
   })
 })

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -15,6 +15,7 @@ import type {
   NotificationMarkAllReadRequest,
   NotificationMarkReadRequest,
   NotificationMarkSessionCompletionsReadRequest,
+  NotificationMarkSessionUnreadRequest,
   OpenSessionFromNotificationRequest
 } from '../shared/notifications'
 import type {
@@ -63,7 +64,8 @@ import type { LogsCommandOwner } from './logs-ipc'
 import {
   requireNotificationMarkAllReadRequest,
   requireNotificationMarkReadRequest,
-  requireNotificationMarkSessionCompletionsReadRequest
+  requireNotificationMarkSessionCompletionsReadRequest,
+  requireNotificationMarkSessionUnreadRequest
 } from './notifications/notification-inbox-requests'
 import {
   canManagePairing,
@@ -172,6 +174,11 @@ const notificationCommands = Object.freeze({
     readonly [request: NotificationMarkSessionCompletionsReadRequest],
     void
   >('notifications:mark-session-completions-read'),
+  markSessionUnread: defineApplicationCommand<
+    'notifications:mark-session-unread',
+    readonly [request: NotificationMarkSessionUnreadRequest],
+    void
+  >('notifications:mark-session-unread'),
   peekPendingOpenSession: defineApplicationCommand<
     'notifications:peek-pending-open-session',
     readonly [],
@@ -377,6 +384,7 @@ type HostApplicationCommandDependencies = Readonly<{
     markSessionCompletionsRead: (
       request: NotificationMarkSessionCompletionsReadRequest
     ) => Promise<void>
+    markSessionUnread: (request: NotificationMarkSessionUnreadRequest) => Promise<void>
     peekPendingOpenSession: () => OpenSessionFromNotificationRequest | null
     takePendingOpenSession: (expectedToken: number) => OpenSessionFromNotificationRequest | null
   }>
@@ -509,6 +517,10 @@ const registerHostApplicationCommands = (
       'notifications:mark-session-completions-read': ({ args }) =>
         dependencies.notifications.markSessionCompletionsRead(
           requireNotificationMarkSessionCompletionsReadRequest(args[0])
+        ),
+      'notifications:mark-session-unread': ({ args }) =>
+        dependencies.notifications.markSessionUnread(
+          requireNotificationMarkSessionUnreadRequest(args[0])
         ),
       'notifications:peek-pending-open-session': () =>
         dependencies.notifications.peekPendingOpenSession(),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3730,6 +3730,7 @@ const createApplicationModules = async (
         markAllRead: (request) => notificationInbox.markAllRead(request.throughSequence),
         markSessionCompletionsRead: (request) =>
           notificationInbox.markSessionCompletionsRead(request.sessionIds),
+        markSessionUnread: (request) => notificationInbox.markSessionUnread(request.sessionIds),
         peekPendingOpenSession: () => taskNotifications.peekPendingOpenSession(),
         takePendingOpenSession: (expectedToken) =>
           taskNotifications.takePendingOpenSession(expectedToken)

--- a/src/main/notifications/notification-inbox-controller.test.ts
+++ b/src/main/notifications/notification-inbox-controller.test.ts
@@ -17,7 +17,12 @@ const repository = (
       unreadCount: 0,
       latestSequence: 0
     })),
-    snapshot: vi.fn(async () => ({ unreadCount: 0, latestSequence: 0, items: [] })),
+    snapshot: vi.fn(async () => ({
+      unreadCount: 0,
+      unreadSessionIds: [],
+      latestSequence: 0,
+      items: []
+    })),
     record: vi.fn(async () => ({ changed: true, unreadCount: 1, latestSequence: 1 })),
     settle: vi.fn(async () => ({ changed: true, unreadCount: 1, latestSequence: 1 })),
     markRead: vi.fn(async () => ({ changed: true, unreadCount: 0, latestSequence: 1 })),

--- a/src/main/notifications/notification-inbox-controller.test.ts
+++ b/src/main/notifications/notification-inbox-controller.test.ts
@@ -33,6 +33,11 @@ const repository = (
       unreadCount: 0,
       latestSequence: 1
     })),
+    markSessionUnread: vi.fn(async () => ({
+      changed: true,
+      unreadCount: 1,
+      latestSequence: 2
+    })),
     invalidateSessions: vi.fn(async () => ({ changed: true, unreadCount: 0, latestSequence: 0 })),
     reconcileSessionCatalog: vi.fn(async () => ({
       changed: false,
@@ -190,6 +195,19 @@ describe('createNotificationInboxController', () => {
     await inbox.markSessionCompletionsRead(['session-1'])
 
     expect(db.markSessionCompletionsRead).toHaveBeenCalledWith(['session-1'], 3500)
+  })
+
+  it('marks a session unread without applying an acknowledgement timestamp', async () => {
+    const db = repository()
+    const inbox = createNotificationInboxController({
+      headless: false,
+      repository: db,
+      onChanged: vi.fn()
+    })
+
+    await inbox.markSessionUnread(['session-1'])
+
+    expect(db.markSessionUnread).toHaveBeenCalledWith(['session-1'])
   })
 
   it('waits for an in-flight authorization record before settling it', async () => {

--- a/src/main/notifications/notification-inbox-controller.ts
+++ b/src/main/notifications/notification-inbox-controller.ts
@@ -46,6 +46,7 @@ type NotificationInboxController = Readonly<{
   markAllRead(throughSequence: number): Promise<void>
   markSessionsRead(sessionIds: readonly string[]): Promise<void>
   markSessionCompletionsRead(sessionIds: readonly string[]): Promise<void>
+  markSessionUnread(sessionIds: readonly string[]): Promise<void>
   invalidateSessions(sessionIds: readonly string[]): Promise<void>
   reconcileSessionCatalog(existingSessionIds: readonly string[]): Promise<void>
   syncViewState(state: UnreadTaskViewState): Promise<void>
@@ -228,6 +229,9 @@ export const createNotificationInboxController = (
   const markSessionCompletionsRead = (sessionIds: readonly string[]): Promise<void> =>
     mutate(() => dependencies.repository.markSessionCompletionsRead(sessionIds, now()))
 
+  const markSessionUnread = (sessionIds: readonly string[]): Promise<void> =>
+    mutate(() => dependencies.repository.markSessionUnread(sessionIds))
+
   const invalidateSessions = async (sessionIds: readonly string[]): Promise<void> => {
     for (const sessionId of sessionIds) {
       const normalized = sessionId.trim()
@@ -267,6 +271,7 @@ export const createNotificationInboxController = (
     markAllRead,
     markSessionsRead,
     markSessionCompletionsRead,
+    markSessionUnread,
     invalidateSessions,
     reconcileSessionCatalog,
     syncViewState,

--- a/src/main/notifications/notification-inbox-ipc.test.ts
+++ b/src/main/notifications/notification-inbox-ipc.test.ts
@@ -18,7 +18,8 @@ describe('notification inbox Electron IPC adapter', () => {
       getSnapshot: vi.fn(async () => snapshot),
       markRead: vi.fn(async () => undefined),
       markAllRead: vi.fn(async () => undefined),
-      markSessionCompletionsRead: vi.fn(async () => undefined)
+      markSessionCompletionsRead: vi.fn(async () => undefined),
+      markSessionUnread: vi.fn(async () => undefined)
     }
     registerNotificationInboxIpcAdapter(owner)
 
@@ -28,10 +29,14 @@ describe('notification inbox Electron IPC adapter', () => {
     await handlers.get('notifications:mark-session-completions-read')?.(undefined, {
       sessionIds: ['session-1']
     })
+    await handlers.get('notifications:mark-session-unread')?.(undefined, {
+      sessionIds: ['session-2']
+    })
 
     expect(owner.markRead).toHaveBeenCalledWith(['message-1'])
     expect(owner.markAllRead).toHaveBeenCalledWith(7)
     expect(owner.markSessionCompletionsRead).toHaveBeenCalledWith(['session-1'])
+    expect(owner.markSessionUnread).toHaveBeenCalledWith(['session-2'])
   })
 
   it('rejects malformed read requests before calling the owner', () => {
@@ -44,7 +49,8 @@ describe('notification inbox Electron IPC adapter', () => {
       })),
       markRead: vi.fn(async () => undefined),
       markAllRead: vi.fn(async () => undefined),
-      markSessionCompletionsRead: vi.fn(async () => undefined)
+      markSessionCompletionsRead: vi.fn(async () => undefined),
+      markSessionUnread: vi.fn(async () => undefined)
     }
     registerNotificationInboxIpcAdapter(owner)
 
@@ -57,8 +63,12 @@ describe('notification inbox Electron IPC adapter', () => {
     expect(() =>
       handlers.get('notifications:mark-session-completions-read')?.(undefined, { sessionIds: [1] })
     ).toThrow('Invalid notifications:mark-session-completions-read request.')
+    expect(() =>
+      handlers.get('notifications:mark-session-unread')?.(undefined, { sessionIds: [1] })
+    ).toThrow('Invalid notifications:mark-session-unread request.')
     expect(owner.markRead).not.toHaveBeenCalled()
     expect(owner.markAllRead).not.toHaveBeenCalled()
     expect(owner.markSessionCompletionsRead).not.toHaveBeenCalled()
+    expect(owner.markSessionUnread).not.toHaveBeenCalled()
   })
 })

--- a/src/main/notifications/notification-inbox-ipc.test.ts
+++ b/src/main/notifications/notification-inbox-ipc.test.ts
@@ -13,7 +13,13 @@ describe('notification inbox Electron IPC adapter', () => {
   beforeEach(() => handlers.clear())
 
   it('registers snapshot and read mutations against the shared owner', async () => {
-    const snapshot = { revision: 1, unreadCount: 0, latestSequence: 0, items: [] }
+    const snapshot = {
+      revision: 1,
+      unreadCount: 0,
+      unreadSessionIds: [],
+      latestSequence: 0,
+      items: []
+    }
     const owner = {
       getSnapshot: vi.fn(async () => snapshot),
       markRead: vi.fn(async () => undefined),
@@ -44,6 +50,7 @@ describe('notification inbox Electron IPC adapter', () => {
       getSnapshot: vi.fn(async () => ({
         revision: 1,
         unreadCount: 0,
+        unreadSessionIds: [],
         latestSequence: 0,
         items: []
       })),

--- a/src/main/notifications/notification-inbox-ipc.ts
+++ b/src/main/notifications/notification-inbox-ipc.ts
@@ -3,12 +3,13 @@ import type { NotificationInboxController } from './notification-inbox-controlle
 import {
   requireNotificationMarkAllReadRequest,
   requireNotificationMarkReadRequest,
-  requireNotificationMarkSessionCompletionsReadRequest
+  requireNotificationMarkSessionCompletionsReadRequest,
+  requireNotificationMarkSessionUnreadRequest
 } from './notification-inbox-requests'
 
 type NotificationInboxIpcOwner = Pick<
   NotificationInboxController,
-  'getSnapshot' | 'markAllRead' | 'markRead' | 'markSessionCompletionsRead'
+  'getSnapshot' | 'markAllRead' | 'markRead' | 'markSessionCompletionsRead' | 'markSessionUnread'
 >
 
 // Electron retains direct IPC adapters while local/remote Web dispatch through the application
@@ -26,6 +27,10 @@ const registerNotificationInboxIpcAdapter = (owner: NotificationInboxIpcOwner): 
   ipcMainHandle('notifications:mark-session-completions-read', (_event, input: unknown) => {
     const request = requireNotificationMarkSessionCompletionsReadRequest(input)
     return owner.markSessionCompletionsRead(request.sessionIds)
+  })
+  ipcMainHandle('notifications:mark-session-unread', (_event, input: unknown) => {
+    const request = requireNotificationMarkSessionUnreadRequest(input)
+    return owner.markSessionUnread(request.sessionIds)
   })
 }
 

--- a/src/main/notifications/notification-inbox-repository.test.ts
+++ b/src/main/notifications/notification-inbox-repository.test.ts
@@ -225,6 +225,42 @@ describe('NotificationInboxDbRepository', () => {
     expect(snapshot.items.find((item) => item.kind === 'task.failed')?.readAt).toBeUndefined()
   })
 
+  it('marks only the latest notification for each session unread and promotes it into snapshots', async () => {
+    const repository = await createRepository()
+    for (const originId of ['older', 'latest']) {
+      await repository.record({
+        id: `item-${originId}`,
+        dedupeKey: `task:${originId}`,
+        kind: 'task.completed',
+        sessionId: 'session-shared',
+        originId,
+        title: 'Task completed',
+        summary: `Task ${originId} finished.`
+      })
+    }
+    await repository.markSessionsRead(['session-shared'], 2800)
+    for (let index = 0; index < 50; index += 1) await record(repository, `newer-${index}`)
+
+    expect((await repository.snapshot()).items.some((item) => item.id === 'item-latest')).toBe(
+      false
+    )
+
+    await repository.markSessionUnread(['session-shared'])
+
+    const snapshot = await repository.snapshot()
+    expect(snapshot.unreadCount).toBe(51)
+    expect(snapshot.items[0]).toMatchObject({
+      id: 'item-latest',
+      sessionId: 'session-shared'
+    })
+    expect(snapshot.items[0]).not.toHaveProperty('readAt')
+    expect(
+      await client!.notificationInboxItem.findUnique({ where: { id: 'item-older' } })
+    ).toMatchObject({
+      readAt: new Date(2800)
+    })
+  })
+
   it('migrates legacy unread sessions exactly once and clears the old projection', async () => {
     const repository = await createRepository()
     await client!.unreadTaskSession.create({ data: { sessionId: 'legacy-session' } })

--- a/src/main/notifications/notification-inbox-repository.test.ts
+++ b/src/main/notifications/notification-inbox-repository.test.ts
@@ -63,6 +63,7 @@ describe('NotificationInboxDbRepository', () => {
     expect((await repository.snapshot()).items.every((item) => item.readAt === undefined)).toBe(
       true
     )
+    expect((await repository.snapshot()).unreadSessionIds).toEqual(['session-one', 'session-two'])
   })
 
   it('returns every active pending action in addition to recent history', async () => {
@@ -100,6 +101,7 @@ describe('NotificationInboxDbRepository', () => {
 
     const snapshot = await repository.snapshot()
     expect(snapshot.unreadCount).toBe(1)
+    expect(snapshot.unreadSessionIds).toEqual(['session-after'])
     expect(snapshot.items.find((item) => item.originId === 'before')?.readAt).toBe(1000)
     expect(snapshot.items.find((item) => item.originId === 'after')?.readAt).toBeUndefined()
   })
@@ -225,7 +227,7 @@ describe('NotificationInboxDbRepository', () => {
     expect(snapshot.items.find((item) => item.kind === 'task.failed')?.readAt).toBeUndefined()
   })
 
-  it('marks only the latest notification for each session unread and promotes it into snapshots', async () => {
+  it('restores only the latest notification per session without advancing its sequence', async () => {
     const repository = await createRepository()
     for (const originId of ['older', 'latest']) {
       await repository.record({
@@ -244,16 +246,19 @@ describe('NotificationInboxDbRepository', () => {
     expect((await repository.snapshot()).items.some((item) => item.id === 'item-latest')).toBe(
       false
     )
+    const latestSequence = (await repository.snapshot()).latestSequence
 
     await repository.markSessionUnread(['session-shared'])
 
     const snapshot = await repository.snapshot()
     expect(snapshot.unreadCount).toBe(51)
-    expect(snapshot.items[0]).toMatchObject({
+    expect(snapshot.latestSequence).toBe(latestSequence)
+    expect(snapshot.unreadSessionIds).toContain('session-shared')
+    expect(snapshot.items.find((item) => item.id === 'item-latest')).toMatchObject({
       id: 'item-latest',
       sessionId: 'session-shared'
     })
-    expect(snapshot.items[0]).not.toHaveProperty('readAt')
+    expect(snapshot.items.find((item) => item.id === 'item-latest')).not.toHaveProperty('readAt')
     expect(
       await client!.notificationInboxItem.findUnique({ where: { id: 'item-older' } })
     ).toMatchObject({

--- a/src/main/notifications/notification-inbox-repository.ts
+++ b/src/main/notifications/notification-inbox-repository.ts
@@ -59,6 +59,7 @@ type NotificationRepositoryState = Readonly<{
 
 type NotificationRepositorySnapshot = Readonly<{
   unreadCount: number
+  unreadSessionIds: readonly string[]
   latestSequence: number
   items: readonly NotificationInboxItem[]
 }>
@@ -164,7 +165,7 @@ export class NotificationInboxDbRepository {
     )
     return this.enqueue(async () => {
       const client = await this.getClient()
-      const [pendingRows, historyRows, metadata] = await Promise.all([
+      const [pendingRows, historyRows, unreadSessionRows, metadata] = await Promise.all([
         client.notificationInboxItem.findMany({
           where: ACTIVE_PENDING_WHERE,
           orderBy: { sequence: 'desc' }
@@ -174,12 +175,30 @@ export class NotificationInboxDbRepository {
           orderBy: { sequence: 'desc' },
           take: limit
         }),
+        client.notificationInboxItem.findMany({
+          where: {
+            readAt: null,
+            sessionId: { not: null },
+            targetInvalidatedAt: null
+          },
+          distinct: ['sessionId'],
+          orderBy: { sequence: 'desc' },
+          take: MAX_SNAPSHOT_LIMIT
+        }),
         stateFor(client, false)
       ])
-      const rows = [...pendingRows, ...historyRows].sort(
-        (left, right) => right.sequence - left.sequence
-      )
-      return { ...metadata, items: rows.map(toInboxItem) }
+      const rows = [
+        ...new Map(
+          [...pendingRows, ...unreadSessionRows, ...historyRows].map((row) => [row.id, row])
+        ).values()
+      ].sort((left, right) => right.sequence - left.sequence)
+      return {
+        ...metadata,
+        unreadSessionIds: normalizeIds(
+          unreadSessionRows.flatMap((row) => (row.sessionId ? [row.sessionId] : []))
+        ).sort(),
+        items: rows.map(toInboxItem)
+      }
     })
   }
 
@@ -311,15 +330,15 @@ export class NotificationInboxDbRepository {
           return row.readAt ? [row] : []
         })
         if (latestReadRows.length === 0) return stateFor(transaction, false)
-        // Reinsert the stable notification identity so its new sequence crosses the bounded
-        // snapshot window. Updating readAt alone could leave an older session outside Messages.
-        await transaction.notificationInboxItem.deleteMany({
-          where: { id: { in: latestReadRows.map((row) => row.id) } }
-        })
-        await transaction.notificationInboxItem.createMany({
-          data: latestReadRows.map((row) => ({ ...row, sequence: undefined, readAt: null }))
-        })
-        return stateFor(transaction, true)
+        const count = await mutateInChunks(
+          latestReadRows.map((row) => row.id),
+          (ids) =>
+            transaction.notificationInboxItem.updateMany({
+              where: { id: { in: ids }, readAt: { not: null } },
+              data: { readAt: null }
+            })
+        )
+        return stateFor(transaction, count > 0)
       })
     })
   }

--- a/src/main/notifications/notification-inbox-repository.ts
+++ b/src/main/notifications/notification-inbox-repository.ts
@@ -291,6 +291,39 @@ export class NotificationInboxDbRepository {
     })
   }
 
+  markSessionUnread(sessionIds: readonly string[]): Promise<NotificationRepositoryState> {
+    const normalized = normalizeIds(sessionIds)
+    if (normalized.length === 0) return this.currentState()
+    return this.enqueue(async () => {
+      const client = await this.getClient()
+      return client.$transaction(async (transaction) => {
+        const rows = await transaction.notificationInboxItem.findMany({
+          where: {
+            sessionId: { in: normalized },
+            targetInvalidatedAt: null
+          },
+          orderBy: { sequence: 'desc' }
+        })
+        const seenSessionIds = new Set<string>()
+        const latestReadRows = rows.flatMap((row) => {
+          if (!row.sessionId || seenSessionIds.has(row.sessionId)) return []
+          seenSessionIds.add(row.sessionId)
+          return row.readAt ? [row] : []
+        })
+        if (latestReadRows.length === 0) return stateFor(transaction, false)
+        // Reinsert the stable notification identity so its new sequence crosses the bounded
+        // snapshot window. Updating readAt alone could leave an older session outside Messages.
+        await transaction.notificationInboxItem.deleteMany({
+          where: { id: { in: latestReadRows.map((row) => row.id) } }
+        })
+        await transaction.notificationInboxItem.createMany({
+          data: latestReadRows.map((row) => ({ ...row, sequence: undefined, readAt: null }))
+        })
+        return stateFor(transaction, true)
+      })
+    })
+  }
+
   invalidateSessions(
     sessionIds: readonly string[],
     invalidatedAt: number

--- a/src/main/notifications/notification-inbox-requests.ts
+++ b/src/main/notifications/notification-inbox-requests.ts
@@ -1,7 +1,8 @@
 import type {
   NotificationMarkAllReadRequest,
   NotificationMarkReadRequest,
-  NotificationMarkSessionCompletionsReadRequest
+  NotificationMarkSessionCompletionsReadRequest,
+  NotificationMarkSessionUnreadRequest
 } from '../../shared/notifications'
 
 const requireNotificationMarkReadRequest = (value: unknown): NotificationMarkReadRequest => {
@@ -46,8 +47,25 @@ const requireNotificationMarkSessionCompletionsReadRequest = (
   return value as NotificationMarkSessionCompletionsReadRequest
 }
 
+const requireNotificationMarkSessionUnreadRequest = (
+  value: unknown
+): NotificationMarkSessionUnreadRequest => {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !Array.isArray((value as { sessionIds?: unknown }).sessionIds) ||
+    !(value as { sessionIds: unknown[] }).sessionIds.every(
+      (sessionId) => typeof sessionId === 'string'
+    )
+  ) {
+    throw new Error('Invalid notifications:mark-session-unread request.')
+  }
+  return value as NotificationMarkSessionUnreadRequest
+}
+
 export {
   requireNotificationMarkAllReadRequest,
   requireNotificationMarkReadRequest,
-  requireNotificationMarkSessionCompletionsReadRequest
+  requireNotificationMarkSessionCompletionsReadRequest,
+  requireNotificationMarkSessionUnreadRequest
 }

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -394,6 +394,7 @@ describe('preload bridge — public surface inventory', () => {
       'notifications.markAllRead',
       'notifications.markRead',
       'notifications.markSessionCompletionsRead',
+      'notifications.markSessionUnread',
       'notifications.onChanged',
       'notifications.onOpenSession',
       'notifications.onViewProbe',

--- a/src/renderer/src/components/NotificationLiveToast.test.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.test.tsx
@@ -109,6 +109,27 @@ afterEach(() => {
 })
 
 describe('NotificationLiveToast', () => {
+  it('does not toast when an existing Session is marked unread', async () => {
+    useNotificationInboxStore.setState({
+      unreadCount: 0,
+      unreadSessionIds: [],
+      latestSequence: 1,
+      items: [item(1, { readAt: 1000 })]
+    })
+    await act(async () => root.render(<NotificationLiveToast />))
+
+    await act(async () => {
+      useNotificationInboxStore.setState({
+        unreadCount: 1,
+        unreadSessionIds: ['session-1'],
+        latestSequence: 1,
+        items: [item(1)]
+      })
+    })
+
+    expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()
+  })
+
   it('does not replay existing messages and anchors a newly arrived message above the bell', async () => {
     await act(async () => root.render(<NotificationLiveToast />))
     expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -12,6 +12,7 @@ import { usePreviewPersistence } from '@/lib/preview-persistence/preview-persist
 import { deleteSession } from '@/lib/session-persistence/session-persistence'
 import { useMemoryStore } from '@/stores/memory-store'
 import { useNavigationStore } from '@/stores/navigation-store'
+import { useNotificationInboxStore } from '@/stores/notification-inbox-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import {
@@ -1004,6 +1005,13 @@ const WorkspacePage = ({
     usePreviewWorkbenchStore.getState().upsertAndActivateItem(createProjectFilesPreviewItem())
   }
 
+  const markSessionUnread = (session: ChatSession): void => {
+    void useNotificationInboxStore
+      .getState()
+      .markSessionUnread([session.id])
+      .catch(() => undefined)
+  }
+
   return (
     <main className="h-[100dvh] overflow-hidden bg-bg-10 text-[13px] leading-normal text-text-000 md:h-screen md:p-[10px]">
       <WorkspacePanelLayout
@@ -1052,6 +1060,7 @@ const WorkspacePage = ({
             onTogglePin={(session) => {
               sessionController.actions.togglePin(session)
             }}
+            onMarkSessionUnread={markSessionUnread}
             canArchiveSession={canArchiveSession}
             onArchiveSession={sessionController.actions.archive}
             onDeleteSession={sessionController.actions.openDelete}
@@ -1120,6 +1129,10 @@ const WorkspacePage = ({
             onTogglePin={(session) => {
               close()
               sessionController.actions.togglePin(session)
+            }}
+            onMarkSessionUnread={(session) => {
+              close()
+              markSessionUnread(session)
             }}
             canArchiveSession={canArchiveSession}
             onArchiveSession={(session) => {

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -135,7 +135,8 @@ const createMessage = (): ChatSession['messages'][number] => ({
 const renderSidebar = async (
   sessions: ChatSession[],
   mobileMode = false,
-  credentialPendingSessionIds?: ReadonlySet<string>
+  credentialPendingSessionIds?: ReadonlySet<string>,
+  unreadSessionIds?: ReadonlySet<string>
 ): Promise<string> => {
   const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
 
@@ -143,6 +144,7 @@ const renderSidebar = async (
     <WorkspaceSidebar
       projectName="Example project"
       sessions={sessions}
+      unreadSessionIds={unreadSessionIds}
       credentialPendingSessionIds={credentialPendingSessionIds}
       activeSessionId={sessions[0]?.id}
       canCreateConversation
@@ -1439,6 +1441,39 @@ describe('WorkspaceSidebar accessible render', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('fills the idle status dot green and emphasizes the title for unread Sessions', async () => {
+    const session = createSession({
+      id: 'session-unread',
+      title: 'Read this later',
+      status: 'idle'
+    })
+    const container = document.createElement('div')
+    container.innerHTML = await renderSidebar([session], false, undefined, new Set([session.id]))
+
+    const title = container.querySelector<HTMLElement>('[data-slot="session-title-marquee"]')
+    const status = container.querySelector<HTMLElement>('[data-slot="session-status-indicator"]')
+
+    expect(title?.classList).toContain('font-semibold')
+    expect(status?.classList).toContain('bg-success-000')
+    expect(status?.classList).not.toContain('bg-destructive')
+    expect(container.querySelector('[data-slot="session-unread-indicator"]')).toBeNull()
+    expect(container.textContent).toContain('Unread')
+  })
+
+  it('keeps lifecycle status colors ahead of unread green', async () => {
+    const session = createSession({
+      id: 'session-waiting-unread',
+      title: 'Needs approval',
+      status: 'waiting-permission'
+    })
+    const container = document.createElement('div')
+    container.innerHTML = await renderSidebar([session], false, undefined, new Set([session.id]))
+
+    const status = container.querySelector<HTMLElement>('[data-slot="session-status-indicator"]')
+    expect(status?.classList).toContain('bg-session-waiting')
+    expect(status?.classList).not.toContain('bg-success-000')
   })
 
   it('wires session open and row menu actions to the matching session', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -1453,6 +1453,7 @@ describe('WorkspaceSidebar accessible render', () => {
     const onDeleteSession = vi.fn()
     const onExportSession = vi.fn()
     const onArchiveSession = vi.fn()
+    const onMarkSessionUnread = vi.fn()
     const tree = WorkspaceSidebarView({
       now: Date.now(),
       projectName: 'Example project',
@@ -1472,6 +1473,7 @@ describe('WorkspaceSidebar accessible render', () => {
       onViewNotebook: vi.fn(),
       onExportSession,
       onTogglePin: vi.fn(),
+      onMarkSessionUnread,
       canArchiveSession: () => true,
       onArchiveSession,
       onDeleteSession,
@@ -1494,6 +1496,9 @@ describe('WorkspaceSidebar accessible render', () => {
     )
     const deleteItems = elements.filter((element) => getTextContent(element).trim() === 'Delete')
     const archiveItems = elements.filter((element) => getTextContent(element).trim() === 'Archive')
+    const unreadItems = elements.filter(
+      (element) => getTextContent(element).trim() === 'Mark as unread'
+    )
     const exportItems = elements.filter(
       (element) => getTextContent(element).trim() === 'Export conversation…'
     )
@@ -1521,6 +1526,10 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(archiveItems[1]?.props.onSelect).toBeTypeOf('function')
     ;(archiveItems[1]?.props.onSelect as () => void)()
     expect(onArchiveSession).toHaveBeenCalledWith(sessions[1])
+
+    expect(unreadItems[1]?.props.onSelect).toBeTypeOf('function')
+    ;(unreadItems[1]?.props.onSelect as () => void)()
+    expect(onMarkSessionUnread).toHaveBeenCalledWith(sessions[1])
 
     expect(deleteItems[0]?.props.onSelect).toBeTypeOf('function')
     ;(deleteItems[0]?.props.onSelect as () => void)()

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   ChevronLeft,
   Download,
+  Eye,
   Files,
   MoreVertical,
   PanelLeft,
@@ -72,6 +73,7 @@ type WorkspaceSidebarProps = {
   onViewNotebook: (session: ChatSession) => void
   onExportSession?: (session: ChatSession) => void
   onTogglePin: (session: ChatSession) => void
+  onMarkSessionUnread?: (session: ChatSession) => void
   canArchiveSession?: (session: ChatSession) => boolean
   onArchiveSession?: (session: ChatSession) => void
   onDeleteSession: (session: ChatSession) => void
@@ -263,6 +265,7 @@ const WorkspaceSidebarView = ({
   onViewNotebook,
   onExportSession,
   onTogglePin,
+  onMarkSessionUnread,
   canArchiveSession,
   onArchiveSession,
   onDeleteSession,
@@ -675,6 +678,16 @@ const WorkspaceSidebarView = ({
                                   <Pencil className="size-4" strokeWidth={2} aria-hidden="true" />
                                 </span>
                                 {t('Edit…')}
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                className="gap-2"
+                                disabled={!onMarkSessionUnread}
+                                onSelect={() => onMarkSessionUnread?.(session)}
+                              >
+                                <span className={sessionMenuIconClassName}>
+                                  <Eye className="size-4" strokeWidth={2} aria-hidden="true" />
+                                </span>
+                                {t('Mark as unread')}
                               </DropdownMenuItem>
                               <DropdownMenuSeparator />
                               {canDownloadArtifacts ? (

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -53,6 +53,7 @@ type WorkspaceSidebarProps = {
   onOpenProject?: (projectId: string) => void
   starNudgeKey?: string
   sessions: ChatSession[]
+  unreadSessionIds?: ReadonlySet<string>
   credentialPendingSessionIds?: ReadonlySet<string>
   activeSessionId: string | undefined
   canCreateConversation: boolean
@@ -129,7 +130,7 @@ const sessionStatusLabelKeys = {
 } as const satisfies Record<SessionStatus, string>
 
 const ACTIVE_SESSION_GRACE_MS = 15 * 60_000
-const EMPTY_CREDENTIAL_SESSION_IDS = new Set<string>()
+const EMPTY_SESSION_IDS = new Set<string>()
 const INITIAL_PROJECT_MENU_LIMIT = 5
 const OPEN_DIALOG_SELECTOR =
   '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
@@ -247,7 +248,8 @@ const WorkspaceSidebarView = ({
   onOpenProject,
   starNudgeKey,
   sessions,
-  credentialPendingSessionIds = EMPTY_CREDENTIAL_SESSION_IDS,
+  unreadSessionIds = EMPTY_SESSION_IDS,
+  credentialPendingSessionIds = EMPTY_SESSION_IDS,
   activeSessionId,
   canCreateConversation,
   canMutateConversations,
@@ -543,6 +545,7 @@ const WorkspaceSidebarView = ({
                   </div>
                   {section.items.map((session) => {
                     const isActive = session.id === activeSessionId
+                    const isUnread = unreadSessionIds.has(session.id)
                     const shortcutNumber = shortcutNumberBySessionId.get(session.id)
                     const presentedStatus = getPresentedSessionStatus(
                       session,
@@ -572,9 +575,12 @@ const WorkspaceSidebarView = ({
                           aria-hidden="true"
                         >
                           <span
+                            data-slot="session-status-indicator"
                             className={cn(
                               'size-[7px] shrink-0 rounded-full',
-                              sessionStatusDotClassName[presentedStatus]
+                              presentedStatus === 'idle' && isUnread
+                                ? 'bg-success-000 ring-2 ring-success-000/20'
+                                : sessionStatusDotClassName[presentedStatus]
                             )}
                           />
                         </span>
@@ -586,11 +592,12 @@ const WorkspaceSidebarView = ({
                         <SessionTitleMarquee
                           title={session.title}
                           className={cn(
-                            section.label === 'Active' &&
-                              presentedStatus !== 'idle' &&
+                            ((section.label === 'Active' && presentedStatus !== 'idle') ||
+                              isUnread) &&
                               'font-semibold'
                           )}
                         />
+                        {isUnread ? <span className="sr-only">{t('Unread')}</span> : null}
                         {showSessionShortcuts && shortcutNumber ? (
                           <kbd
                             aria-hidden="true"
@@ -822,11 +829,7 @@ const WorkspaceSidebarView = ({
 }
 
 const WorkspaceSidebar = (props: WorkspaceSidebarProps): React.JSX.Element => {
-  const {
-    credentialPendingSessionIds = EMPTY_CREDENTIAL_SESSION_IDS,
-    onOpenSession,
-    sessions
-  } = props
+  const { credentialPendingSessionIds = EMPTY_SESSION_IDS, onOpenSession, sessions } = props
   const [now, setNow] = useState(Date.now)
   const [showSessionShortcuts, setShowSessionShortcuts] = useState(false)
   const [openSessionActionsId, setOpenSessionActionsId] = useState<string | null>(null)

--- a/src/renderer/src/pages/workspace/WorkspaceSidebarContainer.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebarContainer.tsx
@@ -6,6 +6,7 @@ import {
   loadPersistedSession
 } from '@/lib/session-persistence/session-persistence'
 import { useNavigationStore } from '@/stores/navigation-store'
+import { useNotificationInboxStore } from '@/stores/notification-inbox-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -37,6 +38,11 @@ const WorkspaceSidebarContainer = ({
     )
   )
   const pendingCredentialRequests = useSettingsStore((state) => state.pendingCredentialRequests)
+  const unreadSessionIdsSnapshot = useNotificationInboxStore((state) => state.unreadSessionIds)
+  const unreadSessionIds = useMemo(
+    () => new Set(unreadSessionIdsSnapshot),
+    [unreadSessionIdsSnapshot]
+  )
   const credentialPendingSessionIds = useMemo(
     () =>
       new Set(
@@ -93,6 +99,7 @@ const WorkspaceSidebarContainer = ({
       onMobileClose={onMobileClose}
       starNudgeKey={projectId}
       sessions={sessions}
+      unreadSessionIds={unreadSessionIds}
       credentialPendingSessionIds={credentialPendingSessionIds}
       otherProjects={otherProjects}
       onOpenProject={handleOpenProject}

--- a/src/renderer/src/stores/notification-inbox-store.test.ts
+++ b/src/renderer/src/stores/notification-inbox-store.test.ts
@@ -14,6 +14,7 @@ describe('notification inbox store', () => {
     const getSnapshot = vi.fn(async () => ({
       revision: 2,
       unreadCount: 1,
+      unreadSessionIds: ['session-1'],
       latestSequence: 4,
       items: []
     }))
@@ -30,6 +31,7 @@ describe('notification inbox store', () => {
     const getSnapshot = vi.fn(async () => ({
       revision: 2,
       unreadCount: 0,
+      unreadSessionIds: [],
       latestSequence: 3,
       items: []
     }))
@@ -46,7 +48,13 @@ describe('notification inbox store', () => {
   })
 
   it('accepts a lower revision from a restarted backend as authoritative', async () => {
-    const snapshot = { revision: 1, unreadCount: 0, latestSequence: 0, items: [] }
+    const snapshot = {
+      revision: 1,
+      unreadCount: 0,
+      unreadSessionIds: [],
+      latestSequence: 0,
+      items: []
+    }
     vi.stubGlobal('window', {
       api: { notifications: { getSnapshot: vi.fn(async () => snapshot) } }
     })
@@ -65,6 +73,7 @@ describe('notification inbox store', () => {
     const getSnapshot = vi.fn(async () => ({
       revision: 2,
       unreadCount: 1,
+      unreadSessionIds: ['session-1'],
       latestSequence: 3,
       items: []
     }))
@@ -100,6 +109,7 @@ describe('notification inbox store', () => {
     const getSnapshot = vi.fn(async () => ({
       revision: 2,
       unreadCount: 1,
+      unreadSessionIds: ['session-1'],
       latestSequence: 3,
       items: []
     }))

--- a/src/renderer/src/stores/notification-inbox-store.test.ts
+++ b/src/renderer/src/stores/notification-inbox-store.test.ts
@@ -9,6 +9,22 @@ afterEach(() => {
 })
 
 describe('notification inbox store', () => {
+  it('marks normalized session ids unread and refreshes the snapshot', async () => {
+    const markSessionUnread = vi.fn(async () => undefined)
+    const getSnapshot = vi.fn(async () => ({
+      revision: 2,
+      unreadCount: 1,
+      latestSequence: 4,
+      items: []
+    }))
+    vi.stubGlobal('window', { api: { notifications: { getSnapshot, markSessionUnread } } })
+
+    await useNotificationInboxStore.getState().markSessionUnread([' session-1 ', 'session-1', ''])
+
+    expect(markSessionUnread).toHaveBeenCalledWith({ sessionIds: ['session-1'] })
+    expect(getSnapshot).toHaveBeenCalledOnce()
+  })
+
   it('marks all completions for normalized session ids and refreshes the snapshot', async () => {
     const markSessionCompletionsRead = vi.fn(async () => undefined)
     const getSnapshot = vi.fn(async () => ({

--- a/src/renderer/src/stores/notification-inbox-store.ts
+++ b/src/renderer/src/stores/notification-inbox-store.ts
@@ -16,6 +16,7 @@ type NotificationInboxStore = NotificationInboxSnapshot & {
 const EMPTY_SNAPSHOT: NotificationInboxSnapshot = {
   revision: 0,
   unreadCount: 0,
+  unreadSessionIds: [],
   latestSequence: 0,
   items: []
 }

--- a/src/renderer/src/stores/notification-inbox-store.ts
+++ b/src/renderer/src/stores/notification-inbox-store.ts
@@ -9,6 +9,7 @@ type NotificationInboxStore = NotificationInboxSnapshot & {
   markRead: (ids: readonly string[]) => Promise<void>
   markAllRead: () => Promise<void>
   markSessionCompletionsRead: (sessionIds: readonly string[]) => Promise<void>
+  markSessionUnread: (sessionIds: readonly string[]) => Promise<void>
   listen: () => () => void
 }
 
@@ -86,6 +87,15 @@ export const useNotificationInboxStore = create<NotificationInboxStore>((set, ge
     const normalized = [...new Set(sessionIds.map((id) => id.trim()).filter(Boolean))]
     if (normalized.length === 0) return
     const mark = window.api?.notifications?.markSessionCompletionsRead
+    if (!mark) return
+    await mark({ sessionIds: normalized })
+    await get().refresh()
+  },
+
+  markSessionUnread: async (sessionIds) => {
+    const normalized = [...new Set(sessionIds.map((id) => id.trim()).filter(Boolean))]
+    if (normalized.length === 0) return
+    const mark = window.api?.notifications?.markSessionUnread
     if (!mark) return
     await mark({ sessionIds: normalized })
     await get().refresh()

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1340,6 +1340,7 @@
     "Managed runtime is not set up yet": "El entorno de ejecución gestionado aún no está configurado",
     "Manual": "Manual",
     "Mark all read": "Marcar todo como leído",
+    "Mark as unread": "Marcar como no leído",
     "Mark completed session {{title}} as read": "Marcar sesión completada {{title}} como leída",
     "Markdown couldn't be read for preview": "No se pudo leer Markdown para obtener una vista previa",
     "Markdown shown to the agent when the skill is invoked.": "Markdown se muestra al agente cuando se invoca la habilidad.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1339,6 +1339,7 @@
     "Managed runtime is not set up yet": "L'environnement d'exécution géré n'est pas encore configuré",
     "Manual": "Manuel",
     "Mark all read": "Marquer tout comme lu",
+    "Mark as unread": "Marquer comme non lu",
     "Mark completed session {{title}} as read": "Marquer la session terminée {{title}} comme lue",
     "Markdown couldn't be read for preview": "Markdown n'a pas pu être lu pour l'aperçu",
     "Markdown shown to the agent when the skill is invoked.": "Markdown affiché à l'agent lorsque la compétence est invoquée.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1278,6 +1278,7 @@
     "Managed runtime is not set up yet": "マネージドランタイムがまだセットアップされていません",
     "Manual": "手動",
     "Mark all read": "すべて既読としてマークする",
+    "Mark as unread": "未読としてマークする",
     "Mark completed session {{title}} as read": "完了したセッション {{title}} を既読としてマークする",
     "Markdown couldn't be read for preview": "マークダウンをプレビュー用に読み取ることができませんでした",
     "Markdown shown to the agent when the skill is invoked.": "スキルが呼び出されたときにエージェントに表示されるマークダウン。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1293,6 +1293,7 @@
     "Managed runtime is not set up yet": "관리형 런타임이 아직 설정되지 않았습니다.",
     "Manual": "수동",
     "Mark all read": "모두 읽은 것으로 표시",
+    "Mark as unread": "읽지 않은 것으로 표시",
     "Mark completed session {{title}} as read": "완료된 세션을 읽음으로 표시: {{title}}",
     "Markdown couldn't be read for preview": "Markdown을 읽지 못해 미리보기를 생성할 수 없습니다.",
     "Markdown shown to the agent when the skill is invoked.": "스킬을 호출하면 에이전트에게 표시되는 Markdown입니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1335,6 +1335,7 @@
     "Managed runtime is not set up yet": "Управляемая среда выполнения ещё не настроена",
     "Manual": "Ручной",
     "Mark all read": "Отметить все как прочитанные",
+    "Mark as unread": "Отметить как непрочитанное",
     "Mark completed session {{title}} as read": "Отметить сессию {{title}} как прочитанную",
     "Markdown couldn't be read for preview": "Невозможно прочитать Markdown для предпросмотра",
     "Markdown shown to the agent when the skill is invoked.": "Содержимое Markdown отображается агенту при вызове навыка.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1500,6 +1500,7 @@
     "Notebook evidence": "Доказательства Notebook",
     "Notebooks run in an app-managed Python environment by default. You can change any of this later in Settings → Runtimes.": "По умолчанию Notebook работают в управляемой приложением среде Python. Позже эти параметры можно изменить в разделе «Настройки → Среды выполнения».",
     "Notifications": "Уведомления",
+    "Unread": "Непрочитано",
     "Notifications only appear while you're using another app. Tasks you cancel and failures the app retries automatically stay silent. Your operating system may ask for notification permission the first time one appears.": "Уведомления появляются, только когда вы работаете в другом приложении. Отменённые задачи и ошибки, после которых приложение повторяет попытку автоматически, не показываются. При первом уведомлении операционная система может запросить разрешение.",
     "OAuth (browser sign-in)": "OAuth (вход через браузер)",
     "OAuth scopes": "Области доступа OAuth",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1354,6 +1354,7 @@
     "Managed runtime is not set up yet": "托管运行时尚未设置",
     "Manual": "手动",
     "Mark all read": "全部标记为已读",
+    "Mark as unread": "标记为未读",
     "Mark completed session {{title}} as read": "将已完成的会话 {{title}} 标记为已读",
     "Markdown couldn't be read for preview": "无法读取 Markdown 以进行预览",
     "Markdown shown to the agent when the skill is invoked.": "技能被调用时展示给智能体的 Markdown。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1352,6 +1352,7 @@
     "Managed runtime is not set up yet": "託管執行環境尚未設定",
     "Manual": "手動",
     "Mark all read": "全部標記為已讀",
+    "Mark as unread": "標記為未讀",
     "Mark completed session {{title}} as read": "將已完成的工作階段 {{title}} 標記為已讀",
     "Markdown couldn't be read for preview": "無法讀取 Markdown 以進行預覽",
     "Markdown shown to the agent when the skill is invoked.": "技能被呼叫時展示給智能體的 Markdown。",

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -61,6 +61,7 @@ export type NotificationInboxItem = Readonly<{
 export type NotificationInboxSnapshot = Readonly<{
   revision: number
   unreadCount: number
+  unreadSessionIds: readonly string[]
   latestSequence: number
   items: readonly NotificationInboxItem[]
 }>

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -81,3 +81,7 @@ export type NotificationMarkAllReadRequest = Readonly<{ throughSequence: number 
 export type NotificationMarkSessionCompletionsReadRequest = Readonly<{
   sessionIds: readonly string[]
 }>
+
+export type NotificationMarkSessionUnreadRequest = Readonly<{
+  sessionIds: readonly string[]
+}>

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -117,6 +117,7 @@ import type {
   NotificationMarkAllReadRequest,
   NotificationMarkReadRequest,
   NotificationMarkSessionCompletionsReadRequest,
+  NotificationMarkSessionUnreadRequest,
   NotificationTestResult,
   OpenSessionFromNotificationRequest,
   UnreadTaskViewState
@@ -1173,6 +1174,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'notifications.markSessionCompletionsRead': callable<
     (request: NotificationMarkSessionCompletionsReadRequest) => Promise<void>
   >()('notifications', ['notifications:mark-session-completions-read']),
+  'notifications.markSessionUnread': callable<
+    (request: NotificationMarkSessionUnreadRequest) => Promise<void>
+  >()('notifications', ['notifications:mark-session-unread']),
   'notifications.sendTest': callable<() => Promise<NotificationTestResult>>()(
     'notifications',
     ['notifications:send-test', ELECTRON],

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -113,6 +113,7 @@ export const WEB_INVOKE_CHANNELS = {
   'notifications.markAllRead': 'notifications:mark-all-read',
   'notifications.markRead': 'notifications:mark-read',
   'notifications.markSessionCompletionsRead': 'notifications:mark-session-completions-read',
+  'notifications.markSessionUnread': 'notifications:mark-session-unread',
   'notifications.peekPendingOpenSession': 'notifications:peek-pending-open-session',
   'notifications.takePendingOpenSession': 'notifications:take-pending-open-session',
   'permissions.extendUndo': 'permissions:extend-undo',


### PR DESCRIPTION
## Problem

A Session that has already been acknowledged cannot be deferred from its sidebar menu. Users need a quick way to return its latest Messages entry to the unread queue without reopening or changing the Session.

## Proposed change

- Add an eye-icon Mark as unread action to the desktop and mobile Session action menus.
- Add the typed renderer, Electron IPC, and local/remote Web command path for marking Sessions unread.
- Transactionally restore the latest valid notification for each requested Session to unread and promote its stable notification identity across the bounded Messages snapshot window.
- Refresh the shared notification store and badge after the mutation.
- Add renderer translations for Spanish, French, Simplified Chinese, Traditional Chinese, Japanese, Korean, and Russian.

## Scope and non-goals

- Only the latest valid notification for a Session is marked unread; older history remains read.
- Sessions without an existing Messages notification do not get a synthetic activity item.
- No database schema, migration, native notification delivery, or Session persistence format changes.

## Acceptance criteria and validation

All listed checks ran after the final material edit and after rebasing onto origin/main at cb795e8d.

- Session menu rendering and action wiring -> npx vitest run with WorkspaceSidebar.render.test.tsx -> passed.
- Latest-notification unread persistence and bounded snapshot promotion -> notification-inbox-repository.test.ts -> passed.
- Renderer store, controller, IPC, host command, preload, renderer-contract, surface inventory, and i18n consumers -> targeted 12-file Vitest set -> 952 tests passed.
- Node and Web type safety -> npm run typecheck -> passed.
- Source lint -> npm run lint -> passed.
- Final impact selection -> npm run test:affected -- --base origin/main --head HEAD -> unknown host-command module ownership failed closed to the complete portable suite; 21,997 tests passed and 238 were conditionally skipped.

The exact-head full portable suite covered the cross-process consumers. No platform-specific native behavior changed, so packaging and Electron E2E lanes were not run locally. No independent code review was performed locally; PR review and CI remain authoritative.

## Review focus

- The transaction in NotificationInboxDbRepository preserves notification id, dedupe key, content, and action state while assigning a fresh sequence so an older marked-unread item re-enters the bounded Messages snapshot.
- The new action remains in the Session-management menu group and applies consistently to desktop and mobile navigation.
- Request validation and contracts remain identical across Electron and Web transports.