### PR TITLE
fix(skills): avoid catalog mutation deadlock

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3996,6 +3996,34 @@ describe('SettingsService: skills', () => {
     await expect(service.getSkillDetail('personal-my-skill')).resolves.toBeDefined()
   })
 
+  it('does not deadlock deletion on an observer read queued behind the mutation owner', async () => {
+    const service = await createSkillService()
+    await service.createSkill({ name: 'my-skill', description: 'Mine.', body: '# Mine' })
+
+    let startObserver!: () => void
+    let markObserverStarted!: () => void
+    // Register the observer continuation outside the deletion's mutation-owner context.
+    const observerTrigger = new Promise<void>((resolve) => (startObserver = resolve))
+    const observerStarted = new Promise<void>((resolve) => (markObserverStarted = resolve))
+    const observerRead = observerTrigger.then(() => {
+      const read = service.listUserSkills()
+      markObserverStarted()
+      return read
+    })
+
+    service.setSkillDeletionGuard(async () => {
+      startObserver()
+      await observerStarted
+      await service.listSpecialistSkillCatalog()
+    })
+
+    await expect(service.deleteSkill({ id: 'personal-my-skill' })).resolves.toEqual([
+      expect.objectContaining({ id: 'demo' })
+    ])
+    await expect(observerRead).resolves.toEqual([])
+    await expect(service.listSkills()).resolves.toEqual([expect.objectContaining({ id: 'demo' })])
+  })
+
   it('uses the immutable name and reconciles references reported by the detail view', async () => {
     const service = await createSkillService()
     const b64 = (text: string): string => Buffer.from(text).toString('base64')

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -17,7 +17,6 @@ import { SkillRegistry } from '../skills/registry'
 import type { FetchLike } from '../skills/github-import'
 import type { UserSkillRepository } from '../skills/user-skill-repository'
 import { SPECIALIST_PACKAGE_SKILL_METADATA } from '../skills/specialist-package-adapter'
-import { skillMutationOwnerFor } from '../skills/skill-mutation-owner'
 import { SettingsRepository } from './repository'
 import { SkillCatalogModule } from './skill-catalog'
 
@@ -131,34 +130,6 @@ describe('SkillCatalogModule', () => {
     expect(list).toHaveBeenCalledOnce()
     finishScan?.([])
     await expect(Promise.all([observerRead, sessionRead])).resolves.toEqual([[], undefined])
-  })
-
-  it('does not reuse an in-flight scan from outside a held mutation context', async () => {
-    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-skill-catalog-'))
-    roots.push(storageRoot)
-    let finishObserverScan: ((skills: []) => void) | undefined
-    const list = vi
-      .fn<() => Promise<[]>>()
-      .mockImplementationOnce(() => new Promise<[]>((resolve) => (finishObserverScan = resolve)))
-      .mockResolvedValueOnce([])
-    const mutationOwner = skillMutationOwnerFor(storageRoot)
-    const catalog = new SkillCatalogModule({
-      repository: new SettingsRepository(storageRoot),
-      storageRoot,
-      skillRegistry: { list: vi.fn().mockResolvedValue([]) } as unknown as SkillRegistry,
-      userSkills: {
-        list,
-        isMutationOwnerContext: () => mutationOwner.isHeldByCurrentContext()
-      } as unknown as UserSkillRepository
-    })
-
-    const observerRead = catalog.listUserSkills()
-    await mutationOwner.runExclusive(async () => {
-      await expect(catalog.listUserSkills()).resolves.toEqual([])
-      expect(list).toHaveBeenCalledTimes(2)
-    })
-    finishObserverScan?.([])
-    await expect(observerRead).resolves.toEqual([])
   })
 
   it('keeps only the newest user Skill when Personal and Imported packages share a name', async () => {

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -17,6 +17,7 @@ import { SkillRegistry } from '../skills/registry'
 import type { FetchLike } from '../skills/github-import'
 import type { UserSkillRepository } from '../skills/user-skill-repository'
 import { SPECIALIST_PACKAGE_SKILL_METADATA } from '../skills/specialist-package-adapter'
+import { skillMutationOwnerFor } from '../skills/skill-mutation-owner'
 import { SettingsRepository } from './repository'
 import { SkillCatalogModule } from './skill-catalog'
 
@@ -130,6 +131,34 @@ describe('SkillCatalogModule', () => {
     expect(list).toHaveBeenCalledOnce()
     finishScan?.([])
     await expect(Promise.all([observerRead, sessionRead])).resolves.toEqual([[], undefined])
+  })
+
+  it('does not reuse an in-flight scan from outside a held mutation context', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-skill-catalog-'))
+    roots.push(storageRoot)
+    let finishObserverScan: ((skills: []) => void) | undefined
+    const list = vi
+      .fn<() => Promise<[]>>()
+      .mockImplementationOnce(() => new Promise<[]>((resolve) => (finishObserverScan = resolve)))
+      .mockResolvedValueOnce([])
+    const mutationOwner = skillMutationOwnerFor(storageRoot)
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: { list: vi.fn().mockResolvedValue([]) } as unknown as SkillRegistry,
+      userSkills: {
+        list,
+        isMutationOwnerContext: () => mutationOwner.isHeldByCurrentContext()
+      } as unknown as UserSkillRepository
+    })
+
+    const observerRead = catalog.listUserSkills()
+    await mutationOwner.runExclusive(async () => {
+      await expect(catalog.listUserSkills()).resolves.toEqual([])
+      expect(list).toHaveBeenCalledTimes(2)
+    })
+    finishObserverScan?.([])
+    await expect(observerRead).resolves.toEqual([])
   })
 
   it('keeps only the newest user Skill when Personal and Imported packages share a name', async () => {

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -304,6 +304,9 @@ class SkillCatalogModule {
   // second production transaction facade while excluding immutable bundled packages from each
   // writable-directory reconciliation.
   async listUserSkills(): Promise<BundledSkill[]> {
+    // A scan started outside the owner can be queued behind a mutation. Reads inside that
+    // mutation must bypass the shared Promise so a guard cannot wait on its own lock.
+    if (this.userSkills.isMutationOwnerContext?.()) return this.userSkills.list()
     if (this.userSkillCatalogRead) return this.userSkillCatalogRead
     const read = this.userSkills.list().finally(() => {
       if (this.userSkillCatalogRead === read) this.userSkillCatalogRead = undefined

--- a/src/main/skills/skill-mutation-owner.ts
+++ b/src/main/skills/skill-mutation-owner.ts
@@ -7,6 +7,10 @@ export class SkillMutationOwner {
   private tail: Promise<void> = Promise.resolve()
   private readonly context = new AsyncLocalStorage<SkillMutationOwner>()
 
+  isHeldByCurrentContext(): boolean {
+    return this.context.getStore() === this
+  }
+
   async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
     // Guards are allowed to inspect the catalog through the same repository while already holding
     // the owner lock. Treat that call chain as re-entrant instead of waiting on itself.

--- a/src/main/skills/skill-package-transaction-owner.ts
+++ b/src/main/skills/skill-package-transaction-owner.ts
@@ -54,6 +54,10 @@ export class SkillPackageTransactionOwner {
     this.validatePromoted = validate
   }
 
+  isHeldByCurrentContext(): boolean {
+    return this.mutationOwner.isHeldByCurrentContext()
+  }
+
   runExclusive<T>(operation: () => Promise<T>): Promise<T> {
     return this.mutationOwner.runExclusive(operation)
   }

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -35,6 +35,8 @@ export type { ImportOutcome } from './user-skill-import-contracts'
 
 // Reads and writes user-authored (personal) and imported skills under `<storageRoot>/skills/`.
 class UserSkillRepository {
+  readonly isMutationOwnerContext = (): boolean => this.transactions.isHeldByCurrentContext()
+
   private readonly transactions: SkillPackageTransactionOwner
   private readonly compatibilityIndex: UserSkillCompatibilityIndex
   private readonly store: UserSkillStore


### PR DESCRIPTION
Fixes #2047

## Problem

Bulk deletion can deadlock the Skill catalog. A filesystem observer may start a shared `listUserSkills()` Promise while a Skill mutation is held. When the deletion guard reuses that Promise from inside the same mutation-owner context, it waits on a read that cannot proceed until the deletion releases its own lock.

## Proposed change

- expose whether the current async call chain holds the existing Skill mutation owner through the repository transaction seam
- bypass only the cross-context in-flight catalog Promise while the current call already holds that owner
- cover the production `SettingsService` → `UserSkillRepository.delete()` → deletion guard → Specialist catalog read chain with a deterministic regression test

## Scope and non-goals

- preserve shared in-flight scans for ordinary callers
- do not change the bulk-delete UI or add a second lock/transaction owner
- no database, persisted settings, on-disk Skill format, migration, historical-data compatibility, enum, or state changes

## Acceptance criteria and validation

The checks below ran after the last material edit:

- deadlock cycle and post-delete readability → `npm test -- src/main/settings/service.test.ts -t 'does not deadlock deletion on an observer read queued behind the mutation owner' --run` → **passed** (1 passed)
- regression sensitivity → the same test with the three-line cache bypass temporarily removed → **failed as expected** by timeout; the implementation was restored and the passing command above was rerun
- User Skill repository owner, contract, and declared consumer coverage → `npm run test:module -- user_skills_repository` → **796 passed, 9 local-environment failures outside the changed concurrency path** (`date not in range` or `canExport: false`); the same paths passed in clean exact-head CI
- Node/main-process types → `npm run typecheck:node` → **passed**
- lint → `npm run lint` → **passed**
- changed-test formatting → `npx prettier --check src/main/settings/service.test.ts src/main/settings/skill-catalog.test.ts` → **passed**
- patch whitespace → `git diff --check` → **passed**

The module impact plan includes the `windows_sensitive` overlay. Local verification covered the shared main-process contract on macOS; exact-head PR Gate run `33613082537` passed the complete portable suite, Linux isolation, Windows core/E2E, macOS build/E2E, static checks, PR policy, and Module tests/coverage. No new UI E2E was added because the regression is fully reproduced at the Settings service boundary without renderer timing.

Independent standards/spec review confirmed that the final integration test covers the reported observer/delete/guard cycle and that the listed impact set covers the changed behavior. No uncovered risk remains after the exact-head PR Gate passed; the nine local module-test failures did not reproduce in its clean full-suite and platform lanes.

## Review focus

- confirm that cache reuse is bypassed only from the currently held mutation-owner context
- confirm that the queued observer read, deletion, and a fresh `listSkills()` call all settle
