### PR TITLE
fix(notebook-network): contain connection reset errors

### DIFF
--- a/packages/notebook-network-sandbox/runtime/src/gateway/command-gateway.ts
+++ b/packages/notebook-network-sandbox/runtime/src/gateway/command-gateway.ts
@@ -574,6 +574,7 @@ class CommandGateway {
   static #routeShared(state: SharedIngressState, socket: Socket): void {
     state.pendingConnections.add(socket)
     socket.once('close', () => state.pendingConnections.delete(socket))
+    socket.once('error', () => socket.destroy())
     socket.once('data', (first: Buffer) => {
       if (first[0] === 0x05) void CommandGateway.#routeSharedSocks(state, socket, first)
       else void CommandGateway.#routeSharedHttp(state, socket, first)
@@ -661,6 +662,7 @@ class CommandGateway {
       return false
     }
     this.#connections.add(socket)
+    socket.once('error', () => socket.destroy())
     socket.once('close', () => this.#connections.delete(socket))
     return true
   }
@@ -755,8 +757,10 @@ class CommandGateway {
                 tls.once('error', reject)
               })
             : tunnel
-        this.#connections.add(connection)
-        connection.once('close', () => this.#connections.delete(connection))
+        if (!this.#trackConnection(connection)) {
+          response.destroy()
+          return
+        }
         const send = target.protocol === 'https:' ? httpsRequest : httpRequest
         const upstream = send(
           {
@@ -881,8 +885,10 @@ class CommandGateway {
         client.destroy()
         return
       }
-      this.#connections.add(upstream)
-      upstream.once('close', () => this.#connections.delete(upstream))
+      if (!this.#trackConnection(upstream)) {
+        client.destroy()
+        return
+      }
       client.write('HTTP/1.1 200 Connection Established\r\n\r\n')
       if (head.length) upstream.write(head)
       client.pipe(upstream).pipe(client)
@@ -954,8 +960,10 @@ class CommandGateway {
       client.destroy()
       return
     }
-    this.#connections.add(upstream)
-    upstream.once('close', () => this.#connections.delete(upstream))
+    if (!this.#trackConnection(upstream)) {
+      client.destroy()
+      return
+    }
     client.write(Buffer.from([5, 0, 0, 1, 0, 0, 0, 0, 0, 0]))
     const buffered = reader.remainder()
     if (buffered.length) upstream.write(buffered)

--- a/packages/notebook-network-sandbox/src/gateway.test.ts
+++ b/packages/notebook-network-sandbox/src/gateway.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { createServer, connect, type Socket } from 'node:net'
 import { createServer as createHttpServer, request } from 'node:http'
 import { createServer as createTlsServer } from 'node:tls'
-import { execFile } from 'node:child_process'
+import { execFile, spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -17,6 +17,88 @@ const credentials = { username: 'command-a', password: 'secret-a' }
 const authorization = `Basic ${Buffer.from('command-a:secret-a').toString('base64')}`
 const execFileAsync = promisify(execFile)
 const openssl = ['/usr/bin/openssl', '/opt/homebrew/bin/openssl'].find(existsSync)
+
+type ChildResult = Readonly<{
+  exitCode: number | null
+  signal: NodeJS.Signals | null
+  stderr: string
+  stdout: string
+}>
+
+const runResetTunnelChild = (
+  resetPoint: 'before-routing' | 'client' | 'destination'
+): Promise<ChildResult> =>
+  new Promise((resolve, reject) => {
+    const gatewayModuleUrl = new URL('../runtime/src/gateway/command-gateway.ts', import.meta.url)
+      .href
+    const script = `
+      import { once } from 'node:events'
+      import { connect, createServer } from 'node:net'
+      import { CommandGateway } from ${JSON.stringify(gatewayModuleUrl)}
+
+      process.on('uncaughtExceptionMonitor', (error) => {
+        process.stderr.write('MONITORED:' + error.code + ':' + error.message + '\\n')
+      })
+
+      const listen = async (server) => {
+        server.listen(0, '127.0.0.1')
+        await once(server, 'listening')
+        return server.address().port
+      }
+      let resolveOriginConnection
+      const originConnection = new Promise((resolve) => (resolveOriginConnection = resolve))
+      const origin = createServer((socket) => {
+        socket.on('error', () => undefined)
+        resolveOriginConnection(socket)
+      })
+      const originPort = await listen(origin)
+      const reservation = createServer()
+      const sharedPort = await listen(reservation)
+      await new Promise((resolve) => reservation.close(resolve))
+      const gateway = await CommandGateway.open({
+        decide: async () => ({ allowed: true, address: '127.0.0.1' }),
+        sharedPort,
+        credentials: { username: 'command', password: 'secret' }
+      })
+      const client = connect({ host: '127.0.0.1', port: gateway.port })
+      await once(client, 'connect')
+      if (${JSON.stringify(resetPoint)} === 'before-routing') {
+        client.resetAndDestroy()
+      } else {
+        const authorization = Buffer.from('command:secret').toString('base64')
+        client.write(
+          'CONNECT example.invalid:' + originPort + ' HTTP/1.1\\r\\n' +
+          'Host: example.invalid:' + originPort + '\\r\\n' +
+          'Proxy-Authorization: Basic ' + authorization + '\\r\\n\\r\\n'
+        )
+        const [response] = await once(client, 'data')
+        if (!response.toString('latin1').includes('200 Connection Established')) {
+          throw new Error('Gateway tunnel did not open.')
+        }
+        if (${JSON.stringify(resetPoint)} === 'client') client.resetAndDestroy()
+        else (await originConnection).resetAndDestroy()
+      }
+
+      setTimeout(async () => {
+        await gateway.close()
+        await new Promise((resolve) => origin.close(resolve))
+        process.stdout.write('NO_UNCAUGHT_EXCEPTION\\n')
+      }, 250)
+    `
+    const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
+      env: { ...process.env, NODE_OPTIONS: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+    let stderr = ''
+    let stdout = ''
+    child.stderr.setEncoding('utf8')
+    child.stdout.setEncoding('utf8')
+    child.stderr.on('data', (chunk: string) => (stderr += chunk))
+    child.stdout.on('data', (chunk: string) => (stdout += chunk))
+    child.once('error', reject)
+    child.once('close', (exitCode, signal) => resolve({ exitCode, signal, stderr, stdout }))
+  })
 
 afterEach(async () => {
   await Promise.all(closeTasks.splice(0).map((close) => close()))
@@ -70,6 +152,22 @@ const readHttpHeader = (socket: Socket): Promise<string> =>
   })
 
 describe('Notebook command gateway', () => {
+  it.each([
+    ['client before routing', 'before-routing'],
+    ['client after routing', 'client'],
+    ['destination after routing', 'destination']
+  ] as const)(
+    'does not raise an uncaught exception when the %s resets the connection',
+    async (_description, resetPoint) => {
+      const result = await runResetTunnelChild(resetPoint)
+
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.signal).toBeNull()
+      expect(result.stderr).not.toContain('MONITORED:ECONNRESET:read ECONNRESET')
+      expect(result.stdout).toContain('NO_UNCAUGHT_EXCEPTION')
+    }
+  )
+
   it('routes concurrent commands by credentials through one shared port', async () => {
     const reservation = await listen(() => undefined)
     await reservation.close()


### PR DESCRIPTION
## Summary

- contain TCP connection errors inside the Notebook command gateway instead of letting ECONNRESET escape to Electron's main process
- route manually-created destination tunnels through the gateway's existing connection ownership path
- add a real shared-gateway regression test covering resets before routing, from the routed client, and from the destination

## Root cause

The Windows protected Notebook path uses a shared local gateway. Accepted and manually-created tunnel sockets were tracked for close, but did not retain an error handler. A TCP RST therefore emitted an unhandled socket error in the Electron main process.

The regression test runs the real shared gateway in a child process so Node's fail-fast behavior is preserved. All three reset points failed before the fix with Error: read ECONNRESET at TCP.onStreamRead and pass after the fix.

## Change impact

No persistence fields, database schema, IPC contract, UI interaction, translations, or data-model changes. Only the failed connection is destroyed; listener-level failures and other programming errors remain fatal.

## Verification

- npm run test:module -- notebook_network_sandbox (73 passed, 13 platform-skipped)
- npm run typecheck:node
- npm run lint
- focused gateway suite (12 passed, 1 OpenSSL-dependent test skipped)
- npm test attempted: 22,924 passed, 185 failed, 384 skipped, 7 unhandled errors. Failures were outside the changed module and included Windows symlink/fsync permissions, unavailable Python, path-budget checks, and timeout/resource failures. The affected Notebook network sandbox module passed independently.