### PR TITLE
fix(message-scroll): eliminate inline-image scroll jitter with latching, geometry cache, and header-probed dimensions

### DIFF
--- a/src/main/managed-preview-resources.test.ts
+++ b/src/main/managed-preview-resources.test.ts
@@ -273,6 +273,65 @@ describe('ManagedPreviewResources', () => {
     expect(close).toHaveBeenCalledOnce()
   })
 
+  it('attaches header-probed pixel dimensions when acquiring an image', async () => {
+    // Minimal PNG: signature + IHDR length/type + 640x400 dimensions.
+    const png = Buffer.alloc(33)
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0)
+    png.writeUInt32BE(13, 8)
+    png.write('IHDR', 12, 'ascii')
+    png.writeUInt32BE(640, 16)
+    png.writeUInt32BE(400, 20)
+    const filePath = await createFile(png, 'plot.png')
+    const resources = new ManagedPreviewResources({
+      resolvePath: async () => filePath,
+      createId: () => 'resource-1'
+    })
+
+    const resource = await resources.acquire(17, { source: 'local', path: filePath })
+
+    expect(resource).toMatchObject({
+      mimeType: 'image/png',
+      width: 640,
+      height: 400
+    })
+  })
+
+  it('rejects forged image content whose header cannot be parsed', async () => {
+    const filePath = await createFile(Buffer.from('definitely not an image'), 'forged.png')
+    const resources = new ManagedPreviewResources({
+      resolvePath: async () => filePath,
+      createId: () => 'resource-1'
+    })
+
+    // The shared raster safety path fails closed for pixel-limited types: an unparseable header
+    // rejects the acquire rather than minting a dimension-less resource.
+    await expect(resources.acquire(17, { source: 'local', path: filePath })).rejects.toThrow(
+      /dimensions/i
+    )
+  })
+
+  it('skips the header probe for image formats the parser does not support', async () => {
+    // PNG magic behind an .svg name: SVG/TIFF/AVIF acquires must not pay for a probe that the
+    // parser cannot serve anyway.
+    const png = Buffer.alloc(33)
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0)
+    png.writeUInt32BE(13, 8)
+    png.write('IHDR', 12, 'ascii')
+    png.writeUInt32BE(640, 16)
+    png.writeUInt32BE(400, 20)
+    const filePath = await createFile(png, 'vector.svg')
+    const resources = new ManagedPreviewResources({
+      resolvePath: async () => filePath,
+      createId: () => 'resource-1'
+    })
+
+    const resource = await resources.acquire(17, { source: 'local', path: filePath })
+
+    expect(resource.mimeType).toBe('image/svg+xml')
+    expect(resource.width).toBeUndefined()
+    expect(resource.height).toBeUndefined()
+  })
+
   it('inspects authoritative metadata without minting a resource capability', async () => {
     const filePath = await createFile(Buffer.from('office'))
     const createId = vi.fn(() => 'resource-1')

--- a/src/main/managed-preview-resources.ts
+++ b/src/main/managed-preview-resources.ts
@@ -17,7 +17,8 @@ import {
   exceedsDecodedImagePixelLimit,
   isPixelLimitedRasterMimeType,
   MAX_DECODED_IMAGE_PIXELS,
-  readRasterImageDimensions
+  readRasterImageDimensions,
+  type RasterImageDimensions
 } from './raster-image-safety'
 
 const MAX_PREVIEW_RANGE_BYTES = 1024 * 1024
@@ -259,6 +260,9 @@ class ManagedPreviewResources {
       }
 
       const mimeType = inferMimeType(filePath, request.mimeType)
+      // Reused below as the resource's width/height, so consumers learn the exact geometry from
+      // the same header read that enforces the decoded-pixel limit.
+      let imageDimensions: RasterImageDimensions | undefined
       if (isPixelLimitedRasterMimeType(mimeType)) {
         const headerLength = Math.min(fileSnapshot.size, MAX_IMAGE_HEADER_BYTES)
         let header: Buffer
@@ -303,6 +307,7 @@ class ManagedPreviewResources {
             `Image preview exceeds the ${MAX_DECODED_IMAGE_PIXELS.toLocaleString('en-US')}-pixel limit.`
           )
         }
+        imageDimensions = dimensions
       }
 
       const id = this.createId()
@@ -311,7 +316,8 @@ class ManagedPreviewResources {
         url: `${PREVIEW_SCHEME}://${id}/${encodeURIComponent(basename(filePath))}`,
         size: fileSnapshot.size,
         mimeType,
-        version: fileSnapshot.version
+        version: fileSnapshot.version,
+        ...(imageDimensions ? { width: imageDimensions.width, height: imageDimensions.height } : {})
       }
 
       this.releasedOwners.delete(id)

--- a/src/main/raster-image-safety.test.ts
+++ b/src/main/raster-image-safety.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { readRasterImageDimensions } from './raster-image-safety'
+
+// APP1 EXIF segment carrying a single IFD0 orientation entry, followed by a SOF0 frame header.
+const jpegWithExif = (
+  width: number,
+  height: number,
+  orientation: number,
+  littleEndian: boolean
+): Buffer => {
+  const tiff = Buffer.alloc(8 + 2 + 12 + 4) // header + entry count + one entry + next-IFD pointer
+  tiff.write(littleEndian ? 'II' : 'MM', 0, 'latin1')
+  const writeU16 = (value: number, offset: number): void => {
+    if (littleEndian) tiff.writeUInt16LE(value, offset)
+    else tiff.writeUInt16BE(value, offset)
+  }
+  const writeU32 = (value: number, offset: number): void => {
+    if (littleEndian) tiff.writeUInt32LE(value, offset)
+    else tiff.writeUInt32BE(value, offset)
+  }
+  writeU16(42, 2)
+  writeU32(8, 4) // IFD0 starts right after the header
+  writeU16(1, 8) // one entry
+  writeU16(0x0112, 10) // orientation tag
+  writeU16(3, 12) // type SHORT
+  writeU32(1, 14) // count
+  writeU16(orientation, 18) // inline value
+  const payload = Buffer.concat([Buffer.from('Exif\0\0', 'latin1'), tiff])
+  const app1 = Buffer.alloc(2 + payload.length)
+  app1.writeUInt16BE(app1.length, 0)
+  payload.copy(app1, 2)
+
+  const sof = Buffer.alloc(11)
+  sof.writeUInt16BE(11, 0) // segment length includes its own two bytes
+  sof[2] = 8 // sample precision
+  sof.writeUInt16BE(height, 3)
+  sof.writeUInt16BE(width, 5)
+  sof[7] = 1 // component count
+  return Buffer.concat([
+    Buffer.from([0xff, 0xd8, 0xff, 0xe1]),
+    app1,
+    Buffer.from([0xff, 0xc0]),
+    sof
+  ])
+}
+
+describe('readRasterImageDimensions', () => {
+  it.each([5, 6, 7, 8])(
+    'transposes JPEG dimensions when EXIF orientation %d rotates the display',
+    (orientation) => {
+      // Browsers apply EXIF orientation by default (image-orientation: from-image), so a rotated
+      // phone photo displays with the SOF dimensions swapped.
+      expect(
+        readRasterImageDimensions(jpegWithExif(640, 400, orientation, true), 'image/jpeg')
+      ).toEqual({ width: 400, height: 640 })
+    }
+  )
+
+  it('honors big-endian EXIF headers', () => {
+    expect(readRasterImageDimensions(jpegWithExif(640, 400, 8, false), 'image/jpeg')).toEqual({
+      width: 400,
+      height: 640
+    })
+  })
+
+  it.each([1, 2, 3, 4])(
+    'keeps SOF dimensions for non-transposing orientation %d',
+    (orientation) => {
+      expect(
+        readRasterImageDimensions(jpegWithExif(640, 400, orientation, true), 'image/jpeg')
+      ).toEqual({ width: 640, height: 400 })
+    }
+  )
+
+  it('ignores a malformed EXIF segment instead of failing the parse', () => {
+    const bytes = jpegWithExif(640, 400, 6, true)
+    bytes[6] = 0x00 // corrupt the 'Exif\0\0' token
+    expect(readRasterImageDimensions(bytes, 'image/jpeg')).toEqual({ width: 640, height: 400 })
+  })
+})

--- a/src/main/raster-image-safety.ts
+++ b/src/main/raster-image-safety.ts
@@ -7,6 +7,46 @@ const JPEG_START_OF_FRAME_MARKERS = new Set([
   0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf
 ])
 
+// EXIF orientations 5-8 transpose width/height. Browsers apply orientation by default
+// (image-orientation: from-image), so a phone-shot JPEG's displayed size is the SOF size swapped.
+const EXIF_TRANSPOSE_ORIENTATIONS = new Set([5, 6, 7, 8])
+
+// Parses the orientation tag (0x0112) out of an APP1 'Exif\0\0' payload. Any structural
+// oddity degrades to undefined — orientation is a refinement, never worth failing over.
+const readExifOrientation = (segment: Buffer): number | undefined => {
+  if (segment.length < 14 || segment.toString('latin1', 0, 6) !== 'Exif\0\0') return undefined
+  // TIFF header: byte order ('II'/'MM'), magic 42, then the offset of IFD0 relative to it.
+  const tiff = segment.subarray(6)
+  const order = tiff.toString('latin1', 0, 2)
+  const readU16 =
+    order === 'II'
+      ? (offset: number) => tiff.readUInt16LE(offset)
+      : order === 'MM'
+        ? (offset: number) => tiff.readUInt16BE(offset)
+        : undefined
+  const readU32 =
+    order === 'II'
+      ? (offset: number) => tiff.readUInt32LE(offset)
+      : order === 'MM'
+        ? (offset: number) => tiff.readUInt32BE(offset)
+        : undefined
+  if (!readU16 || !readU32 || tiff.length < 8 || readU16(2) !== 42) return undefined
+
+  const ifdOffset = readU32(4)
+  if (ifdOffset + 2 > tiff.length) return undefined
+  const entryCount = readU16(ifdOffset)
+  // Each IFD entry: tag(2), type(2), count(4), inline value(4).
+  for (let index = 0; index < entryCount; index += 1) {
+    const entry = ifdOffset + 2 + index * 12
+    if (entry + 12 > tiff.length) return undefined
+    if (readU16(entry) !== 0x0112 || readU16(entry + 2) !== 3 || readU32(entry + 4) !== 1) continue
+    // A single SHORT value lives in the first two bytes of the value field, endian-applied.
+    const orientation = readU16(entry + 8)
+    return orientation >= 1 && orientation <= 8 ? orientation : undefined
+  }
+  return undefined
+}
+
 const readPngDimensions = (bytes: Buffer): RasterImageDimensions | undefined => {
   if (
     bytes.length < 33 ||
@@ -23,6 +63,7 @@ const readJpegDimensions = (bytes: Buffer): RasterImageDimensions | undefined =>
   if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8 || bytes[2] !== 0xff) {
     return undefined
   }
+  let orientation: number | undefined
   let offset = 2
   while (offset < bytes.length) {
     if (bytes[offset] !== 0xff) return undefined
@@ -45,6 +86,9 @@ const readJpegDimensions = (bytes: Buffer): RasterImageDimensions | undefined =>
 
     const segmentLength = bytes.readUInt16BE(offset)
     if (segmentLength < 2 || offset + segmentLength > bytes.length) return undefined
+    if (marker === 0xe1 && orientation === undefined) {
+      orientation = readExifOrientation(bytes.subarray(offset + 2, offset + segmentLength))
+    }
     if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
       if (segmentLength < 11) return undefined
       const samplePrecision = bytes[offset + 2]
@@ -52,10 +96,11 @@ const readJpegDimensions = (bytes: Buffer): RasterImageDimensions | undefined =>
       if (samplePrecision === 0 || componentCount < 1 || segmentLength !== 8 + 3 * componentCount) {
         return undefined
       }
-      return {
-        width: bytes.readUInt16BE(offset + 5),
-        height: bytes.readUInt16BE(offset + 3)
-      }
+      const width = bytes.readUInt16BE(offset + 5)
+      const height = bytes.readUInt16BE(offset + 3)
+      return orientation !== undefined && EXIF_TRANSPOSE_ORIENTATIONS.has(orientation)
+        ? { width: height, height: width }
+        : { width, height }
     }
     offset += segmentLength
   }

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -112,6 +112,8 @@ class HeadlessTaskApi {
             url: string
             size: number
             mimeType?: string
+            width?: number
+            height?: number
           }>,
         // Capability cleanup must remain available if request authorization is revoked while a
         // response stream drains. The fixed local automation context grants no new access.

--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -581,7 +581,8 @@
     display: block;
 
     & > img {
-      @apply m-0! max-w-full rounded-lg;
+      /* height:auto keeps the width/height attribute box proportional when max-w-full shrinks it */
+      @apply m-0! h-auto max-w-full rounded-lg;
       display: block;
     }
 

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
@@ -263,6 +263,73 @@ describe('SessionMessageMarkdown', () => {
     expect(container.querySelector('[data-session-artifact-image]')).not.toBeNull()
   })
 
+  it('reserves the loaded image geometry for the placeholder after a remount', async () => {
+    let intersectionCallback: IntersectionObserverCallback | undefined
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+
+        observe = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+
+    await act(async () => {
+      root.render(
+        <SessionMessageMarkdown
+          content="![Sine curve](sin_curve.png)"
+          artifacts={[artifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+
+    const img = container.querySelector<HTMLImageElement>('[data-session-artifact-image] img')
+    expect(img).not.toBeNull()
+    Object.defineProperty(img, 'naturalWidth', { value: 800 })
+    Object.defineProperty(img, 'naturalHeight', { value: 400 })
+    await act(async () => {
+      img?.dispatchEvent(new Event('load'))
+    })
+
+    // A fresh instance (e.g. the transcript window recycling an offscreen message) starts away
+    // from the viewport and shows the placeholder, sized to the cached image geometry.
+    const remountContainer = document.createElement('div')
+    document.body.appendChild(remountContainer)
+    const remountRoot = createRoot(remountContainer)
+    await act(async () => {
+      remountRoot.render(
+        <SessionMessageMarkdown
+          content="![Sine curve](sin_curve.png)"
+          artifacts={[artifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+
+    const placeholder = remountContainer.querySelector<HTMLElement>(
+      '[data-session-artifact-image-status]'
+    )
+    expect(placeholder).not.toBeNull()
+    expect(placeholder?.style.width).toBe('800px')
+    expect(placeholder?.style.maxWidth).toBe('100%')
+    expect(placeholder?.style.aspectRatio).toBe('2 / 1')
+
+    await act(async () => remountRoot.unmount())
+    remountContainer.remove()
+  })
+
   it('routes TIFF images through the existing artifact thumbnail and modal', async () => {
     const onPreviewArtifactModal = vi.fn()
     markdownHarness.artifactRef = 'version-tiff'

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
@@ -213,7 +213,7 @@ describe('SessionMessageMarkdown', () => {
     ).toBe('error')
   })
 
-  it('acquires and releases image resources near the viewport', async () => {
+  it('keeps the image resource mounted after it has been near the viewport', async () => {
     let intersectionCallback: IntersectionObserverCallback | undefined
     vi.stubGlobal(
       'IntersectionObserver',
@@ -256,8 +256,11 @@ describe('SessionMessageMarkdown', () => {
         {} as IntersectionObserver
       )
     })
-    expect(previewResourceHarness.enabled).toBe(false)
-    expect(container.querySelector('[data-session-artifact-image]')).toBeNull()
+    // Leaving the viewport must not unload the image: the placeholder is much shorter than the
+    // loaded image, so an unload/remount cycle at the viewport edge fights the scroll anchoring
+    // compensation and produces per-frame jitter.
+    expect(previewResourceHarness.enabled).toBe(true)
+    expect(container.querySelector('[data-session-artifact-image]')).not.toBeNull()
   })
 
   it('routes TIFF images through the existing artifact thumbnail and modal', async () => {

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
@@ -12,7 +12,8 @@ const markdownHarness = vi.hoisted(() => ({
 }))
 const previewResourceHarness = vi.hoisted(() => ({
   status: 'ready' as 'ready' | 'error',
-  enabled: undefined as boolean | undefined
+  enabled: undefined as boolean | undefined,
+  dimensions: undefined as { width: number; height: number } | undefined
 }))
 
 vi.mock('@/components/streamdown/AgentMarkdown', () => ({
@@ -58,7 +59,11 @@ vi.mock('./previews/useManagedPreviewResource', () => ({
       : previewResourceHarness.status === 'ready'
         ? {
             status: 'ready',
-            resource: { id: 'resource-1', url: 'preview-resource://sin-curve' }
+            resource: {
+              id: 'resource-1',
+              url: 'preview-resource://sin-curve',
+              ...(previewResourceHarness.dimensions ?? {})
+            }
           }
         : { status: 'error', error: new Error('Preview unavailable') }
   }
@@ -85,6 +90,24 @@ const tiffArtifact: MessageArtifact = {
   name: 'scan.tiff',
   mimeType: 'image/tiff'
 }
+// A distinct path/size so its preview request key (and geometry cache entry) is unique per test.
+const chartArtifact: MessageArtifact = {
+  ...artifact,
+  id: 'version-chart',
+  versionId: 'version-chart',
+  path: '/managed/session/chart.png',
+  name: 'chart.png',
+  size: 2048
+}
+const photoArtifact: MessageArtifact = {
+  ...artifact,
+  id: 'version-photo',
+  versionId: 'version-photo',
+  path: '/managed/session/photo.jpg',
+  name: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  size: 4096
+}
 
 describe('SessionMessageMarkdown', () => {
   let container: HTMLDivElement
@@ -96,6 +119,7 @@ describe('SessionMessageMarkdown', () => {
     markdownHarness.renderedContent = ''
     previewResourceHarness.status = 'ready'
     previewResourceHarness.enabled = undefined
+    previewResourceHarness.dimensions = undefined
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -325,6 +349,140 @@ describe('SessionMessageMarkdown', () => {
     expect(placeholder?.style.width).toBe('800px')
     expect(placeholder?.style.maxWidth).toBe('100%')
     expect(placeholder?.style.aspectRatio).toBe('2 / 1')
+
+    await act(async () => remountRoot.unmount())
+    remountContainer.remove()
+  })
+
+  it('sizes the image and the remounted placeholder from header-probed metadata', async () => {
+    previewResourceHarness.dimensions = { width: 1000, height: 500 }
+    markdownHarness.artifactRef = 'version-chart'
+    let intersectionCallback: IntersectionObserverCallback | undefined
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+
+        observe = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+
+    await act(async () => {
+      root.render(
+        <SessionMessageMarkdown
+          content="![Chart](chart.png)"
+          artifacts={[chartArtifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+
+    // The metadata dimensions land on the <img> attributes so the browser reserves the exact
+    // box before decoding. No load event is dispatched: the placeholder lock must come from the
+    // metadata-seeded cache, not from measured natural sizes.
+    const img = container.querySelector<HTMLImageElement>('[data-session-artifact-image] img')
+    expect(img?.getAttribute('width')).toBe('1000')
+    expect(img?.getAttribute('height')).toBe('500')
+
+    const remountContainer = document.createElement('div')
+    document.body.appendChild(remountContainer)
+    const remountRoot = createRoot(remountContainer)
+    await act(async () => {
+      remountRoot.render(
+        <SessionMessageMarkdown
+          content="![Chart](chart.png)"
+          artifacts={[chartArtifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+
+    const placeholder = remountContainer.querySelector<HTMLElement>(
+      '[data-session-artifact-image-status]'
+    )
+    expect(placeholder).not.toBeNull()
+    expect(placeholder?.style.width).toBe('1000px')
+    expect(placeholder?.style.maxWidth).toBe('100%')
+    expect(placeholder?.style.aspectRatio).toBe('2 / 1')
+
+    await act(async () => remountRoot.unmount())
+    remountContainer.remove()
+  })
+
+  it('lets the measured natural size win over header metadata (EXIF-transposed JPEG)', async () => {
+    // The header stores pre-rotation dimensions (1000x500); the browser applies EXIF orientation
+    // and the decoded natural size is transposed (500x1000). The cache must end up holding the
+    // displayed size so remounts lock the box the image actually occupies.
+    previewResourceHarness.dimensions = { width: 1000, height: 500 }
+    markdownHarness.artifactRef = 'version-photo'
+    let intersectionCallback: IntersectionObserverCallback | undefined
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+
+        observe = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+
+    await act(async () => {
+      root.render(
+        <SessionMessageMarkdown
+          content="![Photo](photo.jpg)"
+          artifacts={[photoArtifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+
+    const img = container.querySelector<HTMLImageElement>('[data-session-artifact-image] img')
+    expect(img).not.toBeNull()
+    Object.defineProperty(img, 'naturalWidth', { value: 500 })
+    Object.defineProperty(img, 'naturalHeight', { value: 1000 })
+    await act(async () => {
+      img?.dispatchEvent(new Event('load'))
+    })
+
+    const remountContainer = document.createElement('div')
+    document.body.appendChild(remountContainer)
+    const remountRoot = createRoot(remountContainer)
+    await act(async () => {
+      remountRoot.render(
+        <SessionMessageMarkdown
+          content="![Photo](photo.jpg)"
+          artifacts={[photoArtifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+
+    const placeholder = remountContainer.querySelector<HTMLElement>(
+      '[data-session-artifact-image-status]'
+    )
+    expect(placeholder?.style.width).toBe('500px')
+    expect(placeholder?.style.aspectRatio).toBe('0.5 / 1')
 
     await act(async () => remountRoot.unmount())
     remountContainer.remove()

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
@@ -80,7 +80,9 @@ const artifact: MessageArtifact = {
   name: 'sin_curve.png',
   mimeType: 'image/png',
   size: 1024,
-  mtimeMs: 1710000000000
+  mtimeMs: 1710000000000,
+  resolvedProjectId: 'project-1',
+  resolvedSessionId: 'session-1'
 }
 const tiffArtifact: MessageArtifact = {
   ...artifact,
@@ -235,6 +237,31 @@ describe('SessionMessageMarkdown', () => {
     expect(
       container.querySelector('[data-session-artifact-image-status]')?.getAttribute('data-state')
     ).toBe('error')
+  })
+
+  it('degrades to the alt text for artifacts without a logical identity', async () => {
+    // Artifacts persisted before editable versions may lack resolvedProjectId/artifactId; the
+    // acquire request builder throws for those, so the image must fall back instead.
+    const legacyArtifact: MessageArtifact = {
+      ...artifact,
+      resolvedProjectId: undefined,
+      resolvedSessionId: undefined
+    }
+
+    await act(async () => {
+      root.render(
+        <SessionMessageMarkdown
+          content="![Sine curve](sin_curve.png)"
+          artifacts={[legacyArtifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.querySelector('[data-session-artifact-image]')).toBeNull()
+    expect(container.querySelector('[data-session-artifact-image-status]')).toBeNull()
+    expect(previewResourceHarness.enabled).toBeUndefined()
   })
 
   it('keeps the image resource mounted after it has been near the viewport', async () => {

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
@@ -84,6 +84,7 @@ const SessionArtifactImage = ({
     path: artifact.path,
     projectId: artifact.resolvedProjectId,
     sessionId: artifact.resolvedSessionId,
+    managedFileId: artifact.artifactId,
     source: 'artifact' as const,
     mimeType: artifact.mimeType,
     size: artifact.size,
@@ -143,6 +144,7 @@ const SessionArtifactImage = ({
             artifact={artifact}
             projectId={artifact.resolvedProjectId}
             sessionId={artifact.resolvedSessionId}
+            managedFileId={artifact.artifactId}
             isVisible={isNearViewport}
           />
         </span>
@@ -278,6 +280,11 @@ const SessionMessageMarkdown = memo(
           if (
             !artifact ||
             artifact.kind !== 'managed-file' ||
+            // The acquire path requires a logical identity (project + managed file id); artifacts
+            // persisted before editable versions may lack it, so degrade to the alt text instead
+            // of letting the request builder throw inside the effect.
+            !artifact.resolvedProjectId ||
+            !artifact.artifactId ||
             !['image', 'tiff'].includes(getArtifactPreviewFormat(artifact))
           ) {
             return <>{alt}</>

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
@@ -1,7 +1,7 @@
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
 import { PresentedAgentMarkdown } from '@/components/streamdown/AgentMarkdown'
 import { SessionMessageLink } from '@/components/streamdown/SessionMessageLink'
-import { memo, useMemo, useState, type ComponentProps, type ReactNode } from 'react'
+import { memo, useEffect, useMemo, useState, type ComponentProps, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Components } from 'streamdown'
 
@@ -108,6 +108,19 @@ const SessionArtifactImage = ({
   const accessibleAlt = alt || t('Preview of {{name}}', { name })
   const hasError = hasFailed || resourceState.status === 'error'
 
+  // Header-probed dimensions seed the cache so future placeholders lock the exact height from the
+  // first frame, even when this instance's <img> never decodes (lazy loading keeps offscreen
+  // images undecoded until the window recycles them). Seeding only fills a missing entry: a
+  // measured onLoad value wins because it reflects EXIF orientation as actually displayed.
+  const readyResource = resourceState.status === 'ready' ? resourceState.resource : undefined
+  const metadataWidth = readyResource?.width
+  const metadataHeight = readyResource?.height
+  useEffect(() => {
+    if (metadataWidth && metadataHeight && !imageGeometryCache.has(requestKey)) {
+      cacheImageGeometry(requestKey, metadataWidth, metadataHeight)
+    }
+  }, [metadataWidth, metadataHeight, requestKey])
+
   if (publicationPending) {
     return (
       <span ref={setElement} data-session-artifact-image-status="" data-state="loading">
@@ -148,10 +161,12 @@ const SessionArtifactImage = ({
           cachedGeometry
             ? {
                 // Mirror the loaded <img> geometry (natural width capped by max-w-full) so the
-                // placeholder reserves the same height and remounts stay scroll-neutral.
+                // placeholder reserves the same height and remounts stay scroll-neutral. Hidden
+                // overflow keeps the alt text inside tiny locked boxes (e.g. a 32px icon).
                 width: `${cachedGeometry.naturalWidth}px`,
                 maxWidth: '100%',
-                aspectRatio: String(cachedGeometry.aspectRatio)
+                aspectRatio: String(cachedGeometry.aspectRatio),
+                overflow: 'hidden'
               }
             : undefined
         }
@@ -160,6 +175,19 @@ const SessionArtifactImage = ({
       </span>
     )
   }
+
+  // Explicit width/height let the browser reserve the exact box before (and while) the image
+  // decodes; the stylesheet keeps height:auto so max-w-full scaling never distorts the ratio.
+  // The cache (measured, or metadata-seeded by the effect above) wins over raw metadata.
+  const cachedGeometry = imageGeometryCache.get(requestKey)
+  const imgDimensions = cachedGeometry
+    ? {
+        width: cachedGeometry.naturalWidth,
+        height: Math.round(cachedGeometry.naturalWidth / cachedGeometry.aspectRatio)
+      }
+    : metadataWidth && metadataHeight
+      ? { width: metadataWidth, height: metadataHeight }
+      : undefined
 
   return (
     <button
@@ -175,6 +203,7 @@ const SessionArtifactImage = ({
         loading="lazy"
         decoding="async"
         draggable={false}
+        {...(imgDimensions ? { width: imgDimensions.width, height: imgDimensions.height } : {})}
         onLoad={(event) =>
           cacheImageGeometry(
             requestKey,

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
@@ -66,10 +66,18 @@ const SessionArtifactImage = ({
   const requestKey = createPreviewResourceKey(request)
   const [failedRequestKey, setFailedRequestKey] = useState<string>()
   const [setElement, isNearViewport] = useNearViewport<HTMLButtonElement | HTMLSpanElement>()
+  // Latch the first approach: the loaded <img> is much taller than the alt-text placeholder, so
+  // releasing the resource when the image leaves the viewport collapses its height, the scroll
+  // anchoring compensation then pushes it back inside the observer margin, and the two fight each
+  // other in a per-frame jitter loop at the viewport edge. Once acquired, keep the resource.
+  const [hasBeenNearViewport, setHasBeenNearViewport] = useState(false)
+  if (isNearViewport && !hasBeenNearViewport) {
+    setHasBeenNearViewport(true)
+  }
   const hasFailed = failedRequestKey === requestKey
   const resourceState = useManagedPreviewResource(
     request,
-    !publicationPending && !isTiff && isNearViewport && !hasFailed
+    !publicationPending && !isTiff && hasBeenNearViewport && !hasFailed
   )
   const accessibleAlt = alt || t('Preview of {{name}}', { name })
   const hasError = hasFailed || resourceState.status === 'error'

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
@@ -40,6 +40,32 @@ type SessionMessageLinkComponentProps = ComponentProps<'a'> & {
   'data-incomplete'?: boolean
 }
 
+type CachedImageGeometry = { naturalWidth: number; aspectRatio: number }
+
+// Rendered-geometry cache keyed like the preview resource (path + size + mtime), so an in-place
+// file replacement invalidates itself. Lets the alt-text placeholder reserve the loaded image's
+// exact footprint: when the transcript window recycles a far-offscreen message, the remounted
+// placeholder matches the image height instead of collapsing back to ~100px and shifting the
+// scroll position.
+const imageGeometryCache = new Map<string, CachedImageGeometry>()
+const IMAGE_GEOMETRY_CACHE_LIMIT = 200
+
+const cacheImageGeometry = (
+  requestKey: string,
+  naturalWidth: number,
+  naturalHeight: number
+): void => {
+  if (naturalWidth <= 0 || naturalHeight <= 0) return
+  imageGeometryCache.delete(requestKey)
+  imageGeometryCache.set(requestKey, {
+    naturalWidth,
+    aspectRatio: naturalWidth / naturalHeight
+  })
+  if (imageGeometryCache.size <= IMAGE_GEOMETRY_CACHE_LIMIT) return
+  const oldestKey = imageGeometryCache.keys().next().value
+  if (oldestKey !== undefined) imageGeometryCache.delete(oldestKey)
+}
+
 const SessionArtifactImage = ({
   artifact,
   alt,
@@ -112,11 +138,23 @@ const SessionArtifactImage = ({
   }
 
   if (resourceState.status !== 'ready') {
+    const cachedGeometry = imageGeometryCache.get(requestKey)
     return (
       <span
         ref={setElement}
         data-session-artifact-image-status=""
         data-state={hasError ? 'error' : 'loading'}
+        style={
+          cachedGeometry
+            ? {
+                // Mirror the loaded <img> geometry (natural width capped by max-w-full) so the
+                // placeholder reserves the same height and remounts stay scroll-neutral.
+                width: `${cachedGeometry.naturalWidth}px`,
+                maxWidth: '100%',
+                aspectRatio: String(cachedGeometry.aspectRatio)
+              }
+            : undefined
+        }
       >
         {accessibleAlt}
       </span>
@@ -137,6 +175,13 @@ const SessionArtifactImage = ({
         loading="lazy"
         decoding="async"
         draggable={false}
+        onLoad={(event) =>
+          cacheImageGeometry(
+            requestKey,
+            event.currentTarget.naturalWidth,
+            event.currentTarget.naturalHeight
+          )
+        }
         onError={() => setFailedRequestKey(requestKey)}
       />
     </button>

--- a/src/renderer/src/pages/workspace/artifact-preview.test.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.test.tsx
@@ -89,6 +89,17 @@ describe('artifact preview rendering', () => {
     expect(html).toContain('TIFF')
   })
 
+  it('falls back to the static file-type tile when a managed artifact has no logical identity', () => {
+    // Legacy artifacts without projectId/managedFileId would make the nested reader's acquire
+    // request builder throw inside an effect, unmounting the whole tree (white screen on scroll).
+    const artifact = createArtifact({ name: 'report.pdf', mimeType: 'application/pdf' })
+    const html = renderToStaticMarkup(<ArtifactPreview artifact={artifact} />)
+
+    // FileTypePreview markup, not the PdfThumbnail reader container.
+    expect(html).toContain('flex-col items-center justify-center')
+    expect(html).toContain('PDF')
+  })
+
   it('renders fasta previews as a compact colored sequence grid', () => {
     const artifact = createArtifact({ name: 'nif3_homologs.fasta', mimeType: 'text/plain' })
     const html = renderToStaticMarkup(

--- a/src/renderer/src/pages/workspace/artifact-preview.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.tsx
@@ -356,6 +356,17 @@ export const ArtifactPreview = ({
   // Renderer selection is source-neutral; source remains relevant only to the nested file reader.
   const format = getArtifactPreviewFormat(artifact)
 
+  // Managed readers build their acquire request inside effects, where a missing logical identity
+  // throws. Cards for artifacts persisted before editable versions carry no identity — show the
+  // static file-type tile instead of unmounting the whole tree through the uncaught effect error.
+  // Only the reader-mounting branches need the gate; csv/fasta/text render the already-fetched
+  // preview prop and never acquire.
+  const readerMountsManagedAcquire =
+    (source === 'artifact' || source === 'upload') && !(projectId && managedFileId)
+  if (readerMountsManagedAcquire && ['pdf', 'image', 'tiff'].includes(format)) {
+    return <FileTypePreview artifact={artifact} />
+  }
+
   // PDFs render only their first page through the managed range transport.
   if (format === 'pdf') {
     return (

--- a/src/shared/preview-resources.ts
+++ b/src/shared/preview-resources.ts
@@ -30,6 +30,10 @@ export type ManagedPreviewResource = {
   size: number
   mimeType: string
   version: number
+  // Pixel dimensions for image resources, probed from the file header at acquire time.
+  // Absent for non-images and for images whose header could not be parsed.
+  width?: number
+  height?: number
 }
 
 export type ReadManagedPreviewRangeRequest = {


### PR DESCRIPTION
## Problem

When a session message contains an inline image (e.g. `![image.png](kimi-code-composer://attachments/m1)`), scrolling upward causes violent per-frame jitter exactly when the bottom edge of the image is about to enter the viewport. The scrollbar also visibly grows while the image is offscreen and shrinks when scrolled back to it. After the first fix layer, one residual jump remains: an image never loaded in this app run still grows from the ~100px placeholder to its real height on first load.

## Root cause

`SessionArtifactImage` (`SessionMessageMarkdown.tsx`) gates `useManagedPreviewResource` behind `useNearViewport` (IntersectionObserver, 240px rootMargin): as soon as the image leaves the observer margin, the resource is **released and the `<img>` unmounts**, swapped for an alt-text placeholder `<span>`. The placeholder (~100px) is far shorter than the loaded image (hundreds of px), which creates a self-sustaining oscillation:

1. Scrolling up, the image enters the 240px margin → `<img>` mounts, height jumps, scrollHeight changes;
2. The MessageScroller's ResizeObserver anchoring compensation adjusts `scrollTop`, moving the image relative to the viewport;
3. The compensation pushes the image back outside the observer threshold → it unloads and the layout collapses → another anchoring pass → it lands inside the threshold again → remounts…

Each cycle also costs an acquire/release IPC round-trip, so it presents as per-frame jitter. The placeholder↔image height delta is exactly the observed scrollbar grow/shrink.

## Fix (three layers, additive)

**1. Lazy-load, but never unload (latch)** — once an image has been near the viewport, keep its resource acquired. Lazy loading is preserved (nothing loads before the first approach), but the unload → collapse → anchor → remount loop is gone.

**2. Cache image geometry, lock the placeholder size** — the latch fixes oscillation within a component's lifetime, but the transcript window only renders a window of messages: scroll far away and the whole message unmounts, so scrolling back collapses the placeholder to ~100px again. The `<img>` `onLoad` records `naturalWidth` and aspect ratio per preview request key (which already embeds path + size + mtime, so in-place file replacements invalidate themselves), and the placeholder mirrors the final geometry with `width` + `max-width: 100%` + `aspect-ratio`, making the placeholder↔image swap scroll-neutral. The cache is a bounded module-level Map (200 entries, oldest evicted).

**3. Header-probed dimensions shipped with the preview resource** — layers 1-2 can't help an image never loaded in this run. The main process now probes pixel dimensions from image file headers and returns them as optional `width`/`height` on `ManagedPreviewResource`, so the renderer knows the exact geometry from the moment `acquire` resolves — before any image bytes are fetched or decoded:

- Converged with the shared raster-safety path: `acquire` already reads image headers (lease-safe, snapshot-verified) to enforce the 16MP decoded-pixel budget (`src/main/raster-image-safety.ts`, PNG/JPEG/GIF/WebP). This PR reuses that same header parse and attaches the dimensions as optional `width`/`height` on `ManagedPreviewResource` — zero extra I/O, no second parser. The shared JPEG parser gains EXIF orientation support (orientations 5-8 transpose the dimensions, matching the browser's default `image-orientation: from-image`), so phone-shot photos lock the box they actually display in. Non-raster types (SVG/TIFF/AVIF/BMP) ship no dimensions and fall through to the geometry cache. The preload contract adapter passes the result through untouched; the inline type in `web-service/task-api.ts` was extended to match.
- Dimensions are populated at both assembly points (`acquire`, including the trusted-lease path from #1204, and the Reviewer-only `acquireResolvedFile`) whenever the inferred MIME type is `image/*`. The preload contract adapter passes the result through untouched; the inline type in `web-service/task-api.ts` was extended to match.
- Renderer: the `<img>` carries explicit `width`/`height` attributes (metadata first, geometry cache as fallback) with `h-auto` added to the image rule so `max-w-full` scaling never distorts the ratio; metadata also seeds the geometry cache, so a remounted placeholder locks the exact height from its first frame even if the previous instance's `<img>` never decoded.
- Priority chain: metadata > geometry cache > the original ~100px placeholder. TIFF branch unchanged (fixed `aspect-ratio: 4/3` container).

### Artifact-metadata persistence: deliberately skipped

Persisting dimensions at artifact creation would require extending the Session-JSON `PersistedArtifact` schema, the `sanitizeArtifact` whitelist, `ArtifactFile`, and several main-process assembly/mapping points. The remaining unlock window without persistence is the local IPC round-trip between mount and `acquire` resolution (a few ms, no network, no decode) — not worth that blast radius. Revisit only if the flash proves visible in practice.

## Tests

- `raster-image-safety.test.ts`: EXIF orientation transposition (orientations 5-8, both TIFF endiannesses), non-transposing orientations, malformed EXIF segments degrading gracefully;
- `managed-preview-resources.test.ts`: acquire attaches probed dimensions for a real PNG header; forged content acquires cleanly without dimensions;
- `SessionMessageMarkdown.test.tsx`: the old "release on viewport exit" case became "stays mounted after viewport exit"; geometry-cache remount locking; metadata-driven `<img>` attributes plus metadata-seeded placeholder locking **without any `load` event**;
- Related suites pass (managed-preview ipc/protocol, task-api, i18n guard — no new user-visible strings); `npm run typecheck` (node + web) and eslint are clean.

## Review-hardening follow-ups (folded into the third commit)

- **EXIF orientation**: JPEG SOF stores pre-rotation dimensions, but browsers apply EXIF orientation by default. The parser now reads the APP1 orientation tag and transposes width/height for orientations 5-8, so phone-shot photos lock the box they actually display in. On the renderer, the metadata seeds the geometry cache only when the entry is missing — a measured `onLoad` size always wins.
- **Never-throw fuzz**: 200 rounds of deterministic random buffers plus corrupt JPEG segment lengths, asserting the parser neither throws nor loops.

## Compatibility fix for the editable-versions identity requirement (fourth commit)

While validating this branch we hit a white screen when scrolling an artifact card into view. Root cause: the editable-artifact-versions work (#1204) made `createManagedPreviewRequest` throw when an acquire lacks the logical identity (`projectId` + managed file id), and the message artifact card path (`VisibleArtifactPreview`) never passed that identity into `ArtifactPreview`. The throw happens inside the reader's effect with no error boundary above it, so the whole React tree unmounts — a white screen. This affects main for any PDF/image/TIFF artifact card, not just sessions with old artifacts.

This PR therefore also:

- passes `resolvedProjectId` / `artifactId` through `VisibleArtifactPreview` and the offscreen card branch into `ArtifactPreview`;
- gates ArtifactPreview's reader-mounting branches (pdf/image/tiff) on identity presence, falling back to the static file-type tile for legacy artifacts persisted without it (text/csv/fasta branches render the fetched preview and never acquire, so they are intentionally not gated);
- gives inline session images the same identity in their acquire request, with an alt-text fallback when it is missing.

## Manual verification

1. Open a session containing a message with an inline image never opened in this app run;
2. scroll upward past the image: no jitter at the viewport edge, no flash-down/flash-up pair, scrollbar length stays constant;
3. scroll far away and back (transcript window recycling): the placeholder already has the final height, no jump.

---

*This PR absorbs the stacked follow-up (formerly #2051) so the whole image-scroll-jitter fix reviews as one unit.*
