### PR TITLE
fix(reviewer): recover interrupted Fix Loops

### DIFF
--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -399,6 +399,7 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
     const client = createProjectDbClient(temporaryRoot!)
     await migrateApplicationDatabase(client)
     const repository = new ReviewRepository(() => Promise.resolve(client))
+    const onReviewUpdate = vi.fn()
 
     const reviewRun = runReview({
       sessionId: 'session-1',
@@ -409,6 +410,7 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
       acpRuntime: runtime,
       artifactStorageRoot: temporaryRoot!,
       mainSessionId: 'main-session-1',
+      onReviewUpdate,
       agentTarget: {
         frameworkId: 'codex',
         providerId: 'provider-1',
@@ -436,6 +438,14 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
         outcome: null,
         checks: [expect.objectContaining({ status: 'fail' })]
       })
+      expect(onReviewUpdate).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          id: initialReview?.id,
+          lifecycle: 'running',
+          outcome: null,
+          checks: [expect.objectContaining({ status: 'fail' })]
+        })
+      )
     } finally {
       releaseCorrection()
     }

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -462,6 +462,75 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
     await client.$disconnect()
   })
 
+  it('publishes the terminal review when the Fix Loop exits exceptionally', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+
+    startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Agent claimed 42 results',
+            evidence: 'Tool output shows 0 results',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc123' }
+          }
+        ],
+        reReviewChecksByRound: [
+          [
+            {
+              status: 'pass',
+              claim: 'Agent claimed 42 results',
+              evidence: 'Correction confirmed: results now correct'
+            }
+          ]
+        ]
+      },
+      shared
+    )
+
+    const runtime = createFixLoopRuntime(process, shared)
+    await runtime.createSession({ cwd: '/workspace' })
+    const client = createProjectDbClient(temporaryRoot!)
+    await migrateApplicationDatabase(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+    const onReviewUpdate = vi.fn()
+    const onFixLoopStart = vi.fn(() => {
+      vi.spyOn(repository, 'commitFindingDispositions').mockRejectedValueOnce(
+        new Error('disposition write failed')
+      )
+    })
+
+    await expect(
+      runReview({
+        sessionId: 'session-1',
+        turnMessageId: 'msg-2',
+        projectId: 'project-1',
+        getSession: () => shared.getSession(),
+        reviewRepository: repository,
+        acpRuntime: runtime,
+        artifactStorageRoot: temporaryRoot!,
+        mainSessionId: 'main-session-1',
+        onReviewUpdate,
+        onFixLoopStart,
+        fixLoopMaxRounds: 0,
+        agentTarget: {
+          frameworkId: 'codex',
+          providerId: 'provider-1',
+          model: 'model-1',
+          reasoningEffort: 'high'
+        }
+      })
+    ).rejects.toThrow('disposition write failed')
+
+    expect(onReviewUpdate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ lifecycle: 'complete', outcome: 'flagged' })
+    )
+    await client.$disconnect()
+  })
+
   it('resolves all checks when re-review passes; exactly 1 [Auditor] injection for 1 round', async () => {
     const process = new FakeAgentProcess()
     const shared = makeSharedSession(

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -431,7 +431,11 @@ describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
         (review) => review.turnMessageId === 'msg-2'
       )
       initialReviewId = initialReview?.id
-      expect(initialReview).toMatchObject({ lifecycle: 'running', outcome: 'flagged' })
+      expect(initialReview).toMatchObject({
+        lifecycle: 'running',
+        outcome: null,
+        checks: [expect.objectContaining({ status: 'fail' })]
+      })
     } finally {
       releaseCorrection()
     }

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -83,6 +83,8 @@ type FixLoopFakeAgentOptions = {
   reReviewChecksByRound?: ReReviewChecks[]
   // Called when a correction prompt arrives at the main session
   onCorrectionPrompt?: (text: string, round: number) => void
+  // Lets a test inspect durable state while the correction turn is in flight.
+  beforeCorrectionReply?: () => Promise<void>
 }
 
 type FixLoopAgentState = {
@@ -199,6 +201,7 @@ const startFixLoopFakeAgent = (
         // This is a main-session correction prompt
         state.correctionCount++
         options.onCorrectionPrompt?.(text, state.correctionCount)
+        await options.beforeCorrectionReply?.()
 
         // Simulate the session JSON being updated with a new agent correction message.
         // The fix loop needs to reload the session to see new messages after the correction.
@@ -350,6 +353,101 @@ afterEach(async () => {
 })
 
 describe('fix loop: all-pass on re-review ends the loop (resolved)', () => {
+  it('keeps the flagged initial review running until the Fix Loop settles', async () => {
+    const process = new FakeAgentProcess()
+    const shared = makeSharedSession(makeSession())
+    let enterCorrection!: () => void
+    let releaseCorrection!: () => void
+    const correctionEntered = new Promise<void>((resolve) => {
+      enterCorrection = resolve
+    })
+    const correctionReleased = new Promise<void>((resolve) => {
+      releaseCorrection = resolve
+    })
+
+    startFixLoopFakeAgent(
+      process,
+      {
+        mainSessionId: 'main-session-1',
+        initialChecks: [
+          {
+            status: 'fail',
+            claim: 'Agent claimed 42 results',
+            evidence: 'Tool output shows 0 results',
+            locator: { blockRef: { blockIndex: 1 }, contentHash: 'abc123' }
+          }
+        ],
+        reReviewChecksByRound: [
+          [
+            {
+              status: 'pass',
+              claim: 'Agent claimed 42 results',
+              evidence: 'Correction confirmed: results now correct'
+            }
+          ]
+        ],
+        beforeCorrectionReply: async () => {
+          enterCorrection()
+          await correctionReleased
+        }
+      },
+      shared
+    )
+
+    const runtime = createFixLoopRuntime(process, shared)
+    await runtime.createSession({ cwd: '/workspace' })
+    const client = createProjectDbClient(temporaryRoot!)
+    await migrateApplicationDatabase(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const reviewRun = runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => shared.getSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1',
+      agentTarget: {
+        frameworkId: 'codex',
+        providerId: 'provider-1',
+        model: 'model-1',
+        reasoningEffort: 'high'
+      }
+    })
+
+    await Promise.race([
+      correctionEntered,
+      reviewRun.then((review) => {
+        throw new Error(
+          `Review run ended before the correction turn started: ${review.lifecycle}/${review.outcome}, ${review.checks.length} checks, ${review.errorMessage ?? 'no error'}.`
+        )
+      })
+    ])
+    let initialReviewId: string | undefined
+    try {
+      const initialReview = (await repository.getReviewsForSession('session-1')).find(
+        (review) => review.turnMessageId === 'msg-2'
+      )
+      initialReviewId = initialReview?.id
+      expect(initialReview).toMatchObject({ lifecycle: 'running', outcome: 'flagged' })
+    } finally {
+      releaseCorrection()
+    }
+
+    await reviewRun
+    const initialReview = (await repository.getReviewsForSession('session-1')).find(
+      (review) => review.id === initialReviewId
+    )
+    expect({
+      lifecycle: initialReview?.lifecycle,
+      outcome: initialReview?.outcome,
+      errorMessage: initialReview?.errorMessage
+    }).toEqual({ lifecycle: 'complete', outcome: 'flagged', errorMessage: undefined })
+    await client.$disconnect()
+  })
+
   it('resolves all checks when re-review passes; exactly 1 [Auditor] injection for 1 round', async () => {
     const process = new FakeAgentProcess()
     const shared = makeSharedSession(

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -177,6 +177,7 @@ const runReviewWithSession = async (
     model,
     onReviewUpdate,
     onStarted,
+    keepFlaggedReviewRunning: mainSessionId !== undefined,
     reviewerTimeoutMs,
     reviewerMaxUpdates,
     abortSignal: fixLoopAbortSignal,
@@ -219,7 +220,17 @@ const runReviewWithSession = async (
         recordUsage
       })
     } finally {
-      onFixLoopEnd?.()
+      try {
+        await runReviewMutation(runSessionMutation, () =>
+          reviewRepository.updateReview(finalReview.id, {
+            lifecycle: 'complete',
+            outcome: 'flagged',
+            errorMessage: null
+          })
+        )
+      } finally {
+        onFixLoopEnd?.()
+      }
     }
 
     // Reload checks after the fix loop so the returned object reflects final resolutions.

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -193,6 +193,7 @@ const runReviewWithSession = async (
   if (mainSessionId && hasWarnOrFail) {
     onReviewUpdate?.(finalReview)
     await onFixLoopStart?.()
+    let terminalReview: ReviewWithChecks | undefined
     try {
       await runReviewerFixLoop({
         sessionId,
@@ -229,12 +230,18 @@ const runReviewWithSession = async (
             errorMessage: null
           })
         )
+        const reviews = await reviewRepository.getReviewsForProjectSession(projectId, sessionId)
+        terminalReview = reviews.find((review) => review.id === finalReview.id)
+        if (terminalReview) onReviewUpdate?.(terminalReview)
       } finally {
         onFixLoopEnd?.()
       }
     }
 
-    // Reload checks after the fix loop so the returned object reflects final resolutions.
+    if (terminalReview) return terminalReview
+
+    // Reload checks after the fix loop so the returned object reflects final resolutions if the
+    // terminal row disappeared between the update and the first reload.
     const reloadedReviews = await reviewRepository.getReviewsForProjectSession(projectId, sessionId)
     const reloadedReview = reloadedReviews.find((review) => review.id === finalReview.id)
     if (reloadedReview) {

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -191,6 +191,7 @@ const runReviewWithSession = async (
   const hasWarnOrFail = finalReview.checks.some((c) => c.status === 'warn' || c.status === 'fail')
 
   if (mainSessionId && hasWarnOrFail) {
+    onReviewUpdate?.(finalReview)
     await onFixLoopStart?.()
     try {
       await runReviewerFixLoop({

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -204,7 +204,8 @@ class ReviewRepository {
         where: {
           projectId: fixLoopReview.projectId,
           sessionId: fixLoopReview.sessionId,
-          turnMessageId: fixLoopReview.turnMessageId
+          turnMessageId: fixLoopReview.turnMessageId,
+          createdAt: { gte: fixLoopReview.createdAt }
         },
         select: { id: true }
       })

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -30,6 +30,8 @@ import { assertReviewSubmissionWithinLimits } from './submission-limits'
 
 const REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE =
   'Review was interrupted because Open Science exited before it completed.'
+const FIX_LOOP_INTERRUPTED_ON_STARTUP_MESSAGE =
+  'Fix Loop was interrupted because Open Science exited before it completed.'
 
 // Legacy alias for callers still using FindingSeverity (now CheckStatus).
 type FindingSeverity = CheckStatus
@@ -189,15 +191,51 @@ class ReviewRepository {
 
   async recoverInterruptedReviews(): Promise<number> {
     const client = await this.getClient()
-    const result = await client.review.updateMany({
-      where: { lifecycle: 'running' },
+    const interruptedFixLoops = await client.review.findMany({
+      where: { lifecycle: 'running', outcome: 'flagged' }
+    })
+
+    for (const fixLoopReview of interruptedFixLoops) {
+      const turnReviews = await client.review.findMany({
+        where: {
+          projectId: fixLoopReview.projectId,
+          sessionId: fixLoopReview.sessionId,
+          turnMessageId: fixLoopReview.turnMessageId
+        },
+        select: { id: true }
+      })
+      const openFindings = await client.finding.findMany({
+        where: {
+          reviewId: { in: turnReviews.map(({ id }) => id) },
+          status: { in: ['warn', 'fail'] },
+          resolution: 'open'
+        },
+        select: { id: true, reviewId: true }
+      })
+      await this.commitFindingDispositions(
+        openFindings.map((finding) => ({
+          reviewId: finding.reviewId,
+          sourceFindingId: finding.id,
+          trigger: 'interrupted',
+          outcome: 'unaddressed',
+          note: FIX_LOOP_INTERRUPTED_ON_STARTUP_MESSAGE
+        }))
+      )
+      await client.review.update({
+        where: { id: fixLoopReview.id },
+        data: { lifecycle: 'complete', outcome: 'flagged', errorMessage: null }
+      })
+    }
+
+    const interruptedAssessments = await client.review.updateMany({
+      where: { lifecycle: 'running', outcome: null },
       data: {
         lifecycle: 'error',
         outcome: null,
         errorMessage: REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE
       }
     })
-    return result.count
+    return interruptedFixLoops.length + interruptedAssessments.count
   }
 
   // Inserts a new review, defaulting a fresh audit to the 'running' lifecycle with no outcome yet.
@@ -364,20 +402,26 @@ class ReviewRepository {
   // submit no checks; tracked mode requires a non-empty submission and exact disposition of its
   // expected ids. Tracked sourceFindingId entries are immutable
   // assessments of existing Review Checks, never new Finding rows; untracked checks are newly
-  // discovered Review Checks. Review completion and every materialized disposition commit in the
+  // discovered Review Checks. The Review outcome and every materialized disposition commit in the
   // same SQLite transaction, so a malformed item cannot leave a partially applied audit result.
+  // An initial flagged submission may remain running while its Fix Loop is active; tracked Reviews
+  // always become terminal when their submission commits.
   async commitScopedSubmission(input: {
     mode: 'initial' | 'tracked'
     reviewId: string
     checks: NewCheck[]
     expectedSourceFindingIds: string[]
     reviewerLog?: ReviewerLogEntry[]
+    keepFlaggedReviewRunning?: boolean
   }): Promise<ReviewWithChecks> {
     if (input.mode !== 'initial' && input.mode !== 'tracked') {
       throw new Error('Review submission mode must be initial or tracked.')
     }
     if (input.mode === 'tracked' && input.checks.length === 0) {
       throw new Error('A tracked Review submission requires at least one Review Check.')
+    }
+    if (input.mode === 'tracked' && input.keepFlaggedReviewRunning) {
+      throw new Error('Only an initial Review may remain running for an active Fix Loop.')
     }
     assertReviewSubmissionWithinLimits(input.checks, input.expectedSourceFindingIds.length)
     const trackedFindingIds = input.checks.flatMap((check) =>
@@ -521,10 +565,13 @@ class ReviewRepository {
       for (const sourceReviewId of touchedSourceReviewIds) {
         await touchReview(tx, sourceReviewId)
       }
-      const completedReview = await tx.review.update({
+      const committedReview = await tx.review.update({
         where: { id: assessmentReview.id },
         data: {
-          lifecycle: 'complete',
+          lifecycle:
+            input.mode === 'initial' && input.keepFlaggedReviewRunning && outcome === 'flagged'
+              ? 'running'
+              : 'complete',
           outcome,
           errorMessage: null,
           reviewerLog: JSON.stringify(input.reviewerLog ?? [])
@@ -535,7 +582,7 @@ class ReviewRepository {
         assessmentReview.id
       )
       return {
-        ...toReview(completedReview),
+        ...toReview(committedReview),
         checks,
         submittedChecks,
         get findings() {
@@ -879,7 +926,12 @@ class ReviewRepository {
   }
 }
 
-export { REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE, ReviewRepository, toReview }
+export {
+  FIX_LOOP_INTERRUPTED_ON_STARTUP_MESSAGE,
+  REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE,
+  ReviewRepository,
+  toReview
+}
 export type { ReviewClient, ReviewClientProvider, ReviewRepositoryOptions, FindingSeverity }
 
 // Legacy exports kept for callers that still reference toFinding.

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -200,18 +200,25 @@ class ReviewRepository {
     })
 
     for (const fixLoopReview of interruptedFixLoops) {
-      const turnReviews = await client.review.findMany({
-        where: {
-          projectId: fixLoopReview.projectId,
-          sessionId: fixLoopReview.sessionId,
-          turnMessageId: fixLoopReview.turnMessageId,
-          createdAt: { gte: fixLoopReview.createdAt }
-        },
-        select: { id: true }
-      })
+      const chainReviewIds = new Set([fixLoopReview.id])
+      for (;;) {
+        const linkedReviews = await client.reviewFindingDisposition.findMany({
+          where: {
+            trigger: 'review_submission',
+            sourceFinding: { reviewId: { in: [...chainReviewIds] } },
+            causeReviewId: { not: null }
+          },
+          select: { causeReviewId: true }
+        })
+        const previousSize = chainReviewIds.size
+        for (const { causeReviewId } of linkedReviews) {
+          if (causeReviewId) chainReviewIds.add(causeReviewId)
+        }
+        if (chainReviewIds.size === previousSize) break
+      }
       const openFindings = await client.finding.findMany({
         where: {
-          reviewId: { in: turnReviews.map(({ id }) => id) },
+          reviewId: { in: [...chainReviewIds] },
           status: { in: ['warn', 'fail'] },
           resolution: 'open'
         },

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -192,7 +192,11 @@ class ReviewRepository {
   async recoverInterruptedReviews(): Promise<number> {
     const client = await this.getClient()
     const interruptedFixLoops = await client.review.findMany({
-      where: { lifecycle: 'running', outcome: 'flagged' }
+      where: {
+        lifecycle: 'running',
+        outcome: null,
+        findings: { some: { status: { in: ['warn', 'fail'] } } }
+      }
     })
 
     for (const fixLoopReview of interruptedFixLoops) {
@@ -216,7 +220,7 @@ class ReviewRepository {
         openFindings.map((finding) => ({
           reviewId: finding.reviewId,
           sourceFindingId: finding.id,
-          trigger: 'interrupted',
+          trigger: 'aborted',
           outcome: 'unaddressed',
           note: FIX_LOOP_INTERRUPTED_ON_STARTUP_MESSAGE
         }))
@@ -228,7 +232,11 @@ class ReviewRepository {
     }
 
     const interruptedAssessments = await client.review.updateMany({
-      where: { lifecycle: 'running', outcome: null },
+      where: {
+        lifecycle: 'running',
+        outcome: null,
+        findings: { none: { status: { in: ['warn', 'fail'] } } }
+      },
       data: {
         lifecycle: 'error',
         outcome: null,
@@ -402,8 +410,8 @@ class ReviewRepository {
   // submit no checks; tracked mode requires a non-empty submission and exact disposition of its
   // expected ids. Tracked sourceFindingId entries are immutable
   // assessments of existing Review Checks, never new Finding rows; untracked checks are newly
-  // discovered Review Checks. The Review outcome and every materialized disposition commit in the
-  // same SQLite transaction, so a malformed item cannot leave a partially applied audit result.
+  // discovered Review Checks. The Review submission state and every materialized disposition commit
+  // in the same SQLite transaction, so a malformed item cannot leave a partially applied audit result.
   // An initial flagged submission may remain running while its Fix Loop is active; tracked Reviews
   // always become terminal when their submission commits.
   async commitScopedSubmission(input: {
@@ -572,7 +580,10 @@ class ReviewRepository {
             input.mode === 'initial' && input.keepFlaggedReviewRunning && outcome === 'flagged'
               ? 'running'
               : 'complete',
-          outcome,
+          outcome:
+            input.mode === 'initial' && input.keepFlaggedReviewRunning && outcome === 'flagged'
+              ? null
+              : outcome,
           errorMessage: null,
           reviewerLog: JSON.stringify(input.reviewerLog ?? [])
         }
@@ -926,12 +937,7 @@ class ReviewRepository {
   }
 }
 
-export {
-  FIX_LOOP_INTERRUPTED_ON_STARTUP_MESSAGE,
-  REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE,
-  ReviewRepository,
-  toReview
-}
+export { REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE, ReviewRepository, toReview }
 export type { ReviewClient, ReviewClientProvider, ReviewRepositoryOptions, FindingSeverity }
 
 // Legacy exports kept for callers that still reference toFinding.

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -64,6 +64,7 @@ type CommonAssessmentOptions = {
 type InitialAssessmentOptions = CommonAssessmentOptions & {
   mode: 'initial'
   onStarted?: () => void
+  keepFlaggedReviewRunning?: boolean
 }
 
 type TrackedAssessmentOptions = CommonAssessmentOptions & {
@@ -527,7 +528,9 @@ export const runReviewAssessment = async (
         reviewId: review.id,
         checks: checksReceived,
         expectedSourceFindingIds: trackedChecks.map((check) => check.id),
-        reviewerLog: capturedLog
+        reviewerLog: capturedLog,
+        keepFlaggedReviewRunning:
+          options.mode === 'initial' && options.keepFlaggedReviewRunning === true
       })
     )
     review = finalReview

--- a/src/main/reviewer/review-submission-read-model.ts
+++ b/src/main/reviewer/review-submission-read-model.ts
@@ -111,7 +111,7 @@ const loadReviewSubmissionProjections = async (
     client.reviewFindingDisposition.findMany({
       where: {
         sourceFinding: { reviewId: { in: [...reviewIds] } },
-        trigger: { in: ['loop_terminated', 'correction_failed', 'aborted', 'interrupted'] },
+        trigger: { in: ['loop_terminated', 'correction_failed', 'aborted'] },
         outcome: 'unaddressed'
       },
       orderBy: [{ sequence: 'desc' }, { createdAt: 'desc' }, { id: 'desc' }]

--- a/src/main/reviewer/review-submission-read-model.ts
+++ b/src/main/reviewer/review-submission-read-model.ts
@@ -111,7 +111,7 @@ const loadReviewSubmissionProjections = async (
     client.reviewFindingDisposition.findMany({
       where: {
         sourceFinding: { reviewId: { in: [...reviewIds] } },
-        trigger: { in: ['loop_terminated', 'correction_failed', 'aborted'] },
+        trigger: { in: ['loop_terminated', 'correction_failed', 'aborted', 'interrupted'] },
         outcome: 'unaddressed'
       },
       orderBy: [{ sequence: 'desc' }, { createdAt: 'desc' }, { id: 'desc' }]

--- a/src/main/reviewer/reviewer-resilience.test.ts
+++ b/src/main/reviewer/reviewer-resilience.test.ts
@@ -92,7 +92,7 @@ describe('Reviewer resilience', () => {
     })
   })
 
-  it('does not abort findings from an older review chain for the same turn', async () => {
+  it('recovers only the causally linked Fix Loop chain when Reviews share a timestamp', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reviewer-fix-loop-history-'))
     const database = await getProjectDbClient(storageRoot)
     const repository = new ReviewRepository(() => Promise.resolve(database))
@@ -106,11 +106,6 @@ describe('Reviewer resilience', () => {
       { status: 'fail', claim: 'Old issue', evidence: 'Still part of review history.' }
     ])
     await repository.updateReview(oldReview.id, { lifecycle: 'complete', outcome: 'flagged' })
-    await database.review.update({
-      where: { id: oldReview.id },
-      data: { createdAt: new Date('2020-01-01T00:00:00.000Z') }
-    })
-
     const activeReview = await repository.createReview({
       projectId: 'project-1',
       sessionId: 'session-1',
@@ -120,6 +115,40 @@ describe('Reviewer resilience', () => {
     await repository.addChecks(activeReview.id, [
       { status: 'fail', claim: 'Current issue', evidence: 'Belongs to the interrupted Fix Loop.' }
     ])
+    const activeFinding = (
+      await repository.getReviewsForProjectSession('project-1', 'session-1')
+    ).find((review) => review.id === activeReview.id)?.checks[0]
+    expect(activeFinding).toBeDefined()
+
+    const reReview = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'turn-1',
+      scope: { turnMessageId: 'correction-1', blocks: [], artifactVersionIds: [] }
+    })
+    await repository.commitScopedSubmission({
+      mode: 'tracked',
+      reviewId: reReview.id,
+      expectedSourceFindingIds: [activeFinding!.id],
+      checks: [
+        {
+          sourceFindingId: activeFinding!.id,
+          status: 'fail',
+          claim: 'Current issue',
+          evidence: 'The correction did not resolve it.'
+        },
+        {
+          status: 'warn',
+          claim: 'New issue',
+          evidence: 'The correction introduced another issue.'
+        }
+      ]
+    })
+
+    await database.review.updateMany({
+      where: { id: { in: [oldReview.id, activeReview.id, reReview.id] } },
+      data: { createdAt: new Date('2020-01-01T00:00:00.000Z') }
+    })
 
     expect(await repository.recoverInterruptedReviews()).toBe(1)
     const reviews = await repository.getReviewsForProjectSession('project-1', 'session-1')
@@ -127,6 +156,10 @@ describe('Reviewer resilience', () => {
       resolution: 'open'
     })
     expect(reviews.find((review) => review.id === activeReview.id)?.checks[0]).toMatchObject({
+      resolution: 'unaddressed',
+      unaddressedTrigger: 'aborted'
+    })
+    expect(reviews.find((review) => review.id === reReview.id)?.checks[0]).toMatchObject({
       resolution: 'unaddressed',
       unaddressedTrigger: 'aborted'
     })

--- a/src/main/reviewer/reviewer-resilience.test.ts
+++ b/src/main/reviewer/reviewer-resilience.test.ts
@@ -92,6 +92,46 @@ describe('Reviewer resilience', () => {
     })
   })
 
+  it('does not abort findings from an older review chain for the same turn', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reviewer-fix-loop-history-'))
+    const database = await getProjectDbClient(storageRoot)
+    const repository = new ReviewRepository(() => Promise.resolve(database))
+    const oldReview = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'turn-1',
+      scope: { turnMessageId: 'turn-1', blocks: [], artifactVersionIds: [] }
+    })
+    await repository.addChecks(oldReview.id, [
+      { status: 'fail', claim: 'Old issue', evidence: 'Still part of review history.' }
+    ])
+    await repository.updateReview(oldReview.id, { lifecycle: 'complete', outcome: 'flagged' })
+    await database.review.update({
+      where: { id: oldReview.id },
+      data: { createdAt: new Date('2020-01-01T00:00:00.000Z') }
+    })
+
+    const activeReview = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'turn-1',
+      scope: { turnMessageId: 'turn-1', blocks: [], artifactVersionIds: [] }
+    })
+    await repository.addChecks(activeReview.id, [
+      { status: 'fail', claim: 'Current issue', evidence: 'Belongs to the interrupted Fix Loop.' }
+    ])
+
+    expect(await repository.recoverInterruptedReviews()).toBe(1)
+    const reviews = await repository.getReviewsForProjectSession('project-1', 'session-1')
+    expect(reviews.find((review) => review.id === oldReview.id)?.checks[0]).toMatchObject({
+      resolution: 'open'
+    })
+    expect(reviews.find((review) => review.id === activeReview.id)?.checks[0]).toMatchObject({
+      resolution: 'unaddressed',
+      unaddressedTrigger: 'aborted'
+    })
+  })
+
   it('accepts no more than five checks in one Reviewer result', () => {
     expect(
       submitFindingsInputSchema.safeParse({ checks: [check, check, check, check, check] }).success

--- a/src/main/reviewer/reviewer-resilience.test.ts
+++ b/src/main/reviewer/reviewer-resilience.test.ts
@@ -47,6 +47,56 @@ describe('Reviewer resilience', () => {
     })
   })
 
+  it('recovers a persisted active Fix Loop without discarding its flagged result', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reviewer-fix-loop-restart-'))
+    const database = await getProjectDbClient(storageRoot)
+    const repository = new ReviewRepository(() => Promise.resolve(database))
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'turn-1',
+      scope: {
+        turnMessageId: 'turn-1',
+        blocks: [
+          {
+            id: 'message:turn-1',
+            kind: 'message',
+            sourceId: 'turn-1',
+            blockIndex: 0,
+            contentHash: 'hash-1'
+          }
+        ],
+        artifactVersionIds: []
+      }
+    })
+    await repository.addChecks(review.id, [
+      {
+        status: 'fail',
+        claim: 'The result is incorrect.',
+        evidence: 'The persisted assessment found a contradiction.',
+        locator: { blockRef: { messageId: 'turn-1', blockIndex: 0 }, contentHash: 'hash-1' }
+      }
+    ])
+
+    await database.review.update({
+      where: { id: review.id },
+      data: { lifecycle: 'running', outcome: 'flagged' }
+    })
+
+    expect(await repository.recoverInterruptedReviews()).toBe(1)
+    const [restored] = await repository.getReviewsForProjectSession('project-1', 'session-1')
+    expect(restored).toMatchObject({
+      lifecycle: 'complete',
+      outcome: 'flagged',
+      checks: [
+        expect.objectContaining({
+          resolution: 'unaddressed',
+          unaddressedTrigger: 'interrupted'
+        })
+      ]
+    })
+  })
+
   it('accepts no more than five checks in one Reviewer result', () => {
     expect(
       submitFindingsInputSchema.safeParse({ checks: [check, check, check, check, check] }).success

--- a/src/main/reviewer/reviewer-resilience.test.ts
+++ b/src/main/reviewer/reviewer-resilience.test.ts
@@ -78,11 +78,6 @@ describe('Reviewer resilience', () => {
       }
     ])
 
-    await database.review.update({
-      where: { id: review.id },
-      data: { lifecycle: 'running', outcome: 'flagged' }
-    })
-
     expect(await repository.recoverInterruptedReviews()).toBe(1)
     const [restored] = await repository.getReviewsForProjectSession('project-1', 'session-1')
     expect(restored).toMatchObject({
@@ -91,7 +86,7 @@ describe('Reviewer resilience', () => {
       checks: [
         expect.objectContaining({
           resolution: 'unaddressed',
-          unaddressedTrigger: 'interrupted'
+          unaddressedTrigger: 'aborted'
         })
       ]
     })

--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -106,6 +106,21 @@ describe('ReviewerCard — running state', () => {
     expect(container.querySelector('[data-testid="reviewer-card"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="open-science-thinking-indicator"]')).toBeNull()
   })
+
+  it('renders persisted findings while the Fix Loop is still running', async () => {
+    await act(async () => {
+      root.render(
+        <ReviewerCard
+          review={makeReview({ lifecycle: 'running', outcome: null, checks: [makeCheck()] })}
+        />
+      )
+    })
+
+    expect(container.querySelector('[data-testid="reviewer-running-state"]')).toBeNull()
+    expect(container.querySelector('[data-testid="reviewer-card"]')).not.toBeNull()
+    expect(container.textContent).toContain('1 finding')
+    expect(container.textContent).not.toContain('No issues found')
+  })
 })
 
 describe('ReviewerCard — borderless grayscale hierarchy', () => {
@@ -867,7 +882,8 @@ describe('ReviewerCard — flagged expand (reference-style)', () => {
 
   it('renders the self-correct footer note for warn/fail expansions', async () => {
     const review = makeReview({
-      outcome: 'flagged',
+      lifecycle: 'running',
+      outcome: null,
       checks: [makeCheck({ status: 'warn' })]
     })
     await act(async () => {

--- a/src/renderer/src/components/ReviewerCard.render.test.tsx
+++ b/src/renderer/src/components/ReviewerCard.render.test.tsx
@@ -1238,6 +1238,35 @@ describe('ReviewerCard — stale review', () => {
     expect(container.querySelector('[data-testid="reviewer-stale-notice"]')).toBeNull()
   })
 
+  it('offers a Re-run button when a tracked submission leaves its source finding unresolved', async () => {
+    const sourceCheck = makeCheck({ id: 'source-finding', reviewId: 'source-review' })
+    const review = makeReview({
+      outcome: 'flagged',
+      checks: [],
+      submittedChecks: [
+        {
+          kind: 'tracked',
+          submissionIndex: 0,
+          sourceFindingId: sourceCheck.id,
+          dispositionOutcome: 'still_open',
+          assessment: {
+            status: 'fail',
+            claim: 'The tracked issue remains',
+            evidence: 'The rerun reproduced the issue.',
+            sortIndex: 0
+          },
+          sourceCheck
+        }
+      ]
+    })
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onRerun={vi.fn().mockResolvedValue(true)} />)
+    })
+
+    expect(container.querySelector('[data-testid="reviewer-unresolved-notice"]')).not.toBeNull()
+    expect(container.textContent).toContain('Re-run review')
+  })
+
   it('disables the Re-run button after the first click so a double-click fires once', async () => {
     const review = makeReview({ outcome: 'pass', checks: [], stale: true })
     const onRerun = vi.fn().mockResolvedValue(true)
@@ -1260,6 +1289,25 @@ describe('ReviewerCard — stale review', () => {
 
     expect(onRerun).toHaveBeenCalledTimes(1)
     expect(rerunButton.disabled).toBe(true)
+  })
+
+  it('removes the old Re-run notice once a replacement review has started', async () => {
+    const review = makeReview({ outcome: 'pass', checks: [], stale: true })
+    const onRerun = vi.fn().mockResolvedValue(true)
+    await act(async () => {
+      root.render(<ReviewerCard review={review} onRerun={onRerun} />)
+    })
+
+    const rerunButton = container.querySelector(
+      '[data-testid="reviewer-stale-notice"] button'
+    ) as HTMLButtonElement
+    await act(async () => {
+      rerunButton.click()
+    })
+
+    expect(onRerun).toHaveBeenCalledOnce()
+    expect(container.querySelector('[data-testid="reviewer-stale-notice"]')).toBeNull()
+    expect(container.textContent).not.toContain('Re-running…')
   })
 
   it('re-enables the Re-run button when no review actually started', async () => {

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -215,14 +215,16 @@ export const ReviewerCard = ({
 }: ReviewerCardProps): React.JSX.Element => {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(defaultExpanded)
-  // Latches on the first Re-run click so the button can't fire twice. Reset whenever the review updates
-  // (a fresh review row arrived, or its lifecycle/timestamp changed) so a later re-stale review can be
-  // re-run again. setState-during-render pattern, matching the composer popup's query reset.
+  // Latches on the first Re-run click so the button can't fire twice. Once main confirms that the
+  // replacement Review row was created, that new card owns progress and this card drops its notice.
+  // Reset if this row itself changes so a later re-stale Review can be re-run again.
   const [rerunRequested, setRerunRequested] = useState(false)
+  const [rerunStarted, setRerunStarted] = useState(false)
   const [lastReviewStamp, setLastReviewStamp] = useState(review.updatedAt)
   if (lastReviewStamp !== review.updatedAt) {
     setLastReviewStamp(review.updatedAt)
     setRerunRequested(false)
+    setRerunStarted(false)
   }
 
   const hasPersistedFlaggedChecks = review.checks.some(
@@ -289,12 +291,28 @@ export const ReviewerCard = ({
   // describe the current turn. Computed at load time (see flagStaleReviews); only meaningful for a
   // completed review, since running/error reviews have no verdict to go stale.
   const isStale = isTerminal && review.stale === true
-  const hasUnresolvedFindings = review.checks.some(
-    (check) =>
-      (check.status === 'warn' || check.status === 'fail') && check.resolution !== 'resolved'
-  )
+  const hasUnresolvedFindings =
+    review.submittedChecks === undefined
+      ? review.checks.some(
+          (check) =>
+            (check.status === 'warn' || check.status === 'fail') && check.resolution !== 'resolved'
+        )
+      : review.submittedChecks.some((item) => {
+          if (item.kind === 'new') {
+            return (
+              (item.check.status === 'warn' || item.check.status === 'fail') &&
+              item.check.resolution !== 'resolved'
+            )
+          }
+          const status = item.assessment?.status ?? item.sourceCheck.status
+          return (
+            (status === 'warn' || status === 'fail') &&
+            item.dispositionOutcome !== 'resolved' &&
+            item.sourceCheck.resolution !== 'resolved'
+          )
+        })
   const canRerunUnresolved = isTerminal && hasUnresolvedFindings
-  const showRerunNotice = isStale || canRerunUnresolved
+  const showRerunNotice = (isStale || canRerunUnresolved) && !rerunStarted
 
   // Compact summary line.
   const summaryText = (): string => {
@@ -409,10 +427,12 @@ export const ReviewerCard = ({
               className="shrink-0 rounded bg-bg-000 px-2 py-0.5 text-[11px] text-amber-800 transition-colors hover:bg-bg-300 disabled:cursor-default disabled:opacity-50 dark:text-amber-300"
               onClick={() => {
                 setRerunRequested(true)
-                // Release the latch if no review actually started (e.g. the session couldn't load), so
-                // the button stays usable; on success the running-review push clears it via updatedAt.
+                // Release the latch if no review actually started (e.g. the session couldn't load).
+                // A true result is emitted only after the replacement running Review row was pushed,
+                // so its new card can take over while this superseded notice disappears.
                 void onRerun(review).then((started) => {
-                  if (!started) setRerunRequested(false)
+                  setRerunRequested(false)
+                  if (started) setRerunStarted(true)
                 })
               }}
             >

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -29,9 +29,9 @@ type ReviewerCardProps = {
   defaultExpanded?: boolean
   // Called when the user clicks "Go to transcript" on any item card.
   onGoToTranscript?: (intent: GoToTranscriptIntent) => void
-  // Called when the user asks to re-run a stale review (its turn changed after it ran). Resolves to
-  // whether a review actually started; a false result (e.g. session load failed) releases the button
-  // latch so the turn stays retriable.
+  // Called when the user asks to re-run a stale review or a terminal review with unresolved findings.
+  // Resolves to whether a review actually started; a false result (e.g. session load failed) releases
+  // the button latch so the turn stays retriable.
   onRerun?: (review: ReviewWithChecks) => Promise<boolean>
 }
 
@@ -225,10 +225,12 @@ export const ReviewerCard = ({
     setRerunRequested(false)
   }
 
-  const isRunning = review.lifecycle === 'running'
+  const isRunningAssessment = review.lifecycle === 'running' && review.outcome === null
+  const isFixLoopActive = review.lifecycle === 'running' && review.outcome === 'flagged'
 
-  // A live review is status, not a result card; keep completed-review controls out of the DOM.
-  if (isRunning) {
+  // An assessment with no result is status, not a result card. A running flagged Review already has
+  // durable findings and stays visible while its Fix Loop owns the Session.
+  if (isRunningAssessment) {
     return (
       <div
         className={cn('mt-2 flex items-center gap-1.5 px-0 py-2 text-xs text-text-300', className)}
@@ -244,7 +246,8 @@ export const ReviewerCard = ({
   }
 
   const isError = review.lifecycle === 'error'
-  const isComplete = review.lifecycle === 'complete'
+  const isTerminal = review.lifecycle === 'complete'
+  const isComplete = isTerminal || isFixLoopActive
 
   // Current reads carry the exact submitted projection. Older in-memory snapshots fall back to the
   // Review-owned Findings without inventing tracked assessment content.
@@ -270,6 +273,10 @@ export const ReviewerCard = ({
     submittedChecks.some(
       (item) => item.isUnaddressed && item.unaddressedTrigger === 'correction_failed'
     )
+  const isInterrupted =
+    isTerminal &&
+    hasWarnOrFail &&
+    submittedChecks.some((item) => item.isUnaddressed && item.unaddressedTrigger === 'interrupted')
 
   // A complete review is expandable if it has any checks; an error review is expandable if it carries
   // a message (kept out of the status bar so a verbose Prisma-style error doesn't overflow the line).
@@ -279,7 +286,13 @@ export const ReviewerCard = ({
   // The turn changed after this review ran (e.g. an artifact was edited) — the verdict may not
   // describe the current turn. Computed at load time (see flagStaleReviews); only meaningful for a
   // completed review, since running/error reviews have no verdict to go stale.
-  const isStale = isComplete && review.stale === true
+  const isStale = isTerminal && review.stale === true
+  const hasUnresolvedFindings = review.checks.some(
+    (check) =>
+      (check.status === 'warn' || check.status === 'fail') && check.resolution !== 'resolved'
+  )
+  const canRerunUnresolved = isTerminal && hasUnresolvedFindings
+  const showRerunNotice = isStale || canRerunUnresolved
 
   // Compact summary line.
   const summaryText = (): string => {
@@ -357,6 +370,12 @@ export const ReviewerCard = ({
             <span className="text-yellow-600 dark:text-yellow-400">{t('correction failed')}</span>
           </>
         )}
+        {isInterrupted && (
+          <>
+            <span className="mx-1 text-text-400">&middot;</span>
+            <span className="text-yellow-600 dark:text-yellow-400">{t('interrupted')}</span>
+          </>
+        )}
         {canExpand && (
           <span className="ml-auto">
             {expanded ? (
@@ -371,13 +390,13 @@ export const ReviewerCard = ({
       {/* Stale notice + explicit re-run: the verdict above may no longer describe the turn (an artifact
           was edited after the review ran). This is the actionable refresh path for THIS review's turn —
           including earlier turns that the composer's "Request review" (last-turn only) cannot reach. */}
-      {isStale && (
+      {showRerunNotice && (
         <div
           className="mt-2 flex items-center justify-between gap-2 rounded-md bg-bg-300 px-2 py-1"
-          data-testid="reviewer-stale-notice"
+          data-testid={isStale ? 'reviewer-stale-notice' : 'reviewer-unresolved-notice'}
         >
           <span className="text-[11px] text-amber-800 dark:text-amber-300">
-            {t('Turn changed after this review ran.')}
+            {isStale ? t('Turn changed after this review ran.') : t('Issues found')}
           </span>
           {onRerun && (
             <button
@@ -429,11 +448,15 @@ export const ReviewerCard = ({
           ))}
 
           {/* Self-correct footer note — shown only for warn/fail (flagged) expansions. */}
-          {hasWarnOrFail && !isCapReached && !isCorrectionFailed && (
-            <p className="mt-1 text-[11px] italic text-text-400">
-              {t('The agent reads these findings and self-corrects in its next message.')}
-            </p>
-          )}
+          {hasWarnOrFail &&
+            !isCapReached &&
+            !isCorrectionFailed &&
+            !isInterrupted &&
+            !canRerunUnresolved && (
+              <p className="mt-1 text-[11px] italic text-text-400">
+                {t('The agent reads these findings and self-corrects in its next message.')}
+              </p>
+            )}
         </div>
       )}
     </div>

--- a/src/renderer/src/components/ReviewerCard.tsx
+++ b/src/renderer/src/components/ReviewerCard.tsx
@@ -225,11 +225,14 @@ export const ReviewerCard = ({
     setRerunRequested(false)
   }
 
-  const isRunningAssessment = review.lifecycle === 'running' && review.outcome === null
-  const isFixLoopActive = review.lifecycle === 'running' && review.outcome === 'flagged'
+  const hasPersistedFlaggedChecks = review.checks.some(
+    (check) => check.status === 'warn' || check.status === 'fail'
+  )
+  const isRunningAssessment = review.lifecycle === 'running' && !hasPersistedFlaggedChecks
+  const isFixLoopActive = review.lifecycle === 'running' && hasPersistedFlaggedChecks
 
-  // An assessment with no result is status, not a result card. A running flagged Review already has
-  // durable findings and stays visible while its Fix Loop owns the Session.
+  // An assessment with no persisted flagged checks is status, not a result card. A running Review
+  // with durable warn/fail checks stays visible while its Fix Loop owns the Session.
   if (isRunningAssessment) {
     return (
       <div
@@ -255,10 +258,9 @@ export const ReviewerCard = ({
   const warnFailCount = submittedChecks.filter((item) => item.isWarnOrFail).length
   const totalCheckCount = submittedChecks.length
   const hasWarnOrFail = warnFailCount > 0
-  // The durable Review verdict is authoritative. A fix-loop Review may commit its tracked failing
-  // assessments as dispositions on earlier Findings, leaving this Review with no local warn/fail
-  // rows (or only newly assessed pass rows) while its outcome correctly remains flagged.
-  const isFlagged = isComplete && review.outcome === 'flagged'
+  // Terminal Reviews use their durable outcome. While a Fix Loop is active, persisted warn/fail
+  // checks are the durable signal because the existing schema requires a running outcome to be null.
+  const isFlagged = isComplete && (review.outcome === 'flagged' || isFixLoopActive)
 
   // Terminal dispositions distinguish a true round cap from correction transport/persistence failure.
   const isCapReached =
@@ -276,7 +278,7 @@ export const ReviewerCard = ({
   const isInterrupted =
     isTerminal &&
     hasWarnOrFail &&
-    submittedChecks.some((item) => item.isUnaddressed && item.unaddressedTrigger === 'interrupted')
+    submittedChecks.some((item) => item.isUnaddressed && item.unaddressedTrigger === 'aborted')
 
   // A complete review is expandable if it has any checks; an error review is expandable if it carries
   // a message (kept out of the status bar so a verbose Prisma-style error doesn't overflow the line).

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3575,6 +3575,52 @@ describe('loop guard: suppressNextAutoReview', () => {
     vi.unstubAllGlobals()
   })
 
+  it('does not auto-review a Reviewer correction when the one-shot suppression event was missed', async () => {
+    const reviewerRun = vi.fn().mockResolvedValue(undefined)
+    stubReviewerApi(reviewerRun)
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'reviewer-correction-prompt',
+        role: 'user',
+        messageId: 'reviewer-correction-prompt',
+        promptMessageId: 'reviewer-correction-prompt',
+        text: '[Auditor] Correct the unsupported claim.',
+        attribution: {
+          kind: 'application',
+          feature: 'reviewer',
+          purpose: 'correction',
+          causeReviewId: 'review-1'
+        }
+      })
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'reviewer-correction-response',
+        role: 'assistant',
+        messageId: 'reviewer-correction-response',
+        promptMessageId: 'reviewer-correction-prompt',
+        text: 'Corrected the unsupported claim.'
+      })
+    )
+
+    // Simulate a refreshed or late-joining renderer: it has the durable correction attribution but
+    // never received reviewer:suppress-next-auto-review before the correction turn stopped.
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'reviewer-correction-stop',
+        kind: 'stop',
+        sessionId: 'transport-session-1',
+        promptMessageId: 'reviewer-correction-prompt'
+      })
+    )
+    await vi.runAllTimersAsync()
+
+    expect(reviewerRun).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+
   it('does not suppress a different session', async () => {
     const reviewerRun = vi.fn().mockResolvedValue(undefined)
     stubReviewerApi(reviewerRun)

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -18,6 +18,7 @@ import type { ReviewRunNotStartedReason, ReviewRunRequest } from '../../../../sh
 import {
   INTERRUPTED_TURN_ERROR,
   isHiddenControlMessage,
+  isReviewerCorrectionAttribution,
   sanitizeMessageAttribution,
   type PersistedChatSession
 } from '../../../../shared/session-persistence'
@@ -489,7 +490,8 @@ const triggerAutoReview = async (
     if (
       session.messages.some(
         (message) =>
-          message.id === reviewedMessage?.responseToMessageId && isHiddenControlMessage(message)
+          message.id === reviewedMessage?.responseToMessageId &&
+          (isHiddenControlMessage(message) || isReviewerCorrectionAttribution(message.attribution))
       )
     ) {
       return

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.render.test.tsx
@@ -7,7 +7,7 @@
 
 import { act, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ReviewWithChecks, ReviewCheck } from '../../../../shared/reviewer'
 
@@ -240,6 +240,20 @@ describe('SessionReviewerPanel — stale review notice', () => {
     })
 
     expect(container.querySelector('[data-testid="reviewer-stale-notice"]')).toBeNull()
+  })
+
+  it('offers a re-run for a fresh terminal review with unresolved findings', () => {
+    const onRerun = vi.fn().mockResolvedValue(true)
+
+    act(() => {
+      root.render(<ReviewerCard review={makeReview()} onRerun={onRerun} />)
+    })
+
+    expect(
+      Array.from(container.querySelectorAll('button')).some(
+        (button) => button.textContent === 'Re-run review'
+      )
+    ).toBe(true)
   })
 })
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -779,7 +779,7 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(conversationProps.conversation.availability.submit).toBe(true)
   })
 
-  it('keeps sending locked until review history hydration establishes no active Fix Loop', async () => {
+  it('keeps idle turn mutations locked until review history hydration establishes no active Fix Loop', async () => {
     useReviewStore.setState(createInitialReviewState())
     useSessionStore.setState({
       ...createInitialSessionState(),
@@ -792,14 +792,18 @@ describe('WorkspacePage send gate while compacting', () => {
       conversationProps.composer.actions.changeDoc(textDoc('wait for review history'))
     })
     expect(conversationProps.conversation.availability.submit).toBe(false)
+    expect(conversationProps.conversation.availability.revise).toBe(false)
+    expect(conversationProps.conversation.availability.branch).toBe(false)
 
     await act(async () => {
       useReviewStore.setState({ loadedReviewSessions: { 'proj-1\0sess-a': true } })
     })
     expect(conversationProps.conversation.availability.submit).toBe(true)
+    expect(conversationProps.conversation.availability.revise).toBe(true)
+    expect(conversationProps.conversation.availability.branch).toBe(true)
   })
 
-  it('keeps queueing locked until review history hydration establishes no active Fix Loop', async () => {
+  it('keeps running turn mutations locked until review history hydration establishes no active Fix Loop', async () => {
     useReviewStore.setState(createInitialReviewState())
     useSessionStore.setState({
       ...createInitialSessionState(),
@@ -812,11 +816,13 @@ describe('WorkspacePage send gate while compacting', () => {
       conversationProps.composer.actions.changeDoc(textDoc('do not queue before review history'))
     })
     expect(conversationProps.conversation.availability.submit).toBe(false)
+    expect(conversationProps.conversation.availability.revise).toBe(false)
 
     await act(async () => {
       useReviewStore.setState({ loadedReviewSessions: { 'proj-1\0sess-a': true } })
     })
     expect(conversationProps.conversation.availability.submit).toBe(true)
+    expect(conversationProps.conversation.availability.revise).toBe(true)
   })
 
   it('keeps sending locked when review history hydration fails', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -739,7 +739,7 @@ describe('WorkspacePage send gate while compacting', () => {
         artifactVersionIds: []
       },
       lifecycle: 'running',
-      outcome: 'flagged',
+      outcome: null,
       model: 'test-model',
       reviewerLog: [],
       createdAt: 1_000,
@@ -768,6 +768,7 @@ describe('WorkspacePage send gate while compacting', () => {
         review: {
           ...activeFixLoopReview,
           lifecycle: 'complete',
+          outcome: 'flagged',
           updatedAt: 2_000
         }
       })

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -715,6 +715,66 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(useSessionStore.getState().sessions[0]?.branchSwitchBlocked).not.toBe(true)
   })
 
+  it('restores the send lock from a persisted active Fix Loop review', async () => {
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createReviewableSession()],
+      selectedSessionId: 'sess-a'
+    })
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.composer.actions.changeDoc(textDoc('do not race the correction'))
+    })
+    expect(conversationProps.conversation.availability.submit).toBe(true)
+
+    const activeFixLoopReview: ReviewWithChecks = {
+      id: 'review-fix-loop',
+      projectId: 'proj-1',
+      sessionId: 'sess-a',
+      turnMessageId: 'agent-1',
+      scope: {
+        turnMessageId: 'agent-1',
+        blocks: [],
+        artifactVersionIds: []
+      },
+      lifecycle: 'running',
+      outcome: 'flagged',
+      model: 'test-model',
+      reviewerLog: [],
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      checks: [
+        {
+          id: 'finding-1',
+          reviewId: 'review-fix-loop',
+          status: 'fail',
+          claim: 'The answer is incorrect.',
+          evidence: 'The persisted result still requires correction.',
+          resolution: 'open',
+          reflagCount: 0,
+          sortIndex: 0
+        }
+      ]
+    }
+
+    await act(async () => {
+      useReviewStore.getState().handleReviewUpdate({ review: activeFixLoopReview })
+    })
+    expect(conversationProps.conversation.availability.submit).toBe(false)
+
+    await act(async () => {
+      useReviewStore.getState().handleReviewUpdate({
+        review: {
+          ...activeFixLoopReview,
+          lifecycle: 'complete',
+          updatedAt: 2_000
+        }
+      })
+    })
+    expect(conversationProps.conversation.availability.submit).toBe(true)
+  })
+
   it('disables sending while the runtime owns an otherwise idle session', async () => {
     await renderPage()
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -176,7 +176,10 @@ describe('WorkspacePage send gate while compacting', () => {
     setDefaultWorkspaceAgentSettings()
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useProjectStore.setState({ projects: [] })
-    useReviewStore.setState(createInitialReviewState())
+    useReviewStore.setState({
+      ...createInitialReviewState(),
+      loadedReviewSessions: { 'proj-1\0sess-a': true }
+    })
     useMemoryStore.setState(createInitialMemoryState())
     useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
     useSessionStore.setState({
@@ -774,6 +777,65 @@ describe('WorkspacePage send gate while compacting', () => {
       })
     })
     expect(conversationProps.conversation.availability.submit).toBe(true)
+  })
+
+  it('keeps sending locked until review history hydration establishes no active Fix Loop', async () => {
+    useReviewStore.setState(createInitialReviewState())
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createReviewableSession()],
+      selectedSessionId: 'sess-a'
+    })
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.composer.actions.changeDoc(textDoc('wait for review history'))
+    })
+    expect(conversationProps.conversation.availability.submit).toBe(false)
+
+    await act(async () => {
+      useReviewStore.setState({ loadedReviewSessions: { 'proj-1\0sess-a': true } })
+    })
+    expect(conversationProps.conversation.availability.submit).toBe(true)
+  })
+
+  it('keeps queueing locked until review history hydration establishes no active Fix Loop', async () => {
+    useReviewStore.setState(createInitialReviewState())
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [{ ...createReviewableSession(), status: 'running' }],
+      selectedSessionId: 'sess-a'
+    })
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.composer.actions.changeDoc(textDoc('do not queue before review history'))
+    })
+    expect(conversationProps.conversation.availability.submit).toBe(false)
+
+    await act(async () => {
+      useReviewStore.setState({ loadedReviewSessions: { 'proj-1\0sess-a': true } })
+    })
+    expect(conversationProps.conversation.availability.submit).toBe(true)
+  })
+
+  it('keeps sending locked when review history hydration fails', async () => {
+    useReviewStore.setState({
+      ...createInitialReviewState(),
+      loadedReviewSessions: { 'proj-1\0sess-a': true },
+      loadErrorsBySession: { 'proj-1\0sess-a': 'database unavailable' }
+    })
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createReviewableSession()],
+      selectedSessionId: 'sess-a'
+    })
+    await renderPage()
+
+    await act(async () => {
+      conversationProps.composer.actions.changeDoc(textDoc('wait for review retry'))
+    })
+    expect(conversationProps.conversation.availability.submit).toBe(false)
   })
 
   it('disables sending while the runtime owns an otherwise idle session', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -844,6 +844,27 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(conversationProps.conversation.availability.submit).toBe(false)
   })
 
+  it('keeps manual review locked until review history hydration establishes no active Fix Loop', async () => {
+    useReviewStore.setState(createInitialReviewState())
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [createReviewableSession()],
+      selectedSessionId: 'sess-a'
+    })
+    await renderPage()
+
+    act(() => {
+      conversationProps.workflows.review.request()
+    })
+    expect(window.api.reviewer.run).not.toHaveBeenCalled()
+    expect(conversationProps.workflows.review.disabled).toBe(true)
+
+    await act(async () => {
+      useReviewStore.setState({ loadedReviewSessions: { 'proj-1\0sess-a': true } })
+    })
+    expect(conversationProps.workflows.review.disabled).toBe(false)
+  })
+
   it('disables sending while the runtime owns an otherwise idle session', async () => {
     await renderPage()
 
@@ -988,6 +1009,27 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(conversationProps.contextWindow.compactDisabledReason).toBe(
       'Resolve the current session error before compacting.'
     )
+  })
+
+  it('keeps context compaction locked until review history hydration establishes no active Fix Loop', async () => {
+    useReviewStore.setState(createInitialReviewState())
+    await renderPage()
+
+    act(() => {
+      conversationProps.contextWindow.compact()
+    })
+    expect(runtime.compactContext).not.toHaveBeenCalled()
+    expect(conversationProps.contextWindow.canCompact).toBe(false)
+
+    await act(async () => {
+      useReviewStore.setState({ loadedReviewSessions: { 'proj-1\0sess-a': true } })
+    })
+    expect(conversationProps.contextWindow.canCompact).toBe(true)
+
+    act(() => {
+      conversationProps.contextWindow.compact()
+    })
+    expect(runtime.compactContext).toHaveBeenCalledWith('sess-a')
   })
 
   it('surfaces restored permission retry errors without replacing the authorization card', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -276,7 +276,11 @@ const WorkspacePage = ({
       state.reviewsBySession,
       storedActiveSession.projectId,
       storedActiveSession.id
-    ).some((review) => review.lifecycle === 'running' && review.outcome === 'flagged')
+    ).some(
+      (review) =>
+        review.lifecycle === 'running' &&
+        review.checks.some((check) => check.status === 'warn' || check.status === 'fail')
+    )
   })
   const activeSession = useMemo(
     () =>

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -28,7 +28,12 @@ import {
   type ChatSession
 } from '@/stores/session-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
-import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
+import {
+  selectProjectSessionReviewLoadError,
+  selectProjectSessionReviewSnapshot,
+  selectProjectSessionReviews,
+  useReviewStore
+} from '@/stores/review-store'
 import {
   assembleReviewRunRequest,
   suppressNextAutoReview,
@@ -270,6 +275,22 @@ const WorkspacePage = ({
     }
     return selected
   })
+  const persistedReviewSnapshot = useReviewStore((state) => {
+    if (!storedActiveSession) return undefined
+    return selectProjectSessionReviewSnapshot(
+      state.reviewsBySession,
+      storedActiveSession.projectId,
+      storedActiveSession.id,
+      state.loadedReviewSessions
+    )
+  })
+  const reviewLoadError = useReviewStore((state) =>
+    selectProjectSessionReviewLoadError(
+      state.loadErrorsBySession,
+      storedActiveSession?.projectId,
+      storedActiveSession?.id
+    )
+  )
   const hasPersistedActiveFixLoop = useReviewStore((state) => {
     if (!storedActiveSession) return false
     return selectProjectSessionReviews(
@@ -289,6 +310,9 @@ const WorkspacePage = ({
         : storedActiveSession,
     [hasPersistedActiveFixLoop, storedActiveSession]
   )
+  const isReviewHistoryUnavailable =
+    storedActiveSession !== undefined &&
+    (persistedReviewSnapshot === undefined || reviewLoadError !== undefined)
   const {
     activeAgentConfiguration,
     agentConfigurationUnavailable,
@@ -534,6 +558,7 @@ const WorkspacePage = ({
     agentConfigurationReady: !agentConfigurationUnavailable,
     permissionProfile: activePermissionProfile,
     isReviewing: isReviewBusy,
+    isTurnAdmissionBlocked: isReviewHistoryUnavailable,
     promptInFlightSessionIds,
     sendPreparationInFlightSessionIds,
     saveAsSkillInFlightSessionIds,

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -262,7 +262,7 @@ const WorkspacePage = ({
   // The selected session is the only conversation rendered in the center panel. Selecting it by
   // id (instead of deriving it from the full list) keeps chunk commits for other sessions from
   // re-rendering the page; the active session's own per-chunk identity changes still do.
-  const activeSession = useSessionStore((state) => {
+  const storedActiveSession = useSessionStore((state) => {
     if (activeProject?.archivedAt !== undefined) return undefined
     const selected = state.sessions.find((session) => session.id === selectedSessionId)
     if (!selected || selected.projectId !== scopedProjectId || selected.archivedAt !== undefined) {
@@ -270,6 +270,21 @@ const WorkspacePage = ({
     }
     return selected
   })
+  const hasPersistedActiveFixLoop = useReviewStore((state) => {
+    if (!storedActiveSession) return false
+    return selectProjectSessionReviews(
+      state.reviewsBySession,
+      storedActiveSession.projectId,
+      storedActiveSession.id
+    ).some((review) => review.lifecycle === 'running' && review.outcome === 'flagged')
+  })
+  const activeSession = useMemo(
+    () =>
+      storedActiveSession && hasPersistedActiveFixLoop && !storedActiveSession.fixLoopActive
+        ? { ...storedActiveSession, fixLoopActive: true }
+        : storedActiveSession,
+    [hasPersistedActiveFixLoop, storedActiveSession]
+  )
   const {
     activeAgentConfiguration,
     agentConfigurationUnavailable,

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -600,6 +600,7 @@ const WorkspacePage = ({
   const isRequestReviewDisabled = useReviewStore((state) => {
     if (!activeSessionId) return true
     if (!activeSession) return true
+    if (isReviewHistoryUnavailable) return true
     if (sessionAwaitsHistoryReplay(activeSession)) return true
     const lastAgentMessage = [...activeSession.messages].reverse().find((m) => m.role === 'agent')
     if (!lastAgentMessage) return true
@@ -681,6 +682,7 @@ const WorkspacePage = ({
     !conversation.queue.hasPendingWork
   const canCompactContext =
     isSessionPersistenceReady &&
+    !isReviewHistoryUnavailable &&
     activeSessionSupportsNativeCompaction &&
     activeSession?.status === 'idle' &&
     !activeSessionHasRuntimeInteraction &&
@@ -957,7 +959,7 @@ const WorkspacePage = ({
   }
 
   const requestManualReview = (): void => {
-    if (!activeSession) return
+    if (!activeSession || isReviewHistoryUnavailable) return
 
     const request = assembleReviewRunRequest(activeSession.id)
 

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -105,6 +105,7 @@ const options = (
     agentConfigurationReady: true,
     permissionProfile: 'full',
     isReviewing: false,
+    isTurnAdmissionBlocked: false,
     promptInFlightSessionIds: [],
     sendPreparationInFlightSessionIds: [],
     saveAsSkillInFlightSessionIds: [],

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -283,6 +283,7 @@ const canRevise = (options: WorkspaceConversationControllerOptions): boolean => 
     (options.actionability?.actions.revise.allowed ?? true) &&
     !hasRuntimeInteraction(options) &&
     !options.isReviewing &&
+    !options.isTurnAdmissionBlocked &&
     !activeSession?.fixLoopActive &&
     !activeSession?.conversationGraphSyncBlocked &&
     !activeSession?.compacting &&
@@ -301,6 +302,7 @@ const canQueueRevision = (options: WorkspaceConversationControllerOptions): bool
     !options.isReviewing &&
     !options.sendPreparationInFlightSessionIds.includes(activeSession.id) &&
     !options.saveAsSkillInFlightSessionIds.includes(activeSession.id) &&
+    !options.isTurnAdmissionBlocked &&
     !activeSession.fixLoopActive &&
     !activeSession.conversationGraphSyncBlocked &&
     !activeSession.compacting &&
@@ -316,6 +318,7 @@ const canBranch = (options: WorkspaceConversationControllerOptions): boolean =>
     options.activeSession &&
     !options.activeSession.activeRun &&
     options.actionability?.actions.branchFromMessage.allowed !== false &&
+    !options.isTurnAdmissionBlocked &&
     !options.activeSession.fixLoopActive &&
     !options.activeSession.compacting &&
     !options.activeSession.branchSwitchBlocked &&

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -99,6 +99,7 @@ type WorkspaceConversationControllerOptions = {
   agentConfigurationReady: boolean
   permissionProfile: PermissionProfileId
   isReviewing: boolean
+  isTurnAdmissionBlocked: boolean
   promptInFlightSessionIds: string[]
   sendPreparationInFlightSessionIds: string[]
   saveAsSkillInFlightSessionIds: string[]
@@ -242,6 +243,7 @@ const canSubmitImmediately = (options: WorkspaceConversationControllerOptions): 
       composer.view.annotations.length > 0) &&
     (options.actionability?.actions.startTurn.allowed ?? true) &&
     !hasRuntimeInteraction(options) &&
+    !options.isTurnAdmissionBlocked &&
     !activeSession?.fixLoopActive &&
     !activeSession?.conversationGraphSyncBlocked &&
     !activeSession?.compacting &&
@@ -263,6 +265,7 @@ const canQueueDraft = (options: WorkspaceConversationControllerOptions): boolean
       composer.view.annotations.length > 0) &&
     !options.sendPreparationInFlightSessionIds.includes(activeSession.id) &&
     !options.saveAsSkillInFlightSessionIds.includes(activeSession.id) &&
+    !options.isTurnAdmissionBlocked &&
     !activeSession.fixLoopActive &&
     !activeSession.conversationGraphSyncBlocked &&
     !activeSession.compacting &&

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -100,8 +100,9 @@ export type DelegatedReviewEvidenceScope = {
   artifactVersionIds: readonly string[]
 }
 
-// Task state of the review itself (did it run/finish/fail). A flagged Review remains running while
-// its automatic Fix Loop owns the audited Session, then becomes complete when remediation settles.
+// Task state of the review itself (did it run/finish/fail). A Review with persisted warn/fail checks
+// remains running while its automatic Fix Loop owns the audited Session, then becomes complete when
+// remediation settles.
 export type ReviewLifecycle = 'running' | 'complete' | 'error'
 // Result of a completed review: no warn/fail checks = pass, at least one warn/fail = flagged.
 export type ReviewOutcome = 'pass' | 'flagged'
@@ -129,7 +130,7 @@ export type FindingResolution = 'open' | 'resolved' | 'unaddressed'
 export type ArtifactBindingState = 'scope_validated' | 'legacy_unverified'
 
 export type ReviewFindingDispositionTrigger =
-  'review_submission' | 'loop_terminated' | 'correction_failed' | 'aborted' | 'interrupted'
+  'review_submission' | 'loop_terminated' | 'correction_failed' | 'aborted'
 export type ReviewFindingDispositionOutcome = 'still_open' | 'resolved' | 'unaddressed'
 
 export type ReviewFindingDisposition = {

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -100,7 +100,8 @@ export type DelegatedReviewEvidenceScope = {
   artifactVersionIds: readonly string[]
 }
 
-// Task state of the review itself (did it run/finish/fail), orthogonal to its outcome.
+// Task state of the review itself (did it run/finish/fail). A flagged Review remains running while
+// its automatic Fix Loop owns the audited Session, then becomes complete when remediation settles.
 export type ReviewLifecycle = 'running' | 'complete' | 'error'
 // Result of a completed review: no warn/fail checks = pass, at least one warn/fail = flagged.
 export type ReviewOutcome = 'pass' | 'flagged'
@@ -128,7 +129,7 @@ export type FindingResolution = 'open' | 'resolved' | 'unaddressed'
 export type ArtifactBindingState = 'scope_validated' | 'legacy_unverified'
 
 export type ReviewFindingDispositionTrigger =
-  'review_submission' | 'loop_terminated' | 'correction_failed' | 'aborted'
+  'review_submission' | 'loop_terminated' | 'correction_failed' | 'aborted' | 'interrupted'
 export type ReviewFindingDispositionOutcome = 'still_open' | 'resolved' | 'unaddressed'
 
 export type ReviewFindingDisposition = {


### PR DESCRIPTION
## Problem

Fix Loop ownership was held only in Main-process memory and one-shot renderer broadcasts. A refreshed or late renderer could miss the active-loop and auto-review suppression events, while an application restart after the initial flagged assessment could leave a non-stale completed Review with open findings and no reliable recovery or retry path.

## Proposed change

- Keep an initial Review `running` after warn/fail findings are atomically persisted and complete it only after the bounded Fix Loop settles.
- Derive the persisted active-loop signal from `lifecycle=running`, `outcome=null`, and persisted warn/fail findings; this stays within the existing database constraints.
- Recover that state on startup by recording existing `aborted/unaddressed` dispositions for remaining open findings and closing the root Review as `complete/flagged`.
- Restore the renderer send lock from hydrated Review data, while retaining live START/END broadcasts.
- Exclude correction responses from ordinary auto-review using their durable reviewer-correction attribution, even if the one-shot suppression event was missed.
- Offer an explicit re-run on terminal Reviews that still contain unresolved findings.

## Scope and non-goals

- No new table, column, SQLite constraint, migration, or lifecycle/disposition enum value.
- Existing `Review`, `Finding`, and `ReviewFindingDisposition` rows are reused; historical `complete/flagged` rows are not rewritten.
- Restart recovery safely terminates the interrupted loop and exposes retry. It does not resume an exact correction prompt or round; resumable execution would require a dedicated Fix Loop aggregate in a separate change.
- No ACP wire protocol, framework adapter, launcher, model, or platform-specific behavior changes. Correction attribution is already part of the shared persisted session contract.

## Acceptance criteria and validation

The commands below were run after the last material edit.

- Active root Review remains durable until remediation settles -> `npm test -- --run src/main/reviewer/fix-loop.test.ts` -> 1 file, 9 tests passed.
- Restart distinguishes an active Fix Loop from an unfinished initial assessment and records terminal dispositions -> focused Reviewer regression command -> covered by `reviewer-resilience.test.ts`, passed.
- Hydrated active-loop state restores the composer lock -> focused Reviewer regression command -> covered by `WorkspacePage.send-gate.test.tsx`, passed.
- Durable correction attribution prevents duplicate ordinary auto-review -> focused Reviewer regression command -> covered by `workspace-events.test.ts`, passed.
- Terminal unresolved Reviews expose a re-run and active findings remain visible -> focused Reviewer regression command -> covered by `SessionReviewerPanel.render.test.tsx` and `ReviewerCard.render.test.tsx`, passed.
- Focused regression set: `npm test -- --run src/main/reviewer/repository.test.ts src/main/reviewer/reviewer-resilience.test.ts src/renderer/src/lib/acp/workspace-events.test.ts src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx src/renderer/src/pages/workspace/SessionReviewerPanel.render.test.tsx src/renderer/src/components/ReviewerCard.render.test.tsx` -> 6 files, 241 tests passed.
- Reviewer owner, contracts, consumers, and Windows-sensitive overlay: `npm run test:module -- reviewer_orchestrator` -> 27 files, 573 tests passed.
- Renderer translation contract: `npm test -- --run src/renderer/src/i18n/resources.test.ts` -> 1 file, 805 tests passed.
- `npm run typecheck:node` -> passed.
- `npm run typecheck:web` -> passed.
- `npm run lint` -> passed.
- `npm run db:schema:check` -> passed; the final diff contains no database/schema changes.

`npm run test:affected:explain -- --base origin/main --head HEAD` selected the full plan because `src/main/reviewer/repository.ts` has no registered module owner. Per the requested local test scope, the complete `npm test` suite was not run locally; PR Gate is the authority for the resulting complete portable and platform lanes.

## Review focus

- The invariant that only an initial Review with atomically persisted warn/fail findings can be `running` with findings.
- Startup recovery idempotency and preservation of the original flagged result.
- Renderer locking from hydrated state without making one-shot broadcasts authoritative.
- Whether `aborted` plus its persisted note is sufficient for restart interruption; this intentionally avoids a new enum and migration.

## Uncovered risks

- Exact-round automatic resume after process restart is intentionally unsupported.
- Complete portable and operating-system CI lanes are pending PR Gate.
- Independent review of the final evidence mapping is pending.
