### PR TITLE
fix(onboarding): bound Windows storage recommendation

### DIFF
--- a/src/renderer/src/pages/onboarding/LocationStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.render.test.tsx
@@ -91,10 +91,10 @@ describe('LocationStep', () => {
     expect(onBack).toHaveBeenCalledOnce()
   })
 
-  it('disables Continue, but not Back or Browse, while resolving the Windows default', async () => {
+  it('keeps navigation available while resolving the optional Windows default', async () => {
     await renderStep(true)
 
-    expect(findButton(/^continue$/i)?.disabled).toBe(true)
+    expect(findButton(/^continue$/i)?.disabled).toBe(false)
     expect(findButton(/back/i)?.disabled).toBe(false)
     expect(findButton(/browse/i)?.disabled).toBe(false)
   })

--- a/src/renderer/src/pages/onboarding/LocationStep.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.tsx
@@ -68,7 +68,7 @@ const LocationStep = ({
 }: LocationStepProps): React.JSX.Element => {
   const { t } = useTranslation()
   const { chosenParent, chosenDataRoot, chosenKind } = locationDraft
-  const isLoadingDefaultLocation = dataRootInfo === null && dataRootError === undefined
+  const isLoadingDefaultLocation = isResolvingDefaultLocation && dataRootInfo === null
   const [locationError, setLocationError] = useState<string | undefined>(undefined)
   const [confirmRestart, setConfirmRestart] = useState(false)
   const requestInFlightRef = useRef(false)

--- a/src/renderer/src/pages/onboarding/LocationStep.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.tsx
@@ -68,6 +68,7 @@ const LocationStep = ({
 }: LocationStepProps): React.JSX.Element => {
   const { t } = useTranslation()
   const { chosenParent, chosenDataRoot, chosenKind } = locationDraft
+  const isLoadingDefaultLocation = dataRootInfo === null && dataRootError === undefined
   const [locationError, setLocationError] = useState<string | undefined>(undefined)
   const [confirmRestart, setConfirmRestart] = useState(false)
   const requestInFlightRef = useRef(false)
@@ -283,7 +284,7 @@ const LocationStep = ({
         <Button
           type="button"
           onClick={handleContinueLocation}
-          disabled={requestInFlight || isResolvingDefaultLocation}
+          disabled={requestInFlight || isLoadingDefaultLocation}
           className="px-4"
         >
           {t('Continue')}

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -365,7 +365,65 @@ describe('OnboardingWizard flow', () => {
     expect(container.textContent).not.toContain('D:\\OpenScience')
   })
 
-  it('waits for the Windows default probe before allowing Continue', async () => {
+  it('keeps Continue available while the Windows default recommendation is pending', async () => {
+    window.api.platform = 'win32'
+    window.api.storage.getInfo = vi.fn().mockResolvedValue(
+      storageInfo({
+        dataRoot: 'C:\\Users\\researcher\\OpenScience',
+        defaultDataRoot: 'C:\\Users\\researcher\\OpenScience',
+        defaultParent: 'C:\\Users\\researcher',
+        canAutoSelectDataDrive: true
+      })
+    )
+    window.api.localFs.listDrives = vi.fn().mockReturnValue(new Promise(() => undefined))
+    readyClaudeState()
+
+    await renderWizard()
+    await goToLocationStep()
+
+    expect(container.textContent).toContain('C:\\Users\\researcher\\OpenScience')
+    expect(findButton(/^continue$/i)?.disabled).toBe(false)
+
+    await clickButton(/^continue$/i)
+    expect(currentSection('Set up the agent runtime')).not.toBeNull()
+  })
+
+  it('ends a pending Windows recommendation and keeps the default after its deadline', async () => {
+    window.api.platform = 'win32'
+    window.api.storage.getInfo = vi.fn().mockResolvedValue(
+      storageInfo({
+        dataRoot: 'C:\\Users\\researcher\\OpenScience',
+        defaultDataRoot: 'C:\\Users\\researcher\\OpenScience',
+        defaultParent: 'C:\\Users\\researcher',
+        canAutoSelectDataDrive: true
+      })
+    )
+    window.api.localFs.listDrives = vi.fn().mockResolvedValue([
+      { path: 'C:\\', label: 'C:' },
+      { path: 'D:\\', label: 'D:' }
+    ])
+    window.api.storage.inspectDataRoot = vi.fn().mockReturnValue(new Promise(() => undefined))
+    readyClaudeState()
+
+    await renderWizard()
+    vi.useFakeTimers()
+    try {
+      await goToLocationStep()
+      expect(currentSection('Choose data location')?.getAttribute('aria-busy')).toBe('true')
+      expect(window.api.storage.inspectDataRoot).toHaveBeenCalledWith('D:\\')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000)
+      })
+
+      expect(currentSection('Choose data location')?.getAttribute('aria-busy')).toBe('false')
+      expect(container.textContent).toContain('C:\\Users\\researcher\\OpenScience')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('applies the Windows default recommendation when the user waits for the probe', async () => {
     let releaseDefaultProbe: (() => void) | undefined
     window.api.platform = 'win32'
     window.api.storage.getInfo = vi.fn().mockResolvedValue(
@@ -392,7 +450,7 @@ describe('OnboardingWizard flow', () => {
     await renderWizard()
     await goToLocationStep()
     expect(container.textContent).toContain('C:\\Users\\researcher\\OpenScience')
-    expect(findButton(/^continue$/i)?.disabled).toBe(true)
+    expect(findButton(/^continue$/i)?.disabled).toBe(false)
 
     await act(async () => releaseDefaultProbe?.())
 

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -388,6 +388,43 @@ describe('OnboardingWizard flow', () => {
     expect(currentSection('Set up the agent runtime')).not.toBeNull()
   })
 
+  it('stops a pending Windows recommendation when the user leaves Location', async () => {
+    let resolveDrives: ((drives: Array<{ path: string; label: string }>) => void) | undefined
+    window.api.platform = 'win32'
+    window.api.storage.getInfo = vi.fn().mockResolvedValue(
+      storageInfo({
+        dataRoot: 'C:\\Users\\researcher\\OpenScience',
+        defaultDataRoot: 'C:\\Users\\researcher\\OpenScience',
+        defaultParent: 'C:\\Users\\researcher',
+        canAutoSelectDataDrive: true
+      })
+    )
+    window.api.localFs.listDrives = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDrives = resolve
+        })
+    )
+    readyClaudeState()
+
+    await renderWizard()
+    await goToLocationStep()
+    expect(window.api.localFs.listDrives).toHaveBeenCalledOnce()
+
+    await clickButton(/back/i)
+    await act(async () => {
+      resolveDrives?.([
+        { path: 'C:\\', label: 'C:' },
+        { path: 'D:\\', label: 'D:' }
+      ])
+    })
+    expect(window.api.storage.inspectDataRoot).not.toHaveBeenCalled()
+
+    await goToLocationStep()
+    expect(window.api.localFs.listDrives).toHaveBeenCalledOnce()
+    expect(currentSection('Choose data location')?.getAttribute('aria-busy')).toBe('false')
+  })
+
   it('ends a pending Windows recommendation and keeps the default after its deadline', async () => {
     window.api.platform = 'win32'
     window.api.storage.getInfo = vi.fn().mockResolvedValue(
@@ -478,6 +515,19 @@ describe('OnboardingWizard flow', () => {
       resolveStorageInfo?.(storageInfo({ canAutoSelectDataDrive: false }))
     })
     expect(findButton(/^continue$/i)?.disabled).toBe(false)
+  })
+
+  it('allows non-Windows onboarding to continue while storage info is pending', async () => {
+    window.api.platform = 'darwin'
+    window.api.storage.getInfo = vi.fn().mockReturnValue(new Promise(() => undefined))
+    readyClaudeState()
+
+    await renderWizard()
+    await goToLocationStep()
+
+    expect(findButton(/^continue$/i)?.disabled).toBe(false)
+    await clickButton(/^continue$/i)
+    expect(currentSection('Set up the agent runtime')).not.toBeNull()
   })
 
   it('does not let a late storage resume override a Browse interaction in flight', async () => {

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -105,21 +105,23 @@ const findWindowsStorageDefault = async (
 // mapped drive may never settle. Recommendation is opportunistic, so bound the whole attempt and
 // keep the already-loaded default instead of leaving the setup UI busy indefinitely.
 const resolveWindowsStorageDefault = async (
-  storageInfo: StorageInfo
+  storageInfo: StorageInfo,
+  signal: AbortSignal
 ): Promise<LocationDraft | null> => {
   const controller = new AbortController()
-  let timeout: ReturnType<typeof setTimeout> | undefined
-  const deadline = new Promise<null>((resolve) => {
-    timeout = setTimeout(() => {
-      controller.abort()
-      resolve(null)
-    }, WINDOWS_STORAGE_RECOMMENDATION_TIMEOUT_MS)
+  const stopped = new Promise<null>((resolve) => {
+    controller.signal.addEventListener('abort', () => resolve(null), { once: true })
   })
+  const stop = (): void => controller.abort()
+  if (signal.aborted) stop()
+  else signal.addEventListener('abort', stop, { once: true })
+  const timeout = setTimeout(stop, WINDOWS_STORAGE_RECOMMENDATION_TIMEOUT_MS)
 
   try {
-    return await Promise.race([findWindowsStorageDefault(storageInfo, controller.signal), deadline])
+    return await Promise.race([findWindowsStorageDefault(storageInfo, controller.signal), stopped])
   } finally {
-    if (timeout !== undefined) clearTimeout(timeout)
+    clearTimeout(timeout)
+    signal.removeEventListener('abort', stop)
   }
 }
 
@@ -210,10 +212,11 @@ const OnboardingWizard = ({
     didResolveStorageResume.current = true
   }, [])
   const leaveLocation = useCallback((nextStep: 'environment' | 'agent'): void => {
-    // Continue is disabled until the automatic probe resolves, so leaving forward freezes the
-    // displayed choice. Back only cancels the in-flight probe; returning to Location retries it.
+    // Leaving freezes the displayed choice. The effect cleanup stops the renderer-side probe, and
+    // marking it resolved prevents Back/return loops from accumulating uncancellable IPC requests.
     didResolveStorageResume.current = true
     if (nextStep === 'agent') locationDraftTouched.current = true
+    setDidResolveStorageDefault(true)
     setStep(nextStep)
   }, [])
   const [relaunchError, setRelaunchError] = useState<string | undefined>(undefined)
@@ -263,7 +266,8 @@ const OnboardingWizard = ({
     }
 
     let cancelled = false
-    void resolveWindowsStorageDefault(dataRootInfo).then((recommendedDraft) => {
+    const controller = new AbortController()
+    void resolveWindowsStorageDefault(dataRootInfo, controller.signal).then((recommendedDraft) => {
       if (cancelled || locationDraftTouched.current) return
 
       if (recommendedDraft) {
@@ -274,6 +278,7 @@ const OnboardingWizard = ({
 
     return () => {
       cancelled = true
+      controller.abort()
     }
   }, [dataRootInfo, didResolveStorageDefault, step])
 

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -37,6 +37,7 @@ const STEP_LABELS = {
   location: 'Data location'
 }
 const loadStorageInfoFromBridge = (): Promise<StorageInfo> => window.api.storage.getInfo()
+const WINDOWS_STORAGE_RECOMMENDATION_TIMEOUT_MS = 2_000
 
 const windowsDriveLetter = (path: string): string | undefined => {
   const match = /^([a-z]):[\\/]/i.exec(path)
@@ -47,7 +48,8 @@ const windowsDriveLetter = (path: string): string | undefined => {
 // OpenScience folders are deliberately skipped: adopting historical data remains an explicit user
 // choice through Browse rather than a silent onboarding default.
 const findWindowsStorageDefault = async (
-  storageInfo: StorageInfo
+  storageInfo: StorageInfo,
+  signal: AbortSignal
 ): Promise<LocationDraft | null> => {
   if (
     window.api.platform !== 'win32' ||
@@ -66,6 +68,7 @@ const findWindowsStorageDefault = async (
   } catch {
     return null
   }
+  if (signal.aborted) return null
 
   const candidates = drives
     .map((drive) => ({ drive, letter: windowsDriveLetter(drive.path) }))
@@ -78,8 +81,10 @@ const findWindowsStorageDefault = async (
     .sort((left, right) => left.letter.localeCompare(right.letter))
 
   for (const { drive } of candidates) {
+    if (signal.aborted) return null
     try {
       const inspection = await window.api.storage.inspectDataRoot(drive.path)
+      if (signal.aborted) return null
       if (inspection.kind === 'move' && inspection.targetWasAbsent === true) {
         return {
           chosenParent: drive.path,
@@ -94,6 +99,28 @@ const findWindowsStorageDefault = async (
   }
 
   return null
+}
+
+// Drive enumeration and candidate inspection cross the OS filesystem boundary, where a disconnected
+// mapped drive may never settle. Recommendation is opportunistic, so bound the whole attempt and
+// keep the already-loaded default instead of leaving the setup UI busy indefinitely.
+const resolveWindowsStorageDefault = async (
+  storageInfo: StorageInfo
+): Promise<LocationDraft | null> => {
+  const controller = new AbortController()
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<null>((resolve) => {
+    timeout = setTimeout(() => {
+      controller.abort()
+      resolve(null)
+    }, WINDOWS_STORAGE_RECOMMENDATION_TIMEOUT_MS)
+  })
+
+  try {
+    return await Promise.race([findWindowsStorageDefault(storageInfo, controller.signal), deadline])
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout)
+  }
 }
 
 // Keeps the five-step sequence visible without turning the lightweight setup flow into navigation.
@@ -236,7 +263,7 @@ const OnboardingWizard = ({
     }
 
     let cancelled = false
-    void findWindowsStorageDefault(dataRootInfo).then((recommendedDraft) => {
+    void resolveWindowsStorageDefault(dataRootInfo).then((recommendedDraft) => {
       if (cancelled || locationDraftTouched.current) return
 
       if (recommendedDraft) {


### PR DESCRIPTION
## Problem

On fresh Windows onboarding, automatic data-drive recommendation can remain pending indefinitely when drive enumeration or candidate inspection reaches a disconnected mapped, network, or sleeping drive. Location treated that opportunistic recommendation as a hard Continue gate, so first launch could not proceed even though the default path was already available.

## Proposed change

- Bound the whole Windows storage recommendation attempt to 2 seconds and keep the loaded default location on timeout or failure.
- Keep Continue disabled while Windows storage information itself is loading, but allow it while only the optional recommendation is pending; preserve the existing non-Windows behavior.
- Connect the recommendation to the Location effect lifecycle so leaving stops renderer-side waiting and prevents a late drive list from starting candidate inspections.
- Mark the automatic attempt resolved on step exit so Back/return loops do not accumulate uncancellable IPC requests.
- Ignore late recommendation results after the user continues or chooses a location.

## Scope and non-goals

- No Windows drive-type classification; fixed, removable, network, and optical drive metadata remain outside this PR.
- No concurrent or per-drive probing.
- No IPC, shared type, database, persisted settings, historical-data compatibility, enum, or i18n changes.
- An already-issued Electron IPC/filesystem request cannot be cancelled by the renderer. This PR limits it to one attempt per wizard, prevents follow-on candidate checks after exit, and removes all onboarding dependency on its completion.

## Acceptance criteria and validation

The final regression tests were run red before their fixes. They reproduced the reported pending drive-list and candidate-inspection paths, plus review-found cross-platform gating and stale follow-on probing.

Final checks ran after the last material edit:

- pending drive listing remains manually continuable; pending candidate inspection falls back to the default; leaving prevents follow-on probes and retries; successful recommendation, Windows storage-info loading, and non-Windows behavior remain intact -> npm test -- src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx src/renderer/src/pages/onboarding/LocationStep.render.test.tsx -> 47 passed
- renderer contracts and lifecycle signal usage -> npm run typecheck:web -> passed
- source lint -> npm run lint -> passed
- changed-file formatting and whitespace -> Prettier check plus git diff --check -> passed

The affected-test planner selected the complete Vitest fallback because onboarding has no module owner. Per maintainer direction, the complete local npm test run was intentionally left to PR CI.

## Review focus

- Whether a 2-second opportunistic recommendation budget is the right UX tradeoff.
- The separation between mandatory Windows storage-info loading and optional drive recommendation.
- The lifecycle boundary: already-issued IPC is not cancellable, but cannot trigger later candidate checks or accumulate on step re-entry.
- The explicit non-goal of identifying fixed local disks in this focused P2 fix.