### PR TITLE
fix(notebook): surface unavailable runtime recovery

### DIFF
--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -13,6 +13,7 @@ import type {
 } from '../../../../shared/notebook'
 import type { ProvisionStatus } from '../../../../shared/notebook-env'
 import { createInitialNotebookEnvState, useNotebookEnvStore } from '../../stores/notebook-env-store'
+import { createInitialSettingsState, useSettingsStore } from '../../stores/settings-store'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
 import { EnvProvisionOverlay } from './EnvProvisionOverlay'
 import { NotebookPreview, type NotebookPreviewItem } from './NotebookPreview'
@@ -44,6 +45,7 @@ let root: Root
 beforeEach(() => {
   notebookCodeBlockSpy.mockClear()
   useNotebookEnvStore.setState(createInitialNotebookEnvState())
+  useSettingsStore.setState(createInitialSettingsState())
   useSessionStore.setState({
     ...createInitialSessionState(),
     sessions: [
@@ -243,6 +245,51 @@ describe('NotebookPreview env gate (mounted)', () => {
       })
     })
     expect(container.querySelector('[data-testid="notebook-env-gate"]')).not.toBeNull()
+  })
+
+  it('shows the initial notebook state failure even when no kernel terminal exists', async () => {
+    vi.mocked(window.api.notebook.state).mockRejectedValueOnce(
+      new Error('Could not load notebook state')
+    )
+
+    await act(async () => {
+      root.render(<NotebookPreview item={item} />)
+    })
+    for (let i = 0; i < 5; i += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+    }
+
+    expect(container.textContent).toContain('Could not load notebook state')
+
+    vi.mocked(window.api.notebook.state).mockResolvedValueOnce({
+      id: 'session-1',
+      sessionId: 'session-1',
+      cwd: '/tmp/proj',
+      notebookSessionRoot: '/tmp/proj/.notebook',
+      dataRoot: '/tmp/proj/.notebook/data',
+      runtimeRoot: '/tmp/proj/.notebook/runtime',
+      kernelStatus: 'idle',
+      runJsonPath: '/tmp/proj/.notebook/run.json',
+      cells: [],
+      runCount: 0,
+      runs: [],
+      recentRuns: [],
+      environments: [],
+      latestRunEnvironments: {}
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    })
+    for (let i = 0; i < 5; i += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+    }
+
+    expect(window.api.notebook.state).toHaveBeenCalledTimes(2)
+    expect(container.textContent).not.toContain('Could not load notebook state')
   })
 })
 
@@ -1631,6 +1678,15 @@ describe('NotebookPreview per-environment selector', () => {
         (container.querySelector('[data-testid="kernel-terminal-input"]') as HTMLTextAreaElement)
           .disabled
       ).toBe(true)
+      expect(
+        container.querySelector('[data-testid="notebook-runtime-binding-status"]')?.textContent
+      ).toBe('Unavailable')
+
+      const binding = container.querySelector<HTMLButtonElement>(
+        '[data-testid="notebook-runtime-binding"]'
+      )
+      fireEvent.focus(binding as HTMLButtonElement)
+      expect((await screen.findByRole('tooltip')).textContent).toContain('Missing')
 
       if (language === 'r') {
         await act(async () => {
@@ -1671,6 +1727,36 @@ describe('NotebookPreview per-environment selector', () => {
     expect(container.querySelector('[data-testid="notebook-runtime-binding"]')?.textContent).toBe(
       'renv-analysis'
     )
+  })
+
+  it('opens Runtime settings from an unavailable binding', async () => {
+    const openSettingsToPanel = vi.fn()
+    useSettingsStore.setState({ openSettingsToPanel })
+    await mountWithRuns(
+      [makeRun({ runId: 'p1', kernelKind: 'python', environment: 'external-python' })],
+      [],
+      { python: 'external-python' },
+      {
+        python: {
+          runtimeId: '/usr/local/bin/python3',
+          language: 'python',
+          label: 'External Python',
+          source: 'external',
+          provenance: 'user-own',
+          interpreterPath: '/usr/local/bin/python3',
+          status: 'unavailable',
+          reason: 'disabled'
+        }
+      }
+    )
+
+    const binding = container.querySelector(
+      '[data-testid="notebook-runtime-binding"]'
+    ) as HTMLElement
+    expect(binding.getAttribute('aria-label')).toContain('Open settings for External Python')
+    fireEvent.click(binding)
+
+    expect(openSettingsToPanel).toHaveBeenCalledWith('runtimes')
   })
 
   it('does not apply data runtime bindings to Agent SDK or Bash tabs', async () => {

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -8,11 +8,13 @@ import {
   type RefObject
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import { RefreshCw, Variable, X } from 'lucide-react'
+import { RefreshCw, TriangleAlert, Variable, X } from 'lucide-react'
 
 import { usePreviewWorkbenchStore, type PreviewToolItem } from '@/stores/preview-workbench-store'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import { useSessionStore } from '@/stores/session-store'
+import { ErrorNotice } from '@/components/error-notice'
 import { cn } from '@/lib/utils'
 import {
   Select,
@@ -529,6 +531,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   const provisionUi = useNotebookEnvStore((s) => s.ui)
   const retryProvision = useNotebookEnvStore((s) => s.retry)
   const provision = useNotebookEnvStore((s) => s.provision)
+  const openSettingsToPanel = useSettingsStore((s) => s.openSettingsToPanel)
   const isPreparingR =
     provisionUi.kind === 'preparing' &&
     provisionUi.scope === 'r' &&
@@ -641,8 +644,28 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       : undefined
   const activeRuntimeTargetReady = hasActiveRuntimeTarget(activeRuntimeBinding)
   const gated = notebookGated(envStatus, provisionUi, item.notebook.sessionId, activeRuntimeBinding)
+  const activeRuntimeUnavailable = activeRuntimeBinding?.status === 'unavailable'
+  const activeRuntimeUnavailableReason =
+    activeRuntimeBinding?.reason === 'disabled'
+      ? t('Disabled')
+      : activeRuntimeBinding?.reason === 'missing'
+        ? t('Missing')
+        : activeRuntimeBinding?.reason === 'repair-required'
+          ? t('Needs repair')
+          : undefined
+  const activeRuntimeSettingsLabel =
+    activeRuntimeUnavailable && activeRuntimeBinding
+      ? t('Open settings for {{name}}', { name: activeRuntimeBinding.label })
+      : undefined
   const activeRuntimeDetails = activeRuntimeBinding
-    ? [activeRuntimeBinding.label, activeRuntimeBinding.version].filter(Boolean).join(' · ')
+    ? [
+        activeRuntimeBinding.label,
+        activeRuntimeBinding.version,
+        activeRuntimeUnavailable ? t('Unavailable') : undefined,
+        activeRuntimeUnavailableReason
+      ]
+        .filter(Boolean)
+        .join(' · ')
     : undefined
 
   // Per-environment selector (design D6): only python/r are env-scoped. Distinct env names among
@@ -1218,6 +1241,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         </ResizablePanel>
       </ResizablePanelGroup>
     )
+  const initialStateError = !notebookState && actionError
 
   return (
     <section
@@ -1350,15 +1374,35 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  aria-label={activeRuntimeDetails}
-                  className="ml-2 flex min-w-0 max-w-40 shrink-0 rounded-md bg-bg-300 px-2 py-1 text-[11px] text-text-200"
+                  aria-label={
+                    activeRuntimeSettingsLabel
+                      ? `${activeRuntimeDetails}. ${activeRuntimeSettingsLabel}`
+                      : activeRuntimeDetails
+                  }
+                  onClick={() => {
+                    if (activeRuntimeUnavailable) openSettingsToPanel('runtimes')
+                  }}
+                  className={cn(
+                    'ml-2 flex min-w-0 max-w-56 shrink-0 items-center gap-1.5 rounded-md bg-bg-300 px-2 py-1 text-[11px] text-text-200',
+                    activeRuntimeUnavailable &&
+                      'bg-status-failure-surface text-status-failure-foreground dark:bg-status-failure-dark-surface dark:text-status-failure-dark-foreground'
+                  )}
                   data-testid="notebook-runtime-binding"
                 >
                   <span className="min-w-0 truncate">{activeRuntimeBinding.label}</span>
+                  {activeRuntimeUnavailable ? (
+                    <span
+                      className="shrink-0 font-medium"
+                      data-testid="notebook-runtime-binding-status"
+                    >
+                      {t('Unavailable')}
+                    </span>
+                  ) : null}
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-[320px] break-words">
-                {activeRuntimeDetails}
+                <div>{activeRuntimeDetails}</div>
+                {activeRuntimeSettingsLabel ? <div>{activeRuntimeSettingsLabel}</div> : null}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -1415,25 +1459,44 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         </div>
       ) : null}
 
-      <div
-        className="flex min-h-0 flex-1"
-        data-testid={
-          showVariables && activeDataLanguage ? 'notebook-responsive-variables-layout' : undefined
-        }
-      >
+      {initialStateError ? (
         <div
-          className={cn(
-            'min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
-            showVariables && activeDataLanguage ? 'hidden @min-[55rem]/notebook:flex' : 'flex'
-          )}
-          data-testid="notebook-primary-view"
+          role="alert"
+          className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-6"
+          data-testid="notebook-state-load-error"
         >
-          {notebookView}
+          <ErrorNotice
+            icon={TriangleAlert}
+            tone="amber"
+            description={actionError}
+            primaryButton={{
+              label: t('Retry'),
+              onClick: () => void loadNotebookState(),
+              loading: isLoading
+            }}
+          />
         </div>
-        {showVariables && activeDataLanguage ? namespaceView : null}
-      </div>
+      ) : (
+        <div
+          className="flex min-h-0 flex-1"
+          data-testid={
+            showVariables && activeDataLanguage ? 'notebook-responsive-variables-layout' : undefined
+          }
+        >
+          <div
+            className={cn(
+              'min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
+              showVariables && activeDataLanguage ? 'hidden @min-[55rem]/notebook:flex' : 'flex'
+            )}
+            data-testid="notebook-primary-view"
+          >
+            {notebookView}
+          </div>
+          {showVariables && activeDataLanguage ? namespaceView : null}
+        </div>
+      )}
 
-      {!showVariables && (isNamespaceLost || isHistoricalEnvironmentView) ? (
+      {!initialStateError && !showVariables && (isNamespaceLost || isHistoricalEnvironmentView) ? (
         <footer
           className="flex h-7 shrink-0 items-center justify-between gap-3 border-t border-border-200 bg-bg-000 px-2 text-[11px] text-text-300"
           data-testid="notebook-read-only-status"

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -1468,7 +1468,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
           <ErrorNotice
             icon={TriangleAlert}
             tone="amber"
-            description={actionError}
+            description={initialStateError}
             primaryButton={{
               label: t('Retry'),
               onClick: () => void loadNotebookState(),


### PR DESCRIPTION
## Problem

Notebook Runtime Bindings already carry durable `status` and `reason` fields, but the Notebook
preview rendered only the binding label/version. An unavailable binding therefore disabled input
without explaining whether the Runtime was disabled, missing, or needed repair.

The initial `notebook.state()` failure had a separate visibility gap: it was stored in
`actionError`, whose only renderer lived inside the kernel terminal. Before the first successful
state load there is no terminal, so the error and any recovery path were hidden.

## Proposed change

- show an `Unavailable` marker and the existing translated binding reason in the Runtime badge;
- open Settings → Runtimes when the unavailable badge is activated;
- render a shared `ErrorNotice` with the original error and Retry when the initial state load fails;
- keep post-load execution/restart errors in the existing terminal surface.

## Scope and non-goals

- no new data fields, enum values, IPC methods, or persisted formats;
- no direct Runtime switcher or repair workflow in NotebookPreview;
- no change to the existing fail-closed main-process execution behavior;
- no change to historical bindings without `status`, which remain active by existing compatibility
  rules.

## Acceptance criteria and validation

The regression test was run before the production fix and failed on all reported remaining
symptoms: the initial load error was absent, Python/R unavailable badges omitted status/reason, and
the badge did not open Runtime settings. The same assertions pass after the fix.

Final checks after the last material edit:

- Runtime status/reason, Settings recovery action, initial load error, and Retry →
  `vitest run src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx` → 52 passed.
- Notebook follow-scroll consumer plus renderer i18n guards →
  `vitest run NotebookPreview.gate.render.test.tsx NotebookPreview.follow-scroll.test.tsx resources.test.ts`
  → 859 passed.
- Direct preview content consumer →
  `vitest run src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx` → 7 passed.
- Renderer types → `npm run typecheck:web` → passed.
- Lint → `npm run lint` → passed.
- Formatting/diff integrity → targeted Prettier check and `git diff --check` → passed.

`npm run test:affected -- --base origin/main --head HEAD --explain` selected the full plan because
NotebookPreview's test file has no module owner in `module-impact.json`. Per maintainer direction,
the complete local `npm test` suite was not run; PR Gate and its platform lanes are the final
authority for the complete suite.

## Review focus

- confirm that one Settings entry point is sufficient recovery without expanding the renderer
  Runtime contract;
- confirm the initial-load-only condition preserves existing terminal error behavior after a valid
  Notebook state exists;
- confirm the unavailable badge remains keyboard accessible and exposes an action-oriented label.
