### PR TITLE
fix(workspace): show notebook environment preparation after approval

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -165,10 +165,12 @@ vi.mock('./WorkspaceMessageScroller', () => ({
   WorkspaceMessageScroller: ({
     credentialPending,
     isResumingSession,
+    visiblePermissionPending,
     pendingElicitations = []
   }: {
     credentialPending?: boolean
     isResumingSession?: boolean
+    visiblePermissionPending?: boolean
     pendingElicitations?: unknown[]
   }): React.JSX.Element => (
     <>
@@ -177,6 +179,9 @@ vi.mock('./WorkspaceMessageScroller', () => ({
       ) : null}
       <span data-testid="scroller-pending-elicitations">{pendingElicitations.length}</span>
       <span data-testid="scroller-credential-pending">{String(credentialPending ?? false)}</span>
+      <span data-testid="scroller-visible-permission-pending">
+        {String(visiblePermissionPending ?? false)}
+      </span>
     </>
   )
 }))
@@ -1187,6 +1192,9 @@ describe('ConversationPanel composer intake', () => {
 
     expect(container.querySelector('[data-testid="permission-composer"]')).toBeNull()
     expect(container.querySelector('[data-testid="permission-approval-controls"]')).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="scroller-visible-permission-pending"]')?.textContent
+    ).toBe('true')
     expect(getComposerForm().hidden).toBe(false)
     expect(getComposerEditor().getAttribute('contenteditable')).toBe('true')
   })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1060,6 +1060,7 @@ const ConversationPanel = ({
             <WorkspaceMessageScroller
               activeSession={activeSession}
               credentialPending={pendingCredentialRequest !== undefined}
+              visiblePermissionPending={pendingPermissions.length > 0}
               optimisticMessage={optimisticMessage}
               isResumingSession={isResuming}
               notebookReference={notebookReference}

--- a/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatSession } from '@/stores/session-store'
+import { createInitialNotebookEnvState, useNotebookEnvStore } from '@/stores/notebook-env-store'
 import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
 import { AgentLoadingIndicator } from './WorkspaceAgentLoadingRow'
 
@@ -43,6 +44,7 @@ const seedRunningSession = (startedAgoMs: number, agentStatus?: string): void =>
 beforeEach(() => {
   vi.useFakeTimers()
   vi.setSystemTime(new Date('2026-07-18T00:00:00.000Z'))
+  useNotebookEnvStore.setState(createInitialNotebookEnvState())
   useSessionStore.setState(createInitialSessionState())
   container = document.createElement('div')
   document.body.appendChild(container)
@@ -56,6 +58,51 @@ afterEach(() => {
 })
 
 describe('WorkspaceAgentLoadingRow', () => {
+  it('shows session environment preparation after the approval request is settled', () => {
+    useNotebookEnvStore.setState({
+      progress: {
+        phase: 'create-r',
+        message: 'Creating default-r environment…',
+        progress: 0.45,
+        scope: 'r',
+        sessionId: 's1',
+        language: 'r'
+      }
+    })
+
+    act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="waiting-for-approval" />))
+
+    expect(container.textContent).toContain('Creating default-r environment…')
+    expect(container.textContent).toContain('45%')
+    expect(container.textContent).not.toContain('Waiting for your approval')
+  })
+
+  it('keeps a visible approval request ahead of environment preparation', () => {
+    useNotebookEnvStore.setState({
+      progress: {
+        phase: 'create-r',
+        message: 'Creating default-r environment…',
+        progress: 0.45,
+        scope: 'r',
+        sessionId: 's1',
+        language: 'r'
+      }
+    })
+
+    act(() =>
+      root.render(
+        <AgentLoadingIndicator
+          sessionId="s1"
+          phase="waiting-for-approval"
+          visiblePermissionPending
+        />
+      )
+    )
+
+    expect(container.textContent).toContain('Waiting for your approval')
+    expect(container.textContent).not.toContain('Creating default-r environment…')
+  })
+
   it('starts elapsed time from the Session timeline', () => {
     seedRunningSession(5000)
     act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />))

--- a/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { OpenScienceThinkingIndicator } from '@/components/OpenScienceThinkingIndicator'
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { cn } from '@/lib/utils'
+import { useNotebookEnvStore } from '@/stores/notebook-env-store'
 import { useSessionStore } from '@/stores/session-store'
 import { getAgentThinkingStartedAt, type AgentLoadingPhase } from './agent-loading-message'
 
@@ -11,6 +12,7 @@ type WorkspaceAgentLoadingRowProps = {
   sessionId: string
   phase: Exclude<AgentLoadingPhase, 'hidden'> | 'resuming'
   agentStatus?: string
+  visiblePermissionPending?: boolean
 }
 
 type AgentLoadingIndicatorProps = Omit<WorkspaceAgentLoadingRowProps, 'sessionId'> & {
@@ -78,13 +80,31 @@ const ThinkingLoadingContent = ({
 const AgentLoadingIndicator = ({
   sessionId,
   phase,
-  agentStatus
+  agentStatus,
+  visiblePermissionPending = false
 }: AgentLoadingIndicatorProps): React.JSX.Element => {
   const { t } = useTranslation()
+  const environmentProgress = useNotebookEnvStore((state) => {
+    const progress = state.progress
+    return sessionId &&
+      progress?.sessionId === sessionId &&
+      progress.phase !== 'done' &&
+      progress.phase !== 'error'
+      ? progress
+      : undefined
+  })
 
   return (
     <div className="flex min-h-5 flex-col gap-1" role="status" aria-live="polite">
-      {phase === 'thinking' ? (
+      {environmentProgress && !visiblePermissionPending && phase !== 'waiting-for-response' ? (
+        <div className="flex items-center gap-2 text-xs text-text-000/70">
+          <OpenScienceThinkingIndicator />
+          <span>{environmentProgress.message}</span>
+          <span className="tabular-nums" aria-hidden="true">
+            {Math.round(environmentProgress.progress * 100)}%
+          </span>
+        </div>
+      ) : phase === 'thinking' ? (
         <ThinkingLoadingContent sessionId={sessionId} agentStatus={agentStatus} />
       ) : (
         <div className="flex items-center gap-2 text-xs text-text-000/70">
@@ -108,7 +128,8 @@ const AgentLoadingIndicator = ({
 const WorkspaceAgentLoadingRow = ({
   sessionId,
   phase,
-  agentStatus
+  agentStatus,
+  visiblePermissionPending
 }: WorkspaceAgentLoadingRowProps): React.JSX.Element => (
   <MessageScrollerItem
     key={`${sessionId}-agent-loading`}
@@ -117,7 +138,12 @@ const WorkspaceAgentLoadingRow = ({
   >
     <div className="px-4 pb-1 pt-5 md:px-6">
       <div className={cn(assistantMessageSurfaceClassName, 'px-0 py-2')}>
-        <AgentLoadingIndicator sessionId={sessionId} phase={phase} agentStatus={agentStatus} />
+        <AgentLoadingIndicator
+          sessionId={sessionId}
+          phase={phase}
+          agentStatus={agentStatus}
+          visiblePermissionPending={visiblePermissionPending}
+        />
       </div>
     </div>
   </MessageScrollerItem>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -102,6 +102,7 @@ import type { AnnotationPort } from './annotations/annotation-port'
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
   credentialPending?: boolean
+  visiblePermissionPending?: boolean
   isResumingSession?: boolean
   notebookReference?: NotebookSessionReference
   onSendEditedMessage: SendEditedMessage
@@ -391,6 +392,7 @@ const EditableWorkspaceMessageItem = (
 const WorkspaceMessageScrollerImpl = ({
   activeSession,
   credentialPending = false,
+  visiblePermissionPending = false,
   isResumingSession = false,
   notebookReference,
   onSendEditedMessage,
@@ -1739,12 +1741,19 @@ const WorkspaceMessageScrollerImpl = ({
               {presentationBarrierIndex < 0 ? trailingContent : null}
 
               {isResumingSession && activeSession ? (
-                <WorkspaceAgentLoadingRow sessionId={activeSession.id} phase="resuming" />
+                <WorkspaceAgentLoadingRow
+                  sessionId={activeSession.id}
+                  phase="resuming"
+                  visiblePermissionPending={visiblePermissionPending}
+                />
               ) : agentLoadingPhase !== 'hidden' && activeSession ? (
                 <WorkspaceAgentLoadingRow
                   sessionId={activeSession.id}
                   phase={agentLoadingPhase}
                   agentStatus={activeSession.agentStatus}
+                  visiblePermissionPending={
+                    visiblePermissionPending || activeSession.status === 'waiting-plan-approval'
+                  }
                 />
               ) : null}
             </MessageScrollerContent>
@@ -1872,6 +1881,7 @@ const areWorkspaceMessageScrollerPropsEqual = (
 ): boolean =>
   previous.onSendEditedMessage === next.onSendEditedMessage &&
   (previous.credentialPending ?? false) === (next.credentialPending ?? false) &&
+  (previous.visiblePermissionPending ?? false) === (next.visiblePermissionPending ?? false) &&
   previous.optimisticMessage === next.optimisticMessage &&
   (previous.canBranchInNewSession ?? false) === (next.canBranchInNewSession ?? false) &&
   (previous.reportPresentationRevealing ?? false) === (next.reportPresentationRevealing ?? false) &&


### PR DESCRIPTION
## Problem

After a user approves a Notebook restart, automatic runtime provisioning can already be running (for example, R at `create-r`, 45%) while the conversation footer still says “Waiting for your approval”. The footer projects the coarse Session wait phase but does not consume the existing session-scoped Notebook environment progress.

This creates three related UI concerns:

1. **Stale post-approval label** — occurs when the approval card has settled but the Session projection still reports `waiting-permission` while provisioning starts. If left unchanged, users can reasonably believe their approval was not accepted and may wait or retry unnecessarily.
2. **Missing preparation feedback** — occurs whenever an automatic Notebook provision operation emits session-scoped progress during the active turn. If left unchanged, the Notebook header and conversation footer disagree and the long-running setup appears stuck.
3. **Approval/progress precedence** — a naive progress-first fix could hide a genuinely visible permission, Plan approval, or credential prompt. If left unguarded, the user could miss the action that is actually blocking the run.

## Proposed change

- Render an existing, non-terminal Notebook environment progress message and percentage in the agent loading row when its `sessionId` matches the active conversation.
- Pass whether a real permission request is visibly pending from `ConversationPanel` through `WorkspaceMessageScroller`.
- Keep visible permission requests, Plan approvals, and credential responses ahead of environment progress.
- Add client-rendered regression coverage for both the reported post-approval state and the inverse “real approval still wins” case, plus a consumer wiring assertion.

## Scope and non-goals

- **Interaction:** changes only the loading-row label/percentage and its display precedence.
- **Architecture:** reuses the existing renderer Notebook environment store and the existing panel/scroller/row component boundary. No ACP, IPC, provisioner, or execution-path architecture changes.
- **Data fields / model:** no new runtime data fields, enums, Session statuses, or Notebook provision phases.
- **Persistence / schema:** no database, serialized format, migration, or persisted-state changes.
- **Historical compatibility:** no migration or compatibility handling is required. Historical failed Notebook runs remain unchanged; this fix only changes the live projection while a matching provision operation is non-terminal.
- **Non-goal:** do not rewrite stale historical activity entries or alter permission settlement semantics.

This is worth fixing because the screenshot exposes a direct contradiction at a blocking interaction boundary. The implementation stays presentation-only and reuses authoritative data already emitted by the provisioner; introducing a new state machine or persisted status would be over-design.

## Acceptance criteria and validation

- After approval settles, matching `create-r` progress renders as `Creating default-r environment… 45%` instead of `Waiting for your approval`.
- A permission request that is still visible continues to render `Waiting for your approval` even when matching environment progress exists.
- Plan approval and credential response phases remain blocking UI.
- Progress for another Session is not selected because the existing progress identity is matched by `sessionId`.

Final Test Impact Set (run after the last material edit):

- Loading-row projection, approval precedence, panel-to-scroller wiring, scroller regressions, workspace structural contracts, and i18n guard → `npm test -- src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx src/renderer/src/i18n/resources.test.ts` → **1055 passed**.
- Renderer type contracts → `npm run typecheck:web` → **passed**.
- Linted source → `npm run lint` → **passed with 0 errors** (one existing Prettier warning in unmodified `scripts/ci/module-impact-shadow.test.ts`).
- Impact classifier → `npm run test:affected:explain -- --base main --head HEAD` → conservatively selected the complete Vitest suite because `ConversationPanel.interaction.test.tsx` has no registered module owner. Per task scope, the complete suite was not run locally; exact-head PR Gate is authoritative.

The change is renderer-only. Main-process Notebook/ACP adapter suites, persistence/migration suites, and platform lanes are excluded locally because no protocol, storage, lifecycle, or platform behavior changed. Uncovered locally: a live Electron end-to-end reproduction and the complete portable suite; PR CI covers the exact head.

## Review focus

- Confirm the precedence rule: visible user action first, otherwise matching non-terminal environment progress, otherwise the existing agent phase.
- Confirm that consuming the existing `ProvisionProgress` is sufficient and no new Session state is warranted.
- Confirm the fix remains shared renderer behavior and does not change ACP protocol semantics.
