### PR TITLE
fix(pr-gate): bound gate process environment on large diffs

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -979,11 +979,6 @@ jobs:
       - windows_e2e
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    env:
-      PR_GATE_EXECUTION_MODE: bundles
-      PR_GATE_NEEDS: ${{ toJSON(needs) }}
-      PR_GATE_PLAN: ${{ needs.preflight.outputs.plan }}
-      PREFLIGHT_RESULT: ${{ needs.preflight.result }}
     steps:
       - name: Checkout trusted gate evaluator
         if: ${{ needs.preflight.result == 'success' }}
@@ -1001,6 +996,13 @@ jobs:
           node-version: 22
       - name: Evaluate deterministic gate from trusted base
         shell: bash
+        # Keep process environment bounded. Embedding the complete needs payload in job env includes
+        # the preflight plan and exceeds Linux ARG_MAX on large diffs before checkout can start.
+        env:
+          PR_GATE_EXECUTION_MODE: bundles
+          PR_GATE_PLAN: ${{ needs.preflight.outputs.plan }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          PR_GATE_NEEDS: '{"preflight":{"result":"${{ needs.preflight.result }}"},"policy":{"result":"${{ needs.policy.result }}"},"static":{"result":"${{ needs.static.result }}"},"unit":{"result":"${{ needs.unit.result }}"},"linux_runtime":{"result":"${{ needs.linux_runtime.result }}"},"coverage_macos":{"result":"${{ needs.coverage_macos.result }}"},"windows_core":{"result":"${{ needs.windows_core.result }}"},"macos_e2e":{"result":"${{ needs.macos_e2e.result }}"},"windows_e2e":{"result":"${{ needs.windows_e2e.result }}"}}'
         run: |
           set -euo pipefail
           if [[ "$PREFLIGHT_RESULT" != "success" ]]; then

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -201,6 +201,17 @@ function escapeHtml(value) {
     .replaceAll("'", '&#039;')
 }
 
+export function toGitHubOutputPlan(plan) {
+  const output = {
+    schemaVersion: plan.schemaVersion,
+    mode: plan.mode,
+    roots: [...plan.roots],
+    lanes: [...plan.lanes]
+  }
+  if (Array.isArray(plan.bundles)) output.bundles = [...plan.bundles]
+  return output
+}
+
 export function formatPlanSummary(plan) {
   const roots = plan.roots.length === 0 ? '_none_' : plan.roots.map(escapeHtml).join(', ')
   const lanes = plan.lanes.length === 0 ? '_none_' : plan.lanes.map(escapeHtml).join(', ')
@@ -229,10 +240,11 @@ export function runClassifierCli(arguments_ = process.argv.slice(2), environment
   const diff = execFileSync('git', ['diff', '--name-status', '-z', base, head])
   const plan = classifyChanges(parseNameStatus(diff.toString('utf8')))
   const planJson = JSON.stringify(plan)
+  const outputPlanJson = JSON.stringify(toGitHubOutputPlan(plan))
   const lanesJson = JSON.stringify(plan.lanes)
 
   if (environment.GITHUB_OUTPUT) {
-    appendFileSync(environment.GITHUB_OUTPUT, `plan=${planJson}\nlanes=${lanesJson}\n`)
+    appendFileSync(environment.GITHUB_OUTPUT, `plan=${outputPlanJson}\nlanes=${lanesJson}\n`)
   } else {
     process.stdout.write(`${planJson}\n`)
   }

--- a/scripts/ci/classify-pr-changes.test.ts
+++ b/scripts/ci/classify-pr-changes.test.ts
@@ -5,7 +5,7 @@ import { join, relative, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { classifyChanges, parseNameStatus } from './classify-pr-changes.mjs'
+import { classifyChanges, parseNameStatus, toGitHubOutputPlan } from './classify-pr-changes.mjs'
 
 const readManifest = (): ReturnType<JSON['parse']> =>
   JSON.parse(readFileSync(resolve('scripts/ci/change-impact.json'), 'utf8'))
@@ -68,7 +68,14 @@ describe('pull request change classification', () => {
           .map((line) => line.split('=', 2))
       )
       expect(JSON.parse(outputs.lanes)).toContain('e2e_workspace_macos')
-      expect(JSON.parse(outputs.plan).mode).toBe('selective')
+      expect(JSON.parse(outputs.plan)).toEqual({
+        schemaVersion: 1,
+        mode: 'selective',
+        roots: expect.any(Array),
+        lanes: expect.any(Array),
+        bundles: expect.arrayContaining(['policy', 'static', 'unit', 'macos_e2e'])
+      })
+      expect(JSON.parse(outputs.plan)).not.toHaveProperty('reasonChains')
       expect(readFileSync(summary, 'utf8')).toContain(
         'src/shared/acp.ts -&gt; shared_contract -&gt; preload_adapter'
       )
@@ -78,6 +85,30 @@ describe('pull request change classification', () => {
     } finally {
       rmSync(root, { force: true, recursive: true })
     }
+  })
+
+  it('keeps GitHub Actions plan output bounded without per-path reason chains', () => {
+    const linuxMaxArgStrlen = 131_072
+    const changes = Array.from({ length: 2_000 }, (_, index) => ({
+      path: `src/renderer/src/pages/workspace/generated-${index}.tsx`,
+      status: 'modified' as const
+    }))
+    const plan = classifyChanges(changes)
+    const output = toGitHubOutputPlan(plan)
+    const outputJson = JSON.stringify(output)
+
+    expect(plan.reasonChains.length).toBeGreaterThan(1_000)
+    expect(JSON.stringify(plan).length).toBeGreaterThan(linuxMaxArgStrlen)
+    expect(output).not.toHaveProperty('reasonChains')
+    expect(outputJson).not.toContain('reasonChains')
+    expect(outputJson.length).toBeLessThan(8_192)
+    expect(output).toMatchObject({
+      schemaVersion: plan.schemaVersion,
+      mode: plan.mode,
+      roots: plan.roots,
+      lanes: plan.lanes,
+      bundles: plan.bundles
+    })
   })
 
   it('preserves both paths from NUL-delimited Git rename and deletion records', () => {

--- a/scripts/ci/evaluate-pr-gate.test.ts
+++ b/scripts/ci/evaluate-pr-gate.test.ts
@@ -139,6 +139,28 @@ describe('PR Gate aggregation', () => {
     })
   })
 
+  it('accepts a compact GitHub Actions plan that omits reason chains', () => {
+    const result = evaluatePrGate(
+      {
+        schemaVersion: 1,
+        mode: 'selective',
+        roots: ['documentation'],
+        lanes: ['policy', 'docs', 'format'],
+        bundles: ['policy', 'static']
+      },
+      {
+        preflight: 'success',
+        policy: 'success',
+        static: 'success',
+        coverage_macos: 'skipped'
+      },
+      { executionMode: 'bundles' }
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.selectedBundles).toEqual(['policy', 'static'])
+  })
+
   it('uses bundle execution mode through the trusted CLI interface', () => {
     const result = spawnSync(process.execPath, [resolve('scripts/ci/evaluate-pr-gate.mjs')], {
       encoding: 'utf8',

--- a/scripts/ci/module-impact-authority.mjs
+++ b/scripts/ci/module-impact-authority.mjs
@@ -5,7 +5,12 @@ import { appendFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { classifyChanges, formatPlanSummary, parseNameStatus } from './classify-pr-changes.mjs'
+import {
+  classifyChanges,
+  formatPlanSummary,
+  parseNameStatus,
+  toGitHubOutputPlan
+} from './classify-pr-changes.mjs'
 import {
   createModuleImpactShadowReport,
   formatModuleImpactShadowSummary
@@ -61,10 +66,11 @@ export function runModuleImpactAuthorityCli(
   const report = createModuleImpactShadowReport(candidatePlan, modulePlan)
   const plan = report.resolved
   const planJson = JSON.stringify(plan)
+  const outputPlanJson = JSON.stringify(toGitHubOutputPlan(plan))
   const lanesJson = JSON.stringify(plan.lanes)
 
   if (environment.GITHUB_OUTPUT) {
-    append(environment.GITHUB_OUTPUT, `plan=${planJson}\nlanes=${lanesJson}\n`)
+    append(environment.GITHUB_OUTPUT, `plan=${outputPlanJson}\nlanes=${lanesJson}\n`)
   } else if (write) {
     write(`${planJson}\n`)
   } else {

--- a/scripts/ci/module-impact-shadow.test.ts
+++ b/scripts/ci/module-impact-shadow.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import { classifyChanges } from './classify-pr-changes.mjs'
+import { classifyChanges, toGitHubOutputPlan } from './classify-pr-changes.mjs'
 import { runModuleImpactAuthorityCli } from './module-impact-authority.mjs'
 import {
   createModuleImpactShadowReport,
@@ -219,8 +219,9 @@ describe('module impact shadow', () => {
     })
     expect(append).toHaveBeenCalledWith(
       '/output',
-      expect.stringContaining(`plan=${JSON.stringify(plan)}`)
+      expect.stringContaining(`plan=${JSON.stringify(toGitHubOutputPlan(plan))}`)
     )
+    expect(append.mock.calls.find(([path]) => path === '/output')?.[1]).not.toContain('reasonChains')
     expect(append).toHaveBeenCalledWith('/summary', expect.stringContaining('Resolved mode'))
   })
 

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -205,12 +205,7 @@ describe('PR Gate workflow', () => {
     expect(gate.needs).toEqual(
       expect.arrayContaining(['preflight', ...manifest.bundleOrder, 'coverage_macos'])
     )
-    expect(gate.env).toEqual({
-      PR_GATE_EXECUTION_MODE: 'bundles',
-      PR_GATE_NEEDS: '${{ toJSON(needs) }}',
-      PR_GATE_PLAN: '${{ needs.preflight.outputs.plan }}',
-      PREFLIGHT_RESULT: '${{ needs.preflight.result }}'
-    })
+    expect(gate.env).toBeUndefined()
     expect(gate.steps?.at(0)).toMatchObject({
       name: 'Checkout trusted gate evaluator',
       if: "${{ needs.preflight.result == 'success' }}",
@@ -220,11 +215,25 @@ describe('PR Gate workflow', () => {
         ref: "${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.base.sha || github.event.merge_group.base_sha || needs.preflight.outputs.base }}"
       }
     })
+    expect(gate.steps?.at(0)?.env).toBeUndefined()
     expect(gate.steps?.at(-1)).toMatchObject({
-      name: 'Evaluate deterministic gate from trusted base'
+      name: 'Evaluate deterministic gate from trusted base',
+      env: {
+        PR_GATE_EXECUTION_MODE: 'bundles',
+        PR_GATE_PLAN: '${{ needs.preflight.outputs.plan }}',
+        PREFLIGHT_RESULT: '${{ needs.preflight.result }}'
+      }
     })
+    const gateNeeds = Array.isArray(gate.needs) ? gate.needs : []
+    for (const jobId of gateNeeds) {
+      expect(gate.steps?.at(-1)?.env?.PR_GATE_NEEDS).toContain(
+        `"${jobId}":{"result":"\${{ needs.${jobId}.result }}"}`
+      )
+    }
+    expect(gate.steps?.at(-1)?.env?.PR_GATE_NEEDS).not.toContain('outputs')
     expect(gate.steps?.at(-1)?.run).toContain('node scripts/ci/evaluate-pr-gate.mjs')
     expect(gate.steps?.at(-1)?.run).toContain('Bootstrap-only strict evaluator')
+    expect(workflowText).not.toContain('toJSON(needs)')
     expect(workflowText).not.toMatch(/needs:.*(?:ai|codex|review)/i)
   })
 


### PR DESCRIPTION
## Problem

[#1204](https://github.com/aipoch/open-science/pull/1204) merged with every selected PR Gate check passing, but the required **PR Gate** aggregator failed before checkout:

```text
An error occurred trying to start process '.../externals/node24/bin/node' ... Argument list too long
```

The 284-file diff produced 1,663 per-path reason chains. The preflight `plan` JSON was 153 KB. The gate job then put that plan into process environment twice (`PR_GATE_PLAN` and `toJSON(needs)`), which exceeds Linux `MAX_ARG_STRLEN` (128 KB). Checkout never started.

## Proposed change

- Publish a compact execution plan (`schemaVersion`, `mode`, `roots`, `lanes`, `bundles`) to GitHub Actions outputs. Per-path reason chains stay in the preflight step summary.
- Move gate evaluator environment off the job and pass only `needs.<job>.result` into `PR_GATE_NEEDS`, so checkout/setup-node never inherit the plan payload.
- Keep the trusted evaluator contract unchanged: it already reads `plan.bundles` / `plan.lanes` and `needs.*.result`.

## Scope and non-goals

- This does not change selected lanes, bundles, or test execution.
- This does not rewrite reason-chain diagnostics in the preflight summary.
- This does not change application runtime, database schema, or persisted formats.

## Acceptance criteria and validation

Local validation after the last material edit:

- `npx vitest run scripts/ci/classify-pr-changes.test.ts scripts/ci/pr-gate-workflow.test.ts scripts/ci/evaluate-pr-gate.test.ts scripts/ci/module-impact-shadow.test.ts scripts/ci/check-ci-integrity.test.ts`: 5 files, 174 tests passed.
- Reconstructing the #1204 plan: full JSON 153,182 bytes; compact output 632 bytes.

Exact-head PR Gate remains authoritative for the complete portable and platform suites.

### Test impact

| Behavior | Command | Result |
| --- | --- | --- |
| Compact GitHub Actions plan omits per-path reason chains and stays under ARG_MAX | `npx vitest run scripts/ci/classify-pr-changes.test.ts scripts/ci/module-impact-shadow.test.ts` | pass |
| Gate job does not embed the complete needs payload in process env | `npx vitest run scripts/ci/pr-gate-workflow.test.ts` | pass |
| Trusted evaluator accepts a plan without `reasonChains` | `npx vitest run scripts/ci/evaluate-pr-gate.test.ts` | pass |
| Control-plane integrity rules remain intact | `npx vitest run scripts/ci/check-ci-integrity.test.ts` | pass |

Consumers and platform lanes are included because `scripts/ci/**` and `.github/workflows/pr-gate.yml` are `global_gate_input`.

Uncovered risks: existing large PRs still using the old workflow on HEAD need to rebase after this lands. The trusted classifier is loaded from base, so this PR's own preflight still uses the previous writer; the diff is small enough that ARG_MAX is not an issue here.

## Review focus

- Job `if:` conditions still use `fromJSON(needs.preflight.outputs.plan).{mode,lanes,bundles}` and do not need reason chains.
- Checkout and Setup Node on the gate job have no plan/needs environment.
- `CI Integrity` is expected to report `protected-gate-control-plane` for this control-plane change and requires a maintainer ruleset bypass.

## Compatibility notes

- Historical data compatibility: none. CI control plane only.
- New persisted or enum state: none.
- Data persistence: none.