### PR TITLE
fix(navigation): preserve notifications on rejected targets

### DIFF
--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -343,8 +343,8 @@ describe('NotificationBell', () => {
       argsPreview: '{}',
       availableScopes: ['once']
     }))
-    const openSessionById = vi.fn()
-    const openProject = vi.fn()
+    const openSessionById = vi.fn(() => true)
+    const openProject = vi.fn(() => true)
     const markRead = vi.fn(async () => undefined)
     window.api.settings.replayConnectorApproval = replayConnectorApproval
     useNavigationStore.setState({ openSessionById, openProject })
@@ -426,6 +426,30 @@ describe('NotificationBell', () => {
     expect(markAllRead).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps a message unread and the center open when target navigation is rejected', async () => {
+    const openSessionById = vi.fn(() => false)
+    const markRead = vi.fn(async () => undefined)
+    useNavigationStore.setState({ openSessionById })
+    const item = useNotificationInboxStore.getState().items[0]
+    useNotificationInboxStore.setState({
+      markRead,
+      items: item ? [{ ...item, sessionId: 'session-missing' }] : []
+    })
+    await act(async () => root.render(<NotificationBell />))
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+
+    const message = [...document.body.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Approval needed')
+    )
+    await act(async () => message?.click())
+
+    expect(openSessionById).toHaveBeenCalledWith('session-missing', 'notification')
+    expect(markRead).not.toHaveBeenCalled()
+    expect(document.body.querySelector('[aria-label="Message center"]')).not.toBeNull()
+  })
+
   it('continues the notification action when marking the message as read fails', async () => {
     const connectorRequest = {
       id: 'request-1',
@@ -436,7 +460,7 @@ describe('NotificationBell', () => {
     } satisfies ConnectorApprovalRequest
     const replayConnectorApproval = vi.fn(async () => connectorRequest)
     const enqueueApproval = vi.fn()
-    const openSessionById = vi.fn()
+    const openSessionById = vi.fn(() => true)
     const markRead = vi.fn(async () => {
       throw new Error('notification write failed')
     })
@@ -466,7 +490,7 @@ describe('NotificationBell', () => {
   })
 
   it('continues navigation when approval replay fails', async () => {
-    const openSessionById = vi.fn()
+    const openSessionById = vi.fn(() => true)
     const markRead = vi.fn(async () => undefined)
     window.api.settings.replayConnectorApproval = vi.fn(async () => {
       throw new Error('approval replay failed')
@@ -493,7 +517,7 @@ describe('NotificationBell', () => {
 
   it('opens a credential wait without replaying it as a connector approval', async () => {
     const replayConnectorApproval = vi.fn(async () => null)
-    const openSessionById = vi.fn()
+    const openSessionById = vi.fn(() => true)
     window.api.settings.replayConnectorApproval = replayConnectorApproval
     useNavigationStore.setState({ openSessionById })
     const item = useNotificationInboxStore.getState().items[0]
@@ -531,7 +555,7 @@ describe('NotificationBell', () => {
           completeMarkRead = resolve
         })
     )
-    const openSessionById = vi.fn()
+    const openSessionById = vi.fn(() => true)
     useNavigationStore.setState({ openSessionById })
     const item = useNotificationInboxStore.getState().items[0]
     useNotificationInboxStore.setState({
@@ -584,7 +608,7 @@ describe('NotificationBell', () => {
       const replayApproval = vi.fn(async () => computeRequest)
       const enqueueConnector = vi.fn()
       const enqueueCompute = vi.fn()
-      const openSessionById = vi.fn()
+      const openSessionById = vi.fn(() => true)
       window.api.settings.replayConnectorApproval = replayConnectorApproval
       window.api.compute.replayApproval = replayApproval
       useSettingsStore.setState({ enqueueApproval: enqueueConnector })

--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -4,10 +4,12 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComputeApprovalRequest } from '../../../shared/compute'
+import type { Project } from '../../../shared/projects'
 import type { ConnectorApprovalRequest } from '../../../shared/settings'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useNotificationInboxStore } from '@/stores/notification-inbox-store'
 import { useComputeStore } from '@/stores/compute-store'
+import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { NotificationBell } from './NotificationBell'
 
@@ -333,6 +335,44 @@ describe('NotificationBell', () => {
 
     expect(document.body.textContent).toContain('Answered')
     expect(document.body.textContent).not.toContain('Waiting for your answer')
+  })
+
+  it('loads Projects before deciding whether a project notification target is valid', async () => {
+    const targetProject = { id: 'project-2', name: 'Fresh project' } as Project
+    const listProjects = vi.fn(async () => [targetProject])
+    window.api = {
+      ...window.api,
+      projects: { list: listProjects }
+    } as unknown as Window['api']
+    useProjectStore.setState(createInitialProjectState())
+    const markRead = vi.fn(async () => undefined)
+    const item = useNotificationInboxStore.getState().items[0]
+    useNotificationInboxStore.setState({
+      markRead,
+      items: item ? [{ ...item, projectId: targetProject.id, sessionId: undefined }] : []
+    })
+    await act(async () => root.render(<NotificationBell />))
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+
+    const message = [...document.body.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.includes('Approval needed')
+    )
+    expect(message).toBeDefined()
+    await act(async () => {
+      message?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(listProjects).toHaveBeenCalledOnce()
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'workspace',
+      activeProjectId: targetProject.id
+    })
+    expect(markRead).toHaveBeenCalledWith(['message-1'])
+    expect(document.body.querySelector('[aria-label="Message center"]')).toBeNull()
   })
 
   it('makes target invalidation override pending labels, replay, and navigation', async () => {

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -23,7 +23,7 @@ import { relativeTimeParts } from '@/lib/format-relative-time'
 import { sessionWaitReasonLabelKeys } from '@/lib/session-wait-reason-labels'
 import { cn } from '@/lib/utils'
 import { useComputeStore } from '@/stores/compute-store'
-import { useNavigationStore } from '@/stores/navigation-store'
+import { openNotificationProject, useNavigationStore } from '@/stores/navigation-store'
 import { useNotificationInboxStore } from '@/stores/notification-inbox-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
@@ -321,7 +321,7 @@ const NotificationBellContent = ({
         if (!opened) return
         setOpen(false)
       } else if (item.projectId) {
-        const opened = useNavigationStore.getState().openProject(item.projectId, 'notification')
+        const opened = await openNotificationProject(item.projectId)
         if (!opened) return
         setOpen(false)
       } else if (replayedApproval) {

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -317,10 +317,12 @@ const NotificationBellContent = ({
 
     try {
       if (item.sessionId) {
-        useNavigationStore.getState().openSessionById(item.sessionId, 'notification')
+        const opened = useNavigationStore.getState().openSessionById(item.sessionId, 'notification')
+        if (!opened) return
         setOpen(false)
       } else if (item.projectId) {
-        useNavigationStore.getState().openProject(item.projectId, 'notification')
+        const opened = useNavigationStore.getState().openProject(item.projectId, 'notification')
+        if (!opened) return
         setOpen(false)
       } else if (replayedApproval) {
         setOpen(false)

--- a/src/renderer/src/components/NotificationLiveToast.test.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.test.tsx
@@ -239,6 +239,7 @@ describe('NotificationLiveToast', () => {
     const open = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
       (button) => button.textContent === 'Open'
     )
+    expect(open).toBeDefined()
     await act(async () => open?.click())
 
     expect(openSessionById).toHaveBeenCalledWith('session-1', 'notification')

--- a/src/renderer/src/components/NotificationLiveToast.test.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.test.tsx
@@ -226,11 +226,9 @@ describe('NotificationLiveToast', () => {
     expect(markRead).not.toHaveBeenCalled()
   })
 
-  it('keeps the toast unread when opening its target fails', async () => {
+  it('keeps the toast unread when opening its target is rejected', async () => {
     const markRead = vi.fn(async () => undefined)
-    const openSessionById = vi.fn(() => {
-      throw new Error('navigation failed')
-    })
+    const openSessionById = vi.fn(() => false)
     useNotificationInboxStore.setState({ markRead })
     useNavigationStore.setState({ openSessionById })
     await act(async () => root.render(<NotificationLiveToast />))

--- a/src/renderer/src/components/NotificationLiveToast.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.tsx
@@ -193,11 +193,14 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
 
   const { notification, projectName, sessionTitle, detailPreview } = notice.lead
   const openLead = (): void => {
+    let opened = true
     try {
       if (notification.sessionId) {
-        useNavigationStore.getState().openSessionById(notification.sessionId, 'notification')
+        opened = useNavigationStore
+          .getState()
+          .openSessionById(notification.sessionId, 'notification')
       } else if (notification.projectId) {
-        useNavigationStore.getState().openProject(notification.projectId, 'notification')
+        opened = useNavigationStore.getState().openProject(notification.projectId, 'notification')
       } else {
         openVisibleNotificationCenter()
       }
@@ -205,6 +208,7 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
       // Keep the durable inbox entry unread when its target cannot be opened.
       return
     }
+    if (!opened) return
     if (notification.readAt === undefined) {
       runNotificationTask(() => markRead([notification.id]))
     }

--- a/src/renderer/src/components/NotificationLiveToast.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { useNavigationStore } from '@/stores/navigation-store'
+import { openNotificationProject, useNavigationStore } from '@/stores/navigation-store'
 import { useNotificationInboxStore } from '@/stores/notification-inbox-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
@@ -192,7 +192,7 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
   if (!notice) return null
 
   const { notification, projectName, sessionTitle, detailPreview } = notice.lead
-  const openLead = (): void => {
+  const openLead = async (): Promise<void> => {
     let opened = true
     try {
       if (notification.sessionId) {
@@ -200,7 +200,7 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
           .getState()
           .openSessionById(notification.sessionId, 'notification')
       } else if (notification.projectId) {
-        opened = useNavigationStore.getState().openProject(notification.projectId, 'notification')
+        opened = await openNotificationProject(notification.projectId)
       } else {
         openVisibleNotificationCenter()
       }

--- a/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
@@ -9,7 +9,7 @@ import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
-import { useProjectStore } from '@/stores/project-store'
+import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
 import {
   createInitialSessionState,
   useSessionStore,
@@ -84,7 +84,7 @@ describe('WorkspacePage notebook entry hydration', () => {
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useSessionStore.setState(createInitialSessionState())
-    useProjectStore.setState({ projects: [] })
+    useProjectStore.setState(createInitialProjectState())
     useNavigationStore.setState({ view: 'workspace', activeProjectId: undefined })
     vi.clearAllMocks()
     getReference = vi.fn(() => Promise.resolve(null))
@@ -96,7 +96,9 @@ describe('WorkspacePage notebook entry hydration', () => {
       },
       preview: {
         load: vi.fn(() => Promise.resolve(undefined)),
-        save: vi.fn(() => Promise.resolve())
+        save: vi.fn(({ expectedRevision }) =>
+          Promise.resolve({ status: 'saved' as const, revision: expectedRevision + 1 })
+        )
       },
       reviewer: {
         onUpdated: vi.fn(() => vi.fn()),
@@ -154,5 +156,44 @@ describe('WorkspacePage notebook entry hydration', () => {
       workspaceCwd: '/workspace/proj-1',
       projectId: 'proj-1'
     })
+  })
+
+  it('returns home and clears an invalid Project after the Project list loads', async () => {
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [
+        {
+          id: 'proj-other',
+          name: 'Other Project',
+          description: '',
+          isExample: false,
+          createdAt: Date.now(),
+          updatedAt: Date.now()
+        }
+      ],
+      isLoaded: true
+    })
+    useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-missing' })
+    useSessionStore.setState({
+      sessions: [createSession('sess-missing', 'proj-missing', '/workspace/proj-missing')],
+      selectedSessionId: 'sess-missing'
+    })
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspacePage
+          isSessionPersistenceHydrated={true}
+          isSessionPersistenceReady={true}
+          canDeleteConversations={true}
+        />
+      )
+    })
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'home',
+      activeProjectId: undefined
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -147,6 +147,9 @@ const WorkspacePage = ({
   const activeProject = useProjectStore((state) =>
     state.projects.find((project) => project.id === scopedProjectId)
   )
+  const isProjectListLoaded = useProjectStore((state) => state.isLoaded)
+  const projectLoadError = useProjectStore((state) => state.loadError)
+  const discardInvalidProject = useNavigationStore((state) => state.discardInvalidProject)
 
   const specialistItems = useSpecialistStore((state) => state.items)
   const specialistCatalogLoaded = useSpecialistStore((state) => state.isLoaded)
@@ -748,6 +751,17 @@ const WorkspacePage = ({
   useEffect(() => {
     if (!activeProjectId) goHome('automatic')
   }, [activeProjectId, goHome])
+
+  useEffect(() => {
+    if (
+      !activeProjectId ||
+      !isProjectListLoaded ||
+      projectLoadError !== undefined ||
+      activeProject !== undefined
+    )
+      return
+    discardInvalidProject(activeProjectId)
+  }, [activeProject, activeProjectId, discardInvalidProject, isProjectListLoaded, projectLoadError])
 
   useEffect(() => {
     if (activeProject?.archivedAt === undefined) return

--- a/src/renderer/src/stores/navigation-store.test.ts
+++ b/src/renderer/src/stores/navigation-store.test.ts
@@ -123,6 +123,35 @@ describe('navigation store', () => {
     expect(useSessionStore.getState().selectedSessionId).toBe('b')
   })
 
+  it.each([
+    ['missing', 'project-missing'],
+    ['archived', 'project-archived']
+  ] as const)(
+    'rejects a %s Project destination without changing navigation',
+    (_kind, projectId) => {
+      useProjectStore.setState({
+        projects: [
+          createProject('project-a'),
+          { ...createProject('project-archived'), archivedAt: 2 }
+        ]
+      })
+      useSessionStore.getState().hydrateSessions([createSession({ id: 'a' })], {
+        version: SESSION_MANIFEST_VERSION
+      })
+      useSessionStore.getState().selectSession('a')
+      useNavigationStore.setState({ view: 'workspace', activeProjectId: 'project-a' })
+
+      const opened = useNavigationStore.getState().openProject(projectId, 'notification')
+
+      expect(opened).toBe(false)
+      expect(useNavigationStore.getState()).toMatchObject({
+        view: 'workspace',
+        activeProjectId: 'project-a'
+      })
+      expect(useSessionStore.getState().selectedSessionId).toBe('a')
+    }
+  )
+
   it('atomically switches preview scope when opening a session in another project', () => {
     useSessionStore
       .getState()
@@ -239,16 +268,18 @@ describe('navigation store', () => {
         version: SESSION_MANIFEST_VERSION
       })
 
-    useNavigationStore.getState().openSessionById('a', 'notification')
+    const opened = useNavigationStore.getState().openSessionById('a', 'notification')
 
+    expect(opened).toBe(true)
     expect(useNavigationStore.getState().view).toBe('workspace')
     expect(useNavigationStore.getState().activeProjectId).toBe('project-a')
     expect(useSessionStore.getState().selectedSessionId).toBe('a')
   })
 
   it('stays put when a notification names a session that no longer exists', () => {
-    useNavigationStore.getState().openSessionById('gone', 'notification')
+    const opened = useNavigationStore.getState().openSessionById('gone', 'notification')
 
+    expect(opened).toBe(false)
     expect(useNavigationStore.getState().view).toBe('home')
     expect(useNavigationStore.getState().activeProjectId).toBeUndefined()
     expect(useSessionStore.getState().selectedSessionId).toBeUndefined()

--- a/src/renderer/src/stores/navigation-store.ts
+++ b/src/renderer/src/stores/navigation-store.ts
@@ -286,3 +286,18 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
   setArtifactMentionAvailability: (availability) =>
     set({ artifactMentionAvailability: availability })
 }))
+
+// Notification surfaces can appear before the startup Project query finishes. Wait for an
+// authoritative list before accepting or rejecting the target so a transient empty cache neither
+// loses a valid click nor consumes a notification for a deleted or archived Project.
+export const openNotificationProject = async (projectId: string): Promise<boolean> => {
+  const projectState = useProjectStore.getState()
+  if (!projectState.isLoaded || projectState.loadError !== undefined) {
+    await projectState.loadProjects()
+  }
+
+  const loadedProjectState = useProjectStore.getState()
+  if (!loadedProjectState.isLoaded || loadedProjectState.loadError !== undefined) return false
+
+  return useNavigationStore.getState().openProject(projectId, 'notification')
+}

--- a/src/renderer/src/stores/navigation-store.ts
+++ b/src/renderer/src/stores/navigation-store.ts
@@ -54,7 +54,10 @@ type NavigationStore = {
   openSession: (projectId: string, sessionId: string, origin: NavigationOrigin) => boolean
   // Opens a session knowing only its id (e.g. a desktop-notification click); a no-op when the
   // session no longer exists or hasn't loaded yet.
-  openSessionById: (sessionId: string, origin: NavigationOrigin) => void
+  openSessionById: (sessionId: string, origin: NavigationOrigin) => boolean
+  // Leaves a Workspace whose Project disappeared from the authoritative Project list. This recovery
+  // bypasses preview leave guards because the missing Project is no longer a valid editing scope.
+  discardInvalidProject: (projectId: string) => void
   // Opens a project's New Conversation draft (no Specialist binding) carrying a `/customize` prefill.
   // The intent does not send, create a session, or imply mutation approval; WorkspacePage consumes the
   // prefill once and clears it.
@@ -166,8 +169,9 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
 
   // Enters a project's workspace, selecting its most recent session when one exists. An explicit user
   // open also records the durable last-opened project so `Chat with agent` re-opens it next time.
-  openProject: (projectId, origin) =>
-    requestPreviewLeaveForNavigation({ view: 'workspace', projectId }, () => {
+  openProject: (projectId, origin) => {
+    if (!isActiveProject(projectId)) return false
+    return requestPreviewLeaveForNavigation({ view: 'workspace', projectId }, () => {
       const mostRecentSessionId = findMostRecentSessionId(projectId)
 
       if (mostRecentSessionId) {
@@ -182,7 +186,8 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
         navigationState(state, origin, { view: 'workspace', activeProjectId: projectId })
       )
       usePreviewWorkbenchStore.getState().activateProject(projectId, undefined, true)
-    }),
+    })
+  },
 
   // Opens a specific session inside its project's workspace. Returns whether navigation happened,
   // so callers that chain side effects (e.g. closing a modal over the conversation panel) can skip
@@ -209,8 +214,16 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
       .getState()
       .sessions.find((candidate) => candidate.id === sessionId)
 
-    if (!session) return
-    get().openSession(session.projectId, session.id, origin)
+    if (!session) return false
+    return get().openSession(session.projectId, session.id, origin)
+  },
+
+  discardInvalidProject: (projectId) => {
+    const navigation = get()
+    if (navigation.view !== 'workspace' || navigation.activeProjectId !== projectId) return
+
+    useSessionStore.getState().clearSelection()
+    set({ view: 'home', activeProjectId: undefined })
   },
 
   // Opens a project's New Conversation draft carrying a `/customize` prefill. Clears session selection


### PR DESCRIPTION
## Problem

Notification target navigation could fail without throwing when a Project or Session was deleted, archived, mismatched, or blocked by the preview leave guard. The live toast and message center still marked the notification read and closed it. `openProject` also accepted missing or archived Projects, and Workspace did not recover when an active Project id no longer resolved after the authoritative Project list loaded.

## Proposed change

- Reject missing and archived Project destinations at the navigation-store boundary.
- Propagate the boolean result from `openSessionById` and consume notifications only after successful navigation.
- Keep the live toast or message center open and unread when navigation is rejected.
- Return Workspace home and clear its invalid Project and Session selection only after the Project list has loaded successfully and the active Project is absent.

## Scope and non-goals

- No database, persisted-format, migration, or historical-data compatibility changes.
- No new data fields, status values, or enums.
- No new user-visible copy or error surface.
- Existing archived-Project and preview leave-guard interactions remain unchanged outside notification target handling.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Rejected Project and Session targets, notification retention, and missing-Workspace recovery -> `npm test -- src/renderer/src/stores/navigation-store.test.ts src/renderer/src/components/NotificationLiveToast.test.tsx src/renderer/src/components/NotificationBell.test.tsx src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx` -> 4 files, 62 tests passed.
- Workspace owner and representative consumers -> `npm run test:module -- workspace_page` -> 30 files, 736 tests passed.
- Navigation interface consumers -> `npm test -- src/renderer/src/App.test.tsx src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx src/renderer/src/pages/workspace/WorkspaceSidebarContainer.test.tsx` -> 4 files, 112 tests passed.
- Renderer type contract -> `npm run typecheck:web` -> passed.
- Linted source and tests -> `npm run lint` -> passed with no errors or warnings.

The local affected-test classifier falls back to the complete Vitest suite because `NotificationBell.test.tsx` has no registered module owner. Per maintainer direction, the complete local suite was not run; exact-head PR Gate CI is authoritative for that uncovered breadth.

## Review focus

- Boolean navigation-result propagation at the notification boundaries.
- The authoritative-load guard before discarding a missing active Project.
- Preservation of notification read state and UI entry points after rejected navigation.
