### PR TITLE
fix(web-service): scope replay to remote authorization

### DIFF
--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -15,6 +15,7 @@ vi.mock('electron', () => ({
 
 import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
 import { ApplicationCommandError } from '../../shared/application-command-contract'
+import { TASK_EVENT_STREAM_PROTOCOL_VERSION } from '../../shared/task-api'
 import {
   isWebRpcChannel,
   WEB_EVENT_STREAM_PROTOCOL_VERSION,
@@ -1544,6 +1545,230 @@ describe('startWebHttpServer', () => {
       })
     ])
     publicSocket.close()
+  })
+
+  it('does not replay event frames that predate a remote principal authorization', async () => {
+    const authorizationFor = (request: IncomingMessage): ExternalWebAccessAuthorization =>
+      accessOnlyExternalAccess(String(request.headers['x-test-principal']))
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'local-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      tasks: {
+        subscribeProgress: () => () => undefined,
+        resolveActiveRun: (sessionId: string) =>
+          sessionId === 'task-session'
+            ? { runId: 'run-1', sessionId, projectId: 'project-1' }
+            : undefined
+      } as never,
+      externalAccess: {
+        authorizeHttp: async (request) => authorizationFor(request),
+        authorizeWebSocket: async (request) => authorizationFor(request)
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const base = `http://127.0.0.1:${server.port}`
+    const bootstrapFor = async (
+      principalId: string
+    ): Promise<{ eventStream: { streamId: string; latestSequence: number } }> =>
+      (await (
+        await fetch(`${base}/api/bootstrap`, {
+          headers: { 'x-test-principal': principalId }
+        })
+      ).json()) as { eventStream: { streamId: string; latestSequence: number } }
+    const eventSocket = (
+      pathname: '/events' | '/api/v1/events',
+      principalId: string,
+      streamId: string,
+      after: number
+    ): WebSocket => {
+      const url = new URL(`${base.replace('http:', 'ws:')}${pathname}`)
+      url.searchParams.set(
+        'eventProtocol',
+        String(
+          pathname === '/events'
+            ? WEB_EVENT_STREAM_PROTOCOL_VERSION
+            : TASK_EVENT_STREAM_PROTOCOL_VERSION
+        )
+      )
+      url.searchParams.set('stream', streamId)
+      url.searchParams.set('after', String(after))
+      return new WebSocket(url, { headers: { 'x-test-principal': principalId } })
+    }
+    const nextMessage = (socket: WebSocket): Promise<Record<string, unknown>> =>
+      new Promise((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error(`Timed out waiting for event frame from ${socket.url}.`)),
+          500
+        )
+        socket.once('message', (data) => {
+          clearTimeout(timeout)
+          resolve(JSON.parse(data.toString()))
+        })
+      })
+
+    const firstPrincipal = await bootstrapFor('principal-before-event')
+    expect(firstPrincipal.eventStream.latestSequence).toBe(0)
+
+    applicationEvents.publish('acp:event', [
+      {
+        id: 'event-before-second-principal',
+        timestamp: 1,
+        level: 'info',
+        sessionId: 'task-session',
+        kind: 'message',
+        text: 'Authorized-principal-only history'
+      }
+    ])
+
+    const firstInternalSocket = eventSocket(
+      '/events',
+      'principal-before-event',
+      firstPrincipal.eventStream.streamId,
+      0
+    )
+    await expect(nextMessage(firstInternalSocket)).resolves.toMatchObject({
+      kind: 'event',
+      sequence: 1,
+      channel: 'acp:event'
+    })
+    firstInternalSocket.close()
+
+    const secondPrincipal = await bootstrapFor('principal-after-event')
+    expect(secondPrincipal.eventStream.latestSequence).toBe(1)
+    const secondInternalSocket = eventSocket(
+      '/events',
+      'principal-after-event',
+      secondPrincipal.eventStream.streamId,
+      0
+    )
+    const secondInternalMessage = await nextMessage(secondInternalSocket)
+    secondInternalSocket.close()
+
+    const publicReadyUrl = new URL(`${base.replace('http:', 'ws:')}/api/v1/events`)
+    publicReadyUrl.searchParams.set('eventProtocol', String(TASK_EVENT_STREAM_PROTOCOL_VERSION))
+    const publicReadySocket = new WebSocket(publicReadyUrl, {
+      headers: { 'x-test-principal': 'principal-after-event' }
+    })
+    const publicReady = await nextMessage(publicReadySocket)
+    expect(publicReady).toMatchObject({
+      type: 'stream.ready',
+      data: { latestSequence: 1, streamId: expect.any(String) }
+    })
+    publicReadySocket.close()
+
+    const publicStreamId = (publicReady.data as { streamId: string }).streamId
+    const secondPublicSocket = eventSocket(
+      '/api/v1/events',
+      'principal-after-event',
+      publicStreamId,
+      0
+    )
+    const secondPublicMessage = await nextMessage(secondPublicSocket)
+    secondPublicSocket.close()
+
+    expect([secondInternalMessage, secondPublicMessage]).toMatchObject([
+      {
+        kind: 'resync-required',
+        reason: 'cursor-expired',
+        latestSequence: 1
+      },
+      {
+        type: 'stream.resync-required',
+        data: { reason: 'cursor-expired', latestSequence: 1 }
+      }
+    ])
+  })
+
+  it('invalidates remote replay floors for one principal or the current authorization generation', async () => {
+    const authorizationFor = (request: IncomingMessage): ExternalWebAccessAuthorization =>
+      accessOnlyExternalAccess(String(request.headers['x-test-principal']))
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'local-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      externalAccess: {
+        authorizeHttp: async (request) => authorizationFor(request),
+        authorizeWebSocket: async (request) => authorizationFor(request)
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const base = `http://127.0.0.1:${server.port}`
+    const bootstrapFor = async (
+      principalId: string
+    ): Promise<{ eventStream: { streamId: string; latestSequence: number } }> =>
+      (await (
+        await fetch(`${base}/api/bootstrap`, {
+          headers: { 'x-test-principal': principalId }
+        })
+      ).json()) as { eventStream: { streamId: string; latestSequence: number } }
+    const resumeFor = (
+      principalId: string,
+      streamId: string,
+      after: number
+    ): Promise<Record<string, unknown>> => {
+      const url = new URL(`${base.replace('http:', 'ws:')}/events`)
+      url.searchParams.set('eventProtocol', String(WEB_EVENT_STREAM_PROTOCOL_VERSION))
+      url.searchParams.set('stream', streamId)
+      url.searchParams.set('after', String(after))
+      const socket = new WebSocket(url, { headers: { 'x-test-principal': principalId } })
+      return new Promise((resolve) =>
+        socket.once('message', (data) => {
+          socket.close()
+          resolve(JSON.parse(data.toString()))
+        })
+      )
+    }
+    const publishProject = (id: string): void =>
+      applicationEvents.publish('project:created', {
+        id,
+        name: id,
+        description: '',
+        isExample: false,
+        createdAt: 1,
+        updatedAt: 1
+      })
+
+    const firstPrincipal = await bootstrapFor('principal-one')
+    publishProject('project-1')
+    const secondPrincipal = await bootstrapFor('principal-two')
+    publishProject('project-2')
+
+    server.closeExternalConnections('principal-one')
+    await bootstrapFor('principal-one')
+
+    await expect(
+      resumeFor('principal-one', firstPrincipal.eventStream.streamId, 0)
+    ).resolves.toMatchObject({ kind: 'resync-required', reason: 'cursor-expired' })
+    await expect(
+      resumeFor('principal-two', secondPrincipal.eventStream.streamId, 1)
+    ).resolves.toMatchObject({ kind: 'event', sequence: 2 })
+
+    server.closeExternalConnections()
+    publishProject('project-3')
+    await bootstrapFor('principal-two')
+
+    await expect(
+      resumeFor('principal-two', secondPrincipal.eventStream.streamId, 1)
+    ).resolves.toMatchObject({ kind: 'resync-required', reason: 'cursor-expired' })
   })
 
   it('replays owned public Task events from the requested sequence', async () => {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -446,7 +446,8 @@ export type ExternalWebAccess = {
 
 export type RunningWebServer = {
   port: number
-  closeExternalConnections: (sessionId?: string) => void
+  // Invalidates retained replay access before closing the matching remotely authorized sockets.
+  closeExternalConnections: (principalId?: string) => void
   close: () => Promise<void>
 }
 
@@ -1100,6 +1101,30 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   const awaitingPong = new WeakSet<WebSocket>()
   const internalEventStream = new InternalWebEventStream()
   const publicTaskEventStream = new PublicTaskEventStream()
+  // A current remote authorization grants replay only from the first sequence that principal saw.
+  // Local Web clients keep the process-wide cursor so remote lifecycle changes never reload them.
+  const remoteReplayFloors = new Map<
+    string,
+    Readonly<{
+      internalAfter: number
+      publicTaskAfter: number
+    }>
+  >()
+  const replayFloorFor = (
+    principalId: string
+  ): Readonly<{
+    internalAfter: number
+    publicTaskAfter: number
+  }> => {
+    const existing = remoteReplayFloors.get(principalId)
+    if (existing) return existing
+    const created = {
+      internalAfter: internalEventStream.cursor().latestSequence,
+      publicTaskAfter: publicTaskEventStream.cursor().latestSequence
+    }
+    remoteReplayFloors.set(principalId, created)
+    return created
+  }
   const commandClient = createApplicationCommandClient()
   const taskIdempotencyRegistry = new TaskIdempotencyRegistry()
   const requestBodyBudgetRegistry = new RequestBodyBudgetRegistry(
@@ -1155,6 +1180,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         response.end('Unauthorized')
         return
       }
+      if (externalAuthorization) replayFloorFor(externalAuthorization.principalId)
       let clientNonce: string
       try {
         clientNonce = requestClientNonce(request)
@@ -1456,6 +1482,9 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       socket.close(1008, 'Remote access expired')
       return
     }
+    const replayFloor = externalAuthorization
+      ? replayFloorFor(externalAuthorization.principalId)
+      : undefined
     const clientId =
       externalAuthorization === undefined
         ? clientNonce
@@ -1499,10 +1528,13 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         const messages =
           streamId === null && afterValue === null
             ? [publicTaskEventStream.ready()]
-            : publicTaskEventStream.resume({
-                streamId: streamId ?? '',
-                after: afterValue === null ? Number.NaN : Number(afterValue)
-              })
+            : publicTaskEventStream.resume(
+                {
+                  streamId: streamId ?? '',
+                  after: afterValue === null ? Number.NaN : Number(afterValue)
+                },
+                replayFloor?.publicTaskAfter
+              )
         for (const message of messages) {
           if (!sendCurrentWebSocketMessage(socket, message)) break
         }
@@ -1521,7 +1553,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         const streamId = url.searchParams.get('stream') ?? ''
         const afterValue = url.searchParams.get('after')
         const after = afterValue === null ? Number.NaN : Number(afterValue)
-        for (const message of internalEventStream.resume({ streamId, after })) {
+        for (const message of internalEventStream.resume(
+          { streamId, after },
+          replayFloor?.internalAfter
+        )) {
           if (!sendCurrentWebSocketMessage(socket, message)) break
         }
       }
@@ -1609,6 +1644,8 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   return {
     port,
     closeExternalConnections: (principalId) => {
+      if (principalId === undefined) remoteReplayFloors.clear()
+      else remoteReplayFloors.delete(principalId)
       for (const [socket, authorization] of externalSockets) {
         if (principalId === undefined || authorization.principalId === principalId) {
           socket.close(1008, 'Remote access revoked')
@@ -1617,6 +1654,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     },
     close: async () => {
       taskIdempotencyRegistry.clear()
+      remoteReplayFloors.clear()
       clearInterval(eventHeartbeatInterval)
       removeBroadcastSink()
       removeTaskProgressSink?.()

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -31,8 +31,8 @@ export type WebServiceController = {
   close: () => Promise<void>
   // Permanently closes the service and its Task adapter. Used only by application shutdown.
   dispose: () => Promise<void>
-  // Closes remotely authenticated sockets without disturbing local Web clients.
-  closeExternalConnections: (sessionId?: string) => void
+  // Invalidates retained replay access and closes remote sockets without disturbing local clients.
+  closeExternalConnections: (principalId?: string) => void
   // Subscribes to actual server stops, including attached shutdown requests from the CLI.
   onStopped: (listener: () => void) => () => void
   isRunning: () => boolean
@@ -123,7 +123,7 @@ const createWebServiceController = (
   let running:
     | {
         close: () => Promise<void>
-        closeExternalConnections: (sessionId?: string) => void
+        closeExternalConnections: (principalId?: string) => void
         port: number
         configRoot: string
       }
@@ -258,7 +258,7 @@ const createWebServiceController = (
     ensureStarted,
     close,
     dispose,
-    closeExternalConnections: (sessionId) => running?.closeExternalConnections(sessionId),
+    closeExternalConnections: (principalId) => running?.closeExternalConnections(principalId),
     onStopped: (listener) => {
       stoppedListeners.add(listener)
       return () => stoppedListeners.delete(listener)

--- a/src/main/web-service/internal-web-event-stream.test.ts
+++ b/src/main/web-service/internal-web-event-stream.test.ts
@@ -128,4 +128,18 @@ describe('InternalWebEventStream', () => {
       }
     ])
   })
+
+  it('refuses to replay frames older than an authorization floor', () => {
+    const stream = new InternalWebEventStream({ streamId: 'stream-1' })
+    stream.publish({ channel: 'settings:changed', payload: { revision: 1 } })
+    stream.publish({ channel: 'settings:changed', payload: { revision: 2 } })
+
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 0 }, 1))).toEqual([
+      expect.objectContaining({ kind: 'resync-required', reason: 'cursor-expired' })
+    ])
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 1 }, 1))).toEqual([
+      expect.objectContaining({ kind: 'event', sequence: 2 }),
+      expect.objectContaining({ kind: 'ready', latestSequence: 2 })
+    ])
+  })
 })

--- a/src/main/web-service/internal-web-event-stream.ts
+++ b/src/main/web-service/internal-web-event-stream.ts
@@ -89,13 +89,14 @@ class InternalWebEventStream {
     })
   }
 
-  resume(cursor: ResumeCursor): readonly string[] {
+  resume(cursor: ResumeCursor, minimumAfter = 0): readonly string[] {
     if (cursor.streamId !== this.#streamId) return [this.#resyncRequired('stream-changed')]
 
     const oldestSequence = this.#frames[0]?.sequence
     if (
       !Number.isSafeInteger(cursor.after) ||
       cursor.after < 0 ||
+      cursor.after < minimumAfter ||
       cursor.after > this.#latestSequence ||
       (cursor.after < this.#latestSequence &&
         (oldestSequence === undefined || cursor.after < oldestSequence - 1))

--- a/src/main/web-service/public-task-event-stream.test.ts
+++ b/src/main/web-service/public-task-event-stream.test.ts
@@ -74,4 +74,28 @@ describe('PublicTaskEventStream', () => {
       }
     ])
   })
+
+  it('refuses to replay frames older than an authorization floor', () => {
+    const stream = new PublicTaskEventStream({ streamId: 'stream-1' })
+    const event = {
+      runId: 'run-1',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      type: 'run.event' as const,
+      data: { id: 'event-1', timestamp: 1, kind: 'message' as const, level: 'info' as const }
+    }
+    stream.publish(event)
+    stream.publish(event)
+
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 0 }, 1))).toEqual([
+      expect.objectContaining({
+        type: 'stream.resync-required',
+        data: expect.objectContaining({ reason: 'cursor-expired' })
+      })
+    ])
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 1 }, 1))).toEqual([
+      expect.objectContaining({ sequence: 2, type: 'run.event' }),
+      expect.objectContaining({ type: 'stream.ready' })
+    ])
+  })
 })

--- a/src/main/web-service/public-task-event-stream.ts
+++ b/src/main/web-service/public-task-event-stream.ts
@@ -69,12 +69,13 @@ class PublicTaskEventStream {
     return serialized
   }
 
-  resume(cursor: PublicTaskEventCursor): readonly string[] {
+  resume(cursor: PublicTaskEventCursor, minimumAfter = 0): readonly string[] {
     if (cursor.streamId !== this.#streamId) return [this.#resyncRequired('stream-changed')]
     const oldestSequence = this.#frames[0]?.sequence
     if (
       !Number.isSafeInteger(cursor.after) ||
       cursor.after < 0 ||
+      cursor.after < minimumAfter ||
       cursor.after > this.#latestSequence ||
       (cursor.after < this.#latestSequence &&
         (oldestSequence === undefined || cursor.after < oldestSequence - 1))


### PR DESCRIPTION
## Problem

Internal Web events and public Task events retain process-wide replay suffixes. Remote authorization
revocation closed sockets but did not bind those retained frames to an authorization generation or
principal, so a newly authorized browser could request frames produced before its grant by supplying
the global stream ID and an older `after` cursor.

## Proposed change

- Record the current internal and public Task sequence as an in-memory replay floor when a remote
  principal first authenticates.
- Reject remote resume cursors below that principal's floor with the existing `cursor-expired`
  resynchronization response.
- Delete one principal's floor on revocation/expiry and clear all floors when the current remote
  authorization generation is invalidated.
- Preserve process-wide replay behavior for local Web clients and valid reconnects within one remote
  grant.

## Scope and non-goals

- No protocol fields or protocol-version changes.
- No database, repository, config-file, cookie, or trusted-browser format changes.
- No new lifecycle enum values or UI interactions.
- Replay frames and authorization floors remain process-local.
- This does not create per-principal copies of the retained payload buffers; it enforces principal
  boundaries over the existing bounded global suffix.

## Acceptance criteria and validation

All checks below ran after the final material edit.

- Authorization boundary for internal and public Task replay, per-principal invalidation, and global
  generation invalidation ->
  `npm test -- src/main/web-service/http-server.test.ts src/main/web-service/internal-web-event-stream.test.ts src/main/web-service/public-task-event-stream.test.ts src/main/web-service/controller.test.ts src/main/remote-access/service.test.ts`
  -> passed (5 files, 103 tests).
- Affected main-process TypeScript contracts -> `npm run typecheck:node` -> passed.
- Source lint and formatting contracts -> `npm run lint` and `git diff --check` -> passed.

The full `npm test` suite was intentionally not run locally per maintainer direction. PR Gate remains
authoritative for the complete portable and platform test plan.

## Review focus

- `replayFloorFor` is called only after current external authorization succeeds; local-token clients
  never receive a replay floor.
- `closeExternalConnections(principalId?)` invalidates the matching replay floor(s) before closing
  sockets, aligning replay authorization with the existing revocation, expiry, mode-switch, disable,
  and shutdown paths.
- A remote principal can still replay a retained suffix produced after its own floor, while a newer
  principal receives `resync-required` for the same older cursor.
