### PR TITLE
fix(acp): keep prompt attachments readable in notebook

### DIFF
--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -402,6 +402,23 @@ describe('AcpNativeFollowUpWorkflow', () => {
     expect(close).toHaveBeenCalledOnce()
   })
 
+  it('closes retained prepared resources when their session is superseded', async () => {
+    const close = vi.fn()
+    const { workflow } = createWorkflow({
+      prepareFollowUp: async () => ({
+        prompt: [{ type: 'text' as const, text: 'see file' }],
+        close
+      })
+    })
+
+    await workflow.steerFollowUp({ sessionId: 'app-1', text: 'see file' })
+    expect(close).not.toHaveBeenCalled()
+
+    workflow.releaseSession('app-1')
+    workflow.releaseSession('app-1')
+    expect(close).toHaveBeenCalledOnce()
+  })
+
   it('does not persist unfinalized attachments that session save cannot recover', async () => {
     const { workflow } = createWorkflow()
     await expect(

--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -385,6 +385,23 @@ describe('AcpNativeFollowUpWorkflow', () => {
     expect(close).toHaveBeenCalledOnce()
   })
 
+  it('closes retained prepared resources during workflow teardown', async () => {
+    const close = vi.fn()
+    const { workflow } = createWorkflow({
+      prepareFollowUp: async () => ({
+        prompt: [{ type: 'text' as const, text: 'see file' }],
+        close
+      })
+    })
+
+    await workflow.steerFollowUp({ sessionId: 'app-1', text: 'see file' })
+    expect(close).not.toHaveBeenCalled()
+
+    workflow.clear()
+    workflow.clear()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
   it('does not persist unfinalized attachments that session save cannot recover', async () => {
     const { workflow } = createWorkflow()
     await expect(

--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -293,6 +293,7 @@ describe('AcpNativeFollowUpWorkflow', () => {
   })
 
   it('injects prepared attachment and skill blocks on advertised steering', async () => {
+    const close = vi.fn()
     const prepareFollowUp = vi.fn(async () => ({
       prompt: [
         {
@@ -319,7 +320,8 @@ describe('AcpNativeFollowUpWorkflow', () => {
           versionNumber: 1,
           checksum: 'abc'
         }
-      ]
+      ],
+      close
     }))
     const { request, workflow } = createWorkflow({ prepareFollowUp })
     await expect(
@@ -378,6 +380,9 @@ describe('AcpNativeFollowUpWorkflow', () => {
       parts: [{ type: 'text', text: 'see file' }]
     })
     expect(published[0]?.uploads?.[0]).not.toHaveProperty('path')
+    expect(close).not.toHaveBeenCalled()
+    workflow.releaseTurn('app-1', 'turn-1')
+    expect(close).toHaveBeenCalledOnce()
   })
 
   it('does not persist unfinalized attachments that session save cannot recover', async () => {
@@ -414,12 +419,13 @@ describe('AcpNativeFollowUpWorkflow', () => {
     'refuses %s ACP steering when permission becomes pending during preparation',
     async (frameworkId) => {
       let pendingPermission = false
+      const close = vi.fn()
       const { request, workflow } = createWorkflow({
         frameworkId,
         pendingPermission: () => pendingPermission,
         prepareFollowUp: async () => {
           pendingPermission = true
-          return { prompt: [{ type: 'text' as const, text: 'late follow-up' }] }
+          return { prompt: [{ type: 'text' as const, text: 'late follow-up' }], close }
         }
       })
 
@@ -428,6 +434,7 @@ describe('AcpNativeFollowUpWorkflow', () => {
       ).resolves.toEqual({ injected: false, reason: 'prompt-required' })
       expect(request).not.toHaveBeenCalled()
       expect(published).toEqual([])
+      expect(close).toHaveBeenCalledOnce()
     }
   )
 
@@ -562,11 +569,20 @@ describe('AcpNativeFollowUpWorkflow', () => {
 
   it('refuses ACP steering that never replies and does not persist a user message', async () => {
     const request = vi.fn(() => new Promise(() => undefined))
-    const { workflow } = createWorkflow({ request, followUpTimeoutMs: 20 })
+    const close = vi.fn()
+    const { workflow } = createWorkflow({
+      request,
+      followUpTimeoutMs: 20,
+      prepareFollowUp: async () => ({
+        prompt: [{ type: 'text' as const, text: 'focus on tests' }],
+        close
+      })
+    })
     await expect(
       workflow.steerFollowUp({ sessionId: 'app-1', text: 'focus on tests' })
     ).resolves.toEqual({ injected: false, reason: 'dispatch-failed' })
     expect(published).toEqual([])
+    expect(close).toHaveBeenCalledOnce()
   })
 
   it('refuses idle promptRequired without persisting a user message', async () => {
@@ -723,6 +739,24 @@ describe('AcpNativeFollowUpWorkflow', () => {
 })
 
 describe('finalizeNativeFollowUpPreparedContent', () => {
+  it('closes prepared resources when image compatibility fails', async () => {
+    const close = vi.fn()
+    await expect(
+      finalizeNativeFollowUpPreparedContent({
+        content: [{ type: 'image', data: 'abc', mimeType: 'image/png' }],
+        projectId: 'project-1',
+        sessionId: 'app-1',
+        supportsImageInput: false,
+        historyImageCount: 0,
+        imageCompatibility: {
+          prepare: vi.fn(async () => Promise.reject(new Error('relay failed')))
+        },
+        close
+      })
+    ).rejects.toThrow('relay failed')
+    expect(close).toHaveBeenCalledOnce()
+  })
+
   it('relays content through image compatibility without changing the live prompt id', async () => {
     const prepare = vi.fn(async () => [{ type: 'text' as const, text: 'relayed image' }])
     await expect(

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -61,6 +61,7 @@ type NativeFollowUpPreparedContent = Readonly<{
   prompt: readonly ContentBlock[]
   uploads?: readonly UploadedAttachment[]
   notebookTurnInputs?: NativeFollowUpNotebookTurnInputs
+  close?: () => void
 }>
 
 type NativeFollowUpRegisterTurnInputs = (request: {
@@ -114,6 +115,7 @@ type NativeFollowUpMediaInput = Readonly<{
   historyImageCount: number
   signal?: AbortSignal
   imageCompatibility?: Pick<ImageInputCompatibilityOwner, 'prepare'>
+  close?: () => void
 }>
 
 const nativeFollowUpPromptBlocks = (content: string | ContentBlock[]): ContentBlock[] => {
@@ -124,20 +126,31 @@ const nativeFollowUpPromptBlocks = (content: string | ContentBlock[]): ContentBl
 const finalizeNativeFollowUpPreparedContent = async (
   input: NativeFollowUpMediaInput
 ): Promise<NativeFollowUpPreparedContent> => {
-  const content = input.imageCompatibility
-    ? await input.imageCompatibility.prepare({
-        content: input.content,
-        supportsImageInput: input.supportsImageInput,
-        projectId: input.projectId,
-        sessionId: input.sessionId,
-        imageSources: input.imageSources,
-        historyImageCount: input.historyImageCount,
-        ...(input.signal ? { signal: input.signal } : {})
-      })
-    : input.content
+  let content: string | ContentBlock[]
+  try {
+    content = input.imageCompatibility
+      ? await input.imageCompatibility.prepare({
+          content: input.content,
+          supportsImageInput: input.supportsImageInput,
+          projectId: input.projectId,
+          sessionId: input.sessionId,
+          imageSources: input.imageSources,
+          historyImageCount: input.historyImageCount,
+          ...(input.signal ? { signal: input.signal } : {})
+        })
+      : input.content
+  } catch (error) {
+    try {
+      input.close?.()
+    } catch {
+      // Media preparation failure remains authoritative over resource cleanup.
+    }
+    throw error
+  }
   return {
     prompt: nativeFollowUpPromptBlocks(content),
     uploads: [...(input.turnInputs?.uploads ?? [])],
+    ...(input.close ? { close: input.close } : {}),
     ...(input.turnInputs && input.livePromptMessageId
       ? {
           notebookTurnInputs: {
@@ -168,7 +181,25 @@ const injected = (transport: NativeFollowUpTransport, messageId: string): AcpSte
   Object.freeze({ injected: true, transport, messageId })
 
 class AcpNativeFollowUpWorkflow {
+  private readonly preparedByTurn = new Map<string, Set<() => void>>()
+
   constructor(private readonly options: NativeFollowUpWorkflowOptions) {}
+
+  releaseTurn(sessionId: string, turnToken: string): void {
+    const key = this.turnKey(sessionId, turnToken)
+    const prepared = this.preparedByTurn.get(key)
+    this.preparedByTurn.delete(key)
+    for (const close of prepared ?? []) {
+      try {
+        close()
+      } catch (error) {
+        log.info('native follow-up resource cleanup failed', {
+          sessionId,
+          reason: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+  }
 
   async steerSideChatAdvisory(
     request: AcpSteerFollowUpRequest
@@ -227,12 +258,31 @@ class AcpNativeFollowUpWorkflow {
     let prompt: readonly ContentBlock[]
     let preparedUploads: readonly UploadedAttachment[] | undefined
     let notebookTurnInputs: NativeFollowUpNotebookTurnInputs | undefined
+    let closePrepared: (() => void) | undefined
+    const closePreparedNow = (): void => {
+      const close = closePrepared
+      closePrepared = undefined
+      if (!close) return
+      try {
+        close()
+      } catch (error) {
+        log.info('native follow-up resource cleanup failed', {
+          sessionId: request.sessionId,
+          reason: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+    const refusePrepared = (reason: AcpSteerFollowUpRefuseReason): AcpSteerFollowUpResult => {
+      closePreparedNow()
+      return refused(reason)
+    }
     try {
       if (this.options.prepareFollowUp) {
         const prepared = await this.options.prepareFollowUp(request)
         prompt = prepared.prompt
         preparedUploads = prepared.uploads
         notebookTurnInputs = prepared.notebookTurnInputs
+        closePrepared = prepared.close
       } else {
         prompt = steeringPromptFromText(text)
       }
@@ -242,7 +292,7 @@ class AcpNativeFollowUpWorkflow {
         reason: 'dispatch-failed',
         transport: route.transport
       })
-      return refused('dispatch-failed')
+      return refusePrepared('dispatch-failed')
     }
     if (prompt.length === 0) {
       log.info('native follow-up refused', {
@@ -250,7 +300,7 @@ class AcpNativeFollowUpWorkflow {
         reason: 'empty-text',
         transport: route.transport
       })
-      return refused('empty-text')
+      return refusePrepared('empty-text')
     }
 
     const live = this.options.livePrompt?.(request.sessionId)
@@ -260,7 +310,7 @@ class AcpNativeFollowUpWorkflow {
         reason: 'no-live-turn',
         transport: route.transport
       })
-      return refused('no-live-turn')
+      return refusePrepared('no-live-turn')
     }
     if (expectedTurnToken && live?.turnToken !== expectedTurnToken) {
       log.info('native follow-up refused', {
@@ -268,7 +318,7 @@ class AcpNativeFollowUpWorkflow {
         reason: 'no-live-turn',
         transport: route.transport
       })
-      return refused('no-live-turn')
+      return refusePrepared('no-live-turn')
     }
     if (this.options.hasPendingPermission(request.sessionId)) {
       log.info('native follow-up refused', {
@@ -277,7 +327,7 @@ class AcpNativeFollowUpWorkflow {
         pendingPermission: true,
         transport: route.transport
       })
-      return refused('prompt-required')
+      return refusePrepared('prompt-required')
     }
 
     const transportSignal = this.transportTimeout(route.transport)
@@ -298,7 +348,7 @@ class AcpNativeFollowUpWorkflow {
           reason: 'dispatch-failed',
           transport: route.transport
         })
-        return refused('dispatch-failed')
+        return refusePrepared('dispatch-failed')
       }
       const outcome = parseSteerOutcome(result)
       const dispatched = interpretSteerOutcome(outcome)
@@ -308,7 +358,7 @@ class AcpNativeFollowUpWorkflow {
           reason: dispatched.reason,
           transport: route.transport
         })
-        return refused(dispatched.reason)
+        return refusePrepared(dispatched.reason)
       }
     } else if (route.transport === 'codebuddy-acp-steer') {
       try {
@@ -326,7 +376,7 @@ class AcpNativeFollowUpWorkflow {
             reason: 'prompt-required',
             transport: route.transport
           })
-          return refused('prompt-required')
+          return refusePrepared('prompt-required')
         }
       } catch {
         log.info('native follow-up refused', {
@@ -334,7 +384,7 @@ class AcpNativeFollowUpWorkflow {
           reason: 'dispatch-failed',
           transport: route.transport
         })
-        return refused('dispatch-failed')
+        return refusePrepared('dispatch-failed')
       }
     } else {
       if (!openCodeUsageApi) {
@@ -343,7 +393,7 @@ class AcpNativeFollowUpWorkflow {
           reason: 'not-advertised',
           transport: route.transport
         })
-        return refused('not-advertised')
+        return refusePrepared('not-advertised')
       }
       const parts = contentBlocksToOpenCodeFollowUpParts(prompt)
       if (parts.length === 0) {
@@ -352,7 +402,7 @@ class AcpNativeFollowUpWorkflow {
           reason: 'empty-text',
           transport: route.transport
         })
-        return refused('empty-text')
+        return refusePrepared('empty-text')
       }
       const accepted = await this.postOpenCodeSteer(
         openCodeUsageApi,
@@ -368,7 +418,7 @@ class AcpNativeFollowUpWorkflow {
           transport: route.transport,
           providerSessionId
         })
-        return refused('dispatch-failed')
+        return refusePrepared('dispatch-failed')
       }
     }
 
@@ -400,7 +450,20 @@ class AcpNativeFollowUpWorkflow {
       transport: route.transport,
       messageId
     })
+    const retainedTurn = this.options.livePrompt?.(request.sessionId)
+    if (closePrepared && retainedTurn) {
+      const key = this.turnKey(request.sessionId, retainedTurn.turnToken)
+      const prepared = this.preparedByTurn.get(key) ?? new Set<() => void>()
+      prepared.add(closePrepared)
+      this.preparedByTurn.set(key, prepared)
+      closePrepared = undefined
+    }
+    closePreparedNow()
     return injected(route.transport, messageId)
+  }
+
+  private turnKey(sessionId: string, turnToken: string): string {
+    return `${sessionId.length}:${sessionId}${turnToken}`
   }
 
   private sameLivePrompt(sessionId: string, live: NativeFollowUpLivePrompt | undefined): boolean {

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -201,6 +201,20 @@ class AcpNativeFollowUpWorkflow {
     }
   }
 
+  clear(): void {
+    const retained = [...this.preparedByTurn.values()].flatMap((prepared) => [...prepared])
+    this.preparedByTurn.clear()
+    for (const close of retained) {
+      try {
+        close()
+      } catch (error) {
+        log.info('native follow-up resource cleanup failed', {
+          reason: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+  }
+
   async steerSideChatAdvisory(
     request: AcpSteerFollowUpRequest
   ): Promise<SideChatAdvisoryFollowUpResult> {

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -181,14 +181,15 @@ const injected = (transport: NativeFollowUpTransport, messageId: string): AcpSte
   Object.freeze({ injected: true, transport, messageId })
 
 class AcpNativeFollowUpWorkflow {
-  private readonly preparedByTurn = new Map<string, Set<() => void>>()
+  private readonly preparedBySession = new Map<string, Map<string, Set<() => void>>>()
 
   constructor(private readonly options: NativeFollowUpWorkflowOptions) {}
 
   releaseTurn(sessionId: string, turnToken: string): void {
-    const key = this.turnKey(sessionId, turnToken)
-    const prepared = this.preparedByTurn.get(key)
-    this.preparedByTurn.delete(key)
+    const turns = this.preparedBySession.get(sessionId)
+    const prepared = turns?.get(turnToken)
+    turns?.delete(turnToken)
+    if (turns?.size === 0) this.preparedBySession.delete(sessionId)
     for (const close of prepared ?? []) {
       try {
         close()
@@ -201,18 +202,23 @@ class AcpNativeFollowUpWorkflow {
     }
   }
 
-  clear(): void {
-    const retained = [...this.preparedByTurn.values()].flatMap((prepared) => [...prepared])
-    this.preparedByTurn.clear()
-    for (const close of retained) {
+  releaseSession(sessionId: string): void {
+    const turns = this.preparedBySession.get(sessionId)
+    this.preparedBySession.delete(sessionId)
+    for (const close of [...(turns?.values() ?? [])].flatMap((prepared) => [...prepared])) {
       try {
         close()
       } catch (error) {
         log.info('native follow-up resource cleanup failed', {
+          sessionId,
           reason: error instanceof Error ? error.message : String(error)
         })
       }
     }
+  }
+
+  clear(): void {
+    for (const sessionId of [...this.preparedBySession.keys()]) this.releaseSession(sessionId)
   }
 
   async steerSideChatAdvisory(
@@ -466,18 +472,15 @@ class AcpNativeFollowUpWorkflow {
     })
     const retainedTurn = this.options.livePrompt?.(request.sessionId)
     if (closePrepared && retainedTurn) {
-      const key = this.turnKey(request.sessionId, retainedTurn.turnToken)
-      const prepared = this.preparedByTurn.get(key) ?? new Set<() => void>()
+      const turns = this.preparedBySession.get(request.sessionId) ?? new Map()
+      const prepared = turns.get(retainedTurn.turnToken) ?? new Set<() => void>()
       prepared.add(closePrepared)
-      this.preparedByTurn.set(key, prepared)
+      turns.set(retainedTurn.turnToken, prepared)
+      this.preparedBySession.set(request.sessionId, turns)
       closePrepared = undefined
     }
     closePreparedNow()
     return injected(route.transport, messageId)
-  }
-
-  private turnKey(sessionId: string, turnToken: string): string {
-    return `${sessionId.length}:${sessionId}${turnToken}`
   }
 
   private sameLivePrompt(sessionId: string, live: NativeFollowUpLivePrompt | undefined): boolean {

--- a/src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
+++ b/src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
@@ -1,0 +1,179 @@
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import { NotebookNetworkSandbox } from '@aipoch/notebook-network-sandbox'
+import { spawn } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { UploadedAttachment } from '../../shared/uploads'
+import { getNotebookInputRoot } from '../notebook/input-staging'
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const run = (
+  argv: readonly string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv
+): Promise<{ code: number | null; stderr: string }> =>
+  new Promise((resolveRun, reject) => {
+    const child = spawn(argv[0]!, argv.slice(1), { cwd, env, shell: false })
+    let stderr = ''
+    child.stderr.setEncoding('utf8').on('data', (chunk: string) => (stderr += chunk))
+    child.on('error', reject)
+    child.on('close', (code) => resolveRun({ code, stderr }))
+  })
+
+const contentBlocks = (content: string | ContentBlock[]): ContentBlock[] => {
+  expect(Array.isArray(content)).toBe(true)
+  return content as ContentBlock[]
+}
+
+describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
+  'ACP attachment access from Notebook',
+  () => {
+    it('lets Notebook copy the exact managed upload snapshot advertised to the Agent', async () => {
+      const storageRoot = await mkdtemp(join(tmpdir(), 'open-science-attachment-sandbox-'))
+      roots.push(storageRoot)
+      const projectId = 'project-1'
+      const sessionId = 'session-1'
+      const notebookDataRoot = join(storageRoot, 'notebooks', projectId, sessionId, 'data')
+      const notebookInputRoot = getNotebookInputRoot(storageRoot, projectId, sessionId)
+      await mkdir(notebookDataRoot, { recursive: true })
+
+      const bytes = Buffer.from('sample,group\n1,Ctrl\n2,IRI\n')
+      const attachment: UploadedAttachment = {
+        id: 'upload-file-1',
+        versionId: 'upload-version-1',
+        versionNumber: 1,
+        sessionId,
+        name: 'samples.csv',
+        originalName: 'samples.csv',
+        path: 'upload-version:stale',
+        mimeType: 'text/csv',
+        size: bytes.byteLength,
+        checksum: '1'.repeat(64),
+        createdAt: '2026-09-02T00:00:00.000Z'
+      }
+      const openLatest = vi.fn(async () => ({
+        path: '/managed/samples.csv',
+        size: bytes.byteLength,
+        read: vi.fn(),
+        readRange: vi.fn(async (begin: number, end: number) => bytes.subarray(begin, end)),
+        copyTo: vi.fn(async (destinationPath: string) =>
+          writeFile(destinationPath, bytes, { flag: 'wx' })
+        ),
+        verifyUnchanged: vi.fn(async () => undefined),
+        close: vi.fn(async () => undefined),
+        logicalFile: {
+          source: 'upload' as const,
+          id: attachment.id,
+          projectId,
+          sessionId,
+          displayName: attachment.originalName,
+          currentVersionId: 'upload-version-1'
+        },
+        version: {
+          id: 'upload-version-1',
+          fileId: attachment.id,
+          versionNumber: 1,
+          state: 'ready',
+          originKind: 'upload',
+          basedOnVersionId: null,
+          storageTag: 'vabc12345',
+          storedFilename: 'vabc12345_samples.csv',
+          writeOperationId: 'operation-1',
+          contentStorageKey: 'uploads/project-1/session-1/upload-file-1/samples.csv',
+          filename: attachment.originalName,
+          originalFilename: attachment.originalName,
+          contentType: 'text/csv',
+          sizeBytes: BigInt(bytes.byteLength),
+          checksum: '1'.repeat(64),
+          createdAt: new Date('2026-09-02T00:00:00.000Z')
+        },
+        versionToken: 1,
+        snapshot: { dev: 0n, ino: 0n, size: 0n, mtimeNs: 0n }
+      }))
+      const owners = composeAcpRuntimeBaseOwners({
+        appVersion: 'test',
+        defaultCwd: notebookDataRoot,
+        notebook: { projectId, mcpEntryPath: '/mcp' },
+        artifacts: {
+          configRoot: join(storageRoot, 'config'),
+          dataRoot: storageRoot,
+          projectId,
+          mcpEntryPath: '/mcp',
+          managedFileVersions: { openLatest, openVersion: vi.fn() }
+        },
+        uploads: {
+          repository: {
+            finalizePendingSessionUploads: vi.fn(async () => [attachment])
+          } as never
+        }
+      })
+      const prepared = await owners.promptContentOwner.prepare({
+        appSessionId: sessionId,
+        projectId,
+        text: 'Draw a pie chart from the attached CSV.',
+        historyImages: [],
+        historyUploads: [],
+        currentUploads: [attachment],
+        references: [],
+        codexSkillInputs: [],
+        skillImportEnabled: false,
+        fileTextBudget: 1
+      })
+      const resource = contentBlocks(prepared.content).find(
+        (block): block is Extract<ContentBlock, { type: 'resource_link' }> =>
+          block.type === 'resource_link'
+      )
+      expect(resource).toBeDefined()
+      const advertisedPath = fileURLToPath(resource!.uri)
+      const advertisedRelativePath = relative(notebookInputRoot, advertisedPath)
+      expect(isAbsolute(advertisedRelativePath)).toBe(false)
+      expect(advertisedRelativePath).not.toBe('..')
+      expect(advertisedRelativePath).not.toMatch(/^\.\.(?:[/\\]|$)/)
+      const destination = join(notebookDataRoot, 'samples.csv')
+      const sandbox = new NotebookNetworkSandbox({
+        policy: { allowedDomains: [], deniedDomains: [] },
+        resources: {
+          root: resolve(import.meta.dirname, '../../../packages/notebook-network-sandbox/vendor')
+        }
+      })
+
+      try {
+        await sandbox.initialize()
+        const wrapped = await sandbox.wrap({
+          command: `/bin/cp ${JSON.stringify(advertisedPath)} ${JSON.stringify(destination)}`,
+          cwd: notebookDataRoot,
+          env: { PATH: '/usr/bin:/bin' },
+          filesystem: {
+            readOnlyRoots: ['/bin', '/usr/bin', notebookInputRoot, dirname('/bin/cp')],
+            readWriteRoots: [notebookDataRoot],
+            deniedReadRoots: [],
+            deniedWriteRoots: []
+          },
+          onNetworkAccessRequest: async () => false
+        })
+        const result = await run(wrapped.argv, notebookDataRoot, wrapped.env)
+        const diagnostic = wrapped.annotateStderr(result.stderr)
+        wrapped.cleanup()
+
+        expect(result.code, diagnostic).toBe(0)
+        await expect(readFile(destination, 'utf8')).resolves.toBe(bytes.toString('utf8'))
+        await expect(readFile(advertisedPath, 'utf8')).resolves.toBe(bytes.toString('utf8'))
+        prepared.close()
+        await expect(readFile(advertisedPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+      } finally {
+        prepared.close()
+        await sandbox.dispose()
+      }
+    })
+  }
+)

--- a/src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
+++ b/src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
@@ -38,7 +38,9 @@ const contentBlocks = (content: string | ContentBlock[]): ContentBlock[] => {
 describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
   'ACP attachment access from Notebook',
   () => {
-    it('lets Notebook copy the exact managed upload snapshot advertised to the Agent', async () => {
+    it('lets Notebook copy the exact managed upload snapshot advertised to the Agent', async ({
+      skip
+    }) => {
       const storageRoot = await mkdtemp(join(tmpdir(), 'open-science-attachment-sandbox-'))
       roots.push(storageRoot)
       const projectId = 'project-1'
@@ -148,6 +150,10 @@ describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
       })
 
       try {
+        const status = await sandbox.status()
+        if (status.kind !== 'ready') {
+          skip(`Notebook network sandbox is unavailable: ${status.kind}`)
+        }
         await sandbox.initialize()
         const wrapped = await sandbox.wrap({
           command: `/bin/cp ${JSON.stringify(advertisedPath)} ${JSON.stringify(destination)}`,

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -65,12 +65,17 @@ type CodexSkillInput = {
   path: string
 }
 
+type ResourceSnapshotScope = Readonly<{
+  appSessionId: string
+  projectId: string
+}>
+
 type AcpPromptContentOwnerOptions = {
   uploadRepository?: UploadRepository
   managedFileVersions?: Pick<ManagedFileVersionService, 'openLatest'>
   fileReferenceResolver: FileReferenceResolver
   inlineImageBudgetBytes?: number
-  createResourceSnapshotStore?: () => TurnResourceSnapshotStore
+  createResourceSnapshotStore?: (scope: ResourceSnapshotScope) => TurnResourceSnapshotStore
 }
 
 type PrepareAcpPromptContentInput = {
@@ -189,7 +194,10 @@ class AcpPromptContentOwner {
 
   async prepare(input: PrepareAcpPromptContentInput): Promise<PreparedAcpPromptContent> {
     const snapshots =
-      this.options.createResourceSnapshotStore?.() ?? new TurnResourceSnapshotStore()
+      this.options.createResourceSnapshotStore?.({
+        appSessionId: input.appSessionId,
+        projectId: input.projectId
+      }) ?? new TurnResourceSnapshotStore()
     let closed = false
     const close = (): void => {
       if (closed) return

--- a/src/main/acp/runtime-base-composition.ts
+++ b/src/main/acp/runtime-base-composition.ts
@@ -4,6 +4,7 @@ import { claudeCodeFramework } from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
 import { createLogger, errorLogFields } from '../logger'
+import { getNotebookInputRoot } from '../notebook/input-staging'
 import { createProductionPlanService } from '../session-plan/production-plan-service'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { AcpAgentConnectionAdapter } from './agent-connection-adapter'
@@ -30,6 +31,7 @@ import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { createNotebookArtifactSourceScopeProvider } from '../notebook/artifact-source-scope'
 import { ArtifactTurnOwner } from './artifact-turn-owner'
 import { AcpTurnSkillOwner } from './turn-skill-owner'
+import { TurnResourceSnapshotStore } from './turn-resource-snapshot-store'
 
 const log = createLogger('acp')
 
@@ -201,6 +203,7 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
     grantedRoots: options.grantedRoots,
     managedFileVersions: options.artifacts?.managedFileVersions
   })
+  const notebookInputStorageRoot = options.notebook ? options.artifacts?.dataRoot : undefined
 
   return Object.freeze({
     snapshotOwner,
@@ -233,7 +236,19 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
       uploadRepository,
       managedFileVersions: options.artifacts?.managedFileVersions,
       fileReferenceResolver,
-      inlineImageBudgetBytes: options.inlineImageBudgetBytes
+      inlineImageBudgetBytes: options.inlineImageBudgetBytes,
+      ...(notebookInputStorageRoot
+        ? {
+            createResourceSnapshotStore: ({ appSessionId, projectId }) =>
+              new TurnResourceSnapshotStore({
+                temporaryRoot: getNotebookInputRoot(
+                  notebookInputStorageRoot,
+                  projectId,
+                  appSessionId
+                )
+              })
+          }
+        : {})
     }),
     sessionPresentationPolicy: new AcpSessionPresentationPolicy(),
     promptOutcomeFinalizer: new AcpPromptOutcomeFinalizer()

--- a/src/main/acp/runtime-lifecycle-composition.test.ts
+++ b/src/main/acp/runtime-lifecycle-composition.test.ts
@@ -13,6 +13,7 @@ describe('ACP Runtime lifecycle composition', () => {
     const create = (): {
       base: AcpRuntimeBaseOwners
       disconnect: ReturnType<typeof vi.fn>
+      clearPromptResources: ReturnType<typeof vi.fn>
       lifecycle: AcpRuntimeLifecycleOwners
     } => {
       const base = composeAcpRuntimeBaseOwners(options)
@@ -20,6 +21,7 @@ describe('ACP Runtime lifecycle composition', () => {
       const host = {
         connect: vi.fn(async () => session.publication.getSnapshot()),
         disconnect: vi.fn(async () => session.publication.getSnapshot()),
+        clearPromptResources: vi.fn(),
         openAgentConnection: vi.fn(async () => {
           throw new Error('not called during composition')
         })
@@ -28,7 +30,12 @@ describe('ACP Runtime lifecycle composition', () => {
       expect(host.connect).not.toHaveBeenCalled()
       expect(host.disconnect).not.toHaveBeenCalled()
       expect(host.openAgentConnection).not.toHaveBeenCalled()
-      return { base, disconnect: host.disconnect, lifecycle }
+      return {
+        base,
+        disconnect: host.disconnect,
+        clearPromptResources: host.clearPromptResources,
+        lifecycle
+      }
     }
 
     const first = create()
@@ -49,6 +56,7 @@ describe('ACP Runtime lifecycle composition', () => {
     await expect(first.lifecycle.connectionClose.disconnect(false)).resolves.toMatchObject({
       status: 'idle'
     })
+    expect(first.clearPromptResources).toHaveBeenCalledOnce()
     expect(first.disconnect).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/acp/runtime-lifecycle-composition.ts
+++ b/src/main/acp/runtime-lifecycle-composition.ts
@@ -30,6 +30,7 @@ type AcpRuntimeLifecycleHost = Readonly<{
     attempt: AcpConnectionResourceAttempt,
     onFrameworkResolved: (framework: AgentFramework['id']) => void
   ) => Promise<AcpAgentConnectionCandidate>
+  clearPromptResources?: () => void
 }>
 
 // Composes the model/connection lifecycle cycle around authoritative base and Session owners.
@@ -90,6 +91,7 @@ const composeAcpRuntimeLifecycleOwners = (
       }
     },
     clearPromptContent: (connectionGeneration) => {
+      host.clearPromptResources?.()
       if (connectionGeneration === undefined) base.promptContentOwner.clear()
       else base.promptContentOwner.clearGeneration(connectionGeneration)
     },

--- a/src/main/acp/runtime-prompt-composition.ts
+++ b/src/main/acp/runtime-prompt-composition.ts
@@ -23,6 +23,7 @@ type AcpRuntimePromptReloadHost = Readonly<{
 type AcpRuntimePromptHost = Readonly<{
   plan: AcpPromptTurnPlanWorkflow
   reload: AcpRuntimePromptReloadHost
+  onPromptEnded?: (sessionId: string, turnToken: string) => void
 }>
 
 const log = createLogger('acp')
@@ -315,7 +316,10 @@ const composeAcpRuntimePromptOwners = (
       errorMessage,
       errorKind: acpErrorKind,
       pushEvent: (event) => session.publication.pushEvent(event),
-      onPromptEnded: (sessionId, turnToken) => callbacks.onPromptEnded?.(sessionId, turnToken),
+      onPromptEnded: (sessionId, turnToken) => {
+        host.onPromptEnded?.(sessionId, turnToken)
+        callbacks.onPromptEnded?.(sessionId, turnToken)
+      },
       generationActivityChanged: base.notifyGenerationActivityChanged,
       autoCompact: (sessionId, active, interaction) =>
         contextCompactionWorkflow.compactAutomatic({

--- a/src/main/acp/runtime-provider-session-composition.test.ts
+++ b/src/main/acp/runtime-provider-session-composition.test.ts
@@ -22,7 +22,8 @@ describe('ACP Runtime Provider Session composition', () => {
       })
     })
     const owners = composeAcpRuntimeProviderSessionOwners(options, base, session, lifecycle, {
-      clearUserChoiceProvenanceForSession: vi.fn()
+      clearUserChoiceProvenanceForSession: vi.fn(),
+      releasePromptResourcesForSession: vi.fn()
     })
     const dependencies = (
       owners.providerSessionResumer as unknown as { deps: { resumeTimeoutMs: number } }
@@ -49,7 +50,8 @@ describe('ACP Runtime Provider Session composition', () => {
       }
       const lifecycle = composeAcpRuntimeLifecycleOwners(options, base, session, lifecycleHost)
       const owners = composeAcpRuntimeProviderSessionOwners(options, base, session, lifecycle, {
-        clearUserChoiceProvenanceForSession: vi.fn()
+        clearUserChoiceProvenanceForSession: vi.fn(),
+        releasePromptResourcesForSession: vi.fn()
       })
 
       expect(lifecycleHost.connect).not.toHaveBeenCalled()
@@ -96,7 +98,8 @@ describe('ACP Runtime Provider Session composition', () => {
       })
     })
     const owners = composeAcpRuntimeProviderSessionOwners(options, base, session, lifecycle, {
-      clearUserChoiceProvenanceForSession: vi.fn()
+      clearUserChoiceProvenanceForSession: vi.fn(),
+      releasePromptResourcesForSession: vi.fn()
     })
 
     // deps is constructor-private; the composition contract is that each workflow holds the exact

--- a/src/main/acp/runtime-provider-session-composition.ts
+++ b/src/main/acp/runtime-provider-session-composition.ts
@@ -25,6 +25,7 @@ const composeAcpRuntimeProviderSessionOwners = (
   lifecycle: AcpRuntimeLifecycleOwners,
   runtime: Readonly<{
     clearUserChoiceProvenanceForSession: (sessionId: string) => void
+    releasePromptResourcesForSession: (sessionId: string) => void
   }>
 ) => {
   const currentConnection = (): ClientConnection | undefined => base.connectionResources.connection
@@ -124,6 +125,7 @@ const composeAcpRuntimeProviderSessionOwners = (
     clearUserChoiceProvenanceForSession: runtime.clearUserChoiceProvenanceForSession,
     appContinuations: session.appContinuations,
     promptContent: base.promptContentOwner,
+    releasePromptResourcesForSession: runtime.releasePromptResourcesForSession,
     contextUsage: base.contextUsageTracker,
     interactions: base.sessionInteractions,
     resolveSpecialistIdentity: options.resolveSpecialistIdentity,
@@ -142,6 +144,7 @@ const composeAcpRuntimeProviderSessionOwners = (
     interactions: base.sessionInteractions,
     capabilities: base.sessionCapabilities,
     promptContent: base.promptContentOwner,
+    releasePromptResourcesForSession: runtime.releasePromptResourcesForSession,
     handoff: base.handoffContinuity,
     contextUsage: base.contextUsageTracker,
     projector: session.sessionUpdateProjector,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -631,7 +631,8 @@ class AcpRuntime {
       reload: {
         disconnect: () => this.disconnect(false),
         resume: (request) => this.resumeSession(request)
-      }
+      },
+      onPromptEnded: (sessionId, turnToken) => this.nativeFollowUp.releaseTurn(sessionId, turnToken)
     })
     this.contextCompactionWorkflow = prompt.contextCompactionWorkflow
     this.promptTurnWorkflow = prompt.promptTurnWorkflow
@@ -1431,7 +1432,8 @@ class AcpRuntime {
       ...(prepared.imageSources ? { imageSources: prepared.imageSources } : {}),
       historyImageCount: prepared.historyImageCount,
       ...(livePrompt?.kind === 'prompt' ? { signal: livePrompt.signal } : {}),
-      ...(imageCompatibility ? { imageCompatibility } : {})
+      ...(imageCompatibility ? { imageCompatibility } : {}),
+      close: prepared.close
     })
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -689,7 +689,9 @@ class AcpRuntime {
       lifecycle,
       {
         clearUserChoiceProvenanceForSession: (sessionId) =>
-          this.clearUserChoiceProvenanceForSession(sessionId)
+          this.clearUserChoiceProvenanceForSession(sessionId),
+        releasePromptResourcesForSession: (sessionId) =>
+          this.nativeFollowUp.releaseSession(sessionId)
       }
     )
     this.providerSessionCreator = providerSessions.providerSessionCreator

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -675,6 +675,7 @@ class AcpRuntime {
     const lifecycle = composeAcpRuntimeLifecycleOwners(options, base, session, {
       connect: (request) => this.connect(request),
       disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
+      clearPromptResources: () => this.nativeFollowUp.clear(),
       openAgentConnection: (attempt, onFrameworkResolved) =>
         this.openAgentConnection(attempt, onFrameworkResolved)
     })

--- a/src/main/acp/session-deletion-workflow.test.ts
+++ b/src/main/acp/session-deletion-workflow.test.ts
@@ -54,6 +54,7 @@ const dependencies = (
   interactions: { supersedeCurrent: vi.fn() },
   capabilities: { revokeSession: vi.fn() },
   promptContent: { resetSession: vi.fn() },
+  releasePromptResourcesForSession: vi.fn(),
   handoff: { clearSession: vi.fn() },
   contextUsage: { deleteSession: vi.fn() },
   projector: { clearSession: vi.fn() },
@@ -103,6 +104,7 @@ describe('AcpSessionDeletionWorkflow', () => {
       interactions: { supersedeCurrent: vi.fn(() => actions.push('interaction')) },
       capabilities: { revokeSession: vi.fn(() => actions.push('capability')) },
       promptContent: { resetSession: vi.fn(() => actions.push('prompt-content')) },
+      releasePromptResourcesForSession: vi.fn(() => actions.push('prompt-resources')),
       handoff: { clearSession: vi.fn(() => actions.push('handoff')) },
       contextUsage: { deleteSession: vi.fn(() => actions.push('context')) },
       projector: { clearSession: vi.fn(() => actions.push('projector')) },
@@ -144,6 +146,7 @@ describe('AcpSessionDeletionWorkflow', () => {
       'interaction',
       'capability',
       'prompt-content',
+      'prompt-resources',
       'handoff',
       'context',
       'projector',
@@ -210,6 +213,7 @@ describe('AcpSessionDeletionWorkflow', () => {
     expect(deps.interactions.supersedeCurrent).toHaveBeenCalledWith('app-session')
     expect(deps.capabilities.revokeSession).toHaveBeenCalledWith('app-session')
     expect(deps.promptContent.resetSession).toHaveBeenCalledWith('app-session')
+    expect(deps.releasePromptResourcesForSession).toHaveBeenCalledWith('app-session')
     expect(deps.handoff.clearSession).toHaveBeenCalledWith('app-session')
     expect(deps.contextUsage.deleteSession).toHaveBeenCalledWith('app-session')
     expect(deps.projector.clearSession).toHaveBeenCalledWith('app-session')
@@ -244,6 +248,7 @@ describe('AcpSessionDeletionWorkflow', () => {
     expect(deps.capabilities.revokeSession).not.toHaveBeenCalled()
     expect(deps.interactions.supersedeCurrent).not.toHaveBeenCalled()
     expect(deps.promptContent.resetSession).not.toHaveBeenCalled()
+    expect(deps.releasePromptResourcesForSession).not.toHaveBeenCalled()
     expect(deps.handoff.clearSession).not.toHaveBeenCalled()
     expect(deps.contextUsage.deleteSession).not.toHaveBeenCalled()
     expect(deps.projector.clearSession).not.toHaveBeenCalled()
@@ -346,6 +351,7 @@ describe('AcpSessionDeletionWorkflow', () => {
     expect(deps.interactions.supersedeCurrent).not.toHaveBeenCalled()
     expect(deps.capabilities.revokeSession).not.toHaveBeenCalled()
     expect(deps.promptContent.resetSession).not.toHaveBeenCalled()
+    expect(deps.releasePromptResourcesForSession).not.toHaveBeenCalled()
     expect(deps.handoff.clearSession).not.toHaveBeenCalled()
     expect(deps.contextUsage.deleteSession).not.toHaveBeenCalled()
     expect(deps.projector.clearSession).not.toHaveBeenCalled()
@@ -375,6 +381,7 @@ describe('AcpSessionDeletionWorkflow', () => {
     expect(deps.capabilities.revokeSession).not.toHaveBeenCalled()
     expect(deps.interactions.supersedeCurrent).not.toHaveBeenCalled()
     expect(deps.promptContent.resetSession).not.toHaveBeenCalled()
+    expect(deps.releasePromptResourcesForSession).not.toHaveBeenCalled()
     expect(deps.handoff.clearSession).not.toHaveBeenCalled()
     expect(deps.contextUsage.deleteSession).not.toHaveBeenCalled()
     expect(deps.projector.clearSession).not.toHaveBeenCalled()

--- a/src/main/acp/session-deletion-workflow.ts
+++ b/src/main/acp/session-deletion-workflow.ts
@@ -29,6 +29,7 @@ type AcpSessionDeletionWorkflowDependencies = Readonly<{
   interactions: Pick<AcpSessionInteractionOwner, 'supersedeCurrent'>
   capabilities: Pick<AcpSessionCapabilityOwner, 'revokeSession'>
   promptContent: Pick<AcpPromptContentOwner, 'resetSession'>
+  releasePromptResourcesForSession: (sessionId: string) => void
   handoff: Pick<AcpHandoffContinuityOwner, 'clearSession'>
   contextUsage: Pick<ContextUsageTracker, 'deleteSession'>
   projector: Pick<AcpSessionUpdateProjector, 'clearSession'>
@@ -83,6 +84,7 @@ class AcpSessionDeletionWorkflow {
     this.deps.capabilities.revokeSession(appSessionId)
     const removal = deletion.finish(target)
     this.deps.promptContent.resetSession(appSessionId)
+    this.deps.releasePromptResourcesForSession(appSessionId)
     this.deps.handoff.clearSession(appSessionId)
     this.deps.contextUsage.deleteSession(appSessionId)
     this.deps.projector.clearSession(appSessionId)

--- a/src/main/acp/session-replacement-workflow.test.ts
+++ b/src/main/acp/session-replacement-workflow.test.ts
@@ -49,6 +49,7 @@ describe('AcpSessionReplacementWorkflow', () => {
     const clearLivePermissionProfile = vi.fn()
     const clearUserChoiceProvenanceForSession = vi.fn()
     const resetPromptContent = vi.fn()
+    const releasePromptResourcesForSession = vi.fn()
     const resetContextUsage = vi.fn()
     const supersedeInteraction = vi.fn()
     const adopt = vi.fn(async () => replacement)
@@ -68,6 +69,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       clearUserChoiceProvenanceForSession,
       appContinuations: { delete: vi.fn() },
       promptContent: { resetSession: resetPromptContent },
+      releasePromptResourcesForSession,
       contextUsage: { deleteSession: resetContextUsage },
       interactions: { current: vi.fn(), supersedeCurrent: supersedeInteraction }
     })
@@ -88,6 +90,7 @@ describe('AcpSessionReplacementWorkflow', () => {
     expect(clearUserChoiceProvenanceForSession).toHaveBeenCalledWith('app-session')
     expect(clearLivePermissionProfile).toHaveBeenCalledWith('app-session')
     expect(resetPromptContent).toHaveBeenCalledWith('app-session')
+    expect(releasePromptResourcesForSession).toHaveBeenCalledWith('app-session')
     expect(resetContextUsage).toHaveBeenCalledWith('app-session')
     expect(supersedeInteraction).toHaveBeenCalledWith('app-session')
     expect(registry.lookup('app-session')?.aggregate.snapshot().memoryEnabled).toBe(false)
@@ -135,6 +138,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       clearUserChoiceProvenanceForSession: vi.fn(),
       appContinuations: { delete: vi.fn() },
       promptContent: { resetSession: vi.fn() },
+      releasePromptResourcesForSession: vi.fn(),
       contextUsage: { deleteSession: vi.fn() },
       interactions: { current: vi.fn(), supersedeCurrent: vi.fn() }
     })
@@ -176,6 +180,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       clearUserChoiceProvenanceForSession: vi.fn(),
       appContinuations: { delete: vi.fn() },
       promptContent: { resetSession: vi.fn() },
+      releasePromptResourcesForSession: vi.fn(),
       contextUsage: { deleteSession: vi.fn() },
       interactions: { current: vi.fn(), supersedeCurrent: vi.fn() },
       resolveSpecialistIdentity: vi.fn(async () => ({
@@ -228,6 +233,7 @@ describe('AcpSessionReplacementWorkflow', () => {
         clearUserChoiceProvenanceForSession: vi.fn(),
         appContinuations: { delete: vi.fn() },
         promptContent: { resetSession: vi.fn() },
+        releasePromptResourcesForSession: vi.fn(),
         contextUsage: { deleteSession: vi.fn() },
         interactions: { current: vi.fn(), supersedeCurrent: vi.fn() },
         resolveSpecialistIdentity: vi.fn(async () => ({
@@ -274,6 +280,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       clearUserChoiceProvenanceForSession: vi.fn(),
       appContinuations: { delete: vi.fn() },
       promptContent: { resetSession: vi.fn() },
+      releasePromptResourcesForSession: vi.fn(),
       contextUsage: { deleteSession: vi.fn() },
       interactions: {
         current: vi.fn(() => ({ kind: 'prompt' }) as never),

--- a/src/main/acp/session-replacement-workflow.ts
+++ b/src/main/acp/session-replacement-workflow.ts
@@ -33,6 +33,7 @@ type AcpSessionReplacementWorkflowDependencies = Readonly<{
   clearUserChoiceProvenanceForSession: (sessionId: string) => void
   appContinuations: Pick<AcpAppContinuationOwner, 'delete'>
   promptContent: Pick<AcpPromptContentOwner, 'resetSession'>
+  releasePromptResourcesForSession: (sessionId: string) => void
   contextUsage: Pick<ContextUsageTracker, 'deleteSession'>
   interactions: Pick<AcpSessionInteractionOwner, 'current' | 'supersedeCurrent'>
   resolveSpecialistIdentity?: (
@@ -88,6 +89,7 @@ export class AcpSessionReplacementWorkflow {
         this.deps.registry.detach(attachment, 'provider')
       }
       this.deps.promptContent.resetSession(request.sessionId)
+      this.deps.releasePromptResourcesForSession(request.sessionId)
       this.deps.contextUsage.deleteSession(request.sessionId)
       this.deps.registry.lookup(request.sessionId)?.aggregate.clearAppliedModel()
       this.deps.interactions.supersedeCurrent(request.sessionId)

--- a/src/main/acp/turn-resource-snapshot-store.ts
+++ b/src/main/acp/turn-resource-snapshot-store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { rmSync } from 'node:fs'
-import { chmod, mkdtemp } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { extname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -65,9 +65,9 @@ class TurnResourceSnapshotStore {
 
   private async ensureRoot(): Promise<string> {
     if (this.rootPath) return this.rootPath
-    const rootPath = await mkdtemp(
-      join(this.options.temporaryRoot ?? tmpdir(), 'open-science-acp-turn-')
-    )
+    const temporaryRoot = this.options.temporaryRoot ?? tmpdir()
+    if (this.options.temporaryRoot) await mkdir(temporaryRoot, { recursive: true })
+    const rootPath = await mkdtemp(join(temporaryRoot, 'open-science-acp-turn-'))
     this.rootPath = rootPath
     await chmod(rootPath, 0o700)
     return rootPath


### PR DESCRIPTION
## Summary

- place Notebook-enabled ACP turn snapshots under the current Session input root
- keep non-Notebook snapshots in the operating-system temporary directory
- retain successful native follow-up snapshots while the Agent may still consume them
- release retained snapshots on turn completion, Session replacement/deletion, and connection teardown
- add real sandbox and lifecycle regressions for advertised resource links

## Root cause

Open Science copied managed attachment Versions into `open-science-acp-turn-*` directories under the operating-system temporary root and advertised those file URIs to the Agent. Attachment guidance tells the Agent to use Notebook tooling for full-file analysis, but the Notebook filesystem sandbox only permits its managed input root and other explicit roots. The shared ACP prompt contract therefore exposed a path that Notebook could not read.

This is shared prompt preparation behavior rather than Claude Code attachment handling, so the fix is applied before the Claude Code, OpenCode, Codex Responses, and Codex Bridge adapters.

Implementation review also exposed lifecycle gaps in native follow-up preparation. A successful dispatch must keep its prepared snapshot alive because the Agent may consume the advertised URL asynchronously. The cleanup handle now follows the owning live turn and is released when that turn ends, its Session is replaced or deleted, or the connection is torn down. Refusal, timeout, dispatch failure, and media compatibility failure close it immediately. Session-deletion cleanup runs only after the workflow confirms that it still owns the target generation, so a concurrent same-ID replacement is not cleared.

## Impact

- no database or schema changes
- no new persisted fields, states, or enum values
- no user interaction changes
- no historical data migration
- snapshots remain transient; only their temporary location and cleanup ownership change

## Verification

The sandbox regression was first run against the unfixed code and repeatedly failed with `OPEN_SCIENCE_FILESYSTEM_ACCESS_BLOCKED` for `/var/folders/.../open-science-acp-turn-*`. A single-variable control using the existing Notebook input root passed.

Lifecycle regressions were also run before their fixes. They failed because successful native follow-ups did not retain a cleanup handle, connection teardown did not clear retained snapshots, and Session replacement/deletion did not invoke Session-scoped cleanup. A timing assertion additionally confirms that successful dispatch does not close the snapshot before the Agent can consume it.

After the fixes:

- focused ACP sandbox, prompt owner, runtime composition, Claude Code, OpenCode, Codex, Responses adapter, and Responses Bridge tests: 8 files, 246 tests passed
- focused native follow-up, Session replacement/deletion, and runtime composition tests: 7 files, 92 tests passed
- real Notebook sandbox attachment regression: passed
- `npm run typecheck:node`: passed, including `notebook-network-sandbox` typecheck
- targeted ESLint and Prettier: passed
- PR Gate: passed on Ubuntu full-suite shards, Linux Notebook isolation, Windows core/E2E, macOS build/E2E, static checks, Module coverage, CodeQL, and final gate
- AI review: mergeable, no actionable findings

The first run of Ubuntu shard 2/3 hit an unrelated SQLite migration-test failure while attempting to modify `sqlite_master`; the exact test passed locally and the CI shard passed on rerun. Per maintainer direction, the full local `npm test` suite was not run; PR Gate supplied complete and platform-specific validation.
