### PR TITLE
fix(runtime): preserve managed runtimes on failed updates

### DIFF
--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -1,6 +1,9 @@
+import { createHash } from 'node:crypto'
 import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, posix } from 'node:path'
+import { Readable } from 'node:stream'
+import { gzipSync } from 'node:zlib'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -40,7 +43,7 @@ const { AgentRuntimeManager } = await import('./agent-runtime-manager')
 const { SettingsRepository } = await import('./repository')
 const { getAppClaudeConfigDir } = await import('./provider-env')
 const { connectorSkillSourceDir } = await import('../connectors/provision')
-const { managedClaudeDir } = await import('./managed-claude')
+const { installManagedClaude, managedClaudeDir } = await import('./managed-claude')
 const { managedOpencodeDir } = await import('./managed-opencode')
 const { managedCodeBuddyDir, verifyCodeBuddyVersion } = await import('./managed-codebuddy')
 
@@ -60,6 +63,27 @@ const createInventory = (): RuntimeInventory => ({
   codexAdapter: new Map(),
   codexNative: new Map()
 })
+
+const buildManagedClaudeTgz = (content: Buffer): Buffer => {
+  const header = Buffer.alloc(512)
+  header.write('package/claude', 0, 'utf8')
+  header.write('0000755\0', 100, 'ascii')
+  header.write('0000000\0', 108, 'ascii')
+  header.write('0000000\0', 116, 'ascii')
+  header.write(`${content.length.toString(8).padStart(11, '0')}\0`, 124, 'ascii')
+  header.write('00000000000\0', 136, 'ascii')
+  header.write('0', 156, 'ascii')
+  header.write('ustar\0', 257, 'ascii')
+  header.write('00', 263, 'ascii')
+  header.fill(0x20, 148, 156)
+  const checksum = header.reduce((sum, byte) => sum + byte, 0)
+  header.write(`${checksum.toString(8).padStart(6, '0')}\0 `, 148, 'ascii')
+  const padding = Buffer.alloc((512 - (content.length % 512)) % 512)
+  return gzipSync(Buffer.concat([header, content, padding, Buffer.alloc(1024)]))
+}
+
+const sha512 = (data: Buffer): string =>
+  `sha512-${createHash('sha512').update(data).digest('base64')}`
 
 const createClaudeDeps = (inventory: RuntimeInventory): ClaudeDetectDeps => ({
   env: {},
@@ -766,34 +790,52 @@ describe('AgentRuntimeManager', () => {
     })
   })
 
-  it('fails a managed Claude install whose installed executable cannot report a version', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(321)
-    const installedPath = join(storageRoot, 'installed', 'claude')
-    const onEvent = vi.fn<(event: ClaudeInstallEvent) => void>()
+  it('preserves a managed Claude runtime when the replacement cannot report a version', async () => {
+    const existingPath = join(managedClaudeDir(storageRoot), 'claude')
+    await mkdir(dirname(existingPath), { recursive: true })
+    await writeFile(existingPath, 'WORKING-CLAUDE')
+    await repository.setClaudeInfo({ resolvedPath: existingPath, version: '2.1.208' })
+    const replacement = Buffer.from('BROKEN-CLAUDE')
+    const tgz = buildManagedClaudeTgz(replacement)
+    const detectDeps = createClaudeDeps(inventory)
+    detectDeps.getVersion = async (path) =>
+      (await readFile(path, 'utf8')) === 'WORKING-CLAUDE' ? '2.1.208' : undefined
     manager = createManager({
-      installManagedClaudeImpl: async ({ installId }) => ({
-        result: { installId, ok: true },
-        resolvedPath: installedPath,
-        version: 'claimed-version'
-      })
+      detectDeps,
+      installManagedClaudeImpl: (options) =>
+        installManagedClaude({
+          ...options,
+          registries: ['https://reg'],
+          platform: {
+            key: 'linux-x64',
+            pkg: '@anthropic-ai/claude-code-linux-x64',
+            binName: 'claude'
+          },
+          fetchJson: async (url) =>
+            url.endsWith('claude-code-linux-x64/2.1.209')
+              ? { dist: { tarball: 'https://reg/x.tgz', integrity: sha512(tgz) } }
+              : { 'dist-tags': { latest: '2.1.209' } },
+          fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length })
+        })
     })
 
-    const result = await manager.installClaude({ source: 'managed' }, onEvent)
-
-    expect(result).toEqual({
-      installId: 'install-321-1',
+    const onEvent = vi.fn<(event: ClaudeInstallEvent) => void>()
+    await expect(manager.installClaude({ source: 'managed' }, onEvent)).resolves.toMatchObject({
       ok: false,
-      error:
-        'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
+      error: expect.stringContaining('could not report its version')
     })
-    expect((await repository.getSettings()).claude).toBeUndefined()
-    expect(onEvent).toHaveBeenCalledWith({
-      kind: 'log',
-      installId: 'install-321-1',
-      stream: 'system',
-      chunk:
-        'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.\n'
+    expect(await readFile(existingPath, 'utf8')).toBe('WORKING-CLAUDE')
+    expect((await repository.getSettings()).claude).toEqual({
+      resolvedPath: existingPath,
+      version: '2.1.208'
     })
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'log',
+        stream: 'system',
+        chunk: expect.stringContaining('could not report its version')
+      })
+    )
   })
 
   it('guards unmanaged uninstall and selects the first actually runnable fallback', async () => {

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -560,6 +560,14 @@ export class AgentRuntimeManager {
         })
 
         if (outcome.result.ok && outcome.resolvedPath) {
+          const installedVersion = await this.detectDeps.getVersion(outcome.resolvedPath)
+          if (!installedVersion) {
+            const error =
+              'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
+            onEvent({ kind: 'log', installId, stream: 'system', chunk: `${error}\n` })
+            return { installId, ok: false, error }
+          }
+
           await this.repository.setClaudeInfo({
             resolvedPath: outcome.resolvedPath,
             version: outcome.version

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -555,18 +555,11 @@ export class AgentRuntimeManager {
           installId,
           onEvent,
           dataRoot: this.storageRoot,
-          registries
+          registries,
+          verifyBinary: this.detectDeps.getVersion
         })
 
         if (outcome.result.ok && outcome.resolvedPath) {
-          const installedVersion = await this.detectDeps.getVersion(outcome.resolvedPath)
-          if (!installedVersion) {
-            const error =
-              'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
-            onEvent({ kind: 'log', installId, stream: 'system', chunk: `${error}\n` })
-            return { installId, ok: false, error }
-          }
-
           await this.repository.setClaudeInfo({
             resolvedPath: outcome.resolvedPath,
             version: outcome.version

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { Readable } from 'node:stream'
 import { createHash } from 'node:crypto'
 import { gzipSync } from 'node:zlib'
@@ -447,7 +447,8 @@ describe('managed-claude: install orchestration', () => {
         url.endsWith('claude-code-linux-x64/2.1.209')
           ? { dist: { tarball: 'https://reg/x.tgz', integrity: sha512(tgz) } }
           : { 'dist-tags': { latest: '2.1.209' } },
-      fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length })
+      fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length }),
+      verifyBinary: async () => '2.1.209'
     })
 
     expect(outcome.result.ok).toBe(true)
@@ -465,6 +466,64 @@ describe('managed-claude: install orchestration', () => {
     ).toBe(true)
   })
 
+  it('preserves the existing runtime when the replacement archive is incomplete', async () => {
+    const existingPath = join(managedClaudeDir(root), 'claude')
+    await mkdir(managedClaudeDir(root), { recursive: true })
+    await writeFile(existingPath, 'WORKING-CLAUDE')
+    const tgz = buildTgz([{ name: 'package/not-claude', content: Buffer.from('replacement') }])
+
+    const outcome = await installManagedClaude({
+      installId: 'preserve-existing',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform,
+      fetchJson: async (url) =>
+        url.endsWith('claude-code-linux-x64/2.1.209')
+          ? { dist: { tarball: 'https://reg/x.tgz', integrity: sha512(tgz) } }
+          : { 'dist-tags': { latest: '2.1.209' } },
+      fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length }),
+      verifyBinary: async () => '2.1.209'
+    })
+
+    expect(outcome.result.ok).toBe(false)
+    expect(await readFile(existingPath, 'utf8')).toBe('WORKING-CLAUDE')
+  })
+
+  it('restores the existing runtime when publication fails', async () => {
+    const existingPath = join(managedClaudeDir(root), 'claude')
+    const managedRoot = dirname(managedClaudeDir(root))
+    await mkdir(managedClaudeDir(root), { recursive: true })
+    await writeFile(existingPath, 'WORKING-CLAUDE')
+    const { tgz } = fixture()
+    const renamePath = vi.fn(async (...args: Parameters<typeof rename>) => {
+      const [source, destination] = args
+      if (String(source).includes('.staging-') && String(destination) === managedRoot) {
+        throw new Error('swap failed')
+      }
+      await rename(source, destination)
+    })
+
+    const outcome = await installManagedClaude({
+      installId: 'restore-existing',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform,
+      fetchJson: async (url) =>
+        url.endsWith('claude-code-linux-x64/2.1.209')
+          ? { dist: { tarball: 'https://reg/x.tgz', integrity: sha512(tgz) } }
+          : { 'dist-tags': { latest: '2.1.209' } },
+      fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length }),
+      verifyBinary: async () => '2.1.209',
+      renamePath
+    })
+
+    expect(outcome.result).toMatchObject({ ok: false, error: 'swap failed' })
+    expect(await readFile(existingPath, 'utf8')).toBe('WORKING-CLAUDE')
+    expect((await readdir(root)).filter((name) => name.includes('.backup-'))).toEqual([])
+  })
+
   it('falls back to the next registry when the first fails', async () => {
     const { tgz } = fixture()
     const events: ClaudeInstallEvent[] = []
@@ -480,7 +539,8 @@ describe('managed-claude: install orchestration', () => {
           ? { dist: { tarball: 'https://good/x.tgz', integrity: sha512(tgz) } }
           : { 'dist-tags': { latest: '2.1.209' } }
       },
-      fetchTarball: async () => ({ stream: Readable.from([tgz]) })
+      fetchTarball: async () => ({ stream: Readable.from([tgz]) }),
+      verifyBinary: async () => '2.1.209'
     })
 
     expect(outcome.result.ok).toBe(true)
@@ -501,14 +561,16 @@ describe('managed-claude: install orchestration', () => {
       fetchJson: async () => {
         throw new Error('boom')
       },
-      fetchTarball: async () => ({ stream: Readable.from([Buffer.from('x')]) })
+      fetchTarball: async () => ({ stream: Readable.from([Buffer.from('x')]) }),
+      verifyBinary: async () => '2.1.209'
     })
 
     expect(outcome.result.ok).toBe(false)
     expect(outcome.result.error).toContain('boom')
     expect(
       events.some(
-        (event) => event.kind === 'log' && event.chunk.includes('remove the incomplete runtime')
+        (event) =>
+          event.kind === 'log' && event.chunk.includes('No candidate runtime was published')
       )
     ).toBe(true)
   })
@@ -524,7 +586,8 @@ describe('managed-claude: install orchestration', () => {
       fetchJson: async () => {
         throw Object.assign(new Error('no space left on device, write'), { code: 'ENOSPC' })
       },
-      fetchTarball: async () => ({ stream: Readable.from([]) })
+      fetchTarball: async () => ({ stream: Readable.from([]) }),
+      verifyBinary: async () => '2.1.209'
     })
 
     expect(outcome.result.ok).toBe(false)
@@ -563,6 +626,23 @@ describe('isManagedClaudePath / uninstallManagedClaude', () => {
     await expect(readFile(bin)).rejects.toThrow()
     // The `claude-code` parent (one level above bin) is gone, not just the file.
     await expect(readFile(join(root, 'claude-code', 'bin', 'claude'))).rejects.toThrow()
+  })
+
+  it('removes only owned staging and backup siblings', async () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc'
+    const stagingMarker = join(root, `claude-code.staging-${uuid}`, 'marker')
+    const backupMarker = join(root, `claude-code.backup-${uuid}`, 'marker')
+    const lookalikeMarker = join(root, 'claude-code.backup-manual', 'marker')
+    for (const marker of [stagingMarker, backupMarker, lookalikeMarker]) {
+      await mkdir(dirname(marker), { recursive: true })
+      await writeFile(marker, 'present')
+    }
+
+    await uninstallManagedClaude(root)
+
+    await expect(readFile(stagingMarker)).rejects.toThrow()
+    await expect(readFile(backupMarker)).rejects.toThrow()
+    await expect(readFile(lookalikeMarker, 'utf8')).resolves.toBe('present')
   })
 
   it('is a no-op (never rejects) when nothing is installed', async () => {

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -596,6 +596,32 @@ describe('managed-claude: install orchestration', () => {
       events.some((event) => event.kind === 'log' && event.chunk.includes('Free some space'))
     ).toBe(true)
   })
+
+  it('returns a structured failure when the staging directory cannot be created', async () => {
+    const blockedDataRoot = join(root, 'blocked-data-root')
+    const events: ClaudeInstallEvent[] = []
+    await writeFile(blockedDataRoot, 'not a directory')
+
+    const outcome = await installManagedClaude({
+      installId: 'staging-setup-failure',
+      onEvent: (event) => events.push(event),
+      dataRoot: blockedDataRoot,
+      registries: ['https://reg'],
+      platform,
+      fetchJson: async () => {
+        throw new Error('registry should not be reached')
+      },
+      fetchTarball: async () => ({ stream: Readable.from([]) }),
+      verifyBinary: async () => '2.1.209'
+    })
+
+    expect(outcome.result).toMatchObject({ ok: false, error: expect.stringContaining('ENOTDIR') })
+    expect(
+      events.some(
+        (event) => event.kind === 'log' && event.stream === 'system' && /ENOTDIR/.test(event.chunk)
+      )
+    ).toBe(true)
+  })
 })
 
 describe('isManagedClaudePath / uninstallManagedClaude', () => {
@@ -630,18 +656,27 @@ describe('isManagedClaudePath / uninstallManagedClaude', () => {
 
   it('removes only owned staging and backup siblings', async () => {
     const uuid = '12345678-1234-1234-1234-123456789abc'
+    const unownedUuid = 'abcdefab-cdef-abcd-efab-cdefabcdefab'
     const stagingMarker = join(root, `claude-code.staging-${uuid}`, 'marker')
     const backupMarker = join(root, `claude-code.backup-${uuid}`, 'marker')
+    const unownedMarker = join(root, `claude-code.backup-${unownedUuid}`, 'marker')
     const lookalikeMarker = join(root, 'claude-code.backup-manual', 'marker')
-    for (const marker of [stagingMarker, backupMarker, lookalikeMarker]) {
+    for (const marker of [stagingMarker, backupMarker, unownedMarker, lookalikeMarker]) {
       await mkdir(dirname(marker), { recursive: true })
       await writeFile(marker, 'present')
+    }
+    for (const ownedRoot of [dirname(stagingMarker), dirname(backupMarker)]) {
+      await writeFile(
+        join(ownedRoot, '.open-science-managed-runtime'),
+        'open-science:claude-code:v1\n'
+      )
     }
 
     await uninstallManagedClaude(root)
 
     await expect(readFile(stagingMarker)).rejects.toThrow()
     await expect(readFile(backupMarker)).rejects.toThrow()
+    await expect(readFile(unownedMarker, 'utf8')).resolves.toBe('present')
     await expect(readFile(lookalikeMarker, 'utf8')).resolves.toBe('present')
   })
 

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -16,9 +16,10 @@ import { createHash } from 'node:crypto'
 import { gzipSync } from 'node:zlib'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { netFetchStandard, nonRegularMarkerPaths } = vi.hoisted(() => ({
+const { netFetchStandard, nonRegularMarkerPaths, markerReplacementsOnRead } = vi.hoisted(() => ({
   netFetchStandard: vi.fn(),
-  nonRegularMarkerPaths: new Set<string>()
+  nonRegularMarkerPaths: new Set<string>(),
+  markerReplacementsOnRead: new Map<string, string>()
 }))
 
 vi.mock('../skills/net-fetch', () => ({ netFetchStandard }))
@@ -29,11 +30,26 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     lstat: async (path: string) =>
       nonRegularMarkerPaths.has(String(path))
         ? ({ isFile: () => false } as Awaited<ReturnType<typeof actual.lstat>>)
-        : actual.lstat(path)
+        : actual.lstat(path),
+    readFile: async (...args: Parameters<typeof actual.readFile>) => {
+      const path = String(args[0])
+      const replacement = markerReplacementsOnRead.get(path)
+      if (replacement !== undefined) {
+        markerReplacementsOnRead.delete(path)
+        const replacementPath = `${path}.replacement`
+        await actual.writeFile(replacementPath, replacement, { flag: 'wx' })
+        await actual.rm(path)
+        await actual.rename(replacementPath, path)
+      }
+      return actual.readFile(...args)
+    }
   }
 })
 
-afterEach(() => nonRegularMarkerPaths.clear())
+afterEach(() => {
+  nonRegularMarkerPaths.clear()
+  markerReplacementsOnRead.clear()
+})
 
 import type { ClaudeInstallEvent } from '../../shared/settings'
 import {
@@ -815,6 +831,21 @@ describe('isManagedClaudePath / uninstallManagedClaude', () => {
     await writeFile(orphanPayload, 'present')
     await writeFile(externalMarker, 'open-science:claude-code:v1\n')
     await link(externalMarker, join(orphanRoot, '.open-science-managed-runtime'))
+
+    await uninstallManagedClaude(root)
+
+    await expect(readFile(orphanPayload, 'utf8')).resolves.toBe('present')
+  })
+
+  it('preserves an orphan when its ownership marker changes after metadata validation', async () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc'
+    const orphanRoot = join(root, `claude-code.backup-${uuid}`)
+    const orphanPayload = join(orphanRoot, 'user-data')
+    const ownerMarker = join(orphanRoot, '.open-science-managed-runtime')
+    await mkdir(orphanRoot, { recursive: true })
+    await writeFile(orphanPayload, 'present')
+    await writeFile(ownerMarker, 'unowned\n')
+    markerReplacementsOnRead.set(ownerMarker, 'open-science:claude-code:v1\n')
 
     await uninstallManagedClaude(root)
 

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -436,6 +436,17 @@ describe('managed-claude: install orchestration', () => {
   it('installs the binary and reports the resolved path + version', async () => {
     const { tgz, binary } = fixture()
     const events: ClaudeInstallEvent[] = []
+    const interruptedStaging = join(
+      root,
+      'claude-code.staging-12345678-1234-1234-1234-123456789abc'
+    )
+    const interruptedPayload = join(interruptedStaging, 'partial-download')
+    await mkdir(interruptedStaging, { recursive: true })
+    await writeFile(
+      join(interruptedStaging, '.open-science-managed-runtime'),
+      'open-science:claude-code:v1\n'
+    )
+    await writeFile(interruptedPayload, 'partial')
     let stagingOwner: string | undefined
     const renamePath = async (...args: Parameters<typeof rename>): Promise<void> => {
       const [source] = args
@@ -465,6 +476,7 @@ describe('managed-claude: install orchestration', () => {
 
     expect(outcome.result.ok).toBe(true)
     expect(stagingOwner).toBe('open-science:claude-code:v1\n')
+    await expect(readFile(interruptedPayload)).rejects.toThrow()
     expect(outcome.version).toBe('2.1.209')
     expect(outcome.resolvedPath).toBe(join(root, 'claude-code', 'bin', 'claude'))
     expect((await readFile(outcome.resolvedPath as string)).equals(binary)).toBe(true)

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -436,6 +436,17 @@ describe('managed-claude: install orchestration', () => {
   it('installs the binary and reports the resolved path + version', async () => {
     const { tgz, binary } = fixture()
     const events: ClaudeInstallEvent[] = []
+    let stagingOwner: string | undefined
+    const renamePath = async (...args: Parameters<typeof rename>): Promise<void> => {
+      const [source] = args
+      if (String(source).includes('.staging-')) {
+        stagingOwner = await readFile(
+          join(dirname(String(source)), '.open-science-managed-runtime'),
+          'utf8'
+        )
+      }
+      await rename(...args)
+    }
 
     const outcome = await installManagedClaude({
       installId: 'i1',
@@ -448,10 +459,12 @@ describe('managed-claude: install orchestration', () => {
           ? { dist: { tarball: 'https://reg/x.tgz', integrity: sha512(tgz) } }
           : { 'dist-tags': { latest: '2.1.209' } },
       fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length }),
-      verifyBinary: async () => '2.1.209'
+      verifyBinary: async () => '2.1.209',
+      renamePath
     })
 
     expect(outcome.result.ok).toBe(true)
+    expect(stagingOwner).toBe('open-science:claude-code:v1\n')
     expect(outcome.version).toBe('2.1.209')
     expect(outcome.resolvedPath).toBe(join(root, 'claude-code', 'bin', 'claude'))
     expect((await readFile(outcome.resolvedPath as string)).equals(binary)).toBe(true)

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { Readable } from 'node:stream'
@@ -513,6 +513,36 @@ describe('managed-claude: install orchestration', () => {
 
     expect(outcome.result.ok).toBe(false)
     expect(await readFile(existingPath, 'utf8')).toBe('WORKING-CLAUDE')
+  })
+
+  it('rejects a symlinked runtime root without modifying its target', async () => {
+    const externalRoot = join(root, 'external-claude')
+    const externalMarker = join(externalRoot, '.open-science-managed-runtime')
+    const managedRoot = dirname(managedClaudeDir(root))
+    await mkdir(externalRoot, { recursive: true })
+    await writeFile(externalMarker, 'EXTERNAL-DATA')
+    await symlink(externalRoot, managedRoot, process.platform === 'win32' ? 'junction' : 'dir')
+    const { tgz } = fixture()
+
+    const outcome = await installManagedClaude({
+      installId: 'reject-symlinked-root',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform,
+      fetchJson: async (url) =>
+        url.endsWith('claude-code-linux-x64/2.1.209')
+          ? { dist: { tarball: 'https://reg/x.tgz', integrity: sha512(tgz) } }
+          : { 'dist-tags': { latest: '2.1.209' } },
+      fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length }),
+      verifyBinary: async () => '2.1.209'
+    })
+
+    expect(await readFile(externalMarker, 'utf8')).toBe('EXTERNAL-DATA')
+    expect(outcome.result).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/symbolic link/i)
+    })
   })
 
   it('restores the existing runtime when publication fails', async () => {

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -1,4 +1,14 @@
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises'
+import {
+  link,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { Readable } from 'node:stream'
@@ -560,6 +570,35 @@ describe('managed-claude: install orchestration', () => {
     })
   })
 
+  it('rejects a hard-linked ownership marker without modifying its external inode', async () => {
+    const externalMarker = join(root, 'external-claude-marker')
+    const managedRoot = dirname(managedClaudeDir(root))
+    await mkdir(managedClaudeDir(root), { recursive: true })
+    await writeFile(externalMarker, 'EXTERNAL-DATA')
+    await link(externalMarker, join(managedRoot, '.open-science-managed-runtime'))
+    const { tgz } = fixture()
+
+    const outcome = await installManagedClaude({
+      installId: 'reject-hard-linked-marker',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform,
+      fetchJson: async (url) =>
+        url.endsWith('claude-code-linux-x64/2.1.209')
+          ? { dist: { tarball: 'https://reg/x.tgz', integrity: sha512(tgz) } }
+          : { 'dist-tags': { latest: '2.1.209' } },
+      fetchTarball: async () => ({ stream: Readable.from([tgz]), totalBytes: tgz.length }),
+      verifyBinary: async () => '2.1.209'
+    })
+
+    expect(await readFile(externalMarker, 'utf8')).toBe('EXTERNAL-DATA')
+    expect(outcome.result).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/hard link/i)
+    })
+  })
+
   it('restores the existing runtime when publication fails', async () => {
     const existingPath = join(managedClaudeDir(root), 'claude')
     const managedRoot = dirname(managedClaudeDir(root))
@@ -761,6 +800,21 @@ describe('isManagedClaudePath / uninstallManagedClaude', () => {
     // Windows CI cannot create file symlinks without extra privileges. Model the no-follow lstat
     // result at the filesystem boundary while retaining real directory and read/remove behavior.
     nonRegularMarkerPaths.add(ownerMarker)
+
+    await uninstallManagedClaude(root)
+
+    await expect(readFile(orphanPayload, 'utf8')).resolves.toBe('present')
+  })
+
+  it('preserves an orphan whose ownership marker has multiple hard links', async () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc'
+    const orphanRoot = join(root, `claude-code.backup-${uuid}`)
+    const orphanPayload = join(orphanRoot, 'user-data')
+    const externalMarker = join(root, 'external-owner-marker')
+    await mkdir(orphanRoot, { recursive: true })
+    await writeFile(orphanPayload, 'present')
+    await writeFile(externalMarker, 'open-science:claude-code:v1\n')
+    await link(externalMarker, join(orphanRoot, '.open-science-managed-runtime'))
 
     await uninstallManagedClaude(root)
 

--- a/src/main/settings/managed-claude.test.ts
+++ b/src/main/settings/managed-claude.test.ts
@@ -6,9 +6,24 @@ import { createHash } from 'node:crypto'
 import { gzipSync } from 'node:zlib'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { netFetchStandard } = vi.hoisted(() => ({ netFetchStandard: vi.fn() }))
+const { netFetchStandard, nonRegularMarkerPaths } = vi.hoisted(() => ({
+  netFetchStandard: vi.fn(),
+  nonRegularMarkerPaths: new Set<string>()
+}))
 
 vi.mock('../skills/net-fetch', () => ({ netFetchStandard }))
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    lstat: async (path: string) =>
+      nonRegularMarkerPaths.has(String(path))
+        ? ({ isFile: () => false } as Awaited<ReturnType<typeof actual.lstat>>)
+        : actual.lstat(path)
+  }
+})
+
+afterEach(() => nonRegularMarkerPaths.clear())
 
 import type { ClaudeInstallEvent } from '../../shared/settings'
 import {
@@ -733,6 +748,23 @@ describe('isManagedClaudePath / uninstallManagedClaude', () => {
     await expect(readFile(backupMarker)).rejects.toThrow()
     await expect(readFile(unownedMarker, 'utf8')).resolves.toBe('present')
     await expect(readFile(lookalikeMarker, 'utf8')).resolves.toBe('present')
+  })
+
+  it('preserves an orphan whose ownership marker is a symbolic link', async () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc'
+    const orphanRoot = join(root, `claude-code.backup-${uuid}`)
+    const orphanPayload = join(orphanRoot, 'user-data')
+    const ownerMarker = join(orphanRoot, '.open-science-managed-runtime')
+    await mkdir(orphanRoot, { recursive: true })
+    await writeFile(orphanPayload, 'present')
+    await writeFile(ownerMarker, 'open-science:claude-code:v1\n')
+    // Windows CI cannot create file symlinks without extra privileges. Model the no-follow lstat
+    // result at the filesystem boundary while retaining real directory and read/remove behavior.
+    nonRegularMarkerPaths.add(ownerMarker)
+
+    await uninstallManagedClaude(root)
+
+    await expect(readFile(orphanPayload, 'utf8')).resolves.toBe('present')
   })
 
   it('is a no-op (never rejects) when nothing is installed', async () => {

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { createReadStream, createWriteStream, type Dirent } from 'node:fs'
-import { chmod, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { chmod, lstat, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -476,6 +476,22 @@ const replaceManagedClaudeRoot = async (
 ): Promise<void> => {
   const backup = `${root}.backup-${randomUUID()}`
   let backedUp = false
+
+  const rejectSymbolicLink = async (path: string, label: string): Promise<void> => {
+    const stats = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return undefined
+      throw error
+    })
+    if (stats?.isSymbolicLink()) {
+      throw new Error(`Refusing to replace ${label} because it is a symbolic link: ${path}`)
+    }
+  }
+
+  await rejectSymbolicLink(root, 'the managed Claude runtime root')
+  await rejectSymbolicLink(
+    join(root, RUNTIME_OWNER_MARKER),
+    'the managed Claude runtime ownership marker'
+  )
 
   try {
     await writeFile(join(root, RUNTIME_OWNER_MARKER), CLAUDE_RUNTIME_OWNER)

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -520,6 +520,7 @@ const installManagedClaude = async ({
 
   try {
     await mkdir(scratch, { recursive: true })
+    await writeFile(join(scratch, RUNTIME_OWNER_MARKER), CLAUDE_RUNTIME_OWNER)
   } catch (error) {
     lastError = describeManagedInstallError(error)
     onEvent({

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -114,6 +114,8 @@ const isManagedClaudePath = (resolvedPath: string, dataRoot: string): boolean =>
 
 const ORPHANED_CLAUDE_RUNTIME_PATTERN =
   /^claude-code\.(?:staging|backup)-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
+const STAGED_CLAUDE_RUNTIME_PATTERN =
+  /^claude-code\.staging-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
 const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
 const CLAUDE_RUNTIME_OWNER = 'open-science:claude-code:v1\n'
 
@@ -121,24 +123,38 @@ const isOwnedClaudeRuntime = async (root: string): Promise<boolean> =>
   (await readFile(join(root, RUNTIME_OWNER_MARKER), 'utf8').catch(() => undefined)) ===
   CLAUDE_RUNTIME_OWNER
 
+const findOwnedClaudeRuntimeSiblings = async (
+  dataRoot: string,
+  pattern: RegExp
+): Promise<string[]> => {
+  const root = dirname(managedClaudeDir(dataRoot))
+  const siblings = await readdir(dirname(root), { withFileTypes: true }).catch(() => [] as Dirent[])
+  const candidates = siblings
+    .filter((entry) => entry.isDirectory() && pattern.test(entry.name))
+    .map((entry) => join(dirname(root), entry.name))
+  return (
+    await Promise.all(
+      candidates.map(async (path) => ((await isOwnedClaudeRuntime(path)) ? path : undefined))
+    )
+  ).filter((path): path is string => path !== undefined)
+}
+
+const removeOwnedClaudeRuntimeSiblings = async (
+  dataRoot: string,
+  pattern: RegExp
+): Promise<void> => {
+  const owned = await findOwnedClaudeRuntimeSiblings(dataRoot, pattern)
+  await Promise.all(
+    owned.map((path) => rm(path, { recursive: true, force: true }).catch(() => undefined))
+  )
+}
+
 // Removes the app-managed Claude install tree and exact installer-owned staging/backup siblings.
 // Resolves (never rejects); a missing dir is a no-op so callers can uninstall idempotently.
 const uninstallManagedClaude = async (dataRoot: string): Promise<void> => {
   const root = dirname(managedClaudeDir(dataRoot))
-  const siblings = await readdir(dirname(root), { withFileTypes: true }).catch(() => [] as Dirent[])
-  const orphanCandidates = siblings
-    .filter((entry) => entry.isDirectory() && ORPHANED_CLAUDE_RUNTIME_PATTERN.test(entry.name))
-    .map((entry) => join(dirname(root), entry.name))
-  const ownedOrphans = (
-    await Promise.all(
-      orphanCandidates.map(async (path) => ((await isOwnedClaudeRuntime(path)) ? path : undefined))
-    )
-  ).filter((path): path is string => path !== undefined)
-  await Promise.all(
-    [root, ...ownedOrphans].map((path) =>
-      rm(path, { recursive: true, force: true }).catch(() => undefined)
-    )
-  )
+  await removeOwnedClaudeRuntimeSiblings(dataRoot, ORPHANED_CLAUDE_RUNTIME_PATTERN)
+  await rm(root, { recursive: true, force: true }).catch(() => undefined)
 }
 
 // ---- Registry metadata -----------------------------------------------------------------------------
@@ -518,6 +534,7 @@ const installManagedClaude = async ({
   const downloadDir = tmpDir ?? scratch
   let lastError = 'no registries configured'
 
+  await removeOwnedClaudeRuntimeSiblings(dataRoot, STAGED_CLAUDE_RUNTIME_PATTERN)
   try {
     await mkdir(scratch, { recursive: true })
     await writeFile(join(scratch, RUNTIME_OWNER_MARKER), CLAUDE_RUNTIME_OWNER)

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -119,10 +119,43 @@ const STAGED_CLAUDE_RUNTIME_PATTERN =
 const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
 const CLAUDE_RUNTIME_OWNER = 'open-science:claude-code:v1\n'
 
+const ensureClaudeRuntimeOwnerMarker = async (root: string): Promise<void> => {
+  const markerPath = join(root, RUNTIME_OWNER_MARKER)
+  const markerStats = await lstat(markerPath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return undefined
+    throw error
+  })
+
+  if (!markerStats) {
+    try {
+      await writeFile(markerPath, CLAUDE_RUNTIME_OWNER, { flag: 'wx' })
+      return
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        return ensureClaudeRuntimeOwnerMarker(root)
+      }
+      throw error
+    }
+  }
+
+  if (markerStats.isSymbolicLink()) {
+    throw new Error(`Refusing to use a symbolic-link ownership marker: ${markerPath}`)
+  }
+  if (!markerStats.isFile()) {
+    throw new Error(`Refusing to use a non-file ownership marker: ${markerPath}`)
+  }
+  if (markerStats.nlink > 1) {
+    throw new Error(`Refusing to use an ownership marker with multiple hard links: ${markerPath}`)
+  }
+  if ((await readFile(markerPath, 'utf8')) !== CLAUDE_RUNTIME_OWNER) {
+    throw new Error(`Refusing to replace an unrecognized ownership marker: ${markerPath}`)
+  }
+}
+
 const isOwnedClaudeRuntime = async (root: string): Promise<boolean> => {
   const markerPath = join(root, RUNTIME_OWNER_MARKER)
   const markerStats = await lstat(markerPath).catch(() => undefined)
-  if (!markerStats?.isFile()) return false
+  if (!markerStats?.isFile() || markerStats.nlink > 1) return false
   return (await readFile(markerPath, 'utf8').catch(() => undefined)) === CLAUDE_RUNTIME_OWNER
 }
 
@@ -491,16 +524,9 @@ const replaceManagedClaudeRoot = async (
   }
 
   await rejectSymbolicLink(root, 'the managed Claude runtime root')
-  await rejectSymbolicLink(
-    join(root, RUNTIME_OWNER_MARKER),
-    'the managed Claude runtime ownership marker'
-  )
-
-  try {
-    await writeFile(join(root, RUNTIME_OWNER_MARKER), CLAUDE_RUNTIME_OWNER)
-  } catch (error) {
+  await ensureClaudeRuntimeOwnerMarker(root).catch((error) => {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-  }
+  })
 
   try {
     await renamePath(root, backup)
@@ -556,7 +582,7 @@ const installManagedClaude = async ({
   await removeOwnedClaudeRuntimeSiblings(dataRoot, STAGED_CLAUDE_RUNTIME_PATTERN)
   try {
     await mkdir(scratch, { recursive: true })
-    await writeFile(join(scratch, RUNTIME_OWNER_MARKER), CLAUDE_RUNTIME_OWNER)
+    await ensureClaudeRuntimeOwnerMarker(scratch)
   } catch (error) {
     lastError = describeManagedInstallError(error)
     onEvent({
@@ -608,7 +634,7 @@ const installManagedClaude = async ({
             'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
           )
         }
-        await writeFile(join(stagedRoot, RUNTIME_OWNER_MARKER), CLAUDE_RUNTIME_OWNER)
+        await ensureClaudeRuntimeOwnerMarker(stagedRoot)
 
         reachedPublication = true
         await replaceManagedClaudeRoot(stagedRoot, root, renamePath)

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { createReadStream, createWriteStream, type Dirent } from 'node:fs'
-import { chmod, mkdir, readdir, rename, rm } from 'node:fs/promises'
+import { chmod, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -114,19 +114,30 @@ const isManagedClaudePath = (resolvedPath: string, dataRoot: string): boolean =>
 
 const ORPHANED_CLAUDE_RUNTIME_PATTERN =
   /^claude-code\.(?:staging|backup)-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
+const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
+const CLAUDE_RUNTIME_OWNER = 'open-science:claude-code:v1\n'
+
+const isOwnedClaudeRuntime = async (root: string): Promise<boolean> =>
+  (await readFile(join(root, RUNTIME_OWNER_MARKER), 'utf8').catch(() => undefined)) ===
+  CLAUDE_RUNTIME_OWNER
 
 // Removes the app-managed Claude install tree and exact installer-owned staging/backup siblings.
 // Resolves (never rejects); a missing dir is a no-op so callers can uninstall idempotently.
 const uninstallManagedClaude = async (dataRoot: string): Promise<void> => {
   const root = dirname(managedClaudeDir(dataRoot))
   const siblings = await readdir(dirname(root), { withFileTypes: true }).catch(() => [] as Dirent[])
+  const orphanCandidates = siblings
+    .filter((entry) => entry.isDirectory() && ORPHANED_CLAUDE_RUNTIME_PATTERN.test(entry.name))
+    .map((entry) => join(dirname(root), entry.name))
+  const ownedOrphans = (
+    await Promise.all(
+      orphanCandidates.map(async (path) => ((await isOwnedClaudeRuntime(path)) ? path : undefined))
+    )
+  ).filter((path): path is string => path !== undefined)
   await Promise.all(
-    [
-      root,
-      ...siblings
-        .filter((entry) => entry.isDirectory() && ORPHANED_CLAUDE_RUNTIME_PATTERN.test(entry.name))
-        .map((entry) => join(dirname(root), entry.name))
-    ].map((path) => rm(path, { recursive: true, force: true }).catch(() => undefined))
+    [root, ...ownedOrphans].map((path) =>
+      rm(path, { recursive: true, force: true }).catch(() => undefined)
+    )
   )
 }
 
@@ -451,6 +462,12 @@ const replaceManagedClaudeRoot = async (
   let backedUp = false
 
   try {
+    await writeFile(join(root, RUNTIME_OWNER_MARKER), CLAUDE_RUNTIME_OWNER)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  try {
     await renamePath(root, backup)
     backedUp = true
   } catch (error) {
@@ -501,7 +518,19 @@ const installManagedClaude = async ({
   const downloadDir = tmpDir ?? scratch
   let lastError = 'no registries configured'
 
-  await mkdir(scratch, { recursive: true })
+  try {
+    await mkdir(scratch, { recursive: true })
+  } catch (error) {
+    lastError = describeManagedInstallError(error)
+    onEvent({
+      kind: 'log',
+      installId,
+      stream: 'system',
+      chunk: `Failed to prepare the Claude staging directory: ${lastError}\n`
+    })
+    await rm(scratch, { recursive: true, force: true }).catch(() => undefined)
+    return { result: { installId, ok: false, error: lastError } }
+  }
   try {
     for (const registry of registries) {
       const tgzPath = join(downloadDir, `claude-download-${randomUUID()}.tgz`)
@@ -542,6 +571,7 @@ const installManagedClaude = async ({
             'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
           )
         }
+        await writeFile(join(stagedRoot, RUNTIME_OWNER_MARKER), CLAUDE_RUNTIME_OWNER)
 
         reachedPublication = true
         await replaceManagedClaudeRoot(stagedRoot, root, renamePath)

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'node:crypto'
-import { createReadStream, createWriteStream } from 'node:fs'
-import { chmod, mkdir, rm } from 'node:fs/promises'
+import { createHash, randomUUID } from 'node:crypto'
+import { createReadStream, createWriteStream, type Dirent } from 'node:fs'
+import { chmod, mkdir, readdir, rename, rm } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -112,11 +112,21 @@ const managedClaudeDir = (dataRoot: string): string => join(dataRoot, 'claude-co
 const isManagedClaudePath = (resolvedPath: string, dataRoot: string): boolean =>
   resolve(dirname(resolvedPath)) === resolve(managedClaudeDir(dataRoot))
 
-// Removes the app-managed Claude install tree (the `claude-code` dir holding `bin/<binName>`).
+const ORPHANED_CLAUDE_RUNTIME_PATTERN =
+  /^claude-code\.(?:staging|backup)-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
+
+// Removes the app-managed Claude install tree and exact installer-owned staging/backup siblings.
 // Resolves (never rejects); a missing dir is a no-op so callers can uninstall idempotently.
 const uninstallManagedClaude = async (dataRoot: string): Promise<void> => {
-  await rm(dirname(managedClaudeDir(dataRoot)), { recursive: true, force: true }).catch(
-    () => undefined
+  const root = dirname(managedClaudeDir(dataRoot))
+  const siblings = await readdir(dirname(root), { withFileTypes: true }).catch(() => [] as Dirent[])
+  await Promise.all(
+    [
+      root,
+      ...siblings
+        .filter((entry) => entry.isDirectory() && ORPHANED_CLAUDE_RUNTIME_PATTERN.test(entry.name))
+        .map((entry) => join(dirname(root), entry.name))
+    ].map((path) => rm(path, { recursive: true, force: true }).catch(() => undefined))
   )
 }
 
@@ -407,6 +417,8 @@ export type InstallManagedClaudeOptions = {
   platform?: ManagedPlatform
   fetchJson?: FetchJson
   fetchTarball?: FetchTarball
+  verifyBinary: (binPath: string) => Promise<string | undefined>
+  renamePath?: typeof rename
   tmpDir?: string
 }
 
@@ -430,6 +442,42 @@ const describeManagedInstallError = (error: unknown): string => {
   return message
 }
 
+const replaceManagedClaudeRoot = async (
+  stagedRoot: string,
+  root: string,
+  renamePath: typeof rename
+): Promise<void> => {
+  const backup = `${root}.backup-${randomUUID()}`
+  let backedUp = false
+
+  try {
+    await renamePath(root, backup)
+    backedUp = true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  try {
+    await renamePath(stagedRoot, root)
+  } catch (swapError) {
+    if (backedUp) {
+      try {
+        await renamePath(backup, root)
+      } catch (restoreError) {
+        const swapMessage = swapError instanceof Error ? swapError.message : String(swapError)
+        const restoreMessage =
+          restoreError instanceof Error ? restoreError.message : String(restoreError)
+        throw new Error(
+          `Claude runtime swap failed: ${swapMessage}. The previous runtime remains at ${backup} because restore failed: ${restoreMessage}.`
+        )
+      }
+    }
+    throw swapError
+  }
+
+  if (backedUp) await rm(backup, { recursive: true, force: true }).catch(() => undefined)
+}
+
 // Downloads + installs the managed Claude binary, trying each registry in order. Streams progress via
 // `onEvent` and resolves (never rejects) with a structured outcome the service can persist.
 const installManagedClaude = async ({
@@ -441,77 +489,101 @@ const installManagedClaude = async ({
   platform = getManagedPlatform(),
   fetchJson = defaultFetchJson,
   fetchTarball = defaultFetchTarball,
+  verifyBinary,
+  renamePath = rename,
   tmpDir
 }: InstallManagedClaudeOptions): Promise<ManagedInstallOutcome> => {
-  const destPath = join(managedClaudeDir(dataRoot), platform.binName)
-  const scratch = tmpDir ?? managedClaudeDir(dataRoot)
+  const root = dirname(managedClaudeDir(dataRoot))
+  const destPath = join(root, 'bin', platform.binName)
+  const scratch = `${root}.staging-${randomUUID()}`
+  const stagedRoot = join(scratch, 'runtime')
+  const stagedPath = join(stagedRoot, 'bin', platform.binName)
+  const downloadDir = tmpDir ?? scratch
   let lastError = 'no registries configured'
 
-  for (const registry of registries) {
-    const tgzPath = join(scratch, `claude-download-${Date.now()}.tgz`)
+  await mkdir(scratch, { recursive: true })
+  try {
+    for (const registry of registries) {
+      const tgzPath = join(downloadDir, `claude-download-${randomUUID()}.tgz`)
+      let reachedPublication = false
 
-    try {
-      onEvent({ kind: 'progress', installId, phase: 'resolving' })
-      onEvent({
-        kind: 'log',
-        installId,
-        stream: 'system',
-        chunk: `Resolving Claude from ${registry} …\n`
-      })
-      const resolution = await resolveNativePackage({ registry, platform, version, fetchJson })
+      try {
+        await rm(stagedRoot, { recursive: true, force: true })
+        onEvent({ kind: 'progress', installId, phase: 'resolving' })
+        onEvent({
+          kind: 'log',
+          installId,
+          stream: 'system',
+          chunk: `Resolving Claude from ${registry} …\n`
+        })
+        const resolution = await resolveNativePackage({ registry, platform, version, fetchJson })
 
-      await downloadAndVerify({
-        url: resolution.tarball,
-        integrity: resolution.integrity,
-        destPath: tgzPath,
-        installId,
-        onEvent,
-        fetchTarball
-      })
+        await downloadAndVerify({
+          url: resolution.tarball,
+          integrity: resolution.integrity,
+          destPath: tgzPath,
+          installId,
+          onEvent,
+          fetchTarball
+        })
 
-      onEvent({ kind: 'progress', installId, phase: 'extracting' })
-      const found = await extractFileFromTgz({
-        tgzPath,
-        entryName: `package/${platform.binName}`,
-        destPath
-      })
+        onEvent({ kind: 'progress', installId, phase: 'extracting' })
+        const found = await extractFileFromTgz({
+          tgzPath,
+          entryName: `package/${platform.binName}`,
+          destPath: stagedPath
+        })
 
-      if (!found) throw new Error(`Native package did not contain ${platform.binName}`)
-      if (process.platform !== 'win32') await chmod(destPath, 0o755)
+        if (!found) throw new Error(`Native package did not contain ${platform.binName}`)
+        if (process.platform !== 'win32') await chmod(stagedPath, 0o755)
+        const installedVersion = await verifyBinary(stagedPath)
+        if (!installedVersion) {
+          throw new Error(
+            'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
+          )
+        }
 
-      onEvent({
-        kind: 'log',
-        installId,
-        stream: 'system',
-        chunk: `Installed Claude ${resolution.version}.\n`
-      })
+        reachedPublication = true
+        await replaceManagedClaudeRoot(stagedRoot, root, renamePath)
 
-      return {
-        result: { installId, ok: true },
-        resolvedPath: destPath,
-        version: resolution.version
+        onEvent({
+          kind: 'log',
+          installId,
+          stream: 'system',
+          chunk: `Installed Claude ${resolution.version}.\n`
+        })
+
+        return {
+          result: { installId, ok: true },
+          resolvedPath: destPath,
+          version: resolution.version
+        }
+      } catch (error) {
+        lastError = describeManagedInstallError(error)
+        onEvent({
+          kind: 'log',
+          installId,
+          stream: 'system',
+          chunk: `${registry} failed: ${lastError}\n`
+        })
+        if (reachedPublication) return { result: { installId, ok: false, error: lastError } }
+      } finally {
+        await rm(tgzPath, { force: true }).catch(() => undefined)
       }
-    } catch (error) {
-      lastError = describeManagedInstallError(error)
-      onEvent({
-        kind: 'log',
-        installId,
-        stream: 'system',
-        chunk: `${registry} failed: ${lastError}\n`
-      })
-    } finally {
-      await rm(tgzPath, { force: true }).catch(() => undefined)
     }
+
+    onEvent({
+      kind: 'log',
+      installId,
+      stream: 'system',
+      chunk:
+        'Automatic setup stopped. Correct the error above and install again. No candidate runtime was published.\n'
+    })
+
+    return { result: { installId, ok: false, error: lastError } }
+  } finally {
+    await rm(scratch, { recursive: true, force: true }).catch(() => undefined)
   }
-
-  onEvent({
-    kind: 'log',
-    installId,
-    stream: 'system',
-    chunk: `Automatic setup stopped. Correct the error above and install again. If an installation was interrupted, remove the incomplete runtime at ${destPath} before retrying.\n`
-  })
-
-  return { result: { installId, ok: false, error: lastError } }
 }
 
 // ---- Default Electron transport (Session-proxy-aware) ---------------------------------------------

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -119,9 +119,12 @@ const STAGED_CLAUDE_RUNTIME_PATTERN =
 const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
 const CLAUDE_RUNTIME_OWNER = 'open-science:claude-code:v1\n'
 
-const isOwnedClaudeRuntime = async (root: string): Promise<boolean> =>
-  (await readFile(join(root, RUNTIME_OWNER_MARKER), 'utf8').catch(() => undefined)) ===
-  CLAUDE_RUNTIME_OWNER
+const isOwnedClaudeRuntime = async (root: string): Promise<boolean> => {
+  const markerPath = join(root, RUNTIME_OWNER_MARKER)
+  const markerStats = await lstat(markerPath).catch(() => undefined)
+  if (!markerStats?.isFile()) return false
+  return (await readFile(markerPath, 'utf8').catch(() => undefined)) === CLAUDE_RUNTIME_OWNER
+}
 
 const findOwnedClaudeRuntimeSiblings = async (
   dataRoot: string,

--- a/src/main/settings/managed-claude.ts
+++ b/src/main/settings/managed-claude.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { createReadStream, createWriteStream, type Dirent } from 'node:fs'
-import { chmod, lstat, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { constants, createReadStream, createWriteStream, type Dirent, type Stats } from 'node:fs'
+import { chmod, lstat, mkdir, open, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -118,6 +118,29 @@ const STAGED_CLAUDE_RUNTIME_PATTERN =
   /^claude-code\.staging-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
 const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
 const CLAUDE_RUNTIME_OWNER = 'open-science:claude-code:v1\n'
+const NO_FOLLOW_OPEN_FLAG = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
+
+const readClaudeRuntimeOwnerMarker = async (
+  markerPath: string,
+  pathStats: Stats
+): Promise<string> => {
+  const marker = await open(markerPath, constants.O_RDONLY | NO_FOLLOW_OPEN_FLAG)
+  try {
+    const markerStats = await marker.stat()
+    if (markerStats.dev !== pathStats.dev || markerStats.ino !== pathStats.ino) {
+      throw new Error(`Refusing to use a changed ownership marker: ${markerPath}`)
+    }
+    if (!markerStats.isFile()) {
+      throw new Error(`Refusing to use a non-file ownership marker: ${markerPath}`)
+    }
+    if (markerStats.nlink > 1) {
+      throw new Error(`Refusing to use an ownership marker with multiple hard links: ${markerPath}`)
+    }
+    return await marker.readFile('utf8')
+  } finally {
+    await marker.close()
+  }
+}
 
 const ensureClaudeRuntimeOwnerMarker = async (root: string): Promise<void> => {
   const markerPath = join(root, RUNTIME_OWNER_MARKER)
@@ -147,7 +170,7 @@ const ensureClaudeRuntimeOwnerMarker = async (root: string): Promise<void> => {
   if (markerStats.nlink > 1) {
     throw new Error(`Refusing to use an ownership marker with multiple hard links: ${markerPath}`)
   }
-  if ((await readFile(markerPath, 'utf8')) !== CLAUDE_RUNTIME_OWNER) {
+  if ((await readClaudeRuntimeOwnerMarker(markerPath, markerStats)) !== CLAUDE_RUNTIME_OWNER) {
     throw new Error(`Refusing to replace an unrecognized ownership marker: ${markerPath}`)
   }
 }
@@ -156,7 +179,10 @@ const isOwnedClaudeRuntime = async (root: string): Promise<boolean> => {
   const markerPath = join(root, RUNTIME_OWNER_MARKER)
   const markerStats = await lstat(markerPath).catch(() => undefined)
   if (!markerStats?.isFile() || markerStats.nlink > 1) return false
-  return (await readFile(markerPath, 'utf8').catch(() => undefined)) === CLAUDE_RUNTIME_OWNER
+  return (
+    (await readClaudeRuntimeOwnerMarker(markerPath, markerStats).catch(() => undefined)) ===
+    CLAUDE_RUNTIME_OWNER
+  )
 }
 
 const findOwnedClaudeRuntimeSiblings = async (

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -231,6 +231,17 @@ describe('installManagedOpencode', () => {
 
     let verifiedContent: string | undefined
     let finalContentDuringVerification: string | undefined
+    let stagingOwner: string | undefined
+    const renamePath = async (...args: Parameters<typeof rename>): Promise<void> => {
+      const [source] = args
+      if (String(source).includes('.staging-')) {
+        stagingOwner = await readFile(
+          join(dirname(String(source)), '.open-science-managed-runtime'),
+          'utf8'
+        )
+      }
+      await rename(...args)
+    }
     const outcome = await installManagedOpencode({
       installId: 'i4',
       onEvent: () => undefined,
@@ -244,10 +255,12 @@ describe('installManagedOpencode', () => {
         finalContentDuringVerification = readFileSync(finalPath, 'utf8')
         return { ok: true }
       },
-      tmpDir: root
+      tmpDir: root,
+      renamePath
     })
 
     expect(outcome.result.ok).toBe(true)
+    expect(stagingOwner).toBe('open-science:opencode:v1\n')
     expect(outcome.resolvedPath).toBe(finalPath)
     expect(verifiedContent).toContain('echo opencode')
     expect(finalContentDuringVerification).toBe('WORKING-OPENCODE')

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { readFileSync } from 'node:fs'
+import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { Readable } from 'node:stream'
 import { gzipSync } from 'node:zlib'
 
@@ -131,8 +132,11 @@ describe('installManagedOpencode', () => {
 
   // A downloaded package that extracts cleanly but cannot run on this CPU (e.g. SIGILL on a non-AVX2
   // x64 host) must fail the install, not persist a broken path.
-  it('fails cleanly and removes the binary when the smoke check reports it cannot run', async () => {
+  it('preserves the existing runtime when the replacement fails its smoke check', async () => {
     root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const existingPath = join(managedOpencodeDir(root), 'opencode')
+    await mkdir(managedOpencodeDir(root), { recursive: true })
+    await writeFile(existingPath, 'WORKING-OPENCODE')
     const tgz = buildTgz([
       { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho opencode\n') }
     ])
@@ -165,12 +169,52 @@ describe('installManagedOpencode', () => {
     // Actionable error mentioning the failed probe and the likely AVX2 cause.
     expect(outcome.result.error).toMatch(/failed to run/)
     expect(outcome.result.error).toMatch(/AVX2/)
-    // The unusable binary is not left on disk.
-    await expect(readFile(join(managedOpencodeDir(root), 'opencode'))).rejects.toThrow()
+    expect(await readFile(existingPath, 'utf8')).toBe('WORKING-OPENCODE')
+  })
+
+  it('restores the existing runtime when publication fails', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const existingPath = join(managedOpencodeDir(root), 'opencode')
+    const managedRoot = dirname(managedOpencodeDir(root))
+    await mkdir(managedOpencodeDir(root), { recursive: true })
+    await writeFile(existingPath, 'WORKING-OPENCODE')
+    const tgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho replacement\n') }
+    ])
+    const renamePath = vi.fn(async (...args: Parameters<typeof rename>) => {
+      const [source, destination] = args
+      if (String(source).includes('.staging-') && String(destination) === managedRoot) {
+        throw new Error('swap failed')
+      }
+      await rename(source, destination)
+    })
+
+    const outcome = await installManagedOpencode({
+      installId: 'restore-existing',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson: async (url) =>
+        url.endsWith('/opencode-ai')
+          ? { 'dist-tags': { latest: '1.18.3' } }
+          : { dist: { tarball: 'https://reg/opencode.tgz', integrity: sha512(tgz) } },
+      fetchTarball: async () => ({ stream: Readable.from(tgz), totalBytes: tgz.length }),
+      verifyBinary: () => ({ ok: true }),
+      tmpDir: root,
+      renamePath
+    })
+
+    expect(outcome.result).toMatchObject({ ok: false, error: 'swap failed' })
+    expect(await readFile(existingPath, 'utf8')).toBe('WORKING-OPENCODE')
+    expect((await readdir(root)).filter((name) => name.includes('.backup-'))).toEqual([])
   })
 
   it('succeeds when the smoke check confirms the binary runs', async () => {
     root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const finalPath = join(managedOpencodeDir(root), 'opencode')
+    await mkdir(managedOpencodeDir(root), { recursive: true })
+    await writeFile(finalPath, 'WORKING-OPENCODE')
     const tgz = buildTgz([
       { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho opencode\n') }
     ])
@@ -185,7 +229,8 @@ describe('installManagedOpencode', () => {
       totalBytes?: number
     }> => ({ stream: Readable.from(tgz), totalBytes: tgz.length })
 
-    let verifiedPath: string | undefined
+    let verifiedContent: string | undefined
+    let finalContentDuringVerification: string | undefined
     const outcome = await installManagedOpencode({
       installId: 'i4',
       onEvent: () => undefined,
@@ -195,16 +240,17 @@ describe('installManagedOpencode', () => {
       fetchJson,
       fetchTarball,
       verifyBinary: (binPath) => {
-        verifiedPath = binPath
+        verifiedContent = readFileSync(binPath, 'utf8')
+        finalContentDuringVerification = readFileSync(finalPath, 'utf8')
         return { ok: true }
       },
       tmpDir: root
     })
 
     expect(outcome.result.ok).toBe(true)
-    expect(outcome.resolvedPath).toBe(join(managedOpencodeDir(root), 'opencode'))
-    // The verifier is handed the installed binary path.
-    expect(verifiedPath).toBe(join(managedOpencodeDir(root), 'opencode'))
+    expect(outcome.resolvedPath).toBe(finalPath)
+    expect(verifiedContent).toContain('echo opencode')
+    expect(finalContentDuringVerification).toBe('WORKING-OPENCODE')
   })
 
   // A non-AVX2 x64 host: the standard build dies with SIGILL, so the installer retries the -baseline
@@ -694,6 +740,23 @@ describe('isManagedOpencodePath / uninstallManagedOpencode', () => {
 
     await expect(readFile(bin)).rejects.toThrow()
     await expect(readFile(join(root, 'opencode-managed', 'bin', 'opencode'))).rejects.toThrow()
+  })
+
+  it('removes only owned staging and backup siblings', async () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc'
+    const stagingMarker = join(root, `opencode-managed.staging-${uuid}`, 'marker')
+    const backupMarker = join(root, `opencode-managed.backup-${uuid}`, 'marker')
+    const lookalikeMarker = join(root, 'opencode-managed.backup-manual', 'marker')
+    for (const marker of [stagingMarker, backupMarker, lookalikeMarker]) {
+      await mkdir(dirname(marker), { recursive: true })
+      await writeFile(marker, 'present')
+    }
+
+    await uninstallManagedOpencode(root)
+
+    await expect(readFile(stagingMarker)).rejects.toThrow()
+    await expect(readFile(backupMarker)).rejects.toThrow()
+    await expect(readFile(lookalikeMarker, 'utf8')).resolves.toBe('present')
   })
 
   it('is a no-op (never rejects) when nothing is installed', async () => {

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -19,6 +19,23 @@ import { gzipSync } from 'node:zlib'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { nonRegularMarkerPaths } = vi.hoisted(() => ({
+  nonRegularMarkerPaths: new Set<string>()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    lstat: async (path: string) =>
+      nonRegularMarkerPaths.has(String(path))
+        ? ({ isFile: () => false } as Awaited<ReturnType<typeof actual.lstat>>)
+        : actual.lstat(path)
+  }
+})
+
+afterEach(() => nonRegularMarkerPaths.clear())
+
 import {
   classifyVerifyResult,
   defaultVerifyBinary,
@@ -859,6 +876,23 @@ describe('isManagedOpencodePath / uninstallManagedOpencode', () => {
     await expect(readFile(backupMarker)).rejects.toThrow()
     await expect(readFile(unownedMarker, 'utf8')).resolves.toBe('present')
     await expect(readFile(lookalikeMarker, 'utf8')).resolves.toBe('present')
+  })
+
+  it('preserves an orphan whose ownership marker is a symbolic link', async () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc'
+    const orphanRoot = join(root, `opencode-managed.backup-${uuid}`)
+    const orphanPayload = join(orphanRoot, 'user-data')
+    const ownerMarker = join(orphanRoot, '.open-science-managed-runtime')
+    await mkdir(orphanRoot, { recursive: true })
+    await writeFile(orphanPayload, 'present')
+    await writeFile(ownerMarker, 'open-science:opencode:v1\n')
+    // Windows CI cannot create file symlinks without extra privileges. Model the no-follow lstat
+    // result at the filesystem boundary while retaining real directory and read/remove behavior.
+    nonRegularMarkerPaths.add(ownerMarker)
+
+    await uninstallManagedOpencode(root)
+
+    await expect(readFile(orphanPayload, 'utf8')).resolves.toBe('present')
   })
 
   it('is a no-op (never rejects) when nothing is installed', async () => {

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -213,8 +213,19 @@ describe('installManagedOpencode', () => {
   it('succeeds when the smoke check confirms the binary runs', async () => {
     root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
     const finalPath = join(managedOpencodeDir(root), 'opencode')
+    const interruptedStaging = join(
+      root,
+      'opencode-managed.staging-12345678-1234-1234-1234-123456789abc'
+    )
+    const interruptedPayload = join(interruptedStaging, 'partial-download')
     await mkdir(managedOpencodeDir(root), { recursive: true })
     await writeFile(finalPath, 'WORKING-OPENCODE')
+    await mkdir(interruptedStaging, { recursive: true })
+    await writeFile(
+      join(interruptedStaging, '.open-science-managed-runtime'),
+      'open-science:opencode:v1\n'
+    )
+    await writeFile(interruptedPayload, 'partial')
     const tgz = buildTgz([
       { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho opencode\n') }
     ])
@@ -261,6 +272,7 @@ describe('installManagedOpencode', () => {
 
     expect(outcome.result.ok).toBe(true)
     expect(stagingOwner).toBe('open-science:opencode:v1\n')
+    await expect(readFile(interruptedPayload)).rejects.toThrow()
     expect(outcome.resolvedPath).toBe(finalPath)
     expect(verifiedContent).toContain('echo opencode')
     expect(finalContentDuringVerification).toBe('WORKING-OPENCODE')

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -1,7 +1,17 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
-import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { Readable } from 'node:stream'
@@ -170,6 +180,40 @@ describe('installManagedOpencode', () => {
     expect(outcome.result.error).toMatch(/failed to run/)
     expect(outcome.result.error).toMatch(/AVX2/)
     expect(await readFile(existingPath, 'utf8')).toBe('WORKING-OPENCODE')
+  })
+
+  it('rejects a symlinked runtime root without modifying its target', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const externalRoot = join(root, 'external-opencode')
+    const externalMarker = join(externalRoot, '.open-science-managed-runtime')
+    const managedRoot = dirname(managedOpencodeDir(root))
+    await mkdir(externalRoot, { recursive: true })
+    await writeFile(externalMarker, 'EXTERNAL-DATA')
+    await symlink(externalRoot, managedRoot, process.platform === 'win32' ? 'junction' : 'dir')
+    const tgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho replacement\n') }
+    ])
+
+    const outcome = await installManagedOpencode({
+      installId: 'reject-symlinked-root',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson: async (url) =>
+        url.endsWith('/opencode-ai')
+          ? { 'dist-tags': { latest: '1.18.3' } }
+          : { dist: { tarball: 'https://reg/opencode.tgz', integrity: sha512(tgz) } },
+      fetchTarball: async () => ({ stream: Readable.from(tgz), totalBytes: tgz.length }),
+      verifyBinary: () => ({ ok: true }),
+      tmpDir: root
+    })
+
+    expect(await readFile(externalMarker, 'utf8')).toBe('EXTERNAL-DATA')
+    expect(outcome.result).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/symbolic link/i)
+    })
   })
 
   it('restores the existing runtime when publication fails', async () => {

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import {
   chmod,
+  link,
   mkdir,
   mkdtemp,
   readFile,
@@ -230,6 +231,39 @@ describe('installManagedOpencode', () => {
     expect(outcome.result).toMatchObject({
       ok: false,
       error: expect.stringMatching(/symbolic link/i)
+    })
+  })
+
+  it('rejects a hard-linked ownership marker without modifying its external inode', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const externalMarker = join(root, 'external-opencode-marker')
+    const managedRoot = dirname(managedOpencodeDir(root))
+    await mkdir(managedOpencodeDir(root), { recursive: true })
+    await writeFile(externalMarker, 'EXTERNAL-DATA')
+    await link(externalMarker, join(managedRoot, '.open-science-managed-runtime'))
+    const tgz = buildTgz([
+      { name: 'package/bin/opencode', content: Buffer.from('#!/bin/sh\necho replacement\n') }
+    ])
+
+    const outcome = await installManagedOpencode({
+      installId: 'reject-hard-linked-marker',
+      onEvent: () => undefined,
+      dataRoot: root,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson: async (url) =>
+        url.endsWith('/opencode-ai')
+          ? { 'dist-tags': { latest: '1.18.3' } }
+          : { dist: { tarball: 'https://reg/opencode.tgz', integrity: sha512(tgz) } },
+      fetchTarball: async () => ({ stream: Readable.from(tgz), totalBytes: tgz.length }),
+      verifyBinary: () => ({ ok: true }),
+      tmpDir: root
+    })
+
+    expect(await readFile(externalMarker, 'utf8')).toBe('EXTERNAL-DATA')
+    expect(outcome.result).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/hard link/i)
     })
   })
 
@@ -889,6 +923,21 @@ describe('isManagedOpencodePath / uninstallManagedOpencode', () => {
     // Windows CI cannot create file symlinks without extra privileges. Model the no-follow lstat
     // result at the filesystem boundary while retaining real directory and read/remove behavior.
     nonRegularMarkerPaths.add(ownerMarker)
+
+    await uninstallManagedOpencode(root)
+
+    await expect(readFile(orphanPayload, 'utf8')).resolves.toBe('present')
+  })
+
+  it('preserves an orphan whose ownership marker has multiple hard links', async () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc'
+    const orphanRoot = join(root, `opencode-managed.backup-${uuid}`)
+    const orphanPayload = join(orphanRoot, 'user-data')
+    const externalMarker = join(root, 'external-owner-marker')
+    await mkdir(orphanRoot, { recursive: true })
+    await writeFile(orphanPayload, 'present')
+    await writeFile(externalMarker, 'open-science:opencode:v1\n')
+    await link(externalMarker, join(orphanRoot, '.open-science-managed-runtime'))
 
     await uninstallManagedOpencode(root)
 

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -253,6 +253,30 @@ describe('installManagedOpencode', () => {
     expect(finalContentDuringVerification).toBe('WORKING-OPENCODE')
   })
 
+  it('returns a structured failure when the staging directory cannot be created', async () => {
+    root = await mkdtemp(join(tmpdir(), 'managed-opencode-'))
+    const blockedDataRoot = join(root, 'blocked-data-root')
+    const logs: string[] = []
+    await writeFile(blockedDataRoot, 'not a directory')
+
+    const outcome = await installManagedOpencode({
+      installId: 'staging-setup-failure',
+      onEvent: (event) => {
+        if (event.kind === 'log') logs.push(event.chunk)
+      },
+      dataRoot: blockedDataRoot,
+      registries: ['https://reg'],
+      platform: { key: 'darwin-arm64', binName: 'opencode' },
+      fetchJson: async () => {
+        throw new Error('registry should not be reached')
+      },
+      fetchTarball: async () => ({ stream: Readable.from([]) })
+    })
+
+    expect(outcome.result).toMatchObject({ ok: false, error: expect.stringContaining('ENOTDIR') })
+    expect(logs.some((chunk) => /ENOTDIR/.test(chunk))).toBe(true)
+  })
+
   // A non-AVX2 x64 host: the standard build dies with SIGILL, so the installer retries the -baseline
   // variant, which runs cleanly. This is what makes the onboarding "auto-installable" claim hold.
   it('retries the -baseline variant when the standard x64 build reports SIGILL, then succeeds', async () => {
@@ -744,18 +768,27 @@ describe('isManagedOpencodePath / uninstallManagedOpencode', () => {
 
   it('removes only owned staging and backup siblings', async () => {
     const uuid = '12345678-1234-1234-1234-123456789abc'
+    const unownedUuid = 'abcdefab-cdef-abcd-efab-cdefabcdefab'
     const stagingMarker = join(root, `opencode-managed.staging-${uuid}`, 'marker')
     const backupMarker = join(root, `opencode-managed.backup-${uuid}`, 'marker')
+    const unownedMarker = join(root, `opencode-managed.backup-${unownedUuid}`, 'marker')
     const lookalikeMarker = join(root, 'opencode-managed.backup-manual', 'marker')
-    for (const marker of [stagingMarker, backupMarker, lookalikeMarker]) {
+    for (const marker of [stagingMarker, backupMarker, unownedMarker, lookalikeMarker]) {
       await mkdir(dirname(marker), { recursive: true })
       await writeFile(marker, 'present')
+    }
+    for (const ownedRoot of [dirname(stagingMarker), dirname(backupMarker)]) {
+      await writeFile(
+        join(ownedRoot, '.open-science-managed-runtime'),
+        'open-science:opencode:v1\n'
+      )
     }
 
     await uninstallManagedOpencode(root)
 
     await expect(readFile(stagingMarker)).rejects.toThrow()
     await expect(readFile(backupMarker)).rejects.toThrow()
+    await expect(readFile(unownedMarker, 'utf8')).resolves.toBe('present')
     await expect(readFile(lookalikeMarker, 'utf8')).resolves.toBe('present')
   })
 

--- a/src/main/settings/managed-opencode.test.ts
+++ b/src/main/settings/managed-opencode.test.ts
@@ -20,8 +20,9 @@ import { gzipSync } from 'node:zlib'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { nonRegularMarkerPaths } = vi.hoisted(() => ({
-  nonRegularMarkerPaths: new Set<string>()
+const { nonRegularMarkerPaths, markerReplacementsOnRead } = vi.hoisted(() => ({
+  nonRegularMarkerPaths: new Set<string>(),
+  markerReplacementsOnRead: new Map<string, string>()
 }))
 
 vi.mock('node:fs/promises', async (importOriginal) => {
@@ -31,11 +32,26 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     lstat: async (path: string) =>
       nonRegularMarkerPaths.has(String(path))
         ? ({ isFile: () => false } as Awaited<ReturnType<typeof actual.lstat>>)
-        : actual.lstat(path)
+        : actual.lstat(path),
+    readFile: async (...args: Parameters<typeof actual.readFile>) => {
+      const path = String(args[0])
+      const replacement = markerReplacementsOnRead.get(path)
+      if (replacement !== undefined) {
+        markerReplacementsOnRead.delete(path)
+        const replacementPath = `${path}.replacement`
+        await actual.writeFile(replacementPath, replacement, { flag: 'wx' })
+        await actual.rm(path)
+        await actual.rename(replacementPath, path)
+      }
+      return actual.readFile(...args)
+    }
   }
 })
 
-afterEach(() => nonRegularMarkerPaths.clear())
+afterEach(() => {
+  nonRegularMarkerPaths.clear()
+  markerReplacementsOnRead.clear()
+})
 
 import {
   classifyVerifyResult,
@@ -938,6 +954,21 @@ describe('isManagedOpencodePath / uninstallManagedOpencode', () => {
     await writeFile(orphanPayload, 'present')
     await writeFile(externalMarker, 'open-science:opencode:v1\n')
     await link(externalMarker, join(orphanRoot, '.open-science-managed-runtime'))
+
+    await uninstallManagedOpencode(root)
+
+    await expect(readFile(orphanPayload, 'utf8')).resolves.toBe('present')
+  })
+
+  it('preserves an orphan when its ownership marker changes after metadata validation', async () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc'
+    const orphanRoot = join(root, `opencode-managed.backup-${uuid}`)
+    const orphanPayload = join(orphanRoot, 'user-data')
+    const ownerMarker = join(orphanRoot, '.open-science-managed-runtime')
+    await mkdir(orphanRoot, { recursive: true })
+    await writeFile(orphanPayload, 'present')
+    await writeFile(ownerMarker, 'unowned\n')
+    markerReplacementsOnRead.set(ownerMarker, 'open-science:opencode:v1\n')
 
     await uninstallManagedOpencode(root)
 

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -1,7 +1,7 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { readFileSync, type Dirent } from 'node:fs'
-import { chmod, lstat, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { constants, readFileSync, type Dirent, type Stats } from 'node:fs'
+import { chmod, lstat, mkdir, open, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
@@ -174,6 +174,29 @@ const STAGED_OPENCODE_RUNTIME_PATTERN =
   /^opencode-managed\.staging-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
 const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
 const OPENCODE_RUNTIME_OWNER = 'open-science:opencode:v1\n'
+const NO_FOLLOW_OPEN_FLAG = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
+
+const readOpencodeRuntimeOwnerMarker = async (
+  markerPath: string,
+  pathStats: Stats
+): Promise<string> => {
+  const marker = await open(markerPath, constants.O_RDONLY | NO_FOLLOW_OPEN_FLAG)
+  try {
+    const markerStats = await marker.stat()
+    if (markerStats.dev !== pathStats.dev || markerStats.ino !== pathStats.ino) {
+      throw new Error(`Refusing to use a changed ownership marker: ${markerPath}`)
+    }
+    if (!markerStats.isFile()) {
+      throw new Error(`Refusing to use a non-file ownership marker: ${markerPath}`)
+    }
+    if (markerStats.nlink > 1) {
+      throw new Error(`Refusing to use an ownership marker with multiple hard links: ${markerPath}`)
+    }
+    return await marker.readFile('utf8')
+  } finally {
+    await marker.close()
+  }
+}
 
 const ensureOpencodeRuntimeOwnerMarker = async (root: string): Promise<void> => {
   const markerPath = join(root, RUNTIME_OWNER_MARKER)
@@ -203,7 +226,7 @@ const ensureOpencodeRuntimeOwnerMarker = async (root: string): Promise<void> => 
   if (markerStats.nlink > 1) {
     throw new Error(`Refusing to use an ownership marker with multiple hard links: ${markerPath}`)
   }
-  if ((await readFile(markerPath, 'utf8')) !== OPENCODE_RUNTIME_OWNER) {
+  if ((await readOpencodeRuntimeOwnerMarker(markerPath, markerStats)) !== OPENCODE_RUNTIME_OWNER) {
     throw new Error(`Refusing to replace an unrecognized ownership marker: ${markerPath}`)
   }
 }
@@ -212,7 +235,10 @@ const isOwnedOpencodeRuntime = async (root: string): Promise<boolean> => {
   const markerPath = join(root, RUNTIME_OWNER_MARKER)
   const markerStats = await lstat(markerPath).catch(() => undefined)
   if (!markerStats?.isFile() || markerStats.nlink > 1) return false
-  return (await readFile(markerPath, 'utf8').catch(() => undefined)) === OPENCODE_RUNTIME_OWNER
+  return (
+    (await readOpencodeRuntimeOwnerMarker(markerPath, markerStats).catch(() => undefined)) ===
+    OPENCODE_RUNTIME_OWNER
+  )
 }
 
 const findOwnedOpencodeRuntimeSiblings = async (

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -175,9 +175,12 @@ const STAGED_OPENCODE_RUNTIME_PATTERN =
 const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
 const OPENCODE_RUNTIME_OWNER = 'open-science:opencode:v1\n'
 
-const isOwnedOpencodeRuntime = async (root: string): Promise<boolean> =>
-  (await readFile(join(root, RUNTIME_OWNER_MARKER), 'utf8').catch(() => undefined)) ===
-  OPENCODE_RUNTIME_OWNER
+const isOwnedOpencodeRuntime = async (root: string): Promise<boolean> => {
+  const markerPath = join(root, RUNTIME_OWNER_MARKER)
+  const markerStats = await lstat(markerPath).catch(() => undefined)
+  if (!markerStats?.isFile()) return false
+  return (await readFile(markerPath, 'utf8').catch(() => undefined)) === OPENCODE_RUNTIME_OWNER
+}
 
 const findOwnedOpencodeRuntimeSiblings = async (
   dataRoot: string,

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -1,6 +1,7 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
-import { readFileSync } from 'node:fs'
-import { chmod, rm } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { readFileSync, type Dirent } from 'node:fs'
+import { chmod, mkdir, readdir, rename, rm } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
@@ -167,11 +168,23 @@ export const managedOpencodeDir = (dataRoot: string): string =>
 export const isManagedOpencodePath = (resolvedPath: string, dataRoot: string): boolean =>
   resolve(dirname(resolvedPath)) === resolve(managedOpencodeDir(dataRoot))
 
-// Removes the app-managed OpenCode install tree (the `opencode-managed` dir holding `bin/<binName>`).
+const ORPHANED_OPENCODE_RUNTIME_PATTERN =
+  /^opencode-managed\.(?:staging|backup)-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
+
+// Removes the app-managed OpenCode install tree and exact installer-owned staging/backup siblings.
 // Resolves (never rejects); a missing dir is a no-op so callers can uninstall idempotently.
 export const uninstallManagedOpencode = async (dataRoot: string): Promise<void> => {
-  await rm(dirname(managedOpencodeDir(dataRoot)), { recursive: true, force: true }).catch(
-    () => undefined
+  const root = dirname(managedOpencodeDir(dataRoot))
+  const siblings = await readdir(dirname(root), { withFileTypes: true }).catch(() => [] as Dirent[])
+  await Promise.all(
+    [
+      root,
+      ...siblings
+        .filter(
+          (entry) => entry.isDirectory() && ORPHANED_OPENCODE_RUNTIME_PATTERN.test(entry.name)
+        )
+        .map((entry) => join(dirname(root), entry.name))
+    ].map((path) => rm(path, { recursive: true, force: true }).catch(() => undefined))
   )
 }
 
@@ -284,6 +297,7 @@ export type InstallManagedOpencodeOptions = {
   fetchTarball?: FetchTarball
   verifyBinary?: VerifyBinary
   detectAvx2?: () => boolean
+  renamePath?: typeof rename
   tmpDir?: string
 }
 
@@ -293,6 +307,42 @@ export type InstallManagedOpencodeOptions = {
 type PackageAttempt =
   | { ok: true; version: string }
   | { ok: false; error: string; illegalInstruction: boolean; resolvedVersion: string }
+
+const replaceManagedOpencodeRoot = async (
+  stagedRoot: string,
+  root: string,
+  renamePath: typeof rename
+): Promise<void> => {
+  const backup = `${root}.backup-${randomUUID()}`
+  let backedUp = false
+
+  try {
+    await renamePath(root, backup)
+    backedUp = true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  try {
+    await renamePath(stagedRoot, root)
+  } catch (swapError) {
+    if (backedUp) {
+      try {
+        await renamePath(backup, root)
+      } catch (restoreError) {
+        const swapMessage = swapError instanceof Error ? swapError.message : String(swapError)
+        const restoreMessage =
+          restoreError instanceof Error ? restoreError.message : String(restoreError)
+        throw new Error(
+          `OpenCode runtime swap failed: ${swapMessage}. The previous runtime remains at ${backup} because restore failed: ${restoreMessage}.`
+        )
+      }
+    }
+    throw swapError
+  }
+
+  if (backedUp) await rm(backup, { recursive: true, force: true }).catch(() => undefined)
+}
 
 // Downloads + installs the managed opencode binary, trying each registry in order. Resolves (never
 // rejects) with a structured outcome the service can persist.
@@ -307,10 +357,15 @@ export const installManagedOpencode = async ({
   fetchTarball = defaultFetchTarball,
   verifyBinary = defaultVerifyBinary,
   detectAvx2: detectAvx2Dep = detectAvx2,
+  renamePath = rename,
   tmpDir
 }: InstallManagedOpencodeOptions): Promise<ManagedInstallOutcome> => {
-  const destPath = join(managedOpencodeDir(dataRoot), platform.binName)
-  const scratch = tmpDir ?? managedOpencodeDir(dataRoot)
+  const root = dirname(managedOpencodeDir(dataRoot))
+  const destPath = join(root, 'bin', platform.binName)
+  const scratch = `${root}.staging-${randomUUID()}`
+  const stagedRoot = join(scratch, 'runtime')
+  const stagedPath = join(stagedRoot, 'bin', platform.binName)
+  const downloadDir = tmpDir ?? scratch
   let lastError = 'no registries configured'
 
   // Downloads, extracts, and smoke-checks one package key. Throws on registry-level errors (so the
@@ -321,9 +376,10 @@ export const installManagedOpencode = async ({
     packageKey: string,
     pinnedVersion: string | undefined
   ): Promise<PackageAttempt> => {
-    const tgzPath = join(scratch, `opencode-download-${Date.now()}.tgz`)
+    const tgzPath = join(downloadDir, `opencode-download-${randomUUID()}.tgz`)
 
     try {
+      await rm(stagedRoot, { recursive: true, force: true })
       onEvent({ kind: 'progress', installId, phase: 'resolving' })
       onEvent({
         kind: 'log',
@@ -346,17 +402,16 @@ export const installManagedOpencode = async ({
       const found = await extractFileFromTgz({
         tgzPath,
         entryName: `package/bin/${platform.binName}`,
-        destPath
+        destPath: stagedPath
       })
 
       if (!found) throw new Error(`Native package did not contain bin/${platform.binName}`)
-      if (process.platform !== 'win32') await chmod(destPath, 0o755)
+      if (process.platform !== 'win32') await chmod(stagedPath, 0o755)
 
-      // Smoke-check the binary before reporting success — a clean download does not guarantee it runs
-      // on this CPU. Remove the unusable binary and report a soft failure so no broken path is persisted.
-      const verification = verifyBinary(destPath)
+      // Smoke-check the staged binary before reporting success — a clean download does not guarantee
+      // it runs on this CPU. Report a soft failure so no broken candidate is published.
+      const verification = verifyBinary(stagedPath)
       if (!verification.ok) {
-        await rm(destPath, { force: true }).catch(() => undefined)
         const illegalInstruction = verification.illegalInstruction
         const hint = illegalInstruction
           ? ' Your CPU may not support the required instruction set (AVX2).'
@@ -384,43 +439,54 @@ export const installManagedOpencode = async ({
   const preferBaseline = isX64 && !detectAvx2Dep()
   const firstKey = preferBaseline ? baselinePackageKey(platform.key) : platform.key
 
-  for (const registry of registries) {
-    try {
-      const first = await installFromPackage(registry, firstKey, version)
-      if (first.ok) {
-        onEvent({
-          kind: 'log',
-          installId,
-          stream: 'system',
-          chunk: `Installed OpenCode ${first.version}${preferBaseline ? ' (baseline)' : ''}.\n`
-        })
-        return {
-          result: { installId, ok: true },
-          resolvedPath: destPath,
-          version: first.version
+  await mkdir(scratch, { recursive: true })
+  try {
+    for (const registry of registries) {
+      let reachedPublication = false
+      try {
+        const first = await installFromPackage(registry, firstKey, version)
+        if (first.ok) {
+          reachedPublication = true
+          await replaceManagedOpencodeRoot(stagedRoot, root, renamePath)
+          onEvent({
+            kind: 'log',
+            installId,
+            stream: 'system',
+            chunk: `Installed OpenCode ${first.version}${preferBaseline ? ' (baseline)' : ''}.\n`
+          })
+          return {
+            result: { installId, ok: true },
+            resolvedPath: destPath,
+            version: first.version
+          }
         }
-      }
 
-      // The first build extracted but died on this CPU. If we did NOT already prefer baseline and this is
-      // an x64 host reporting an illegal instruction (SIGILL on POSIX, the NTSTATUS status on Windows),
-      // retry once with the `-baseline` variant so the onboarding "auto-installable" claim holds. Gating
-      // on `!preferBaseline` avoids building a double-`baseline` key when the first attempt already was
-      // baseline. If the baseline package is missing (404 at resolve) or also fails to run, surface the
-      // illegal-instruction/AVX2 diagnosis rather than crashing on an unverifiable package name.
-      if (!preferBaseline && first.illegalInstruction && isX64) {
-        onEvent({
-          kind: 'log',
-          installId,
-          stream: 'system',
-          chunk: 'Standard build is not runnable on this CPU; retrying the -baseline variant …\n'
-        })
-        try {
-          const baseline = await installFromPackage(
-            registry,
-            baselinePackageKey(platform.key),
-            first.resolvedVersion
-          )
-          if (baseline.ok) {
+        // The first build extracted but died on this CPU. If we did NOT already prefer baseline and this is
+        // an x64 host reporting an illegal instruction (SIGILL on POSIX, the NTSTATUS status on Windows),
+        // retry once with the `-baseline` variant so the onboarding "auto-installable" claim holds. Gating
+        // on `!preferBaseline` avoids building a double-`baseline` key when the first attempt already was
+        // baseline. If the baseline package is missing (404 at resolve) or also fails to run, surface the
+        // illegal-instruction/AVX2 diagnosis rather than crashing on an unverifiable package name.
+        if (!preferBaseline && first.illegalInstruction && isX64) {
+          onEvent({
+            kind: 'log',
+            installId,
+            stream: 'system',
+            chunk: 'Standard build is not runnable on this CPU; retrying the -baseline variant …\n'
+          })
+          let baseline: PackageAttempt | undefined
+          try {
+            baseline = await installFromPackage(
+              registry,
+              baselinePackageKey(platform.key),
+              first.resolvedVersion
+            )
+          } catch {
+            // Baseline unavailable (e.g. 404): fall through to the illegal-instruction/AVX2 error below.
+          }
+          if (baseline?.ok) {
+            reachedPublication = true
+            await replaceManagedOpencodeRoot(stagedRoot, root, renamePath)
             onEvent({
               kind: 'log',
               installId,
@@ -433,22 +499,23 @@ export const installManagedOpencode = async ({
               version: baseline.version
             }
           }
-        } catch {
-          // Baseline unavailable (e.g. 404): fall through to the illegal-instruction/AVX2 error below.
         }
+
+        throw new Error(first.error)
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error)
+        onEvent({
+          kind: 'log',
+          installId,
+          stream: 'system',
+          chunk: `${registry} failed: ${lastError}\n`
+        })
+        if (reachedPublication) return { result: { installId, ok: false, error: lastError } }
       }
-
-      throw new Error(first.error)
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error)
-      onEvent({
-        kind: 'log',
-        installId,
-        stream: 'system',
-        chunk: `${registry} failed: ${lastError}\n`
-      })
     }
-  }
 
-  return { result: { installId, ok: false, error: lastError } }
+    return { result: { installId, ok: false, error: lastError } }
+  } finally {
+    await rm(scratch, { recursive: true, force: true }).catch(() => undefined)
+  }
 }

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -459,6 +459,7 @@ export const installManagedOpencode = async ({
 
   try {
     await mkdir(scratch, { recursive: true })
+    await writeFile(join(scratch, RUNTIME_OWNER_MARKER), OPENCODE_RUNTIME_OWNER)
   } catch (error) {
     lastError = error instanceof Error ? error.message : String(error)
     onEvent({

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -1,7 +1,7 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { readFileSync, type Dirent } from 'node:fs'
-import { chmod, mkdir, readdir, rename, rm } from 'node:fs/promises'
+import { chmod, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
@@ -170,21 +170,32 @@ export const isManagedOpencodePath = (resolvedPath: string, dataRoot: string): b
 
 const ORPHANED_OPENCODE_RUNTIME_PATTERN =
   /^opencode-managed\.(?:staging|backup)-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
+const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
+const OPENCODE_RUNTIME_OWNER = 'open-science:opencode:v1\n'
+
+const isOwnedOpencodeRuntime = async (root: string): Promise<boolean> =>
+  (await readFile(join(root, RUNTIME_OWNER_MARKER), 'utf8').catch(() => undefined)) ===
+  OPENCODE_RUNTIME_OWNER
 
 // Removes the app-managed OpenCode install tree and exact installer-owned staging/backup siblings.
 // Resolves (never rejects); a missing dir is a no-op so callers can uninstall idempotently.
 export const uninstallManagedOpencode = async (dataRoot: string): Promise<void> => {
   const root = dirname(managedOpencodeDir(dataRoot))
   const siblings = await readdir(dirname(root), { withFileTypes: true }).catch(() => [] as Dirent[])
+  const orphanCandidates = siblings
+    .filter((entry) => entry.isDirectory() && ORPHANED_OPENCODE_RUNTIME_PATTERN.test(entry.name))
+    .map((entry) => join(dirname(root), entry.name))
+  const ownedOrphans = (
+    await Promise.all(
+      orphanCandidates.map(async (path) =>
+        (await isOwnedOpencodeRuntime(path)) ? path : undefined
+      )
+    )
+  ).filter((path): path is string => path !== undefined)
   await Promise.all(
-    [
-      root,
-      ...siblings
-        .filter(
-          (entry) => entry.isDirectory() && ORPHANED_OPENCODE_RUNTIME_PATTERN.test(entry.name)
-        )
-        .map((entry) => join(dirname(root), entry.name))
-    ].map((path) => rm(path, { recursive: true, force: true }).catch(() => undefined))
+    [root, ...ownedOrphans].map((path) =>
+      rm(path, { recursive: true, force: true }).catch(() => undefined)
+    )
   )
 }
 
@@ -317,6 +328,12 @@ const replaceManagedOpencodeRoot = async (
   let backedUp = false
 
   try {
+    await writeFile(join(root, RUNTIME_OWNER_MARKER), OPENCODE_RUNTIME_OWNER)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  try {
     await renamePath(root, backup)
     backedUp = true
   } catch (error) {
@@ -423,6 +440,7 @@ export const installManagedOpencode = async ({
           error: `OpenCode installed but failed to run (${verification.reason}).${hint}`
         }
       }
+      await writeFile(join(stagedRoot, RUNTIME_OWNER_MARKER), OPENCODE_RUNTIME_OWNER)
 
       return { ok: true, version: resolution.version }
     } finally {
@@ -439,7 +457,19 @@ export const installManagedOpencode = async ({
   const preferBaseline = isX64 && !detectAvx2Dep()
   const firstKey = preferBaseline ? baselinePackageKey(platform.key) : platform.key
 
-  await mkdir(scratch, { recursive: true })
+  try {
+    await mkdir(scratch, { recursive: true })
+  } catch (error) {
+    lastError = error instanceof Error ? error.message : String(error)
+    onEvent({
+      kind: 'log',
+      installId,
+      stream: 'system',
+      chunk: `Failed to prepare the OpenCode staging directory: ${lastError}\n`
+    })
+    await rm(scratch, { recursive: true, force: true }).catch(() => undefined)
+    return { result: { installId, ok: false, error: lastError } }
+  }
   try {
     for (const registry of registries) {
       let reachedPublication = false

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -175,10 +175,43 @@ const STAGED_OPENCODE_RUNTIME_PATTERN =
 const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
 const OPENCODE_RUNTIME_OWNER = 'open-science:opencode:v1\n'
 
+const ensureOpencodeRuntimeOwnerMarker = async (root: string): Promise<void> => {
+  const markerPath = join(root, RUNTIME_OWNER_MARKER)
+  const markerStats = await lstat(markerPath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return undefined
+    throw error
+  })
+
+  if (!markerStats) {
+    try {
+      await writeFile(markerPath, OPENCODE_RUNTIME_OWNER, { flag: 'wx' })
+      return
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        return ensureOpencodeRuntimeOwnerMarker(root)
+      }
+      throw error
+    }
+  }
+
+  if (markerStats.isSymbolicLink()) {
+    throw new Error(`Refusing to use a symbolic-link ownership marker: ${markerPath}`)
+  }
+  if (!markerStats.isFile()) {
+    throw new Error(`Refusing to use a non-file ownership marker: ${markerPath}`)
+  }
+  if (markerStats.nlink > 1) {
+    throw new Error(`Refusing to use an ownership marker with multiple hard links: ${markerPath}`)
+  }
+  if ((await readFile(markerPath, 'utf8')) !== OPENCODE_RUNTIME_OWNER) {
+    throw new Error(`Refusing to replace an unrecognized ownership marker: ${markerPath}`)
+  }
+}
+
 const isOwnedOpencodeRuntime = async (root: string): Promise<boolean> => {
   const markerPath = join(root, RUNTIME_OWNER_MARKER)
   const markerStats = await lstat(markerPath).catch(() => undefined)
-  if (!markerStats?.isFile()) return false
+  if (!markerStats?.isFile() || markerStats.nlink > 1) return false
   return (await readFile(markerPath, 'utf8').catch(() => undefined)) === OPENCODE_RUNTIME_OWNER
 }
 
@@ -355,16 +388,9 @@ const replaceManagedOpencodeRoot = async (
   }
 
   await rejectSymbolicLink(root, 'the managed OpenCode runtime root')
-  await rejectSymbolicLink(
-    join(root, RUNTIME_OWNER_MARKER),
-    'the managed OpenCode runtime ownership marker'
-  )
-
-  try {
-    await writeFile(join(root, RUNTIME_OWNER_MARKER), OPENCODE_RUNTIME_OWNER)
-  } catch (error) {
+  await ensureOpencodeRuntimeOwnerMarker(root).catch((error) => {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-  }
+  })
 
   try {
     await renamePath(root, backup)
@@ -473,7 +499,7 @@ export const installManagedOpencode = async ({
           error: `OpenCode installed but failed to run (${verification.reason}).${hint}`
         }
       }
-      await writeFile(join(stagedRoot, RUNTIME_OWNER_MARKER), OPENCODE_RUNTIME_OWNER)
+      await ensureOpencodeRuntimeOwnerMarker(stagedRoot)
 
       return { ok: true, version: resolution.version }
     } finally {
@@ -493,7 +519,7 @@ export const installManagedOpencode = async ({
   await removeOwnedOpencodeRuntimeSiblings(dataRoot, STAGED_OPENCODE_RUNTIME_PATTERN)
   try {
     await mkdir(scratch, { recursive: true })
-    await writeFile(join(scratch, RUNTIME_OWNER_MARKER), OPENCODE_RUNTIME_OWNER)
+    await ensureOpencodeRuntimeOwnerMarker(scratch)
   } catch (error) {
     lastError = error instanceof Error ? error.message : String(error)
     onEvent({

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -1,7 +1,7 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { readFileSync, type Dirent } from 'node:fs'
-import { chmod, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { chmod, lstat, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { arch as osArch } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
@@ -340,6 +340,22 @@ const replaceManagedOpencodeRoot = async (
 ): Promise<void> => {
   const backup = `${root}.backup-${randomUUID()}`
   let backedUp = false
+
+  const rejectSymbolicLink = async (path: string, label: string): Promise<void> => {
+    const stats = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return undefined
+      throw error
+    })
+    if (stats?.isSymbolicLink()) {
+      throw new Error(`Refusing to replace ${label} because it is a symbolic link: ${path}`)
+    }
+  }
+
+  await rejectSymbolicLink(root, 'the managed OpenCode runtime root')
+  await rejectSymbolicLink(
+    join(root, RUNTIME_OWNER_MARKER),
+    'the managed OpenCode runtime ownership marker'
+  )
 
   try {
     await writeFile(join(root, RUNTIME_OWNER_MARKER), OPENCODE_RUNTIME_OWNER)

--- a/src/main/settings/managed-opencode.ts
+++ b/src/main/settings/managed-opencode.ts
@@ -170,6 +170,8 @@ export const isManagedOpencodePath = (resolvedPath: string, dataRoot: string): b
 
 const ORPHANED_OPENCODE_RUNTIME_PATTERN =
   /^opencode-managed\.(?:staging|backup)-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
+const STAGED_OPENCODE_RUNTIME_PATTERN =
+  /^opencode-managed\.staging-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
 const RUNTIME_OWNER_MARKER = '.open-science-managed-runtime'
 const OPENCODE_RUNTIME_OWNER = 'open-science:opencode:v1\n'
 
@@ -177,26 +179,38 @@ const isOwnedOpencodeRuntime = async (root: string): Promise<boolean> =>
   (await readFile(join(root, RUNTIME_OWNER_MARKER), 'utf8').catch(() => undefined)) ===
   OPENCODE_RUNTIME_OWNER
 
+const findOwnedOpencodeRuntimeSiblings = async (
+  dataRoot: string,
+  pattern: RegExp
+): Promise<string[]> => {
+  const root = dirname(managedOpencodeDir(dataRoot))
+  const siblings = await readdir(dirname(root), { withFileTypes: true }).catch(() => [] as Dirent[])
+  const candidates = siblings
+    .filter((entry) => entry.isDirectory() && pattern.test(entry.name))
+    .map((entry) => join(dirname(root), entry.name))
+  return (
+    await Promise.all(
+      candidates.map(async (path) => ((await isOwnedOpencodeRuntime(path)) ? path : undefined))
+    )
+  ).filter((path): path is string => path !== undefined)
+}
+
+const removeOwnedOpencodeRuntimeSiblings = async (
+  dataRoot: string,
+  pattern: RegExp
+): Promise<void> => {
+  const owned = await findOwnedOpencodeRuntimeSiblings(dataRoot, pattern)
+  await Promise.all(
+    owned.map((path) => rm(path, { recursive: true, force: true }).catch(() => undefined))
+  )
+}
+
 // Removes the app-managed OpenCode install tree and exact installer-owned staging/backup siblings.
 // Resolves (never rejects); a missing dir is a no-op so callers can uninstall idempotently.
 export const uninstallManagedOpencode = async (dataRoot: string): Promise<void> => {
   const root = dirname(managedOpencodeDir(dataRoot))
-  const siblings = await readdir(dirname(root), { withFileTypes: true }).catch(() => [] as Dirent[])
-  const orphanCandidates = siblings
-    .filter((entry) => entry.isDirectory() && ORPHANED_OPENCODE_RUNTIME_PATTERN.test(entry.name))
-    .map((entry) => join(dirname(root), entry.name))
-  const ownedOrphans = (
-    await Promise.all(
-      orphanCandidates.map(async (path) =>
-        (await isOwnedOpencodeRuntime(path)) ? path : undefined
-      )
-    )
-  ).filter((path): path is string => path !== undefined)
-  await Promise.all(
-    [root, ...ownedOrphans].map((path) =>
-      rm(path, { recursive: true, force: true }).catch(() => undefined)
-    )
-  )
+  await removeOwnedOpencodeRuntimeSiblings(dataRoot, ORPHANED_OPENCODE_RUNTIME_PATTERN)
+  await rm(root, { recursive: true, force: true }).catch(() => undefined)
 }
 
 // Resolves the native package tarball URL + sha512 for one registry: `opencode-ai` latest (unless a
@@ -457,6 +471,7 @@ export const installManagedOpencode = async ({
   const preferBaseline = isX64 && !detectAvx2Dep()
   const firstKey = preferBaseline ? baselinePackageKey(platform.key) : platform.key
 
+  await removeOwnedOpencodeRuntimeSiblings(dataRoot, STAGED_OPENCODE_RUNTIME_PATTERN)
   try {
     await mkdir(scratch, { recursive: true })
     await writeFile(join(scratch, RUNTIME_OWNER_MARKER), OPENCODE_RUNTIME_OWNER)


### PR DESCRIPTION
## Problem

Managed Claude extracted a replacement directly over the stable runtime path and only ran its
`--version` check afterward in `AgentRuntimeManager`. Managed OpenCode likewise extracted and smoke
tested at the stable path, deleting that path when the candidate failed. A failed update could
therefore remove or overwrite the last working runtime.

The regression tests reproduced both destructive outcomes before the fix:

- an incomplete Claude archive removed the existing binary (`ENOENT`);
- a Claude candidate that could not report a version replaced `WORKING-CLAUDE` with
  `BROKEN-CLAUDE`;
- an OpenCode smoke failure removed the existing binary (`ENOENT`).

## Proposed change

- Download and extract Claude and OpenCode candidates into UUID-scoped sibling staging directories.
- Apply executable permissions and run `--version`/smoke checks before publication.
- Rename the existing runtime to a UUID-scoped backup, publish the staged directory, and restore the
  backup automatically if publication fails.
- Stop retrying registries after a local publication failure, while preserving registry fallback and
  OpenCode's AVX2 baseline fallback before publication.
- Mark installer-created runtime trees with an exact product-specific ownership marker. Uninstall
  removes UUID-scoped staging/backup siblings only when both the name and marker prove ownership.
- Before each install, reconcile ownership-marked staging siblings left by an interrupted attempt,
  independently of persisted runtime settings; retain backups because one may be the only manual
  recovery copy after a failed restore.
- Convert staging-directory setup failures into the installers' existing structured failure result
  and system log instead of rejecting the install call.
- Move Claude candidate version validation into the installer transaction by injecting the manager's
  existing version probe, while retaining the manager's established final-path validation.

## Scope and non-goals

- No database/schema, persisted settings record, data-model, enum, IPC, or renderer changes.
- Stable managed runtime paths and stored path compatibility are unchanged; no data migration is
  needed.
- No generic installer framework is introduced.
- UUID-scoped staging/backup directories and `.open-science-managed-runtime` ownership markers are
  operational app-owned files, not business data. Successful installs clean temporary directories;
  retries clean ownership-marked interrupted staging directories; an unrecoverable restore retains
  the marked backup path in the error for manual recovery, and managed uninstall owns cleanup of
  marked orphans.
- A pre-existing managed runtime receives the marker immediately before its first atomic backup; no
  historical runtime or settings conversion is required.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- Claude extraction/version/setup failure preserves the prior runtime and returns structured errors
  -> `npm test -- src/main/settings/managed-claude.test.ts` -> 33 passed.
- OpenCode smoke/publication/setup failure preserves or restores the prior runtime ->
  `npm test -- src/main/settings/managed-opencode.test.ts` -> 40 passed, 2 skipped.
- Manager validates Claude before persistence and keeps prior settings on failure ->
  `npm test -- src/main/settings/agent-runtime-manager.test.ts` -> 30 passed.
- Existing service contract for final-path version validation -> targeted test passed.
- Main-process interfaces compile -> `npm run typecheck:node` -> passed.
- Source and tests satisfy lint/format rules -> `npm run lint` -> passed.

`npm run test:affected:explain -- --base main --head HEAD` selected full mode because
`agent-runtime-manager.ts` has no module owner. Per the requested local validation scope, the complete
Vitest suite was not run locally; PR Gate is authoritative for that fallback and platform lanes.

## Review focus

- Backup restoration and error preservation when the staged rename fails.
- OpenCode standard-to-baseline fallback remaining entirely inside staging.
- Marker-backed orphan cleanup preserving unowned UUID-shaped directories.
- Pre-install reconciliation removing only ownership-marked interrupted staging directories.
- Staging setup failures staying inside the structured installer result boundary.
