### PR TITLE
fix(web-service): harden transport boundaries

### DIFF
--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -141,6 +141,28 @@ describe('RemoteSessionPairingManager', () => {
       principalId: expect.any(String),
       isCurrent: expect.any(Function)
     })
+    await expect(
+      manager.webAccess.authorizeWebSocket(
+        request('/api/v1/events', {
+          host: 'home.example.ts.net:4443',
+          cookie: sessionCookie,
+          origin: 'https://home.example.ts.net:4443'
+        }),
+        new URL('https://home.example.ts.net:4443/api/v1/events')
+      )
+    ).resolves.toMatchObject({
+      principalId: expect.any(String),
+      isCurrent: expect.any(Function)
+    })
+    await expect(
+      manager.webAccess.authorizeWebSocket(
+        request('/api/v1/events', {
+          cookie: sessionCookie,
+          origin: 'https://home.example.ts.net:4443'
+        }),
+        new URL('https://home.example.ts.net/api/v1/events')
+      )
+    ).resolves.toBeUndefined()
     expect(manager.trustedViews()).toHaveLength(0)
     expect(changed).toHaveBeenCalled()
   })

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -106,14 +106,30 @@ const pairingCookie = (value: string): string =>
 const clearCookie = (name: string): string =>
   `${name}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0`
 
-const normalizeHost = (host: string | undefined): string | undefined => {
+const normalizeRemoteHost = (
+  host: string | undefined
+): Readonly<{ hostname: string; origin: string }> | undefined => {
   if (!host) return undefined
   try {
-    return new URL(`https://${host}`).hostname.toLowerCase()
+    const parsed = new URL(`https://${host}`)
+    if (
+      parsed.protocol !== 'https:' ||
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== '/' ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return undefined
+    }
+    return { hostname: parsed.hostname.toLowerCase(), origin: parsed.origin }
   } catch {
     return undefined
   }
 }
+
+const normalizeHost = (host: string | undefined): string | undefined =>
+  normalizeRemoteHost(host)?.hostname
 
 const describeBrowser = (userAgent: string | undefined): BrowserDescription => {
   const value = userAgent ?? ''
@@ -402,14 +418,22 @@ export class RemoteSessionPairingManager {
 
   private isExpectedRemoteRequest(request: IncomingMessage, requireOrigin: boolean): boolean {
     if (!this.options.isEnabled()) return false
-    const remoteHost = normalizeHost(request.headers.host)
-    if (!remoteHost || !this.options.isAllowedRemoteHost(remoteHost)) return false
+    const remoteHost = normalizeRemoteHost(request.headers.host)
+    if (!remoteHost || !this.options.isAllowedRemoteHost(remoteHost.hostname)) return false
 
     const origin = request.headers.origin
     if (!origin) return !requireOrigin
     try {
       const parsed = new URL(origin)
-      return parsed.protocol === 'https:' && parsed.hostname.toLowerCase() === remoteHost
+      return (
+        parsed.protocol === 'https:' &&
+        !parsed.username &&
+        !parsed.password &&
+        parsed.pathname === '/' &&
+        !parsed.search &&
+        !parsed.hash &&
+        parsed.origin === remoteHost.origin
+      )
     } catch {
       return false
     }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -828,12 +828,33 @@ describe('startWebHttpServer', () => {
       },
       body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
     })
-    expect(invalidResponse.status).toBe(500)
+    expect(invalidResponse.status).toBe(400)
     expect(await invalidResponse.json()).toEqual({
       protocolVersion: WEB_RPC_PROTOCOL_VERSION,
       ok: false,
       error: { code: 'invalid-command-arguments', message: 'Invalid project request.' }
     })
+
+    for (const [code, expectedStatus] of [
+      ['command-unavailable', 404],
+      ['session-revision-conflict', 409]
+    ] as const) {
+      directInvoke.mockRejectedValueOnce(new ApplicationCommandError(code, `Rejected: ${code}`))
+      const rejectedResponse = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer test-token',
+          'content-type': 'application/json',
+          'x-open-science-client': 'direct-client'
+        },
+        body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+      })
+      expect(rejectedResponse.status).toBe(expectedStatus)
+      expect(await rejectedResponse.json()).toMatchObject({
+        ok: false,
+        error: { code }
+      })
+    }
 
     directInvoke.mockRejectedValueOnce(
       new Error('SQLITE_CANTOPEN: /Users/private/.open-science/open-science.db')
@@ -1981,6 +2002,113 @@ describe('startWebHttpServer', () => {
     ])
     internalSocket.close()
     publicSocket.close()
+  })
+
+  it('closes event sockets with a protocol error when a client sends data', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const socket = new WebSocket(`ws://127.0.0.1:${server.port}/events?token=test-token`)
+    await new Promise<void>((resolve) => socket.once('open', resolve))
+    const closed = new Promise<{ code: number; reason: string } | undefined>((resolve) => {
+      const timeout = setTimeout(() => resolve(undefined), 500)
+      socket.once('close', (code, reason) => {
+        clearTimeout(timeout)
+        resolve({ code, reason: reason.toString() })
+      })
+    })
+
+    socket.send('unexpected inbound data')
+
+    const outcome = await closed
+    if (socket.readyState === WebSocket.OPEN) socket.close()
+    expect(outcome).toEqual({ code: 1002, reason: 'Inbound messages are not supported' })
+  })
+
+  it('rejects event socket messages larger than the inbound payload budget', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const socket = new WebSocket(`ws://127.0.0.1:${server.port}/events?token=test-token`)
+    socket.on('error', () => undefined)
+    await new Promise<void>((resolve) => socket.once('open', resolve))
+    const closed = new Promise<number | undefined>((resolve) => {
+      const timeout = setTimeout(() => resolve(undefined), 500)
+      socket.once('close', (code) => {
+        clearTimeout(timeout)
+        resolve(code)
+      })
+    })
+
+    socket.send(Buffer.alloc(1_025))
+
+    const outcome = await closed
+    if (socket.readyState === WebSocket.OPEN) socket.close()
+    expect(outcome).toBe(1009)
+  })
+
+  it('rejects Web RPC responses larger than the response byte budget', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: {
+        channels: () => ['projects:list'],
+        invoke: vi.fn().mockResolvedValue('x'.repeat(16 * 1024 * 1024))
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+    })
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+      ok: false,
+      error: {
+        code: 'handler_error',
+        message: 'RPC response exceeds the 16 MiB byte budget.'
+      }
+    })
   })
 
   it('exposes only versioned, schema-valid RPC contract channels', async () => {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -57,11 +57,13 @@ const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 // for other authenticated clients. Browser uploads use much smaller 8 MiB chunks in normal use.
 const MAX_CLIENT_IN_FLIGHT_RPC_BODY_BYTES = 64 * 1024 * 1024
 const MAX_SERVER_IN_FLIGHT_RPC_BODY_BYTES = 128 * 1024 * 1024
+const MAX_WEB_RPC_RESPONSE_BYTES = 16 * 1024 * 1024
 const MIN_GZIP_BYTES = 1_024
 const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 const DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS = 10_000
 // The replay stream retains 16 MiB. Keep 64 KiB for its mandatory ready frame and framing overhead.
 const MAX_WEBSOCKET_BUFFERED_BYTES = 16 * 1024 * 1024 + 64 * 1024
+const MAX_WEBSOCKET_INBOUND_BYTES = 1_024
 const TASK_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1_000
 const MAX_TASK_IDEMPOTENCY_ENTRIES = 1_024
 const MAX_TASK_IDEMPOTENCY_BYTES = 64 * 1024 * 1024
@@ -400,6 +402,13 @@ const publicApplicationCommandError = (
     ? toApplicationCommandErrorEnvelope(error)
     : { code: 'command-failed', message: INTERNAL_SERVER_ERROR_MESSAGE }
 
+const applicationCommandErrorStatus = (error: ApplicationCommandError): number => {
+  if (error.code === 'invalid-command-arguments') return 400
+  if (error.code === 'command-unavailable') return 404
+  if (error.code === 'session-revision-conflict') return 409
+  return 500
+}
+
 const sendWebSocketMessage = (socket: WebSocket, message: string): boolean => {
   if (socket.readyState !== WebSocket.OPEN) return false
   if (socket.bufferedAmount + Buffer.byteLength(message) > MAX_WEBSOCKET_BUFFERED_BYTES) {
@@ -453,22 +462,35 @@ export type RunningWebServer = {
   close: () => Promise<void>
 }
 
-const json = (response: ServerResponse, status: number, value: unknown): void => {
-  const content = Buffer.from(
-    JSON.stringify(value ?? null, (_key, child) => {
-      if (child instanceof ArrayBuffer || ArrayBuffer.isView(child)) {
-        const bytes =
-          child instanceof ArrayBuffer
-            ? new Uint8Array(child)
-            : new Uint8Array(child.buffer, child.byteOffset, child.byteLength)
-        return { $binary: Buffer.from(bytes).toString('base64') }
-      }
-      return child
-    })
-  )
+class WebRpcResponseBudgetExceededError extends Error {
+  readonly name = 'WebRpcResponseBudgetExceededError'
+
+  constructor() {
+    super('RPC response exceeds the 16 MiB byte budget.')
+  }
+}
+
+const json = (
+  response: ServerResponse,
+  status: number,
+  value: unknown,
+  maxBytes = Number.POSITIVE_INFINITY
+): void => {
+  const content = JSON.stringify(value ?? null, (_key, child) => {
+    if (child instanceof ArrayBuffer || ArrayBuffer.isView(child)) {
+      const bytes =
+        child instanceof ArrayBuffer
+          ? new Uint8Array(child)
+          : new Uint8Array(child.buffer, child.byteOffset, child.byteLength)
+      return { $binary: Buffer.from(bytes).toString('base64') }
+    }
+    return child
+  })
+  const contentBytes = Buffer.byteLength(content)
+  if (contentBytes > maxBytes) throw new WebRpcResponseBudgetExceededError()
   response.writeHead(status, {
     'content-type': 'application/json; charset=utf-8',
-    'content-length': String(content.byteLength),
+    'content-length': String(contentBytes),
     'cache-control': 'no-store',
     'x-content-type-options': 'nosniff'
   })
@@ -1171,7 +1193,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     options.webClientRetention?.maxClientsPerPrincipal,
     options.webClientRetention?.httpIdleTtlMs
   )
-  const wsServer = new WebSocketServer({ noServer: true })
+  const wsServer = new WebSocketServer({
+    noServer: true,
+    maxPayload: MAX_WEBSOCKET_INBOUND_BYTES
+  })
 
   const isWebSocketAuthorizationCurrent = (socket: WebSocket): boolean => {
     const authorization = externalSockets.get(socket)
@@ -1414,11 +1439,16 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
             callerContext,
             parsed.data.args
           )
-          json(response, 200, {
-            protocolVersion: WEB_RPC_PROTOCOL_VERSION,
-            ok: true,
-            result: result ?? null
-          })
+          json(
+            response,
+            200,
+            {
+              protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+              ok: true,
+              result: result ?? null
+            },
+            MAX_WEB_RPC_RESPONSE_BYTES
+          )
         } catch (error) {
           log.warn('web rpc rejected', {
             channel,
@@ -1430,8 +1460,14 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
             webRpcError(response, 401, 'invalid_request', error.message)
             return
           }
+          if (error instanceof WebRpcResponseBudgetExceededError) {
+            webRpcError(response, 500, 'handler_error', error.message)
+            return
+          }
           const publicError = publicApplicationCommandError(error)
-          webRpcError(response, 500, publicError.code, publicError.message)
+          const status =
+            error instanceof ApplicationCommandError ? applicationCommandErrorStatus(error) : 500
+          webRpcError(response, status, publicError.code, publicError.message)
         } finally {
           request.off('aborted', releaseDisconnectedClient)
           response.off('close', releaseDisconnectedClient)
@@ -1543,6 +1579,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       releaseApprovalPresence?.()
       lease.release()
     })
+    // This is a server-to-client event stream. `ws` performs the protocol close for oversized
+    // messages before emitting `error`; consuming it here prevents an attacker-triggered exception.
+    socket.on('error', () => undefined)
+    socket.on('message', () => socket.close(1002, 'Inbound messages are not supported'))
     socket.on('pong', () => awaitingPong.delete(socket))
     if (url.searchParams.get('liveness') === '1') livenessSockets.add(socket)
     if (url.pathname === '/api/v1/events') {

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -254,7 +254,7 @@ describe('Web bootstrap event connection', () => {
                 message: 'Invalid project request.'
               }
             }),
-            { status: 500, headers: { 'content-type': 'application/json' } }
+            { status: 400, headers: { 'content-type': 'application/json' } }
           )
         }
         throw new Error(`Unexpected fetch: ${String(input)}`)


### PR DESCRIPTION
## Summary

- cap inbound event WebSocket messages at 1 KiB and close read-only streams when clients send data
- cap serialized Web RPC responses at 16 MiB, remove the explicit full-response Buffer copy, and preserve the existing error envelope on overflow
- map application command errors to meaningful HTTP statuses while keeping unclassified failures at 500
- compare normalized remote HTTPS origins including ports

## Regression coverage

The new server and pairing tests were run twice before the production fix. They consistently failed on the reported behavior: inbound WebSocket data remained open, oversized RPC results returned 200, application argument errors returned 500, and a different-origin port was authorized.

After the fix:

- `npx vitest run src/main/web-service/http-server.test.ts src/main/remote-access/pairing.test.ts src/renderer/web/bootstrap.test.ts` — 101 passed
- ESLint on all five changed files — passed
- `npm run typecheck` — passed after generating the Prisma Client required by current main
- Prettier and `git diff --check` — passed

The full `npm test` was also attempted in the original workspace. It remains blocked by unrelated Windows environment failures including missing `py`, symlink `EPERM`, managed-runtime path-budget failures, and their asynchronous cleanup errors; the touched test suites pass independently.