### PR TITLE
feat(providers): add NVIDIA Build provider

### DIFF
--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -179,6 +179,7 @@ describe('provider-kind helpers', () => {
     expect(apiKeys).toContain('official:tencent')
     expect(apiKeys).toContain('official:tencentcodingplan')
     expect(apiKeys).toContain('official:tencenttokenplan')
+    expect(apiKeys).toContain('official:nvidia')
     // The two subscription sign-ins each get their own group, parallel to one another, rather than
     // the Claude one hiding under Official API.
     expect(groupKeys('codex')).toEqual(['codex-subscription'])

--- a/src/renderer/src/pages/settings/provider-icons.render.test.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.render.test.tsx
@@ -26,4 +26,13 @@ describe('ProviderKindIcon', () => {
       expect(html).not.toContain('text-muted-foreground')
     }
   )
+
+  it('renders the NVIDIA provider logo', () => {
+    const html = renderToStaticMarkup(<ProviderKindIcon kindKey="official:nvidia" />)
+
+    expect(html).toContain('<svg')
+    expect(html).toContain('<title>Nvidia</title>')
+    expect(html).toContain('#74B71B')
+    expect(html).not.toContain('text-muted-foreground')
+  })
 })

--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -3,6 +3,7 @@ import { CirclePlus, Sparkles } from 'lucide-react'
 // Import the bare icon components so this shared renderer stays free of @lobehub/ui.
 import ClaudeColor from '@lobehub/icons/es/Claude/components/Color'
 import Codex from '@lobehub/icons/es/Codex/components/Mono'
+import NvidiaColor from '@lobehub/icons/es/Nvidia/components/Color'
 import OpenCode from '@lobehub/icons/es/OpenCode/components/Mono'
 import TencentCloudColor from '@lobehub/icons/es/TencentCloud/components/Color'
 
@@ -117,6 +118,10 @@ export const ProviderKindIcon = ({
         aria-hidden="true"
       />
     )
+  }
+
+  if (kindKey === 'official:nvidia') {
+    return <NvidiaColor size={20} className={cn('size-5 shrink-0', className)} aria-hidden="true" />
   }
 
   if (

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -40,6 +40,7 @@ describe('provider registry', () => {
     expect(isOfficialVendorId('tencent')).toBe(true)
     expect(isOfficialVendorId('tencentcodingplan')).toBe(true)
     expect(isOfficialVendorId('tencenttokenplan')).toBe(true)
+    expect(isOfficialVendorId('nvidia')).toBe(true)
     expect(isOfficialVendorId(undefined)).toBe(false)
     expect(isOfficialVendorId(42)).toBe(false)
   })
@@ -144,6 +145,26 @@ describe('provider registry', () => {
     expect(resolveVendorModelApiEndpoints('opencode', 'minimax-m3')).toEqual(['openai'])
     expect(isVendorModelMultimodal('opencode-go', 'glm-5.3-flash')).toBe(true)
     expect(isVendorModelMultimodal('opencode', 'gpt-5.3-codex-spark')).toBe(false)
+  })
+
+  it('routes NVIDIA through Chat Completions with a curated agent catalog', () => {
+    expect(resolveVendorApiEndpoints('nvidia')).toEqual(['openai'])
+    expect(resolveVendorBaseUrl('nvidia')).toBe('https://integrate.api.nvidia.com/v1')
+    expect(resolveVendorApiKeyUrl('nvidia')).toBe('https://build.nvidia.com/settings/api-keys')
+    expect(resolveVendorModelsUrl('nvidia')).toBeUndefined()
+    expect(defaultVendorModel('nvidia')).toBe('nvidia/nemotron-3.5-lightning-30b-a3b')
+    expect(getOfficialVendor('nvidia')?.models.map(({ id }) => id)).toEqual([
+      'nvidia/nemotron-3.5-lightning-30b-a3b',
+      'deepseek-ai/deepseek-v4-pro-0813',
+      'minimaxai/minimax-m3',
+      'poolside/laguna-xs-2.1',
+      'meta/muse-glimmer-30b',
+      'moonshotai/kimi-k3'
+    ])
+    expect(isVendorModelMultimodal('nvidia', 'minimaxai/minimax-m3')).toBe(true)
+    expect(isVendorModelMultimodal('nvidia', 'meta/muse-glimmer-30b')).toBe(true)
+    expect(isVendorModelMultimodal('nvidia', 'moonshotai/kimi-k3')).toBe(true)
+    expect(isVendorModelMultimodal('nvidia', 'poolside/laguna-xs-2.1')).toBe(false)
   })
 
   it('resolves a single-endpoint vendor base URL', () => {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -34,6 +34,7 @@ export type OfficialVendorId =
   | 'tencent'
   | 'tencentcodingplan'
   | 'tencenttokenplan'
+  | 'nvidia'
   | 'opencode-go'
   | 'opencode'
   | 'openrouter'
@@ -703,6 +704,27 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       { id: 'minimax-m3', contextWindow: 1_000_000 }
     ],
     multimodal: { multimodalModels: ['kimi-k2.6'] }
+  },
+  {
+    id: 'nvidia',
+    label: 'NVIDIA',
+    reasoningEffort: 'unsupported',
+    apiEndpoints: ['openai'],
+    baseUrl: 'https://integrate.api.nvidia.com/v1',
+    apiKeyUrl: 'https://build.nvidia.com/settings/api-keys',
+    // The live catalog mixes chat, embedding, image, OCR, safety, and other model types, so keep the
+    // agent-capable chat catalog curated instead of exposing refresh-from-vendor.
+    models: [
+      { id: 'nvidia/nemotron-3.5-lightning-30b-a3b', contextWindow: 1_000_000 },
+      { id: 'deepseek-ai/deepseek-v4-pro-0813', contextWindow: 1_000_000 },
+      { id: 'minimaxai/minimax-m3', contextWindow: 1_000_000 },
+      { id: 'poolside/laguna-xs-2.1', contextWindow: 262_144 },
+      { id: 'meta/muse-glimmer-30b', contextWindow: 131_072 },
+      { id: 'moonshotai/kimi-k3', contextWindow: 1_048_576 }
+    ],
+    multimodal: {
+      multimodalModels: ['minimaxai/minimax-m3', 'meta/muse-glimmer-30b', 'moonshotai/kimi-k3']
+    }
   },
   {
     id: 'opencode-go',


### PR DESCRIPTION
## Problem

NVIDIA Build exposes an OpenAI-compatible Chat Completions endpoint, but users currently have to configure it as a single-model custom gateway and do not get a curated model catalog or NVIDIA identity in Settings.

## Proposed change

- Add NVIDIA as an official API provider using `https://integrate.api.nvidia.com/v1`.
- Offer six current agent-capable models, including `moonshotai/kimi-k3`, with NVIDIA Nemotron 3.5 Lightning as the default.
- Mark MiniMax M3, Muse Glimmer 30B, and Kimi K3 as multimodal.
- Reuse the installed LobeHub NVIDIA icon.
- Keep the catalog curated rather than enabling live refresh because NVIDIA's `/v1/models` mixes chat models with embedding, image, OCR, safety, and other model types.

## Scope and non-goals

- No new transport or protocol implementation; NVIDIA uses the existing OpenAI Chat Completions route.
- No dependency, database, migration, or i18n changes.
- No live NVIDIA API request is made by tests because no project credential is available.
- Existing framework routing remains unchanged: OpenCode and CodeBuddy use Chat Completions directly, Codex uses the existing Responses-to-Chat bridge, and Claude Code excludes OpenAI-only providers.

## Acceptance criteria and validation

The listed checks ran after the last material edit:

- NVIDIA registry identity, endpoint, key URL, curated models, context windows, and multimodal flags -> `npx --no-install vitest run src/shared/provider-registry.test.ts src/renderer/src/pages/settings/provider-icons.render.test.tsx src/renderer/src/pages/settings/provider-form-value.test.ts` -> 3 files, 90 tests passed.
- Provider account ownership, validation, runtime projection, backend consumer, and Windows-sensitive overlay -> `npm run test:module -- settings_provider_accounts` -> 22 files, 438 tests passed.
- Main-process contracts -> `npm run typecheck:node` -> passed.
- Renderer contracts and installed NVIDIA icon import -> `npm run typecheck:web` -> passed.
- Source formatting and lint rules -> `npm run lint` -> passed.

Consumer and platform scope: the existing provider-account module suite includes backend resolver consumers and the Windows-sensitive overlay. No protocol implementation or path handling changed, so no additional platform lane was run locally; exact-head PR Gate remains authoritative. Per maintainer direction, the complete local `npm test` suite was not run.

## Compatibility and persistence

- New state value: adds `nvidia` to `OfficialVendorId`; this is a TypeScript union/registry value, not a database enum.
- Persistence: saving the provider records `vendorId: "nvidia"`, the encrypted key reference, masked key hint, and validation state in `settings.json`. No persisted format version or database schema changes.
- Historical compatibility: existing settings require no migration. Downgrading to an older build that does not recognize `nvidia` will sanitize the provider as unknown and remove it.

## Review focus

- Whether the six-model curated catalog is the right initial surface.
- NVIDIA's live streaming function-call behavior, especially the documented possible `202` polling path for Kimi K3, remains the uncovered integration risk until exercised with a real NVIDIA API key.
