### PR TITLE
fix(startup): exit Electron after UI startup failure

### DIFF
--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -257,6 +257,81 @@ describe('orchestrateAppStartup', () => {
     expect(diagnostics.fail).toHaveBeenCalledWith(failure)
     expect(diagnostics.complete).not.toHaveBeenCalled()
   })
+
+  it('cleans the prepared runtime before rejecting a post-composition startup failure', async () => {
+    const failure = new Error('mark ready failed')
+    const cleanup = deferred<void>()
+    const events: string[] = []
+    const deps = makeDeps({
+      markReady: vi.fn(() => {
+        throw failure
+      }),
+      cleanupAfterStartupFailure: vi.fn(async () => {
+        events.push('cleanup:start')
+        await cleanup.promise
+        events.push('cleanup:end')
+      })
+    })
+
+    const startupOutcome = orchestrateAppStartup(deps).then(
+      () => undefined,
+      (error: unknown) => {
+        events.push('startup:rejected')
+        return error
+      }
+    )
+
+    await vi.waitFor(() => expect(events).toEqual(['cleanup:start']))
+    cleanup.resolve()
+
+    await expect(startupOutcome).resolves.toBe(failure)
+    expect(events).toEqual(['cleanup:start', 'cleanup:end', 'startup:rejected'])
+    expect(deps.cleanupAfterStartupFailure).toHaveBeenCalledWith({ tag: 'ctx' }, failure)
+  })
+
+  it('cancels the startup system-shutdown fallback before failure cleanup', async () => {
+    vi.useFakeTimers()
+    try {
+      const failure = new Error('mark ready failed')
+      const cleanup = deferred<void>()
+      const cleanupStarted = deferred<void>()
+      const forceExit = vi.fn()
+      let requestSystemShutdown = (): void => {}
+      const deps = {
+        ...makeDeps({
+          prepare: vi.fn(async () => {
+            requestSystemShutdown()
+            return { tag: 'ctx' }
+          }),
+          markReady: vi.fn(() => {
+            throw failure
+          }),
+          cleanupAfterStartupFailure: vi.fn(() => {
+            cleanupStarted.resolve()
+            return cleanup.promise
+          })
+        }),
+        installSystemShutdownListeners: (request: () => void) => {
+          requestSystemShutdown = request
+        },
+        forceExit,
+        startupSystemShutdownTimeoutMs: 25
+      } as Parameters<typeof orchestrateAppStartup<{ tag: string }>>[0]
+
+      const startupOutcome = orchestrateAppStartup(deps).then(
+        () => undefined,
+        (error: unknown) => error
+      )
+      await cleanupStarted.promise
+      await vi.advanceTimersByTimeAsync(25)
+
+      expect(forceExit).not.toHaveBeenCalled()
+      cleanup.resolve()
+      await expect(startupOutcome).resolves.toBe(failure)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('prepareVisibleStartupRuntime', () => {

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -23,6 +23,7 @@ export type SecondInstanceRelay = {
 type SystemShutdownRelay = {
   signal: () => void
   bind: (handler: () => void) => void
+  cancel: () => void
 }
 
 const STARTUP_SYSTEM_SHUTDOWN_TIMEOUT_MS = 5_000
@@ -87,9 +88,17 @@ const createSystemShutdownRelay = (
   let pending = false
   let handler: (() => void) | undefined
   let forceExitTimer: ReturnType<typeof setTimeout> | undefined
+  let cancelled = false
+
+  const clearForceExitTimer = (): void => {
+    if (!forceExitTimer) return
+    clearTimeout(forceExitTimer)
+    forceExitTimer = undefined
+  }
 
   return {
     signal: () => {
+      if (cancelled) return
       if (handler) handler()
       else {
         pending = true
@@ -99,14 +108,18 @@ const createSystemShutdownRelay = (
       }
     },
     bind: (next) => {
+      if (cancelled) return
       handler = next
-      if (forceExitTimer) {
-        clearTimeout(forceExitTimer)
-        forceExitTimer = undefined
-      }
+      clearForceExitTimer()
       if (!pending) return
       pending = false
       handler()
+    },
+    cancel: () => {
+      cancelled = true
+      pending = false
+      handler = undefined
+      clearForceExitTimer()
     }
   }
 }
@@ -136,6 +149,9 @@ export type AppStartupDeps<Context> = {
     onSecondInstance: (argv: string[]) => void
     onSystemShutdown?: () => void
   }
+  // Best-effort, bounded cleanup for failures after prepare() has transferred runtime ownership.
+  // The callback owns cleanup diagnostics; a cleanup failure must not replace the startup error.
+  cleanupAfterStartupFailure?: (context: Context, error: unknown) => Promise<void> | void
   // Publishes renderer readiness only after lifecycle installation and adapter wiring complete.
   markReady?: (context: Context) => void
   diagnostics?: DiagnosticOperation
@@ -221,6 +237,7 @@ export const orchestrateAppStartup = async <Context>(
     deps.forceExit,
     deps.startupSystemShutdownTimeoutMs
   )
+  let preparedContext: { value: Context } | undefined
 
   try {
     deps.diagnostics?.phase('single-instance-lock')
@@ -233,6 +250,7 @@ export const orchestrateAppStartup = async <Context>(
     deps.installSystemShutdownListeners?.(systemShutdownRelay.signal)
     deps.diagnostics?.phase('prepare-runtime')
     const context = await deps.prepare()
+    preparedContext = { value: context }
     deps.diagnostics?.phase('install-lifecycle')
     deps.installMigrationQuitGuard(context)
     const { onSecondInstance, onSystemShutdown } = deps.installAppLifecycle(context)
@@ -241,7 +259,15 @@ export const orchestrateAppStartup = async <Context>(
     relay.bind(onSecondInstance)
     deps.diagnostics?.complete({ instance: 'primary' })
   } catch (error) {
+    systemShutdownRelay.cancel()
     deps.diagnostics?.fail(error)
+    if (preparedContext && deps.cleanupAfterStartupFailure) {
+      try {
+        await deps.cleanupAfterStartupFailure(preparedContext.value, error)
+      } catch {
+        // The original startup failure remains authoritative; cleanup owns its own diagnostics.
+      }
+    }
     throw error
   }
 }

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -453,6 +453,29 @@ describe('application surface shutdown', () => {
     ])
   })
 
+  it('shares one application surface shutdown across concurrent lifecycle requests', async () => {
+    const disposeApplicationRuntime = vi.fn()
+    const shutdownRemoteAccess = vi.fn()
+    const disposeWebController = vi.fn()
+    const disposeIpcHandlers = vi.fn()
+    const lifecycle = withApplicationRuntimeShutdown(
+      {},
+      {
+        disposeApplicationRuntime,
+        remoteAccess: { shutdown: shutdownRemoteAccess },
+        webController: { dispose: disposeWebController },
+        disposeIpcHandlers
+      }
+    )
+
+    await Promise.all([lifecycle.shutdownBackends(), lifecycle.shutdownBackends()])
+
+    expect(disposeApplicationRuntime).toHaveBeenCalledOnce()
+    expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
+    expect(disposeWebController).toHaveBeenCalledOnce()
+    expect(disposeIpcHandlers).toHaveBeenCalledOnce()
+  })
+
   it('diagnoses runtime failure and continues closing surfaces without rejecting lifecycle', async () => {
     const failure = new Error('backend shutdown failed')
     const shutdownRemoteAccess = vi.fn()

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -175,14 +175,17 @@ export const createApplicationLifecycleShutdown = ({
   disposeIpcHandlers,
   log
 }: ApplicationLifecycleShutdownDependencies): (() => Promise<ShutdownStepOutcome>) => {
-  return () =>
-    shutdownApplicationSurfaces({
+  let shutdownPromise: Promise<ShutdownStepOutcome> | undefined
+  return () => {
+    shutdownPromise ??= shutdownApplicationSurfaces({
       disposeApplicationRuntime,
       shutdownRemoteAccess: () => remoteAccess.shutdown(),
       disposeWebController: () => webController.dispose(),
       disposeIpcHandlers,
       log
     })
+    return shutdownPromise
+  }
 }
 
 export const withApplicationRuntimeShutdown = <Options extends object>(

--- a/src/main/index-fatal-errors.test.ts
+++ b/src/main/index-fatal-errors.test.ts
@@ -162,9 +162,35 @@ afterEach(() => {
 })
 
 describe('main-process fatal errors', () => {
+  it('exits Electron after reporting a UI startup failure', async () => {
+    const originalExitCode = process.exitCode
+    let finishReporting!: () => void
+    mocks.reportApplicationStartupFailure.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finishReporting = () => resolve(undefined)
+        })
+    )
+
+    try {
+      await bootUntilFailureHandlersAreInstalled()
+
+      await vi.waitFor(() => expect(mocks.reportApplicationStartupFailure).toHaveBeenCalledOnce())
+      expect(mocks.app.exit).not.toHaveBeenCalled()
+
+      finishReporting()
+      await vi.waitFor(() => expect(mocks.app.exit).toHaveBeenCalledExactlyOnceWith(1))
+    } finally {
+      process.exitCode = originalExitCode
+    }
+  })
+
   it('observes both fatal origins without installing a consuming listener', async () => {
     const listeners = await bootUntilFailureHandlersAreInstalled()
     const monitor = listeners.get('uncaughtExceptionMonitor')
+
+    await vi.waitFor(() => expect(mocks.app.exit).toHaveBeenCalledExactlyOnceWith(1))
+    mocks.app.exit.mockClear()
 
     expect(monitor).toBeTypeOf('function')
     expect(listeners.has('uncaughtException')).toBe(false)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,7 +12,7 @@ import {
   SKILL_IMPORT_MCP_SERVER_ARG,
   SKILL_RUNTIME_MCP_SERVER_ARG
 } from './mcp-server-args'
-import { withApplicationRuntimeShutdown } from './application-runtime'
+import { createApplicationLifecycleShutdown } from './application-runtime'
 import { installChildProcessGoneLogging, startLocalCrashReporting } from './crash-diagnostics'
 import type { DiagnosticOperation } from './diagnostics/operation'
 import {
@@ -85,13 +85,14 @@ if (shouldRunArtifactMcpServer) {
     })
 } else {
   void startElectronApp(fileURLToPath(import.meta.url)).catch(async (error: unknown) => {
+    bootstrapLog.error('application startup failed', diagnosticErrorFields(error))
     await reportApplicationStartupFailure({
       operation: startupDiagnostics,
       error,
       flush: startupFlush
     })
-    bootstrapLog.error('application startup failed', diagnosticErrorFields(error))
-    process.exitCode = 1
+    const { app } = createRequire(import.meta.url)('electron') as typeof import('electron')
+    app.exit(1)
   })
 }
 
@@ -626,6 +627,21 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             // A missing or signed-out third-party remote-access installation must never delay the desktop window.
             void remoteAccess.restore()
 
+            const disposeApplicationIpcHandlers = (): void => {
+              disposeTrayLocaleSubscription()
+              disposeLocalePreferenceIpc()
+              managedPreviewProtocolBridge.dispose()
+              disposeDatabaseStartupIpc()
+              disposeIpcHandlerRegistry()
+            }
+            const shutdownApplicationSurfaces = createApplicationLifecycleShutdown({
+              disposeApplicationRuntime,
+              remoteAccess,
+              webController,
+              disposeIpcHandlers: disposeApplicationIpcHandlers,
+              log
+            })
+
             return {
               installMigrationQuitGuard,
               isMigrationInProgress,
@@ -679,15 +695,9 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               webMode,
               webController,
               remoteAccess,
+              shutdownApplicationSurfaces,
               databaseStartupOwner,
-              databaseStartupQuitGuard,
-              disposeIpcHandlerRegistry: () => {
-                disposeTrayLocaleSubscription()
-                disposeLocalePreferenceIpc()
-                managedPreviewProtocolBridge.dispose()
-                disposeDatabaseStartupIpc()
-                disposeIpcHandlerRegistry()
-              }
+              databaseStartupQuitGuard
             }
           } catch (error) {
             // Invalidate caller leases immediately if composition fails after registering IPC. The
@@ -720,76 +730,66 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     // is bound with the live backend handles; the agent teardown latches shutting-down and awaits the
     // process tree so a Windows taskkill /T completes before app.exit.
     installAppLifecycle: (ctx) => {
-      const lifecycle = ctx.installAppLifecycle(
-        withApplicationRuntimeShutdown(
-          {
-            app,
-            createMainWindow: ctx.createMainWindow,
-            configureMainWindow: ctx.configureMainWindow,
-            initialWindow: ctx.startupWindow,
-            createTray: (handlers) => {
-              const webPort = ctx.webController.runningPort()
-              const headlessWeb = ctx.webMode.headless && webPort !== undefined
-              const tray = ctx.createAppTray({
-                iconPath: trayIconPath,
-                variantIconPaths: trayVariantIconPaths,
-                initialVariant: ctx.getAppIconVariant(),
-                translate: ctx.translate,
-                templateIconPath: process.platform === 'darwin' ? trayMacTemplate : undefined,
-                ...handlers,
-                ...(headlessWeb
-                  ? {
-                      headless: true,
-                      onOpenWeb: async () => {
-                        const { shell } = await import('electron')
-                        await shell.openExternal(await ctx.buildAuthenticatedWebUrl(webPort))
-                      },
-                      onCopyWebUrl: async () => {
-                        const { clipboard } = await import('electron')
-                        clipboard.writeText(await ctx.buildAuthenticatedWebUrl(webPort))
-                      }
-                    }
-                  : {})
-              })
-              // Publish the tray so a later settings change can restyle it (onAppIconVariantChanged).
-              ctx.appTrayBox.current = tray
-              return tray
-            },
-            isMigrationInProgress: ctx.isMigrationInProgress,
-            quit: () => app.quit(),
-            countWindows: () => BrowserWindow.getAllWindows().length,
-            createInitialWindow: !ctx.webMode.headless,
-            bindSystemShutdownWindow,
-            detectActiveSessions: ctx.detectActiveSessions,
-            hasActiveReviewerWork: ctx.hasActiveReviewerWork,
-            prepareForQuit: ctx.prepareForQuit,
-            abortQuitPreparation: (reason) => {
-              ctx.abortQuitPreparation()
-              ctx.notifySessionPersistenceFlushAborted(
-                () => ctx.mainWindowGetterBox.current?.(),
-                reason
-              )
-            },
-            flushSessionPersistence: ctx.createSessionPersistenceFlush(() =>
-              ctx.mainWindowGetterBox.current?.()
-            ),
-            createConfirmClose: ctx.createConfirmClose,
-            onAppearanceChanged: (appearance) =>
-              ctx.appIconControllerBox.current?.setAppearance(appearance),
-            log: ctx.log,
-            flushLogs
-          } satisfies Omit<Parameters<typeof ctx.installAppLifecycle>[0], 'shutdownBackends'>,
-          {
-            // Application composition owns the one bounded ACP/Notebook shutdown. Remaining surfaces
-            // close afterward in their established order, even when an earlier disposer rejects.
-            disposeApplicationRuntime: ctx.disposeApplicationRuntime,
-            remoteAccess: ctx.remoteAccess,
-            webController: ctx.webController,
-            disposeIpcHandlers: ctx.disposeIpcHandlerRegistry,
-            log: ctx.log
-          }
-        )
-      )
+      const lifecycle = ctx.installAppLifecycle({
+        app,
+        createMainWindow: ctx.createMainWindow,
+        configureMainWindow: ctx.configureMainWindow,
+        initialWindow: ctx.startupWindow,
+        createTray: (handlers) => {
+          const webPort = ctx.webController.runningPort()
+          const headlessWeb = ctx.webMode.headless && webPort !== undefined
+          const tray = ctx.createAppTray({
+            iconPath: trayIconPath,
+            variantIconPaths: trayVariantIconPaths,
+            initialVariant: ctx.getAppIconVariant(),
+            translate: ctx.translate,
+            templateIconPath: process.platform === 'darwin' ? trayMacTemplate : undefined,
+            ...handlers,
+            ...(headlessWeb
+              ? {
+                  headless: true,
+                  onOpenWeb: async () => {
+                    const { shell } = await import('electron')
+                    await shell.openExternal(await ctx.buildAuthenticatedWebUrl(webPort))
+                  },
+                  onCopyWebUrl: async () => {
+                    const { clipboard } = await import('electron')
+                    clipboard.writeText(await ctx.buildAuthenticatedWebUrl(webPort))
+                  }
+                }
+              : {})
+          })
+          // Publish the tray so a later settings change can restyle it (onAppIconVariantChanged).
+          ctx.appTrayBox.current = tray
+          return tray
+        },
+        isMigrationInProgress: ctx.isMigrationInProgress,
+        quit: () => app.quit(),
+        countWindows: () => BrowserWindow.getAllWindows().length,
+        createInitialWindow: !ctx.webMode.headless,
+        bindSystemShutdownWindow,
+        detectActiveSessions: ctx.detectActiveSessions,
+        hasActiveReviewerWork: ctx.hasActiveReviewerWork,
+        prepareForQuit: ctx.prepareForQuit,
+        abortQuitPreparation: (reason) => {
+          ctx.abortQuitPreparation()
+          ctx.notifySessionPersistenceFlushAborted(
+            () => ctx.mainWindowGetterBox.current?.(),
+            reason
+          )
+        },
+        flushSessionPersistence: ctx.createSessionPersistenceFlush(() =>
+          ctx.mainWindowGetterBox.current?.()
+        ),
+        createConfirmClose: ctx.createConfirmClose,
+        onAppearanceChanged: (appearance) =>
+          ctx.appIconControllerBox.current?.setAppearance(appearance),
+        log: ctx.log,
+        flushLogs,
+        // Application composition owns the one bounded ACP/Notebook shutdown. Startup failures
+        // after composition and ordinary lifecycle shutdown reuse this exact ordered owner.
+        shutdownBackends: ctx.shutdownApplicationSurfaces
+      })
       const { showMainWindow, getMainWindow, isMainWindowHidden, onSystemShutdown } = lifecycle
 
       // Window lifecycle now exists: expose it to the restored controller, reapply any Windows
@@ -840,6 +840,9 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         })
       preStartupSecondInstanceRelay.bind(onSecondInstance)
       return { onSecondInstance, onSystemShutdown }
+    },
+    cleanupAfterStartupFailure: async (ctx) => {
+      await ctx.shutdownApplicationSurfaces()
     },
     markReady: (ctx) => {
       ctx.databaseStartupOwner.complete()


### PR DESCRIPTION
## Problem

A rejected normal UI startup only set `process.exitCode = 1`. That exit code is observed only when the event loop drains naturally, so a ready or partially initialized Electron process can retain windows, tray state, IPC resources, or the single-instance lock and remain resident without a usable window.

The main-entry regression test reproduces the reported termination gap. Before the fix, diagnostics reporting completed but `app.exit(1)` was never called. A second regression test covers failures after runtime composition; before the cleanup change, the startup promise rejected immediately without disposing the composed application surfaces.

## Proposed change

- Record the top-level startup failure before flushing diagnostics.
- After runtime composition has transferred ownership, await the existing bounded application-surface shutdown before propagating a later startup failure.
- Make the shared application-surface shutdown idempotent so concurrent lifecycle and startup-failure requests join one cleanup operation.
- Terminalize the pre-lifecycle OS-shutdown relay before failure cleanup so its success-code force-exit fallback cannot preempt diagnostics and `app.exit(1)`.
- Await the existing bounded diagnostics flush, then call `app.exit(1)` for the normal Electron UI path.
- Keep all MCP subprocess modes on their existing `process.exitCode` behavior.

## Scope and non-goals

- The startup coordinator gains one optional post-prepare failure-cleanup hook; normal lifecycle shutdown reuses the same ordered cleanup owner.
- No renderer copy or user interaction changes.
- No data relationship, persistence, schema, or model changes.
- No MCP subprocess lifecycle changes.

## Acceptance criteria and validation

Local validation after the last material edit:

- Focused startup, runtime-shutdown, lifecycle, and diagnostics coverage -> `npx vitest run src/main/index-fatal-errors.test.ts src/main/index-startup-order.test.ts src/main/app-startup.test.ts src/main/application-runtime.test.ts src/main/app-lifecycle.test.ts src/main/diagnostics/startup.test.ts` -> 6 files, 114 tests passed.
- The OS-shutdown race regression test failed twice on the unfixed path because the success-code `forceExit` callback fired during failure cleanup, then passed after relay cancellation was restored.
- Main-process TypeScript remains valid -> `npm run typecheck:node` -> passed.
- Source and test lint rules remain valid -> `npm run lint` -> 0 errors; one pre-existing Prettier warning remains in the unchanged `scripts/ci/module-impact-shadow.test.ts`.
- Changed files match repository formatting -> focused `npx prettier --check ...` -> passed.
- Patch whitespace validation -> `git diff --check` -> passed.

The complete Vitest suite and cross-platform packaged behavior were not run locally; exact-head PR Gate remains authoritative for those risks.

## Review focus

- Post-composition startup failures await the same bounded ACP/Notebook, Web, Remote Access, and IPC cleanup used by normal lifecycle shutdown.
- Concurrent cleanup requests execute the disposer chain only once.
- A pending startup OS-shutdown fallback is cancelled before fatal cleanup begins.
- The fatal log entry and bounded diagnostics flush complete before `app.exit(1)`.
- Forced exit remains limited to the normal UI startup rejection path; MCP modes retain natural Node subprocess termination.

## Compatibility notes

- Historical data compatibility: none.
- New persisted fields or enum values: none.
- Data persistence: none.
- Data model or schema changes: none.
- User interaction changes: none.