### PR TITLE
fix(notebook): honor injected runtime platform

### DIFF
--- a/src/main/notebook/data-execution-admission.ts
+++ b/src/main/notebook/data-execution-admission.ts
@@ -46,6 +46,7 @@ type NotebookDataExecutionAdmissionOwnerOptions = {
   ensureRecovered: () => Promise<void>
   resolveRuntimeEnablement: (language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>
   repairPolicy: Pick<NotebookRuntimeRepairPolicy, 'blockKey' | 'requirement'>
+  platform?: NodeJS.Platform
 }
 
 const defaultEnvironment = (language: NotebookLanguage): string =>
@@ -132,7 +133,9 @@ class NotebookDataExecutionAdmissionOwner {
     const recoveryBlocked =
       (binding?.runtimeId && this.options.recovery.isRuntimeIdBlocked(binding.runtimeId)) ||
       (!isExternal &&
-        this.options.recovery.isPrefixBlocked(envPrefix(runtimeRoot, route.environment))) ||
+        this.options.recovery.isPrefixBlocked(
+          envPrefix(runtimeRoot, route.environment, this.options.platform)
+        )) ||
       (isExternal && this.options.recovery.isGloballyBlocked())
     const repairRequired =
       this.options.environmentOperations.isRepairBlocked(
@@ -173,7 +176,8 @@ class NotebookDataExecutionAdmissionOwner {
       source: cell.code,
       surface: cell.language,
       runtimeRoot: session.runtimeRoot,
-      cwd: session.cwd
+      cwd: session.cwd,
+      platform: this.options.platform
     })
     if (blockedMutation && rejection === undefined) {
       rejection = new Error(`MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`)
@@ -231,8 +235,11 @@ class NotebookDataExecutionAdmissionOwner {
   ): Promise<boolean> {
     const enablement = await this.options.resolveRuntimeEnablement(language)
     if (!enablement) return false
-    const prefix = envPrefix(runtimeRoot, defaultEnvironment(language))
-    const interpreter = language === 'r' ? rBin(prefix) : pythonBin(prefix)
+    const prefix = envPrefix(runtimeRoot, defaultEnvironment(language), this.options.platform)
+    const interpreter =
+      language === 'r'
+        ? rBin(prefix, this.options.platform)
+        : pythonBin(prefix, this.options.platform)
     let environmentId = interpreter
     try {
       environmentId = realpathSync(interpreter)
@@ -254,7 +261,7 @@ class NotebookDataExecutionAdmissionOwner {
       sessionId: session.sessionId,
       ensureRecovered: this.options.ensureRecovered,
       assertRecoverable: () => {
-        const prefix = envPrefix(session.runtimeRoot, environment)
+        const prefix = envPrefix(session.runtimeRoot, environment, this.options.platform)
         if (this.options.recovery.isPrefixBlocked(prefix)) {
           throw new Error(
             `RUNTIME_RECOVERY_BLOCKED: a previous operation on "${prefix}" was interrupted and its worker ` +

--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -11,7 +11,7 @@ import {
   discoverInterpreters,
   type DiscoveryDeps
 } from './environment-discovery'
-import { DEFAULT_R_ENV, envPrefix, rBin, rScriptBin } from './runtime-paths'
+import { DEFAULT_PY_ENV, DEFAULT_R_ENV, envPrefix, rBin, rScriptBin } from './runtime-paths'
 
 describe('defaultDiscoveryDeps Windows conda R probes', () => {
   it('activates the interpreter own conda prefix for version and jsonlite probes', async () => {
@@ -135,6 +135,28 @@ describe('discoverInterpreters', () => {
     const notPy3 = await discoverInterpreters('python', makeDeps(['/x/python2'], {}))
     expect(notPy3[0].runnable).toBe(false)
     expect(notPy3[0].detail).toMatch(/Python 3/)
+  })
+
+  it('uses the injected platform when classifying interpreter provenance', async () => {
+    const platform: NodeJS.Platform = process.platform === 'win32' ? 'linux' : 'win32'
+    const runtimeRoot = join(tmpdir(), 'OpenScience', 'runtime')
+    const interpreterPath = join(
+      tmpdir(),
+      'openscience',
+      'runtime',
+      'envs',
+      'analysis',
+      platform === 'win32' ? 'python.exe' : join('bin', 'python')
+    )
+    const deps: DiscoveryDeps = {
+      ...makeDeps([interpreterPath], { versions: { [interpreterPath]: '3.12.4' } }),
+      runtimeRoot,
+      platform
+    }
+
+    const [found] = await discoverInterpreters('python', deps)
+
+    expect(found.provenance).toBe(platform === 'win32' ? 'agent-created' : 'user-own')
   })
 
   it('keeps the logical default name when discovery sees a short physical directory', async () => {
@@ -294,6 +316,25 @@ describe('collapseRscript', () => {
 })
 
 describe('defaultCandidatePaths (targeted enumeration)', () => {
+  it('uses the injected platform for app-managed interpreter paths', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'os-disc-platform-'))
+    const platform: NodeJS.Platform = process.platform === 'win32' ? 'linux' : 'win32'
+    const prefix = envPrefix(root, DEFAULT_PY_ENV, platform)
+    const interpreter =
+      platform === 'win32' ? join(prefix, 'python.exe') : join(prefix, 'bin', 'python')
+    mkdirSync(join(interpreter, '..'), { recursive: true })
+    writeFileSync(interpreter, 'x')
+
+    try {
+      const paths = await defaultDiscoveryDeps(root, undefined, { platform }).candidatePaths(
+        'python'
+      )
+      expect(paths).toContain(interpreter)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('includes manually-added interpreters and the app-managed default, and collapses R/Rscript', async () => {
     const root = mkdtempSync(join(tmpdir(), 'os-disc-'))
     // App-managed default-r on disk under runtime/envs.
@@ -325,18 +366,15 @@ describe('defaultCandidatePaths Windows CRAN R detection', () => {
     writeFileSync(join(r443Dir, 'R.exe'), 'x')
     writeFileSync(join(r443Dir, 'Rscript.exe'), 'x')
 
-    // Override env to point to our fake Program Files and mock Windows platform
-    const originalEnv = process.env.ProgramFiles
-    const originalPlatform = process.platform
-    process.env.ProgramFiles = join(root, 'Program Files')
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
     try {
-      const paths = await defaultCandidatePaths(root)('r')
+      const paths = await defaultCandidatePaths(root, undefined, {
+        platform: 'win32',
+        env: { ProgramFiles: join(root, 'Program Files') },
+        home: root
+      })('r')
       expect(paths).toContain(join(r443Dir, 'R.exe'))
       expect(paths).not.toContain(join(r443Dir, 'Rscript.exe'))
     } finally {
-      process.env.ProgramFiles = originalEnv
-      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
       rmSync(root, { recursive: true, force: true })
     }
   })

--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -14,6 +14,30 @@ import {
 import { DEFAULT_PY_ENV, DEFAULT_R_ENV, envPrefix, rBin, rScriptBin } from './runtime-paths'
 
 describe('defaultDiscoveryDeps Windows conda R probes', () => {
+  it('uses the injected environment and subprocess port for interpreter probes', async () => {
+    const env = { PATH: 'injected-path', DISCOVERY_SENTINEL: 'injected' }
+    const exec = vi.fn(
+      async (
+        _file: string,
+        args: readonly string[],
+        options: { env?: NodeJS.ProcessEnv }
+      ): Promise<{ stdout: string; stderr: string }> => {
+        expect(options.env).toBe(env)
+        return args.includes('--version')
+          ? { stdout: 'Python 3.12.4', stderr: '' }
+          : { stdout: 'TRUE', stderr: '' }
+      }
+    )
+    const deps = defaultDiscoveryDeps('/runtime', undefined, {
+      platform: 'linux',
+      env,
+      exec
+    })
+
+    await expect(deps.probeVersion('/python', 'python')).resolves.toBe('3.12.4')
+    expect(exec).toHaveBeenCalledWith('/python', ['--version'], expect.objectContaining({ env }))
+  })
+
   it('activates the interpreter own conda prefix for version and jsonlite probes', async () => {
     const prefix = 'C:\\Users\\HM\\OpenScience\\runtime\\envs\\default-r'
     const interpreter = `${prefix}\\Lib\\R\\bin\\R.exe`
@@ -52,13 +76,14 @@ describe('defaultDiscoveryDeps Windows conda R probes', () => {
 
   it('does not inject conda activation into an external Windows R installation', async () => {
     const interpreter = 'C:\\Program Files\\R\\R-4.4.3\\bin\\R.exe'
+    const env = { PATH: 'injected-path', DISCOVERY_SENTINEL: 'injected' }
     const exec = vi.fn(
       async (
         _file: string,
         args: readonly string[],
         options: { env?: NodeJS.ProcessEnv }
       ): Promise<{ stdout: string; stderr: string }> => {
-        expect(options.env).toBeUndefined()
+        expect(options.env).toBe(env)
         return args.includes('--version')
           ? { stdout: '', stderr: 'R version 4.4.3 (2025-02-28 ucrt)' }
           : { stdout: 'TRUE', stderr: '' }
@@ -66,6 +91,7 @@ describe('defaultDiscoveryDeps Windows conda R probes', () => {
     )
     const deps = defaultDiscoveryDeps('C:\\Users\\HM\\OpenScience\\runtime', undefined, {
       platform: 'win32',
+      env,
       exec
     })
 

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -8,7 +8,7 @@ import { promisify } from 'node:util'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { DiscoveredInterpreter, EnvProvenance } from '../../shared/notebook-runtime'
 import { createLogger } from '../logger'
-import { isMacOSDeveloperToolsPythonStub, probeInterpreterVersion } from './python-command'
+import { isMacOSDeveloperToolsPythonStub, isPython3Version } from './python-command'
 import { parseRVersion, rHasJsonlite } from './r-command'
 import {
   condaActivatedPath,
@@ -484,7 +484,12 @@ export const rscriptFor = (rInterpreterPath: string): string =>
 type DiscoveryExec = (
   file: string,
   args: readonly string[],
-  options: { timeout: number; windowsHide: boolean; env?: NodeJS.ProcessEnv }
+  options: {
+    timeout: number
+    windowsHide: boolean
+    env?: NodeJS.ProcessEnv
+    shell?: boolean
+  }
 ) => Promise<{ stdout: string; stderr: string }>
 
 type DefaultDiscoveryRuntimeDeps = DiscoveryEnvironmentDeps & {
@@ -518,13 +523,20 @@ export const defaultDiscoveryDeps = (
             PATH: condaActivatedPath(prefix, env.PATH, platform)
           }
         }
-      : { timeout, windowsHide: true }
+      : { timeout, windowsHide: true, env }
   }
   return {
     candidatePaths: defaultCandidatePaths(runtimeRoot, manualPaths, runtimeDeps),
     probeVersion: async (interpreterPath, language) => {
-      if (language === 'python') return probeInterpreterVersion(interpreterPath, [], { platform })
       try {
+        if (language === 'python') {
+          const { stdout, stderr } = await exec(interpreterPath, ['--version'], {
+            ...probeOptions(interpreterPath),
+            shell: platform === 'win32'
+          })
+          const output = `${stdout}\n${stderr}`
+          return isPython3Version(output) ? output.trim().replace(/^Python\s+/i, '') : undefined
+        }
         // No shell: execFile runs the interpreter directly, so a path with spaces/metacharacters is
         // handled safely (shell:true would break "C:\Program Files\…" and allow injection).
         const { stdout, stderr } = await exec(

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -34,7 +34,12 @@ const PROBE_EXEC_OPTS = { timeout: PROBE_TIMEOUT_MS, windowsHide: true } as cons
 // Upper bound on concurrent interpreter probes so a machine with many envs doesn't spawn a burst of
 // subprocesses / exhaust file descriptors; fast enough to keep discovery responsive.
 const PROBE_CONCURRENCY = 8
-const isWin = (): boolean => process.platform === 'win32'
+
+type DiscoveryEnvironmentDeps = {
+  platform?: NodeJS.Platform
+  env?: NodeJS.ProcessEnv
+  home?: string
+}
 
 // Injectable so discovery is unit-testable without a real machine. The real defaults enumerate PATH,
 // common install dirs, pyenv, conda/mamba envs, and the app's own runtime/envs.
@@ -65,17 +70,24 @@ const safeRealpath = (p: string): string => {
 }
 
 // Interpreter basenames per language and platform.
-const interpreterNames = (language: NotebookLanguage): string[] => {
-  if (language === 'python') return isWin() ? ['python.exe', 'python3.exe'] : ['python3', 'python']
-  return isWin() ? ['R.exe', 'Rscript.exe'] : ['R', 'Rscript']
+const interpreterNames = (language: NotebookLanguage, platform: NodeJS.Platform): string[] => {
+  if (language === 'python')
+    return platform === 'win32' ? ['python.exe', 'python3.exe'] : ['python3', 'python']
+  return platform === 'win32' ? ['R.exe', 'Rscript.exe'] : ['R', 'Rscript']
 }
 
 // `which -a <name>` (POSIX) / `where <name>` (Windows) → existing absolute paths, best-effort.
-const whichAll = async (name: string): Promise<string[]> => {
+const whichAll = async (
+  name: string,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv
+): Promise<string[]> => {
+  const options = { ...PROBE_EXEC_OPTS, env }
   try {
-    const { stdout } = isWin()
-      ? await execFileAsync('where', [name], PROBE_EXEC_OPTS)
-      : await execFileAsync('which', ['-a', name], PROBE_EXEC_OPTS)
+    const { stdout } =
+      platform === 'win32'
+        ? await execFileAsync('where', [name], options)
+        : await execFileAsync('which', ['-a', name], options)
     return stdout
       .split('\n')
       .map((line) => line.trim())
@@ -86,11 +98,18 @@ const whichAll = async (name: string): Promise<string[]> => {
 }
 
 // conda/mamba env prefixes, best-effort: `conda env list --json`, else scan common install roots.
-const listCondaPrefixes = async (): Promise<string[]> => {
+const listCondaPrefixes = async (
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  home: string
+): Promise<string[]> => {
   const prefixes = new Set<string>()
   for (const bin of ['conda', 'mamba', 'micromamba']) {
     try {
-      const { stdout } = await execFileAsync(bin, ['env', 'list', '--json'], PROBE_EXEC_OPTS)
+      const { stdout } = await execFileAsync(bin, ['env', 'list', '--json'], {
+        ...PROBE_EXEC_OPTS,
+        env
+      })
       const parsed = JSON.parse(stdout) as { envs?: unknown }
       if (Array.isArray(parsed.envs)) {
         for (const env of parsed.envs) if (typeof env === 'string') prefixes.add(env)
@@ -103,37 +122,37 @@ const listCondaPrefixes = async (): Promise<string[]> => {
   // Scan known conda/mamba/micromamba install ROOTS directly — essential in a packaged GUI app where
   // conda itself isn't on PATH (so `env list` above found nothing). Each root's base prefix + every
   // dir under its envs/ is a candidate; a non-existent root is simply skipped.
-  const home = homedir()
   // Home-based roots exist on every platform (installers default to the user profile).
   const homeRoots = ['miniconda3', 'anaconda3', 'miniforge3', 'mambaforge', 'micromamba'].map((d) =>
     join(home, d)
   )
   // Plus per-platform SYSTEM install locations.
-  const systemRoots = isWin()
-    ? [
-        'C:\\ProgramData\\miniconda3',
-        'C:\\ProgramData\\anaconda3',
-        'C:\\ProgramData\\miniforge3',
-        'C:\\miniconda3',
-        'C:\\anaconda3',
-        join(process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'miniconda3'),
-        join(process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'anaconda3')
-      ]
-    : process.platform === 'darwin'
+  const systemRoots =
+    platform === 'win32'
       ? [
-          '/opt/miniconda3',
-          '/opt/anaconda3',
-          '/opt/homebrew/anaconda3',
-          '/opt/homebrew/Caskroom/miniconda/base',
-          '/opt/homebrew/Caskroom/miniforge/base'
+          'C:\\ProgramData\\miniconda3',
+          'C:\\ProgramData\\anaconda3',
+          'C:\\ProgramData\\miniforge3',
+          'C:\\miniconda3',
+          'C:\\anaconda3',
+          join(env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'miniconda3'),
+          join(env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'anaconda3')
         ]
-      : [
-          '/opt/conda', // common in Linux/Docker images
-          '/opt/miniconda3',
-          '/opt/anaconda3',
-          '/usr/local/miniconda3',
-          '/usr/local/anaconda3'
-        ]
+      : platform === 'darwin'
+        ? [
+            '/opt/miniconda3',
+            '/opt/anaconda3',
+            '/opt/homebrew/anaconda3',
+            '/opt/homebrew/Caskroom/miniconda/base',
+            '/opt/homebrew/Caskroom/miniforge/base'
+          ]
+        : [
+            '/opt/conda', // common in Linux/Docker images
+            '/opt/miniconda3',
+            '/opt/anaconda3',
+            '/usr/local/miniconda3',
+            '/usr/local/anaconda3'
+          ]
   const roots = [...homeRoots, ...systemRoots]
   for (const root of roots) {
     if (existsSync(root)) prefixes.add(root)
@@ -149,9 +168,9 @@ const listCondaPrefixes = async (): Promise<string[]> => {
 
 // Windows `py -0p`: the launcher lists installed pythons; each line ends with the interpreter path.
 // Best-effort (parsing is loose; on-device verification pending).
-const pyLauncherPaths = async (): Promise<string[]> => {
+const pyLauncherPaths = async (env: NodeJS.ProcessEnv): Promise<string[]> => {
   try {
-    const { stdout } = await execFileAsync('py', ['-0p'], PROBE_EXEC_OPTS)
+    const { stdout } = await execFileAsync('py', ['-0p'], { ...PROBE_EXEC_OPTS, env })
     return stdout
       .split('\n')
       .map((line) => {
@@ -165,12 +184,16 @@ const pyLauncherPaths = async (): Promise<string[]> => {
 }
 
 // The interpreter path for a language inside a conda-style env prefix.
-const prefixInterpreter = (prefix: string, language: NotebookLanguage): string =>
+const prefixInterpreter = (
+  prefix: string,
+  language: NotebookLanguage,
+  platform: NodeJS.Platform
+): string =>
   language === 'python'
-    ? isWin()
+    ? platform === 'win32'
       ? join(prefix, 'python.exe')
       : join(prefix, 'bin', 'python')
-    : rBin(prefix)
+    : rBin(prefix, platform)
 
 // A conda-forge Windows R interpreter lives at <prefix>\Lib\R\bin\R[script].exe and depends on
 // DLLs in <prefix>\Library\bin. Return only that interpreter's own prefix: external CRAN R paths do
@@ -190,9 +213,16 @@ export const windowsCondaPrefixForR = (
 // on PATH / in a conda root still surfaces as a card). `manualPaths` is a sync getter over a settings
 // snapshot; a missing/failed lookup contributes nothing.
 export const defaultCandidatePaths =
-  (runtimeRoot: string, manualPaths?: (language: NotebookLanguage) => string[]) =>
+  (
+    runtimeRoot: string,
+    manualPaths?: (language: NotebookLanguage) => string[],
+    runtimeDeps: DiscoveryEnvironmentDeps = {}
+  ) =>
   async (language: NotebookLanguage): Promise<string[]> => {
-    const names = interpreterNames(language)
+    const platform = runtimeDeps.platform ?? process.platform
+    const env = runtimeDeps.env ?? process.env
+    const home = runtimeDeps.home ?? homedir()
+    const names = interpreterNames(language, platform)
     const found = new Set<string>()
 
     // Targeted probes of KNOWN interpreter locations — never a recursive filesystem walk. A packaged
@@ -204,7 +234,7 @@ export const defaultCandidatePaths =
     for (const p of manualPaths?.(language) ?? []) found.add(p)
 
     // On PATH (`which -a` / `where`) — the happy path when launched from a shell.
-    for (const name of names) for (const p of await whichAll(name)) found.add(p)
+    for (const name of names) for (const p of await whichAll(name, platform, env)) found.add(p)
 
     // Well-known install bin dirs (Homebrew, /usr/local, /usr/bin) — reached even without a shell PATH.
     const commonBinDirs = ['/usr/bin', '/usr/local/bin', '/opt/homebrew/bin']
@@ -223,7 +253,8 @@ export const defaultCandidatePaths =
       for (const ver of readdirSync(frameworkGlobs)) {
         const p = prefixInterpreter(
           join(frameworkGlobs, ver, language === 'r' ? 'Resources' : ''),
-          language
+          language,
+          platform
         )
         if (existsSync(p)) found.add(p)
       }
@@ -233,7 +264,7 @@ export const defaultCandidatePaths =
 
     // pyenv versions (python only): pyenv shims are rarely on a GUI app's PATH.
     if (language === 'python') {
-      const versionsDir = join(homedir(), '.pyenv', 'versions')
+      const versionsDir = join(home, '.pyenv', 'versions')
       try {
         for (const ver of readdirSync(versionsDir)) {
           const p = join(versionsDir, ver, 'bin', 'python')
@@ -246,24 +277,24 @@ export const defaultCandidatePaths =
 
     // conda / mamba / micromamba envs: `env list --json` when a tool is reachable, else the conda-root
     // scan inside listCondaPrefixes (so envs are found even when conda itself is off the GUI PATH).
-    for (const prefix of await listCondaPrefixes()) {
-      const p = prefixInterpreter(prefix, language)
+    for (const prefix of await listCondaPrefixes(platform, env, home)) {
+      const p = prefixInterpreter(prefix, language, platform)
       if (existsSync(p)) found.add(p)
     }
 
     // Windows Python launcher: `py -0p` lists installed interpreters' paths.
-    if (language === 'python' && isWin()) for (const p of await pyLauncherPaths()) found.add(p)
+    if (language === 'python' && platform === 'win32')
+      for (const p of await pyLauncherPaths(env)) found.add(p)
 
     // Windows CRAN R standard installations: check Program Files and user-local directories for versioned
     // R installs (R-x.y.z). CRAN R doesn't register with a launcher like Python's `py`, so we enumerate
     // the standard install roots directly. Each version may have 64-bit (bin/x64/R.exe, most common) or
     // fallback (bin/R.exe) layouts.
-    if (language === 'r' && isWin()) {
-      const home = homedir()
+    if (language === 'r' && platform === 'win32') {
       const programFiles = [
-        process.env.ProgramFiles ?? 'C:\\Program Files',
-        process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
-        join(process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'Programs')
+        env.ProgramFiles ?? 'C:\\Program Files',
+        env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
+        join(env.LOCALAPPDATA ?? join(home, 'AppData', 'Local'), 'Programs')
       ]
       for (const installRoot of programFiles) {
         const rRoot = join(installRoot, 'R')
@@ -313,8 +344,8 @@ export const defaultCandidatePaths =
       for (const directory of readdirSync(appEnvsDir)) {
         const name = logicalEnvNameFromDirectory(directory)
         const prefix = join(appEnvsDir, directory)
-        if (prefix !== envPrefix(runtimeRoot, name)) continue
-        const p = language === 'python' ? pythonBin(prefix) : rBin(prefix)
+        if (prefix !== envPrefix(runtimeRoot, name, platform)) continue
+        const p = language === 'python' ? pythonBin(prefix, platform) : rBin(prefix, platform)
         if (existsSync(p)) found.add(p)
       }
     } catch {
@@ -344,10 +375,14 @@ export const collapseRscript = (paths: string[]): string[] => {
 
 // Classifies an interpreter by whether it lives under runtime/envs (app-owned) and, if so, whether it
 // is a default (app-managed) or a named env (agent-created); anything else is the user's own.
-const classify = (interpreterPath: string, runtimeRoot: string): EnvProvenance => {
+const classify = (
+  interpreterPath: string,
+  runtimeRoot: string,
+  platform: NodeJS.Platform
+): EnvProvenance => {
   const comparisonKey = (path: string): string => {
     const normalized = safeRealpath(path).replaceAll('\\', '/').replace(/\/+$/, '')
-    return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+    return platform === 'win32' ? normalized.toLowerCase() : normalized
   }
   const envsRoot = comparisonKey(join(runtimeRoot, 'envs'))
   const real = comparisonKey(interpreterPath)
@@ -399,7 +434,7 @@ export const discoverInterpreters = async (
     envId: string
   }): Promise<DiscoveredInterpreter> => {
     const version = await deps.probeVersion(path, language)
-    const provenance = classify(path, deps.runtimeRoot)
+    const provenance = classify(path, deps.runtimeRoot, deps.platform ?? process.platform)
     const conda = condaEnvName(path)
     let runnable: boolean
     let detail: string | undefined
@@ -452,8 +487,7 @@ type DiscoveryExec = (
   options: { timeout: number; windowsHide: boolean; env?: NodeJS.ProcessEnv }
 ) => Promise<{ stdout: string; stderr: string }>
 
-type DefaultDiscoveryRuntimeDeps = {
-  platform?: NodeJS.Platform
+type DefaultDiscoveryRuntimeDeps = DiscoveryEnvironmentDeps & {
   exec?: DiscoveryExec
 }
 
@@ -463,6 +497,7 @@ export const defaultDiscoveryDeps = (
   runtimeDeps: DefaultDiscoveryRuntimeDeps = {}
 ): DiscoveryDeps => {
   const platform = runtimeDeps.platform ?? process.platform
+  const env = runtimeDeps.env ?? process.env
   const exec: DiscoveryExec =
     runtimeDeps.exec ??
     (async (file, args, options) => {
@@ -479,16 +514,16 @@ export const defaultDiscoveryDeps = (
           timeout,
           windowsHide: true,
           env: {
-            ...process.env,
-            PATH: condaActivatedPath(prefix, process.env.PATH, platform)
+            ...env,
+            PATH: condaActivatedPath(prefix, env.PATH, platform)
           }
         }
       : { timeout, windowsHide: true }
   }
   return {
-    candidatePaths: defaultCandidatePaths(runtimeRoot, manualPaths),
+    candidatePaths: defaultCandidatePaths(runtimeRoot, manualPaths, runtimeDeps),
     probeVersion: async (interpreterPath, language) => {
-      if (language === 'python') return probeInterpreterVersion(interpreterPath)
+      if (language === 'python') return probeInterpreterVersion(interpreterPath, [], { platform })
       try {
         // No shell: execFile runs the interpreter directly, so a path with spaces/metacharacters is
         // handled safely (shell:true would break "C:\Program Files\…" and allow injection).

--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -50,6 +50,7 @@ const createLifecycle = (
   provisioner: RuntimeProvisioner | undefined,
   options: {
     root?: string
+    platform?: NodeJS.Platform
     projectProgress?: (progress: ProvisionProgress) => void
     waitForRecovery?: () => Promise<void>
     assertProvisionAllowed?: (language: 'python' | 'r') => void
@@ -59,6 +60,7 @@ const createLifecycle = (
   createNotebookEnvironmentLifecycle({
     provisioner,
     root: options.root ?? '/runtime',
+    platform: options.platform,
     projectProgress: options.projectProgress ?? (() => undefined),
     waitForRecovery: options.waitForRecovery,
     assertProvisionAllowed: options.assertProvisionAllowed,
@@ -662,6 +664,22 @@ describe('environment lifecycle startup', () => {
     const provisioner = fakeProvisioner()
     await startLifecycle(provisioner, dir)
     expect(provisioner.provisionPython).not.toHaveBeenCalled()
+    expect(provisioner.upgradeIfNeeded).not.toHaveBeenCalled()
+    expect(provisioner.repair).not.toHaveBeenCalled()
+  })
+
+  it('uses the injected platform when checking startup readiness', async () => {
+    const { writeReadyMarker, envPrefix, pythonBin, DEFAULT_ENV_VERSION, DEFAULT_PY_ENV } =
+      await import('./runtime-paths')
+    const dir = mkdtempSync(join(tmpdir(), 'os-gate-win32-'))
+    const bin = pythonBin(envPrefix(dir, DEFAULT_PY_ENV, 'win32'), 'win32')
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'x')
+    writeReadyMarker(dir, DEFAULT_ENV_VERSION, 't', '.p')
+    const provisioner = fakeProvisioner()
+
+    await createLifecycle(provisioner, { root: dir, platform: 'win32' }).startup()
+
     expect(provisioner.upgradeIfNeeded).not.toHaveBeenCalled()
     expect(provisioner.repair).not.toHaveBeenCalled()
   })

--- a/src/main/notebook/environment-lifecycle-workflows.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.ts
@@ -30,6 +30,7 @@ type NotebookEnvironmentLifecycle = {
 type NotebookEnvironmentLifecycleDeps = {
   provisioner: RuntimeProvisioner | undefined
   root: string
+  platform?: NodeJS.Platform
   projectProgress: (progress: ProvisionProgress) => void
   waitForRecovery?: () => Promise<void>
   assertProvisionAllowed?: (language: NotebookLanguage) => void
@@ -84,6 +85,7 @@ const createNotebookEnvironmentLifecycle = (
   if (!deps.provisioner) return createUnavailableLifecycle(deps)
 
   const provisioner = serializeProvisioner(deps.provisioner)
+  const platform = deps.platform ?? process.platform
 
   const status = (): Promise<ProvisionStatus> =>
     withDataRootWrite(async () => {
@@ -148,7 +150,7 @@ const createNotebookEnvironmentLifecycle = (
         if (deps.waitForRecovery) await deps.waitForRecovery()
         await provisioner.restoreRelocatedEnvs(deps.projectProgress)
 
-        const action = planStartupAction(deps.root, DEFAULT_ENV_VERSION)
+        const action = planStartupAction(deps.root, DEFAULT_ENV_VERSION, platform)
         if (action === 'ready') return
         if (action === 'upgrade') {
           await provisioner.upgradeIfNeeded(deps.projectProgress)
@@ -160,7 +162,7 @@ const createNotebookEnvironmentLifecycle = (
         // maintain Python eagerly when it was actually provisioned before; fresh Python stays lazy.
         const pythonWasProvisioned =
           readReadyMarker(deps.root) !== undefined ||
-          existsSync(envPrefix(deps.root, DEFAULT_PY_ENV))
+          existsSync(envPrefix(deps.root, DEFAULT_PY_ENV, platform))
         if (pythonWasProvisioned) await provisioner.repair('python', deps.projectProgress)
       })
     } catch (error) {

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -510,7 +510,8 @@ class NotebookExecutionOwner {
       source: request.code,
       surface: 'repl',
       runtimeRoot: session.runtimeRoot,
-      cwd: session.cwd
+      cwd: session.cwd,
+      platform: this.options.platform
     })
     const replWasTerminated =
       !blockedMutation &&
@@ -651,7 +652,8 @@ class NotebookExecutionOwner {
           source: request.command,
           surface: this.options.platform === 'win32' ? 'powershell' : 'bash',
           runtimeRoot: session.runtimeRoot,
-          cwd: session.cwd
+          cwd: session.cwd,
+          platform: this.options.platform
         })
         let shellResult: NotebookShellResult | undefined
         try {

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -221,8 +221,12 @@ const rScriptExecutable = ['/usr/local/bin/Rscript', '/opt/homebrew/bin/Rscript'
 
 // Symlinks an env's python interpreter to the system python3 under a runtime root, so the strict
 // resolver (env interpreter only -- no system-PATH fallback) finds it and spawns the fake loop.
-const stubEnvPython = async (runtimeRootDir: string, name: string): Promise<void> => {
-  const bin = pythonBin(envPrefix(runtimeRootDir, name))
+const stubEnvPython = async (
+  runtimeRootDir: string,
+  name: string,
+  platform: NodeJS.Platform = process.platform
+): Promise<void> => {
+  const bin = pythonBin(envPrefix(runtimeRootDir, name, platform), platform)
   await mkdir(dirname(bin), { recursive: true })
   await symlink(python3 as string, bin)
 }
@@ -236,9 +240,12 @@ const stubEnvR = async (runtimeRootDir: string, name: string): Promise<void> => 
 
 // Makes a temp cwd AND stubs its default-python env interpreter, so a default-env execute() passes the
 // readiness gate and spawns the fake loop under an on-disk env interpreter (never a system python).
-const makeDefaultEnvCwd = async (prefix: string): Promise<string> => {
+const makeDefaultEnvCwd = async (
+  prefix: string,
+  platform: NodeJS.Platform = process.platform
+): Promise<string> => {
   const dir = await mkdtemp(join(tmpdir(), prefix))
-  await stubEnvPython(join(dir, 'runtime'), DEFAULT_PY_ENV)
+  await stubEnvPython(join(dir, 'runtime'), DEFAULT_PY_ENV, platform)
   return dir
 }
 
@@ -992,7 +999,7 @@ gate('NotebookKernelExecutor (fake loop)', () => {
   }, 15_000)
 
   it('drops and respawns the kernel when Windows cancellation cannot preserve it', async () => {
-    cwdDir = await makeDefaultEnvCwd('os-kernel-windows-cancel-')
+    cwdDir = await makeDefaultEnvCwd('os-kernel-windows-cancel-', 'win32')
     const terminated: Array<['python' | 'r' | 'repl', string]> = []
     const executor = new NotebookKernelExecutor({
       pythonLoopPath: FIXTURE,

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -653,13 +653,13 @@ class NotebookKernelExecutor implements NotebookExecutor {
     // clear spawn ENOENT below.
     if (request.resolvedInterpreter) return
 
-    const prefix = envPrefix(request.runtimeRoot, env)
+    const prefix = envPrefix(request.runtimeRoot, env, this.platform)
 
     if (kind === 'python') {
       // Every env (default and named) is gated on its own on-disk interpreter: there is no system-PATH
       // fallback, so a missing interpreter is always a hard error here rather than a silent leak to a
       // system python. The default env keeps its "still being prepared" wording; a named env is named.
-      if (!existsSync(pythonBin(prefix))) {
+      if (!existsSync(pythonBin(prefix, this.platform))) {
         throw new Error(
           env === DEFAULT_PY_ENV
             ? 'The Python environment is still being prepared — retry shortly. Do NOT create a new environment; the default one provisions automatically.'
@@ -669,7 +669,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
       return
     }
 
-    if (!existsSync(rBin(prefix))) {
+    if (!existsSync(rBin(prefix, this.platform))) {
       throw new Error(
         env === DEFAULT_R_ENV
           ? 'The R environment is still being prepared — retry shortly. Do NOT create a new environment; the default one provisions automatically.'
@@ -795,7 +795,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
     // spawn fails only for a genuinely missing interpreter.
     const spawnCwd = existsSync(request.cwd) ? request.cwd : undefined
     const spawnEnv = this.buildEnv(kind, request, figuresDir, workloadCacheEnv)
-    const prefix = envPrefix(request.runtimeRoot, env)
+    const prefix = envPrefix(request.runtimeRoot, env, this.platform)
 
     let command: string
     let args: string[]
@@ -812,7 +812,8 @@ class NotebookKernelExecutor implements NotebookExecutor {
       // system-PATH fallback; a missing managed interpreter still surfaces a clear ENOENT). This is
       // the seam that lets the user choose the kernel instead of hard-binding the app conda prefix.
       loopPath = kind === 'r' ? this.rLoopPath : this.pythonLoopPath
-      const managedBin = kind === 'r' ? rScriptBin(prefix) : pythonBin(prefix)
+      const managedBin =
+        kind === 'r' ? rScriptBin(prefix, this.platform) : pythonBin(prefix, this.platform)
       command = request.resolvedInterpreter?.command ?? managedBin
       args = [...(request.resolvedInterpreter?.args ?? []), loopPath]
     }
@@ -920,7 +921,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
           ? this.platform === 'win32'
             ? request.resolvedInterpreter.condaPrefix
             : undefined
-          : envPrefix(request.runtimeRoot, resolveRequestEnv(kind, request))
+          : envPrefix(request.runtimeRoot, resolveRequestEnv(kind, request), this.platform)
     const env: NodeJS.ProcessEnv = {
       ...buildNotebookKernelEnvironment(this.platform),
       ...workloadCacheEnv,

--- a/src/main/notebook/managed-runtime-guard.test.ts
+++ b/src/main/notebook/managed-runtime-guard.test.ts
@@ -9,6 +9,20 @@ import { describe, expect, it } from 'vitest'
 import { detectManagedRuntimeMutation, protectManagedRuntimeWrites } from './managed-runtime-guard'
 
 describe('detectManagedRuntimeMutation', () => {
+  it('uses the injected platform for managed-runtime path comparisons', () => {
+    const platform: NodeJS.Platform = process.platform === 'win32' ? 'linux' : 'win32'
+    const runtimeRoot = join(tmpdir(), 'OpenScience', 'runtime')
+    const target = join(tmpdir(), 'openscience', 'runtime', 'pwn.txt')
+    const mutation = detectManagedRuntimeMutation({
+      source: `touch "${target}"`,
+      surface: 'bash',
+      runtimeRoot,
+      platform
+    })
+
+    expect(mutation !== undefined).toBe(platform === 'win32')
+  })
+
   const runtimeRoot = '/tmp/open-science/runtime'
 
   it.each([

--- a/src/main/notebook/managed-runtime-guard.ts
+++ b/src/main/notebook/managed-runtime-guard.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer'
 import { realpathSync } from 'node:fs'
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { join, posix, resolve, win32 } from 'node:path'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 
@@ -83,40 +83,57 @@ const RUNTIME_WRITE_RULES: Record<NotebookExecutionSurface, RegExp> = {
   repl: /\b(?:writeFile|writeFileSync|appendFile|appendFileSync|rm|rmSync|unlink|unlinkSync|rename|renameSync|mkdir|mkdirSync|mkdtemp|mkdtempSync|copyFile|copyFileSync)\s*\(/iu
 }
 
-const canonicalGuardPath = (value: string, cwd: string): string | undefined => {
+const guardPathApi = (platform: NodeJS.Platform): typeof posix =>
+  platform === 'win32' ? win32 : posix
+
+const canonicalGuardPath = (
+  value: string,
+  cwd: string,
+  platform: NodeJS.Platform
+): string | undefined => {
   const raw = value.trim().replace(/^(?:(["']))([\s\S]*)\1$/u, '$2')
   if (!raw || /[$%`<>|;&\r\n]/u.test(raw)) return undefined
-  const absolute = resolve(cwd, raw)
+  const pathApi = guardPathApi(platform)
+  const absolute = pathApi.resolve(cwd, raw)
   let cursor = absolute
   const suffix: string[] = []
   while (true) {
     try {
-      return resolve(realpathSync(cursor), ...suffix)
+      return pathApi.resolve(realpathSync(cursor), ...suffix)
     } catch {
-      const parent = dirname(cursor)
+      const parent = pathApi.dirname(cursor)
       if (parent === cursor) return absolute
-      suffix.unshift(basename(cursor))
+      suffix.unshift(pathApi.basename(cursor))
       cursor = parent
     }
   }
 }
 
-const canonicalPathIsWithin = (candidate: string, root: string): boolean => {
-  const normalizedCandidate = process.platform === 'win32' ? candidate.toLowerCase() : candidate
-  const normalizedRoot = process.platform === 'win32' ? root.toLowerCase() : root
-  const pathFromRoot = relative(normalizedRoot, normalizedCandidate)
+const canonicalPathIsWithin = (
+  candidate: string,
+  root: string,
+  platform: NodeJS.Platform
+): boolean => {
+  const pathApi = guardPathApi(platform)
+  const normalizedCandidate = platform === 'win32' ? candidate.toLowerCase() : candidate
+  const normalizedRoot = platform === 'win32' ? root.toLowerCase() : root
+  const pathFromRoot = pathApi.relative(normalizedRoot, normalizedCandidate)
   return (
     pathFromRoot === '' ||
-    (pathFromRoot !== '..' && !pathFromRoot.startsWith(`..${sep}`) && !isAbsolute(pathFromRoot))
+    (pathFromRoot !== '..' &&
+      !pathFromRoot.startsWith(`..${pathApi.sep}`) &&
+      !pathApi.isAbsolute(pathFromRoot))
   )
 }
 
 const referencesManagedRuntimePath = (
   source: string,
   runtimeRoot: string,
-  cwd: string
+  cwd: string,
+  platform: NodeJS.Platform
 ): boolean => {
-  const canonical = resolve(runtimeRoot)
+  const pathApi = guardPathApi(platform)
+  const canonical = pathApi.resolve(runtimeRoot)
   const variants = new Set([
     canonical,
     canonical.replaceAll('\\', '/'),
@@ -142,10 +159,12 @@ const referencesManagedRuntimePath = (
   if (/(?:^|[^A-Za-z0-9_])OPEN_SCIENCE_RUNTIME_DIR(?:$|[^A-Za-z0-9_])/u.test(source)) {
     return true
   }
-  const canonicalTarget = canonicalGuardPath(source, cwd)
-  const canonicalRoot = canonicalGuardPath(runtimeRoot, cwd)
+  const canonicalTarget = canonicalGuardPath(source, cwd, platform)
+  const canonicalRoot = canonicalGuardPath(runtimeRoot, cwd, platform)
   return Boolean(
-    canonicalTarget && canonicalRoot && canonicalPathIsWithin(canonicalTarget, canonicalRoot)
+    canonicalTarget &&
+    canonicalRoot &&
+    canonicalPathIsWithin(canonicalTarget, canonicalRoot, platform)
   )
 }
 
@@ -600,7 +619,8 @@ const commandName = (word: string | undefined): string =>
 const resolveSequenceCwd = (
   target: string | undefined,
   runtimeRoot: string,
-  cwd: string
+  cwd: string,
+  platform: NodeJS.Platform
 ): string => {
   if (!target) return cwd
   const unquoted = target.replace(/^['"]|['"]$/gu, '')
@@ -608,23 +628,31 @@ const resolveSequenceCwd = (
     .replace(/\$\{?env:OPEN_SCIENCE_RUNTIME_DIR\}?/giu, () => runtimeRoot)
     .replace(/\$\{?OPEN_SCIENCE_RUNTIME_DIR\}?/gu, () => runtimeRoot)
     .replace(/%OPEN_SCIENCE_RUNTIME_DIR%/giu, () => runtimeRoot)
+  const pathApi = guardPathApi(platform)
   const normalizedExpanded =
-    sep === '\\' ? expanded.replaceAll('/', sep) : expanded.replaceAll('\\', sep)
-  const resolvedTarget = canonicalGuardPath(normalizedExpanded, cwd)
+    pathApi.sep === '\\'
+      ? expanded.replaceAll('/', pathApi.sep)
+      : expanded.replaceAll('\\', pathApi.sep)
+  const resolvedTarget = canonicalGuardPath(normalizedExpanded, cwd, platform)
   if (resolvedTarget) return resolvedTarget
-  if (referencesManagedRuntimePath(target, runtimeRoot, cwd)) {
-    return canonicalGuardPath(runtimeRoot, cwd) ?? resolve(cwd, runtimeRoot)
+  if (referencesManagedRuntimePath(target, runtimeRoot, cwd, platform)) {
+    return canonicalGuardPath(runtimeRoot, cwd, platform) ?? pathApi.resolve(cwd, runtimeRoot)
   }
-  return resolve(cwd, normalizedExpanded)
+  return pathApi.resolve(cwd, normalizedExpanded)
 }
 
-const sequenceTargetWritesRuntime = (target: string, runtimeRoot: string, cwd: string): boolean => {
-  if (referencesManagedRuntimePath(target, runtimeRoot, cwd)) return true
+const sequenceTargetWritesRuntime = (
+  target: string,
+  runtimeRoot: string,
+  cwd: string,
+  platform: NodeJS.Platform
+): boolean => {
+  if (referencesManagedRuntimePath(target, runtimeRoot, cwd, platform)) return true
   // Preserve the existing fail-closed behavior for a dynamic target while the current directory is
   // managed, but allow a statically resolved absolute destination outside the runtime.
   return (
-    canonicalGuardPath(target, cwd) === undefined &&
-    referencesManagedRuntimePath('.', runtimeRoot, cwd)
+    canonicalGuardPath(target, cwd, platform) === undefined &&
+    referencesManagedRuntimePath('.', runtimeRoot, cwd, platform)
   )
 }
 
@@ -632,6 +660,7 @@ const shellSequenceWritesRuntime = (
   source: string,
   runtimeRoot: string,
   cwd: string,
+  platform: NodeJS.Platform,
   depth = 0
 ): boolean => {
   let currentCwd = cwd
@@ -640,23 +669,33 @@ const shellSequenceWritesRuntime = (
     const executable = commandName(words[0])
     if (executable === 'cd') {
       const target = words.find((word, index) => index > 0 && !word.startsWith('-'))
-      currentCwd = resolveSequenceCwd(target, runtimeRoot, currentCwd)
+      currentCwd = resolveSequenceCwd(target, runtimeRoot, currentCwd, platform)
     }
     const targets = shellRuntimeWriteTargets(command)
-    if (targets.some((target) => sequenceTargetWritesRuntime(target, runtimeRoot, currentCwd))) {
+    if (
+      targets.some((target) =>
+        sequenceTargetWritesRuntime(target, runtimeRoot, currentCwd, platform)
+      )
+    ) {
       return true
     }
-    if (referencesManagedRuntimePath('.', runtimeRoot, currentCwd) && depth < 8) {
+    if (referencesManagedRuntimePath('.', runtimeRoot, currentCwd, platform) && depth < 8) {
       const payload = invocationPayload(words)
       if (
         payload?.surface === 'bash' &&
-        shellSequenceWritesRuntime(payload.source, runtimeRoot, currentCwd, depth + 1)
+        shellSequenceWritesRuntime(payload.source, runtimeRoot, currentCwd, platform, depth + 1)
       ) {
         return true
       }
       if (
         payload?.surface === 'powershell' &&
-        powerShellSequenceWritesRuntime(payload.source, runtimeRoot, currentCwd, depth + 1)
+        powerShellSequenceWritesRuntime(
+          payload.source,
+          runtimeRoot,
+          currentCwd,
+          platform,
+          depth + 1
+        )
       ) {
         return true
       }
@@ -664,7 +703,14 @@ const shellSequenceWritesRuntime = (
         payload &&
         payload.surface !== 'bash' &&
         payload.surface !== 'powershell' &&
-        hasManagedRuntimeWrite(payload.source, payload.surface, runtimeRoot, currentCwd, depth + 1)
+        hasManagedRuntimeWrite(
+          payload.source,
+          payload.surface,
+          runtimeRoot,
+          currentCwd,
+          platform,
+          depth + 1
+        )
       ) {
         return true
       }
@@ -718,7 +764,8 @@ const powerShellRuntimeWriteTargets = (command: string): string[] => {
 const powerShellDotNetWritesRuntime = (
   source: string,
   runtimeRoot: string,
-  cwd: string
+  cwd: string,
+  platform: NodeJS.Platform
 ): boolean => {
   const pattern =
     /\[(?:System\.)?IO\.(?:File|Directory)\]::(?:WriteAllText|AppendAllText|WriteAllBytes|Create|CreateText|AppendText|Move|Replace|Delete|CreateDirectory)\s*\(/giu
@@ -726,7 +773,7 @@ const powerShellDotNetWritesRuntime = (
     const openIndex = match.index + match[0].lastIndexOf('(')
     const call = matchingCall(source, match.index, openIndex)
     const target = call ? callArguments(call, openIndex - match.index)[0] : undefined
-    if (target && referencesManagedRuntimePath(target, runtimeRoot, cwd)) return true
+    if (target && referencesManagedRuntimePath(target, runtimeRoot, cwd, platform)) return true
   }
   return false
 }
@@ -735,6 +782,7 @@ const powerShellSequenceWritesRuntime = (
   source: string,
   runtimeRoot: string,
   cwd: string,
+  platform: NodeJS.Platform,
   depth = 0
 ): boolean => {
   let currentCwd = cwd
@@ -747,24 +795,34 @@ const powerShellSequenceWritesRuntime = (
         pathFlag >= 0
           ? words[pathFlag + 1]
           : words.find((word, index) => index > 0 && !word.startsWith('-'))
-      currentCwd = resolveSequenceCwd(target, runtimeRoot, currentCwd)
+      currentCwd = resolveSequenceCwd(target, runtimeRoot, currentCwd, platform)
     }
     const targets = powerShellRuntimeWriteTargets(command)
-    if (targets.some((target) => sequenceTargetWritesRuntime(target, runtimeRoot, currentCwd))) {
+    if (
+      targets.some((target) =>
+        sequenceTargetWritesRuntime(target, runtimeRoot, currentCwd, platform)
+      )
+    ) {
       return true
     }
-    if (powerShellDotNetWritesRuntime(command, runtimeRoot, currentCwd)) return true
-    if (referencesManagedRuntimePath('.', runtimeRoot, currentCwd) && depth < 8) {
+    if (powerShellDotNetWritesRuntime(command, runtimeRoot, currentCwd, platform)) return true
+    if (referencesManagedRuntimePath('.', runtimeRoot, currentCwd, platform) && depth < 8) {
       const payload = invocationPayload(words)
       if (
         payload?.surface === 'bash' &&
-        shellSequenceWritesRuntime(payload.source, runtimeRoot, currentCwd, depth + 1)
+        shellSequenceWritesRuntime(payload.source, runtimeRoot, currentCwd, platform, depth + 1)
       ) {
         return true
       }
       if (
         payload?.surface === 'powershell' &&
-        powerShellSequenceWritesRuntime(payload.source, runtimeRoot, currentCwd, depth + 1)
+        powerShellSequenceWritesRuntime(
+          payload.source,
+          runtimeRoot,
+          currentCwd,
+          platform,
+          depth + 1
+        )
       ) {
         return true
       }
@@ -772,7 +830,14 @@ const powerShellSequenceWritesRuntime = (
         payload &&
         payload.surface !== 'bash' &&
         payload.surface !== 'powershell' &&
-        hasManagedRuntimeWrite(payload.source, payload.surface, runtimeRoot, currentCwd, depth + 1)
+        hasManagedRuntimeWrite(
+          payload.source,
+          payload.surface,
+          runtimeRoot,
+          currentCwd,
+          platform,
+          depth + 1
+        )
       ) {
         return true
       }
@@ -1023,12 +1088,13 @@ const hasDirectManagedRuntimeWrite = (
   source: string,
   surface: NotebookExecutionSurface,
   runtimeRoot: string,
-  cwd: string
+  cwd: string,
+  platform: NodeJS.Platform
 ): boolean => {
   if (surface === 'bash') {
     const executableSource = stripShellComments(source)
     return [executableSource, resolveShellLiteralAssignments(executableSource)].some((candidate) =>
-      shellSequenceWritesRuntime(candidate, runtimeRoot, cwd)
+      shellSequenceWritesRuntime(candidate, runtimeRoot, cwd, platform)
     )
   }
 
@@ -1036,8 +1102,8 @@ const hasDirectManagedRuntimeWrite = (
     const executableSource = stripShellComments(source)
     return [executableSource, resolvePowerShellLiteralAssignments(executableSource)].some(
       (candidate) =>
-        powerShellSequenceWritesRuntime(candidate, runtimeRoot, cwd) ||
-        powerShellDotNetWritesRuntime(candidate, runtimeRoot, cwd)
+        powerShellSequenceWritesRuntime(candidate, runtimeRoot, cwd, platform) ||
+        powerShellDotNetWritesRuntime(candidate, runtimeRoot, cwd, platform)
     )
   }
 
@@ -1058,7 +1124,7 @@ const hasDirectManagedRuntimeWrite = (
         call,
         source.slice(match.index, openIndex + 1),
         openIndex - match.index
-      ).some((target) => referencesManagedRuntimePath(target, runtimeRoot, cwd))
+      ).some((target) => referencesManagedRuntimePath(target, runtimeRoot, cwd, platform))
     ) {
       return true
     }
@@ -1071,7 +1137,8 @@ const executionBridgeWritesRuntime = (
   source: string,
   surface: NotebookExecutionSurface,
   runtimeRoot: string,
-  cwd: string
+  cwd: string,
+  platform: NodeJS.Platform
 ): boolean => {
   if (surface === 'bash' || surface === 'powershell') return false
   const maskedSource =
@@ -1085,7 +1152,7 @@ const executionBridgeWritesRuntime = (
 
     if (bridgeUsesShellCommandString(call, surface)) {
       const command = quotedLiteralValues(firstArgument)[0]
-      return command ? shellSequenceWritesRuntime(command, runtimeRoot, cwd) : false
+      return command ? shellSequenceWritesRuntime(command, runtimeRoot, cwd, platform) : false
     }
 
     if (
@@ -1100,7 +1167,7 @@ const executionBridgeWritesRuntime = (
     if (firstArgument.at(-1) !== closing) return false
     const argv = callArguments(`(${firstArgument.slice(1, -1)})`, 0)
     return shellRuntimeWriteTargetsFromWords(argv, [], true).some((target) =>
-      sequenceTargetWritesRuntime(target, runtimeRoot, cwd)
+      sequenceTargetWritesRuntime(target, runtimeRoot, cwd, platform)
     )
   })
 }
@@ -1110,13 +1177,14 @@ const hasManagedRuntimeWrite = (
   surface: NotebookExecutionSurface,
   runtimeRoot: string,
   cwd: string,
+  platform: NodeJS.Platform,
   depth = 0
 ): boolean =>
-  hasDirectManagedRuntimeWrite(source, surface, runtimeRoot, cwd) ||
-  executionBridgeWritesRuntime(source, surface, runtimeRoot, cwd) ||
+  hasDirectManagedRuntimeWrite(source, surface, runtimeRoot, cwd, platform) ||
+  executionBridgeWritesRuntime(source, surface, runtimeRoot, cwd, platform) ||
   (depth < 8 &&
     executionPayloads(source, surface).some((payload) =>
-      hasManagedRuntimeWrite(payload.source, payload.surface, runtimeRoot, cwd, depth + 1)
+      hasManagedRuntimeWrite(payload.source, payload.surface, runtimeRoot, cwd, platform, depth + 1)
     ))
 
 // Single policy seam shared by data-cell and shell execution. This is intentionally independent from
@@ -1125,12 +1193,14 @@ export const detectManagedRuntimeMutation = ({
   source,
   surface,
   runtimeRoot,
-  cwd = process.cwd()
+  cwd = process.cwd(),
+  platform = process.platform
 }: {
   source: string
   surface: NotebookExecutionSurface
   runtimeRoot: string
   cwd?: string
+  platform?: NodeJS.Platform
 }): ManagedRuntimeMutation | undefined => {
   const rule = findPackageMutationRule(source, surface)
   if (rule) {
@@ -1142,7 +1212,7 @@ export const detectManagedRuntimeMutation = ({
     }
   }
 
-  if (hasManagedRuntimeWrite(source, surface, runtimeRoot, cwd)) {
+  if (hasManagedRuntimeWrite(source, surface, runtimeRoot, cwd, platform)) {
     return {
       installer: 'direct managed-runtime write',
       message:

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -83,9 +83,9 @@ const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): Provi
       // argv[3] is --prefix / -p value depending on form; find the prefix and drop a bin file.
       const pIdx = argv.findIndex((a) => a === '--prefix' || a === '-p')
       const prefix = argv[pIdx + 1]
-      const isPython =
-        prefix === envPrefix(root, DEFAULT_PY_ENV, overrides.platform ?? process.platform)
-      const bin = isPython ? pythonBin(prefix) : rBin(prefix)
+      const platform = overrides.platform ?? process.platform
+      const isPython = prefix === envPrefix(root, DEFAULT_PY_ENV, platform)
+      const bin = isPython ? pythonBin(prefix, platform) : rBin(prefix, platform)
       mkdirSync(join(bin, '..'), { recursive: true })
       writeFileSync(bin, 'x')
       created.push(argv[1])
@@ -573,8 +573,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
   it('repairs and retries after a Windows native access violation leaves an incomplete cache', async () => {
     const root = makeRoot()
     const cache = pkgsCache(root)
-    const prefix = envPrefix(root, DEFAULT_PY_ENV)
-    const bin = pythonBin(prefix)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV, 'win32')
+    const bin = pythonBin(prefix, 'win32')
     mkdirSync(join(cache, 'interrupted-pkg'), { recursive: true })
     writeFileSync(join(cache, 'interrupted-pkg', 'partial'), 'x')
 
@@ -621,8 +621,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
   it('repairs an access violation from the short-cache MAX_PATH retry', async () => {
     const root = makeRoot()
     const cache = pkgsCache(root)
-    const prefix = envPrefix(root, DEFAULT_PY_ENV)
-    const bin = pythonBin(prefix)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV, 'win32')
+    const bin = pythonBin(prefix, 'win32')
     const leaf = 'broken-package-1.0-0'
     const packageDir = join(cache, 'https', 'host', 'channel', 'noarch', leaf)
     const missing = join(packageDir, 'Library', 'x'.repeat(280))
@@ -1344,7 +1344,8 @@ const makeNamedEnvDeps = (
       const prefix = argv[idx + 1]
       // Named envs are always Python in these tests unless the packages carry r-base.
       const isR = argv.includes('r-base')
-      const bin = isR ? rBin(prefix) : pythonBin(prefix)
+      const platform = overrides.platform ?? process.platform
+      const bin = isR ? rBin(prefix, platform) : pythonBin(prefix, platform)
       mkdirSync(join(bin, '..'), { recursive: true })
       writeFileSync(bin, 'x')
     },
@@ -1360,6 +1361,21 @@ const makeNamedEnvDeps = (
 }
 
 describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
+  it('uses the injected platform for the interpreter it verifies', async () => {
+    const root = makeRoot()
+    const platform: NodeJS.Platform = process.platform === 'win32' ? 'linux' : 'win32'
+    const verify = vi.fn(async () => undefined)
+    const { deps } = makeNamedEnvDeps(root, { platform, verify })
+
+    await new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
+
+    const prefix = envPrefix(root, 'analysis', platform)
+    expect(verify).toHaveBeenLastCalledWith(
+      platform === 'win32' ? join(prefix, 'python.exe') : join(prefix, 'bin', 'python'),
+      prefix
+    )
+  })
+
   it('publishes and releases the Windows working cache after a successful create', async () => {
     const root = makeRoot()
     const release = vi.fn().mockResolvedValue(true)
@@ -1830,11 +1846,11 @@ describe('DefaultRuntimeProvisioner.listEnvironments', () => {
   it('maps short Windows default directories to logical names and ignores legacy duplicates', () => {
     const root = makeRoot()
     const shortPrefix = join(root, 'envs', '.p')
-    mkdirSync(join(pythonBin(shortPrefix), '..'), { recursive: true })
-    writeFileSync(pythonBin(shortPrefix), 'short')
+    mkdirSync(join(pythonBin(shortPrefix, 'win32'), '..'), { recursive: true })
+    writeFileSync(pythonBin(shortPrefix, 'win32'), 'short')
     const legacyPrefix = join(root, 'envs', DEFAULT_PY_ENV)
-    mkdirSync(join(pythonBin(legacyPrefix), '..'), { recursive: true })
-    writeFileSync(pythonBin(legacyPrefix), 'legacy')
+    mkdirSync(join(pythonBin(legacyPrefix, 'win32'), '..'), { recursive: true })
+    writeFileSync(pythonBin(legacyPrefix, 'win32'), 'legacy')
 
     const infos = new DefaultRuntimeProvisioner(
       makeDeps(root, { platform: 'win32' })
@@ -2691,21 +2707,22 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     writeSpawnIntent(root, 'orphan', BOOT_A) // no-PID orphan with a Linux boot token
     const runArgv = vi.fn(async () => undefined)
 
-    // Simulate a boot token available (Linux-like) but SAME boot (no reboot proof). The actual platform
-    // detection is process.platform, so we can't mock it in the test, but we can verify the error message
-    // contains appropriate guidance: on the real test platform (likely darwin/win32), it should mention
-    // manual cleanup; on Linux CI, it should mention reboot.
+    // Simulate a boot token available (Linux-like) but SAME boot (no reboot proof). Inject the opposite
+    // platform policy from the real host so this exercises the provisioner's dependency seam instead of
+    // accidentally agreeing with process.platform.
+    const platform: NodeJS.Platform = process.platform === 'linux' ? 'darwin' : 'linux'
     const deps = makeDeps(root, {
       runArgv,
       isPrefixBlocked: () => true,
-      readBootToken: () => BOOT_A
+      readBootToken: () => BOOT_A,
+      platform
     })
     const error = await new DefaultRuntimeProvisioner(deps)
       .repair('python', () => {}, { force: true })
       .catch((e) => e)
     expect(error.message).toMatch(/RUNTIME_RECOVERY_BLOCKED/)
-    // The guidance varies by platform: Linux → reboot, others → manual cleanup.
-    if (process.platform === 'linux') {
+    // The guidance varies by the injected platform: Linux → reboot, others → manual cleanup.
+    if (platform === 'linux') {
       expect(error.message).toMatch(/Restart your computer.*reboot proves/)
     } else {
       expect(error.message).toMatch(/manually delete the recovery metadata files/)

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -349,6 +349,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
 
   constructor(private readonly deps: ProvisionerDeps) {}
 
+  private get platform(): NodeJS.Platform {
+    return this.deps.platform ?? process.platform
+  }
+
   private async resolveChannel(): Promise<string> {
     return typeof this.deps.channel === 'string' ? this.deps.channel : this.deps.channel()
   }
@@ -361,7 +365,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     const path = pkgsCache(this.deps.root)
     return {
       path,
-      lockKey: micromambaCacheLockKey(path, { platform: this.deps.platform })
+      lockKey: micromambaCacheLockKey(path, { platform: this.platform })
     }
   }
 
@@ -372,7 +376,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   private cacheLockKeys(cache: MicromambaCache): string[] {
     return [
       cache.lockKey,
-      micromambaCacheLockKey(pkgsCache(this.deps.root), { platform: this.deps.platform })
+      micromambaCacheLockKey(pkgsCache(this.deps.root), { platform: this.platform })
     ]
   }
 
@@ -400,10 +404,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     if (!bundle.packageSourceDir) return
     const legacyCache = pkgsCache(this.deps.root)
     const legacyLockKey = micromambaCacheLockKey(legacyCache, {
-      platform: this.deps.platform
+      platform: this.platform
     })
     const selectedLockKey = micromambaCacheLockKey(cache.path, {
-      platform: this.deps.platform
+      platform: this.platform
     })
     if (legacyLockKey === selectedLockKey) return
     await validateAndSeedPackIntoCache(bundle.packageSourceDir, bundle.lockPath, cache)
@@ -413,7 +417,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     spec: EnvSpec,
     bundle: FetchedBundle
   ): { cache: MicromambaCache; budget: PackPathBudget } {
-    const platform = this.deps.platform ?? process.platform
+    const platform = this.platform
     const budget =
       bundle.pathBudget ??
       (platform === 'win32'
@@ -428,7 +432,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
 
     const cache =
       this.deps.cache ?? selectMicromambaCache(this.deps.root, budget.maxCacheRelativePath)
-    const prefix = envPrefix(this.deps.root, spec.name)
+    const prefix = envPrefix(this.deps.root, spec.name, this.platform)
     if (
       cache.path.length + budget.maxCacheRelativePath > WINDOWS_MAX_USABLE_PATH ||
       prefix.length + budget.maxEnvRelativePath > WINDOWS_MAX_USABLE_PATH
@@ -453,7 +457,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       const recovered = await withExclusiveCacheLocks(this.cacheLockKeys(cache), () =>
         Promise.resolve(
           recoverWindowsMaxPathPackage(original, this.cacheRoots(cache), {
-            platform: this.deps.platform
+            platform: this.platform
           })
         )
       )
@@ -471,12 +475,11 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     cache: MicromambaCache,
     onProgress: (p: ProvisionProgress) => void
   ): Promise<void> {
-    if (this.legacyCacheCleanupComplete || (this.deps.platform ?? process.platform) !== 'win32')
-      return
+    if (this.legacyCacheCleanupComplete || this.platform !== 'win32') return
     const removed = await withExclusiveCacheLocks(this.cacheLockKeys(cache), () =>
       Promise.resolve(
         removeOverBudgetUrlPackages(pkgsCache(this.deps.root), {
-          platform: this.deps.platform
+          platform: this.platform
         })
       )
     )
@@ -758,7 +761,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     if (!bootTokenProvesReboot(recordedBoot, readBoot())) {
       // Platform-specific guidance: Linux can prove reboot via boot_id; macOS/Windows cannot, so we tell
       // the user the manual escape hatch (deleting the recovery metadata) rather than an impossible reboot.
-      const isLinux = process.platform === 'linux'
+      const isLinux = this.platform === 'linux'
       const guidance = isLinux
         ? 'Restart your computer, then try Reset again (a reboot proves the process is gone).'
         : 'The process cannot be verified as stopped on this platform. If you are certain no install is ' +
@@ -870,15 +873,19 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   status(): ProvisionStatus {
     const marker = readReadyMarker(this.deps.root)
     return {
-      pythonReady: pythonReady(this.deps.root, DEFAULT_ENV_VERSION),
-      rReady: rReady(this.deps.root),
+      pythonReady: pythonReady(this.deps.root, DEFAULT_ENV_VERSION, this.platform),
+      rReady: rReady(this.deps.root, DEFAULT_ENV_VERSION, this.platform),
       version: marker?.defaultEnvVersion ?? 0,
       provisioning: this.provisioning,
       bundleSource: this.deps.bundleSource,
       // Surface a recovery quarantine so the UI can offer Reset even when the interpreter/marker still
       // read as ready (recovery blocks the prefix in memory without touching the marker).
-      pythonRecoveryBlocked: this.deps.isPrefixBlocked?.(envPrefix(this.deps.root, DEFAULT_PY_ENV)),
-      rRecoveryBlocked: this.deps.isPrefixBlocked?.(envPrefix(this.deps.root, DEFAULT_R_ENV))
+      pythonRecoveryBlocked: this.deps.isPrefixBlocked?.(
+        envPrefix(this.deps.root, DEFAULT_PY_ENV, this.platform)
+      ),
+      rRecoveryBlocked: this.deps.isPrefixBlocked?.(
+        envPrefix(this.deps.root, DEFAULT_R_ENV, this.platform)
+      )
     }
   }
 
@@ -892,7 +899,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   }
 
   private cleanupLegacyDefaultPrefix(name: string): void {
-    if ((this.deps.platform ?? process.platform) !== 'win32') return
+    if (this.platform !== 'win32') return
     if (name !== DEFAULT_PY_ENV && name !== DEFAULT_R_ENV) return
     const legacy = legacyDefaultEnvPrefix(this.deps.root, name)
     if (envPrefix(this.deps.root, name, 'win32') === legacy) return
@@ -908,7 +915,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   private markerPrefixDirectory(
     name: typeof DEFAULT_PY_ENV | typeof DEFAULT_R_ENV
   ): string | undefined {
-    const platform = this.deps.platform ?? process.platform
+    const platform = this.platform
     return platform === 'win32' ? basename(envPrefix(this.deps.root, name, platform)) : undefined
   }
 
@@ -959,7 +966,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     const onProgress = withLanguage(rawProgress, 'r')
     // R is lazy, but once present it has its own version marker. A legacy/stale R prefix is upgraded
     // from the current explicit pack instead of being accepted merely because R.exe exists.
-    if (rMaterialized(this.deps.root) && !rReady(this.deps.root)) {
+    if (
+      rMaterialized(this.deps.root, this.platform) &&
+      !rReady(this.deps.root, DEFAULT_ENV_VERSION, this.platform)
+    ) {
       await this.upgradeOrRebuildR(onProgress)
     } else {
       await this.materialize(DEFAULT_R_SPEC, onProgress)
@@ -981,7 +991,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     try {
       // Refuse to write the python prefix if recovery flagged it possibly-live — an additive
       // `install --file` still writes into it, so it must not race a survivor either.
-      this.assertPrefixWritable(envPrefix(this.deps.root, DEFAULT_PY_ENV))
+      this.assertPrefixWritable(envPrefix(this.deps.root, DEFAULT_PY_ENV, this.platform))
       // Apply the exact published baseline to the existing env. `install --file --offline` preserves
       // extra user packages while avoiding a repodata solve for the platform-maintained floor.
       onProgress({ phase: 'upgrade', message: 'Updating default packages…', progress: 0.1 })
@@ -993,8 +1003,8 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       // R is upgraded additively only if already materialized (lazy; spec §6.5) AND not recovery-blocked
       // — a blocked R prefix skips its upgrade rather than failing the (already-applied) python upgrade.
       if (
-        rMaterialized(this.deps.root) &&
-        !this.deps.isPrefixBlocked?.(envPrefix(this.deps.root, DEFAULT_R_ENV))
+        rMaterialized(this.deps.root, this.platform) &&
+        !this.deps.isPrefixBlocked?.(envPrefix(this.deps.root, DEFAULT_R_ENV, this.platform))
       ) {
         onProgress({ phase: 'upgrade-r', message: 'Updating R packages…', progress: 0.6 })
         await this.withEnvPrefixLock(DEFAULT_R_ENV, () => this.upgradeOrRebuildR(onProgress))
@@ -1024,7 +1034,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   ): Promise<void> {
     const onProgress = withLanguage(rawProgress, lang)
     const spec = lang === 'r' ? DEFAULT_R_SPEC : DEFAULT_PYTHON_SPEC
-    const prefix = envPrefix(this.deps.root, spec.name)
+    const prefix = envPrefix(this.deps.root, spec.name, this.platform)
     // Hold the env lock across the WHOLE destructive cycle (quarantine clear / block check → rm →
     // rebuild), so a package install into this env can't slip in between the rm and the rebuild and
     // write into a half-deleted prefix. The rebuild calls the LOCK-FREE do* variants (not the public
@@ -1052,7 +1062,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           }
           // Manual repair / corruption path (spec §6.3): delete the env prefix then re-provision fresh.
           // For python also clear the marker so a partially-deleted state cannot read as ready.
-          rmSync(envPrefix(this.deps.root, spec.name), { recursive: true, force: true })
+          rmSync(envPrefix(this.deps.root, spec.name, this.platform), {
+            recursive: true,
+            force: true
+          })
           if (lang === 'python') {
             rmSync(readyMarkerPath(this.deps.root), { force: true })
             await this.doProvisionPython(onProgress)
@@ -1120,17 +1133,17 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
         // the same key): restore rm -rf's + rebuilds the prefix, and the startup gate runs async with
         // IPC already registered, so without one shared lock a restore could race an installer mid-write.
         await this.withEnvPrefixLock(name, async () => {
-          const prefix = envPrefix(this.deps.root, name)
+          const prefix = envPrefix(this.deps.root, name, this.platform)
           // Skip (leave the lock for a later launch) if recovery flagged this prefix possibly-live: the
           // restore path rm -rf's a broken partial and recreates, which must not race an orphan writer.
           // Other envs still restore; a later restart re-checks the pid and unblocks.
           if (this.deps.isPrefixBlocked?.(prefix)) return
           // A prior restore may have materialized the interpreter before being interrupted. Verify it
           // before consuming the lock; a broken partial prefix is removed and rebuilt below.
-          const existingBin = existsSync(pythonBin(prefix))
-            ? pythonBin(prefix)
-            : existsSync(rBin(prefix))
-              ? rBin(prefix)
+          const existingBin = existsSync(pythonBin(prefix, this.platform))
+            ? pythonBin(prefix, this.platform)
+            : existsSync(rBin(prefix, this.platform))
+              ? rBin(prefix, this.platform)
               : undefined
           if (existingBin) {
             let verified = false
@@ -1207,7 +1220,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
                   : []
               }
             )
-            const bin = existsSync(pythonBin(prefix)) ? pythonBin(prefix) : rBin(prefix)
+            const bin = existsSync(pythonBin(prefix, this.platform))
+              ? pythonBin(prefix, this.platform)
+              : rBin(prefix, this.platform)
             await this.deps.verify(bin, prefix)
             stampDefaultMarkerBeforeLock(name) // marker BEFORE lock delete (no data-loss window)
             rmSync(join(dir, file), { force: true })
@@ -1242,9 +1257,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     }
     const base = language === 'python' ? BASE_PYTHON_PACKAGES : BASE_R_PACKAGES
     const pkgs = [...new Set([...base, ...packages])]
-    const prefix = envPrefix(this.deps.root, name)
+    const prefix = envPrefix(this.deps.root, name, this.platform)
     if (
-      (this.deps.platform ?? process.platform) === 'win32' &&
+      this.platform === 'win32' &&
       prefix.length + DEFAULT_MAX_ENV_RELATIVE_PATH > WINDOWS_MAX_USABLE_PATH
     ) {
       throw new Error(
@@ -1252,7 +1267,8 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           'choose a shorter name or data-root path.'
       )
     }
-    const bin = language === 'python' ? pythonBin(prefix) : rBin(prefix)
+    const bin =
+      language === 'python' ? pythonBin(prefix, this.platform) : rBin(prefix, this.platform)
     // Refuse if recovery flagged this named prefix possibly-live (an orphan create/install may still
     // be writing it) — the service also gates this, but self-guarding covers every caller.
     this.assertPrefixWritable(prefix)
@@ -1336,12 +1352,12 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     const infos: EnvironmentInfo[] = []
     for (const entry of entries) {
       if (!entry.isDirectory()) continue
-      const platform = this.deps.platform ?? process.platform
+      const platform = this.platform
       const name = logicalEnvNameFromDirectory(entry.name)
       const prefix = join(envsDir, entry.name)
       if (prefix !== envPrefix(this.deps.root, name, platform)) continue
-      const isPython = existsSync(pythonBin(prefix))
-      const isR = !isPython && existsSync(rBin(prefix))
+      const isPython = existsSync(pythonBin(prefix, platform))
+      const isR = !isPython && existsSync(rBin(prefix, platform))
       if (!isPython && !isR) continue
       infos.push({
         name,
@@ -1360,16 +1376,16 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     if (name === DEFAULT_PY_ENV || name === DEFAULT_R_ENV) {
       throw new Error(`Refusing to remove the default environment "${name}"`)
     }
-    rmSync(envPrefix(this.deps.root, name), { recursive: true, force: true })
+    rmSync(envPrefix(this.deps.root, name, this.platform), { recursive: true, force: true })
   }
 
   // Keeps a healthy legacy R prefix additive, but replaces an invalid partial prefix from the lock.
   private async upgradeOrRebuildR(onProgress: (p: ProvisionProgress) => void): Promise<void> {
-    const prefix = envPrefix(this.deps.root, DEFAULT_R_ENV)
+    const prefix = envPrefix(this.deps.root, DEFAULT_R_ENV, this.platform)
     // Refuse before the rmSync-and-rebuild branch below can delete a possibly-live prefix.
     this.assertPrefixWritable(prefix)
     try {
-      await this.deps.verify(rBin(prefix), prefix)
+      await this.deps.verify(rBin(prefix, this.platform), prefix)
     } catch {
       // A failed create can leave R.exe before the prefix is runnable. Do not apply an additive
       // upgrade onto unknown partial state; clear it and recreate exactly from the published lock.
@@ -1398,8 +1414,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           'in OPEN_SCIENCE_ENV_BUNDLE_DIR.'
       )
     }
-    const prefix = envPrefix(this.deps.root, spec.name)
-    const bin = spec.language === 'python' ? pythonBin(prefix) : rBin(prefix)
+    const prefix = envPrefix(this.deps.root, spec.name, this.platform)
+    const bin =
+      spec.language === 'python' ? pythonBin(prefix, this.platform) : rBin(prefix, this.platform)
     // Journal the upgrade (child PID + prefix) so a crash mid-install is recovered: the prefix is
     // reconciled only once the survivor is provably gone, else it is blocked. Shared pkgs cache lock (+
     // MAX_PATH recovery):
@@ -1487,11 +1504,12 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     spec: EnvSpec,
     onProgress: (p: ProvisionProgress) => void
   ): Promise<void> {
-    const prefix = envPrefix(this.deps.root, spec.name)
+    const prefix = envPrefix(this.deps.root, spec.name, this.platform)
     // Refuse to touch a prefix recovery flagged possibly-live, even for the idempotent verify path
     // below: an orphan may be mid-write, so treating a half-built interpreter as "ready" is unsafe.
     this.assertPrefixWritable(prefix)
-    const bin = spec.language === 'python' ? pythonBin(prefix) : rBin(prefix)
+    const bin =
+      spec.language === 'python' ? pythonBin(prefix, this.platform) : rBin(prefix, this.platform)
     // Idempotent: if the interpreter is already on disk the env is materialized, so skip fetch+create.
     // This makes a duplicate/concurrent provision (e.g. the UI R-tab and an on-demand agent run both
     // asking for default-r) a no-op instead of a `create -p <existing prefix>` error. repair() deletes
@@ -1611,10 +1629,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           // re-seed and retry the create ONCE. A Windows native access violation is also recoverable:
           // it carries no stderr signature, and a transient crash may leave only a partial prefix after
           // micromamba already removed its cache leaf. Other failures still surface without retrying.
-          const windowsAccessViolation = isWindowsAccessViolationError(
-            error,
-            this.deps.platform ?? process.platform
-          )
+          const windowsAccessViolation = isWindowsAccessViolationError(error, this.platform)
           if (
             this.abort?.signal.aborted ||
             (!windowsAccessViolation &&
@@ -1757,12 +1772,16 @@ export type StartupAction = 'ready' | 'upgrade' | 'repair' | 'fresh'
 // Decides what the app-startup gate must do. 'upgrade' is chosen before 'repair' so a healthy but
 // outdated env is upgraded additively (spec §6.3) rather than nuked; 'repair' covers a corrupt env
 // (marker without bin, or a residual env dir). Empty root → 'fresh'.
-export const planStartupAction = (root: string, expectedVersion: number): StartupAction => {
-  if (pythonReady(root, expectedVersion)) return 'ready'
+export const planStartupAction = (
+  root: string,
+  expectedVersion: number,
+  platform: NodeJS.Platform = process.platform
+): StartupAction => {
+  if (pythonReady(root, expectedVersion, platform)) return 'ready'
   const marker = readReadyMarker(root)
-  const pyBinPresent = existsSync(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))
+  const pyBinPresent = existsSync(pythonBin(envPrefix(root, DEFAULT_PY_ENV, platform), platform))
   if (marker && pyBinPresent) return 'upgrade'
-  if (needsRepair(root, expectedVersion)) return 'repair'
+  if (needsRepair(root, expectedVersion, platform)) return 'repair'
   return 'fresh'
 }
 

--- a/src/main/notebook/runtime-binding.ts
+++ b/src/main/notebook/runtime-binding.ts
@@ -405,7 +405,9 @@ export class NotebookRuntimeBindingOwner {
         ? await injected(language)
         : discoverInterpreters(
             language,
-            defaultDiscoveryDeps(getRuntimeRoot(this.options.dataRoot), () => manualInterpreters)
+            defaultDiscoveryDeps(getRuntimeRoot(this.options.dataRoot), () => manualInterpreters, {
+              platform: this.options.platform
+            })
           )
     } catch {
       return []

--- a/src/main/notebook/runtime-paths.ts
+++ b/src/main/notebook/runtime-paths.ts
@@ -191,32 +191,32 @@ export const windowsDefaultEnvPrefixReserve = (): number =>
 // <root>/pkgs — the shared micromamba package cache (offline seed target; $MAMBA_ROOT_PREFIX/pkgs).
 export const pkgsCache = (root: string): string => join(root, 'pkgs')
 
-// conda env layout differs by OS: Unix puts interpreters under <prefix>/bin, Windows puts python.exe
-// at the prefix root and console tools under <prefix>\Scripts. These helpers branch on the CURRENT
-// platform (read at call time), so darwin/linux are unchanged and Windows resolves the real files.
-const isWindows = (): boolean => process.platform === 'win32'
-
 // The Python interpreter inside an env prefix (Unix: <prefix>/bin/python; Windows: <prefix>\python.exe).
-export const pythonBin = (prefix: string): string =>
-  isWindows() ? join(prefix, 'python.exe') : join(prefix, 'bin', 'python')
+export const pythonBin = (prefix: string, platform: NodeJS.Platform = process.platform): string =>
+  platform === 'win32' ? join(prefix, 'python.exe') : join(prefix, 'bin', 'python')
 
 // The pip CLI inside an env prefix (Unix: <prefix>/bin/pip; Windows: <prefix>\Scripts\pip.exe).
-export const pipBin = (prefix: string): string =>
-  isWindows() ? join(prefix, 'Scripts', 'pip.exe') : join(prefix, 'bin', 'pip')
+export const pipBin = (prefix: string, platform: NodeJS.Platform = process.platform): string =>
+  platform === 'win32' ? join(prefix, 'Scripts', 'pip.exe') : join(prefix, 'bin', 'pip')
 
 // The R interpreter inside an env prefix. Windows conda-forge r-base installs R under
 // <prefix>\Lib\R\bin; the .exe suffix and that layout are the Windows convention (verify on a real
 // Windows build — the runtime is macOS-baselined today).
-export const rBin = (prefix: string): string =>
-  isWindows() ? join(prefix, 'Lib', 'R', 'bin', 'R.exe') : join(prefix, 'bin', 'R')
+export const rBin = (prefix: string, platform: NodeJS.Platform = process.platform): string =>
+  platform === 'win32' ? join(prefix, 'Lib', 'R', 'bin', 'R.exe') : join(prefix, 'bin', 'R')
 
 // The Rscript CLI inside an env prefix (see rBin for the Windows-layout caveat).
-export const rScriptBin = (prefix: string): string =>
-  isWindows() ? join(prefix, 'Lib', 'R', 'bin', 'Rscript.exe') : join(prefix, 'bin', 'Rscript')
+export const rScriptBin = (prefix: string, platform: NodeJS.Platform = process.platform): string =>
+  platform === 'win32'
+    ? join(prefix, 'Lib', 'R', 'bin', 'Rscript.exe')
+    : join(prefix, 'bin', 'Rscript')
 
 // The env's own R package library (Unix: <prefix>/lib/R/library; Windows: <prefix>\Lib\R\library).
-export const rLibraryDir = (prefix: string): string =>
-  isWindows() ? join(prefix, 'Lib', 'R', 'library') : join(prefix, 'lib', 'R', 'library')
+export const rLibraryDir = (
+  prefix: string,
+  platform: NodeJS.Platform = process.platform
+): string =>
+  platform === 'win32' ? join(prefix, 'Lib', 'R', 'library') : join(prefix, 'lib', 'R', 'library')
 
 // Conda activation prepends more than <prefix>\bin on Windows. Native R links BLAS/LAPACK and other
 // runtime DLLs from Library\bin, so starting R.exe with the host PATH alone fails with 0xC0000135.
@@ -487,28 +487,48 @@ export const clearRepairRequired = (root: string, runtimeId: string): void => {
 
 // Python gate: marker present, version >= expected, and default-python interpreter on disk. This is
 // the first-run / app-usable gate that onboarding and the upgrade gate read (spec §4).
-export const pythonReady = (root: string, expectedVersion: number): boolean => {
+export const pythonReady = (
+  root: string,
+  expectedVersion: number,
+  platform: NodeJS.Platform = process.platform
+): boolean => {
   const marker = readReadyMarker(root)
   if (!marker || marker.defaultEnvVersion < expectedVersion) return false
-  return isFile(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))
+  return isFile(pythonBin(envPrefix(root, DEFAULT_PY_ENV, platform), platform))
 }
 
 // R gate: current-version marker plus the default-r interpreter. It remains lazy because no marker
 // exists until R is explicitly provisioned, but unlike a bin-only check it cannot strand an old R
 // baseline after DEFAULT_ENV_VERSION changes.
-export const rMaterialized = (root: string): boolean => isFile(rBin(envPrefix(root, DEFAULT_R_ENV)))
+export const rMaterialized = (
+  root: string,
+  platform: NodeJS.Platform = process.platform
+): boolean => isFile(rBin(envPrefix(root, DEFAULT_R_ENV, platform), platform))
 
-export const rReady = (root: string, expectedVersion: number = DEFAULT_ENV_VERSION): boolean => {
+export const rReady = (
+  root: string,
+  expectedVersion: number = DEFAULT_ENV_VERSION,
+  platform: NodeJS.Platform = process.platform
+): boolean => {
   const marker = readRReadyMarker(root)
-  return Boolean(marker && marker.defaultEnvVersion >= expectedVersion && rMaterialized(root))
+  return Boolean(
+    marker && marker.defaultEnvVersion >= expectedVersion && rMaterialized(root, platform)
+  )
 }
 
 // True when a rebuild must clear stale state first: not python-ready for the expected version AND
 // something is already on disk (marker present, or either default env prefix exists). Empty root
 // (first run) → false → plain provision. (Faithful port of globalenv.rs::needs_rebuild; the
 // additive-vs-rebuild decision itself lives in the provisioner's startup gate, Task 6.)
-export const needsRepair = (root: string, expectedVersion: number): boolean => {
-  if (pythonReady(root, expectedVersion)) return false
+export const needsRepair = (
+  root: string,
+  expectedVersion: number,
+  platform: NodeJS.Platform = process.platform
+): boolean => {
+  if (pythonReady(root, expectedVersion, platform)) return false
   if (readReadyMarker(root) !== undefined) return true
-  return existsSync(envPrefix(root, DEFAULT_PY_ENV)) || existsSync(envPrefix(root, DEFAULT_R_ENV))
+  return (
+    existsSync(envPrefix(root, DEFAULT_PY_ENV, platform)) ||
+    existsSync(envPrefix(root, DEFAULT_R_ENV, platform))
+  )
 }

--- a/src/main/notebook/runtime-relocation.test.ts
+++ b/src/main/notebook/runtime-relocation.test.ts
@@ -69,7 +69,7 @@ describe('exportRuntimeLocks', () => {
     const shortPrefix = join(envsDir, '.p')
     const legacyPrefix = join(envsDir, DEFAULT_PY_ENV)
     for (const prefix of [shortPrefix, legacyPrefix]) {
-      const bin = pythonBin(prefix)
+      const bin = pythonBin(prefix, 'win32')
       await mkdir(dirname(bin), { recursive: true })
       await writeFile(bin, '')
     }

--- a/src/main/notebook/runtime-relocation.ts
+++ b/src/main/notebook/runtime-relocation.ts
@@ -67,7 +67,8 @@ export const exportRuntimeLocks = async (
     if (seen.has(name)) continue
     seen.add(name)
     // Skip mid-creation leftovers with no interpreter — nothing to reconstruct.
-    if (!existsSync(pythonBin(prefix)) && !existsSync(rBin(prefix))) continue
+    if (!existsSync(pythonBin(prefix, deps.platform)) && !existsSync(rBin(prefix, deps.platform)))
+      continue
     try {
       const raw = await deps.capture([
         deps.mm,

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -534,7 +534,8 @@ class NotebookRuntimeService {
       recovery: this.recoveryCoordinator,
       ensureRecovered: () => this.ensureRecovered(),
       resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language),
-      repairPolicy: this.repairPolicy
+      repairPolicy: this.repairPolicy,
+      platform: options.platform
     })
     this.runTerminalization = new NotebookRunTerminalizationOwner({
       repository: this.repository,
@@ -632,8 +633,15 @@ class NotebookRuntimeService {
   ): Promise<boolean> {
     const enablement = await this.resolveRuntimeEnablement(language)
     if (!enablement) return false
-    const prefix = envPrefix(runtimeRootDir, language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV)
-    const interp = language === 'r' ? rBin(prefix) : pythonBin(prefix)
+    const prefix = envPrefix(
+      runtimeRootDir,
+      language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV,
+      this.options.platform
+    )
+    const interp =
+      language === 'r'
+        ? rBin(prefix, this.options.platform)
+        : pythonBin(prefix, this.options.platform)
     // Match by real path if the interpreter is on disk (how the Settings card keys it); else the path
     // as-is (an unprovisioned default can't have been toggled, so this only matters once it exists).
     let envId = interp
@@ -664,13 +672,16 @@ class NotebookRuntimeService {
     resolvedInterpreter: ResolvedInterpreter | undefined,
     runtimeRootDir: string
   ): EnvironmentCaptureTarget {
-    const prefix = envPrefix(runtimeRootDir, environmentName)
+    const prefix = envPrefix(runtimeRootDir, environmentName, this.options.platform)
     return {
       language,
       environmentName,
       runtimeSource: binding?.source === 'external' ? 'external' : 'managed',
       command:
-        resolvedInterpreter?.command ?? (language === 'r' ? rScriptBin(prefix) : pythonBin(prefix)),
+        resolvedInterpreter?.command ??
+        (language === 'r'
+          ? rScriptBin(prefix, this.options.platform)
+          : pythonBin(prefix, this.options.platform)),
       args: resolvedInterpreter?.args,
       ...(language === 'r' && (resolvedInterpreter?.condaPrefix || binding?.source !== 'external')
         ? { condaPrefix: resolvedInterpreter?.condaPrefix ?? prefix }
@@ -1206,7 +1217,8 @@ class NotebookRuntimeService {
   isDefaultEnvRecoveryBlocked(language: NotebookLanguage): boolean {
     const prefix = envPrefix(
       getRuntimeRoot(this.options.dataRoot),
-      language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+      language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV,
+      this.options.platform
     )
     return this.isPrefixRecoveryBlocked(prefix)
   }


### PR DESCRIPTION
## Problem

Notebook owners already accept injected platform/environment values, but downstream helpers sometimes read `process.platform`, `process.env`, or `homedir()` again. An injected Windows policy on a macOS test host can therefore combine Windows decisions with POSIX interpreter layouts, provenance rules, recovery guidance, or managed-runtime path checks.

The failure was reproduced before the fix with opposite-host platform injections at public behavior boundaries: provisioner recovery guidance and interpreter verification, runtime discovery candidates/provenance, and the managed-runtime mutation guard all failed for the reported mixed-decision reason.

## Proposed change

- Thread the existing platform policy through provisioner, runtime-path readiness/layout helpers, kernel execution, relocation, runtime service admission, and execution mutation checks.
- Let runtime discovery use one injected platform, process environment, and home directory for command lookup, standard install roots, interpreter layout, probes, and provenance classification.
- Use the injected platform's `node:path` implementation for managed-runtime guard normalization and containment.
- Keep production defaults backward-compatible by falling back to the real process when no dependency is injected.

## Scope and non-goals

- This is dependency propagation, not a new application architecture layer. It intentionally does not add a broad `RuntimeEnvironment` object containing packaged/resources/temp/shell state because the reproduced failures do not require that interface.
- `micromamba-cache` host ACL/PowerShell adapters continue to use the real host process. They perform host I/O and must not execute Windows security commands merely because a test injects `win32`; its logical cache selection paths already accept injected platform/environment dependencies.
- No user interaction, persisted data, schema, data model, historical migration, or enum/status value changes.

## Acceptance criteria and validation

The following checks ran after the last material edit and after rebasing onto the latest `origin/main`:

- Provisioning, discovery, runtime path readiness, and relocation behavior -> `npm test -- src/main/notebook/provisioner.test.ts src/main/notebook/environment-discovery.test.ts src/main/notebook/runtime-paths.test.ts src/main/notebook/runtime-relocation.test.ts` -> 161 passed.
- Mutation policy plus kernel/runtime-service consumers under injected platforms -> `npm test -- src/main/notebook/managed-runtime-guard.test.ts src/main/notebook/kernel-executor.test.ts src/main/notebook/runtime-service.test.ts -t 'uses the injected platform|drops and respawns the kernel when Windows cancellation|uses the PowerShell runtime-write policy on Windows|activates the complete Windows conda PATH|carries an external Windows conda R own activation prefix|does not infer Windows conda activation'` -> 7 passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.
- Formatting/diff integrity -> Prettier check and `git diff --check` -> passed.

Per the requested workflow, the full portable `npm test` was not run locally; exact-head PR Gate and platform lanes are authoritative. The local sandbox also denies a loopback-listen kernel test and one macOS Seatbelt cache-write test; both failures reproduce unchanged on `main`, while the focused regression and consumer tests pass.

## Review focus

- Confirm every changed decision uses the owner-injected platform/environment consistently through nested helpers.
- Confirm real host-only micromamba ACL/PowerShell adapters remain outside the simulated platform policy.
- Confirm the optional parameters preserve existing production callers and do not imply persistence or compatibility work.
