### PR TITLE
fix(workspace): defer generated previews until publication

### DIFF
--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx
@@ -146,6 +146,35 @@ describe('SessionMessageMarkdown', () => {
     expect(onPreviewArtifactModal).toHaveBeenCalledWith(artifact)
   })
 
+  it('keeps unpublished artifact links and inline images inert until publication', async () => {
+    const onPreviewArtifact = vi.fn()
+    const onPreviewArtifactModal = vi.fn()
+    const pendingArtifact = {
+      ...artifact,
+      path: '/managed/session/.pending/run-1/sin_curve.png'
+    }
+
+    await act(async () => {
+      root.render(
+        <SessionMessageMarkdown
+          content={'![Sine curve](sin_curve.png)\n\n[sin_curve.png](sin_curve.png)'}
+          artifacts={[pendingArtifact]}
+          onPreviewArtifact={onPreviewArtifact}
+          onPreviewArtifactModal={onPreviewArtifactModal}
+        />
+      )
+    })
+
+    const artifactLink = container.querySelector<HTMLButtonElement>('[data-session-artifact-link]')
+    expect(artifactLink?.disabled).toBe(true)
+    expect(previewResourceHarness.enabled).toBe(false)
+    expect(container.querySelector('[data-session-artifact-image]')).toBeNull()
+
+    await act(async () => artifactLink?.click())
+    expect(onPreviewArtifact).not.toHaveBeenCalled()
+    expect(onPreviewArtifactModal).not.toHaveBeenCalled()
+  })
+
   it('retains the existing safe-link component for external links', async () => {
     markdownHarness.href = 'https://example.com/sin_curve.png'
 

--- a/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
+++ b/src/renderer/src/pages/workspace/SessionMessageMarkdown.tsx
@@ -6,7 +6,11 @@ import { useTranslation } from 'react-i18next'
 import type { Components } from 'streamdown'
 
 import { ArtifactPreview } from './artifact-preview'
-import { getArtifactName, getArtifactPreviewFormat } from './artifact-preview-utils'
+import {
+  getArtifactName,
+  getArtifactPreviewFormat,
+  isPendingArtifactPublication
+} from './artifact-preview-utils'
 import { createPreviewResourceKey } from './previews/preview-resource-key'
 import { useManagedPreviewResource } from './previews/useManagedPreviewResource'
 import { useNearViewport } from './previews/useNearViewport'
@@ -49,6 +53,7 @@ const SessionArtifactImage = ({
   const name = getArtifactName(artifact)
   const previewFormat = getArtifactPreviewFormat(artifact)
   const isTiff = previewFormat === 'tiff'
+  const publicationPending = isPendingArtifactPublication(artifact)
   const request = {
     path: artifact.path,
     projectId: artifact.resolvedProjectId,
@@ -62,9 +67,20 @@ const SessionArtifactImage = ({
   const [failedRequestKey, setFailedRequestKey] = useState<string>()
   const [setElement, isNearViewport] = useNearViewport<HTMLButtonElement | HTMLSpanElement>()
   const hasFailed = failedRequestKey === requestKey
-  const resourceState = useManagedPreviewResource(request, !isTiff && isNearViewport && !hasFailed)
+  const resourceState = useManagedPreviewResource(
+    request,
+    !publicationPending && !isTiff && isNearViewport && !hasFailed
+  )
   const accessibleAlt = alt || t('Preview of {{name}}', { name })
   const hasError = hasFailed || resourceState.status === 'error'
+
+  if (publicationPending) {
+    return (
+      <span ref={setElement} data-session-artifact-image-status="" data-state="loading">
+        {accessibleAlt}
+      </span>
+    )
+  }
 
   if (isTiff) {
     return (
@@ -158,6 +174,7 @@ const SessionMessageMarkdown = memo(
             <button
               type="button"
               className={className}
+              disabled={isPendingArtifactPublication(artifact)}
               data-incomplete={dataIncomplete}
               data-session-message-link=""
               data-session-artifact-link=""

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -106,6 +106,8 @@ type MessageArtifact = NonNullable<ChatSession['artifacts']>[number] & {
   resolvedProjectId?: string
   resolvedSessionId?: string
 }
+const isPendingArtifactPublication = (artifact: MessageArtifact): boolean =>
+  artifact.path.split(/[\\/]/u).includes('.pending')
 type MessageUploadAttachment = NonNullable<ChatMessage['uploads']>[number]
 type MessageImage = NonNullable<ChatMessage['images']>[number]
 type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>
@@ -914,6 +916,7 @@ const ArtifactCard = ({
   const artifactName = getArtifactName(artifact)
   const sizeLabel = formatByteSize(artifact.size) ?? ''
   const [setElement, isNearViewport] = useNearViewport<HTMLButtonElement>()
+  const publicationPending = isPendingArtifactPublication(artifact)
   const requestKey = JSON.stringify([
     artifact.id,
     artifact.artifactId ?? null,
@@ -924,7 +927,10 @@ const ArtifactCard = ({
     artifact.mtimeMs ?? null
   ])
   const missing = useUnavailablePreviewProbe({
-    enabled: isNearViewport && Boolean(artifact.resolvedProjectId && artifact.artifactId),
+    enabled:
+      isNearViewport &&
+      !publicationPending &&
+      Boolean(artifact.resolvedProjectId && artifact.artifactId),
     projectId: artifact.resolvedProjectId,
     sessionId: artifact.resolvedSessionId,
     managedFileId: artifact.artifactId,
@@ -939,6 +945,7 @@ const ArtifactCard = ({
       ref={setElement}
       type="button"
       className={cn('group flex min-w-0 flex-col', artifactCardClassName)}
+      disabled={publicationPending}
       onClick={() => {
         onPreviewArtifact(artifact)
       }}
@@ -948,7 +955,7 @@ const ArtifactCard = ({
       <div className={cn('relative', artifactPreviewClassName)}>
         <span className={cn('block size-full', missing && 'opacity-40')}>
           {/* Unmount the reader outside the overscan window so message history stays lightweight. */}
-          {isNearViewport ? (
+          {isNearViewport && !publicationPending ? (
             <VisibleArtifactPreview artifact={artifact} requestKey={requestKey} />
           ) : (
             <ArtifactPreview artifact={artifact} isVisible={false} />

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -72,6 +72,7 @@ import {
 import {
   ARTIFACT_PREVIEW_BYTES,
   getArtifactName,
+  isPendingArtifactPublication,
   shouldReadArtifactPreview
 } from './artifact-preview-utils'
 import {
@@ -106,8 +107,6 @@ type MessageArtifact = NonNullable<ChatSession['artifacts']>[number] & {
   resolvedProjectId?: string
   resolvedSessionId?: string
 }
-const isPendingArtifactPublication = (artifact: MessageArtifact): boolean =>
-  artifact.path.split(/[\\/]/u).includes('.pending')
 type MessageUploadAttachment = NonNullable<ChatMessage['uploads']>[number]
 type MessageImage = NonNullable<ChatMessage['images']>[number]
 type ArtifactMentionPart = Extract<MessagePart, { type: 'artifact' }>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -954,7 +954,7 @@ const ArtifactCard = ({
       <div className={cn('relative', artifactPreviewClassName)}>
         <span className={cn('block size-full', missing && 'opacity-40')}>
           {/* Unmount the reader outside the overscan window so message history stays lightweight. */}
-          {isNearViewport && !publicationPending ? (
+          {publicationPending ? null : isNearViewport ? (
             <VisibleArtifactPreview artifact={artifact} requestKey={requestKey} />
           ) : (
             <ArtifactPreview artifact={artifact} isVisible={false} />

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -18,6 +18,7 @@ import { createUploadVersionReference, type UploadedAttachment } from '../../../
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReviewWithChecks } from '../../../../shared/reviewer'
 import type { ArtifactVersionDescriptor } from '../../../../shared/artifact-provenance'
+import type { ManagedPreviewResource } from '../../../../shared/preview-resources'
 import type {
   HandoffLifecycleEvent,
   HandoffLifecycleEventSource
@@ -306,24 +307,33 @@ const createDeferred = <Value,>(): {
 }
 
 const installIntersectionObserver = (): (() => void) => {
-  let intersectionCallback: IntersectionObserverCallback | undefined
+  const observers = new Set<{
+    callback: IntersectionObserverCallback
+    elements: Set<Element>
+  }>()
   vi.stubGlobal(
     'IntersectionObserver',
     class {
-      observe = vi.fn()
-      unobserve = vi.fn()
-      disconnect = vi.fn()
+      private readonly record: { callback: IntersectionObserverCallback; elements: Set<Element> }
+      observe = vi.fn((element: Element) => this.record.elements.add(element))
+      unobserve = vi.fn((element: Element) => this.record.elements.delete(element))
+      disconnect = vi.fn(() => observers.delete(this.record))
 
       constructor(callback: IntersectionObserverCallback) {
-        intersectionCallback = callback
+        this.record = { callback, elements: new Set() }
+        observers.add(this.record)
       }
     }
   )
   return () => {
-    intersectionCallback?.(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver
-    )
+    for (const { callback, elements } of observers) {
+      callback(
+        [...elements].map(
+          (target) => ({ target, isIntersecting: true }) as IntersectionObserverEntry
+        ),
+        {} as IntersectionObserver
+      )
+    }
   }
 }
 
@@ -3713,6 +3723,53 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       }
     }
   )
+
+  it('does not acquire a PDF thumbnail while artifact publication is pending', async () => {
+    const enterViewport = installIntersectionObserver()
+    window.api.previewResources.acquire = vi.fn(
+      () => new Promise<ManagedPreviewResource>(() => undefined)
+    )
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const session = createSession({
+      status: 'idle',
+      messages: [
+        createMessage({
+          id: 'reply-1',
+          role: 'agent',
+          content: 'Created the file',
+          artifactIds: ['artifact-version-1']
+        })
+      ],
+      artifacts: [
+        {
+          id: 'artifact-version-1',
+          artifactId: 'managed-artifact-1',
+          versionId: 'artifact-version-1',
+          kind: 'managed-file',
+          path: '/workspace/.pending/run-1/report.pdf',
+          name: 'report.pdf',
+          mimeType: 'application/pdf',
+          size: 2048,
+          mtimeMs: 1710000000100
+        }
+      ]
+    })
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+      )
+    })
+
+    await act(async () => {
+      enterViewport()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(window.api.previewResources.acquire).not.toHaveBeenCalled()
+  })
 
   it('keeps a published artifact named .pending previewable', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3648,61 +3648,71 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
   })
 
-  it('keeps an unpublished managed thumbnail quiet while finalization is pending', async () => {
-    const enterViewport = installIntersectionObserver()
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    window.api.artifacts.readPreview = vi
-      .fn()
-      .mockRejectedValue(
-        new Error(
-          "Error invoking remote method 'artifacts:read-preview': ManagedFileVersionError: Managed file has no published version."
+  it.each(['/workspace/.pending/report.txt', 'C:\\workspace\\.pending\\report.txt'])(
+    'keeps an unpublished managed thumbnail quiet while finalization is pending (%s)',
+    async (path) => {
+      const enterViewport = installIntersectionObserver()
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      window.api.artifacts.readPreview = vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "Error invoking remote method 'artifacts:read-preview': ManagedFileVersionError: Managed file has no published version."
+          )
         )
-      )
-    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
-    const session = createSession({
-      status: 'idle',
-      messages: [
-        createMessage({
-          id: 'reply-1',
-          role: 'agent',
-          content: 'Created the file',
-          artifactIds: ['artifact-version-1']
+      const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+      const session = createSession({
+        status: 'idle',
+        messages: [
+          createMessage({
+            id: 'reply-1',
+            role: 'agent',
+            content: 'Created the file',
+            artifactIds: ['artifact-version-1']
+          })
+        ],
+        artifacts: [
+          {
+            id: 'artifact-version-1',
+            artifactId: 'managed-artifact-1',
+            versionId: 'artifact-version-1',
+            kind: 'managed-file',
+            path,
+            name: 'report.txt',
+            mimeType: 'text/plain',
+            size: 2048,
+            mtimeMs: 1710000000100
+          }
+        ]
+      })
+
+      try {
+        root = createRoot(container)
+        await act(async () => {
+          root.render(
+            <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+          )
         })
-      ],
-      artifacts: [
-        {
-          id: 'artifact-version-1',
-          artifactId: 'managed-artifact-1',
-          versionId: 'artifact-version-1',
-          kind: 'managed-file',
-          path: '/workspace/.pending/report.txt',
-          name: 'report.txt',
-          mimeType: 'text/plain',
-          size: 2048,
-          mtimeMs: 1710000000100
-        }
-      ]
-    })
 
-    try {
-      root = createRoot(container)
-      await act(async () => {
-        root.render(
-          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
-        )
-      })
+        expect(
+          container.querySelector<HTMLButtonElement>(
+            'button[aria-label="Preview generated file report.txt"]'
+          )?.disabled
+        ).toBe(true)
 
-      await act(async () => {
-        enterViewport()
-        await Promise.resolve()
-        await Promise.resolve()
-      })
+        await act(async () => {
+          enterViewport()
+          await Promise.resolve()
+          await Promise.resolve()
+        })
 
-      expect(consoleError).not.toHaveBeenCalled()
-    } finally {
-      consoleError.mockRestore()
+        expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
+        expect(consoleError).not.toHaveBeenCalled()
+      } finally {
+        consoleError.mockRestore()
+      }
     }
-  })
+  )
 
   it('mounts desktop Run Marks from visible human prompts', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3648,7 +3648,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
   })
 
-  it.each(['/workspace/.pending/report.txt', 'C:\\workspace\\.pending\\report.txt'])(
+  it.each(['/workspace/.pending/run-1/report.txt', 'C:\\workspace\\.pending\\run-1\\report.txt'])(
     'keeps an unpublished managed thumbnail quiet while finalization is pending (%s)',
     async (path) => {
       const enterViewport = installIntersectionObserver()
@@ -3713,6 +3713,51 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       }
     }
   )
+
+  it('keeps a published artifact named .pending previewable', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const session = createSession({
+      status: 'idle',
+      messages: [
+        createMessage({
+          id: 'reply-1',
+          role: 'agent',
+          content: 'Created the file',
+          artifactIds: ['artifact-version-1']
+        })
+      ],
+      artifacts: [
+        {
+          id: 'artifact-version-1',
+          artifactId: 'managed-artifact-1',
+          versionId: 'artifact-version-1',
+          kind: 'managed-file',
+          path: '/workspace/message-1/.pending',
+          name: '.pending',
+          mimeType: 'text/plain',
+          size: 2048,
+          mtimeMs: 1710000000100
+        }
+      ]
+    })
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+      )
+    })
+
+    const card = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Preview generated file .pending"]'
+    )
+    expect(card?.disabled).toBe(false)
+
+    await act(async () => card?.click())
+    expect(upsertAndActivateItem).toHaveBeenCalledWith(
+      expect.objectContaining({ managedFileId: 'managed-artifact-1', name: '.pending' })
+    )
+  })
 
   it('mounts desktop Run Marks from visible human prompts', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')

--- a/src/renderer/src/pages/workspace/artifact-preview-utils.ts
+++ b/src/renderer/src/pages/workspace/artifact-preview-utils.ts
@@ -14,6 +14,12 @@ export const ARTIFACT_IMAGE_PREVIEW_BYTES = 1024 * 1024
 
 export const getArtifactName = (artifact: MessageArtifact): string => artifact.name ?? artifact.path
 
+export const isPendingArtifactPublication = (artifact: MessageArtifact): boolean => {
+  const segments = artifact.path.split(/[\\/]+/u)
+  // Pending files end in `.pending/<runId>/<filename>`; a published filename may itself be `.pending`.
+  return segments[segments.length - 3] === '.pending'
+}
+
 export const getArtifactExtension = (artifact: MessageArtifact): string =>
   getFileExtension(getArtifactName(artifact)) || 'file'
 


### PR DESCRIPTION
## Problem

GENERATED artifacts can reach renderer preview surfaces before turn finalization publishes their first managed Artifact Version. The card starts both a thumbnail read and an availability probe for the pending path; inline Markdown images and links are a second preview entry point. `ManagedFileVersionService` correctly rejects these reads with `VERSION_NOT_FOUND`, so Electron logs `Error occurred in handler for 'artifacts:read-preview'` even though the renderer suppresses its own console error.

## Proposed change

- Recognize the exact cross-platform pending-file suffix: `.pending/<runId>/<filename>`.
- Keep pending GENERATED cards and inline Markdown references visible but inert; skip card previews, availability probes, image resources, TIFF previews, and click navigation until finalization replaces the artifact metadata.
- Share the pending-publication predicate across card and Markdown surfaces.
- Preserve the managed-version fail-closed behavior; do not swallow `VERSION_NOT_FOUND` in main.
- Keep a finalized artifact whose legal filename is `.pending` previewable.

## Scope and non-goals

- No schema, persisted field, enum, migration, data-model, or persistence changes.
- Historical compatibility requires no migration. The narrower suffix check avoids regressing existing finalized artifacts named `.pending`.
- Does not change artifact finalization or reconciliation. A path that remains pending indefinitely would be a separate lifecycle defect requiring its own reproduction.
- No new user-visible copy or i18n catalog entries.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Card and Markdown preview boundaries -> `npx vitest run src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx --reporter=dot` -> 2 files, 61 tests passed.
- Workspace renderer consumers -> `npm run test:module -- workspace_page` -> 30 files, 736 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.
- Prettier and `git diff --check` -> passed.
- Cross-platform pending paths -> regression coverage includes `/workspace/.pending/run-1/report.txt` and `C:\\workspace\\.pending\\run-1\\report.txt`.

Before the first production fix, the original tightened card regression failed identically on three runs: `artifacts.readPreview` was called twice for the pending path (32 KiB thumbnail plus 1-byte probe), matching the reported handler failure.

After Codex review identified the Markdown bypass and `.pending` filename collision, the two added public-boundary regressions also failed identically on three unmodified runs: the pending Markdown link remained enabled, and a finalized `.pending` file card remained disabled. Both pass after the shared exact-suffix guard.

A follow-up Codex review identified the PDF-specific nested viewport pipeline. With the observer harness dispatching every observed target, the pending-PDF regression failed identically on three pre-fix runs with `Managed preview requires a logical identity`; after pending cards stopped mounting `ArtifactPreview`, it passes without acquiring a preview resource.

`npm run test:affected:explain -- --base origin/main --head HEAD` selects the full CI fallback because `WorkspaceMessageItem.tsx` is not currently assigned to a module owner. Per maintainer direction, the full local `npm test` suite was not run; PR Gate is the final authority for that coverage.

## Review focus

- Confirm no card, inline image, TIFF, or Markdown link can acquire/open a pending Artifact Version.
- Confirm finalized artifacts, including a file literally named `.pending`, retain existing preview behavior.
- Confirm `.pending/<runId>/<filename>` remains the storage-layout invariant without adding publication state to persisted renderer data.
