### PR TITLE
fix(update): clear transfer progress after cancellation

### DIFF
--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -437,6 +437,12 @@ describe('ElectronUpdaterStrategy', () => {
     // Hang the download until released, then mimic electron-updater rejecting a cancelled download.
     updater.runDownload = async (token) => {
       seenToken = token
+      updater.emit('download-progress', {
+        percent: 40,
+        transferred: 4000,
+        total: 10000,
+        bytesPerSecond: 12000
+      })
       await new Promise<void>((resolve) => (release = resolve))
       if (token?.cancelled) throw new Error('cancelled')
     }
@@ -454,8 +460,19 @@ describe('ElectronUpdaterStrategy', () => {
     }
 
     const downloading = strategy.download()
+    await vi.waitFor(() => {
+      expect(strategy.getStatus()).toMatchObject({
+        state: 'downloading',
+        downloadedBytes: 4000,
+        totalBytes: 10000
+      })
+    })
     const cancelled = await strategy.cancel()
     expect(cancelled.state).toBe('available')
+    expect(cancelled).not.toHaveProperty('progress')
+    expect(cancelled).not.toHaveProperty('downloadedBytes')
+    expect(cancelled).not.toHaveProperty('downloadProgress')
+    expect(cancelled.totalBytes).toBe(10000)
     expect(seenToken?.cancelled).toBe(true)
 
     // The rejected downloadUpdate must not clobber the reset status with an error.

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -8,7 +8,12 @@ import { isNewer, type UpdateApplyOptions, type UpdateStatus } from '../../share
 import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
 import type { Logger } from '../logger'
 import { fetchManifest } from './manifest'
-import { canStartUpdateDownload, type InstallGate, type UpdateStrategy } from './strategy'
+import {
+  canStartUpdateDownload,
+  toAvailableUpdateStatus,
+  type InstallGate,
+  type UpdateStrategy
+} from './strategy'
 import type { ApplicationEventMap } from '../application-events'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { markApplicationShutdownTrigger } from '../application-shutdown-trigger'
@@ -504,7 +509,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.downloadToken?.cancel()
     this.downloadToken = undefined
     if (this.status.state === 'downloading') {
-      this.setStatus({ ...this.status, state: 'available', progress: undefined })
+      this.setStatus(toAvailableUpdateStatus(this.status))
     }
     this.downloadOperation?.cancel({ reason: 'user' })
     return this.status

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -884,8 +884,19 @@ describe('UpdateService.download', () => {
     vi.mocked(log.info).mockClear()
     const downloading = service.download()
     await fetched
+    await vi.waitFor(() => {
+      expect(service.getStatus()).toMatchObject({
+        state: 'downloading',
+        downloadedBytes: 3,
+        totalBytes: 100
+      })
+    })
     const cancelled = await service.cancel()
     expect(cancelled.state).toBe('available')
+    expect(cancelled).not.toHaveProperty('progress')
+    expect(cancelled).not.toHaveProperty('downloadedBytes')
+    expect(cancelled).not.toHaveProperty('downloadProgress')
+    expect(cancelled.totalBytes).toBe(100)
 
     const final = await downloading
     expect(final.state).toBe('available')

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -16,7 +16,7 @@ import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnosti
 import type { Logger } from '../logger'
 import { downloadInstaller } from './downloader'
 import { fetchManifest } from './manifest'
-import { canStartUpdateDownload, type UpdateStrategy } from './strategy'
+import { canStartUpdateDownload, toAvailableUpdateStatus, type UpdateStrategy } from './strategy'
 import type { ApplicationEventMap } from '../application-events'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { englishNativeTranslator, type NativeTranslator } from '../locale/main-process-messages'
@@ -402,7 +402,7 @@ export class UpdateService implements UpdateStrategy {
     this.downloadAbort = undefined
     this.downloadOperation?.cancel({ reason: 'user' })
     if (this.status.state === 'downloading') {
-      this.setStatus({ ...this.status, state: 'available', progress: undefined })
+      this.setStatus(toAvailableUpdateStatus(this.status))
     }
     return this.status
   }

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -83,6 +83,29 @@ export const createDurableInstallGate =
 export const canStartUpdateDownload = (status: UpdateStatus): boolean =>
   status.state === 'available' || (status.state === 'error' && Boolean(status.latest))
 
+// Restores the release offer after a cancelled transfer. Build a fresh object so download-only
+// fields are absent from the returned/broadcast payload rather than retained with stale values (or
+// retained explicitly as undefined). totalBytes belongs to the offer itself and remains useful before
+// a retry starts.
+export const toAvailableUpdateStatus = ({
+  current,
+  latest,
+  notes,
+  localizedNotes,
+  download,
+  totalBytes,
+  applyKind
+}: UpdateStatus): UpdateStatus => ({
+  state: 'available',
+  current,
+  ...(latest === undefined ? {} : { latest }),
+  ...(notes === undefined ? {} : { notes }),
+  ...(localizedNotes === undefined ? {} : { localizedNotes }),
+  ...(download === undefined ? {} : { download }),
+  ...(totalBytes === undefined ? {} : { totalBytes }),
+  ...(applyKind === undefined ? {} : { applyKind })
+})
+
 // The platform-agnostic update contract the IPC layer and scheduler drive. Two implementations exist:
 // ElectronUpdaterStrategy (win/linux, and signed stable macOS — in-place download/restart) and
 // UpdateService (dev/nightly macOS + any other fallback — manifest download + manual reinstall). Both


### PR DESCRIPTION
## Problem

Cancelling an in-flight update changed the state back to available by spreading the downloading status. Both update strategies therefore returned and broadcast transfer-only fields after cancellation, including an explicitly present progress field and stale downloaded byte counts.

## Proposed change

- add one shared fresh-object transition for restoring the available update offer
- preserve release metadata and totalBytes because the artifact size is valid before and after a transfer
- omit progress, downloadedBytes, downloadProgress, localPath, error, and blockedBy from the cancelled status
- cover both manifest and electron-updater strategies through their public cancel behavior after observed progress

## Scope and non-goals

- no UpdateStatus discriminated-union refactor
- no new data fields or UpdateState values
- no persistence or historical-data compatibility impact
- no intended user-interaction change
- download failure and other non-cancellation transitions remain out of scope

## Acceptance criteria and validation

The regression assertions were first run against the old cancellation implementations and failed because the available result still had a progress property. After the fix, the following final checks ran after the last material edit:

- cancellation behavior in both update adapters, update IPC, and renderer update store -> npm test -- src/main/update/service.test.ts src/main/update/electron-updater-strategy.test.ts src/main/update/ipc.test.ts src/renderer/src/stores/update-store.test.ts -> 99 passed
- affected main-process types -> npm run typecheck:node -> passed
- repository lint -> npm run lint -> passed
- whitespace validation -> git diff --check -> passed

The complete npm test suite was intentionally not run locally per maintainer direction; PR CI remains authoritative for the full suite and platform lanes.

## Review focus

Please verify that cancellation omits all transfer-only fields while retaining totalBytes and the metadata needed to retry the same offered release.