### PR TITLE
fix(ci): check PR formatting from the merge-base

### DIFF
--- a/packages/notebook-network-sandbox/runtime/src/notebook-runtime.ts
+++ b/packages/notebook-network-sandbox/runtime/src/notebook-runtime.ts
@@ -164,6 +164,7 @@ const initialize = async (config: NetworkRuntimeConfig, ask: NetworkAskCallback)
 const wrap = async (
   request: NetworkWrapRequest
 ): Promise<{ argv: string[]; env: NodeJS.ProcessEnv }> => {
+  if (finishing.size > 0) await Promise.allSettled([...finishing])
   const config = runtimeConfig
   if (!config) throw new Error('Notebook process runtime is not initialized.')
   const filesystem = normalizeFilesystemLayout({

--- a/packages/notebook-network-sandbox/runtime/src/platform/macos-isolation.ts
+++ b/packages/notebook-network-sandbox/runtime/src/platform/macos-isolation.ts
@@ -1,4 +1,5 @@
 import { homedir, tmpdir } from 'node:os'
+import { basename } from 'node:path'
 
 import { findExecutable } from './executable.js'
 import {
@@ -75,11 +76,24 @@ const seatbeltProfile = (request: MacLaunchRequest): string => {
   return rules.join('\n')
 }
 
+const shellArguments = (shell: string, command: string): readonly string[] => {
+  const name = basename(shell).toLowerCase()
+  if (name === 'bash' || name === 'bash.exe' || name === 'zsh' || name === 'zsh.exe') {
+    return [shell, '--noprofile', '--norc', '-c', command]
+  }
+  return [shell, '-c', command]
+}
+
 const macosLaunch = (request: MacLaunchRequest): { argv: string[]; env: NodeJS.ProcessEnv } => {
   const shell = findExecutable(request.shell, request.env.PATH)
   if (!shell) throw new Error(`Notebook sandbox shell is not executable: ${request.shell}`)
   return {
-    argv: ['/usr/bin/sandbox-exec', '-p', seatbeltProfile(request), shell, '-c', request.command],
+    argv: [
+      '/usr/bin/sandbox-exec',
+      '-p',
+      seatbeltProfile(request),
+      ...shellArguments(shell, request.command)
+    ],
     env: {
       ...request.env,
       ...proxyEnvironment(request.gatewayPort, request.gatewayCredentials)

--- a/packages/notebook-network-sandbox/runtime/src/platform/macos-isolation.ts
+++ b/packages/notebook-network-sandbox/runtime/src/platform/macos-isolation.ts
@@ -78,8 +78,11 @@ const seatbeltProfile = (request: MacLaunchRequest): string => {
 
 const shellArguments = (shell: string, command: string): readonly string[] => {
   const name = basename(shell).toLowerCase()
-  if (name === 'bash' || name === 'bash.exe' || name === 'zsh' || name === 'zsh.exe') {
+  if (name === 'bash' || name === 'bash.exe') {
     return [shell, '--noprofile', '--norc', '-c', command]
+  }
+  if (name === 'zsh' || name === 'zsh.exe') {
+    return [shell, '-d', '-f', '-c', command]
   }
   return [shell, '-c', command]
 }

--- a/packages/notebook-network-sandbox/src/filesystem-policy.test.ts
+++ b/packages/notebook-network-sandbox/src/filesystem-policy.test.ts
@@ -1,4 +1,12 @@
-import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -73,42 +81,52 @@ describe('Notebook filesystem policy', () => {
     expect(profile).not.toContain('(deny system-socket')
   })
 
+  const expectMacosShellLaunch = (shell: string, extraFlags: readonly string[]): void => {
+    const root = mkdtempSync(join(tmpdir(), 'open-science-shell-rc-'))
+    const workspace = join(root, 'workspace')
+    mkdirSync(workspace)
+
+    try {
+      const launch = macosLaunch({
+        command: '/usr/bin/curl --silent http://example.com/',
+        gatewayPort: 4312,
+        gatewayCredentials: { username: 'command', password: 'secret' },
+        shell,
+        env: { PATH: '/usr/bin:/bin' },
+        filesystem: {
+          privateRoot: root,
+          readOnlyRoots: ['/bin', '/usr/bin'],
+          readWriteRoots: [workspace],
+          deniedReadRoots: [],
+          deniedWriteRoots: []
+        }
+      })
+
+      expect(launch.argv).toEqual([
+        '/usr/bin/sandbox-exec',
+        '-p',
+        expect.any(String),
+        shell,
+        ...extraFlags,
+        '-c',
+        '/usr/bin/curl --silent http://example.com/'
+      ])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+
   it.skipIf(process.platform === 'win32')(
     'launches bash without reading profile or rc files',
     () => {
-      const root = mkdtempSync(join(tmpdir(), 'open-science-bash-rc-'))
-      const workspace = join(root, 'workspace')
-      mkdirSync(workspace)
+      expectMacosShellLaunch('/bin/bash', ['--noprofile', '--norc'])
+    }
+  )
 
-      try {
-        const launch = macosLaunch({
-          command: '/usr/bin/curl --silent http://example.com/',
-          gatewayPort: 4312,
-          gatewayCredentials: { username: 'command', password: 'secret' },
-          shell: '/bin/bash',
-          env: { PATH: '/usr/bin:/bin' },
-          filesystem: {
-            privateRoot: root,
-            readOnlyRoots: ['/bin', '/usr/bin'],
-            readWriteRoots: [workspace],
-            deniedReadRoots: [],
-            deniedWriteRoots: []
-          }
-        })
-
-        expect(launch.argv).toEqual([
-          '/usr/bin/sandbox-exec',
-          '-p',
-          expect.any(String),
-          '/bin/bash',
-          '--noprofile',
-          '--norc',
-          '-c',
-          '/usr/bin/curl --silent http://example.com/'
-        ])
-      } finally {
-        rmSync(root, { recursive: true, force: true })
-      }
+  it.skipIf(process.platform === 'win32' || !existsSync('/bin/zsh'))(
+    'launches zsh without reading profile or rc files',
+    () => {
+      expectMacosShellLaunch('/bin/zsh', ['-d', '-f'])
     }
   )
 

--- a/packages/notebook-network-sandbox/src/filesystem-policy.test.ts
+++ b/packages/notebook-network-sandbox/src/filesystem-policy.test.ts
@@ -8,7 +8,7 @@ import {
   hiddenByFilesystemLayout,
   normalizeFilesystemLayout
 } from '../runtime/src/platform/filesystem-layout.js'
-import { seatbeltProfile } from '../runtime/src/platform/macos-isolation.js'
+import { macosLaunch, seatbeltProfile } from '../runtime/src/platform/macos-isolation.js'
 import { linuxLaunch } from '../runtime/src/platform/linux-isolation.js'
 import { ViolationLog } from '../runtime/src/gateway/violation-log.js'
 
@@ -69,8 +69,48 @@ describe('Notebook filesystem policy', () => {
         absolutePhysicalPath('/tmp/open-science-notebook.sock')
       )}))`
     )
+    expect(profile).toContain('(allow network-outbound (remote ip "localhost:3128"))')
     expect(profile).not.toContain('(deny system-socket')
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'launches bash without reading profile or rc files',
+    () => {
+      const root = mkdtempSync(join(tmpdir(), 'open-science-bash-rc-'))
+      const workspace = join(root, 'workspace')
+      mkdirSync(workspace)
+
+      try {
+        const launch = macosLaunch({
+          command: '/usr/bin/curl --silent http://example.com/',
+          gatewayPort: 4312,
+          gatewayCredentials: { username: 'command', password: 'secret' },
+          shell: '/bin/bash',
+          env: { PATH: '/usr/bin:/bin' },
+          filesystem: {
+            privateRoot: root,
+            readOnlyRoots: ['/bin', '/usr/bin'],
+            readWriteRoots: [workspace],
+            deniedReadRoots: [],
+            deniedWriteRoots: []
+          }
+        })
+
+        expect(launch.argv).toEqual([
+          '/usr/bin/sandbox-exec',
+          '-p',
+          expect.any(String),
+          '/bin/bash',
+          '--noprofile',
+          '--norc',
+          '-c',
+          '/usr/bin/curl --silent http://example.com/'
+        ])
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('turns native permission failures into an actionable structured violation', () => {
     const log = new ViolationLog()

--- a/packages/notebook-network-sandbox/src/runtime-config.test.ts
+++ b/packages/notebook-network-sandbox/src/runtime-config.test.ts
@@ -85,6 +85,40 @@ describe('Notebook runtime configuration updates', () => {
     expect(gateway.resetConnections).toHaveBeenCalledOnce()
   })
 
+  it('opens the next command only after the previous gateway has closed', async () => {
+    let releaseClose: (() => void) | undefined
+    gateway.close.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseClose = resolve
+        })
+    )
+
+    try {
+      NotebookNetworkRuntime.cleanupAfterCommand('command-1')
+      const wrapping = NotebookNetworkRuntime.wrap({
+        command: 'curl https://example.com',
+        commandId: 'command-2',
+        cwd: '/workspace',
+        env: {},
+        filesystem: {
+          readOnlyRoots: ['/usr/bin'],
+          readWriteRoots: ['/workspace'],
+          deniedReadRoots: [],
+          deniedWriteRoots: []
+        }
+      })
+
+      expect(CommandGateway.open).toHaveBeenCalledTimes(1)
+      expect(releaseClose).toBeTypeOf('function')
+      releaseClose?.()
+      await wrapping
+      expect(CommandGateway.open).toHaveBeenCalledTimes(2)
+    } finally {
+      releaseClose?.()
+    }
+  })
+
   it('forwards inherited file descriptors to the Linux isolation launcher', async () => {
     await NotebookNetworkRuntime.reset()
     vi.clearAllMocks()

--- a/scripts/ci/check-changed-format.mjs
+++ b/scripts/ci/check-changed-format.mjs
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -12,6 +13,24 @@ export function selectFormattingPaths(paths, kind) {
     const markdown = /\.mdx?$/i.test(path)
     return kind === 'markdown' ? markdown : !markdown
   })
+}
+
+export function changedFormattingPaths(
+  base,
+  head,
+  kind,
+  { execute = execFileSync, exists = existsSync } = {}
+) {
+  // Classify the pull request's own files (merge-base...head). Two-dot base..head
+  // also includes later main commits, including paths already deleted from the tree.
+  const mergeBase = execute('git', ['merge-base', base, head], { encoding: 'utf8' }).trim()
+  if (!/^[0-9a-f]{40}$/i.test(mergeBase)) {
+    throw new Error('Unable to resolve a merge-base commit for formatting checks')
+  }
+  const diff = execute('git', ['diff', '--name-only', '--diff-filter=ACMR', '-z', mergeBase, head])
+  return selectFormattingPaths(diff.toString('utf8').split('\0').filter(Boolean), kind).filter(
+    (path) => exists(path)
+  )
 }
 
 function argumentValue(arguments_, name) {
@@ -26,12 +45,14 @@ function requireCommit(value, name) {
   return value
 }
 
-export function runChangedFormatCli(arguments_ = process.argv.slice(2)) {
+export function runChangedFormatCli(
+  arguments_ = process.argv.slice(2),
+  { execute = execFileSync, exists = existsSync } = {}
+) {
   const base = requireCommit(argumentValue(arguments_, '--base'), '--base')
   const head = requireCommit(argumentValue(arguments_, '--head'), '--head')
   const kind = argumentValue(arguments_, '--kind')
-  const diff = execFileSync('git', ['diff', '--name-only', '--diff-filter=ACMR', '-z', base, head])
-  const paths = selectFormattingPaths(diff.toString('utf8').split('\0').filter(Boolean), kind)
+  const paths = changedFormattingPaths(base, head, kind, { execute, exists })
 
   if (paths.length === 0) {
     process.stdout.write(`No changed ${kind} files require formatting checks.\n`)

--- a/scripts/ci/check-changed-format.test.ts
+++ b/scripts/ci/check-changed-format.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { selectFormattingPaths } from './check-changed-format.mjs'
+import { changedFormattingPaths, selectFormattingPaths } from './check-changed-format.mjs'
 
 describe('changed-file formatting selection', () => {
   it('separates Markdown from other Prettier-supported candidates', () => {
@@ -10,6 +10,37 @@ describe('changed-file formatting selection', () => {
     expect(selectFormattingPaths(paths, 'non-markdown')).toEqual([
       'src/main/index.ts',
       'assets/icon.bin'
+    ])
+  })
+
+  it('formats the merge-base diff and skips files missing from the work tree', () => {
+    const base = 'b'.repeat(40)
+    const head = 'c'.repeat(40)
+    const mergeBase = 'a'.repeat(40)
+    const execute = vi.fn((command, arguments_) => {
+      expect(command).toBe('git')
+      if (arguments_[0] === 'merge-base') return `${mergeBase}\n`
+      return Buffer.from(
+        ['README.md', 'src/main/index.ts', 'src/main/session-artifact-file-resolver.ts'].join(
+          '\0'
+        ) + '\0'
+      )
+    })
+    const exists = (path: string): boolean => path !== 'src/main/session-artifact-file-resolver.ts'
+
+    expect(changedFormattingPaths(base, head, 'non-markdown', { execute, exists })).toEqual([
+      'src/main/index.ts'
+    ])
+    expect(execute).toHaveBeenNthCalledWith(1, 'git', ['merge-base', base, head], {
+      encoding: 'utf8'
+    })
+    expect(execute).toHaveBeenNthCalledWith(2, 'git', [
+      'diff',
+      '--name-only',
+      '--diff-filter=ACMR',
+      '-z',
+      mergeBase,
+      head
     ])
   })
 })

--- a/scripts/ci/module-impact-shadow.test.ts
+++ b/scripts/ci/module-impact-shadow.test.ts
@@ -221,7 +221,9 @@ describe('module impact shadow', () => {
       '/output',
       expect.stringContaining(`plan=${JSON.stringify(toGitHubOutputPlan(plan))}`)
     )
-    expect(append.mock.calls.find(([path]) => path === '/output')?.[1]).not.toContain('reasonChains')
+    expect(append.mock.calls.find(([path]) => path === '/output')?.[1]).not.toContain(
+      'reasonChains'
+    )
     expect(append).toHaveBeenCalledWith('/summary', expect.stringContaining('Resolved mode'))
   })
 


### PR DESCRIPTION
## Problem

PR Gate on #2030 failed two selected lanes that the startup-exit change did not own:

- **Format** used a two-dot `git diff` of current `main` against the PR tip. Because that branch was not rebased, Prettier received unrelated files from later `main` commits, including deleted paths (`src/main/session-artifact-file-resolver.ts`) and an unformatted line in `scripts/ci/module-impact-shadow.test.ts`.
- **macOS native units** failed `allows a listed destination and blocks it after a live policy update`. The Seatbelt child invoked `/bin/bash -c`, which read `/Users/runner/.bashrc`. That filesystem deny ran before the policy gateway could annotate `OPEN_SCIENCE_NETWORK_DOMAIN_BLOCKED`. Closing the previous command's gateway is also asynchronous, so the next wrap could race the listener.

This PR does not change #2030. After it lands, a re-run of #2030's merge commit will pick up the fixes.

## Proposed change

- Format checks classify `merge-base...head` (the pull request's own files) and skip paths missing from the work tree.
- Reformat the already-landed `reasonChains` assertion so `main` itself is Prettier-clean.
- Launch bash/zsh under Seatbelt with `--noprofile --norc`.
- Wait for in-flight gateway close work before wrapping the next command.

## Scope and non-goals

- No historical-data compatibility requirement.
- No new state or enum values.
- No data-model, relationship, or persisted-format changes.
- No change to PR #2030 (`fix/electron-startup-fatal-exit`).
- Classifier/authority still uses two-dot `base..head` for lane selection; that remains a follow-up. This PR only fixes the format checker and the macOS sandbox failure that blocked #2030.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Format selection uses merge-base and ignores missing work-tree paths -> `npm test -- scripts/ci/check-changed-format.test.ts` -> 1 file passed, 2 tests passed.
- Unformatted `reasonChains` assertion is wrapped -> `npx prettier --check scripts/ci/module-impact-shadow.test.ts` -> passed.
- macOS bash launch omits rc files; next wrap waits for gateway close -> `npm run test:module -- notebook_network_sandbox` -> 12 files passed, 81 tests passed, 1 skipped.
- Changed TypeScript remains valid -> `npm run typecheck:node` -> passed.
- Changed files satisfy ESLint -> `npx eslint` on the edited files -> passed.

The complete Vitest suite and cross-platform packaged behavior were not run locally; PR CI is authoritative for those risks.

## Review focus

- Confirm format checks match GitHub's three-dot PR file list rather than later `main` commits.
- Confirm Seatbelt still uses `localhost` as the only network host (sandbox-exec rejects `127.0.0.1` in `(remote ip ...)`).
- Confirm forced `app.exit` work in #2030 is untouched.

## Uncovered risks

- `classify-pr-changes.mjs` / `module-impact-authority.mjs` still two-dot-diff current `main`, so a stale PR can still select a full Gate plan. That is conservative over-testing, not a false pass.
- The Electron-as-Node launch integration test needs a fully installed `electron` binary; worktree `npm install` skipped that script here. CI installs it.