### PR TITLE
fix(windows-installer): reject locked uninstaller targets

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -239,6 +239,35 @@ FunctionEnd
 # These callbacks cover cancellation or an installer failure before the post-uninstall hooks run.
 # The normal path restores each directory immediately after its matching old-uninstaller pass.
 !macro customHeader
+  # NSIS extracts the new uninstaller after the application package. Probe the same write access
+  # its File command will request before extracting anything, so a stale locked uninstaller cannot
+  # turn a silent install into a false success or leave an interactive install offering the unsafe
+  # Ignore choice. OPEN_EXISTING keeps this check non-destructive; Retry lets the user release a
+  # transient lock, while silent installs take the Cancel path and return a failure code.
+  Function ensureExistingUninstallerIsWritable
+    IfFileExists "$INSTDIR\${UNINSTALL_FILENAME}" ensureExistingUninstallerIsWritable_retry ensureExistingUninstallerIsWritable_done
+
+    ensureExistingUninstallerIsWritable_retry:
+      System::Call 'kernel32::SetLastError(i 0)'
+      System::Call 'kernel32::CreateFile(t "$INSTDIR\${UNINSTALL_FILENAME}", i 0x40000000, i 1, i 0, i 3, i 0x80, i 0) i.rR0 ?e'
+      Pop $R1
+      StrCmp $R1 0 0 ensureExistingUninstallerIsWritable_failed
+      System::Call 'kernel32::CloseHandle(i rR0)'
+      Return
+
+    ensureExistingUninstallerIsWritable_failed:
+      DetailPrint `Cannot replace the existing uninstaller: "$INSTDIR\${UNINSTALL_FILENAME}".`
+      IfSilent ensureExistingUninstallerIsWritable_cancel
+      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(uninstallFailed)$\r$\n$INSTDIR\${UNINSTALL_FILENAME}" IDRETRY ensureExistingUninstallerIsWritable_retry
+
+    ensureExistingUninstallerIsWritable_cancel:
+      SetErrorLevel 2
+      Quit
+
+    ensureExistingUninstallerIsWritable_done:
+      Return
+  FunctionEnd
+
   Function protectNestedDataRootsForInstall
     !ifdef openScienceOriginalInstFilesPre
       Call ${openScienceOriginalInstFilesPre}
@@ -436,6 +465,7 @@ FunctionEnd
   ${else}
     !insertmacro restoreAllNestedDataRoots
     !insertmacro quitIfDataRestoreFailed
+    Call ensureExistingUninstallerIsWritable
   ${endif}
 !macroend
 
@@ -461,6 +491,7 @@ FunctionEnd
   # still-preserved backup is what keeps a recreated data directory from short-circuiting retry.
   !insertmacro restoreNestedDataRoot $perUserInstallDirCache $perUserDataBackup
   !insertmacro quitIfDataRestoreFailed
+  Call ensureExistingUninstallerIsWritable
 !macroend
 
 !endif

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -1058,10 +1058,16 @@ const findUninstaller = async (installDirectory) => {
   return join(installDirectory, uninstallers[0])
 }
 
-const launchUninstallerLockHolder = async (installDirectory, env) => {
+const launchUninstallerLockHolder = async (
+  installDirectory,
+  env,
+  spawnProcess = spawn,
+  waitForReady = waitFor,
+  terminate = terminateProcessTree
+) => {
   const uninstaller = await findUninstaller(installDirectory)
   const ready = join(env.TEMP, 'installer-smoke-lock-holder.ready')
-  const child = spawn(
+  const child = spawnProcess(
     'powershell.exe',
     [
       '-NoProfile',
@@ -1079,14 +1085,19 @@ const launchUninstallerLockHolder = async (installDirectory, env) => {
     }
   )
   const exit = observeChildExit(child)
-  await Promise.race([
-    waitFor('the old uninstaller to be exclusively locked', async () =>
-      (await pathExists(ready)) ? true : undefined
-    ),
-    exit.then((code) => {
-      throw new Error(`Uninstaller lock holder exited before becoming ready (${code}).`)
-    })
-  ])
+  try {
+    await Promise.race([
+      waitForReady('the old uninstaller to be exclusively locked', async () =>
+        (await pathExists(ready)) ? true : undefined
+      ),
+      exit.then((code) => {
+        throw new Error(`Uninstaller lock holder exited before becoming ready (${code}).`)
+      })
+    ])
+  } catch (error) {
+    await terminate(child)
+    throw error
+  }
   return { child, uninstaller }
 }
 
@@ -1098,25 +1109,24 @@ const drillOrphanedUninstallerLock = async ({ installer, installDirectory, env }
     .update(await readFile(staleUninstaller))
     .digest('hex')
   const lock = await launchUninstallerLockHolder(installDirectory, env)
-  const writeProbe = await runProcess(
-    'powershell.exe',
-    [
-      '-NoProfile',
-      '-NonInteractive',
-      '-Command',
-      "try { $stream = [System.IO.File]::Open($env:OPEN_SCIENCE_LOCK_PROBE_PATH, 'Open', 'Write', 'None'); $stream.Dispose(); exit 0 } catch { exit 1 }"
-    ],
-    {
-      allowNonZero: true,
-      env: { ...env, OPEN_SCIENCE_LOCK_PROBE_PATH: lock.uninstaller }
-    }
-  )
-  if (writeProbe.code !== 1) {
-    throw new Error('Uninstaller lock fixture did not block an independent write handle.')
-  }
-
   let installResult
   try {
+    const writeProbe = await runProcess(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        "try { $stream = [System.IO.File]::Open($env:OPEN_SCIENCE_LOCK_PROBE_PATH, 'Open', 'Write', 'None'); $stream.Dispose(); exit 0 } catch { exit 1 }"
+      ],
+      {
+        allowNonZero: true,
+        env: { ...env, OPEN_SCIENCE_LOCK_PROBE_PATH: lock.uninstaller }
+      }
+    )
+    if (writeProbe.code !== 1) {
+      throw new Error('Uninstaller lock fixture did not block an independent write handle.')
+    }
     installResult = await runProcess(installer, ['/S', `/D=${installDirectory}`], {
       allowNonZero: true,
       env,
@@ -1415,6 +1425,7 @@ export {
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
+  launchUninstallerLockHolder,
   launchAndExpectDatabaseBlocked,
   installAndProbe,
   launchAndProbe,

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -2,7 +2,16 @@
 
 import { spawn } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
-import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import {
+  access,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile
+} from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { homedir, tmpdir } from 'node:os'
 import { basename, join, resolve, win32 } from 'node:path'
@@ -35,6 +44,7 @@ const RPC_SMOKE_ROOT_PREFIX = 'open-science-rpc-smoke-'
 const UPGRADE_SENTINEL_PREFIX = 'installer-smoke-upgrade-sentinel-'
 const UPGRADE_SENTINEL_CONTENT = 'previous-version-profile-preserved\n'
 const RPC_SMOKE_CONTENT = 'windows-rpc-smoke\n'
+const ORPHANED_UNINSTALLER_LOCK_SCENARIO = 'orphaned-uninstaller-lock'
 const RPC_SMOKE_RESERVATION_ID = 'installer-smoke-reservation'
 const RPC_SMOKE_ARTIFACT_SCOPE = {
   projectId: 'installer-smoke-project',
@@ -1048,6 +1058,103 @@ const findUninstaller = async (installDirectory) => {
   return join(installDirectory, uninstallers[0])
 }
 
+const launchUninstallerLockHolder = async (installDirectory, env) => {
+  const uninstaller = await findUninstaller(installDirectory)
+  const ready = join(env.TEMP, 'installer-smoke-lock-holder.ready')
+  const child = spawn(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      "$stream = [System.IO.File]::Open($env:OPEN_SCIENCE_LOCK_PATH, 'Open', 'Read', 'None'); [System.IO.File]::WriteAllText($env:OPEN_SCIENCE_LOCK_READY, 'ready'); [System.Threading.Thread]::Sleep([System.Threading.Timeout]::Infinite)"
+    ],
+    {
+      env: {
+        ...env,
+        OPEN_SCIENCE_LOCK_PATH: uninstaller,
+        OPEN_SCIENCE_LOCK_READY: ready
+      },
+      windowsHide: true
+    }
+  )
+  const exit = observeChildExit(child)
+  await Promise.race([
+    waitFor('the old uninstaller to be exclusively locked', async () =>
+      (await pathExists(ready)) ? true : undefined
+    ),
+    exit.then((code) => {
+      throw new Error(`Uninstaller lock holder exited before becoming ready (${code}).`)
+    })
+  ])
+  return { child, uninstaller }
+}
+
+const drillOrphanedUninstallerLock = async ({ installer, installDirectory, env }) => {
+  await mkdir(installDirectory, { recursive: true })
+  const staleUninstaller = join(installDirectory, 'Uninstall open-science.exe')
+  await copyFile(installer, staleUninstaller)
+  const staleUninstallerHash = createHash('sha256')
+    .update(await readFile(staleUninstaller))
+    .digest('hex')
+  const lock = await launchUninstallerLockHolder(installDirectory, env)
+  const writeProbe = await runProcess(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      "try { $stream = [System.IO.File]::Open($env:OPEN_SCIENCE_LOCK_PROBE_PATH, 'Open', 'Write', 'None'); $stream.Dispose(); exit 0 } catch { exit 1 }"
+    ],
+    {
+      allowNonZero: true,
+      env: { ...env, OPEN_SCIENCE_LOCK_PROBE_PATH: lock.uninstaller }
+    }
+  )
+  if (writeProbe.code !== 1) {
+    throw new Error('Uninstaller lock fixture did not block an independent write handle.')
+  }
+
+  let installResult
+  try {
+    installResult = await runProcess(installer, ['/S', `/D=${installDirectory}`], {
+      allowNonZero: true,
+      env,
+      timeoutMs: 30_000
+    })
+    await delay(250)
+    if (lock.child.exitCode !== null) {
+      throw new Error(`Installer terminated the external lock holder with ${lock.child.exitCode}.`)
+    }
+  } catch (error) {
+    throw new Error(
+      `Installer could not recover the orphaned locked uninstaller at ${lock.uninstaller}.`,
+      { cause: error }
+    )
+  } finally {
+    await terminateProcessTree(lock.child)
+  }
+
+  const appInstalled = await pathExists(join(installDirectory, APP_EXECUTABLE))
+  if (installResult.code !== 0) {
+    if (appInstalled) {
+      throw new Error('Installer failed after partially extracting the new application.')
+    }
+    return
+  }
+  const installedUninstaller = await findUninstaller(installDirectory)
+  const installedUninstallerHash = createHash('sha256')
+    .update(await readFile(installedUninstaller))
+    .digest('hex')
+  if (installedUninstallerHash === staleUninstallerHash) {
+    throw new Error(
+      `Installer reported success without replacing the locked uninstaller at ${installedUninstaller}.`
+    )
+  }
+  if (!appInstalled)
+    throw new Error('Installer reported success without installing the application.')
+}
+
 const terminateDirectoryProcesses = async (directory, run = runProcess) => {
   const root = `${directory.replace(/[\\/]+$/u, '')}\\`
   await run(
@@ -1113,13 +1220,18 @@ const parseArguments = (argv) => {
   if (expectedMigrationCount !== undefined && !Number.isSafeInteger(expectedMigrationCount)) {
     throw new Error('Expected migration count must be a positive safe integer.')
   }
+  const scenario = valueFor('--scenario')
+  if (scenario !== undefined && scenario !== ORPHANED_UNINSTALLER_LOCK_SCENARIO) {
+    throw new Error(`Unsupported Windows installer smoke scenario: ${scenario}`)
+  }
   return {
     installerDirectory: resolve(installerDirectory),
     previousInstallerDirectory: valueFor('--previous-installer-dir')
       ? resolve(valueFor('--previous-installer-dir'))
       : undefined,
     artifactRpcContract,
-    expectedMigrationCount
+    expectedMigrationCount,
+    scenario
   }
 }
 
@@ -1140,15 +1252,42 @@ const cleanupSmokeRoot = async (root, primaryError, remove = removeSmokeRoot) =>
   }
 }
 
+const runOrphanedUninstallerLockSmoke = async (installer) => {
+  const root = await mkdtemp(join(process.env.RUNNER_TEMP || tmpdir(), SMOKE_ROOT_PREFIX))
+  const installDirectory = join(root, 'installed app 程序')
+  const profileDirectory = join(root, 'profile 数据 with spaces')
+  const env = windowsProfileEnvironment(profileDirectory)
+  await Promise.all([
+    mkdir(env.APPDATA, { recursive: true }),
+    mkdir(env.LOCALAPPDATA, { recursive: true }),
+    mkdir(env.TEMP, { recursive: true })
+  ])
+
+  let primaryError
+  try {
+    await drillOrphanedUninstallerLock({ installer, installDirectory, env })
+  } catch (error) {
+    primaryError = error
+  }
+  await cleanupSmokeRoot(root, primaryError)
+  if (primaryError) throw primaryError
+  console.log('Windows orphaned-uninstaller lock smoke completed successfully.')
+}
+
 const main = async () => {
   if (process.platform !== 'win32') throw new Error('Windows installer smoke requires Windows.')
   const options = parseArguments(process.argv.slice(2))
   const currentInstaller = await findSetupInstaller(options.installerDirectory)
+  if (options.scenario === ORPHANED_UNINSTALLER_LOCK_SCENARIO) {
+    await runOrphanedUninstallerLockSmoke(currentInstaller)
+    return
+  }
   const previousInstaller = options.previousInstallerDirectory
     ? await findSetupInstaller(options.previousInstallerDirectory)
     : undefined
   const root = await mkdtemp(join(process.env.RUNNER_TEMP || tmpdir(), SMOKE_ROOT_PREFIX))
   const installDirectory = join(root, 'installed app 程序')
+  const lockedInstallDirectory = join(root, 'locked uninstaller 程序')
   const profileDirectory = join(root, 'profile 数据 with spaces')
   const freshStorageRoot = join(root, 'fresh database 数据 with spaces')
   const legacyStorageRoot = join(root, 'legacy database 数据 with spaces')
@@ -1168,6 +1307,11 @@ const main = async () => {
 
   let primaryError
   try {
+    await drillOrphanedUninstallerLock({
+      installer: currentInstaller,
+      installDirectory: lockedInstallDirectory,
+      env
+    })
     await executeSmokePlan(
       buildSmokePlan({ currentInstaller, previousInstaller }),
       async (cycle) => {
@@ -1266,6 +1410,7 @@ export {
   buildSmokePlan,
   cleanupSmokeRoot,
   createUpgradeProfileGuard,
+  drillOrphanedUninstallerLock,
   executeSmokePlan,
   fetchWithTimeout,
   findSetupInstaller,

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -109,6 +109,16 @@ describe('Windows installer smoke plan', () => {
     }
   })
 
+  it('accepts only the orphaned-uninstaller lock scenario', () => {
+    expect(
+      parseArguments(['--installer-dir', 'dist', '--scenario', 'orphaned-uninstaller-lock'])
+        .scenario
+    ).toBe('orphaned-uninstaller-lock')
+    expect(() => parseArguments(['--installer-dir', 'dist', '--scenario', 'unsupported'])).toThrow(
+      /Unsupported Windows installer smoke scenario/
+    )
+  })
+
   it('accepts only explicit packaged Artifact RPC contracts', () => {
     expect(
       parseArguments(['--installer-dir', 'dist', '--artifact-rpc-contract', 'legacy'])

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -18,6 +18,7 @@ import {
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
+  launchUninstallerLockHolder,
   observeChildClose,
   packagedArtifactSmokeRpcResult,
   packagedMainEntryPath,
@@ -496,6 +497,26 @@ Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0C
         terminateSlowly
       )
     ).rejects.toThrow(/timed out after 25ms/)
+  })
+
+  it('terminates a lock holder when readiness fails', async () => {
+    const installDirectory = await mkdtemp(join(tmpdir(), 'open-science-lock-holder-'))
+    await writeFile(join(installDirectory, 'Uninstall open-science.exe'), '')
+    const child = Object.assign(new EventEmitter(), { pid: 4242 })
+    const spawnProcess = vi.fn(() => child)
+    const waitForReady = vi.fn().mockRejectedValue(new Error('lock readiness failed'))
+    const terminate = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      launchUninstallerLockHolder(
+        installDirectory,
+        { TEMP: installDirectory },
+        spawnProcess,
+        waitForReady,
+        terminate
+      )
+    ).rejects.toThrow('lock readiness failed')
+    expect(terminate).toHaveBeenCalledWith(child)
   })
 
   it('terminates and awaits an aborted process', async () => {


### PR DESCRIPTION
## Problem

When an unregistered `Uninstall open-science.exe` already exists at the selected Windows install directory and another process holds it exclusively, NSIS extracts the new application before trying to overwrite the uninstaller. The interactive installer then offers Abort/Retry/Ignore, while a silent install can report success after leaving the stale uninstaller and a mixed installation behind.

## Proposed change

- Probe the existing uninstaller with the same write/share access NSIS uses, using `OPEN_EXISTING` so the check does not modify the file.
- Run the probe at the final post-uninstall hook for both current-user and all-users install paths, before application extraction.
- Offer Retry/Cancel for interactive installs; make silent installs exit with code 2 before extracting application files.
- Extend the real Windows installer smoke with an exclusive external lock and assertions that a failure cannot leave `open-science.exe` partially extracted.
- Guarantee that readiness, probe, and installer failures terminate the external lock-holder process.

## Scope and non-goals

- No data fields, schema, architecture, domain/data model, persisted format, or new enum/state values.
- No historical installation migration or install-scope conversion.
- No registry repair, ACL changes, antivirus handling, or broad process termination.
- Existing registered-version uninstall recovery and nested data-folder preservation remain unchanged.

## Acceptance criteria and validation

The regression was first run against the unfixed installer and failed consistently with `Installer reported success without replacing the locked uninstaller`, matching the reported NSIS write failure/Ignore behavior.

Final evidence mapping:

- Locked orphaned uninstaller fails before payload extraction -> `node scripts/windows-installer-smoke.mjs --installer-dir .debug/windows-uninstaller-fixture/dist --scenario orphaned-uninstaller-lock` -> passed repeatedly with a dedicated test GUID after the final installer edit; the later change only hardens failure cleanup in the smoke harness.
- Smoke CLI contract, lock-holder cleanup, packaging contract, and electron-builder configuration -> `npm test -- scripts/windows-installer-smoke.test.ts build/packaging.test.ts scripts/electron-builder-config.test.ts` -> 3 files and 68 tests passed after the last material edit.
- Changed smoke files follow lint rules -> `npx eslint scripts/windows-installer-smoke.mjs scripts/windows-installer-smoke.test.ts` -> passed after the last material edit.
- Final NSIS source compiles into an assisted x64 installer -> dedicated `electron-builder --win nsis --x64` fixture build passed after the final installer edit; later edits affected only smoke cleanup code.
- Both exact-head CI runs passed completely, including the review follow-up commit; the latest independent Codex review reports `mergeable` with no actionable findings.

The full local suite was intentionally not run; exact-head PR CI is authoritative for the complete portable and Windows lanes. The exclusive-lock failure is automated, but the visual Retry/Cancel dialog is not UI-automated.

## Review focus

- Placement of the probe after the final old-uninstaller pass but before `installApplicationFiles` for both install modes.
- Non-destructive Win32 open/error handling and silent exit behavior.
- The smoke assertion that rejects both false success and failure after partial extraction.
- Cleanup of the external lock holder on readiness, probe, installer, and assertion failures.
