### PR TITLE
fix(updates): ignore unsupported release-note locales

### DIFF
--- a/src/main/update/manifest.test.ts
+++ b/src/main/update/manifest.test.ts
@@ -38,10 +38,17 @@ describe('parseManifest', () => {
   it('throws on a malformed download entry', () => {
     expect(() => parseManifest({ version: '1.0.0', downloads: { x: { url: 1 } } })).toThrow()
   })
-  it('throws on unsupported or malformed localized release notes', () => {
-    expect(() =>
-      parseManifest({ version: '1.0.0', downloads: {}, localizedNotes: { it: 'Novità' } })
-    ).toThrow(/it/)
+  it('ignores unsupported localized notes without dropping supported locales', () => {
+    const manifest = parseManifest({
+      version: '1.0.0',
+      downloads: {},
+      localizedNotes: { 'zh-Hans': '更新说明', it: 'Novità' }
+    })
+
+    expect(manifest.localizedNotes).toEqual({ 'zh-Hans': '更新说明' })
+  })
+
+  it('throws on malformed supported localized release notes', () => {
     expect(() =>
       parseManifest({ version: '1.0.0', downloads: {}, localizedNotes: { fr: '' } })
     ).toThrow(/fr/)

--- a/src/main/update/manifest.ts
+++ b/src/main/update/manifest.ts
@@ -52,7 +52,8 @@ const parseLocalizedNotes = (value: unknown): LocalizedReleaseNotes | undefined 
 
   const localizedNotes: LocalizedReleaseNotes = {}
   for (const [locale, notes] of Object.entries(value)) {
-    if (!LOCALIZED_NOTE_LOCALES.has(locale) || typeof notes !== 'string' || !notes.trim()) {
+    if (!LOCALIZED_NOTE_LOCALES.has(locale)) continue
+    if (typeof notes !== 'string' || !notes.trim()) {
       throw new Error(`Invalid localized release notes: ${locale}`)
     }
     localizedNotes[locale as keyof LocalizedReleaseNotes] = notes


### PR DESCRIPTION
## Problem

An older app rejects the entire localizedNotes object when a newer update manifest introduces an unsupported locale. A single new language can therefore make every supported translation fall back to English.

## Proposed change

Ignore unsupported locale entries while continuing to validate supported entries. Add one parseManifest regression test proving that a supported Simplified Chinese note survives alongside an unknown locale.

## Scope and non-goals

- No renderer, release-note generation, or update lifecycle changes.
- Malformed values for supported locales still fail validation.
- This does not retroactively change parsers already shipped in older app versions or republish the current CDN manifest.

## Acceptance criteria and validation

- Forward-compatible localized-note parsing -> npm test -- src/main/update/manifest.test.ts src/main/update/service.test.ts src/main/update/electron-updater-strategy.test.ts -> 3 files, 110 tests passed.
- Source lint -> npm run lint -> passed.
- Node typecheck was run but remains blocked by pre-existing repository errors that reproduce unchanged on main; none reference the modified files.
- No renderer or platform-specific lane is required because the change is confined to the main-process manifest parser.

All listed checks ran after the final material edit.

## Review focus

Confirm that unknown locale keys are ignored without weakening validation for locales the current client supports.