### PR TITLE
feat(codex): add adaptive subscription transport

### DIFF
--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -47,6 +47,7 @@ const {
   deleteSession,
   disconnect,
   resetSessionContext,
+  requestProviderReconnect,
   resumeSession,
   sendAppContinuation,
   sendPrompt,
@@ -62,6 +63,7 @@ const {
   const resetSessionContext = vi
     .fn()
     .mockResolvedValue({ sessionId: 's-1', cwd: '/workspace', contextReset: true })
+  const requestProviderReconnect = vi.fn().mockResolvedValue(undefined)
   const resumeSession = vi.fn().mockResolvedValue({ sessionId: 's-1', cwd: '/workspace' })
   const sendAppContinuation = vi.fn().mockResolvedValue(undefined)
   const sendPrompt = vi.fn().mockResolvedValue(undefined)
@@ -78,6 +80,7 @@ const {
         context: { window: 100_000, supportsImageInput: true }
       }),
       resetSessionContext,
+      requestProviderReconnect,
       resumeSession,
       sendAppContinuation: (request, promptAttemptId) => {
         const prompting = sendAppContinuation(request, promptAttemptId)
@@ -112,6 +115,7 @@ const {
     deleteSession,
     disconnect,
     resetSessionContext,
+    requestProviderReconnect,
     resumeSession,
     sendAppContinuation,
     sendPrompt,
@@ -124,6 +128,18 @@ const {
 const { errorLogSpy, infoLogSpy } = vi.hoisted(() => ({
   errorLogSpy: vi.fn(),
   infoLogSpy: vi.fn()
+}))
+
+const { fallbackBegin, fallbackEnd } = vi.hoisted(() => ({
+  fallbackBegin: vi.fn(),
+  fallbackEnd: vi.fn(() => false)
+}))
+
+vi.mock('../settings/codex-transport-fallback-log', () => ({
+  CodexTransportFallbackLogObserver: class {
+    begin = fallbackBegin
+    end = fallbackEnd
+  }
 }))
 vi.mock('../logger', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../logger')>()
@@ -203,7 +219,8 @@ const registerWithFakes = (overrides?: {
         .mockResolvedValue(overrides?.provisionedConnectorSkillNames ?? []),
       getConnectors: vi.fn().mockResolvedValue({
         customMcpServers: overrides?.customMcpServers ?? []
-      })
+      }),
+      rememberCodexAutoHttpsFallback: vi.fn().mockResolvedValue(true)
     } as never,
     taskNotifications: taskNotifications as never,
     onSessionCancellationRequested: overrides?.onSessionCancellationRequested,
@@ -242,6 +259,7 @@ afterEach(() => {
   createSession.mockReset()
   createSession.mockImplementation(async (request) => ({ sessionId: 's-new', cwd: request.cwd }))
   resetSessionContext.mockClear()
+  requestProviderReconnect.mockClear()
   compactSession.mockClear()
   cancelPrompt.mockClear()
   deleteSession.mockClear()
@@ -253,6 +271,8 @@ afterEach(() => {
   sendPrompt.mockResolvedValue(undefined)
   errorLogSpy.mockClear()
   infoLogSpy.mockClear()
+  fallbackBegin.mockClear()
+  fallbackEnd.mockClear()
   AcpRuntimeMock.mockClear()
 })
 
@@ -655,6 +675,46 @@ describe('ACP runtime composition — memory eligibility', () => {
       delegatedNotebookConnection: {} as AcpTestOptions['delegatedNotebookConnection']
     })
     expect(AcpRuntimeMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('memory')
+  })
+})
+
+describe('ACP runtime composition — Codex transport memory', () => {
+  it('persists HTTPS when the completed prompt log contains a native Codex fallback', async () => {
+    fallbackEnd.mockReturnValueOnce(true)
+    const options = registerWithFakes()
+    const callbacks = AcpRuntimeMock.mock.calls.at(-1)?.[0].callbacks
+    let finishRemembering: ((remembered: boolean) => void) | undefined
+    const remembering = new Promise<boolean>((resolve) => {
+      finishRemembering = resolve
+    })
+    vi.mocked(options.settingsService.rememberCodexAutoHttpsFallback).mockReturnValueOnce(
+      remembering
+    )
+
+    callbacks.onPromptStarted?.('session-1', 'turn-1')
+    callbacks.onPromptEnded?.('session-1', 'turn-1')
+
+    expect(fallbackBegin).toHaveBeenCalledOnce()
+    expect(options.settingsService.rememberCodexAutoHttpsFallback).toHaveBeenCalledOnce()
+    expect(requestProviderReconnect).not.toHaveBeenCalled()
+
+    finishRemembering?.(true)
+    await vi.waitFor(() => expect(requestProviderReconnect).toHaveBeenCalledOnce())
+  })
+
+  it('does not reconnect when Auto fallback memory is no longer applicable', async () => {
+    fallbackEnd.mockReturnValueOnce(true)
+    const options = registerWithFakes()
+    vi.mocked(options.settingsService.rememberCodexAutoHttpsFallback).mockResolvedValueOnce(false)
+    const callbacks = AcpRuntimeMock.mock.calls.at(-1)?.[0].callbacks
+
+    callbacks.onPromptStarted?.('session-1', 'turn-1')
+    callbacks.onPromptEnded?.('session-1', 'turn-1')
+
+    await vi.waitFor(() =>
+      expect(options.settingsService.rememberCodexAutoHttpsFallback).toHaveBeenCalledOnce()
+    )
+    expect(requestProviderReconnect).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -6,6 +6,7 @@ import { app } from 'electron'
 import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_ID } from '../../shared/artifacts'
 import { resolveActiveConversationMessages } from '../../shared/conversation-graph'
+import { CODEX_SUBSCRIPTION_PROVIDER_ID } from '../../shared/settings'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { imageAttachmentMimeType } from '../../shared/uploads'
 import {
@@ -34,6 +35,7 @@ import { ProjectRepository } from '../projects/repository'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { createAcpRuntimeEventBroadcastCoalescer } from './runtime-event-broadcast-coalescer'
 import type { AcpSettingsCapabilities } from '../settings/service-capabilities'
+import { CodexTransportFallbackLogObserver } from '../settings/codex-transport-fallback-log'
 import {
   buildSpecialistIdentityAppend,
   buildSpecialistIdentityPrefix
@@ -215,7 +217,7 @@ const createAcpRuntime = ({
   const eventBroadcast = createAcpRuntimeEventBroadcastCoalescer({
     publish: (events) => broadcastToRenderers('acp:event', events)
   })
-  const callbacks: AcpRuntimeCallbacks = runtimeCallbacks ?? {
+  const defaultCallbacks: AcpRuntimeCallbacks = {
     onStateChanged: (state: AcpStateSnapshot) => broadcastToRenderers('acp:state', state),
     onEvent: (event: AcpRuntimeEvent) => {
       const projectId = event.sessionId
@@ -247,6 +249,42 @@ const createAcpRuntime = ({
         () => notificationInbox.settleAuthorization('agent-tool', requestId, state),
         (error) => log.warn('permission inbox settlement failed', errorLogFields(error))
       )
+    }
+  }
+  const clientCallbacks = runtimeCallbacks ?? defaultCallbacks
+  const codexTransportFallbackLog = new CodexTransportFallbackLogObserver()
+  const rememberCodexHttps = (): void => {
+    void settingsService
+      .rememberCodexAutoHttpsFallback()
+      .then((remembered) =>
+        remembered
+          ? runtimeCoordinatorRef.current?.requestProviderReconnect(
+              [CODEX_SUBSCRIPTION_PROVIDER_ID],
+              true
+            )
+          : undefined
+      )
+      .catch((error) =>
+        log.warn('Codex automatic transport memory update failed', errorLogFields(error))
+      )
+  }
+  const callbacks: AcpRuntimeCallbacks = {
+    ...clientCallbacks,
+    onPromptStarted: (sessionId, turnToken, promptAttemptId) => {
+      codexTransportFallbackLog.begin(
+        sessionId,
+        runtimeCoordinatorRef.current?.captureSessionBackend(sessionId)
+      )
+      clientCallbacks.onPromptStarted?.(sessionId, turnToken, promptAttemptId)
+    },
+    onPromptEnded: (sessionId, turnToken) => {
+      if (codexTransportFallbackLog.end(sessionId)) rememberCodexHttps()
+      clientCallbacks.onPromptEnded?.(sessionId, turnToken)
+    },
+    // Retain compatibility with adapters that explicitly publish this diagnostic on stderr.
+    onCodexWebSocketFallback: () => {
+      rememberCodexHttps()
+      clientCallbacks.onCodexWebSocketFallback?.()
     }
   }
 

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -351,6 +351,26 @@ const createFakeRuntime = (options: {
 }
 
 describe('AcpRuntimeCoordinator', () => {
+  it('forwards a Codex WebSocket fallback from a runtime to the application callback', () => {
+    const onCodexWebSocketFallback = vi.fn()
+    let runtimeCallbacks: AcpRuntimeCallbacks | undefined
+    new AcpRuntimeCoordinator(
+      (callbacks) => {
+        runtimeCallbacks = callbacks
+        return createFakeRuntime({
+          frameworkId: 'codex',
+          sessionIds: ['session-1'],
+          callbacks
+        }).runtime
+      },
+      { onCodexWebSocketFallback }
+    )
+
+    runtimeCallbacks?.onCodexWebSocketFallback?.()
+
+    expect(onCodexWebSocketFallback).toHaveBeenCalledOnce()
+  })
+
   it('routes Sessions through runtimes keyed by their explicit agent target', async () => {
     const targets: Array<AcpSessionAgentTarget | undefined> = []
     const created: ReturnType<typeof createFakeRuntime>[] = []

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1676,6 +1676,9 @@ class AcpRuntimeCoordinator {
           }
           this.callbacks.onProviderPromptAccepted?.(sessionId, promptAttemptId)
         },
+        onCodexWebSocketFallback: () => {
+          this.callbacks.onCodexWebSocketFallback?.()
+        },
         onPromptEnded: (sessionId, turnToken) => {
           const remaining = (this.activePromptCounts.get(sessionId) ?? 1) - 1
           if (remaining > 0) this.activePromptCounts.set(sessionId, remaining)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -23320,17 +23320,19 @@ describe('ACP runtime — agent process lifecycle logging', () => {
       modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
     })
     const events: AcpRuntimeEvent[] = []
+    const onCodexWebSocketFallback = vi.fn()
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       resolveBackend: () => ({
         framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
-        backendId: 'codex:provider-a',
+        providerId: 'builtin-codex-subscription',
+        backendId: 'codex:builtin-codex-subscription',
         modelRoute: 'codex-responses',
         executablePath: '/bin/codex',
         env: {}
       }),
-      callbacks: { onEvent: (event) => events.push(event) }
+      callbacks: { onEvent: (event) => events.push(event), onCodexWebSocketFallback }
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
@@ -23346,16 +23348,18 @@ describe('ACP runtime — agent process lifecycle logging', () => {
             'Warning: Skill descriptions were shortened to fit the 2% skills context budget.',
             'Codex can still see every skill, but some descriptions are shorter.',
             'Disable unused skills or plugins to leave more room for the rest.',
-            'Warning: Falling back from WebSockets to HTTPS transport. request timed out'
+            'Warning: Falling back from WebSock'
           ].join('\n')
         )
       )
+      process.stderr.emit('data', Buffer.from('ets to HTTPS transport. request timed out'))
       await vi.advanceTimersByTimeAsync(1000)
 
       expect(warnLogSpy.mock.calls.some(([message]) => message === 'agent stderr summary')).toBe(
         true
       )
       expect(events.some((event) => event.kind === 'system' && event.title === 'agent')).toBe(false)
+      expect(onCodexWebSocketFallback).toHaveBeenCalledOnce()
     } finally {
       vi.useRealTimers()
       promptResponse.resolve({ stopReason: 'end_turn' })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -34,7 +34,7 @@ import {
   type AcpStateSnapshot
 } from '../../shared/acp'
 import type { GrantedLocalRoot } from '../../shared/local-fs'
-import { type AgentFrameworkId } from '../../shared/settings'
+import { isCodexSubscriptionProviderId, type AgentFrameworkId } from '../../shared/settings'
 import {
   sanitizeSessionReferences,
   type MessageAttribution
@@ -166,6 +166,7 @@ export type AcpRuntimeCallbacks = {
   // Fires after the provider prompt yields its first update/terminal response. Reaching this point
   // proves startup did not reject before the provider accepted the request.
   onProviderPromptAccepted?: (sessionId: string, promptAttemptId?: string) => void
+  onCodexWebSocketFallback?: () => void
   onPromptEnded?: (sessionId: string, turnToken: string) => void
   onSkillImportAttachmentEligible?: (
     sessionId: string,
@@ -438,6 +439,7 @@ const PLAN_CONTINUATION_CLAIM_MAX_ATTEMPTS = 3
 const PLAN_CONTINUATION_CLAIM_RETRY_BASE_DELAY_MS = 25
 const AGENT_STDERR_REPORT_WINDOW_MS = 1000
 const MAX_RAW_AGENT_STDERR_SAMPLE_BYTES = 4096
+const CODEX_TRANSPORT_SIGNAL_SAMPLE_CHARACTERS = 512
 // Support-only opt-in. Raw agent stderr can contain research data, local paths, and tool output.
 const RAW_AGENT_STDERR_ENV = 'OPEN_SCIENCE_AGENT_STDERR'
 
@@ -450,12 +452,17 @@ const isNonActionableCodexStderr = (text: string): boolean => {
     ''
   )
   const withoutTransportFallback = withoutSkillBudgetNotice.replace(
-    /Warning:\s*Falling back from WebSockets to HTTPS transport\.\s*request timed out\s*/gi,
+    /Warning:\s*Falling\s*back\s*from\s*WebSockets\s*to\s*HTTPS\s*transport\.\s*request\s*timed\s*out\s*/gi,
     ''
   )
 
   return withoutTransportFallback.trim().length === 0
 }
+
+const hasCodexWebSocketFallback = (text: string): boolean =>
+  /Warning:\s*Falling\s*back\s*from\s*WebSockets\s*to\s*HTTPS\s*transport\.\s*request\s*timed\s*out\s*/i.test(
+    text
+  )
 
 const utf8PrefixWithinBytes = (value: string, maxBytes: number): string => {
   if (maxBytes <= 0) return ''
@@ -489,6 +496,8 @@ type AgentStderrWindow = {
   interactionSequence?: number
   sessionAttributionConsistent: boolean
   nonActionableCodexOnly: boolean
+  codexTransportSignalSample: string
+  codexWebSocketFallbackObserved: boolean
   eventEligible: boolean
   timer: ReturnType<typeof setTimeout>
 }
@@ -2677,6 +2686,7 @@ class AcpRuntime {
         existing.sessionAttributionConsistent = false
       }
       this.appendAgentStderrSample(existing, text)
+      this.observeCodexTransportSignal(existing, text)
       return
     }
 
@@ -2699,11 +2709,39 @@ class AcpRuntime {
       interactionSequence,
       sessionAttributionConsistent: true,
       nonActionableCodexOnly: context.framework === 'codex' && isNonActionableCodexStderr(text),
+      codexTransportSignalSample: '',
+      codexWebSocketFallbackObserved: false,
       eventEligible: disposition === 'current',
       timer
     }
     this.appendAgentStderrSample(window, text)
+    this.observeCodexTransportSignal(window, text)
     this.agentStderrWindows.set(context.process, window)
+  }
+
+  // Codex diagnostics can cross Node stderr chunk boundaries. Retain only a short ephemeral suffix
+  // for this exact operational signal; it is never logged or persisted as user-visible output.
+  private observeCodexTransportSignal(window: AgentStderrWindow, text: string): void {
+    if (window.framework !== 'codex' || window.codexWebSocketFallbackObserved) return
+    window.codexTransportSignalSample = `${window.codexTransportSignalSample}${text}`.slice(
+      -CODEX_TRANSPORT_SIGNAL_SAMPLE_CHARACTERS
+    )
+    if (!hasCodexWebSocketFallback(window.codexTransportSignalSample)) return
+    window.codexWebSocketFallbackObserved = true
+    window.nonActionableCodexOnly = isNonActionableCodexStderr(window.codexTransportSignalSample)
+    if (
+      !window.eventEligible ||
+      this.processEventDisposition(window.process, window.epoch) !== 'current' ||
+      this.backend.providerId === undefined ||
+      !isCodexSubscriptionProviderId(this.backend.providerId)
+    ) {
+      return
+    }
+    try {
+      this.options.callbacks?.onCodexWebSocketFallback?.()
+    } catch (error) {
+      safeLogError('Codex WebSocket fallback observation failed', errorLogFields(error))
+    }
   }
 
   private includeRawAgentStderr(): boolean {

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -515,6 +515,87 @@ describe('AgentBackendResolver configured and explicit targets', () => {
     expectRuntimeNotStarted(harness.runtime)
   })
 
+  it('keeps projecting learned HTTPS while the Codex subscription preference remains Auto', async () => {
+    const provider: StoredProvider = {
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      codexAuthMode: 'isolated',
+      codexTransport: 'auto',
+      codexAutoUseHttps: true,
+      name: 'Codex subscription',
+      model: 'gpt-5.4'
+    }
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [provider],
+        activeProviderId: provider.id,
+        activeModel: provider.model,
+        agentFrameworkId: 'codex'
+      }),
+      targetOverride: () => ({
+        apiEndpoints: ['responses'],
+        provider: {
+          type: 'codex-isolated',
+          codexAuthMode: 'isolated',
+          codexTransport: 'auto',
+          codexAutoUseHttps: true,
+          apiEndpoints: ['responses']
+        }
+      })
+    })
+
+    await harness.resolver.resolveExplicitTarget({
+      frameworkId: 'codex',
+      providerId: provider.id,
+      model: { kind: 'required', id: 'gpt-5.4' },
+      reasoningEffort: 'high'
+    })
+
+    expect(harness.ensureCodexSubscriptionHome).toHaveBeenCalledWith('https')
+  })
+
+  it.each(['https', 'websocket'] as const)(
+    'ignores automatic transport memory for the manual %s preference',
+    async (codexTransport) => {
+      const provider: StoredProvider = {
+        id: 'builtin-codex-subscription',
+        type: 'codex-isolated',
+        codexAuthMode: 'isolated',
+        codexTransport,
+        codexAutoUseHttps: true,
+        name: 'Codex subscription',
+        model: 'gpt-5.4'
+      }
+      const harness = makeHarness({
+        settings: makeSettings({
+          providers: [provider],
+          activeProviderId: provider.id,
+          activeModel: provider.model,
+          agentFrameworkId: 'codex'
+        }),
+        targetOverride: () => ({
+          apiEndpoints: ['responses'],
+          provider: {
+            type: 'codex-isolated',
+            codexAuthMode: 'isolated',
+            codexTransport,
+            codexAutoUseHttps: true,
+            apiEndpoints: ['responses']
+          }
+        })
+      })
+
+      await harness.resolver.resolveExplicitTarget({
+        frameworkId: 'codex',
+        providerId: provider.id,
+        model: { kind: 'required', id: 'gpt-5.4' },
+        reasoningEffort: 'high'
+      })
+
+      expect(harness.ensureCodexSubscriptionHome).toHaveBeenCalledWith(codexTransport)
+    }
+  )
+
   it('registers third-party Claude model ids through canonical override lanes', async () => {
     const provider: StoredProvider = {
       ...makeStoredProvider('provider-a', 'third-party/model-a'),

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 
-import type { ReasoningEffort } from '../../shared/settings'
+import type { CodexSubscriptionTransport, ReasoningEffort } from '../../shared/settings'
 import {
   DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
   DEFAULT_REASONING_EFFORT,
@@ -36,7 +36,7 @@ import {
   type ProviderRuntimeTarget,
   type RuntimeProviderModelSelection
 } from './provider-accounts'
-import { ensureCodexAuthHome } from './codex-auth'
+import { ensureCodexAuthHome, resolveEffectiveCodexSubscriptionTransport } from './codex-auth'
 import type { StoredSettings } from './types'
 import type { ClaudeRuntimeModelConfig } from './claude-config-provision'
 import {
@@ -114,7 +114,7 @@ export type AgentBackendResolverOptions = ProviderTransportOwnerOptions & {
   userClaudeDir: string
   skillRuntimeMcpEntryPath: string
   readFrameworkOverride?: () => string | undefined
-  ensureCodexSubscriptionHome?: () => Promise<void>
+  ensureCodexSubscriptionHome?: (transport: CodexSubscriptionTransport) => Promise<void>
 }
 
 // Coordinates stable backend decisions while ProviderTransportOwner owns every live generation.
@@ -130,7 +130,9 @@ export class AgentBackendResolver {
   private readonly selection: BackendSelectionOwner
   private readonly planner: BackendRoutePlanner
   private readonly transports: ProviderTransportOwner
-  private readonly ensureCodexSubscriptionHome: () => Promise<void>
+  private readonly ensureCodexSubscriptionHome: (
+    transport: CodexSubscriptionTransport
+  ) => Promise<void>
 
   constructor(options: AgentBackendResolverOptions) {
     this.readSettings = options.readSettings
@@ -151,7 +153,7 @@ export class AgentBackendResolver {
     this.transports = new ProviderTransportOwner(options)
     this.ensureCodexSubscriptionHome =
       options.ensureCodexSubscriptionHome ??
-      (() => ensureCodexAuthHome('isolated', this.storageRoot))
+      ((transport) => ensureCodexAuthHome('isolated', this.storageRoot, transport))
   }
 
   async resolveActiveSpawnConfig(
@@ -395,7 +397,9 @@ export class AgentBackendResolver {
     }
 
     if (framework.id === 'codex' && isCodexSubscriptionProvider(target.provider.type)) {
-      await this.ensureCodexSubscriptionHome()
+      await this.ensureCodexSubscriptionHome(
+        resolveEffectiveCodexSubscriptionTransport(target.provider)
+      )
     }
     const backendProviderId = plan.backendProviderId
     if (framework.supportsSkills || framework.id === 'codebuddy') {

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -12,6 +12,7 @@ import {
   ensureCodexAuthHome,
   importCodexAuthentication,
   projectSafeCodexProviderRoute,
+  resolveEffectiveCodexSubscriptionTransport,
   type CodexAuthSession
 } from './codex-auth'
 
@@ -29,28 +30,75 @@ const session = (overrides: Partial<CodexAuthSession> = {}): CodexAuthSession =>
   ...overrides
 })
 
+const autoTransportConfig = (prefix: string[] = []): string =>
+  [...prefix, 'cli_auth_credentials_store = "file"', ''].join('\n')
+
+describe('resolveEffectiveCodexSubscriptionTransport', () => {
+  it('retains learned HTTPS only while the preference is Auto', () => {
+    expect(
+      resolveEffectiveCodexSubscriptionTransport({
+        codexTransport: 'auto',
+        codexAutoUseHttps: true
+      })
+    ).toBe('https')
+    expect(
+      resolveEffectiveCodexSubscriptionTransport({
+        codexTransport: 'websocket',
+        codexAutoUseHttps: true
+      })
+    ).toBe('websocket')
+    expect(resolveEffectiveCodexSubscriptionTransport({})).toBe('auto')
+  })
+})
+
 describe('ensureCodexAuthHome', () => {
-  it('creates the same app-owned home with file-only credentials for both auth modes', async () => {
+  it('projects Auto, HTTPS, and WebSocket as distinct public profile configurations', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-transports-'))
+    const configPath = join(codexSubscriptionStorageDir(root), 'config.toml')
+    try {
+      await ensureCodexAuthHome('isolated', root, 'auto')
+      expect(await readFile(configPath, 'utf8')).toBe('cli_auth_credentials_store = "file"\n')
+
+      await ensureCodexAuthHome('isolated', root, 'https')
+      let configToml = await readFile(configPath, 'utf8')
+      expect(configToml).toContain('model_provider = "open-science-chatgpt-https"')
+      expect(configToml).toContain('supports_websockets = false')
+
+      await ensureCodexAuthHome('isolated', root, 'websocket')
+      configToml = await readFile(configPath, 'utf8')
+      expect(configToml).toContain('model_provider = "open-science-chatgpt-websocket"')
+      expect(configToml).toContain('supports_websockets = true')
+      expect(configToml).not.toContain('open-science-chatgpt-https')
+
+      await ensureCodexAuthHome('isolated', root, 'auto')
+      expect(await readFile(configPath, 'utf8')).toBe('cli_auth_credentials_store = "file"\n')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('creates the same app-owned home with file-only credentials and Auto transport for both auth modes', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codex-auth-home-'))
+    const expectedConfig = autoTransportConfig()
     try {
       await ensureCodexAuthHome('shared', root)
       expect(existsSync(codexSubscriptionStorageDir(root))).toBe(true)
       expect(await readFile(join(codexSubscriptionStorageDir(root), 'config.toml'), 'utf8')).toBe(
-        'cli_auth_credentials_store = "file"\n'
+        expectedConfig
       )
 
       await rm(codexSubscriptionStorageDir(root), { recursive: true, force: true })
       await ensureCodexAuthHome('isolated', root)
       expect(existsSync(codexSubscriptionStorageDir(root))).toBe(true)
       expect(await readFile(join(codexSubscriptionStorageDir(root), 'config.toml'), 'utf8')).toBe(
-        'cli_auth_credentials_store = "file"\n'
+        expectedConfig
       )
     } finally {
       await rm(root, { recursive: true, force: true })
     }
   })
 
-  it('replaces a global-capable credential store without changing other profile config', async () => {
+  it('replaces a global-capable credential store and preserves other profile config idempotently', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codex-auth-home-'))
     const home = codexSubscriptionStorageDir(root)
     try {
@@ -68,17 +116,12 @@ describe('ensureCodexAuthHome', () => {
       )
 
       await ensureCodexAuthHome('isolated', root)
+      await ensureCodexAuthHome('isolated', root)
 
-      expect(await readFile(join(home, 'config.toml'), 'utf8')).toBe(
-        [
-          'model = "account-default"',
-          '',
-          'cli_auth_credentials_store = "file"',
-          '[model_providers.local]',
-          'base_url = "http://127.0.0.1:1087/v1"',
-          ''
-        ].join('\n')
-      )
+      const configToml = await readFile(join(home, 'config.toml'), 'utf8')
+      expect(configToml).toContain('cli_auth_credentials_store = "file"')
+      expect(configToml).not.toContain('open-science-chatgpt-')
+      expect(configToml).toContain('[model_providers.local]\nbase_url = "http://127.0.0.1:1087/v1"')
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -160,6 +203,38 @@ describe('createCodexAuthEnvironment', () => {
 })
 
 describe('importCodexAuthentication', () => {
+  it('keeps an explicitly imported safe route ahead of the transport preference', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-import-priority-'))
+    const source = join(root, 'source')
+    const destination = codexSubscriptionStorageDir(root)
+    try {
+      await mkdir(source, { recursive: true })
+      await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+      await writeFile(
+        join(source, 'config.toml'),
+        [
+          'model_provider = "subscription-route"',
+          '[model_providers.subscription-route]',
+          'base_url = "http://127.0.0.1:1087/v1"',
+          'wire_api = "responses"',
+          'requires_openai_auth = true',
+          ''
+        ].join('\n')
+      )
+
+      await importCodexAuthentication(source, destination)
+      await ensureCodexAuthHome('shared', root, 'websocket')
+
+      const configToml = await readFile(join(destination, 'config.toml'), 'utf8')
+      expect(configToml).toContain('model_provider = "subscription-route"')
+      expect(configToml).toContain('base_url = "http://127.0.0.1:1087/v1"')
+      expect(configToml).not.toContain('open-science-chatgpt-websocket')
+      expect(configToml).not.toContain('open-science-chatgpt-https')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('projects only a validated provider route from app-owned configuration', () => {
     expect(
       projectSafeCodexProviderRoute(
@@ -215,10 +290,26 @@ describe('importCodexAuthentication', () => {
         expect((await stat(join(destination, 'auth.json'))).mode & 0o777).toBe(0o600)
       }
       expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
-        'model = "app-default"\n'
+        autoTransportConfig(['model = "app-default"'])
       )
       expect(existsSync(join(destination, 'skills'))).toBe(false)
       expect(existsSync(join(destination, 'sessions'))).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('creates the Auto transport default when importing auth without a provider route', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-import-default-route-'))
+    const source = join(root, 'source')
+    const destination = join(root, 'destination')
+    try {
+      await mkdir(source, { recursive: true })
+      await writeFile(join(source, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+
+      await importCodexAuthentication(source, destination)
+
+      expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(autoTransportConfig())
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -257,6 +348,7 @@ describe('importCodexAuthentication', () => {
       expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
         [
           'model = "app-default"',
+          'cli_auth_credentials_store = "file"',
           '# Open Science: begin imported Codex route selection',
           'model_provider = "subscription-route"',
           '# Open Science: end imported Codex route selection',
@@ -279,7 +371,7 @@ describe('importCodexAuthentication', () => {
       await importCodexAuthentication(source, destination)
 
       expect(await readFile(join(destination, 'config.toml'), 'utf8')).toBe(
-        'model = "app-default"\n'
+        autoTransportConfig(['model = "app-default"'])
       )
     } finally {
       await rm(root, { recursive: true, force: true })
@@ -321,7 +413,10 @@ describe('importCodexAuthentication', () => {
 
       await importCodexAuthentication(source, destination)
 
-      expect(existsSync(join(destination, 'config.toml'))).toBe(false)
+      const configToml = await readFile(join(destination, 'config.toml'), 'utf8')
+      expect(configToml).toContain('cli_auth_credentials_store = "file"')
+      expect(configToml).not.toContain('open-science-chatgpt-')
+      expect(configToml).not.toContain('subscription-route')
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -425,7 +520,10 @@ describe('importCodexAuthentication', () => {
 
       await importCodexAuthentication(source, destination)
 
-      expect(existsSync(join(destination, 'config.toml'))).toBe(false)
+      const configToml = await readFile(join(destination, 'config.toml'), 'utf8')
+      expect(configToml).toContain('cli_auth_credentials_store = "file"')
+      expect(configToml).not.toContain('open-science-chatgpt-')
+      expect(configToml).not.toContain('private-gateway')
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -456,7 +554,10 @@ describe('importCodexAuthentication', () => {
 
         await importCodexAuthentication(source, destination)
 
-        expect(existsSync(join(destination, 'config.toml'))).toBe(false)
+        const configToml = await readFile(join(destination, 'config.toml'), 'utf8')
+        expect(configToml).toContain('cli_auth_credentials_store = "file"')
+        expect(configToml).not.toContain('open-science-chatgpt-')
+        expect(configToml).not.toContain('remote-route')
       } finally {
         await rm(root, { recursive: true, force: true })
       }
@@ -488,7 +589,10 @@ describe('importCodexAuthentication', () => {
 
         await importCodexAuthentication(source, destination)
 
-        expect(existsSync(join(destination, 'config.toml'))).toBe(false)
+        const configToml = await readFile(join(destination, 'config.toml'), 'utf8')
+        expect(configToml).toContain('cli_auth_credentials_store = "file"')
+        expect(configToml).not.toContain('open-science-chatgpt-')
+        expect(configToml).not.toContain('subscription-route')
       } finally {
         await rm(root, { recursive: true, force: true })
       }

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -7,6 +7,7 @@ import { Readable, Writable } from 'node:stream'
 
 import * as acp from '@agentclientprotocol/sdk'
 
+import type { CodexSubscriptionTransport } from '../../shared/settings'
 import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { terminateProcessTree } from '../process-tree'
 import { augmentedPathEnv } from './shell-path'
@@ -40,6 +41,7 @@ export type CodexAuthLaunch = {
   nativePath?: string
   mode: CodexAuthMode
   storageRoot: string
+  transport?: CodexSubscriptionTransport
   proxyEnv?: SystemProxyEnvironment
 }
 
@@ -276,6 +278,22 @@ const IMPORTED_ROUTE_PROVIDER_BEGIN = '# Open Science: begin imported Codex prov
 const IMPORTED_ROUTE_PROVIDER_END = '# Open Science: end imported Codex provider'
 const IMPORTED_ROUTE_PRESERVED_LINE = '# Open Science: preserved Codex config '
 const CODEX_FILE_CREDENTIAL_STORE = 'cli_auth_credentials_store = "file"'
+const TRANSPORT_ROUTE_SELECTION_BEGIN = '# Open Science: begin Codex transport route selection'
+const TRANSPORT_ROUTE_SELECTION_END = '# Open Science: end Codex transport route selection'
+const TRANSPORT_ROUTE_PROVIDER_BEGIN = '# Open Science: begin Codex transport provider'
+const TRANSPORT_ROUTE_PROVIDER_END = '# Open Science: end Codex transport provider'
+const CODEX_TRANSPORT_PROVIDER_IDS = [
+  'open-science-chatgpt-https',
+  'open-science-chatgpt-websocket'
+] as const
+
+export const resolveEffectiveCodexSubscriptionTransport = (provider: {
+  codexTransport?: CodexSubscriptionTransport
+  codexAutoUseHttps?: boolean
+}): CodexSubscriptionTransport => {
+  const preference = provider.codexTransport ?? 'auto'
+  return preference === 'auto' && provider.codexAutoUseHttps === true ? 'https' : preference
+}
 
 const isCodexCredentialStoreAssignment = (line: string): boolean =>
   /^\s*(?:cli_auth_credentials_store|"cli_auth_credentials_store"|'cli_auth_credentials_store')\s*=/.test(
@@ -298,7 +316,11 @@ const serializeCodexFileCredentialStore = (existingConfigToml: string): string =
 
   while (result.at(-1) === '') result.pop()
   const firstOwnedMarkerIndex = result.findIndex(
-    (line) => line === IMPORTED_ROUTE_SELECTION_BEGIN || line === IMPORTED_ROUTE_PROVIDER_BEGIN
+    (line) =>
+      line === IMPORTED_ROUTE_SELECTION_BEGIN ||
+      line === IMPORTED_ROUTE_PROVIDER_BEGIN ||
+      line === TRANSPORT_ROUTE_SELECTION_BEGIN ||
+      line === TRANSPORT_ROUTE_PROVIDER_BEGIN
   )
   const firstTableIndex = result.findIndex((line) => /^\s*\[/.test(line))
   const insertionCandidates = [firstOwnedMarkerIndex, firstTableIndex].filter((index) => index >= 0)
@@ -340,6 +362,100 @@ const restoreCompleteMarkedBlock = (lines: string[], begin: string, end: string)
 const hasCompleteMarkedBlock = (lines: string[], begin: string, end: string): boolean => {
   const beginIndex = lines.indexOf(begin)
   return beginIndex >= 0 && lines.slice(beginIndex + 1).includes(end)
+}
+
+const isOwnedTransportProviderId = (value: unknown): boolean =>
+  typeof value === 'string' &&
+  CODEX_TRANSPORT_PROVIDER_IDS.includes(value as (typeof CODEX_TRANSPORT_PROVIDER_IDS)[number])
+
+// Builds before the transport selector used an unmarked HTTPS provider. Its reserved app-owned id
+// makes that exact selection/table safe to migrate without touching user-authored provider routes.
+const removeLegacyCodexTransportRoute = (lines: string[]): string[] => {
+  const result: string[] = []
+  let inTopLevel = true
+  let inOwnedProviderTable = false
+
+  for (const line of lines) {
+    if (/^\s*\[/.test(line)) {
+      inTopLevel = false
+      inOwnedProviderTable = isOwnedTransportProviderId(parseModelProviderTableRootId(line))
+      if (inOwnedProviderTable) continue
+    } else if (inOwnedProviderTable) {
+      continue
+    }
+
+    const assignment = inTopLevel ? parseTomlScalarAssignment(line) : undefined
+    if (assignment?.key === 'model_provider' && isOwnedTransportProviderId(assignment.value)) {
+      continue
+    }
+    result.push(line)
+  }
+  return result
+}
+
+const removeCodexTransportRoute = (configToml: string): string =>
+  removeLegacyCodexTransportRoute(
+    restoreCompleteMarkedBlock(
+      restoreCompleteMarkedBlock(
+        configToml.split(/\r?\n/),
+        TRANSPORT_ROUTE_SELECTION_BEGIN,
+        TRANSPORT_ROUTE_SELECTION_END
+      ),
+      TRANSPORT_ROUTE_PROVIDER_BEGIN,
+      TRANSPORT_ROUTE_PROVIDER_END
+    )
+  ).join('\n')
+
+// Imported routes are explicit user configuration and may describe a loopback gateway. They always
+// take precedence over this ChatGPT transport preference.
+const serializeCodexSubscriptionTransport = (
+  existingConfigToml: string,
+  transport: CodexSubscriptionTransport
+): string => {
+  const withoutOwnedRoute = removeCodexTransportRoute(existingConfigToml)
+  if (transport === 'auto') return withoutOwnedRoute
+
+  const lines = withoutOwnedRoute.split(/\r?\n/)
+  if (
+    hasCompleteMarkedBlock(lines, IMPORTED_ROUTE_SELECTION_BEGIN, IMPORTED_ROUTE_SELECTION_END) ||
+    hasCompleteMarkedBlock(lines, IMPORTED_ROUTE_PROVIDER_BEGIN, IMPORTED_ROUTE_PROVIDER_END)
+  ) {
+    return withoutOwnedRoute
+  }
+
+  const firstTableIndex = lines.findIndex((line) => /^\s*\[/.test(line))
+  const topLevelEnd = firstTableIndex < 0 ? lines.length : firstTableIndex
+  if (
+    lines.slice(0, topLevelEnd).some((line) => parseTomlAssignmentKey(line) === 'model_provider')
+  ) {
+    return withoutOwnedRoute
+  }
+
+  while (lines.at(-1) === '') lines.pop()
+  const providerId = `open-science-chatgpt-${transport}`
+  const selectionIndex = lines.findIndex((line) => /^\s*\[/.test(line))
+  lines.splice(
+    selectionIndex < 0 ? lines.length : selectionIndex,
+    0,
+    TRANSPORT_ROUTE_SELECTION_BEGIN,
+    `model_provider = ${JSON.stringify(providerId)}`,
+    TRANSPORT_ROUTE_SELECTION_END,
+    ''
+  )
+  while (lines.at(-1) === '') lines.pop()
+  if (lines.length > 0) lines.push('')
+  lines.push(
+    TRANSPORT_ROUTE_PROVIDER_BEGIN,
+    `[model_providers.${JSON.stringify(providerId)}]`,
+    `name = ${JSON.stringify(transport === 'https' ? 'OpenAI HTTPS' : 'OpenAI WebSocket')}`,
+    'base_url = "https://chatgpt.com/backend-api/codex"',
+    'wire_api = "responses"',
+    'requires_openai_auth = true',
+    `supports_websockets = ${String(transport === 'websocket')}`,
+    TRANSPORT_ROUTE_PROVIDER_END,
+    ''
+  )
+  return lines.join('\n')
 }
 
 const removeImportedCodexProviderRoute = (configToml: string): string => {
@@ -455,6 +571,28 @@ const writePrivateFileAtomically = async (
   }
 }
 
+const ensureCodexAuthConfigHome = async (
+  codexHome: string,
+  transport: CodexSubscriptionTransport
+): Promise<void> => {
+  const configPath = join(codexHome, 'config.toml')
+  await mkdir(codexHome, { recursive: true })
+
+  let existingConfigToml = ''
+  try {
+    existingConfigToml = await readFile(configPath, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  const nextConfigToml = serializeCodexFileCredentialStore(
+    serializeCodexSubscriptionTransport(existingConfigToml, transport)
+  )
+  if (nextConfigToml !== existingConfigToml) {
+    await writePrivateFileAtomically(configPath, nextConfigToml)
+  }
+}
+
 export const createCodexAuthEnvironment = (
   _mode: CodexAuthMode,
   storageRoot: string,
@@ -516,6 +654,7 @@ export const importCodexAuthentication = async (
   } else {
     await clearImportedCodexProviderRoute(destinationHome)
   }
+  await ensureCodexAuthConfigHome(destinationHome, 'auto')
 }
 
 export const clearImportedCodexProviderRoute = async (destinationHome: string): Promise<void> => {
@@ -775,23 +914,10 @@ export type CodexAuthControllerPort = Pick<
 // not permission to read the user's global Codex profile at runtime.
 export const ensureCodexAuthHome = async (
   _mode: CodexAuthMode,
-  storageRoot: string
+  storageRoot: string,
+  transport: CodexSubscriptionTransport = 'auto'
 ): Promise<void> => {
-  const codexHome = codexSubscriptionStorageDir(storageRoot)
-  const configPath = join(codexHome, 'config.toml')
-  await mkdir(codexHome, { recursive: true })
-
-  let existingConfigToml = ''
-  try {
-    existingConfigToml = await readFile(configPath, 'utf8')
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-  }
-
-  const nextConfigToml = serializeCodexFileCredentialStore(existingConfigToml)
-  if (nextConfigToml !== existingConfigToml) {
-    await writePrivateFileAtomically(configPath, nextConfigToml)
-  }
+  await ensureCodexAuthConfigHome(codexSubscriptionStorageDir(storageRoot), transport)
 }
 
 export const openCodexAuthSession = async ({
@@ -799,9 +925,10 @@ export const openCodexAuthSession = async ({
   nativePath,
   mode,
   storageRoot,
+  transport = 'auto',
   proxyEnv
 }: CodexAuthLaunch): Promise<CodexAuthSession> => {
-  await ensureCodexAuthHome(mode, storageRoot)
+  await ensureCodexAuthHome(mode, storageRoot, transport)
 
   const isJavaScript = /\.[cm]?js$/i.test(adapterPath)
   const needsShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(adapterPath)

--- a/src/main/settings/codex-transport-fallback-log.test.ts
+++ b/src/main/settings/codex-transport-fallback-log.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  CodexTransportFallbackLogObserver,
+  hasCodexHttpsFallbackAfter,
+  readCodexFallbackLogPosition
+} from './codex-transport-fallback-log'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const createLogDatabase = async (): Promise<{ codexHome: string; database: DatabaseSync }> => {
+  const codexHome = await mkdtemp(join(tmpdir(), 'codex-transport-log-'))
+  roots.push(codexHome)
+  const database = new DatabaseSync(join(codexHome, 'logs_2.sqlite'))
+  database.exec(`
+    CREATE TABLE logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER NOT NULL,
+      target TEXT NOT NULL,
+      feedback_log_body TEXT
+    )
+  `)
+  return { codexHome, database }
+}
+
+describe('Codex transport fallback log cursor', () => {
+  it('observes only a Codex client fallback appended after the prompt starts', async () => {
+    const { codexHome, database } = await createLogDatabase()
+    try {
+      const insert = database.prepare(
+        'INSERT INTO logs (ts, target, feedback_log_body) VALUES (?, ?, ?)'
+      )
+      insert.run(100, 'codex_core::client', 'falling back to HTTP')
+      const afterId = readCodexFallbackLogPosition(codexHome)
+      expect(afterId).toBe(1)
+
+      // These rows deliberately share the previous row's second-resolution timestamp.
+      insert.run(100, 'codex_core::responses_retry', 'falling back to HTTP')
+      expect(hasCodexHttpsFallbackAfter(codexHome, afterId!)).toBe(false)
+
+      insert.run(100, 'codex_core::client', 'falling back to HTTP')
+      expect(hasCodexHttpsFallbackAfter(codexHome, afterId!)).toBe(true)
+    } finally {
+      database.close()
+    }
+  })
+
+  it('returns false before Codex has created its log database', () => {
+    expect(readCodexFallbackLogPosition('/missing/codex-home')).toBe(0)
+    expect(hasCodexHttpsFallbackAfter('/missing/codex-home', 0)).toBe(false)
+  })
+})
+
+describe('CodexTransportFallbackLogObserver', () => {
+  it('checks each completed Codex subscription prompt once from its recorded start time', () => {
+    const readFallback = vi.fn(() => true)
+    const readPosition = vi.fn(() => 17)
+    const observer = new CodexTransportFallbackLogObserver(readFallback, readPosition)
+    observer.begin('session-1', {
+      framework: { id: 'codex' },
+      providerId: 'builtin-codex-subscription',
+      adapter: { codexHome: '/codex-home' }
+    })
+
+    expect(observer.end('session-1')).toBe(true)
+    expect(observer.end('session-1')).toBe(false)
+    expect(readFallback).toHaveBeenCalledOnce()
+    expect(readPosition).toHaveBeenCalledWith('/codex-home')
+    expect(readFallback).toHaveBeenCalledWith('/codex-home', 17)
+  })
+
+  it('ignores Codex API providers and non-Codex sessions', () => {
+    const readFallback = vi.fn(() => true)
+    const observer = new CodexTransportFallbackLogObserver(readFallback)
+
+    observer.begin('official', {
+      framework: { id: 'codex' },
+      providerId: 'provider-openai',
+      adapter: { codexHome: '/codex-home' }
+    })
+    observer.begin('claude', {
+      framework: { id: 'claude-code' },
+      providerId: 'builtin-claude-shared',
+      adapter: { codexHome: '/codex-home' }
+    })
+
+    expect(observer.end('official')).toBe(false)
+    expect(observer.end('claude')).toBe(false)
+    expect(readFallback).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/settings/codex-transport-fallback-log.ts
+++ b/src/main/settings/codex-transport-fallback-log.ts
@@ -1,0 +1,109 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { DatabaseSync as NodeDatabaseSync } from 'node:sqlite'
+
+import { isCodexSubscriptionProviderId } from '../../shared/settings'
+
+const codexLogDatabasePath = (codexHome: string): string => join(codexHome, 'logs_2.sqlite')
+
+// Native Codex timestamps have one-second precision, so time comparisons cannot distinguish an
+// earlier fallback from a prompt that starts later in the same second. Capture the append-only row
+// position at prompt start instead. A missing database is position zero; an unreadable existing
+// database disables observation for that prompt so old rows cannot be mistaken for new ones.
+export const readCodexFallbackLogPosition = (codexHome: string): number | undefined => {
+  if (!codexHome.trim()) return undefined
+  const databasePath = codexLogDatabasePath(codexHome)
+  if (!existsSync(databasePath)) return 0
+
+  let database: NodeDatabaseSync | undefined
+  try {
+    const sqlite = process.getBuiltinModule('node:sqlite') as
+      typeof import('node:sqlite') | undefined
+    if (!sqlite) return undefined
+    const { DatabaseSync } = sqlite
+    database = new DatabaseSync(databasePath, { readOnly: true })
+    const row = database.prepare('SELECT MAX(id) AS id FROM logs').get() as
+      { id?: number | null } | undefined
+    return typeof row?.id === 'number' && Number.isSafeInteger(row.id) ? row.id : 0
+  } catch {
+    return undefined
+  } finally {
+    database?.close()
+  }
+}
+
+// Query only rows appended after the captured prompt boundary and return a boolean; prompt content
+// and other diagnostic fields never leave SQLite.
+export const hasCodexHttpsFallbackAfter = (codexHome: string, afterId: number): boolean => {
+  if (!codexHome.trim() || !Number.isSafeInteger(afterId) || afterId < 0) return false
+
+  let database: NodeDatabaseSync | undefined
+  try {
+    const sqlite = process.getBuiltinModule('node:sqlite') as
+      typeof import('node:sqlite') | undefined
+    if (!sqlite) return false
+    const { DatabaseSync } = sqlite
+    database = new DatabaseSync(codexLogDatabasePath(codexHome), { readOnly: true })
+    return (
+      database
+        .prepare(
+          `SELECT 1
+             FROM logs
+            WHERE id > ?
+              AND target = 'codex_core::client'
+              AND feedback_log_body LIKE '%falling back to HTTP%'
+            LIMIT 1`
+        )
+        .get(afterId) !== undefined
+    )
+  } catch {
+    // The database does not exist until native Codex emits its first structured log. A locked,
+    // unavailable, or older-schema database must not affect an otherwise successful prompt.
+    return false
+  } finally {
+    database?.close()
+  }
+}
+
+type ObservableBackend = Readonly<{
+  framework: Readonly<{ id: string }>
+  providerId?: string
+  adapter: Readonly<{ codexHome?: string }>
+}>
+
+type FallbackReader = (codexHome: string, afterId: number) => boolean
+type PositionReader = (codexHome: string) => number | undefined
+
+export class CodexTransportFallbackLogObserver {
+  private readonly prompts = new Map<string, { codexHome: string; afterId: number }>()
+
+  constructor(
+    private readonly readFallback: FallbackReader = hasCodexHttpsFallbackAfter,
+    private readonly readPosition: PositionReader = readCodexFallbackLogPosition
+  ) {}
+
+  begin(sessionId: string, backend: ObservableBackend | undefined): void {
+    const codexHome = backend?.adapter.codexHome?.trim()
+    if (
+      backend?.framework.id !== 'codex' ||
+      backend.providerId === undefined ||
+      !isCodexSubscriptionProviderId(backend.providerId) ||
+      !codexHome
+    ) {
+      this.prompts.delete(sessionId)
+      return
+    }
+    const afterId = this.readPosition(codexHome)
+    if (afterId === undefined) {
+      this.prompts.delete(sessionId)
+      return
+    }
+    this.prompts.set(sessionId, { codexHome, afterId })
+  }
+
+  end(sessionId: string): boolean {
+    const prompt = this.prompts.get(sessionId)
+    this.prompts.delete(sessionId)
+    return prompt ? this.readFallback(prompt.codexHome, prompt.afterId) : false
+  }
+}

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -394,6 +394,88 @@ describe('ProviderAccountsModule', () => {
     })
   })
 
+  it('persists and projects the Codex subscription transport preference', async () => {
+    await module.upsertProvider({ type: 'codex-isolated', codexTransport: 'https' })
+
+    let stored = (await repository.getSettings()).providers[0]
+    expect(stored.codexTransport).toBe('https')
+    expect(module.toProviderView(stored).codexTransport).toBe('https')
+
+    await module.upsertProvider({
+      id: stored.id,
+      type: 'codex-isolated',
+      codexTransport: 'websocket',
+      requireExisting: true
+    })
+    stored = (await repository.getSettings()).providers[0]
+    expect(stored.codexTransport).toBe('websocket')
+  })
+
+  it.each([
+    ['auto', 'https'],
+    ['auto', 'websocket'],
+    ['https', 'auto'],
+    ['websocket', 'auto']
+  ] as const)(
+    'clears learned transport state when the preference changes from %s to %s',
+    async (initialTransport, nextTransport) => {
+      await module.upsertProvider({
+        type: 'codex-isolated',
+        codexTransport: initialTransport
+      })
+      const initial = (await repository.getSettings()).providers[0]
+      await repository.upsertProvider({
+        ...initial,
+        codexAutoUseHttps: true
+      })
+
+      await module.upsertProvider({
+        id: 'builtin-codex-subscription',
+        type: 'codex-isolated',
+        codexTransport: nextTransport,
+        requireExisting: true
+      })
+
+      expect((await repository.getSettings()).providers[0].codexAutoUseHttps).toBeUndefined()
+    }
+  )
+
+  it('does not retain learned transport state while a manual preference is resaved', async () => {
+    await module.upsertProvider({ type: 'codex-isolated', codexTransport: 'https' })
+    const manual = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({
+      ...manual,
+      codexAutoUseHttps: true
+    })
+
+    await module.upsertProvider({
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      codexTransport: 'https',
+      requireExisting: true
+    })
+
+    expect((await repository.getSettings()).providers[0].codexAutoUseHttps).toBeUndefined()
+  })
+
+  it('preserves learned HTTPS while an Auto preference is resaved', async () => {
+    await module.upsertProvider({ type: 'codex-isolated', codexTransport: 'auto' })
+    const stored = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({
+      ...stored,
+      codexAutoUseHttps: true
+    })
+
+    await module.upsertProvider({
+      id: stored.id,
+      type: 'codex-isolated',
+      codexTransport: 'auto',
+      requireExisting: true
+    })
+
+    expect((await repository.getSettings()).providers[0].codexAutoUseHttps).toBe(true)
+  })
+
   it.each([
     {
       sourceType: 'claude-isolated',

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -176,6 +176,14 @@ class ProviderAccountsModule {
     if (isCodexSubscriptionProvider(request.type)) {
       provider.apiEndpoints = ['responses']
       provider.codexAuthMode = request.type === 'codex-shared' ? 'imported' : 'isolated'
+      provider.codexTransport = request.codexTransport ?? existing?.codexTransport ?? 'auto'
+      if (
+        provider.codexTransport === 'auto' &&
+        (existing?.codexTransport ?? 'auto') === 'auto' &&
+        existing?.codexAutoUseHttps !== undefined
+      ) {
+        provider.codexAutoUseHttps = existing.codexAutoUseHttps
+      }
       credentialsChanged =
         existing !== undefined &&
         (existing.codexAuthMode !== provider.codexAuthMode || reimportCodexAuthentication)
@@ -574,6 +582,7 @@ class ProviderAccountsModule {
     return (
       left.type === right.type &&
       left.codexAuthMode === right.codexAuthMode &&
+      left.codexTransport === right.codexTransport &&
       left.baseUrl === right.baseUrl &&
       left.openaiBaseUrl === right.openaiBaseUrl &&
       left.model === right.model &&

--- a/src/main/settings/provider-auth-lifecycle.ts
+++ b/src/main/settings/provider-auth-lifecycle.ts
@@ -18,6 +18,7 @@ import {
   ensureCodexAuthHome,
   importCodexAuthentication,
   openCodexAuthSession,
+  resolveEffectiveCodexSubscriptionTransport,
   type CodexAuthControllerPort,
   type CodexAuthStatus
 } from './codex-auth'
@@ -81,6 +82,9 @@ class ProviderAuthLifecycleOwner {
       new CodexAuthController({
         openSession: async (mode) => {
           const settings = await this.repository.getSettings()
+          const provider = settings.providers.find((candidate) =>
+            isCodexSubscriptionProvider(candidate.type)
+          )
           return openCodexAuthSession({
             adapterPath: await options.resolveCodexExecutable(
               settings.codex?.resolvedPath,
@@ -89,6 +93,7 @@ class ProviderAuthLifecycleOwner {
             nativePath: settings.codex?.nativePath,
             mode,
             storageRoot: options.storageRoot,
+            transport: resolveEffectiveCodexSubscriptionTransport(provider ?? {}),
             proxyEnv: await options.resolveCodexProxyEnvironment()
           })
         }
@@ -174,7 +179,8 @@ class ProviderAuthLifecycleOwner {
     if (isCodexSubscriptionProvider(request.type)) {
       await ensureCodexAuthHome(
         request.type === 'codex-shared' ? 'shared' : 'isolated',
-        this.options.storageRoot
+        this.options.storageRoot,
+        request.codexTransport ?? existing?.codexTransport ?? 'auto'
       )
     }
   }
@@ -249,7 +255,11 @@ class ProviderAuthLifecycleOwner {
 
     await this.codexAuth.cancelLogin()
     try {
-      await ensureCodexAuthHome('isolated', this.options.storageRoot)
+      await ensureCodexAuthHome(
+        'isolated',
+        this.options.storageRoot,
+        provider.codexTransport ?? 'auto'
+      )
       await clearAppOwnedCodexAuthentication(codexSubscriptionStorageDir(this.options.storageRoot))
     } catch {
       return {

--- a/src/main/settings/provider-draft-projection.ts
+++ b/src/main/settings/provider-draft-projection.ts
@@ -26,6 +26,7 @@ export const resolveProviderDraft = (draft: ProviderDraft): ResolvedProvider => 
   const tokenLimits = draft.type === 'custom' ? resolveCustomTokenLimits(draft) : undefined
   return {
     type: draft.type,
+    ...(draft.codexTransport === undefined ? {} : { codexTransport: draft.codexTransport }),
     baseUrl: draft.baseUrl,
     model: draft.model,
     ...(draft.type === 'custom'

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os'
 import type {
   ChatApiEndpoint,
   CodexSubscriptionAuthMode,
+  CodexSubscriptionTransport,
   ProviderType
 } from '../../shared/settings'
 import type { OfficialVendorId } from '../../shared/provider-registry'
@@ -20,6 +21,8 @@ export type ResolvedProvider = {
   // It is derived from the persisted provider/model identity and never contains a credential.
   agentProviderId?: string
   codexAuthMode?: CodexSubscriptionAuthMode
+  codexTransport?: CodexSubscriptionTransport
+  codexAutoUseHttps?: boolean
   // Retained for official providers even though they use the custom credential path at runtime.
   // Transport adapters need this stable identity because `none` has vendor-specific wire semantics.
   vendorId?: OfficialVendorId

--- a/src/main/settings/provider-runtime-projection.ts
+++ b/src/main/settings/provider-runtime-projection.ts
@@ -86,6 +86,7 @@ class ProviderRuntimeProjectionOwner {
       id: provider.id,
       type: provider.type,
       codexAuthMode: provider.codexAuthMode,
+      codexTransport: provider.codexTransport,
       name: provider.name,
       apiEndpoints: this.resolveProviderApiEndpoints(provider, activeModel),
       baseUrl: provider.baseUrl,
@@ -236,6 +237,10 @@ class ProviderRuntimeProjectionOwner {
     return {
       type: provider.type,
       ...(provider.codexAuthMode === undefined ? {} : { codexAuthMode: provider.codexAuthMode }),
+      ...(provider.codexTransport === undefined ? {} : { codexTransport: provider.codexTransport }),
+      ...(provider.codexAutoUseHttps === undefined
+        ? {}
+        : { codexAutoUseHttps: provider.codexAutoUseHttps }),
       baseUrl: provider.baseUrl,
       model,
       ...(contextWindow === undefined ? {} : { contextWindow }),

--- a/src/main/settings/record-codec.ts
+++ b/src/main/settings/record-codec.ts
@@ -158,6 +158,8 @@ export const sanitizeProvider = (value: unknown): StoredProvider | undefined => 
   const expiresAt = asNumber(value.expiresAt)
   const disconnectedAt = asNumber(value.disconnectedAt)
   const codexAuthMode = asString(value.codexAuthMode)
+  const codexTransport = asString(value.codexTransport)
+  const codexAutoUseHttps = asBoolean(value.codexAutoUseHttps)
   // Keep only non-empty model ids from persisted discovery results.
   const fetchedModels = Array.isArray(value.fetchedModels)
     ? value.fetchedModels.filter(
@@ -215,6 +217,15 @@ export const sanitizeProvider = (value: unknown): StoredProvider | undefined => 
     (codexAuthMode === 'imported' || codexAuthMode === 'isolated')
   ) {
     provider.codexAuthMode = codexAuthMode
+  }
+  if (
+    isCodexSubscriptionProvider(type) &&
+    (codexTransport === 'auto' || codexTransport === 'https' || codexTransport === 'websocket')
+  ) {
+    provider.codexTransport = codexTransport
+  }
+  if (isCodexSubscriptionProvider(type) && codexAutoUseHttps !== undefined) {
+    provider.codexAutoUseHttps = codexAutoUseHttps
   }
   return provider
 }

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -355,6 +355,75 @@ describe('settings repository', () => {
     })
   })
 
+  it('sanitizes the main-only Codex Auto HTTPS preference', () => {
+    const valid = sanitizeSettings({
+      providers: [
+        {
+          id: 'builtin-codex-subscription',
+          type: 'codex-isolated',
+          name: 'Codex subscription',
+          codexAutoUseHttps: true
+        }
+      ]
+    })
+    expect(valid.providers[0].codexAutoUseHttps).toBe(true)
+
+    const invalid = sanitizeSettings({
+      providers: [
+        {
+          id: 'builtin-codex-subscription',
+          type: 'codex-isolated',
+          name: 'Codex subscription',
+          codexAutoUseHttps: 'true'
+        }
+      ]
+    })
+    expect(invalid.providers[0].codexAutoUseHttps).toBeUndefined()
+  })
+
+  it('atomically remembers HTTPS only while the preference remains Auto', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+    await repository.upsertProvider({
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      codexTransport: 'auto',
+      name: 'Codex subscription'
+    })
+
+    await expect(repository.rememberCodexAutoHttpsFallback()).resolves.toBe(true)
+    expect((await repository.getSettings()).providers[0].codexAutoUseHttps).toBe(true)
+    await expect(repository.rememberCodexAutoHttpsFallback()).resolves.toBe(false)
+
+    const stored = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({
+      ...stored,
+      codexTransport: 'https',
+      codexAutoUseHttps: undefined
+    })
+    await expect(repository.rememberCodexAutoHttpsFallback()).resolves.toBe(false)
+    expect((await repository.getSettings()).providers[0].codexAutoUseHttps).toBeUndefined()
+  })
+
+  it('preserves learned Auto HTTPS when a stale full-provider update lands afterward', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+    await repository.upsertProvider({
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      codexTransport: 'auto',
+      name: 'Codex subscription'
+    })
+    const staleProvider = (await repository.getSettings()).providers[0]
+
+    await repository.rememberCodexAutoHttpsFallback()
+    await repository.upsertProvider({ ...staleProvider, lastValidatedAt: 123 })
+
+    expect((await repository.getSettings()).providers[0]).toMatchObject({
+      codexTransport: 'auto',
+      codexAutoUseHttps: true,
+      lastValidatedAt: 123
+    })
+  })
+
   it('returns empty settings when nothing is stored yet', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -13,7 +13,8 @@ import {
   CODEX_SUBSCRIPTION_PROVIDER_ID,
   claudeIsolatedProviderIdentity,
   isClaudeSubscriptionProvider,
-  isClaudeSubscriptionProviderId
+  isClaudeSubscriptionProviderId,
+  isCodexSubscriptionProvider
 } from '../../shared/settings'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import type { PackageMirror } from '../../shared/mirror'
@@ -83,8 +84,20 @@ class SettingsRepository {
       if (existingId && !settings.providers.some(({ id }) => id === existingId))
         throw new Error('Provider no longer exists.')
       const providers = [...settings.providers]
-      if (index >= 0) providers[index] = provider
-      else providers.push(provider)
+      if (index >= 0) {
+        const existing = providers[index]
+        // Full-provider saves can be based on a snapshot read before the runtime learned its Auto
+        // fallback. Keep that main-owned state across Auto-to-Auto replacement; explicit transport
+        // changes still clear it because either side of this guard is no longer Auto.
+        providers[index] =
+          isCodexSubscriptionProvider(existing.type) &&
+          isCodexSubscriptionProvider(provider.type) &&
+          (existing.codexTransport ?? 'auto') === 'auto' &&
+          (provider.codexTransport ?? 'auto') === 'auto' &&
+          existing.codexAutoUseHttps === true
+            ? { ...provider, codexAutoUseHttps: true }
+            : provider
+      } else providers.push(provider)
       return {
         ...settings,
         providers,
@@ -174,6 +187,24 @@ class SettingsRepository {
       return { ...settings, providers }
     })
 
+    return applied
+  }
+
+  async rememberCodexAutoHttpsFallback(): Promise<boolean> {
+    let applied = false
+    await this.mutate((settings) => {
+      const index = settings.providers.findIndex(
+        (provider) =>
+          isCodexSubscriptionProvider(provider.type) &&
+          (provider.codexTransport ?? 'auto') === 'auto' &&
+          provider.codexAutoUseHttps !== true
+      )
+      if (index < 0) return settings
+      const providers = [...settings.providers]
+      providers[index] = { ...providers[index], codexAutoUseHttps: true }
+      applied = true
+      return { ...settings, providers }
+    })
     return applied
   }
 

--- a/src/main/settings/service-capabilities.ts
+++ b/src/main/settings/service-capabilities.ts
@@ -18,6 +18,7 @@ export type AcpSettingsCapabilities = Pick<
   | 'getConnectors'
   | 'listSpecialistSkillCatalog'
   | 'provisionedConnectorSkillNames'
+  | 'rememberCodexAutoHttpsFallback'
 > &
   Partial<Pick<SettingsService, 'resolveAdmittedSubagentBackend'>>
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -524,7 +524,13 @@ describe('SettingsService: providers', () => {
 
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
-    ).resolves.toBe('cli_auth_credentials_store = "file"\n')
+    ).resolves.toContain('cli_auth_credentials_store = "file"')
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.not.toContain('open-science-chatgpt-')
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.not.toContain('model_provider = "subscription-route"')
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')
     ).rejects.toMatchObject({ code: 'ENOENT' })
@@ -562,7 +568,13 @@ describe('SettingsService: providers', () => {
 
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
-    ).resolves.toBe('cli_auth_credentials_store = "file"\n')
+    ).resolves.toContain('cli_auth_credentials_store = "file"')
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.not.toContain('open-science-chatgpt-')
+    await expect(
+      readFile(join(storageRoot, 'codex-subscription', 'config.toml'), 'utf8')
+    ).resolves.not.toContain('model_provider = "subscription-route"')
     await expect(
       readFile(join(storageRoot, 'codex-subscription', 'auth.json'), 'utf8')
     ).rejects.toMatchObject({ code: 'ENOENT' })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -920,6 +920,10 @@ class SettingsService {
     return this.getSettingsView()
   }
 
+  async rememberCodexAutoHttpsFallback(): Promise<boolean> {
+    return this.repository.rememberCodexAutoHttpsFallback()
+  }
+
   async deleteProvider(id: string): Promise<SettingsSnapshot> {
     await this.providers.deleteProvider(id)
     return this.getSettingsView()

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -355,6 +355,7 @@ describe('Settings backend ownership architecture', () => {
       'markLegacyDataMovePromptDismissed',
       'markOnboardingComplete',
       'markPathsNormalized',
+      'rememberCodexAutoHttpsFallback',
       'removeCustomServer',
       'setActiveProvider',
       'setAgentFramework',
@@ -486,7 +487,7 @@ describe('Settings backend ownership architecture', () => {
         logoutClaudeShared logoutIsolatedClaude logoutIsolatedCodex logoutXaiOAuth markOnboardingComplete
         markPathsNormalized migrateAgentHomeSkillIdentities previewAgentHomeSkill previewCustomServerTemplateExport
         previewCustomServerTemplateImport previewGitHubSkill previewSkillArchive previewSkillZip
-        provisionedConnectorSkillNames publishHostSkill refreshProviderModels registeredHelperCatalog removeCustomServer removeDeviceCredential removeGitHubToken removeNotebookNetwork
+        provisionedConnectorSkillNames publishHostSkill refreshProviderModels registeredHelperCatalog rememberCodexAutoHttpsFallback removeCustomServer removeDeviceCredential removeGitHubToken removeNotebookNetwork
         removeManualInterpreter resolveActiveModelChangeTarget resolveActiveReasoningEffort
         resolveAdmittedSubagentBackend resolveAgentBackend resolveDeviceOAuthCredential resolveExplicitAgentBackend resolveSubagentExecutionModel saveCustomServerOAuthState saveGitHubToken
         scanRepoSkills setActiveProvider setAgentFramework setAppIconVariant setClosePreference
@@ -708,6 +709,8 @@ describe('Settings backend ownership architecture', () => {
       'apiEndpoints',
       'baseUrl',
       'codexAuthMode',
+      'codexAutoUseHttps',
+      'codexTransport',
       'contextWindow',
       'disconnectedAt',
       'expiresAt',

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -4,6 +4,7 @@ import type {
   ClaudeSubscriptionProviderId,
   ClaudeInfo,
   CodexSubscriptionAuthMode,
+  CodexSubscriptionTransport,
   CodexInfo,
   ProjectFilesFilterPreference,
   ProviderType,
@@ -48,6 +49,10 @@ export type StoredProvider = {
   // Records whether the app-owned Codex profile came from an import or an in-app sign-in. Runtime
   // behavior still keys on the normalized codex-isolated provider type.
   codexAuthMode?: CodexSubscriptionAuthMode
+  // Transport preference for the app-owned Codex subscription profile. Absence is Auto.
+  codexTransport?: CodexSubscriptionTransport
+  // Main-only learned Auto fallback. Never projected to ProviderView or renderer drafts.
+  codexAutoUseHttps?: boolean
   name: string
   // Which chat APIs a custom gateway speaks. Official providers derive it from the registry; absent
   // means ['anthropic'] (all pre-existing providers). Legacy records may carry the removed scalar

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -42,6 +42,7 @@ const isBrowserSignInProvider = (type: ProviderFormValue['type']): boolean =>
 // Converts a form value into the upsert request the main process expects.
 const toUpsertRequest = (value: ProviderFormValue): UpsertProviderRequest => ({
   type: value.type,
+  codexTransport: value.codexTransport,
   name: value.name,
   baseUrl: value.baseUrl,
   model: value.model,

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -350,6 +350,33 @@ describe('ProviderForm field switching', () => {
     const trigger = container.querySelector('[aria-label="Codex authentication"]')
     expect(trigger).not.toBeNull()
     expect(trigger?.textContent).toContain('Import existing Codex sign-in')
+    expect(container.querySelector('[aria-label="Transport"]')).toBeNull()
+
+    act(() => {
+      Array.from(container.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Advanced settings')
+        ?.click()
+    })
+
+    expect(container.querySelector('[aria-label="Transport"]')?.textContent).toContain(
+      'Auto (recommended)'
+    )
+  })
+
+  it('opens Codex Advanced settings when a manual transport would otherwise be hidden', () => {
+    render(
+      createEmptyProviderFormValue({
+        type: 'codex-isolated',
+        codexTransport: 'https'
+      }),
+      { showCodexSubscriptions: true }
+    )
+
+    const disclosure = container.querySelector<HTMLButtonElement>(
+      'button[aria-controls="provider-advanced-settings"]'
+    )
+    expect(disclosure?.getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[aria-label="Transport"]')?.textContent).toContain('HTTPS')
   })
 
   it('shows a fixed Claude subscription without an editable name or API key', () => {

--- a/src/renderer/src/pages/settings/ProviderForm.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.tsx
@@ -108,6 +108,44 @@ const RequiredMark = (): React.JSX.Element => (
   </span>
 )
 
+type AdvancedSettingsDisclosureProps = {
+  expanded: boolean
+  label: string
+  onToggle: () => void
+  children: React.ReactNode
+}
+
+const AdvancedSettingsDisclosure = ({
+  expanded,
+  label,
+  onToggle,
+  children
+}: AdvancedSettingsDisclosureProps): React.JSX.Element => (
+  <div>
+    <button
+      type="button"
+      aria-expanded={expanded}
+      aria-controls="provider-advanced-settings"
+      onClick={onToggle}
+      className="flex min-h-8 w-full items-center gap-2 rounded-lg py-1.5 text-left text-sm font-medium whitespace-nowrap text-foreground transition-colors duration-150 outline-none motion-reduce:transition-none hover:text-primary focus-visible:ring-3 focus-visible:ring-ring/50"
+    >
+      <ChevronDown
+        className={`size-4 shrink-0 text-muted-foreground transition-transform duration-150 motion-reduce:transition-none ${
+          expanded ? '' : '-rotate-90'
+        }`}
+        aria-hidden="true"
+      />
+      {label}
+    </button>
+
+    {expanded ? (
+      <div id="provider-advanced-settings" className="mt-3 flex min-w-0 flex-col gap-4 pl-6">
+        {children}
+      </div>
+    ) : null}
+  </div>
+)
+
 const tokenPresetLabel = (value: number): string =>
   value >= 1_000_000 && value % 1_000_000 === 0
     ? `${value / 1_000_000}M`
@@ -214,6 +252,7 @@ const ProviderForm = ({
   const vendor = isOfficial && value.vendorId ? getOfficialVendor(value.vendorId) : undefined
   const [advancedOpen, setAdvancedOpen] = useState(
     () =>
+      value.codexTransport !== 'auto' ||
       value.supportsImageInput ||
       value.reasoningEffortPreset !== 'unsupported' ||
       Boolean(value.maxInputTokens.trim()) ||
@@ -393,39 +432,81 @@ const ProviderForm = ({
           <code className="font-mono text-xs text-muted-foreground">{t('grok-4.6 · 500K')}</code>
         </div>
       ) : isCodexSubscription ? (
-        <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-3">
-          <div className="space-y-1.5">
-            <span className={fieldLabelClassName}>{t('Codex authentication')}</span>
-            <Select
-              value={value.type}
-              disabled={disabled}
-              onValueChange={(type) =>
-                onChange({ type: type as 'codex-shared' | 'codex-isolated' })
-              }
-            >
-              <SelectTrigger aria-label={t('Codex authentication')} disabled={disabled}>
-                <span>
-                  {value.type === 'codex-shared'
-                    ? t('Import existing Codex sign-in')
-                    : t('Sign in with Open Science')}
-                </span>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="codex-shared">{t('Import existing Codex sign-in')}</SelectItem>
-                <SelectItem value="codex-isolated">{t('Sign in with Open Science')}</SelectItem>
-              </SelectContent>
-            </Select>
+        <>
+          <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-3">
+            <div className="space-y-1.5">
+              <span className={fieldLabelClassName}>{t('Codex authentication')}</span>
+              <Select
+                value={value.type}
+                disabled={disabled}
+                onValueChange={(type) =>
+                  onChange({ type: type as 'codex-shared' | 'codex-isolated' })
+                }
+              >
+                <SelectTrigger aria-label={t('Codex authentication')} disabled={disabled}>
+                  <span>
+                    {value.type === 'codex-shared'
+                      ? t('Import existing Codex sign-in')
+                      : t('Sign in with Open Science')}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="codex-shared">{t('Import existing Codex sign-in')}</SelectItem>
+                  <SelectItem value="codex-isolated">{t('Sign in with Open Science')}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {value.type === 'codex-shared'
+                ? t(
+                    "Copies Codex authentication and, when compatible, the active provider's non-secret loopback route into Open Science app data. Other global config, Skills and sessions are not imported."
+                  )
+                : t(
+                    'Stores a separate Codex login in Open Science app data without changing your Codex CLI profile.'
+                  )}
+            </p>
           </div>
-          <p className="text-xs text-muted-foreground">
-            {value.type === 'codex-shared'
-              ? t(
-                  "Copies Codex authentication and, when compatible, the active provider's non-secret loopback route into Open Science app data. Other global config, Skills and sessions are not imported."
-                )
-              : t(
-                  'Stores a separate Codex login in Open Science app data without changing your Codex CLI profile.'
-                )}
-          </p>
-        </div>
+          <AdvancedSettingsDisclosure
+            expanded={advancedVisible}
+            label={t('Advanced settings')}
+            onToggle={() => setAdvancedOpen((open) => !open)}
+          >
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-1">
+                <span className={fieldLabelClassName}>{t('Transport')}</span>
+                <FieldHelp
+                  content={t(
+                    'Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.'
+                  )}
+                />
+              </div>
+              <Select
+                value={value.codexTransport}
+                disabled={disabled}
+                onValueChange={(codexTransport) =>
+                  onChange({
+                    codexTransport: codexTransport as ProviderFormValue['codexTransport']
+                  })
+                }
+              >
+                <SelectTrigger aria-label={t('Transport')} disabled={disabled}>
+                  <span>
+                    {value.codexTransport === 'auto'
+                      ? t('Auto (recommended)')
+                      : value.codexTransport === 'https'
+                        ? t('HTTPS')
+                        : t('WebSocket')}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auto">{t('Auto (recommended)')}</SelectItem>
+                  <SelectItem value="https">{t('HTTPS')}</SelectItem>
+                  <SelectItem value="websocket">{t('WebSocket')}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </AdvancedSettingsDisclosure>
+        </>
       ) : isClaudeSubscription ? (
         <>
           <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-3">
@@ -603,214 +684,187 @@ const ProviderForm = ({
             t={t}
           />
 
-          <div>
-            <button
-              type="button"
-              aria-expanded={advancedVisible}
-              aria-controls="provider-advanced-settings"
-              onClick={() => setAdvancedOpen((open) => !open)}
-              className="flex min-h-8 w-full items-center gap-2 rounded-lg py-1.5 text-left text-sm font-medium whitespace-nowrap text-foreground transition-colors duration-150 outline-none motion-reduce:transition-none hover:text-primary focus-visible:ring-3 focus-visible:ring-ring/50"
-            >
-              <ChevronDown
-                className={`size-4 shrink-0 text-muted-foreground transition-transform duration-150 motion-reduce:transition-none ${
-                  advancedVisible ? '' : '-rotate-90'
-                }`}
-                aria-hidden="true"
-              />
-              {t('Advanced settings')}
-            </button>
+          <AdvancedSettingsDisclosure
+            expanded={advancedVisible}
+            label={t('Advanced settings')}
+            onToggle={() => setAdvancedOpen((open) => !open)}
+          >
+            <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+              <div className="flex items-start justify-between gap-3">
+                <label className="space-y-0.5" htmlFor="provider-image-input">
+                  <span className="block text-xs font-medium">{t('Image input')}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {t('The gateway and model accept image content.')}
+                  </span>
+                </label>
+                <Switch
+                  id="provider-image-input"
+                  aria-label={t('Supports image input')}
+                  checked={value.supportsImageInput}
+                  disabled={disabled}
+                  onCheckedChange={(supportsImageInput) => onChange({ supportsImageInput })}
+                />
+              </div>
 
-            {advancedVisible ? (
-              <div id="provider-advanced-settings" className="mt-3 flex flex-col gap-4">
-                <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
-                  <div className="flex items-start justify-between gap-3">
-                    <label className="space-y-0.5" htmlFor="provider-image-input">
-                      <span className="block text-xs font-medium">{t('Image input')}</span>
-                      <span className="block text-xs text-muted-foreground">
-                        {t('The gateway and model accept image content.')}
-                      </span>
-                    </label>
-                    <Switch
-                      id="provider-image-input"
-                      aria-label={t('Supports image input')}
-                      checked={value.supportsImageInput}
-                      disabled={disabled}
-                      onCheckedChange={(supportsImageInput) => onChange({ supportsImageInput })}
-                    />
-                  </div>
+              <div className="flex items-start justify-between gap-3">
+                <label className="space-y-0.5" htmlFor="provider-thinking-mode">
+                  <span className="block text-xs font-medium">{t('Thinking mode')}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {t('The gateway and model accept thinking or effort controls.')}
+                  </span>
+                </label>
+                <Switch
+                  id="provider-thinking-mode"
+                  aria-label={t('Supports thinking mode')}
+                  checked={value.reasoningEffortPreset !== 'unsupported'}
+                  disabled={disabled}
+                  onCheckedChange={(supported) =>
+                    onChange({
+                      reasoningEffortPreset: supported ? 'standard-5' : 'unsupported'
+                    })
+                  }
+                />
+              </div>
+            </div>
 
-                  <div className="flex items-start justify-between gap-3">
-                    <label className="space-y-0.5" htmlFor="provider-thinking-mode">
-                      <span className="block text-xs font-medium">{t('Thinking mode')}</span>
-                      <span className="block text-xs text-muted-foreground">
-                        {t('The gateway and model accept thinking or effort controls.')}
-                      </span>
-                    </label>
-                    <Switch
-                      id="provider-thinking-mode"
-                      aria-label={t('Supports thinking mode')}
-                      checked={value.reasoningEffortPreset !== 'unsupported'}
+            {value.reasoningEffortPreset !== 'unsupported' ? (
+              <div className="space-y-3 border-t border-border-200 pt-3">
+                <div
+                  className={cn('grid gap-3', value.apiEndpoint === 'openai' && 'sm:grid-cols-2')}
+                >
+                  <div className="space-y-1.5">
+                    <div className="flex items-center gap-1">
+                      <span className={fieldLabelClassName}>{t('Supported effort levels')}</span>
+                      <FieldHelp
+                        content={
+                          <>
+                            <span className="block">
+                              {t(
+                                'Open Science maps five relative strengths onto the exact levels accepted by this model.'
+                              )}
+                            </span>
+                            <span className="mt-1 block">
+                              {t(
+                                'Examples reflect common native model APIs. A gateway may use different mappings.'
+                              )}
+                            </span>
+                            {value.apiEndpoint === 'anthropic' ? (
+                              <span className="mt-1 block">
+                                {t(
+                                  "Messages API uses the framework's Anthropic-compatible thinking request automatically."
+                                )}
+                              </span>
+                            ) : value.apiEndpoint === 'responses' ? (
+                              <span className="mt-1 block">
+                                {t(
+                                  'Responses API uses its native reasoning request automatically.'
+                                )}
+                              </span>
+                            ) : null}
+                          </>
+                        }
+                      />
+                    </div>
+                    <Select
+                      value={value.reasoningEffortPreset}
                       disabled={disabled}
-                      onCheckedChange={(supported) =>
+                      onValueChange={(reasoningEffortPreset) =>
                         onChange({
-                          reasoningEffortPreset: supported ? 'standard-5' : 'unsupported'
+                          reasoningEffortPreset: reasoningEffortPreset as ReasoningEffortPresetId
                         })
                       }
-                    />
-                  </div>
-                </div>
-
-                {value.reasoningEffortPreset !== 'unsupported' ? (
-                  <div className="space-y-3 border-t border-border-200 pt-3">
-                    <div
-                      className={cn(
-                        'grid gap-3',
-                        value.apiEndpoint === 'openai' && 'sm:grid-cols-2'
-                      )}
                     >
-                      <div className="space-y-1.5">
-                        <div className="flex items-center gap-1">
-                          <span className={fieldLabelClassName}>
-                            {t('Supported effort levels')}
-                          </span>
-                          <FieldHelp
-                            content={
-                              <>
-                                <span className="block">
-                                  {t(
-                                    'Open Science maps five relative strengths onto the exact levels accepted by this model.'
-                                  )}
-                                </span>
-                                <span className="mt-1 block">
-                                  {t(
-                                    'Examples reflect common native model APIs. A gateway may use different mappings.'
-                                  )}
-                                </span>
-                                {value.apiEndpoint === 'anthropic' ? (
-                                  <span className="mt-1 block">
-                                    {t(
-                                      "Messages API uses the framework's Anthropic-compatible thinking request automatically."
-                                    )}
-                                  </span>
-                                ) : value.apiEndpoint === 'responses' ? (
-                                  <span className="mt-1 block">
-                                    {t(
-                                      'Responses API uses its native reasoning request automatically.'
-                                    )}
-                                  </span>
-                                ) : null}
-                              </>
-                            }
-                          />
-                        </div>
-                        <Select
-                          value={value.reasoningEffortPreset}
-                          disabled={disabled}
-                          onValueChange={(reasoningEffortPreset) =>
-                            onChange({
-                              reasoningEffortPreset:
-                                reasoningEffortPreset as ReasoningEffortPresetId
-                            })
+                      <SelectTrigger aria-label={t('Reasoning effort levels')} disabled={disabled}>
+                        <span>
+                          {
+                            CUSTOM_REASONING_EFFORT_PRESETS.find(
+                              (preset) => preset.id === value.reasoningEffortPreset
+                            )?.label
                           }
-                        >
-                          <SelectTrigger
-                            aria-label={t('Reasoning effort levels')}
-                            disabled={disabled}
-                          >
-                            <span>
-                              {
-                                CUSTOM_REASONING_EFFORT_PRESETS.find(
-                                  (preset) => preset.id === value.reasoningEffortPreset
-                                )?.label
-                              }
-                            </span>
-                          </SelectTrigger>
-                          <SelectContent>
-                            {CUSTOM_REASONING_EFFORT_PRESETS.map((preset) => (
-                              <SelectItem key={preset.id} value={preset.id}>
-                                {preset.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-
-                      {value.apiEndpoint === 'openai' ? (
-                        <div className="space-y-1.5">
-                          <div className="flex items-center gap-1">
-                            <span className={fieldLabelClassName}>
-                              {t('Reasoning request format')}
-                            </span>
-                            <FieldHelp
-                              content={t(
-                                'The JSON fields sent to a Chat Completions gateway. Follow the gateway documentation; OpenAI-compatible services commonly use {{parameter}}.',
-                                { parameter: 'reasoning_effort' }
-                              )}
-                            />
-                          </div>
-                          <Select
-                            value={value.reasoningEffortTransport}
-                            disabled={disabled}
-                            onValueChange={(reasoningEffortTransport) =>
-                              onChange({
-                                reasoningEffortTransport:
-                                  reasoningEffortTransport as CustomReasoningEffortTransport
-                              })
-                            }
-                          >
-                            <SelectTrigger
-                              aria-label={t('Reasoning effort request format')}
-                              disabled={disabled}
-                            >
-                              <span>
-                                {
-                                  CUSTOM_REASONING_EFFORT_TRANSPORTS.find(
-                                    (transport) => transport.id === value.reasoningEffortTransport
-                                  )?.label
-                                }
-                              </span>
-                            </SelectTrigger>
-                            <SelectContent>
-                              {CUSTOM_REASONING_EFFORT_TRANSPORTS.map((transport) => (
-                                <SelectItem key={transport.id} value={transport.id}>
-                                  {transport.label}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      ) : null}
-                    </div>
+                        </span>
+                      </SelectTrigger>
+                      <SelectContent>
+                        {CUSTOM_REASONING_EFFORT_PRESETS.map((preset) => (
+                          <SelectItem key={preset.id} value={preset.id}>
+                            {preset.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
-                ) : null}
 
-                <div className="grid gap-4 border-t border-border-200 pt-3 sm:grid-cols-2">
-                  <TokenLimitField
-                    id="provider-max-input-tokens"
-                    label={t('Maximum input tokens')}
-                    help={t('Optional provider-reported input cap.')}
-                    value={value.maxInputTokens}
-                    presets={CUSTOM_PROVIDER_MAX_INPUT_TOKEN_PRESETS}
-                    disabled={disabled}
-                    error={errors.maxInputTokens}
-                    onValueChange={(maxInputTokens) => onChange({ maxInputTokens })}
-                    t={t}
-                  />
-                  <TokenLimitField
-                    id="provider-max-output-tokens"
-                    label={t('Maximum output tokens')}
-                    help={t('Optional provider-reported output cap.')}
-                    value={value.maxOutputTokens}
-                    presets={CUSTOM_PROVIDER_MAX_OUTPUT_TOKEN_PRESETS}
-                    disabled={disabled}
-                    error={errors.maxOutputTokens}
-                    onValueChange={(maxOutputTokens) => onChange({ maxOutputTokens })}
-                    t={t}
-                  />
+                  {value.apiEndpoint === 'openai' ? (
+                    <div className="space-y-1.5">
+                      <div className="flex items-center gap-1">
+                        <span className={fieldLabelClassName}>{t('Reasoning request format')}</span>
+                        <FieldHelp
+                          content={t(
+                            'The JSON fields sent to a Chat Completions gateway. Follow the gateway documentation; OpenAI-compatible services commonly use {{parameter}}.',
+                            { parameter: 'reasoning_effort' }
+                          )}
+                        />
+                      </div>
+                      <Select
+                        value={value.reasoningEffortTransport}
+                        disabled={disabled}
+                        onValueChange={(reasoningEffortTransport) =>
+                          onChange({
+                            reasoningEffortTransport:
+                              reasoningEffortTransport as CustomReasoningEffortTransport
+                          })
+                        }
+                      >
+                        <SelectTrigger
+                          aria-label={t('Reasoning effort request format')}
+                          disabled={disabled}
+                        >
+                          <span>
+                            {
+                              CUSTOM_REASONING_EFFORT_TRANSPORTS.find(
+                                (transport) => transport.id === value.reasoningEffortTransport
+                              )?.label
+                            }
+                          </span>
+                        </SelectTrigger>
+                        <SelectContent>
+                          {CUSTOM_REASONING_EFFORT_TRANSPORTS.map((transport) => (
+                            <SelectItem key={transport.id} value={transport.id}>
+                              {transport.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  ) : null}
                 </div>
               </div>
             ) : null}
-          </div>
+
+            <div className="grid gap-4 border-t border-border-200 pt-3 sm:grid-cols-2">
+              <TokenLimitField
+                id="provider-max-input-tokens"
+                label={t('Maximum input tokens')}
+                help={t('Optional provider-reported input cap.')}
+                value={value.maxInputTokens}
+                presets={CUSTOM_PROVIDER_MAX_INPUT_TOKEN_PRESETS}
+                disabled={disabled}
+                error={errors.maxInputTokens}
+                onValueChange={(maxInputTokens) => onChange({ maxInputTokens })}
+                t={t}
+              />
+              <TokenLimitField
+                id="provider-max-output-tokens"
+                label={t('Maximum output tokens')}
+                help={t('Optional provider-reported output cap.')}
+                value={value.maxOutputTokens}
+                presets={CUSTOM_PROVIDER_MAX_OUTPUT_TOKEN_PRESETS}
+                disabled={disabled}
+                error={errors.maxOutputTokens}
+                onValueChange={(maxOutputTokens) => onChange({ maxOutputTokens })}
+                t={t}
+              />
+            </div>
+          </AdvancedSettingsDisclosure>
         </>
       ) : isOfficial ? (
         <>

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -228,6 +228,7 @@ const toFormValue = (provider: ProviderView): ProviderFormValue =>
       provider.type === 'codex-shared' || provider.type === 'codex-isolated'
         ? resolveCodexSubscriptionType(provider)
         : provider.type,
+    codexTransport: provider.codexTransport ?? 'auto',
     name: provider.name,
     baseUrl: provider.baseUrl ?? '',
     model: provider.model ?? '',
@@ -248,6 +249,7 @@ const toUpsertRequest = (
 ): UpsertProviderRequest => ({
   id,
   type: value.type,
+  codexTransport: value.codexTransport,
   name: value.name,
   baseUrl: value.baseUrl,
   model: value.model,

--- a/src/renderer/src/pages/settings/provider-form-value.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.ts
@@ -5,6 +5,7 @@ import {
   preferredEndpoint,
   type AgentFrameworkId,
   type ChatApiEndpoint,
+  type CodexSubscriptionTransport,
   type ProviderDraft,
   type ProviderType
 } from '../../../../shared/settings'
@@ -24,6 +25,7 @@ import type {
 // component (satisfying react-refresh) while the wizard and settings page share this shape/factory.
 export type ProviderFormValue = {
   type: ProviderType
+  codexTransport: CodexSubscriptionTransport
   name: string
   baseUrl: string
   model: string
@@ -56,6 +58,7 @@ export const createEmptyProviderFormValue = (
   overrides: Partial<ProviderFormValue> = {}
 ): ProviderFormValue => ({
   type: 'custom',
+  codexTransport: 'auto',
   name: '',
   baseUrl: '',
   model: '',

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -106,6 +106,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   // caller can show inline feedback and re-enable the form.
   createProject: async (request) => {
     const project = await window.api.projects.create(request)
+    if (!project) return undefined
 
     projectMutationSequence += 1
     if (get().projects.some((current) => current.id === project.id)) {
@@ -125,6 +126,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   updateProject: async (request) => {
     const generation = beginProjectProjection()
     const project = await window.api.projects.update(request)
+    if (!project) return undefined
 
     projectMutationSequence += 1
     if (commitProjectProjection(project.id, generation)) {

--- a/src/renderer/src/stores/settings-store.architecture.test.ts
+++ b/src/renderer/src/stores/settings-store.architecture.test.ts
@@ -314,6 +314,8 @@ const importBoundaryViolations = (path: string, source = readSource(path)): read
 const allowedFacadeVariableCounts = new Map<string, number>([
   ['createInitialSettingsState', 1],
   ['applySnapshot', 1],
+  ['canApplySnapshot', 1],
+  ['mergeSnapshot', 1],
   ['DEFAULT_FRAMEWORK_API_ENDPOINTS', 1],
   ['selectFrameworkApiEndpoints', 1],
   ['selectVisionRelayAvailable', 1],

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4031,6 +4031,10 @@
     "Neither the official registry nor the China-friendly mirror is reachable.": "Weder die offizielle Registry noch der für China optimierte Mirror ist erreichbar.",
     "Check the network, proxy, VPN, or firewall, then run the check again.": "Überprüfen Sie Netzwerk, Proxy, VPN oder Firewall und führen Sie die Prüfung erneut aus.",
     "official npm registry": "Die offizielle npm-Registry",
-    "China-friendly npmmirror": "Das für China optimierte npmmirror"
+    "China-friendly npmmirror": "Das für China optimierte npmmirror",
+    "Auto (recommended)": "Automatisch (empfohlen)",
+    "HTTPS": "HTTPS",
+    "WebSocket": "WebSocket",
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Im automatischen Modus wird WebSocket verwendet, wenn verfügbar, und andernfalls auf HTTPS zurückgegriffen. Verwenden Sie HTTPS für bessere Kompatibilität oder WebSocket für geringere Latenz."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4186,6 +4186,10 @@
     "Neither the official registry nor the China-friendly mirror is reachable.": "No se puede acceder ni al registro oficial ni al mirror optimizado para China.",
     "Check the network, proxy, VPN, or firewall, then run the check again.": "Compruebe la red, el proxy, la VPN o el firewall y vuelva a ejecutar la comprobación.",
     "official npm registry": "El registro oficial de npm",
-    "China-friendly npmmirror": "El mirror de npmmirror optimizado para China"
+    "China-friendly npmmirror": "El mirror de npmmirror optimizado para China",
+    "Auto (recommended)": "Automático (recomendado)",
+    "HTTPS": "HTTPS",
+    "WebSocket": "WebSocket",
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "El modo automático usa WebSocket cuando está disponible y recurre a HTTPS. Use HTTPS para mayor compatibilidad o WebSocket para reducir la latencia."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4186,6 +4186,10 @@
     "Neither the official registry nor the China-friendly mirror is reachable.": "Ni le registre officiel ni le miroir adapté à la Chine ne sont accessibles.",
     "Check the network, proxy, VPN, or firewall, then run the check again.": "Vérifiez le réseau, le proxy, le VPN ou le pare-feu, puis relancez la vérification.",
     "official npm registry": "Le registre npm officiel",
-    "China-friendly npmmirror": "Le miroir npmmirror adapté à la Chine"
+    "China-friendly npmmirror": "Le miroir npmmirror adapté à la Chine",
+    "Auto (recommended)": "Automatique (recommandé)",
+    "HTTPS": "HTTPS",
+    "WebSocket": "WebSocket",
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Le mode automatique utilise WebSocket lorsqu’il est disponible et se replie sur HTTPS. Utilisez HTTPS pour la compatibilité ou WebSocket pour réduire la latence."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3876,6 +3876,10 @@
     "Neither the official registry nor the China-friendly mirror is reachable.": "公式レジストリにも、中国向けミラーにも接続できません。",
     "Check the network, proxy, VPN, or firewall, then run the check again.": "ネットワーク、プロキシ、VPN、またはファイアウォールを確認してから、もう一度チェックを実行してください。",
     "official npm registry": "公式 npm レジストリ",
-    "China-friendly npmmirror": "中国向け npmmirror"
+    "China-friendly npmmirror": "中国向け npmmirror",
+    "Auto (recommended)": "自動（推奨）",
+    "HTTPS": "HTTPS",
+    "WebSocket": "WebSocket",
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自動では、利用可能な場合は WebSocket を使用し、HTTPS にフォールバックします。互換性を重視する場合は HTTPS、低遅延を重視する場合は WebSocket を使用してください。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3874,6 +3874,10 @@
     "Neither the official registry nor the China-friendly mirror is reachable.": "공식 레지스트리와 중국 환경용 미러에 모두 연결할 수 없습니다.",
     "Check the network, proxy, VPN, or firewall, then run the check again.": "네트워크, 프록시, VPN 또는 방화벽을 확인한 후 다시 검사하세요.",
     "official npm registry": "공식 npm 레지스트리",
-    "China-friendly npmmirror": "중국 환경용 npmmirror"
+    "China-friendly npmmirror": "중국 환경용 npmmirror",
+    "Auto (recommended)": "자동(권장)",
+    "HTTPS": "HTTPS",
+    "WebSocket": "WebSocket",
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "자동 모드는 사용 가능한 경우 WebSocket을 사용하고 HTTPS로 대체합니다. 호환성이 중요하면 HTTPS를, 지연 시간을 줄이려면 WebSocket을 사용하세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -2547,7 +2547,7 @@
     "Tools found": "Найденные инструменты",
     "Total": "Всего",
     "Total tokens shared by the request and response.": "Общее количество токенов, совместно используемых запросом и ответом.",
-    "Transport": "Перевозка",
+    "Transport": "Транспорт",
     "Match the transport used by the Connector.": "Выберите тот же транспорт, что и у Коннектора.",
     "Trusted browsers": "Доверенные браузеры",
     "Try again": "Попробуйте снова",
@@ -4316,6 +4316,10 @@
     "Neither the official registry nor the China-friendly mirror is reachable.": "Ни официальный реестр пакетов, ни зеркало для пользователей из Китая недоступны.",
     "Check the network, proxy, VPN, or firewall, then run the check again.": "Проверьте сеть, прокси, VPN или межсетевой экран, затем запустите проверку ещё раз.",
     "official npm registry": "Официальный реестр npm",
-    "China-friendly npmmirror": "Зеркало npmmirror для пользователей из Китая"
+    "China-friendly npmmirror": "Зеркало npmmirror для пользователей из Китая",
+    "Auto (recommended)": "Автоматически (рекомендуется)",
+    "HTTPS": "HTTPS",
+    "WebSocket": "WebSocket",
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Автоматический режим использует WebSocket, когда он доступен, и переключается на HTTPS. Используйте HTTPS для совместимости или WebSocket для снижения задержки."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -3876,6 +3876,10 @@
     "Neither the official registry nor the China-friendly mirror is reachable.": "官方软件源和适合中国大陆网络的镜像均无法访问。",
     "Check the network, proxy, VPN, or firewall, then run the check again.": "请检查网络、代理、VPN 或防火墙，然后重新运行检查。",
     "official npm registry": "npm 官方软件源",
-    "China-friendly npmmirror": "适合中国大陆网络的 npmmirror 镜像"
+    "China-friendly npmmirror": "适合中国大陆网络的 npmmirror 镜像",
+    "Auto (recommended)": "自动（推荐）",
+    "HTTPS": "HTTPS",
+    "WebSocket": "WebSocket",
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自动模式会在可用时使用 WebSocket，并在不可用时回退到 HTTPS。使用 HTTPS 可提高兼容性，使用 WebSocket 可降低延迟。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -3876,6 +3876,10 @@
     "Neither the official registry nor the China-friendly mirror is reachable.": "官方套件來源和適合中國大陸網路的鏡像均無法連線。",
     "Check the network, proxy, VPN, or firewall, then run the check again.": "請檢查網路、Proxy、VPN 或防火牆，然後重新執行檢查。",
     "official npm registry": "npm 官方套件來源",
-    "China-friendly npmmirror": "適合中國大陸網路的 npmmirror 鏡像"
+    "China-friendly npmmirror": "適合中國大陸網路的 npmmirror 鏡像",
+    "Auto (recommended)": "自動（建議）",
+    "HTTPS": "HTTPS",
+    "WebSocket": "WebSocket",
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自動模式會在可用時使用 WebSocket，並在不可用時回退到 HTTPS。使用 HTTPS 可提高相容性，使用 WebSocket 可降低延遲。"
   }
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -37,6 +37,7 @@ export type ProviderType =
 // which setup choice produced it so editing an imported profile does not masquerade as an isolated
 // sign-in and accidentally discard its imported loopback route.
 export type CodexSubscriptionAuthMode = 'imported' | 'isolated'
+export type CodexSubscriptionTransport = 'auto' | 'https' | 'websocket'
 
 // Stored Codex subscriptions share one runtime type, while renderer surfaces still need the setup
 // choice. Legacy codex-shared views have no discriminator, so their type remains the fallback.
@@ -287,6 +288,7 @@ export type ProviderView = {
   id: string
   type: ProviderType
   codexAuthMode?: CodexSubscriptionAuthMode
+  codexTransport?: CodexSubscriptionTransport
   name: string
   // Which chat APIs this provider's endpoint speaks; drives per-framework availability. Absent ⇒
   // treat as ['anthropic'] (every legacy provider).
@@ -637,6 +639,7 @@ export type Preflight = {
 // typed a new one; leaving it undefined on edit keeps the previously stored key.
 export type ProviderDraft = {
   type: ProviderType
+  codexTransport?: CodexSubscriptionTransport
   name?: string
   baseUrl?: string
   model?: string


### PR DESCRIPTION
## Problem

Codex subscription profiles had no explicit transport control, and automatic WebSocket fallback could be forgotten or inferred from stale native log entries. Authentication and runtime startup could therefore disagree about the transport to use, while users had no manual HTTPS or WebSocket override.

## Proposed change

- Add `Auto`, `HTTPS`, and `WebSocket` transport choices for Codex subscription profiles under Advanced settings.
- Keep transport selection aligned across persisted settings, authentication, account status, and ACP runtime startup.
- Detect native WebSocket fallback with an exact SQLite log row-id watermark and persist the learned HTTPS choice idempotently.
- Add focused repository, resolver, authentication, runtime, renderer, and localization coverage across all supported locales.

## Scope and non-goals

This changes Codex subscription transport selection only. It does not change API-key providers, introduce a new durable external component, or alter the database schema. It also does not replace native fallback behavior; Auto observes and remembers that decision.

## Acceptance criteria and validation

All listed checks ran after the last material edit, against the final squashed commit.

- Settings and runtime behavior -> `npm run test:affected -- --base origin/main --head HEAD` -> 22,326 tests passed; one unrelated delegation temporary-directory cleanup race failed, and its exact isolated rerun passed.
- Localization and settings architecture contracts -> `npm test -- src/renderer/src/i18n/resources.test.ts src/main/settings/settings-backend.architecture.test.ts` -> 815 tests passed.
- Type safety across main, preload, renderer, and shared code -> `npm run typecheck` -> passed.
- Lint and repository style -> `npm run lint` -> passed.
- Upstream installer patch contract exposed by the full suite -> isolated packaging test passed after applying the checked-in `patches/` to the resolved dependency tree.
- Independent Standards and Spec reviews -> passed with no remaining findings.

The full affected plan failed closed to the complete Vitest suite because `src/main/acp/ipc.test.ts` has no module owner mapping. The sole final-suite failure was an `ENOTEMPTY` cleanup race in `src/main/delegation/production-composition.test.ts`; the same test passed immediately in isolation. No source file in that module is changed by this pull request.

Uncovered risks: no live Codex subscription endpoint or cross-platform packaged application was exercised locally. Exact-head CI and the post-merge Nightly workflow remain authoritative for those environments.

## Review focus

- The row-id watermark prevents pre-existing fallback logs from being attributed to a new authentication attempt.
- Learned Auto-to-HTTPS persistence is idempotent and does not trigger duplicate reconnects.
- Explicit HTTPS and WebSocket overrides remain authoritative and the selector stays in Advanced settings.