### PR TITLE
feat(agent): disable native memory for ACP sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
       },
       "devDependencies": {
         "@aiden0z/pptx-renderer": "1.2.4",
+        "@anthropic-ai/claude-agent-sdk": "0.3.232",
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
         "@electron-toolkit/eslint-config-ts": "^3.1.0",
         "@electron-toolkit/tsconfig": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@aiden0z/pptx-renderer": "1.2.4",
+    "@anthropic-ai/claude-agent-sdk": "0.3.232",
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
     "@electron-toolkit/eslint-config-ts": "^3.1.0",
     "@electron-toolkit/tsconfig": "^2.0.0",

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -10541,7 +10541,7 @@ describe('ACP runtime session management', () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1'], { supportsResume: true })
     const sessionOptions = {
-      settings: '/app/claude/settings.json',
+      settings: { apiKeyHelper: '/app/claude/api-key-helper' },
       plugins: [{ type: 'local', path: '/app/claude' }]
     }
     const runtime = new AcpRuntime({
@@ -10559,10 +10559,28 @@ describe('ACP runtime session management', () => {
     await runtime.resumeSession({ sessionId: 'remote-session-2', cwd: '/workspace' })
 
     expect(fakeAgent.newSessions[0]._meta).toMatchObject({
-      claudeCode: { options: { ...sessionOptions, settingSources: ['user'] } }
+      claudeCode: {
+        options: {
+          plugins: [{ type: 'local', path: '/app/claude' }],
+          settingSources: ['user'],
+          settings: {
+            apiKeyHelper: '/app/claude/api-key-helper',
+            env: { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' }
+          }
+        }
+      }
     })
     expect(fakeAgent.resumedSessions[0]._meta).toMatchObject({
-      claudeCode: { options: { ...sessionOptions, settingSources: ['user'] } }
+      claudeCode: {
+        options: {
+          plugins: [{ type: 'local', path: '/app/claude' }],
+          settingSources: ['user'],
+          settings: {
+            apiKeyHelper: '/app/claude/api-key-helper',
+            env: { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' }
+          }
+        }
+      }
     })
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16516,7 +16516,13 @@ describe('ACP runtime session management', () => {
               },
               env: {
                 CLAUDE_CODE_DISABLE_AGENT_VIEW: '1',
+                CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
                 CLAUDE_CODE_DISABLE_WORKFLOWS: '1'
+              },
+              settings: {
+                env: {
+                  CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1'
+                }
               }
             }
           },

--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -241,7 +241,13 @@ describe('ACP Session presentation policy', () => {
               },
               env: {
                 CLAUDE_CODE_DISABLE_AGENT_VIEW: '1',
+                CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
                 CLAUDE_CODE_DISABLE_WORKFLOWS: '1'
+              },
+              settings: {
+                env: {
+                  CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1'
+                }
               },
               skills: []
             }

--- a/src/main/agent-framework/claude-code-memory.integration.test.ts
+++ b/src/main/agent-framework/claude-code-memory.integration.test.ts
@@ -1,0 +1,175 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { AddressInfo } from 'node:net'
+import { query, type Options } from '@anthropic-ai/claude-agent-sdk'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { claudeCodeFramework } from './claude-code'
+
+const temporaryRoots: string[] = []
+const inheritedProcessEnvironmentKeys = [
+  'PATH',
+  'Path',
+  'SYSTEMROOT',
+  'SystemRoot',
+  'WINDIR',
+  'COMSPEC',
+  'PATHEXT',
+  'TEMP',
+  'TMP',
+  'TMPDIR',
+  'LANG',
+  'LC_ALL'
+] as const
+
+const anthropicMessage = [
+  'event: message_start',
+  'data: {"type":"message_start","message":{"id":"msg_memory_probe","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}',
+  '',
+  'event: content_block_start',
+  'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+  '',
+  'event: content_block_delta',
+  'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}}',
+  '',
+  'event: content_block_stop',
+  'data: {"type":"content_block_stop","index":0}',
+  '',
+  'event: message_delta',
+  'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}',
+  '',
+  'event: message_stop',
+  'data: {"type":"message_stop"}',
+  '',
+  ''
+].join('\n')
+
+const projectKey = (cwd: string): string => cwd.replace(/[^a-zA-Z0-9]/g, '-')
+
+type MemoryProbeResult = {
+  memoryContents: string
+  memoryEntries: string[]
+  requestContainsSentinel: boolean
+}
+
+const runMemoryProbe = async (memoryFlag: '0' | '1'): Promise<MemoryProbeResult> => {
+  const root = mkdtempSync(join(tmpdir(), 'open-science-claude-memory-'))
+  temporaryRoots.push(root)
+  const cwd = join(root, 'workspace')
+  mkdirSync(cwd)
+  const canonicalCwd = realpathSync(cwd)
+  const sentinel = 'ACP_MEMORY_SENTINEL_DO_NOT_LOAD'
+  const memoryDir = join(root, 'config', 'projects', projectKey(canonicalCwd), 'memory')
+  const memoryContents = `# Auto memory\n\n${sentinel}\n`
+  mkdirSync(memoryDir, { recursive: true })
+  writeFileSync(join(memoryDir, 'MEMORY.md'), memoryContents)
+
+  const requestBodies: string[] = []
+  const server = createServer((request, response) => {
+    const chunks: Buffer[] = []
+    request.on('data', (chunk: Buffer) => chunks.push(chunk))
+    request.on('end', () => {
+      if (request.method === 'POST' && request.url?.startsWith('/v1/messages')) {
+        requestBodies.push(Buffer.concat(chunks).toString('utf8'))
+      }
+      response.writeHead(200, { 'content-type': 'text/event-stream' })
+      response.end(anthropicMessage)
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+  try {
+    const address = server.address() as AddressInfo
+    const apiKey = 'synthetic-memory-probe-key'
+    const baseUrl = `http://127.0.0.1:${address.port}`
+    const setup = claudeCodeFramework.buildSessionSetup({ systemPromptAppends: [] })
+    const frameworkOptions = (
+      setup.meta?.claudeCode as { options: Pick<Options, 'env' | 'settings' | 'settingSources'> }
+    ).options
+    const env: Record<string, string> = {}
+    for (const key of inheritedProcessEnvironmentKeys) {
+      const value = process.env[key]
+      if (value !== undefined) env[key] = value
+    }
+    Object.assign(env, {
+      ...frameworkOptions.env,
+      ANTHROPIC_API_KEY: apiKey,
+      ANTHROPIC_BASE_URL: baseUrl,
+      APPDATA: join(root, 'appdata'),
+      CLAUDE_CONFIG_DIR: join(root, 'config'),
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: memoryFlag,
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+      HOME: root,
+      LOCALAPPDATA: join(root, 'local-appdata'),
+      NO_PROXY: '127.0.0.1,localhost',
+      no_proxy: '127.0.0.1,localhost',
+      USERPROFILE: root,
+      XDG_CACHE_HOME: join(root, 'xdg-cache'),
+      XDG_CONFIG_HOME: join(root, 'xdg-config')
+    })
+    const settings = {
+      ...(frameworkOptions.settings as Exclude<Options['settings'], string | undefined>),
+      env: {
+        ...((frameworkOptions.settings as { env?: Record<string, string> }).env ?? {}),
+        ANTHROPIC_API_KEY: apiKey,
+        ANTHROPIC_BASE_URL: baseUrl,
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: memoryFlag
+      }
+    }
+
+    for await (const message of query({
+      prompt: 'Reply with OK.',
+      options: {
+        cwd: canonicalCwd,
+        env,
+        maxTurns: 1,
+        model: 'claude-sonnet-4-5',
+        settingSources: frameworkOptions.settingSources,
+        settings,
+        systemPrompt: { type: 'preset', preset: 'claude_code' },
+        tools: []
+      }
+    })) {
+      if (message.type === 'result') break
+    }
+
+    expect(requestBodies).toHaveLength(1)
+    return {
+      memoryContents: readFileSync(join(memoryDir, 'MEMORY.md'), 'utf8'),
+      memoryEntries: readdirSync(memoryDir),
+      requestContainsSentinel: requestBodies[0]?.includes(sentinel) ?? false
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    )
+  }
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('Claude Code ACP memory isolation', () => {
+  it('keeps seeded auto memory out of model requests only when the ACP session flag is active', async () => {
+    const enabled = await runMemoryProbe('0')
+    const disabled = await runMemoryProbe('1')
+
+    expect(enabled.requestContainsSentinel).toBe(true)
+    expect(disabled).toEqual({
+      memoryContents: '# Auto memory\n\nACP_MEMORY_SENTINEL_DO_NOT_LOAD\n',
+      memoryEntries: ['MEMORY.md'],
+      requestContainsSentinel: false
+    })
+  }, 30_000)
+})

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -34,7 +34,11 @@ describe('claudeCodeFramework', () => {
             disableWorkflows: true,
             workflowKeywordTriggerEnabled: false
           },
+          settings: {
+            env: { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' }
+          },
           env: {
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
             CLAUDE_CODE_DISABLE_AGENT_VIEW: '1',
             CLAUDE_CODE_DISABLE_WORKFLOWS: '1'
           }
@@ -57,7 +61,14 @@ describe('claudeCodeFramework', () => {
       sessionOptions: {
         disallowedTools: ['CustomDeniedTool'],
         managedSettings: { disableAgentView: false, disableWorkflows: false },
+        settings: {
+          env: {
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+            SAFE_SETTING_VALUE: 'preserved'
+          }
+        },
         env: {
+          CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
           CLAUDE_CODE_DISABLE_AGENT_VIEW: '0',
           CLAUDE_CODE_DISABLE_WORKFLOWS: '0',
           SAFE_BACKEND_VALUE: 'preserved'
@@ -81,8 +92,15 @@ describe('claudeCodeFramework', () => {
       disableWorkflows: true,
       workflowKeywordTriggerEnabled: false
     })
+    expect(options.settings).toEqual({
+      env: {
+        SAFE_SETTING_VALUE: 'preserved',
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1'
+      }
+    })
     expect(options.env).toEqual({
       SAFE_BACKEND_VALUE: 'preserved',
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
       CLAUDE_CODE_DISABLE_AGENT_VIEW: '1',
       CLAUDE_CODE_DISABLE_WORKFLOWS: '1'
     })

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -106,9 +106,18 @@ describe('claudeCodeFramework', () => {
     })
   })
 
+  it('rejects unresolved settings paths that could override ACP session policy', () => {
+    expect(() =>
+      claudeCodeFramework.buildSessionSetup({
+        systemPromptAppends: [],
+        sessionOptions: { settings: '/app/claude/settings.json' }
+      })
+    ).toThrow('Claude Code session settings must be resolved before building ACP session metadata.')
+  })
+
   it('injects resolved settings and local plugins into Claude session options', () => {
     const sessionOptions = {
-      settings: '/app/claude/settings.json',
+      settings: { apiKeyHelper: '/app/claude/api-key-helper' },
       plugins: [{ type: 'local', path: '/app/claude' }]
     }
 

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -159,19 +159,24 @@ export const claudeCodeFramework: AgentFramework = {
       workflowKeywordTriggerEnabled: false
     })
     const configuredSettings = sessionOptions.settings
+    // The ACP adapter resolves string paths against the later session cwd, after this synchronous
+    // boundary has lost the chance to enforce settings.env. Require callers to resolve files first
+    // so app-owned policy cannot be reopened by a higher-priority settings file.
+    if (typeof configuredSettings === 'string') {
+      throw new Error(
+        'Claude Code session settings must be resolved before building ACP session metadata.'
+      )
+    }
     const settingsValues = recordValue(configuredSettings)
     // Claude applies settings.env after the subprocess env, so enforce the same session-only flag
     // in the programmatic settings tier while preserving app-owned settings and their environment.
-    const settings =
-      typeof configuredSettings === 'string'
-        ? configuredSettings
-        : Object.freeze({
-            ...settingsValues,
-            env: Object.freeze({
-              ...recordValue(settingsValues.env),
-              ...CLAUDE_CODE_DISABLED_AUTO_MEMORY_ENV
-            })
-          })
+    const settings = Object.freeze({
+      ...settingsValues,
+      env: Object.freeze({
+        ...recordValue(settingsValues.env),
+        ...CLAUDE_CODE_DISABLED_AUTO_MEMORY_ENV
+      })
+    })
     const env = Object.freeze({
       ...recordValue(sessionOptions.env),
       ...CLAUDE_CODE_DISABLED_AUTO_MEMORY_ENV,

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -45,6 +45,9 @@ const CLAUDE_CODE_NATIVE_DELEGATION_TOOLS = Object.freeze([
 // Shell execution is app-owned so every framework follows the Notebook runtime's managed working
 // directory, environment-mutation guard, permission identity, and durable Run recording contract.
 const CLAUDE_CODE_NATIVE_EXECUTION_TOOLS = Object.freeze(['Bash'] as const)
+const CLAUDE_CODE_DISABLED_AUTO_MEMORY_ENV = Object.freeze({
+  CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1'
+})
 
 const recordValue = (value: unknown): Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -155,8 +158,23 @@ export const claudeCodeFramework: AgentFramework = {
       disableWorkflows: true,
       workflowKeywordTriggerEnabled: false
     })
+    const configuredSettings = sessionOptions.settings
+    const settingsValues = recordValue(configuredSettings)
+    // Claude applies settings.env after the subprocess env, so enforce the same session-only flag
+    // in the programmatic settings tier while preserving app-owned settings and their environment.
+    const settings =
+      typeof configuredSettings === 'string'
+        ? configuredSettings
+        : Object.freeze({
+            ...settingsValues,
+            env: Object.freeze({
+              ...recordValue(settingsValues.env),
+              ...CLAUDE_CODE_DISABLED_AUTO_MEMORY_ENV
+            })
+          })
     const env = Object.freeze({
       ...recordValue(sessionOptions.env),
+      ...CLAUDE_CODE_DISABLED_AUTO_MEMORY_ENV,
       CLAUDE_CODE_DISABLE_AGENT_VIEW: '1',
       CLAUDE_CODE_DISABLE_WORKFLOWS: '1'
     })
@@ -174,6 +192,7 @@ export const claudeCodeFramework: AgentFramework = {
           ...(hooks !== undefined ? { hooks } : {}),
           disallowedTools,
           managedSettings,
+          settings,
           env,
           ...(ctx.skillWhitelist !== undefined ? { skills: ctx.skillWhitelist } : {})
         }

--- a/src/main/agent-framework/codebuddy.test.ts
+++ b/src/main/agent-framework/codebuddy.test.ts
@@ -48,6 +48,8 @@ describe('codebuddy framework', () => {
       CODEBUDDY_MODEL: 'test-model',
       OPEN_SCIENCE_CODEBUDDY_CHAT_COMPLETIONS_URL:
         'https://gateway.example.test/v1/chat/completions',
+      CODEBUDDY_DISABLE_AUTO_MEMORY: '1',
+      CODEBUDDY_CODE_DISABLE_AUTO_MEMORY: '1',
       CODEBUDDY_DISABLE_FORK_SUBAGENT: '1',
       CODEBUDDY_CODE_DISABLE_BACKGROUND_TASKS: '1',
       DISABLE_AUTOUPDATER: '1',

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -288,7 +288,7 @@ describe('codexFramework', () => {
     expect(codexNativeModelInstructions).not.toContain('coding agent')
   })
 
-  it('disables native multi-agent and Shell features across every backend route', () => {
+  it('disables native multi-agent, Shell, and memory across every backend route', () => {
     const framework = createCodexFramework()
     const configurations = [
       framework.prepareModelConfig(
@@ -354,8 +354,18 @@ describe('codexFramework', () => {
       )
     ]
 
-    expect(configurations.map(({ env }) => JSON.parse(env?.CODEX_CONFIG ?? '{}').features)).toEqual(
-      configurations.map(() => ({ multi_agent: false, multi_agent_v2: false, shell_tool: false }))
+    const codexConfigs = configurations.map(({ env }) => JSON.parse(env?.CODEX_CONFIG ?? '{}'))
+
+    expect(codexConfigs.map(({ features }) => features)).toEqual(
+      configurations.map(() => ({
+        memories: false,
+        multi_agent: false,
+        multi_agent_v2: false,
+        shell_tool: false
+      }))
+    )
+    expect(codexConfigs.map(({ memories }) => memories)).toEqual(
+      configurations.map(() => ({ generate_memories: false, use_memories: false }))
     )
   })
 
@@ -822,7 +832,13 @@ describe('codexFramework', () => {
         HOME: join('/data', 'codex-subscription'),
         CODEX_HOME: join('/data', 'codex-subscription'),
         CODEX_CONFIG: JSON.stringify({
-          features: { multi_agent: false, multi_agent_v2: false, shell_tool: false }
+          features: {
+            memories: false,
+            multi_agent: false,
+            multi_agent_v2: false,
+            shell_tool: false
+          },
+          memories: { generate_memories: false, use_memories: false }
         })
       }
     })
@@ -840,7 +856,13 @@ describe('codexFramework', () => {
         HOME: join('/data', 'codex-subscription'),
         CODEX_HOME: join('/data', 'codex-subscription'),
         CODEX_CONFIG: JSON.stringify({
-          features: { multi_agent: false, multi_agent_v2: false, shell_tool: false }
+          features: {
+            memories: false,
+            multi_agent: false,
+            multi_agent_v2: false,
+            shell_tool: false
+          },
+          memories: { generate_memories: false, use_memories: false }
         })
       }
     })

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -73,11 +73,16 @@ const CODEX_MODE_IDS = {
 // contract. This must live in CODEX_CONFIG (rather than only custom model metadata), because trusted
 // bundled models intentionally do not receive an app-authored model catalog.
 const CODEX_DISABLED_NATIVE_FEATURES = Object.freeze({
+  memories: false,
   multi_agent: false,
   multi_agent_v2: false,
   // Disabling unified_exec alone falls back to shell_command. shell_tool disables both generations
   // so execution stays on the app-owned Notebook bash_execute MCP tool.
   shell_tool: false
+})
+const CODEX_DISABLED_NATIVE_MEMORY = Object.freeze({
+  generate_memories: false,
+  use_memories: false
 })
 
 const CODEX_ENV_KEYS = [
@@ -174,6 +179,7 @@ const buildCodexConfig = (provider: {
   return {
     ...buildCodexModelOptions(provider),
     features: CODEX_DISABLED_NATIVE_FEATURES,
+    memories: CODEX_DISABLED_NATIVE_MEMORY,
     ...(contextWindow
       ? {
           model_context_window: contextWindow,
@@ -461,6 +467,7 @@ export const createCodexFramework = ({
       const codexConfig = {
         ...modelOptions,
         features: CODEX_DISABLED_NATIVE_FEATURES,
+        memories: CODEX_DISABLED_NATIVE_MEMORY,
         ...(persistentSystemPrompt ? { developer_instructions: persistentSystemPrompt } : {})
       }
       const codexConfigJson =


### PR DESCRIPTION
## Summary

- disable Claude Code Auto Memory in both ACP subprocess env and the higher-priority programmatic `settings.env`
- reject unresolved Claude settings paths so a later-loaded settings file cannot reopen ACP memory
- explicitly disable Codex memory loading and generation in `CODEX_CONFIG` across all provider routes
- lock the existing CodeBuddy auto-memory environment switches with regression coverage
- certify the Claude flag against the pinned SDK/native CLI with an isolated loopback Anthropic endpoint

## Scope

The overrides are injected only into ACP processes or sessions launched by Open Science. This does not write user-global Claude or Codex configuration and does not affect either agent when launched independently outside Open Science.

Claude settings files are already resolved to app-owned objects by every production backend route. The framework now fails closed if a future caller supplies an unresolved string path, because that file would be applied after subprocess env and could override the session policy.

OpenCode is unchanged because it has no equivalent native automatic long-term memory subsystem in the supported integration.

## Validation

- TDD RED: the new unresolved-settings regression failed before the fail-closed implementation
- `npx vitest run src/main/acp/runtime.test.ts src/main/acp/session-presentation-policy.test.ts src/main/agent-framework/claude-code.test.ts src/main/agent-framework/claude-code-memory.integration.test.ts src/main/agent-framework/codebuddy.test.ts src/main/agent-framework/codex.test.ts` (6 files, 698 tests)
- Claude behavior certification uses pinned `@anthropic-ai/claude-agent-sdk@0.3.232` and its native CLI: control flag `0` loads a seeded memory sentinel; ACP flag `1` excludes it and leaves the memory file unchanged
- the certification test uses a deny-by-default child environment, synthetic credentials, isolated HOME/config roots, and a loopback endpoint; ambient Bedrock/Vertex/Foundry credentials and proxies are not inherited
- `npm run typecheck`
- `npm run lint -- --no-cache`
- `npm run check:claude-acp-patch`
- Prettier check on changed files
- `git diff --check upstream/main...HEAD`
- independent review: no blocking findings after the test-isolation fix

The repository's affected-test planner recommends the complete Vitest suite because `src/main/agent-framework/claude-code.ts` is not registered to a module owner. The complete portable suite and platform jobs are delegated to PR CI; local validation uses the agreed related-call-chain scope.
