### PR TITLE
fix(compute): replace print() with return in remote-compute-ssh JS examples

### DIFF
--- a/resources/skills/remote-compute-ssh/SKILL.md
+++ b/resources/skills/remote-compute-ssh/SKILL.md
@@ -120,7 +120,7 @@ await new Promise((resolve) => setTimeout(resolve, 2000))
 // result() is a non-blocking local DB/directory read in every state; it never waits for completion,
 // triggers SSH, or starts another harvest. Fetching it once exposes immediate stderr/error details.
 const initial = await c.attachJob(job.job_id).result()
-print(initial)
+return initial
 ```
 
 ### Immediate failure check after submission
@@ -279,7 +279,7 @@ for (const seed of [0, 1, 2, 3, 4]) {
   )
   jobs.push(job.job_id)
 }
-print(jobs) // end the cell — no waiting, no loop
+return jobs // end the cell — no waiting, no loop
 ```
 
 The app triggers one analysis turn per job completion (or a merged turn for simultaneous

--- a/src/main/compute/remote-compute-skill.test.ts
+++ b/src/main/compute/remote-compute-skill.test.ts
@@ -46,11 +46,11 @@ describe('remote-compute-ssh immediate failure guidance', () => {
       events.push('create')
       return { submitJob, attachJob }
     })
-    const print = vi.fn((value: unknown) => {
-      events.push('print')
-      expect(value).toBe(resultSnapshot)
+    const print = vi.fn(() => {
+      throw new Error('the JS kernel has no print; use a trailing expression or return')
     })
     const execute = new AsyncFunction('host', 'print', workflow!)
+    let returned: unknown
     vi.useFakeTimers()
     try {
       const completion = execute({ compute: { create } }, print)
@@ -59,12 +59,13 @@ describe('remote-compute-ssh immediate failure guidance', () => {
       await vi.advanceTimersByTimeAsync(1999)
       expect(result).not.toHaveBeenCalled()
       await vi.advanceTimersByTimeAsync(1)
-      await completion
+      returned = await completion
     } finally {
       vi.useRealTimers()
     }
 
-    expect(events).toEqual(['create', 'submit', 'attach:job-1', 'result', 'print'])
+    expect(events).toEqual(['create', 'submit', 'attach:job-1', 'result'])
+    expect(returned).toBe(resultSnapshot)
     expect(status).not.toHaveBeenCalled()
     expect(result).toHaveBeenCalledOnce()
   })


### PR DESCRIPTION
## Problem

Agents writing Host SDK code in the notebook's JS kernel repeatedly produce `ReferenceError: print is not defined` after copying the remote-compute-ssh skill's JavaScript examples, which end cells with `print(...)`.

The JS kernel (`resources/notebook/repl_loop.js`) defines no global `print`. Verified against the real kernel: `print(help)` throws `ReferenceError`, while `return <expr>` and a trailing expression both land the value in the cell's `result` (JSON-serialized). The trailing-expression form silently degrades to `result: null` with no error once a statement follows it, so explicit `return` is the reliable pattern to teach — and it matches the convention used throughout `repl-loop.integration.test.ts`.

The executable skill test injected a working `print` mock, so the examples passed in the test environment while failing in the real kernel.

## Proposed change

- `resources/skills/remote-compute-ssh/SKILL.md`: both JavaScript examples now end with `return initial` / `return jobs` instead of `print(...)`; the "end the cell — no waiting, no loop" intent is unchanged.
- `src/main/compute/remote-compute-skill.test.ts`: the injected `print` now throws exactly like the real kernel, so reintroducing `print()` into the doc fails the test the same way it fails in production; the test now asserts the `return` contract (the result snapshot becomes the cell's returned value).

## Scope and non-goals

- Only the two `print()` call sites in this skill's JS examples and the test that executes them. The Python-kernel skills' `print()` usage is legitimate and untouched.
- No system-prompt or `host.help` changes; those surfaces contain no `print` references.

## Acceptance criteria and validation

Ran after the last material edit:

- `npm test -- src/main/compute/remote-compute-skill.test.ts src/main/compute/skill-doc.test.ts src/main/compute/skill-provisioning.test.ts src/main/compute/compute-service.architecture.test.ts` — 20 passed
- `npm run typecheck:node` — pass
- `npx eslint src/main/compute/remote-compute-skill.test.ts` — pass
- Kernel behavior (print throws; return lands in result) exercised directly against `resources/notebook/repl_loop.js`

## Review focus

Whether the executable-doc mock should model the kernel's missing `print` by throwing (chosen) versus dropping the `print` parameter entirely (a stray `print()` call would then surface as a plain ReferenceError).