### PR TITLE
fix(delegation): clarify immutable input identities

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -16,6 +16,8 @@ const NOTEBOOK_LIFECYCLE_PROMPT = 'Verify the notebook lifecycle.'
 const PERFORMANCE_NOTEBOOK_LIFECYCLE_PROMPT = 'Profile the notebook lifecycle.'
 const ARTIFACT_PROVENANCE_PROMPT = 'Create a provenance artifact.'
 const DELEGATION_TERMINAL_PROMPT = 'Run the production delegation terminal journey.'
+const DELEGATION_ARTIFACT_VERSION_INPUT_PROMPT =
+  'Run the production Artifact Version input delegation journey.'
 const DELEGATION_BOUNDED_COLLECT_PROMPT = 'Run the production bounded collect journey.'
 const DELEGATION_BOUNDED_RECOLLECT_PROMPT = 'Collect the running Subagent in Turn B.'
 const DELEGATION_PERMISSION_PROMPT = 'Run the production delegated permission journey.'
@@ -50,6 +52,9 @@ const SUBAGENT_MODEL_INHERITED_PROMPT = 'Run the inherited Subagent model journe
 const SUBAGENT_MODEL_HOLDER_PROMPT = 'Create the global Active model holder.'
 const DELEGATED_TERMINAL_TASK = 'Complete the certified delegated terminal fixture.'
 const DELEGATED_TERMINAL_NAME = 'Certified delegated terminal'
+const DELEGATED_ARTIFACT_VERSION_INPUT_TASK = 'Read the delegated immutable Artifact Version input.'
+const DELEGATED_ARTIFACT_VERSION_INPUT_NAME = 'Artifact Version input child'
+const DELEGATED_ARTIFACT_VERSION_PRODUCER_NAME = 'Artifact Version producer child'
 const DELEGATED_MODEL_CONTINUATION_NAME = 'Model continuation child'
 const DELEGATED_INHERITED_SPECIALIST_NAME = 'Inherited specialist terminal'
 const DELEGATED_BOUNDED_SLOW_TASK = 'Complete the bounded fixture after a delay.'
@@ -444,6 +449,45 @@ const createProvenanceArtifact = async (sessionId) => {
   return `Artifact provenance verified for session ${sessionId}, artifact ${stored.artifact.artifact_id}, version ${stored.artifact.version_id}.`
 }
 
+const runArtifactVersionInputDelegation = async (sessionId) => {
+  const produced = controlResultValue(
+    await runProductionDelegationRequest(
+      sessionId,
+      {
+        task: DELEGATED_STRUCTURED_OUTPUT_TASK,
+        name: DELEGATED_ARTIFACT_VERSION_PRODUCER_NAME,
+        outputSchema: {
+          type: 'object',
+          required: ['count'],
+          properties: { count: { type: 'number' } },
+          additionalProperties: false
+        }
+      },
+      true
+    )
+  )
+  const producer = produced.children?.[0]
+  const versionId = producer?.artifactsCreated?.[0]?.versionId
+  if (producer?.status !== 'completed' || !versionId) {
+    throw new Error(
+      `The producer child returned no immutable versionId: ${JSON.stringify(produced)}`
+    )
+  }
+  const delegated = await runProductionDelegationRequest(
+    sessionId,
+    {
+      task: DELEGATED_ARTIFACT_VERSION_INPUT_TASK,
+      name: DELEGATED_ARTIFACT_VERSION_INPUT_NAME,
+      inputs: [versionId]
+    },
+    true
+  )
+  if (delegated.status !== 'completed') {
+    throw new Error(`Artifact Version input delegation failed: ${JSON.stringify(delegated)}`)
+  }
+  return 'Artifact Version input delegation completed.'
+}
+
 if (process.argv.includes('--version')) {
   process.stdout.write(`${VERSION}\n`)
 } else {
@@ -494,6 +538,25 @@ if (process.argv.includes('--version')) {
         )
         await waitForSessionCancellation(context.params.sessionId)
         return { stopReason: 'cancelled' }
+      }
+
+      if (prompt.includes(DELEGATED_ARTIFACT_VERSION_INPUT_TASK)) {
+        const route = sessionRoutes.get(context.params.sessionId)
+        if (!route?.cwd) throw new Error('The delegated working directory is unavailable.')
+        const inputPath = join(route.cwd, 'inputs', '01-provenance-evidence.txt')
+        const content = await readFile(inputPath, 'utf8')
+        if (content !== 'artifact provenance e2e') {
+          throw new Error(`Delegated Artifact Version input mismatch: ${JSON.stringify(content)}`)
+        }
+        await context.client.notify(acp.methods.client.session.update, {
+          sessionId: context.params.sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            messageId: `e2e-message-${nextMessageId++}`,
+            content: { type: 'text', text: 'Delegated immutable Artifact Version input verified.' }
+          }
+        })
+        return { stopReason: 'end_turn' }
       }
 
       if (prompt.includes(DELEGATION_STOP_PROMPT)) {
@@ -790,6 +853,8 @@ if (process.argv.includes('--version')) {
             throw new Error(`Production delegation failed: ${JSON.stringify(delegated)}`)
           }
           reply = 'Production delegation reached a terminal result.'
+        } else if (prompt.includes(DELEGATION_ARTIFACT_VERSION_INPUT_PROMPT)) {
+          reply = await runArtifactVersionInputDelegation(context.params.sessionId)
         } else if (prompt.includes(DELEGATION_BOUNDED_COLLECT_PROMPT)) {
           const dispatched = controlResultValue(
             await executeControlCode(

--- a/e2e/subagent-release-gate.spec.ts
+++ b/e2e/subagent-release-gate.spec.ts
@@ -12,6 +12,8 @@ import { test } from './fixtures/electron-app'
 const ROOT_PROMPT = 'Coordinate the release-gate delegates.'
 const CHILD_COUNT = 24
 const TERMINAL_PROMPT = 'Run the production delegation terminal journey.'
+const ARTIFACT_VERSION_INPUT_PROMPT =
+  'Run the production Artifact Version input delegation journey.'
 const BOUNDED_COLLECT_PROMPT = 'Run the production bounded collect journey.'
 const BOUNDED_RECOLLECT_PROMPT = 'Collect the running Subagent in Turn B.'
 const PERMISSION_PROMPT = 'Run the production delegated permission journey.'
@@ -30,6 +32,7 @@ const RELIABLE_FAIRNESS_PROMPT = 'Start the reliable messaging fairness journey.
 const RELIABLE_FAIRNESS_USER_PROMPT = 'Run the concurrent real user prompt.'
 const STRUCTURED_OUTPUT_CHILD = 'Create certified structured evidence.'
 const TERMINAL_CHILD = 'Certified delegated terminal'
+const ARTIFACT_VERSION_INPUT_CHILD = 'Artifact Version input child'
 const INHERITED_SPECIALIST_CHILD = 'Inherited specialist terminal'
 const PERMISSION_CHILD = 'Request the delegated fixture permission.'
 const USER_QUESTION_CHILD = 'Delegated scope researcher'
@@ -247,6 +250,57 @@ const seedDelegatedWork = async (page: Page, projectId: string): Promise<void> =
     { childCount: CHILD_COUNT, projectId, rootPrompt: ROOT_PROMPT }
   )
 }
+
+test('resolves a bare Artifact version_id into a delegated read-only input', async ({ app }) => {
+  test.setTimeout(180_000)
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await createProject(page, 'Artifact Version input delegation gate')
+
+  await sendPrompt(
+    page,
+    ARTIFACT_VERSION_INPUT_PROMPT,
+    'Artifact Version input delegation completed.',
+    120_000
+  )
+  await expectDurableChildStatus(page, ARTIFACT_VERSION_INPUT_CHILD, 'completed')
+
+  const evidence = await page.evaluate(
+    async ({ childName }) => {
+      const sessions = (await window.api.sessions.loadAll()).sessions
+      for (const session of sessions) {
+        const frame = session.conversationGraph?.frames.find(
+          (candidate) => candidate.delegateName === childName
+        )
+        const attempt = session.runtimeContext?.delegatedWork?.records
+          .find((record) => record.agentFrameId === frame?.id)
+          ?.attempts.at(-1)
+        if (!frame || !attempt) continue
+        const terminal = session.conversationGraph?.messages.find(
+          (message) => message.id === attempt.terminalMessageId
+        )
+        return {
+          status: attempt.status,
+          error: attempt.error,
+          terminalText: terminal?.content,
+          artifactVersions: (session.artifacts ?? [])
+            .filter((artifact) => artifact.name === 'provenance-evidence.txt')
+            .map((artifact) => artifact.versionId)
+        }
+      }
+      return undefined
+    },
+    { childName: ARTIFACT_VERSION_INPUT_CHILD }
+  )
+
+  expect(evidence).toMatchObject({
+    status: 'completed',
+    error: undefined,
+    terminalText: 'Delegated immutable Artifact Version input verified.'
+  })
+  expect(evidence?.artifactVersions).toHaveLength(1)
+  expect(evidence?.artifactVersions[0]).toMatch(/^[0-9a-f-]{36}$/)
+})
 
 test('projects real production-composed delegation, permission, and Stop lifecycle', async ({
   app

--- a/src/main/delegation/delegated-work-admission.ts
+++ b/src/main/delegation/delegated-work-admission.ts
@@ -13,6 +13,10 @@ import type {
 type DurableResolvedAgent = DurableSnapshot['records'][number]['attempts'][number]['resolvedAgent']
 
 const MAX_DELEGATE_NAME_CODE_POINTS = 48
+const DELEGATION_INPUT_SHAPE_MESSAGE =
+  'delegation inputs must be a string[] of exact finalized Artifact version_id/versionId or upload-version: references; do not pass objects, artifact_id, filenames, or paths; omit inputs when no file handoff is needed'
+const DELEGATION_INPUT_UNAVAILABLE_MESSAGE =
+  'delegation input is unavailable in this Session; pass the exact Artifact version_id/versionId returned by the artifact tool (not artifact_id, filename, or path), or an immutable upload-version: reference; omit inputs when no file handoff is needed'
 
 const codePoints = (value: string): string[] => Array.from(value)
 
@@ -151,10 +155,7 @@ const assertDelegateInputShape = (requests: readonly DurableDelegateRequest[]): 
           request.inputs.some((input) => typeof input !== 'string' || !input.trim()))
     )
   ) {
-    throw new DurableDelegatedWorkError(
-      'admission_rejection',
-      'delegation inputs must be immutable Version identities'
-    )
+    throw new DurableDelegatedWorkError('admission_rejection', DELEGATION_INPUT_SHAPE_MESSAGE)
   }
 }
 
@@ -214,7 +215,7 @@ class DelegatedWorkAdmissionPolicy {
       if (validInputs.some((valid) => !valid)) {
         throw new DurableDelegatedWorkError(
           'admission_rejection',
-          'delegation inputs must be immutable Upload or Artifact Version identities'
+          DELEGATION_INPUT_UNAVAILABLE_MESSAGE
         )
       }
     }
@@ -338,6 +339,8 @@ class DelegatedWorkAdmissionPolicy {
 }
 
 export {
+  DELEGATION_INPUT_SHAPE_MESSAGE,
+  DELEGATION_INPUT_UNAVAILABLE_MESSAGE,
   MAX_DELEGATE_NAME_CODE_POINTS,
   allocateDelegateNames,
   assertDelegateInputShape,

--- a/src/main/host-sdk/help.test.ts
+++ b/src/main/host-sdk/help.test.ts
@@ -235,6 +235,8 @@ describe('Host SDK help', () => {
     expect(named(requestFields, 'name').description).toMatch(/1–48.*emoji.*current branch/i)
     expect(named(requestFields, 'profile').description).toMatch(/omit.*inherit/i)
     expect(named(requestFields, 'inputs').description).toMatch(/immutable.*\.\/inputs\//i)
+    expect(named(requestFields, 'inputs').description).toMatch(/version_id\/versionId.*strings/i)
+    expect(named(requestFields, 'inputs').description).toMatch(/read-only.*\.\/inputs\//i)
     expect(requestFields).not.toContainEqual(expect.objectContaining({ name: 'context' }))
 
     const optionFields = fields(canonical.options)

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -187,7 +187,7 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         name: 'inputs',
         type: 'string[]',
         required: false,
-        description: 'Immutable Version ids staged read-only under ./inputs/.'
+        description: 'Immutable version_id/versionId strings; read-only ./inputs/.'
       },
       {
         name: 'outputSchema',

--- a/src/main/notebook/local-rpc-server.delegated-work.test.ts
+++ b/src/main/notebook/local-rpc-server.delegated-work.test.ts
@@ -634,6 +634,11 @@ describe('authenticated delegatedWorkCall route', () => {
         })
       })
       expect(response.status).toBe(500)
+      if (identity === 'artifact-1') {
+        await expect(response.json()).resolves.toEqual({
+          error: expect.stringMatching(/version_id\/versionId.*not artifact_id.*omit inputs/i)
+        })
+      }
     }
 
     expect(delegate).not.toHaveBeenCalled()
@@ -661,6 +666,15 @@ describe('authenticated delegatedWorkCall route', () => {
       { request: [], error: shapeError },
       { request: [null], error: shapeError },
       { request: ['not-an-object'], error: shapeError },
+      {
+        request: {
+          task: 'Reject mutable input shape',
+          name: 'Reject input object',
+          inputs: [{ versionId: 'artifact-version-1' }]
+        },
+        error:
+          'delegation inputs must be a string[] of exact finalized Artifact version_id/versionId or upload-version: references; do not pass objects, artifact_id, filenames, or paths; omit inputs when no file handoff is needed'
+      },
       {
         request: Array.from({ length: 5 }, (_, index) => ({
           task: `Task ${index + 1}`,

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -78,6 +78,7 @@ import type {
   DurableDelegatedWork
 } from '../delegation/durable-delegated-work'
 import {
+  DELEGATION_INPUT_UNAVAILABLE_MESSAGE,
   assertDelegateInputShape,
   assertDelegateRequestShape
 } from '../delegation/delegated-work-admission'
@@ -1004,9 +1005,7 @@ class NotebookLocalRpcServer {
       if (pending) return pending
       const lookup = (async () => {
         if (!this.delegationInputCatalog) {
-          throw new Error(
-            'delegation inputs must be immutable Upload or Artifact Version identities'
-          )
+          throw new Error(DELEGATION_INPUT_UNAVAILABLE_MESSAGE)
         }
         const candidates = await this.delegationInputCatalog.readHostArtifactCatalog({
           projectId: caller.session.projectId,
@@ -1019,9 +1018,7 @@ class NotebookLocalRpcServer {
           item.projectId !== caller.session.projectId ||
           item.sessionId !== caller.session.sessionId
         ) {
-          throw new Error(
-            'delegation inputs must be immutable Upload or Artifact Version identities'
-          )
+          throw new Error(DELEGATION_INPUT_UNAVAILABLE_MESSAGE)
         }
         return item.source === 'upload'
           ? createUploadVersionReference(item.versionId, {


### PR DESCRIPTION
## Problem

`host.delegate.inputs` did not clearly distinguish immutable Version identities from Artifact identities, filenames, paths, or object-shaped values. The resulting errors did not tell callers which exact identity to pass.

## Proposed change

- Clarify that delegated inputs use exact finalized Artifact `version_id`/`versionId` strings or immutable `upload-version:` references.
- Reject object-shaped inputs, Artifact ids, filenames, and paths with actionable guidance, including when no file handoff is needed.
- Keep the bounded Host SDK Help entry explicit about the accepted string identity and read-only `./inputs/` staging.
- Add Help and RPC contract assertions plus a production-composed E2E journey that creates an Artifact Version, delegates its bare Version id, and verifies the child receives the staged content.

## Scope and non-goals

This change does not alter the `host.delegate` request shape, canonicalization or staging semantics, persisted formats, database schema, renderer UI, or localization catalogs. Mutable paths, filenames, Artifact ids, and object-shaped values remain unsupported.

## Acceptance criteria and validation

All listed passing checks ran after the last material edit on the final commit.

- Host SDK Help and authenticated RPC contracts -> `npm test -- src/main/host-sdk/help.test.ts src/main/notebook/local-rpc-server.delegated-work.test.ts` -> 33 tests passed.
- Main and renderer type safety -> `npm run typecheck` -> passed.
- Source and test style -> `npm run lint` -> passed.
- Production application bundle -> `npm run build:e2e` -> passed.
- Finalized Artifact Version identity handoff -> `npm run test:e2e -- e2e/subagent-release-gate.spec.ts --grep "resolves a bare Artifact version_id into a delegated read-only input"` -> 1 test passed.
- Full fallback -> `npm test` -> ran 22,545 tests: 22,297 passed, 243 skipped, and 5 failed outside this diff. The failures are the German catalog guard for `Notebook evidence`/`Execution evidence`, the NSIS old-uninstaller assertion, a compute queue-capacity timeout with cleanup fallout, and the Electron-as-Node network-sandbox launch check.

## Review focus

Please review the Version identity terminology, the actionable admission guidance, and whether the E2E journey represents the Artifact Version handoff contract at the production host seam.

## Uncovered risks

- The new E2E covers a bare finalized Artifact Version id, but not an upload Version reference.
- The child reads the staged input, but the journey does not attempt to mutate it.
- Callers that match the previous error strings exactly will observe the updated actionable text.
- The unrelated full-suite failures above remain subject to base-branch CI authority.