### PR TITLE
fix(message-stream): keep streamed rows out of content-visibility

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.containment.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.containment.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+// Completing a streamed Agent row must not re-enable content-visibility. The 10rem intrinsic
+// fallback is taller than a one-line reply, and that height flash pushes a live tool below it.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { JSX, PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatMessage } from '@/stores/session-store'
+
+import { WorkspaceMessageItem } from './WorkspaceMessageItem'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@/components/ui/message-scroller', () => ({
+  MessageScrollerItem: ({
+    children,
+    disableContainment
+  }: PropsWithChildren<{ disableContainment?: boolean }>): JSX.Element => (
+    <div data-disable-containment={disableContainment || undefined}>{children}</div>
+  )
+}))
+
+vi.mock('@/components/streamdown/AgentMarkdown', () => ({
+  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+  PresentedAgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
+}))
+
+// Drive presentation from sourceOpen so completing a streamed row is not masked by the
+// real jitter buffer still reporting isPresenting in jsdom.
+vi.mock('@/components/streamdown/use-smooth-streaming-content', () => ({
+  useSmoothStreamingContent: (content: string, sourceOpen: boolean) => ({
+    content,
+    isPresenting: sourceOpen
+  })
+}))
+
+vi.mock('./artifact-preview', () => ({
+  ArtifactPreview: () => <div data-testid="artifact-preview" />
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+const createMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+  id: 'message-1',
+  role: 'agent',
+  content: 'Next step.',
+  status: 'complete',
+  eventIds: [],
+  createdAt: 1710000000000,
+  updatedAt: 1710000000000,
+  ...overrides
+})
+
+const noop = (): void => {}
+
+const renderItem = async (message: ChatMessage): Promise<void> => {
+  await act(async () => {
+    root.render(
+      <WorkspaceMessageItem
+        message={message}
+        projectId="project-1"
+        onPreviewArtifact={noop}
+        onPreviewUploadAttachment={noop}
+        onOpenSkillMention={noop}
+        onPreviewMentionArtifact={noop}
+      />
+    )
+  })
+}
+
+const containmentDisabled = (): boolean =>
+  container.querySelector('[data-disable-containment]') !== null
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('WorkspaceMessageItem content-visibility containment', () => {
+  it('keeps containment disabled after a streamed one-line Agent reply completes', async () => {
+    await renderItem(createMessage({ status: 'streaming' }))
+    expect(containmentDisabled()).toBe(true)
+
+    await renderItem(createMessage({ status: 'complete' }))
+    expect(containmentDisabled()).toBe(true)
+  })
+
+  it('contains a historical Agent reply that never streamed in this mount', async () => {
+    await renderItem(createMessage({ status: 'complete' }))
+    expect(containmentDisabled()).toBe(false)
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1292,6 +1292,13 @@ const WorkspaceMessageItemImpl = ({
   const [isResendingEdit, setIsResendingEdit] = useState(false)
   // True while the destructive-resend confirmation dialog is open.
   const [isConfirmingEdit, setIsConfirmingEdit] = useState(false)
+  // content-visibility:auto uses contain-intrinsic-size 10rem until a size is remembered. A
+  // one-line streamed reply is ~44px; turning containment on at completion inflates it to 160px
+  // and pushes a live tool below it. Keep this row out of that path for the rest of the mount.
+  const skipContentVisibilityNow =
+    message.status === 'streaming' || isAssistantPresenting || isEditing
+  const [skipContentVisibility, setSkipContentVisibility] = useState(skipContentVisibilityNow)
+  if (skipContentVisibilityNow && !skipContentVisibility) setSkipContentVisibility(true)
   const copyResetTimeoutRef = useRef<number | null>(null)
   const editButtonRef = useRef<HTMLButtonElement | null>(null)
   const editDocRef = useRef(editDoc)
@@ -1440,7 +1447,7 @@ const WorkspaceMessageItemImpl = ({
     <MessageScrollerItem
       key={message.id}
       messageId={message.id}
-      disableContainment={message.status === 'streaming' || isAssistantPresenting || isEditing}
+      disableContainment={skipContentVisibilityNow || skipContentVisibility}
       scrollAnchor={message.role === 'user'}
       className="min-w-0"
     >


### PR DESCRIPTION
## Problem

Windows workspace E2E on the merged lifecycle work failed as a flake in `e2e/message-tool-layout-stability.spec.ts`:

**keeps a running tool stationary while one line of buffered Markdown finishes rendering**

The running tool group's viewport `top` jumped by **116px** (`370.34` → `486.34`) during the 1.5s sample window, then passed on retry. `--fail-on-flaky-tests` failed `e2e_workspace_windows`.

The jump matches the transcript `content-visibility: auto` fallback (`contain-intrinsic-size: auto 10rem` = 160px) minus a one-line Agent row (~44px). Completing the streamed "Next step." row turned containment back on, so the placeholder inflated the message and pushed the live tool down. The Playwright snapshot at failure already showed the turn idle, which is when that toggle happens. The same journey is already covered on macOS and did not fail there.

Observed on https://github.com/aipoch/open-science/pull/1945 (merged).

## Proposed change

Once a transcript row has streamed, presented, or been edited, keep `disableContainment` latched for the rest of the mount. Historical complete rows that never streamed in this mount still use content-visibility.

A focused jsdom test renders a streaming one-line Agent reply, completes it on the same instance, and asserts containment stays off.

## Scope and non-goals

- Fixes the live stream → complete containment toggle on `WorkspaceMessageItem`.
- Does not change autoscroll, presentation buffering, or the E2E assertion (viewport excursion ≤ 2px).
- Does not change how historical messages that never streamed in the current mount are contained.

## Acceptance criteria and validation

- Completing a streamed one-line Agent reply does not re-enable the 10rem content-visibility placeholder on that mount.
- A historical complete Agent reply still uses content-visibility.
- Windows workspace E2E layout journey no longer fails as flaky.

### Evidence (after last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Streamed row stays uncontained after complete | `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.containment.test.tsx` | pass (2) |
| Existing message actions | `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx` | pass (36) |
| Mentions / scroller / workspace component pins | `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx src/renderer/src/components/ui/message-scroller.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx` | pass |
| Renderer types | `npm run typecheck:web` | pass |
| Lint on changed files | `npx eslint` on the two touched files | pass |
| Windows workspace E2E | PR Gate `e2e_workspace_windows` | not run locally; CI is authoritative |

Uncovered risk: the original failure is Windows Electron + rAF sampling. Local verification is jsdom plus typecheck; the layout journey must pass on PR CI.

## Review focus

- The latch is mount-local React state, not session/domain state.
- `setState` during render is the React "adjust state from previous props" pattern so the complete render already skips containment (an effect would be one frame too late).

## Compatibility notes

- **Historical data:** none. No stored messages, schema, or migrations change.
- **New enum / persisted state:** none. `skipContentVisibility` is component-local React state only.
- **Persistence:** none.