### PR TITLE
fix(session-persistence): scope project deletion waits

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -248,7 +248,10 @@ import { withSessionCacheDeletion } from './compute/session-cache-owner'
 import { createMainPromptSideChatRelay } from './side-chat/main-prompt-relay'
 import { registerSideChatIpcHandlers } from './side-chat/ipc'
 import { SideChatRuntimeOwner } from './side-chat/runtime-owner'
-import { type SessionPersistenceBackend } from './session-persistence/ipc'
+import {
+  coordinateSessionPersistenceWithProjectDeletions,
+  type SessionPersistenceBackend
+} from './session-persistence/ipc'
 import { MainMessageAttributionAuthority } from './session-persistence/message-attribution-authority'
 import {
   SessionAuxiliaryTurnUsageRecorder,
@@ -1264,7 +1267,7 @@ const createApplicationModules = async (
     )
     return { ...projection, result }
   }
-  const sessionPersistenceBackend: SessionPersistenceBackend = {
+  const uncoordinatedSessionPersistenceBackend: SessionPersistenceBackend = {
     loadAll: loadAllSessions,
     list: async () => {
       const projection = await ensureSessionProjection()
@@ -1294,7 +1297,6 @@ const createApplicationModules = async (
         : session
     },
     saveSession: async (session, options) => {
-      await projectDeletionCoordinator.recoverPendingDeletions()
       const created =
         (await sessionRepository.loadSession(session.projectId, session.id)) === undefined
       let durableSession = created
@@ -1323,24 +1325,24 @@ const createApplicationModules = async (
       return { created, session: durableSession }
     },
     setDelegationPolicy: async (projectId, sessionId, policy) => {
-      await projectDeletionCoordinator.recoverPendingDeletions()
       return sessionPersistenceCoordinator.setSessionDelegationPolicy(projectId, sessionId, policy)
     },
     updateArchive: async (request) => {
-      await projectDeletionCoordinator.recoverPendingDeletions()
       return archiveCoordinator.updateSessionArchive(request)
     },
     deleteSession: async (projectId, sessionId) => {
-      await projectDeletionCoordinator.recoverPendingDeletions()
       const result = await sessionPersistenceCoordinator.deleteSession(projectId, sessionId)
       await permissionGrantRegistry.prune({ kind: 'session', projectId, sessionId })
       return result
     },
     saveManifest: async (request) => {
-      await projectDeletionCoordinator.recoverPendingDeletions()
       return sessionPersistenceCoordinator.saveManifest(request)
     }
   }
+  const sessionPersistenceBackend = coordinateSessionPersistenceWithProjectDeletions(
+    uncoordinatedSessionPersistenceBackend,
+    projectDeletionCoordinator
+  )
   let backendTeardownOwnedByCoordinator = false
   const provisioningRoot = runtimeRoot(resolveDataRoot())
   // One runner owns Windows integrity/preflight/fallback state for every production micromamba

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -7,6 +7,11 @@ import {
   type PersistedChatSession
 } from '../../shared/session-persistence'
 import type { Logger } from '../logger'
+import {
+  ProjectDeletionCoordinator,
+  type ProjectDeletionRepository,
+  type ProjectSessionDeletion
+} from '../projects/deletion-coordinator'
 import type { ReviewRepository } from '../reviewer/repository'
 
 const { broadcastLifecycleEvent, getLifecycleClientId, ipcHandlers, registrationFailure } =
@@ -37,6 +42,7 @@ vi.mock('../lifecycle-broadcast', () => ({
 
 import {
   canReconcileSessionAbsences,
+  coordinateSessionPersistenceWithProjectDeletions,
   createSessionPersistenceHandlers,
   createSessionPersistenceHandlersWithAttributionAuthority,
   loadSessionMetadataAfterProjectRecovery,
@@ -76,6 +82,87 @@ const createMockReviewRepository = (): ReviewRepository =>
   }) as unknown as ReviewRepository
 
 describe('session persistence IPC handlers', () => {
+  it('saves a Session for Project B while Project A cleanup remains failed', async () => {
+    const projects: ProjectDeletionRepository = {
+      get: vi.fn().mockResolvedValue(null),
+      delete: vi.fn().mockResolvedValue(undefined),
+      createDeletionIntent: vi.fn().mockResolvedValue(undefined),
+      deleteDeletionIntent: vi.fn().mockResolvedValue(undefined),
+      listDeletionIntents: vi.fn().mockResolvedValue(['project-a'])
+    }
+    const sessions: ProjectSessionDeletion = {
+      deleteProjectSessions: vi.fn(async (projectId: string) => {
+        if (projectId === 'project-a') throw new Error('Project A derived cleanup failed')
+        return { status: 'completed' as const }
+      }),
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('absent'),
+      completeProjectSessionDeletion: vi.fn().mockResolvedValue(undefined),
+      listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue([])
+    }
+    const projectDeletion = new ProjectDeletionCoordinator(projects, sessions)
+    const projectBSession = { ...createSession(), projectId: 'project-b' }
+    const saveSession = vi.fn(async () => ({ created: false, session: projectBSession }))
+    const repository = coordinateSessionPersistenceWithProjectDeletions(
+      {
+        loadAll: vi.fn(),
+        loadOne: vi.fn(),
+        saveSession,
+        deleteSession: vi.fn(),
+        saveManifest: vi.fn()
+      },
+      projectDeletion
+    )
+
+    await expect(repository.saveSession(projectBSession)).resolves.toEqual({
+      created: false,
+      session: projectBSession
+    })
+    expect(saveSession).toHaveBeenCalledOnce()
+  })
+
+  it('waits only for the Project owned by each Session mutation', async () => {
+    const session = createSession()
+    const waitForProjectOperations = vi.fn().mockResolvedValue(undefined)
+    const projectDeletion = {
+      recoverPendingDeletions: vi
+        .fn()
+        .mockRejectedValue(new Error('strict global recovery must not gate Session mutations')),
+      waitForProjectOperations
+    }
+    const repository = coordinateSessionPersistenceWithProjectDeletions(
+      {
+        loadAll: vi.fn(),
+        loadOne: vi.fn(),
+        saveSession: vi.fn().mockResolvedValue({ created: false, session }),
+        setDelegationPolicy: vi.fn().mockResolvedValue(session),
+        updateArchive: vi.fn().mockResolvedValue(session),
+        deleteSession: vi.fn().mockResolvedValue(undefined),
+        saveManifest: vi.fn().mockResolvedValue(undefined)
+      },
+      projectDeletion
+    )
+
+    await repository.saveSession(session)
+    await repository.setDelegationPolicy?.(session.projectId, session.id, 'allow')
+    await repository.updateArchive?.({
+      projectId: session.projectId,
+      sessionId: session.id,
+      archived: true,
+      expectedArchivedAt: null
+    })
+    await repository.deleteSession(session.projectId, session.id)
+    await repository.saveManifest({ lastProjectId: session.projectId, lastSessionId: session.id })
+
+    expect(waitForProjectOperations.mock.calls).toEqual([
+      [[session.projectId]],
+      [[session.projectId]],
+      [[session.projectId]],
+      [[session.projectId]],
+      [[]]
+    ])
+    expect(projectDeletion.recoverPendingDeletions).not.toHaveBeenCalled()
+  })
+
   it('keeps absence-based reconciliation closed for quarantined Session authority', () => {
     expect(
       canReconcileSessionAbsences({

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -74,6 +74,10 @@ type ProjectDeletionRecoveryBackend = {
   recoverPendingDeletions: () => Promise<void>
 }
 
+type ProjectDeletionMutationCoordinator = {
+  waitForProjectOperations: (projectIds: readonly string[]) => Promise<void>
+}
+
 type SessionStartupLoader = {
   loadAll: () => Promise<LoadAllSessionsResult>
   loadAllReadOnly: () => Promise<LoadAllSessionsResult>
@@ -210,6 +214,42 @@ const createSessionPersistenceHandlers = (
     new MainMessageAttributionAuthority()
   )
 
+// Keeps the application-composition boundary injectable without exposing the rest of main-process
+// startup to tests. The coordinator owns admission; the wrapped backend owns the durable mutation.
+const coordinateSessionPersistenceWithProjectDeletions = (
+  repository: SessionPersistenceBackend,
+  projectDeletion: ProjectDeletionMutationCoordinator
+): SessionPersistenceBackend => {
+  const coordinated: SessionPersistenceBackend = {
+    ...repository,
+    saveSession: async (session, options) => {
+      await projectDeletion.waitForProjectOperations([session.projectId])
+      return options ? repository.saveSession(session, options) : repository.saveSession(session)
+    },
+    deleteSession: async (projectId, sessionId) => {
+      await projectDeletion.waitForProjectOperations([projectId])
+      return repository.deleteSession(projectId, sessionId)
+    },
+    saveManifest: async (request) => {
+      await projectDeletion.waitForProjectOperations([])
+      return repository.saveManifest(request)
+    }
+  }
+  if (repository.setDelegationPolicy) {
+    coordinated.setDelegationPolicy = async (projectId, sessionId, policy) => {
+      await projectDeletion.waitForProjectOperations([projectId])
+      return repository.setDelegationPolicy!(projectId, sessionId, policy)
+    }
+  }
+  if (repository.updateArchive) {
+    coordinated.updateArchive = async (request) => {
+      await projectDeletion.waitForProjectOperations([request.projectId])
+      return repository.updateArchive!(request)
+    }
+  }
+  return coordinated
+}
+
 // Creates the production repository rooted at the (dev-aware) storage root.
 const createDefaultSessionRepository = (
   hasActiveRuntimePrompt: (projectId: string, sessionId: string) => boolean = () => false,
@@ -316,6 +356,7 @@ const registerSessionPersistenceIpcHandlers = (
 
 export {
   canReconcileSessionAbsences,
+  coordinateSessionPersistenceWithProjectDeletions,
   createDefaultReviewRepository,
   createDefaultSessionRepository,
   createSessionPersistenceHandlers,
@@ -326,6 +367,7 @@ export {
   registerSessionPersistenceIpcHandlers
 }
 export type {
+  ProjectDeletionMutationCoordinator,
   ProjectDeletionRecoveryForSessionRead,
   ProjectDeletionRecoveryBackend,
   SessionCatalogHydrator,


### PR DESCRIPTION
## Problem

Session persistence mutations used strict global Project deletion recovery. If derived cleanup for Project A remained failed, saving or mutating a Session in unrelated Project B was rejected with Project A's recovery error.

## Proposed change

- Route Session save, archive, delegation-policy, and deletion mutations through Project-scoped deletion admission.
- Treat manifest persistence as Project-neutral while still waiting for the deletion queue and infrastructure recovery.
- Keep strict global recovery for background recovery and global coordination.
- Add a deterministic regression test using the real Project deletion coordinator, plus a contract test for every mutation scope.

## Scope and non-goals

- No renderer interaction change.
- No database schema, persisted-format, data-model, enum, or historical-compatibility change.
- Infrastructure-level recovery failures remain global and fail closed.
- A Project's own cleanup failure still blocks mutations owned by that Project.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Project A cleanup failure does not block Project B Session persistence -> npm test -- src/main/session-persistence/ipc.test.ts src/main/projects/deletion-coordinator.test.ts -> 60/60 passed.
- Session persistence owner and consumer behavior remains intact -> npm run test:module -- session_persistence -> 486/486 passed.
- Main-process contracts remain type-safe -> npm run typecheck:node -> passed.
- Changed source meets repository lint rules -> npm run lint -> passed.

The complete npm test suite was intentionally not run locally per maintainer direction; PR Gate is authoritative for global-composition and platform coverage.

## Review focus

- Confirm Project-owned mutations always pass their owning projectId.
- Confirm the global manifest uses an empty Project set rather than inheriting lastProjectId ownership.
- Confirm strict global recovery remains limited to background/global coordination paths.
- Confirm the internal backend decorator is the minimum observable seam for the regression.