### PR TITLE
fix(artifacts): classify permanent finalization failures

### DIFF
--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -11,7 +11,10 @@ import {
   createWebCallerContext,
   type CallerContext
 } from './caller-context'
-import { ArtifactOwnershipPersistenceRaceError } from './artifacts/provenance-repository'
+import {
+  ArtifactFinalizationProofError,
+  ArtifactOwnershipPersistenceRaceError
+} from './artifacts/provenance-repository'
 import {
   dataContentApplicationCommandGroups,
   dataContentApplicationCommands,
@@ -748,6 +751,30 @@ describe('Data and content application commands', () => {
       invocation([{ path: 'artifact://report' }] as const)
     )
     expect(deps.artifacts.openFile).toHaveBeenCalledWith({ path: 'artifact://report' })
+  })
+
+  it('classifies permanent artifact finalization proof failures for public transports', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    deps.artifacts.finalizeRunArtifacts.mockRejectedValueOnce(
+      new ArtifactFinalizationProofError(
+        'version-message-conflict',
+        'Artifact Version private-version-id is already finalized to a different message.'
+      )
+    )
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.artifactFinalizeRun,
+        invocation([{ claimId: 'claim-1', messageId: 'message-1' }] as const)
+      )
+    ).rejects.toMatchObject({
+      name: 'ApplicationCommandError',
+      code: 'command-failed',
+      message:
+        'Artifact finalization was rejected because its ownership no longer matches the saved Session.'
+    })
   })
 
   it('publishes project and session mutations after durable owner completion without failing commits', async () => {

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -7,7 +7,10 @@ import {
 } from './application-command-router'
 import type { ApplicationEventMap, ApplicationEventPublisher } from './application-events'
 import type { ArtifactHandlers } from './artifacts/ipc'
-import { ArtifactOwnershipPersistenceRaceError } from './artifacts/provenance-repository'
+import {
+  ArtifactFinalizationProofError,
+  ArtifactOwnershipPersistenceRaceError
+} from './artifacts/provenance-repository'
 import type { ProjectFilesHandlers } from './project-files/ipc'
 import type { ProjectHandlers } from './projects/ipc'
 import type { SessionPersistenceHandlers } from './session-persistence/ipc'
@@ -485,12 +488,20 @@ const registerDataContentApplicationCommands = (
             artifacts: await dependencies.artifacts.finalizeRunArtifacts(args[0])
           }
         } catch (error) {
-          if (!(error instanceof ArtifactOwnershipPersistenceRaceError)) throw error
-          return {
-            ok: false as const,
-            code: Artifacts.ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
-            message: error.message
+          if (error instanceof ArtifactOwnershipPersistenceRaceError) {
+            return {
+              ok: false as const,
+              code: Artifacts.ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+              message: error.message
+            }
           }
+          if (error instanceof ArtifactFinalizationProofError) {
+            throw new ApplicationCommandError(
+              'command-failed',
+              'Artifact finalization was rejected because its ownership no longer matches the saved Session.'
+            )
+          }
+          throw error
         }
       },
       'artifacts:generate-code-reconstruction': ({ args }) =>


### PR DESCRIPTION
## Problem

Permanent artifact finalization proof failures, including `version-message-conflict`, escaped the
transport-neutral application command boundary as `ArtifactFinalizationProofError`. Web RPC treats
unknown errors as private failures, so headless and Web clients received only
`command-failed: Internal server error` and lost the safe artifact ownership classification.

Related to #2059. This PR addresses only the behavior reproduced on current `main`; it does not
weaken provenance validation or change Task/Session terminal-state semantics.

## Proposed change

- Preserve `ArtifactOwnershipPersistenceRaceError` as the existing recoverable result.
- Translate other `ArtifactFinalizationProofError` instances to the existing public
  `ApplicationCommandError('command-failed', ...)` with a sanitized message.
- Add a command-boundary regression test for `version-message-conflict`.

## Scope and non-goals

- No new API error code or persisted status.
- No database field, schema, migration, filesystem, or historical-data compatibility change.
- No retry-policy, reviewer, Session status, Task status, or provenance ownership-model change.
- Unrelated errors still propagate to the existing private-error handling path.

## Acceptance criteria and validation

The regression test was run twice before the production change. Both runs failed consistently
because the actual rejection was `ArtifactFinalizationProofError(version-message-conflict)` rather
than a public `ApplicationCommandError(command-failed)`, matching the reported Web RPC symptom.

All listed green checks ran after the last material edit:

- Permanent proof error classification -> focused Vitest regression -> passed.
- Artifact owner, contract, and representative consumer behavior ->
  `npm run test:module -- artifact_provenance` -> 26 files / 1,543 tests passed.
- Main and notebook-sandbox types -> `npm run typecheck:node` -> passed.
- Linted source -> `npm run lint` -> passed.
- Patch hygiene -> `git diff --check` -> passed.

`npm run test:affected:explain -- --base origin/main --head HEAD` conservatively selects the full
suite because `src/main/data-content-application-commands.ts` has no module owner in the impact
manifest. Per the issue request, the full suite was not run locally; PR CI remains authoritative.

## Review focus

- The subclass check for the transient ownership race must remain before the permanent proof-error
  check.
- The public message must not expose artifact Version IDs or the raw proof failure.
- The change must remain classification-only, without relaxing fail-closed provenance checks.
