### PR TITLE
fix(workspaces): preserve managed workspace ownership

### DIFF
--- a/src/main/acp/create-session-workflow.test.ts
+++ b/src/main/acp/create-session-workflow.test.ts
@@ -9,7 +9,7 @@ type AcpCreateSessionWorkflowHarness = {
   createSession: Mock<(request: AcpCreateSessionRequest) => Promise<AcpCreateSessionResponse>>
   lease: ManagedSessionWorkspaceLease
   workspaces: {
-    acquire: Mock<() => Promise<ManagedSessionWorkspaceLease>>
+    acquire: Mock<(input: { projectId: string }) => Promise<ManagedSessionWorkspaceLease>>
   }
   dataRootWriteCalls: () => number
   events: string[]
@@ -28,13 +28,15 @@ const createHarness = (
   })
   const lease: ManagedSessionWorkspaceLease = {
     cwd: '/data/workspaces/managed-1',
-    commit: vi.fn(() => events.push('commit')),
+    commit: vi.fn(async () => {
+      events.push('commit')
+    }),
     release: vi.fn(async () => {
       events.push('release')
     })
   }
   const workspaces: AcpCreateSessionWorkflowHarness['workspaces'] = {
-    acquire: vi.fn<() => Promise<ManagedSessionWorkspaceLease>>(async () => {
+    acquire: vi.fn(async () => {
       events.push('acquire')
       return lease
     })
@@ -137,6 +139,8 @@ describe('ACP create-Session workflow', () => {
         projectId: 'project-1',
         permissionProfile: 'ask'
       })
+      expect(harness.workspaces.acquire).toHaveBeenCalledWith({ projectId: 'project-1' })
+      expect(harness.lease.commit).toHaveBeenCalledWith('session-1')
       expect(harness.events).toEqual([
         'guard:start',
         'acquire',

--- a/src/main/acp/create-session-workflow.test.ts
+++ b/src/main/acp/create-session-workflow.test.ts
@@ -7,6 +7,7 @@ import type { ManagedSessionWorkspaceLease } from './managed-session-workspace'
 type AcpCreateSessionWorkflowHarness = {
   workflow: ReturnType<typeof createAcpCreateSessionWorkflow>
   createSession: Mock<(request: AcpCreateSessionRequest) => Promise<AcpCreateSessionResponse>>
+  deleteSession: Mock<(request: { sessionId: string }) => Promise<unknown>>
   lease: ManagedSessionWorkspaceLease
   workspaces: {
     acquire: Mock<(input: { projectId: string }) => Promise<ManagedSessionWorkspaceLease>>
@@ -25,6 +26,10 @@ const createHarness = (
     events.push('session')
     if (createSessionResult instanceof Error) throw createSessionResult
     return { sessionId: 'session-1', cwd: request.cwd }
+  })
+  const deleteSession = vi.fn<(request: { sessionId: string }) => Promise<unknown>>(async () => {
+    events.push('delete-session')
+    return undefined
   })
   const lease: ManagedSessionWorkspaceLease = {
     cwd: '/data/workspaces/managed-1',
@@ -52,12 +57,13 @@ const createHarness = (
     }
   }
   const workflow = createAcpCreateSessionWorkflow(
-    { createSession },
+    { createSession, deleteSession },
     { workspaces, withDataRootWrite }
   )
   return {
     workflow,
     createSession,
+    deleteSession,
     lease,
     workspaces,
     dataRootWriteCalls: () => dataRootWriteCalls,
@@ -85,7 +91,10 @@ describe('ACP create-Session workflow', () => {
         admissionActive = false
       }
     }
-    const workflow = createAcpCreateSessionWorkflow({ createSession }, { withProjectAvailable })
+    const workflow = createAcpCreateSessionWorkflow(
+      { createSession, deleteSession: vi.fn() },
+      { withProjectAvailable }
+    )
 
     const pending = workflow.create({
       cwd: '/workspace',
@@ -163,6 +172,28 @@ describe('ACP create-Session workflow', () => {
       expect(harness.events).toEqual(['guard:start', 'acquire', 'session', 'release', 'guard:end'])
     }
   )
+
+  it('deletes the published Session when final ownership publication fails', async () => {
+    const harness = createHarness()
+    const failure = new Error('receipt publication failed')
+    vi.mocked(harness.lease.commit).mockImplementationOnce(async () => {
+      harness.events.push('commit')
+      throw failure
+    })
+
+    await expect(harness.workflow.create({ projectId: 'project-1' })).rejects.toBe(failure)
+
+    expect(harness.deleteSession).toHaveBeenCalledWith({ sessionId: 'session-1' })
+    expect(harness.events).toEqual([
+      'guard:start',
+      'acquire',
+      'session',
+      'commit',
+      'delete-session',
+      'release',
+      'guard:end'
+    ])
+  })
 })
 
 const createDeferred = <Value>(): {

--- a/src/main/acp/create-session-workflow.test.ts
+++ b/src/main/acp/create-session-workflow.test.ts
@@ -110,6 +110,44 @@ describe('ACP create-Session workflow', () => {
     expect(admissionActive).toBe(false)
   })
 
+  it.each([
+    { requestedProjectId: '  project-1  ', expectedProjectId: 'project-1' },
+    { requestedProjectId: '   ', expectedProjectId: undefined }
+  ])(
+    'normalizes "$requestedProjectId" before Project admission',
+    async ({ requestedProjectId, expectedProjectId }) => {
+      const createSession = vi.fn(async (request: AcpCreateSessionRequest) => ({
+        sessionId: 'session-1',
+        cwd: request.cwd
+      }))
+      const admittedProjectIds: (string | undefined)[] = []
+      const withProjectAvailable = async <Result>(
+        projectId: string | undefined,
+        operation: () => Promise<Result>
+      ): Promise<Result> => {
+        admittedProjectIds.push(projectId)
+        return operation()
+      }
+      const workflow = createAcpCreateSessionWorkflow(
+        { createSession, deleteSession: vi.fn() },
+        { withProjectAvailable }
+      )
+
+      await workflow.create({
+        cwd: '/workspace',
+        projectId: requestedProjectId,
+        permissionProfile: 'ask'
+      })
+
+      expect(admittedProjectIds).toEqual([expectedProjectId])
+      expect(createSession).toHaveBeenCalledWith({
+        cwd: '/workspace',
+        projectId: expectedProjectId,
+        permissionProfile: 'ask'
+      })
+    }
+  )
+
   it('trims and uses an explicit workspace without acquiring managed storage', async () => {
     const harness = createHarness()
     const request = {

--- a/src/main/acp/create-session-workflow.test.ts
+++ b/src/main/acp/create-session-workflow.test.ts
@@ -194,6 +194,34 @@ describe('ACP create-Session workflow', () => {
       'guard:end'
     ])
   })
+
+  it('retains the workspace when ownership publication and Session rollback both fail', async () => {
+    const harness = createHarness()
+    const publicationFailure = new Error('receipt publication failed')
+    const rollbackFailure = new Error('Session rollback failed')
+    vi.mocked(harness.lease.commit).mockImplementationOnce(async () => {
+      harness.events.push('commit')
+      throw publicationFailure
+    })
+    harness.deleteSession.mockImplementationOnce(async () => {
+      harness.events.push('delete-session')
+      throw rollbackFailure
+    })
+
+    await expect(harness.workflow.create({ projectId: 'project-1' })).rejects.toMatchObject({
+      errors: [publicationFailure, rollbackFailure]
+    })
+
+    expect(harness.lease.release).not.toHaveBeenCalled()
+    expect(harness.events).toEqual([
+      'guard:start',
+      'acquire',
+      'session',
+      'commit',
+      'delete-session',
+      'guard:end'
+    ])
+  })
 })
 
 const createDeferred = <Value>(): {

--- a/src/main/acp/create-session-workflow.ts
+++ b/src/main/acp/create-session-workflow.ts
@@ -1,4 +1,5 @@
 import type { AcpCreateSessionRequest, AcpCreateSessionResponse } from '../../shared/acp'
+import { DEFAULT_ARTIFACT_PROJECT_ID } from '../../shared/artifacts'
 import { withDataRootWrite } from '../storage/migration-state'
 import {
   createManagedSessionWorkspaceCapability,
@@ -43,10 +44,15 @@ const createAcpCreateSessionWorkflow = (
         }
 
         return runDataRootWrite(async () => {
-          const workspace = await workspaces.acquire()
+          const projectId = request.projectId?.trim() || DEFAULT_ARTIFACT_PROJECT_ID
+          const workspace = await workspaces.acquire({ projectId })
           try {
-            const response = await sessions.createSession({ ...request, cwd: workspace.cwd })
-            workspace.commit()
+            const response = await sessions.createSession({
+              ...request,
+              projectId,
+              cwd: workspace.cwd
+            })
+            await workspace.commit(response.sessionId)
             return response
           } finally {
             await workspace.release()

--- a/src/main/acp/create-session-workflow.ts
+++ b/src/main/acp/create-session-workflow.ts
@@ -51,6 +51,7 @@ const createAcpCreateSessionWorkflow = (
         return runDataRootWrite(async () => {
           const projectId = request.projectId?.trim() || DEFAULT_ARTIFACT_PROJECT_ID
           const workspace = await workspaces.acquire({ projectId })
+          let releaseWorkspace = true
           try {
             const response = await sessions.createSession({
               ...request,
@@ -63,6 +64,7 @@ const createAcpCreateSessionWorkflow = (
               try {
                 await sessions.deleteSession({ sessionId: response.sessionId })
               } catch (cleanupError) {
+                releaseWorkspace = false
                 throw new AggregateError(
                   [publicationError, cleanupError],
                   'Managed workspace publication and Session rollback failed.'
@@ -72,7 +74,7 @@ const createAcpCreateSessionWorkflow = (
             }
             return response
           } finally {
-            await workspace.release()
+            if (releaseWorkspace) await workspace.release()
           }
         })
       }

--- a/src/main/acp/create-session-workflow.ts
+++ b/src/main/acp/create-session-workflow.ts
@@ -42,19 +42,24 @@ const createAcpCreateSessionWorkflow = (
 
   return {
     async create(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse> {
+      const requestedProjectId = request.projectId?.trim() || undefined
+      const normalizedRequest =
+        requestedProjectId === request.projectId
+          ? request
+          : { ...request, projectId: requestedProjectId }
       const createAvailableSession = async (): Promise<AcpCreateSessionResponse> => {
         const explicitCwd = request.cwd?.trim()
         if (explicitCwd) {
-          return sessions.createSession({ ...request, cwd: explicitCwd })
+          return sessions.createSession({ ...normalizedRequest, cwd: explicitCwd })
         }
 
         return runDataRootWrite(async () => {
-          const projectId = request.projectId?.trim() || DEFAULT_ARTIFACT_PROJECT_ID
+          const projectId = requestedProjectId ?? DEFAULT_ARTIFACT_PROJECT_ID
           const workspace = await workspaces.acquire({ projectId })
           let releaseWorkspace = true
           try {
             const response = await sessions.createSession({
-              ...request,
+              ...normalizedRequest,
               projectId,
               cwd: workspace.cwd
             })
@@ -79,7 +84,7 @@ const createAcpCreateSessionWorkflow = (
         })
       }
       return dependencies.withProjectAvailable
-        ? dependencies.withProjectAvailable(request.projectId, createAvailableSession)
+        ? dependencies.withProjectAvailable(requestedProjectId, createAvailableSession)
         : createAvailableSession()
     }
   }

--- a/src/main/acp/create-session-workflow.ts
+++ b/src/main/acp/create-session-workflow.ts
@@ -1,4 +1,8 @@
-import type { AcpCreateSessionRequest, AcpCreateSessionResponse } from '../../shared/acp'
+import type {
+  AcpCreateSessionRequest,
+  AcpCreateSessionResponse,
+  AcpDeleteSessionRequest
+} from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_ID } from '../../shared/artifacts'
 import { withDataRootWrite } from '../storage/migration-state'
 import {
@@ -8,6 +12,7 @@ import {
 
 type AcpSessionCreator = {
   createSession(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse>
+  deleteSession(request: AcpDeleteSessionRequest): Promise<unknown>
 }
 
 type DataRootWrite = <Result>(write: () => Promise<Result>) => Promise<Result>
@@ -52,7 +57,19 @@ const createAcpCreateSessionWorkflow = (
               projectId,
               cwd: workspace.cwd
             })
-            await workspace.commit(response.sessionId)
+            try {
+              await workspace.commit(response.sessionId)
+            } catch (publicationError) {
+              try {
+                await sessions.deleteSession({ sessionId: response.sessionId })
+              } catch (cleanupError) {
+                throw new AggregateError(
+                  [publicationError, cleanupError],
+                  'Managed workspace publication and Session rollback failed.'
+                )
+              }
+              throw publicationError
+            }
             return response
           } finally {
             await workspace.release()

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -25,7 +25,11 @@ import {
 
 // Capture every ipcMain.handle registration so a handler can be invoked directly.
 const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
-const { mkdir, rm } = vi.hoisted(() => ({
+const { lstat, mkdir, rm } = vi.hoisted(() => ({
+  lstat: vi.fn().mockResolvedValue({
+    isDirectory: () => true,
+    isSymbolicLink: () => false
+  }),
   mkdir: vi.fn().mockResolvedValue(undefined),
   rm: vi.fn().mockResolvedValue(undefined)
 }))
@@ -39,7 +43,7 @@ vi.mock('electron', () => ({
   app: { getVersion: () => '0.0.0-test' },
   BrowserWindow: { getAllWindows: () => [] }
 }))
-vi.mock('node:fs/promises', () => ({ mkdir, rm }))
+vi.mock('node:fs/promises', () => ({ lstat, mkdir, rm }))
 vi.mock('../storage/managed-workspace-ownership', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../storage/managed-workspace-ownership')>()),
   initializeManagedWorkspaceOwnership: vi.fn().mockResolvedValue(undefined),
@@ -274,6 +278,7 @@ const registerWithFakes = (overrides?: {
 
 afterEach(() => {
   clearMigrationPending()
+  lstat.mockClear()
   mkdir.mockClear()
   rm.mockClear()
   // Restore the default managed-workspace implementation (a test may have overridden it once).
@@ -1033,8 +1038,10 @@ describe('installAcpIpcHandlers — managed session workspace', () => {
       new RegExp(`^${join('/tmp/data', 'workspaces').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`)
     )
     expect(secondRequest.cwd).not.toBe(firstRequest.cwd)
-    expect(mkdir).toHaveBeenNthCalledWith(1, firstRequest.cwd, { recursive: true })
-    expect(mkdir).toHaveBeenNthCalledWith(2, secondRequest.cwd, { recursive: true })
+    expect(mkdir).toHaveBeenNthCalledWith(1, join('/tmp/data', 'workspaces'), { recursive: true })
+    expect(mkdir).toHaveBeenNthCalledWith(2, firstRequest.cwd, { recursive: false })
+    expect(mkdir).toHaveBeenNthCalledWith(3, join('/tmp/data', 'workspaces'), { recursive: true })
+    expect(mkdir).toHaveBeenNthCalledWith(4, secondRequest.cwd, { recursive: false })
     expect(rm).not.toHaveBeenCalled()
     expect(firstResult).toEqual({ sessionId: 's-new', cwd: firstRequest.cwd })
     expect(secondResult).toEqual({ sessionId: 's-new', cwd: secondRequest.cwd })
@@ -1084,7 +1091,8 @@ describe('installAcpIpcHandlers — managed session workspace', () => {
 
     const request = createSession.mock.calls[0][0]
     expect(request.cwd).not.toBe('   ')
-    expect(mkdir).toHaveBeenCalledWith(request.cwd, { recursive: true })
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/data', 'workspaces'), { recursive: true })
+    expect(mkdir).toHaveBeenCalledWith(request.cwd, { recursive: false })
   })
 
   it('rejects managed workspace creation while a data-root migration is pending', async () => {
@@ -1140,7 +1148,8 @@ describe('installAcpIpcHandlers — managed session workspace', () => {
     ).rejects.toBe(error)
 
     const request = createSession.mock.calls[0][0]
-    expect(mkdir).toHaveBeenCalledWith(request.cwd, { recursive: true })
+    expect(mkdir).toHaveBeenCalledWith(join('/tmp/data', 'workspaces'), { recursive: true })
+    expect(mkdir).toHaveBeenCalledWith(request.cwd, { recursive: false })
     expect(rm).toHaveBeenCalledWith(request.cwd, { recursive: true, force: true })
   })
 

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -40,6 +40,12 @@ vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: () => [] }
 }))
 vi.mock('node:fs/promises', () => ({ mkdir, rm }))
+vi.mock('../storage/managed-workspace-ownership', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../storage/managed-workspace-ownership')>()),
+  initializeManagedWorkspaceOwnership: vi.fn().mockResolvedValue(undefined),
+  finalizeManagedWorkspaceOwnership: vi.fn().mockResolvedValue(undefined),
+  removeManagedWorkspaceOwnership: vi.fn().mockResolvedValue(undefined)
+}))
 
 // A fake runtime whose methods are spies; registration wires closures over these, so only the invoked
 // handler's method needs meaningful behavior. Hoisted so the (hoisted) vi.mock factory can reference it.

--- a/src/main/acp/managed-session-workspace.test.ts
+++ b/src/main/acp/managed-session-workspace.test.ts
@@ -99,7 +99,7 @@ describe('managed Session workspace capability', () => {
     expect(removeOwnership).not.toHaveBeenCalled()
   })
 
-  it('retains a provisional ownership receipt when final publication fails', async () => {
+  it('releases the provisional workspace when final publication fails', async () => {
     const { capability, finalizeOwnership, removeDirectory, removeOwnership } = createCapability()
     const lease = await capability.acquire({ projectId: 'project-1' })
     finalizeOwnership.mockRejectedValueOnce(new Error('receipt publication failed'))
@@ -107,7 +107,7 @@ describe('managed Session workspace capability', () => {
     await expect(lease.commit('session-1')).rejects.toThrow('receipt publication failed')
     await lease.release()
 
-    expect(removeDirectory).not.toHaveBeenCalled()
-    expect(removeOwnership).not.toHaveBeenCalled()
+    expect(removeDirectory).toHaveBeenCalledWith(lease.cwd)
+    expect(removeOwnership).toHaveBeenCalledWith(lease.cwd, '/relocatable/data')
   })
 })

--- a/src/main/acp/managed-session-workspace.test.ts
+++ b/src/main/acp/managed-session-workspace.test.ts
@@ -8,29 +8,46 @@ type ManagedSessionWorkspaceHarness = {
   capability: ReturnType<typeof createManagedSessionWorkspaceCapability>
   createDirectory: Mock<(path: string) => Promise<void>>
   removeDirectory: Mock<(path: string) => Promise<void>>
+  initializeOwnership: Mock<(path: string, projectId: string, dataRoot: string) => Promise<void>>
+  finalizeOwnership: Mock<(path: string, sessionId: string, dataRoot: string) => Promise<void>>
+  removeOwnership: Mock<(path: string, dataRoot: string) => Promise<void>>
 }
 
 const createCapability = (): ManagedSessionWorkspaceHarness => {
   const createDirectory = vi.fn<(path: string) => Promise<void>>().mockResolvedValue(undefined)
   const removeDirectory = vi.fn<(path: string) => Promise<void>>().mockResolvedValue(undefined)
+  const initializeOwnership = vi.fn().mockResolvedValue(undefined)
+  const finalizeOwnership = vi.fn().mockResolvedValue(undefined)
+  const removeOwnership = vi.fn().mockResolvedValue(undefined)
   const capability = createManagedSessionWorkspaceCapability({
     resolveRoot: () => '/relocatable/data',
     createId: () => 'workspace-id',
     createDirectory,
-    removeDirectory
+    removeDirectory,
+    initializeOwnership,
+    finalizeOwnership,
+    removeOwnership
   })
-  return { capability, createDirectory, removeDirectory }
+  return {
+    capability,
+    createDirectory,
+    removeDirectory,
+    initializeOwnership,
+    finalizeOwnership,
+    removeOwnership
+  }
 }
 
 describe('managed Session workspace capability', () => {
   it('allocates a unique provisional workspace under the current data root', async () => {
-    const { capability, createDirectory } = createCapability()
+    const { capability, createDirectory, initializeOwnership } = createCapability()
 
-    const lease = await capability.acquire()
+    const lease = await capability.acquire({ projectId: 'project-1' })
 
     expect(lease.cwd).toBe(join('/relocatable/data', 'workspaces', 'workspace-id'))
     expect(createDirectory).toHaveBeenCalledOnce()
     expect(createDirectory).toHaveBeenCalledWith(lease.cwd)
+    expect(initializeOwnership).toHaveBeenCalledWith(lease.cwd, 'project-1', '/relocatable/data')
   })
 
   it('resolves the data root when each workspace is acquired', async () => {
@@ -39,42 +56,58 @@ describe('managed Session workspace capability', () => {
     const capability = createManagedSessionWorkspaceCapability({
       resolveRoot: () => dataRoot,
       createId: () => 'workspace-id',
-      createDirectory
+      createDirectory,
+      initializeOwnership: vi.fn().mockResolvedValue(undefined)
     })
     dataRoot = '/data-after-relocation'
 
-    const lease = await capability.acquire()
+    const lease = await capability.acquire({ projectId: 'project-1' })
 
     expect(lease.cwd).toBe(join(dataRoot, 'workspaces', 'workspace-id'))
     expect(createDirectory).toHaveBeenCalledWith(lease.cwd)
   })
 
   it('releases an uncommitted workspace at most once', async () => {
-    const { capability, removeDirectory } = createCapability()
-    const lease = await capability.acquire()
+    const { capability, removeDirectory, removeOwnership } = createCapability()
+    const lease = await capability.acquire({ projectId: 'project-1' })
 
     await lease.release()
     await lease.release()
 
     expect(removeDirectory).toHaveBeenCalledOnce()
     expect(removeDirectory).toHaveBeenCalledWith(lease.cwd)
+    expect(removeOwnership).toHaveBeenCalledWith(lease.cwd, '/relocatable/data')
   })
 
   it('retains a committed workspace when the lease is released', async () => {
-    const { capability, removeDirectory } = createCapability()
-    const lease = await capability.acquire()
+    const { capability, finalizeOwnership, removeDirectory } = createCapability()
+    const lease = await capability.acquire({ projectId: 'project-1' })
 
-    lease.commit()
+    await lease.commit('session-1')
     await lease.release()
 
+    expect(finalizeOwnership).toHaveBeenCalledWith(lease.cwd, 'session-1', '/relocatable/data')
     expect(removeDirectory).not.toHaveBeenCalled()
   })
 
   it('keeps rollback best effort when directory removal fails', async () => {
-    const { capability, removeDirectory } = createCapability()
-    const lease = await capability.acquire()
+    const { capability, removeDirectory, removeOwnership } = createCapability()
+    const lease = await capability.acquire({ projectId: 'project-1' })
     removeDirectory.mockRejectedValueOnce(new Error('remove failed'))
 
     await expect(lease.release()).resolves.toBeUndefined()
+    expect(removeOwnership).not.toHaveBeenCalled()
+  })
+
+  it('retains a provisional ownership receipt when final publication fails', async () => {
+    const { capability, finalizeOwnership, removeDirectory, removeOwnership } = createCapability()
+    const lease = await capability.acquire({ projectId: 'project-1' })
+    finalizeOwnership.mockRejectedValueOnce(new Error('receipt publication failed'))
+
+    await expect(lease.commit('session-1')).rejects.toThrow('receipt publication failed')
+    await lease.release()
+
+    expect(removeDirectory).not.toHaveBeenCalled()
+    expect(removeOwnership).not.toHaveBeenCalled()
   })
 })

--- a/src/main/acp/managed-session-workspace.ts
+++ b/src/main/acp/managed-session-workspace.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import { mkdir, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { resolveDataRoot } from '../storage-root'
 import {
+  assertManagedWorkspacesRoot,
   finalizeManagedWorkspaceOwnership,
   initializeManagedWorkspaceOwnership,
   removeManagedWorkspaceOwnership
@@ -32,8 +33,18 @@ type ManagedSessionWorkspaceDependencies = {
 const defaultDependencies: ManagedSessionWorkspaceDependencies = {
   resolveRoot: resolveDataRoot,
   createId: randomUUID,
-  createDirectory: (path) => mkdir(path, { recursive: true }).then(() => undefined),
-  removeDirectory: (path) => rm(path, { recursive: true, force: true }),
+  createDirectory: async (path) => {
+    const workspacesRoot = dirname(path)
+    await mkdir(workspacesRoot, { recursive: true })
+    if (!(await assertManagedWorkspacesRoot(workspacesRoot))) {
+      throw new Error('Managed workspaces root is missing.')
+    }
+    await mkdir(path, { recursive: false })
+  },
+  removeDirectory: async (path) => {
+    if (!(await assertManagedWorkspacesRoot(dirname(path)))) return
+    await rm(path, { recursive: true, force: true })
+  },
   initializeOwnership: (path, projectId, dataRoot) =>
     initializeManagedWorkspaceOwnership(path, projectId, Date.now(), dataRoot),
   finalizeOwnership: (path, sessionId, dataRoot) =>

--- a/src/main/acp/managed-session-workspace.ts
+++ b/src/main/acp/managed-session-workspace.ts
@@ -70,10 +70,8 @@ const createManagedSessionWorkspaceCapability = (
         cwd,
         commit: async (sessionId) => {
           if (released) return
-          // Preserve the successfully-created Session workspace if publishing the final receipt
-          // fails; the provisional receipt still proves its Project ownership for later recovery.
-          committed = true
           await resolvedDependencies.finalizeOwnership(cwd, sessionId, dataRoot)
+          committed = true
         },
         release: async () => {
           if (released) return

--- a/src/main/acp/managed-session-workspace.ts
+++ b/src/main/acp/managed-session-workspace.ts
@@ -3,15 +3,20 @@ import { mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { resolveDataRoot } from '../storage-root'
+import {
+  finalizeManagedWorkspaceOwnership,
+  initializeManagedWorkspaceOwnership,
+  removeManagedWorkspaceOwnership
+} from '../storage/managed-workspace-ownership'
 
 type ManagedSessionWorkspaceLease = {
   readonly cwd: string
-  commit(): void
+  commit(sessionId: string): Promise<void>
   release(): Promise<void>
 }
 
 type ManagedSessionWorkspaceCapability = {
-  acquire(): Promise<ManagedSessionWorkspaceLease>
+  acquire(input: { projectId: string }): Promise<ManagedSessionWorkspaceLease>
 }
 
 type ManagedSessionWorkspaceDependencies = {
@@ -19,13 +24,21 @@ type ManagedSessionWorkspaceDependencies = {
   createId: () => string
   createDirectory: (path: string) => Promise<void>
   removeDirectory: (path: string) => Promise<void>
+  initializeOwnership: (path: string, projectId: string, dataRoot: string) => Promise<void>
+  finalizeOwnership: (path: string, sessionId: string, dataRoot: string) => Promise<void>
+  removeOwnership: (path: string, dataRoot: string) => Promise<void>
 }
 
 const defaultDependencies: ManagedSessionWorkspaceDependencies = {
   resolveRoot: resolveDataRoot,
   createId: randomUUID,
   createDirectory: (path) => mkdir(path, { recursive: true }).then(() => undefined),
-  removeDirectory: (path) => rm(path, { recursive: true, force: true })
+  removeDirectory: (path) => rm(path, { recursive: true, force: true }),
+  initializeOwnership: (path, projectId, dataRoot) =>
+    initializeManagedWorkspaceOwnership(path, projectId, Date.now(), dataRoot),
+  finalizeOwnership: (path, sessionId, dataRoot) =>
+    finalizeManagedWorkspaceOwnership(path, sessionId, Date.now(), dataRoot),
+  removeOwnership: removeManagedWorkspaceOwnership
 }
 
 // Owns the provisional directory from allocation until the application workflow either publishes the
@@ -37,26 +50,39 @@ const createManagedSessionWorkspaceCapability = (
   const resolvedDependencies = { ...defaultDependencies, ...dependencies }
 
   return {
-    async acquire(): Promise<ManagedSessionWorkspaceLease> {
-      const cwd = join(
-        resolvedDependencies.resolveRoot(),
-        'workspaces',
-        resolvedDependencies.createId()
-      )
+    async acquire(input): Promise<ManagedSessionWorkspaceLease> {
+      const dataRoot = resolvedDependencies.resolveRoot()
+      const cwd = join(dataRoot, 'workspaces', resolvedDependencies.createId())
       await resolvedDependencies.createDirectory(cwd)
+      try {
+        await resolvedDependencies.initializeOwnership(cwd, input.projectId, dataRoot)
+      } catch (error) {
+        await resolvedDependencies
+          .removeDirectory(cwd)
+          .then(() => resolvedDependencies.removeOwnership(cwd, dataRoot))
+          .catch(() => undefined)
+        throw error
+      }
 
       let committed = false
       let released = false
       return {
         cwd,
-        commit: () => {
-          if (!released) committed = true
+        commit: async (sessionId) => {
+          if (released) return
+          // Preserve the successfully-created Session workspace if publishing the final receipt
+          // fails; the provisional receipt still proves its Project ownership for later recovery.
+          committed = true
+          await resolvedDependencies.finalizeOwnership(cwd, sessionId, dataRoot)
         },
         release: async () => {
           if (released) return
           released = true
           if (committed) return
-          await resolvedDependencies.removeDirectory(cwd).catch(() => undefined)
+          await resolvedDependencies
+            .removeDirectory(cwd)
+            .then(() => resolvedDependencies.removeOwnership(cwd, dataRoot))
+            .catch(() => undefined)
         }
       }
     }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -359,6 +359,7 @@ import { normalizeLegacyDataPaths } from './storage/normalize-legacy-paths'
 import { DataRootCleanupJournal } from './storage/data-root-cleanup'
 import {
   markManagedWorkspaceRetained,
+  reconcileProvisionalManagedWorkspaces,
   restoreManagedWorkspaceActive
 } from './storage/managed-workspace-ownership'
 import { deleteSources } from './storage/data-migration'
@@ -996,6 +997,7 @@ const createApplicationModules = async (
       .filter((chat) => chat.running)
       .map((chat) => ({ projectId: chat.projectId, sessionId: chat.parentSessionId }))
 
+  const managedWorkspaceRecoveryCutoff = Date.now()
   const sessionPersistenceCoordinator = new SessionPersistenceCoordinator(
     sessionRepository,
     projectFilesRepository,
@@ -1033,6 +1035,8 @@ const createApplicationModules = async (
       }
     },
     {
+      reconcileProvisional: (sessions) =>
+        reconcileProvisionalManagedWorkspaces(sessions, managedWorkspaceRecoveryCutoff),
       markRetained: markManagedWorkspaceRetained,
       restoreActive: restoreManagedWorkspaceActive
     }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -358,8 +358,10 @@ import {
 import { normalizeLegacyDataPaths } from './storage/normalize-legacy-paths'
 import { DataRootCleanupJournal } from './storage/data-root-cleanup'
 import {
+  markManagedProjectWorkspacesRetained,
   markManagedWorkspaceRetained,
   reconcileProvisionalManagedWorkspaces,
+  restoreManagedProjectWorkspacesActive,
   restoreManagedWorkspaceActive
 } from './storage/managed-workspace-ownership'
 import { deleteSources } from './storage/data-migration'
@@ -1037,6 +1039,8 @@ const createApplicationModules = async (
     {
       reconcileProvisional: (sessions) =>
         reconcileProvisionalManagedWorkspaces(sessions, managedWorkspaceRecoveryCutoff),
+      markProjectRetained: markManagedProjectWorkspacesRetained,
+      restoreProjectActive: restoreManagedProjectWorkspacesActive,
       markRetained: markManagedWorkspaceRetained,
       restoreActive: restoreManagedWorkspaceActive
     }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -357,6 +357,10 @@ import {
 } from './storage/migration-state'
 import { normalizeLegacyDataPaths } from './storage/normalize-legacy-paths'
 import { DataRootCleanupJournal } from './storage/data-root-cleanup'
+import {
+  markManagedWorkspaceRetained,
+  restoreManagedWorkspaceActive
+} from './storage/managed-workspace-ownership'
 import { deleteSources } from './storage/data-migration'
 import { removeMicromambaCacheForRoot } from './notebook/micromamba-cache'
 import { removeNotebookWorkloadCache } from './notebook/notebook-workload-cache-paths'
@@ -1027,6 +1031,10 @@ const createApplicationModules = async (
       if (session.delegationPolicy === 'allow') {
         delegatedWorkRef.current?.root.clearUnavailableReason?.(session.id)
       }
+    },
+    {
+      markRetained: markManagedWorkspaceRetained,
+      restoreActive: restoreManagedWorkspaceActive
     }
   )
   const sessionPdfContextOwner = new SessionPdfContextOwner({

--- a/src/main/projects/project-owned-data.catalog.architecture.test.ts
+++ b/src/main/projects/project-owned-data.catalog.architecture.test.ts
@@ -274,7 +274,7 @@ describe('Project-owned data catalog architecture', () => {
       PROJECT_OWNED_DATA_CATALOG.find((entry) => entry.id === 'managed-session-workspaces')
     ).toMatchObject({
       medium: 'filesystem',
-      resources: ['workspaces/<workspaceId>/'],
+      resources: ['workspaces/<workspaceId>/', 'workspaces/.ownership/<workspaceId>.json'],
       policy: {
         kind: 'retained-history',
         effect: 'retain'

--- a/src/main/projects/project-owned-data.catalog.ts
+++ b/src/main/projects/project-owned-data.catalog.ts
@@ -460,12 +460,13 @@ const PROJECT_OWNED_DATA_CATALOG: readonly ProjectOwnedDataCatalogEntry[] = [
   {
     id: 'managed-session-workspaces',
     medium: 'filesystem',
-    resources: ['workspaces/<workspaceId>/'],
+    resources: ['workspaces/<workspaceId>/', 'workspaces/.ownership/<workspaceId>.json'],
     policy: {
       kind: 'retained-history',
       effect: 'retain',
       retention: 'Retained until the user removes the workspace files.',
-      reason: 'Session and Project deletion preserve ordinary workspace files for user recovery.'
+      reason:
+        'Session and Project deletion preserve ordinary workspace files and their ownership receipt for user recovery.'
     }
   },
   {

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -491,7 +491,8 @@ describe('Session persistence coordinator architecture', () => {
       'log:defaulted',
       'computeJobs:optional',
       'onDelegatedWorkSessionUpdated:optional',
-      'onDelegationPolicyUpdated:optional'
+      'onDelegationPolicyUpdated:optional',
+      'workspaceOwnership:optional'
     ])
     expect(exportedNames(facadeFile, 'value')).toEqual(
       ['SessionPersistenceCoordinator', 'SessionRuntimeContextRevisionConflictError'].sort()
@@ -576,7 +577,8 @@ describe('Session persistence coordinator architecture', () => {
         'provenance',
         'repository',
         'stateOwner',
-        'uploads'
+        'uploads',
+        'workspaceOwnership'
       ].sort()
     )
     expect(fields(reconciliationOwner)).toEqual(

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -530,7 +530,8 @@ describe('Session persistence coordinator architecture', () => {
         'repository',
         'sessionDeletionHandlers',
         'sideChatOwner',
-        'stateOwner'
+        'stateOwner',
+        'workspaceOwnership'
       ].sort()
     )
     expect(mutableFields(facade)).toEqual(

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -3337,6 +3337,41 @@ describe('SessionPersistenceCoordinator', () => {
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
   })
 
+  it('reconciles provisional managed workspaces during the first authoritative hydration', async () => {
+    const session = createSession()
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+        result: { sessions: [session], manifest: { version: 1 as const } },
+        isComplete: true
+      })
+    })
+    const reconcileProvisional = vi.fn().mockResolvedValue(undefined)
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        markRetained: vi.fn().mockResolvedValue(false),
+        restoreActive: vi.fn().mockResolvedValue(undefined),
+        reconcileProvisional
+      }
+    )
+
+    await coordinator.loadAll()
+    await coordinator.loadAll()
+
+    expect(reconcileProvisional).toHaveBeenCalledOnce()
+    expect(reconcileProvisional).toHaveBeenCalledWith([session])
+  })
+
   it('keeps cleanup closed across scans after quarantining corrupt Session authority', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-corrupt-session-reconciliation-'))
     const projectDir = join(root, 'sessions', 'project-1')

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -3359,7 +3359,9 @@ describe('SessionPersistenceCoordinator', () => {
       undefined,
       undefined,
       {
+        markProjectRetained: vi.fn().mockResolvedValue([]),
         markRetained: vi.fn().mockResolvedValue(false),
+        restoreProjectActive: vi.fn().mockResolvedValue(undefined),
         restoreActive: vi.fn().mockResolvedValue(undefined),
         reconcileProvisional
       }

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -59,7 +59,8 @@ import {
 import {
   SessionPersistenceDeletionOwner,
   type ComputeJobDeletionParticipant,
-  type ProjectSessionDeletionResult
+  type ProjectSessionDeletionResult,
+  type SessionWorkspaceOwnership
 } from './deletion-owner'
 import {
   SessionPersistenceReconciliationOwner,
@@ -192,7 +193,8 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     private readonly log: Logger = createLogger('session-persistence'),
     private readonly computeJobs?: ComputeJobDeletionParticipant,
     onDelegatedWorkSessionUpdated?: SessionUpdatePublisher,
-    onDelegationPolicyUpdated?: (session: PersistedChatSession) => void
+    onDelegationPolicyUpdated?: (session: PersistedChatSession) => void,
+    workspaceOwnership?: SessionWorkspaceOwnership
   ) {
     const publishSessionUpdate = safeSessionUpdates(onDelegatedWorkSessionUpdated, log)
     this.stateOwner = new SessionPersistenceStateOwner({
@@ -221,6 +223,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
       provenance,
       uploads,
       computeJobs,
+      workspaceOwnership,
       log,
       assertArchiveMutable: (projectId, sessionId) => {
         if (this.deletedProjects.has(projectId)) {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -194,7 +194,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     private readonly computeJobs?: ComputeJobDeletionParticipant,
     onDelegatedWorkSessionUpdated?: SessionUpdatePublisher,
     onDelegationPolicyUpdated?: (session: PersistedChatSession) => void,
-    workspaceOwnership?: SessionWorkspaceOwnership
+    private readonly workspaceOwnership?: SessionWorkspaceOwnership
   ) {
     const publishSessionUpdate = safeSessionUpdates(onDelegatedWorkSessionUpdated, log)
     this.stateOwner = new SessionPersistenceStateOwner({
@@ -389,6 +389,20 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
           warningCount: scan.warnings?.length ?? 0
         })
         return result
+      }
+
+      if (mayRunDestructiveStartupCleanup && this.workspaceOwnership) {
+        operation.phase('reconcile-provisional-managed-workspaces')
+        try {
+          await this.workspaceOwnership.reconcileProvisional(sessions)
+        } catch (error) {
+          emitRecoverableDiagnostic(this.log, 'managed workspace reconciliation failed', {
+            operation: 'session-hydration',
+            phase: 'reconcile-provisional-managed-workspaces',
+            outcome: 'degraded',
+            ...diagnosticErrorFields(error)
+          })
+        }
       }
 
       if (!this.delegatedStartupRecoveryComplete) {

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -352,8 +352,9 @@ class SessionPersistenceDeletionOwner {
         try {
           if (this.workspaceOwnership) {
             for (const session of scan.sessions) {
-              if (await this.workspaceOwnership.markRetained(session)) {
-                retainedWorkspaceSessions.push(session)
+              retainedWorkspaceSessions.push(session)
+              if (!(await this.workspaceOwnership.markRetained(session))) {
+                retainedWorkspaceSessions.pop()
               }
             }
           }
@@ -455,10 +456,11 @@ class SessionPersistenceDeletionOwner {
         operation.phase(failurePhase)
         token = await this.fileIndex.softDeleteSession(projectId, sessionId)
       }
-      if (session) {
+      if (session && this.workspaceOwnership) {
         failurePhase = 'retain-managed-workspace'
         operation.phase(failurePhase)
-        managedWorkspaceRetained = (await this.workspaceOwnership?.markRetained(session)) ?? false
+        managedWorkspaceRetained = true
+        managedWorkspaceRetained = await this.workspaceOwnership.markRetained(session)
       }
       failurePhase = 'delete-authority'
       operation.phase(failurePhase)

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -347,26 +347,50 @@ class SessionPersistenceDeletionOwner {
             if (cleanup.hasUnsafeResidual) this.fileIndex.markReconciliationIncomplete()
           }
         }
-        if (this.workspaceOwnership) {
-          for (const session of scan.sessions) {
-            await this.workspaceOwnership.markRetained(session)
+        const retainedWorkspaceSessions: PersistedChatSession[] = []
+        let sessionAuthorityDeleted = false
+        try {
+          if (this.workspaceOwnership) {
+            for (const session of scan.sessions) {
+              if (await this.workspaceOwnership.markRetained(session)) {
+                retainedWorkspaceSessions.push(session)
+              }
+            }
           }
-        }
-        if (deletionState === 'legacy-committed') {
-          await this.repository.markCommittedProjectSessionsPrepared(projectId)
-        }
-        await this.repository.deleteProjectSessions(projectId)
-        await this.computeJobs?.commitProjectJobDeletion(projectId)
-        this.stateOwner.removeProject(projectId, deletedSessionIds)
-        await this.fileIndex.softDeleteProject(projectId)
+          if (deletionState === 'legacy-committed') {
+            await this.repository.markCommittedProjectSessionsPrepared(projectId)
+          }
+          await this.repository.deleteProjectSessions(projectId)
+          sessionAuthorityDeleted = true
+          await this.computeJobs?.commitProjectJobDeletion(projectId)
+          this.stateOwner.removeProject(projectId, deletedSessionIds)
+          await this.fileIndex.softDeleteProject(projectId)
 
-        this.notifyFilesChanged({
-          projectId,
-          sources: ['artifact', 'upload'],
-          kind: 'reset'
-        })
-        await this.notifySessionsDeleted(deletedSessionIds)
-        return { status: 'completed' }
+          this.notifyFilesChanged({
+            projectId,
+            sources: ['artifact', 'upload'],
+            kind: 'reset'
+          })
+          await this.notifySessionsDeleted(deletedSessionIds)
+          return { status: 'completed' }
+        } catch (error) {
+          if (sessionAuthorityDeleted || !this.workspaceOwnership) throw error
+          const recoveryErrors: unknown[] = []
+          for (const session of retainedWorkspaceSessions.reverse()) {
+            try {
+              await this.workspaceOwnership.restoreActive(session)
+            } catch (recoveryError) {
+              recoveryErrors.push(recoveryError)
+            }
+          }
+          if (recoveryErrors.length > 0) {
+            throw new AggregateError(
+              [error, ...recoveryErrors],
+              `Project Session deletion and managed workspace rollback failed: ${projectId}`
+            )
+          }
+          throw error
+        }
       }
     )
   }

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -97,6 +97,13 @@ type ComputeJobDeletionParticipant = {
   abortProjectJobDeletion?(projectId: string): Promise<void>
 }
 
+type SessionWorkspaceOwnership = {
+  markRetained(
+    session: Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<boolean>
+  restoreActive(session: Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id'>): Promise<void>
+}
+
 type SessionPersistenceDeletionOwnerOptions = {
   repository: SessionDeletionRepository
   fileIndex: SessionDeletionFileIndex
@@ -104,6 +111,7 @@ type SessionPersistenceDeletionOwnerOptions = {
   provenance?: SessionDeletionProvenance
   uploads?: SessionDeletionUploads
   computeJobs?: ComputeJobDeletionParticipant
+  workspaceOwnership?: SessionWorkspaceOwnership
   log: Logger
   assertArchiveMutable(projectId: string, sessionId: string): void
   notifyFilesChanged(event: ProjectFilesChangedEvent): void
@@ -138,6 +146,7 @@ class SessionPersistenceDeletionOwner {
   private readonly provenance: SessionDeletionProvenance | undefined
   private readonly uploads: SessionDeletionUploads | undefined
   private readonly computeJobs: ComputeJobDeletionParticipant | undefined
+  private readonly workspaceOwnership: SessionWorkspaceOwnership | undefined
   private readonly log: Logger
   private readonly assertArchiveMutable: (projectId: string, sessionId: string) => void
   private readonly notifyFilesChanged: (event: ProjectFilesChangedEvent) => void
@@ -150,6 +159,7 @@ class SessionPersistenceDeletionOwner {
     this.provenance = options.provenance
     this.uploads = options.uploads
     this.computeJobs = options.computeJobs
+    this.workspaceOwnership = options.workspaceOwnership
     this.log = options.log
     this.assertArchiveMutable = options.assertArchiveMutable
     this.notifyFilesChanged = options.notifyFilesChanged
@@ -337,6 +347,11 @@ class SessionPersistenceDeletionOwner {
             if (cleanup.hasUnsafeResidual) this.fileIndex.markReconciliationIncomplete()
           }
         }
+        if (this.workspaceOwnership) {
+          for (const session of scan.sessions) {
+            await this.workspaceOwnership.markRetained(session)
+          }
+        }
         if (deletionState === 'legacy-committed') {
           await this.repository.markCommittedProjectSessionsPrepared(projectId)
         }
@@ -384,6 +399,7 @@ class SessionPersistenceDeletionOwner {
     let receipt: SessionDeletionReceipt = { kind: 'ordinary', projectId, sessionId }
     let jsonDeleted = false
     let computeJobsPrepared = false
+    let managedWorkspaceRetained = false
     let session: PersistedChatSession | undefined
 
     try {
@@ -414,6 +430,11 @@ class SessionPersistenceDeletionOwner {
         failurePhase = 'soft-delete-file-index'
         operation.phase(failurePhase)
         token = await this.fileIndex.softDeleteSession(projectId, sessionId)
+      }
+      if (session) {
+        failurePhase = 'retain-managed-workspace'
+        operation.phase(failurePhase)
+        managedWorkspaceRetained = (await this.workspaceOwnership?.markRetained(session)) ?? false
       }
       failurePhase = 'delete-authority'
       operation.phase(failurePhase)
@@ -452,6 +473,15 @@ class SessionPersistenceDeletionOwner {
             } catch (computeRestoreError) {
               recoveryPhase = 'abort-compute-cleanup'
               recoveryError = computeRestoreError
+              recoveryFailed = true
+            }
+          }
+          if (managedWorkspaceRetained && session) {
+            try {
+              recoveryPhase = 'restore-managed-workspace'
+              await this.workspaceOwnership?.restoreActive(session)
+            } catch (workspaceRestoreError) {
+              recoveryError = workspaceRestoreError
               recoveryFailed = true
             }
           }
@@ -566,6 +596,7 @@ class SessionPersistenceDeletionOwner {
 export { SessionPersistenceDeletionOwner, hasLegacySessionUpload }
 export type {
   ComputeJobDeletionParticipant,
+  SessionWorkspaceOwnership,
   ProjectSessionDeletionResult,
   SessionPersistenceDeletionOwnerOptions
 }

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -98,6 +98,7 @@ type ComputeJobDeletionParticipant = {
 }
 
 type SessionWorkspaceOwnership = {
+  reconcileProvisional(sessions: readonly PersistedChatSession[]): Promise<void>
   markRetained(
     session: Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id' | 'createdAt' | 'updatedAt'>
   ): Promise<boolean>

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -99,6 +99,8 @@ type ComputeJobDeletionParticipant = {
 
 type SessionWorkspaceOwnership = {
   reconcileProvisional(sessions: readonly PersistedChatSession[]): Promise<void>
+  markProjectRetained(projectId: string): Promise<readonly string[]>
+  restoreProjectActive(projectId: string, directories: readonly string[]): Promise<void>
   markRetained(
     session: Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id' | 'createdAt' | 'updatedAt'>
   ): Promise<boolean>
@@ -349,6 +351,7 @@ class SessionPersistenceDeletionOwner {
           }
         }
         const retainedWorkspaceSessions: PersistedChatSession[] = []
+        let retainedProjectWorkspaceDirectories: readonly string[] = []
         let sessionAuthorityDeleted = false
         try {
           if (this.workspaceOwnership) {
@@ -357,6 +360,10 @@ class SessionPersistenceDeletionOwner {
               if (!(await this.workspaceOwnership.markRetained(session))) {
                 retainedWorkspaceSessions.pop()
               }
+            }
+            if (!scan.isComplete) {
+              retainedProjectWorkspaceDirectories =
+                await this.workspaceOwnership.markProjectRetained(projectId)
             }
           }
           if (deletionState === 'legacy-committed') {
@@ -378,6 +385,16 @@ class SessionPersistenceDeletionOwner {
         } catch (error) {
           if (sessionAuthorityDeleted || !this.workspaceOwnership) throw error
           const recoveryErrors: unknown[] = []
+          if (retainedProjectWorkspaceDirectories.length > 0) {
+            try {
+              await this.workspaceOwnership.restoreProjectActive(
+                projectId,
+                retainedProjectWorkspaceDirectories
+              )
+            } catch (recoveryError) {
+              recoveryErrors.push(recoveryError)
+            }
+          }
           for (const session of retainedWorkspaceSessions.reverse()) {
             try {
               await this.workspaceOwnership.restoreActive(session)

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -17,6 +17,7 @@ import {
   finalizeManagedWorkspaceOwnership,
   initializeManagedWorkspaceOwnership,
   markManagedWorkspaceRetained,
+  removeManagedWorkspaceOwnership,
   restoreManagedWorkspaceActive
 } from './managed-workspace-ownership'
 import { computeStorageUsage } from './usage'
@@ -196,6 +197,54 @@ describe('managed workspace ownership', () => {
     )
 
     await expect(readdir(externalCwd)).resolves.toEqual([])
+  })
+
+  it('allows Session deletion after its managed workspace was removed independently', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-missing-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Session',
+      cwd,
+      status: 'idle',
+      messages: [],
+      createdAt: 10,
+      updatedAt: 20
+    }
+    const liveSessions = new Map([[session.id, session]])
+    await initializeManagedWorkspaceOwnership(cwd, session.projectId, session.createdAt, dataRoot)
+    await finalizeManagedWorkspaceOwnership(cwd, session.id, session.updatedAt, dataRoot)
+    await rm(cwd, { recursive: true })
+
+    await createDeletionOwner(liveSessions).deleteSession(session.projectId, session.id)
+    expect(liveSessions).toEqual(new Map())
+  })
+
+  it('does not follow a symlinked ownership directory for receipt writes or removals', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-linked-ownership-'))
+    const externalOwnership = await mkdtemp(join(tmpdir(), 'managed-workspace-external-ownership-'))
+    roots.push(dataRoot, externalOwnership)
+    initDataRoot(dataRoot)
+    const workspacesRoot = join(dataRoot, 'workspaces')
+    const cwd = join(workspacesRoot, 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    await symlink(
+      externalOwnership,
+      join(workspacesRoot, '.ownership'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    await expect(
+      initializeManagedWorkspaceOwnership(cwd, 'project-1', 10, dataRoot)
+    ).rejects.toThrow(/ownership/i)
+    await writeFile(join(externalOwnership, 'workspace-1.json'), 'external receipt')
+
+    await expect(removeManagedWorkspaceOwnership(cwd, dataRoot)).resolves.toBeUndefined()
+    await expect(readdir(externalOwnership)).resolves.toEqual(['workspace-1.json'])
   })
 
   it('restores active ownership when Session authority deletion fails', async () => {

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -240,6 +240,47 @@ describe('managed workspace ownership', () => {
     await expect(readdir(join(dataRoot, 'workspaces', '.ownership'))).resolves.toEqual([])
   })
 
+  it('deletes a branch that shares its source Session managed workspace', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-shared-branch-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    const source = {
+      id: 'source-session',
+      projectId: 'project-1',
+      title: 'Source Session',
+      cwd,
+      status: 'idle' as const,
+      messages: [],
+      createdAt: 10,
+      updatedAt: 20
+    }
+    const branch = {
+      ...source,
+      id: 'branch-session',
+      title: 'Branch Session',
+      createdAt: 30,
+      updatedAt: 40
+    }
+    const liveSessions = new Map<string, PersistedChatSession>([
+      [source.id, source],
+      [branch.id, branch]
+    ])
+    await initializeManagedWorkspaceOwnership(cwd, source.projectId, source.createdAt, dataRoot)
+    await finalizeManagedWorkspaceOwnership(cwd, source.id, source.updatedAt, dataRoot)
+
+    await expect(
+      createDeletionOwner(liveSessions).deleteSession(branch.projectId, branch.id)
+    ).resolves.toBe('ordinary')
+
+    expect([...liveSessions.keys()]).toEqual([source.id])
+    await expect(readManagedWorkspaceOwnership(cwd, dataRoot)).resolves.toMatchObject({
+      sessionId: source.id,
+      retainedAfterDelete: false
+    })
+  })
+
   it('removes a provisional workspace left by an earlier process', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-provisional-orphan-'))
     roots.push(dataRoot)

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -247,6 +247,31 @@ describe('managed workspace ownership', () => {
     await expect(readdir(externalOwnership)).resolves.toEqual(['workspace-1.json'])
   })
 
+  it('does not follow a symlinked workspaces root for receipt writes or removals', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-linked-root-'))
+    const externalWorkspaces = await mkdtemp(join(tmpdir(), 'managed-workspace-external-root-'))
+    roots.push(dataRoot, externalWorkspaces)
+    initDataRoot(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(join(externalWorkspaces, 'workspace-1'))
+    await symlink(
+      externalWorkspaces,
+      join(dataRoot, 'workspaces'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    await expect(
+      initializeManagedWorkspaceOwnership(cwd, 'project-1', 10, dataRoot)
+    ).rejects.toThrow(/workspace/i)
+    await mkdir(join(externalWorkspaces, '.ownership'))
+    await writeFile(join(externalWorkspaces, '.ownership', 'workspace-1.json'), 'external receipt')
+
+    await expect(removeManagedWorkspaceOwnership(cwd, dataRoot)).resolves.toBeUndefined()
+    await expect(readdir(join(externalWorkspaces, '.ownership'))).resolves.toEqual([
+      'workspace-1.json'
+    ])
+  })
+
   it('restores active ownership when Session authority deletion fails', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-delete-failure-'))
     roots.push(dataRoot)

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -26,7 +26,11 @@ const roots: string[] = []
 
 const createDeletionOwner = (
   liveSessions: Map<string, PersistedChatSession>,
-  options: { deleteSessionError?: Error; deleteProjectSessionsError?: Error } = {}
+  options: {
+    deleteSessionError?: Error
+    deleteProjectSessionsError?: Error
+    markRetainedErrorAfterWrite?: Error
+  } = {}
 ): SessionPersistenceDeletionOwner =>
   new SessionPersistenceDeletionOwner({
     repository: {
@@ -74,7 +78,11 @@ const createDeletionOwner = (
     notifyFilesChanged: vi.fn(),
     notifySessionsDeleted: vi.fn().mockResolvedValue(undefined),
     workspaceOwnership: {
-      markRetained: (session) => markManagedWorkspaceRetained(session),
+      markRetained: async (session) => {
+        const retained = await markManagedWorkspaceRetained(session)
+        if (options.markRetainedErrorAfterWrite) throw options.markRetainedErrorAfterWrite
+        return retained
+      },
       restoreActive: (session) => restoreManagedWorkspaceActive(session)
     }
   })
@@ -306,6 +314,39 @@ describe('managed workspace ownership', () => {
     })
   })
 
+  it('restores active ownership when Session retention throws after writing', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-retain-failure-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Session',
+      cwd,
+      status: 'idle',
+      messages: [],
+      createdAt: 10,
+      updatedAt: 20
+    }
+    const liveSessions = new Map([[session.id, session]])
+    await initializeManagedWorkspaceOwnership(cwd, session.projectId, session.createdAt, dataRoot)
+    await finalizeManagedWorkspaceOwnership(cwd, session.id, session.updatedAt, dataRoot)
+
+    await expect(
+      createDeletionOwner(liveSessions, {
+        markRetainedErrorAfterWrite: new Error('Retention directory sync failed')
+      }).deleteSession(session.projectId, session.id)
+    ).rejects.toThrow('Retention directory sync failed')
+
+    const usage = await computeStorageUsage(dataRoot)
+    expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
+      retainedAfterDelete: false
+    })
+    expect(liveSessions.has(session.id)).toBe(true)
+  })
+
   it('restores active ownership when Project Session authority deletion fails', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-project-delete-failure-'))
     roots.push(dataRoot)
@@ -352,5 +393,38 @@ describe('managed workspace ownership', () => {
       retainedAfterDelete: false
     })
     expect(liveSessions.has('session-1')).toBe(true)
+  })
+
+  it('restores active ownership when Project retention throws after writing', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-project-retain-failure-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Session',
+      cwd,
+      status: 'idle',
+      messages: [],
+      createdAt: 10,
+      updatedAt: 20
+    }
+    const liveSessions = new Map([[session.id, session]])
+    await initializeManagedWorkspaceOwnership(cwd, session.projectId, session.createdAt, dataRoot)
+    await finalizeManagedWorkspaceOwnership(cwd, session.id, session.updatedAt, dataRoot)
+
+    await expect(
+      createDeletionOwner(liveSessions, {
+        markRetainedErrorAfterWrite: new Error('Retention directory sync failed')
+      }).deleteProjectSessions(session.projectId, (_sessionIds, operation) => operation())
+    ).rejects.toThrow('Retention directory sync failed')
+
+    const usage = await computeStorageUsage(dataRoot)
+    expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
+      retainedAfterDelete: false
+    })
+    expect(liveSessions.has(session.id)).toBe(true)
   })
 })

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -360,6 +360,44 @@ describe('managed workspace ownership', () => {
     await expect(readdir(join(workspacesRoot, '.ownership'))).resolves.toEqual([])
   })
 
+  it('removes a finalized workspace with no authoritative Session', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-finalized-orphan-'))
+    roots.push(dataRoot)
+    const workspacesRoot = join(dataRoot, 'workspaces')
+    const cwd = join(workspacesRoot, 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    await writeFile(join(cwd, 'partial-output.txt'), 'orphaned')
+    await initializeManagedWorkspaceOwnership(cwd, 'project-1', 10, dataRoot)
+    await finalizeManagedWorkspaceOwnership(cwd, 'session-1', 15, dataRoot)
+
+    await reconcileProvisionalManagedWorkspaces([], 20, dataRoot)
+
+    await expect(readdir(workspacesRoot)).resolves.toEqual(['.ownership'])
+    await expect(readdir(join(workspacesRoot, '.ownership'))).resolves.toEqual([])
+  })
+
+  it('preserves a finalized workspace referenced by another Session', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-finalized-shared-'))
+    roots.push(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    await initializeManagedWorkspaceOwnership(cwd, 'project-1', 10, dataRoot)
+    await finalizeManagedWorkspaceOwnership(cwd, 'source-session', 15, dataRoot)
+    const branch = {
+      id: 'branch-session',
+      projectId: 'project-1',
+      cwd,
+      updatedAt: 30
+    }
+
+    await reconcileProvisionalManagedWorkspaces([branch], 20, dataRoot)
+
+    await expect(readManagedWorkspaceOwnership(cwd, dataRoot)).resolves.toMatchObject({
+      sessionId: 'source-session',
+      retainedAfterDelete: false
+    })
+  })
+
   it('recovers a provisional durable temp receipt before startup cleanup', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-provisional-temp-'))
     roots.push(dataRoot)

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -14,6 +14,8 @@ import { createManagedSessionWorkspaceCapability } from '../acp/managed-session-
 import { SessionPersistenceDeletionOwner } from '../session-persistence/deletion-owner'
 import { initDataRoot } from '../storage-root'
 import {
+  finalizeManagedWorkspaceOwnership,
+  initializeManagedWorkspaceOwnership,
   markManagedWorkspaceRetained,
   restoreManagedWorkspaceActive
 } from './managed-workspace-ownership'
@@ -23,7 +25,7 @@ const roots: string[] = []
 
 const createDeletionOwner = (
   liveSessions: Map<string, PersistedChatSession>,
-  options: { deleteSessionError?: Error } = {}
+  options: { deleteSessionError?: Error; deleteProjectSessionsError?: Error } = {}
 ): SessionPersistenceDeletionOwner =>
   new SessionPersistenceDeletionOwner({
     repository: {
@@ -45,6 +47,7 @@ const createDeletionOwner = (
         liveSessions.delete(sessionId)
       },
       deleteProjectSessions: async (projectId: string) => {
+        if (options.deleteProjectSessionsError) throw options.deleteProjectSessionsError
         for (const [sessionId, session] of liveSessions) {
           if (session.projectId === projectId) liveSessions.delete(sessionId)
         }
@@ -101,7 +104,8 @@ describe('managed workspace ownership', () => {
             updatedAt: now + 1_000
           })
           return { sessionId: 'session-1', cwd: request.cwd }
-        }
+        },
+        deleteSession: async () => undefined
       },
       {
         workspaces: createManagedSessionWorkspaceCapability({
@@ -131,7 +135,7 @@ describe('managed workspace ownership', () => {
     expect(liveSessions).toEqual(new Map())
   })
 
-  it('backfills a retained receipt from a historical live Session before deleting it', async () => {
+  it('does not adopt an unproven direct child workspace during historical Session deletion', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-backfill-'))
     roots.push(dataRoot)
     initDataRoot(dataRoot)
@@ -159,14 +163,9 @@ describe('managed workspace ownership', () => {
     )
 
     const usage = await computeStorageUsage(dataRoot)
-    expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
+    expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toEqual({
       name: 'legacy-workspace',
-      workspaceId: 'legacy-workspace',
-      projectId: 'legacy-project',
-      sessionId: 'legacy-session',
-      createdAt: 10,
-      lastUsedAt: 20,
-      retainedAfterDelete: true
+      bytes: 0
     })
   })
 
@@ -216,6 +215,8 @@ describe('managed workspace ownership', () => {
       updatedAt: 20
     }
     const liveSessions = new Map([[session.id, session]])
+    await initializeManagedWorkspaceOwnership(cwd, session.projectId, session.createdAt, dataRoot)
+    await finalizeManagedWorkspaceOwnership(cwd, session.id, session.updatedAt, dataRoot)
 
     await expect(
       createDeletionOwner(liveSessions, {
@@ -229,5 +230,53 @@ describe('managed workspace ownership', () => {
       sessionId: 'session-1',
       retainedAfterDelete: false
     })
+  })
+
+  it('restores active ownership when Project Session authority deletion fails', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-project-delete-failure-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const liveSessions = new Map<string, PersistedChatSession>()
+    const workflow = createAcpCreateSessionWorkflow(
+      {
+        createSession: async (request) => {
+          const session: PersistedChatSession = {
+            id: 'session-1',
+            projectId: request.projectId!,
+            title: 'Session',
+            cwd: request.cwd!,
+            status: 'idle',
+            messages: [],
+            createdAt: 10,
+            updatedAt: 20
+          }
+          liveSessions.set(session.id, session)
+          return { sessionId: session.id, cwd: session.cwd }
+        },
+        deleteSession: async () => undefined
+      },
+      {
+        workspaces: createManagedSessionWorkspaceCapability({
+          resolveRoot: () => dataRoot,
+          createId: () => 'workspace-1'
+        }),
+        withDataRootWrite: (write) => write()
+      }
+    )
+    await workflow.create({ projectId: 'project-1' })
+
+    await expect(
+      createDeletionOwner(liveSessions, {
+        deleteProjectSessionsError: new Error('Project Session authority delete failed')
+      }).deleteProjectSessions('project-1', (_sessionIds, operation) => operation())
+    ).rejects.toThrow('Project Session authority delete failed')
+
+    const usage = await computeStorageUsage(dataRoot)
+    expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      retainedAfterDelete: false
+    })
+    expect(liveSessions.has('session-1')).toBe(true)
   })
 })

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -17,6 +17,8 @@ import {
   finalizeManagedWorkspaceOwnership,
   initializeManagedWorkspaceOwnership,
   markManagedWorkspaceRetained,
+  readManagedWorkspaceOwnership,
+  reconcileProvisionalManagedWorkspaces,
   removeManagedWorkspaceOwnership,
   restoreManagedWorkspaceActive
 } from './managed-workspace-ownership'
@@ -78,6 +80,7 @@ const createDeletionOwner = (
     notifyFilesChanged: vi.fn(),
     notifySessionsDeleted: vi.fn().mockResolvedValue(undefined),
     workspaceOwnership: {
+      reconcileProvisional: vi.fn().mockResolvedValue(undefined),
       markRetained: async (session) => {
         const retained = await markManagedWorkspaceRetained(session)
         if (options.markRetainedErrorAfterWrite) throw options.markRetainedErrorAfterWrite
@@ -235,6 +238,62 @@ describe('managed workspace ownership', () => {
     await createDeletionOwner(liveSessions).deleteSession(session.projectId, session.id)
     expect(liveSessions).toEqual(new Map())
     await expect(readdir(join(dataRoot, 'workspaces', '.ownership'))).resolves.toEqual([])
+  })
+
+  it('removes a provisional workspace left by an earlier process', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-provisional-orphan-'))
+    roots.push(dataRoot)
+    const workspacesRoot = join(dataRoot, 'workspaces')
+    const cwd = join(workspacesRoot, 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    await writeFile(join(cwd, 'partial-output.txt'), 'orphaned')
+    await initializeManagedWorkspaceOwnership(cwd, 'project-1', 10, dataRoot)
+
+    await reconcileProvisionalManagedWorkspaces([], 20, dataRoot)
+
+    await expect(readdir(workspacesRoot)).resolves.toEqual(['.ownership'])
+    await expect(readdir(join(workspacesRoot, '.ownership'))).resolves.toEqual([])
+  })
+
+  it('finalizes a provisional receipt referenced by an authoritative Session', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-provisional-session-'))
+    roots.push(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    await initializeManagedWorkspaceOwnership(cwd, 'project-1', 10, dataRoot)
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Session',
+      cwd,
+      status: 'idle',
+      messages: [],
+      createdAt: 10,
+      updatedAt: 30
+    }
+
+    await reconcileProvisionalManagedWorkspaces([session], 20, dataRoot)
+
+    await expect(readManagedWorkspaceOwnership(cwd, dataRoot)).resolves.toMatchObject({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      lastUsedAt: 30
+    })
+  })
+
+  it('preserves a provisional workspace created after the recovery cutoff', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-current-provisional-'))
+    roots.push(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    await initializeManagedWorkspaceOwnership(cwd, 'project-1', 20, dataRoot)
+
+    await reconcileProvisionalManagedWorkspaces([], 20, dataRoot)
+
+    await expect(readManagedWorkspaceOwnership(cwd, dataRoot)).resolves.toMatchObject({
+      workspaceId: 'workspace-1',
+      projectId: 'project-1'
+    })
   })
 
   it('does not remove an external directory through a symlinked workspaces root', async () => {

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -360,6 +360,32 @@ describe('managed workspace ownership', () => {
     await expect(readdir(join(workspacesRoot, '.ownership'))).resolves.toEqual([])
   })
 
+  it('recovers a provisional durable temp receipt before startup cleanup', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-provisional-temp-'))
+    roots.push(dataRoot)
+    const workspacesRoot = join(dataRoot, 'workspaces')
+    const ownershipDirectory = join(workspacesRoot, '.ownership')
+    const cwd = join(workspacesRoot, 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    await mkdir(ownershipDirectory)
+    await writeFile(
+      join(ownershipDirectory, 'workspace-1.json.1700000000000-1.tmp'),
+      `${JSON.stringify({
+        version: 1,
+        workspaceId: 'workspace-1',
+        projectId: 'project-1',
+        createdAt: 10,
+        lastUsedAt: 10,
+        retainedAfterDelete: false
+      })}\n`
+    )
+
+    await reconcileProvisionalManagedWorkspaces([], 20, dataRoot)
+
+    await expect(readdir(workspacesRoot)).resolves.toEqual(['.ownership'])
+    await expect(readdir(ownershipDirectory)).resolves.toEqual([])
+  })
+
   it('finalizes a provisional receipt referenced by an authoritative Session', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-provisional-session-'))
     roots.push(dataRoot)

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -1,0 +1,233 @@
+import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => tmpdir(), isPackaged: true }
+}))
+
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createAcpCreateSessionWorkflow } from '../acp/create-session-workflow'
+import { createManagedSessionWorkspaceCapability } from '../acp/managed-session-workspace'
+import { SessionPersistenceDeletionOwner } from '../session-persistence/deletion-owner'
+import { initDataRoot } from '../storage-root'
+import {
+  markManagedWorkspaceRetained,
+  restoreManagedWorkspaceActive
+} from './managed-workspace-ownership'
+import { computeStorageUsage } from './usage'
+
+const roots: string[] = []
+
+const createDeletionOwner = (
+  liveSessions: Map<string, PersistedChatSession>,
+  options: { deleteSessionError?: Error } = {}
+): SessionPersistenceDeletionOwner =>
+  new SessionPersistenceDeletionOwner({
+    repository: {
+      getProjectSessionDeletionState: async () => 'live',
+      loadProjectWithDiagnostics: async (projectId: string) => ({
+        sessions: [...liveSessions.values()].filter((session) => session.projectId === projectId),
+        isComplete: true
+      }),
+      loadCommittedProjectWithDiagnostics: async (projectId: string) => ({
+        sessions: [...liveSessions.values()].filter((session) => session.projectId === projectId),
+        isComplete: true
+      }),
+      loadSessionWithDiagnostics: async (_projectId: string, sessionId: string) => ({
+        status: 'found',
+        session: liveSessions.get(sessionId)!
+      }),
+      deleteSession: async (_projectId: string, sessionId: string) => {
+        if (options.deleteSessionError) throw options.deleteSessionError
+        liveSessions.delete(sessionId)
+      },
+      deleteProjectSessions: async (projectId: string) => {
+        for (const [sessionId, session] of liveSessions) {
+          if (session.projectId === projectId) liveSessions.delete(sessionId)
+        }
+      }
+    } as never,
+    fileIndex: {
+      softDeleteSession: vi.fn().mockResolvedValue({}),
+      restoreSession: vi.fn().mockResolvedValue(undefined),
+      softDeleteProject: vi.fn().mockResolvedValue({}),
+      markReconciliationIncomplete: vi.fn()
+    } as never,
+    stateOwner: {
+      metadataSnapshot: () => ({ sessions: [...liveSessions.values()] }),
+      removeProject: vi.fn()
+    } as never,
+    log: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    },
+    assertArchiveMutable: vi.fn(),
+    notifyFilesChanged: vi.fn(),
+    notifySessionsDeleted: vi.fn().mockResolvedValue(undefined),
+    workspaceOwnership: {
+      markRetained: (session) => markManagedWorkspaceRetained(session),
+      restoreActive: (session) => restoreManagedWorkspaceActive(session)
+    }
+  })
+
+afterEach(async () => {
+  initDataRoot(undefined)
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('managed workspace ownership', () => {
+  it('keeps Project and Session identity after the live Session record is gone', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-ownership-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const liveSessions = new Map<string, PersistedChatSession>()
+    const workflow = createAcpCreateSessionWorkflow(
+      {
+        createSession: async (request) => {
+          const now = Date.now()
+          liveSessions.set('session-1', {
+            id: 'session-1',
+            projectId: request.projectId!,
+            title: 'Session',
+            cwd: request.cwd!,
+            status: 'idle',
+            messages: [],
+            createdAt: now,
+            updatedAt: now + 1_000
+          })
+          return { sessionId: 'session-1', cwd: request.cwd }
+        }
+      },
+      {
+        workspaces: createManagedSessionWorkspaceCapability({
+          resolveRoot: () => dataRoot,
+          createId: () => 'workspace-1'
+        }),
+        withDataRootWrite: (write) => write()
+      }
+    )
+
+    await workflow.create({ projectId: 'project-1' })
+    const deletion = createDeletionOwner(liveSessions)
+
+    await deletion.deleteSession('project-1', 'session-1')
+
+    const usage = await computeStorageUsage(dataRoot)
+    const workspace = usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]
+
+    expect(workspace).toMatchObject({
+      name: 'workspace-1',
+      workspaceId: 'workspace-1',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      retainedAfterDelete: true
+    })
+    expect(workspace?.lastUsedAt).toBeGreaterThan(workspace?.createdAt ?? 0)
+    expect(liveSessions).toEqual(new Map())
+  })
+
+  it('backfills a retained receipt from a historical live Session before deleting it', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-backfill-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'legacy-workspace')
+    await mkdir(cwd, { recursive: true })
+    const liveSessions = new Map<string, PersistedChatSession>([
+      [
+        'legacy-session',
+        {
+          id: 'legacy-session',
+          projectId: 'legacy-project',
+          title: 'Legacy Session',
+          cwd,
+          status: 'idle',
+          messages: [],
+          createdAt: 10,
+          updatedAt: 20
+        }
+      ]
+    ])
+
+    await createDeletionOwner(liveSessions).deleteProjectSessions(
+      'legacy-project',
+      (_sessionIds, operation) => operation()
+    )
+
+    const usage = await computeStorageUsage(dataRoot)
+    expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
+      name: 'legacy-workspace',
+      workspaceId: 'legacy-workspace',
+      projectId: 'legacy-project',
+      sessionId: 'legacy-session',
+      createdAt: 10,
+      lastUsedAt: 20,
+      retainedAfterDelete: true
+    })
+  })
+
+  it('leaves an external Session directory unowned and untouched during Project deletion', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-external-data-'))
+    const externalCwd = await mkdtemp(join(tmpdir(), 'managed-workspace-external-cwd-'))
+    roots.push(dataRoot, externalCwd)
+    initDataRoot(dataRoot)
+    const liveSessions = new Map<string, PersistedChatSession>([
+      [
+        'external-session',
+        {
+          id: 'external-session',
+          projectId: 'project-1',
+          title: 'External Session',
+          cwd: externalCwd,
+          status: 'idle',
+          messages: [],
+          createdAt: 10,
+          updatedAt: 20
+        }
+      ]
+    ])
+
+    await createDeletionOwner(liveSessions).deleteProjectSessions(
+      'project-1',
+      (_sessionIds, operation) => operation()
+    )
+
+    await expect(readdir(externalCwd)).resolves.toEqual([])
+  })
+
+  it('restores active ownership when Session authority deletion fails', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-delete-failure-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-1')
+    await mkdir(cwd, { recursive: true })
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Session',
+      cwd,
+      status: 'idle',
+      messages: [],
+      createdAt: 10,
+      updatedAt: 20
+    }
+    const liveSessions = new Map([[session.id, session]])
+
+    await expect(
+      createDeletionOwner(liveSessions, {
+        deleteSessionError: new Error('Session authority delete failed')
+      }).deleteSession(session.projectId, session.id)
+    ).rejects.toThrow('Session authority delete failed')
+
+    const usage = await computeStorageUsage(dataRoot)
+    expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      retainedAfterDelete: false
+    })
+  })
+})

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -228,8 +228,40 @@ describe('managed workspace ownership', () => {
     await finalizeManagedWorkspaceOwnership(cwd, session.id, session.updatedAt, dataRoot)
     await rm(cwd, { recursive: true })
 
+    await expect(computeStorageUsage(dataRoot)).resolves.toMatchObject({
+      categories: expect.arrayContaining([{ key: 'workspaces', bytes: 0 }])
+    })
+
     await createDeletionOwner(liveSessions).deleteSession(session.projectId, session.id)
     expect(liveSessions).toEqual(new Map())
+    await expect(readdir(join(dataRoot, 'workspaces', '.ownership'))).resolves.toEqual([])
+  })
+
+  it('does not remove an external directory through a symlinked workspaces root', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-allocation-root-'))
+    const externalWorkspaces = await mkdtemp(
+      join(tmpdir(), 'managed-workspace-allocation-external-')
+    )
+    roots.push(dataRoot, externalWorkspaces)
+    initDataRoot(dataRoot)
+    await mkdir(join(externalWorkspaces, 'workspace-1'))
+    await writeFile(join(externalWorkspaces, 'workspace-1', 'user-data.txt'), 'keep')
+    await symlink(
+      externalWorkspaces,
+      join(dataRoot, 'workspaces'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const workspaces = createManagedSessionWorkspaceCapability({
+      resolveRoot: () => dataRoot,
+      createId: () => 'workspace-1'
+    })
+
+    await expect(workspaces.acquire({ projectId: 'project-1' })).rejects.toThrow(/workspace/i)
+
+    await expect(readdir(externalWorkspaces)).resolves.toEqual(['workspace-1'])
+    await expect(readdir(join(externalWorkspaces, 'workspace-1'))).resolves.toEqual([
+      'user-data.txt'
+    ])
   })
 
   it('does not follow a symlinked ownership directory for receipt writes or removals', async () => {

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -16,10 +16,12 @@ import { initDataRoot } from '../storage-root'
 import {
   finalizeManagedWorkspaceOwnership,
   initializeManagedWorkspaceOwnership,
+  markManagedProjectWorkspacesRetained,
   markManagedWorkspaceRetained,
   readManagedWorkspaceOwnership,
   reconcileProvisionalManagedWorkspaces,
   removeManagedWorkspaceOwnership,
+  restoreManagedProjectWorkspacesActive,
   restoreManagedWorkspaceActive
 } from './managed-workspace-ownership'
 import { computeStorageUsage } from './usage'
@@ -32,6 +34,7 @@ const createDeletionOwner = (
     deleteSessionError?: Error
     deleteProjectSessionsError?: Error
     markRetainedErrorAfterWrite?: Error
+    projectScanComplete?: boolean
   } = {}
 ): SessionPersistenceDeletionOwner =>
   new SessionPersistenceDeletionOwner({
@@ -39,7 +42,7 @@ const createDeletionOwner = (
       getProjectSessionDeletionState: async () => 'live',
       loadProjectWithDiagnostics: async (projectId: string) => ({
         sessions: [...liveSessions.values()].filter((session) => session.projectId === projectId),
-        isComplete: true
+        isComplete: options.projectScanComplete ?? true
       }),
       loadCommittedProjectWithDiagnostics: async (projectId: string) => ({
         sessions: [...liveSessions.values()].filter((session) => session.projectId === projectId),
@@ -81,6 +84,9 @@ const createDeletionOwner = (
     notifySessionsDeleted: vi.fn().mockResolvedValue(undefined),
     workspaceOwnership: {
       reconcileProvisional: vi.fn().mockResolvedValue(undefined),
+      markProjectRetained: (projectId) => markManagedProjectWorkspacesRetained(projectId),
+      restoreProjectActive: (projectId, directories) =>
+        restoreManagedProjectWorkspacesActive(projectId, directories),
       markRetained: async (session) => {
         const retained = await markManagedWorkspaceRetained(session)
         if (options.markRetainedErrorAfterWrite) throw options.markRetainedErrorAfterWrite
@@ -277,6 +283,64 @@ describe('managed workspace ownership', () => {
     expect([...liveSessions.keys()]).toEqual([source.id])
     await expect(readManagedWorkspaceOwnership(cwd, dataRoot)).resolves.toMatchObject({
       sessionId: source.id,
+      retainedAfterDelete: false
+    })
+  })
+
+  it('retains owned workspaces when deleting an incomplete Project catalog', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-incomplete-project-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const readableCwd = join(dataRoot, 'workspaces', 'workspace-readable')
+    const unreadableCwd = join(dataRoot, 'workspaces', 'workspace-unreadable')
+    await mkdir(readableCwd, { recursive: true })
+    await mkdir(unreadableCwd, { recursive: true })
+    const readableSession: PersistedChatSession = {
+      id: 'readable-session',
+      projectId: 'project-1',
+      title: 'Readable Session',
+      cwd: readableCwd,
+      status: 'idle',
+      messages: [],
+      createdAt: 10,
+      updatedAt: 20
+    }
+    const liveSessions = new Map([[readableSession.id, readableSession]])
+    await initializeManagedWorkspaceOwnership(readableCwd, 'project-1', 10, dataRoot)
+    await finalizeManagedWorkspaceOwnership(readableCwd, readableSession.id, 20, dataRoot)
+    await initializeManagedWorkspaceOwnership(unreadableCwd, 'project-1', 30, dataRoot)
+    await finalizeManagedWorkspaceOwnership(unreadableCwd, 'unreadable-session', 40, dataRoot)
+
+    await createDeletionOwner(liveSessions, { projectScanComplete: false }).deleteProjectSessions(
+      'project-1',
+      (_sessionIds, operation) => operation()
+    )
+
+    await expect(readManagedWorkspaceOwnership(readableCwd, dataRoot)).resolves.toMatchObject({
+      retainedAfterDelete: true
+    })
+    await expect(readManagedWorkspaceOwnership(unreadableCwd, dataRoot)).resolves.toMatchObject({
+      retainedAfterDelete: true
+    })
+  })
+
+  it('restores Project-scanned ownership when incomplete authority deletion fails', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'managed-workspace-incomplete-rollback-'))
+    roots.push(dataRoot)
+    initDataRoot(dataRoot)
+    const cwd = join(dataRoot, 'workspaces', 'workspace-unreadable')
+    await mkdir(cwd, { recursive: true })
+    await initializeManagedWorkspaceOwnership(cwd, 'project-1', 10, dataRoot)
+    await finalizeManagedWorkspaceOwnership(cwd, 'unreadable-session', 20, dataRoot)
+
+    await expect(
+      createDeletionOwner(new Map(), {
+        projectScanComplete: false,
+        deleteProjectSessionsError: new Error('Project Session authority delete failed')
+      }).deleteProjectSessions('project-1', (_sessionIds, operation) => operation())
+    ).rejects.toThrow('Project Session authority delete failed')
+
+    await expect(readManagedWorkspaceOwnership(cwd, dataRoot)).resolves.toMatchObject({
       retainedAfterDelete: false
     })
   })

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -23,6 +23,7 @@ type ManagedWorkspaceOwnership = Readonly<{
 }>
 
 type ManagedWorkspaceLocation = Readonly<{
+  workspacesRoot: string
   directory: string
   workspaceId: string
   ownershipDirectory: string
@@ -89,11 +90,26 @@ const locateManagedWorkspace = (
   }
   const ownershipDirectory = join(workspacesRoot, MANAGED_WORKSPACE_OWNERSHIP_DIR)
   return {
+    workspacesRoot,
     directory,
     workspaceId,
     ownershipDirectory,
     receiptPath: join(ownershipDirectory, `${workspaceId}.json`)
   }
+}
+
+const assertWorkspacesRoot = async (location: ManagedWorkspaceLocation): Promise<boolean> => {
+  let info
+  try {
+    info = await lstat(location.workspacesRoot)
+  } catch (error) {
+    if (isFileSystemError(error, 'ENOENT')) return false
+    throw error
+  }
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error('Managed workspaces root must be a regular directory.')
+  }
+  return true
 }
 
 const assertManagedWorkspaceDirectory = async (
@@ -102,6 +118,7 @@ const assertManagedWorkspaceDirectory = async (
 ): Promise<ManagedWorkspaceLocation | undefined> => {
   const location = locateManagedWorkspace(cwd, dataRoot)
   if (!location) return undefined
+  if (!(await assertWorkspacesRoot(location))) return undefined
   let info
   try {
     info = await lstat(location.directory)
@@ -116,6 +133,7 @@ const assertManagedWorkspaceDirectory = async (
 }
 
 const assertOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<boolean> => {
+  if (!(await assertWorkspacesRoot(location))) return false
   let info
   try {
     info = await lstat(location.ownershipDirectory)
@@ -130,6 +148,9 @@ const assertOwnershipDirectory = async (location: ManagedWorkspaceLocation): Pro
 }
 
 const ensureOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<void> => {
+  if (!(await assertWorkspacesRoot(location))) {
+    throw new Error('Managed workspaces root is missing.')
+  }
   try {
     await mkdir(location.ownershipDirectory, { recursive: false })
   } catch (error) {

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -170,21 +170,20 @@ const markManagedWorkspaceRetained = async (
   const location = await assertManagedWorkspaceDirectory(session.cwd, dataRoot)
   if (!location) return false
   const current = await readOwnershipForUpdate(location)
+  if (!current) return false
   if (
-    current &&
-    (current.projectId !== session.projectId ||
-      (current.sessionId !== undefined && current.sessionId !== session.id))
+    current.projectId !== session.projectId ||
+    (current.sessionId !== undefined && current.sessionId !== session.id)
   ) {
     throw new Error('Managed workspace ownership conflicts with the deleting Session.')
   }
-  const createdAt = current?.createdAt ?? session.createdAt
   await writeOwnership(location, {
     version: MANAGED_WORKSPACE_OWNERSHIP_VERSION,
     workspaceId: location.workspaceId,
     projectId: session.projectId,
     sessionId: session.id,
-    createdAt,
-    lastUsedAt: Math.max(current?.lastUsedAt ?? createdAt, session.updatedAt),
+    createdAt: current.createdAt,
+    lastUsedAt: Math.max(current.lastUsedAt, session.updatedAt),
     retainedAfterDelete: true
   })
   return true

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, rm } from 'node:fs/promises'
+import { lstat, mkdir, readdir, rm } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
@@ -132,11 +132,14 @@ const assertManagedWorkspaceDirectory = async (
   return location
 }
 
-const assertOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<boolean> => {
-  if (!(await assertManagedWorkspacesRoot(location.workspacesRoot))) return false
+const assertOwnershipDirectoryPath = async (
+  workspacesRoot: string,
+  ownershipDirectory: string
+): Promise<boolean> => {
+  if (!(await assertManagedWorkspacesRoot(workspacesRoot))) return false
   let info
   try {
-    info = await lstat(location.ownershipDirectory)
+    info = await lstat(ownershipDirectory)
   } catch (error) {
     if (isFileSystemError(error, 'ENOENT')) return false
     throw error
@@ -146,6 +149,9 @@ const assertOwnershipDirectory = async (location: ManagedWorkspaceLocation): Pro
   }
   return true
 }
+
+const assertOwnershipDirectory = (location: ManagedWorkspaceLocation): Promise<boolean> =>
+  assertOwnershipDirectoryPath(location.workspacesRoot, location.ownershipDirectory)
 
 const ensureOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<void> => {
   if (!(await assertManagedWorkspacesRoot(location.workspacesRoot))) {
@@ -280,6 +286,60 @@ const restoreManagedWorkspaceActive = async (
   await writeOwnership(location, { ...current, retainedAfterDelete: false })
 }
 
+const reconcileProvisionalManagedWorkspaces = async (
+  sessions: readonly Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id' | 'updatedAt'>[],
+  createdBefore: number,
+  dataRoot = resolveDataRoot()
+): Promise<void> => {
+  const workspacesRoot = resolve(dataRoot, 'workspaces')
+  const ownershipDirectory = join(workspacesRoot, MANAGED_WORKSPACE_OWNERSHIP_DIR)
+  if (!(await assertOwnershipDirectoryPath(workspacesRoot, ownershipDirectory))) return
+
+  const sessionsByDirectory = new Map<string, typeof sessions>()
+  for (const session of sessions) {
+    const directory = resolve(session.cwd)
+    sessionsByDirectory.set(directory, [...(sessionsByDirectory.get(directory) ?? []), session])
+  }
+
+  const entries = await readdir(ownershipDirectory, { withFileTypes: true })
+  let firstFailure: unknown
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue
+    const workspaceId = entry.name.slice(0, -'.json'.length)
+    const location = locateManagedWorkspace(join(workspacesRoot, workspaceId), dataRoot)
+    if (!location || location.receiptPath !== join(ownershipDirectory, entry.name)) continue
+
+    try {
+      const ownership = await readOwnershipForUpdate(location)
+      if (!ownership || ownership.sessionId || ownership.retainedAfterDelete) continue
+
+      const matchingSessions = sessionsByDirectory.get(location.directory) ?? []
+      if (matchingSessions.length > 0) {
+        if (
+          matchingSessions.length === 1 &&
+          matchingSessions[0].projectId === ownership.projectId
+        ) {
+          await finalizeManagedWorkspaceOwnership(
+            location.directory,
+            matchingSessions[0].id,
+            matchingSessions[0].updatedAt,
+            dataRoot
+          )
+        }
+        continue
+      }
+      if (ownership.createdAt >= createdBefore) continue
+
+      const workspace = await assertManagedWorkspaceDirectory(location.directory, dataRoot)
+      if (workspace) await rm(workspace.directory, { recursive: true, force: true })
+      await removeManagedWorkspaceOwnership(location.directory, dataRoot)
+    } catch (error) {
+      firstFailure ??= error
+    }
+  }
+  if (firstFailure) throw firstFailure
+}
+
 const readManagedWorkspaceOwnership = async (
   cwd: string,
   dataRoot?: string
@@ -312,6 +372,7 @@ export {
   initializeManagedWorkspaceOwnership,
   markManagedWorkspaceRetained,
   readManagedWorkspaceOwnership,
+  reconcileProvisionalManagedWorkspaces,
   removeManagedWorkspaceOwnership,
   restoreManagedWorkspaceActive
 }

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -1,11 +1,12 @@
 import { lstat, mkdir, readdir, rm } from 'node:fs/promises'
-import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { resolveDataRoot } from '../storage-root'
 import {
   DurableJsonRecoveryBarrierError,
   readDurableJsonFile,
+  recoverDurableJsonDirectory,
   writeDurableJsonFile
 } from './durable-json-file'
 
@@ -159,6 +160,19 @@ const listManagedWorkspaceOwnershipLocations = async (
   const workspacesRoot = resolve(dataRoot, 'workspaces')
   const ownershipDirectory = join(workspacesRoot, MANAGED_WORKSPACE_OWNERSHIP_DIR)
   if (!(await assertOwnershipDirectoryPath(workspacesRoot, ownershipDirectory))) return []
+
+  await recoverDurableJsonDirectory(ownershipDirectory, (targetPath, contents) => {
+    const workspaceId = basename(targetPath, '.json')
+    const location = locateManagedWorkspace(join(workspacesRoot, workspaceId), dataRoot)
+    if (location?.receiptPath !== targetPath) {
+      throw new Error('Managed workspace ownership temporary path is invalid.')
+    }
+    const ownership = decodeOwnership(contents)
+    if (ownership.workspaceId !== location.workspaceId) {
+      throw new Error('Managed workspace ownership does not match its directory.')
+    }
+    return ownership
+  })
 
   const locations: ManagedWorkspaceLocation[] = []
   for (const entry of await readdir(ownershipDirectory, { withFileTypes: true })) {

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -98,10 +98,10 @@ const locateManagedWorkspace = (
   }
 }
 
-const assertWorkspacesRoot = async (location: ManagedWorkspaceLocation): Promise<boolean> => {
+const assertManagedWorkspacesRoot = async (workspacesRoot: string): Promise<boolean> => {
   let info
   try {
-    info = await lstat(location.workspacesRoot)
+    info = await lstat(workspacesRoot)
   } catch (error) {
     if (isFileSystemError(error, 'ENOENT')) return false
     throw error
@@ -118,7 +118,7 @@ const assertManagedWorkspaceDirectory = async (
 ): Promise<ManagedWorkspaceLocation | undefined> => {
   const location = locateManagedWorkspace(cwd, dataRoot)
   if (!location) return undefined
-  if (!(await assertWorkspacesRoot(location))) return undefined
+  if (!(await assertManagedWorkspacesRoot(location.workspacesRoot))) return undefined
   let info
   try {
     info = await lstat(location.directory)
@@ -133,7 +133,7 @@ const assertManagedWorkspaceDirectory = async (
 }
 
 const assertOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<boolean> => {
-  if (!(await assertWorkspacesRoot(location))) return false
+  if (!(await assertManagedWorkspacesRoot(location.workspacesRoot))) return false
   let info
   try {
     info = await lstat(location.ownershipDirectory)
@@ -148,7 +148,7 @@ const assertOwnershipDirectory = async (location: ManagedWorkspaceLocation): Pro
 }
 
 const ensureOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<void> => {
-  if (!(await assertWorkspacesRoot(location))) {
+  if (!(await assertManagedWorkspacesRoot(location.workspacesRoot))) {
     throw new Error('Managed workspaces root is missing.')
   }
   try {
@@ -228,9 +228,25 @@ const markManagedWorkspaceRetained = async (
   session: Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id' | 'createdAt' | 'updatedAt'>,
   dataRoot?: string
 ): Promise<boolean> => {
+  const candidate = locateManagedWorkspace(session.cwd, dataRoot)
+  if (!candidate) return false
   const location = await assertManagedWorkspaceDirectory(session.cwd, dataRoot)
-  if (!location) return false
-  const current = await readOwnershipForUpdate(location)
+  if (!location) {
+    let orphanedOwnership: ManagedWorkspaceOwnership | undefined
+    try {
+      orphanedOwnership = await readOwnershipForUpdate(candidate)
+    } catch {
+      return false
+    }
+    if (
+      orphanedOwnership?.projectId === session.projectId &&
+      (orphanedOwnership.sessionId === undefined || orphanedOwnership.sessionId === session.id)
+    ) {
+      await rm(candidate.receiptPath, { force: true, recursive: false })
+    }
+    return false
+  }
+  const current = await readOwnershipForUpdate(candidate)
   if (!current) return false
   if (
     current.projectId !== session.projectId ||
@@ -291,6 +307,7 @@ const removeManagedWorkspaceOwnership = async (cwd: string, dataRoot?: string): 
 
 export {
   MANAGED_WORKSPACE_OWNERSHIP_DIR,
+  assertManagedWorkspacesRoot,
   finalizeManagedWorkspaceOwnership,
   initializeManagedWorkspaceOwnership,
   markManagedWorkspaceRetained,

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -1,4 +1,4 @@
-import { lstat, rm } from 'node:fs/promises'
+import { lstat, mkdir, rm } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
@@ -25,6 +25,7 @@ type ManagedWorkspaceOwnership = Readonly<{
 type ManagedWorkspaceLocation = Readonly<{
   directory: string
   workspaceId: string
+  ownershipDirectory: string
   receiptPath: string
 }>
 
@@ -33,6 +34,9 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isTimestamp = (value: unknown): value is number =>
   typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+
+const isFileSystemError = (error: unknown, code: string): boolean =>
+  typeof error === 'object' && error !== null && 'code' in error && error.code === code
 
 const decodeOwnership = (contents: string): ManagedWorkspaceOwnership => {
   const value: unknown = JSON.parse(contents)
@@ -83,10 +87,12 @@ const locateManagedWorkspace = (
   ) {
     return undefined
   }
+  const ownershipDirectory = join(workspacesRoot, MANAGED_WORKSPACE_OWNERSHIP_DIR)
   return {
     directory,
     workspaceId,
-    receiptPath: join(workspacesRoot, MANAGED_WORKSPACE_OWNERSHIP_DIR, `${workspaceId}.json`)
+    ownershipDirectory,
+    receiptPath: join(ownershipDirectory, `${workspaceId}.json`)
   }
 }
 
@@ -96,16 +102,48 @@ const assertManagedWorkspaceDirectory = async (
 ): Promise<ManagedWorkspaceLocation | undefined> => {
   const location = locateManagedWorkspace(cwd, dataRoot)
   if (!location) return undefined
-  const info = await lstat(location.directory)
+  let info
+  try {
+    info = await lstat(location.directory)
+  } catch (error) {
+    if (isFileSystemError(error, 'ENOENT')) return undefined
+    throw error
+  }
   if (!info.isDirectory() || info.isSymbolicLink()) {
     throw new Error('Managed workspace must be a regular directory.')
   }
   return location
 }
 
+const assertOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<boolean> => {
+  let info
+  try {
+    info = await lstat(location.ownershipDirectory)
+  } catch (error) {
+    if (isFileSystemError(error, 'ENOENT')) return false
+    throw error
+  }
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error('Managed workspace ownership path must be a regular directory.')
+  }
+  return true
+}
+
+const ensureOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<void> => {
+  try {
+    await mkdir(location.ownershipDirectory, { recursive: false })
+  } catch (error) {
+    if (!isFileSystemError(error, 'EEXIST')) throw error
+  }
+  if (!(await assertOwnershipDirectory(location))) {
+    throw new Error('Managed workspace ownership directory is missing.')
+  }
+}
+
 const readOwnershipForUpdate = async (
   location: ManagedWorkspaceLocation
 ): Promise<ManagedWorkspaceOwnership | undefined> => {
+  if (!(await assertOwnershipDirectory(location))) return undefined
   const result = await readDurableJsonFile(location.receiptPath, decodeOwnership)
   if (result.status === 'missing') return undefined
   if (result.value.workspaceId !== location.workspaceId) {
@@ -118,7 +156,9 @@ const writeOwnership = (
   location: ManagedWorkspaceLocation,
   ownership: ManagedWorkspaceOwnership
 ): Promise<void> =>
-  writeDurableJsonFile(location.receiptPath, `${JSON.stringify(ownership, null, 2)}\n`)
+  ensureOwnershipDirectory(location).then(() =>
+    writeDurableJsonFile(location.receiptPath, `${JSON.stringify(ownership, null, 2)}\n`)
+  )
 
 const initializeManagedWorkspaceOwnership = async (
   cwd: string,
@@ -220,6 +260,11 @@ const readManagedWorkspaceOwnership = async (
 const removeManagedWorkspaceOwnership = async (cwd: string, dataRoot?: string): Promise<void> => {
   const location = locateManagedWorkspace(cwd, dataRoot)
   if (!location) return
+  try {
+    if (!(await assertOwnershipDirectory(location))) return
+  } catch {
+    return
+  }
   await rm(location.receiptPath, { force: true, recursive: false })
 }
 

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -254,12 +254,10 @@ const markManagedWorkspaceRetained = async (
   }
   const current = await readOwnershipForUpdate(candidate)
   if (!current) return false
-  if (
-    current.projectId !== session.projectId ||
-    (current.sessionId !== undefined && current.sessionId !== session.id)
-  ) {
+  if (current.projectId !== session.projectId) {
     throw new Error('Managed workspace ownership conflicts with the deleting Session.')
   }
+  if (current.sessionId !== undefined && current.sessionId !== session.id) return false
   await writeOwnership(location, {
     version: MANAGED_WORKSPACE_OWNERSHIP_VERSION,
     workspaceId: location.workspaceId,

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -387,10 +387,12 @@ const reconcileProvisionalManagedWorkspaces = async (
   for (const location of await listManagedWorkspaceOwnershipLocations(dataRoot)) {
     try {
       const ownership = await readOwnershipForUpdate(location)
-      if (!ownership || ownership.sessionId || ownership.retainedAfterDelete) continue
+      if (!ownership || ownership.retainedAfterDelete) continue
 
       const matchingSessions = sessionsByDirectory.get(location.directory) ?? []
-      if (matchingSessions.length > 0) {
+      if (ownership.sessionId) {
+        if (matchingSessions.length > 0 || ownership.lastUsedAt >= createdBefore) continue
+      } else if (matchingSessions.length > 0) {
         if (
           matchingSessions.length === 1 &&
           matchingSessions[0].projectId === ownership.projectId
@@ -403,8 +405,7 @@ const reconcileProvisionalManagedWorkspaces = async (
           )
         }
         continue
-      }
-      if (ownership.createdAt >= createdBefore) continue
+      } else if (ownership.createdAt >= createdBefore) continue
 
       const workspace = await assertManagedWorkspaceDirectory(location.directory, dataRoot)
       if (workspace) await rm(workspace.directory, { recursive: true, force: true })

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -153,6 +153,23 @@ const assertOwnershipDirectoryPath = async (
 const assertOwnershipDirectory = (location: ManagedWorkspaceLocation): Promise<boolean> =>
   assertOwnershipDirectoryPath(location.workspacesRoot, location.ownershipDirectory)
 
+const listManagedWorkspaceOwnershipLocations = async (
+  dataRoot: string
+): Promise<ManagedWorkspaceLocation[]> => {
+  const workspacesRoot = resolve(dataRoot, 'workspaces')
+  const ownershipDirectory = join(workspacesRoot, MANAGED_WORKSPACE_OWNERSHIP_DIR)
+  if (!(await assertOwnershipDirectoryPath(workspacesRoot, ownershipDirectory))) return []
+
+  const locations: ManagedWorkspaceLocation[] = []
+  for (const entry of await readdir(ownershipDirectory, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue
+    const workspaceId = entry.name.slice(0, -'.json'.length)
+    const location = locateManagedWorkspace(join(workspacesRoot, workspaceId), dataRoot)
+    if (location?.receiptPath === join(ownershipDirectory, entry.name)) locations.push(location)
+  }
+  return locations
+}
+
 const ensureOwnershipDirectory = async (location: ManagedWorkspaceLocation): Promise<void> => {
   if (!(await assertManagedWorkspacesRoot(location.workspacesRoot))) {
     throw new Error('Managed workspaces root is missing.')
@@ -284,29 +301,76 @@ const restoreManagedWorkspaceActive = async (
   await writeOwnership(location, { ...current, retainedAfterDelete: false })
 }
 
+const restoreManagedProjectWorkspacesActive = async (
+  projectId: string,
+  directories: readonly string[],
+  dataRoot = resolveDataRoot()
+): Promise<void> => {
+  const failures: unknown[] = []
+  for (const directory of directories) {
+    try {
+      const location = locateManagedWorkspace(directory, dataRoot)
+      if (!location) continue
+      const current = await readOwnershipForUpdate(location)
+      if (!current || !current.retainedAfterDelete) continue
+      if (current.projectId !== projectId) {
+        throw new Error('Managed workspace ownership conflicts with the restored Project.')
+      }
+      await writeOwnership(location, { ...current, retainedAfterDelete: false })
+    } catch (error) {
+      failures.push(error)
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Managed Project workspace ownership restoration failed.')
+  }
+}
+
+const markManagedProjectWorkspacesRetained = async (
+  projectId: string,
+  dataRoot = resolveDataRoot()
+): Promise<readonly string[]> => {
+  if (!projectId.trim()) throw new Error('Managed workspace Project identity is required.')
+  const retainedDirectories: string[] = []
+  try {
+    for (const location of await listManagedWorkspaceOwnershipLocations(dataRoot)) {
+      let current: ManagedWorkspaceOwnership | undefined
+      try {
+        current = await readOwnershipForUpdate(location)
+      } catch {
+        continue
+      }
+      if (!current || current.projectId !== projectId || current.retainedAfterDelete) continue
+      retainedDirectories.push(location.directory)
+      await writeOwnership(location, { ...current, retainedAfterDelete: true })
+    }
+    return retainedDirectories
+  } catch (error) {
+    try {
+      await restoreManagedProjectWorkspacesActive(projectId, retainedDirectories, dataRoot)
+    } catch (recoveryError) {
+      throw new AggregateError(
+        [error, recoveryError],
+        'Managed Project workspace ownership retention failed and rollback was incomplete.'
+      )
+    }
+    throw error
+  }
+}
+
 const reconcileProvisionalManagedWorkspaces = async (
   sessions: readonly Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id' | 'updatedAt'>[],
   createdBefore: number,
   dataRoot = resolveDataRoot()
 ): Promise<void> => {
-  const workspacesRoot = resolve(dataRoot, 'workspaces')
-  const ownershipDirectory = join(workspacesRoot, MANAGED_WORKSPACE_OWNERSHIP_DIR)
-  if (!(await assertOwnershipDirectoryPath(workspacesRoot, ownershipDirectory))) return
-
   const sessionsByDirectory = new Map<string, typeof sessions>()
   for (const session of sessions) {
     const directory = resolve(session.cwd)
     sessionsByDirectory.set(directory, [...(sessionsByDirectory.get(directory) ?? []), session])
   }
 
-  const entries = await readdir(ownershipDirectory, { withFileTypes: true })
   let firstFailure: unknown
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.json')) continue
-    const workspaceId = entry.name.slice(0, -'.json'.length)
-    const location = locateManagedWorkspace(join(workspacesRoot, workspaceId), dataRoot)
-    if (!location || location.receiptPath !== join(ownershipDirectory, entry.name)) continue
-
+  for (const location of await listManagedWorkspaceOwnershipLocations(dataRoot)) {
     try {
       const ownership = await readOwnershipForUpdate(location)
       if (!ownership || ownership.sessionId || ownership.retainedAfterDelete) continue
@@ -368,10 +432,12 @@ export {
   assertManagedWorkspacesRoot,
   finalizeManagedWorkspaceOwnership,
   initializeManagedWorkspaceOwnership,
+  markManagedProjectWorkspacesRetained,
   markManagedWorkspaceRetained,
   readManagedWorkspaceOwnership,
   reconcileProvisionalManagedWorkspaces,
   removeManagedWorkspaceOwnership,
+  restoreManagedProjectWorkspacesActive,
   restoreManagedWorkspaceActive
 }
 export type { ManagedWorkspaceOwnership }

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -1,0 +1,236 @@
+import { lstat, rm } from 'node:fs/promises'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { resolveDataRoot } from '../storage-root'
+import {
+  DurableJsonRecoveryBarrierError,
+  readDurableJsonFile,
+  writeDurableJsonFile
+} from './durable-json-file'
+
+const MANAGED_WORKSPACE_OWNERSHIP_DIR = '.ownership'
+const MANAGED_WORKSPACE_OWNERSHIP_VERSION = 1
+
+type ManagedWorkspaceOwnership = Readonly<{
+  version: typeof MANAGED_WORKSPACE_OWNERSHIP_VERSION
+  workspaceId: string
+  projectId: string
+  sessionId?: string
+  createdAt: number
+  lastUsedAt: number
+  retainedAfterDelete: boolean
+}>
+
+type ManagedWorkspaceLocation = Readonly<{
+  directory: string
+  workspaceId: string
+  receiptPath: string
+}>
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isTimestamp = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+
+const decodeOwnership = (contents: string): ManagedWorkspaceOwnership => {
+  const value: unknown = JSON.parse(contents)
+  if (!isRecord(value)) throw new Error('Managed workspace ownership receipt must be an object.')
+  if (typeof value.version === 'number' && value.version > MANAGED_WORKSPACE_OWNERSHIP_VERSION) {
+    throw new DurableJsonRecoveryBarrierError(
+      `Unsupported managed workspace ownership version: ${value.version}`
+    )
+  }
+  if (
+    value.version !== MANAGED_WORKSPACE_OWNERSHIP_VERSION ||
+    typeof value.workspaceId !== 'string' ||
+    !value.workspaceId ||
+    typeof value.projectId !== 'string' ||
+    !value.projectId ||
+    (value.sessionId !== undefined && (typeof value.sessionId !== 'string' || !value.sessionId)) ||
+    !isTimestamp(value.createdAt) ||
+    !isTimestamp(value.lastUsedAt) ||
+    typeof value.retainedAfterDelete !== 'boolean'
+  ) {
+    throw new Error('Managed workspace ownership receipt is invalid.')
+  }
+  return {
+    version: MANAGED_WORKSPACE_OWNERSHIP_VERSION,
+    workspaceId: value.workspaceId,
+    projectId: value.projectId,
+    ...(value.sessionId ? { sessionId: value.sessionId } : {}),
+    createdAt: value.createdAt,
+    lastUsedAt: value.lastUsedAt,
+    retainedAfterDelete: value.retainedAfterDelete
+  }
+}
+
+const locateManagedWorkspace = (
+  cwd: string,
+  dataRoot = resolveDataRoot()
+): ManagedWorkspaceLocation | undefined => {
+  const workspacesRoot = resolve(dataRoot, 'workspaces')
+  const directory = resolve(cwd)
+  const workspaceId = relative(workspacesRoot, directory)
+  if (
+    !workspaceId ||
+    workspaceId === MANAGED_WORKSPACE_OWNERSHIP_DIR ||
+    workspaceId === '..' ||
+    workspaceId.startsWith(`..${sep}`) ||
+    isAbsolute(workspaceId) ||
+    workspaceId.includes(sep)
+  ) {
+    return undefined
+  }
+  return {
+    directory,
+    workspaceId,
+    receiptPath: join(workspacesRoot, MANAGED_WORKSPACE_OWNERSHIP_DIR, `${workspaceId}.json`)
+  }
+}
+
+const assertManagedWorkspaceDirectory = async (
+  cwd: string,
+  dataRoot?: string
+): Promise<ManagedWorkspaceLocation | undefined> => {
+  const location = locateManagedWorkspace(cwd, dataRoot)
+  if (!location) return undefined
+  const info = await lstat(location.directory)
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error('Managed workspace must be a regular directory.')
+  }
+  return location
+}
+
+const readOwnershipForUpdate = async (
+  location: ManagedWorkspaceLocation
+): Promise<ManagedWorkspaceOwnership | undefined> => {
+  const result = await readDurableJsonFile(location.receiptPath, decodeOwnership)
+  if (result.status === 'missing') return undefined
+  if (result.value.workspaceId !== location.workspaceId) {
+    throw new Error('Managed workspace ownership does not match its directory.')
+  }
+  return result.value
+}
+
+const writeOwnership = (
+  location: ManagedWorkspaceLocation,
+  ownership: ManagedWorkspaceOwnership
+): Promise<void> =>
+  writeDurableJsonFile(location.receiptPath, `${JSON.stringify(ownership, null, 2)}\n`)
+
+const initializeManagedWorkspaceOwnership = async (
+  cwd: string,
+  projectId: string,
+  createdAt = Date.now(),
+  dataRoot?: string
+): Promise<void> => {
+  const location = await assertManagedWorkspaceDirectory(cwd, dataRoot)
+  if (!location) throw new Error('Managed workspace is outside the app workspace root.')
+  if (!projectId.trim()) throw new Error('Managed workspace Project identity is required.')
+  if (await readOwnershipForUpdate(location)) {
+    throw new Error('Managed workspace already has an ownership receipt.')
+  }
+  await writeOwnership(location, {
+    version: MANAGED_WORKSPACE_OWNERSHIP_VERSION,
+    workspaceId: location.workspaceId,
+    projectId,
+    createdAt,
+    lastUsedAt: createdAt,
+    retainedAfterDelete: false
+  })
+}
+
+const finalizeManagedWorkspaceOwnership = async (
+  cwd: string,
+  sessionId: string,
+  lastUsedAt = Date.now(),
+  dataRoot?: string
+): Promise<void> => {
+  const location = await assertManagedWorkspaceDirectory(cwd, dataRoot)
+  if (!location) throw new Error('Managed workspace is outside the app workspace root.')
+  const current = await readOwnershipForUpdate(location)
+  if (!current) throw new Error('Managed workspace ownership receipt is missing.')
+  if (!sessionId.trim()) throw new Error('Managed workspace Session identity is required.')
+  if (current.sessionId && current.sessionId !== sessionId) {
+    throw new Error('Managed workspace is already owned by another Session.')
+  }
+  await writeOwnership(location, {
+    ...current,
+    sessionId,
+    lastUsedAt: Math.max(current.lastUsedAt, lastUsedAt)
+  })
+}
+
+const markManagedWorkspaceRetained = async (
+  session: Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id' | 'createdAt' | 'updatedAt'>,
+  dataRoot?: string
+): Promise<boolean> => {
+  const location = await assertManagedWorkspaceDirectory(session.cwd, dataRoot)
+  if (!location) return false
+  const current = await readOwnershipForUpdate(location)
+  if (
+    current &&
+    (current.projectId !== session.projectId ||
+      (current.sessionId !== undefined && current.sessionId !== session.id))
+  ) {
+    throw new Error('Managed workspace ownership conflicts with the deleting Session.')
+  }
+  const createdAt = current?.createdAt ?? session.createdAt
+  await writeOwnership(location, {
+    version: MANAGED_WORKSPACE_OWNERSHIP_VERSION,
+    workspaceId: location.workspaceId,
+    projectId: session.projectId,
+    sessionId: session.id,
+    createdAt,
+    lastUsedAt: Math.max(current?.lastUsedAt ?? createdAt, session.updatedAt),
+    retainedAfterDelete: true
+  })
+  return true
+}
+
+const restoreManagedWorkspaceActive = async (
+  session: Pick<PersistedChatSession, 'cwd' | 'projectId' | 'id'>,
+  dataRoot?: string
+): Promise<void> => {
+  const location = await assertManagedWorkspaceDirectory(session.cwd, dataRoot)
+  if (!location) return
+  const current = await readOwnershipForUpdate(location)
+  if (!current) return
+  if (current.projectId !== session.projectId || current.sessionId !== session.id) {
+    throw new Error('Managed workspace ownership conflicts with the restored Session.')
+  }
+  await writeOwnership(location, { ...current, retainedAfterDelete: false })
+}
+
+const readManagedWorkspaceOwnership = async (
+  cwd: string,
+  dataRoot?: string
+): Promise<ManagedWorkspaceOwnership | undefined> => {
+  try {
+    const location = await assertManagedWorkspaceDirectory(cwd, dataRoot)
+    return location ? await readOwnershipForUpdate(location) : undefined
+  } catch {
+    // Corrupt, unreadable, future, or untrusted receipts stay visible as unknown and never authorize
+    // cleanup. Writers still fail closed through the strict helpers above.
+    return undefined
+  }
+}
+
+const removeManagedWorkspaceOwnership = async (cwd: string, dataRoot?: string): Promise<void> => {
+  const location = locateManagedWorkspace(cwd, dataRoot)
+  if (!location) return
+  await rm(location.receiptPath, { force: true, recursive: false })
+}
+
+export {
+  MANAGED_WORKSPACE_OWNERSHIP_DIR,
+  finalizeManagedWorkspaceOwnership,
+  initializeManagedWorkspaceOwnership,
+  markManagedWorkspaceRetained,
+  readManagedWorkspaceOwnership,
+  removeManagedWorkspaceOwnership,
+  restoreManagedWorkspaceActive
+}
+export type { ManagedWorkspaceOwnership }

--- a/src/main/storage/usage.ts
+++ b/src/main/storage/usage.ts
@@ -8,6 +8,10 @@ import {
   type UsageChild
 } from '../../shared/storage'
 import { logicalEnvNameFromDirectory } from '../notebook/runtime-paths'
+import {
+  MANAGED_WORKSPACE_OWNERSHIP_DIR,
+  readManagedWorkspaceOwnership
+} from './managed-workspace-ownership'
 
 const isMissingPathError = (error: unknown): boolean => {
   const code = (error as NodeJS.ErrnoException)?.code
@@ -77,7 +81,25 @@ const workspaceUsage = async (dir: string): Promise<{ bytes: number; children: U
     if (entry.isSymbolicLink()) continue
     const path = join(dir, entry.name)
     if (entry.isDirectory()) {
-      children.push({ name: entry.name, bytes: await dirSize(path, seen) })
+      if (entry.name === MANAGED_WORKSPACE_OWNERSHIP_DIR) {
+        looseBytes += await dirSize(path, seen)
+        continue
+      }
+      const ownership = await readManagedWorkspaceOwnership(path, join(dir, '..'))
+      children.push({
+        name: entry.name,
+        bytes: await dirSize(path, seen),
+        ...(ownership
+          ? {
+              workspaceId: ownership.workspaceId,
+              projectId: ownership.projectId,
+              ...(ownership.sessionId ? { sessionId: ownership.sessionId } : {}),
+              createdAt: ownership.createdAt,
+              lastUsedAt: ownership.lastUsedAt,
+              retainedAfterDelete: ownership.retainedAfterDelete
+            }
+          : {})
+      })
     } else if (entry.isFile()) {
       looseBytes += await fileSize(path, seen)
     }

--- a/src/main/storage/usage.ts
+++ b/src/main/storage/usage.ts
@@ -82,7 +82,6 @@ const workspaceUsage = async (dir: string): Promise<{ bytes: number; children: U
     const path = join(dir, entry.name)
     if (entry.isDirectory()) {
       if (entry.name === MANAGED_WORKSPACE_OWNERSHIP_DIR) {
-        looseBytes += await dirSize(path, seen)
         continue
       }
       const ownership = await readManagedWorkspaceOwnership(path, join(dir, '..'))

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -11,7 +11,16 @@ export const STORAGE_USAGE_CATEGORY_KEYS = [
   'workspaces'
 ] as const
 export type UsageCategoryKey = (typeof STORAGE_USAGE_CATEGORY_KEYS)[number]
-export type UsageChild = { name: string; bytes: number }
+export type UsageChild = {
+  name: string
+  bytes: number
+  workspaceId?: string
+  projectId?: string
+  sessionId?: string
+  createdAt?: number
+  lastUsedAt?: number
+  retainedAfterDelete?: boolean
+}
 export type UsageCategory = { key: UsageCategoryKey; bytes: number; children?: UsageChild[] }
 export type StorageUsage = { categories: UsageCategory[]; totalBytes: number }
 


### PR DESCRIPTION
## Problem

Managed Session workspaces use opaque UUID directory names. Session and Project deletion deliberately
retain those directories but remove the Session JSON that previously supplied their Project and
Session association. Storage usage could therefore report only an opaque directory name and size,
with no durable ownership, last-use, or retained-after-delete evidence.

The regression was reproduced before the fix through the existing create-Session and storage-usage
boundaries. The new test failed consistently because the usage row contained only `name` and `bytes`.

## Proposed change

- Write one versioned, owner-only receipt per managed workspace under
  `workspaces/.ownership/<workspaceId>.json`.
- Record Project identity before invoking the Agent Session creator, then finalize the receipt with
  the returned Session identity.
- Inject a narrow workspace-ownership capability into Session deletion. Individual Session and whole
  Project deletion update the receipt before removing Session authority; a failed individual deletion
  restores the active marker.
- Backfill receipts only when a still-existing Session JSON authoritatively points at a direct child
  of the managed workspace root.
- Enrich workspace storage-usage rows with optional IDs, timestamps, and `retainedAfterDelete`.

All supported ACP backends and the Task adapter share the same create-Session workflow, so managed
workspace receipt publication is backend-neutral.

## Scope and non-goals

- No Prisma schema or database migration.
- No new lifecycle enum; the persisted addition uses a `retainedAfterDelete` boolean.
- No Settings UI, cleanup button, or automatic deletion behavior.
- Explicit external working directories remain reference-only and receive no receipt or mutation.
- Previously deleted historical workspaces cannot be attributed reliably. They remain unknown and
  must not authorize automatic cleanup.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- managed creation, deletion, historical backfill, external preservation, storage projection, and
  Project-owned-data catalog -> targeted Vitest command -> 45 passed.
- ACP managed-workspace IPC ordering and rollback -> targeted `src/main/acp/ipc.test.ts` selection ->
  6 passed.
- Session deletion, Project deletion, recovery, contracts, and consumers ->
  `npm run test:module -- session_persistence` -> 486 passed.
- Main/Sandbox type safety -> `npm run typecheck:node` -> passed.
- Renderer/shared-contract type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.

The exact-head affected-test explainer fails closed to the complete suite because the existing module
manifest does not own `src/main/acp/create-session-workflow.test.ts`. Per maintainer request, the full
local `npm test` was not run; PR Gate is the final complete and platform-specific authority.

## Review focus

- Receipt path validation rejects nested, external, reserved, and symlinked workspace directories.
- A provisional Project receipt exists before Agent Session creation; rollback removes it only after
  the provisional workspace directory was removed successfully.
- Corrupt or future receipts remain visible as unknown and never become cleanup authority.
- Project deletion performs bounded legacy backfill while Session JSON is still authoritative.
