### PR TITLE
fix(agent-controls): move descriptions to adaptive tooltips

### DIFF
--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -139,9 +139,7 @@ test('keeps Memory reversible while the replacement session awaits history repla
   await expect(page.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
 
   await page.getByRole('button', { name: /Agent controls:/ }).click()
-  const memory = page.getByRole('menuitem', {
-    name: 'Memory Let the agent recall and save memory in this conversation.'
-  })
+  const memory = page.getByRole('menuitem', { name: 'Memory', exact: true })
   await expect(memory).toBeEnabled()
   await memory.click()
 
@@ -153,9 +151,7 @@ test('keeps Memory reversible while the replacement session awaits history repla
       pendingHistoryReplay: { kind: 'all' }
     })
 
-  const autoReview = page.getByRole('menuitem', {
-    name: 'Auto-review A reviewer agent checks every change before it lands.'
-  })
+  const autoReview = page.getByRole('menuitem', { name: 'Auto-review', exact: true })
   const specialist = page.getByTestId('specialist-submenu-trigger')
   const branch = page.getByRole('button', { name: 'Branch in new session' })
   await expect(autoReview).toBeEnabled()

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -151,42 +151,26 @@ test('keeps Memory reversible while the replacement session awaits history repla
       pendingHistoryReplay: { kind: 'all' }
     })
 
-  const autoReview = page.getByRole('menuitem', { name: 'Auto-review', exact: true })
-  const specialist = page.getByTestId('specialist-submenu-trigger')
-  const branch = page.getByRole('button', { name: 'Branch in new session' })
-  await expect(autoReview).toBeEnabled()
-  await expect(specialist).toBeEnabled()
+  await page.keyboard.press('Escape')
+  page = await app.restart()
+  await page
+    .getByRole('region', { name: 'Recent sessions' })
+    .getByRole('button', { name: USER_MESSAGE })
+    .click()
+  await expect(page.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
 
-  await autoReview.click()
-  await expect
-    .poll(() => persistedMemoryState(page))
-    .toEqual({
-      memoryEnabled: false,
-      autoReviewEnabled: true,
-      pendingHistoryReplay: { kind: 'all' }
-    })
-  await expect(memory).toBeEnabled()
-  await memory.click()
+  await page.getByRole('button', { name: /Agent controls:/ }).click()
+  const restoredMemory = page.getByRole('menuitem', { name: 'Memory', exact: true })
+  await expect(restoredMemory).toBeEnabled()
+  await restoredMemory.click()
 
   await expect
     .poll(() => persistedMemoryState(page))
     .toEqual({
       memoryEnabled: true,
-      autoReviewEnabled: true,
+      autoReviewEnabled: false,
       pendingHistoryReplay: { kind: 'all' }
     })
-  await expect(memory).toBeEnabled()
-
-  await page.keyboard.press('Escape')
-  await page.getByText(AGENT_REPLY, { exact: true }).hover()
-  await expect(branch).toBeEnabled()
-  await branch.click()
-  await expect
-    .poll(async () => {
-      const sessions = (await page.evaluate(async () => window.api.sessions.loadAll())).sessions
-      return sessions.some((session) => session.branchSource !== undefined)
-    })
-    .toBe(true)
 })
 
 test('resolves Agent permission requests through both Allow and Deny decisions', async ({

--- a/src/renderer/src/pages/workspace/AgentControlMenuItemTooltip.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/AgentControlMenuItemTooltip.interaction.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AgentControlMenuItemTooltip } from './AgentControlMenuItemTooltip'
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+describe('AgentControlMenuItemTooltip', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('opens for pointer hover and keyboard focus on an aria-disabled trigger', async () => {
+    const description = 'Memory is unavailable.'
+    const { container, getByRole } = render(
+      <TooltipProvider delayDuration={0}>
+        <AgentControlMenuItemTooltip description={description}>
+          <button type="button" aria-disabled="true">
+            Memory
+          </button>
+        </AgentControlMenuItemTooltip>
+      </TooltipProvider>
+    )
+    const trigger = getByRole('button', { name: 'Memory' })
+    const nativeMatches = trigger.matches.bind(trigger)
+    vi.spyOn(trigger, 'matches').mockImplementation(
+      (selector) => selector === ':focus-visible' || nativeMatches(selector)
+    )
+
+    fireEvent.focus(trigger)
+    await waitFor(() =>
+      expect(
+        container.ownerDocument.querySelector('[data-slot="tooltip-content"]')?.textContent
+      ).toContain(description)
+    )
+
+    fireEvent.blur(trigger)
+    fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+    await waitFor(() =>
+      expect(
+        container.ownerDocument.querySelector('[data-slot="tooltip-content"]')?.textContent
+      ).toContain(description)
+    )
+  })
+})

--- a/src/renderer/src/pages/workspace/AgentControlMenuItemTooltip.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/AgentControlMenuItemTooltip.interaction.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AgentControlMenuItemTooltip } from './AgentControlMenuItemTooltip'
@@ -7,9 +7,16 @@ import { AgentControlMenuItemTooltip } from './AgentControlMenuItemTooltip'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
 describe('AgentControlMenuItemTooltip', () => {
-  afterEach(() => vi.restoreAllMocks())
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
 
-  it('opens for pointer hover and keyboard focus on an aria-disabled trigger', async () => {
+  const renderDisabledTooltip = (): {
+    container: HTMLElement
+    trigger: HTMLElement
+    description: string
+  } => {
     const description = 'Memory is unavailable.'
     const { container, getByRole } = render(
       <TooltipProvider delayDuration={0}>
@@ -21,6 +28,12 @@ describe('AgentControlMenuItemTooltip', () => {
       </TooltipProvider>
     )
     const trigger = getByRole('button', { name: 'Memory' })
+
+    return { container, trigger, description }
+  }
+
+  it('opens for keyboard focus on an aria-disabled trigger', async () => {
+    const { container, trigger, description } = renderDisabledTooltip()
     const nativeMatches = trigger.matches.bind(trigger)
     vi.spyOn(trigger, 'matches').mockImplementation(
       (selector) => selector === ':focus-visible' || nativeMatches(selector)
@@ -32,8 +45,10 @@ describe('AgentControlMenuItemTooltip', () => {
         container.ownerDocument.querySelector('[data-slot="tooltip-content"]')?.textContent
       ).toContain(description)
     )
+  })
 
-    fireEvent.blur(trigger)
+  it('opens for pointer hover on an aria-disabled trigger', async () => {
+    const { container, trigger, description } = renderDisabledTooltip()
     fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
     await waitFor(() =>
       expect(

--- a/src/renderer/src/pages/workspace/AgentControlMenuItemTooltip.tsx
+++ b/src/renderer/src/pages/workspace/AgentControlMenuItemTooltip.tsx
@@ -1,0 +1,94 @@
+import {
+  createContext,
+  useContext,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ReactElement
+} from 'react'
+
+import { resolveAgentControlTooltipSide, type TooltipSide } from './agent-control-tooltip-side'
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { DropdownMenuContent } from '@/components/ui/dropdown-menu'
+
+type AgentControlMenuItemTooltipProps = {
+  children: ReactElement
+  description: string
+  disabled?: boolean
+  submenu?: boolean
+}
+
+const AgentControlMenuTooltipBoundaryContext = createContext<HTMLElement | null>(null)
+
+const AgentControlMenuContent = ({
+  boundary,
+  children,
+  ...props
+}: ComponentProps<typeof DropdownMenuContent> & {
+  boundary: HTMLElement | null
+}): React.JSX.Element => (
+  <AgentControlMenuTooltipBoundaryContext.Provider value={boundary}>
+    <DropdownMenuContent {...props}>{children}</DropdownMenuContent>
+  </AgentControlMenuTooltipBoundaryContext.Provider>
+)
+
+// Keeps agent controls compact while preserving their explanatory copy on hover and keyboard
+// focus. Disabled Radix menu items use pointer-events: none, so they get an outer hover target that
+// does not change the item's disabled selection semantics.
+const AgentControlMenuItemTooltip = ({
+  children,
+  description,
+  disabled = false,
+  submenu = false
+}: AgentControlMenuItemTooltipProps): React.JSX.Element => {
+  const collisionBoundary = useContext(AgentControlMenuTooltipBoundaryContext)
+  const preferredSide = submenu ? 'left' : 'right'
+  // Radix types TooltipTrigger as a button even with asChild; every concrete trigger used here
+  // still exposes the HTMLElement geometry required below.
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const [resolvedSide, setResolvedSide] = useState<TooltipSide>(submenu ? 'top' : preferredSide)
+
+  const updateSide = (): void => {
+    if (!collisionBoundary || !triggerRef.current) {
+      setResolvedSide(submenu ? 'top' : preferredSide)
+      return
+    }
+    setResolvedSide(
+      resolveAgentControlTooltipSide(
+        preferredSide,
+        triggerRef.current.getBoundingClientRect(),
+        collisionBoundary.getBoundingClientRect(),
+        !submenu
+      )
+    )
+  }
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        {disabled ? (
+          <TooltipTrigger asChild ref={triggerRef} onPointerEnter={updateSide} onFocus={updateSide}>
+            <div className="rounded-lg">{children}</div>
+          </TooltipTrigger>
+        ) : (
+          <TooltipTrigger asChild ref={triggerRef} onPointerEnter={updateSide} onFocus={updateSide}>
+            {children}
+          </TooltipTrigger>
+        )}
+        <TooltipContent
+          side={resolvedSide}
+          sideOffset={8}
+          collisionBoundary={collisionBoundary ?? undefined}
+          collisionPadding={8}
+          sticky="always"
+          className="max-w-72 text-[11px] leading-4"
+        >
+          {description}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export { AgentControlMenuContent, AgentControlMenuItemTooltip }

--- a/src/renderer/src/pages/workspace/AgentControlMenuItemTooltip.tsx
+++ b/src/renderer/src/pages/workspace/AgentControlMenuItemTooltip.tsx
@@ -15,7 +15,6 @@ import { DropdownMenuContent } from '@/components/ui/dropdown-menu'
 type AgentControlMenuItemTooltipProps = {
   children: ReactElement
   description: string
-  disabled?: boolean
   submenu?: boolean
 }
 
@@ -28,18 +27,18 @@ const AgentControlMenuContent = ({
 }: ComponentProps<typeof DropdownMenuContent> & {
   boundary: HTMLElement | null
 }): React.JSX.Element => (
-  <AgentControlMenuTooltipBoundaryContext.Provider value={boundary}>
-    <DropdownMenuContent {...props}>{children}</DropdownMenuContent>
-  </AgentControlMenuTooltipBoundaryContext.Provider>
+  <TooltipProvider delayDuration={300}>
+    <AgentControlMenuTooltipBoundaryContext.Provider value={boundary}>
+      <DropdownMenuContent {...props}>{children}</DropdownMenuContent>
+    </AgentControlMenuTooltipBoundaryContext.Provider>
+  </TooltipProvider>
 )
 
 // Keeps agent controls compact while preserving their explanatory copy on hover and keyboard
-// focus. Disabled Radix menu items use pointer-events: none, so they get an outer hover target that
-// does not change the item's disabled selection semantics.
+// focus. Callers keep standing-disabled rows focusable with aria-disabled and neutralized selection.
 const AgentControlMenuItemTooltip = ({
   children,
   description,
-  disabled = false,
   submenu = false
 }: AgentControlMenuItemTooltipProps): React.JSX.Element => {
   const collisionBoundary = useContext(AgentControlMenuTooltipBoundaryContext)
@@ -64,30 +63,27 @@ const AgentControlMenuItemTooltip = ({
     )
   }
 
+  const handleFocus = (event: React.FocusEvent<HTMLButtonElement>): void => {
+    updateSide()
+    if (!event.currentTarget.matches(':focus-visible')) event.preventDefault()
+  }
+
   return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        {disabled ? (
-          <TooltipTrigger asChild ref={triggerRef} onPointerEnter={updateSide} onFocus={updateSide}>
-            <div className="rounded-lg">{children}</div>
-          </TooltipTrigger>
-        ) : (
-          <TooltipTrigger asChild ref={triggerRef} onPointerEnter={updateSide} onFocus={updateSide}>
-            {children}
-          </TooltipTrigger>
-        )}
-        <TooltipContent
-          side={resolvedSide}
-          sideOffset={8}
-          collisionBoundary={collisionBoundary ?? undefined}
-          collisionPadding={8}
-          sticky="always"
-          className="max-w-72 text-[11px] leading-4"
-        >
-          {description}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild ref={triggerRef} onPointerEnter={updateSide} onFocus={handleFocus}>
+        {children}
+      </TooltipTrigger>
+      <TooltipContent
+        side={resolvedSide}
+        sideOffset={8}
+        collisionBoundary={collisionBoundary ?? undefined}
+        collisionPadding={8}
+        sticky="always"
+        className="max-w-72 text-[11px] leading-4"
+      >
+        {description}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -59,25 +59,15 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
     children,
     disabled,
     onSelect,
-    'data-testid': testId,
-    role,
-    'aria-checked': ariaChecked,
-    'aria-label': ariaLabel
+    ...rest
   }: PropsWithChildren<{
     disabled?: boolean
     onSelect?: (event: { preventDefault: () => void }) => void
-    'data-testid'?: string
-    role?: string
-    'aria-checked'?: boolean
-    'aria-label'?: string
+    [key: string]: unknown
   }>): React.JSX.Element => (
     <button
       type="button"
       disabled={disabled}
-      data-testid={testId}
-      role={role}
-      aria-checked={ariaChecked}
-      aria-label={ariaLabel}
       onClick={() => {
         const event = {
           prevented: false,
@@ -88,6 +78,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
         selectEvents.push(event)
         onSelect?.(event)
       }}
+      {...rest}
     >
       {children}
     </button>
@@ -224,6 +215,11 @@ const findButton = (label: string): HTMLButtonElement => {
   return button
 }
 
+const expectStandingDisabled = (button: HTMLButtonElement, disabled: boolean): void => {
+  expect(button.disabled).toBe(false)
+  expect(button.getAttribute('aria-disabled')).toBe(String(disabled))
+}
+
 describe('ComposerAgentControlsMenu', () => {
   it('opens when the composer requests Specialist selection', () => {
     const props = {
@@ -341,18 +337,13 @@ describe('ComposerAgentControlsMenu', () => {
     })
 
     const memoryRow = findButton('Memory')
-    expect(memoryRow.disabled).toBe(true)
-    expect(
-      Array.from(container.querySelectorAll<HTMLElement>('[data-testid="tooltip-content"]')).find(
-        (tooltip) => tooltip.textContent === reason
-      )
-    ).toBeDefined()
+    expectStandingDisabled(memoryRow, true)
     expect(container.querySelector('[data-testid="controls-nondefault-dot"]')).toBeNull()
     act(() => memoryRow.click())
     expect(onMemoryChange).not.toHaveBeenCalled()
   })
 
-  it('keeps rows compact while preserving their descriptions in tooltips', () => {
+  it('keeps menu descriptions out of the compact rows', () => {
     act(() => {
       root.render(
         <ComposerAgentControlsMenu
@@ -368,14 +359,6 @@ describe('ComposerAgentControlsMenu', () => {
     expect(findButton('Ask for approval').textContent).toBe('Ask for approval')
     expect(findButton('Auto-review').textContent).toBe('Auto-review')
     expect(findButton('Memory').textContent).toBe('Memory')
-
-    const tooltipDescriptions = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-testid="tooltip-content"]')
-    ).map((tooltip) => tooltip.textContent)
-    expect(tooltipDescriptions).toContain('A reviewer agent checks every change before it lands.')
-    expect(tooltipDescriptions).toContain(
-      'Applies to future actions; completed actions are unchanged.'
-    )
   })
 
   it('opens permission choices inside the same menu on mobile and can return', () => {
@@ -485,7 +468,7 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    expect(findButton('Full access').disabled).toBe(true)
+    expectStandingDisabled(findButton('Full access'), true)
   })
 
   it('lists session grants and revokes the clicked one', () => {
@@ -608,7 +591,7 @@ describe('ComposerAgentControlsMenu', () => {
     expect(fullCapsule?.getAttribute('class')).toContain('text-amber-600')
   })
 
-  it('renders the Full access label as a warning and moves its description to a tooltip', () => {
+  it('renders the compact Full access label as a warning', () => {
     act(() => {
       root.render(
         <ComposerAgentControlsMenu
@@ -624,12 +607,6 @@ describe('ComposerAgentControlsMenu', () => {
     const title = row.querySelector('span.text-\\[13px\\]')
     expect(title?.getAttribute('class')).toContain('text-amber-600')
     expect(row.querySelector('span.text-\\[11px\\]')).toBeNull()
-    expect(
-      Array.from(container.querySelectorAll('[data-testid="tooltip-content"]')).some(
-        (tooltip) =>
-          tooltip.textContent === 'Run everything without prompts, including commands and network.'
-      )
-    ).toBe(true)
   })
 
   it('hides the non-default dot at defaults and shows it for a non-default profile', () => {
@@ -713,7 +690,7 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
     const row = findButton('Auto-review')
-    expect(row.disabled).toBe(true)
+    expectStandingDisabled(row, true)
 
     act(() => row.click())
 
@@ -741,8 +718,8 @@ describe('ComposerAgentControlsMenu', () => {
     expect(trigger?.hasAttribute('disabled')).toBe(false)
 
     // Every mutating control is disabled: profile items, auto-review row, grant actions.
-    expect(findButton('Ask for approval').disabled).toBe(true)
-    expect(findButton('Auto-review').disabled).toBe(true)
+    expectStandingDisabled(findButton('Ask for approval'), true)
+    expectStandingDisabled(findButton('Auto-review'), true)
 
     const clearButton = Array.from(container.querySelectorAll('button')).find(
       (candidate) => candidate.getAttribute('aria-label') === 'Clear all session grants'
@@ -772,8 +749,8 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    expect(findButton('Auto-approve edits').disabled).toBe(false)
-    expect(findButton('Auto-review').disabled).toBe(true)
+    expectStandingDisabled(findButton('Auto-approve edits'), false)
+    expectStandingDisabled(findButton('Auto-review'), true)
     expect(
       container.querySelector<HTMLButtonElement>(
         '[data-testid="compute-host-enabled-ssh:cluster-1"]'
@@ -810,9 +787,9 @@ describe('ComposerAgentControlsMenu', () => {
     })
 
     const autoReviewRow = findButton('Auto-review')
-    expect(autoReviewRow.disabled).toBe(false)
+    expectStandingDisabled(autoReviewRow, false)
     const memoryRow = findButton('Memory')
-    expect(memoryRow.disabled).toBe(false)
+    expectStandingDisabled(memoryRow, false)
     expect(
       container
         .querySelector('[data-testid="specialist-submenu-stub"]')
@@ -853,7 +830,7 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    expect(findButton('Ask for approval').disabled).toBe(true)
+    expectStandingDisabled(findButton('Ask for approval'), true)
 
     const clearButton = Array.from(container.querySelectorAll('button')).find(
       (candidate) => candidate.getAttribute('aria-label') === 'Clear all session grants'

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -293,11 +293,7 @@ describe('ComposerAgentControlsMenu', () => {
     expect(trigger?.getAttribute('aria-label')).toBe(
       'Agent controls: Ask for approval, auto-review off'
     )
-    act(() =>
-      findButton(
-        'Auto-approve editsAuto-approve edits to files in the workspace. Still ask before commands, network, and MCP.'
-      ).click()
-    )
+    act(() => findButton('Auto-approve edits').click())
 
     expect(onProfileChange).toHaveBeenCalledWith('auto')
     expect(container.textContent).not.toContain('Enable Full access?')
@@ -319,9 +315,7 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    act(() =>
-      findButton('MemoryLet the agent recall and save memory in this conversation.').click()
-    )
+    act(() => findButton('Memory').click())
 
     expect(onMemoryChange).toHaveBeenCalledWith(false)
     expect(selectEvents.at(-1)?.prevented).toBe(true)
@@ -346,11 +340,42 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    const memoryRow = findButton(`Memory${reason}`)
+    const memoryRow = findButton('Memory')
     expect(memoryRow.disabled).toBe(true)
+    expect(
+      Array.from(container.querySelectorAll<HTMLElement>('[data-testid="tooltip-content"]')).find(
+        (tooltip) => tooltip.textContent === reason
+      )
+    ).toBeDefined()
     expect(container.querySelector('[data-testid="controls-nondefault-dot"]')).toBeNull()
     act(() => memoryRow.click())
     expect(onMemoryChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps rows compact while preserving their descriptions in tooltips', () => {
+    act(() => {
+      root.render(
+        <ComposerAgentControlsMenu
+          profile="ask"
+          autoReviewEnabled={false}
+          memoryEnabled
+          onProfileChange={vi.fn()}
+          onAutoReviewChange={vi.fn()}
+        />
+      )
+    })
+
+    expect(findButton('Ask for approval').textContent).toBe('Ask for approval')
+    expect(findButton('Auto-review').textContent).toBe('Auto-review')
+    expect(findButton('Memory').textContent).toBe('Memory')
+
+    const tooltipDescriptions = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-testid="tooltip-content"]')
+    ).map((tooltip) => tooltip.textContent)
+    expect(tooltipDescriptions).toContain('A reviewer agent checks every change before it lands.')
+    expect(tooltipDescriptions).toContain(
+      'Applies to future actions; completed actions are unchanged.'
+    )
   })
 
   it('opens permission choices inside the same menu on mobile and can return', () => {
@@ -402,11 +427,7 @@ describe('ComposerAgentControlsMenu', () => {
         />
       )
     })
-    act(() =>
-      findButton(
-        'Full accessRun everything without prompts, including commands and network.'
-      ).click()
-    )
+    act(() => findButton('Full access').click())
 
     expect(onProfileChange).not.toHaveBeenCalled()
     expect(container.textContent).toContain('Enable Full access?')
@@ -464,9 +485,7 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    expect(
-      findButton('Full accessThe current agent does not support native bypass mode.').disabled
-    ).toBe(true)
+    expect(findButton('Full access').disabled).toBe(true)
   })
 
   it('lists session grants and revokes the clicked one', () => {
@@ -589,7 +608,7 @@ describe('ComposerAgentControlsMenu', () => {
     expect(fullCapsule?.getAttribute('class')).toContain('text-amber-600')
   })
 
-  it('renders the Full access submenu row as a warning in amber', () => {
+  it('renders the Full access label as a warning and moves its description to a tooltip', () => {
     act(() => {
       root.render(
         <ComposerAgentControlsMenu
@@ -600,14 +619,17 @@ describe('ComposerAgentControlsMenu', () => {
         />
       )
     })
-    const row = findButton(
-      'Full accessRun everything without prompts, including commands and network.'
-    )
+    const row = findButton('Full access')
 
     const title = row.querySelector('span.text-\\[13px\\]')
-    const description = row.querySelector('span.text-\\[11px\\]')
     expect(title?.getAttribute('class')).toContain('text-amber-600')
-    expect(description?.getAttribute('class')).toContain('text-amber-600/70')
+    expect(row.querySelector('span.text-\\[11px\\]')).toBeNull()
+    expect(
+      Array.from(container.querySelectorAll('[data-testid="tooltip-content"]')).some(
+        (tooltip) =>
+          tooltip.textContent === 'Run everything without prompts, including commands and network.'
+      )
+    ).toBe(true)
   })
 
   it('hides the non-default dot at defaults and shows it for a non-default profile', () => {
@@ -668,9 +690,7 @@ describe('ComposerAgentControlsMenu', () => {
         />
       )
     })
-    act(() =>
-      findButton('Auto-reviewA reviewer agent checks every change before it lands.').click()
-    )
+    act(() => findButton('Auto-review').click())
 
     expect(onAutoReviewChange).toHaveBeenCalledWith(true)
     // The row must not bubble into a profile change or close the menu (preventDefault).
@@ -692,7 +712,7 @@ describe('ComposerAgentControlsMenu', () => {
         />
       )
     })
-    const row = findButton('Auto-reviewA reviewer agent checks every change before it lands.')
+    const row = findButton('Auto-review')
     expect(row.disabled).toBe(true)
 
     act(() => row.click())
@@ -721,13 +741,8 @@ describe('ComposerAgentControlsMenu', () => {
     expect(trigger?.hasAttribute('disabled')).toBe(false)
 
     // Every mutating control is disabled: profile items, auto-review row, grant actions.
-    expect(
-      findButton('Ask for approvalAsk before file edits, commands, network, and MCP tools.')
-        .disabled
-    ).toBe(true)
-    expect(
-      findButton('Auto-reviewA reviewer agent checks every change before it lands.').disabled
-    ).toBe(true)
+    expect(findButton('Ask for approval').disabled).toBe(true)
+    expect(findButton('Auto-review').disabled).toBe(true)
 
     const clearButton = Array.from(container.querySelectorAll('button')).find(
       (candidate) => candidate.getAttribute('aria-label') === 'Clear all session grants'
@@ -757,14 +772,8 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    expect(
-      findButton(
-        'Auto-approve editsAuto-approve edits to files in the workspace. Still ask before commands, network, and MCP.'
-      ).disabled
-    ).toBe(false)
-    expect(
-      findButton('Auto-reviewA reviewer agent checks every change before it lands.').disabled
-    ).toBe(true)
+    expect(findButton('Auto-approve edits').disabled).toBe(false)
+    expect(findButton('Auto-review').disabled).toBe(true)
     expect(
       container.querySelector<HTMLButtonElement>(
         '[data-testid="compute-host-enabled-ssh:cluster-1"]'
@@ -800,11 +809,9 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    const autoReviewRow = findButton(
-      'Auto-reviewA reviewer agent checks every change before it lands.'
-    )
+    const autoReviewRow = findButton('Auto-review')
     expect(autoReviewRow.disabled).toBe(false)
-    const memoryRow = findButton('MemoryLet the agent recall and save memory in this conversation.')
+    const memoryRow = findButton('Memory')
     expect(memoryRow.disabled).toBe(false)
     expect(
       container
@@ -846,10 +853,7 @@ describe('ComposerAgentControlsMenu', () => {
       )
     })
 
-    expect(
-      findButton('Ask for approvalAsk before file edits, commands, network, and MCP tools.')
-        .disabled
-    ).toBe(true)
+    expect(findButton('Ask for approval').disabled).toBe(true)
 
     const clearButton = Array.from(container.querySelectorAll('button')).find(
       (candidate) => candidate.getAttribute('aria-label') === 'Clear all session grants'
@@ -1151,9 +1155,7 @@ describe('ComposerAgentControlsMenu', () => {
     }
     const permissionTrigger = orderAnchor('Permission mode')
     const computeTrigger = computeTriggers[0] as Element
-    const autoReviewRow = findButton(
-      'Auto-reviewA reviewer agent checks every change before it lands.'
-    )
+    const autoReviewRow = findButton('Auto-review')
     const sessionGrantsHeading = Array.from(container.querySelectorAll('span')).find(
       (element) => element.textContent === 'Allowed this session'
     )

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -204,6 +204,7 @@ const ComposerAgentControlsMenu = ({
     profile !== DEFAULT_PERMISSION_PROFILE ||
     autoReviewEnabled ||
     (!memoryEnabled && !memoryDisabledReason)
+  const autoReviewItemDisabled = autoReviewReadOnly || autoReviewDisabled
 
   useEffect(() => {
     if (openRequest === undefined || openRequest === previousOpenRequest.current) return
@@ -276,15 +277,17 @@ const ComposerAgentControlsMenu = ({
           : t(candidate.descriptionKey)
 
         return (
-          <AgentControlMenuItemTooltip
-            key={candidate.id}
-            description={description}
-            disabled={itemDisabled}
-          >
+          <AgentControlMenuItemTooltip key={candidate.id} description={description}>
             <DropdownMenuItem
-              disabled={itemDisabled}
-              className="items-center gap-2 px-2 py-1.5"
-              onSelect={() => selectProfile(candidate.id)}
+              aria-disabled={itemDisabled}
+              className="items-center gap-2 px-2 py-1.5 aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+              onSelect={(event) => {
+                if (itemDisabled) {
+                  event.preventDefault()
+                  return
+                }
+                selectProfile(candidate.id)
+              }}
             >
               <ProfileIcon
                 className={cn(
@@ -494,14 +497,13 @@ const ComposerAgentControlsMenu = ({
               {/* The whole row toggles auto-review; the Switch is a visual indicator only. */}
               <AgentControlMenuItemTooltip
                 description={t('A reviewer agent checks every change before it lands.')}
-                disabled={autoReviewReadOnly || autoReviewDisabled}
               >
                 <DropdownMenuItem
-                  disabled={autoReviewReadOnly || autoReviewDisabled}
-                  className="items-center gap-2 px-2 py-1.5"
+                  aria-disabled={autoReviewItemDisabled}
+                  className="items-center gap-2 px-2 py-1.5 aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
                   onSelect={(event) => {
                     event.preventDefault()
-                    onAutoReviewChange(!autoReviewEnabled)
+                    if (!autoReviewItemDisabled) onAutoReviewChange(!autoReviewEnabled)
                   }}
                 >
                   <ScanEye
@@ -527,14 +529,13 @@ const ComposerAgentControlsMenu = ({
                   memoryDisabledReason ??
                   t('Let the agent recall and save memory in this conversation.')
                 }
-                disabled={memoryReadOnly}
               >
                 <DropdownMenuItem
-                  disabled={memoryReadOnly}
-                  className="items-center gap-2 px-2 py-1.5"
+                  aria-disabled={memoryReadOnly}
+                  className="items-center gap-2 px-2 py-1.5 aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
                   onSelect={(event) => {
                     event.preventDefault()
-                    onMemoryChange(!memoryEnabled)
+                    if (!memoryReadOnly) onMemoryChange(!memoryEnabled)
                   }}
                 >
                   <BrainCircuit

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -36,6 +36,7 @@ import { AlertDialog } from 'radix-ui'
 import { useTranslation } from 'react-i18next'
 
 import { SpecialistSubmenu } from './SpecialistSubmenu'
+import { AgentControlMenuContent, AgentControlMenuItemTooltip } from './AgentControlMenuItemTooltip'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -51,7 +52,6 @@ import {
 } from '@/components/ui/dialog-chrome'
 import {
   DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -189,6 +189,8 @@ const ComposerAgentControlsMenu = ({
   const [mobilePermissionOpen, setMobilePermissionOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [computeMenuOpen, setComputeMenuOpen] = useState(false)
+  const [tooltipCollisionBoundary, setTooltipCollisionBoundary] = useState<HTMLElement | null>(null)
+  const controlsTriggerRef = useRef<HTMLButtonElement>(null)
   const previousOpenRequest = useRef(openRequest)
   const previousComputeOpenRequest = useRef(computeOpenRequest)
   const isMobile = useMediaQuery('(max-width: 767px)')
@@ -208,6 +210,13 @@ const ComposerAgentControlsMenu = ({
     previousOpenRequest.current = openRequest
     setMenuOpen(true)
   }, [openRequest])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    setTooltipCollisionBoundary(
+      controlsTriggerRef.current?.closest<HTMLElement>('[data-slot="resizable-panel"]') ?? null
+    )
+  }, [menuOpen])
 
   const selectProfile = (next: PermissionProfileId): void => {
     if (next === profile) return
@@ -260,46 +269,44 @@ const ComposerAgentControlsMenu = ({
         const isSelected = candidate.id === profile
         const isFull = candidate.id === 'full'
         const isDisabled = isFull && fullAccessUnavailable
+        const itemDisabled = permissionProfileReadOnly || isDisabled
+
+        const description = isDisabled
+          ? t('The current agent does not support native bypass mode.')
+          : t(candidate.descriptionKey)
 
         return (
-          <DropdownMenuItem
+          <AgentControlMenuItemTooltip
             key={candidate.id}
-            disabled={permissionProfileReadOnly || isDisabled}
-            className="items-center gap-2 px-2 py-1.5"
-            onSelect={() => selectProfile(candidate.id)}
+            description={description}
+            disabled={itemDisabled}
           >
-            <ProfileIcon
-              className={cn(
-                'size-4 shrink-0',
-                isFull ? 'text-amber-600 dark:text-amber-400' : 'text-text-200'
-              )}
-              strokeWidth={2}
-              aria-hidden="true"
-            />
-            <span className="min-w-0 flex-1">
+            <DropdownMenuItem
+              disabled={itemDisabled}
+              className="items-center gap-2 px-2 py-1.5"
+              onSelect={() => selectProfile(candidate.id)}
+            >
+              <ProfileIcon
+                className={cn(
+                  'size-4 shrink-0',
+                  isFull ? 'text-amber-600 dark:text-amber-400' : 'text-text-200'
+                )}
+                strokeWidth={2}
+                aria-hidden="true"
+              />
               <span
                 className={cn(
-                  'block text-[13px] font-medium leading-5',
+                  'min-w-0 flex-1 truncate text-[13px] font-medium leading-5',
                   isFull && 'text-amber-600 dark:text-amber-400'
                 )}
               >
                 {t(candidate.labelKey)}
               </span>
-              <span
-                className={cn(
-                  'block text-[11px] leading-4',
-                  isFull ? 'text-amber-600/70 dark:text-amber-400/70' : 'text-text-300'
-                )}
-              >
-                {isDisabled
-                  ? t('The current agent does not support native bypass mode.')
-                  : t(candidate.descriptionKey)}
-              </span>
-            </span>
-            {isSelected ? (
-              <Check className="size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
-            ) : null}
-          </DropdownMenuItem>
+              {isSelected ? (
+                <Check className="size-4 shrink-0" strokeWidth={2} aria-hidden="true" />
+              ) : null}
+            </DropdownMenuItem>
+          </AgentControlMenuItemTooltip>
         )
       })}
       {profile === 'auto' && profileState?.autoReviewStrategy === 'conservative' ? (
@@ -315,11 +322,8 @@ const ComposerAgentControlsMenu = ({
   const permissionSummary = (
     <>
       <Shield className="size-4 shrink-0 text-text-200" strokeWidth={2} aria-hidden="true" />
-      <span className="min-w-0 flex-1">
-        <span className="block text-[13px] font-medium leading-5">{t('Permission mode')}</span>
-        <span className="block text-[11px] leading-4 text-text-300">
-          {t('Applies to future actions; completed actions are unchanged.')}
-        </span>
+      <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
+        {t('Permission mode')}
       </span>
       <span
         data-testid="profile-capsule"
@@ -342,6 +346,7 @@ const ComposerAgentControlsMenu = ({
             remains browsable while a session is running; only the controls are disabled. */}
         <DropdownMenuTrigger asChild>
           <button
+            ref={controlsTriggerRef}
             type="button"
             className={triggerButtonClassName}
             aria-label={t('Agent controls: {{profile}}, auto-review {{autoReview}}', {
@@ -369,7 +374,8 @@ const ComposerAgentControlsMenu = ({
             ) : null}
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent
+        <AgentControlMenuContent
+          boundary={tooltipCollisionBoundary}
           side="top"
           align="start"
           sideOffset={8}
@@ -397,21 +403,30 @@ const ComposerAgentControlsMenu = ({
             <>
               {/* On mobile, open the permission choices in this panel. Desktop keeps the submenu. */}
               {isMobile ? (
-                <DropdownMenuItem
-                  className="items-center gap-2 px-2 py-1.5"
-                  data-testid="mobile-permission-trigger"
-                  onSelect={(event) => {
-                    event.preventDefault()
-                    setMobilePermissionOpen(true)
-                  }}
+                <AgentControlMenuItemTooltip
+                  description={t('Applies to future actions; completed actions are unchanged.')}
                 >
-                  {permissionSummary}
-                </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="items-center gap-2 px-2 py-1.5"
+                    data-testid="mobile-permission-trigger"
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      setMobilePermissionOpen(true)
+                    }}
+                  >
+                    {permissionSummary}
+                  </DropdownMenuItem>
+                </AgentControlMenuItemTooltip>
               ) : (
                 <DropdownMenuSub>
-                  <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
-                    {permissionSummary}
-                  </DropdownMenuSubTrigger>
+                  <AgentControlMenuItemTooltip
+                    description={t('Applies to future actions; completed actions are unchanged.')}
+                    submenu
+                  >
+                    <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
+                      {permissionSummary}
+                    </DropdownMenuSubTrigger>
+                  </AgentControlMenuItemTooltip>
                   <DropdownMenuSubContent
                     collisionPadding={8}
                     className="max-h-[calc(100dvh-1rem)] w-72 max-w-[calc(100vw-1rem)] overflow-y-auto p-1"
@@ -477,64 +492,68 @@ const ComposerAgentControlsMenu = ({
               <DropdownMenuSeparator />
 
               {/* The whole row toggles auto-review; the Switch is a visual indicator only. */}
-              <DropdownMenuItem
+              <AgentControlMenuItemTooltip
+                description={t('A reviewer agent checks every change before it lands.')}
                 disabled={autoReviewReadOnly || autoReviewDisabled}
-                className="items-center gap-2 px-2 py-1.5"
-                onSelect={(event) => {
-                  event.preventDefault()
-                  onAutoReviewChange(!autoReviewEnabled)
-                }}
               >
-                <ScanEye
-                  className="size-4 shrink-0 text-text-200"
-                  strokeWidth={2}
-                  aria-hidden="true"
-                />
-                <span className="min-w-0 flex-1">
-                  <span className="block text-[13px] font-medium leading-5">
+                <DropdownMenuItem
+                  disabled={autoReviewReadOnly || autoReviewDisabled}
+                  className="items-center gap-2 px-2 py-1.5"
+                  onSelect={(event) => {
+                    event.preventDefault()
+                    onAutoReviewChange(!autoReviewEnabled)
+                  }}
+                >
+                  <ScanEye
+                    className="size-4 shrink-0 text-text-200"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
                     {t('Auto-review')}
                   </span>
-                  <span className="block text-[11px] leading-4 text-text-300">
-                    {t('A reviewer agent checks every change before it lands.')}
-                  </span>
-                </span>
-                <Switch
-                  size="sm"
-                  checked={autoReviewEnabled}
-                  tabIndex={-1}
-                  aria-hidden="true"
-                  className="pointer-events-none"
-                />
-              </DropdownMenuItem>
+                  <Switch
+                    size="sm"
+                    checked={autoReviewEnabled}
+                    tabIndex={-1}
+                    aria-hidden="true"
+                    className="pointer-events-none"
+                  />
+                </DropdownMenuItem>
+              </AgentControlMenuItemTooltip>
 
-              <DropdownMenuItem
+              <AgentControlMenuItemTooltip
+                description={
+                  memoryDisabledReason ??
+                  t('Let the agent recall and save memory in this conversation.')
+                }
                 disabled={memoryReadOnly}
-                className="items-center gap-2 px-2 py-1.5"
-                onSelect={(event) => {
-                  event.preventDefault()
-                  onMemoryChange(!memoryEnabled)
-                }}
               >
-                <BrainCircuit
-                  className="size-4 shrink-0 text-text-200"
-                  strokeWidth={2}
-                  aria-hidden="true"
-                />
-                <span className="min-w-0 flex-1">
-                  <span className="block text-[13px] font-medium leading-5">{t('Memory')}</span>
-                  <span className="block text-[11px] leading-4 text-text-300">
-                    {memoryDisabledReason ??
-                      t('Let the agent recall and save memory in this conversation.')}
+                <DropdownMenuItem
+                  disabled={memoryReadOnly}
+                  className="items-center gap-2 px-2 py-1.5"
+                  onSelect={(event) => {
+                    event.preventDefault()
+                    onMemoryChange(!memoryEnabled)
+                  }}
+                >
+                  <BrainCircuit
+                    className="size-4 shrink-0 text-text-200"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
+                    {t('Memory')}
                   </span>
-                </span>
-                <Switch
-                  size="sm"
-                  checked={memoryEnabled}
-                  tabIndex={-1}
-                  aria-hidden="true"
-                  className="pointer-events-none"
-                />
-              </DropdownMenuItem>
+                  <Switch
+                    size="sm"
+                    checked={memoryEnabled}
+                    tabIndex={-1}
+                    aria-hidden="true"
+                    className="pointer-events-none"
+                  />
+                </DropdownMenuItem>
+              </AgentControlMenuItemTooltip>
 
               {/* Specialist + Compute are one resource-selection group: a single divider leads
                   the group (above Specialist when present, above Compute otherwise), so the two
@@ -554,29 +573,31 @@ const ComposerAgentControlsMenu = ({
               )}
 
               <DropdownMenuSub open={computeMenuOpen} onOpenChange={setComputeMenuOpen}>
-                <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
-                  <Server
-                    className="size-4 shrink-0 text-text-200"
-                    strokeWidth={2}
-                    aria-hidden="true"
-                  />
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-[13px] font-medium leading-5">{t('Compute')}</span>
-                    <span className="block text-[11px] leading-4 text-text-300">
-                      {t('Run jobs on a remote SSH host, or manage hosts.')}
-                    </span>
-                  </span>
-                  {/* Align the chevron with the capsule chevrons on the Permission/Specialist
-                      rows: same px-2 (one vertical line) and text-text-100 (depth) as the
-                      capsule chevrons — Compute has no capsule, so the color is set here. */}
-                  <span className="flex shrink-0 items-center px-2 py-0.5 text-text-100">
-                    <ChevronRight
-                      className="size-3 shrink-0 opacity-60"
+                <AgentControlMenuItemTooltip
+                  description={t('Run jobs on a remote SSH host, or manage hosts.')}
+                  submenu
+                >
+                  <DropdownMenuSubTrigger className="items-center gap-2 px-2 py-1.5">
+                    <Server
+                      className="size-4 shrink-0 text-text-200"
                       strokeWidth={2}
                       aria-hidden="true"
                     />
-                  </span>
-                </DropdownMenuSubTrigger>
+                    <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
+                      {t('Compute')}
+                    </span>
+                    {/* Align the chevron with the capsule chevrons on the Permission/Specialist
+                        rows: same px-2 (one vertical line) and text-text-100 (depth) as the
+                        capsule chevrons — Compute has no capsule, so the color is set here. */}
+                    <span className="flex shrink-0 items-center px-2 py-0.5 text-text-100">
+                      <ChevronRight
+                        className="size-3 shrink-0 opacity-60"
+                        strokeWidth={2}
+                        aria-hidden="true"
+                      />
+                    </span>
+                  </DropdownMenuSubTrigger>
+                </AgentControlMenuItemTooltip>
                 <DropdownMenuSubContent
                   collisionPadding={8}
                   className="max-h-[calc(100dvh-1rem)] w-72 max-w-[calc(100vw-1rem)] overflow-y-auto p-1"
@@ -687,7 +708,7 @@ const ComposerAgentControlsMenu = ({
               </DropdownMenuSub>
             </>
           )}
-        </DropdownMenuContent>
+        </AgentControlMenuContent>
       </DropdownMenu>
 
       <AlertDialog.Root open={confirmFullAccess} onOpenChange={setConfirmFullAccess}>

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.render.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SpecialistSubmenu } from './SpecialistSubmenu'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { useSettingsStore } from '@/stores/settings-store'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type { SpecialistListItem } from '../../../../shared/specialist'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -145,7 +146,11 @@ afterEach(() => {
 
 const renderSubmenu = (props: React.ComponentProps<typeof SpecialistSubmenu>): void => {
   act(() => {
-    root.render(<SpecialistSubmenu {...props} />)
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <SpecialistSubmenu {...props} />
+      </TooltipProvider>
+    )
   })
 }
 
@@ -188,7 +193,7 @@ describe('SpecialistSubmenu — trigger', () => {
     expect(trigger.textContent).toContain('Unavailable')
   })
 
-  it('keeps a bound session specialist visible but disables the trigger and hides options', () => {
+  it('keeps a bound session specialist focusable but non-activating and hides options', () => {
     const sp = makeSpecialist('uuid-1', 'RNA-seq Reviewer')
     mockStore([sp])
     renderSubmenu({ selectedId: 'uuid-1', onChange: vi.fn(), readOnly: true })
@@ -196,7 +201,8 @@ describe('SpecialistSubmenu — trigger', () => {
       '[data-testid="specialist-submenu-trigger"]'
     )!
     expect(trigger.textContent).toContain('RNA-seq Reviewer')
-    expect(trigger.hasAttribute('disabled')).toBe(true)
+    expect(trigger.hasAttribute('disabled')).toBe(false)
+    expect(trigger.getAttribute('aria-disabled')).toBe('true')
     // No mutable submenu content is offered for a bound session.
     expect(container.querySelector('[data-testid="dd-subcontent"]')).toBeNull()
     expect(container.querySelector('[data-testid="specialist-option-none"]')).toBeNull()

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.render.test.tsx
@@ -170,6 +170,7 @@ describe('SpecialistSubmenu — trigger', () => {
     renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
     const trigger = container.querySelector('[data-testid="specialist-submenu-trigger"]')!
     expect(trigger.textContent).toContain('None')
+    expect(trigger.textContent).not.toContain('Bind a personal specialist to this conversation.')
   })
 
   it('shows the specialist name in the capsule when one is selected', () => {

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
@@ -8,6 +8,8 @@ import { Check, ChevronRight, UserRound } from 'lucide-react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { AgentControlMenuItemTooltip } from './AgentControlMenuItemTooltip'
+
 import {
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -85,8 +87,6 @@ const SpecialistSubmenu = ({
     none: t('None'),
     unavailable: t('Unavailable')
   })
-  const showValue = Boolean(selectedId) || unavailable
-
   // When the selected specialist is unavailable, keep it visible in the list as struck-through so
   // the user understands which profile is bound. Only applies to the currently-bound unavailable
   // profile; other disabled profiles stay out of the picker as normal.
@@ -98,46 +98,47 @@ const SpecialistSubmenu = ({
 
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger
+      <AgentControlMenuItemTooltip
+        description={t('Bind a personal specialist to this conversation.')}
         disabled={readOnly}
-        className="items-center gap-2 px-2 py-1.5"
-        data-testid="specialist-submenu-trigger"
+        submenu
       >
-        <UserRound
-          className={cn(
-            'size-4 shrink-0 text-text-200',
-            unavailable && 'text-amber-600 dark:text-amber-400'
-          )}
-          strokeWidth={2}
-          aria-hidden="true"
-        />
-        <span className="min-w-0 flex-1">
-          <span className="block text-[13px] font-medium leading-5">{t('Specialist')}</span>
-          {!showValue ? (
-            <span className="block text-[11px] leading-4 text-text-300">
-              {t('Bind a personal specialist to this conversation.')}
-            </span>
-          ) : null}
-        </span>
-        {/* Value capsule mirrors the permission-mode capsule: current selection on the right. */}
-        <span
-          className={cn(
-            'flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium leading-4',
-            unavailable
-              ? 'bg-amber-500/10 text-amber-600 dark:text-amber-400'
-              : 'bg-bg-200 text-text-100'
-          )}
+        <DropdownMenuSubTrigger
+          disabled={readOnly}
+          className="items-center gap-2 px-2 py-1.5"
+          data-testid="specialist-submenu-trigger"
         >
-          <span className="max-w-[120px] truncate">{label}</span>
-          {!readOnly ? (
-            <ChevronRight
-              className="size-3 shrink-0 opacity-60"
-              strokeWidth={2}
-              aria-hidden="true"
-            />
-          ) : null}
-        </span>
-      </DropdownMenuSubTrigger>
+          <UserRound
+            className={cn(
+              'size-4 shrink-0 text-text-200',
+              unavailable && 'text-amber-600 dark:text-amber-400'
+            )}
+            strokeWidth={2}
+            aria-hidden="true"
+          />
+          <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
+            {t('Specialist')}
+          </span>
+          {/* Value capsule mirrors the permission-mode capsule: current selection on the right. */}
+          <span
+            className={cn(
+              'flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium leading-4',
+              unavailable
+                ? 'bg-amber-500/10 text-amber-600 dark:text-amber-400'
+                : 'bg-bg-200 text-text-100'
+            )}
+          >
+            <span className="max-w-[120px] truncate">{label}</span>
+            {!readOnly ? (
+              <ChevronRight
+                className="size-3 shrink-0 opacity-60"
+                strokeWidth={2}
+                aria-hidden="true"
+              />
+            ) : null}
+          </span>
+        </DropdownMenuSubTrigger>
+      </AgentControlMenuItemTooltip>
 
       {!readOnly ? (
         <DropdownMenuSubContent className="w-56 p-1">

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
@@ -96,48 +96,59 @@ const SpecialistSubmenu = ({
       : undefined
   const unavailableProfile = unavailableItem?.kind !== 'reviewer' ? unavailableItem : undefined
 
+  const triggerContent = (
+    <>
+      <UserRound
+        className={cn(
+          'size-4 shrink-0 text-text-200',
+          unavailable && 'text-amber-600 dark:text-amber-400'
+        )}
+        strokeWidth={2}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
+        {t('Specialist')}
+      </span>
+      {/* Value capsule mirrors the permission-mode capsule: current selection on the right. */}
+      <span
+        className={cn(
+          'flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium leading-4',
+          unavailable
+            ? 'bg-amber-500/10 text-amber-600 dark:text-amber-400'
+            : 'bg-bg-200 text-text-100'
+        )}
+      >
+        <span className="max-w-[120px] truncate">{label}</span>
+        {!readOnly ? (
+          <ChevronRight className="size-3 shrink-0 opacity-60" strokeWidth={2} aria-hidden="true" />
+        ) : null}
+      </span>
+    </>
+  )
+
   return (
     <DropdownMenuSub>
       <AgentControlMenuItemTooltip
         description={t('Bind a personal specialist to this conversation.')}
-        disabled={readOnly}
         submenu
       >
-        <DropdownMenuSubTrigger
-          disabled={readOnly}
-          className="items-center gap-2 px-2 py-1.5"
-          data-testid="specialist-submenu-trigger"
-        >
-          <UserRound
-            className={cn(
-              'size-4 shrink-0 text-text-200',
-              unavailable && 'text-amber-600 dark:text-amber-400'
-            )}
-            strokeWidth={2}
-            aria-hidden="true"
-          />
-          <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
-            {t('Specialist')}
-          </span>
-          {/* Value capsule mirrors the permission-mode capsule: current selection on the right. */}
-          <span
-            className={cn(
-              'flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium leading-4',
-              unavailable
-                ? 'bg-amber-500/10 text-amber-600 dark:text-amber-400'
-                : 'bg-bg-200 text-text-100'
-            )}
+        {readOnly ? (
+          <DropdownMenuItem
+            aria-disabled="true"
+            className="items-center gap-2 px-2 py-1.5 aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+            data-testid="specialist-submenu-trigger"
+            onSelect={(event) => event.preventDefault()}
           >
-            <span className="max-w-[120px] truncate">{label}</span>
-            {!readOnly ? (
-              <ChevronRight
-                className="size-3 shrink-0 opacity-60"
-                strokeWidth={2}
-                aria-hidden="true"
-              />
-            ) : null}
-          </span>
-        </DropdownMenuSubTrigger>
+            {triggerContent}
+          </DropdownMenuItem>
+        ) : (
+          <DropdownMenuSubTrigger
+            className="items-center gap-2 px-2 py-1.5"
+            data-testid="specialist-submenu-trigger"
+          >
+            {triggerContent}
+          </DropdownMenuSubTrigger>
+        )}
       </AgentControlMenuItemTooltip>
 
       {!readOnly ? (

--- a/src/renderer/src/pages/workspace/agent-control-tooltip-side.test.ts
+++ b/src/renderer/src/pages/workspace/agent-control-tooltip-side.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveAgentControlTooltipSide } from './agent-control-tooltip-side'
+
+const horizontalRect = (left: number, right: number): Pick<DOMRect, 'left' | 'right'> => ({
+  left,
+  right
+})
+
+describe('resolveAgentControlTooltipSide', () => {
+  it('keeps the preferred side when the session panel has room', () => {
+    expect(
+      resolveAgentControlTooltipSide('left', horizontalRect(320, 608), horizontalRect(0, 1000))
+    ).toBe('left')
+  })
+
+  it('flips leaf controls horizontally when only the opposite side fits', () => {
+    expect(
+      resolveAgentControlTooltipSide('left', horizontalRect(24, 312), horizontalRect(0, 640))
+    ).toBe('right')
+  })
+
+  it('moves submenu controls above instead of flipping into their expanded submenu', () => {
+    expect(
+      resolveAgentControlTooltipSide('left', horizontalRect(24, 312), horizontalRect(0, 640), false)
+    ).toBe('top')
+  })
+
+  it('moves above the item when a narrow session panel fits neither horizontal side', () => {
+    expect(
+      resolveAgentControlTooltipSide('left', horizontalRect(24, 312), horizontalRect(0, 360))
+    ).toBe('top')
+  })
+})

--- a/src/renderer/src/pages/workspace/agent-control-tooltip-side.test.ts
+++ b/src/renderer/src/pages/workspace/agent-control-tooltip-side.test.ts
@@ -26,6 +26,12 @@ describe('resolveAgentControlTooltipSide', () => {
     ).toBe('top')
   })
 
+  it('accounts for the tooltip width, offset, and collision padding', () => {
+    expect(
+      resolveAgentControlTooltipSide('left', horizontalRect(300, 600), horizontalRect(0, 700))
+    ).toBe('top')
+  })
+
   it('moves above the item when a narrow session panel fits neither horizontal side', () => {
     expect(
       resolveAgentControlTooltipSide('left', horizontalRect(24, 312), horizontalRect(0, 360))

--- a/src/renderer/src/pages/workspace/agent-control-tooltip-side.ts
+++ b/src/renderer/src/pages/workspace/agent-control-tooltip-side.ts
@@ -1,7 +1,8 @@
 type TooltipSide = 'left' | 'right' | 'top'
 type HorizontalRect = Pick<DOMRect, 'left' | 'right'>
 
-const MINIMUM_SIDE_SPACE = 224
+// max-w-72 content + 8px side offset + 8px collision padding.
+const MINIMUM_SIDE_SPACE = 304
 
 const resolveAgentControlTooltipSide = (
   preferredSide: 'left' | 'right',

--- a/src/renderer/src/pages/workspace/agent-control-tooltip-side.ts
+++ b/src/renderer/src/pages/workspace/agent-control-tooltip-side.ts
@@ -1,0 +1,28 @@
+type TooltipSide = 'left' | 'right' | 'top'
+type HorizontalRect = Pick<DOMRect, 'left' | 'right'>
+
+const MINIMUM_SIDE_SPACE = 224
+
+const resolveAgentControlTooltipSide = (
+  preferredSide: 'left' | 'right',
+  triggerRect: HorizontalRect,
+  boundaryRect: HorizontalRect,
+  allowHorizontalFlip = true
+): TooltipSide => {
+  const available = {
+    left: Math.max(0, triggerRect.left - boundaryRect.left),
+    right: Math.max(0, boundaryRect.right - triggerRect.right)
+  }
+  if (available[preferredSide] >= MINIMUM_SIDE_SPACE) return preferredSide
+
+  // Submenu controls reserve the opposite side for their expanded menu. Moving their tooltip
+  // there would place two portals on top of each other, so fall back vertically instead.
+  if (!allowHorizontalFlip) return 'top'
+
+  const oppositeSide = preferredSide === 'left' ? 'right' : 'left'
+  if (available[oppositeSide] >= MINIMUM_SIDE_SPACE) return oppositeSide
+
+  return 'top'
+}
+
+export { resolveAgentControlTooltipSide, type TooltipSide }


### PR DESCRIPTION
## Problem

Inline descriptions make the agent controls menu unnecessarily tall and leave less vertical room for future controls. Tooltips also need to remain visible in narrow session panels and while a submenu is open.

## Proposed change

- Keep each default menu row to icon, label, and status control.
- Move explanatory copy into hover and keyboard-focus tooltips.
- Keep standing-disabled rows hoverable and focusable with `aria-disabled`, while neutralizing selection.
- Prefer side placement when enough room exists, and fall back above the row in narrow panels or beside open submenus.
- Share one tooltip provider across the menu and use the established focus-visible guard.

## Scope and non-goals

This changes only the composer agent-controls menu presentation and interaction semantics. It does not change permission, review, memory, specialist, or compute behavior.

## Acceptance criteria and validation

- Compact rows and disabled activation semantics: `npm test -- AgentControlMenuItemTooltip.interaction.test.tsx agent-control-tooltip-side.test.ts ComposerAgentControlsMenu.interaction.test.tsx SpecialistSubmenu.render.test.tsx` — 4 files, 62 tests passed after rebasing onto latest `origin/main`.
- Adaptive placement, including submenu-safe top fallback: covered by `agent-control-tooltip-side.test.ts`.
- Disabled Memory hover and keyboard focus: covered independently against the real Radix tooltip in `AgentControlMenuItemTooltip.interaction.test.tsx`.
- Renderer types: `npm run typecheck:web` passed.
- Lint: `npm run lint` passed.
- Translation guard: `npx vitest run src/renderer/src/i18n/resources.test.ts` — 805 tests passed.
- Full suite: one run passed 1339 files and 22512 tests. A later run had one unrelated 15-second timeout in `src/main/compute/concurrency-integration.test.ts`; that exact test passed when rerun in isolation.
- Standards and Spec reviews were rerun after fixes and reported no actionable findings.

## Review focus

Please focus on tooltip collision behavior in narrow panels, submenu-safe placement, and the `aria-disabled` interaction semantics.