### PR TITLE
fix(session-persistence): block archive for pending delegated questions

### DIFF
--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -8,6 +8,7 @@ vi.mock('electron', () => ({
 }))
 
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
+import { hasAnswerableDelegatedQuestion } from '../../shared/delegated-work-projection'
 import {
   createLinearConversationGraph,
   forkEditedConversationMessage,
@@ -151,6 +152,73 @@ const createIdleSessionWithRunningChild = (originMessageId = 'root-prompt'): Per
       }
     }
   })
+
+const createIdleSessionWithPendingDelegatedQuestion = (): PersistedChatSession => {
+  const session = createIdleSessionWithRunningChild()
+  const delegatedWork = session.runtimeContext?.delegatedWork
+  const attempt = delegatedWork?.records[0]?.attempts[0]
+  const child = session.conversationGraph?.frames.find((frame) => frame.id === 'child')
+  if (!delegatedWork || !attempt || !child) throw new Error('Invalid delegated Session fixture')
+
+  Object.assign(attempt, {
+    status: 'completed',
+    runtimeSegmentIds: ['runtime-1'],
+    endedAt: 3,
+    terminalMessageId: 'child-terminal'
+  })
+  Object.assign(child, { status: 'completed', delegateName: 'Researcher' })
+  const childBranch = session.conversationGraph?.branches.find(
+    (branch) => branch.id === 'child-branch'
+  )
+  if (!childBranch) throw new Error('Invalid delegated Session fixture')
+  childBranch.headMessageId = 'child-terminal'
+  session.conversationGraph?.messages.push({
+    id: 'child-terminal',
+    role: 'agent',
+    content: 'Waiting for an answer',
+    status: 'complete',
+    eventIds: [],
+    agentFrameId: child.id,
+    introducedOnBranchId: childBranch.id,
+    runtimeSegmentId: 'runtime-1',
+    createdAt: 3,
+    updatedAt: 3
+  })
+  session.conversationGraph?.runtimeSegments.push({
+    id: 'runtime-1',
+    agentFrameId: child.id,
+    frameworkId: 'codex',
+    startedAt: 2,
+    endedAt: 3
+  })
+  Object.assign(delegatedWork, {
+    questionRequests: [
+      {
+        requestId: 'question-1',
+        canonicalDigest: 'a'.repeat(64),
+        sourceFrameId: child.id,
+        sourceAttemptId: attempt.id,
+        sourceRuntimeSegmentId: 'runtime-1',
+        sourceName: 'Researcher',
+        rootBranchId: 'root-branch',
+        rootOriginMessageId: 'root-prompt',
+        sourceMessageBranchId: 'child-branch',
+        questions: [
+          {
+            question: 'Choose a source',
+            options: [{ label: 'Primary' }, { label: 'Secondary' }]
+          }
+        ],
+        sequence: 1,
+        askedAt: 3,
+        status: 'pending',
+        draftAnswers: [],
+        draftQuestionIndex: 0
+      }
+    ]
+  })
+  return session
+}
 
 const createRuntimePlan = (
   overrides: Partial<SessionPlanRuntimeContext> = {}
@@ -2060,6 +2128,45 @@ describe('SessionPersistenceCoordinator', () => {
         expectedArchivedAt: null
       })
     ).resolves.toMatchObject({ archivedAt: expect.any(Number) })
+  })
+
+  it('rejects archive while an idle Session has an answerable delegated question', async () => {
+    const delegated = createIdleSessionWithPendingDelegatedQuestion()
+    const root = await mkdtemp(join(tmpdir(), 'open-science-pending-question-archive-'))
+    const repository = new SessionRepository(root)
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+    try {
+      await repository.saveSession(delegated)
+      const persisted = await repository.loadSession(delegated.projectId, delegated.id)
+      expect(hasAnswerableDelegatedQuestion(persisted)).toBe(true)
+
+      const [projectArchive] = await Promise.allSettled([
+        coordinator.assertProjectArchivable(delegated.projectId)
+      ])
+      const [sessionArchive] = await Promise.allSettled([
+        coordinator.updateArchive({
+          projectId: delegated.projectId,
+          sessionId: delegated.id,
+          archived: true,
+          expectedArchivedAt: null
+        })
+      ])
+
+      expect([projectArchive.status, sessionArchive.status]).toEqual(['rejected', 'rejected'])
+      expect(projectArchive).toMatchObject({
+        status: 'rejected',
+        reason: { message: 'Finish or stop active sessions before archiving this project.' }
+      })
+      expect(sessionArchive).toMatchObject({
+        status: 'rejected',
+        reason: { message: 'Finish or stop this session before archiving.' }
+      })
+      await expect(
+        repository.loadSession(delegated.projectId, delegated.id)
+      ).resolves.not.toHaveProperty('archivedAt')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('does not let a renderer whole-session save create runtime authority', async () => {

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -1,5 +1,8 @@
 import type { ProjectFilesChangedEvent, ProjectFileSource } from '../../shared/project-files'
-import { hasCurrentRunningDelegatedAttempt } from '../../shared/delegated-work-projection'
+import {
+  hasAnswerableDelegatedQuestion,
+  hasCurrentRunningDelegatedAttempt
+} from '../../shared/delegated-work-projection'
 import type {
   LoadAllSessionsResult,
   PersistedChatSession,
@@ -124,7 +127,9 @@ const isSessionArchiveBlocked = (session: PersistedChatSession): boolean =>
   ARCHIVE_BLOCKING_SESSION_STATUSES.has(session.status)
 
 const isSessionArchiveBlockedByPersistedWork = (session: PersistedChatSession): boolean =>
-  isSessionArchiveBlocked(session) || hasCurrentRunningDelegatedAttempt(session)
+  isSessionArchiveBlocked(session) ||
+  hasCurrentRunningDelegatedAttempt(session) ||
+  hasAnswerableDelegatedQuestion(session)
 
 class SessionPersistenceDeletionOwner {
   private readonly repository: SessionDeletionRepository

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -93,6 +93,42 @@ const sessionWithRunningChild = (): ChatSession => {
   })
 }
 
+const sessionWithPendingDelegatedQuestion = (): ChatSession => {
+  const pending = sessionWithRunningChild()
+  const graph = pending.conversationGraph
+  const delegatedWork = pending.runtimeContext?.delegatedWork
+  const child = graph?.frames.find(({ id }) => id === 'child-frame')
+  const root = graph?.frames.find(({ id }) => id === graph.rootFrameId)
+  const attempt = delegatedWork?.records[0]?.attempts[0]
+  if (!graph || !delegatedWork || !child || !root || !attempt) {
+    throw new Error('Invalid delegated Session fixture')
+  }
+
+  Object.assign(child, { status: 'completed', delegateName: 'Researcher' })
+  Object.assign(attempt, { status: 'completed', endedAt: 3 })
+  Object.assign(delegatedWork, {
+    questionRequests: [
+      {
+        requestId: 'question-1',
+        canonicalDigest: 'a'.repeat(64),
+        sourceFrameId: child.id,
+        sourceAttemptId: attempt.id,
+        sourceRuntimeSegmentId: 'runtime-1',
+        sourceMessageBranchId: child.activeBranchId,
+        rootOriginMessageId: 'root-prompt',
+        rootBranchId: root.activeBranchId,
+        sourceName: 'Researcher',
+        questions: [{ question: 'Choose a source' }],
+        askedAt: 3,
+        status: 'pending',
+        draftAnswers: [],
+        draftQuestionIndex: 0
+      }
+    ]
+  })
+  return pending
+}
+
 const specialist = (id: string, name: string): SpecialistListItem =>
   ({ kind: 'custom', id, name, enabled: true }) as SpecialistListItem
 
@@ -677,6 +713,18 @@ describe('workspace session controller', () => {
     mounted.push(hook)
 
     expect(hook.result.current.lifecycle.canArchive(active)).toBe(false)
+  })
+
+  it('does not archive an idle Session while a delegated question awaits an answer', () => {
+    const active = sessionWithPendingDelegatedQuestion()
+    const updateSessionArchive = vi.fn()
+    useSessionStore.setState({ sessions: [active], updateSessionArchive })
+    const hook = renderController({ activeSession: active })
+    mounted.push(hook)
+
+    expect(hook.result.current.lifecycle.canArchive(active)).toBe(false)
+    act(() => hook.result.current.actions.archive(active))
+    expect(updateSessionArchive).not.toHaveBeenCalled()
   })
 
   it('does not archive while Save as skill owns prompt admission', () => {

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -16,7 +16,6 @@ import type {
   CompletionHandoffLifecycleEvent,
   SpecialistListItem
 } from '../../../../shared/specialist'
-import { hasCurrentRunningDelegatedAttempt } from '../../../../shared/delegated-work-projection'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
 import { projectSessionActionability, useSessionStore } from '@/stores/session-store'
@@ -40,6 +39,7 @@ import {
   type WorkspaceSpecialistReconfigureError as ReconfigureError
 } from './workspace-specialist-reconfiguration'
 import { useWorkspaceSessionDetailsController } from './workspace-session-details-controller'
+import { projectPresentedSessionActionability } from './session-wait-reason'
 
 type WorkspaceSessionControllerOptions = {
   activeSession: ChatSession | undefined
@@ -244,9 +244,7 @@ const useWorkspaceSessionController = ({
     !promptInFlightSessionIds.includes(session.id) &&
     !sendPreparationInFlightSessionIds.includes(session.id) &&
     !saveAsSkillInFlightSessionIds.includes(session.id) &&
-    projectSessionActionability(session, {
-      hasRunningWork: hasCurrentRunningDelegatedAttempt(session)
-    }).actions.archive.allowed &&
+    projectPresentedSessionActionability(session).actions.archive.allowed &&
     !hasUnfinishedTransfers(session.id)
   const archive = (session: ChatSession): void => {
     if (!canArchive(session)) return


### PR DESCRIPTION
## Problem

An idle Session can retain an answerable delegated question after its current child Attempt completes. The Session projection presents that state as `waiting-for-user`, and conversation export rejects it, but archive admission only checked the raw Session status and current running delegated Attempts. Both Session and Project archive therefore succeeded while the question still needed an answer. The Workspace archive action also remained enabled until the main process rejected it.

## Proposed change

- Reuse `hasAnswerableDelegatedQuestion` in the shared persisted-work archive guard used by Session and Project archive admission.
- Reuse `projectPresentedSessionActionability` in the Workspace archive predicate so the renderer affordance matches the main-process guard.
- Add a persistence regression test that writes the completed-Attempt/pending-question state through `SessionRepository`, reloads it, and verifies both public archive operations reject without persisting `archivedAt`.
- Add a renderer controller regression test that verifies the same state disables the archive action and does not dispatch an archive request.

Both regressions were run before their corresponding production changes and failed for the reported reasons: the server operations fulfilled, and the renderer returned `canArchive === true`. Both pass after the fixes.

## Scope and non-goals

- No new database or persisted JSON fields.
- No migration or historical-data rewrite.
- No new Session status or enum value.
- No new renderer copy, layout, or interaction flow. The existing archive action is now disabled while an answerable delegated question is pending.
- No broader unification of presentation, export, and lifecycle policies beyond reusing the existing presented actionability projection at the Workspace archive boundary.

Historical Sessions that still contain a valid answerable delegated question now remain unarchivable until that question is answered or cancelled. Malformed or quarantined question owners are not newly treated as answerable.

## Acceptance criteria and validation

Server archive guard:

- Pending delegated question archive behavior -> targeted `vitest` regression -> passed (1 test; 151 skipped).
- Session Persistence owner, contract, and representative consumer behavior -> `npm run test:module -- session_persistence` -> passed (7 files, 373 tests).
- Main-process and sandbox TypeScript surfaces -> `npm run typecheck:node` -> passed.
- Linted source and tests -> `npm run lint` -> passed.

Workspace actionability follow-up:

- Targeted Workspace controller regression -> passed (34/34).
- `npm run test:module -- workspace_page` -> passed (29 files, 710 tests).
- `npm run typecheck:web` -> passed.
- Targeted ESLint and Prettier checks -> passed.

Current-head PR CI has passed Preflight, PR policy, Static checks, Module tests and coverage, CodeQL, Windows core, and the second AI PR Review. Platform E2E lanes may continue independently as the final CI authority.

## Test Impact Set

The server-side coordinator regression selects Session Persistence and the registered Artifact Provenance and Project Files consumers. The renderer change selects Workspace Page with the `renderer_state` overlay and `renderer_view` fallback. Local validation used the Session Persistence and Workspace Page module plans; broader platform and consumer coverage remains delegated to PR Gate CI as requested.

## Review focus

- Confirm archive admission uses the same active-branch answerability predicate as Session presentation.
- Confirm the Workspace affordance matches the main-process guard.
- Confirm quarantined, inactive-branch, answered, and cancelled questions remain outside the new guard.
