### PR TITLE
chore(eslint): lint runtime JavaScript resources

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,10 @@ import eslintPluginReact from 'eslint-plugin-react'
 import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
 import eslintPluginReactRefresh from 'eslint-plugin-react-refresh'
 
+const typescriptRulesOff = Object.fromEntries(
+  Object.keys(tseslint.plugin.rules).map((rule) => [`@typescript-eslint/${rule}`, 'off'])
+)
+
 export default defineConfig(
   {
     ignores: [
@@ -16,10 +20,6 @@ export default defineConfig(
       '**/tmp/**',
       // Packaged e2e build output (electron-builder --dir into dist-e2e-*); bundled JS, not source.
       '**/dist-e2e-*',
-      // Runtime kernel loop scripts shipped as raw resources (CommonJS, not part of the TS source tree).
-      'resources/notebook/*.js',
-      // Whole-window find overlay: an ES-module page shipped as a raw resource (not part of the TS source tree).
-      'resources/find-overlay/*.js',
       // Git worktrees hold full source copies; don't lint duplicate source from either supported root.
       '**/.claude/**',
       '**/.worktree/**',
@@ -56,6 +56,10 @@ export default defineConfig(
       ...eslintPluginReactHooks.configs.recommended.rules,
       ...eslintPluginReactRefresh.configs.vite.rules
     }
+  },
+  {
+    files: ['resources/notebook/*.js', 'resources/find-overlay/*.js'],
+    rules: typescriptRulesOff
   },
   eslintConfigPrettier
 )


### PR DESCRIPTION
## Problem

Three raw JavaScript resources shipped in production were globally ignored by ESLint:

- `resources/notebook/repl_loop.js`: a Node/CommonJS REPL process. The gap appears when edits introduce undefined names, duplicate declarations, unreachable code, or similar defects that still parse and escape focused behavior coverage.
- `resources/notebook/file_evidence_worker.js`: a Node/CommonJS evidence worker. The same gap can leave worker-only paths without static feedback until runtime or an integration test reaches them.
- `resources/find-overlay/findOverlay.js`: a browser ES module. Static mistakes can otherwise reach the packaged overlay even when `node --check` succeeds.

Applying the TypeScript rule set directly produced 205 errors: 193 return-type errors and 12 CommonJS `require` errors. Those are rule/runtime mismatches, not evidence of 205 product bugs.

## Proposed change

- Remove the directory-level ESLint ignores for notebook and find-overlay JavaScript.
- Add a raw-JavaScript override that disables all loaded `@typescript-eslint/*` rules for those directories.
- Keep the existing ESLint core recommended rules, including `no-undef`, `no-redeclare`, and `no-unreachable`.

## Scope and non-goals

This is lint configuration only. It changes no production runtime code, data fields, architecture, user interaction, data model, enum/state values, persisted format, or persistence behavior. No historical-data compatibility is required. It also adds no dependency or custom lint plugin. The adjacent `findOverlay.test.js` is linted with the same raw-JavaScript override.

The change is worth making rather than over-design: it closes a roughly 5,500-line static-analysis gap using the existing ESLint stack and one narrow override. Migrating the resources to TypeScript or introducing a separate lint tool is out of scope.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Raw JavaScript rule selection -> `npx eslint --print-config resources/notebook/repl_loop.js` assertion -> 0 active TypeScript rules; `no-undef`, `no-redeclare`, and `no-unreachable` remain errors.
- Target resources parse -> `node --check` for all three production files -> passed.
- Target resources lint -> `npx eslint --no-cache` for the three production files plus `findOverlay.test.js` -> passed.
- Repository lint -> `npm run lint -- --no-cache` -> passed.
- Find overlay and file-evidence behavior -> Vitest for `resources/find-overlay/findOverlay.test.js` and `src/main/notebook/working-file-observer.test.ts` -> 2 files, 93 tests passed.
- REPL behavior -> Vitest for `src/main/notebook/repl-loop.integration.test.ts` -> 1 file, 26 passed and 32 platform-conditional skips.

Full `npm test` was intentionally not run; PR CI is the final authority for the complete and platform-specific suites. No runtime interface or consumer path changed, so no additional consumer or platform lane was selected locally.

## Review focus

Please confirm that the resource globs remain narrow and that disabling TypeScript rules while retaining core recommended JavaScript rules matches the intended policy.