### PR TITLE
fix(workspace): seed project-switcher E2E without UI create loops

### DIFF
--- a/e2e/workspace-project-switcher.spec.ts
+++ b/e2e/workspace-project-switcher.spec.ts
@@ -3,15 +3,13 @@ import type { Page } from 'playwright'
 
 import { test } from './fixtures/electron-app'
 
-const dismissStarDialog = async (page: Page): Promise<void> => {
-  const starDialog = page.getByRole('dialog', { name: 'Star on GitHub' })
-  try {
-    await expect(starDialog).toBeVisible({ timeout: 2_000 })
-    await starDialog.getByRole('button', { name: 'Close' }).click()
-    await expect(starDialog).toHaveCount(0)
-  } catch {
-    // The GitHub star nudge is optional and may not appear in this journey.
-  }
+// Keep in sync with GitHubStarBadge. Workspace variant waits 5s, then opens above menus.
+const STAR_NUDGE_LAST_SHOWN_STORAGE_KEY = 'open-science:github-star-nudge-last-shown-at'
+
+const suppressStarNudge = async (page: Page): Promise<void> => {
+  await page.evaluate((storageKey) => {
+    window.localStorage.setItem(storageKey, String(Date.now()))
+  }, STAR_NUDGE_LAST_SHOWN_STORAGE_KEY)
 }
 
 const createProject = async (
@@ -38,7 +36,6 @@ const createProject = async (
   await dialog.getByLabel('Description').fill(description)
   await dialog.getByRole('button', { name: 'Create project' }).click()
   await expect(page.locator(`button[title="${name}"]`)).toBeVisible()
-  await dismissStarDialog(page)
 }
 
 const seedWorkspaceProjects = async (page: Page, count: number): Promise<void> => {
@@ -65,6 +62,7 @@ test('switches projects from the Workspace project menu and expands remaining pr
   test.setTimeout(180_000)
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()
+  await suppressStarNudge(page)
 
   await seedWorkspaceProjects(page, 16)
   const homeProjects = page.getByRole('region', { name: 'Projects' })
@@ -73,7 +71,6 @@ test('switches projects from the Workspace project menu and expands remaining pr
   })
   await homeProjects.getByRole('button', { name: 'Project 16', exact: true }).click()
   await expect(page.locator('button[title="Project 16"]')).toBeVisible()
-  await dismissStarDialog(page)
 
   await page.setViewportSize({ width: 1280, height: 600 })
   await page.locator('button[title="Project 16"]').click()
@@ -190,6 +187,7 @@ test('switches projects from the Workspace project menu and expands remaining pr
 test('closes mobile navigation when switching projects', async ({ app }) => {
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()
+  await suppressStarNudge(page)
 
   await createProject(page, 'Project 1', 'Description 1', false)
   await createProject(page, 'Project 2', 'Description 2', true)

--- a/e2e/workspace-project-switcher.spec.ts
+++ b/e2e/workspace-project-switcher.spec.ts
@@ -3,6 +3,17 @@ import type { Page } from 'playwright'
 
 import { test } from './fixtures/electron-app'
 
+const dismissStarDialog = async (page: Page): Promise<void> => {
+  const starDialog = page.getByRole('dialog', { name: 'Star on GitHub' })
+  try {
+    await expect(starDialog).toBeVisible({ timeout: 2_000 })
+    await starDialog.getByRole('button', { name: 'Close' }).click()
+    await expect(starDialog).toHaveCount(0)
+  } catch {
+    // The GitHub star nudge is optional and may not appear in this journey.
+  }
+}
+
 const createProject = async (
   page: Page,
   name: string,
@@ -27,21 +38,42 @@ const createProject = async (
   await dialog.getByLabel('Description').fill(description)
   await dialog.getByRole('button', { name: 'Create project' }).click()
   await expect(page.locator(`button[title="${name}"]`)).toBeVisible()
-  const starDialog = page.getByRole('dialog', { name: 'Star on GitHub' })
-  if (await starDialog.isVisible()) {
-    await starDialog.getByRole('button', { name: 'Close' }).click()
-  }
+  await dismissStarDialog(page)
+}
+
+const seedWorkspaceProjects = async (page: Page, count: number): Promise<void> => {
+  await page.evaluate(async (projectCount) => {
+    const bridge = globalThis as unknown as {
+      api: {
+        projects: {
+          create: (request: { name: string; description: string }) => Promise<unknown>
+        }
+      }
+    }
+    for (let index = 1; index <= projectCount; index += 1) {
+      await bridge.api.projects.create({
+        name: `Project ${index}`,
+        description: `Description ${index}`
+      })
+    }
+  }, count)
 }
 
 test('switches projects from the Workspace project menu and expands remaining projects locally', async ({
   app
 }) => {
+  test.setTimeout(180_000)
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()
 
-  for (let index = 1; index <= 16; index += 1) {
-    await createProject(page, `Project ${index}`, `Description ${index}`, index > 1)
-  }
+  await seedWorkspaceProjects(page, 16)
+  const homeProjects = page.getByRole('region', { name: 'Projects' })
+  await expect(homeProjects.getByRole('button', { name: 'Project 16', exact: true })).toBeVisible({
+    timeout: 30_000
+  })
+  await homeProjects.getByRole('button', { name: 'Project 16', exact: true }).click()
+  await expect(page.locator('button[title="Project 16"]')).toBeVisible()
+  await dismissStarDialog(page)
 
   await page.setViewportSize({ width: 1280, height: 600 })
   await page.locator('button[title="Project 16"]').click()


### PR DESCRIPTION
## Problem

Recently merged PRs fail Windows workspace E2E because `e2e/workspace-project-switcher.spec.ts` creates 16 projects through the New project dialog. On Windows that exceeds the 120s test timeout; the retry often passes, and `--fail-on-flaky-tests` fails the lane. This started with #1957 and then blocked unrelated PRs that run the workspace E2E bundle.

## Proposed change

- Seed the 16 projects through `window.api.projects.create` so the store still receives `onCreated` updates.
- Open Project 16 from the home Projects region, then keep the existing menu-expansion, remaining-count, and layout assertions.
- Raise the test timeout to 180s and dismiss the optional GitHub star dialog if it appears.

## Scope and non-goals

- E2E-only. No Workspace sidebar production change.
- Project creation through the dialog remains covered by `e2e/electron-foundation.spec.ts` and the two-project mobile switcher case in this file.
- Does not change menu overflow policy (`INITIAL_PROJECT_MENU_LIMIT = 5`).

## Acceptance criteria and validation

- Windows workspace E2E no longer reports this test as flaky.
- Menu still shows 5 recent projects, `Show remaining 10 projects`, then 15 items after expand.

Final Test Impact Set (after last material edit):

| behavior | command | result |
| --- | --- | --- |
| Lint of the E2E spec | `npx eslint --cache e2e/workspace-project-switcher.spec.ts` | passed |

The Windows `e2e_workspace_windows` PR Gate lane is the authority for this journey. It was not rerun locally (no Windows Electron host). Uncovered: whether home project cards refresh if `projects.onCreated` is delayed; the spec waits 30s for Project 16.

## Review focus

Confirm API seeding still exercises the same recency order (most recently updated first) that the original UI create loop produced.