### PR TITLE
perf(workspace): coalesce delegated question drafts

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.test.tsx
@@ -92,6 +92,35 @@ describe('WorkspaceDelegatedQuestionCard', () => {
     )
   })
 
+  it('persists the latest custom answer when the card unmounts during the debounce window', async () => {
+    vi.useFakeTimers()
+    const onRespond = vi.fn<(response: ElicitationResponse) => Promise<void>>(async () => undefined)
+    const { unmount } = render(
+      <WorkspaceDelegatedQuestionCard
+        projectId="project-1"
+        sessionId="session-1"
+        request={{ ...request, questions: request.questions.slice(0, 1) }}
+        onRespond={onRespond}
+      />
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Type your own answer' }), {
+      target: { value: 'final' }
+    })
+    unmount()
+    await act(async () => Promise.resolve())
+
+    expect(onRespond).toHaveBeenCalledTimes(1)
+    expect(onRespond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delegatedQuestion: expect.objectContaining({
+          action: 'draft',
+          answers: [{ questionIndex: 0, value: 'final' }]
+        })
+      })
+    )
+  })
+
   it('finishes with the latest answer without waiting for an in-flight draft', async () => {
     vi.useFakeTimers()
     let releaseDraft: (() => void) | undefined

--- a/src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ElicitationResponse } from '../../../../shared/acp'
@@ -28,9 +28,157 @@ const request: DelegatedQuestionRequest = {
   draftQuestionIndex: 0
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
 
 describe('WorkspaceDelegatedQuestionCard', () => {
+  it('persists only the latest custom answer after rapid typing', async () => {
+    vi.useFakeTimers()
+    const onRespond = vi.fn<(response: ElicitationResponse) => Promise<void>>(async () => undefined)
+    render(
+      <WorkspaceDelegatedQuestionCard
+        projectId="project-1"
+        sessionId="session-1"
+        request={{ ...request, questions: request.questions.slice(0, 1) }}
+        onRespond={onRespond}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Type your own answer' })
+    fireEvent.change(input, { target: { value: 'f' } })
+    fireEvent.change(input, { target: { value: 'fi' } })
+    fireEvent.change(input, { target: { value: 'final' } })
+
+    await act(() => vi.advanceTimersByTimeAsync(300))
+
+    expect(onRespond).toHaveBeenCalledTimes(1)
+    expect(onRespond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delegatedQuestion: expect.objectContaining({
+          action: 'draft',
+          answers: [{ questionIndex: 0, value: 'final' }]
+        })
+      })
+    )
+  })
+
+  it('persists the latest custom answer immediately on blur', async () => {
+    vi.useFakeTimers()
+    const onRespond = vi.fn<(response: ElicitationResponse) => Promise<void>>(async () => undefined)
+    render(
+      <WorkspaceDelegatedQuestionCard
+        projectId="project-1"
+        sessionId="session-1"
+        request={{ ...request, questions: request.questions.slice(0, 1) }}
+        onRespond={onRespond}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Type your own answer' })
+    fireEvent.change(input, { target: { value: 'final' } })
+    fireEvent.blur(input)
+    await act(async () => Promise.resolve())
+
+    expect(onRespond).toHaveBeenCalledTimes(1)
+    expect(onRespond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delegatedQuestion: expect.objectContaining({
+          action: 'draft',
+          answers: [{ questionIndex: 0, value: 'final' }]
+        })
+      })
+    )
+  })
+
+  it('finishes with the latest answer without waiting for an in-flight draft', async () => {
+    vi.useFakeTimers()
+    let releaseDraft: (() => void) | undefined
+    const onRespond = vi.fn<(response: ElicitationResponse) => Promise<void>>((response) =>
+      response.delegatedQuestion?.action === 'draft'
+        ? new Promise<void>((resolve) => {
+            releaseDraft = resolve
+          })
+        : Promise.resolve()
+    )
+    render(
+      <WorkspaceDelegatedQuestionCard
+        projectId="project-1"
+        sessionId="session-1"
+        request={{ ...request, questions: request.questions.slice(0, 1) }}
+        onRespond={onRespond}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Type your own answer' })
+    fireEvent.change(input, { target: { value: 'first' } })
+    await act(() => vi.advanceTimersByTimeAsync(300))
+    expect(onRespond).toHaveBeenCalledTimes(1)
+
+    fireEvent.change(input, { target: { value: 'final' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Finish' }))
+    await act(async () => Promise.resolve())
+
+    expect(onRespond).toHaveBeenCalledTimes(2)
+    expect(onRespond).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        delegatedQuestion: expect.objectContaining({
+          action: 'confirm',
+          answers: [{ questionIndex: 0, value: 'final' }]
+        })
+      })
+    )
+    releaseDraft?.()
+  })
+
+  it('replaces drafts that have not started with the latest answer', async () => {
+    vi.useFakeTimers()
+    let releaseFirstDraft: (() => void) | undefined
+    let isFirstDraft = true
+    const onRespond = vi.fn<(response: ElicitationResponse) => Promise<void>>(() => {
+      if (!isFirstDraft) return Promise.resolve()
+      isFirstDraft = false
+      return new Promise<void>((resolve) => {
+        releaseFirstDraft = resolve
+      })
+    })
+    render(
+      <WorkspaceDelegatedQuestionCard
+        projectId="project-1"
+        sessionId="session-1"
+        request={{ ...request, questions: request.questions.slice(0, 1) }}
+        onRespond={onRespond}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Type your own answer' })
+    fireEvent.change(input, { target: { value: 'first' } })
+    await act(() => vi.advanceTimersByTimeAsync(300))
+    expect(onRespond).toHaveBeenCalledTimes(1)
+
+    fireEvent.change(input, { target: { value: 'obsolete' } })
+    await act(() => vi.advanceTimersByTimeAsync(300))
+    fireEvent.change(input, { target: { value: 'final' } })
+    await act(() => vi.advanceTimersByTimeAsync(300))
+    expect(onRespond).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      releaseFirstDraft?.()
+      await Promise.resolve()
+    })
+
+    expect(onRespond).toHaveBeenCalledTimes(2)
+    expect(onRespond).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        delegatedQuestion: expect.objectContaining({
+          action: 'draft',
+          answers: [{ questionIndex: 0, value: 'final' }]
+        })
+      })
+    )
+  })
+
   it('serializes durable drafts before later navigation writes', async () => {
     let releaseFirstDraft: (() => void) | undefined
     const onRespond = vi.fn<(response: ElicitationResponse) => Promise<void>>(

--- a/src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Check, ChevronLeft, ChevronRight } from 'lucide-react'
 
@@ -15,6 +15,7 @@ import type {
 // matter the UI language. Only the buttons' visible labels are translated.
 const AGENT_DECIDES_ANSWER = 'Let the agent decide'
 const SKIPPED_ANSWER = 'Skipped'
+const DRAFT_DEBOUNCE_MS = 300
 
 type Props = Readonly<{
   projectId: string
@@ -34,9 +35,44 @@ const WorkspaceDelegatedQuestionCard = ({
   const [questionIndex, setQuestionIndex] = useState(request.draftQuestionIndex)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string>()
-  const responseQueue = useRef<Promise<void>>(Promise.resolve())
+  const draftInFlight = useRef(false)
+  const pendingDraft = useRef<ElicitationResponse | undefined>(undefined)
+  const draftTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const question = request.questions[questionIndex]
   const currentAnswer = answers.find((answer) => answer.questionIndex === questionIndex)?.value
+
+  const cancelScheduledDraft = (): void => {
+    if (draftTimer.current === undefined) return
+    clearTimeout(draftTimer.current)
+    draftTimer.current = undefined
+  }
+
+  useEffect(
+    () => () => {
+      cancelScheduledDraft()
+      pendingDraft.current = undefined
+    },
+    []
+  )
+
+  const responseError = (caught: unknown): void => {
+    setError(caught instanceof Error ? caught.message : t('Could not save the response.'))
+  }
+
+  const drainDrafts = (): void => {
+    const response = pendingDraft.current
+    if (draftInFlight.current || !response) return
+    pendingDraft.current = undefined
+    draftInFlight.current = true
+    setError(undefined)
+    void Promise.resolve()
+      .then(() => onRespond(response))
+      .catch(responseError)
+      .finally(() => {
+        draftInFlight.current = false
+        drainDrafts()
+      })
+  }
 
   const send = async (
     action: 'draft' | 'confirm',
@@ -55,26 +91,39 @@ const WorkspaceDelegatedQuestionCard = ({
         ...(action === 'draft' ? { questionIndex: nextQuestionIndex } : {})
       }
     }
-    const operation = responseQueue.current.catch(() => undefined).then(() => onRespond(response))
-    responseQueue.current = operation
+    if (action === 'draft') {
+      pendingDraft.current = response
+      drainDrafts()
+      return
+    }
+    pendingDraft.current = undefined
     try {
-      await operation
+      await onRespond(response)
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : t('Could not save the response.'))
+      responseError(caught)
       throw caught
     }
   }
 
-  const choose = (value: string): void => {
+  const choose = (value: string, debounce = false): void => {
     const next = [
       ...answers.filter((answer) => answer.questionIndex !== questionIndex),
       ...(value.trim() ? [{ questionIndex, value }] : [])
     ].sort((left, right) => left.questionIndex - right.questionIndex)
     setAnswers(next)
+    cancelScheduledDraft()
+    if (debounce) {
+      draftTimer.current = setTimeout(() => {
+        draftTimer.current = undefined
+        void send('draft', next).catch(() => undefined)
+      }, DRAFT_DEBOUNCE_MS)
+      return
+    }
     void send('draft', next).catch(() => undefined)
   }
 
   const move = (nextIndex: number): void => {
+    cancelScheduledDraft()
     setQuestionIndex(nextIndex)
     void send('draft', answers, nextIndex).catch(() => undefined)
   }
@@ -82,6 +131,7 @@ const WorkspaceDelegatedQuestionCard = ({
   const confirm = async (): Promise<void> => {
     if (submitting || answers.length !== request.questions.length) return
     setSubmitting(true)
+    cancelScheduledDraft()
     try {
       await send('confirm', answers)
     } finally {
@@ -163,7 +213,8 @@ const WorkspaceDelegatedQuestionCard = ({
                 : ''
             }
             className="min-h-9 flex-1 resize-none border-0 bg-transparent shadow-none focus-visible:ring-0"
-            onChange={(event) => choose(event.currentTarget.value)}
+            onChange={(event) => choose(event.currentTarget.value, true)}
+            onBlur={(event) => choose(event.currentTarget.value)}
           />
           <Button type="button" variant="ghost" onClick={() => choose(SKIPPED_ANSWER)}>
             {t('Skip')}

--- a/src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.tsx
@@ -35,28 +35,19 @@ const WorkspaceDelegatedQuestionCard = ({
   const [questionIndex, setQuestionIndex] = useState(request.draftQuestionIndex)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string>()
+  const mounted = useRef(true)
   const draftInFlight = useRef(false)
   const pendingDraft = useRef<ElicitationResponse | undefined>(undefined)
+  const scheduledDraft = useRef<ElicitationResponse | undefined>(undefined)
   const draftTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const flushScheduledDraftRef = useRef<() => void>(() => undefined)
   const question = request.questions[questionIndex]
   const currentAnswer = answers.find((answer) => answer.questionIndex === questionIndex)?.value
 
-  const cancelScheduledDraft = (): void => {
-    if (draftTimer.current === undefined) return
-    clearTimeout(draftTimer.current)
-    draftTimer.current = undefined
-  }
-
-  useEffect(
-    () => () => {
-      cancelScheduledDraft()
-      pendingDraft.current = undefined
-    },
-    []
-  )
-
   const responseError = (caught: unknown): void => {
-    setError(caught instanceof Error ? caught.message : t('Could not save the response.'))
+    if (mounted.current) {
+      setError(caught instanceof Error ? caught.message : t('Could not save the response.'))
+    }
   }
 
   const drainDrafts = (): void => {
@@ -64,7 +55,7 @@ const WorkspaceDelegatedQuestionCard = ({
     if (draftInFlight.current || !response) return
     pendingDraft.current = undefined
     draftInFlight.current = true
-    setError(undefined)
+    if (mounted.current) setError(undefined)
     void Promise.resolve()
       .then(() => onRespond(response))
       .catch(responseError)
@@ -74,26 +65,62 @@ const WorkspaceDelegatedQuestionCard = ({
       })
   }
 
+  const queueDraft = (response: ElicitationResponse): void => {
+    pendingDraft.current = response
+    drainDrafts()
+  }
+
+  const cancelScheduledDraft = (): void => {
+    if (draftTimer.current !== undefined) clearTimeout(draftTimer.current)
+    draftTimer.current = undefined
+    scheduledDraft.current = undefined
+  }
+
+  const flushScheduledDraft = (): void => {
+    if (draftTimer.current !== undefined) clearTimeout(draftTimer.current)
+    draftTimer.current = undefined
+    const response = scheduledDraft.current
+    scheduledDraft.current = undefined
+    if (response) queueDraft(response)
+  }
+
+  useEffect(() => {
+    flushScheduledDraftRef.current = flushScheduledDraft
+  })
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      flushScheduledDraftRef.current()
+    }
+  }, [])
+
+  const buildResponse = (
+    action: 'draft' | 'confirm',
+    nextAnswers: readonly DelegatedQuestionAnswer[],
+    nextQuestionIndex = questionIndex
+  ): ElicitationResponse => ({
+    requestId: request.requestId,
+    action: 'accept',
+    delegatedQuestion: {
+      projectId,
+      sessionId,
+      action,
+      answers: nextAnswers,
+      ...(action === 'draft' ? { questionIndex: nextQuestionIndex } : {})
+    }
+  })
+
   const send = async (
     action: 'draft' | 'confirm',
     nextAnswers: readonly DelegatedQuestionAnswer[],
     nextQuestionIndex = questionIndex
   ): Promise<void> => {
-    setError(undefined)
-    const response: ElicitationResponse = {
-      requestId: request.requestId,
-      action: 'accept',
-      delegatedQuestion: {
-        projectId,
-        sessionId,
-        action,
-        answers: nextAnswers,
-        ...(action === 'draft' ? { questionIndex: nextQuestionIndex } : {})
-      }
-    }
+    if (mounted.current) setError(undefined)
+    const response = buildResponse(action, nextAnswers, nextQuestionIndex)
     if (action === 'draft') {
-      pendingDraft.current = response
-      drainDrafts()
+      queueDraft(response)
       return
     }
     pendingDraft.current = undefined
@@ -113,10 +140,8 @@ const WorkspaceDelegatedQuestionCard = ({
     setAnswers(next)
     cancelScheduledDraft()
     if (debounce) {
-      draftTimer.current = setTimeout(() => {
-        draftTimer.current = undefined
-        void send('draft', next).catch(() => undefined)
-      }, DRAFT_DEBOUNCE_MS)
+      scheduledDraft.current = buildResponse('draft', next)
+      draftTimer.current = setTimeout(flushScheduledDraft, DRAFT_DEBOUNCE_MS)
       return
     }
     void send('draft', next).catch(() => undefined)


### PR DESCRIPTION
## Problem

Typing a custom delegated-question answer submitted one full durable draft per character. The renderer retained every stale draft in a FIFO promise queue, so slow Session persistence produced an unbounded backlog and Finish waited behind intermediate values.

The public component regression tests reproduced each symptom deterministically before the fix:
- rapid typing: expected 1 draft, observed 3, in three consecutive runs;
- Finish with an in-flight draft: expected the confirm call immediately, observed only the blocked draft, in three consecutive runs;
- pending coalescing: expected 2 total calls, observed 3, in three consecutive runs;
- blur flush: expected 1 immediate draft, observed 0, in three consecutive runs.

## Proposed change

- Debounce free-text drafts for 300 ms.
- Keep at most one in-flight draft and one replaceable latest pending draft.
- Flush the current value on blur and when navigation changes the question.
- Drop unstarted drafts when Finish sends the final answers directly in confirm.
- Clear scheduled and pending drafts when the card unmounts.

## Scope and non-goals

- Renderer component scheduling only; no ACP, IPC, Main persistence, or framework-adapter changes.
- No new persisted fields, data-model changes, migrations, historical-data compatibility work, enums, or UI state.
- Existing draftAnswers, draftQuestionIndex, and final answers payloads remain unchanged.
- No generic queue abstraction or Session persistence redesign.
- The shared renderer path precedes Claude Code, OpenCode, Codex, and CodeBuddy adapters, so framework wire behavior is unchanged.

Persistence now has a bounded 300 ms custom-text window while the user is actively typing. Blur, question navigation, and Finish close that window. Main remains responsible for Session-level ordering and CAS.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- rapid typing, blur flush, pending coalescing, and direct Finish behavior -> npm test -- src/renderer/src/pages/workspace/WorkspaceDelegatedQuestionCard.test.tsx -> 7 passed
- ConversationPanel delegated-question consumer behavior -> npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -> 133 passed
- Workspace page owner and representative consumers -> npm run test:module -- workspace_page -> 29 files, 709 tests passed
- renderer type safety -> npm run typecheck:web -> passed
- repository lint -> npm run lint -> passed
- exact-head impact explanation -> npm run test:affected:explain -- --base origin/main --head HEAD -> full CI fallback because WorkspaceDelegatedQuestionCard.test.tsx has no module owner

Per maintainer direction, the complete local npm test suite was not run. PR Gate is the authority for the full portable and platform checks selected by the exact-head classifier. No platform-specific behavior changed; local E2E was excluded because the public component and direct ConversationPanel consumer seams expose the affected behavior deterministically.

## Review focus

- The single in-flight plus latest-pending invariant.
- Confirm bypasses renderer draft backlog while Main preserves Session mutation ordering.
- Unmount, blur, navigation, and error ordering do not revive stale drafts.