### PR TITLE
fix(settings): reject unsupported settings documents

### DIFF
--- a/src/main/settings/document-store.test.ts
+++ b/src/main/settings/document-store.test.ts
@@ -59,6 +59,25 @@ describe('settings document store', () => {
     ).resolves.toMatchObject({ providers: [], notificationsEnabled: false })
   })
 
+  it('migrates a version 1 settings document through the registered pipeline', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    await writeFile(
+      join(storageRoot, 'settings.json'),
+      JSON.stringify({
+        version: 1,
+        providers: [{ id: 'provider-1', type: 'custom', name: 'Provider', model: 'model-1' }],
+        activeProviderId: 'provider-1'
+      }),
+      'utf8'
+    )
+
+    await expect(new SettingsDocumentStore(storageRoot).read()).resolves.toMatchObject({
+      version: 2,
+      activeProviderId: 'provider-1',
+      activeModel: 'model-1'
+    })
+  })
+
   it('recovers a valid historical Settings temp when the primary is missing', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-temp-'))
     await writeFile(
@@ -77,6 +96,19 @@ describe('settings document store', () => {
     await expect(readdir(storageRoot)).resolves.toEqual(['settings.json'])
   })
 
+  it('does not skip a future Settings temp and recover an older format', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-temp-'))
+    const temporaryName = 'settings.json.1700000000000-1.tmp'
+    const futureContents = '{"version":3,"futurePreference":"must-survive"}\n'
+    await writeFile(join(storageRoot, temporaryName), futureContents, 'utf8')
+
+    await expect(new SettingsDocumentStore(storageRoot).read()).rejects.toThrow(
+      'Settings document version 3 is newer than supported version 2.'
+    )
+    await expect(readFile(join(storageRoot, temporaryName), 'utf8')).resolves.toBe(futureContents)
+    await expect(readdir(storageRoot)).resolves.toEqual([temporaryName])
+  })
+
   it('rejects corrupt JSON and prevents a mutation from publishing over it', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
     const settingsPath = join(storageRoot, 'settings.json')
@@ -90,6 +122,38 @@ describe('settings document store', () => {
 
     expect(update).not.toHaveBeenCalled()
     await expect(readFile(settingsPath, 'utf8')).resolves.toBe(corruptContents)
+  })
+
+  it('rejects mutation of a future settings document without overwriting its fields', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    const settingsPath = join(storageRoot, 'settings.json')
+    const futureContents = `${JSON.stringify({
+      version: 3,
+      providers: [],
+      futurePreference: 'must-survive'
+    })}\n`
+    await writeFile(settingsPath, futureContents, 'utf8')
+    const store = new SettingsDocumentStore(storageRoot)
+    const update = vi.fn((settings) => ({ ...settings, notificationsEnabled: false }))
+
+    await expect(store.mutate(update)).rejects.toThrow(
+      'Settings document version 3 is newer than supported version 2.'
+    )
+
+    expect(update).not.toHaveBeenCalled()
+    await expect(readFile(settingsPath, 'utf8')).resolves.toBe(futureContents)
+  })
+
+  it('rejects an unversioned settings document', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    const settingsPath = join(storageRoot, 'settings.json')
+    const unversionedContents = '{"providers":[]}\n'
+    await writeFile(settingsPath, unversionedContents, 'utf8')
+
+    await expect(new SettingsDocumentStore(storageRoot).read()).rejects.toThrow(
+      'Settings document is corrupt.'
+    )
+    await expect(readFile(settingsPath, 'utf8')).resolves.toBe(unversionedContents)
   })
 
   it('propagates a read I/O failure without publishing and recovers its mutation queue', async () => {

--- a/src/main/settings/document-store.test.ts
+++ b/src/main/settings/document-store.test.ts
@@ -109,6 +109,22 @@ describe('settings document store', () => {
     await expect(readdir(storageRoot)).resolves.toEqual([temporaryName])
   })
 
+  it('does not delete a future Settings temp when an older primary exists', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-temp-'))
+    const settingsPath = join(storageRoot, 'settings.json')
+    const temporaryName = 'settings.json.1700000000000-1.tmp'
+    const primaryContents = '{"version":2,"providers":[]}\n'
+    const futureContents = '{"version":3,"futurePreference":"must-survive"}\n'
+    await writeFile(settingsPath, primaryContents, 'utf8')
+    await writeFile(join(storageRoot, temporaryName), futureContents, 'utf8')
+
+    await expect(new SettingsDocumentStore(storageRoot).read()).rejects.toThrow(
+      'Settings document version 3 is newer than supported version 2.'
+    )
+    await expect(readFile(settingsPath, 'utf8')).resolves.toBe(primaryContents)
+    await expect(readFile(join(storageRoot, temporaryName), 'utf8')).resolves.toBe(futureContents)
+  })
+
   it('rejects corrupt JSON and prevents a mutation from publishing over it', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
     const settingsPath = join(storageRoot, 'settings.json')

--- a/src/main/settings/document-store.ts
+++ b/src/main/settings/document-store.ts
@@ -1,10 +1,50 @@
 import { join } from 'node:path'
 
-import { readDurableJsonFile, writeDurableJsonFile } from '../storage/durable-json-file'
+import { SETTINGS_FILE_VERSION } from '../../shared/settings'
+import {
+  DurableJsonRecoveryBarrierError,
+  readDurableJsonFile,
+  writeDurableJsonFile
+} from '../storage/durable-json-file'
 import { sanitizeSettings } from './document-codec'
 import { createEmptySettings, type StoredSettings } from './types'
+import { isRecord } from './value-guards'
 
 const SETTINGS_FILE = 'settings.json'
+
+class UnsupportedSettingsDocumentVersionError extends DurableJsonRecoveryBarrierError {
+  constructor(version: number) {
+    super(
+      `Settings document version ${version} is newer than supported version ${SETTINGS_FILE_VERSION}.`
+    )
+  }
+}
+
+const migrateSettingsDocument = (value: unknown): StoredSettings | undefined => {
+  if (!isRecord(value)) return undefined
+  let migrated = value
+  while (migrated.version !== SETTINGS_FILE_VERSION) {
+    switch (migrated.version) {
+      case 1:
+        migrated = { ...migrated, version: 2 }
+        break
+      default:
+        return undefined
+    }
+  }
+  return sanitizeSettings(migrated)
+}
+
+const decodeSettingsDocument = (contents: string): StoredSettings => {
+  const value: unknown = JSON.parse(contents)
+  const version = isRecord(value) ? value.version : undefined
+  if (Number.isSafeInteger(version) && Number(version) > SETTINGS_FILE_VERSION) {
+    throw new UnsupportedSettingsDocumentVersionError(Number(version))
+  }
+  const migrated = migrateSettingsDocument(value)
+  if (!migrated) throw new Error('Settings document is corrupt.')
+  return migrated
+}
 
 // Owns the complete settings.json transaction: fresh read, serialized mutation, atomic publish and
 // queue recovery. Callers sharing this instance cannot overwrite one another with stale snapshots.
@@ -18,9 +58,7 @@ class SettingsDocumentStore {
   }
 
   async read(): Promise<StoredSettings> {
-    const result = await readDurableJsonFile(this.path, (contents) =>
-      sanitizeSettings(JSON.parse(contents) as unknown)
-    )
+    const result = await readDurableJsonFile(this.path, decodeSettingsDocument)
     return result.status === 'found' ? result.value : createEmptySettings()
   }
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -5966,7 +5966,7 @@ describe('SettingsService: default permission profile', () => {
   it('projects a valid profile from settings.json', async () => {
     await writeFile(
       join(storageRoot, 'settings.json'),
-      JSON.stringify({ defaultPermissionProfile: 'auto' }),
+      JSON.stringify({ version: 2, defaultPermissionProfile: 'auto' }),
       'utf8'
     )
     const service = createService()

--- a/src/main/storage/durable-json-file.test.ts
+++ b/src/main/storage/durable-json-file.test.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  DurableJsonRecoveryBarrierError,
   readDurableJsonFile,
   writeDurableJsonFile,
   type DurableJsonFileDependencies
@@ -167,6 +168,27 @@ describe('durable JSON file recovery', () => {
       value: { source: 'primary' }
     })
     await expect(readdir(root)).resolves.toEqual(['settings.json'])
+  })
+
+  it('preserves a recovery-barrier temp when a valid primary exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-primary-barrier-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const temporaryPath = `${filePath}.1700000000000-1.tmp`
+    const primaryContents = '{"version":2}\n'
+    const futureContents = '{"version":3}\n'
+    await writeFile(filePath, primaryContents, 'utf8')
+    await writeFile(temporaryPath, futureContents, 'utf8')
+
+    const decode = (contents: string): { version: number } => {
+      const value = JSON.parse(contents) as { version: number }
+      if (value.version > 2) throw new DurableJsonRecoveryBarrierError('future version')
+      return value
+    }
+
+    await expect(readDurableJsonFile(filePath, decode)).rejects.toThrow('future version')
+    await expect(readFile(filePath, 'utf8')).resolves.toBe(primaryContents)
+    await expect(readFile(temporaryPath, 'utf8')).resolves.toBe(futureContents)
   })
 
   it('does not treat an unrelated tmp file as publication residue', async () => {

--- a/src/main/storage/durable-json-file.test.ts
+++ b/src/main/storage/durable-json-file.test.ts
@@ -237,6 +237,43 @@ describe('durable JSON file recovery', () => {
     await expect(readdir(root)).resolves.toEqual(['settings.json'])
   })
 
+  it('preserves a recovery-barrier temp before promoting another candidate', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-mixed-barrier-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const currentTemporaryPath = `${filePath}.1700000001000-2.tmp`
+    const futureTemporaryPath = `${filePath}.1700000000000-1.tmp`
+    const currentContents = '{"version":2}\n'
+    const futureContents = '{"version":3}\n'
+    await writeFile(currentTemporaryPath, currentContents, 'utf8')
+    await writeFile(futureTemporaryPath, futureContents, 'utf8')
+    const now = new Date()
+    await utimes(
+      futureTemporaryPath,
+      new Date(now.getTime() - 2_000),
+      new Date(now.getTime() - 2_000)
+    )
+    await utimes(
+      currentTemporaryPath,
+      new Date(now.getTime() - 1_000),
+      new Date(now.getTime() - 1_000)
+    )
+
+    const decode = (contents: string): { version: number } => {
+      const value = JSON.parse(contents) as { version: number }
+      if (value.version > 2) throw new DurableJsonRecoveryBarrierError('future version')
+      return value
+    }
+
+    await expect(readDurableJsonFile(filePath, decode)).rejects.toThrow('future version')
+    await expect(readFile(currentTemporaryPath, 'utf8')).resolves.toBe(currentContents)
+    await expect(readFile(futureTemporaryPath, 'utf8')).resolves.toBe(futureContents)
+    await expect(readdir(root)).resolves.toEqual([
+      'settings.json.1700000000000-1.tmp',
+      'settings.json.1700000001000-2.tmp'
+    ])
+  })
+
   it('does not mask a corrupt committed primary with a valid temp', async () => {
     const root = await mkdtemp(join(tmpdir(), 'durable-json-corrupt-primary-'))
     roots.push(root)

--- a/src/main/storage/durable-json-file.ts
+++ b/src/main/storage/durable-json-file.ts
@@ -228,6 +228,20 @@ const cleanupTemporaryCandidates = async (
   )
 }
 
+const assertNoRecoveryBarrier = async <Value>(
+  candidates: readonly TemporaryCandidate[],
+  decode: (contents: string) => Value,
+  dependencies: DurableJsonFileDependencies
+): Promise<void> => {
+  for (const candidate of candidates) {
+    try {
+      decode(await dependencies.readFile(candidate.path))
+    } catch (error) {
+      if (error instanceof DurableJsonRecoveryBarrierError) throw error
+    }
+  }
+}
+
 export const readDurableJsonFile = async <Value>(
   filePath: string,
   decode: (contents: string) => Value,
@@ -268,10 +282,9 @@ export const readDurableJsonFile = async <Value>(
     }
 
     const value = decode(primaryContents)
-    await cleanupTemporaryCandidates(
-      await listTemporaryCandidates(filePath, dependencies),
-      dependencies
-    )
+    const candidates = await listTemporaryCandidates(filePath, dependencies)
+    await assertNoRecoveryBarrier(candidates, decode, dependencies)
+    await cleanupTemporaryCandidates(candidates, dependencies)
     return { status: 'found', value }
   })
 }

--- a/src/main/storage/durable-json-file.ts
+++ b/src/main/storage/durable-json-file.ts
@@ -255,6 +255,7 @@ export const readDurableJsonFile = async <Value>(
     } catch (error) {
       if (!isMissingFileError(error)) throw error
       const candidates = await listTemporaryCandidates(filePath, dependencies)
+      await assertNoRecoveryBarrier(candidates, decode, dependencies)
       for (const candidate of candidates) {
         let candidateContents: string
         try {


### PR DESCRIPTION
## Problem

`settings.json` is sanitized without validating its persisted version. After a downgrade, an older app can therefore read a future document, drop unknown fields, and rewrite it as v2 during any settings mutation.

Related crash-recovery paths can also delete a future-version temporary document, either beside an older valid primary or behind a compatible temporary candidate, because recognized temps were cleaned up without first checking all of them for version barriers.

## Proposed change

- validate the persisted version before sanitizing the document;
- route released v1 documents through an explicit v1 -> v2 migration step;
- reject missing, invalid, and future versions before a mutation callback can run;
- scan every recognized durable JSON recovery candidate for a recovery barrier before promoting or cleaning any candidate.

## Scope and non-goals

- No new persisted fields or schema version.
- No new renderer state, enum, or settings interaction.
- Future-version documents fail closed during startup; this PR does not add an in-app read-only recovery UI.
- Historical compatibility is limited to the released v1 format. Unversioned documents are treated as corrupt.

## Acceptance criteria and validation

- Future settings mutation is rejected and the original bytes remain unchanged.
- Future recovery candidates are preserved beside an older primary and among mixed temporary candidates.
- Released v1 settings migrate to v2 and retain the active model.
- Existing JSON syntax errors retain their `SyntaxError` behavior.

Final Test Impact Set, run after the last material edit:

- durable JSON, Settings, Notebook, Session, and cleanup-journal recovery behavior -> `npm test -- src/main/storage/durable-json-file.test.ts src/main/settings/document-store.test.ts src/main/notebook/repository.test.ts src/main/session-persistence/repository.test.ts src/main/storage/data-root-cleanup.test.ts` -> 5 files passed, 158 tests passed;
- settings repository behavior -> `npm run test:module -- settings_repository` -> 20 files passed, 726 tests passed;
- main-process types -> `npm run typecheck:node` -> passed;
- linted source and tests -> `npm run lint` -> passed.

The module plan includes the `windows_sensitive` capability overlay. No renderer, IPC contract, database schema, or platform path handling changed, so renderer/E2E/database checks were excluded locally. Full portable and platform suites remain CI-authoritative.

## Review focus

- version classification occurs before sanitization;
- every historical version requires an explicit migration case;
- all recognized recovery candidates are checked before any candidate is promoted or deleted.
