### PR TITLE
test(workspace): hydrate review history in send-path tests

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -21,7 +21,10 @@ import { useSpecialistStore } from '@/stores/specialist-store'
 import type { TextAnnotation } from '../../../../shared/annotations'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import { emptyDoc, type ComposerDoc } from './composer/composer-doc'
-import { setDefaultWorkspaceAgentSettings } from './workspace-page-test-fixtures'
+import {
+  markWorkspaceReviewHistoryLoaded,
+  setDefaultWorkspaceAgentSettings
+} from './workspace-page-test-fixtures'
 
 // Capture the props passed to the heavy child components so the test can drive selection and drafts.
 let conversationProps: Parameters<(typeof import('./ConversationPanel'))['ConversationPanel']>[0]
@@ -213,6 +216,10 @@ describe('WorkspacePage draft preservation', () => {
       sessions: [createSession('sess-a', 'proj-1'), createSession('sess-b', 'proj-1')],
       selectedSessionId: 'sess-a'
     })
+    markWorkspaceReviewHistoryLoaded(
+      { projectId: 'proj-1', sessionId: 'sess-a' },
+      { projectId: 'proj-1', sessionId: 'sess-b' }
+    )
     useSettingsStore.setState({ skills: [], defaultPermissionProfile: 'ask' })
     useSpecialistStore.setState({ items: [], isLoaded: false })
     vi.clearAllMocks()

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -20,7 +20,10 @@ import {
 } from '@/stores/session-store'
 
 import { emptyDoc, type ComposerDoc } from './composer/composer-doc'
-import { setDefaultWorkspaceAgentSettings } from './workspace-page-test-fixtures'
+import {
+  markWorkspaceReviewHistoryLoaded,
+  setDefaultWorkspaceAgentSettings
+} from './workspace-page-test-fixtures'
 
 // Capture the ConversationPanel props the page computes, notably canEditMessage and the resend handler.
 let conversationProps: Parameters<(typeof import('./ConversationPanel'))['ConversationPanel']>[0]
@@ -172,6 +175,7 @@ describe('WorkspacePage inline edit resend', () => {
 
   beforeEach(() => {
     setDefaultWorkspaceAgentSettings()
+    markWorkspaceReviewHistoryLoaded({ projectId: 'proj-1', sessionId: 'sess-a' })
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useProjectStore.setState({ projects: [] })
     useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })

--- a/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
@@ -25,6 +25,7 @@ import {
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import { VISION_MODEL_NOT_CONFIGURED_MESSAGE } from '../../../../shared/run-error-classification'
 import { usePdfContextAction } from './use-pdf-context-action'
+import { markWorkspaceReviewHistoryLoaded } from './workspace-page-test-fixtures'
 
 // Capture the ConversationPanel props the page computes on each render.
 let conversationProps: Parameters<(typeof import('./ConversationPanel'))['ConversationPanel']>[0]
@@ -149,6 +150,7 @@ describe('WorkspacePage image attachment gating', () => {
   }
 
   beforeEach(() => {
+    markWorkspaceReviewHistoryLoaded({ projectId: 'proj-1', sessionId: 'sess-a' })
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useProjectStore.setState({ projects: [] })
     useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })

--- a/src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx
@@ -24,7 +24,10 @@ import {
 import { useSpecialistStore } from '@/stores/specialist-store'
 
 import { type ComposerDoc } from './composer/composer-doc'
-import { setDefaultWorkspaceAgentSettings } from './workspace-page-test-fixtures'
+import {
+  markWorkspaceReviewHistoryLoaded,
+  setDefaultWorkspaceAgentSettings
+} from './workspace-page-test-fixtures'
 import type {
   CompletionHandoffLifecycleEvent,
   SpecialistListItem
@@ -201,6 +204,7 @@ const renderPage = async (r: Root): Promise<void> => {
 
 const setupBase = (): void => {
   setDefaultWorkspaceAgentSettings()
+  markWorkspaceReviewHistoryLoaded({ projectId: 'proj-1', sessionId: 'sess-a' })
   usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
   useProjectStore.setState({ projects: [] })
   useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -24,7 +24,10 @@ import type { ReviewWithChecks } from '../../../../shared/reviewer'
 import type { ActivePlanProjection } from '../../../../shared/session-plan/contract'
 
 import { type ComposerDoc } from './composer/composer-doc'
-import { setDefaultWorkspaceAgentSettings } from './workspace-page-test-fixtures'
+import {
+  markWorkspaceReviewHistoryLoaded,
+  setDefaultWorkspaceAgentSettings
+} from './workspace-page-test-fixtures'
 
 // Capture the ConversationPanel props the page computes, notably canSendMessage and the draft callback.
 let conversationProps: Parameters<(typeof import('./ConversationPanel'))['ConversationPanel']>[0]
@@ -176,10 +179,7 @@ describe('WorkspacePage send gate while compacting', () => {
     setDefaultWorkspaceAgentSettings()
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useProjectStore.setState({ projects: [] })
-    useReviewStore.setState({
-      ...createInitialReviewState(),
-      loadedReviewSessions: { 'proj-1\0sess-a': true }
-    })
+    markWorkspaceReviewHistoryLoaded({ projectId: 'proj-1', sessionId: 'sess-a' })
     useMemoryStore.setState(createInitialMemoryState())
     useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
     useSessionStore.setState({

--- a/src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx
@@ -21,7 +21,10 @@ import {
 import { useSpecialistStore } from '@/stores/specialist-store'
 
 import { type ComposerDoc } from './composer/composer-doc'
-import { setDefaultWorkspaceAgentSettings } from './workspace-page-test-fixtures'
+import {
+  markWorkspaceReviewHistoryLoaded,
+  setDefaultWorkspaceAgentSettings
+} from './workspace-page-test-fixtures'
 import type { SpecialistListItem } from '../../../../shared/specialist'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -171,6 +174,7 @@ const renderPage = async (r: Root): Promise<void> => {
 
 const setupBase = (): void => {
   setDefaultWorkspaceAgentSettings()
+  markWorkspaceReviewHistoryLoaded({ projectId: 'proj-1', sessionId: 'sess-a' })
   usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
   useProjectStore.setState({ projects: [] })
   useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })

--- a/src/renderer/src/pages/workspace/workspace-page-test-fixtures.ts
+++ b/src/renderer/src/pages/workspace/workspace-page-test-fixtures.ts
@@ -1,3 +1,4 @@
+import { createInitialReviewState, useReviewStore } from '@/stores/review-store'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import type { ProviderView } from '../../../../shared/settings'
 
@@ -11,6 +12,9 @@ const TEST_PROVIDER: ProviderView = {
   needsKey: false
 }
 
+const workspaceReviewSessionKey = (projectId: string, sessionId: string): string =>
+  `${projectId}\0${sessionId}`
+
 const setDefaultWorkspaceAgentSettings = (): void => {
   useSettingsStore.setState({
     ...createInitialSettingsState(),
@@ -21,4 +25,20 @@ const setDefaultWorkspaceAgentSettings = (): void => {
   })
 }
 
-export { setDefaultWorkspaceAgentSettings }
+// WorkspacePage tests mock ConversationPanel, so WorkspaceMessageScroller never loads review history.
+// Mark the selected Session as hydrated so turn admission is not fail-closed for unrelated send paths.
+const markWorkspaceReviewHistoryLoaded = (
+  ...sessions: ReadonlyArray<{ projectId: string; sessionId: string }>
+): void => {
+  useReviewStore.setState({
+    ...createInitialReviewState(),
+    loadedReviewSessions: Object.fromEntries(
+      sessions.map(({ projectId, sessionId }) => [
+        workspaceReviewSessionKey(projectId, sessionId),
+        true
+      ])
+    )
+  })
+}
+
+export { markWorkspaceReviewHistoryLoaded, setDefaultWorkspaceAgentSettings }


### PR DESCRIPTION
## Problem

#2019 made WorkspacePage fail-closed for send, revise, branch, compact, and manual review until the selected Session's review history has loaded. WorkspacePage suites that mock `ConversationPanel` never run `WorkspaceMessageScroller`'s `loadReviewsForSession`, so CI treated idle Sessions as still hydrating and blocked turn admission.

That produced 26 portable-suite failures on #2019:

- `WorkspacePage.specialist-barrier.test.tsx` (7)
- `WorkspacePage.pending-switch.test.tsx` (6)
- `WorkspacePage.draft-preservation.test.tsx` (6)
- `WorkspacePage.edit-message.test.tsx` (4)
- `WorkspacePage.image-staging.test.tsx` (3)

## Proposed change

Share a test helper that marks the selected Session's review history as loaded, and use it in the send-path WorkspacePage suites. The dedicated send-gate tests still cover the unhydrated and load-error fail-closed paths.

## Scope and non-goals

- Test-only. No production, schema, IPC, enum, or persistence changes.
- Does not change Fix Loop recovery, review hydration, or admission behavior.
- Does not address the unrelated macOS native flake in `packages/notebook-network-sandbox/src/network-enforcement.integration.test.ts` (`allows a listed destination and blocks it after a live policy update`, curl exit 7). That test is outside this PR's diff and has passed on later `main` pushes.

## Acceptance criteria and validation

The commands below were run after the last material edit.

- Previously failing send-path suites pass with hydrated review history -> `npx vitest run --reporter=dot src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx` -> 6 files, 109 tests passed.
- Workspace page owner module, including send-gate fail-closed coverage -> `npm run test:module -- workspace_page` -> 29 files, 728 tests passed.
- Targeted ESLint on the changed files -> passed.

`npm test` was not run locally; PR Gate remains the authority for the complete portable and platform lanes.

## Review focus

- Whether marking `loadedReviewSessions` is the right test seam, given these suites mock `ConversationPanel` and therefore skip the real history load.
- Whether send-gate still owns the unhydrated and load-error cases.

## Uncovered risks

- Exact-head portable CI and macOS native lanes are pending PR Gate.
- Independent review of the final evidence mapping is pending.