### PR TITLE
fix(message-scroll): respect small upward scrolls

### DIFF
--- a/src/renderer/src/components/ui/message-scroller.test.tsx
+++ b/src/renderer/src/components/ui/message-scroller.test.tsx
@@ -12,12 +12,15 @@ import {
   MessageScrollerViewport
 } from './message-scroller'
 
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
 let container: HTMLDivElement | undefined
 let root: Root | undefined
 
 afterEach(() => {
   if (root) act(() => root?.unmount())
   container?.remove()
+  vi.unstubAllGlobals()
   root = undefined
   container = undefined
 })
@@ -97,5 +100,94 @@ describe('MessageScrollerItem', () => {
 
     await act(async () => button?.click())
     expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
+  })
+
+  it('releases bottom following for a small scrollbar drag before animated content grows', async () => {
+    const resizeCallbacks = new Map<Element, ResizeObserverCallback>()
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        private readonly callback: ResizeObserverCallback
+
+        constructor(callback: ResizeObserverCallback) {
+          this.callback = callback
+        }
+
+        observe(target: Element): void {
+          resizeCallbacks.set(target, this.callback)
+        }
+
+        disconnect(): void {
+          /* no-op */
+        }
+      }
+    )
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MessageScrollerProvider autoScroll>
+          <MessageScroller>
+            <MessageScrollerViewport>
+              <MessageScrollerContent>
+                <MessageScrollerItem messageId="animated-tool-details">
+                  Tool details
+                </MessageScrollerItem>
+              </MessageScrollerContent>
+            </MessageScrollerViewport>
+          </MessageScroller>
+        </MessageScrollerProvider>
+      )
+    })
+
+    const viewport = container.querySelector<HTMLElement>('[data-slot="message-scroller-viewport"]')
+    const content = container.querySelector<HTMLElement>('[data-slot="message-scroller-content"]')
+    const item = container.querySelector<HTMLElement>('[data-message-id="animated-tool-details"]')
+    expect(viewport).not.toBeNull()
+    expect(content).not.toBeNull()
+    expect(item).not.toBeNull()
+
+    let contentHeight = 200
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, get: () => contentHeight },
+      scrollTop: { configurable: true, writable: true, value: 100 },
+      getBoundingClientRect: {
+        configurable: true,
+        value: () => ({ top: 0, bottom: 100, height: 100 })
+      },
+      scrollTo: {
+        configurable: true,
+        value: ({ top }: ScrollToOptions) => {
+          if (typeof top === 'number' && viewport) viewport.scrollTop = top
+        }
+      }
+    })
+    Object.defineProperty(item, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        top: -(viewport?.scrollTop ?? 0),
+        bottom: contentHeight - (viewport?.scrollTop ?? 0),
+        height: contentHeight
+      })
+    })
+
+    // Establish bottom-follow mode, then mimic a small scrollbar-thumb drag. Unlike a wheel event,
+    // a scrollbar drag emits only `scroll`, so the scroller must notice the upward movement itself.
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+    if (viewport) viewport.scrollTop = 96
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+
+    // A tool expansion height tween keeps producing content resize frames after the reader moves.
+    contentHeight = 240
+    await act(async () => {
+      resizeCallbacks.get(content!)?.([], {} as ResizeObserver)
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+    })
+
+    expect(viewport?.scrollTop).toBe(96)
   })
 })

--- a/src/renderer/src/components/ui/message-scroller.tsx
+++ b/src/renderer/src/components/ui/message-scroller.tsx
@@ -14,7 +14,7 @@ import { ArrowDownIcon } from 'lucide-react'
 function MessageScrollerProvider(
   props: React.ComponentProps<typeof MessageScrollerPrimitive.Provider>
 ) {
-  return <MessageScrollerPrimitive.Provider {...props} />
+  return <MessageScrollerPrimitive.Provider scrollEdgeThreshold={0} {...props} />
 }
 
 function MessageScroller({


### PR DESCRIPTION
## Problem

While the conversation is following the bottom, a small upward scrollbar-thumb drag can remain inside the message scroller's default 8 px end threshold. If a tool group is expanding at the same time, its height tween emits repeated content resize frames and bottom-follow snaps the viewport back to the new end. A continued small drag can therefore alternate between moving up and snapping down.

The pre-fix regression reproduced this deterministically: after moving from `scrollTop = 100` to `96`, one animated-content resize moved the viewport to `140` instead of preserving `96` (three consecutive failing runs).

## Proposed change

- Default the shared `MessageScrollerProvider` end threshold to zero, while preserving explicit caller overrides.
- Add a public-boundary regression test using the real provider, viewport, content, and item components. It controls only DOM geometry and `ResizeObserver` so the reported scrollbar-drag/animated-growth sequence is deterministic.

## Scope and non-goals

- Interaction change: any real upward movement immediately releases bottom-follow; the reader's position is then preserved while content grows.
- No tool animation rewrite and no new state machine or test-only production seam.
- No data fields, architecture, data model, enum/state values, persistence, migrations, or historical-data compatibility changes.

## Acceptance criteria and validation

- Small upward scrollbar drag followed by animated content growth preserves the reader position:
  - Before fix: focused test failed 3/3 with expected `96`, received `140`.
  - After fix: `npm test -- src/renderer/src/components/ui/message-scroller.test.tsx` — 3/3 passed.
- Workspace conversation behavior: `npm run test:module -- workspace_page` — 29 files, 709 tests passed.
- Shared consumers and tool animation: focused six-file Vitest run covering `WorkspaceCollapsiblePanel`, both `WorkspaceMessageScroller` suites, and both artifact provenance suites — 6 files, 163 tests passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed.
- `npm run build:web` — passed (existing build warnings only).
- Real-browser smoke test against the saved report session: tool group collapsed and expanded successfully; Notebook detail expanded successfully.
- `npm run test:affected -- --base origin/main --head HEAD --explain` selects the full Vitest suite because the shared UI test has no module owner. Per request, the full suite is left to PR CI.

## Review focus

- Confirm that zero tolerance is the intended shared behavior for both workspace conversations and artifact provenance: any nonzero upward distance should release bottom-follow and show the return-to-end affordance.
