### PR TITLE
fix(session-contracts): validate runtime IPC payloads

### DIFF
--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -484,7 +484,14 @@ describe('Data and content application commands', () => {
       },
       {
         key: 'sessionUpdateArchive',
-        args: [request('session-update-archive')],
+        args: [
+          {
+            projectId: 'project-1',
+            sessionId: 'session-1',
+            archived: true,
+            expectedArchivedAt: null
+          }
+        ],
         owner: deps.sessions.updateArchive
       },
       {
@@ -1072,10 +1079,6 @@ describe('Data and content application commands', () => {
   it('sanitizes a renderer Session once at the main-process save boundary', async () => {
     const router = createApplicationCommandRouter()
     const deps = createDependencies()
-    deps.sessions.saveSession.mockImplementationOnce(async (session) => ({
-      created: false,
-      session
-    }))
     registerDataContentApplicationCommands(router.registrar, deps.dependencies)
 
     const malformedSession = {
@@ -1091,7 +1094,10 @@ describe('Data and content application commands', () => {
       expect.objectContaining({ status: 'idle', revision: 0, createdAt: 0 }),
       undefined
     )
-    expect(deps.sessions.saveSession.mock.calls[0]?.[0].runtimeContext).toBeUndefined()
+    const savedSession = (
+      deps.sessions.saveSession.mock.calls as unknown as Array<readonly [Record<string, unknown>]>
+    )[0]?.[0]
+    expect(savedSession?.runtimeContext).toBeUndefined()
   })
 
   it('dispatches every remaining Project and Session wrapper to its existing owner', async () => {

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -1016,6 +1016,84 @@ describe('Data and content application commands', () => {
     ).rejects.toMatchObject({ code: 'invalid-command-result' })
   })
 
+  it('sanitizes the complete authoritative Session result instead of passing malformed fields', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    deps.sessions.editDetails.mockResolvedValueOnce({
+      ...deps.session,
+      status: 'future-status',
+      revision: -1,
+      createdAt: 'yesterday',
+      updatedAt: Number.NaN,
+      runtimeContext: { version: 1, revision: 'invalid' }
+    } as never)
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    const result = await router.dispatcher.invoke(
+      dataContentApplicationCommands.sessionEditDetails,
+      invocation([
+        {
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          title: 'Updated title',
+          description: 'Updated description'
+        }
+      ] as const)
+    )
+
+    expect(result).toMatchObject({ status: 'idle', revision: 0, createdAt: 0, updatedAt: 0 })
+    expect(result.runtimeContext).toBeUndefined()
+  })
+
+  it('rejects a malformed Session conversation graph returned by archive', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    deps.sessions.updateArchive.mockResolvedValueOnce({
+      ...deps.session,
+      conversationGraph: { schemaVersion: 1 }
+    } as never)
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionUpdateArchive,
+        invocation([
+          {
+            projectId: 'project-1',
+            sessionId: 'session-1',
+            archived: true,
+            expectedArchivedAt: null
+          }
+        ] as const)
+      )
+    ).rejects.toMatchObject({ code: 'invalid-command-result' })
+  })
+
+  it('sanitizes a renderer Session once at the main-process save boundary', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    deps.sessions.saveSession.mockImplementationOnce(async (session) => ({
+      created: false,
+      session
+    }))
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    const malformedSession = {
+      ...deps.session,
+      status: 'future-status',
+      revision: -1,
+      createdAt: 'yesterday',
+      runtimeContext: { version: 1, revision: 'invalid' }
+    }
+    await dispatchCommand(router, 'sessionSave', [malformedSession]).result
+
+    expect(deps.sessions.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'idle', revision: 0, createdAt: 0 }),
+      undefined
+    )
+    expect(deps.sessions.saveSession.mock.calls[0]?.[0].runtimeContext).toBeUndefined()
+  })
+
   it('dispatches every remaining Project and Session wrapper to its existing owner', async () => {
     const router = createApplicationCommandRouter()
     const deps = createDependencies()
@@ -1134,6 +1212,8 @@ describe('Data and content application commands', () => {
       label: 'unknown extra field',
       request: { projectId: 'project-1', sessionId: 'session-1', force: true }
     },
+    { label: 'empty project id', request: { projectId: '', sessionId: 'session-1' } },
+    { label: 'empty session id', request: { projectId: 'project-1', sessionId: '' } },
     { label: 'missing session id', request: { projectId: 'project-1' } },
     { label: 'scalar payload', request: 'session-1' }
   ])(
@@ -1154,6 +1234,53 @@ describe('Data and content application commands', () => {
       expect(deps.events.publish).not.toHaveBeenCalled()
     }
   )
+
+  it.each([
+    {
+      label: 'archive request with a surplus field',
+      command: 'sessionUpdateArchive' as const,
+      request: {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        archived: true,
+        expectedArchivedAt: null,
+        force: true
+      },
+      owner: 'updateArchive' as const
+    },
+    {
+      label: 'archive request with an invalid timestamp',
+      command: 'sessionUpdateArchive' as const,
+      request: {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        archived: false,
+        expectedArchivedAt: Number.NaN
+      },
+      owner: 'updateArchive' as const
+    },
+    {
+      label: 'manifest request with an empty project id',
+      command: 'sessionSaveManifest' as const,
+      request: { lastProjectId: '', lastSessionId: 'session-1' },
+      owner: 'saveManifest' as const
+    },
+    {
+      label: 'manifest request with a surplus field',
+      command: 'sessionSaveManifest' as const,
+      request: { lastProjectId: 'project-1', lastSessionId: 'session-1', path: '/private/data' },
+      owner: 'saveManifest' as const
+    }
+  ])('rejects a malformed Session $label before reaching the owner', async (testCase) => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    const { result: dispatched } = dispatchCommand(router, testCase.command, [testCase.request])
+
+    await expect(dispatched).rejects.toMatchObject({ code: 'invalid-command-arguments' })
+    expect(deps.sessions[testCase.owner]).not.toHaveBeenCalled()
+  })
 
   it('rejects a malformed Session deletion owner result without publishing deletion', async () => {
     const router = createApplicationCommandRouter()

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -1156,6 +1156,57 @@ describe('Data and content application commands', () => {
     })
   })
 
+  it('preserves legacy upload paths through live save and archive command boundaries', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    const legacyPath = '/data/uploads/project-1/session-1/legacy.csv'
+    const legacySession = materializeSessionConversationGraph({
+      ...deps.session,
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Analyze this upload',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: 'upload-1',
+              sessionId: 'session-1',
+              name: 'legacy.csv',
+              originalName: 'legacy.csv',
+              path: legacyPath,
+              size: 12
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    } as PersistedChatSession)
+    deps.sessions.updateArchive.mockResolvedValueOnce(legacySession as never)
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    await dispatchCommand(router, 'sessionSave', [legacySession]).result
+    const submitted = (
+      deps.sessions.saveSession.mock.calls as unknown as Array<readonly [PersistedChatSession]>
+    )[0]?.[0]
+    expect(submitted?.messages[0]?.uploads?.[0]).toMatchObject({ path: legacyPath })
+
+    const archived = await router.dispatcher.invoke(
+      dataContentApplicationCommands.sessionUpdateArchive,
+      invocation([
+        {
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          archived: true,
+          expectedArchivedAt: null
+        }
+      ] as const)
+    )
+    expect(archived.messages[0]?.uploads?.[0]).toMatchObject({ path: legacyPath })
+  })
+
   it('dispatches every remaining Project and Session wrapper to its existing owner', async () => {
     const router = createApplicationCommandRouter()
     const deps = createDependencies()

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -22,7 +22,9 @@ import {
   type DataContentApplicationCommandDependencies
 } from './data-content-application-commands'
 import {
+  materializeSessionConversationGraph,
   SessionRevisionConflictError,
+  type PersistedChatSession,
   type SessionDeletionResult
 } from '../shared/session-persistence'
 import { ApplicationCommandError } from '../shared/application-command-contract'
@@ -1100,6 +1102,60 @@ describe('Data and content application commands', () => {
     expect(savedSession?.runtimeContext).toBeUndefined()
   })
 
+  it('normalizes graph-only Session arguments and results without preserving incomplete objects', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    const graphOnlySession: Partial<PersistedChatSession> = structuredClone(
+      materializeSessionConversationGraph(deps.session as PersistedChatSession)
+    )
+    delete graphOnlySession.messages
+    deps.sessions.updateArchive.mockResolvedValueOnce(graphOnlySession as never)
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    await dispatchCommand(router, 'sessionSave', [graphOnlySession]).result
+    const submitted = (
+      deps.sessions.saveSession.mock.calls as unknown as Array<readonly [PersistedChatSession]>
+    )[0]?.[0]
+    expect(submitted?.messages).toEqual([])
+
+    const result = await router.dispatcher.invoke(
+      dataContentApplicationCommands.sessionUpdateArchive,
+      invocation([
+        {
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          archived: true,
+          expectedArchivedAt: null
+        }
+      ] as const)
+    )
+    expect(result).not.toBe(graphOnlySession)
+    expect(result.messages).toEqual([])
+  })
+
+  it('normalizes incomplete nested Session messages before persistence', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    await dispatchCommand(router, 'sessionSave', [
+      {
+        ...deps.session,
+        messages: [{ id: 'message-1', role: 'user', content: 'Hello' }]
+      }
+    ]).result
+
+    const submitted = (
+      deps.sessions.saveSession.mock.calls as unknown as Array<readonly [PersistedChatSession]>
+    )[0]?.[0]
+    expect(submitted?.messages[0]).toMatchObject({
+      status: 'complete',
+      eventIds: [],
+      createdAt: 0,
+      updatedAt: 0
+    })
+  })
+
   it('dispatches every remaining Project and Session wrapper to its existing owner', async () => {
     const router = createApplicationCommandRouter()
     const deps = createDependencies()
@@ -1266,15 +1322,15 @@ describe('Data and content application commands', () => {
       owner: 'updateArchive' as const
     },
     {
-      label: 'manifest request with an empty project id',
+      label: 'manifest request with the removed project id',
       command: 'sessionSaveManifest' as const,
-      request: { lastProjectId: '', lastSessionId: 'session-1' },
+      request: { lastProjectId: 'project-1', lastSessionId: 'session-1' },
       owner: 'saveManifest' as const
     },
     {
       label: 'manifest request with a surplus field',
       command: 'sessionSaveManifest' as const,
-      request: { lastProjectId: 'project-1', lastSessionId: 'session-1', path: '/private/data' },
+      request: { lastSessionId: 'session-1', path: '/private/data' },
       owner: 'saveManifest' as const
     }
   ])('rejects a malformed Session $label before reaching the owner', async (testCase) => {

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -311,8 +311,16 @@ const dataContentApplicationCommands = Object.freeze({
   sessionLoadAll: sessionCommand('sessions:load-all', 'loadAll'),
   sessionLoadOne: sessionCommand('sessions:load-one', 'loadOne'),
   sessionLoadUsage: sessionCommand('sessions:load-usage', 'loadUsage'),
-  sessionSaveManifest: sessionCommand('sessions:save-manifest', 'saveManifest'),
-  sessionUpdateArchive: sessionCommand('sessions:update-archive', 'updateArchive'),
+  sessionSaveManifest: sessionCommand(
+    'sessions:save-manifest',
+    'saveManifest',
+    SessionPersistence.sessionApplicationCommandContracts.saveManifest
+  ),
+  sessionUpdateArchive: sessionCommand(
+    'sessions:update-archive',
+    'updateArchive',
+    SessionPersistence.sessionApplicationCommandContracts.updateArchive
+  ),
   sessionUnlinkPdfContext: sessionCommand(
     'sessions:unlink-pdf-context',
     'unlinkPdfContext',
@@ -325,7 +333,7 @@ const dataContentApplicationCommands = Object.freeze({
       options?: SessionPersistence.SaveSessionOptions
     ],
     SessionPersistence.PersistedChatSession
-  >('sessions:save-session'),
+  >('sessions:save-session', SessionPersistence.sessionApplicationCommandContracts.save),
   sessionSetDelegationPolicy: defineApplicationCommand<
     'sessions:set-delegation-policy',
     readonly [projectId: string, sessionId: string, policy: SessionPersistence.DelegationPolicy],

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -4433,7 +4433,10 @@ const hasRequiredSessionFields = (value: unknown): value is PersistedChatSession
 // nested message, graph, activity and runtime-context field while upgrading historical shapes.
 export const persistedChatSessionCodec: RuntimeCodec<PersistedChatSession> = Object.freeze({
   parse: (value): PersistedChatSession => {
-    const decoded = decodeSessionFile(value, { preserveRuntimeState: true })
+    const decoded = decodeSessionFile(value, {
+      preserveLegacyUploadPaths: true,
+      preserveRuntimeState: true
+    })
     if (decoded.status !== 'ok' || decoded.session.projectId.length === 0) {
       throw new Error('Invalid Session payload.')
     }

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 
-import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
+import {
+  defineApplicationCommandContract,
+  type RuntimeCodec,
+  validationCodec
+} from './application-command-contract'
 import type { PersistedUploadedAttachment } from './uploads'
 import type { FileReference } from './artifacts'
 import { sanitizeAnnotations, type Annotation } from './annotations'
@@ -4390,6 +4394,37 @@ export const normalizeSessionFile = (
   return decoded.status === 'ok' ? decoded.session : undefined
 }
 
+const matchesSanitizedProjection = (value: unknown, sanitized: unknown): boolean => {
+  if (Object.is(value, sanitized)) return true
+  if (Array.isArray(value)) {
+    return (
+      Array.isArray(sanitized) &&
+      value.length === sanitized.length &&
+      value.every((item, index) => matchesSanitizedProjection(item, sanitized[index]))
+    )
+  }
+  if (!isRecord(value) || !isRecord(sanitized)) return false
+  return Object.entries(value).every(
+    ([key, item]) =>
+      Object.hasOwn(sanitized, key) && matchesSanitizedProjection(item, sanitized[key])
+  )
+}
+
+// The wire boundary uses the same recursive decoder as durable Session files, but preserves live
+// runtime state instead of applying restart recovery. This keeps one source of truth for every
+// nested message, graph, activity and runtime-context field while upgrading historical shapes.
+export const persistedChatSessionCodec: RuntimeCodec<PersistedChatSession> = Object.freeze({
+  parse: (value): PersistedChatSession => {
+    const decoded = decodeSessionFile(value, { preserveRuntimeState: true })
+    if (decoded.status !== 'ok' || decoded.session.projectId.length === 0) {
+      throw new Error('Invalid Session payload.')
+    }
+    return matchesSanitizedProjection(value, decoded.session)
+      ? (value as PersistedChatSession)
+      : decoded.session
+  }
+})
+
 // Tiny app-level pointer restoring the last-open Session after a restart.
 export type PersistedSessionManifest = {
   version: typeof SESSION_MANIFEST_VERSION
@@ -4517,7 +4552,7 @@ export const unlinkSessionPdfContextRequestSchema = z
   .strict()
 
 export const deleteSessionRequestSchema = z
-  .object({ projectId: z.string(), sessionId: z.string() })
+  .object({ projectId: z.string().min(1), sessionId: z.string().min(1) })
   .strict()
 
 // Manual details edits mutate only authority-owned display fields server-side, so they carry no
@@ -4556,29 +4591,38 @@ export const sessionDeletionResultSchema = z.union([
 
 export type SessionDeletionResult = z.infer<typeof sessionDeletionResultSchema>
 
-export type UpdateSessionArchiveRequest = {
-  projectId: string
-  sessionId: string
-  archived: boolean
-  expectedArchivedAt: number | null
-}
+export const updateSessionArchiveRequestSchema = z
+  .object({
+    projectId: z.string().min(1),
+    sessionId: z.string().min(1),
+    archived: z.boolean(),
+    expectedArchivedAt: z.number().int().positive().nullable()
+  })
+  .strict()
 
-export type SaveSessionManifestRequest = {
-  lastSessionId?: string
-}
+export const saveSessionManifestRequestSchema = z
+  .object({
+    lastSessionId: z.string().min(1).optional()
+  })
+  .strict()
 
-const persistedChatSessionResultSchema = z.custom<PersistedChatSession>(
-  (value) =>
-    isRecord(value) &&
-    typeof value.id === 'string' &&
-    typeof value.projectId === 'string' &&
-    typeof value.title === 'string' &&
-    Array.isArray(value.messages)
-)
+export type UpdateSessionArchiveRequest = z.infer<typeof updateSessionArchiveRequestSchema>
+export type SaveSessionManifestRequest = z.infer<typeof saveSessionManifestRequestSchema>
 
-// Runtime-validated contract for the Electron-facing terminal Session deletion command. The request
-// and result schemas double as the wire types so the router enforces exactly the union the
-// SessionDeletionOwner can produce.
+const saveSessionArgsCodec: RuntimeCodec<
+  readonly [session: PersistedChatSession, options?: SaveSessionOptions]
+> = Object.freeze({
+  parse: (value) => {
+    if (!Array.isArray(value) || value.length < 1 || value.length > 2) {
+      throw new Error('Invalid Session save arguments.')
+    }
+    const session = persistedChatSessionCodec.parse(value[0])
+    return value.length === 1 ? [session] : [session, value[1] as SaveSessionOptions | undefined]
+  }
+})
+
+// Runtime-validated contracts for Electron-facing Session commands. Request schemas double as wire
+// types, while Session-bearing commands share the recursive persistence codec above.
 export const sessionApplicationCommandContracts = Object.freeze({
   filterPdfContextCandidates: defineApplicationCommandContract(
     validationCodec(z.tuple([filterSessionPdfContextCandidatesRequestSchema])),
@@ -4600,12 +4644,21 @@ export const sessionApplicationCommandContracts = Object.freeze({
     validationCodec(z.tuple([deleteSessionRequestSchema])),
     validationCodec(sessionDeletionResultSchema)
   ),
+  saveManifest: defineApplicationCommandContract(
+    validationCodec(z.tuple([saveSessionManifestRequestSchema])),
+    validationCodec(z.void())
+  ),
+  updateArchive: defineApplicationCommandContract(
+    validationCodec(z.tuple([updateSessionArchiveRequestSchema])),
+    persistedChatSessionCodec
+  ),
+  save: defineApplicationCommandContract(saveSessionArgsCodec, persistedChatSessionCodec),
   editDetails: defineApplicationCommandContract(
     validationCodec(z.tuple([editSessionDetailsRequestSchema])),
-    validationCodec(persistedChatSessionResultSchema)
+    persistedChatSessionCodec
   ),
   setDelegationPolicy: defineApplicationCommandContract(
     validationCodec(z.tuple([z.string(), z.string(), delegationPolicySchema])),
-    validationCodec(persistedChatSessionResultSchema)
+    persistedChatSessionCodec
   )
 })

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -4394,7 +4394,11 @@ export const normalizeSessionFile = (
   return decoded.status === 'ok' ? decoded.session : undefined
 }
 
-const matchesSanitizedProjection = (value: unknown, sanitized: unknown): boolean => {
+const matchesSanitizedProjection = (
+  value: unknown,
+  sanitized: unknown,
+  allowMissingSanitizedFields = false
+): boolean => {
   if (Object.is(value, sanitized)) return true
   if (Array.isArray(value)) {
     return (
@@ -4404,11 +4408,25 @@ const matchesSanitizedProjection = (value: unknown, sanitized: unknown): boolean
     )
   }
   if (!isRecord(value) || !isRecord(sanitized)) return false
+  if (!allowMissingSanitizedFields && Object.keys(value).length !== Object.keys(sanitized).length) {
+    return false
+  }
   return Object.entries(value).every(
     ([key, item]) =>
       Object.hasOwn(sanitized, key) && matchesSanitizedProjection(item, sanitized[key])
   )
 }
+
+const hasRequiredSessionFields = (value: unknown): value is PersistedChatSession =>
+  isRecord(value) &&
+  Object.hasOwn(value, 'id') &&
+  Object.hasOwn(value, 'projectId') &&
+  Object.hasOwn(value, 'title') &&
+  Object.hasOwn(value, 'cwd') &&
+  Object.hasOwn(value, 'status') &&
+  Object.hasOwn(value, 'messages') &&
+  Object.hasOwn(value, 'createdAt') &&
+  Object.hasOwn(value, 'updatedAt')
 
 // The wire boundary uses the same recursive decoder as durable Session files, but preserves live
 // runtime state instead of applying restart recovery. This keeps one source of truth for every
@@ -4419,8 +4437,9 @@ export const persistedChatSessionCodec: RuntimeCodec<PersistedChatSession> = Obj
     if (decoded.status !== 'ok' || decoded.session.projectId.length === 0) {
       throw new Error('Invalid Session payload.')
     }
-    return matchesSanitizedProjection(value, decoded.session)
-      ? (value as PersistedChatSession)
+    return hasRequiredSessionFields(value) &&
+      matchesSanitizedProjection(value, decoded.session, true)
+      ? value
       : decoded.session
   }
 })


### PR DESCRIPTION
## Problem

Several Session application commands relied on TypeScript-only payload types at runtime. Deletion accepted empty identifiers, archive and manifest writes had no strict command contract, and Session-valued results checked only four top-level fields. Malformed status, timestamps, revisions, conversation graphs, runtime context, and incomplete nested messages could therefore cross the application-command boundary or reach persistence.

## Proposed change

- require non-empty project and Session identifiers for deletion;
- add strict archive and manifest request schemas, aligned with the current `lastSessionId`-only manifest contract;
- promote the existing recursive Session file decoder/sanitizer to a shared runtime codec;
- apply that codec once at the main-process Session save boundary and to Session-valued save, archive, details, and delegation results; and
- preserve recoverable legacy upload paths across live command boundaries until the existing persistence owner upgrades them to immutable Upload Versions; and
- preserve object identity only for complete, already-valid payloads while normalizing recoverable historical and incomplete nested shapes and rejecting undecodable graphs.

## Scope and non-goals

- No new fields, enum values, database changes, migrations, or persisted-format versions.
- Historical Session files continue through the existing permissive disk decoder.
- Unversioned historical uploads retain their recoverable path in live projections until the existing live-save upgrade succeeds; persisted versioned uploads remain path-free.
- Historical version-1 manifests containing the removed `lastProjectId` field remain readable; the field is ignored on disk and rejected at the live strict command boundary.
- Valid archive, manifest, and Session-save behavior is unchanged.
- This does not add a second parallel Zod model for the full evolving Session graph, repeat validation inside repository layers, or change lifecycle-event publication architecture.

## Acceptance criteria and validation

The regression tests were first run against the unfixed implementation and produced stable failures matching the reported boundary gaps. After the final material edit:

- malformed, incomplete, and legacy-compatible Session command requests/results -> `npm test -- src/main/data-content-application-commands.test.ts` -> 39 passed;
- Session persistence owner, contract, and representative consumer behavior -> `npm run test:module -- session_persistence` -> 487 passed across 9 files;
- main/shared TypeScript contracts -> `npm run typecheck:node` -> passed;
- renderer/shared TypeScript consumers -> `npm run typecheck:web` -> passed;
- linted source and tests -> `npm run lint` -> passed.

The complete local `npm test` suite was intentionally not run. The Session persistence module plan covers the changed owner, shared codec, delegation consumers, deletion integration, and Windows-sensitive overlay; PR CI remains the authority for the complete portable and platform suites. No local E2E claim is made.

## Review focus

- Confirm that strict request rejection is appropriate for empty identifiers, invalid archive timestamps, surplus fields, and the removed live `lastProjectId` manifest field.
- Confirm that the shared codec preserves historical disk compatibility while sanitizing renderer save inputs exactly once at the application-command boundary.
- Check that complete valid Session objects retain identity while graph-only and incomplete nested payloads normalize before persistence or return.
- Check that legacy upload paths survive live save/archive boundaries only until the persistence owner creates immutable Upload Versions.
