### PR TITLE
fix(session-lifecycle): block archive during compaction

### DIFF
--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -643,6 +643,24 @@ describe('workspace session controller', () => {
     expect(hook.result.current.lifecycle.canArchive(active)).toBe(true)
   })
 
+  it('does not archive while context compaction owns the Session', () => {
+    const active = session()
+    const updateSessionArchive = vi.fn()
+    useSessionStore.setState({
+      sessions: [active],
+      selectedSessionId: active.id,
+      updateSessionArchive
+    })
+    useSessionStore.getState().beginCompaction(active.id)
+    const compacting = useSessionStore.getState().sessions[0]
+    const hook = renderController({ activeSession: compacting })
+    mounted.push(hook)
+
+    expect(hook.result.current.lifecycle.canArchive(compacting)).toBe(false)
+    act(() => hook.result.current.actions.archive(compacting))
+    expect(updateSessionArchive).not.toHaveBeenCalled()
+  })
+
   it('does not archive an idle Session while a current child Attempt is running on any branch', () => {
     const active = sessionWithRunningChild()
     const graph = active.conversationGraph

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -237,6 +237,7 @@ const useWorkspaceSessionController = ({
   const canArchive = (session: ChatSession): boolean =>
     isPersistenceReady &&
     !session.isPending &&
+    !session.compacting &&
     session.archivedAt === undefined &&
     !archivingIds.has(session.id) &&
     !deletingIds.has(session.id) &&


### PR DESCRIPTION
## Problem

Native context compaction intentionally leaves the durable Session status at `idle` while the renderer tracks the provider control turn with transient `compacting` state. The Workspace Session controller did not include that transient owner in Archive admission, so the sidebar could archive a Session before compaction settled.

The broader lifecycle investigation also confirmed that compaction cannot be globally treated as an ordinary running turn: context-overflow recovery intentionally re-admits the failed prompt while compaction is active.

## Proposed change

- block Session Archive while `session.compacting` is true;
- cover the behavior through the existing Workspace Session controller seam after entering compaction with the public store action;
- retain the existing context-overflow recovery admission behavior.

## Scope and non-goals

- No new Session status or enum value.
- No new data field or data-model change.
- No persistence format, schema, migration, or historical-data compatibility change.
- No ACP method, event shape, framework adapter, or user-visible copy change.
- No attempt to replace the intentionally orthogonal durable, runtime, interaction, and presentation facts with one cross-product state machine.

## Acceptance criteria and validation

The regression test was run three times before the fix and failed deterministically because `canArchive()` returned `true` during compaction.

Final evidence after the last material edit:

- compaction owns Session -> Archive is unavailable and the durable archive command is not invoked -> `npm test -- src/renderer/src/pages/workspace/workspace-session-controller.test.ts -t 'does not archive while context compaction owns the Session'` -> passed;
- Workspace Page owner and contract behavior -> `npm run test:module -- workspace_page` -> 29 files, 709 tests passed;
- Session renderer and context-overflow recovery compatibility -> `npm run test:module -- session_renderer` -> 5 files, 577 tests passed;
- renderer type safety -> `npm run typecheck:web` -> passed;
- linted source and tests -> `npm run lint` -> passed;
- exact-head impact explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> selective `workspace_page` plan.

The complete portable and platform suites are left to PR CI as requested. No local E2E run was added because the controller test exercises the same archive admission used by the sidebar without timing or browser dependencies.

## Review focus

Please verify that the Archive-specific guard is the correct seam. A broader `projectSessionActionability` change was tested and rejected because it blocked 12 legitimate context-overflow recovery scenarios while compaction owns the provider control turn.
