### PR TITLE
fix(notebook): honor runtime targets in gating and restart

### DIFF
--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -163,6 +163,7 @@ describe('notebook IPC handlers', () => {
     ])
 
     const session = { sessionId: 'session-1', workspaceCwd: '/workspace' }
+    const restartTarget = { ...session, language: 'r' as const, environment: 'default-r' }
     const namespace = { ...session, language: 'python' as const, environment: 'default-python' }
     const begin = { ...session }
     const append = { ...session, cellId: 'cell-1', writeId: 'write-1', delta: 'hello' }
@@ -194,7 +195,7 @@ describe('notebook IPC handlers', () => {
     await ipcHandlers.get('notebook:execute')?.(undefined, execute)
     await ipcHandlers.get('notebook:export-ipynb')?.(undefined, session)
     await ipcHandlers.get('notebook:export-ipynb-all')?.(undefined, session)
-    await ipcHandlers.get('notebook:restart')?.(undefined, session)
+    await ipcHandlers.get('notebook:restart')?.(undefined, restartTarget)
     await ipcHandlers.get('notebook:shutdown')?.(undefined, session)
 
     expect(service.state).toHaveBeenCalledWith(session)
@@ -207,7 +208,7 @@ describe('notebook IPC handlers', () => {
     expect(service.execute).toHaveBeenCalledWith(publicExecute)
     expect(service.exportIpynb).toHaveBeenCalledWith(session)
     expect(service.exportIpynbAll).toHaveBeenCalledWith(session)
-    expect(service.restart).toHaveBeenCalledWith(session)
+    expect(service.restart).toHaveBeenCalledWith(restartTarget)
     expect(service.shutdown).toHaveBeenCalledWith(session)
   })
 

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -9,6 +9,7 @@ import type {
   ExportNotebookKernelRequest,
   FinishNotebookCodeCellRequest,
   NotebookNamespaceRequest,
+  NotebookRestartRequest,
   NotebookSessionRequest,
   NotebookSessionStateRequest,
   RunNotebookCellRequest
@@ -77,7 +78,7 @@ const registerNotebookIpcHandlers = (handlers: NotebookCommandWorkflows): void =
   ipcMainHandle('notebook:export-ipynb-all', (_event, request: ExportNotebookAllRequest) =>
     handlers.exportIpynbAll(request)
   )
-  ipcMainHandle('notebook:restart', (_event, request: NotebookSessionRequest) =>
+  ipcMainHandle('notebook:restart', (_event, request: NotebookRestartRequest) =>
     handlers.restart(request)
   )
   ipcMainHandle('notebook:shutdown', (_event, request: NotebookSessionRequest) =>

--- a/src/main/notebook/local-rpc-notebook-adapter.test.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.test.ts
@@ -65,7 +65,7 @@ const requestByMethod = {
     reason: 'Download the requested public dataset.'
   },
   state: request,
-  restart: request,
+  restart: { ...request, language: 'r', environment: 'default-r' },
   shutdown: request,
   inspectPackages: { ...request, language: 'python', packages: ['numpy'] },
   managePackages: { ...request, language: 'python', packages: ['numpy'] },
@@ -252,6 +252,17 @@ describe('notebook local RPC adapter', () => {
       })
     ).not.toThrow()
   })
+
+  it.each([{ language: 'r' }, { environment: 'default-r' }])(
+    'rejects a half-specified restart target',
+    (target) => {
+      const capability = createCapability()
+
+      expect(() =>
+        resolveNotebookLocalRpcHandler(capability, 'restart', { ...request, ...target })
+      ).toThrow('Invalid notebook RPC params for restart')
+    }
+  )
 
   it('rejects unknown methods after validating common routing fields', () => {
     const capability = createCapability()

--- a/src/main/notebook/local-rpc-notebook-adapter.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.ts
@@ -9,6 +9,7 @@ import {
   type ExecuteShellRequest,
   type FinishNotebookCodeCellRequest,
   type NotebookLanguage,
+  type NotebookRestartRequest,
   type NotebookSessionRequest,
   type RequestNotebookNetworkAccessRequest,
   type RunNotebookCellRequest
@@ -116,7 +117,13 @@ const notebookLocalRpcRequestSchemas = {
     command: z.string().min(1).optional()
   }),
   state: notebookSessionRequestSchema,
-  restart: notebookSessionRequestSchema,
+  restart: z.union([
+    notebookSessionRequestSchema,
+    notebookSessionRequestSchema.extend({
+      language: notebookLanguageSchema,
+      environment: z.string().min(1)
+    })
+  ]),
   shutdown: notebookSessionRequestSchema,
   inspectPackages: notebookSessionRequestSchema.extend({
     language: notebookLanguageSchema,
@@ -199,7 +206,7 @@ type NotebookLocalRpcCapability = {
     signal?: AbortSignal
   ): Promise<unknown>
   state(request: NotebookSessionRequest): Promise<unknown>
-  restart(request: NotebookSessionRequest): Promise<unknown>
+  restart(request: NotebookRestartRequest): Promise<unknown>
   shutdown(request: NotebookSessionRequest): Promise<unknown>
   inspectPackages(request: InspectPackagesRequest): Promise<unknown>
   managePackages(request: InstallRequest): Promise<InstallResult>

--- a/src/main/notebook/notebook-workflows.ts
+++ b/src/main/notebook/notebook-workflows.ts
@@ -10,6 +10,7 @@ import type {
   NotebookCell,
   NotebookNamespaceRequest,
   NotebookNamespaceSnapshot,
+  NotebookRestartRequest,
   NotebookRunSummary,
   NotebookSessionReference,
   NotebookSessionRequest,
@@ -53,7 +54,7 @@ type NotebookCommandRuntime = {
   execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary>
   exportIpynb(request: ExportNotebookKernelRequest): Promise<ExportNotebookResult>
   exportIpynbAll(request: ExportNotebookAllRequest): Promise<ExportNotebookAllResult>
-  restart(request: NotebookSessionRequest): Promise<NotebookSessionState>
+  restart(request: NotebookRestartRequest): Promise<NotebookSessionState>
   shutdown(request: NotebookSessionRequest): Promise<NotebookShutdownResult>
 }
 
@@ -68,7 +69,7 @@ type NotebookCommandWorkflows = {
   execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary>
   exportIpynb(request: ExportNotebookKernelRequest): Promise<ExportNotebookResult>
   exportIpynbAll(request: ExportNotebookAllRequest): Promise<ExportNotebookAllResult>
-  restart(request: NotebookSessionRequest): Promise<NotebookSessionState>
+  restart(request: NotebookRestartRequest): Promise<NotebookSessionState>
   shutdown(request: NotebookSessionRequest): Promise<NotebookShutdownResult>
 }
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4105,7 +4105,7 @@ describe('notebook runtime service', () => {
     expect(terminated).toEqual([['r', DEFAULT_R_ENV]])
   })
 
-  it('persists default Python idle after a targeted restart recovers a coarse error', async () => {
+  it('persists default Python idle after reload when a targeted restart recovers a coarse error', async () => {
     const root = await createStorageRoot()
     const request = { sessionId: 'session-1', workspaceCwd: root }
     const executorFactory = (): NotebookSessionExecutor => ({
@@ -4133,13 +4133,6 @@ describe('notebook runtime service', () => {
     await service.execute({ ...request, code: '1' })
     await expect(service.restart(request)).rejects.toThrow('restart failed')
 
-    const restarted = await service.restart({
-      ...request,
-      language: 'python',
-      environment: DEFAULT_PY_ENV
-    })
-    expect(restarted.kernelStatus).toBe('idle')
-
     const reloadedService = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
@@ -4147,7 +4140,21 @@ describe('notebook runtime service', () => {
       repository: new NotebookRunRepository(root),
       executorFactory
     })
-    expect((await reloadedService.state(request)).kernelStatus).toBe('idle')
+    const restarted = await reloadedService.restart({
+      ...request,
+      language: 'python',
+      environment: DEFAULT_PY_ENV
+    })
+    expect(restarted.kernelStatus).toBe('idle')
+
+    const verifiedService = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory
+    })
+    expect((await verifiedService.state(request)).kernelStatus).toBe('idle')
   })
 
   it('preserves durable termination when targeted restart cleanup fails', async () => {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4213,6 +4213,149 @@ describe('notebook runtime service', () => {
     expect((await service.state(request)).kernelStatus).toBe('terminated')
   })
 
+  it('persists a targeted default Python restart failure across reload', async () => {
+    const root = await createStorageRoot()
+    const request = { sessionId: 'session-1', workspaceCwd: root }
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (execution): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: execution.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true }),
+        terminate: async () => {
+          throw new Error('targeted restart failed')
+        }
+      })
+    })
+    await service.execute({ ...request, code: '1' })
+
+    await expect(
+      service.restart({ ...request, language: 'python', environment: DEFAULT_PY_ENV })
+    ).rejects.toThrow('targeted restart failed')
+    expect((await service.state(request)).kernelStatus).toBe('error')
+
+    const reloadedService = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (execution): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: execution.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    expect((await reloadedService.state(request)).kernelStatus).toBe('error')
+  })
+
+  it('holds later executions until targeted restart persistence completes', async () => {
+    const root = await createStorageRoot()
+    const request = { sessionId: 'session-1', workspaceCwd: root }
+    const repository = new NotebookRunRepository(root)
+    const secondExecutionStarted = createDeferred<void>()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository,
+      executorFactory: () => ({
+        execute: async (execution): Promise<NotebookExecutionResult> => {
+          if (execution.code === '2') secondExecutionStarted.resolve()
+          return {
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: execution.cwd,
+            outputs: []
+          }
+        },
+        shutdown: async () => ({ reaped: true }),
+        terminate: async () => undefined
+      })
+    })
+    await service.execute({ ...request, code: '1' })
+
+    const persistenceGate = createDeferred<void>()
+    const updateKernelStatus = repository.updateKernelStatus.bind(repository)
+    let holdNextIdle = true
+    const persistenceStarted = createDeferred<void>()
+    vi.spyOn(repository, 'updateKernelStatus').mockImplementation(async (update) => {
+      if (holdNextIdle && update.status === 'idle') {
+        holdNextIdle = false
+        persistenceStarted.resolve()
+        await persistenceGate.promise
+      }
+      return updateKernelStatus(update)
+    })
+
+    const restarting = service.restart({
+      ...request,
+      language: 'python',
+      environment: DEFAULT_PY_ENV
+    })
+    await persistenceStarted.promise
+    const nextExecution = service.execute({ ...request, code: '2' })
+
+    try {
+      const startedBeforePersistence = await Promise.race([
+        secondExecutionStarted.promise.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 20))
+      ])
+      expect(startedBeforePersistence).toBe(false)
+    } finally {
+      persistenceGate.resolve()
+      await Promise.allSettled([restarting, nextExecution])
+    }
+  })
+
+  it('does not create a live environment entry for a dormant targeted restart', async () => {
+    const root = await createStorageRoot()
+    const request = { sessionId: 'session-1', workspaceCwd: root }
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (execution): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: execution.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true }),
+        terminate: async () => undefined
+      })
+    })
+
+    const settled = await service.restart({
+      ...request,
+      language: 'python',
+      environment: DEFAULT_PY_ENV
+    })
+
+    expect(settled.kernelStatus).toBe('idle')
+    expect(settled.environments).toEqual([])
+  })
+
   it('reports a restarting kernel status while restart() is in flight, then settles to idle', async () => {
     const root = await createStorageRoot()
     let releaseRestart: (() => void) | undefined

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4048,6 +4048,63 @@ describe('notebook runtime service', () => {
     expect(shutdowns).toBe(0)
   })
 
+  it('restarts only the requested R environment without restarting the session executor', async () => {
+    const root = await createStorageRoot()
+    let restarts = 0
+    const terminated: Array<['python' | 'r' | 'repl', string]> = []
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true }),
+        restart: async () => {
+          restarts += 1
+        },
+        terminate: async (kind, environment) => {
+          terminated.push([kind, environment])
+        }
+      })
+    })
+    const request = { sessionId: 'session-1', workspaceCwd: root }
+    await service.execute({ ...request, language: 'python', code: 'python_state = 1' })
+    await service.execute({ ...request, language: 'r', code: 'r_state <- 1' })
+
+    const restarted = await service.restart({
+      ...request,
+      language: 'r',
+      environment: DEFAULT_R_ENV
+    })
+
+    expect(restarts).toBe(0)
+    expect(terminated).toEqual([['r', DEFAULT_R_ENV]])
+    expect(restarted.environments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ processKey: `python:${DEFAULT_PY_ENV}`, status: 'idle' }),
+        expect.objectContaining({ processKey: `r:${DEFAULT_R_ENV}`, status: 'idle' })
+      ])
+    )
+    for (const malformedTarget of [{ language: 'r' as const }, { environment: DEFAULT_R_ENV }]) {
+      await expect(
+        service.restart({
+          ...request,
+          ...malformedTarget
+        } as never)
+      ).rejects.toThrow('language and environment must be provided together')
+    }
+    expect(restarts).toBe(0)
+    expect(terminated).toEqual([['r', DEFAULT_R_ENV]])
+  })
+
   it('reports a restarting kernel status while restart() is in flight, then settles to idle', async () => {
     const root = await createStorageRoot()
     let releaseRestart: (() => void) | undefined

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4105,6 +4105,107 @@ describe('notebook runtime service', () => {
     expect(terminated).toEqual([['r', DEFAULT_R_ENV]])
   })
 
+  it('persists default Python idle after a targeted restart recovers a coarse error', async () => {
+    const root = await createStorageRoot()
+    const request = { sessionId: 'session-1', workspaceCwd: root }
+    const executorFactory = (): NotebookSessionExecutor => ({
+      execute: async (execution): Promise<NotebookExecutionResult> => ({
+        status: 'completed',
+        stdout: '',
+        stderr: '',
+        traceback: '',
+        cwdAfter: execution.cwd,
+        outputs: []
+      }),
+      shutdown: async () => ({ reaped: true }),
+      restart: async () => {
+        throw new Error('restart failed')
+      },
+      terminate: async () => undefined
+    })
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory
+    })
+    await service.execute({ ...request, code: '1' })
+    await expect(service.restart(request)).rejects.toThrow('restart failed')
+
+    const restarted = await service.restart({
+      ...request,
+      language: 'python',
+      environment: DEFAULT_PY_ENV
+    })
+    expect(restarted.kernelStatus).toBe('idle')
+
+    const reloadedService = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory
+    })
+    expect((await reloadedService.state(request)).kernelStatus).toBe('idle')
+  })
+
+  it('preserves durable termination when targeted restart cleanup fails', async () => {
+    const root = await createStorageRoot()
+    const request = { sessionId: 'session-1', workspaceCwd: root }
+    let lifecycle!: NotebookExecutorLifecycleCallbacks
+    const firstService = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: (_sessionId, callbacks) => {
+        lifecycle = callbacks
+        return {
+          execute: async (execution): Promise<NotebookExecutionResult> => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: execution.cwd,
+            outputs: []
+          }),
+          shutdown: async () => ({ reaped: true })
+        }
+      }
+    })
+    await firstService.execute({ ...request, code: '1' })
+    await lifecycle.onTerminated('python', DEFAULT_PY_ENV)
+
+    const repository = new NotebookRunRepository(root)
+    vi.spyOn(repository, 'clearKernelTermination').mockRejectedValueOnce(
+      new Error('could not clear durable termination')
+    )
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository,
+      executorFactory: () => ({
+        execute: async (execution): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: execution.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true }),
+        terminate: async () => undefined
+      })
+    })
+
+    await expect(
+      service.restart({ ...request, language: 'python', environment: DEFAULT_PY_ENV })
+    ).rejects.toThrow('could not clear durable termination')
+    expect((await service.state(request)).kernelStatus).toBe('terminated')
+  })
+
   it('reports a restarting kernel status while restart() is in flight, then settles to idle', async () => {
     const root = await createStorageRoot()
     let releaseRestart: (() => void) | undefined

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -18,6 +18,7 @@ import type {
   NotebookLanguage,
   NotebookNamespaceRequest,
   NotebookNamespaceSnapshot,
+  NotebookRestartRequest,
   NotebookRunSummary,
   RequestNotebookNetworkAccessRequest,
   RequestNotebookNetworkAccessResult,
@@ -31,7 +32,8 @@ import {
   isNotebookRunCursor,
   NOTEBOOK_STATE_HISTORY_FRAME_ID_LIMIT_BYTES,
   NOTEBOOK_STATE_HISTORY_PAGE_LIMIT,
-  NOTEBOOK_STATE_TARGET_RUN_LIMIT
+  NOTEBOOK_STATE_TARGET_RUN_LIMIT,
+  parseNotebookLanguage
 } from '../../shared/notebook'
 import type {
   ManageEnvironmentsRequest,
@@ -1046,15 +1048,66 @@ class NotebookRuntimeService {
     return saveIpynbAll(files, undefined, this.options.translate)
   }
 
-  // Replaces the interpreter process while preserving cells and durable run history. Prefers the
-  // executor's own in-place restart (keeps the same instance, e.g. NotebookKernelExecutor tears down
-  // and lazily respawns its loops) and only shuts down + recreates for executors that don't support it.
-  // Reports 'restarting' for the duration. A successful restart clears stale termination evidence and
-  // settles to 'idle'; a failed restart keeps that evidence and reports 'error' for kernels that were
-  // not already known to be terminated.
-  async restart(request: NotebookSessionRequest): Promise<NotebookSessionState> {
+  // Replaces one exact language/environment interpreter when a target is present. Omitting the target
+  // preserves the historical session-wide restart for callers that intentionally restart every loop.
+  // Both paths preserve cells and durable run history, report 'restarting' for affected kernels, and
+  // clear only the termination evidence covered by the restart.
+  async restart(request: NotebookRestartRequest): Promise<NotebookSessionState> {
     return this.sessionLifecycle.runProjectOperation(request, async () => {
+      const hasLanguage = request.language !== undefined
+      const hasEnvironment = request.environment !== undefined
+      if (hasLanguage !== hasEnvironment) {
+        throw new Error('Notebook restart language and environment must be provided together.')
+      }
+
+      let target: { language: NotebookLanguage; environment: string } | undefined
+      if (request.language !== undefined && request.environment !== undefined) {
+        const language = parseNotebookLanguage(request.language)
+        if (!request.environment.trim()) {
+          throw new Error('Notebook restart environment must not be empty.')
+        }
+        target = {
+          language,
+          environment: resolveEnvName(language, request.environment)
+        }
+      }
+
       const session = await this.sessionLifecycle.ensure(request)
+
+      if (target) {
+        const { language, environment } = target
+        const processKey = dataProcessKey(language, environment)
+        const statusBeforeRestart = session.kernelStatus(processKey)
+        const hasTargetState =
+          statusBeforeRestart !== undefined || session.hasDurableKernelTermination(processKey)
+
+        if (hasTargetState) {
+          session.setKernelStatus(processKey, 'restarting')
+          this.sessionLifecycle.notifyChanged(session)
+        }
+
+        try {
+          await session.drainExecution(processKey)
+          await session.terminateExecutor(language, environment)
+          await this.sessionLifecycle.clearPersistedKernelTermination(session, processKey)
+          session.clearKernelTerminated(processKey)
+          this.environmentOperations.clearRestartRecommendations([processKey])
+          if (hasTargetState) session.setKernelStatus(processKey, 'idle')
+        } catch (error) {
+          if (hasTargetState) {
+            session.setKernelStatus(
+              processKey,
+              statusBeforeRestart === 'terminated' ? 'terminated' : 'error'
+            )
+          }
+          this.sessionLifecycle.notifyChanged(session)
+          throw error
+        }
+
+        this.sessionLifecycle.notifyChanged(session)
+        await this.runTerminalization.reconcilePending(session)
+        return this.sessionReadModel.state(session)
+      }
 
       // A restart respawns fresh loops, so any pending R-restart recommendation for this session's envs
       // is cleared. Snapshot the keys before teardown drops them from kernelStatuses.

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1077,7 +1077,11 @@ class NotebookRuntimeService {
       if (target) {
         const { language, environment } = target
         const processKey = dataProcessKey(language, environment)
-        const statusBeforeRestart = session.kernelStatus(processKey)
+        const statusBeforeRestart =
+          session.kernelStatus(processKey) ??
+          (processKey === dataProcessKey('python', DEFAULT_PY_ENV)
+            ? session.restoredKernelStatus()
+            : undefined)
         const wasDurablyTerminated = session.hasDurableKernelTermination(processKey)
         const hasTargetState = statusBeforeRestart !== undefined || wasDurablyTerminated
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1078,8 +1078,8 @@ class NotebookRuntimeService {
         const { language, environment } = target
         const processKey = dataProcessKey(language, environment)
         const statusBeforeRestart = session.kernelStatus(processKey)
-        const hasTargetState =
-          statusBeforeRestart !== undefined || session.hasDurableKernelTermination(processKey)
+        const wasDurablyTerminated = session.hasDurableKernelTermination(processKey)
+        const hasTargetState = statusBeforeRestart !== undefined || wasDurablyTerminated
 
         if (hasTargetState) {
           session.setKernelStatus(processKey, 'restarting')
@@ -1089,15 +1089,16 @@ class NotebookRuntimeService {
         try {
           await session.drainExecution(processKey)
           await session.terminateExecutor(language, environment)
-          await this.sessionLifecycle.clearPersistedKernelTermination(session, processKey)
+          if (hasTargetState) {
+            await this.sessionLifecycle.persistKernelStatus(session, 'idle', processKey)
+          }
           session.clearKernelTerminated(processKey)
           this.environmentOperations.clearRestartRecommendations([processKey])
-          if (hasTargetState) session.setKernelStatus(processKey, 'idle')
         } catch (error) {
           if (hasTargetState) {
             session.setKernelStatus(
               processKey,
-              statusBeforeRestart === 'terminated' ? 'terminated' : 'error'
+              statusBeforeRestart === 'terminated' || wasDurablyTerminated ? 'terminated' : 'error'
             )
           }
           this.sessionLifecycle.notifyChanged(session)

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1077,11 +1077,11 @@ class NotebookRuntimeService {
       if (target) {
         const { language, environment } = target
         const processKey = dataProcessKey(language, environment)
+        const isDefaultPython = processKey === dataProcessKey('python', DEFAULT_PY_ENV)
+        const restoredKernelStatus = session.restoredKernelStatus()
         const statusBeforeRestart =
           session.kernelStatus(processKey) ??
-          (processKey === dataProcessKey('python', DEFAULT_PY_ENV)
-            ? session.restoredKernelStatus()
-            : undefined)
+          (isDefaultPython && restoredKernelStatus !== 'idle' ? restoredKernelStatus : undefined)
         const wasDurablyTerminated = session.hasDurableKernelTermination(processKey)
         const hasTargetState = statusBeforeRestart !== undefined || wasDurablyTerminated
 
@@ -1090,24 +1090,42 @@ class NotebookRuntimeService {
           this.sessionLifecycle.notifyChanged(session)
         }
 
-        try {
-          await session.drainExecution(processKey)
-          await session.terminateExecutor(language, environment)
-          if (hasTargetState) {
-            await this.sessionLifecycle.persistKernelStatus(session, 'idle', processKey)
+        const restartTransition = (async (): Promise<void> => {
+          try {
+            await session.drainExecution(processKey)
+            await session.terminateExecutor(language, environment)
+            if (hasTargetState) {
+              await this.sessionLifecycle.persistKernelStatus(session, 'idle', processKey)
+            }
+            session.clearKernelTerminated(processKey)
+            this.environmentOperations.clearRestartRecommendations([processKey])
+          } catch (error) {
+            if (hasTargetState) {
+              const failureStatus =
+                statusBeforeRestart === 'terminated' || wasDurablyTerminated
+                  ? 'terminated'
+                  : 'error'
+              try {
+                if (failureStatus === 'terminated' || isDefaultPython) {
+                  await this.sessionLifecycle.persistKernelStatus(
+                    session,
+                    failureStatus,
+                    processKey
+                  )
+                } else {
+                  session.setKernelStatus(processKey, failureStatus)
+                }
+              } catch {
+                // Keep the original restart failure while retaining the best available live state.
+                session.setKernelStatus(processKey, failureStatus)
+              }
+            }
+            this.sessionLifecycle.notifyChanged(session)
+            throw error
           }
-          session.clearKernelTerminated(processKey)
-          this.environmentOperations.clearRestartRecommendations([processKey])
-        } catch (error) {
-          if (hasTargetState) {
-            session.setKernelStatus(
-              processKey,
-              statusBeforeRestart === 'terminated' || wasDurablyTerminated ? 'terminated' : 'error'
-            )
-          }
-          this.sessionLifecycle.notifyChanged(session)
-          throw error
-        }
+        })()
+        session.blockKernelExecutionUntil(processKey, restartTransition)
+        await restartTransition
 
         this.sessionLifecycle.notifyChanged(session)
         await this.runTerminalization.reconcilePending(session)

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -245,6 +245,7 @@ export class NotebookSessionAggregate<
   private mcpRpcConnection: NotebookSessionMcpRpcConnection | undefined
   private readonly terminatedKernels = new Set<string>()
   private readonly kernelStatuses = new Map<string, NotebookKernelMetadata['lastKnownStatus']>()
+  private readonly restoredKernelStatusValue?: NotebookKernelMetadata['lastKnownStatus']
   private readonly durableTerminatedKernelKeys = new Set<string>()
   private durableUnknownKernelTermination: boolean
   private readonly runtimeBindings = new Map<NotebookLanguage, NotebookSessionRuntimeBinding>()
@@ -271,6 +272,7 @@ export class NotebookSessionAggregate<
     this.durableUnknownKernelTermination =
       init.initialKernelStatus === 'terminated' &&
       init.initialTerminatedKernelInstances === undefined
+    this.restoredKernelStatusValue = init.initialKernelStatus
     this.executorValue = init.executor
     this.executorGenerationValue = init.executorGeneration
   }
@@ -476,6 +478,10 @@ export class NotebookSessionAggregate<
 
   kernelStatus(processKey: string): NotebookKernelMetadata['lastKnownStatus'] | undefined {
     return this.kernelStatuses.get(processKey)
+  }
+
+  restoredKernelStatus(): NotebookKernelMetadata['lastKnownStatus'] | undefined {
+    return this.restoredKernelStatusValue
   }
 
   kernelStatusEntries(): Array<[string, NotebookKernelMetadata['lastKnownStatus']]> {

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -506,6 +506,10 @@ export class NotebookSessionAggregate<
     return this.durableTerminatedKernelKeys.has(processKey)
   }
 
+  hasAnyDurableKernelTermination(): boolean {
+    return this.durableUnknownKernelTermination || this.durableTerminatedKernelKeys.size > 0
+  }
+
   markDurableKernelTermination(processKey: string): void {
     this.durableTerminatedKernelKeys.add(processKey)
   }

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -86,6 +86,8 @@ const processKeyFor = (kind: KernelProcessKind | undefined, env: string | undefi
   return `${resolvedKind}:${resolvedEnv}`
 }
 
+const DEFAULT_KERNEL_PROCESS_KEY = processKeyFor('python', DEFAULT_PY_ENV)
+
 const kernelInstanceForProcessKey = (processKey: string): NotebookKernelInstanceIdentity => {
   if (processKey === 'repl') return { kind: 'repl' }
   const separator = processKey.indexOf(':')
@@ -461,6 +463,18 @@ class NotebookSessionLifecycleOwner {
           kernelInstance
         })
         session.clearDurableKernelTermination(processKey)
+      } else if (
+        processKey === DEFAULT_KERNEL_PROCESS_KEY &&
+        !session.hasAnyDurableKernelTermination()
+      ) {
+        // The coarse status represents only the default Python kernel. Persist its recovery from an
+        // error, but never overwrite termination evidence owned by another exact target.
+        await this.options.repository.updateKernelStatus({
+          projectId: session.projectId,
+          sessionId: session.sessionId,
+          lane: session.lane,
+          status
+        })
       }
     } else {
       await this.options.repository.updateKernelStatus({

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -1581,6 +1581,68 @@ describe('NotebookPreview per-environment selector', () => {
     }
   )
 
+  it.each([
+    {
+      language: 'python' as const,
+      environment: 'external-python',
+      runtimeId: '/usr/local/bin/python3'
+    },
+    {
+      language: 'r' as const,
+      environment: 'external-r',
+      runtimeId: '/usr/local/bin/R'
+    }
+  ])(
+    'does not fall back to managed provisioning for an unavailable explicit $language binding',
+    async ({ language, environment, runtimeId }) => {
+      await mountWithRuns(
+        [makeRun({ runId: `${language}-1`, kernelKind: language, environment })],
+        [],
+        { [language]: environment },
+        {
+          [language]: {
+            runtimeId,
+            language,
+            label: `Unavailable ${language}`,
+            source: 'external',
+            provenance: 'user-own',
+            interpreterPath: runtimeId,
+            status: 'unavailable',
+            reason: 'missing'
+          }
+        }
+      )
+
+      const unavailableManagedStatus: ProvisionStatus = {
+        pythonReady: false,
+        rReady: false,
+        version: 1,
+        provisioning: false
+      }
+      act(() => {
+        useNotebookEnvStore.setState({
+          status: unavailableManagedStatus,
+          ui: deriveProvisionUi(unavailableManagedStatus, undefined, undefined, undefined)
+        })
+      })
+
+      expect(container.querySelector('[data-testid="notebook-env-gate"]')).toBeNull()
+      expect(
+        (container.querySelector('[data-testid="kernel-terminal-input"]') as HTMLTextAreaElement)
+          .disabled
+      ).toBe(true)
+
+      if (language === 'r') {
+        await act(async () => {
+          fireEvent.click(
+            container.querySelector('[data-testid="kernel-switcher-r"]') as HTMLElement
+          )
+        })
+        expect(window.api.notebookEnv.provision).not.toHaveBeenCalled()
+      }
+    }
+  )
+
   it('shows the current R runtime binding on the R kernel tab', async () => {
     await mountWithRuns(
       [

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -670,6 +670,9 @@ describe('NotebookPreview per-kernel tabs', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
+    expect(window.api.notebook.restart).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'r', environment: 'default-r' })
+    )
     expect(window.api.notebook.inspectNamespace).toHaveBeenCalledTimes(2)
     expect(window.api.notebook.inspectNamespace).toHaveBeenLastCalledWith(
       expect.objectContaining({ language: 'r', environment: 'default-r' })
@@ -1514,6 +1517,60 @@ describe('NotebookPreview per-environment selector', () => {
       'pandas-demo2'
     )
   })
+
+  it.each([
+    {
+      language: 'python' as const,
+      environment: 'external-python',
+      runtimeId: '/usr/local/bin/python3',
+      label: 'External Python'
+    },
+    {
+      language: 'r' as const,
+      environment: 'external-r',
+      runtimeId: '/usr/local/bin/R',
+      label: 'External R'
+    }
+  ])(
+    'keeps an externally bound $language runtime usable when managed runtimes are unavailable',
+    async ({ language, environment, runtimeId, label }) => {
+      await mountWithRuns(
+        [makeRun({ runId: `${language}-1`, kernelKind: language, environment })],
+        [],
+        { [language]: environment },
+        {
+          [language]: {
+            runtimeId,
+            language,
+            label,
+            source: 'external',
+            provenance: 'user-own',
+            interpreterPath: runtimeId,
+            ...(language === 'r' ? { status: 'active' as const } : {})
+          }
+        }
+      )
+
+      const unavailableManagedStatus: ProvisionStatus = {
+        pythonReady: false,
+        rReady: false,
+        version: 1,
+        provisioning: false
+      }
+      act(() => {
+        useNotebookEnvStore.setState({
+          status: unavailableManagedStatus,
+          ui: deriveProvisionUi(unavailableManagedStatus, undefined, undefined, undefined)
+        })
+      })
+
+      expect(container.querySelector('[data-testid="notebook-env-gate"]')).toBeNull()
+      expect(
+        (container.querySelector('[data-testid="kernel-terminal-input"]') as HTMLTextAreaElement)
+          .disabled
+      ).toBe(false)
+    }
+  )
 
   it('shows the current R runtime binding on the R kernel tab', async () => {
     await mountWithRuns(

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -1569,6 +1569,15 @@ describe('NotebookPreview per-environment selector', () => {
         (container.querySelector('[data-testid="kernel-terminal-input"]') as HTMLTextAreaElement)
           .disabled
       ).toBe(false)
+
+      if (language === 'r') {
+        await act(async () => {
+          fireEvent.click(
+            container.querySelector('[data-testid="kernel-switcher-r"]') as HTMLElement
+          )
+        })
+        expect(window.api.notebookEnv.provision).not.toHaveBeenCalled()
+      }
     }
   )
 

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -539,7 +539,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   const onSelectLanguage = (lang: NotebookLanguage): void => {
     setShowVariables(false)
     const binding = notebookState?.runtimeBindings?.[lang]
-    if (!hasActiveRuntimeTarget(binding) && shouldProvisionR(envStatus, lang)) void provision('r')
+    if (binding === undefined && shouldProvisionR(envStatus, lang)) void provision('r')
   }
 
   // Keeps state assignment isolated so load paths and event paths share the same update hook.
@@ -755,6 +755,10 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     activeKernelStatus === 'starting' ||
     activeKernelStatus === 'running' ||
     activeKernelStatus === 'restarting'
+  const explicitRuntimeTargetUnavailable =
+    activeDataLanguage !== undefined &&
+    activeRuntimeBinding !== undefined &&
+    !activeRuntimeTargetReady
   // The Session Aggregate owns one active write and run, so input stays globally locked even when a
   // different persistent data kernel is selected.
   const isTerminalLocked =
@@ -763,8 +767,11 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     Boolean(notebookState?.activeWrite) ||
     Boolean(notebookState?.activeRunId) ||
     gated ||
+    explicitRuntimeTargetUnavailable ||
     isSelectedKernelRunning ||
-    (activeDataLanguage === 'r' && !activeRuntimeTargetReady && (!envStatus.rReady || isPreparingR))
+    (activeDataLanguage === 'r' &&
+      activeRuntimeBinding === undefined &&
+      (!envStatus.rReady || isPreparingR))
   const cellCount = notebookState?.runCount ?? runs.length
 
   const loadNamespace = async (): Promise<void> => {

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -39,7 +39,7 @@ import { isCurrentInFlight } from '../../../../shared/in-flight-promise'
 import { resolveProjectId } from '../../../../shared/project-scope'
 import { EnvProvisionOverlay } from './EnvProvisionOverlay'
 import { shouldProvisionR } from './lazy-r'
-import { notebookGated } from './provisioning-view'
+import { hasActiveRuntimeTarget, notebookGated } from './provisioning-view'
 import { NotebookCodeBlock } from './notebook-code'
 import { NotebookRunOutputs } from './NotebookRunOutputs'
 import { NotebookInputDataStrip } from './NotebookInputDataStrip'
@@ -529,7 +529,6 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   const provisionUi = useNotebookEnvStore((s) => s.ui)
   const retryProvision = useNotebookEnvStore((s) => s.retry)
   const provision = useNotebookEnvStore((s) => s.provision)
-  const gated = notebookGated(envStatus, provisionUi, item.notebook.sessionId)
   const isPreparingR =
     provisionUi.kind === 'preparing' &&
     provisionUi.scope === 'r' &&
@@ -639,6 +638,8 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     effectiveActiveKind === 'python' || effectiveActiveKind === 'r'
       ? notebookState?.runtimeBindings?.[effectiveActiveKind]
       : undefined
+  const activeRuntimeTargetReady = hasActiveRuntimeTarget(activeRuntimeBinding)
+  const gated = notebookGated(envStatus, provisionUi, item.notebook.sessionId, activeRuntimeBinding)
   const activeRuntimeDetails = activeRuntimeBinding
     ? [activeRuntimeBinding.label, activeRuntimeBinding.version].filter(Boolean).join(' · ')
     : undefined
@@ -762,7 +763,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     Boolean(notebookState?.activeRunId) ||
     gated ||
     isSelectedKernelRunning ||
-    (activeDataLanguage === 'r' && (!envStatus.rReady || isPreparingR))
+    (activeDataLanguage === 'r' && !activeRuntimeTargetReady && (!envStatus.rReady || isPreparingR))
   const cellCount = notebookState?.runCount ?? runs.length
 
   const loadNamespace = async (): Promise<void> => {
@@ -952,8 +953,9 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     }
   }
 
-  // Restarts the shared interpreter, replacing state with the fresh snapshot so the banner clears.
+  // Restarts only the selected R environment, then replaces state so its banner clears.
   const handleRestart = async (): Promise<void> => {
+    if (!activeEnvName) return
     setIsRestarting(true)
     setActionError(null)
     namespaceRequestId.current += 1
@@ -962,7 +964,11 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     setNamespaceSnapshot(undefined)
     setNamespaceStatus('unavailable')
     try {
-      const next = await window.api.notebook.restart(createNotebookRequest(item.notebook))
+      const next = await window.api.notebook.restart({
+        ...createNotebookRequest(item.notebook),
+        language: 'r',
+        environment: activeEnvName
+      })
       namespaceRefreshQueued.current = showVariables
       applyNotebookState(next)
     } catch (error) {

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -538,7 +538,8 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   // usable throughout (D6 — see lazy-r.ts). R-kernel execution routing is wired later in E5.
   const onSelectLanguage = (lang: NotebookLanguage): void => {
     setShowVariables(false)
-    if (shouldProvisionR(envStatus, lang)) void provision('r')
+    const binding = notebookState?.runtimeBindings?.[lang]
+    if (!hasActiveRuntimeTarget(binding) && shouldProvisionR(envStatus, lang)) void provision('r')
   }
 
   // Keeps state assignment isolated so load paths and event paths share the same update hook.

--- a/src/renderer/src/pages/workspace/provisioning-view.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.ts
@@ -66,7 +66,8 @@ export function deriveProvisionUi(
 }
 
 // The notebook pane is greyed while its implicit managed Python target is unavailable or while an
-// additive upgrade is running. An active explicit runtime binding bypasses managed provisioning.
+// additive upgrade is running. Any explicit binding bypasses managed provisioning; callers handle
+// a non-active binding as an unavailable target instead of silently switching runtime ownership.
 export function notebookGated(
   status: ProvisionStatus,
   ui: ProvisionUiState,
@@ -76,9 +77,10 @@ export function notebookGated(
   if (ui.kind !== 'ready' && ui.sessionId && sessionId && ui.sessionId !== sessionId) {
     return false
   }
-  // Explicit Session bindings have already been validated by the runtime registry. Only the absent
-  // binding (the implicit app-managed default) depends on global provisioning readiness.
-  if (hasActiveRuntimeTarget(binding)) return false
+  // Only the absent binding (the implicit app-managed default) depends on global provisioning
+  // readiness. A present but unavailable/revoking binding must stay explicit so the user is not sent
+  // through the unrelated managed-runtime recovery path.
+  if (binding !== undefined) return false
   // A progress event can identify Python/upgrade work before its follow-up status refresh observes
   // provisioning=true. Fail closed from either signal so a refresh failure never opens the gate;
   // R-only work stays additive, and the error overlay still exposes Retry.

--- a/src/renderer/src/pages/workspace/provisioning-view.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.ts
@@ -5,6 +5,7 @@ import type {
   ProvisionScope,
   ProvisionStatus
 } from '../../../../shared/notebook-env'
+import type { NotebookRuntimeBinding } from '../../../../shared/notebook-runtime'
 
 // Preparing scope can arrive explicitly on progress events. Older main-process senders omit it, so
 // the reducer retains the legacy `(provisioning && pythonReady)` upgrade inference as a fallback.
@@ -24,6 +25,10 @@ export type ProvisionUiState =
       download?: DownloadProgress
     }
   | { kind: 'error'; message: string; scope?: PreparingScope; sessionId?: string }
+
+export const hasActiveRuntimeTarget = (
+  binding: Pick<NotebookRuntimeBinding, 'status'> | undefined
+): boolean => binding !== undefined && (binding.status ?? 'active') === 'active'
 
 // Pure mapping from the mirrored main-process state to the UI state. `scope` is the renderer's last
 // explicit provision request (undefined for an auto upgrade); `error` is the last failed attempt.
@@ -60,16 +65,20 @@ export function deriveProvisionUi(
   return { kind: 'ready' }
 }
 
-// The notebook pane is greyed while python is unavailable or while an additive upgrade is running.
-// An R-only preparation never gates the pane — Python stays interactive (spec §6.5).
+// The notebook pane is greyed while its implicit managed Python target is unavailable or while an
+// additive upgrade is running. An active explicit runtime binding bypasses managed provisioning.
 export function notebookGated(
   status: ProvisionStatus,
   ui: ProvisionUiState,
-  sessionId?: string
+  sessionId?: string,
+  binding?: Pick<NotebookRuntimeBinding, 'status'>
 ): boolean {
   if (ui.kind !== 'ready' && ui.sessionId && sessionId && ui.sessionId !== sessionId) {
     return false
   }
+  // Explicit Session bindings have already been validated by the runtime registry. Only the absent
+  // binding (the implicit app-managed default) depends on global provisioning readiness.
+  if (hasActiveRuntimeTarget(binding)) return false
   // A progress event can identify Python/upgrade work before its follow-up status refresh observes
   // provisioning=true. Fail closed from either signal so a refresh failure never opens the gate;
   // R-only work stays additive, and the error overlay still exposes Retry.

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -678,6 +678,12 @@ export type NotebookSessionRequest = OptionalProjectIdScope & {
   inputRunLeaseId?: string
 }
 
+// Restarts either every kernel in the Session (target omitted, preserving the historical behavior)
+// or one exact data-kernel target. Runtime boundaries reject half-specified targets.
+export type NotebookRestartRequest =
+  | (NotebookSessionRequest & { language: NotebookLanguage; environment: string })
+  | (NotebookSessionRequest & { language?: never; environment?: never })
+
 // A normal state read returns the latest renderer window. Transcript hydration may additionally
 // request immutable historical Runs by id without changing or widening that default window.
 export const NOTEBOOK_STATE_TARGET_RUN_LIMIT = 20

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -168,6 +168,7 @@ import type {
   NotebookLanguage,
   NotebookNamespaceRequest,
   NotebookNamespaceSnapshot,
+  NotebookRestartRequest,
   NotebookRunSummary,
   NotebookSessionReference,
   NotebookSessionRequest,
@@ -1162,7 +1163,7 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
   >()('notebook', ['notebook:read-input-preview']),
   'notebook.restart': callable<
-    (request: NotebookSessionRequest) => Promise<NotebookSessionState>
+    (request: NotebookRestartRequest) => Promise<NotebookSessionState>
   >()('notebook', ['notebook:restart']),
   'notebook.runCell': callable<(request: RunNotebookCellRequest) => Promise<NotebookRunSummary>>()(
     'notebook',


### PR DESCRIPTION
## Problem

Notebook readiness and restart behavior were scoped more broadly than the runtime target the user was operating:

- The renderer disabled the whole Notebook whenever the managed Python runtime was unavailable, even when the Session had an active explicit Python or R runtime binding that the main process could execute.
- The “Restart R kernel” action invoked the historical Session-wide restart, which shut down Python, every R environment, and REPL state instead of the selected R environment.

Both behaviors were reproduced at public boundaries before implementation. The new renderer tests failed because the external-runtime terminal remained disabled and because the restart request had no target; the runtime-service test failed because the Session executor restarted and no exact R executor was terminated.

## Proposed change

- Treat an active `runtimeBindings[language]` entry as the current valid runtime target for renderer gating. Only a missing binding—the implicit app-managed default—depends on `pythonReady` / `rReady`.
- Extend the existing `notebook.restart` request with an exact `language` + `environment` target.
- Send the selected R target from the existing restart action.
- Reuse the runtime service's existing targeted executor termination path so sibling Python, R, and REPL kernels keep their state.
- Preserve the historical Session-wide restart when both target fields are omitted, and reject half-specified targets at runtime boundaries.

## Scope and non-goals

- No new API method, database schema, persisted field, migration, or runtime status enum.
- The two request fields are transient command data only.
- Existing untargeted restart callers remain compatible and retain Session-wide behavior.
- Historical runtime bindings that omit `status` retain their existing implicit-active meaning.
- No user-visible copy or i18n catalog changes.
- This does not add a generic kernel-management UI; it corrects the existing R restart action and readiness gate.

## Acceptance criteria and validation

- Active external Python and R bindings remain interactive while managed runtimes report unavailable.
  - `npm test -- src/renderer/src/pages/workspace/provisioning-view.test.ts src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx` (65 tests passed)
- Restarting the selected R kernel terminates only that language/environment and preserves sibling kernel state.
  - `npm test -- src/main/notebook/runtime-service.test.ts src/main/notebook/ipc.test.ts src/main/notebook/local-rpc-notebook-adapter.test.ts` (263 tests passed)
- Target fields are forwarded through Electron IPC and local RPC; malformed half-targets fail closed.
  - Covered by the same main-process test command above.
- Static contracts remain valid.
  - `npm run typecheck:node`
  - `npm run typecheck:web`
  - `npm run lint`
  - `npm run check:web-api-map`
  - `git diff --check`

`test:affected --explain` conservatively selected the complete suite because the touched Notebook IPC test has no module owner. Per project guidance, focused module tests were run locally and the complete suite is left to this PR's exact-head CI.

## Review focus

- Whether an absent runtime binding should continue to mean the implicit managed default.
- Whether preserving untargeted Session-wide restart is the right compatibility boundary.
- Targeted restart cleanup: only the selected process key's termination and restart-recommendation state should be cleared.
