### PR TITLE
feat(workspace): show expandable skill document in load_skill permission card

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -9,6 +9,7 @@ import { Readable, Writable } from 'node:stream'
 
 const VERSION = '1.0.0'
 const PERMISSION_PROMPT = 'Request fixture permission.'
+const SKILL_PERMISSION_PROMPT = 'Request fixture skill permission.'
 const MEMORY_RECALL_PROMPT = 'Verify automatic memory recall.'
 const MEMORY_RECALL_ENTRY = 'Keep every response concise and welcoming.'
 const PROVIDER_BRIDGE_PROMPT = 'Verify the provider bridge.'
@@ -1351,6 +1352,29 @@ if (process.argv.includes('--version')) {
             permission.outcome.optionId === 'allow-once'
               ? 'Fixture permission allowed.'
               : 'Fixture permission denied.'
+        } else if (prompt.includes(SKILL_PERMISSION_PROMPT)) {
+          // The broker classifies mcp__skills__load_skill via the legacy Claude prefix into
+          // mcpIdentity 'skills/load_skill' without any server configuration.
+          const permission = await context.client.request(
+            acp.methods.client.session.requestPermission,
+            {
+              sessionId: context.params.sessionId,
+              toolCall: {
+                toolCallId: 'e2e-skill-permission-tool',
+                title: 'mcp__skills__load_skill',
+                rawInput: { skill: 'fixture-skill' }
+              },
+              options: [
+                { kind: 'allow_once', name: 'Allow once', optionId: 'allow-once' },
+                { kind: 'reject_once', name: 'Deny', optionId: 'deny-once' }
+              ]
+            }
+          )
+          reply =
+            permission.outcome.outcome === 'selected' &&
+            permission.outcome.optionId === 'allow-once'
+              ? 'Fixture skill permission allowed.'
+              : 'Fixture skill permission denied.'
         }
       } catch (error) {
         reply = `E2E fixture failure: ${error instanceof Error ? error.message : String(error)}`

--- a/e2e/skill-permission-card.spec.ts
+++ b/e2e/skill-permission-card.spec.ts
@@ -7,8 +7,8 @@ import { test } from './fixtures/electron-app'
 const PROJECT_NAME = 'Skill permission project'
 const SKILL_PERMISSION_PROMPT = 'Request fixture skill permission.'
 const SKILL_NAME = 'fixture-skill'
-// Long enough to exceed the transcript sheet's 320px cap, so the permission card's roomier
-// 480px sheet is what the expanded screenshot exercises.
+// Long enough to exceed the transcript sheet's 320px cap, so the permission card's width-scaled
+// sheet (37.5cqw ≈ 292px at the e2e window width) is what the expanded screenshot exercises.
 const SKILL_BODY = [
   '# Fixture Skill',
   '',

--- a/e2e/skill-permission-card.spec.ts
+++ b/e2e/skill-permission-card.spec.ts
@@ -8,7 +8,7 @@ const PROJECT_NAME = 'Skill permission project'
 const SKILL_PERMISSION_PROMPT = 'Request fixture skill permission.'
 const SKILL_NAME = 'fixture-skill'
 // Long enough to exceed the transcript sheet's 320px cap, so the permission card's width-scaled
-// sheet (37.5cqw ≈ 292px at the e2e window width) is what the expanded screenshot exercises.
+// sheet (25cqw ≈ 195px at the e2e window width) is what the expanded screenshot exercises.
 const SKILL_BODY = [
   '# Fixture Skill',
   '',

--- a/e2e/skill-permission-card.spec.ts
+++ b/e2e/skill-permission-card.spec.ts
@@ -47,14 +47,32 @@ const seedFixtureSkill = async (page: Page): Promise<void> => {
   await page.getByText('Loading settings...').waitFor({ state: 'hidden', timeout: 60_000 })
 }
 
+const clickPermissionDecision = async (page: Page, decision: 'allow' | 'deny'): Promise<void> => {
+  const button = page
+    .getByTestId('permission-actions')
+    .getByTestId(decision === 'allow' ? 'allow-primary' : 'deny-button')
+  await expect(button).toBeEnabled()
+  // Same rationale as workspace-conversation.spec.ts: activate through the DOM click handler so an
+  // overlay can never swallow the pointer click.
+  await button.evaluate((element: HTMLButtonElement) => {
+    element.click()
+  })
+}
+
+const sendSkillPermissionPrompt = async (page: Page): Promise<void> => {
+  const composer = page.getByRole('textbox', { name: 'Ask anything' })
+  await expect(composer).toBeVisible()
+  await composer.fill(SKILL_PERMISSION_PROMPT)
+  await page.getByRole('button', { name: 'Send message' }).click()
+}
+
 test('renders the SKILL.md document in the skill load permission card', async ({ app }) => {
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()
   await seedFixtureSkill(page)
   await createProject(page)
 
-  await page.getByRole('textbox', { name: 'Ask anything' }).fill(SKILL_PERMISSION_PROMPT)
-  await page.getByRole('button', { name: 'Send message' }).click()
+  await sendSkillPermissionPrompt(page)
 
   const card = page.getByTestId('permission-card')
   await expect(card).toBeVisible()
@@ -74,9 +92,21 @@ test('renders the SKILL.md document in the skill load permission card', async ({
   await expect(card.getByText('Review fixture evidence carefully.')).toBeHidden()
   await card.screenshot({ path: join(SCREENSHOT_ROOT, 'skill-permission-card-collapsed.png') })
 
-  // The approval flow still completes through the new section.
-  const allow = page.getByTestId('permission-actions').getByTestId('allow-primary')
-  await expect(allow).toBeEnabled()
-  await allow.evaluate((element: HTMLButtonElement) => element.click())
+  // The approval flow still completes through the new section, on the Deny path too.
+  await clickPermissionDecision(page, 'deny')
+  await expect(page.getByText('Fixture skill permission denied.', { exact: true })).toBeVisible()
+
+  // Regression guard: a repeated load_skill approval must keep the skill document section rather
+  // than regressing to the generic JSON input.
+  await sendSkillPermissionPrompt(page)
+  const secondToggle = page.getByTestId('permission-skill-toggle')
+  await expect(secondToggle).toBeVisible()
+  await expect(secondToggle).toHaveAttribute('aria-expanded', 'true')
+  await expect(
+    page.getByTestId('permission-card').getByText('Review fixture evidence carefully.')
+  ).toBeVisible()
+  await expect(page.getByTestId('permission-code-toggle')).toHaveCount(0)
+
+  await clickPermissionDecision(page, 'allow')
   await expect(page.getByText('Fixture skill permission allowed.', { exact: true })).toBeVisible()
 })

--- a/e2e/skill-permission-card.spec.ts
+++ b/e2e/skill-permission-card.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import type { Page } from 'playwright'
+import { test } from './fixtures/electron-app'
+
+const PROJECT_NAME = 'Skill permission project'
+const SKILL_PERMISSION_PROMPT = 'Request fixture skill permission.'
+const SKILL_NAME = 'fixture-skill'
+const SKILL_BODY =
+  '# Fixture Skill\n\nReview fixture evidence carefully.\n\n## Steps\n\n1. Load the skill.\n2. Check the details.'
+// PR-summary screenshots land in the git-ignored test-results root, outside the per-test outputDir.
+const SCREENSHOT_ROOT = resolve(process.cwd(), 'test-results')
+
+const createProject = async (page: Page): Promise<void> => {
+  await page.getByRole('button', { name: 'New project' }).click()
+  const dialog = page.getByRole('dialog', { name: 'New project' })
+  await dialog.getByLabel('Name').fill(PROJECT_NAME)
+  await dialog.getByRole('button', { name: 'Create project' }).click()
+  await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
+}
+
+// Seed the skills catalog through the real Settings bridge. The workspace composer loads the
+// catalog into the renderer settings store on mount, so reload once to pick the new skill up
+// before the permission card tries to resolve it.
+const seedFixtureSkill = async (page: Page): Promise<void> => {
+  await page.evaluate(
+    async ({ name, body }) => {
+      await window.api.settings.createSkill({
+        name,
+        description: 'Fixture skill for the permission card journey.',
+        body
+      })
+    },
+    { name: SKILL_NAME, body: SKILL_BODY }
+  )
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.getByText('Loading settings...').waitFor({ state: 'hidden', timeout: 60_000 })
+}
+
+test('renders the SKILL.md document in the skill load permission card', async ({ app }) => {
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await seedFixtureSkill(page)
+  await createProject(page)
+
+  await page.getByRole('textbox', { name: 'Ask anything' }).fill(SKILL_PERMISSION_PROMPT)
+  await page.getByRole('button', { name: 'Send message' }).click()
+
+  const card = page.getByTestId('permission-card')
+  await expect(card).toBeVisible()
+  const toggle = page.getByTestId('permission-skill-toggle')
+  await expect(toggle).toBeVisible()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  await expect(card.getByText('Review fixture evidence carefully.')).toBeVisible()
+  // The skill document replaces the generic MCP JSON preview entirely.
+  await expect(page.getByTestId('permission-code-toggle')).toHaveCount(0)
+  await expect(card.getByText('External service input')).toHaveCount(0)
+
+  await mkdir(SCREENSHOT_ROOT, { recursive: true })
+  await card.screenshot({ path: join(SCREENSHOT_ROOT, 'skill-permission-card-expanded.png') })
+
+  await toggle.evaluate((element: HTMLButtonElement) => element.click())
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await expect(card.getByText('Review fixture evidence carefully.')).toBeHidden()
+  await card.screenshot({ path: join(SCREENSHOT_ROOT, 'skill-permission-card-collapsed.png') })
+
+  // The approval flow still completes through the new section.
+  const allow = page.getByTestId('permission-actions').getByTestId('allow-primary')
+  await expect(allow).toBeEnabled()
+  await allow.evaluate((element: HTMLButtonElement) => element.click())
+  await expect(page.getByText('Fixture skill permission allowed.', { exact: true })).toBeVisible()
+})

--- a/e2e/skill-permission-card.spec.ts
+++ b/e2e/skill-permission-card.spec.ts
@@ -7,8 +7,17 @@ import { test } from './fixtures/electron-app'
 const PROJECT_NAME = 'Skill permission project'
 const SKILL_PERMISSION_PROMPT = 'Request fixture skill permission.'
 const SKILL_NAME = 'fixture-skill'
-const SKILL_BODY =
-  '# Fixture Skill\n\nReview fixture evidence carefully.\n\n## Steps\n\n1. Load the skill.\n2. Check the details.'
+// Long enough to exceed the transcript sheet's 320px cap, so the permission card's roomier
+// 480px sheet is what the expanded screenshot exercises.
+const SKILL_BODY = [
+  '# Fixture Skill',
+  '',
+  'Review fixture evidence carefully.',
+  '',
+  '## Steps',
+  '',
+  ...Array.from({ length: 18 }, (_, index) => `${index + 1}. Check fixture detail ${index + 1}.`)
+].join('\n')
 // PR-summary screenshots land in the git-ignored test-results root, outside the per-test outputDir.
 const SCREENSHOT_ROOT = resolve(process.cwd(), 'test-results')
 

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -94,6 +94,7 @@ type FakeSettingsService = Record<
   | 'setNotebookNetwork'
   | 'listSkills'
   | 'getSkillDetail'
+  | 'resolveSkillDocument'
   | 'buildSkillExport'
   | 'setSkillEnabled'
   | 'setSkillsEnabled'
@@ -233,6 +234,7 @@ const createFakeService = (): FakeSettingsService => ({
     enabled: true,
     body: 'b'
   }),
+  resolveSkillDocument: vi.fn().mockResolvedValue(null),
   buildSkillExport: vi.fn().mockResolvedValue({
     fileName: 'my-skill.zip',
     archiveBytes: new Uint8Array([1, 2, 3])
@@ -861,6 +863,9 @@ describe('settings IPC handlers', () => {
 
     await invoke('settings:get-skill-detail', 'demo')
     expect(service.getSkillDetail).toHaveBeenCalledWith('demo')
+
+    await invoke('settings:resolve-skill-document', { name: 'demo' })
+    expect(service.resolveSkillDocument).toHaveBeenCalledWith({ name: 'demo' })
 
     await invoke('settings:set-skill-enabled', { id: 'demo', enabled: false })
     expect(service.setSkillEnabled).toHaveBeenCalledWith({ id: 'demo', enabled: false })

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -36,6 +36,7 @@ import {
   type ExportCustomServerTemplateResult,
   type RemoveCustomServerRequest,
   type RemoveDeviceCredentialRequest,
+  type ResolveSkillDocumentRequest,
   type SelectCustomServerTemplateRequest,
   type SetCustomServerEnabledRequest,
   type UpdateCustomServerRequest,
@@ -357,6 +358,9 @@ const registerSettingsIpcHandlers = ({
   )
   ipcMainHandle('settings:remove-github-token', () => service.removeGitHubToken())
   ipcMainHandle('settings:get-skill-detail', (_event, id: string) => service.getSkillDetail(id))
+  ipcMainHandle('settings:resolve-skill-document', (_event, request: ResolveSkillDocumentRequest) =>
+    service.resolveSkillDocument(request)
+  )
   ipcMainHandle('settings:export-skill', async (event, request: ExportSkillRequest) => {
     if (!skillExportFiles) throw new Error('Skill export is unavailable')
     return skillExportFiles.save(await service.buildSkillExport(request.id), event.sender)

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3908,6 +3908,74 @@ describe('SettingsService: skills', () => {
     expect(detail.body).toContain('demo body')
   })
 
+  it('resolves a managed-catalog skill document by canonical name', async () => {
+    const service = await createSkillService()
+
+    await expect(service.resolveSkillDocument({ name: 'demo' })).resolves.toEqual({
+      name: 'demo',
+      displayName: 'Demo',
+      description: 'A demo skill.',
+      body: 'demo body'
+    })
+  })
+
+  it('resolves an enabled bundled connector skill from its generated document', async () => {
+    const service = await createSkillService()
+
+    // Bundled connectors are default-on, so mcp-molecule resolves without any settings change.
+    const resolved = await service.resolveSkillDocument({ name: 'mcp-molecule' })
+    expect(resolved).toMatchObject({ name: 'mcp-molecule', displayName: 'Molecule Viewer' })
+    expect(resolved?.description).toContain('chemical structure')
+    expect(resolved?.body).toContain('## Tools')
+    expect(resolved?.body).not.toContain('name: mcp-molecule')
+  })
+
+  it('does not resolve a disabled bundled connector skill', async () => {
+    const service = await createSkillService()
+    await service.setConnectorEnabled({ id: 'molecule', enabled: false })
+
+    await expect(service.resolveSkillDocument({ name: 'mcp-molecule' })).resolves.toBeNull()
+  })
+
+  it('resolves a materialized custom connector skill from the provisioned source dir', async () => {
+    const service = await createSkillService()
+    service.setCustomServerRuntimeProjectionProvider({
+      materializedSkillNames: () => ['mcp-custom'],
+      availability: () => undefined,
+      isRefreshing: () => false
+    })
+    const dir = join(storageRoot, 'runtime-support', 'connector-skills', 'mcp-custom')
+    await mkdir(dir, { recursive: true })
+    await writeFile(
+      join(dir, 'SKILL.md'),
+      [
+        '---',
+        'name: mcp-custom',
+        'description: Custom server tools.',
+        '---',
+        '',
+        'custom body'
+      ].join('\n'),
+      'utf8'
+    )
+
+    await expect(service.resolveSkillDocument({ name: 'mcp-custom' })).resolves.toEqual({
+      name: 'mcp-custom',
+      description: 'Custom server tools.',
+      body: 'custom body'
+    })
+  })
+
+  it('returns null for unknown, unprovisioned, and unsafe skill names', async () => {
+    const service = await createSkillService()
+
+    await expect(service.resolveSkillDocument({ name: 'unknown-skill' })).resolves.toBeNull()
+    // A custom-skill-shaped name that was never provisioned must not read the filesystem.
+    await expect(service.resolveSkillDocument({ name: 'mcp-not-real' })).resolves.toBeNull()
+    await expect(service.resolveSkillDocument({ name: '../outside' })).resolves.toBeNull()
+    await expect(service.resolveSkillDocument({ name: 'Bad Name' })).resolves.toBeNull()
+  })
+
   it('keeps a Main-disabled installed Skill in the Specialist catalog', async () => {
     const service = await createSkillService()
     await service.setSkillEnabled({ id: 'demo', enabled: false })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1,4 +1,5 @@
 import { homedir } from 'node:os'
+import { readFile, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { CloseActionPreference } from '../../shared/window-controls'
@@ -34,6 +35,8 @@ import type {
   Preflight,
   RefreshProviderModelsRequest,
   RefreshProviderModelsResult,
+  ResolveSkillDocumentRequest,
+  ResolvedSkillDocument,
   SetConnectorAutoAllowRequest,
   SetConnectorEnabledRequest,
   SetNcbiCredentialsRequest,
@@ -120,6 +123,13 @@ import {
 } from './backend-resolver'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
+import { SAFE_SKILL_NAME } from '../skills/skill-name'
+import { parseFrontmatter } from '../skills/frontmatter'
+import { SKILL_IMPORT_LIMITS } from '../skills/import-limits'
+import { CONNECTOR_CATALOG } from '../connectors/catalog'
+import { ALL_CONNECTOR_IDS } from '../connectors/registry'
+import { renderSkillDoc } from '../connectors/skill-doc'
+import { connectorSkillSourceDir } from '../connectors/provision'
 import type { SkillExportArchive } from '../skills/export'
 import type { FetchLike } from '../skills/github-import'
 import type { StoredConnectors, StoredCustomMcpOAuthState, StoredSettings } from './types'
@@ -689,6 +699,69 @@ class SettingsService {
 
   async getSkillDetail(id: string): Promise<SkillDetailView> {
     return this.skills.getSkillDetail(id)
+  }
+
+  // Resolves a renderable SKILL.md document by canonical invocation name across every source the
+  // runtime can load from. The permission card and transcript rows need this because connector
+  // skills (mcp-<id> for enabled bundled connectors, materialized custom MCP server skills) are
+  // invocable through load_skill but are NOT part of the renderer's managed catalog. Sources, in
+  // order: the managed catalog (an enabled entry wins a name collision, mirroring the renderer's
+  // own rule), enabled bundled connectors (document rendered on the fly), then materialized custom
+  // server skills (read from the provisioned source dir, gated by the provisioned-name projection
+  // so arbitrary directories are never served). Returns null when no source provides the name.
+  async resolveSkillDocument(
+    request: ResolveSkillDocumentRequest
+  ): Promise<ResolvedSkillDocument | null> {
+    const name = request.name.trim()
+    // The same lowercase-hyphen shape the runtime accepts; keeps the filesystem read below safe.
+    if (!SAFE_SKILL_NAME.test(name)) return null
+
+    const skills = await this.skills.listSkills()
+    const entry =
+      skills.find((skill) => skill.name === name && skill.enabled) ??
+      skills.find((skill) => skill.name === name)
+    if (entry) {
+      const detail = await this.getSkillDetail(entry.id)
+      return {
+        name: detail.name,
+        displayName: detail.displayName,
+        description: detail.description,
+        body: detail.body
+      }
+    }
+
+    const bundledId = /^mcp-(.+)$/.exec(name)?.[1]
+    if (bundledId && ALL_CONNECTOR_IDS.includes(bundledId)) {
+      const settings = await this.repository.getSettings()
+      if (!this.connectors.enabledConnectorIds(settings.connectors).includes(bundledId)) {
+        return null
+      }
+      const meta = CONNECTOR_CATALOG.find((connector) => connector.id === bundledId)
+      const { fields, body } = parseFrontmatter(renderSkillDoc(bundledId))
+      return {
+        name,
+        ...(meta ? { displayName: meta.displayName } : {}),
+        ...(fields.description ? { description: fields.description } : {}),
+        body
+      }
+    }
+
+    if (!(await this.connectors.provisionedConnectorSkillNames()).includes(name)) return null
+    const filePath = join(connectorSkillSourceDir(this.storageRoot), name, 'SKILL.md')
+    const metadata = await stat(filePath).catch(() => undefined)
+    // The body is renderer-bound preview text; cap it at the shared preview budget before reading.
+    if (!metadata?.isFile() || metadata.size > SKILL_IMPORT_LIMITS.maxPreviewContentBytes) {
+      return null
+    }
+    const raw = await readFile(filePath, 'utf8').catch(() => undefined)
+    if (!raw) return null
+    const { fields, body } = parseFrontmatter(raw)
+    if (fields.name !== name) return null
+    return {
+      name,
+      ...(fields.description ? { description: fields.description } : {}),
+      body
+    }
   }
 
   async setSkillEnabled(request: SetSkillEnabledRequest): Promise<SkillView[]> {

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -489,7 +489,7 @@ describe('Settings backend ownership architecture', () => {
         previewCustomServerTemplateImport previewGitHubSkill previewSkillArchive previewSkillZip
         provisionedConnectorSkillNames publishHostSkill refreshProviderModels registeredHelperCatalog rememberCodexAutoHttpsFallback removeCustomServer removeDeviceCredential removeGitHubToken removeNotebookNetwork
         removeManualInterpreter resolveActiveModelChangeTarget resolveActiveReasoningEffort
-        resolveAdmittedSubagentBackend resolveAgentBackend resolveDeviceOAuthCredential resolveExplicitAgentBackend resolveSubagentExecutionModel saveCustomServerOAuthState saveGitHubToken
+        resolveAdmittedSubagentBackend resolveAgentBackend resolveDeviceOAuthCredential resolveExplicitAgentBackend resolveSkillDocument resolveSubagentExecutionModel saveCustomServerOAuthState saveGitHubToken
         scanRepoSkills setActiveProvider setAgentEnvironmentCreationEnabled setAgentFramework setAppIconVariant setClosePreference
         setComputeBookmarks setConnectorAutoAllow setConnectorEnabled
         setConversationSkillImportEnabled setCustomServerAuthenticator setCustomServerEnabled

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -572,6 +572,7 @@ describe('preload bridge — public surface inventory', () => {
       'settings.replayPendingConnectorApprovals',
       'settings.replayPendingConnectorCredentialRequests',
       'settings.replayPendingSkillImportApprovals',
+      'settings.resolveSkillDocument',
       'settings.respondConnectorApproval',
       'settings.respondConnectorCredentialRequest',
       'settings.respondSkillImportApproval',

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 
 import { act } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createRoot, type Root } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { AcpPermissionRequest } from '../../../../shared/acp'
-import { describe, expect, it } from 'vitest'
+import type { SkillView } from '../../../../shared/settings'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { i18next } from '@/i18n'
+import { useSettingsStore } from '@/stores/settings-store'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -169,6 +171,39 @@ const networkApprovalRequest: AcpPermissionRequest = {
   ]
 }
 
+// A skills/load_skill approval: the broker pins the stable skills/load_skill identity and the
+// raw input names the skill being loaded; the SKILL.md body is resolved from the skills catalog.
+const skillLoadPermissionRequest: AcpPermissionRequest = {
+  requestId: 'skill-1',
+  sessionId: 'session-1',
+  toolCallId: 'tool-skill',
+  title: 'mcp__skills__load_skill',
+  providerToolName: 'mcp__skills__load_skill',
+  isMcp: true,
+  mcpIdentity: 'skills/load_skill',
+  rawInput: { skill: 'mcp-pubmed' },
+  options: [
+    { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+    { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' }
+  ]
+}
+
+const catalogSkill: SkillView = {
+  id: 'imported-mcp-pubmed',
+  name: 'mcp-pubmed',
+  displayName: 'PubMed Search',
+  description: 'Search PubMed',
+  source: 'imported',
+  updatedAt: '2026-08-27T00:00:00Z',
+  enabled: true
+}
+
+const installSkillDetail = (body: string): ReturnType<typeof vi.fn> => {
+  const getSkillDetail = vi.fn().mockResolvedValue({ body })
+  window.api = { settings: { getSkillDetail } } as unknown as Window['api']
+  return getSkillDetail
+}
+
 const renderControls = (): string =>
   renderToStaticMarkup(
     <PermissionApprovalControls requests={[permissionRequest]} onRespond={() => undefined} />
@@ -188,6 +223,32 @@ const secondPermissionRequest: AcpPermissionRequest = {
 }
 
 describe('PermissionApprovalControls', () => {
+  // jsdom-mounted cards to unmount after each test (static-markup tests mount nothing).
+  const mounted: Array<{ root: Root; host: HTMLDivElement }> = []
+
+  afterEach(async () => {
+    for (const { root, host } of mounted.splice(0)) {
+      await act(async () => {
+        root.unmount()
+      })
+      host.remove()
+    }
+    useSettingsStore.setState({ skills: [], skillsLoaded: false })
+    window.api = undefined as unknown as Window['api']
+    vi.restoreAllMocks()
+  })
+
+  const mountControls = async (request: AcpPermissionRequest): Promise<HTMLDivElement> => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root = createRoot(host)
+    await act(async () => {
+      root.render(<PermissionApprovalControls requests={[request]} onRespond={() => undefined} />)
+    })
+    mounted.push({ root, host })
+    return host
+  }
+
   it('renders Notebook domain requests as a conversation approval without exposing raw payload JSON', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls requests={[networkApprovalRequest]} onRespond={() => undefined} />
@@ -935,5 +996,99 @@ describe('PermissionApprovalControls', () => {
       />
     )
     expect(html).toContain('/repo/config/prod.env')
+  })
+
+  it('renders the SKILL.md document for a catalog skill load instead of the raw JSON input', async () => {
+    useSettingsStore.setState({ skills: [catalogSkill], skillsLoaded: true })
+    const getSkillDetail = installSkillDetail('# mcp-pubmed\n\nSearch **PubMed** articles.')
+
+    const host = await mountControls(skillLoadPermissionRequest)
+
+    expect(getSkillDetail).toHaveBeenCalledWith('imported-mcp-pubmed')
+
+    const toggle = host.querySelector('[data-testid="permission-skill-toggle"]')
+    expect(toggle).not.toBeNull()
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true')
+    expect(toggle?.textContent).toContain('PubMed Search')
+    expect(toggle?.textContent).toContain('Skill')
+    expect(host.querySelector('[data-testid="permission-code-toggle"]')).toBeNull()
+    expect(host.querySelector('.shadow-sheet')).not.toBeNull()
+    expect(host.querySelector('h1')?.textContent).toBe('mcp-pubmed')
+  })
+
+  it('resolves the skill from the Codex arguments envelope and namespaced tool identity', async () => {
+    useSettingsStore.setState({ skills: [catalogSkill], skillsLoaded: true })
+    const getSkillDetail = installSkillDetail('# mcp-pubmed')
+
+    const host = await mountControls({
+      ...skillLoadPermissionRequest,
+      title: 'mcp.skills.load_skill',
+      providerToolName: 'mcp.skills.load_skill',
+      mcpIdentity: undefined,
+      rawInput: { arguments: { skill: 'mcp-pubmed', args: '--depth full' } }
+    })
+
+    expect(getSkillDetail).toHaveBeenCalledWith('imported-mcp-pubmed')
+    expect(host.querySelector('[data-testid="permission-skill-toggle"]')).not.toBeNull()
+    expect(host.querySelector('[data-testid="permission-code-toggle"]')).toBeNull()
+  })
+
+  it('keeps the generic JSON input when the skill is not in the catalog', () => {
+    useSettingsStore.setState({ skills: [], skillsLoaded: true })
+    const getSkillDetail = installSkillDetail('# unused')
+
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[skillLoadPermissionRequest]}
+        onRespond={() => undefined}
+      />
+    )
+
+    expect(html).toContain('data-testid="permission-code-toggle"')
+    expect(html).toContain('External service input')
+    expect(html).toContain('mcp-pubmed')
+    expect(html).not.toContain('permission-skill-toggle')
+    expect(getSkillDetail).not.toHaveBeenCalled()
+  })
+
+  it('offers a retry when the skill document fetch fails', async () => {
+    useSettingsStore.setState({ skills: [catalogSkill], skillsLoaded: true })
+    const getSkillDetail = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ipc down'))
+      .mockResolvedValue({ body: '# mcp-pubmed\n\nRecovered.' })
+    window.api = { settings: { getSkillDetail } } as unknown as Window['api']
+
+    const host = await mountControls(skillLoadPermissionRequest)
+
+    const retry = Array.from(host.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Retry'
+    )
+    expect(retry).toBeDefined()
+
+    await act(async () => {
+      retry?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(getSkillDetail).toHaveBeenCalledTimes(2)
+    expect(host.querySelector('h1')?.textContent).toBe('mcp-pubmed')
+    expect(host.textContent).toContain('Recovered.')
+  })
+
+  it('collapses and re-expands the skill document via the toggle', async () => {
+    useSettingsStore.setState({ skills: [catalogSkill], skillsLoaded: true })
+    installSkillDetail('# mcp-pubmed')
+
+    const host = await mountControls(skillLoadPermissionRequest)
+    const toggle = host.querySelector<HTMLButtonElement>('[data-testid="permission-skill-toggle"]')
+    expect(host.querySelector('.shadow-sheet')).not.toBeNull()
+
+    await act(async () => toggle?.click())
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false')
+    expect(host.querySelector('.shadow-sheet')).toBeNull()
+
+    await act(async () => toggle?.click())
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true')
+    expect(host.querySelector('.shadow-sheet')).not.toBeNull()
   })
 })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -199,9 +199,18 @@ const catalogSkill: SkillView = {
 }
 
 const installSkillDetail = (body: string): ReturnType<typeof vi.fn> => {
-  const getSkillDetail = vi.fn().mockResolvedValue({ body })
+  const getSkillDetail = vi
+    .fn()
+    .mockResolvedValue({ ...catalogSkill, body, references: [], packageFiles: [] })
   window.api = { settings: { getSkillDetail } } as unknown as Window['api']
   return getSkillDetail
+}
+
+const installSkillDocumentResolver = (
+  resolveSkillDocument: ReturnType<typeof vi.fn>
+): ReturnType<typeof vi.fn> => {
+  window.api = { settings: { resolveSkillDocument } } as unknown as Window['api']
+  return resolveSkillDocument
 }
 
 const renderControls = (): string =>
@@ -1033,22 +1042,46 @@ describe('PermissionApprovalControls', () => {
     expect(host.querySelector('[data-testid="permission-code-toggle"]')).toBeNull()
   })
 
-  it('keeps the generic JSON input when the skill is not in the catalog', () => {
+  it('resolves the skill document through the main-process resolver on a catalog miss', async () => {
     useSettingsStore.setState({ skills: [], skillsLoaded: true })
-    const getSkillDetail = installSkillDetail('# unused')
-
-    const html = renderToStaticMarkup(
-      <PermissionApprovalControls
-        requests={[skillLoadPermissionRequest]}
-        onRespond={() => undefined}
-      />
+    const resolveSkillDocument = installSkillDocumentResolver(
+      vi.fn().mockResolvedValue({
+        name: 'mcp-pubmed',
+        displayName: 'PubMed Connector',
+        body: '# mcp-pubmed\n\nConnector-provided document.'
+      })
     )
 
-    expect(html).toContain('data-testid="permission-code-toggle"')
-    expect(html).toContain('External service input')
-    expect(html).toContain('mcp-pubmed')
-    expect(html).not.toContain('permission-skill-toggle')
-    expect(getSkillDetail).not.toHaveBeenCalled()
+    const host = await mountControls(skillLoadPermissionRequest)
+
+    expect(resolveSkillDocument).toHaveBeenCalledWith({ name: 'mcp-pubmed' })
+
+    const toggle = host.querySelector('[data-testid="permission-skill-toggle"]')
+    expect(toggle).not.toBeNull()
+    expect(toggle?.textContent).toContain('PubMed Connector')
+    expect(host.querySelector('h1')?.textContent).toBe('mcp-pubmed')
+    expect(host.textContent).toContain('Connector-provided document.')
+    // The resolved document replaces the raw JSON input.
+    expect(host.querySelector('[data-testid="permission-code-toggle"]')).toBeNull()
+    expect(host.querySelector('[data-testid="tool-code-block"]')).toBeNull()
+  })
+
+  it('keeps the raw JSON input inside the skill section when no source provides the skill', async () => {
+    useSettingsStore.setState({ skills: [], skillsLoaded: true })
+    const resolveSkillDocument = installSkillDocumentResolver(vi.fn().mockResolvedValue(null))
+
+    const host = await mountControls(skillLoadPermissionRequest)
+
+    expect(resolveSkillDocument).toHaveBeenCalledWith({ name: 'mcp-pubmed' })
+
+    const toggle = host.querySelector('[data-testid="permission-skill-toggle"]')
+    expect(toggle).not.toBeNull()
+    expect(toggle?.textContent).toContain('mcp-pubmed')
+    // The unavailable document falls back to the reviewable raw input inside the same section.
+    const codeBlock = host.querySelector('[data-testid="tool-code-block"]')
+    expect(codeBlock).not.toBeNull()
+    expect(codeBlock?.textContent).toContain('"skill"')
+    expect(codeBlock?.textContent).toContain('mcp-pubmed')
   })
 
   it('offers a retry when the skill document fetch fails', async () => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -15,7 +15,6 @@ import { dialogTitleClassName } from '@/components/ui/dialog-chrome'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { useSettingsStore } from '@/stores/settings-store'
 import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
 import {
   describePermissionRequest,
@@ -41,6 +40,7 @@ import { WorkspaceLiteratureToolCard } from './WorkspaceLiteratureToolCard'
 import { SkillDocumentSheet } from './WorkspaceSkillLoadRow'
 import { buildLiteratureToolSummary } from './literature-tool-presentation'
 import { getSkillLoadPermissionSkillName } from './workspace-skill-load'
+import { useSkillDocument } from './use-skill-document'
 
 type PermissionApprovalControlsProps = {
   requests: AcpPermissionRequest[]
@@ -331,45 +331,22 @@ const PermissionCodeSection = ({
 
 // Activity-style collapsible card for a skills/load_skill approval. The request carries only the
 // skill's invocation name, so — like the transcript's load_skill rows — the SKILL.md body is
-// resolved from the app's skills catalog by catalog id. It defaults to expanded and fetches on
-// mount (rather than on first expand) because the document IS the payload under review.
+// resolved through useSkillDocument: the managed catalog when listed, the main-process
+// connector-aware resolver otherwise. It defaults to expanded and fetches on mount (rather than on
+// first expand) because the document IS the payload under review. When no source provides the
+// name, the raw JSON input stays reviewable as the fallback block.
 const PermissionSkillSection = ({
-  title,
-  skillId
+  skillName,
+  fallback
 }: {
-  title: string
-  skillId: string
-}): React.JSX.Element => {
+  skillName: string
+  fallback?: PermissionCode
+}): React.JSX.Element | null => {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(true)
-  // Keyed by catalog id so a re-imported or renamed skill cannot show a stale body.
-  const [loaded, setLoaded] = useState<{ id: string; body: string } | undefined>()
-  const [failedId, setFailedId] = useState<string | undefined>()
-  const requestRef = useRef(0)
-  const markdown = loaded && loaded.id === skillId ? loaded.body : undefined
-  const failed = failedId === skillId
+  const document = useSkillDocument(skillName)
 
-  useEffect(() => {
-    if (markdown !== undefined || failed) return undefined
-
-    const requestId = ++requestRef.current
-    let cancelled = false
-
-    void window.api.settings.getSkillDetail(skillId).then(
-      (detail) => {
-        if (!cancelled && requestRef.current === requestId) {
-          setLoaded({ id: skillId, body: detail.body })
-        }
-      },
-      () => {
-        if (!cancelled && requestRef.current === requestId) setFailedId(skillId)
-      }
-    )
-
-    return () => {
-      cancelled = true
-    }
-  }, [skillId, markdown, failed])
+  if (document.status === 'unavailable' && !fallback) return null
 
   return (
     <div className="w-full overflow-hidden rounded-lg bg-muted/60 px-2 py-1.5">
@@ -388,7 +365,9 @@ const PermissionSkillSection = ({
         >
           <ChevronRight className="size-3.5" strokeWidth={2.2} aria-hidden="true" />
         </span>
-        <span className="min-w-0 truncate text-left font-medium text-foreground">{title}</span>
+        <span className="min-w-0 truncate text-left font-medium text-foreground">
+          {document.status === 'ready' ? document.title : skillName}
+        </span>
         <span className="ml-auto shrink-0 whitespace-nowrap text-xs text-muted-foreground">
           {t('Skill')}
         </span>
@@ -397,16 +376,21 @@ const PermissionSkillSection = ({
         // The sheet caps at a 16:9 height of its own width (56.25cqw against this container),
         // so the preview scales with the card instead of a fixed pixel ceiling.
         <div className="@container mx-1 mb-1.5 md:ml-[30px]">
-          {markdown ? (
-            <SkillDocumentSheet markdown={markdown} maxHeightClassName="max-h-[56.25cqw]" />
-          ) : failed ? (
+          {document.status === 'ready' ? (
+            <SkillDocumentSheet
+              markdown={document.markdown}
+              maxHeightClassName="max-h-[56.25cqw]"
+            />
+          ) : document.status === 'failed' ? (
             <button
               type="button"
               className="rounded-md px-1 py-1 text-[12px] text-text-300 transition-colors hover:text-text-100"
-              onClick={() => setFailedId(undefined)}
+              onClick={document.retry}
             >
               {t('Retry')}
             </button>
+          ) : document.status === 'unavailable' && fallback ? (
+            <WorkspaceToolCodeBlock code={fallback.code} language={fallback.language} copyable />
           ) : (
             <div className="px-1 py-1 text-[12px] text-text-300">{t('Loading preview…')}</div>
           )}
@@ -772,17 +756,10 @@ const PermissionApprovalCard = ({
   // Guard against a stale scope no longer offered by the current request.
   const effectiveScope = availableScopes.has(scope) ? scope : defaultScope
   const permCode = extractPermissionCode(request)
-  // A skills/load_skill approval names the skill being loaded; resolve its catalog entry so the
-  // card can show the SKILL.md document instead of the raw JSON input (mirroring the transcript's
-  // load_skill rows). The runtime materializes enabled skills, so an enabled entry wins a name
-  // collision; a skill outside the catalog keeps the generic JSON preview.
+  // A skills/load_skill approval names the skill being loaded; the section resolves the SKILL.md
+  // document (managed catalog first, then the connector-aware main resolver) and falls back to the
+  // raw JSON input when no source provides the name.
   const skillLoadName = getSkillLoadPermissionSkillName(request)
-  const skillEntry = useSettingsStore((state) =>
-    skillLoadName
-      ? (state.skills.find((skill) => skill.name === skillLoadName && skill.enabled) ??
-        state.skills.find((skill) => skill.name === skillLoadName))
-      : undefined
-  )
   const literatureSummary = isLiteratureReadRequest(request)
     ? buildLiteratureToolSummary(request.rawInput)
     : undefined
@@ -1002,12 +979,8 @@ const PermissionApprovalCard = ({
         <SpecialistSwitchDetail request={request} />
       ) : isSpecialistDeleteRequest(request) ? (
         <SpecialistDeleteDetail request={request} />
-      ) : skillEntry && skillLoadName ? (
-        <PermissionSkillSection
-          key={requestId}
-          title={skillEntry.displayName || skillLoadName}
-          skillId={skillEntry.id}
-        />
+      ) : skillLoadName ? (
+        <PermissionSkillSection key={requestId} skillName={skillLoadName} fallback={permCode} />
       ) : permCode ? (
         <PermissionCodeSection
           key={requestId}

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -373,11 +373,11 @@ const PermissionSkillSection = ({
         </span>
       </button>
       {expanded && (
-        // The sheet caps at a 3:8 height of its own width (37.5cqw against this container),
+        // The sheet caps at a quarter of its own width (25cqw against this container),
         // so the preview scales with the card instead of a fixed pixel ceiling.
         <div className="@container mx-1 mb-1.5 md:ml-[30px]">
           {document.status === 'ready' ? (
-            <SkillDocumentSheet markdown={document.markdown} maxHeightClassName="max-h-[37.5cqw]" />
+            <SkillDocumentSheet markdown={document.markdown} maxHeightClassName="max-h-[25cqw]" />
           ) : document.status === 'failed' ? (
             <button
               type="button"

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -373,14 +373,11 @@ const PermissionSkillSection = ({
         </span>
       </button>
       {expanded && (
-        // The sheet caps at a 16:9 height of its own width (56.25cqw against this container),
+        // The sheet caps at a 3:8 height of its own width (37.5cqw against this container),
         // so the preview scales with the card instead of a fixed pixel ceiling.
         <div className="@container mx-1 mb-1.5 md:ml-[30px]">
           {document.status === 'ready' ? (
-            <SkillDocumentSheet
-              markdown={document.markdown}
-              maxHeightClassName="max-h-[56.25cqw]"
-            />
+            <SkillDocumentSheet markdown={document.markdown} maxHeightClassName="max-h-[37.5cqw]" />
           ) : document.status === 'failed' ? (
             <button
               type="button"

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -396,7 +396,7 @@ const PermissionSkillSection = ({
       {expanded && (
         <div className="mx-1 mb-1.5 md:ml-[30px]">
           {markdown ? (
-            <SkillDocumentSheet markdown={markdown} />
+            <SkillDocumentSheet markdown={markdown} maxHeightClassName="max-h-[480px]" />
           ) : failed ? (
             <button
               type="button"

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -394,9 +394,11 @@ const PermissionSkillSection = ({
         </span>
       </button>
       {expanded && (
-        <div className="mx-1 mb-1.5 md:ml-[30px]">
+        // The sheet caps at a 16:9 height of its own width (56.25cqw against this container),
+        // so the preview scales with the card instead of a fixed pixel ceiling.
+        <div className="@container mx-1 mb-1.5 md:ml-[30px]">
           {markdown ? (
-            <SkillDocumentSheet markdown={markdown} maxHeightClassName="max-h-[480px]" />
+            <SkillDocumentSheet markdown={markdown} maxHeightClassName="max-h-[56.25cqw]" />
           ) : failed ? (
             <button
               type="button"

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -15,6 +15,7 @@ import { dialogTitleClassName } from '@/components/ui/dialog-chrome'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { useSettingsStore } from '@/stores/settings-store'
 import { resolveNotebookLanguage, resolveNotebookRunToolName } from './notebook-tool-names'
 import {
   describePermissionRequest,
@@ -37,7 +38,9 @@ import { SpecialistDeleteDetail } from './SpecialistDeleteDetail'
 import { SpecialistSwitchDetail } from './SpecialistSwitchDetail'
 import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
 import { WorkspaceLiteratureToolCard } from './WorkspaceLiteratureToolCard'
+import { SkillDocumentSheet } from './WorkspaceSkillLoadRow'
 import { buildLiteratureToolSummary } from './literature-tool-presentation'
+import { getSkillLoadPermissionSkillName } from './workspace-skill-load'
 
 type PermissionApprovalControlsProps = {
   requests: AcpPermissionRequest[]
@@ -320,6 +323,91 @@ const PermissionCodeSection = ({
       {expanded && (
         <div className="mx-1 mb-1.5 md:ml-[30px]">
           <WorkspaceToolCodeBlock code={code} language={language} copyable />
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Activity-style collapsible card for a skills/load_skill approval. The request carries only the
+// skill's invocation name, so — like the transcript's load_skill rows — the SKILL.md body is
+// resolved from the app's skills catalog by catalog id. It defaults to expanded and fetches on
+// mount (rather than on first expand) because the document IS the payload under review.
+const PermissionSkillSection = ({
+  title,
+  skillId
+}: {
+  title: string
+  skillId: string
+}): React.JSX.Element => {
+  const { t } = useTranslation()
+  const [expanded, setExpanded] = useState(true)
+  // Keyed by catalog id so a re-imported or renamed skill cannot show a stale body.
+  const [loaded, setLoaded] = useState<{ id: string; body: string } | undefined>()
+  const [failedId, setFailedId] = useState<string | undefined>()
+  const requestRef = useRef(0)
+  const markdown = loaded && loaded.id === skillId ? loaded.body : undefined
+  const failed = failedId === skillId
+
+  useEffect(() => {
+    if (markdown !== undefined || failed) return undefined
+
+    const requestId = ++requestRef.current
+    let cancelled = false
+
+    void window.api.settings.getSkillDetail(skillId).then(
+      (detail) => {
+        if (!cancelled && requestRef.current === requestId) {
+          setLoaded({ id: skillId, body: detail.body })
+        }
+      },
+      () => {
+        if (!cancelled && requestRef.current === requestId) setFailedId(skillId)
+      }
+    )
+
+    return () => {
+      cancelled = true
+    }
+  }, [skillId, markdown, failed])
+
+  return (
+    <div className="w-full overflow-hidden rounded-lg bg-muted/60 px-2 py-1.5">
+      <button
+        type="button"
+        data-testid="permission-skill-toggle"
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 rounded-lg px-1.5 py-1.5 text-[13px] transition-colors hover:bg-muted"
+        onClick={() => setExpanded((e) => !e)}
+      >
+        <span
+          className={cn(
+            'inline-flex w-4 shrink-0 items-center justify-center text-muted-foreground transition-transform duration-200',
+            expanded && 'rotate-90'
+          )}
+        >
+          <ChevronRight className="size-3.5" strokeWidth={2.2} aria-hidden="true" />
+        </span>
+        <span className="min-w-0 truncate text-left font-medium text-foreground">{title}</span>
+        <span className="ml-auto shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+          {t('Skill')}
+        </span>
+      </button>
+      {expanded && (
+        <div className="mx-1 mb-1.5 md:ml-[30px]">
+          {markdown ? (
+            <SkillDocumentSheet markdown={markdown} />
+          ) : failed ? (
+            <button
+              type="button"
+              className="rounded-md px-1 py-1 text-[12px] text-text-300 transition-colors hover:text-text-100"
+              onClick={() => setFailedId(undefined)}
+            >
+              {t('Retry')}
+            </button>
+          ) : (
+            <div className="px-1 py-1 text-[12px] text-text-300">{t('Loading preview…')}</div>
+          )}
         </div>
       )}
     </div>
@@ -682,6 +770,17 @@ const PermissionApprovalCard = ({
   // Guard against a stale scope no longer offered by the current request.
   const effectiveScope = availableScopes.has(scope) ? scope : defaultScope
   const permCode = extractPermissionCode(request)
+  // A skills/load_skill approval names the skill being loaded; resolve its catalog entry so the
+  // card can show the SKILL.md document instead of the raw JSON input (mirroring the transcript's
+  // load_skill rows). The runtime materializes enabled skills, so an enabled entry wins a name
+  // collision; a skill outside the catalog keeps the generic JSON preview.
+  const skillLoadName = getSkillLoadPermissionSkillName(request)
+  const skillEntry = useSettingsStore((state) =>
+    skillLoadName
+      ? (state.skills.find((skill) => skill.name === skillLoadName && skill.enabled) ??
+        state.skills.find((skill) => skill.name === skillLoadName))
+      : undefined
+  )
   const literatureSummary = isLiteratureReadRequest(request)
     ? buildLiteratureToolSummary(request.rawInput)
     : undefined
@@ -891,7 +990,8 @@ const PermissionApprovalCard = ({
       ) : null}
 
       {/* Specialist switch/delete requests show a friendly detail block instead of the raw
-          redacted payload; all other requests keep the activity-style code preview. */}
+          redacted payload; all other requests keep the activity-style code preview. Skill loads
+          show the SKILL.md document itself — it is the payload being approved. */}
       {literatureSummary ? (
         <WorkspaceLiteratureToolCard summary={literatureSummary} />
       ) : isNotebookNetworkApprovalRequest(request) ? (
@@ -900,6 +1000,12 @@ const PermissionApprovalCard = ({
         <SpecialistSwitchDetail request={request} />
       ) : isSpecialistDeleteRequest(request) ? (
         <SpecialistDeleteDetail request={request} />
+      ) : skillEntry && skillLoadName ? (
+        <PermissionSkillSection
+          key={requestId}
+          title={skillEntry.displayName || skillLoadName}
+          skillId={skillEntry.id}
+        />
       ) : permCode ? (
         <PermissionCodeSection
           key={requestId}

--- a/src/renderer/src/pages/workspace/WorkspaceActivityGroup.rowToggle.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityGroup.rowToggle.render.test.tsx
@@ -4,6 +4,8 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ToolActivity } from '@/stores/session-store'
+import type { SkillView } from '../../../../shared/settings'
+import { useSettingsStore } from '@/stores/settings-store'
 
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
 
@@ -54,6 +56,7 @@ describe('WorkspaceActivityGroup row toggling', () => {
       root.unmount()
     })
     container.remove()
+    useSettingsStore.setState({ skills: [], skillsLoaded: false })
     vi.clearAllMocks()
   })
 
@@ -140,5 +143,60 @@ describe('WorkspaceActivityGroup row toggling', () => {
     expect(onToggleRow).toHaveBeenCalledWith('activity-skill-load-1', true)
 
     viewport.remove()
+  })
+
+  it('routes a documentless load_skill row to the catalog/IPC skill row, not the generic JSON details', async () => {
+    // Claude-reported skill loads arrive WITHOUT any payload (main strips it): the row must still
+    // expand into the SKILL.md document resolved by invocation name, never the raw input JSON.
+    const documentless: ToolActivity = {
+      ...SKILL_LOAD_ACTIVITY,
+      id: 'activity-skill-load-2',
+      title: 'Load skill: mcp-pubmed',
+      providerToolName: 'Skill',
+      toolContent: undefined
+    }
+    const catalogSkill: SkillView = {
+      id: 'imported-mcp-pubmed',
+      name: 'mcp-pubmed',
+      displayName: 'mcp-pubmed',
+      description: 'Search PubMed',
+      source: 'imported',
+      updatedAt: '2026-08-27T00:00:00Z',
+      enabled: true
+    }
+    useSettingsStore.setState({ skills: [catalogSkill], skillsLoaded: true })
+    const getSkillDetail = vi.fn().mockResolvedValue({
+      ...catalogSkill,
+      body: '# mcp-pubmed\n\nResolved document.',
+      references: [],
+      packageFiles: []
+    })
+    window.api = { settings: { getSkillDetail } } as unknown as Window['api']
+
+    await act(async () => {
+      root.render(
+        <WorkspaceActivityGroup
+          group={{
+            id: 'group-skill-2',
+            type: 'activity-group',
+            createdAt: 1,
+            sortIndex: 1,
+            title: '',
+            activities: [documentless]
+          }}
+          isExpanded={true}
+          onToggleGroup={vi.fn()}
+          expansionOverrides={{ 'activity-skill-load-2': true }}
+          onToggleRow={vi.fn()}
+        />
+      )
+    })
+
+    expect(getSkillDetail).toHaveBeenCalledWith('imported-mcp-pubmed')
+
+    const panel = container.querySelector('[data-testid="skill-load-details"]')
+
+    expect(panel?.querySelector('h1')?.textContent).toBe('mcp-pubmed')
+    expect(container.textContent).not.toContain('"skill"')
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
@@ -21,7 +21,7 @@ import {
   getSkillLoadDocument,
   isSkillActivity
 } from './workspace-tool-activity-details'
-import { getLoadedSkillName } from './workspace-skill-load'
+import { getLoadedSkillName, isSkillLoadActivity } from './workspace-skill-load'
 import {
   formatActivityGroupElapsed,
   formatActivityGroupPresentationTitle,
@@ -185,11 +185,16 @@ const WorkspaceActivityGroup = ({
               // Search rows get bespoke query/result details; other tools reuse the shared builder.
               const isSearch = isSearchActivity(activity, group.activities, activityIndex)
               const searchDetails = isSearch ? formatWebSearchDetails(activity) : undefined
-              // A completed load_skill expands into its rendered SKILL.md; while the document
-              // is unavailable (running, failed, or old sessions) it keeps the generic row.
+              // A completed load_skill expands into its rendered SKILL.md when the output carries
+              // the document; without it (payload stripped, running, failed, or old sessions) the
+              // IPC-capable skill row resolves the document by invocation name instead of showing
+              // the generic input/output JSON.
               const skillLoadDocument = !isSearch ? getSkillLoadDocument(activity) : undefined
+              const skillLoadWithoutDocument = !skillLoadDocument && isSkillLoadActivity(activity)
               const toolDetails =
-                isSearch || skillLoadDocument ? undefined : buildToolActivityDetails(activity, t)
+                isSearch || skillLoadDocument || skillLoadWithoutDocument
+                  ? undefined
+                  : buildToolActivityDetails(activity, t)
               // All tool rows — notebook cells included — default collapsed (meaningful title
               // only); clicking the title reveals the code and output. A user toggle still wins.
               const isRowExpanded = expansionOverrides[activity.id] ?? false
@@ -225,6 +230,16 @@ const WorkspaceActivityGroup = ({
                       phase={phase}
                       skillName={getLoadedSkillName(activity)}
                       markdown={skillLoadDocument}
+                      isExpanded={isRowExpanded}
+                      onToggle={handleToggleRow}
+                    />
+                  ) : skillLoadWithoutDocument ? (
+                    // load_skill without a document payload: the row resolves the SKILL.md from
+                    // the skills catalog or the connector-aware resolver, keeping the raw JSON out
+                    // of the transcript; it stays compact when no source provides the name.
+                    <WorkspaceSkillActivityRow
+                      activity={activity}
+                      phase={phase}
                       isExpanded={isRowExpanded}
                       onToggle={handleToggleRow}
                     />

--- a/src/renderer/src/pages/workspace/WorkspaceSkillActivityRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSkillActivityRow.render.test.tsx
@@ -86,14 +86,57 @@ describe('WorkspaceSkillActivityRow', () => {
     )
   })
 
-  it('does not fetch the document while collapsed', async () => {
+  it('resolves on mount but keeps the document hidden while collapsed', async () => {
     useSettingsStore.setState({ skills: [catalogSkill], skillsLoaded: true })
     const getSkillDetail = installSkillDetail('# mcp-pubmed')
 
     await renderRow(false)
 
-    expect(getSkillDetail).not.toHaveBeenCalled()
+    // Resolution is eager — the row must know whether ANY source provides the skill before it can
+    // decide between the expandable and the compact presentation — but the body stays hidden.
+    expect(getSkillDetail).toHaveBeenCalledWith('imported-mcp-pubmed')
     expect(container.querySelector('[data-testid="skill-load-details"]')).toBeNull()
+    expect(container.querySelector('h1')).toBeNull()
+  })
+
+  it('resolves the document through the main-process resolver when the skill is unlisted', async () => {
+    useSettingsStore.setState({ skills: [], skillsLoaded: true })
+    const resolveSkillDocument = vi.fn().mockResolvedValue({
+      name: 'mcp-pubmed',
+      body: '# mcp-pubmed\n\nConnector document.'
+    })
+    window.api = { settings: { resolveSkillDocument } } as unknown as Window['api']
+
+    await renderRow(true)
+
+    expect(resolveSkillDocument).toHaveBeenCalledWith({ name: 'mcp-pubmed' })
+
+    const panel = container.querySelector('[data-testid="skill-load-details"]')
+
+    expect(panel?.querySelector('h1')?.textContent).toBe('mcp-pubmed')
+    expect(panel?.textContent).toContain('Connector document.')
+  })
+
+  it('parses the imperative Load skill title variant', async () => {
+    useSettingsStore.setState({ skills: [catalogSkill], skillsLoaded: true })
+    const getSkillDetail = installSkillDetail('# mcp-pubmed')
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceSkillActivityRow
+          activity={createActivity({
+            providerToolName: 'Skill',
+            title: 'Load skill: mcp-pubmed'
+          })}
+          isExpanded={true}
+          onToggle={() => {}}
+        />
+      )
+    })
+
+    expect(getSkillDetail).toHaveBeenCalledWith('imported-mcp-pubmed')
+    expect(container.querySelector('[data-testid="skill-load-details"]')).not.toBeNull()
   })
 
   it('keeps the compact non-expandable row when the skill is not in the catalog', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceSkillActivityRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSkillActivityRow.tsx
@@ -1,13 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ToolActivity } from '@/stores/session-store'
-import { useSettingsStore } from '@/stores/settings-store'
 
 import { WorkspaceToolActivityRow } from './WorkspaceToolActivityRow'
 import { WorkspaceToolActivityRowButton } from './WorkspaceToolActivityRowButton'
 import { SkillDocumentSheet } from './WorkspaceSkillLoadRow'
 import { getLoadedSkillName } from './workspace-skill-load'
+import { useSkillDocument } from './use-skill-document'
 import type { ToolExecutionPhase } from './tool-execution-phase'
 
 type WorkspaceSkillActivityRowProps = {
@@ -18,9 +17,11 @@ type WorkspaceSkillActivityRowProps = {
 }
 
 // A native Skill activity ("Loaded skill: <name>") carries no document — main deliberately strips
-// the instruction payload from the activity pipelines — so the expanded row resolves the SKILL.md
-// body from the app's skills catalog by its stable invocation name, fetching on first expand.
-// Skills outside the catalog (e.g. session-scoped projections) keep the compact non-expandable row.
+// the instruction payload from the activity pipelines — so the row resolves the SKILL.md body by
+// its stable invocation name: from the app's skills catalog when listed, otherwise through the
+// main-process connector-aware resolver (mcp-* connector skills are invocable but unlisted). While
+// resolution is pending, and for skills no source provides (e.g. session-scoped projections), the
+// row keeps the compact non-expandable look.
 const WorkspaceSkillActivityRow = ({
   activity,
   phase,
@@ -29,45 +30,11 @@ const WorkspaceSkillActivityRow = ({
 }: WorkspaceSkillActivityRowProps): React.JSX.Element => {
   const { t } = useTranslation()
   const skillName = getLoadedSkillName(activity)
-  // The runtime materializes enabled skills, so an enabled catalog entry wins a name collision.
-  const skillId = useSettingsStore((state) =>
-    skillName
-      ? (state.skills.find(
-          (skill) => skill.available !== false && skill.name === skillName && skill.enabled
-        )?.id ??
-        state.skills.find((skill) => skill.available !== false && skill.name === skillName)?.id)
-      : undefined
-  )
-  // Keyed by catalog id so a re-imported or renamed skill cannot show a stale body.
-  const [loaded, setLoaded] = useState<{ id: string; body: string } | undefined>()
-  const [failedId, setFailedId] = useState<string | undefined>()
-  const requestRef = useRef(0)
-  const markdown = loaded && loaded.id === skillId ? loaded.body : undefined
-  const failed = skillId !== undefined && failedId === skillId
+  const document = useSkillDocument(skillName)
 
-  useEffect(() => {
-    if (!isExpanded || !skillId || markdown !== undefined || failed) return undefined
-
-    const requestId = ++requestRef.current
-    let cancelled = false
-
-    void window.api.settings.getSkillDetail(skillId).then(
-      (detail) => {
-        if (!cancelled && requestRef.current === requestId) {
-          setLoaded({ id: skillId, body: detail.body })
-        }
-      },
-      () => {
-        if (!cancelled && requestRef.current === requestId) setFailedId(skillId)
-      }
-    )
-
-    return () => {
-      cancelled = true
-    }
-  }, [isExpanded, skillId, markdown, failed])
-
-  if (!skillId) return <WorkspaceToolActivityRow activity={activity} phase={phase} />
+  if (document.status === 'loading' || document.status === 'unavailable') {
+    return <WorkspaceToolActivityRow activity={activity} phase={phase} />
+  }
 
   return (
     <WorkspaceToolActivityRowButton
@@ -80,18 +47,16 @@ const WorkspaceSkillActivityRow = ({
       panelTestId="skill-load-details"
       onToggle={onToggle}
     >
-      {markdown ? (
-        <SkillDocumentSheet markdown={markdown} />
-      ) : failed ? (
+      {document.status === 'ready' ? (
+        <SkillDocumentSheet markdown={document.markdown} />
+      ) : (
         <button
           type="button"
           className="rounded-md px-1 py-1 text-[12px] text-text-300 transition-colors hover:text-text-100"
-          onClick={() => setFailedId(undefined)}
+          onClick={document.retry}
         >
           {t('Retry')}
         </button>
-      ) : (
-        <div className="px-1 py-1 text-[12px] text-text-300">{t('Loading preview…')}</div>
       )}
     </WorkspaceToolActivityRowButton>
   )

--- a/src/renderer/src/pages/workspace/WorkspaceSkillLoadRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSkillLoadRow.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import type { ToolActivity } from '@/stores/session-store'
 import { PresentedAgentMarkdown } from '@/components/streamdown/AgentMarkdown'
+import { cn } from '@/lib/utils'
 
 import { WorkspaceToolActivityRowButton } from './WorkspaceToolActivityRowButton'
 import type { ToolExecutionPhase } from './tool-execution-phase'
@@ -17,8 +18,20 @@ type WorkspaceSkillLoadRowProps = {
 
 // The shared SKILL.md sheet: a full-width white surface with a fixed max height (scrolls beyond
 // it), no border, and the subtle ringless sheet shadow. Shared by the load_skill and native rows.
-const SkillDocumentSheet = ({ markdown }: { markdown: string }): React.JSX.Element => (
-  <div className="max-h-[320px] overflow-y-auto rounded-md bg-bg-000 px-4 py-3 shadow-sheet">
+// `maxHeightClassName` lets roomier surfaces (the permission card) raise the 320px transcript cap.
+const SkillDocumentSheet = ({
+  markdown,
+  maxHeightClassName = 'max-h-[320px]'
+}: {
+  markdown: string
+  maxHeightClassName?: string
+}): React.JSX.Element => (
+  <div
+    className={cn(
+      maxHeightClassName,
+      'overflow-y-auto rounded-md bg-bg-000 px-4 py-3 shadow-sheet'
+    )}
+  >
     <PresentedAgentMarkdown content={markdown} allowMedia={false} />
   </div>
 )

--- a/src/renderer/src/pages/workspace/use-skill-document.ts
+++ b/src/renderer/src/pages/workspace/use-skill-document.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { useSettingsStore } from '@/stores/settings-store'
+
+type SkillDocumentState =
+  | {
+      status: 'loading' | 'failed' | 'unavailable'
+    }
+  | {
+      status: 'ready'
+      title: string
+      markdown: string
+    }
+
+type UseSkillDocumentResult = SkillDocumentState & { retry: () => void }
+
+// Resolves the renderable SKILL.md document for a canonical skill invocation name. The runtime
+// materializes enabled skills, so an enabled catalog entry wins a name collision; its body comes
+// from getSkillDetail. Skills outside the managed catalog (connector-provisioned mcp-* skills) are
+// resolved through the main process, which knows every source the runtime can load from. 'failed'
+// is a transient fetch error (Retry re-attempts); 'unavailable' means no source provides the name
+// and the caller should fall back to its generic presentation.
+const useSkillDocument = (skillName: string | undefined): UseSkillDocumentResult => {
+  const entry = useSettingsStore((state) =>
+    skillName
+      ? (state.skills.find(
+          (skill) => skill.available !== false && skill.name === skillName && skill.enabled
+        ) ?? state.skills.find((skill) => skill.available !== false && skill.name === skillName))
+      : undefined
+  )
+  // Keyed by catalog id (or bare name on the IPC path) so a re-imported or renamed skill cannot
+  // show a stale body.
+  const key = skillName ? (entry?.id ?? `name:${skillName}`) : undefined
+  const [loaded, setLoaded] = useState<
+    { key: string; title: string; markdown: string } | undefined
+  >()
+  const [failedKey, setFailedKey] = useState<string | undefined>()
+  const [unavailableKey, setUnavailableKey] = useState<string | undefined>()
+  const requestRef = useRef(0)
+  const ready = loaded && loaded.key === key ? loaded : undefined
+  const failed = key !== undefined && failedKey === key
+  const unavailable = key !== undefined && unavailableKey === key
+
+  useEffect(() => {
+    if (!key || !skillName || ready || failed || unavailable) return undefined
+
+    const requestId = ++requestRef.current
+    let cancelled = false
+    const settle = (action: () => void): void => {
+      if (!cancelled && requestRef.current === requestId) action()
+    }
+
+    if (entry) {
+      void window.api.settings.getSkillDetail(entry.id).then(
+        (detail) =>
+          settle(() =>
+            setLoaded({
+              key,
+              title: detail.displayName || detail.name,
+              markdown: detail.body
+            })
+          ),
+        () => settle(() => setFailedKey(key))
+      )
+    } else {
+      // Electron-only bridge: off-Electron hosts have no connector document sources. Deferred so
+      // the classification never sets state synchronously inside the effect body.
+      const resolveSkillDocument = window.api.settings.resolveSkillDocument
+      if (typeof resolveSkillDocument !== 'function') {
+        queueMicrotask(() => settle(() => setUnavailableKey(key)))
+        return undefined
+      }
+      void resolveSkillDocument({ name: skillName }).then(
+        (document) =>
+          settle(() => {
+            if (document) {
+              setLoaded({
+                key,
+                title: document.displayName || document.name,
+                markdown: document.body
+              })
+            } else {
+              setUnavailableKey(key)
+            }
+          }),
+        () => settle(() => setFailedKey(key))
+      )
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [key, skillName, entry, ready, failed, unavailable])
+
+  const retry = useCallback(() => setFailedKey(undefined), [])
+
+  if (!key) return { status: 'unavailable', retry }
+  if (ready) return { status: 'ready', title: ready.title, markdown: ready.markdown, retry }
+  if (failed) return { status: 'failed', retry }
+  if (unavailable) return { status: 'unavailable', retry }
+  return { status: 'loading', retry }
+}
+
+export { useSkillDocument }
+export type { UseSkillDocumentResult }

--- a/src/renderer/src/pages/workspace/workspace-skill-load.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-skill-load.test.ts
@@ -46,6 +46,13 @@ describe('workspace skill load helpers', () => {
     expect(getLoadedSkillName(activity)).toBe('pubmed')
   })
 
+  it('parses the imperative Load skill title variant', () => {
+    expect(getLoadedSkillName(createActivity({ title: 'Load skill: self-awareness' }))).toBe(
+      'self-awareness'
+    )
+    expect(getLoadedSkillName(createActivity({ title: 'Loading skill: pubmed' }))).toBe('pubmed')
+  })
+
   it('strips the base-directory prefix and YAML frontmatter from a skill document', () => {
     const output =
       'Base directory for this skill: /repo/.claude/skills/mcp-pubmed\n\n' +

--- a/src/renderer/src/pages/workspace/workspace-skill-load.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-skill-load.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import type { AcpPermissionRequest } from '../../../../shared/acp'
 import type { ToolActivity } from '@/stores/session-store'
 
 import {
   extractSkillLoadDocument,
   getLoadedSkillName,
+  getSkillLoadPermissionSkillName,
   isSkillLoadActivity
 } from './workspace-skill-load'
 
@@ -69,5 +71,77 @@ describe('workspace skill load helpers', () => {
   it('rejects outputs without the skill-document prefix or without a body', () => {
     expect(extractSkillLoadDocument('Unknown skill: nope')).toBeUndefined()
     expect(extractSkillLoadDocument('Base directory for this skill: /x\n\n   ')).toBeUndefined()
+  })
+})
+
+describe('getSkillLoadPermissionSkillName', () => {
+  const createRequest = (overrides: Partial<AcpPermissionRequest>): AcpPermissionRequest => ({
+    requestId: 'permission-1',
+    sessionId: 'session-1',
+    toolCallId: 'tool-1',
+    title: 'mcp__skills__load_skill',
+    isMcp: true,
+    options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }],
+    ...overrides
+  })
+
+  it('matches the broker-resolved skills/load_skill identity and trims the skill name', () => {
+    const request = createRequest({
+      title: 'Allow tool?',
+      mcpIdentity: 'skills/load_skill',
+      rawInput: { skill: ' literature-review ' }
+    })
+
+    expect(getSkillLoadPermissionSkillName(request)).toBe('literature-review')
+  })
+
+  it('matches provider namespacing in providerToolName and title without an mcpIdentity', () => {
+    expect(
+      getSkillLoadPermissionSkillName(
+        createRequest({
+          providerToolName: 'mcp.skills.load_skill',
+          title: 'Allow tool?',
+          rawInput: { skill: 'pubmed' }
+        })
+      )
+    ).toBe('pubmed')
+    expect(
+      getSkillLoadPermissionSkillName(
+        createRequest({
+          title: 'mcp__skills__load_skill',
+          rawInput: { skill: 'pubmed' }
+        })
+      )
+    ).toBe('pubmed')
+  })
+
+  it('unwraps the Codex arguments envelope', () => {
+    const request = createRequest({
+      mcpIdentity: 'skills/load_skill',
+      rawInput: { arguments: { skill: 'pubmed', args: '--depth full' } }
+    })
+
+    expect(getSkillLoadPermissionSkillName(request)).toBe('pubmed')
+  })
+
+  it('returns undefined for non-skill requests and skill loads without a usable name', () => {
+    expect(
+      getSkillLoadPermissionSkillName(
+        createRequest({
+          title: 'mcp__open-science-notebook__notebook_execute',
+          providerToolName: 'mcp__open-science-notebook__notebook_execute',
+          mcpIdentity: 'open-science-notebook/notebook_execute',
+          rawInput: { skill: 'pubmed' }
+        })
+      )
+    ).toBeUndefined()
+    expect(
+      getSkillLoadPermissionSkillName(
+        createRequest({ mcpIdentity: 'skills/load_skill', rawInput: { skill: '  ' } })
+      )
+    ).toBeUndefined()
+    expect(
+      getSkillLoadPermissionSkillName(createRequest({ mcpIdentity: 'skills/load_skill' }))
+    ).toBeUndefined()
   })
 })

--- a/src/renderer/src/pages/workspace/workspace-skill-load.ts
+++ b/src/renderer/src/pages/workspace/workspace-skill-load.ts
@@ -1,3 +1,4 @@
+import type { AcpPermissionRequest } from '../../../../shared/acp'
 import type { ToolActivity } from '@/stores/session-store'
 
 // The Skill runtime serves loads through its own MCP server; ACP providers namespace the tool as
@@ -39,6 +40,26 @@ const getLoadedSkillName = (activity: ToolActivity): string | undefined => {
   return skillName || undefined
 }
 
+// The permission card's counterpart to getLoadedSkillName: an approval request carries no
+// projected lifecycle title, so detection leans on the broker-resolved mcpIdentity first
+// (skills/load_skill) and falls back to the namespaced tool identity in providerToolName/title.
+// The canonical skill name still comes from the `skill` argument, with the same Codex
+// `arguments` envelope unwrap as the transcript path.
+const getSkillLoadPermissionSkillName = (request: AcpPermissionRequest): string | undefined => {
+  const isSkillLoad =
+    request.mcpIdentity === 'skills/load_skill' ||
+    SKILL_LOAD_TOOL_PATTERN.test(request.providerToolName?.trim() ?? '') ||
+    SKILL_LOAD_TOOL_PATTERN.test(request.title.trim())
+
+  if (!isSkillLoad) return undefined
+
+  const rawInput = isRecord(request.rawInput) ? request.rawInput : undefined
+  const args = rawInput && isRecord(rawInput.arguments) ? rawInput.arguments : rawInput
+  const skillName = typeof args?.skill === 'string' ? args.skill.trim() : ''
+
+  return skillName || undefined
+}
+
 // Extracts the renderable SKILL.md body from a load_skill output text: the base-directory prefix
 // line and the YAML frontmatter block are removed. Returns nothing when the output is not a skill
 // document (e.g. an error payload), so callers can fall back to the generic input/output view.
@@ -53,4 +74,9 @@ const extractSkillLoadDocument = (output: string): string | undefined => {
   return document || undefined
 }
 
-export { extractSkillLoadDocument, getLoadedSkillName, isSkillLoadActivity }
+export {
+  extractSkillLoadDocument,
+  getLoadedSkillName,
+  getSkillLoadPermissionSkillName,
+  isSkillLoadActivity
+}

--- a/src/renderer/src/pages/workspace/workspace-skill-load.ts
+++ b/src/renderer/src/pages/workspace/workspace-skill-load.ts
@@ -5,7 +5,9 @@ import type { ToolActivity } from '@/stores/session-store'
 // mcp__skills__load_skill (Claude), mcp.skills.load_skill (Codex), or a flattened underscore form.
 const SKILL_LOAD_TOOL_PATTERN = /^(?:mcp__|mcp\.)?skills(?:__|\.|_)load_skill$/iu
 
-const SKILL_NAME_PATTERN = /^(?:loading|loaded)\s+skill:\s*(.+?)\s*$/iu
+// Providers project either the imperative ("Load skill: …") or the lifecycle ("Loading/Loaded
+// skill: …") title variant; all three carry the canonical invocation name.
+const SKILL_NAME_PATTERN = /^(?:load|loading|loaded)\s+skill:\s*(.+?)\s*$/iu
 
 // load_skill results prepend the runtime-resolved package root before the SKILL.md document. The
 // prefix is server-added transport context (and an absolute local path), never document content.

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -60,6 +60,17 @@ describe('workspace tool activity details', () => {
     expect(buildToolActivityDetails(activity)).toBeUndefined()
   })
 
+  it('recognizes the imperative Claude Skill activity title variant', () => {
+    const activity = createActivity({
+      providerToolName: 'Skill',
+      title: 'Load skill: self-awareness'
+    })
+
+    expect(isSkillActivity(activity)).toBe(true)
+    expect(getLoadedSkillName(activity)).toBe('self-awareness')
+    expect(buildToolActivityDetails(activity)).toBeUndefined()
+  })
+
   it('labels a load_skill MCP row with the loaded Skill name and keeps its generic details', () => {
     const activity = createActivity({
       providerToolName: 'mcp__skills__load_skill',

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -63,7 +63,7 @@ type ToolActivityDetails = {
 
 // Bounds very large tool payloads so a single read/execute row cannot flood the transcript.
 const MAX_CODE_CHARS = 20000
-const SKILL_ACTIVITY_TITLE_PATTERN = /^(?:run|loading|loaded)\s+skill(?:\?|:|\s|$)/iu
+const SKILL_ACTIVITY_TITLE_PATTERN = /^(?:run|load|loading|loaded)\s+skill(?:\?|:|\s|$)/iu
 
 // Human-readable fallbacks for ACP tool kinds when the provider tool name is unavailable.
 const TOOL_KIND_LABELS: Record<ToolKind, string> = {

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -323,6 +323,8 @@ import type {
   PreviewAgentHomeSkillRequest,
   PreviewGitHubSkillRequest,
   PreviewSkillZipRequest,
+  ResolveSkillDocumentRequest,
+  ResolvedSkillDocument,
   SkillBundlePreviewResult,
   SkillImportPreviewContent,
   ScanRepoRequest,
@@ -1663,6 +1665,11 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'settings.getSkillDetail': callable<(id: string) => Promise<SkillDetailView>>()('settings', [
     'settings:get-skill-detail'
   ]),
+  // Electron-only: the connector-skill document sources live on the main-process filesystem, so
+  // the web adapter does not project this member — renderer callers must guard its presence.
+  'settings.resolveSkillDocument': callable<
+    (request: ResolveSkillDocumentRequest) => Promise<ResolvedSkillDocument | null>
+  >()('settings', ['settings:resolve-skill-document', ELECTRON]),
   'settings.importAgentHomeSkills': callable<
     (request: ImportAgentHomeSkillsRequest) => Promise<ImportAgentHomeSkillsResult>
   >()('settings', ['settings:import-agent-home-skills', MAPPED_ELECTRON]),

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -89,6 +89,7 @@ const GENERATED_SOURCE_OMISSIONS = [
   'settings.onConnectorCredentialSettled',
   'settings.previewCustomServerTemplateExport',
   'settings.replayPendingConnectorCredentialRequests',
+  'settings.resolveSkillDocument',
   'settings.respondConnectorCredentialRequest',
   'settings.selectCustomServerTemplate',
   'sideChat.cancel',

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1091,6 +1091,20 @@ export type ExportSkillRequest = { id: string }
 
 export type ExportSkillResult = { saved: boolean }
 
+// Resolves a renderable SKILL.md document by its canonical invocation name across every source the
+// runtime can load from: the managed Skills catalog, enabled bundled connectors (rendered on the
+// fly), and materialized custom MCP server skills. Electron-only — the document sources live on the
+// main-process filesystem. A null result means no source provides the name.
+export type ResolveSkillDocumentRequest = { name: string }
+
+export type ResolvedSkillDocument = {
+  name: string
+  displayName?: string
+  description?: string
+  // SKILL.md body with the YAML frontmatter stripped, matching SkillDetailView.body.
+  body: string
+}
+
 // A reference file's name and byte size, without its content.
 export type SkillReferenceInfo = {
   path: string


### PR DESCRIPTION
## Summary

The **Skills / Load Skill** permission approval card previously showed only a generic "External service input" JSON block. It now matches the transcript's skill tool rows: an expandable section renders the full **SKILL.md document** (reusing `SkillDocumentSheet`), so reviewers can inspect what they are approving.

Investigating a real Claude run then exposed three deeper gaps behind one root cause — the renderer could only resolve skill documents from the settings catalog, and load_skill activities that lose their document payload in the main pipeline never got a markdown view:

- **Message list**: main strips native-Skill payloads (`projectToolDetailPayload`), so Claude's load_skill activities arrive documentless and fell back to the generic JSON row; the imperative `Load skill: X` title variant also failed name resolution. Both now route to the catalog/IPC-resolving skill row.
- **Permission card**: connector-provisioned skills (`mcp-<connectorId>`, e.g. `mcp-molecule`) are invocable via load_skill but absent from the settings catalog, so the card regressed to the old JSON view for them. The skill section now resolves via a new `settings.resolveSkillDocument` IPC covering the managed catalog, enabled bundled connector skills (`renderSkillDoc`), and materialized custom connector skills — falling back to the raw JSON input only when no source knows the name.
- Both surfaces share a new `use-skill-document` hook (eager resolution so connector skills classify correctly); the sheet caps at a 16:9 height of its width (`max-h-[56.25cqw]`).

## Test plan

- Main resolver unit tests (catalog hit / bundled connector / disabled connector / custom connector / unsafe-name rejection); preload + IPC contract tests; web-api-map regenerated.
- Renderer: hook/row/section/group suites updated (IPC-hit path, JSON fallback inside the section, imperative title parsing, documentless load_skill routing).
- e2e `skill-permission-card.spec.ts`: seeds a skill, triggers `mcp__skills__load_skill` permission, asserts the rendered SKILL.md, screenshots expanded/collapsed, and now denies then re-prompts to guard the second card keeping the skill section.
- `src/renderer/src/pages/workspace` + preload + ipc: 3311 tests green; i18n guard green; `typecheck` (node+web) / eslint / `check:web-api-map` clean.