### PR TITLE
fix(compute): stream large SSH commands over stdin

### DIFF
--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -70,6 +70,7 @@ vi.mock('node:os', async (importOriginal) => ({
 // Controllable ChildProcess double matching execFile's surface used by
 // SystemSshRunner: stdout/stderr are EventEmitters, kill() records the signal.
 class FakeChild extends EventEmitter {
+  stdin = Object.assign(new EventEmitter(), { end: vi.fn() })
   stdout = Object.assign(new EventEmitter(), { destroy: vi.fn() })
   stderr = Object.assign(new EventEmitter(), { destroy: vi.fn() })
   kill = vi.fn(() => true)
@@ -512,6 +513,27 @@ describe('SystemSshRunner', () => {
     sshBinary: '/usr/bin/ssh',
     host: 'aliyun-xt-test',
     extraArgs: []
+  })
+
+  it('does not place a large remote command in the local process arguments', async () => {
+    const child = new FakeChild()
+    execFileMock.mockImplementationOnce((_file: string, args: string[]) => {
+      queueMicrotask(() => {
+        if (args.join(' ').length > 20_000) {
+          child.emit('error', new Error('spawn ENAMETOOLONG'))
+        } else {
+          child.emit('close', 0)
+        }
+      })
+      return child as unknown as ReturnType<typeof execFileMock>
+    })
+    const command = `# ${'x'.repeat(24_000)}\nprintf 'ok\\n' > long-command-ok.txt`
+
+    const result = await runner.run(target(), command, { timeoutMs: 5000 })
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: '' })
+    expect(execFileMock.mock.calls[0]?.[1]).not.toContain(command)
+    expect(child.stdin.end).toHaveBeenCalledWith(command)
   })
 
   it('captures stdout/stderr and reports exitCode on a clean child close', async () => {

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -11,6 +11,10 @@ import { assertSafeSshAlias, shellSingleQuote } from './remote-path-security'
 // Maximum bytes captured per stream before we truncate. Caller can pass a smaller cap.
 const DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024
 
+// Keep a wide margin below local process argument limits. Commands above this size travel over
+// stdin instead, while ordinary commands retain the existing OpenSSH invocation semantics.
+const MAX_INLINE_REMOTE_COMMAND_LENGTH = 8 * 1024
+
 // Short connect timeout used for probe calls; SSH itself honors ConnectTimeout from config but we
 // add it explicitly to override any large value from ~/.ssh/config (design.md §1).
 const DEFAULT_CONNECT_TIMEOUT_SECS = 10
@@ -271,7 +275,12 @@ export class SystemSshRunner implements SshRunner {
     const loginCommand = `if [ -r ~/.bashrc ]; then . ~/.bashrc || exit $?; fi; ${remoteCommand}`
     const finalCommand = loginShell ? `bash -lc ${shellSingleQuote(loginCommand)}` : remoteCommand
 
-    const args = [...target.extraArgs, target.host, finalCommand]
+    const streamCommand = finalCommand.length > MAX_INLINE_REMOTE_COMMAND_LENGTH
+    const args = [
+      ...target.extraArgs,
+      target.host,
+      streamCommand ? 'exec "${SHELL:-/bin/sh}"' : finalCommand
+    ]
 
     opts.signal?.throwIfAborted()
     return new Promise((resolve, reject) => {
@@ -306,12 +315,17 @@ export class SystemSshRunner implements SshRunner {
         stderrBuf.push(chunk)
       }
 
+      // ssh reports the useful transport/process status itself. Observe stdin errors so a closed
+      // pipe cannot become an unhandled stream error while that status is still settling.
+      const onStdinError = (): void => undefined
+
       const cleanup = (): void => {
         clearTimer(timeoutTimer)
         termination.stop()
         opts.signal?.removeEventListener('abort', onAbort)
         child.stdout?.removeListener('data', onStdout)
         child.stderr?.removeListener('data', onStderr)
+        child.stdin?.removeListener('error', onStdinError)
         child.removeListener('exit', onExit)
         child.removeListener('close', onClose)
         child.removeListener('error', onError)
@@ -368,9 +382,11 @@ export class SystemSshRunner implements SshRunner {
       opts.signal?.addEventListener('abort', onAbort, { once: true })
       child.stdout?.on('data', onStdout)
       child.stderr?.on('data', onStderr)
+      if (streamCommand) child.stdin?.once('error', onStdinError)
       child.once('exit', onExit)
       child.once('close', onClose)
       child.once('error', onError)
+      if (streamCommand) child.stdin?.end(finalCommand)
 
       // The signal may have changed between throwIfAborted() and listener registration.
       if (opts.signal?.aborted) onAbort()


### PR DESCRIPTION
## Problem

SSH ComputeJob dispatch embeds the entire generated launcher payload in the local `ssh` process arguments. On Windows, a moderately large submitted command can expand past the process command-line limit and fail with `spawn ENAMETOOLONG` before the remote process starts.

Closes #2014.

## Proposed change

- keep the existing OpenSSH invocation for commands up to 8 KiB;
- send larger remote commands through the SSH child's stdin using a fixed-length remote shell launcher;
- add a regression test using the reported 24,000-character payload shape and a simulated local argument limit.

The regression test failed before the fix with `exitCode: null` and `stderr: "spawn ENAMETOOLONG"`, then passed after the transport change.

## Scope and non-goals

- No public `SshRunner` or Compute interface changes.
- No UI or interaction changes.
- No database fields, schema migrations, data-model changes, or new status enum values.
- Persisted ComputeJob commands keep their existing format. Historical failed jobs are not rewritten or automatically retried.
- This does not introduce temporary-file staging, SCP lifecycle state, or a client-visible command-size error.

For commands above 8 KiB, SSH server policies that inspect `SSH_ORIGINAL_COMMAND` will observe the fixed shell launcher while the actual command arrives over stdin. Short commands retain their previous invocation semantics.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- large-command local argument regression -> `npm test -- src/main/compute/ssh-runner.test.ts` -> 60 passed;
- Compute owner, contract, and representative consumer behavior -> `npm run test:module -- compute_service` -> 1,143 passed, 6 environment-gated tests skipped;
- downstream Workspace consumer behavior -> `npm run test:module -- workspace_page` -> 736 passed;
- affected Node runtime types -> `npm run typecheck:node` -> passed;
- downstream Web runtime types -> `npm run typecheck:web` -> passed;
- linted source -> `npm run lint` -> passed;
- final impact selection -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> selected `compute_service`, `workspace_page`, and Windows-sensitive coverage.

Per maintainer direction, the complete portable and platform suites were not run locally and remain authoritative in PR Gate. A real Windows-to-SSH-host certification was not available locally; the regression exercises the public `SystemSshRunner.run()` boundary with the reported payload and failure mode.

## Review focus

- Whether the 8 KiB switchover leaves a sufficient margin for Windows process arguments.
- The stdin stream lifecycle on spawn, timeout, abort, and early SSH exit.
- Compatibility for remote accounts with ForceCommand or command-auditing policies.
