### PR TITLE
feat(agent-framework): disable native shell tools

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16233,7 +16233,8 @@ describe('ACP runtime session management', () => {
                 'Workflow',
                 'SendMessage',
                 'TeamCreate',
-                'TeamDelete'
+                'TeamDelete',
+                'Bash'
               ],
               managedSettings: {
                 disableAgentView: true,

--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -231,7 +231,8 @@ describe('ACP Session presentation policy', () => {
                 'Workflow',
                 'SendMessage',
                 'TeamCreate',
-                'TeamDelete'
+                'TeamDelete',
+                'Bash'
               ],
               managedSettings: {
                 disableAgentView: true,

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -13,14 +13,22 @@ import { codexFramework } from './codex'
 import { opencodeFramework } from './opencode'
 
 describe('claudeCodeFramework', () => {
-  it('disables every Claude-native delegation path without removing ordinary built-in tools', () => {
+  it('disables native delegation and Bash while keeping the ordinary built-in preset', () => {
     const setup = claudeCodeFramework.buildSessionSetup({ systemPromptAppends: [] })
 
     expect(setup.meta).toMatchObject({
       claudeCode: {
         options: {
           tools: { type: 'preset', preset: 'claude_code' },
-          disallowedTools: ['Agent', 'Task', 'Workflow', 'SendMessage', 'TeamCreate', 'TeamDelete'],
+          disallowedTools: [
+            'Agent',
+            'Task',
+            'Workflow',
+            'SendMessage',
+            'TeamCreate',
+            'TeamDelete',
+            'Bash'
+          ],
           managedSettings: {
             disableAgentView: true,
             disableWorkflows: true,
@@ -65,7 +73,8 @@ describe('claudeCodeFramework', () => {
       'Workflow',
       'SendMessage',
       'TeamCreate',
-      'TeamDelete'
+      'TeamDelete',
+      'Bash'
     ])
     expect(options.managedSettings).toMatchObject({
       disableAgentView: true,

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -31,8 +31,8 @@ import {
 const CLAUDE_CODE_BUILTIN_TOOLS = { type: 'preset', preset: 'claude_code' } as const
 
 // Claude's Agent tool (formerly Task), Workflows, and team messaging can create or control work
-// outside the app-owned Frame/Attempt graph. Keep the complete ordinary Claude Code preset,
-// including TaskOutput/TaskStop for background shell jobs, but remove native delegation entry points.
+// outside the app-owned Frame/Attempt graph. Keep the complete ordinary Claude Code preset, but
+// remove native delegation entry points. Native execution is filtered separately below.
 const CLAUDE_CODE_NATIVE_DELEGATION_TOOLS = Object.freeze([
   'Agent',
   'Task',
@@ -41,6 +41,10 @@ const CLAUDE_CODE_NATIVE_DELEGATION_TOOLS = Object.freeze([
   'TeamCreate',
   'TeamDelete'
 ] as const)
+
+// Shell execution is app-owned so every framework follows the Notebook runtime's managed working
+// directory, environment-mutation guard, permission identity, and durable Run recording contract.
+const CLAUDE_CODE_NATIVE_EXECUTION_TOOLS = Object.freeze(['Bash'] as const)
 
 const recordValue = (value: unknown): Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -141,7 +145,8 @@ export const claudeCodeFramework: AgentFramework = {
     const disallowedTools = Object.freeze([
       ...new Set([
         ...stringArrayValue(sessionOptions.disallowedTools),
-        ...CLAUDE_CODE_NATIVE_DELEGATION_TOOLS
+        ...CLAUDE_CODE_NATIVE_DELEGATION_TOOLS,
+        ...CLAUDE_CODE_NATIVE_EXECUTION_TOOLS
       ])
     ])
     const managedSettings = Object.freeze({

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -21,7 +21,7 @@ describe('codexFramework', () => {
     expect(codexNativeModelInstructions).not.toContain('coding agent')
   })
 
-  it('disables every Codex native multi-agent implementation in every spawned profile', () => {
+  it('disables native multi-agent and Shell features across every backend route', () => {
     const framework = createCodexFramework()
     const configurations = [
       framework.prepareModelConfig(
@@ -36,16 +36,59 @@ describe('codexFramework', () => {
         { storageRoot: '/data/official', executablePath: '/runtime/codex-acp' }
       ),
       framework.prepareModelConfig(
+        {
+          type: 'custom',
+          apiEndpoints: ['responses'],
+          baseUrl: 'https://gateway.example/v1',
+          model: 'custom-responses',
+          key: 'secret'
+        },
+        { storageRoot: '/data/custom', executablePath: '/runtime/codex-acp' }
+      ),
+      framework.prepareModelConfig(
+        {
+          type: 'custom',
+          apiEndpoints: ['openai'],
+          baseUrl: 'https://gateway.example/v1',
+          model: 'chat-model',
+          key: 'secret'
+        },
+        {
+          storageRoot: '/data/bridge',
+          executablePath: '/runtime/codex-acp',
+          responsesBridge: { baseUrl: 'http://127.0.0.1:43123/v1', token: 'local-token' }
+        }
+      ),
+      framework.prepareModelConfig(
+        {
+          type: 'custom',
+          apiEndpoints: ['responses'],
+          baseUrl: 'https://gateway.example/v1',
+          model: 'compatibility-model',
+          key: 'secret'
+        },
+        {
+          storageRoot: '/data/compatibility',
+          executablePath: '/runtime/codex-acp',
+          responsesBridge: {
+            baseUrl: 'http://127.0.0.1:43124/v1',
+            token: 'local-token',
+            kind: 'responses-compatibility'
+          }
+        }
+      ),
+      framework.prepareModelConfig(
+        { type: 'codex-shared', model: 'gpt-5.4' },
+        { storageRoot: '/data/shared', executablePath: '/runtime/codex-acp' }
+      ),
+      framework.prepareModelConfig(
         { type: 'codex-isolated', model: 'gpt-5.4' },
         { storageRoot: '/data/subscription', executablePath: '/runtime/codex-acp' }
       )
     ]
 
     expect(configurations.map(({ env }) => JSON.parse(env?.CODEX_CONFIG ?? '{}').features)).toEqual(
-      [
-        { multi_agent: false, multi_agent_v2: false },
-        { multi_agent: false, multi_agent_v2: false }
-      ]
+      configurations.map(() => ({ multi_agent: false, multi_agent_v2: false, shell_tool: false }))
     )
   })
 
@@ -511,7 +554,9 @@ describe('codexFramework', () => {
       env: {
         HOME: join('/data', 'codex-subscription'),
         CODEX_HOME: join('/data', 'codex-subscription'),
-        CODEX_CONFIG: JSON.stringify({ features: { multi_agent: false, multi_agent_v2: false } })
+        CODEX_CONFIG: JSON.stringify({
+          features: { multi_agent: false, multi_agent_v2: false, shell_tool: false }
+        })
       }
     })
   })
@@ -527,7 +572,9 @@ describe('codexFramework', () => {
       env: {
         HOME: join('/data', 'codex-subscription'),
         CODEX_HOME: join('/data', 'codex-subscription'),
-        CODEX_CONFIG: JSON.stringify({ features: { multi_agent: false, multi_agent_v2: false } })
+        CODEX_CONFIG: JSON.stringify({
+          features: { multi_agent: false, multi_agent_v2: false, shell_tool: false }
+        })
       }
     })
   })

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -68,9 +68,12 @@ const CODEX_MODE_IDS = {
 // and preview Codex implementations off in every profile so native children cannot bypass that Host
 // contract. This must live in CODEX_CONFIG (rather than only custom model metadata), because trusted
 // bundled models intentionally do not receive an app-authored model catalog.
-const CODEX_DELEGATION_FEATURES = Object.freeze({
+const CODEX_DISABLED_NATIVE_FEATURES = Object.freeze({
   multi_agent: false,
-  multi_agent_v2: false
+  multi_agent_v2: false,
+  // Disabling unified_exec alone falls back to shell_command. shell_tool disables both generations
+  // so execution stays on the app-owned Notebook bash_execute MCP tool.
+  shell_tool: false
 })
 
 const CODEX_ENV_KEYS = [
@@ -170,7 +173,7 @@ const buildCodexConfig = (provider: {
 
   return {
     ...buildCodexModelOptions(provider),
-    features: CODEX_DELEGATION_FEATURES,
+    features: CODEX_DISABLED_NATIVE_FEATURES,
     ...(contextWindow
       ? {
           model_context_window: contextWindow,
@@ -426,7 +429,7 @@ export const createCodexFramework = ({
       })
       const codexConfig = {
         ...modelOptions,
-        features: CODEX_DELEGATION_FEATURES,
+        features: CODEX_DISABLED_NATIVE_FEATURES,
         ...(persistentSystemPrompt ? { developer_instructions: persistentSystemPrompt } : {})
       }
       const codexConfigJson =

--- a/src/main/agent-framework/native-shell-policy.test.ts
+++ b/src/main/agent-framework/native-shell-policy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
+import { claudeCodeFramework } from './claude-code'
+import { createCodeBuddyFramework } from './codebuddy'
+import { createCodexFramework } from './codex'
+import { opencodeFramework } from './opencode'
+import { listAgentFrameworks } from './registry'
+
+describe('native shell policy', () => {
+  it('disables each framework-native shell surface', () => {
+    const claudeOptions = (
+      claudeCodeFramework.buildSessionSetup({ systemPromptAppends: [] }).meta?.claudeCode as {
+        options: { disallowedTools: string[] }
+      }
+    ).options
+    expect(claudeOptions.disallowedTools).toContain('Bash')
+
+    const opencode = opencodeFramework.prepareModelConfig(
+      {
+        type: 'custom',
+        apiEndpoints: ['openai'],
+        baseUrl: 'https://gateway.example/v1',
+        model: 'test-model',
+        key: 'test-key'
+      },
+      { storageRoot: '/data', executablePath: '/runtime/opencode' }
+    )
+    expect(JSON.parse(opencode.env?.OPENCODE_CONFIG_CONTENT ?? '{}').permission.bash).toBe('deny')
+
+    const codex = createCodexFramework().prepareModelConfig(
+      { type: 'codex-isolated', model: 'gpt-5.4' },
+      { storageRoot: '/data', executablePath: '/runtime/codex-acp' }
+    )
+    expect(JSON.parse(codex.env?.CODEX_CONFIG ?? '{}').features.shell_tool).toBe(false)
+
+    const codebuddy = createCodeBuddyFramework({ platform: 'linux' }).prepareModelConfig(
+      {
+        type: 'custom',
+        apiEndpoints: ['openai'],
+        baseUrl: 'https://gateway.example/v1',
+        model: 'test-model',
+        key: 'test-key'
+      },
+      { storageRoot: '/data', executablePath: '/runtime/codebuddy' }
+    )
+    const enabledTools = codebuddy.args?.[codebuddy.args.indexOf('--tools') + 1]
+    expect(enabledTools?.split(',')).not.toContain('Bash')
+  })
+
+  it('keeps the app-owned Notebook shell available to every framework', () => {
+    expect(listAgentFrameworks()).toHaveLength(4)
+    expect(listAgentFrameworks().every((framework) => framework.acceptsStdioMcp)).toBe(true)
+    expect(NOTEBOOK_RPC_TOOLS).toContainEqual(
+      expect.objectContaining({ name: 'bash_execute', method: 'executeShell' })
+    )
+  })
+})

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -149,9 +149,10 @@ describe('opencodeFramework.prepareModelConfig', () => {
     for (const tool of ['read', 'glob', 'grep', 'list', 'lsp', 'skill']) {
       expect(rules[tool]).toBe('allow')
     }
-    for (const tool of ['edit', 'bash', 'webfetch', 'websearch', 'external_directory']) {
+    for (const tool of ['edit', 'webfetch', 'websearch', 'external_directory']) {
       expect(rules[tool]).toBe('ask')
     }
+    expect(rules.bash).toBe('deny')
     expect(rules.task).toBe('deny')
     expect(JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}').agent).toEqual({
       general: { disable: true },
@@ -663,7 +664,7 @@ describe('buildOpencodeConfig', () => {
     expect(config.provider.anthropic.options.apiKey).toBeUndefined()
   })
 
-  it('pins sensitive built-in tools to ask and disables native task delegation', () => {
+  it('pins sensitive built-ins to ask and disables native Bash and task delegation', () => {
     const config = JSON.parse(
       buildOpencodeConfig(
         { type: 'custom', baseUrl: 'https://gw/v1', model: 'm' },
@@ -672,9 +673,10 @@ describe('buildOpencodeConfig', () => {
     )
 
     // Our rules override the base for every side-effecting built-in.
-    for (const tool of ['edit', 'bash', 'webfetch', 'websearch', 'external_directory']) {
+    for (const tool of ['edit', 'webfetch', 'websearch', 'external_directory']) {
       expect(config.permission[tool]).toBe('ask')
     }
+    expect(config.permission.bash).toBe('deny')
     expect(config.permission.task).toBe('deny')
     expect(config.agent).toEqual({
       general: { disable: true },
@@ -696,9 +698,10 @@ describe('buildOpencodeConfig', () => {
     for (const tool of ['read', 'glob', 'grep', 'list', 'lsp', 'skill']) {
       expect(config.permission[tool]).toBe('allow')
     }
-    // Mutating/external tools are pinned to ask (and unlisted MCP tools fall through to "*" → ask).
+    // Mutating/external tools are pinned to ask (and unlisted MCP tools fall through to "*" → ask),
+    // while native Bash is removed independently of the Notebook bash_execute MCP tool.
     expect(config.permission.edit).toBe('ask')
-    expect(config.permission.bash).toBe('ask')
+    expect(config.permission.bash).toBe('deny')
     expect(config.permission.task).toBe('deny')
   })
 

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -121,7 +121,9 @@ const OPENCODE_PERMISSION_RULES: Record<string, 'ask' | 'allow' | 'deny'> = {
   list: 'allow',
   lsp: 'allow',
   edit: 'ask',
-  bash: 'ask',
+  // Shell execution stays on the app-owned Notebook tool, which retains its separate MCP identity
+  // and continues through the wildcard ask rule below.
+  bash: 'deny',
   // OpenCode's Task tool creates provider-owned subagent Sessions outside the app-owned delegated
   // work graph. Deny it at the highest-precedence config layer: asking is insufficient because an
   // approval would still create an invisible child that bypasses Attempt authority and lifecycle.
@@ -555,8 +557,9 @@ export const createOpencodeFramework = ({
   ): PermissionProfileApplication {
     // opencode advertises `build`/`plan` modes, not Claude's `default`/`bypassPermissions`, so no mode
     // is set here — the app owns permission decisions instead. prepareModelConfig configures opencode
-    // to delegate every edit/bash/webfetch prompt to the client (see buildOpencodeConfig), so the broker
-    // enforces ask/auto/full app-side. That's why Full access is offered even without a native bypass.
+    // to delegate every edit/webfetch prompt to the client (see buildOpencodeConfig), while native bash
+    // is disabled in favor of Notebook bash_execute. The broker enforces ask/auto/full app-side for the
+    // remaining side effects. That's why Full access is offered even without a native bypass.
     return resolvePermissionProfileApplication(profile, modes, { brokerEnforcesFullAccess: true })
   }
 })


### PR DESCRIPTION
## Problem

The four supported agent runtimes did not share one enforceable policy for native shell execution. Claude Code, OpenCode, and Codex could expose their framework-owned shell tools, allowing execution to bypass the app-owned Notebook MCP path and its durable execution records. CodeBuddy already used an explicit tool allowlist that omitted Bash.

## Proposed change

- Add `Bash` to Claude Code's final `disallowedTools` metadata.
- Set OpenCode's `bash` permission to `deny`.
- Set Codex's `shell_tool` feature to `false` for every supported backend route/profile.
- Keep CodeBuddy's existing non-shell tool allowlist unchanged.
- Add a shared four-framework contract test that also locks in stdio MCP support and preserves Notebook `bash_execute` routing.
- Update exact ACP presentation-policy expectations affected by the Claude metadata change.

## Scope and non-goals

This disables framework-native shell tools only. It intentionally preserves the app-owned Notebook `bash_execute -> executeShell` capability. It does not change Notebook authorization, execution semantics, PTY support, or background-process behavior.

## Acceptance criteria and validation

- Four-runtime policy contract and affected ACP/framework suites: `npx vitest run ...` — 8 files, 844 tests passed.
- Complete unit/integration fallback: `npm test -- --reporter=dot` — 1,304 files and 21,893 tests passed; 16 files and 238 tests skipped by their existing gates.
- Node and renderer types: `npm run typecheck` — passed.
- Repository lint: `npm run lint` — passed.
- Real Notebook shell route: kernel-gated `bash_execute` certification — passed for stdout, exit code 0, and non-zero exit propagation.
- Production Electron bundle: `npm run build:e2e` — passed.
- Actual desktop startup/relaunch path: Playwright `creates a project through the desktop stack` — passed against Electron.
- OpenCode 1.18.14 runtime inspection — resolved `tools.bash` to `false`.
- Codex 0.144.6 request capture — `--disable shell_tool` removed `exec_command` and `write_stdin` across the tested Responses path.

## Review focus

- Vendor-specific disable semantics in the Claude Code, OpenCode, and Codex adapters.
- The invariant that native shell is absent while Notebook `bash_execute` remains available through stdio MCP.
- Codex coverage across official Responses, custom direct Responses, Chat bridge, Responses compatibility, shared, and isolated profiles.

## Residual risk

Live provider-backed prompts were not sent through Claude Code or CodeBuddy accounts; their deterministic CLI metadata/tool allowlists and the shared contract are covered locally. Platform-specific binary behavior beyond the tested macOS arm64 environment remains covered by CI and downstream release testing.
