### PR TITLE
ci(pr-gate): parallelize Windows E2E spec files

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -868,7 +868,8 @@ jobs:
         id: e2e_functional_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_windows') }}
         continue-on-error: true
-        run: npm run test:e2e:journey -- --workers=2 --fail-on-flaky-tests
+        # Balance tests inside slow spec files without increasing the two-worker concurrency cap.
+        run: npm run test:e2e:journey -- --workers=2 --fully-parallel --fail-on-flaky-tests
       - name: Upload functional failure artifacts
         if: ${{ steps.e2e_functional_windows.outcome == 'failure' }}
         continue-on-error: true
@@ -884,7 +885,7 @@ jobs:
         id: e2e_workspace_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_windows') }}
         continue-on-error: true
-        run: npm run test:e2e:workspace -- --workers=2 --fail-on-flaky-tests
+        run: npm run test:e2e:workspace -- --workers=2 --fully-parallel --fail-on-flaky-tests
       - name: Upload workspace failure artifacts
         if: ${{ steps.e2e_workspace_windows.outcome == 'failure' }}
         continue-on-error: true

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -445,8 +445,8 @@ describe('PR Gate workflow', () => {
     expect(windowsRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)
     expect(windowsRuns).toEqual(
       expect.arrayContaining([
-        'npm run test:e2e:journey -- --workers=2 --fail-on-flaky-tests',
-        'npm run test:e2e:workspace -- --workers=2 --fail-on-flaky-tests',
+        'npm run test:e2e:journey -- --workers=2 --fully-parallel --fail-on-flaky-tests',
+        'npm run test:e2e:workspace -- --workers=2 --fully-parallel --fail-on-flaky-tests',
         'npm run test:e2e:accessibility -- --fail-on-flaky-tests'
       ])
     )


### PR DESCRIPTION
## Problem

Recent successful PR Gate runs spend about 15–16.6 minutes in Windows E2E. The functional lane alone takes about 7 minutes because `settings-persistence.spec.ts` runs for roughly 6.9 minutes in one worker while the second worker becomes idle. `--workers=2` limits concurrency but does not distribute tests within a spec file while Playwright `fullyParallel` remains disabled.

## Proposed change

Enable `--fully-parallel` for the Windows functional and workspace E2E commands while retaining the existing `--workers=2` cap. This lets Playwright balance tests from slow spec files across the same two workers without adding dependency installs, builds, runners, or test coverage.

## Scope and non-goals

- Keep the existing Windows E2E lanes, test selections, retries, failure artifacts, and enforcement behavior.
- Keep one dependency installation and one Electron build in the Windows E2E bundle.
- Leave Windows core and all macOS lanes unchanged.
- Do not change application behavior, historical data compatibility, enums/state, or persistence.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Windows E2E workflow contract -> `npx vitest run scripts/ci/pr-gate-workflow.test.ts` -> 23 passed.
- Changed TypeScript lint -> `npx eslint scripts/ci/pr-gate-workflow.test.ts` -> passed.
- Changed-file formatting -> `npx prettier --check .github/workflows/pr-gate.yml scripts/ci/pr-gate-workflow.test.ts` -> passed.
- Functional selection and CLI contract -> `npm run test:e2e:journey -- --workers=2 --fully-parallel --fail-on-flaky-tests --list` -> 21 tests in 3 files.
- Workspace selection and CLI contract -> `npm run test:e2e:workspace -- --workers=2 --fully-parallel --fail-on-flaky-tests --list` -> 21 tests in 5 files.

The workflow is a global validation input. Per maintainer direction, the full local `npm run test` fallback was not run; exact-head PR Gate CI is authoritative for the complete classified plan and actual Windows timing/flakiness evidence. Windows E2E is the affected platform lane; Windows core and macOS consumers are excluded because their commands and scheduling are unchanged.

## Review focus

- Confirm that per-test temp storage/profile isolation is sufficient for file-level parallel scheduling.
- Confirm that retaining `--workers=2` preserves the existing maximum Electron concurrency.
- Compare Windows E2E wall-clock time and flake behavior with recent PR Gate runs.
## PR CI observation

Exact-head PR Gate run `33402598236` completed successfully with the full plan, including both macOS full-suite shards, coverage merge, static checks, Windows core, Windows E2E, and the final gate evaluator. Automated Codex review reported the PR mergeable with no actionable findings.

Windows E2E step comparison against four recent successful full-plan runs:

- Functional journeys: 367 seconds vs a 442-second recent median (75 seconds / about 17% faster).
- Workspace journeys: 263 seconds vs a 258-second recent median (effectively unchanged).
- Combined pure E2E execution: 630 seconds vs a 700-second recent median (70 seconds / 10% faster).

The total Windows E2E job was 16m43s because dependency installation took 247 seconds, compared with roughly 150 seconds in the recent samples. Dependency installation is unchanged by this PR, so step-level E2E time is the meaningful performance signal.

`CI Integrity` reports the expected `protected-gate-control-plane` failure for any established `.github/workflows/pr-gate.yml` change. Merging this CI-control-plane PR therefore requires an explicit maintainer ruleset bypass; the PR cannot make that check green without weakening the repository protection.