### PR TITLE
test(module-coverage): cover omitted module behavior

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -101,6 +101,7 @@
           "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts",
           "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx",
           "src/renderer/src/lib/acp/workspace-runtime-event-owner.test.ts",
+          "src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.test.ts",
           "src/renderer/src/lib/acp/workspace-runtime-session-memory.test.ts",
           "src/renderer/src/lib/acp/workspace-runtime-save-as-skill-owner.test.tsx",
           "src/renderer/src/lib/acp/workspace-events.test.ts"
@@ -108,7 +109,10 @@
         "contract": [
           "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.first-output.render.test.tsx"
         ],
-        "consumer": ["src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx"]
+        "consumer": [
+          "src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx",
+          "src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx"
+        ]
       },
       "capabilityOverlays": ["renderer_state"],
       "fallbackCapability": "renderer_view"
@@ -204,6 +208,7 @@
           "src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts",
           "src/renderer/src/pages/workspace/use-side-chat-controller.test.ts",
           "src/renderer/src/pages/workspace/workspace-session-controller.test.ts",
+          "src/renderer/src/pages/workspace/workspace-session-agent-configuration-controller.test.ts",
           "src/renderer/src/pages/workspace/composer-attachment-intake.test.ts",
           "src/renderer/src/pages/workspace/composer-upload-transfer.test.ts",
           "src/renderer/src/pages/workspace/composer/composer-history.test.ts",
@@ -363,7 +368,9 @@
           "src/main/compute/job-deletion-runtime-isolation.test.ts",
           "src/main/compute/harvest-engine.test.ts",
           "src/main/compute/job-notifier.test.ts",
+          "src/main/compute/remote-job-handle.test.ts",
           "src/main/compute/remote-compute-skill.test.ts",
+          "src/renderer/src/lib/compute/WorkspaceComputeRecoveryBridge.render.test.tsx",
           "src/renderer/src/lib/compute/job-analysis-trigger.test.ts",
           "src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx",
           "src/renderer/src/lib/compute/useSessionJobHydration.render.test.tsx"
@@ -511,6 +518,7 @@
           "src/main/settings/provider-runtime-projection.test.ts",
           "src/main/settings/provider-runtime-projection.architecture.test.ts",
           "src/main/settings/xai-oauth.test.ts",
+          "src/main/settings/xai-provider-account-owner.test.ts",
           "src/main/settings/codex-auth.test.ts",
           "src/main/settings/claude-isolated-auth.test.ts",
           "src/main/settings/claude-shared-auth.test.ts",
@@ -590,6 +598,7 @@
           "src/main/settings/provider-error-replay.test.ts",
           "src/main/settings/system-proxy.test.ts",
           "src/main/settings/network-proxy-runtime.test.ts",
+          "src/main/settings/environment-check.test.ts",
           "src/main/settings/environment-check-proxy.test.ts"
         ],
         "contract": [
@@ -634,6 +643,7 @@
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
           "src/main/settings/settings-snapshot-commit-owner.test.ts",
+          "src/main/settings/network-proxy-settings.test.ts",
           "src/main/settings/service.test.ts",
           "src/main/settings/service.providers.test.ts",
           "src/main/settings/service.connectors.test.ts"
@@ -782,6 +792,7 @@
           "src/main/artifacts/provenance-repository.architecture.test.ts",
           "src/main/artifacts/provenance-repository.test.ts",
           "src/main/artifacts/provenance-write-contract.test.ts",
+          "src/main/artifacts/reviewer-turn-file-evidence-reader.test.ts",
           "src/main/artifacts/write-budget-owner.test.ts"
         ],
         "contract": [
@@ -838,6 +849,8 @@
           "src/main/session-persistence/coordinator-contract.test.ts"
         ],
         "consumer": [
+          "src/main/delegation/durable-delegated-work.test.ts",
+          "src/main/delegation/session-record-adapter.test.ts",
           "src/main/session-persistence/artifact-finalization-recovery.integration.test.ts",
           "src/main/session-persistence/deletion-integration.test.ts"
         ]

--- a/src/main/artifacts/provenance-repository.architecture.test.ts
+++ b/src/main/artifacts/provenance-repository.architecture.test.ts
@@ -404,6 +404,7 @@ describe('Artifact Provenance repository architecture', () => {
         'src/main/artifacts/provenance-message-snapshot.test.ts',
         'src/main/artifacts/provenance-repository.architecture.test.ts',
         'src/main/artifacts/provenance-repository.test.ts',
+        'src/main/artifacts/reviewer-turn-file-evidence-reader.test.ts',
         'src/main/artifacts/provenance-write-contract.test.ts',
         'src/main/artifacts/write-budget-owner.test.ts'
       ].sort()

--- a/src/main/compute/concurrency-integration.test.ts
+++ b/src/main/compute/concurrency-integration.test.ts
@@ -458,15 +458,23 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       { sessionId: 'session-1', projectId: 'project-1' }
     )
 
-    // Queue 100 jobs
+    // Seed the already-queued state directly; this test exercises rejection of the next submit,
+    // not the cost of submitting every preceding job through the full service pipeline.
     for (let i = 0; i < 100; i++) {
-      await service.submitJob(
+      await jobRepo.create({
+        allowUnencryptedPersistence: true,
+        id: `queued-${i}`,
         providerId,
-        `job ${i}`,
-        'echo test',
-        {},
-        { sessionId: 'session-1', projectId: 'project-1' }
-      )
+        shape: 'direct_ssh',
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        intent: `job ${i}`,
+        command: 'echo test',
+        commandHash: `hash-${i}`,
+        timeoutSeconds: 60,
+        remoteWorkdir: `~/.openscience/jobs/queued-${i}`,
+        initialStatus: 'queued'
+      })
     }
 
     // 101st job should throw queue_full error
@@ -479,7 +487,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
         { sessionId: 'session-1', projectId: 'project-1' }
       )
     ).rejects.toThrow(/queue is full/)
-  }, 30_000)
+  })
 
   it('dispatches immediately when the queue is full but an active slot is available', async () => {
     const providerId = computeProviderId('test-host')

--- a/src/main/compute/concurrency-integration.test.ts
+++ b/src/main/compute/concurrency-integration.test.ts
@@ -479,7 +479,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
         { sessionId: 'session-1', projectId: 'project-1' }
       )
     ).rejects.toThrow(/queue is full/)
-  })
+  }, 30_000)
 
   it('dispatches immediately when the queue is full but an active slot is available', async () => {
     const providerId = computeProviderId('test-host')

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -1038,6 +1038,8 @@ describe('Session persistence coordinator architecture', () => {
       'src/main/session-persistence/coordinator-contract.test.ts'
     ])
     expect(sessionPersistence.testFiles.consumer).toEqual([
+      'src/main/delegation/durable-delegated-work.test.ts',
+      'src/main/delegation/session-record-adapter.test.ts',
       'src/main/session-persistence/artifact-finalization-recovery.integration.test.ts',
       'src/main/session-persistence/deletion-integration.test.ts'
     ])

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -5996,6 +5996,44 @@ describe('SettingsService: default permission profile', () => {
   })
 })
 
+describe('SettingsService: compatibility projections', () => {
+  it('round-trips provider-scoped Compute bookmarks through the facade', async () => {
+    const service = createService()
+
+    await expect(service.getComputeBookmarks('ssh:cluster')).resolves.toEqual([])
+    await service.setComputeBookmarks('ssh:cluster', ['/scratch/project', '/data/results'])
+
+    await expect(service.getComputeBookmarks('ssh:cluster')).resolves.toEqual([
+      '/scratch/project',
+      '/data/results'
+    ])
+  })
+
+  it('returns and clears the valid legacy granted roots', async () => {
+    await writeFile(
+      join(storageRoot, 'settings.json'),
+      JSON.stringify({
+        version: 1,
+        providers: [],
+        grantedLocalRoots: [
+          { id: 'root-1', path: '/data/project', name: 'Project data', access: 'rw' },
+          { id: 'invalid-root', path: '/data/private', name: 'Private data', access: 'owner' }
+        ]
+      })
+    )
+    const service = createService()
+
+    await expect(service.getGrantedLocalRoots()).resolves.toEqual([
+      { id: 'root-1', path: '/data/project', name: 'Project data', access: 'rw' }
+    ])
+    await service.clearGrantedLocalRoots()
+
+    expect(
+      JSON.parse(await readFile(join(storageRoot, 'settings.json'), 'utf8'))
+    ).not.toHaveProperty('grantedLocalRoots')
+  })
+})
+
 describe('SettingsService: listAgentHomeSkills framework routing', () => {
   // The shared ~/.agents/skills directory is always scanned. The active framework contributes one
   // additional source: ~/.claude/skills for Claude Code or ~/.codex/skills for Codex.

--- a/src/renderer/src/lib/compute/WorkspaceComputeRecoveryBridge.render.test.tsx
+++ b/src/renderer/src/lib/compute/WorkspaceComputeRecoveryBridge.render.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  admitMessage: vi.fn(),
+  error: undefined as string | undefined,
+  retry: vi.fn(),
+  useJobAnalysisEffect: vi.fn()
+}))
+
+vi.mock('@/pages/workspace/workspace-message-queue-controller', () => ({
+  useWorkspaceApplicationMessageAdmission: () => mocks.admitMessage
+}))
+
+vi.mock('./useJobAnalysisEffect', () => ({
+  useJobAnalysisEffect: (options: unknown) => {
+    mocks.useJobAnalysisEffect(options)
+    return { error: mocks.error, retry: mocks.retry }
+  }
+}))
+
+import { WorkspaceComputeRecoveryBridge } from './WorkspaceComputeRecoveryBridge'
+
+afterEach(() => {
+  cleanup()
+  mocks.error = undefined
+  mocks.retry.mockReset()
+  mocks.useJobAnalysisEffect.mockReset()
+})
+
+describe('WorkspaceComputeRecoveryBridge', () => {
+  it('stays hidden while recovery is healthy', () => {
+    render(<WorkspaceComputeRecoveryBridge enabled />)
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(mocks.useJobAnalysisEffect).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true, admitMessage: mocks.admitMessage })
+    )
+  })
+
+  it('surfaces a retryable recovery failure', () => {
+    mocks.error = 'database busy'
+    render(<WorkspaceComputeRecoveryBridge enabled />)
+
+    expect(screen.getByRole('alert').textContent).toContain('Remote job recovery needs attention')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(mocks.retry).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Problem

The module-impact manifest omitted several existing owner and consumer tests, which understated coverage for module-scoped validation. A renderer compute recovery surface also had no direct render coverage, and two SettingsService compatibility projections lacked focused facade tests.

The audit measured all 21 modules independently using each module's declared owner/contract/consumer tests against its owner/interface sources. The most material gaps were in session persistence, the settings facade, artifact provenance, and workspace runtime.

## Proposed change

- Register omitted existing tests for workspace runtime/page, compute, provider accounts, backend resolution, settings facade, artifact provenance, and session persistence.
- Add direct render coverage for `WorkspaceComputeRecoveryBridge`, including its healthy and retryable-error states.
- Add SettingsService facade coverage for provider-scoped Compute bookmarks and the existing legacy `grantedLocalRoots` read/filter/clear projection.
- Seed the existing 100-job queue integration case through the repository fixture so it tests rejection of the next submit without paying for 100 unrelated full service submissions.
- Keep architecture assertions aligned with the expanded manifest ownership.

Measured coverage changes (lines / branches):

| Module | Before | After |
| --- | ---: | ---: |
| `workspace_runtime` | 90.81% / 79.78% | 93.22% / 82.46% |
| `compute_service` | 88.93% / 78.01% | 89.04% / 78.04% |
| `settings_provider_accounts` | 83.55% / 68.84% | 85.05% / 68.99% |
| `settings_backend_resolution` | 88.27% / 74.34% | 91.05% / 78.26% |
| `settings_service_facade` | 76.74% / 70.04% | 79.63% / 75.11% |
| `artifact_provenance` | 84.25% / 74.82% | 86.83% / 76.28% |
| `session_persistence` | 78.47% / 60.76% | 87.58% / 71.18% |

`workspace_page` remained 86.79% / 80.51%; its change makes an already-executed owner test explicit rather than increasing observed coverage.

## Scope and non-goals

- No production code, API, schema, enum, or persisted data format changes.
- Historical compatibility: the existing `grantedLocalRoots` compatibility projection is now covered, including rejecting invalid legacy entries and removing the field when cleared. This PR does not add or change compatibility behavior.
- State values: no enum/status values are added.
- Persistence: tests exercise existing settings JSON and session persistence behavior; there are no migrations, new stored fields, or persistence logic changes.
- The macOS audit leaves `notebook_network_sandbox` at 73.87% line coverage because `windows-appcontainer.ts` is Windows-only. The module already declares the `windows_sensitive` overlay; Windows CI remains authoritative for that branch.
- No complete local `npm run test` was run, per the requested module-scoped workflow. Changing `module-impact.json` intentionally makes the PR gate select the complete CI suite.

## Acceptance criteria and validation

- All 21 manifest modules were measured independently with V8 coverage.
- Standard module tests passed for:
  - `workspace_runtime` (430 tests)
  - `workspace_page` (736 tests)
  - `compute_service` (1,142 passed, 6 platform-skipped)
  - `settings_provider_accounts` (437 tests)
  - `settings_backend_resolution` (705 passed, 4 skipped)
  - `settings_service_facade` (913 tests)
  - `artifact_provenance` (1,536 tests)
  - `session_persistence` (486 tests)
- `npm test -- src/main/compute/concurrency-integration.test.ts src/main/settings/service.test.ts src/renderer/src/lib/compute/WorkspaceComputeRecoveryBridge.render.test.tsx scripts/ci/module-test-impact.test.ts scripts/ci/validate-module-impact.test.ts --reporter=dot` — 5 files, 323 tests passed.
- `VITEST_DEFER_COVERAGE_THRESHOLDS=1 VITEST_PORTABLE_CI=1 npx vitest run src/main/compute/concurrency-integration.test.ts --coverage --coverage.reporter=text-summary --testTimeout=30000 --reporter=dot` — 16 tests passed in 20.76 seconds; test execution was 11.81 seconds.
- `npm run typecheck:node` — passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed with one pre-existing Prettier warning in `scripts/ci/module-impact-shadow.test.ts`; changed files have no lint warnings.
- `npm run test:affected:explain -- --base origin/main --head HEAD` — full PR CI selected because `module-impact.json` is a global gate input.

## Review focus

- Whether each newly declared test is classified correctly as owner or consumer.
- Whether the focused compatibility tests capture stable existing behavior without implying a new migration commitment.
- Whether the queue-saturation fixture still isolates the intended behavior: the 101st submit is rejected while the queue is already full.
