### PR TITLE
fix(side-chat): include active replies in exit detection

### DIFF
--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -152,6 +152,19 @@ describe('production application command wiring', () => {
     )
   })
 
+  it('holds side chat admission through the in-place update handoff', () => {
+    const updateGate = compact(
+      between(ipcSource, 'const durableBackendHandoffGate', 'const detectResearchBlockers')
+    )
+    const updateStrategy = compact(
+      between(ipcSource, 'const updateStrategy', 'const updateCommandOwner')
+    )
+    expect(updateGate).toContain(
+      'shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS, { holdSideChatAdmission: true })'
+    )
+    expect(updateStrategy).toContain('releaseInstallHandoff: abortUpdateHandoff')
+  })
+
   it('keeps native-only commands inside the Electron owner adapter and exposes only narrow views', () => {
     const electronOwner = compact(
       between(dependencyBlock, 'electron: {', 'events: applicationEvents')

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -301,6 +301,10 @@ describe('application surface shutdown', () => {
         notebook: {
           dispose: async () => ({ reaped: true }),
           shutdownAll: async () => ({ reaped: true })
+        },
+        sideChat: {
+          shutdown: async () => undefined,
+          suspendAll: async () => undefined
         }
       })
       const runtime = await composeApplicationRuntime(async (modules) => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4040,9 +4040,9 @@ const createApplicationModules = async (
     }
   }
 
-  // The shared coordinator remains the sole ACP + Side Chat + Notebook teardown owner. Register
-  // command routing after it so reverse disposal removes adapters, then the router, before any
-  // underlying owner stops.
+  // The shared coordinator remains the sole ACP + Notebook teardown owner.
+  // It also coordinates Side Chat suspension/shutdown. Register command routing after it so reverse
+  // disposal removes adapters, then the router, before any underlying owner stops.
   await modules.add({ shutdownCoordinator }, ({ shutdownCoordinator: coordinator }) => ({
     name: 'backend-shutdown-coordinator',
     capability: undefined,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3055,7 +3055,10 @@ const createApplicationModules = async (
     log: createLogger('shutdown')
   })
   const durableBackendHandoffGate = createDurableInstallGate(
-    () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS),
+    () =>
+      shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS, {
+        holdSideChatAdmission: true
+      }),
     () => confirmRendererDurability()
   )
   const detectResearchBlockers = (): UpdateBlocker[] => {
@@ -3094,14 +3097,21 @@ const createApplicationModules = async (
   // Construct update handling only after its backend-shutdown gate exists. The in-place strategy owns
   // this immutable dependency from construction; the manifest fallback ignores it because it does not
   // quit the running app to install.
+  const abortUpdateHandoff = (): void => {
+    try {
+      sideChatRuntime.resumeAfterHandoff()
+    } finally {
+      notifyRendererDurabilityAborted()
+    }
+  }
   const updateStrategy = createUpdateStrategy(process.platform, {
     translate,
     installGate: createActiveResearchSafeInstallGate(
       detectResearchBlockers,
       durableBackendHandoffGate,
-      () => isMigrationInProgress() || isMigrationPending(),
-      notifyRendererDurabilityAborted
-    )
+      () => isMigrationInProgress() || isMigrationPending()
+    ),
+    releaseInstallHandoff: abortUpdateHandoff
   })
   const updateCommandOwner = createUpdateCommandOwner(updateStrategy)
   let stopUpdateScheduler: (() => void) | undefined

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3050,7 +3050,7 @@ const createApplicationModules = async (
     notebook: notebookService,
     sideChat: {
       shutdown: () => sideChatRuntime.shutdown(),
-      suspendAll: () => sideChatRuntime.suspendAll()
+      suspendAll: (options) => sideChatRuntime.suspendAll(options)
     },
     log: createLogger('shutdown')
   })
@@ -3075,7 +3075,10 @@ const createApplicationModules = async (
     createDurableInstallGate(
       createDataRootResearchSafeInstallGate(
         detectResearchBlockers,
-        () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS),
+        () =>
+          shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS, {
+            holdSideChatAdmission: true
+          }),
         confirmedInterruption
       ),
       async () => {
@@ -3597,14 +3600,24 @@ const createApplicationModules = async (
     acknowledgeWebRendererFlush: webSessionPersistenceFlush.acknowledge,
     notifyDataRootHandoffAborted: () => {
       try {
-        notifyRendererDurabilityAborted()
+        sideChatRuntime.resumeAfterHandoff()
       } finally {
-        webSessionPersistenceFlush.notifyAborted()
+        try {
+          notifyRendererDurabilityAborted()
+        } finally {
+          webSessionPersistenceFlush.notifyAborted()
+        }
       }
     },
     prepareDataRootHandoff: async (target, confirmedInterruption) => {
-      const readiness = await durableDataRootHandoffGate(target, confirmedInterruption)
-      return readiness.completed && readiness.reaped
+      let prepared = false
+      try {
+        const readiness = await durableDataRootHandoffGate(target, confirmedInterruption)
+        prepared = readiness.completed && readiness.reaped
+        return prepared
+      } finally {
+        if (!prepared) sideChatRuntime.resumeAfterHandoff()
+      }
     },
     cleanupJournal: dataRootCleanupJournal
   })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3048,6 +3048,10 @@ const createApplicationModules = async (
       }
     },
     notebook: notebookService,
+    sideChat: {
+      shutdown: () => sideChatRuntime.shutdown(),
+      suspendAll: () => sideChatRuntime.suspendAll()
+    },
     log: createLogger('shutdown')
   })
   const durableBackendHandoffGate = createDurableInstallGate(
@@ -4036,8 +4040,9 @@ const createApplicationModules = async (
     }
   }
 
-  // The shared coordinator remains the sole ACP + Notebook teardown owner. Register command routing
-  // after it so reverse disposal removes adapters, then the router, before any underlying owner stops.
+  // The shared coordinator remains the sole ACP + Side Chat + Notebook teardown owner. Register
+  // command routing after it so reverse disposal removes adapters, then the router, before any
+  // underlying owner stops.
   await modules.add({ shutdownCoordinator }, ({ shutdownCoordinator: coordinator }) => ({
     name: 'backend-shutdown-coordinator',
     capability: undefined,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -987,6 +987,10 @@ const createApplicationModules = async (
   const delegatedActivity = createDelegatedActivityProjection()
   const getActiveDelegatedSessions = (): { projectId: string; sessionId: string }[] =>
     delegatedActivity.getActiveDelegatedSessions()
+  const getActiveSideChatSessions = (): { projectId: string; sessionId: string }[] =>
+    (sideChatOwnerRef.current?.list().chats ?? [])
+      .filter((chat) => chat.running)
+      .map((chat) => ({ projectId: chat.projectId, sessionId: chat.parentSessionId }))
 
   const sessionPersistenceCoordinator = new SessionPersistenceCoordinator(
     sessionRepository,
@@ -1151,6 +1155,7 @@ const createApplicationModules = async (
       runtime: {
         getActivePromptSessions: () => runtimeRef.current?.getActivePromptSessions() ?? []
       },
+      sideChat: { getActivePromptSessions: getActiveSideChatSessions },
       delegated: { getActiveDelegatedSessions },
       notebook: {
         getActiveNotebookSessions: () =>
@@ -3052,6 +3057,7 @@ const createApplicationModules = async (
   const detectResearchBlockers = (): UpdateBlocker[] => {
     const blockers: UpdateBlocker[] = detectActiveSessions({
       runtime: { getActivePromptSessions: () => runtime.getQuitBlockingPromptSessions() },
+      sideChat: { getActivePromptSessions: getActiveSideChatSessions },
       delegated: { getActiveDelegatedSessions },
       notebook: notebookService
     }).map((session) => session.kind)
@@ -3579,6 +3585,7 @@ const createApplicationModules = async (
     runtime,
     notebook: notebookService,
     getActivePromptSessions: () => runtime.getActivePromptSessions(),
+    getActiveSideChatSessions,
     getActiveDelegatedSessions,
     hasActiveReviewerWork: () => reviewerModelRuntimeShutdown?.hasActiveWork() ?? false,
     settingsService,
@@ -3603,6 +3610,7 @@ const createApplicationModules = async (
         runtime,
         notebook: notebookService,
         getActivePromptSessions: () => runtime.getActivePromptSessions(),
+        getActiveSideChatSessions,
         getActiveDelegatedSessions,
         hasActiveReviewerWork: () => reviewerModelRuntimeShutdown?.hasActiveWork() ?? false,
         settingsService
@@ -4082,6 +4090,7 @@ const createApplicationModules = async (
     detectActiveSessions: () =>
       detectActiveSessions({
         runtime: { getActivePromptSessions: () => runtime.getQuitBlockingPromptSessions() },
+        sideChat: { getActivePromptSessions: getActiveSideChatSessions },
         delegated: { getActiveDelegatedSessions },
         notebook: notebookService
       }),

--- a/src/main/lifecycle-shutdown.test.ts
+++ b/src/main/lifecycle-shutdown.test.ts
@@ -188,6 +188,32 @@ describe('BackendShutdownCoordinator', () => {
     })
   })
 
+  it('keeps waiting for a hung runtime when Side Chat suspension fails first', async () => {
+    vi.useFakeTimers()
+    const deps = makeDeps({
+      runtime: {
+        shutdownForQuit: vi.fn(async () => ({ reaped: true })),
+        shutdownForUpdateGate: vi.fn(() => new Promise<never>(() => {}))
+      },
+      sideChat: {
+        shutdown: vi.fn(async () => undefined),
+        suspendAll: vi.fn(async () => Promise.reject(new Error('save failed')))
+      }
+    })
+    const coordinator = new BackendShutdownCoordinator(deps)
+
+    const pending = coordinator.runForUpdateGate(25)
+    let settled = false
+    void pending.then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(24)
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(pending).resolves.toEqual({ completed: false, reaped: false })
+  })
+
   it('reports completed:false (and reaped:false) when the gate teardown exceeds its budget', async () => {
     vi.useFakeTimers()
     const deps = makeDeps({

--- a/src/main/lifecycle-shutdown.test.ts
+++ b/src/main/lifecycle-shutdown.test.ts
@@ -18,6 +18,10 @@ const makeDeps = (overrides: Partial<BackendShutdownDeps> = {}): BackendShutdown
     shutdownAll: vi.fn(async () => ({ reaped: true })),
     dispose: vi.fn(async () => ({ reaped: true }))
   },
+  sideChat: {
+    shutdown: vi.fn(async () => undefined),
+    suspendAll: vi.fn(async () => undefined)
+  },
   log: { error: vi.fn() },
   ...overrides
 })
@@ -137,7 +141,13 @@ describe('BackendShutdownCoordinator', () => {
   })
 
   it('runForUpdateGate uses the non-latching teardown', async () => {
-    const deps = makeDeps()
+    const suspendAll = vi.fn(async () => undefined)
+    const deps = makeDeps({
+      sideChat: {
+        shutdown: vi.fn(async () => undefined),
+        suspendAll
+      }
+    })
     const coordinator = new BackendShutdownCoordinator(deps)
 
     const outcome = await coordinator.runForUpdateGate()
@@ -146,6 +156,7 @@ describe('BackendShutdownCoordinator', () => {
     expect(deps.runtime.shutdownForUpdateGate).toHaveBeenCalledTimes(1)
     expect(deps.runtime.shutdownForQuit).not.toHaveBeenCalled()
     expect(deps.notebook.shutdownAll).toHaveBeenCalledTimes(1)
+    expect(suspendAll).toHaveBeenCalledOnce()
   })
 
   it('reports reaped:false when a tree kill was degraded', async () => {
@@ -160,6 +171,21 @@ describe('BackendShutdownCoordinator', () => {
     const outcome = await coordinator.runForUpdateGate()
 
     expect(outcome).toEqual({ completed: true, reaped: false })
+  })
+
+  it('refuses a handoff when Side Chat suspension cannot persist its conversation', async () => {
+    const deps = makeDeps({
+      sideChat: {
+        shutdown: vi.fn(async () => undefined),
+        suspendAll: vi.fn(async () => Promise.reject(new Error('save failed')))
+      }
+    })
+    const coordinator = new BackendShutdownCoordinator(deps)
+
+    await expect(coordinator.runForUpdateGate()).resolves.toEqual({
+      completed: true,
+      reaped: false
+    })
   })
 
   it('reports completed:false (and reaped:false) when the gate teardown exceeds its budget', async () => {

--- a/src/main/lifecycle-shutdown.test.ts
+++ b/src/main/lifecycle-shutdown.test.ts
@@ -159,6 +159,25 @@ describe('BackendShutdownCoordinator', () => {
     expect(suspendAll).toHaveBeenCalledOnce()
   })
 
+  it('holds Side Chat admission for a data-root handoff', async () => {
+    const suspendAll = vi.fn(async () => undefined)
+    const deps = makeDeps({
+      sideChat: {
+        shutdown: vi.fn(async () => undefined),
+        suspendAll
+      }
+    })
+    const coordinator = new BackendShutdownCoordinator(deps)
+
+    await expect(
+      coordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS, {
+        holdSideChatAdmission: true
+      })
+    ).resolves.toEqual({ completed: true, reaped: true })
+
+    expect(suspendAll).toHaveBeenCalledWith({ holdAdmission: true })
+  })
+
   it('reports reaped:false when a tree kill was degraded', async () => {
     const deps = makeDeps({
       notebook: {

--- a/src/main/lifecycle-shutdown.ts
+++ b/src/main/lifecycle-shutdown.ts
@@ -67,8 +67,14 @@ const withSideChatShutdown = async (
   runtimeTeardown: Promise<{ reaped: boolean }>,
   sideChatTeardown: Promise<void>
 ): Promise<{ reaped: boolean }> => {
-  const [runtimeOutcome] = await Promise.all([runtimeTeardown, sideChatTeardown])
-  return runtimeOutcome
+  const [runtimeResult, sideChatResult] = await Promise.allSettled([
+    runtimeTeardown,
+    sideChatTeardown
+  ])
+  if (runtimeResult.status === 'rejected') throw runtimeResult.reason
+  return {
+    reaped: runtimeResult.value?.reaped === true && sideChatResult.status === 'fulfilled'
+  }
 }
 
 // Normal quit/relaunch budget: keep it short so a stuck backend can't hang quit.

--- a/src/main/lifecycle-shutdown.ts
+++ b/src/main/lifecycle-shutdown.ts
@@ -59,7 +59,7 @@ export type BackendShutdownDeps = QuitShutdownDeps & {
   sideChat: {
     shutdown: () => Promise<void>
     // Reusable Side Chat suspension for handoffs that may leave the current app running.
-    suspendAll: () => Promise<void>
+    suspendAll: (options?: { holdAdmission?: boolean }) => Promise<void>
   }
 }
 
@@ -195,11 +195,14 @@ export class BackendShutdownCoordinator {
     )
   }
 
-  runForUpdateGate(budgetMs: number = UPDATE_SHUTDOWN_BUDGET_MS): Promise<ShutdownOutcome> {
+  runForUpdateGate(
+    budgetMs: number = UPDATE_SHUTDOWN_BUDGET_MS,
+    options: { holdSideChatAdmission?: boolean } = {}
+  ): Promise<ShutdownOutcome> {
     return runBounded(
       withSideChatShutdown(
         this.deps.runtime.shutdownForUpdateGate(),
-        this.deps.sideChat.suspendAll()
+        this.deps.sideChat.suspendAll({ holdAdmission: options.holdSideChatAdmission === true })
       ),
       this.deps.notebook.shutdownAll(),
       budgetMs,

--- a/src/main/lifecycle-shutdown.ts
+++ b/src/main/lifecycle-shutdown.ts
@@ -1,8 +1,8 @@
-// Coordinates a bounded, best-effort shutdown of the app's backend subsystems (agent runtime and
-// notebook kernels). Kept free of Electron imports so it stays trivially unit-testable: callers inject
-// the runtime/notebook handles. Every operation is time-bounded so app quit can never hang on a backend
-// that refuses to settle, and reports { reaped } so the update-install gate can tell a clean teardown
-// (all process trees gone, file handles released) from a degraded one (taskkill fell back to the parent).
+// Coordinates a bounded, best-effort shutdown of the app's backend subsystems (main/Side Chat agent
+// runtimes and notebook kernels). Kept free of Electron imports so it stays trivially unit-testable:
+// callers inject the runtime handles. Every operation is time-bounded so app quit can never hang on a
+// backend that refuses to settle, and reports { reaped } so the update-install gate can tell a clean
+// teardown (all process trees gone, file handles released) from a degraded one.
 
 import { diagnosticErrorFields, type Logger } from './logger'
 
@@ -56,6 +56,19 @@ export type BackendShutdownDeps = QuitShutdownDeps & {
     // Reusable kernel teardown for update checks that may leave the current app running.
     shutdownAll: () => Promise<{ reaped: boolean }>
   }
+  sideChat: {
+    shutdown: () => Promise<void>
+    // Reusable Side Chat suspension for handoffs that may leave the current app running.
+    suspendAll: () => Promise<void>
+  }
+}
+
+const withSideChatShutdown = async (
+  runtimeTeardown: Promise<{ reaped: boolean }>,
+  sideChatTeardown: Promise<void>
+): Promise<{ reaped: boolean }> => {
+  const [runtimeOutcome] = await Promise.all([runtimeTeardown, sideChatTeardown])
+  return runtimeOutcome
 }
 
 // Normal quit/relaunch budget: keep it short so a stuck backend can't hang quit.
@@ -155,8 +168,8 @@ export const shutdownBackends = async (deps: QuitShutdownDeps): Promise<void> =>
   )
 }
 
-// Single shared owner of backend teardown, used by BOTH the before-quit handler and the pre-update-install
-// gate so the two paths agree on the backend handles. The two entry points differ deliberately:
+// Single shared owner of backend teardown, used by BOTH the before-quit handler and the
+// pre-update-install gate so the two paths agree on the backend handles. The two entry points differ:
 //   - runForQuit uses the LATCHING runtime teardown and a short budget (the app is going down regardless).
 //   - runForUpdateGate uses the NON-LATCHING runtime teardown and a longer budget, so a degraded teardown
 //     can be refused without wedging a runtime that must keep serving the still-open app.
@@ -169,7 +182,7 @@ export class BackendShutdownCoordinator {
     budgetMs: number = this.deps.timeoutMs ?? QUIT_SHUTDOWN_BUDGET_MS
   ): Promise<ShutdownOutcome> {
     return runBounded(
-      this.deps.runtime.shutdownForQuit(),
+      withSideChatShutdown(this.deps.runtime.shutdownForQuit(), this.deps.sideChat.shutdown()),
       this.deps.notebook.dispose(),
       budgetMs,
       this.deps.log
@@ -178,7 +191,10 @@ export class BackendShutdownCoordinator {
 
   runForUpdateGate(budgetMs: number = UPDATE_SHUTDOWN_BUDGET_MS): Promise<ShutdownOutcome> {
     return runBounded(
-      this.deps.runtime.shutdownForUpdateGate(),
+      withSideChatShutdown(
+        this.deps.runtime.shutdownForUpdateGate(),
+        this.deps.sideChat.suspendAll()
+      ),
       this.deps.notebook.shutdownAll(),
       budgetMs,
       this.deps.log

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -1778,7 +1778,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     expect(String(sent[1]?.historyPreamble)).not.toContain('Failed follow-up')
   })
 
-  it('keeps durable state and provider data when app shutdown interrupts a turn', async () => {
+  it('keeps durable state and remains reusable when a handoff suspends a turn', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-shutdown-'))
     const persistence = createPersistence()
     let runtimeOptions: AcpRuntimeOptions | undefined
@@ -1807,6 +1807,11 @@ describe('SideChatRuntimeOwner lifecycle', () => {
             sessionId: 'provider-shutdown',
             frameworkId: 'claude-code' as const
           })),
+          resumeSession: vi.fn(async () => ({
+            sessionId: 'provider-shutdown',
+            providerSessionId: 'provider-shutdown',
+            frameworkId: 'claude-code' as const
+          })),
           sendPrompt: vi.fn((request: { sessionId: string }) => {
             runtimeOptions!.callbacks?.onProviderPromptAccepted?.(request.sessionId)
             return turn
@@ -1824,7 +1829,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       projectId: 'project-1',
       text: 'Still running'
     })
-    await owner.shutdown()
+    await owner.suspendAll()
 
     expect(cancelPrompt).toHaveBeenCalledWith({ sessionId: 'provider-shutdown' })
     expect(deleteSession).not.toHaveBeenCalled()
@@ -1848,6 +1853,11 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     await expect(
       stat(join(temporaryRoot, 'runtime-support', 'side-chat', started.sideSessionId))
     ).resolves.toBeDefined()
+
+    await expect(
+      owner.send({ sideSessionId: started.sideSessionId, text: 'Continue after handoff' })
+    ).resolves.toBeUndefined()
+    await owner.close({ sideSessionId: started.sideSessionId })
   })
 
   it('waits for dormant activation and blocks prompt admission during app shutdown', async () => {

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -1873,6 +1873,89 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     await owner.close({ sideSessionId: started.sideSessionId })
   })
 
+  it('waits for an admitted prompt before completing handoff suspension', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-handoff-dispatch-'))
+    const persistence = createPersistence()
+    const followUpSave = deferred<void>()
+    let blockedFollowUpSave = false
+    persistence.save.mockImplementation(async (input) => {
+      if (
+        !blockedFollowUpSave &&
+        input.sideChat.entries.some(
+          (entry) => entry.kind === 'message' && entry.text === 'Admitted before handoff'
+        )
+      ) {
+        blockedFollowUpSave = true
+        await followUpSave.promise
+      }
+      return input.sideChat
+    })
+
+    let runtimeOptions: AcpRuntimeOptions | undefined
+    const followUpTurn = deferred<{ stopReason: 'cancelled' }>()
+    let promptCount = 0
+    const sendPrompt = vi.fn((request: { sessionId: string }) => {
+      promptCount += 1
+      runtimeOptions!.callbacks?.onProviderPromptAccepted?.(request.sessionId)
+      if (promptCount === 1) return Promise.resolve({ stopReason: 'end_turn' as const })
+      return followUpTurn.promise
+    })
+    const owner = new SideChatRuntimeOwner({
+      appVersion: '0.11.0',
+      configRoot: temporaryRoot,
+      captureTarget: vi.fn(async () => target),
+      resolveTarget: vi.fn(async () => backend(claudeCodeFramework)),
+      relay: createRelayOwner(),
+      persistence,
+      onEvent: vi.fn(),
+      createRuntime: (options) => {
+        runtimeOptions = options
+        return {
+          createSession: vi.fn(async () => ({
+            sessionId: 'provider-handoff-dispatch',
+            frameworkId: 'claude-code' as const
+          })),
+          sendPrompt,
+          cancelPrompt: vi.fn(async () => {
+            followUpTurn.resolve({ stopReason: 'cancelled' })
+            return { stopReason: 'cancelled' as const }
+          }),
+          deleteSession: vi.fn(async () => ({ sessionIds: [] })),
+          respondToPermission: vi.fn(async () => undefined),
+          shutdownForQuit: vi.fn(async () => undefined)
+        } as never
+      }
+    })
+
+    const started = await owner.start({
+      parentSessionId: 'main-handoff-dispatch',
+      projectId: 'project-1',
+      text: 'Initial question'
+    })
+    await vi.waitFor(() => expect(owner.list().chats[0]?.running).toBe(false))
+
+    const send = owner.send({
+      sideSessionId: started.sideSessionId,
+      text: 'Admitted before handoff'
+    })
+    await vi.waitFor(() => expect(blockedFollowUpSave).toBe(true))
+    const suspension = owner.suspendAll({ holdAdmission: true })
+    followUpSave.resolve()
+    await expect(send).rejects.toThrow('Side chat is shutting down.')
+    await suspension
+    expect(sendPrompt).toHaveBeenCalledOnce()
+    expect(persistence.save).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sideChat: expect.objectContaining({
+          lifecycle: 'interrupted',
+          entries: expect.arrayContaining([
+            expect.objectContaining({ text: 'Admitted before handoff' })
+          ])
+        })
+      })
+    )
+  })
+
   it('waits for dormant activation and blocks prompt admission during app shutdown', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-shutdown-resume-'))
     const resumed = deferred<{

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -1865,7 +1865,10 @@ describe('SideChatRuntimeOwner lifecycle', () => {
 
     await owner.suspendAll()
     await expect(
-      owner.send({ sideSessionId: started.sideSessionId, text: 'Continue after ordinary suspension' })
+      owner.send({
+        sideSessionId: started.sideSessionId,
+        text: 'Continue after ordinary suspension'
+      })
     ).resolves.toBeUndefined()
     await owner.close({ sideSessionId: started.sideSessionId })
   })

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -1778,7 +1778,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     expect(String(sent[1]?.historyPreamble)).not.toContain('Failed follow-up')
   })
 
-  it('keeps durable state and remains reusable when a handoff suspends a turn', async () => {
+  it('keeps durable state and blocks prompt admission until a handoff is released', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-shutdown-'))
     const persistence = createPersistence()
     let runtimeOptions: AcpRuntimeOptions | undefined
@@ -1829,7 +1829,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       projectId: 'project-1',
       text: 'Still running'
     })
-    await owner.suspendAll()
+    await owner.suspendAll({ holdAdmission: true })
 
     expect(cancelPrompt).toHaveBeenCalledWith({ sessionId: 'provider-shutdown' })
     expect(deleteSession).not.toHaveBeenCalled()
@@ -1855,7 +1855,17 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     ).resolves.toBeDefined()
 
     await expect(
+      owner.send({ sideSessionId: started.sideSessionId, text: 'Blocked during handoff' })
+    ).rejects.toThrow('Side chat is shutting down.')
+
+    owner.resumeAfterHandoff()
+    await expect(
       owner.send({ sideSessionId: started.sideSessionId, text: 'Continue after handoff' })
+    ).resolves.toBeUndefined()
+
+    await owner.suspendAll()
+    await expect(
+      owner.send({ sideSessionId: started.sideSessionId, text: 'Continue after ordinary suspension' })
     ).resolves.toBeUndefined()
     await owner.close({ sideSessionId: started.sideSessionId })
   })

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -288,6 +288,7 @@ class SideChatRuntimeOwner {
   private readonly pausedParents = new Set<string>()
   private revision = 0
   private shuttingDown = false
+  private suspension: Promise<void> | undefined
 
   constructor(private readonly options: SideChatRuntimeOwnerOptions) {
     this.root = join(options.configRoot, 'runtime-support', 'side-chat')
@@ -370,7 +371,7 @@ class SideChatRuntimeOwner {
   }
 
   async start(request: SideChatRuntimeStartRequest): Promise<SideChatStartResponse> {
-    if (this.shuttingDown) throw new Error('Side chat is shutting down.')
+    if (this.shuttingDown || this.suspension) throw new Error('Side chat is shutting down.')
     if (this.invalidatedParents.has(request.parentSessionId)) {
       throw new Error('The parent Session is unavailable.')
     }
@@ -747,8 +748,23 @@ class SideChatRuntimeOwner {
     }
   }
 
-  async shutdown(): Promise<void> {
+  suspendAll(): Promise<void> {
+    if (this.suspension) return this.suspension
+    const suspension = this.drainActive()
+    this.suspension = suspension
+    const clear = (): void => {
+      if (this.suspension === suspension) this.suspension = undefined
+    }
+    void suspension.then(clear, clear)
+    return suspension
+  }
+
+  shutdown(): Promise<void> {
     this.shuttingDown = true
+    return this.suspendAll()
+  }
+
+  private async drainActive(): Promise<void> {
     const failures: unknown[] = []
     const settle = async (operations: readonly Promise<unknown>[]): Promise<void> => {
       const results = await Promise.allSettled(operations)
@@ -776,7 +792,7 @@ class SideChatRuntimeOwner {
   ): Promise<void> {
     const text = requirePromptText(request.text)
     const active = await this.ensureActive(request.sideSessionId)
-    if (this.shuttingDown) throw new Error('Side chat is shutting down.')
+    if (this.shuttingDown || this.suspension) throw new Error('Side chat is shutting down.')
     if (active.turn || active.running) throw new Error('A Side chat prompt is already running.')
     await this.flushQueuedPersistence(active)
     let historyPreamble = request.historyPreamble
@@ -885,7 +901,7 @@ class SideChatRuntimeOwner {
   }
 
   private async activateDormant(dormant: DormantSideChat): Promise<ActiveSideChat> {
-    if (this.shuttingDown) throw new Error('Side chat is shutting down.')
+    if (this.shuttingDown || this.suspension) throw new Error('Side chat is shutting down.')
     const sideChat = dormant.sideChat
     const jobRoot = join(this.root, sideChat.id)
     const cwd = join(jobRoot, 'cwd')

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -282,6 +282,7 @@ class SideChatRuntimeOwner {
   private readonly dormantByParent = new Map<string, DormantSideChat>()
   private readonly startingByParent = new Map<string, StartingSideChat>()
   private readonly closingByParent = new Map<string, Promise<void>>()
+  private readonly dispatches = new Set<Promise<void>>()
   private readonly closeRequestedParents = new Set<string>()
   private readonly invalidatedParents = new Set<string>()
   private readonly invalidatedProjects = new Set<string>()
@@ -561,7 +562,13 @@ class SideChatRuntimeOwner {
   }
 
   send(request: SideChatPromptRequest & Readonly<{ historyPreamble?: string }>): Promise<void> {
-    return this.dispatch(request)
+    const dispatch = this.dispatch(request)
+    this.dispatches.add(dispatch)
+    const finish = (): void => {
+      this.dispatches.delete(dispatch)
+    }
+    void dispatch.then(finish, finish)
+    return dispatch
   }
 
   parentFor(
@@ -783,12 +790,14 @@ class SideChatRuntimeOwner {
         if (result.status === 'rejected') failures.push(result.reason)
       }
     }
+    const dispatches = [...this.dispatches]
     const starting = [...this.startingByParent.values()]
     const activating = [...this.dormantByParent.values()]
       .map((dormant) => dormant.activating)
       .filter((activation): activation is Promise<ActiveSideChat> => Boolean(activation))
     for (const chat of starting) this.closeRequestedParents.add(chat.parentSessionId)
     await settle(this.activeChats().map((active) => this.suspendActive(active)))
+    await Promise.allSettled(dispatches)
     await Promise.all(activating.map((activation) => activation.catch(() => undefined)))
     await settle(starting.map((chat) => chat.done.promise))
     await settle(this.activeChats().map((active) => this.suspendActive(active)))
@@ -803,9 +812,10 @@ class SideChatRuntimeOwner {
   ): Promise<void> {
     const text = requirePromptText(request.text)
     const active = await this.ensureActive(request.sideSessionId)
-    if (this.isAdmissionSuspended()) throw new Error('Side chat is shutting down.')
+    this.assertDispatchActive(active)
     if (active.turn || active.running) throw new Error('A Side chat prompt is already running.')
     await this.flushQueuedPersistence(active)
+    this.assertDispatchActive(active)
     let historyPreamble = request.historyPreamble
     let needsReplay = active.needsReplay === true
     if (needsReplay) {
@@ -814,6 +824,7 @@ class SideChatRuntimeOwner {
     while (active.reconnect) {
       const reconnect = active.reconnect
       await reconnect
+      this.assertDispatchActive(active)
       if (active.reconnect !== reconnect) continue
       const resumed = await active.runtime.resumeSession({
         sessionId: active.runtimeSessionId,
@@ -826,6 +837,7 @@ class SideChatRuntimeOwner {
         previousFrameworkId: active.frameworkId,
         ...(active.backendId ? { previousBackendId: active.backendId } : {})
       })
+      this.assertDispatchActive(active)
       this.applyProviderIdentity(active, resumed)
       this.syncBridgeScopes(active)
       if (active.reconnect === reconnect) active.reconnect = undefined
@@ -835,6 +847,7 @@ class SideChatRuntimeOwner {
         historyPreamble = buildResumeFallback(active)
       }
       await this.persistActive(active, 'open')
+      this.assertDispatchActive(active)
     }
     const resumeFallback = buildResumeFallback(active)
     active.entrySequence += 1
@@ -858,6 +871,7 @@ class SideChatRuntimeOwner {
       this.touch(active)
       throw error
     }
+    this.assertDispatchActive(active)
     const accepted = deferred()
     active.turnAccepted = accepted
     const turn = active.runtime.sendPrompt({
@@ -1098,6 +1112,16 @@ class SideChatRuntimeOwner {
 
   private isAdmissionSuspended(): boolean {
     return this.shuttingDown || Boolean(this.suspension) || this.handoffAdmissionHeld
+  }
+
+  private assertDispatchActive(active: ActiveSideChat): void {
+    if (
+      this.isAdmissionSuspended() ||
+      active.closing ||
+      this.activeByParent.get(active.parentSessionId) !== active
+    ) {
+      throw new Error('Side chat is shutting down.')
+    }
   }
 
   private applyProviderIdentity(
@@ -1512,7 +1536,9 @@ class SideChatRuntimeOwner {
 
   private async suspendActive(
     active: ActiveSideChat,
-    lifecycle: PersistedSideChat['lifecycle'] = active.turn ? 'interrupted' : 'open'
+    lifecycle: PersistedSideChat['lifecycle'] = active.turn || active.running
+      ? 'interrupted'
+      : 'open'
   ): Promise<void> {
     const existing = this.closingByParent.get(active.parentSessionId)
     if (existing) return existing

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -289,6 +289,9 @@ class SideChatRuntimeOwner {
   private revision = 0
   private shuttingDown = false
   private suspension: Promise<void> | undefined
+  // Data-root handoffs keep admission closed after the drain completes; the existing abort path
+  // releases it only when the old root is authoritative again.
+  private handoffAdmissionHeld = false
 
   constructor(private readonly options: SideChatRuntimeOwnerOptions) {
     this.root = join(options.configRoot, 'runtime-support', 'side-chat')
@@ -371,7 +374,7 @@ class SideChatRuntimeOwner {
   }
 
   async start(request: SideChatRuntimeStartRequest): Promise<SideChatStartResponse> {
-    if (this.shuttingDown || this.suspension) throw new Error('Side chat is shutting down.')
+    if (this.isAdmissionSuspended()) throw new Error('Side chat is shutting down.')
     if (this.invalidatedParents.has(request.parentSessionId)) {
       throw new Error('The parent Session is unavailable.')
     }
@@ -748,15 +751,23 @@ class SideChatRuntimeOwner {
     }
   }
 
-  suspendAll(): Promise<void> {
+  suspendAll(options: { holdAdmission?: boolean } = {}): Promise<void> {
+    if (options.holdAdmission) this.handoffAdmissionHeld = true
     if (this.suspension) return this.suspension
     const suspension = this.drainActive()
     this.suspension = suspension
     const clear = (): void => {
       if (this.suspension === suspension) this.suspension = undefined
     }
-    void suspension.then(clear, clear)
+    void suspension.then(clear, () => {
+      clear()
+      this.handoffAdmissionHeld = false
+    })
     return suspension
+  }
+
+  resumeAfterHandoff(): void {
+    if (!this.shuttingDown) this.handoffAdmissionHeld = false
   }
 
   shutdown(): Promise<void> {
@@ -792,7 +803,7 @@ class SideChatRuntimeOwner {
   ): Promise<void> {
     const text = requirePromptText(request.text)
     const active = await this.ensureActive(request.sideSessionId)
-    if (this.shuttingDown || this.suspension) throw new Error('Side chat is shutting down.')
+    if (this.isAdmissionSuspended()) throw new Error('Side chat is shutting down.')
     if (active.turn || active.running) throw new Error('A Side chat prompt is already running.')
     await this.flushQueuedPersistence(active)
     let historyPreamble = request.historyPreamble
@@ -901,7 +912,7 @@ class SideChatRuntimeOwner {
   }
 
   private async activateDormant(dormant: DormantSideChat): Promise<ActiveSideChat> {
-    if (this.shuttingDown || this.suspension) throw new Error('Side chat is shutting down.')
+    if (this.isAdmissionSuspended()) throw new Error('Side chat is shutting down.')
     const sideChat = dormant.sideChat
     const jobRoot = join(this.root, sideChat.id)
     const cwd = join(jobRoot, 'cwd')
@@ -1083,6 +1094,10 @@ class SideChatRuntimeOwner {
       this.dormantByParent.set(dormant.parentSessionId, dormant)
       throw error
     }
+  }
+
+  private isAdmissionSuspended(): boolean {
+    return this.shuttingDown || Boolean(this.suspension) || this.handoffAdmissionHeld
   }
 
   private applyProviderIdentity(

--- a/src/main/storage/command-owner.atomicity.test.ts
+++ b/src/main/storage/command-owner.atomicity.test.ts
@@ -95,6 +95,7 @@ describe('storage command owner onboarding persistence', () => {
         getActiveNotebookSessions: vi.fn().mockReturnValue([])
       },
       getActivePromptSessions: vi.fn().mockReturnValue([]),
+      getActiveSideChatSessions: vi.fn().mockReturnValue([]),
       getActiveDelegatedSessions: vi.fn().mockReturnValue([]),
       hasActiveReviewerWork: vi.fn().mockReturnValue(false),
       settingsService: {

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -78,6 +78,7 @@ type StorageCommandOwnerDeps = {
     getActiveNotebookSessions: () => NotebookSessionSource[]
   }
   getActivePromptSessions: () => LegacySessionSource[]
+  getActiveSideChatSessions: () => LegacySessionSource[]
   getActiveDelegatedSessions: () => LegacySessionSource[]
   hasActiveReviewerWork: () => boolean
   settingsService: {
@@ -342,6 +343,7 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   const detectActive = (): ActiveSessionInfo[] =>
     detectActiveSessions({
       runtime: { getActivePromptSessions: deps.getActivePromptSessions },
+      sideChat: { getActivePromptSessions: deps.getActiveSideChatSessions },
       delegated: { getActiveDelegatedSessions: deps.getActiveDelegatedSessions },
       // Call as a method (arrow wrapper), never a bare reference: the real notebook service is a
       // class whose getActiveNotebookSessions reads `this.sessions`, so extracting it loose would

--- a/src/main/storage/detect-active.test.ts
+++ b/src/main/storage/detect-active.test.ts
@@ -39,6 +39,7 @@ describe('detectActiveSessions', () => {
   it('tags runtime prompts as agent and notebook sessions as notebook', () => {
     const result = detectActiveSessions({
       runtime: { getActivePromptSessions: () => [{ projectId: 'p', sessionId: 's1' }] },
+      sideChat: { getActivePromptSessions: () => [] },
       delegated: {
         getActiveDelegatedSessions: () => [{ projectId: 'p', sessionId: 'delegated-1' }]
       },
@@ -53,9 +54,10 @@ describe('detectActiveSessions', () => {
     ])
   })
 
-  it('returns an empty array when both sources are idle', () => {
+  it('returns an empty array when all sources are idle', () => {
     const result = detectActiveSessions({
       runtime: { getActivePromptSessions: () => [] },
+      sideChat: { getActivePromptSessions: () => [] },
       delegated: { getActiveDelegatedSessions: () => [] },
       notebook: { getActiveNotebookSessions: () => [] }
     })
@@ -63,10 +65,26 @@ describe('detectActiveSessions', () => {
     expect(result).toEqual([])
   })
 
+  it('includes a running Side Chat in active Session detection', () => {
+    const sources = {
+      runtime: { getActivePromptSessions: () => [] },
+      delegated: { getActiveDelegatedSessions: () => [] },
+      notebook: { getActiveNotebookSessions: () => [] },
+      sideChat: {
+        getActivePromptSessions: () => [{ projectId: 'p', sessionId: 'side-chat-parent' }]
+      }
+    }
+
+    expect(detectActiveSessions(sources)).toEqual([
+      { projectId: 'p', sessionId: 'side-chat-parent', kind: 'agent' }
+    ])
+  })
+
   it('deduplicates root and delegated agent work for the same Session', () => {
     const source = { projectId: 'p', sessionId: 's1' }
     const result = detectActiveSessions({
       runtime: { getActivePromptSessions: () => [source] },
+      sideChat: { getActivePromptSessions: () => [source] },
       delegated: { getActiveDelegatedSessions: () => [source] },
       notebook: { getActiveNotebookSessions: () => [{ projectId: 'p', sessionId: 's1' }] }
     })
@@ -82,6 +100,7 @@ describe('detectActiveSessions', () => {
     const detect = (): ReturnType<typeof detectActiveSessions> =>
       detectActiveSessions({
         runtime: { getActivePromptSessions: () => [] },
+        sideChat: { getActivePromptSessions: () => [] },
         delegated,
         notebook: { getActiveNotebookSessions: () => [] }
       })

--- a/src/main/storage/detect-active.ts
+++ b/src/main/storage/detect-active.ts
@@ -1,7 +1,7 @@
-// Aggregates the authoritative sources of "actively running" sessions (an in-flight root prompt,
-// delegated Attempt, or notebook cell mid-execution) so the storage-migration and close/quit flows can warn
-// the user before interrupting them. Pure function driven by structural deps so tests can pass fakes
-// without constructing the real runtimes.
+// Aggregates the authoritative sources of "actively running" sessions (an in-flight root or Side Chat
+// prompt, delegated Attempt, or notebook cell mid-execution) so the storage-migration and close/quit flows
+// can warn the user before interrupting them. Pure function driven by structural deps so tests can pass
+// fakes without constructing the real runtimes.
 
 import type { ActiveSessionInfo } from '../../shared/storage'
 import { hasCurrentRunningDelegatedAttempt } from '../../shared/delegated-work-projection'
@@ -14,6 +14,7 @@ type ActiveNotebookSessionSource = { projectId: string; sessionId: string }
 
 type ActiveDetectionDeps = {
   runtime: { getActivePromptSessions(): LegacyActiveSessionSource[] }
+  sideChat: { getActivePromptSessions(): LegacyActiveSessionSource[] }
   delegated: { getActiveDelegatedSessions(): LegacyActiveSessionSource[] }
   notebook: { getActiveNotebookSessions(): ActiveNotebookSessionSource[] }
 }
@@ -41,28 +42,34 @@ const createDelegatedActivityProjection = (): DelegatedActivityProjection => {
   }
 }
 
-// Delegated work supersedes a root-agent row for the same Session because it carries the stronger
-// hard-blocking policy. Notebook work remains distinct, so a Session can still appear once as
-// delegated/agent and once as notebook.
+const sessionKey = (entry: LegacyActiveSessionSource): string =>
+  JSON.stringify([entry.projectId, entry.sessionId])
+
+// Delegated work supersedes an agent row for the same Session because it carries the stronger
+// hard-blocking policy. Root and Side Chat prompts share one agent row for their parent Session.
+// Notebook work remains distinct, so a Session can still appear once as delegated/agent and once as
+// notebook.
 export const detectActiveSessions = (deps: ActiveDetectionDeps): ActiveSessionInfo[] => {
   const delegatedSessions = deps.delegated.getActiveDelegatedSessions()
-  const delegatedKeys = new Set(
-    delegatedSessions.map((entry) => JSON.stringify([entry.projectId, entry.sessionId]))
+  const delegatedKeys = new Set(delegatedSessions.map(sessionKey))
+  const agentSessions = new Map(
+    [...deps.runtime.getActivePromptSessions(), ...deps.sideChat.getActivePromptSessions()].map(
+      (entry) => [sessionKey(entry), entry] as const
+    )
   )
-  const rootSessions = deps.runtime
-    .getActivePromptSessions()
-    .filter((entry) => !delegatedKeys.has(JSON.stringify([entry.projectId, entry.sessionId])))
   return [
     ...delegatedSessions.map((entry): ActiveSessionInfo => ({
       projectId: entry.projectId,
       sessionId: entry.sessionId,
       kind: 'delegated'
     })),
-    ...rootSessions.map((entry): ActiveSessionInfo => ({
-      projectId: entry.projectId,
-      sessionId: entry.sessionId,
-      kind: 'agent'
-    })),
+    ...[...agentSessions.entries()]
+      .filter(([key]) => !delegatedKeys.has(key))
+      .map(([, entry]): ActiveSessionInfo => ({
+        projectId: entry.projectId,
+        sessionId: entry.sessionId,
+        kind: 'agent'
+      })),
     ...deps.notebook.getActiveNotebookSessions().map((entry) => ({
       projectId: entry.projectId,
       sessionId: entry.sessionId,

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -120,6 +120,7 @@ const fakeDeps = (overrides: Partial<FakeDeps> = {}): FakeDeps => ({
     getActiveNotebookSessions: vi.fn().mockReturnValue([])
   },
   getActivePromptSessions: vi.fn().mockReturnValue([]),
+  getActiveSideChatSessions: vi.fn().mockReturnValue([]),
   getActiveDelegatedSessions: vi.fn().mockReturnValue([]),
   hasActiveReviewerWork: vi.fn().mockReturnValue(false),
   settingsService: {
@@ -689,9 +690,12 @@ describe('storage IPC handlers', () => {
     expect(info.dataRootMissing).toBe(true)
   })
 
-  it('detect-active maps runtime and notebook session sources into ActiveSessionInfo', async () => {
+  it('detect-active maps agent, Side Chat, delegated, and notebook sources', async () => {
     const deps = fakeDeps({
       getActivePromptSessions: vi.fn().mockReturnValue([{ projectId: 'p', sessionId: 'agent-1' }]),
+      getActiveSideChatSessions: vi
+        .fn()
+        .mockReturnValue([{ projectId: 'p', sessionId: 'side-chat-parent' }]),
       getActiveDelegatedSessions: vi
         .fn()
         .mockReturnValue([{ projectId: 'p', sessionId: 'delegated-1' }]),
@@ -706,6 +710,7 @@ describe('storage IPC handlers', () => {
     await expect(invoke('storage:detect-active')).resolves.toEqual([
       { projectId: 'p', sessionId: 'delegated-1', kind: 'delegated' },
       { projectId: 'p', sessionId: 'agent-1', kind: 'agent' },
+      { projectId: 'p', sessionId: 'side-chat-parent', kind: 'agent' },
       { projectId: 'p', sessionId: 'nb-1', kind: 'notebook' }
     ])
   })

--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -95,6 +95,22 @@ describe('createUpdateStrategy', () => {
     expect(quitAndInstall).toHaveBeenCalledWith(true, true)
   })
 
+  it('forwards update handoff cleanup to the in-place strategy', async () => {
+    const releaseInstallHandoff = vi.fn()
+    quitAndInstall.mockImplementationOnce(() => {
+      throw new Error('installer unavailable')
+    })
+    const strategy = createUpdateStrategy('win32', {
+      installGate: vi.fn(async () => ({ completed: true, reaped: true })),
+      releaseInstallHandoff
+    })
+    updaterListeners.get('update-downloaded')?.()
+
+    await strategy.apply()
+
+    expect(releaseInstallHandoff).toHaveBeenCalledOnce()
+  })
+
   it('uses ElectronUpdaterStrategy on darwin for a packaged stable build', () => {
     expect(createUpdateStrategy('darwin', { isPackaged: true, version: '1.2.3' })).toBeInstanceOf(
       ElectronUpdaterStrategy

--- a/src/main/update/create-strategy.ts
+++ b/src/main/update/create-strategy.ts
@@ -17,6 +17,7 @@ export type CreateStrategyOptions = {
   // Immutable pre-install backend shutdown gate for in-place strategies. The manual installer flow
   // ignores it because applying there does not quit or replace the running app.
   installGate?: InstallGate
+  releaseInstallHandoff?: () => void
   translate?: NativeTranslator
 }
 
@@ -60,6 +61,7 @@ export const createUpdateStrategy = (
   const createInPlaceStrategy = (): ElectronUpdaterStrategy =>
     new ElectronUpdaterStrategy({
       ...(opts.installGate ? { installGate: opts.installGate } : {}),
+      ...(opts.releaseInstallHandoff ? { releaseInstallHandoff: opts.releaseInstallHandoff } : {}),
       log
     })
 

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -709,15 +709,18 @@ describe('ElectronUpdaterStrategy', () => {
     expect(updater.quitAndInstall).toHaveBeenCalledWith(true, false)
   })
 
-  it('rolls back the update shutdown trigger when quitAndInstall throws', async () => {
+  it('rolls back the update handoff when quitAndInstall throws', async () => {
     const updater = new FakeUpdater()
+    const releaseInstallHandoff = vi.fn()
     updater.quitAndInstall.mockImplementation(() => {
       throw new Error('installer unavailable')
     })
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
-      broadcast: vi.fn()
+      broadcast: vi.fn(),
+      installGate: vi.fn(async () => ({ completed: true, reaped: true })),
+      releaseInstallHandoff
     })
     markUpdateReady(updater)
 
@@ -726,6 +729,7 @@ describe('ElectronUpdaterStrategy', () => {
     expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true)
     expect(status.state).toBe('error')
     expect(currentApplicationShutdownTrigger()).toBe('quit')
+    expect(releaseInstallHandoff).toHaveBeenCalledOnce()
   })
 
   it('apply runs the install gate before quitAndInstall when the teardown is clean', async () => {
@@ -866,12 +870,14 @@ describe('ElectronUpdaterStrategy', () => {
   it('apply refuses to install and reports an error when the teardown times out', async () => {
     const updater = new FakeUpdater()
     const gate = vi.fn(async () => ({ completed: false, reaped: false }))
+    const releaseInstallHandoff = vi.fn()
     const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
       installGate: gate,
+      releaseInstallHandoff,
       log
     })
     markUpdateReady(updater)
@@ -879,6 +885,7 @@ describe('ElectronUpdaterStrategy', () => {
     const status = await strategy.apply()
 
     expect(updater.quitAndInstall).not.toHaveBeenCalled()
+    expect(releaseInstallHandoff).toHaveBeenCalledOnce()
     expect(status.state).toBe('error')
     expect(diagnosticRecords(log)).toEqual(
       expect.arrayContaining([
@@ -950,11 +957,14 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('restores an actionable error after the installer handoff starts', async () => {
     const updater = new FakeUpdater()
+    const releaseInstallHandoff = vi.fn()
     const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
+      installGate: vi.fn(async () => ({ completed: true, reaped: true })),
+      releaseInstallHandoff,
       log
     })
     markUpdateReady(updater)
@@ -966,6 +976,7 @@ describe('ElectronUpdaterStrategy', () => {
     expect(strategy.getStatus().state).toBe('error')
     expect(strategy.getStatus().error).toBe('installer failed')
     expect(currentApplicationShutdownTrigger()).toBe('quit')
+    expect(releaseInstallHandoff).toHaveBeenCalledOnce()
     expect(diagnosticRecords(log)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -64,6 +64,8 @@ export type ElectronUpdaterDeps = {
   manifestUrl?: string
   // Pre-install backend-shutdown gate, fixed when the strategy is constructed.
   installGate?: InstallGate
+  // Releases resources the install gate may have held when the installer handoff is aborted.
+  releaseInstallHandoff?: () => void
   // Diagnostics sink for update lifecycle operations; defaults to a no-op so unit tests stay quiet.
   log?: Logger
   // Marks the app lifecycle handoff immediately before quitAndInstall. Injectable for tests.
@@ -202,6 +204,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private pendingInstallRollback?: () => void
   // Pre-install backend-shutdown gate, owned immutably for the strategy lifetime.
   private readonly installGate?: InstallGate
+  private readonly releaseInstallHandoff: () => void
   private readonly markUpdateShutdown: () => () => void
 
   constructor(deps: ElectronUpdaterDeps = {}) {
@@ -229,6 +232,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.log = deps.log ?? NOOP_LOGGER
     this.createCancellationToken = deps.createCancellationToken ?? (() => new CancellationToken())
     this.installGate = deps.installGate
+    this.releaseInstallHandoff = deps.releaseInstallHandoff ?? (() => undefined)
     this.markUpdateShutdown =
       deps.markUpdateShutdown ?? (() => markApplicationShutdownTrigger('update'))
     this.status = { state: 'idle', current: this.currentVersion, applyKind: 'restart' }
@@ -312,6 +316,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       if (this.installerStarted) {
         this.pendingInstallRollback?.()
         this.pendingInstallRollback = undefined
+        this.releaseAbortedInstallHandoff()
         const operation = startDiagnosticOperation(this.log, {
           operation: 'update-installer',
           fields: { strategy: 'in-place' }
@@ -327,6 +332,14 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         error: err instanceof Error ? err.message : 'Update error'
       })
     })
+  }
+
+  private releaseAbortedInstallHandoff(): void {
+    try {
+      this.releaseInstallHandoff()
+    } catch (error) {
+      this.log.warn('update install handoff cleanup failed', error)
+    }
   }
 
   // Always re-stamps current + applyKind so every broadcast status is self-consistent regardless of
@@ -545,6 +558,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       try {
         readiness = await this.installGate()
       } catch (error) {
+        this.releaseAbortedInstallHandoff()
         this.log.error('update install gate failed', error)
         this.applying = false
         this.setStatus({
@@ -556,10 +570,12 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         return this.status
       }
       if (!this.applying) {
+        this.releaseAbortedInstallHandoff()
         operation.cancel({ reason: 'apply-interrupted' })
         return this.status
       }
       if (!readiness.completed || !readiness.reaped) {
+        this.releaseAbortedInstallHandoff()
         this.log.error('update install gate refused: backend teardown degraded', readiness)
         this.applying = false
         this.setStatus({
@@ -593,6 +609,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     } catch (error) {
       rollbackTrigger()
       this.pendingInstallRollback = undefined
+      this.releaseAbortedInstallHandoff()
       this.applying = false
       this.installerStarted = false
       this.setStatus({


### PR DESCRIPTION
## Problem

Side Chat owns an independent runtime and can be generating a reply while the main Agent, delegated work, Notebook, and Reviewer are idle. Its running state was not included in `detectActiveSessions`, so an ordinary quit treated the app as idle, skipped the existing confirmation, and interrupted the Side Chat turn during shutdown.

The existing shutdown path persists generated transcript content with an `interrupted` lifecycle, but the in-flight inference is still cancelled without advance notice.

## Proposed change

- Project Side Chat snapshots whose existing `running` flag is true into parent Session identities.
- Add those identities to the shared active-session aggregator as existing `agent` rows.
- Deduplicate root Agent and Side Chat work for the same parent Session, while preserving delegated work's stronger blocking policy.
- Feed the same projection to quit/close, storage migration, update, and archive activity checks.

## Scope and non-goals

- No second confirmation system or Side Chat-specific dialog.
- No new `ActiveSessionInfo.kind` value or other enum state.
- No new persisted field, database migration, lifecycle value, or serialized-format change.
- No historical-data compatibility work is required.
- No ACP method, event, provider adapter, model path, or protocol behavior changes; all Side Chat frameworks use the same runtime-owner snapshot.

## Acceptance criteria and validation

The regression test was added before the production fix and run three times on the unfixed code:

`npm test -- src/main/storage/detect-active.test.ts -t 'includes a running Side Chat in active Session detection'`

Each run failed deterministically because the detector returned `[]` instead of the Side Chat parent Session, matching the reported missing-confirmation condition.

Final evidence after the last material edit:

- Side Chat-only active detection and source deduplication -> `npm test -- src/main/storage/detect-active.test.ts` -> 5 passed.
- Storage IPC exposes the Side Chat parent Session through the existing contract -> focused storage IPC regression -> passed.
- Quit/confirmation behavior, storage detection, and Side Chat shutdown persistence -> `npm test -- src/main/storage/detect-active.test.ts src/main/storage/ipc.test.ts src/main/storage/command-owner.atomicity.test.ts src/main/side-chat/runtime-owner.test.ts src/main/app-lifecycle.test.ts src/main/window-close-confirm.test.ts` -> 6 files, 267 tests passed.
- Main-process and sandbox types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed with one pre-existing Prettier warning in unchanged `scripts/ci/module-impact-shadow.test.ts`.
- Diff hygiene -> `git diff --check` -> passed.

`npm run test:affected:explain -- --base origin/main --head HEAD` selects the full fallback because `src/main/ipc.ts` has no declared module owner. Per maintainer instruction, the complete local `npm test` suite was not run; PR CI is authoritative for the remaining portable and platform lanes.

## Review focus

- Confirm that `running` Side Chat snapshots are the correct authority and dormant/open-but-idle Side Chats remain non-blocking.
- Confirm mapping Side Chat work to the existing parent Session `agent` row is preferable to expanding the shared enum and renderer surfaces.
- Confirm the shared aggregation coverage for quit, migration, update, and archive gates is appropriate.
