### PR TITLE
fix(web-service): complete message event test fixtures

### DIFF
--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1665,6 +1665,7 @@ describe('startWebHttpServer', () => {
         level: 'info',
         sessionId: 'task-session',
         kind: 'message',
+        role: 'assistant',
         text: 'Authorized-principal-only history'
       }
     ])

--- a/src/main/web-service/public-task-event-stream.test.ts
+++ b/src/main/web-service/public-task-event-stream.test.ts
@@ -96,7 +96,14 @@ describe('PublicTaskEventStream', () => {
       sessionId: 'session-1',
       projectId: 'project-1',
       type: 'run.event' as const,
-      data: { id: 'event-1', timestamp: 1, kind: 'message' as const, level: 'info' as const }
+      data: {
+        id: 'event-1',
+        timestamp: 1,
+        kind: 'message' as const,
+        level: 'info' as const,
+        role: 'assistant' as const,
+        text: 'done'
+      }
     }
     stream.publish(event)
     stream.publish(event)


### PR DESCRIPTION
## Problem

PR #2007's Static checks job failed `typecheck:node` on three pre-existing fixture errors that #2005 introduced when `AcpRuntimeEvent` message payloads became discriminated (`role` and `text` required). The scroll-jitter change itself was unrelated and has already merged.

The failing sites were:

- `src/main/web-service/http-server.test.ts`: a `kind: 'message'` event was missing `role`
- `src/main/web-service/public-task-event-stream.test.ts`: a `kind: 'message'` event was missing `role` and `text`

## Proposed change

Complete those two test fixtures so they match the sibling message events in the same files (`role: 'assistant'` and an explicit `text`).

## Scope and non-goals

- Test-fixture typing only. No production runtime, protocol, or UI behavior change.
- No new event kinds, roles, or other enum/state values.
- No persistence, migration, or historical-data compatibility work.

## Compatibility notes

- **Historical data compatibility:** none. Existing stored events are unchanged.
- **New state / enum values:** none. The fixtures use the existing `'assistant'` role.
- **Data persistence:** none. No schema, codec, or storage path is touched.

## Acceptance criteria and validation

These checks ran after the last material edit:

- `npm run typecheck:node` — passed (the Static checks failure from #2007)
- `npx eslint src/main/web-service/http-server.test.ts src/main/web-service/public-task-event-stream.test.ts` — no issues
- `npm test -- src/main/web-service/public-task-event-stream.test.ts src/main/web-service/http-server.test.ts` — 2 files, 57 tests passed

`npm run test:affected -- --base origin/main --head HEAD --explain` selects the complete Vitest suite because these web-service tests have no module owner. Per request, the full suite is left to PR CI.

## Review focus

- Confirm the completed fixtures match the discriminated `kind: 'message'` contract without changing what the tests assert.