### PR TITLE
fix(settings): preserve compute bookmarks on reload

### DIFF
--- a/src/main/settings/document-codec.ts
+++ b/src/main/settings/document-codec.ts
@@ -379,6 +379,15 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
   const notebookManualInterpreters = sanitizeManualInterpreters(value.notebookManualInterpreters)
   if (notebookManualInterpreters) settings.notebookManualInterpreters = notebookManualInterpreters
 
+  if (isRecord(value.computeBookmarks)) {
+    const computeBookmarks: Record<string, string[]> = Object.fromEntries(
+      Object.entries(value.computeBookmarks).flatMap(([providerId, folders]) =>
+        Array.isArray(folders) ? [[providerId, asStringArray(folders)]] : []
+      )
+    )
+    if (Object.keys(computeBookmarks).length > 0) settings.computeBookmarks = computeBookmarks
+  }
+
   const computeGrants = Array.isArray(value.computeGrants)
     ? value.computeGrants
         .map(sanitizeComputeGrant)

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -997,6 +997,27 @@ describe('settings repository', () => {
     expect(reloaded.onboardingCompletedAt).toBe(1234)
   })
 
+  it('preserves compute bookmarks across a reload', async () => {
+    const root = await createStorageRoot()
+    const repository = new SettingsRepository(root)
+
+    await repository.setComputeBookmarks('ssh:cluster', ['/scratch/project', '/data/results'])
+    expect(JSON.parse(await readFile(join(root, 'settings.json'), 'utf8'))).toMatchObject({
+      computeBookmarks: { 'ssh:cluster': ['/scratch/project', '/data/results'] }
+    })
+
+    const reloaded = await new SettingsRepository(root).getSettings()
+    expect(reloaded.computeBookmarks).toEqual({
+      'ssh:cluster': ['/scratch/project', '/data/results']
+    })
+
+    await new SettingsRepository(root).setNotificationsEnabled(false)
+    await expect(new SettingsRepository(root).getSettings()).resolves.toMatchObject({
+      computeBookmarks: { 'ssh:cluster': ['/scratch/project', '/data/results'] },
+      notificationsEnabled: false
+    })
+  })
+
   it('stamps pathsNormalizedAt once, is idempotent, and survives a reload', async () => {
     const root = await createStorageRoot()
     const repository = new SettingsRepository(root)


### PR DESCRIPTION
## Problem

`computeBookmarks` is written by `SettingsRepository`, but `sanitizeSettings()` omitted it while rebuilding `StoredSettings`. A save therefore reached `settings.json`, then disappeared on the next read; any later settings mutation published the sanitized document and permanently removed the bookmark data.

## Proposed change

- Preserve well-shaped `computeBookmarks` records at the settings codec boundary, retaining each provider's ordered string-array value, including empty arrays.
- Add a repository-level regression test that proves the raw file contains the write, a fresh repository reads it back, and an unrelated settings mutation does not delete it.

## Scope and non-goals

- Persistence: fixes the existing `settings.json` field; no new field, format version, database schema, or migration is introduced.
- Historical compatibility: bookmark data still present in an existing settings file is recovered automatically after upgrade. Data already removed by a prior unrelated settings write cannot be reconstructed.
- Architecture/data model/interaction: no architecture, data relationship, TypeScript model, IPC, or UI interaction changes.
- State: no enum or persisted state value is added.
- Invalid hand-edited entries remain fail-closed: non-array provider values are dropped and non-string array members are filtered.

## Acceptance criteria and validation

All listed checks ran after the last material edit and after rebasing onto the current `origin/main`:

- Bookmark write, reload, and unrelated-mutation preservation -> `npm test -- src/main/settings/repository.test.ts -t 'preserves compute bookmarks across a reload'` -> passed.
- Settings repository owner, contract, and representative consumer coverage -> `npm run test:module -- settings_repository` -> 20 files passed, 722 tests passed.
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.

The regression test was first run against the unmodified codec and failed deterministically with `reloaded.computeBookmarks` equal to `undefined` while the raw JSON assertion passed.

Uncovered local risk: the module plan selects the `windows_sensitive` overlay, but no Windows lane was run locally. CI remains authoritative for complete and cross-platform coverage. The full local `npm test` suite was intentionally not run for this module-scoped fix.

## Review focus

- Confirm the codec preserves every valid bookmark entry without normalizing opaque platform-specific paths.
- Confirm the repository regression exercises both silent read loss and deletion during a later settings mutation.
