### PR TITLE
fix(installer): route failed uninstalls through recovery

### DIFF
--- a/build/packaging.test.ts
+++ b/build/packaging.test.ts
@@ -71,6 +71,24 @@ describe('NSIS installer include (build/installer.nsh)', () => {
     expect(include).toMatch(/!macro customUnInstallCheckCurrentUser\b/)
   })
 
+  it('hands the first failed old-uninstaller attempt to project recovery without a misleading close-app dialog', () => {
+    // installUtil runs before customUnInstallCheck. If it loops internally, users see
+    // appCannotBeClosed after five non-zero exits even though that same exit may mean a stale or
+    // partially removed first-install registration. Return the first failure to the path-scoped
+    // recovery in this include instead of blaming a process that may not exist.
+    const installUtil = readFileSync(
+      join(appBuilderLibRoot, 'templates/nsis/include/installUtil.nsh'),
+      'utf8'
+    )
+    const uninstallOldVersion =
+      installUtil.match(/Function uninstallOldVersion([\s\S]*?)FunctionEnd/)?.[1] ?? ''
+    const checkResult = uninstallOldVersion.slice(uninstallOldVersion.indexOf('CheckResult:'))
+
+    expect(uninstallOldVersion).not.toContain('$(appCannotBeClosed)')
+    expect(checkResult).toMatch(/CheckResult:[\s\S]*?Return\s+DoesNotExist:/)
+    expect(checkResult).not.toContain('Goto UninstallLoop')
+  })
+
   it('continues the install when the old version is already gone despite a non-zero exit code', () => {
     // The spurious-exit-2 case: the uninstall completed but a benign trailing error leaked as the
     // process exit code. Detect it by the old executable no longer existing and keep installing.

--- a/patches/app-builder-lib+26.15.3.patch
+++ b/patches/app-builder-lib+26.15.3.patch
@@ -1,0 +1,54 @@
+diff --git a/node_modules/app-builder-lib/templates/nsis/include/installUtil.nsh b/node_modules/app-builder-lib/templates/nsis/include/installUtil.nsh
+--- a/node_modules/app-builder-lib/templates/nsis/include/installUtil.nsh
++++ b/node_modules/app-builder-lib/templates/nsis/include/installUtil.nsh
+@@ -209,34 +209,20 @@ Function uninstallOldVersion
+   StrCpy $uninstallerFileNameTemp "$PLUGINSDIR\old-uninstaller.exe"
+   !insertmacro copyFile "$uninstallerFileName" "$uninstallerFileNameTemp"
+-
++
+-  # Retry counter
+-  StrCpy $R5 0
+-
+-  UninstallLoop:
+-    IntOp $R5 $R5 + 1
+-
+-    ${if} $R5 > 5
+-      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY OneMoreAttempt
+-      Return
+-    ${endIf}
+-
+-  OneMoreAttempt:
+-    ExecWait '"$uninstallerFileNameTemp" /S /KEEP_APP_DATA $0 _?=$installationDir' $R0
+-    ifErrors TryInPlace CheckResult
++  ExecWait '"$uninstallerFileNameTemp" /S /KEEP_APP_DATA $0 _?=$installationDir' $R0
++  ifErrors TryInPlace CheckResult
+-
++
+-    TryInPlace:
+-      # the execution failed - might have been caused by some group policy restrictions
+-      # we try to execute the uninstaller in place
+-      ExecWait '"$uninstallerFileName" /S /KEEP_APP_DATA $0 _?=$installationDir' $R0
+-      ifErrors DoesNotExist
++  TryInPlace:
++    # the execution failed - might have been caused by some group policy restrictions
++    # we try to execute the uninstaller in place
++    ExecWait '"$uninstallerFileName" /S /KEEP_APP_DATA $0 _?=$installationDir' $R0
++    ifErrors DoesNotExist
+-
++
+-    CheckResult:
+-      ${if} $R0 == 0
+-        Return
+-      ${endIf}
+-
+-    Sleep 1000
+-    Goto UninstallLoop
++  CheckResult:
++    # Open Science handles a non-zero result in customUnInstallCheck with path-scoped process
++    # cleanup and one controlled retry. Return immediately so the upstream retry loop cannot
++    # misreport every old-uninstaller failure as an application that could not be closed.
++    Return
+-
++
+   DoesNotExist:
+     SetErrors


### PR DESCRIPTION
## Problem

The Windows installer can report that Open Science cannot be closed after an old uninstaller returns a non-zero status. `app-builder-lib` retries that uninstaller five times and displays `appCannotBeClosed` before Open Science's existing path-scoped recovery hook can inspect the result. A first-time user can reach this path when Windows still has a machine-level, per-user, partial, or stale uninstall registration.

## Proposed change

- Patch `app-builder-lib@26.15.3` so the first completed old-uninstaller result returns to Open Science's existing recovery hook.
- Keep the existing recovery contract: accept a completed removal, otherwise stop install-directory processes and retry once, then fail with the real uninstall error.
- Add a packaging regression test that rejects the misleading upstream dialog and retry loop.

## Scope and non-goals

- No change to the PowerShell-restricted, image-name fallback process detector.
- No schema, data-model, data-field, persistence, migration, or state-enum change.
- Historical compatibility is intentional: stale and partially removed install registrations now use the existing recovery path.

## Acceptance criteria and validation

Checks listed below ran after the last material edit.

- Misleading old-uninstaller prompt -> `vitest run build/packaging.test.ts` on unpatched code -> stable failure in 3/3 runs on `$(appCannotBeClosed)`.
- Dependency patch applicability -> `patch-package --patch-dir .patch-validation --error-on-fail` against a clean `app-builder-lib@26.15.3` copy -> passed.
- Installer recovery and packaging contracts -> `vitest run build/packaging.test.ts scripts/electron-builder-config.test.ts` -> 31 tests passed.
- Test formatting -> `prettier --check build/packaging.test.ts` -> passed.
- Changed test lint -> `eslint build/packaging.test.ts` -> passed.
- NSIS compilation -> targeted Windows build with the installed Electron 39.8.10 distribution -> installer and block map generated, exit code 0.

The complete `npm test` suite was not run locally as requested; PR Gate is authoritative for the full portable and platform-specific plan. A live replay on the reporter's Windows 10 Enterprise machine remains uncovered locally.

## Review focus

- Confirm the dependency patch returns every completed non-zero uninstall result to `customUnInstallCheck` without weakening the existing final failure path.
- Confirm the patch remains appropriately scoped to `app-builder-lib@26.15.3`.
