### PR TITLE
feat(message-scroll): ship header-probed image dimensions with preview resources

### DIFF
--- a/src/main/image-header-dimensions.test.ts
+++ b/src/main/image-header-dimensions.test.ts
@@ -1,0 +1,148 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { parseImageHeaderDimensions, readImageHeaderDimensions } from './image-header-dimensions'
+
+const pngBuffer = (width: number, height: number): Buffer => {
+  const buffer = Buffer.alloc(33)
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buffer, 0)
+  buffer.writeUInt32BE(13, 8)
+  buffer.write('IHDR', 12, 'ascii')
+  buffer.writeUInt32BE(width, 16)
+  buffer.writeUInt32BE(height, 20)
+  return buffer
+}
+
+const jpegBuffer = (width: number, height: number): Buffer => {
+  const app0Payload = Buffer.alloc(14)
+  const sof = Buffer.alloc(11)
+  sof.writeUInt16BE(11, 0) // segment length includes its own two bytes
+  sof[2] = 8 // sample precision
+  sof.writeUInt16BE(height, 3)
+  sof.writeUInt16BE(width, 5)
+  sof[7] = 1 // component count
+  return Buffer.concat([
+    Buffer.from([0xff, 0xd8]),
+    Buffer.from([0xff, 0xe0]),
+    Buffer.from([0x00, 0x10]),
+    app0Payload,
+    Buffer.from([0xff, 0xc0]),
+    sof
+  ])
+}
+
+const gifBuffer = (width: number, height: number): Buffer => {
+  const buffer = Buffer.alloc(13)
+  buffer.write('GIF89a', 0, 'ascii')
+  buffer.writeUInt16LE(width, 6)
+  buffer.writeUInt16LE(height, 8)
+  return buffer
+}
+
+const webpBuffer = (width: number, height: number, variant: 'VP8 ' | 'VP8L' | 'VP8X'): Buffer => {
+  const buffer = Buffer.alloc(30)
+  buffer.write('RIFF', 0, 'ascii')
+  buffer.writeUInt32LE(22, 4)
+  buffer.write('WEBP', 8, 'ascii')
+  buffer.write(variant, 12, 'ascii')
+  if (variant === 'VP8X') {
+    buffer.writeUIntLE(width - 1, 24, 3)
+    buffer.writeUIntLE(height - 1, 27, 3)
+  } else if (variant === 'VP8L') {
+    buffer[20] = 0x2f
+    buffer.writeUInt32LE(((height - 1) << 14) | (width - 1), 21)
+  } else {
+    buffer[23] = 0x9d
+    buffer[24] = 0x01
+    buffer[25] = 0x2a
+    buffer.writeUInt16LE(width, 26)
+    buffer.writeUInt16LE(height, 28)
+  }
+  return buffer
+}
+
+const bmpBuffer = (width: number, height: number): Buffer => {
+  const buffer = Buffer.alloc(26)
+  buffer.write('BM', 0, 'ascii')
+  buffer.writeInt32LE(width, 18)
+  buffer.writeInt32LE(height, 22)
+  return buffer
+}
+
+describe('parseImageHeaderDimensions', () => {
+  it('parses PNG IHDR dimensions', () => {
+    expect(parseImageHeaderDimensions(pngBuffer(1920, 1080))).toEqual({ width: 1920, height: 1080 })
+  })
+
+  it('parses JPEG dimensions by scanning past APP segments to the SOF marker', () => {
+    expect(parseImageHeaderDimensions(jpegBuffer(640, 400))).toEqual({ width: 640, height: 400 })
+  })
+
+  it('parses GIF logical screen dimensions', () => {
+    expect(parseImageHeaderDimensions(gifBuffer(320, 200))).toEqual({ width: 320, height: 200 })
+  })
+
+  it.each(['VP8 ', 'VP8L', 'VP8X'] as const)('parses WebP %s dimensions', (variant) => {
+    expect(parseImageHeaderDimensions(webpBuffer(800, 600, variant))).toEqual({
+      width: 800,
+      height: 600
+    })
+  })
+
+  it('parses BMP dimensions, including top-down bitmaps with negative height', () => {
+    expect(parseImageHeaderDimensions(bmpBuffer(1024, 768))).toEqual({ width: 1024, height: 768 })
+    expect(parseImageHeaderDimensions(bmpBuffer(1024, -768))).toEqual({ width: 1024, height: 768 })
+  })
+
+  it('returns undefined for truncated headers', () => {
+    expect(parseImageHeaderDimensions(pngBuffer(10, 10).subarray(0, 12))).toBeUndefined()
+    expect(parseImageHeaderDimensions(jpegBuffer(10, 10).subarray(0, 8))).toBeUndefined()
+    expect(parseImageHeaderDimensions(gifBuffer(10, 10).subarray(0, 6))).toBeUndefined()
+    expect(parseImageHeaderDimensions(webpBuffer(10, 10, 'VP8X').subarray(0, 22))).toBeUndefined()
+  })
+
+  it('returns undefined for forged headers', () => {
+    const forgedPng = pngBuffer(10, 10)
+    forgedPng.write('XXXX', 12, 'ascii') // not an IHDR chunk
+    expect(parseImageHeaderDimensions(forgedPng)).toBeUndefined()
+
+    const forgedWebp = webpBuffer(10, 10, 'VP8 ')
+    forgedWebp[23] = 0x00 // broken lossy sync code
+    expect(parseImageHeaderDimensions(forgedWebp)).toBeUndefined()
+  })
+
+  it('returns undefined for implausible dimensions', () => {
+    expect(parseImageHeaderDimensions(pngBuffer(0, 100))).toBeUndefined()
+    expect(parseImageHeaderDimensions(gifBuffer(0, 0))).toBeUndefined()
+  })
+
+  it('returns undefined for unknown formats', () => {
+    expect(parseImageHeaderDimensions(Buffer.from('not an image at all'))).toBeUndefined()
+    expect(parseImageHeaderDimensions(Buffer.from([0x25, 0x50, 0x44, 0x46]))).toBeUndefined() // %PDF
+  })
+})
+
+describe('readImageHeaderDimensions', () => {
+  let directory: string
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'image-header-dimensions-'))
+  })
+
+  afterEach(async () => {
+    await rm(directory, { recursive: true, force: true })
+  })
+
+  it('reads dimensions from a file on disk', async () => {
+    const filePath = join(directory, 'plot.png')
+    await writeFile(filePath, Buffer.concat([pngBuffer(48, 32), Buffer.alloc(1024)]))
+    await expect(readImageHeaderDimensions(filePath)).resolves.toEqual({ width: 48, height: 32 })
+  })
+
+  it('degrades to undefined for missing or unreadable files instead of throwing', async () => {
+    await expect(readImageHeaderDimensions(join(directory, 'missing.png'))).resolves.toBeUndefined()
+  })
+})

--- a/src/main/image-header-dimensions.ts
+++ b/src/main/image-header-dimensions.ts
@@ -1,0 +1,147 @@
+import { open } from 'node:fs/promises'
+
+type ImageHeaderDimensions = { width: number; height: number }
+
+// SOF0-15 minus the non-frame markers (DHT/DAC/JPG/RST-Adjacent C4/C8/CC).
+const JPEG_START_OF_FRAME_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf
+])
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+// Dimensions must be plausible; anything larger is a corrupt header, not a real image.
+const MAX_PLAUSIBLE_DIMENSION = 1_000_000
+
+const plausible = (width: number, height: number): ImageHeaderDimensions | undefined =>
+  width >= 1 && height >= 1 && width <= MAX_PLAUSIBLE_DIMENSION && height <= MAX_PLAUSIBLE_DIMENSION
+    ? { width, height }
+    : undefined
+
+const parsePng = (bytes: Buffer): ImageHeaderDimensions | undefined => {
+  // 8-byte signature, then the IHDR chunk: length(4)=13, type(4)='IHDR', width(4), height(4).
+  if (
+    bytes.length < 24 ||
+    bytes.readUInt32BE(8) !== 13 ||
+    bytes.toString('ascii', 12, 16) !== 'IHDR'
+  ) {
+    return undefined
+  }
+  return plausible(bytes.readUInt32BE(16), bytes.readUInt32BE(20))
+}
+
+const parseJpeg = (bytes: Buffer): ImageHeaderDimensions | undefined => {
+  let offset = 2
+  while (offset < bytes.length) {
+    if (bytes[offset] !== 0xff) return undefined
+    while (offset < bytes.length && bytes[offset] === 0xff) offset += 1
+    if (offset >= bytes.length) return undefined
+
+    const marker = bytes[offset]
+    offset += 1
+    // Standalone markers without a length field; scan data means no SOF was found in time.
+    if (
+      marker === 0x00 ||
+      marker === 0x01 ||
+      marker === 0xd8 ||
+      marker === 0xd9 ||
+      marker === 0xda ||
+      (marker >= 0xd0 && marker <= 0xd7)
+    ) {
+      return undefined
+    }
+    if (offset + 2 > bytes.length) return undefined
+
+    const segmentLength = bytes.readUInt16BE(offset)
+    if (segmentLength < 2 || offset + segmentLength > bytes.length) return undefined
+    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
+      if (segmentLength < 9) return undefined
+      return plausible(bytes.readUInt16BE(offset + 5), bytes.readUInt16BE(offset + 3))
+    }
+    offset += segmentLength
+  }
+  return undefined
+}
+
+const parseGif = (bytes: Buffer): ImageHeaderDimensions | undefined => {
+  // Header(6) 'GIF87a'/'GIF89a', then the logical screen descriptor: width(2 LE), height(2 LE).
+  if (bytes.length < 10) return undefined
+  return plausible(bytes.readUInt16LE(6), bytes.readUInt16LE(8))
+}
+
+const parseWebp = (bytes: Buffer): ImageHeaderDimensions | undefined => {
+  // RIFF(4) size(4) 'WEBP'(4), then the first chunk fourcc at offset 12.
+  if (bytes.length < 21) return undefined
+  const chunkType = bytes.toString('ascii', 12, 16)
+  if (chunkType === 'VP8X') {
+    // flags(1) reserved(3), canvas width minus one (3 LE) at 24, height minus one at 27.
+    if (bytes.length < 30) return undefined
+    const width = 1 + bytes.readUIntLE(24, 3)
+    const height = 1 + bytes.readUIntLE(27, 3)
+    return plausible(width, height)
+  }
+  if (chunkType === 'VP8L') {
+    // signature byte 0x2f, then 14-bit width-1 and height-1 packed into 4 little-endian bytes.
+    if (bytes.length < 25 || bytes[20] !== 0x2f) return undefined
+    const bits = bytes.readUInt32LE(21)
+    return plausible((bits & 0x3fff) + 1, ((bits >> 14) & 0x3fff) + 1)
+  }
+  if (chunkType === 'VP8 ') {
+    // frame tag(3), start code 9d 01 2a, then width/height as 14-bit little-endian values.
+    if (bytes.length < 30 || bytes[23] !== 0x9d || bytes[24] !== 0x01 || bytes[25] !== 0x2a) {
+      return undefined
+    }
+    return plausible(bytes.readUInt16LE(26) & 0x3fff, bytes.readUInt16LE(28) & 0x3fff)
+  }
+  return undefined
+}
+
+const parseBmp = (bytes: Buffer): ImageHeaderDimensions | undefined => {
+  // 'BM', then the DIB header carries width/height as signed int32 LE at offsets 18/22
+  // (a negative height marks a top-down bitmap).
+  if (bytes.length < 26) return undefined
+  return plausible(bytes.readInt32LE(18), Math.abs(bytes.readInt32LE(22)))
+}
+
+// Pure header parser: sniffs the magic bytes (not the claimed extension) and returns the pixel
+// dimensions, or undefined for unknown, truncated, or forged content.
+const parseImageHeaderDimensions = (bytes: Buffer): ImageHeaderDimensions | undefined => {
+  if (bytes.length >= 8 && bytes.subarray(0, 8).equals(PNG_SIGNATURE)) return parsePng(bytes)
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return parseJpeg(bytes)
+  }
+  if (bytes.length >= 6 && bytes.toString('ascii', 0, 4) === 'GIF8') return parseGif(bytes)
+  if (
+    bytes.length >= 16 &&
+    bytes.toString('ascii', 0, 4) === 'RIFF' &&
+    bytes.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return parseWebp(bytes)
+  }
+  if (bytes.length >= 2 && bytes.toString('ascii', 0, 2) === 'BM') return parseBmp(bytes)
+  return undefined
+}
+
+// JPEG SOF markers can sit behind a large EXIF segment, so read generously but never whole files.
+const HEADER_READ_LIMIT = 256 * 1024
+
+// Best-effort dimension probe for the preview acquire path: any I/O or parse failure degrades to
+// undefined so acquire never fails because of a header quirk.
+const readImageHeaderDimensions = async (
+  filePath: string
+): Promise<ImageHeaderDimensions | undefined> => {
+  try {
+    const handle = await open(filePath, 'r')
+    try {
+      const buffer = Buffer.alloc(HEADER_READ_LIMIT)
+      const { bytesRead } = await handle.read(buffer, 0, HEADER_READ_LIMIT, 0)
+      return parseImageHeaderDimensions(buffer.subarray(0, bytesRead))
+    } finally {
+      await handle.close()
+    }
+  } catch {
+    return undefined
+  }
+}
+
+export { parseImageHeaderDimensions, readImageHeaderDimensions }
+export type { ImageHeaderDimensions }

--- a/src/main/managed-preview-resources.test.ts
+++ b/src/main/managed-preview-resources.test.ts
@@ -223,6 +223,43 @@ describe('ManagedPreviewResources', () => {
     expect(close).toHaveBeenCalledOnce()
   })
 
+  it('attaches header-probed pixel dimensions when acquiring an image', async () => {
+    // Minimal PNG: signature + IHDR length/type + 640x400 dimensions.
+    const png = Buffer.alloc(33)
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0)
+    png.writeUInt32BE(13, 8)
+    png.write('IHDR', 12, 'ascii')
+    png.writeUInt32BE(640, 16)
+    png.writeUInt32BE(400, 20)
+    const filePath = await createFile(png, 'plot.png')
+    const resources = new ManagedPreviewResources({
+      resolvePath: async () => filePath,
+      createId: () => 'resource-1'
+    })
+
+    const resource = await resources.acquire(17, { source: 'local', path: filePath })
+
+    expect(resource).toMatchObject({
+      mimeType: 'image/png',
+      width: 640,
+      height: 400
+    })
+  })
+
+  it('omits dimensions for content that only pretends to be an image', async () => {
+    const filePath = await createFile(Buffer.from('definitely not an image'), 'forged.png')
+    const resources = new ManagedPreviewResources({
+      resolvePath: async () => filePath,
+      createId: () => 'resource-1'
+    })
+
+    const resource = await resources.acquire(17, { source: 'local', path: filePath })
+
+    expect(resource.mimeType).toBe('image/png')
+    expect(resource.width).toBeUndefined()
+    expect(resource.height).toBeUndefined()
+  })
+
   it('inspects authoritative metadata without minting a resource capability', async () => {
     const filePath = await createFile(Buffer.from('office'))
     const createId = vi.fn(() => 'resource-1')

--- a/src/main/managed-preview-resources.ts
+++ b/src/main/managed-preview-resources.ts
@@ -4,6 +4,7 @@ import { open, stat } from 'node:fs/promises'
 import { basename, extname } from 'node:path'
 
 import { FileObservationMismatchError, type FileObservation } from './bounded-file-io'
+import { readImageHeaderDimensions, type ImageHeaderDimensions } from './image-header-dimensions'
 import type { OfficePreviewAdmissionError } from '../shared/office-preview'
 import type {
   AcquireManagedPreviewRequest,
@@ -56,6 +57,14 @@ const inferMimeType = (filePath: string, fallback?: string): string =>
   MIME_TYPES_BY_EXTENSION[extname(filePath).toLowerCase()] ??
   normalizeMimeType(fallback) ??
   'application/octet-stream'
+
+// Header probing is cheap (first bytes only) and best-effort: the parser sniffs magic bytes, so
+// mislabeled extensions and unsupported image formats (SVG, TIFF) simply yield no dimensions.
+const probeImageDimensions = (
+  filePath: string,
+  mimeType: string
+): Promise<ImageHeaderDimensions | undefined> =>
+  mimeType.startsWith('image/') ? readImageHeaderDimensions(filePath) : Promise.resolve(undefined)
 
 type ManagedPreviewResourcesOptions = {
   resolvePath: (
@@ -252,12 +261,15 @@ class ManagedPreviewResources {
       }
 
       const id = this.createId()
+      const resolvedMimeType = inferMimeType(filePath, request.mimeType)
+      const dimensions = await probeImageDimensions(filePath, resolvedMimeType)
       const resource: ManagedPreviewResource = {
         id,
         url: `${PREVIEW_SCHEME}://${id}/${encodeURIComponent(basename(filePath))}`,
         size: fileSnapshot.size,
-        mimeType: inferMimeType(filePath, request.mimeType),
-        version: fileSnapshot.version
+        mimeType: resolvedMimeType,
+        version: fileSnapshot.version,
+        ...(dimensions ? { width: dimensions.width, height: dimensions.height } : {})
       }
 
       this.releasedOwners.delete(id)
@@ -318,12 +330,15 @@ class ManagedPreviewResources {
     }
 
     const id = this.createId()
+    const resolvedMimeType = inferMimeType(request.path, request.mimeType)
+    const dimensions = await probeImageDimensions(request.path, resolvedMimeType)
     const resource: ManagedPreviewResource = {
       id,
       url: `${PREVIEW_SCHEME}://${id}/${encodeURIComponent(basename(request.path))}`,
       size: expected.sizeBytes,
-      mimeType: inferMimeType(request.path, request.mimeType),
-      version: expected.modifiedAtMs
+      mimeType: resolvedMimeType,
+      version: expected.modifiedAtMs,
+      ...(dimensions ? { width: dimensions.width, height: dimensions.height } : {})
     }
     this.releasedOwners.delete(id)
     this.resources.set(id, {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -112,6 +112,8 @@ class HeadlessTaskApi {
             url: string
             size: number
             mimeType?: string
+            width?: number
+            height?: number
           }>,
         // Capability cleanup must remain available if request authorization is revoked while a
         // response stream drains. The fixed local automation context grants no new access.

--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -581,7 +581,8 @@
     display: block;
 
     & > img {
-      @apply m-0! max-w-full rounded-lg;
+      /* height:auto keeps the width/height attribute box proportional when max-w-full shrinks it */
+      @apply m-0! h-auto max-w-full rounded-lg;
       display: block;
     }
 

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
@@ -184,7 +184,7 @@ describe('SessionMessageMarkdown', () => {
     ).toBe('error')
   })
 
-  it('acquires and releases image resources near the viewport', async () => {
+  it('keeps the image resource mounted after it has been near the viewport', async () => {
     let intersectionCallback: IntersectionObserverCallback | undefined
     vi.stubGlobal(
       'IntersectionObserver',
@@ -227,8 +227,11 @@ describe('SessionMessageMarkdown', () => {
         {} as IntersectionObserver
       )
     })
-    expect(previewResourceHarness.enabled).toBe(false)
-    expect(container.querySelector('[data-session-artifact-image]')).toBeNull()
+    // Leaving the viewport must not unload the image: the placeholder is much shorter than the
+    // loaded image, so an unload/remount cycle at the viewport edge fights the scroll anchoring
+    // compensation and produces per-frame jitter.
+    expect(previewResourceHarness.enabled).toBe(true)
+    expect(container.querySelector('[data-session-artifact-image]')).not.toBeNull()
   })
 
   it('routes TIFF images through the existing artifact thumbnail and modal', async () => {

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
@@ -12,7 +12,8 @@ const markdownHarness = vi.hoisted(() => ({
 }))
 const previewResourceHarness = vi.hoisted(() => ({
   status: 'ready' as 'ready' | 'error',
-  enabled: undefined as boolean | undefined
+  enabled: undefined as boolean | undefined,
+  dimensions: undefined as { width: number; height: number } | undefined
 }))
 
 vi.mock('@/components/streamdown/AgentMarkdown', () => ({
@@ -58,7 +59,11 @@ vi.mock('./previews/useManagedPreviewResource', () => ({
       : previewResourceHarness.status === 'ready'
         ? {
             status: 'ready',
-            resource: { id: 'resource-1', url: 'preview-resource://sin-curve' }
+            resource: {
+              id: 'resource-1',
+              url: 'preview-resource://sin-curve',
+              ...(previewResourceHarness.dimensions ?? {})
+            }
           }
         : { status: 'error', error: new Error('Preview unavailable') }
   }
@@ -85,6 +90,15 @@ const tiffArtifact: MessageArtifact = {
   name: 'scan.tiff',
   mimeType: 'image/tiff'
 }
+// A distinct path/size so its preview request key (and geometry cache entry) is unique per test.
+const chartArtifact: MessageArtifact = {
+  ...artifact,
+  id: 'version-chart',
+  versionId: 'version-chart',
+  path: '/managed/session/chart.png',
+  name: 'chart.png',
+  size: 2048
+}
 
 describe('SessionMessageMarkdown', () => {
   let container: HTMLDivElement
@@ -96,6 +110,7 @@ describe('SessionMessageMarkdown', () => {
     markdownHarness.renderedContent = ''
     previewResourceHarness.status = 'ready'
     previewResourceHarness.enabled = undefined
+    previewResourceHarness.dimensions = undefined
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -294,6 +309,72 @@ describe('SessionMessageMarkdown', () => {
     )
     expect(placeholder).not.toBeNull()
     expect(placeholder?.style.width).toBe('800px')
+    expect(placeholder?.style.maxWidth).toBe('100%')
+    expect(placeholder?.style.aspectRatio).toBe('2 / 1')
+
+    await act(async () => remountRoot.unmount())
+    remountContainer.remove()
+  })
+
+  it('sizes the image and the remounted placeholder from header-probed metadata', async () => {
+    previewResourceHarness.dimensions = { width: 1000, height: 500 }
+    markdownHarness.artifactRef = 'version-chart'
+    let intersectionCallback: IntersectionObserverCallback | undefined
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+
+        observe = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+
+    await act(async () => {
+      root.render(
+        <SessionMessageMarkdown
+          content="![Chart](chart.png)"
+          artifacts={[chartArtifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+
+    // The metadata dimensions land on the <img> attributes so the browser reserves the exact
+    // box before decoding. No load event is dispatched: the placeholder lock must come from the
+    // metadata-seeded cache, not from measured natural sizes.
+    const img = container.querySelector<HTMLImageElement>('[data-session-artifact-image] img')
+    expect(img?.getAttribute('width')).toBe('1000')
+    expect(img?.getAttribute('height')).toBe('500')
+
+    const remountContainer = document.createElement('div')
+    document.body.appendChild(remountContainer)
+    const remountRoot = createRoot(remountContainer)
+    await act(async () => {
+      remountRoot.render(
+        <SessionMessageMarkdown
+          content="![Chart](chart.png)"
+          artifacts={[chartArtifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+
+    const placeholder = remountContainer.querySelector<HTMLElement>(
+      '[data-session-artifact-image-status]'
+    )
+    expect(placeholder).not.toBeNull()
+    expect(placeholder?.style.width).toBe('1000px')
     expect(placeholder?.style.maxWidth).toBe('100%')
     expect(placeholder?.style.aspectRatio).toBe('2 / 1')
 

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
@@ -234,6 +234,73 @@ describe('SessionMessageMarkdown', () => {
     expect(container.querySelector('[data-session-artifact-image]')).not.toBeNull()
   })
 
+  it('reserves the loaded image geometry for the placeholder after a remount', async () => {
+    let intersectionCallback: IntersectionObserverCallback | undefined
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback
+        }
+
+        observe = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+
+    await act(async () => {
+      root.render(
+        <SessionMessageMarkdown
+          content="![Sine curve](sin_curve.png)"
+          artifacts={[artifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+
+    const img = container.querySelector<HTMLImageElement>('[data-session-artifact-image] img')
+    expect(img).not.toBeNull()
+    Object.defineProperty(img, 'naturalWidth', { value: 800 })
+    Object.defineProperty(img, 'naturalHeight', { value: 400 })
+    await act(async () => {
+      img?.dispatchEvent(new Event('load'))
+    })
+
+    // A fresh instance (e.g. the transcript window recycling an offscreen message) starts away
+    // from the viewport and shows the placeholder, sized to the cached image geometry.
+    const remountContainer = document.createElement('div')
+    document.body.appendChild(remountContainer)
+    const remountRoot = createRoot(remountContainer)
+    await act(async () => {
+      remountRoot.render(
+        <SessionMessageMarkdown
+          content="![Sine curve](sin_curve.png)"
+          artifacts={[artifact]}
+          onPreviewArtifact={vi.fn()}
+          onPreviewArtifactModal={vi.fn()}
+        />
+      )
+    })
+
+    const placeholder = remountContainer.querySelector<HTMLElement>(
+      '[data-session-artifact-image-status]'
+    )
+    expect(placeholder).not.toBeNull()
+    expect(placeholder?.style.width).toBe('800px')
+    expect(placeholder?.style.maxWidth).toBe('100%')
+    expect(placeholder?.style.aspectRatio).toBe('2 / 1')
+
+    await act(async () => remountRoot.unmount())
+    remountContainer.remove()
+  })
+
   it('routes TIFF images through the existing artifact thumbnail and modal', async () => {
     const onPreviewArtifactModal = vi.fn()
     markdownHarness.artifactRef = 'version-tiff'

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
@@ -36,6 +36,32 @@ type SessionMessageLinkComponentProps = ComponentProps<'a'> & {
   'data-incomplete'?: boolean
 }
 
+type CachedImageGeometry = { naturalWidth: number; aspectRatio: number }
+
+// Rendered-geometry cache keyed like the preview resource (path + size + mtime), so an in-place
+// file replacement invalidates itself. Lets the alt-text placeholder reserve the loaded image's
+// exact footprint: when the transcript window recycles a far-offscreen message, the remounted
+// placeholder matches the image height instead of collapsing back to ~100px and shifting the
+// scroll position.
+const imageGeometryCache = new Map<string, CachedImageGeometry>()
+const IMAGE_GEOMETRY_CACHE_LIMIT = 200
+
+const cacheImageGeometry = (
+  requestKey: string,
+  naturalWidth: number,
+  naturalHeight: number
+): void => {
+  if (naturalWidth <= 0 || naturalHeight <= 0) return
+  imageGeometryCache.delete(requestKey)
+  imageGeometryCache.set(requestKey, {
+    naturalWidth,
+    aspectRatio: naturalWidth / naturalHeight
+  })
+  if (imageGeometryCache.size <= IMAGE_GEOMETRY_CACHE_LIMIT) return
+  const oldestKey = imageGeometryCache.keys().next().value
+  if (oldestKey !== undefined) imageGeometryCache.delete(oldestKey)
+}
+
 const SessionArtifactImage = ({
   artifact,
   alt,
@@ -99,11 +125,23 @@ const SessionArtifactImage = ({
   }
 
   if (resourceState.status !== 'ready') {
+    const cachedGeometry = imageGeometryCache.get(requestKey)
     return (
       <span
         ref={setElement}
         data-session-artifact-image-status=""
         data-state={hasError ? 'error' : 'loading'}
+        style={
+          cachedGeometry
+            ? {
+                // Mirror the loaded <img> geometry (natural width capped by max-w-full) so the
+                // placeholder reserves the same height and remounts stay scroll-neutral.
+                width: `${cachedGeometry.naturalWidth}px`,
+                maxWidth: '100%',
+                aspectRatio: String(cachedGeometry.aspectRatio)
+              }
+            : undefined
+        }
       >
         {accessibleAlt}
       </span>
@@ -124,6 +162,13 @@ const SessionArtifactImage = ({
         loading="lazy"
         decoding="async"
         draggable={false}
+        onLoad={(event) =>
+          cacheImageGeometry(
+            requestKey,
+            event.currentTarget.naturalWidth,
+            event.currentTarget.naturalHeight
+          )
+        }
         onError={() => setFailedRequestKey(requestKey)}
       />
     </button>

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
@@ -103,6 +103,16 @@ const SessionArtifactImage = ({
   const accessibleAlt = alt || t('Preview of {{name}}', { name })
   const hasError = hasFailed || resourceState.status === 'error'
 
+  // Header-probed dimensions beat the measured cache. Seeding the cache with them lets future
+  // placeholders lock the exact height from the first frame, even when this instance's <img>
+  // never decodes (lazy loading keeps offscreen images undecoded until the window recycles them).
+  const readyResource = resourceState.status === 'ready' ? resourceState.resource : undefined
+  const metadataWidth = readyResource?.width
+  const metadataHeight = readyResource?.height
+  if (metadataWidth && metadataHeight) {
+    cacheImageGeometry(requestKey, metadataWidth, metadataHeight)
+  }
+
   if (isTiff) {
     return (
       <button
@@ -148,6 +158,19 @@ const SessionArtifactImage = ({
     )
   }
 
+  // Explicit width/height let the browser reserve the exact box before (and while) the image
+  // decodes; the stylesheet keeps height:auto so max-w-full scaling never distorts the ratio.
+  const cachedGeometry = imageGeometryCache.get(requestKey)
+  const imgDimensions =
+    metadataWidth && metadataHeight
+      ? { width: metadataWidth, height: metadataHeight }
+      : cachedGeometry
+        ? {
+            width: cachedGeometry.naturalWidth,
+            height: Math.round(cachedGeometry.naturalWidth / cachedGeometry.aspectRatio)
+          }
+        : undefined
+
   return (
     <button
       ref={setElement}
@@ -162,6 +185,7 @@ const SessionArtifactImage = ({
         loading="lazy"
         decoding="async"
         draggable={false}
+        {...(imgDimensions ? { width: imgDimensions.width, height: imgDimensions.height } : {})}
         onLoad={(event) =>
           cacheImageGeometry(
             requestKey,

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
@@ -61,8 +61,19 @@ const SessionArtifactImage = ({
   const requestKey = createPreviewResourceKey(request)
   const [failedRequestKey, setFailedRequestKey] = useState<string>()
   const [setElement, isNearViewport] = useNearViewport<HTMLButtonElement | HTMLSpanElement>()
+  // Latch the first approach: the loaded <img> is much taller than the alt-text placeholder, so
+  // releasing the resource when the image leaves the viewport collapses its height, the scroll
+  // anchoring compensation then pushes it back inside the observer margin, and the two fight each
+  // other in a per-frame jitter loop at the viewport edge. Once acquired, keep the resource.
+  const [hasBeenNearViewport, setHasBeenNearViewport] = useState(false)
+  if (isNearViewport && !hasBeenNearViewport) {
+    setHasBeenNearViewport(true)
+  }
   const hasFailed = failedRequestKey === requestKey
-  const resourceState = useManagedPreviewResource(request, !isTiff && isNearViewport && !hasFailed)
+  const resourceState = useManagedPreviewResource(
+    request,
+    !isTiff && hasBeenNearViewport && !hasFailed
+  )
   const accessibleAlt = alt || t('Preview of {{name}}', { name })
   const hasError = hasFailed || resourceState.status === 'error'
 

--- a/src/shared/preview-resources.ts
+++ b/src/shared/preview-resources.ts
@@ -30,6 +30,10 @@ export type ManagedPreviewResource = {
   size: number
   mimeType: string
   version: number
+  // Pixel dimensions for image resources, probed from the file header at acquire time.
+  // Absent for non-images and for images whose header could not be parsed.
+  width?: number
+  height?: number
 }
 
 export type ReadManagedPreviewRangeRequest = {


### PR DESCRIPTION
## Problem

Follow-up to #2021 (viewport-edge image jitter). That PR eliminated the unload/remount oscillation (latch) and made remounts scroll-neutral (geometry cache), but one jump remains: an image that has **never been loaded in this app run** still renders the ~100px alt-text placeholder first, then grows to its real height when the resource arrives and the `<img>` decodes — a one-time layout shift (content flashes down a frame, anchoring compensation flashes it back up).

## Approach

Have the main process probe pixel dimensions from image file headers and ship them with the preview capability, so the renderer knows the exact geometry from the moment `acquire` resolves — before any image bytes are fetched or decoded.

**Main process** — new zero-dependency parser `src/main/image-header-dimensions.ts`:

- PNG (IHDR), JPEG (SOF0-15 marker scan, skipping non-frame markers), GIF (logical screen descriptor), WebP (all three variants: `VP8 `, `VP8L`, `VP8X`), BMP (including top-down negative heights);
- sniffs magic bytes rather than trusting extensions, so forged/mislabeled files simply yield `undefined`;
- reads at most the first 256 KiB (JPEG SOF can sit behind a large EXIF segment); any I/O or parse failure degrades to `undefined` and never fails the acquire;
- implausible dimensions (0 or absurd sizes) are rejected.

**Acquire path** — `ManagedPreviewResource` gains optional `width?: number; height?: number`, populated in both assembly points (`acquireFilePath` and the Reviewer-only `acquireResolvedFile`) whenever the inferred MIME type is `image/*`. The preload contract adapter passes the result through untouched, so no preload changes; the inline type in `web-service/task-api.ts` was extended to match.

**Renderer** (`SessionArtifactImage`):

- the `<img>` now carries explicit `width`/`height` attributes (metadata first, geometry cache as fallback), so the browser reserves the exact box before and during decode; the stylesheet gains `h-auto` on the image rule so `max-w-full` scaling never distorts the ratio;
- metadata dimensions also seed the geometry cache, so a remounted placeholder (transcript window recycling) locks the exact height from its first frame **even if the previous instance's `<img>` never decoded** (lazy loading keeps offscreen images undecoded);
- priority chain: metadata > geometry cache > the original ~100px placeholder. Both #2021 mechanisms (latch, geometry cache) remain untouched — this is additive;
- TIFF branch unchanged (fixed `aspect-ratio: 4/3` container).

## Artifact-metadata persistence: deliberately skipped

Persisting dimensions at artifact creation would require extending the Session-JSON `PersistedArtifact` schema, the `sanitizeArtifact` whitelist, `ArtifactFile`, and several main-process assembly/mapping points (provenance-repository, storage-access, reconciliation, task-runner). The remaining unlock window without persistence is the local IPC round-trip between mount and `acquire` resolution (a few ms, no network, no decode) — not worth that blast radius. Revisit only if the flash proves visible in practice.

## Tests

- `image-header-dimensions.test.ts` (13 cases): every supported format, truncated/forged/implausible headers, unknown formats → `undefined`, on-disk read, missing file → `undefined` (no throw);
- `managed-preview-resources.test.ts`: acquire attaches probed dimensions for a real PNG header; forged content acquires cleanly without dimensions;
- `SessionMessageMarkdown.test.tsx`: with metadata present, the `<img>` carries exact `width`/`height` and a remounted placeholder locks the exact geometry **without any `load` event** (proving the metadata-seeded cache path);
- related suites pass (managed-preview ipc/protocol, task-api, i18n guard — no new user-visible strings); `npm run typecheck` and eslint are clean.

## Manual verification

1. Open a session containing a message with an inline image never opened in this app run;
2. scroll upward past the image: no flash-down/flash-up pair, scrollbar length stays constant;
3. scroll far away and back (transcript window recycling): the placeholder already has the final height, no jump.

## Relationship to #2021

Stacks on `fix/message-image-scroll-jitter` (branch base). Merge #2021 first; this PR will then diff cleanly against main.
