### PR TITLE
fix(session-persistence): block flush after failed writes

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -28,6 +28,7 @@ import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
 } from '../../stores/preview-workbench-store'
+import { resetSessionPersistenceWriteFailuresForTests } from '../session-persistence/session-persistence'
 import { applyWorkspaceRuntimeEvent } from './workspace-events'
 import {
   clearLinkedPendingPdfContext,
@@ -137,6 +138,10 @@ const flushRuntimeTasks = async (): Promise<void> => {
   await Promise.resolve()
   await Promise.resolve()
 }
+
+beforeEach(() => {
+  resetSessionPersistenceWriteFailuresForTests()
+})
 
 describe('workspace permission wait recovery', () => {
   it('projects a restored main-owned request and prefers a matching live request', () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -308,6 +308,7 @@ describe('session persistence startup', () => {
       errorCategory: 'error',
       fingerprint: expect.stringMatching(/^[a-f0-9]{8}$/)
     })
+    await expect(flushSessionPersistence()).rejects.toThrow('could not write')
 
     await act(async () => {
       useSessionStore.getState().appendUserMessage({
@@ -329,6 +330,52 @@ describe('session persistence startup', () => {
     expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
       'changes saved'
     )
+    await expect(flushSessionPersistence()).resolves.toBeUndefined()
+  })
+
+  it('keeps a failed Session blocking flush when another Session saves successfully', async () => {
+    let failedSessionWritesFail = true
+    loadAll.mockReset().mockResolvedValue(emptyLoadResult())
+    saveSession.mockImplementation(async (session) => {
+      if (session.id === 'session-1' && failedSessionWritesFail) throw new Error('disk full')
+      return session
+    })
+
+    await act(async () => root.render(<Probe />))
+
+    await act(async () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'Unsaved Session',
+        cwd: '/workspace/project',
+        projectId: 'project-a'
+      })
+      await Promise.resolve()
+    })
+    await act(async () => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-2',
+        content: 'Durable Session',
+        cwd: '/workspace/project',
+        projectId: 'project-a'
+      })
+      await Promise.resolve()
+    })
+
+    await expect(flushSessionPersistence()).rejects.toThrow('disk full')
+    expect(saveSession.mock.calls.map(([session]) => session.id)).toEqual([
+      'session-1',
+      'session-2'
+    ])
+
+    failedSessionWritesFail = false
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-writes"]')?.click()
+      await Promise.resolve()
+    })
+
+    await expect(flushSessionPersistence()).resolves.toBeUndefined()
+    expect(saveSession.mock.calls.at(-1)?.[0].id).toBe('session-1')
   })
 
   it('reloads after a Session revision conflict instead of resending stale JSON', async () => {
@@ -417,6 +464,7 @@ describe('session persistence startup', () => {
     expect(container.querySelector('[data-testid="write-error"]')?.textContent).toBe(
       'Open Science could not save the latest conversation changes. Retry before closing the app.'
     )
+    await expect(flushSessionPersistence()).rejects.toThrow('disk full')
 
     await act(async () => {
       // Production removes renderer state only after the authoritative delete IPC succeeds.
@@ -428,6 +476,7 @@ describe('session persistence startup', () => {
     expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
       'changes saved'
     )
+    await expect(flushSessionPersistence()).resolves.toBeUndefined()
   })
 
   it('ignores a save failure that arrives after its Session was deleted', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -118,6 +118,7 @@ type OrderedSessionPersistence = Pick<SessionPersistenceApi, 'saveSession' | 'sa
   ) => Promise<PersistedChatSession>
   seedAcknowledgedSessions: (sessions: readonly PersistedChatSession[]) => void
   getAcknowledgedSession: (sessionId: string) => PersistedChatSession | undefined
+  clearWriteFailure: (target: string) => void
   flush: () => Promise<void>
 }
 
@@ -629,6 +630,8 @@ const createOrderedSessionPersistence = (
   const acknowledgedRevisions = new Map<string, number>()
   const acknowledgedSessions = new Map<string, PersistedChatSession>()
   const pendingLatestByTarget = new Map<string, PendingLatestSessionSave>()
+  // The queue swallows rejections to stay usable; retain terminal failures until that target heals.
+  const failedWritesByTarget = new Map<string, unknown>()
   let hydrationGeneration = 0
   let latestSessionSaveStartedAt = Number.NEGATIVE_INFINITY
 
@@ -673,10 +676,29 @@ const createOrderedSessionPersistence = (
     }
   }
 
-  const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
+  const trackWrite = async <Result>(
+    target: string,
+    task: () => Promise<Result>
+  ): Promise<Result> => {
+    try {
+      const result = await task()
+      failedWritesByTarget.delete(target)
+      return result
+    } catch (error) {
+      if (!(error instanceof SessionPersistenceGenerationChangedError)) {
+        failedWritesByTarget.set(target, error)
+      }
+      throw error
+    }
+  }
+
+  const enqueue = <Result>(target: string, task: () => Promise<Result>): Promise<Result> => {
     releasePendingLatestCadence()
     pendingLatestByTarget.clear()
-    const run = queue.then(task, task)
+    const run = queue.then(
+      () => trackWrite(target, task),
+      () => trackWrite(target, task)
+    )
     queue = run.then(
       () => undefined,
       () => undefined
@@ -730,7 +752,10 @@ const createOrderedSessionPersistence = (
       acknowledgeSession(durable)
       return durable
     }
-    const run = queue.then(runTask, runTask)
+    const run = queue.then(
+      () => trackWrite(target, runTask),
+      () => trackWrite(target, runTask)
+    )
     entry.promise = run
     pendingLatestByTarget.set(target, entry)
     queue = run.then(
@@ -749,6 +774,9 @@ const createOrderedSessionPersistence = (
       releasePendingLatestCadence()
       pendingLatestByTarget.clear()
       latestSessionSaveStartedAt = Number.NEGATIVE_INFINITY
+      for (const target of failedWritesByTarget.keys()) {
+        if (target.startsWith('session:')) failedWritesByTarget.delete(target)
+      }
       for (const session of sessions) {
         acknowledgedRevisions.set(session.id, sessionRevision(session))
         acknowledgedSessions.set(session.id, structuredClone(session))
@@ -758,9 +786,11 @@ const createOrderedSessionPersistence = (
       const session = acknowledgedSessions.get(sessionId)
       return session ? structuredClone(session) : undefined
     },
-    saveSession: (session, options) => enqueue(() => saveSubmittedSession(session, options)),
+    clearWriteFailure: (target) => failedWritesByTarget.delete(target),
+    saveSession: (session, options) =>
+      enqueue(`session:${session.id}`, () => saveSubmittedSession(session, options)),
     saveSessionWithRecovery: (session, options, recover) =>
-      enqueue(async () => {
+      enqueue(`session:${session.id}`, async () => {
         const submitted = structuredClone(session)
         submitted.revision = Math.max(
           sessionRevision(submitted),
@@ -772,10 +802,12 @@ const createOrderedSessionPersistence = (
           return recover(error, submitted, saveSubmittedSession)
         }
       }),
-    saveManifest: (request) => enqueue(() => api.saveManifest(request)),
-    flush: () => {
+    saveManifest: (request) => enqueue('manifest', () => api.saveManifest(request)),
+    flush: async () => {
       releasePendingLatestCadence()
-      return queue.then(() => undefined)
+      await queue
+      const failure = failedWritesByTarget.values().next()
+      if (!failure.done) throw failure.value
     }
   }
 }
@@ -1026,6 +1058,7 @@ const pruneRemovedSessionWriteTargets = (
       targets.delete(target)
       conflictRebaseFields?.delete(target)
       for (const related of relatedTargets) related.delete(target)
+      liveSessionPersistence.clearWriteFailure(target)
     }
   }
 }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -119,6 +119,7 @@ type OrderedSessionPersistence = Pick<SessionPersistenceApi, 'saveSession' | 'sa
   seedAcknowledgedSessions: (sessions: readonly PersistedChatSession[]) => void
   getAcknowledgedSession: (sessionId: string) => PersistedChatSession | undefined
   clearWriteFailure: (target: string) => void
+  clearWriteFailures: () => void
   flush: () => Promise<void>
 }
 
@@ -787,6 +788,7 @@ const createOrderedSessionPersistence = (
       return session ? structuredClone(session) : undefined
     },
     clearWriteFailure: (target) => failedWritesByTarget.delete(target),
+    clearWriteFailures: () => failedWritesByTarget.clear(),
     saveSession: (session, options) =>
       enqueue(`session:${session.id}`, () => saveSubmittedSession(session, options)),
     saveSessionWithRecovery: (session, options, recover) =>
@@ -823,6 +825,10 @@ const liveSessionPersistence = createOrderedSessionPersistence({
 })
 
 const unresolvedSessionRevisionConflictTargets = new Set<string>()
+
+const resetSessionPersistenceWriteFailuresForTests = (): void => {
+  liveSessionPersistence.clearWriteFailures()
+}
 
 const saveSessionInOrder = async (
   session: PersistedChatSession,
@@ -1818,6 +1824,7 @@ export {
   loadPersistedSession,
   loadPersistedSessions,
   reconcilePendingArtifacts,
+  resetSessionPersistenceWriteFailuresForTests,
   deriveSessionCatalogRecovery,
   deleteSession,
   saveSessionInOrder,


### PR DESCRIPTION
## Problem

The renderer write queue converts its tail rejection into a fulfilled promise so later writes can continue. A normal Session autosave could therefore fail while the quit flush only observed a fulfilled queue tail and reported completion, allowing the app to exit with the latest conversation changes missing from durable storage.

## Proposed change

- Retain the latest terminal write failure per persistence target inside the ordered Session persistence owner.
- Keep flush blocked until that same target saves successfully or a durably deleted Session target is removed.
- Preserve queue liveness and existing revision-conflict behavior.

## Scope and non-goals

- No database or persisted-format changes.
- No historical-data compatibility work.
- No new enum values, IPC statuses, user-facing copy, or interaction changes.
- The new target health map is renderer-memory state only.

## Acceptance criteria and validation

- Ordinary save failure blocks flush; retry success restores flush.
- A successful save for another Session does not clear the failed Session target.
- Durable Session deletion clears the failed target.

Final evidence after the last material edit:

- Session write failure, retry, target isolation, deletion, queue ordering, and quit classification -> npm test -- src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/hooks/useQuitPersistenceFlush.test.ts -> 93 passed.
- Renderer TypeScript surface -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed.
- Diff hygiene -> git diff --check -> passed before commit.

The affected-test planner selected the complete Vitest suite because the changed render test is not registered to a module owner. Per maintainer direction, the complete suite was not run locally; exact-head PR Gate CI is the authority for that fallback plan and platform coverage.

## Review focus

- Verify failures remain isolated by target and only same-target success clears them.
- Verify hydration/deletion cleanup cannot leave stale in-memory failures blocking later flushes.
- Verify the queue still absorbs individual rejections so later writes continue.
