### PR TITLE
fix(projects): gate project access during data migration

### DIFF
--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -232,7 +232,10 @@ describe('application command composition', () => {
     const composition = createApplicationCommandComposition(
       {
         ...dependencies(),
-        dataContent: { projects: { list: listProjects } } as never
+        dataContent: {
+          projects: { list: listProjects },
+          withDataRootWrite: async (operation: () => Promise<unknown>) => operation()
+        } as never
       },
       onDiagnostic
     )
@@ -520,7 +523,10 @@ describe('application command composition', () => {
       .mockResolvedValueOnce([project('from-task')])
     const composition = createApplicationCommandComposition({
       ...dependencies(),
-      dataContent: { projects: { list: listProjects } } as never
+      dataContent: {
+        projects: { list: listProjects },
+        withDataRootWrite: async (operation: () => Promise<unknown>) => operation()
+      } as never
     })
 
     await expect(composition.localWeb.invoke('projects:list', invocation())).resolves.toEqual([

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -19,6 +19,12 @@ import {
 } from '../shared/session-persistence'
 import { ApplicationCommandError } from '../shared/application-command-contract'
 import { ApplicationEventHub } from './application-events'
+import {
+  beginMigration,
+  clearMigrationPending,
+  waitForDataRootWriters,
+  withDataRootWrite
+} from './storage/migration-state'
 
 const callerContext = createCallerContext({
   clientId: 'renderer-1',
@@ -762,8 +768,10 @@ describe('Data and content application commands', () => {
     ).resolves.toBe(deps.session)
 
     expect(order).toEqual([
+      'write:start',
       'project:commit',
       'publish:project:created',
+      'write:end',
       'write:start',
       'session:commit',
       'publish:session:created',
@@ -773,6 +781,88 @@ describe('Data and content application commands', () => {
       session: deps.session,
       originClientId: 'web:renderer-1'
     })
+  })
+
+  it('rejects Project repository access while a data-root migration is pending', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    deps.withDataRootWrite.mockImplementation(withDataRootWrite)
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const operations = [
+      {
+        command: 'projectCreate' as const,
+        args: [{ name: 'Project' }]
+      },
+      {
+        command: 'projectGet' as const,
+        args: ['project-1']
+      },
+      {
+        command: 'projectList' as const,
+        args: []
+      },
+      {
+        command: 'projectUpdateArchive' as const,
+        args: [{ id: 'project-1', archived: true, expectedArchivedAt: null }]
+      },
+      {
+        command: 'projectUpdate' as const,
+        args: [{ id: 'project-1', name: 'Updated project', expectedUpdatedAt: 1 }]
+      }
+    ]
+
+    beginMigration()
+    try {
+      for (const operation of operations) {
+        await expect(
+          dispatchCommand(router, operation.command, operation.args).result
+        ).rejects.toThrow('Open Science is moving your data.')
+      }
+    } finally {
+      clearMigrationPending()
+    }
+
+    expect(deps.projects.create).not.toHaveBeenCalled()
+    expect(deps.projects.get).not.toHaveBeenCalled()
+    expect(deps.projects.list).not.toHaveBeenCalled()
+    expect(deps.projects.updateArchive).not.toHaveBeenCalled()
+    expect(deps.projects.update).not.toHaveBeenCalled()
+  })
+
+  it('keeps migration drain pending until an already-started Project operation finishes', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    let finishProject: (() => void) | undefined
+    deps.projects.create.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishProject = () => resolve(deps.project)
+        })
+    )
+    deps.withDataRootWrite.mockImplementation(withDataRootWrite)
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    const projectResult = dispatchCommand(router, 'projectCreate', [{ name: 'Project' }]).result
+    await vi.waitFor(() => expect(finishProject).toBeTypeOf('function'))
+
+    beginMigration()
+    let drained = false
+    const drain = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+
+    try {
+      expect(drained).toBe(false)
+      finishProject?.()
+      await expect(projectResult).resolves.toBe(deps.project)
+      await drain
+      expect(drained).toBe(true)
+    } finally {
+      finishProject?.()
+      clearMigrationPending()
+      await projectResult.catch(() => undefined)
+    }
   })
 
   it('preserves the Session revision conflict code across the application command boundary', async () => {
@@ -911,7 +1001,7 @@ describe('Data and content application commands', () => {
     expect(deps.sessions.saveManifest).toHaveBeenCalledWith(manifestRequest)
     expect(deps.sessions.deleteSession).toHaveBeenCalledWith(deleteSessionRequest)
     expect(deps.sessions.editDetails).toHaveBeenCalledWith(editDetailsRequest)
-    expect(deps.withDataRootWrite).toHaveBeenCalledTimes(6)
+    expect(deps.withDataRootWrite).toHaveBeenCalledTimes(7)
     expect(deps.events.publish).toHaveBeenCalledWith('project:updated', deps.project)
     expect(deps.events.publish).not.toHaveBeenCalledWith('project:deleted', expect.anything())
     expect(deps.events.publish).toHaveBeenCalledWith('session:deleted', deleteSessionRequest)

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -530,24 +530,28 @@ const registerDataContentApplicationCommands = (
         dependencies.projectFiles.searchArtifacts(args[0])
     })
     scope.registerGroup(dataContentApplicationCommandGroups[5], {
-      'projects:create': async ({ args }) => {
-        const project = await dependencies.projects.create(args[0])
-        publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectCreated, project)
-        return project
-      },
+      'projects:create': ({ args }) =>
+        dependencies.withDataRootWrite(async () => {
+          const project = await dependencies.projects.create(args[0])
+          publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectCreated, project)
+          return project
+        }),
       'projects:delete': ({ args }) => dependencies.projects.delete(args[0].id),
-      'projects:get': ({ args }) => dependencies.projects.get(args[0]),
-      'projects:list': () => dependencies.projects.list(),
-      'projects:update-archive': async ({ args }) => {
-        const project = await dependencies.projects.updateArchive(args[0])
-        publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectUpdated, project)
-        return project
-      },
-      'projects:update': async ({ args }) => {
-        const project = await dependencies.projects.update(args[0])
-        publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectUpdated, project)
-        return project
-      }
+      'projects:get': ({ args }) =>
+        dependencies.withDataRootWrite(() => dependencies.projects.get(args[0])),
+      'projects:list': () => dependencies.withDataRootWrite(() => dependencies.projects.list()),
+      'projects:update-archive': ({ args }) =>
+        dependencies.withDataRootWrite(async () => {
+          const project = await dependencies.projects.updateArchive(args[0])
+          publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectUpdated, project)
+          return project
+        }),
+      'projects:update': ({ args }) =>
+        dependencies.withDataRootWrite(async () => {
+          const project = await dependencies.projects.update(args[0])
+          publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectUpdated, project)
+          return project
+        })
     })
     scope.registerGroup(dataContentApplicationCommandGroups[6], {
       'sessions:delete-session': async ({ args }) => {


### PR DESCRIPTION
## Problem

Project create, get, list, update, and archive application commands bypassed the shared data-root writer barrier.

This allowed Project repository access after a data-root migration became pending, and let migration drain report completion while an already-started Project operation was still running. A Project read could also lazily reopen the fixed config-root SQLite connection after migration had disconnected it for checkpoint and provenance validation.

The current Project database is fixed under the config root and is not part of the relocated/delete set, so this PR does not claim that the Project database file itself would be deleted. The confirmed defect is the violated quiescence and verification boundary.

## Proposed change

- Wrap `projects:create`, `projects:get`, `projects:list`, `projects:update`, and `projects:update-archive` in the existing `withDataRootWrite` barrier.
- Keep mutation completion and lifecycle publication inside the same writer lease.
- Add public application-command regression coverage proving that pending migration rejects all five Project operations and that migration drain waits for an in-flight Project operation.
- Keep `projects:delete` unchanged because `ProjectDeletionCoordinator` already owns its own `withDataRootWrite` boundary.

## Scope and non-goals

- No database schema, field, persisted-format, or data-model changes.
- No new state or enum values.
- No historical-data migration or compatibility handling.
- No new UI copy or migration interaction state; pending calls reuse the existing migration-in-progress error.
- No Repository-level barrier or second locking mechanism.

## Acceptance criteria and validation

The regression command was run twice before the production fix and failed deterministically:

- pending Project access resolved successfully instead of rejecting;
- migration drain completed before the in-flight Project operation completed.

After the final material edit:

- Project migration admission and drain behavior -> `npm test -- src/main/data-content-application-commands.test.ts src/main/application-command-composition.test.ts src/main/application-command-wiring.test.ts` -> 43/43 passed.
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Source/test lint -> `npm run lint` -> passed.
- Patch whitespace -> `git diff --check` -> passed.

The complete `npm test` suite was intentionally not run locally; PR Gate is authoritative for the complete portable and platform-selected plan.

## Review focus

- Whether the application-command boundary is the correct shared admission point for Electron, Web, and Task callers.
- Whether lifecycle publication should remain within the writer lease for Project mutations.
- Whether any Project path other than deletion legitimately needs to bypass migration admission.