### PR TITLE
fix(notebook): handle interrupted local RPC responses

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -143,6 +143,8 @@ const capturedRpcFetch = (input, init = {}) => {
         let body = ''
         response.setEncoding('utf8')
         response.on('data', (chunk) => (body += chunk))
+        response.once('aborted', () => reject(new Error('RPC response was interrupted')))
+        response.once('error', reject)
         response.once('end', () => {
           const status = response.statusCode || 500
           resolve({

--- a/src/main/notebook/host-compute.integration.test.ts
+++ b/src/main/notebook/host-compute.integration.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import { listenForLocalRpc } from '../local-rpc-transport'
 import { NotebookKernelExecutor } from './kernel-executor'
 
 // host.compute lives ONLY in the control-plane repl kernel (a Node process), reached via the same
@@ -44,12 +45,15 @@ const makeNotebookRoots = (): {
 // snake_case result projections.
 const startStub = async (
   options: {
+    transport?: 'tcp' | 'pipe'
+    dropFirstListHostsBody?: boolean
     dropFirstSubmitResponse?: boolean
     dropFirstSubmitBody?: boolean
     rejectSubmit?: boolean
   } = {}
 ): Promise<{
   endpoint: string
+  socketPath?: string
   close: () => void
   received: () => Array<{ params?: Record<string, unknown> }>
 }> => {
@@ -63,6 +67,20 @@ const startStub = async (
       const request = body ? JSON.parse(body) : {}
       requests.push(request)
       const op = request.params?.op
+      if (op === 'list_hosts' && options.dropFirstListHostsBody && !droppedFirstSubmitResponse) {
+        droppedFirstSubmitResponse = true
+        const responseBody = JSON.stringify({
+          result: [{ provider_id: 'ssh:x', display_name: 'x', role: 'selected' }]
+        })
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(responseBody)
+        })
+        res.flushHeaders()
+        res.write(responseBody.slice(0, -1))
+        setImmediate(() => res.destroy())
+        return
+      }
       if (op === 'submit_job' && options.dropFirstSubmitResponse && !droppedFirstSubmitResponse) {
         droppedFirstSubmitResponse = true
         res.destroy()
@@ -99,10 +117,12 @@ const startStub = async (
       res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify({ result }))
     })
   })
-  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
-  const addr = server.address() as { port: number }
+  const connection = await listenForLocalRpc(server, {
+    name: 'host-compute-integration-test',
+    transport: options.transport
+  })
   return {
-    endpoint: `http://127.0.0.1:${addr.port}`,
+    ...connection,
     close: () => server.close(),
     received: () => requests
   }
@@ -115,6 +135,7 @@ const baseRequest = (
   overrides: Partial<{
     code: string
     mcpRpcEndpoint: string
+    mcpRpcSocketPath: string
     mcpRpcToken: string
     sessionId: string
     projectId: string
@@ -127,6 +148,44 @@ const baseRequest = (
 })
 
 gate('repl kernel host.compute', () => {
+  it('keeps the kernel alive when a pipe listHosts response is interrupted', async () => {
+    const stub = await startStub({ transport: 'pipe', dropFirstListHostsBody: true })
+    if (!stub.socketPath) throw new Error('Expected pipe transport.')
+    const exec = makeExecutor()
+    const request = baseRequest({
+      code: 'await host.compute.listHosts()',
+      mcpRpcEndpoint: stub.endpoint,
+      mcpRpcSocketPath: stub.socketPath,
+      mcpRpcToken: 'tok',
+      sessionId: 'session-7'
+    })
+
+    const execution = exec.execute(request)
+    const outcome = await Promise.race([
+      execution.then((result) => ({ kind: 'settled' as const, result })),
+      new Promise<{ kind: 'stalled' }>((resolve) =>
+        setTimeout(() => resolve({ kind: 'stalled' }), 1_000)
+      )
+    ])
+    const subsequent =
+      outcome.kind === 'settled'
+        ? await exec.execute({ ...request, code: "console.log('still alive')" })
+        : undefined
+    await exec.shutdown()
+    if (outcome.kind === 'stalled') await execution
+    stub.close()
+
+    if (outcome.kind === 'stalled') {
+      throw new Error(
+        'host.compute.listHosts() stalled after its pipe response was interrupted, forcing the Notebook kernel to time out or exit.'
+      )
+    }
+    expect(outcome.result.status).toBe('failed')
+    expect(outcome.result.traceback).not.toContain('Notebook kernel process exited')
+    expect(subsequent?.status).toBe('completed')
+    expect(subsequent?.stdout).toContain('still alive')
+  })
+
   it('callCommand posts unchanged call_command wire params and returns the ExecResult', async () => {
     const stub = await startStub()
     const exec = makeExecutor()


### PR DESCRIPTION
## Problem

On the Windows named-pipe local RPC path, an interrupted response body never settles the shared control-kernel request. When `host.compute.listHosts()` hits that condition, the call remains pending until an outer timeout or restart tears down the Notebook kernel, surfacing the reported `Notebook kernel process exited` symptom instead of the transport failure.

The supplied log also contains `Notebook file-evidence reconciliation failed closed` for the Session. That warning is independent: it is caught during persisted working-file evidence reconciliation and does not call Compute Host discovery or terminate the REPL kernel. This PR intentionally does not change that persistence path without a matching reproduction.

## Proposed change

- Reject the shared named-pipe/proxy RPC promise when the response is aborted or emits an error.
- Add a production-boundary regression test that interrupts a pipe `listHosts()` response, verifies the call fails promptly, and proves the same control kernel can run the next request.

## Scope and non-goals

- No new data fields, schema, architecture, data model, state enum, persistence, or user interaction.
- No historical-data compatibility or migration requirement.
- No retry is added to non-idempotent Host SDK calls.
- This does not claim to fix an independent SSH authentication, network, or remote-server outage; `listHosts()` is local catalog discovery and does not connect to the remote SSH host.

## Acceptance criteria and validation

- Pre-fix regression proof: the new focused test failed 3/3 runs in about 1 second because `host.compute.listHosts()` stalled after an interrupted pipe response.
- Interrupted `listHosts()` response -> `RUN_KERNEL=1 npx vitest run src/main/notebook/host-compute.integration.test.ts -t 'keeps the kernel alive when a pipe listHosts response is interrupted'` -> passed after the fix.
- Existing Host Compute behavior -> `RUN_KERNEL=1 npx vitest run src/main/notebook/host-compute.integration.test.ts` -> 8 passed.
- Shared REPL/Host SDK pipe transport -> `RUN_KERNEL=1 npx vitest run src/main/notebook/repl-loop.integration.test.ts` -> 58 passed.
- Node and sandbox types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting -> `npx prettier --check resources/notebook/repl_loop.js src/main/notebook/host-compute.integration.test.ts` -> passed.

These checks ran after the last material edit. Full portable and Windows runtime-certification CI remain authoritative; a real remote SSH endpoint was not available for end-to-end probing.

## Review focus

- Whether both `aborted` and `error` are required to close every incomplete Node `IncomingMessage` path without changing successful responses.
- Whether the regression test sufficiently proves the kernel remains reusable after the failure.
