### PR TITLE
fix(projects): surface fallback errors when project mutations resolve empty

### DIFF
--- a/src/renderer/src/hooks/useProjectFormDialog.test.tsx
+++ b/src/renderer/src/hooks/useProjectFormDialog.test.tsx
@@ -250,4 +250,18 @@ describe('useProjectFormDialog', () => {
     expect(openProject).not.toHaveBeenCalled()
     hook.unmount()
   })
+
+  it('shows a fallback error when the update mutation resolves without a project', async () => {
+    setProjectsApi({ update: vi.fn().mockResolvedValue(undefined) })
+    const hook = renderHook()
+
+    act(() => hook.current().openEditDialog(createProject()))
+    await act(async () => submitForm(hook.current()))
+
+    expect(hook.current().dialogProps.open).toBe(true)
+    expect(hook.current().dialogProps.error).toBe('Could not save project.')
+    expect(hook.current().dialogProps.isSubmitting).toBe(false)
+    expect(openProject).not.toHaveBeenCalled()
+    hook.unmount()
+  })
 })

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -107,6 +107,28 @@ describe('project store', () => {
     expect(useProjectStore.getState().projects[0]).toEqual(created)
   })
 
+  it('resolves an empty create result untouched and leaves the cache alone', async () => {
+    setProjectsApi({ create: vi.fn().mockResolvedValue(undefined) })
+
+    const result = await useProjectStore.getState().createProject({ name: 'New' })
+
+    expect(result).toBeUndefined()
+    expect(useProjectStore.getState().projects).toEqual([])
+  })
+
+  it('resolves an empty update result untouched and leaves the cache alone', async () => {
+    const original = createProject({ id: 'kept', name: 'Kept', updatedAt: 1 })
+    setProjectsApi({ update: vi.fn().mockResolvedValue(undefined) })
+    useProjectStore.setState({ projects: [original], isLoaded: true })
+
+    const result = await useProjectStore
+      .getState()
+      .updateProject({ id: 'kept', expectedUpdatedAt: 1, name: 'Command' })
+
+    expect(result).toBeUndefined()
+    expect(useProjectStore.getState().projects).toEqual([original])
+  })
+
   it('does not let a late update result replace a newer lifecycle projection', async () => {
     const original = createProject({ name: 'Original', updatedAt: 1 })
     const command = createDeferred<Project>()

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -107,6 +107,10 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   createProject: async (request) => {
     const project = await window.api.projects.create(request)
 
+    // The IPC layer can resolve without a row; hand it back untouched so callers surface the
+    // failure instead of this store reading fields off undefined.
+    if (!project) return project
+
     projectMutationSequence += 1
     if (get().projects.some((current) => current.id === project.id)) {
       set({ loadError: undefined })
@@ -125,6 +129,9 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   updateProject: async (request) => {
     const generation = beginProjectProjection()
     const project = await window.api.projects.update(request)
+
+    // Same empty-row contract as create: nothing to merge, so leave the cache untouched.
+    if (!project) return project
 
     projectMutationSequence += 1
     if (commitProjectProjection(project.id, generation)) {

--- a/src/renderer/src/stores/settings-store.architecture.test.ts
+++ b/src/renderer/src/stores/settings-store.architecture.test.ts
@@ -314,6 +314,8 @@ const importBoundaryViolations = (path: string, source = readSource(path)): read
 const allowedFacadeVariableCounts = new Map<string, number>([
   ['createInitialSettingsState', 1],
   ['applySnapshot', 1],
+  ['canApplySnapshot', 1],
+  ['mergeSnapshot', 1],
   ['DEFAULT_FRAMEWORK_API_ENDPOINTS', 1],
   ['selectFrameworkApiEndpoints', 1],
   ['selectVisionRelayAvailable', 1],


### PR DESCRIPTION
## Problem

Two renderer module-test failures reproduce deterministically on `main` (independently of any in-flight PR) and fail the macOS Full Module tests shards:

- `useProjectFormDialog.test.tsx` — "shows a fallback error when the mutation resolves without a project" expects the `Could not save project.` fallback, but the project store reads `.id` off the empty row and throws `Cannot read properties of undefined (reading 'id')`, so the hook's catch branch echoes the TypeError instead.
- `settings-store.architecture.test.ts` — the facade state allowlist does not inventory the `canApplySnapshot` / `mergeSnapshot` helpers, so the guard reports both as new facade state.

## Proposed change

- `project-store.ts`: when `create` / `update` resolves without a row, return the empty result untouched instead of reading fields off `undefined`; the cache and projection sequence stay as they were and the existing hook-level fallback error surfaces.
- `settings-store.architecture.test.ts`: register `canApplySnapshot` and `mergeSnapshot` in `allowedFacadeVariableCounts`.
- Tests: store-level contract tests for the empty-row resolution of both actions, and a hook-level edit-mode fallback test mirroring the existing create-mode one.

## Scope and non-goals

- No changes to store behavior for successful rows, rejections, or projection bookkeeping.
- No dialog/copy changes; the hook already owns the fallback message.

## Acceptance criteria and validation

- `npx vitest run src/renderer/src/hooks/useProjectFormDialog.test.tsx src/renderer/src/stores/project-store.test.ts src/renderer/src/stores/settings-store.architecture.test.ts` — 48 passed (includes the two previously failing tests), run after the last material edit.
- The macOS Full Module tests shards blocked by these baselines are the target lanes for PR Gate.

## Review focus

- Whether `updateProject` should keep `beginProjectProjection()` before the empty-row early return (chosen: yes, so generation ordering is unchanged for the no-row path).
