### PR TITLE
fix(windows): use host path helpers in ACP tests

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -8217,7 +8217,7 @@ describe('ACP runtime session management', () => {
 
     expect(agent.resumedSessions.at(-1)).toMatchObject({
       sessionId: 'codebuddy-session-1',
-      cwd: '/workspace/first'
+      cwd: resolve('/workspace/first')
     })
     expect(agent.prompts.at(-1)).toEqual({
       sessionId: 'codebuddy-session-1',

--- a/src/main/agent-framework/codebuddy.test.ts
+++ b/src/main/agent-framework/codebuddy.test.ts
@@ -32,15 +32,17 @@ describe('codebuddy framework', () => {
       },
       spawnProcess
     })
+    const storageRoot = '/app-data'
+    const configDir = join(storageRoot, 'codebuddy')
     const config = framework.prepareModelConfig(provider, {
-      storageRoot: '/app-data',
+      storageRoot,
       executablePath: '/usr/bin/codebuddy',
       systemPromptAppends: ['APP GUIDANCE'],
       reasoningEfforts: ['none', 'high']
     })
 
     expect(config.env).toMatchObject({
-      CODEBUDDY_CONFIG_DIR: join('/app-data', 'codebuddy'),
+      CODEBUDDY_CONFIG_DIR: configDir,
       CODEBUDDY_API_KEY: 'test-key',
       CODEBUDDY_BASE_URL: 'https://gateway.example.test/v1',
       CODEBUDDY_MODEL: 'test-model',
@@ -83,11 +85,11 @@ describe('codebuddy framework', () => {
       'Bash(git ls-remote:*)',
       'Bash(git submodule:*)',
       '--system-prompt-file',
-      '/app-data/codebuddy/system-prompt.md'
+      join(configDir, 'system-prompt.md')
     ])
     expect(config.configFiles).toEqual([
       {
-        path: '/app-data/codebuddy/models.json',
+        path: join(configDir, 'models.json'),
         mode: 0o600,
         content: `${JSON.stringify(
           {
@@ -112,7 +114,7 @@ describe('codebuddy framework', () => {
         )}\n`
       },
       {
-        path: '/app-data/codebuddy/settings.json',
+        path: join(configDir, 'settings.json'),
         mode: 0o600,
         content: `${JSON.stringify(
           {
@@ -132,7 +134,7 @@ describe('codebuddy framework', () => {
         )}\n`
       },
       {
-        path: '/app-data/codebuddy/system-prompt.md',
+        path: join(configDir, 'system-prompt.md'),
         mode: 0o600,
         content: 'APP GUIDANCE'
       }

--- a/src/main/agent-framework/codebuddy.test.ts
+++ b/src/main/agent-framework/codebuddy.test.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -39,7 +40,7 @@ describe('codebuddy framework', () => {
     })
 
     expect(config.env).toMatchObject({
-      CODEBUDDY_CONFIG_DIR: '/app-data/codebuddy',
+      CODEBUDDY_CONFIG_DIR: join('/app-data', 'codebuddy'),
       CODEBUDDY_API_KEY: 'test-key',
       CODEBUDDY_BASE_URL: 'https://gateway.example.test/v1',
       CODEBUDDY_MODEL: 'test-model',

--- a/src/main/notebook/working-file-observer.test.ts
+++ b/src/main/notebook/working-file-observer.test.ts
@@ -79,7 +79,9 @@ describe('working-file evidence', () => {
         win32.sep
       )
     ).toBe('data/plot.png')
-    expect(toPortableNotebookRelativePath('data/literal\\name.png')).toBe('data/literal\\name.png')
+    expect(toPortableNotebookRelativePath('data/literal\\name.png', '/')).toBe(
+      'data/literal\\name.png'
+    )
   })
 
   it('freezes Compute inputs before dispatch and publishes harvested outputs as one Activity', async () => {


### PR DESCRIPTION
## Problem

Scheduled Windows Full Test failed after recent merges because several unit tests compared host filesystem values to POSIX literals:

- CodeBuddy `CODEBUDDY_CONFIG_DIR` expected `/app-data/codebuddy`
- CodeBuddy compaction resume expected `cwd: '/workspace/first'`
- `toPortableNotebookRelativePath('data/literal\\name.png')` expected a literal backslash on Windows, where `\` is the host separator

These tests pass on macOS/Linux and fail on Windows CI.

## Proposed change

Assert host-resolved paths:

- `join('/app-data', 'codebuddy')` for the CodeBuddy config directory
- `resolve('/workspace/first')` for the resumed session cwd
- pass `'/'` as the host separator when the portable-path helper is proving that a POSIX-style backslash stays literal

## Scope and non-goals

- Test-only. No production path, persistence, or ACP protocol change.
- Does **not** address the broader Windows Full Test failures in working-file-observer generation capture, provisioner MAX_PATH budget, or Runtime Soak.

## Acceptance criteria and validation

- Windows Full Test no longer fails these three assertions.
- Portable path helper still converts Windows relative paths to `/` when given `win32.sep`.

Final Test Impact Set (after last material edit):

| behavior | command | result |
| --- | --- | --- |
| CodeBuddy config dir uses `path.join` | `npx vitest run src/main/agent-framework/codebuddy.test.ts` | passed (11) |
| Portable path helper POSIX backslash case | `npx vitest run src/main/notebook/working-file-observer.test.ts -t 'normalizes persisted paths'` | passed |
| CodeBuddy compaction resume cwd | `npx vitest run src/main/acp/runtime.test.ts -t 'reactivates the target CodeBuddy session'` | passed |
| Lint of changed tests | `npx eslint --cache` on the three files | passed |

Windows Full Test remains the authority for the host-separator cases. Uncovered: other Windows Full Test failures outside these three assertions.

## Review focus

Confirm the production `join`/`resolve` behavior is what the tests should pin, and that the portable-path case is intentionally POSIX-only.