### PR TITLE
fix(notebook): stabilize input and artifact file workflows

### DIFF
--- a/resources/notebook/python_loop.py
+++ b/resources/notebook/python_loop.py
@@ -138,6 +138,23 @@ def _install_protected_paths_policy(entries):
     sys.addaudithook(audit)
 _runtime_dir_value = os.environ.get("OPEN_SCIENCE_RUNTIME_DIR", "")
 _managed_runtime_dir = _guard_path(_runtime_dir_value) if _runtime_dir_value else ""
+_cache_dir_value = os.environ.get("OPEN_SCIENCE_NOTEBOOK_CACHE_DIR", "")
+_managed_cache_dir = _guard_path(_cache_dir_value) if _cache_dir_value else ""
+
+def _path_is_within(path, directory):
+    return bool(directory) and (path == directory or path.startswith(directory + os.sep))
+
+if not (
+    _managed_runtime_dir
+    and _managed_cache_dir != _managed_runtime_dir
+    and _path_is_within(_managed_cache_dir, _managed_runtime_dir)
+):
+    _managed_cache_dir = ""
+
+def _runtime_path_is_blocked(path):
+    return _path_is_within(path, _managed_runtime_dir) and not _path_is_within(
+        path, _managed_cache_dir
+    )
 
 _package_mutation_command = re.compile(
     r"(?:\b(?:micromamba|mamba|conda|pip|pip3|pipx|uv|poetry)(?:\.exe)?\b.{0,160}"
@@ -234,15 +251,11 @@ def _text_references_managed_runtime(text):
 
 def _runtime_target_is_managed(value):
     text = str(value).strip().strip("\"'")
-    if _text_references_managed_runtime(text):
-        return True
     try:
-        resolved = _guard_path(text)
+        resolved = _guard_path(os.path.expandvars(os.path.expanduser(text)))
     except (TypeError, ValueError):
-        return False
-    return bool(_managed_runtime_dir) and (
-        resolved == _managed_runtime_dir or resolved.startswith(_managed_runtime_dir + os.sep)
-    )
+        return _text_references_managed_runtime(text)
+    return _runtime_path_is_blocked(resolved)
 
 def _runtime_write_targets(words, redirections=()):
     if not words:
@@ -362,9 +375,7 @@ def _protected_paths_audit(event, args):
             resolved = _guard_path(target)
         except (TypeError, ValueError):
             continue
-        if _managed_runtime_dir and (
-            resolved == _managed_runtime_dir or resolved.startswith(_managed_runtime_dir + os.sep)
-        ):
+        if _runtime_path_is_blocked(resolved):
             _blocked_environment_mutation()
 
     if event != "open" or not args:
@@ -386,9 +397,7 @@ def _protected_paths_audit(event, args):
     )
     if write_open and os.path.basename(resolved).casefold() == "pyvenv.cfg":
         _blocked_environment_mutation()
-    if write_open and _managed_runtime_dir and (
-        resolved == _managed_runtime_dir or resolved.startswith(_managed_runtime_dir + os.sep)
-    ):
+    if write_open and _runtime_path_is_blocked(resolved):
         _blocked_environment_mutation()
 sys.addaudithook(_protected_paths_audit)
 

--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -161,6 +161,7 @@
         "src/main/notebook/package-manager.ts",
         "src/main/notebook/package-process-sandbox.ts",
         "src/main/notebook/process-environment.ts",
+        "src/main/notebook/prompt-input-materialization.ts",
         "src/main/notebook/provisioner-runtime.ts",
         "src/main/notebook/provisioner.ts",
         "src/main/notebook/python-command.ts",

--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -161,7 +161,6 @@
         "src/main/notebook/package-manager.ts",
         "src/main/notebook/package-process-sandbox.ts",
         "src/main/notebook/process-environment.ts",
-        "src/main/notebook/prompt-input-materialization.ts",
         "src/main/notebook/provisioner-runtime.ts",
         "src/main/notebook/provisioner.ts",
         "src/main/notebook/python-command.ts",

--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -651,10 +651,25 @@ describe('AcpNativeFollowUpWorkflow', () => {
     expect(published).toEqual([])
   })
 
-  it('registers notebook inputs only after steering injects', async () => {
-    const registerTurnInputs = vi.fn(async () => undefined)
-    const request = vi.fn(async () => {
-      expect(registerTurnInputs).not.toHaveBeenCalled()
+  it('materializes and advertises notebook inputs before steering, then commits after injection', async () => {
+    const registerTurnInputs = vi.fn(async (input: { materializeOnly?: boolean }) =>
+      input.materializeOnly
+        ? [
+            {
+              sourceKind: 'upload-version' as const,
+              inputFileVersionId: 'upload-version-1',
+              filename: 'samples.csv',
+              notebookPath: 'inputs/samples-123456789abc.csv'
+            }
+          ]
+        : undefined
+    )
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      expect(registerTurnInputs).toHaveBeenCalledWith(
+        expect.objectContaining({ materializeOnly: true })
+      )
+      expect(JSON.stringify(params)).toContain('inputs/samples-123456789abc.csv')
+      expect(JSON.stringify(params)).toContain('use only the exact notebookPath')
       return { outcome: 'injected' }
     })
     const { workflow } = createWorkflow({
@@ -678,7 +693,15 @@ describe('AcpNativeFollowUpWorkflow', () => {
         messageId: 'message-steer-1'
       }
     )
-    expect(registerTurnInputs).toHaveBeenCalledWith({
+    expect(registerTurnInputs).toHaveBeenNthCalledWith(1, {
+      projectId: 'project-1',
+      appSessionId: 'app-1',
+      promptMessageId: 'prompt-live',
+      uploads: [],
+      references: [],
+      materializeOnly: true
+    })
+    expect(registerTurnInputs).toHaveBeenNthCalledWith(2, {
       projectId: 'project-1',
       appSessionId: 'app-1',
       promptMessageId: 'prompt-live',
@@ -716,7 +739,10 @@ describe('AcpNativeFollowUpWorkflow', () => {
       transport: 'acp-steering',
       messageId: 'message-steer-1'
     })
-    expect(registerTurnInputs).not.toHaveBeenCalled()
+    expect(registerTurnInputs).toHaveBeenCalledOnce()
+    expect(registerTurnInputs).toHaveBeenCalledWith(
+      expect.objectContaining({ materializeOnly: true })
+    )
     expect(published).toEqual([{ sessionId: 'app-1', messageId: 'message-steer-1', text: 'late' }])
   })
 
@@ -748,7 +774,7 @@ describe('AcpNativeFollowUpWorkflow', () => {
     ])
   })
 
-  it('does not register notebook inputs when steering is refused', async () => {
+  it('does not commit notebook inputs when steering is refused', async () => {
     const registerTurnInputs = vi.fn(async () => undefined)
     const { workflow } = createWorkflow({
       request: vi.fn(async () => ({})),
@@ -767,7 +793,10 @@ describe('AcpNativeFollowUpWorkflow', () => {
     await expect(workflow.steerFollowUp({ sessionId: 'app-1', text: 'see file' })).resolves.toEqual(
       { injected: false, reason: 'unrecognized-success' }
     )
-    expect(registerTurnInputs).not.toHaveBeenCalled()
+    expect(registerTurnInputs).toHaveBeenCalledOnce()
+    expect(registerTurnInputs).toHaveBeenCalledWith(
+      expect.objectContaining({ materializeOnly: true })
+    )
     expect(published).toEqual([])
   })
 })

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../shared/acp'
 import type { FileReference } from '../../shared/artifacts'
 import type { MessagePart } from '../../shared/session-persistence'
+import type { NotebookPromptInput } from '../../shared/notebook'
 import type { AgentFrameworkId } from '../../shared/settings'
 import {
   toPersistedUploadedAttachment,
@@ -70,7 +71,7 @@ type NativeFollowUpRegisterTurnInputs = (request: {
   promptMessageId: string
   uploads: UploadedAttachment[]
   references: FileReference[]
-}) => Promise<void>
+}) => Promise<readonly NotebookPromptInput[] | void>
 
 type NativeFollowUpLivePrompt = Readonly<{
   turnToken: string

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -21,6 +21,7 @@ import type { AcpOpenCodeUsageApi } from './backend-generation-owner'
 import type { AcpConnectionCapabilities } from './connection-resource-owner'
 import type { ImageInputCompatibilityOwner } from './image-input-compatibility-owner'
 import type { VisionEvidenceSource } from './vision-evidence-repository'
+import { appendNotebookInputPrompt } from './prompt-preparation-owner'
 import {
   ACP_STEERING_METHOD,
   ACP_STEERING_TIMEOUT_MS,
@@ -71,6 +72,7 @@ type NativeFollowUpRegisterTurnInputs = (request: {
   promptMessageId: string
   uploads: UploadedAttachment[]
   references: FileReference[]
+  materializeOnly?: boolean
 }) => Promise<readonly NotebookPromptInput[] | void>
 
 type NativeFollowUpLivePrompt = Readonly<{
@@ -349,6 +351,41 @@ class AcpNativeFollowUpWorkflow {
         transport: route.transport
       })
       return refusePrepared('prompt-required')
+    }
+
+    if (notebookTurnInputs && this.options.registerTurnInputs) {
+      try {
+        const notebookInputs = await this.options.registerTurnInputs({
+          projectId: notebookTurnInputs.projectId,
+          appSessionId: notebookTurnInputs.sessionId,
+          promptMessageId: notebookTurnInputs.livePromptMessageId,
+          uploads: [...notebookTurnInputs.uploads],
+          references: [...notebookTurnInputs.references],
+          materializeOnly: true
+        })
+        if (notebookInputs) {
+          const preparedPrompt = appendNotebookInputPrompt([...prompt], notebookInputs)
+          prompt =
+            typeof preparedPrompt === 'string'
+              ? steeringPromptFromText(preparedPrompt)
+              : preparedPrompt
+        }
+      } catch (error) {
+        log.info('native follow-up notebook materialization failed', {
+          sessionId: notebookTurnInputs.sessionId,
+          promptMessageId: notebookTurnInputs.livePromptMessageId,
+          reason: error instanceof Error ? error.message : String(error)
+        })
+        return refusePrepared('dispatch-failed')
+      }
+      if (!this.sameLivePrompt(request.sessionId, live)) {
+        log.info('native follow-up refused', {
+          sessionId: request.sessionId,
+          reason: 'no-live-turn',
+          transport: route.transport
+        })
+        return refusePrepared('no-live-turn')
+      }
     }
 
     const transportSignal = this.transportTimeout(route.transport)

--- a/src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
+++ b/src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
@@ -1,14 +1,17 @@
 import type { ContentBlock } from '@agentclientprotocol/sdk'
 import { NotebookNetworkSandbox } from '@aipoch/notebook-network-sandbox'
 import { spawn } from 'node:child_process'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { UploadedAttachment } from '../../shared/uploads'
+import type { NotebookRunInputFile } from '../../shared/notebook'
 import { getNotebookInputRoot } from '../notebook/input-staging'
+import { NotebookInputRegistry } from '../notebook/input-registry'
 import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
 
 const roots: string[] = []
@@ -21,13 +24,15 @@ const run = (
   argv: readonly string[],
   cwd: string,
   env: NodeJS.ProcessEnv
-): Promise<{ code: number | null; stderr: string }> =>
+): Promise<{ code: number | null; stdout: string; stderr: string }> =>
   new Promise((resolveRun, reject) => {
     const child = spawn(argv[0]!, argv.slice(1), { cwd, env, shell: false })
+    let stdout = ''
     let stderr = ''
+    child.stdout.setEncoding('utf8').on('data', (chunk: string) => (stdout += chunk))
     child.stderr.setEncoding('utf8').on('data', (chunk: string) => (stderr += chunk))
     child.on('error', reject)
-    child.on('close', (code) => resolveRun({ code, stderr }))
+    child.on('close', (code) => resolveRun({ code, stdout, stderr }))
   })
 
 const contentBlocks = (content: string | ContentBlock[]): ContentBlock[] => {
@@ -38,7 +43,7 @@ const contentBlocks = (content: string | ContentBlock[]): ContentBlock[] => {
 describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
   'ACP attachment access from Notebook',
   () => {
-    it('lets Notebook copy the exact managed upload snapshot advertised to the Agent', async ({
+    it('lets Notebook read the exact managed upload Version through its advertised relative path', async ({
       skip
     }) => {
       const storageRoot = await mkdtemp(join(tmpdir(), 'open-science-attachment-sandbox-'))
@@ -50,6 +55,7 @@ describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
       await mkdir(notebookDataRoot, { recursive: true })
 
       const bytes = Buffer.from('sample,group\n1,Ctrl\n2,IRI\n')
+      const checksum = createHash('sha256').update(bytes).digest('hex')
       const attachment: UploadedAttachment = {
         id: 'upload-file-1',
         versionId: 'upload-version-1',
@@ -60,7 +66,7 @@ describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
         path: 'upload-version:stale',
         mimeType: 'text/csv',
         size: bytes.byteLength,
-        checksum: '1'.repeat(64),
+        checksum,
         createdAt: '2026-09-02T00:00:00.000Z'
       }
       const openLatest = vi.fn(async () => ({
@@ -96,7 +102,7 @@ describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
           originalFilename: attachment.originalName,
           contentType: 'text/csv',
           sizeBytes: BigInt(bytes.byteLength),
-          checksum: '1'.repeat(64),
+          checksum,
           createdAt: new Date('2026-09-02T00:00:00.000Z')
         },
         versionToken: 1,
@@ -141,7 +147,53 @@ describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
       expect(isAbsolute(advertisedRelativePath)).toBe(false)
       expect(advertisedRelativePath).not.toBe('..')
       expect(advertisedRelativePath).not.toMatch(/^\.\.(?:[/\\]|$)/)
-      const destination = join(notebookDataRoot, 'samples.csv')
+      const registeredInput: NotebookRunInputFile = {
+        inputFileVersionId: 'upload-version-1',
+        sourceKind: 'upload-version',
+        sourceFileId: attachment.id,
+        sourceVersionNumber: 1,
+        sourceProjectId: projectId,
+        sourceSessionId: sessionId,
+        filename: attachment.originalName,
+        contentType: attachment.mimeType,
+        sizeBytes: bytes.byteLength,
+        checksum,
+        storageKey: 'uploads/project-1/session-1/upload-file-1/content',
+        association: 'turn-attached'
+      }
+      const stagedPath = join(notebookInputRoot, registeredInput.sourceKind, checksum, 'content')
+      const inputRegistry = new NotebookInputRegistry({
+        storageRoot,
+        inputAuthority: {
+          resolveVersion: vi.fn(async () => registeredInput),
+          validateVersion: vi.fn(async () => ({
+            state: 'available' as const,
+            input: registeredInput
+          })),
+          openContent: vi.fn(),
+          stageContent: vi.fn(async () => {
+            await mkdir(dirname(stagedPath), { recursive: true })
+            await writeFile(stagedPath, bytes)
+            await chmod(stagedPath, 0o444)
+            return stagedPath
+          })
+        }
+      })
+      const promptInputs = await inputRegistry.registerTurn({
+        projectId,
+        appSessionId: sessionId,
+        promptMessageId: 'prompt-1',
+        uploads: prepared.turnInputs!.uploads,
+        references: prepared.turnInputs!.references
+      })
+      expect(promptInputs).toEqual([
+        expect.objectContaining({
+          filename: 'samples.csv',
+          notebookPath: expect.stringMatching(/^inputs[/\\]samples-[a-f0-9]{12}\.csv$/)
+        })
+      ])
+      expect(isAbsolute(promptInputs[0]!.notebookPath)).toBe(false)
+      expect(promptInputs[0]!.notebookPath).not.toContain('..')
       const sandbox = new NotebookNetworkSandbox({
         policy: { allowedDomains: [], deniedDomains: [] },
         resources: {
@@ -156,11 +208,11 @@ describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
         }
         await sandbox.initialize()
         const wrapped = await sandbox.wrap({
-          command: `/bin/cp ${JSON.stringify(advertisedPath)} ${JSON.stringify(destination)}`,
+          command: `/bin/cat ${JSON.stringify(promptInputs[0]!.notebookPath)}`,
           cwd: notebookDataRoot,
           env: { PATH: '/usr/bin:/bin' },
           filesystem: {
-            readOnlyRoots: ['/bin', '/usr/bin', notebookInputRoot, dirname('/bin/cp')],
+            readOnlyRoots: ['/bin', '/usr/bin', notebookInputRoot, dirname('/bin/cat')],
             readWriteRoots: [notebookDataRoot],
             deniedReadRoots: [],
             deniedWriteRoots: []
@@ -172,10 +224,13 @@ describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
         wrapped.cleanup()
 
         expect(result.code, diagnostic).toBe(0)
-        await expect(readFile(destination, 'utf8')).resolves.toBe(bytes.toString('utf8'))
+        expect(result.stdout).toBe(bytes.toString('utf8'))
         await expect(readFile(advertisedPath, 'utf8')).resolves.toBe(bytes.toString('utf8'))
         prepared.close()
         await expect(readFile(advertisedPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+        await expect(
+          readFile(join(notebookDataRoot, promptInputs[0]!.notebookPath), 'utf8')
+        ).resolves.toBe(bytes.toString('utf8'))
       } finally {
         prepared.close()
         await sandbox.dispose()

--- a/src/main/acp/prompt-preparation-owner.test.ts
+++ b/src/main/acp/prompt-preparation-owner.test.ts
@@ -439,6 +439,58 @@ describe('AcpPromptPreparationOwner', () => {
     ])
   })
 
+  it('advertises materialized Notebook inputs as short relative paths before dispatch', async () => {
+    const fixture = setup()
+    fixture.promptContent.prepare.mockResolvedValueOnce({
+      content: [
+        {
+          type: 'resource_link',
+          uri: 'file:///private/internal/turn/samples.csv',
+          name: 'samples.csv'
+        }
+      ],
+      historyImageCount: 0,
+      turnInputs: {
+        uploads: [
+          {
+            id: 'upload-1',
+            versionId: 'upload-version-1',
+            versionNumber: 1,
+            sessionId: 'session-1',
+            name: 'samples.csv',
+            originalName: 'samples.csv',
+            path: 'upload-version:upload-version-1',
+            size: 10
+          }
+        ],
+        references: []
+      },
+      close: fixture.promptClose
+    })
+    fixture.registerTurnInputs.mockResolvedValueOnce([
+      {
+        sourceKind: 'upload-version',
+        inputFileVersionId: 'upload-version-1',
+        filename: 'samples.csv',
+        notebookPath: 'inputs/samples-123456789abc.csv'
+      }
+    ])
+
+    const handle = await fixture.prepare()
+
+    expect(handle.status).toBe('ready')
+    if (handle.status !== 'ready') throw new Error('Expected a prepared prompt.')
+    expect(handle.content).toEqual([
+      expect.objectContaining({ type: 'resource_link', name: 'samples.csv' }),
+      {
+        type: 'text',
+        text: expect.stringContaining('"notebookPath":"inputs/samples-123456789abc.csv"')
+      }
+    ])
+    expect(JSON.stringify(handle.content)).toContain('Do not copy inputs to /tmp')
+    handle.close()
+  })
+
   it('injects recalled memory as untrusted user context immediately before the current task', async () => {
     const recallForPrompt = vi.fn(async () =>
       [

--- a/src/main/acp/prompt-preparation-owner.test.ts
+++ b/src/main/acp/prompt-preparation-owner.test.ts
@@ -488,6 +488,7 @@ describe('AcpPromptPreparationOwner', () => {
       }
     ])
     expect(JSON.stringify(handle.content)).toContain('Do not copy inputs to /tmp')
+    expect(JSON.stringify(handle.content)).toContain('including its inputs/ prefix')
     handle.close()
   })
 

--- a/src/main/acp/prompt-preparation-owner.ts
+++ b/src/main/acp/prompt-preparation-owner.ts
@@ -136,7 +136,7 @@ const appendNotebookInputPrompt = (
       '<open_science_notebook_inputs>',
       JSON.stringify(inputs),
       '</open_science_notebook_inputs>',
-      'These exact input Versions already exist relative to the Notebook working directory. Use notebookPath directly in Notebook and shell code. Do not copy inputs to /tmp or embed absolute file URIs in Notebook cells.'
+      'These exact input Versions already exist relative to the Notebook working directory. When Notebook or shell code reads an attached file, ignore the attachment resource URI, path, and basename; use only the exact notebookPath shown above, including its inputs/ prefix. Do not copy inputs to /tmp or embed absolute file URIs in Notebook cells.'
     ].join('\n')
   }
   return typeof content === 'string'
@@ -471,7 +471,7 @@ class AcpPromptPreparationOwner {
   }
 }
 
-export { AcpPromptPreparationOwner }
+export { AcpPromptPreparationOwner, appendNotebookInputPrompt }
 export type {
   AcpPromptPreparationInput,
   AcpPromptPreparationOwnerOptions,

--- a/src/main/acp/prompt-preparation-owner.ts
+++ b/src/main/acp/prompt-preparation-owner.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises'
 import type { AcpPromptRequest } from '../../shared/acp'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactReference, FileReference } from '../../shared/artifacts'
+import type { NotebookPromptInput } from '../../shared/notebook'
 import { resolveFileTextBudget } from '../../shared/history-preamble'
 import type { NotebookHandoffContext } from '../notebook/runtime-service'
 import type { ResolvedAgentBackend, SkillSelectorUsageObservation } from '../agent-framework'
@@ -67,7 +68,9 @@ type AcpPromptPreparationOwnerOptions = Readonly<{
   isMemoryEnabledForSession?: (sessionId: string) => boolean
   notebook?: Readonly<{
     peekHandoffContext?: (sessionId: string) => NotebookHandoffContext | undefined
-    registerTurnInputs?: (input: NotebookTurnInputs) => Promise<void>
+    registerTurnInputs?: (
+      input: NotebookTurnInputs
+    ) => Promise<readonly NotebookPromptInput[] | void>
   }>
   emitState: () => void
 }>
@@ -121,6 +124,25 @@ const notebookHandoffPrompt = (context: NotebookHandoffContext): string =>
     JSON.stringify(context),
     '</open_science_notebook_continuity>'
   ].join('\n')
+
+const appendNotebookInputPrompt = (
+  content: string | ContentBlock[],
+  inputs: readonly NotebookPromptInput[]
+): string | ContentBlock[] => {
+  if (inputs.length === 0) return content
+  const guidance: ContentBlock = {
+    type: 'text',
+    text: [
+      '<open_science_notebook_inputs>',
+      JSON.stringify(inputs),
+      '</open_science_notebook_inputs>',
+      'These exact input Versions already exist relative to the Notebook working directory. Use notebookPath directly in Notebook and shell code. Do not copy inputs to /tmp or embed absolute file URIs in Notebook cells.'
+    ].join('\n')
+  }
+  return typeof content === 'string'
+    ? [{ type: 'text', text: content }, guidance]
+    : [...content, guidance]
+}
 
 const isPdfUpload = (upload: UploadedAttachment): boolean =>
   upload.mimeType?.split(';', 1)[0]?.trim().toLowerCase() === 'application/pdf' ||
@@ -343,7 +365,7 @@ class AcpPromptPreparationOwner {
         )
         if (await cancelled()) return cancelPrepared()
       }
-      const providerContent = this.options.imageInputCompatibility
+      let providerContent = this.options.imageInputCompatibility
         ? await this.options.imageInputCompatibility.prepare({
             content: prepared.content,
             supportsImageInput: input.backend.context.supportsImageInput,
@@ -357,7 +379,7 @@ class AcpPromptPreparationOwner {
       if (await cancelled()) return cancelPrepared()
 
       if (this.options.notebook?.registerTurnInputs && prepared.turnInputs) {
-        await this.options.notebook.registerTurnInputs({
+        const notebookInputs = await this.options.notebook.registerTurnInputs({
           projectId: input.projectId,
           appSessionId: input.request.sessionId,
           promptMessageId:
@@ -367,6 +389,9 @@ class AcpPromptPreparationOwner {
           uploads: prepared.turnInputs.uploads,
           references: prepared.turnInputs.references
         })
+        if (notebookInputs) {
+          providerContent = appendNotebookInputPrompt(providerContent, notebookInputs)
+        }
         if (await cancelled()) return cancelPrepared()
       }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -70,7 +70,7 @@ import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
 import type { NotebookRpcConnection } from '../notebook/mcp-server'
 import type { NotebookHandoffContext } from '../notebook/runtime-service'
-import type { NotebookExecutionRpcMethod } from '../../shared/notebook'
+import type { NotebookExecutionRpcMethod, NotebookPromptInput } from '../../shared/notebook'
 import type { SkillImportRpcConnection } from '../skills/mcp-server'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
@@ -367,7 +367,7 @@ type AcpRuntimeNotebookOptions = {
     promptMessageId: string
     uploads: UploadedAttachment[]
     references: FileReference[]
-  }) => Promise<void>
+  }) => Promise<readonly NotebookPromptInput[] | void>
   peekHandoffContext?: (sessionId: string) => NotebookHandoffContext | undefined
 }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -367,6 +367,7 @@ type AcpRuntimeNotebookOptions = {
     promptMessageId: string
     uploads: UploadedAttachment[]
     references: FileReference[]
+    materializeOnly?: boolean
   }) => Promise<readonly NotebookPromptInput[] | void>
   peekHandoffContext?: (sessionId: string) => NotebookHandoffContext | undefined
 }

--- a/src/main/artifacts/mcp-server.test.ts
+++ b/src/main/artifacts/mcp-server.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
 
 const { log } = vi.hoisted(() => ({
   log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
@@ -18,6 +19,7 @@ import {
   createArtifactMcpEnvironmentFromProcess,
   createArtifactMcpServerConfig,
   toWriteArtifactToolResult,
+  writeArtifactFileToolDefinition,
   writeArtifactFileForCurrentRun,
   type ArtifactMcpEnvironment
 } from './mcp-server'
@@ -56,6 +58,21 @@ afterEach(async () => {
 })
 
 describe('artifact MCP server', () => {
+  it('publishes filename as a required write_artifact_file argument', () => {
+    const schema = z.object(writeArtifactFileToolDefinition.inputSchema)
+
+    expect(schema.safeParse({}).error?.issues).toEqual([
+      expect.objectContaining({ path: ['filename'] })
+    ])
+    expect(
+      schema.parse({
+        filename: 'plot.png',
+        source: { kind: 'localPath', path: 'plot.png' },
+        producerRunId: 'notebook-run-1'
+      })
+    ).toMatchObject({ filename: 'plot.png', producerRunId: 'notebook-run-1' })
+  })
+
   it('keeps legacy content and encoding input working for the current run', async () => {
     const root = await createStorageRoot()
     const repository = new ArtifactRepository(root)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -893,6 +893,7 @@ const createApplicationModules = async (
     uploadRepository
   )
   const notebookInputRegistry = new NotebookInputRegistry({
+    storageRoot: resolveDataRoot(),
     inputAuthority: immutableInputAuthority,
     resolveArtifactVersionIdentity: async (projectId, versionId) => {
       const [artifact] = await projectFilesRepository.readHostArtifactCatalog({

--- a/src/main/notebook/input-registry.test.ts
+++ b/src/main/notebook/input-registry.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join } from 'node:path'
 
 import type { PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -12,6 +12,7 @@ import { ManagedFileVersionService } from '../managed-file-versions/service'
 import { NotebookInputRegistry } from './input-registry'
 import { createNotebookInputPreviewKey } from '../../shared/notebook'
 import { getNotebookInputRoot } from './input-staging'
+import { getNotebookDataRoot } from './repository'
 
 // Hosted Windows runners migrate a fresh database for each case under disk
 // contention. The Windows full-test workflow default is 60s; the heavier
@@ -153,6 +154,7 @@ const setup = async (): Promise<NotebookInputRegistry> => {
     ]
   })
   return new NotebookInputRegistry({
+    storageRoot,
     inputAuthority: new ImmutableInputAuthority({
       storageRoot,
       managedFileVersions: new ManagedFileVersionService({
@@ -194,7 +196,7 @@ describe('NotebookInputRegistry', () => {
       content: 'value\n1\n'
     })
 
-    await registry.registerTurn({
+    const promptInputs = await registry.registerTurn({
       projectId: 'project-1',
       appSessionId: 'active-session',
       promptMessageId: 'prompt-1',
@@ -221,6 +223,41 @@ describe('NotebookInputRegistry', () => {
         }
       ]
     })
+
+    expect(promptInputs).toEqual([
+      {
+        sourceKind: 'upload-version',
+        inputFileVersionId: 'upload-version-1',
+        filename: 'groups.csv',
+        notebookPath: 'inputs/groups-dbdc13461d5e.csv'
+      },
+      {
+        sourceKind: 'artifact-version',
+        inputFileVersionId: 'artifact-version-1',
+        filename: 'normalized.csv',
+        notebookPath: 'inputs/normalized-1a8098611195.csv'
+      }
+    ])
+    expect(promptInputs.every(({ notebookPath }) => !isAbsolute(notebookPath))).toBe(true)
+    expect(promptInputs.every(({ notebookPath }) => !notebookPath.includes('..'))).toBe(true)
+    await expect(
+      readFile(
+        join(
+          getNotebookDataRoot(storageRoot!, 'project-1', 'active-session'),
+          promptInputs[0]!.notebookPath
+        ),
+        'utf8'
+      )
+    ).resolves.toBe('group\nA\n')
+    await expect(
+      readFile(
+        join(
+          getNotebookDataRoot(storageRoot!, 'project-1', 'active-session'),
+          promptInputs[1]!.notebookPath
+        ),
+        'utf8'
+      )
+    ).resolves.toBe('value\n1\n')
 
     const inputs = registry.getTurnInputs({
       projectId: 'project-1',
@@ -284,7 +321,12 @@ describe('NotebookInputRegistry', () => {
           }
         ]
       })
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual([
+      expect.objectContaining({
+        inputFileVersionId: 'artifact-version-1',
+        notebookPath: 'inputs/normalized-1a8098611195.csv'
+      })
+    ])
 
     expect(
       registry.getTurnInputs({
@@ -298,6 +340,98 @@ describe('NotebookInputRegistry', () => {
         inputFileVersionId: 'artifact-version-1'
       })
     ])
+  })
+
+  it('keeps same-name input Versions distinct without nested or parent-relative paths', async () => {
+    const registry = await setup()
+    await createUpload({
+      projectId: 'project-1',
+      sessionId: 'source-session-1',
+      uploadFileId: 'upload-1',
+      versionId: 'upload-version-1',
+      filename: 'groups.csv',
+      content: 'group\nA\n'
+    })
+    await createUpload({
+      projectId: 'project-1',
+      sessionId: 'source-session-2',
+      uploadFileId: 'upload-2',
+      versionId: 'upload-version-2',
+      filename: 'groups.csv',
+      content: 'group\nB\n'
+    })
+
+    const promptInputs = await registry.registerTurn({
+      projectId: 'project-1',
+      appSessionId: 'active-session',
+      promptMessageId: 'prompt-1',
+      uploads: [
+        {
+          id: 'upload-1',
+          versionId: 'upload-version-1',
+          versionNumber: 1,
+          sessionId: 'source-session-1',
+          name: 'groups.csv',
+          originalName: 'groups.csv',
+          path: '/ignored-a',
+          size: 8
+        },
+        {
+          id: 'upload-2',
+          versionId: 'upload-version-2',
+          versionNumber: 1,
+          sessionId: 'source-session-2',
+          name: 'groups.csv',
+          originalName: 'groups.csv',
+          path: '/ignored-b',
+          size: 8
+        }
+      ],
+      references: []
+    })
+
+    expect(promptInputs.map(({ notebookPath }) => notebookPath)).toEqual([
+      'inputs/groups-dbdc13461d5e.csv',
+      'inputs/groups-872ae8afd45b.csv'
+    ])
+    expect(promptInputs.every(({ notebookPath }) => notebookPath.split('/').length === 2)).toBe(
+      true
+    )
+  })
+
+  it('keeps a near-limit input name portable after adding its immutable suffix', async () => {
+    const registry = await setup()
+    const filename = `${'a'.repeat(240)}.csv`
+    await createUpload({
+      projectId: 'project-1',
+      sessionId: 'source-session-1',
+      uploadFileId: 'upload-1',
+      versionId: 'upload-version-1',
+      filename,
+      content: 'group\nA\n'
+    })
+
+    const [promptInput] = await registry.registerTurn({
+      projectId: 'project-1',
+      appSessionId: 'active-session',
+      promptMessageId: 'prompt-1',
+      uploads: [
+        {
+          id: 'upload-1',
+          versionId: 'upload-version-1',
+          versionNumber: 1,
+          sessionId: 'source-session-1',
+          name: filename,
+          originalName: filename,
+          path: '/ignored',
+          size: 8
+        }
+      ],
+      references: []
+    })
+
+    expect(Buffer.byteLength(promptInput!.notebookPath.split('/').at(-1)!)).toBeLessThanOrEqual(255)
+    expect(promptInput!.notebookPath).toMatch(/^inputs\/a+-dbdc13461d5e\.csv$/)
   })
 
   it('upgrades only resolver-used Versions on an execution-scoped run lease', async () => {

--- a/src/main/notebook/input-registry.test.ts
+++ b/src/main/notebook/input-registry.test.ts
@@ -1,5 +1,15 @@
 import { createHash } from 'node:crypto'
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join } from 'node:path'
 
@@ -177,6 +187,85 @@ const setup = async (): Promise<NotebookInputRegistry> => {
 }
 
 describe('NotebookInputRegistry', () => {
+  it('rejects a replaced Notebook data-root symlink before materializing prompt inputs', async () => {
+    const registry = await setup()
+    await createUpload({
+      projectId: 'project-1',
+      sessionId: 'source-session-1',
+      uploadFileId: 'upload-1',
+      versionId: 'upload-version-1',
+      filename: 'groups.csv',
+      content: 'group\nA\n'
+    })
+    const dataRoot = getNotebookDataRoot(storageRoot!, 'project-1', 'active-session')
+    const outsideRoot = join(storageRoot!, 'outside')
+    await mkdir(dirname(dataRoot), { recursive: true })
+    await mkdir(outsideRoot)
+    await symlink(outsideRoot, dataRoot, process.platform === 'win32' ? 'junction' : 'dir')
+
+    await expect(
+      registry.registerTurn({
+        projectId: 'project-1',
+        appSessionId: 'active-session',
+        promptMessageId: 'prompt-1',
+        uploads: [
+          {
+            id: 'upload-1',
+            versionId: 'upload-version-1',
+            versionNumber: 1,
+            sessionId: 'source-session-1',
+            name: 'groups.csv',
+            originalName: 'groups.csv',
+            path: '/untrusted-renderer-path',
+            size: 8
+          }
+        ],
+        references: []
+      })
+    ).rejects.toThrow('trusted Notebook storage')
+    await expect(
+      readFile(join(outsideRoot, 'inputs', 'groups-dbdc13461d5e.csv'))
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('materializes prompt inputs without committing a refused turn registration', async () => {
+    const registry = await setup()
+    await createUpload({
+      projectId: 'project-1',
+      sessionId: 'source-session-1',
+      uploadFileId: 'upload-1',
+      versionId: 'upload-version-1',
+      filename: 'groups.csv',
+      content: 'group\nA\n'
+    })
+    const request = {
+      projectId: 'project-1',
+      appSessionId: 'active-session',
+      promptMessageId: 'prompt-1',
+      uploads: [
+        {
+          id: 'upload-1',
+          versionId: 'upload-version-1',
+          versionNumber: 1,
+          sessionId: 'source-session-1',
+          name: 'groups.csv',
+          originalName: 'groups.csv',
+          path: '/untrusted-renderer-path',
+          size: 8
+        }
+      ],
+      references: []
+    }
+
+    await expect(registry.registerTurn({ ...request, materializeOnly: true })).resolves.toEqual([
+      expect.objectContaining({ notebookPath: 'inputs/groups-dbdc13461d5e.csv' })
+    ])
+    expect(registry.getTurnInputs(request)).toEqual([])
+
+    await registry.registerTurn(request)
+    expect(registry.getTurnInputs(request)).toHaveLength(1)
+  })
+
   it('freezes exact Upload and Artifact Versions in turn order without exposing absolute paths', async () => {
     const registry = await setup()
     await createUpload({

--- a/src/main/notebook/input-registry.ts
+++ b/src/main/notebook/input-registry.ts
@@ -17,6 +17,7 @@ type RegisterNotebookTurnInputsRequest = {
   promptMessageId: string
   uploads: UploadedAttachment[]
   references: FileReference[]
+  materializeOnly?: boolean
 }
 
 type GetNotebookTurnInputsRequest = Pick<
@@ -172,7 +173,7 @@ class NotebookInputRegistry {
         })
       )
     )
-    this.turns.set(key, { fingerprint, inputs: deduplicated })
+    if (!request.materializeOnly) this.turns.set(key, { fingerprint, inputs: deduplicated })
     return promptInputs
   }
 

--- a/src/main/notebook/input-registry.ts
+++ b/src/main/notebook/input-registry.ts
@@ -1,10 +1,15 @@
 import type { FileReference } from '../../shared/artifacts'
 import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../../shared/artifacts'
-import { parseNotebookInputPreviewKey, type NotebookRunInputFile } from '../../shared/notebook'
+import {
+  parseNotebookInputPreviewKey,
+  type NotebookPromptInput,
+  type NotebookRunInputFile
+} from '../../shared/notebook'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ImmutableInputAuthority } from '../immutable-input-authority'
 import type { ImmutableInputContentLease } from '../immutable-input-authority'
 import { readBoundedManagedFilePreviewLease } from '../managed-file-preview'
+import { materializeNotebookPromptInput } from './prompt-input-materialization'
 
 type RegisterNotebookTurnInputsRequest = {
   projectId: string
@@ -45,6 +50,7 @@ type NotebookInputPreviewTarget = {
 }
 
 type NotebookInputRegistryOptions = {
+  storageRoot: string
   inputAuthority: Pick<
     ImmutableInputAuthority,
     'openContent' | 'resolveVersion' | 'stageContent' | 'validateVersion'
@@ -110,7 +116,7 @@ class NotebookInputRegistry {
 
   constructor(private readonly options: NotebookInputRegistryOptions) {}
 
-  async registerTurn(request: RegisterNotebookTurnInputsRequest): Promise<void> {
+  async registerTurn(request: RegisterNotebookTurnInputsRequest): Promise<NotebookPromptInput[]> {
     const inputs: NotebookRunInputFile[] = []
     for (const upload of request.uploads) {
       if (!upload.versionId) {
@@ -155,7 +161,19 @@ class NotebookInputRegistry {
     if (existing && existing.fingerprint !== fingerprint) {
       throw new Error('Notebook turn inputs conflict with an existing immutable registration.')
     }
+    const promptInputs = await Promise.all(
+      deduplicated.map(async (input) =>
+        materializeNotebookPromptInput({
+          storageRoot: this.options.storageRoot,
+          projectId: request.projectId,
+          appSessionId: request.appSessionId,
+          input,
+          stagedPath: await this.options.inputAuthority.stageContent(input, request.appSessionId)
+        })
+      )
+    )
     this.turns.set(key, { fingerprint, inputs: deduplicated })
+    return promptInputs
   }
 
   getTurnInputs(request: GetNotebookTurnInputsRequest): NotebookRunInputFile[] {

--- a/src/main/notebook/local-rpc-server.llm.test.ts
+++ b/src/main/notebook/local-rpc-server.llm.test.ts
@@ -111,7 +111,7 @@ describe('llmCall RPC', () => {
       transport: 'tcp',
       hostModel: hostLlm,
       inputRegistry: {
-        registerTurn: vi.fn(async () => undefined),
+        registerTurn: vi.fn(async () => []),
         getTurnInputs: vi.fn(() => []),
         clearSession: vi.fn()
       }

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -2276,7 +2276,7 @@ describe('notebook local RPC server', () => {
       token: 'secret-token',
       agentsService: { read: agentsRead },
       inputRegistry: {
-        registerTurn: vi.fn(async () => undefined),
+        registerTurn: vi.fn(async () => []),
         getTurnInputs: vi.fn(() => [
           {
             inputFileVersionId: 'upload-version-1',
@@ -3050,7 +3050,7 @@ describe('notebook local RPC server', () => {
       transport: 'tcp',
       token: 'secret-token',
       inputRegistry: {
-        registerTurn: async () => undefined,
+        registerTurn: async () => [],
         getTurnInputs: () => [registeredInput],
         openRun,
         clearSession: () => undefined
@@ -3438,7 +3438,7 @@ describe('notebook local RPC server', () => {
       transport: 'tcp',
       token: 'secret-token',
       inputRegistry: {
-        registerTurn: vi.fn().mockResolvedValue(undefined),
+        registerTurn: vi.fn().mockResolvedValue([]),
         getTurnInputs: () => [registeredInput],
         openRun: vi.fn().mockResolvedValue({
           getRunInputFiles: () => [registeredInput],

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -1353,9 +1353,11 @@ class NotebookLocalRpcServer {
     this.consumedExecutionToolCalls.delete(sessionId)
   }
 
-  async registerNotebookTurnInputs(request: RegisterNotebookTurnInputsRequest): Promise<void> {
-    if (!this.inputRegistry) return
-    await this.inputRegistry.registerTurn(request)
+  async registerNotebookTurnInputs(
+    request: RegisterNotebookTurnInputsRequest
+  ): ReturnType<NotebookInputRegistry['registerTurn']> {
+    if (!this.inputRegistry) return []
+    return this.inputRegistry.registerTurn(request)
   }
 
   private acquireArtifactRpcRequest(

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -241,10 +241,12 @@ describe('notebook MCP server config', () => {
     // write_artifact_file now resolves a relative name against the notebook data dir, so the guidance
     // must steer the model to the saved relative filename — not to a rebuilt absolute path. Guard the
     // old "use an ABSOLUTE path" / "will not resolve a bare relative name" wording from regressing.
-    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('the SAME relative filename you saved with')
+    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('Reuse saved relative filename and runId')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain(
-      'producerRunId` set to the exact `runId` returned by the execution'
+      '`write_artifact_file({ "filename": "plot.png", "source": { "kind": "localPath", "path": "plot.png" }, "producerRunId": "<runId>" })`'
     )
+    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toMatch(/validation errors.*correct once/i)
+    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toMatch(/never repeat.*identical.*failed arguments/i)
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain('use an ABSOLUTE path')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain('will not resolve a bare relative name')
   })

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -49,7 +49,7 @@ const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
   'Retry once at most; repeated kernel-process failures mean stop Notebook tools and report the failure.',
   'After OPEN_SCIENCE_NETWORK_DOMAIN_BLOCKED, call `request_network_access` with the exact hostname, runtime, reason, and failed bash command when applicable. Never call speculatively; retry only after an allowed result.',
   'Dependency status is not an execution verdict: `clear` means unchanged; `stale` means a tracked dependency changed after that run; `unknown` means incomplete tracking. `stale` does not mean the run failed or its captured output is incorrect; rerun only for current state.',
-  'For final files, call `write_artifact_file` from `open-science-artifacts` first with `source: { "kind": "localPath", "path": "plot.png" }`, the SAME relative filename you saved with, and `producerRunId` set to the exact `runId` returned by the execution. Inline only small text.',
+  'Call `write_artifact_file({ "filename": "plot.png", "source": { "kind": "localPath", "path": "plot.png" }, "producerRunId": "<runId>" })` from `open-science-artifacts`. Reuse saved relative filename and runId; inline small text. On validation errors, correct once; never repeat identical failed arguments.',
   '</open_science_notebook_instructions>'
 ].join('\n')
 

--- a/src/main/notebook/prompt-input-materialization.ts
+++ b/src/main/notebook/prompt-input-materialization.ts
@@ -71,11 +71,7 @@ const materializeNotebookPromptInput = async (request: {
   input: NotebookRunInputFile
   stagedPath: string
 }): Promise<NotebookPromptInput> => {
-  const dataRoot = getNotebookDataRoot(
-    request.storageRoot,
-    request.projectId,
-    request.appSessionId
-  )
+  const dataRoot = getNotebookDataRoot(request.storageRoot, request.projectId, request.appSessionId)
   const inputsRoot = await ensureInputDirectory(dataRoot)
   const candidates = [
     inputFilename(request.input.filename, request.input.checksum),

--- a/src/main/notebook/prompt-input-materialization.ts
+++ b/src/main/notebook/prompt-input-materialization.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto'
+import { constants, createReadStream } from 'node:fs'
+import { chmod, copyFile, lstat, mkdir, realpath, rm } from 'node:fs/promises'
+import { basename, extname, isAbsolute, join, posix, relative } from 'node:path'
+
+import type { NotebookPromptInput, NotebookRunInputFile } from '../../shared/notebook'
+import { toSafeUploadFilename } from '../uploads/storage-helpers'
+import { getNotebookDataRoot } from './repository'
+
+const INPUTS_DIR = 'inputs'
+const MAX_FILENAME_BYTES = 255
+
+const sha256File = async (path: string): Promise<string> => {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+const isFileExistsError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as NodeJS.ErrnoException).code === 'EEXIST'
+
+const inputFilename = (filename: string, checksum: string, fullChecksum = false): string => {
+  const safeName = toSafeUploadFilename(filename)
+  const extension = extname(safeName)
+  const stem = basename(safeName, extension)
+  const suffix = `-${checksum.slice(0, fullChecksum ? checksum.length : 12)}`
+  const maxStemBytes = MAX_FILENAME_BYTES - Buffer.byteLength(extension) - suffix.length
+  return `${stem.slice(0, maxStemBytes)}${suffix}${extension}`
+}
+
+const ensureInputDirectory = async (dataRoot: string): Promise<string> => {
+  const inputsRoot = join(dataRoot, INPUTS_DIR)
+  await mkdir(inputsRoot, { recursive: true, mode: 0o700 })
+  const state = await lstat(inputsRoot)
+  if (!state.isDirectory() || state.isSymbolicLink()) {
+    throw new Error('Notebook input path is not a trusted directory.')
+  }
+  const [resolvedDataRoot, resolvedInputsRoot] = await Promise.all([
+    realpath(dataRoot),
+    realpath(inputsRoot)
+  ])
+  const relativePath = relative(resolvedDataRoot, resolvedInputsRoot)
+  if (
+    !relativePath ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error('Notebook input directory escapes the current Notebook data root.')
+  }
+  return resolvedInputsRoot
+}
+
+const matchesInput = async (path: string, input: NotebookRunInputFile): Promise<boolean> => {
+  const state = await lstat(path)
+  return (
+    state.isFile() &&
+    !state.isSymbolicLink() &&
+    state.size === input.sizeBytes &&
+    (await sha256File(path)) === input.checksum
+  )
+}
+
+const materializeNotebookPromptInput = async (request: {
+  storageRoot: string
+  projectId: string
+  appSessionId: string
+  input: NotebookRunInputFile
+  stagedPath: string
+}): Promise<NotebookPromptInput> => {
+  const dataRoot = getNotebookDataRoot(
+    request.storageRoot,
+    request.projectId,
+    request.appSessionId
+  )
+  const inputsRoot = await ensureInputDirectory(dataRoot)
+  const candidates = [
+    inputFilename(request.input.filename, request.input.checksum),
+    inputFilename(request.input.filename, request.input.checksum, true)
+  ]
+
+  for (const candidate of candidates) {
+    const destination = join(inputsRoot, candidate)
+    try {
+      await copyFile(request.stagedPath, destination, constants.COPYFILE_EXCL)
+      try {
+        await chmod(destination, 0o444)
+      } catch (error) {
+        await rm(destination, { force: true })
+        throw error
+      }
+      return {
+        sourceKind: request.input.sourceKind,
+        inputFileVersionId: request.input.inputFileVersionId,
+        filename: request.input.filename,
+        notebookPath: posix.join(INPUTS_DIR, candidate)
+      }
+    } catch (error) {
+      if (!isFileExistsError(error)) throw error
+      if (await matchesInput(destination, request.input)) {
+        await chmod(destination, 0o444)
+        return {
+          sourceKind: request.input.sourceKind,
+          inputFileVersionId: request.input.inputFileVersionId,
+          filename: request.input.filename,
+          notebookPath: posix.join(INPUTS_DIR, candidate)
+        }
+      }
+    }
+  }
+
+  throw new Error(`Notebook input path conflicts with another file: ${request.input.filename}`)
+}
+
+export { materializeNotebookPromptInput }

--- a/src/main/notebook/prompt-input-materialization.ts
+++ b/src/main/notebook/prompt-input-materialization.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { constants, createReadStream } from 'node:fs'
 import { chmod, copyFile, lstat, mkdir, realpath, rm } from 'node:fs/promises'
-import { basename, extname, isAbsolute, join, posix, relative, sep } from 'node:path'
+import { basename, extname, isAbsolute, join, posix, relative, resolve, sep } from 'node:path'
 
 import type { NotebookPromptInput, NotebookRunInputFile } from '../../shared/notebook'
 import { toSafeUploadFilename } from '../uploads/storage-helpers'
@@ -31,27 +31,41 @@ const inputFilename = (filename: string, checksum: string, fullChecksum = false)
   return `${stem.slice(0, maxStemBytes)}${suffix}${extension}`
 }
 
-const ensureInputDirectory = async (dataRoot: string): Promise<string> => {
-  const inputsRoot = join(dataRoot, INPUTS_DIR)
-  await mkdir(inputsRoot, { recursive: true, mode: 0o700 })
-  const state = await lstat(inputsRoot)
-  if (!state.isDirectory() || state.isSymbolicLink()) {
-    throw new Error('Notebook input path is not a trusted directory.')
-  }
-  const [resolvedDataRoot, resolvedInputsRoot] = await Promise.all([
-    realpath(dataRoot),
-    realpath(inputsRoot)
-  ])
-  const relativePath = relative(resolvedDataRoot, resolvedInputsRoot)
+const ensureInputDirectory = async (
+  storageRoot: string,
+  projectId: string,
+  appSessionId: string
+): Promise<string> => {
+  const dataRoot = getNotebookDataRoot(storageRoot, projectId, appSessionId)
+  const relativeDataRoot = relative(resolve(storageRoot), resolve(dataRoot))
   if (
-    !relativePath ||
-    relativePath === '..' ||
-    relativePath.startsWith(`..${sep}`) ||
-    isAbsolute(relativePath)
+    !relativeDataRoot ||
+    relativeDataRoot === '..' ||
+    relativeDataRoot.startsWith(`..${sep}`) ||
+    isAbsolute(relativeDataRoot)
   ) {
-    throw new Error('Notebook input directory escapes the current Notebook data root.')
+    throw new Error('Notebook input path is outside trusted Notebook storage.')
   }
-  return resolvedInputsRoot
+
+  let current = await realpath(storageRoot)
+  for (const segment of [...relativeDataRoot.split(sep), INPUTS_DIR]) {
+    const candidate = join(current, segment)
+    try {
+      await mkdir(candidate, { mode: 0o700 })
+    } catch (error) {
+      if (!isFileExistsError(error)) throw error
+    }
+    const state = await lstat(candidate)
+    if (!state.isDirectory() || state.isSymbolicLink()) {
+      throw new Error('Notebook input path is not trusted Notebook storage.')
+    }
+    const resolvedCandidate = await realpath(candidate)
+    if (relative(current, resolvedCandidate) !== segment) {
+      throw new Error('Notebook input path is outside trusted Notebook storage.')
+    }
+    current = resolvedCandidate
+  }
+  return current
 }
 
 const matchesInput = async (path: string, input: NotebookRunInputFile): Promise<boolean> => {
@@ -71,14 +85,25 @@ const materializeNotebookPromptInput = async (request: {
   input: NotebookRunInputFile
   stagedPath: string
 }): Promise<NotebookPromptInput> => {
-  const dataRoot = getNotebookDataRoot(request.storageRoot, request.projectId, request.appSessionId)
-  const inputsRoot = await ensureInputDirectory(dataRoot)
+  const inputsRoot = await ensureInputDirectory(
+    request.storageRoot,
+    request.projectId,
+    request.appSessionId
+  )
   const candidates = [
     inputFilename(request.input.filename, request.input.checksum),
     inputFilename(request.input.filename, request.input.checksum, true)
   ]
 
   for (const candidate of candidates) {
+    const verifiedInputsRoot = await ensureInputDirectory(
+      request.storageRoot,
+      request.projectId,
+      request.appSessionId
+    )
+    if (verifiedInputsRoot !== inputsRoot) {
+      throw new Error('Notebook input path changed outside trusted Notebook storage.')
+    }
     const destination = join(inputsRoot, candidate)
     try {
       await copyFile(request.stagedPath, destination, constants.COPYFILE_EXCL)

--- a/src/main/notebook/prompt-input-materialization.ts
+++ b/src/main/notebook/prompt-input-materialization.ts
@@ -1,11 +1,21 @@
 import { createHash } from 'node:crypto'
 import { constants, createReadStream } from 'node:fs'
-import { chmod, copyFile, lstat, mkdir, realpath, rm } from 'node:fs/promises'
-import { basename, extname, isAbsolute, join, posix, relative, resolve, sep } from 'node:path'
+import { chmod, copyFile, lstat, mkdir, readdir, realpath, rm } from 'node:fs/promises'
+import {
+  basename,
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  posix,
+  relative,
+  resolve,
+  sep
+} from 'node:path'
 
 import type { NotebookPromptInput, NotebookRunInputFile } from '../../shared/notebook'
 import { toSafeUploadFilename } from '../uploads/storage-helpers'
-import { getNotebookDataRoot } from './repository'
+import { getNotebookDataRoot, getNotebookSessionRoot } from './repository'
 
 const INPUTS_DIR = 'inputs'
 const MAX_FILENAME_BYTES = 255
@@ -22,6 +32,12 @@ const isFileExistsError = (error: unknown): boolean =>
   'code' in error &&
   (error as NodeJS.ErrnoException).code === 'EEXIST'
 
+const isMissingFileError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as NodeJS.ErrnoException).code === 'ENOENT'
+
 const inputFilename = (filename: string, checksum: string, fullChecksum = false): string => {
   const safeName = toSafeUploadFilename(filename)
   const extension = extname(safeName)
@@ -31,41 +47,109 @@ const inputFilename = (filename: string, checksum: string, fullChecksum = false)
   return `${stem.slice(0, maxStemBytes)}${suffix}${extension}`
 }
 
-const ensureInputDirectory = async (
+const resolveTrustedDirectory = async (
   storageRoot: string,
-  projectId: string,
-  appSessionId: string
-): Promise<string> => {
-  const dataRoot = getNotebookDataRoot(storageRoot, projectId, appSessionId)
-  const relativeDataRoot = relative(resolve(storageRoot), resolve(dataRoot))
+  target: string,
+  create: boolean
+): Promise<string | undefined> => {
+  const relativeTarget = relative(resolve(storageRoot), resolve(target))
   if (
-    !relativeDataRoot ||
-    relativeDataRoot === '..' ||
-    relativeDataRoot.startsWith(`..${sep}`) ||
-    isAbsolute(relativeDataRoot)
+    !relativeTarget ||
+    relativeTarget === '..' ||
+    relativeTarget.startsWith(`..${sep}`) ||
+    isAbsolute(relativeTarget)
   ) {
     throw new Error('Notebook input path is outside trusted Notebook storage.')
   }
 
-  let current = await realpath(storageRoot)
-  for (const segment of [...relativeDataRoot.split(sep), INPUTS_DIR]) {
+  let current: string
+  try {
+    current = await realpath(storageRoot)
+  } catch (error) {
+    if (!create && isMissingFileError(error)) return undefined
+    throw error
+  }
+  for (const segment of relativeTarget.split(sep)) {
     const candidate = join(current, segment)
-    try {
-      await mkdir(candidate, { mode: 0o700 })
-    } catch (error) {
-      if (!isFileExistsError(error)) throw error
+    if (create) {
+      try {
+        await mkdir(candidate, { mode: 0o700 })
+      } catch (error) {
+        if (!isFileExistsError(error)) throw error
+      }
     }
-    const state = await lstat(candidate)
+    let state
+    try {
+      state = await lstat(candidate)
+    } catch (error) {
+      if (!create && isMissingFileError(error)) return undefined
+      throw error
+    }
     if (!state.isDirectory() || state.isSymbolicLink()) {
+      if (!create) return undefined
       throw new Error('Notebook input path is not trusted Notebook storage.')
     }
     const resolvedCandidate = await realpath(candidate)
     if (relative(current, resolvedCandidate) !== segment) {
+      if (!create) return undefined
       throw new Error('Notebook input path is outside trusted Notebook storage.')
     }
     current = resolvedCandidate
   }
   return current
+}
+
+const ensureInputDirectory = async (
+  storageRoot: string,
+  projectId: string,
+  appSessionId: string
+): Promise<string> => {
+  const inputRoot = await resolveTrustedDirectory(
+    storageRoot,
+    join(getNotebookDataRoot(storageRoot, projectId, appSessionId), INPUTS_DIR),
+    true
+  )
+  if (!inputRoot) throw new Error('Notebook input path is not trusted Notebook storage.')
+  return inputRoot
+}
+
+const deleteNotebookPromptInputDirectory = async (
+  storageRoot: string,
+  sessionRoot: string
+): Promise<void> => {
+  const inputRoot = await resolveTrustedDirectory(
+    storageRoot,
+    join(sessionRoot, 'data', INPUTS_DIR),
+    false
+  )
+  if (inputRoot) await rm(inputRoot, { recursive: true, force: true })
+}
+
+const deleteNotebookSessionPromptInputs = (
+  storageRoot: string,
+  projectId: string,
+  appSessionId: string
+): Promise<void> =>
+  deleteNotebookPromptInputDirectory(
+    storageRoot,
+    getNotebookSessionRoot(storageRoot, projectId, appSessionId)
+  )
+
+const deleteNotebookProjectPromptInputs = async (
+  storageRoot: string,
+  projectId: string
+): Promise<void> => {
+  const projectPath = dirname(getNotebookSessionRoot(storageRoot, projectId, 'session'))
+  const projectRoot = await resolveTrustedDirectory(storageRoot, projectPath, false)
+  if (!projectRoot) return
+  const sessions = await readdir(projectRoot, { withFileTypes: true })
+  await Promise.all(
+    sessions
+      .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
+      .map((entry) =>
+        deleteNotebookPromptInputDirectory(storageRoot, join(projectPath, entry.name))
+      )
+  )
 }
 
 const matchesInput = async (path: string, input: NotebookRunInputFile): Promise<boolean> => {
@@ -136,4 +220,8 @@ const materializeNotebookPromptInput = async (request: {
   throw new Error(`Notebook input path conflicts with another file: ${request.input.filename}`)
 }
 
-export { materializeNotebookPromptInput }
+export {
+  deleteNotebookProjectPromptInputs,
+  deleteNotebookSessionPromptInputs,
+  materializeNotebookPromptInput
+}

--- a/src/main/notebook/prompt-input-materialization.ts
+++ b/src/main/notebook/prompt-input-materialization.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { constants, createReadStream } from 'node:fs'
 import { chmod, copyFile, lstat, mkdir, realpath, rm } from 'node:fs/promises'
-import { basename, extname, isAbsolute, join, posix, relative } from 'node:path'
+import { basename, extname, isAbsolute, join, posix, relative, sep } from 'node:path'
 
 import type { NotebookPromptInput, NotebookRunInputFile } from '../../shared/notebook'
 import { toSafeUploadFilename } from '../uploads/storage-helpers'
@@ -46,7 +46,7 @@ const ensureInputDirectory = async (dataRoot: string): Promise<string> => {
   if (
     !relativePath ||
     relativePath === '..' ||
-    relativePath.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) ||
+    relativePath.startsWith(`..${sep}`) ||
     isAbsolute(relativePath)
   ) {
     throw new Error('Notebook input directory escapes the current Notebook data root.')

--- a/src/main/notebook/python-loop.integration.test.ts
+++ b/src/main/notebook/python-loop.integration.test.ts
@@ -3,7 +3,15 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { createInterface } from 'node:readline'
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { mkdtempSync, readFileSync, existsSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  existsSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { framePythonNamespaceRequest } from './kernel-protocol'
 
@@ -265,6 +273,34 @@ gate('python_loop.py', () => {
       child.kill()
       rmSync(runtimeRoot, { recursive: true, force: true })
       rmSync(workspace, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  it('allows libraries to create workload caches without opening the managed runtime', async () => {
+    const runtimeRoot = mkdtempSync(join(tmpdir(), 'os-python-runtime-cache-'))
+    const cacheRoot = join(runtimeRoot, 'cache', 'notebook')
+    const matplotlibCache = join(cacheRoot, 'matplotlib')
+    mkdirSync(cacheRoot, { recursive: true })
+    const { child, send } = startLoop(pyBin as string, {
+      OPEN_SCIENCE_RUNTIME_DIR: runtimeRoot,
+      OPEN_SCIENCE_NOTEBOOK_CACHE_DIR: cacheRoot,
+      MPLCONFIGDIR: matplotlibCache,
+      MPLBACKEND: 'Agg'
+    })
+    try {
+      const imported = await send('import matplotlib; print(matplotlib.get_configdir())')
+
+      expect(imported.error).toBeNull()
+      expect(imported.stderr).not.toContain('Package/environment mutation is not allowed')
+      expect(imported.stdout.trim()).toBe(realpathSync.native(matplotlibCache))
+
+      const blocked = await send(
+        `import os; os.makedirs(${JSON.stringify(join(runtimeRoot, 'blocked'))})`
+      )
+      expect(blocked.error).toMatch(/manage_packages/)
+    } finally {
+      child.kill()
+      rmSync(runtimeRoot, { recursive: true, force: true })
     }
   }, 60_000)
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -18,7 +18,7 @@ import {
 } from './runtime-service'
 import { effectiveMirrorAsync, resetAutoMirrorCache } from './mirror-probe'
 import { getNotebookInputRoot } from './input-staging'
-import { NotebookRunRepository, getRuntimeRoot } from './repository'
+import { getNotebookDataRoot, NotebookRunRepository, getRuntimeRoot } from './repository'
 import { createRootNotebookLane } from './lane-identity'
 import {
   RuntimeOperationJournal,
@@ -209,6 +209,49 @@ const lifecycleCallbackHarness = (
 }
 
 describe('notebook runtime service', () => {
+  it('deletes generated prompt input copies with their Session and Project input caches', async () => {
+    const root = await createStorageRoot()
+    const { service } = lifecycleCallbackHarness(root)
+    const sessionAData = getNotebookDataRoot(root, 'project-a', 'session-a')
+    const sessionBData = getNotebookDataRoot(root, 'project-a', 'session-b')
+    const otherProjectData = getNotebookDataRoot(root, 'project-b', 'session-a')
+    const sessionAPromptInput = join(sessionAData, 'inputs', 'groups-a.csv')
+    const sessionBPromptInput = join(sessionBData, 'inputs', 'groups-b.csv')
+    const otherProjectPromptInput = join(otherProjectData, 'inputs', 'groups-other.csv')
+    const sessionAWorkingFile = join(sessionAData, 'analysis.csv')
+    const sessionBWorkingFile = join(sessionBData, 'analysis.csv')
+    const sessionAStagedInput = join(getNotebookInputRoot(root, 'project-a', 'session-a'), 'staged')
+    const sessionBStagedInput = join(getNotebookInputRoot(root, 'project-a', 'session-b'), 'staged')
+
+    await Promise.all(
+      [
+        sessionAPromptInput,
+        sessionBPromptInput,
+        otherProjectPromptInput,
+        sessionAWorkingFile,
+        sessionBWorkingFile,
+        sessionAStagedInput,
+        sessionBStagedInput
+      ].map(async (path) => {
+        await mkdir(dirname(path), { recursive: true })
+        await writeFile(path, path)
+      })
+    )
+
+    await service.deleteSessionInputs('project-a', 'session-a')
+    await expect(readFile(sessionAPromptInput)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(sessionAStagedInput)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(sessionAWorkingFile, 'utf8')).resolves.toBe(sessionAWorkingFile)
+    await expect(readFile(sessionBPromptInput, 'utf8')).resolves.toBe(sessionBPromptInput)
+    await expect(readFile(otherProjectPromptInput, 'utf8')).resolves.toBe(otherProjectPromptInput)
+
+    await service.deleteProjectInputs('project-a')
+    await expect(readFile(sessionBPromptInput)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(sessionBStagedInput)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(sessionBWorkingFile, 'utf8')).resolves.toBe(sessionBWorkingFile)
+    await expect(readFile(otherProjectPromptInput, 'utf8')).resolves.toBe(otherProjectPromptInput)
+  })
+
   it('returns only live-epoch namespace snapshots and does not create a session to inspect', async () => {
     const root = await createStorageRoot()
     const inspectNamespace = vi.fn(async () => ({

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -134,6 +134,10 @@ import {
 } from './content-limits'
 import { NotebookHelperModuleHost, type NotebookHelperModuleCatalog } from './helper-module-host'
 import { deleteNotebookProjectInputs, deleteNotebookSessionInputs } from './input-staging'
+import {
+  deleteNotebookProjectPromptInputs,
+  deleteNotebookSessionPromptInputs
+} from './prompt-input-materialization'
 
 // The default stays outside CN mirror routing when no explicit locale is injected.
 const DEFAULT_LOCALE = 'en-US'
@@ -1239,11 +1243,17 @@ class NotebookRuntimeService {
   }
 
   async deleteSessionInputs(projectId: string, sessionId: string): Promise<void> {
-    await deleteNotebookSessionInputs(this.options.dataRoot, projectId, sessionId)
+    await Promise.all([
+      deleteNotebookSessionInputs(this.options.dataRoot, projectId, sessionId),
+      deleteNotebookSessionPromptInputs(this.options.dataRoot, projectId, sessionId)
+    ])
   }
 
   async deleteProjectInputs(projectId: string): Promise<void> {
-    await deleteNotebookProjectInputs(this.options.dataRoot, projectId)
+    await Promise.all([
+      deleteNotebookProjectInputs(this.options.dataRoot, projectId),
+      deleteNotebookProjectPromptInputs(this.options.dataRoot, projectId)
+    ])
   }
 
   beginProjectDeletion(projectId: string): void {

--- a/src/main/projects/project-owned-data.catalog.architecture.test.ts
+++ b/src/main/projects/project-owned-data.catalog.architecture.test.ts
@@ -269,6 +269,19 @@ describe('Project-owned data catalog architecture', () => {
     ).toEqual(['execution-file-evidence/<projectId>/', 'notebook-file-evidence/<projectId>/'])
   })
 
+  it('catalogs generated Notebook prompt input copies for Project cleanup', () => {
+    expect(
+      PROJECT_OWNED_DATA_CATALOG.find((entry) => entry.id === 'notebook-input-cache')
+    ).toMatchObject({
+      resources: ['notebook-inputs/<projectId>/', 'notebooks/<projectId>/<sessionId>/data/inputs/'],
+      policy: {
+        kind: 'coordinator-cleanup',
+        effect: 'hard-delete',
+        operation: 'NotebookRuntimeService.deleteProjectInputs'
+      }
+    })
+  })
+
   it('catalogs retained managed Session workspaces as Project-owned data', () => {
     expect(
       PROJECT_OWNED_DATA_CATALOG.find((entry) => entry.id === 'managed-session-workspaces')

--- a/src/main/projects/project-owned-data.catalog.ts
+++ b/src/main/projects/project-owned-data.catalog.ts
@@ -592,13 +592,13 @@ const PROJECT_OWNED_DATA_CATALOG: readonly ProjectOwnedDataCatalogEntry[] = [
   {
     id: 'notebook-input-cache',
     medium: 'filesystem',
-    resources: ['notebook-inputs/<projectId>/'],
+    resources: ['notebook-inputs/<projectId>/', 'notebooks/<projectId>/<sessionId>/data/inputs/'],
     policy: {
       kind: 'coordinator-cleanup',
       effect: 'hard-delete',
       path: 'notebook-input-cache-tail',
       operation: 'NotebookRuntimeService.deleteProjectInputs',
-      note: 'The durable Project deletion intent removes derived, read-only Notebook input copies after runtime quiescence.'
+      note: 'The durable Project deletion intent removes derived, read-only Notebook input copies, including their relative-path projection inside the otherwise retained workspace, after runtime quiescence.'
     }
   },
   {

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -292,6 +292,15 @@ export type NotebookRunInputFile = {
 
 export type NotebookInputFileSummary = Omit<NotebookRunInputFile, 'storageKey'>
 
+// Transient model-facing projection of one exact Notebook input Version. The relative path is
+// materialized under the current Notebook data directory and is never persisted in run history.
+export type NotebookPromptInput = Pick<
+  NotebookRunInputFile,
+  'sourceKind' | 'inputFileVersionId' | 'filename'
+> & {
+  notebookPath: string
+}
+
 export type NotebookInputPreviewIdentity = {
   projectId: string
   sourceKind: NotebookRunInputFile['sourceKind']


### PR DESCRIPTION
## Problem

A real “draw a pie chart” turn exposed four related failures:

1. The Agent first copied an uploaded CSV to `/tmp`, which Notebook shell correctly rejected, because the prompt exposed only an absolute turn snapshot and no usable Notebook-relative input path.
2. Matplotlib could not create its configured workload cache. The native sandbox allowed `<runtime>/cache/notebook`, but the Python audit hook rejected every runtime write, so Matplotlib fell back to a random temporary cache and prompted the Agent to try another forbidden directory.
3. Seven consecutive `write_artifact_file` calls used the identical empty `{}` arguments. The MCP parser returned the missing required `filename` error every time, but the model-facing guidance did not show one complete invocation or forbid repeating identical validation failures.
4. Generated Notebook cells could embed app-internal absolute upload snapshot paths, which are machine-specific and disappear when the prepared turn closes.

## Proposed change

- Allow Python libraries to write only inside the canonical `OPEN_SCIENCE_NOTEBOOK_CACHE_DIR`, while retaining the runtime mutation block everywhere else.
- Materialize exact registered Upload/Artifact Versions under the Notebook Session data directory as stable paths such as `inputs/groups-dbdc13461d5e.csv`.
- Return those paths from the Notebook input owner and append a transient `notebookPath` projection to the provider prompt before dispatch.
- Keep names one directory deep, content-addressed, collision-safe, portable within the 255-byte filename limit, and free of absolute or parent-relative components.
- Replace the Artifact guidance fragment with one complete `write_artifact_file` invocation containing `filename`, `source`, and `producerRunId`, plus a rule not to repeat identical failed arguments.
- Add an Artifact schema contract proving that `{}` is rejected specifically because `filename` is required.

## Scope and non-goals

- No database schema or persisted model changes.
- No new enum or retry state.
- No `/tmp` or home-directory permission expansion.
- No automatic Artifact filename inference or Artifact retry state machine.
- No migration or rewrite of historical Notebook cells that already contain absolute snapshot paths.
- Existing absolute attachment snapshots remain available for provider attachment transport; new Notebook code is directed to the materialized relative path.

Persistence impact: exact input copies now persist under the existing app-managed Notebook Session root at `data/inputs/`. They inherit the existing Notebook Session/Project deletion lifecycle and add no independent ownership record. Reattaching identical content reuses the verified file; same-name different content receives a different checksum suffix.

## Acceptance criteria and validation

All listed checks ran against the final material implementation:

| Behavior | Framework/path | Command | Result |
| --- | --- | --- | --- |
| Matplotlib uses the configured workload cache while other runtime writes remain blocked | real `python_loop.py` | targeted 11-file Vitest command with `RUN_KERNEL=1` | 283 passed |
| Exact Upload/Artifact Versions become stable relative Notebook inputs | input registry + ACP prompt preparation | same targeted 11-file Vitest command | passed |
| Relative input remains readable after the turn snapshot is deleted | native Notebook sandbox | targeted platform-capability Vitest command | passed |
| Artifact prompt contains complete required arguments and stays inside the static context budget | Notebook MCP + Artifact MCP schema | targeted 11-file Vitest command | passed |
| Shared ACP behavior remains compatible | `claude-code`, `opencode`, `codex-response`, `codex-bridge` representative contract tests | two targeted Vitest commands | passed |
| Local RPC return projection and Notebook execution consumers | local RPC server suites | targeted platform-capability Vitest command | passed |
| Node and Notebook sandbox types | `npm run typecheck:node` | typecheck | passed |
| Changed TypeScript files | targeted ESLint over `origin/main...HEAD` | lint | passed with no warnings |

Test totals:

- Portable/module-focused set: 283 passed across 11 files.
- Platform-capability set (`ps`, loopback RPC, native Notebook sandbox): 124 passed across 4 files.
- `git diff --check`: passed.

`npm run test:affected:explain -- --base origin/main --head HEAD` conservatively selected the full fallback because `resources/notebook/python_loop.py` is not owned by the module-impact manifest. Per the requested local test scope, the complete `npm test` suite was not run; the real Python loop integration test directly covers that unknown resource, and PR CI remains the authority for the complete portable and platform suites.

Platform coverage: local macOS native sandbox passed. Path assertions use portable relative paths and run in the portable input-registry suite; Windows/Linux native sandbox and packaging behavior remain CI-covered risks.

## Review focus

- The canonical cache exemption must not permit writes elsewhere in the managed runtime.
- `NotebookInputRegistry` remains the sole owner of exact Version registration and model-facing materialization.
- `data/inputs` creation must reject symlinked directories, never overwrite mismatched content, and remain within the Notebook data root.
- The prompt projection must occur before provider dispatch without adding provider-specific branches.
- Artifact recovery remains guidance-only; the business layer must not guess which generated file to save.
