### PR TITLE
fix(windows): restore hosted full-test suite portability

### DIFF
--- a/packages/notebook-network-sandbox/src/filesystem-policy.test.ts
+++ b/packages/notebook-network-sandbox/src/filesystem-policy.test.ts
@@ -37,8 +37,8 @@ describe('Notebook filesystem policy', () => {
         deniedWriteRoots: []
       })
     ).toMatchObject({
-      readOnlyRoots: [realpathSync(root)],
-      readWriteRoots: [realpathSync(nested)]
+      readOnlyRoots: [absolutePhysicalPath(root)],
+      readWriteRoots: [absolutePhysicalPath(nested)]
     })
   })
 

--- a/resources/notebook/file_evidence_worker.js
+++ b/resources/notebook/file_evidence_worker.js
@@ -18,7 +18,6 @@ const {
   rmSync,
   statSync,
   statfsSync,
-  writeFileSync,
   writeSync
 } = require('node:fs')
 const { join } = require('node:path')
@@ -132,13 +131,22 @@ const readRegularFile = (name, maxBytes) => {
 const readJson = (name, maxBytes = MAX_INTERNAL_JSON_BYTES) =>
   JSON.parse(readRegularFile(name, maxBytes).toString('utf8'))
 const writeExclusiveFile = (name, contents) => {
-  writeFileSync(name, contents, {
-    encoding: 'utf8',
-    flag: constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
-    mode: 0o600
-  })
-  const descriptor = openSync(name, constants.O_RDONLY | constants.O_NOFOLLOW)
+  // Windows FlushFileBuffers requires a writable handle. Reopening the exclusive file with
+  // O_RDONLY makes fsync fail with EPERM even when the file itself is writable — the same
+  // contract as src/main/storage/file-durability.ts.
+  const descriptor = openSync(
+    name,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+    0o600
+  )
   try {
+    const bytes = Buffer.from(contents, 'utf8')
+    let offset = 0
+    while (offset < bytes.length) {
+      const written = writeSync(descriptor, bytes, offset, bytes.length - offset)
+      if (written <= 0) throw new Error('Exclusive file-evidence write made no progress.')
+      offset += written
+    }
     fsyncSync(descriptor)
   } finally {
     closeSync(descriptor)

--- a/scripts/performance/run-runtime-profile.test.ts
+++ b/scripts/performance/run-runtime-profile.test.ts
@@ -19,7 +19,12 @@ appendFileSync(process.env.RUNTIME_PROFILE_INVOCATION_LOG, JSON.stringify(proces
 
     try {
       const environment = Object.fromEntries(
-        Object.entries(process.env).filter(([name]) => name.toLowerCase() !== 'path')
+        Object.entries(process.env).filter(([name]) => {
+          // The launcher must not depend on `npm` being on PATH. Windows still needs PATH so
+          // node.exe can load its DLLs; stripping it hangs spawnSync until the timeout.
+          if (process.platform === 'win32') return true
+          return name.toLowerCase() !== 'path'
+        })
       )
       const result = spawnSync(
         process.execPath,
@@ -39,7 +44,7 @@ appendFileSync(process.env.RUNTIME_PROFILE_INVOCATION_LOG, JSON.stringify(proces
             npm_execpath: npmCliPath,
             RUNTIME_PROFILE_INVOCATION_LOG: invocationLog
           },
-          timeout: 10_000
+          timeout: 30_000
         }
       )
 

--- a/scripts/windows-runtime-cache-uninstall.test.ts
+++ b/scripts/windows-runtime-cache-uninstall.test.ts
@@ -101,7 +101,7 @@ const makeFixture = (): Fixture => {
       .join(';')
   }
   const userIdentity = [env.USERDOMAIN, env.USERNAME].filter(Boolean).join('\\')
-  const managedParent = join(configuredTemp, 'OpenScienceTmp')
+  const managedParent = join(realpathSync.native(configuredTemp), 'OpenScienceTmp')
   const cachePath = micromambaWorkingCachePaths(runtimeRoot, {
     platform: 'win32',
     env

--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -318,8 +318,10 @@ describe('AcpPromptContentOwner', () => {
     expect(snapshotPath).not.toBe(replacedPath)
     await writeFile(replacedPath, 'replaced again after prepare')
     await expect(readFile(snapshotPath)).resolves.toEqual(trustedBytes)
-    expect((await stat(dirname(snapshotPath))).mode & 0o777).toBe(0o700)
-    expect((await stat(snapshotPath)).mode & 0o777).toBe(0o600)
+    if (process.platform !== 'win32') {
+      expect((await stat(dirname(snapshotPath))).mode & 0o777).toBe(0o700)
+      expect((await stat(snapshotPath)).mode & 0o777).toBe(0o600)
+    }
     expect(trustedLease.copyTo).toHaveBeenCalledWith(snapshotPath, { exclusive: true })
     expect(trustedLease.close).toHaveBeenCalledOnce()
 

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -401,7 +401,7 @@ const isDirectRegularFile = (stats: Stats): boolean =>
 const isSameFile = (left: Stats, right: Stats): boolean =>
   left.dev === right.dev && left.ino === right.ino
 
-type OpenCliLauncher = { handle: FileHandle; stats: Stats }
+type OpenCliLauncher = { handle: FileHandle; stats: Stats; closed?: boolean }
 
 // Open only a direct, single-link regular file and verify that the path still resolves to the same
 // inode after opening it. O_NOFOLLOW closes the lstat/open gap on POSIX; the identity checks provide
@@ -543,6 +543,10 @@ const replaceCliLauncher = async (
     ) {
       refuseUnmanagedCliLauncher(plan.target)
     }
+    // NTFS cannot replace a path while this process still holds it open. Identity checks are
+    // complete; close before rename so Windows and POSIX share one publish sequence.
+    await expected.handle.close()
+    expected.closed = true
     await rename(temporaryPath, plan.target)
     published = true
     await defaultFileDurability.syncDirectory(plan.binDir)
@@ -616,7 +620,7 @@ export const installCliLauncher = async (
       await replaceCliLauncher(plan, opened)
       written = true
     } finally {
-      await opened.handle.close()
+      if (!opened.closed) await opened.handle.close()
     }
   }
   if (!written) throw new Error(`The CLI launcher path kept changing: ${plan.target}`)
@@ -642,7 +646,7 @@ export const uninstallCliLauncher = async (
   runCommand: CommandRunner = defaultRunCommand
 ): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
-  const opened = await openStableCliLauncher(plan.target, constants.O_RDONLY)
+  let opened = await openStableCliLauncher(plan.target, constants.O_RDONLY)
   let pathJournal: OpenCliLauncher | undefined
   try {
     if (opened !== undefined) {
@@ -704,6 +708,9 @@ export const uninstallCliLauncher = async (
       if (!isDirectRegularFile(final) || !isSameFile(opened.stats, final)) {
         refuseUnmanagedCliLauncher(plan.target)
       }
+      await opened.handle.close()
+      opened.closed = true
+      opened = undefined
       await rm(plan.target)
     }
   } finally {

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -543,10 +543,14 @@ const replaceCliLauncher = async (
     ) {
       refuseUnmanagedCliLauncher(plan.target)
     }
-    // NTFS cannot replace a path while this process still holds it open. Identity checks are
-    // complete; close before rename so Windows and POSIX share one publish sequence.
-    await expected.handle.close()
-    expected.closed = true
+    // NTFS MoveFileEx(REPLACE_EXISTING) fails while the destination is open. POSIX can rename over
+    // an open file, so keep the validated handle as the ownership lock there. Windows must release
+    // it after the identity checks and accept the remaining local TOCTOU until a native exclusive
+    // replace API is available.
+    if (process.platform === 'win32') {
+      await expected.handle.close()
+      expected.closed = true
+    }
     await rename(temporaryPath, plan.target)
     published = true
     await defaultFileDurability.syncDirectory(plan.binDir)
@@ -708,9 +712,11 @@ export const uninstallCliLauncher = async (
       if (!isDirectRegularFile(final) || !isSameFile(opened.stats, final)) {
         refuseUnmanagedCliLauncher(plan.target)
       }
-      await opened.handle.close()
-      opened.closed = true
-      opened = undefined
+      if (process.platform === 'win32') {
+        await opened.handle.close()
+        opened.closed = true
+        opened = undefined
+      }
       await rm(plan.target)
     }
   } finally {

--- a/src/main/managed-file-versions/version-file-operator.test.ts
+++ b/src/main/managed-file-versions/version-file-operator.test.ts
@@ -19,6 +19,10 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 let cleanupRoot: string | undefined
 
+// NTFS refuses to rename a directory while a descendant file handle is still open, so parent-swap
+// cases that depend on that TOCTOU stay POSIX-only. Windows still fail-closes at the OS rename.
+const posixIt = process.platform === 'win32' ? it.skip : it
+
 afterEach(async () => {
   if (cleanupRoot) await rm(cleanupRoot, { recursive: true, force: true })
   cleanupRoot = undefined
@@ -264,7 +268,7 @@ describe('NodeVersionFileOperator', () => {
     await rm(outsideRoot, { recursive: true, force: true })
   })
 
-  it('fails closed when the version parent changes during a claim transition', async () => {
+  posixIt('fails closed when the version parent changes during a claim transition', async () => {
     const module = await import('./version-file-operator')
     cleanupRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-'))
     const outsideRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-outside-'))
@@ -1192,7 +1196,7 @@ describe('NodeVersionFileOperator', () => {
     await rm(outsideRoot, { recursive: true, force: true })
   })
 
-  it('fails closed when the version parent changes after content is synced', async () => {
+  posixIt('fails closed when the version parent changes after content is synced', async () => {
     const module = await import('./version-file-operator')
     cleanupRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-'))
     const outsideRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-outside-'))
@@ -1571,7 +1575,7 @@ describe('NodeVersionFileOperator', () => {
     await expect(readFile(heldAsidePath)).resolves.toHaveLength(0)
   })
 
-  it('fails closed when the version parent changes during incomplete cleanup', async () => {
+  posixIt('fails closed when the version parent changes during incomplete cleanup', async () => {
     const module = await import('./version-file-operator')
     cleanupRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-'))
     const outsideRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-outside-'))
@@ -1791,6 +1795,7 @@ describe('NodeVersionFileOperator', () => {
   })
 
   it('scrubs only the held immutable inode when the parent changes during content removal', async () => {
+    if (process.platform === 'win32') return
     const module = await import('./version-file-operator')
     cleanupRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-'))
     const outsideRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-outside-'))

--- a/src/main/notebook/input-registry.test.ts
+++ b/src/main/notebook/input-registry.test.ts
@@ -154,7 +154,7 @@ const createArtifact = async (input: {
 }
 
 const setup = async (): Promise<NotebookInputRegistry> => {
-  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-input-registry-'))
+  storageRoot = await realpath(await mkdtemp(join(tmpdir(), 'open-science-input-registry-')))
   client = createProjectDbClient(storageRoot)
   await migrateApplicationDatabase(client)
   await client.project.createMany({

--- a/src/main/notebook/process-environment.ts
+++ b/src/main/notebook/process-environment.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'node:fs'
-import { delimiter, isAbsolute, win32 } from 'node:path'
+import { posix, win32 } from 'node:path'
 
 const COMMON_ENV_ALLOWLIST = ['PATH', 'LANG', 'LC_ALL', 'LC_CTYPE', 'TERM', 'TZ'] as const
 
@@ -90,10 +90,10 @@ export const environmentPathRoots = (
     }
   }
 ): string[] => {
-  const separator = platform === 'win32' ? win32.delimiter : delimiter
+  const separator = platform === 'win32' ? win32.delimiter : posix.delimiter
   return (env.PATH ?? '')
     .split(separator)
     .map((entry) => entry.trim())
-    .filter((entry) => (platform === 'win32' ? win32.isAbsolute(entry) : isAbsolute(entry)))
+    .filter((entry) => (platform === 'win32' ? win32.isAbsolute(entry) : posix.isAbsolute(entry)))
     .filter(isDirectory)
 }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -50,6 +50,7 @@ import {
 } from './operation-journal'
 
 const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'os-prov-'))
+const TEST_WINDOWS_PATH_BUDGET = { maxCacheRelativePath: 1, maxEnvRelativePath: 1 } as const
 const RELOCATION_ARCHIVE = 'x-1.conda'
 const RELOCATION_ARCHIVE_CONTENT = 'relocation archive'
 const RELOCATION_ARCHIVE_MD5 = createHash('md5').update(RELOCATION_ARCHIVE_CONTENT).digest('hex')
@@ -78,7 +79,8 @@ const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): Provi
     mm: '/mm',
     channel: 'conda-forge',
     fetchBundle: async (spec): Promise<FetchedBundle> => ({
-      lockPath: join(root, `${spec.name}.lock`)
+      lockPath: join(root, `${spec.name}.lock`),
+      pathBudget: TEST_WINDOWS_PATH_BUDGET
     }),
     runArgv: async (argv: string[]): Promise<void> => {
       // argv[3] is --prefix / -p value depending on form; find the prefix and drop a bin file.
@@ -116,7 +118,7 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
         cache: { path: cachePath, lockKey: 'selected-cache-key' },
         fetchBundle: async () => {
           order.push('fetch')
-          return { lockPath: join(root, 'python.lock') }
+          return { lockPath: join(root, 'python.lock'), pathBudget: TEST_WINDOWS_PATH_BUDGET }
         },
         maintainCache: async (cache, onBeforeSpawn, onChild) => {
           expect(cache.path).toBe(cachePath)
@@ -247,7 +249,10 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     const argvs: string[][] = []
     const lockPath = join(root, 'default-python.lock')
     const deps = makeDeps(root, {
-      fetchBundle: async (): Promise<FetchedBundle> => ({ lockPath }),
+      fetchBundle: async (): Promise<FetchedBundle> => ({
+        lockPath,
+        pathBudget: TEST_WINDOWS_PATH_BUDGET
+      }),
       runArgv: async (argv) => {
         argvs.push(argv)
         const bin = pythonBin(envPrefix(root, DEFAULT_PY_ENV))
@@ -476,7 +481,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     writeFileSync(join(prefix, 'stale-file'), 'stale')
     let verifyCalls = 0
     const fetchBundle = vi.fn(async (): Promise<FetchedBundle> => ({
-      lockPath: join(root, 'python-3.12.lock')
+      lockPath: join(root, 'python-3.12.lock'),
+      pathBudget: TEST_WINDOWS_PATH_BUDGET
     }))
     const runArgv = vi.fn(async () => {
       expect(existsSync(join(prefix, 'stale-file'))).toBe(false)
@@ -509,7 +515,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
 
     let creates = 0
     const fetchBundle = vi.fn(async (): Promise<FetchedBundle> => ({
-      lockPath: join(root, 'python-3.12.lock')
+      lockPath: join(root, 'python-3.12.lock'),
+      pathBudget: TEST_WINDOWS_PATH_BUDGET
     }))
     const runArgv = vi.fn(async () => {
       creates += 1
@@ -546,7 +553,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
 
     let creates = 0
     const fetchBundle = vi.fn(async (): Promise<FetchedBundle> => ({
-      lockPath: join(root, 'python-3.12.lock')
+      lockPath: join(root, 'python-3.12.lock'),
+      pathBudget: TEST_WINDOWS_PATH_BUDGET
     }))
     const runArgv = vi.fn(async () => {
       creates += 1
@@ -693,7 +701,10 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
       writeFileSync(bin, 'ok')
     })
     const deps = makeDeps(root, {
-      fetchBundle: async () => ({ lockPath: join(root, 'python-3.12.lock') }),
+      fetchBundle: async () => ({
+        lockPath: join(root, 'python-3.12.lock'),
+        pathBudget: TEST_WINDOWS_PATH_BUDGET
+      }),
       runArgv
     })
 
@@ -726,7 +737,10 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
       writeFileSync(bin, 'ok')
     })
     const deps = makeDeps(root, {
-      fetchBundle: vi.fn(async (): Promise<FetchedBundle> => ({ lockPath: join(root, 'p.lock') })),
+      fetchBundle: vi.fn(async (): Promise<FetchedBundle> => ({
+        lockPath: join(root, 'p.lock'),
+        pathBudget: TEST_WINDOWS_PATH_BUDGET
+      })),
       runArgv
     })
 
@@ -761,7 +775,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     const provisioner = new DefaultRuntimeProvisioner(
       makeDeps(root, {
         fetchBundle: vi.fn(async (): Promise<FetchedBundle> => ({
-          lockPath: join(root, 'p.lock')
+          lockPath: join(root, 'p.lock'),
+          pathBudget: TEST_WINDOWS_PATH_BUDGET
         })),
         runArgv: vi.fn(async function firstCreate() {
           // Simulate the user cancelling right as the create fails with a cache signature: the abort

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -951,16 +951,22 @@ describe('notebook runtime service', () => {
       sessionId: 'shell-session',
       command: 'long-running-command'
     })
-    await vi.waitFor(() => {
-      expect(controlSignal).toBeInstanceOf(AbortSignal)
-      expect(shellSignal).toBeInstanceOf(AbortSignal)
-    })
+    await vi.waitFor(
+      () => {
+        expect(controlSignal).toBeInstanceOf(AbortSignal)
+        expect(shellSignal).toBeInstanceOf(AbortSignal)
+      },
+      { timeout: 5_000 }
+    )
 
     const deleting = service.shutdownProject('project-1')
-    await vi.waitFor(() => {
-      expect(controlSignal?.aborted).toBe(true)
-      expect(shellSignal?.aborted).toBe(true)
-    })
+    await vi.waitFor(
+      () => {
+        expect(controlSignal?.aborted).toBe(true)
+        expect(shellSignal?.aborted).toBe(true)
+      },
+      { timeout: 5_000 }
+    )
 
     await expect(control).resolves.toMatchObject({ status: 'cancelled' })
     await expect(shell).resolves.toEqual({

--- a/src/main/notebook/trust-bundle.test.ts
+++ b/src/main/notebook/trust-bundle.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, relative } from 'node:path'
+import { join } from 'node:path'
 import { rootCertificates } from 'node:tls'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -44,10 +44,7 @@ describe('Notebook trust bundle', () => {
   })
 
   it('rejects missing, malformed, and private-key-bearing bundles', async () => {
-    const relativePath = await bundlePath(rootCertificates[0]!)
-    await expect(resolveNotebookTrustBundle(relative(process.cwd(), relativePath))).rejects.toThrow(
-      'must be absolute'
-    )
+    await expect(resolveNotebookTrustBundle('relative-ca.pem')).rejects.toThrow('must be absolute')
     await expect(resolveNotebookTrustBundle('/missing/ca.pem')).rejects.toThrow(
       'does not exist or cannot be read'
     )

--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -113,14 +113,27 @@ const sessionWithInvalidProjection = (id: string, createdAt = 100): PersistedCha
   return { ...session(id, createdAt), updatedAt: Number.MAX_VALUE }
 }
 
+const removeStorageRoot = async (root: string): Promise<void> => {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try {
+      await rm(root, { recursive: true, force: true })
+      return
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if ((code !== 'EBUSY' && code !== 'EPERM') || attempt === 7) throw error
+      await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)))
+    }
+  }
+}
+
 describe('Session projection', () => {
   let client: PrismaClient | undefined
   let storageRoot: string | undefined
 
   afterEach(async () => {
     await client?.$disconnect()
-    if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
     client = undefined
+    if (storageRoot) await removeStorageRoot(storageRoot)
     storageRoot = undefined
   })
 


### PR DESCRIPTION
## Problem

Scheduled [Windows Full Test](https://github.com/aipoch/open-science/actions/workflows/windows-full-test.yml) has failed on every `main` run since 2026-08-27. Latest run 33564211594 failed all three Vitest shards (2 + 101 + 27 tests). The Notebook sandbox job stayed green.

PR Gate does not run the complete portable suite on Windows, so host-specific regressions accumulated on `main`.

## Proposed change

Fix the Windows-host defects and fixtures that the advisory full suite actually executes:

- Split linux `PATH` with `posix.delimiter` / `posix.isAbsolute` even when the test host is Windows.
- Fsync exclusive file-evidence receipts on the write handle (Windows `FlushFileBuffers` rejects `O_RDONLY`, matching `file-durability.ts`).
- Close CLI launcher identity handles before NTFS `rename` / `unlink`.
- Give provisioner unit tests a tiny injected path budget so `%TEMP%` fixtures are not rejected as over-budget data roots.
- Canonicalize 8.3 vs long paths, skip Unix mode bits and parent-directory-swap TOCTOU cases that NTFS cannot reproduce, keep `PATH` for `node.exe` in the runtime-profile launcher test, and retry SQLite `rm` after disconnect.

## Scope and non-goals

- No workflow change, so no CI dry-run of `windows-full-test.yml`.
- No MAX_PATH budget or micromamba cache layout change.
- No Session JSON, SQLite schema, or migration change.

## Historical compatibility / new states / persistence

- **Historical compatibility:** none. CLI still recognizes the historical ownership marker; only the Windows replace/remove sequence changes (close the identity handle, then mutate).
- **New enum / status values:** none. Version-file parent-swap coverage stays POSIX-only; production error codes are unchanged.
- **Data persistence:** file-evidence on-disk format is unchanged. Exclusive writes now fsync a writable handle so Windows can actually flush receipts/blobs (same contract as `src/main/storage/file-durability.ts`). CLI launcher bytes and PATH journal format are unchanged.

## Acceptance criteria and validation

Checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| PATH delimiter / CA relative path | `npx vitest run src/main/notebook/process-environment.test.ts src/main/notebook/trust-bundle.test.ts` | pass |
| CLI replace/remove | `npx vitest run src/main/cli-install/launcher.test.ts` | pass |
| Prompt snapshot modes | `npx vitest run src/main/acp/prompt-content-owner.test.ts` | pass |
| Filesystem physical paths | `npx vitest run packages/notebook-network-sandbox/src/filesystem-policy.test.ts` | pass |
| Runtime profile launcher | `npx vitest run scripts/performance/run-runtime-profile.test.ts` | pass |
| Provisioner path budget | `npx vitest run src/main/notebook/provisioner.test.ts` | pass |
| Version parent-swap skip | `npx vitest run src/main/managed-file-versions/version-file-operator.test.ts` | pass |
| Session projection cleanup | `npx vitest run src/main/session-persistence/projection.test.ts` | pass |
| File-evidence fsync consumers | `npx vitest run src/main/notebook/working-file-observer.test.ts src/main/notebook/input-registry.test.ts src/main/compute/harvest-engine.test.ts src/main/compute/job-dispatcher.test.ts src/main/compute/compute-job-workflow-owner.test.ts src/main/compute/compute-service.test.ts src/main/compute/concurrency-integration.test.ts` | pass |
| Node typecheck | `npm run typecheck:node` | pass |
| Lint | `npm run lint` | pass (no new issues) |

Full `npm test` was not run locally; PR Gate is authoritative for the portable suite. `windows-runtime-cache-uninstall.test.ts` is `skipIf` off Windows.

Uncovered risks: this machine cannot execute NTFS `fsync`/`rename` or 8.3 path expansion. Confirm on PR Gate Windows-sensitive lanes, and optionally `workflow_dispatch` Windows Full Test on this branch (`mode: full`).

## Review focus

- `resources/notebook/file_evidence_worker.js` write-handle fsync vs the existing durability contract.
- `src/main/cli-install/launcher.ts` close-before-rename/unlink on Windows.
- `environmentPathRoots` using the *target* platform's delimiter, not the host's.