### PR TITLE
test(projects): catalog Side Chat deletion ownership

### DIFF
--- a/src/main/projects/project-owned-data.catalog.architecture.test.ts
+++ b/src/main/projects/project-owned-data.catalog.architecture.test.ts
@@ -227,6 +227,7 @@ describe('Project-owned data catalog architecture', () => {
       'artifact-bytes',
       'upload-bytes',
       'delegated-frame-workspaces',
+      'side-chat-runtime-profiles',
       'acp-runtime-state',
       'reviewer-runtime-state',
       'side-chat-runtime-state',
@@ -256,7 +257,8 @@ describe('Project-owned data catalog architecture', () => {
       'project-runtime-quiescence',
       'project-session-json-delete',
       'provenance-tail',
-      'review-tail'
+      'review-tail',
+      'side-chat-profile-tail'
     ])
   })
 
@@ -636,6 +638,40 @@ describe('Project-owned data catalog architecture', () => {
     )
     const workspaceDelete = nestedMethod(workspace, 'deleteProject')
     expectCallsInOrder(workspaceDelete, ['makeTreeRemovable', 'rm'])
+  })
+
+  it('catalogs persistent Side Chat profiles and wires their Project deletion tail', () => {
+    expect(
+      PROJECT_OWNED_DATA_CATALOG.find((entry) => entry.id === 'side-chat-runtime-profiles')
+    ).toMatchObject({
+      medium: 'filesystem',
+      resources: ['runtime-support/side-chat/<sideChatId>/'],
+      policy: {
+        kind: 'coordinator-cleanup',
+        effect: 'hard-delete',
+        path: 'side-chat-profile-tail',
+        operation: 'SideChatRuntimeOwner.completeProjectDeletion'
+      }
+    })
+
+    const constructor = newExpression('src/main/ipc.ts', 'ProjectDeletionCoordinator')
+    if (!isNewExpression(constructor.node)) throw new Error('Expected constructor expression.')
+    const lifecycle = constructor.node.arguments?.[5]
+    if (!lifecycle || !isObjectLiteralExpression(lifecycle)) {
+      throw new Error('Project deletion lifecycle wiring is not an object literal.')
+    }
+    expectCall(
+      objectMethod(constructor.file, lifecycle, 'finalizeProjectDeletion'),
+      'owner.completeProjectDeletion'
+    )
+    expectCall(
+      classMethod(
+        'src/main/side-chat/runtime-owner.ts',
+        'SideChatRuntimeOwner',
+        'completeProjectDeletion'
+      ),
+      'rm'
+    )
   })
 
   it('proves provenance cleanup owns Restrict-ordered rows and managed bytes', () => {

--- a/src/main/projects/project-owned-data.catalog.ts
+++ b/src/main/projects/project-owned-data.catalog.ts
@@ -34,6 +34,7 @@ type ProjectDeletionPath =
   | 'project-session-json-delete'
   | 'provenance-tail'
   | 'review-tail'
+  | 'side-chat-profile-tail'
 
 type ForeignKeyCascadePolicy = Readonly<{
   kind: 'foreign-key-cascade'
@@ -485,6 +486,18 @@ const PROJECT_OWNED_DATA_CATALOG: readonly ProjectOwnedDataCatalogEntry[] = [
       path: 'delegated-runtime-quiescence',
       operation: 'ProductionFrameWorkspace.deleteProject',
       note: 'The delegated owner removes both live work and dormant Project workspace directories.'
+    }
+  },
+  {
+    id: 'side-chat-runtime-profiles',
+    medium: 'filesystem',
+    resources: ['runtime-support/side-chat/<sideChatId>/'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'side-chat-profile-tail',
+      operation: 'SideChatRuntimeOwner.completeProjectDeletion',
+      note: 'The durable Project deletion tail removes restricted backend profiles for hydrated Side Chats before releasing its deletion intent.'
     }
   },
   {


### PR DESCRIPTION
## Problem

`SideChatRuntimeOwner.completeProjectDeletion` removes persistent restricted-backend profiles from `runtime-support/side-chat/<sideChatId>/`, but the Project-owned data catalog did not record that filesystem owner. The existing architecture suite therefore passed while test metadata and production cleanup had drifted.

## Proposed change

- Catalog persistent Side Chat runtime profiles as Project-owned filesystem data.
- Give that cleanup its explicit `side-chat-profile-tail` deletion path.
- Add a regression that binds the catalog entry to the production `ProjectDeletionCoordinator` tail and the actual `SideChatRuntimeOwner` removal call.

## Scope and non-goals

- No runtime deletion behavior changes.
- No executable per-resource manifest or generic startup orphan scanner.
- No Prisma schema, migration, persisted format, historical-data compatibility, persisted status, enum, or user-interaction changes.
- Session-only ownership-field classification remains outside this focused fix.

## Acceptance criteria and validation

Red-first evidence:

- Before the catalog fix, `npm test -- src/main/projects/project-owned-data.catalog.architecture.test.ts` failed deterministically with one failed assertion because `side-chat-runtime-profiles` was `undefined` (13 existing tests passed).
- After the last material edit, the same command passed all 14 tests.

Final evidence mapping:

- Catalog/runtime ownership agreement -> `npm test -- src/main/projects/project-owned-data.catalog.architecture.test.ts` -> passed, 14/14.
- Existing Side Chat Project profile deletion behavior -> `npm test -- src/main/side-chat/runtime-owner.test.ts -t 'invalidates every Side chat in a deleted Project and rejects concurrent starts'` -> passed, 1/1.
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed.
- Impact explanation -> `npm run test:affected:explain -- --base e46a17c4b039e5b8a93cd8b8e944206d5a610956 --head HEAD` -> fail-closed full plan because the architecture catalog test has no module owner.

The complete local Vitest suite was intentionally not run per maintainer direction; exact-head PR Gate CI is the final authority. No platform-specific behavior changed, so no local platform lane was added.

## Review focus

- Confirm the new resource path matches `SideChatRuntimeOwner` storage layout.
- Confirm the architecture assertion reaches both composition wiring and the physical removal operation without changing production behavior.
