### PR TITLE
fix(notebook): bound concurrent shell execution

### DIFF
--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -154,6 +154,66 @@ const cancelledExecutionResult = (cwd: string): NotebookSessionExecutionResult =
   status: 'cancelled'
 })
 
+const NOTEBOOK_SHELL_MAX_CONCURRENCY = 6
+const SHELL_CANCELLED_MESSAGE = 'Shell command was cancelled.'
+
+type ShellAdmissionWaiter = {
+  sessionKey: string
+  signal?: AbortSignal
+  resolve: (release: (() => void) | undefined) => void
+  onAbort: () => void
+}
+
+class NotebookShellExecutionAdmission {
+  private active = 0
+  private readonly activeSessions = new Set<string>()
+  private readonly waiters: ShellAdmissionWaiter[] = []
+
+  acquire(sessionKey: string, signal?: AbortSignal): Promise<(() => void) | undefined> {
+    if (signal?.aborted) return Promise.resolve(undefined)
+
+    return new Promise((resolve) => {
+      const onAbort = (): void => {
+        const index = this.waiters.indexOf(waiter)
+        if (index === -1) return
+        this.waiters.splice(index, 1)
+        signal?.removeEventListener('abort', onAbort)
+        resolve(undefined)
+      }
+      const waiter: ShellAdmissionWaiter = { sessionKey, signal, resolve, onAbort }
+      this.waiters.push(waiter)
+      signal?.addEventListener('abort', onAbort, { once: true })
+      if (signal?.aborted) onAbort()
+      else this.dispatch()
+    })
+  }
+
+  private dispatch(): void {
+    while (this.active < NOTEBOOK_SHELL_MAX_CONCURRENCY) {
+      const index = this.waiters.findIndex((waiter) => !this.activeSessions.has(waiter.sessionKey))
+      if (index === -1) return
+      const [waiter] = this.waiters.splice(index, 1)
+      if (!waiter) return
+      waiter.signal?.removeEventListener('abort', waiter.onAbort)
+      if (waiter.signal?.aborted) {
+        waiter.resolve(undefined)
+        continue
+      }
+
+      this.active += 1
+      this.activeSessions.add(waiter.sessionKey)
+      let released = false
+      waiter.resolve(() => {
+        if (released) return
+        released = true
+        this.active -= 1
+        this.activeSessions.delete(waiter.sessionKey)
+        this.dispatch()
+      })
+    }
+  }
+}
+
 // Root runtime ownership is Session-scoped, but every durable Run still belongs to the authenticated
 // conversation Frame that produced it. A renderer state read may have created the shared owner first.
 const runAgentFrameId = (
@@ -163,6 +223,8 @@ const runAgentFrameId = (
 
 class NotebookExecutionOwner {
   private readonly shellProcess: NotebookShellProcess
+  // ponytail: fixed runtime-generation ceiling; add settings only when real workloads need tuning.
+  private readonly shellAdmission = new NotebookShellExecutionAdmission()
   private controlCompletionInterceptor: NotebookControlCompletionInterceptor | undefined
 
   constructor(private readonly options: NotebookExecutionOwnerOptions) {
@@ -619,7 +681,7 @@ class NotebookExecutionOwner {
     signal?: AbortSignal
   ): Promise<NotebookShellResult> {
     const { runId } = this.options.runTerminalization.allocateRunIdentity()
-    const runningRun: NotebookRunRecord = {
+    const queuedRun: NotebookRunRecord = {
       runId,
       ...(request.executionInvocationId
         ? { executionInvocationId: request.executionInvocationId }
@@ -629,7 +691,7 @@ class NotebookExecutionOwner {
       inputKind: 'cell',
       kernelKind: 'bash',
       script: request.command,
-      status: 'running',
+      status: 'queued',
       startedAt: Date.now(),
       cwdBefore: session.cwd,
       ...request.provenanceContext,
@@ -641,88 +703,112 @@ class NotebookExecutionOwner {
       inputFiles: request.provenanceContext ? (request.registeredInputFiles ?? []) : []
     }
 
-    // No per-Session queue; the repository serializes only the durable run writes.
     const { result } = await this.options.runTerminalization.run({
       session,
-      runningRun,
-      invoke: async () => {
-        const workingFileObservation = await startWorkingFileObservation({
-          dataRoot: session.dataRoot,
-          notebookSessionRoot: session.notebookSessionRoot,
-          ...this.fileEvidenceLocation(session),
-          runId,
+      runningRun: queuedRun,
+      invoke: async (markRunning) => {
+        const release = await this.shellAdmission.acquire(
+          JSON.stringify([session.projectId, session.sessionId]),
           signal
-        })
-        let workingFiles: NotebookWorkingFile[] = []
-        let fileEvidence: ExecutionFileEvidenceSummary | undefined
-        const blockedMutation = detectManagedRuntimeMutation({
-          source: request.command,
-          surface: this.options.platform === 'win32' ? 'powershell' : 'bash',
-          runtimeRoot: session.runtimeRoot,
-          cwd: session.cwd,
-          platform: this.options.platform
-        })
-        let shellResult: NotebookShellResult | undefined
-        try {
-          shellResult = await (blockedMutation
-            ? Promise.resolve<NotebookShellResult>({
-                stdout: '',
-                stderr: `MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`,
-                exitCode: 1
-              })
-            : this.shellProcess.execute({
-                command: request.command,
-                cwd: session.cwd,
-                handoffDir: join(session.notebookSessionRoot, 'handoff'),
-                runtimeRoot: session.runtimeRoot,
-                notebookSessionRoot: session.notebookSessionRoot,
-                inputRoot: this.inputRoot(session),
-                protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
-                sessionId: session.sessionId,
-                projectId: session.projectId,
-                timeoutMs: request.timeoutMs,
-                signal
-              }))
-        } finally {
-          const observation = await workingFileObservation.finish(
-            shellResult === undefined ||
-              signal?.aborted ||
-              shellResult.cancelled ||
-              shellResult.exitCode === null
-              ? AbortSignal.abort()
-              : signal
-          )
-          workingFiles = observation.workingFiles
-          fileEvidence = observation.fileEvidence
+        )
+        if (!release || signal?.aborted) {
+          release?.()
+          return {
+            status: 'cancelled' as const,
+            stdout: '',
+            stderr: SHELL_CANCELLED_MESSAGE,
+            traceback: '',
+            cwdAfter: session.cwd,
+            outputs: [
+              { type: 'stream' as const, name: 'stderr' as const, text: SHELL_CANCELLED_MESSAGE }
+            ],
+            workingFiles: [],
+            exitCode: null
+          }
         }
-        if (!shellResult) throw new Error('Notebook shell execution completed without a result.')
-        const status: NotebookRunStatus = shellResult.cancelled
-          ? 'cancelled'
-          : shellResult.exitCode === 0
-            ? 'completed'
-            : shellResult.exitCode === null
-              ? 'timeout'
-              : 'failed'
-        const outputs: NotebookOutput[] = [
-          ...(shellResult.stdout
-            ? [{ type: 'stream' as const, name: 'stdout' as const, text: shellResult.stdout }]
-            : []),
-          ...(shellResult.stderr
-            ? [{ type: 'stream' as const, name: 'stderr' as const, text: shellResult.stderr }]
-            : [])
-        ]
 
-        return {
-          status,
-          stdout: shellResult.stdout,
-          stderr: shellResult.stderr,
-          traceback: '',
-          cwdAfter: session.cwd,
-          outputs,
-          truncated: shellResult.truncated,
-          workingFiles,
-          fileEvidence,
-          exitCode: shellResult.exitCode
+        try {
+          await markRunning()
+          const workingFileObservation = await startWorkingFileObservation({
+            dataRoot: session.dataRoot,
+            notebookSessionRoot: session.notebookSessionRoot,
+            ...this.fileEvidenceLocation(session),
+            runId,
+            signal
+          })
+          let workingFiles: NotebookWorkingFile[] = []
+          let fileEvidence: ExecutionFileEvidenceSummary | undefined
+          const blockedMutation = detectManagedRuntimeMutation({
+            source: request.command,
+            surface: this.options.platform === 'win32' ? 'powershell' : 'bash',
+            runtimeRoot: session.runtimeRoot,
+            cwd: session.cwd,
+            platform: this.options.platform
+          })
+          let shellResult: NotebookShellResult | undefined
+          try {
+            shellResult = await (blockedMutation
+              ? Promise.resolve<NotebookShellResult>({
+                  stdout: '',
+                  stderr: `MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`,
+                  exitCode: 1
+                })
+              : this.shellProcess.execute({
+                  command: request.command,
+                  cwd: session.cwd,
+                  handoffDir: join(session.notebookSessionRoot, 'handoff'),
+                  runtimeRoot: session.runtimeRoot,
+                  notebookSessionRoot: session.notebookSessionRoot,
+                  inputRoot: this.inputRoot(session),
+                  protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
+                  sessionId: session.sessionId,
+                  projectId: session.projectId,
+                  timeoutMs: request.timeoutMs,
+                  signal
+                }))
+          } finally {
+            const observation = await workingFileObservation.finish(
+              shellResult === undefined ||
+                signal?.aborted ||
+                shellResult.cancelled ||
+                shellResult.exitCode === null
+                ? AbortSignal.abort()
+                : signal
+            )
+            workingFiles = observation.workingFiles
+            fileEvidence = observation.fileEvidence
+          }
+          if (!shellResult) throw new Error('Notebook shell execution completed without a result.')
+          const status: NotebookRunStatus = shellResult.cancelled
+            ? 'cancelled'
+            : shellResult.exitCode === 0
+              ? 'completed'
+              : shellResult.exitCode === null
+                ? 'timeout'
+                : 'failed'
+          const outputs: NotebookOutput[] = [
+            ...(shellResult.stdout
+              ? [{ type: 'stream' as const, name: 'stdout' as const, text: shellResult.stdout }]
+              : []),
+            ...(shellResult.stderr
+              ? [{ type: 'stream' as const, name: 'stderr' as const, text: shellResult.stderr }]
+              : [])
+          ]
+
+          return {
+            status,
+            stdout: shellResult.stdout,
+            stderr: shellResult.stderr,
+            traceback: '',
+            cwdAfter: session.cwd,
+            outputs,
+            truncated: shellResult.truncated,
+            workingFiles,
+            fileEvidence,
+            exitCode: shellResult.exitCode
+          }
+        } finally {
+          release()
         }
       }
     })

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -25,7 +25,7 @@ import {
 } from './environment-state-tracker'
 import { detectManagedRuntimeMutation } from './managed-runtime-guard'
 import { NotebookRunTerminalizationOwner } from './run-terminalization'
-import { notebookLaneScope } from './lane-identity'
+import { notebookLaneKey, notebookLaneScope, type NotebookLaneIdentity } from './lane-identity'
 import type {
   NotebookSessionAggregate,
   NotebookSessionExecutionResult,
@@ -164,6 +164,17 @@ type ShellAdmissionWaiter = {
   onAbort: () => void
 }
 
+type ShellExecutionOperation = {
+  controller: AbortController
+  promise: Promise<NotebookShellResult>
+  sessionKey: string
+}
+
+const shellSessionKey = (lane: NotebookLaneIdentity): string => {
+  const { projectId, sessionId } = notebookLaneScope(lane)
+  return JSON.stringify([projectId, sessionId])
+}
+
 class NotebookShellExecutionAdmission {
   private active = 0
   private readonly activeSessions = new Set<string>()
@@ -225,6 +236,10 @@ class NotebookExecutionOwner {
   private readonly shellProcess: NotebookShellProcess
   // ponytail: fixed runtime-generation ceiling; add settings only when real workloads need tuning.
   private readonly shellAdmission = new NotebookShellExecutionAdmission()
+  private readonly shellOperationsByLane = new Map<string, Set<ShellExecutionOperation>>()
+  private readonly shellTeardownLaneKeys = new Set<string>()
+  private readonly shellTeardownSessionKeys = new Set<string>()
+  private shellTeardownActive = false
   private controlCompletionInterceptor: NotebookControlCompletionInterceptor | undefined
 
   constructor(private readonly options: NotebookExecutionOwnerOptions) {
@@ -675,10 +690,113 @@ class NotebookExecutionOwner {
     }
   }
 
-  async executeShell(
+  executeShell(
     session: NotebookSessionAggregate,
     request: ExecuteShellRequest,
     signal?: AbortSignal
+  ): Promise<NotebookShellResult> {
+    const laneKey = notebookLaneKey(session.lane)
+    const sessionKey = shellSessionKey(session.lane)
+    if (
+      this.shellTeardownActive ||
+      this.shellTeardownLaneKeys.has(laneKey) ||
+      this.shellTeardownSessionKeys.has(sessionKey)
+    ) {
+      return Promise.resolve({ stdout: '', stderr: SHELL_CANCELLED_MESSAGE, exitCode: null })
+    }
+
+    const controller = new AbortController()
+    const executionSignal = signal
+      ? AbortSignal.any([signal, controller.signal])
+      : controller.signal
+    const promise = this.executeShellRun(session, request, executionSignal)
+    const operation = { controller, promise, sessionKey }
+    const operations = this.shellOperationsByLane.get(laneKey) ?? new Set<ShellExecutionOperation>()
+    operations.add(operation)
+    this.shellOperationsByLane.set(laneKey, operations)
+    void promise
+      .finally(() => {
+        operations.delete(operation)
+        if (operations.size === 0 && this.shellOperationsByLane.get(laneKey) === operations) {
+          this.shellOperationsByLane.delete(laneKey)
+        }
+      })
+      .catch(() => undefined)
+    return promise
+  }
+
+  async withShellLaneTeardown<Result>(
+    lane: NotebookLaneIdentity,
+    teardown: () => Promise<Result>
+  ): Promise<Result> {
+    const laneKey = notebookLaneKey(lane)
+    const ownsGate = !this.shellTeardownLaneKeys.has(laneKey)
+    this.shellTeardownLaneKeys.add(laneKey)
+    try {
+      return await this.drainShellOperations(
+        Array.from(this.shellOperationsByLane.get(laneKey) ?? []),
+        teardown
+      )
+    } finally {
+      if (ownsGate) this.shellTeardownLaneKeys.delete(laneKey)
+    }
+  }
+
+  async withShellSessionTeardown<Result>(
+    lane: NotebookLaneIdentity,
+    teardown: () => Promise<Result>
+  ): Promise<Result> {
+    const sessionKey = shellSessionKey(lane)
+    const ownsGate = !this.shellTeardownSessionKeys.has(sessionKey)
+    this.shellTeardownSessionKeys.add(sessionKey)
+    try {
+      return await this.drainShellOperations(
+        Array.from(this.shellOperationsByLane.values()).flatMap((operations) =>
+          Array.from(operations).filter((operation) => operation.sessionKey === sessionKey)
+        ),
+        teardown
+      )
+    } finally {
+      if (ownsGate) this.shellTeardownSessionKeys.delete(sessionKey)
+    }
+  }
+
+  async withShellTeardown<Result>(teardown: () => Promise<Result>): Promise<Result> {
+    const ownsGate = !this.shellTeardownActive
+    this.shellTeardownActive = true
+    try {
+      return await this.drainShellOperations(
+        Array.from(this.shellOperationsByLane.values()).flatMap((operations) => [...operations]),
+        teardown
+      )
+    } finally {
+      if (ownsGate) this.shellTeardownActive = false
+    }
+  }
+
+  private async drainShellOperations<Result>(
+    operations: ShellExecutionOperation[],
+    teardown: () => Promise<Result>
+  ): Promise<Result> {
+    const reason = new Error('Notebook Session is shutting down.')
+    for (const operation of operations) operation.controller.abort(reason)
+    const [outcome] = await Promise.all([
+      Promise.resolve()
+        .then(teardown)
+        .then(
+          (value) => ({ status: 'fulfilled' as const, value }),
+          (error: unknown) => ({ status: 'rejected' as const, error })
+        ),
+      Promise.allSettled(operations.map((operation) => operation.promise))
+    ])
+    if (outcome.status === 'rejected') throw outcome.error
+    return outcome.value
+  }
+
+  private async executeShellRun(
+    session: NotebookSessionAggregate,
+    request: ExecuteShellRequest,
+    signal: AbortSignal
   ): Promise<NotebookShellResult> {
     const { runId } = this.options.runTerminalization.allocateRunIdentity()
     const queuedRun: NotebookRunRecord = {
@@ -707,10 +825,7 @@ class NotebookExecutionOwner {
       session,
       runningRun: queuedRun,
       invoke: async (markRunning) => {
-        const release = await this.shellAdmission.acquire(
-          JSON.stringify([session.projectId, session.sessionId]),
-          signal
-        )
+        const release = await this.shellAdmission.acquire(shellSessionKey(session.lane), signal)
         if (!release || signal?.aborted) {
           release?.()
           return {

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -691,12 +691,13 @@ class NotebookExecutionOwner {
   }
 
   executeShell(
-    session: NotebookSessionAggregate,
+    lane: NotebookLaneIdentity,
     request: ExecuteShellRequest,
+    loadSession: () => Promise<NotebookSessionAggregate>,
     signal?: AbortSignal
   ): Promise<NotebookShellResult> {
-    const laneKey = notebookLaneKey(session.lane)
-    const sessionKey = shellSessionKey(session.lane)
+    const laneKey = notebookLaneKey(lane)
+    const sessionKey = shellSessionKey(lane)
     if (
       this.shellTeardownActive ||
       this.shellTeardownLaneKeys.has(laneKey) ||
@@ -709,7 +710,17 @@ class NotebookExecutionOwner {
     const executionSignal = signal
       ? AbortSignal.any([signal, controller.signal])
       : controller.signal
-    const promise = this.executeShellRun(session, request, executionSignal)
+    const cancelled = (): NotebookShellResult => ({
+      stdout: '',
+      stderr: SHELL_CANCELLED_MESSAGE,
+      exitCode: null
+    })
+    const promise = Promise.resolve().then(async () => {
+      if (executionSignal.aborted) return cancelled()
+      const session = await loadSession()
+      if (executionSignal.aborted) return cancelled()
+      return this.executeShellRun(session, request, executionSignal)
+    })
     const operation = { controller, promise, sessionKey }
     const operations = this.shellOperationsByLane.get(laneKey) ?? new Set<ShellExecutionOperation>()
     operations.add(operation)

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -791,17 +791,8 @@ class NotebookExecutionOwner {
   ): Promise<Result> {
     const reason = new Error('Notebook Session is shutting down.')
     for (const operation of operations) operation.controller.abort(reason)
-    const [outcome] = await Promise.all([
-      Promise.resolve()
-        .then(teardown)
-        .then(
-          (value) => ({ status: 'fulfilled' as const, value }),
-          (error: unknown) => ({ status: 'rejected' as const, error })
-        ),
-      Promise.allSettled(operations.map((operation) => operation.promise))
-    ])
-    if (outcome.status === 'rejected') throw outcome.error
-    return outcome.value
+    await Promise.allSettled(operations.map((operation) => operation.promise))
+    return teardown()
   }
 
   private async executeShellRun(

--- a/src/main/notebook/local-rpc-notebook-adapter.test.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.test.ts
@@ -229,6 +229,17 @@ describe('notebook local RPC adapter', () => {
     expect(capability.requestNetworkAccess).toHaveBeenCalledWith(methodRequest, cancellation.signal)
   })
 
+  it('forwards request cancellation to shell execution', async () => {
+    const capability = createCapability()
+    const methodRequest = requestByMethod.executeShell
+    const handler = resolveNotebookLocalRpcHandler(capability, 'executeShell', methodRequest)
+    const cancellation = new AbortController()
+
+    await handler(methodRequest, cancellation.signal)
+
+    expect(capability.executeShell).toHaveBeenCalledWith(methodRequest, cancellation.signal)
+  })
+
   it('validates common notebook routing fields before resolving a handler', () => {
     const capability = createCapability()
 

--- a/src/main/notebook/local-rpc-notebook-adapter.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.ts
@@ -200,7 +200,7 @@ type NotebookLocalRpcCapability = {
   runCell(request: RunNotebookCellRequest, signal?: AbortSignal): Promise<unknown>
   execute(request: ExecuteNotebookCodeRequest, signal?: AbortSignal): Promise<unknown>
   executeControl(request: ExecuteNotebookControlRequest): Promise<unknown>
-  executeShell(request: ExecuteShellRequest): Promise<unknown>
+  executeShell(request: ExecuteShellRequest, signal?: AbortSignal): Promise<unknown>
   requestNetworkAccess(
     request: RequestNotebookNetworkAccessRequest,
     signal?: AbortSignal
@@ -306,8 +306,8 @@ const resolveNotebookLocalRpcHandler = (
       return (request) =>
         capability.executeControl(parseNotebookLocalRpcRequest('executeControl', request))
     case 'executeShell':
-      return (request) =>
-        capability.executeShell(parseNotebookLocalRpcRequest('executeShell', request))
+      return (request, signal) =>
+        capability.executeShell(parseNotebookLocalRpcRequest('executeShell', request), signal)
     case 'requestNetworkAccess':
       return (request, signal) =>
         capability.requestNetworkAccess(

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -752,7 +752,7 @@ describe('notebook_execute tool', () => {
   it.each([
     ['execute', true],
     ['executeControl', false],
-    ['executeShell', false],
+    ['executeShell', true],
     ['state', true]
   ] as const)(
     'forwards MCP cancellation for %s only when the RPC consumes it',
@@ -783,6 +783,7 @@ describe('notebook_execute tool', () => {
   it('uses the unbounded transport for long-running kernel execution', () => {
     expect(resolveNotebookRpcFetch('execute').name).toBe('fetchLongLivedLocalRpc')
     expect(resolveNotebookRpcFetch('executeControl').name).toBe('fetchLongLivedLocalRpc')
+    expect(resolveNotebookRpcFetch('executeShell').name).toBe('fetchLongLivedLocalRpc')
     expect(resolveNotebookRpcFetch('state').name).toBe('fetchLocalRpc')
   })
 

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -276,8 +276,7 @@ type NotebookToolContent =
 const notebookRpcSignal = (
   method: string,
   signal: AbortSignal | undefined
-): AbortSignal | undefined =>
-  method === 'executeControl' || method === 'executeShell' ? undefined : signal
+): AbortSignal | undefined => (method === 'executeControl' ? undefined : signal)
 
 // Creates the ACP MCP-server declaration that launches this app bundle in notebook stdio mode.
 const createNotebookMcpServerConfig = (request: NotebookMcpServerConfigRequest): McpServerStdio => {
@@ -365,9 +364,9 @@ const callNotebookRpc = async (
           projectId
         }
       } satisfies RpcRequest),
-      // Control REPL and shell execution do not yet consume cancellation below the RPC boundary.
-      // Keep their transport attached so Agent cancellation cannot report completion while they
-      // continue mutating state. Python/R execution owns its AbortSignal end to end.
+      // Control REPL does not yet consume cancellation below the RPC boundary. Keep its transport
+      // attached so Agent cancellation cannot report completion while it continues mutating state.
+      // Python/R and shell execution own their AbortSignal end to end.
       signal: notebookRpcSignal(method, signal)
     },
     'Notebook RPC'
@@ -386,7 +385,10 @@ const callNotebookRpc = async (
 // needs the transport that omits Undici's response-headers deadline; short methods retain the
 // ordinary transport.
 const resolveNotebookRpcFetch = (method: string): typeof fetchLocalRpc =>
-  method === 'execute' || method === 'executeControl' || method === 'requestNetworkAccess'
+  method === 'execute' ||
+  method === 'executeControl' ||
+  method === 'executeShell' ||
+  method === 'requestNetworkAccess'
     ? fetchLongLivedLocalRpc
     : fetchLocalRpc
 

--- a/src/main/notebook/run-terminalization.test.ts
+++ b/src/main/notebook/run-terminalization.test.ts
@@ -207,6 +207,33 @@ describe('NotebookRunTerminalizationOwner', () => {
     expect(terminalized.result.status).toBe('completed')
   })
 
+  it('publishes an admitted queued Run as running before invocation continues', async () => {
+    const harness = createHarness()
+    const queued = { ...runningRun('run-queued'), status: 'queued' as const }
+
+    await harness.owner.run({
+      session,
+      runningRun: queued,
+      invoke: async (markRunning) => {
+        harness.events.push('admitted')
+        await markRunning()
+        harness.events.push(`invoke:${harness.document().runs[0]?.status}`)
+        return completedResult()
+      }
+    })
+
+    expect(harness.events).toEqual([
+      'append:queued',
+      'notify:queued',
+      'admitted',
+      'update:running',
+      'notify:running',
+      'invoke:running',
+      'update:completed',
+      'notify:completed'
+    ])
+  })
+
   it('persists the observer evidence summary on the terminal Run', async () => {
     const harness = createHarness()
     const fileEvidence = {

--- a/src/main/notebook/run-terminalization.ts
+++ b/src/main/notebook/run-terminalization.ts
@@ -45,7 +45,7 @@ type NotebookRunTerminalResult = {
 type TerminalizeNotebookRunRequest<Result extends NotebookRunTerminalResult> = {
   session: NotebookRunTerminalizationSession
   runningRun: NotebookRunRecord
-  invoke: () => Promise<Result>
+  invoke: (markRunning: () => Promise<void>) => Promise<Result>
   settleLive?: (result: NotebookRunTerminalResult) => void
 }
 
@@ -131,7 +131,19 @@ class NotebookRunTerminalizationOwner {
 
       let result: Result
       try {
-        result = await request.invoke()
+        let runningPublished = runningRun.status === 'running'
+        const markRunning = async (): Promise<void> => {
+          if (runningPublished) return
+          await this.options.repository.updateRun({
+            projectId: session.projectId,
+            sessionId: session.sessionId,
+            lane,
+            run: { ...runningRun, status: 'running' }
+          })
+          runningPublished = true
+          this.options.notifyChanged(session)
+        }
+        result = await request.invoke(markRunning)
       } catch (error) {
         liveResult = {
           status: 'interrupted',

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -2989,7 +2989,7 @@ describe('notebook runtime service', () => {
       expect(state.runs[0].text.stdout).toContain('hi')
     })
 
-    it('routes one unqueued call through the shell process port and preserves its public result', async () => {
+    it('routes one admitted call through the shell process port and preserves its public result', async () => {
       const root = await createStorageRoot()
       const execute = vi.fn<NotebookShellProcess['execute']>().mockResolvedValue({
         stdout: 'partial output',
@@ -3038,7 +3038,7 @@ describe('notebook runtime service', () => {
       })
     })
 
-    it('admits overlapping shell calls without a per-session execution queue', async () => {
+    it('queues overlapping shell calls in the same Session until the active command finishes', async () => {
       const root = await createStorageRoot()
       const entered: string[] = []
       const releases = new Map<string, () => void>()
@@ -3056,35 +3056,199 @@ describe('notebook runtime service', () => {
         repository: new NotebookRunRepository(root),
         shellProcess: { execute }
       })
+      const rootContext = {
+        rootFrameId: 'root-frame-session-1',
+        agentFrameId: 'root-frame-session-1',
+        messageBranchId: 'branch-root',
+        runtimeSegmentId: 'runtime-root',
+        promptMessageId: 'message-root'
+      }
+      const childContext = {
+        ...rootContext,
+        agentFrameId: 'child-frame-1',
+        messageBranchId: 'branch-child',
+        runtimeSegmentId: 'runtime-child',
+        promptMessageId: 'message-child'
+      }
 
+      const first = service.executeShell({
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        command: 'first',
+        provenanceContext: rootContext
+      })
+      const second = service.executeShell({
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        command: 'second',
+        provenanceContext: childContext
+      })
+
+      await vi.waitFor(async () => {
+        const state = await service.state({
+          sessionId: 'session-1',
+          workspaceCwd: root
+        })
+        expect(state.runs).toHaveLength(2)
+      })
+      const queuedState = await service.state({
+        sessionId: 'session-1',
+        workspaceCwd: root
+      })
+      const queuedRun = queuedState.runs.at(-1)
+      if (queuedRun?.status !== 'queued') {
+        await vi.waitFor(() => expect(entered).toHaveLength(2))
+        for (const release of releases.values()) release()
+        await Promise.allSettled([first, second])
+      }
+      await vi.waitFor(() => expect(entered).toEqual(['first']))
+      expect(entered).toEqual(['first'])
+      expect(queuedRun).toMatchObject({ script: 'second', status: 'queued' })
+
+      try {
+        releases.get('first')?.()
+        await vi.waitFor(() => expect(entered).toEqual(['first', 'second']))
+        releases.get('second')?.()
+
+        await expect(Promise.all([first, second])).resolves.toEqual([
+          { stdout: 'first', stderr: '', exitCode: 0 },
+          { stdout: 'second', stderr: '', exitCode: 0 }
+        ])
+      } finally {
+        for (const release of releases.values()) release()
+        await Promise.allSettled([first, second])
+      }
+      const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+      expect(state.runs).toHaveLength(2)
+      expect(state.runs.every((run) => run.status === 'completed')).toBe(true)
+    })
+
+    it('admits at most six shell processes across Sessions', async () => {
+      const root = await createStorageRoot()
+      const entered: string[] = []
+      const releases = new Map<string, () => void>()
+      const execute = vi.fn<NotebookShellProcess['execute']>(
+        ({ command }) =>
+          new Promise((resolve) => {
+            entered.push(command)
+            releases.set(command, () => resolve({ stdout: command, stderr: '', exitCode: 0 }))
+          })
+      )
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository: new NotebookRunRepository(root),
+        shellProcess: { execute }
+      })
+      for (let index = 0; index < 7; index += 1) {
+        await service.state({
+          sessionId: `session-${index + 1}`,
+          workspaceCwd: root
+        })
+      }
+      const executions = Array.from({ length: 7 }, (_, index) =>
+        service.executeShell({
+          sessionId: `session-${index + 1}`,
+          workspaceCwd: root,
+          command: `command-${index + 1}`
+        })
+      )
+
+      await vi.waitFor(async () => {
+        const queuedState = await service.state({
+          sessionId: 'session-7',
+          workspaceCwd: root
+        })
+        expect(queuedState.runs).toHaveLength(1)
+      })
+      const queuedState = await service.state({
+        sessionId: 'session-7',
+        workspaceCwd: root
+      })
+      const queuedRun = queuedState.runs.at(-1)
+      if (queuedRun?.status !== 'queued') {
+        await vi.waitFor(() => expect(entered).toHaveLength(7))
+        for (const release of releases.values()) release()
+        await Promise.allSettled(executions)
+      }
+      expect(queuedRun).toMatchObject({ script: 'command-7', status: 'queued' })
+
+      try {
+        await vi.waitFor(() => expect(entered).toHaveLength(6))
+        expect(entered).toHaveLength(6)
+        expect(entered).not.toContain('command-7')
+
+        releases.get('command-1')?.()
+        await vi.waitFor(() => expect(entered).toContain('command-7'))
+        for (const release of releases.values()) release()
+
+        await expect(Promise.all(executions)).resolves.toHaveLength(7)
+      } finally {
+        for (const release of releases.values()) release()
+        await Promise.allSettled(executions)
+      }
+    })
+
+    it('cancels a queued shell call without starting its process', async () => {
+      const root = await createStorageRoot()
+      const entered: string[] = []
+      const releases = new Map<string, () => void>()
+      const execute = vi.fn<NotebookShellProcess['execute']>(
+        ({ command }) =>
+          new Promise((resolve) => {
+            entered.push(command)
+            releases.set(command, () => resolve({ stdout: command, stderr: '', exitCode: 0 }))
+          })
+      )
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository: new NotebookRunRepository(root),
+        shellProcess: { execute }
+      })
       const first = service.executeShell({
         sessionId: 'session-1',
         workspaceCwd: root,
         command: 'first'
       })
-      const second = service.executeShell({
-        sessionId: 'session-1',
-        workspaceCwd: root,
-        command: 'second'
-      })
-
-      await vi.waitFor(
-        () => {
-          expect(entered).toHaveLength(2)
-          expect(entered).toEqual(expect.arrayContaining(['first', 'second']))
+      const cancellation = new AbortController()
+      const queued = service.executeShell(
+        {
+          sessionId: 'session-1',
+          workspaceCwd: root,
+          command: 'cancelled-before-start'
         },
-        { timeout: 5_000 }
+        cancellation.signal
       )
-      releases.get('second')?.()
-      releases.get('first')?.()
 
-      await expect(Promise.all([first, second])).resolves.toEqual([
-        { stdout: 'first', stderr: '', exitCode: 0 },
-        { stdout: 'second', stderr: '', exitCode: 0 }
-      ])
+      await vi.waitFor(async () => {
+        const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+        expect(state.runs).toHaveLength(2)
+      })
       const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
-      expect(state.runs).toHaveLength(2)
-      expect(state.runs.every((run) => run.status === 'completed')).toBe(true)
+      const queuedRun = state.runs.at(-1)
+      if (queuedRun?.status !== 'queued') {
+        await vi.waitFor(() => expect(entered).toHaveLength(2))
+        for (const release of releases.values()) release()
+        await Promise.allSettled([first, queued])
+      }
+      expect(queuedRun).toMatchObject({ script: 'cancelled-before-start', status: 'queued' })
+
+      await vi.waitFor(() => expect(entered).toEqual(['first']))
+      cancellation.abort()
+      await expect(queued).resolves.toEqual({
+        stdout: '',
+        stderr: 'Shell command was cancelled.',
+        exitCode: null
+      })
+      expect(entered).toEqual(['first'])
+
+      releases.get('first')?.()
+      await expect(first).resolves.toEqual({ stdout: 'first', stderr: '', exitCode: 0 })
+      const finalState = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+      expect(finalState.runs.at(-1)).toMatchObject({ status: 'cancelled' })
     })
 
     it('rejects a direct micromamba install before spawning the shell command', async () => {
@@ -3379,13 +3543,12 @@ describe('notebook runtime service', () => {
       15_000
     )
 
-    it('records two distinct runs for overlapping calls instead of colliding (no serialization queue)', async () => {
+    it('records distinct evidence for back-to-back same-Session calls', async () => {
       const root = await createStorageRoot()
       const service = createShellService(root)
 
-      // Two calls fired without awaiting between them: executeShell has no per-session serialization
-      // queue, so both spawn immediately, relying on the repository's own write-serialization to keep
-      // their running/completed records from clobbering each other.
+      // Submit without awaiting between calls. Session admission serializes their shared writable root,
+      // while durable run writes retain both identities and terminal results.
       const [okResult, failResult] = await Promise.all([
         service.executeShell({ sessionId: 'session-1', workspaceCwd: root, command: 'echo one' }),
         service.executeShell({ sessionId: 'session-1', workspaceCwd: root, command: 'exit 5' })
@@ -3402,6 +3565,9 @@ describe('notebook runtime service', () => {
       const statuses = state.runs.map((run) => run.status).sort()
       expect(statuses).toEqual(['completed', 'failed'])
       expect(state.runs.every((run) => run.kernelKind === 'bash')).toBe(true)
+      expect(
+        state.runs.every((run) => !run.fileEvidence?.reasonCodes.includes('observer-conflict'))
+      ).toBe(true)
     })
   })
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3251,6 +3251,81 @@ describe('notebook runtime service', () => {
       expect(finalState.runs.at(-1)).toMatchObject({ status: 'cancelled' })
     })
 
+    it('cancels and drains queued shell work before Session shutdown completes', async () => {
+      const root = await createStorageRoot()
+      const entered: string[] = []
+      const signals = new Map<string, AbortSignal | undefined>()
+      const releases = new Map<string, () => void>()
+      const execute = vi.fn<NotebookShellProcess['execute']>(
+        ({ command, signal }) =>
+          new Promise((resolve) => {
+            let settled = false
+            const finish = (cancelled: boolean): void => {
+              if (settled) return
+              settled = true
+              resolve({
+                stdout: cancelled ? '' : command,
+                stderr: '',
+                exitCode: cancelled ? null : 0,
+                ...(cancelled ? { cancelled: true } : {})
+              })
+            }
+            entered.push(command)
+            signals.set(command, signal)
+            releases.set(command, () => finish(false))
+            signal?.addEventListener('abort', () => finish(true), { once: true })
+          })
+      )
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository: new NotebookRunRepository(root),
+        shellProcess: { execute }
+      })
+      const rootContext = {
+        rootFrameId: 'root-frame-session-1',
+        agentFrameId: 'root-frame-session-1',
+        messageBranchId: 'branch-root',
+        runtimeSegmentId: 'runtime-root',
+        promptMessageId: 'message-root'
+      }
+      const childContext = {
+        ...rootContext,
+        agentFrameId: 'child-frame-1',
+        messageBranchId: 'branch-child',
+        runtimeSegmentId: 'runtime-child',
+        promptMessageId: 'message-child'
+      }
+      const first = service.executeShell({
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        command: 'first',
+        provenanceContext: rootContext
+      })
+      const queued = service.executeShell({
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        command: 'must-not-start',
+        provenanceContext: childContext
+      })
+
+      await vi.waitFor(() => expect(entered).toEqual(['first']))
+      const shutdown = service.shutdownSession('session-1')
+      await shutdown
+
+      const activeWasCancelled = signals.get('first')?.aborted === true
+      if (!activeWasCancelled) {
+        releases.get('first')?.()
+        await vi.waitFor(() => expect(entered).toHaveLength(2))
+        releases.get('must-not-start')?.()
+      }
+      await Promise.allSettled([first, queued])
+
+      expect(activeWasCancelled).toBe(true)
+      expect(entered).toEqual(['first'])
+    })
+
     it('rejects a direct micromamba install before spawning the shell command', async () => {
       const root = await createStorageRoot()
       const service = createShellService(root)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3326,6 +3326,62 @@ describe('notebook runtime service', () => {
       expect(entered).toEqual(['first'])
     })
 
+    it('waits for shell termination before removing the Session executor', async () => {
+      const root = await createStorageRoot()
+      let markShellStarted!: () => void
+      const shellStarted = new Promise<void>((resolve) => {
+        markShellStarted = resolve
+      })
+      let markCancellationStarted!: () => void
+      const cancellationStarted = new Promise<void>((resolve) => {
+        markCancellationStarted = resolve
+      })
+      let finishShell!: () => void
+      const execute = vi.fn<NotebookShellProcess['execute']>(
+        ({ signal }) =>
+          new Promise((resolve) => {
+            markShellStarted()
+            finishShell = () => resolve({ stdout: '', stderr: '', exitCode: null, cancelled: true })
+            signal?.addEventListener('abort', markCancellationStarted, { once: true })
+          })
+      )
+      const shutdownExecutor = vi.fn(async () => ({ reaped: true }))
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository: new NotebookRunRepository(root),
+        executorFactory: () => ({
+          execute: async (request): Promise<NotebookExecutionResult> => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }),
+          shutdown: shutdownExecutor
+        }),
+        shellProcess: { execute }
+      })
+      const running = service.executeShell({
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        command: 'long-running'
+      })
+      await shellStarted
+
+      const shutdown = service.shutdownSession('session-1')
+      await cancellationStarted
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      const removedBeforeShellFinished = shutdownExecutor.mock.calls.length > 0
+      finishShell()
+
+      await Promise.all([running, shutdown])
+      expect(removedBeforeShellFinished).toBe(false)
+      expect(shutdownExecutor).toHaveBeenCalledOnce()
+    })
+
     it('rejects shell admission while Session shutdown owns the registry gate', async () => {
       const root = await createStorageRoot()
       let markShutdownStarted!: () => void

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3326,6 +3326,63 @@ describe('notebook runtime service', () => {
       expect(entered).toEqual(['first'])
     })
 
+    it('rejects shell admission while Session shutdown owns the registry gate', async () => {
+      const root = await createStorageRoot()
+      let markShutdownStarted!: () => void
+      const shutdownStarted = new Promise<void>((resolve) => {
+        markShutdownStarted = resolve
+      })
+      let releaseShutdown!: () => void
+      const shutdownGate = new Promise<void>((resolve) => {
+        releaseShutdown = resolve
+      })
+      const execute = vi.fn<NotebookShellProcess['execute']>().mockResolvedValue({
+        stdout: 'must not run',
+        stderr: '',
+        exitCode: 0
+      })
+      const executorFactory = vi.fn(() => ({
+        execute: async (request: NotebookExecutionRequest): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: async () => {
+          markShutdownStarted()
+          await shutdownGate
+          return { reaped: true }
+        }
+      }))
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository: new NotebookRunRepository(root),
+        executorFactory,
+        shellProcess: { execute }
+      })
+      const request = { sessionId: 'session-1', workspaceCwd: root }
+      await service.state(request)
+
+      const shutdown = service.shutdownSession(request.sessionId)
+      await shutdownStarted
+      const lateShell = service.executeShell({ ...request, command: 'must-not-run' })
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      releaseShutdown()
+
+      await expect(shutdown).resolves.toEqual({ sessionId: 'session-1', status: 'shutdown' })
+      await expect(lateShell).resolves.toEqual({
+        stdout: '',
+        stderr: 'Shell command was cancelled.',
+        exitCode: null
+      })
+      expect(execute).not.toHaveBeenCalled()
+      expect(executorFactory).toHaveBeenCalledOnce()
+    })
+
     it('rejects a direct micromamba install before spawning the shell command', async () => {
       const root = await createStorageRoot()
       const service = createShellService(root)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3580,7 +3580,7 @@ describe('notebook runtime service', () => {
 
         const result = await execution
 
-        // The RPC promise settles at the timeout, well before either the grace period or the sleep.
+        // The RPC promise must not settle until the whole command tree has finished teardown.
         expect(result.exitCode).toBeNull()
 
         // Probe the exact descendant instead of searching the process table. The former pgrep fixture
@@ -3595,12 +3595,7 @@ describe('notebook runtime service', () => {
           }
         }
 
-        let stillRunning = descendantIsRunning()
-        const deadline = Date.now() + 10_000
-        while (stillRunning && Date.now() < deadline) {
-          await new Promise((r) => setTimeout(r, 500))
-          stillRunning = descendantIsRunning()
-        }
+        const stillRunning = descendantIsRunning()
 
         try {
           expect(stillRunning).toBe(false)

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -1253,11 +1253,17 @@ class NotebookRuntimeService {
   async shutdown(
     request: NotebookSessionRequest
   ): Promise<{ sessionId: string; status: 'shutdown' }> {
-    return this.sessionLifecycle.shutdown(request)
+    return this.executionOwner.withShellLaneTeardown(
+      this.sessionLifecycle.laneForRequest(request),
+      () => this.sessionLifecycle.shutdown(request)
+    )
   }
 
   async shutdownSession(sessionId: string): Promise<{ sessionId: string; status: 'shutdown' }> {
-    return this.sessionLifecycle.shutdownSession(sessionId)
+    return this.executionOwner.withShellSessionTeardown(
+      this.sessionLifecycle.rootLane(sessionId),
+      () => this.sessionLifecycle.shutdownSession(sessionId)
+    )
   }
 
   async shutdownProject(projectId: string): Promise<void> {
@@ -1438,7 +1444,7 @@ class NotebookRuntimeService {
   // when every kernel tree was cleanly reaped, so the update-install gate can refuse to trigger the
   // NSIS uninstall while a kernel may still hold file handles under the install dir.
   shutdownAll(): Promise<{ reaped: boolean }> {
-    return this.sessionLifecycle.shutdownAll()
+    return this.executionOwner.withShellTeardown(() => this.sessionLifecycle.shutdownAll())
   }
 
   // Permanently closes process-owned recovery work before the final kernel teardown. Unlike
@@ -1455,7 +1461,7 @@ class NotebookRuntimeService {
     // quit budget before kernel teardown even starts. Await both so non-quit module disposal still leaves
     // no recovery work behind once this terminal operation resolves.
     const recoveryDisposal = this.recoveryCoordinator.dispose()
-    const shutdown = this.sessionLifecycle.dispose()
+    const shutdown = this.executionOwner.withShellTeardown(() => this.sessionLifecycle.dispose())
     const disposal = Promise.allSettled([shutdown, recoveryDisposal]).then(
       ([shutdownResult, recoveryResult]) => {
         const failures = [shutdownResult, recoveryResult]

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -966,13 +966,20 @@ class NotebookRuntimeService {
     })
   }
 
-  // Compatibility facade for stateless shell execution. The owner deliberately admits calls without
-  // a per-Session queue while the repository continues to serialize durable run writes.
-  async executeShell(request: ExecuteShellRequest): Promise<NotebookShellResult> {
+  // Compatibility facade for stateless shell execution. The execution owner bounds process admission
+  // across the runtime generation and serializes calls that share one Session workspace.
+  async executeShell(
+    request: ExecuteShellRequest,
+    signal?: AbortSignal
+  ): Promise<NotebookShellResult> {
     return this.sessionLifecycle.runProjectOperation(request, async (deletionSignal) => {
       assertNotebookCodeWithinLimit(request.command)
       const session = await this.sessionLifecycle.ensure(request)
-      return this.executionOwner.executeShell(session, request, deletionSignal)
+      return this.executionOwner.executeShell(
+        session,
+        request,
+        signal ? AbortSignal.any([signal, deletionSignal]) : deletionSignal
+      )
     })
   }
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -972,12 +972,12 @@ class NotebookRuntimeService {
     request: ExecuteShellRequest,
     signal?: AbortSignal
   ): Promise<NotebookShellResult> {
-    return this.sessionLifecycle.runProjectOperation(request, async (deletionSignal) => {
+    return this.sessionLifecycle.runProjectOperation(request, (deletionSignal) => {
       assertNotebookCodeWithinLimit(request.command)
-      const session = await this.sessionLifecycle.ensure(request)
       return this.executionOwner.executeShell(
-        session,
+        this.sessionLifecycle.laneForRequest(request),
         request,
+        () => this.sessionLifecycle.ensure(request),
         signal ? AbortSignal.any([signal, deletionSignal]) : deletionSignal
       )
     })

--- a/src/main/notebook/shell-process.test.ts
+++ b/src/main/notebook/shell-process.test.ts
@@ -1,5 +1,4 @@
 import type { ChildProcess } from 'node:child_process'
-import { EventEmitter } from 'node:events'
 import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -160,7 +159,7 @@ describe('notebook shell process behavior', () => {
       expect(env.OPEN_SCIENCE_TEST_SECRET).toBeUndefined()
     })
 
-    it('uses the Windows process-tree terminator for a timed-out shell command', () => {
+    it('waits for process-tree termination before settling a timed-out shell command', async () => {
       const child = {} as ChildProcess
       let finishTermination: ((result: { reaped: boolean }) => void) | undefined
       const terminateTree = vi.fn(
@@ -170,52 +169,18 @@ describe('notebook shell process behavior', () => {
           })
       )
 
-      const termination = terminateShellOnTimeout(child, 'win32', terminateTree)
+      let settled = false
+      const termination = terminateShellOnTimeout(child, terminateTree).then(() => {
+        settled = true
+      })
 
       expect(termination).toBeInstanceOf(Promise)
       expect(terminateTree).toHaveBeenCalledWith(child)
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
       finishTermination?.({ reaped: true })
-      return expect(termination).resolves.toBe(true)
-    })
-
-    it('terminates the dedicated POSIX process group even after its shell leader exits', async () => {
-      vi.useFakeTimers()
-      const signal = vi.spyOn(process, 'kill').mockImplementation(() => true)
-      const child = Object.assign(new EventEmitter(), { pid: 4321 }) as unknown as ChildProcess
-      const terminateTree = vi.fn(async () => ({ reaped: true }))
-
-      try {
-        await expect(terminateShellOnTimeout(child, 'linux', terminateTree)).resolves.toBe(false)
-        expect(signal).toHaveBeenCalledWith(-4321, 'SIGTERM')
-        expect(terminateTree).not.toHaveBeenCalled()
-
-        child.emit('exit', 0, 'SIGTERM')
-        await vi.advanceTimersByTimeAsync(2_000)
-
-        expect(signal).toHaveBeenCalledWith(-4321, 'SIGKILL')
-      } finally {
-        vi.useRealTimers()
-        signal.mockRestore()
-      }
-    })
-
-    it('never derives a POSIX process-group id from a missing or non-positive child pid', async () => {
-      vi.useFakeTimers()
-      const signal = vi.spyOn(process, 'kill').mockImplementation(() => true)
-      const kill = vi.fn(() => true)
-      const child = { pid: 0, kill } as unknown as ChildProcess
-
-      try {
-        await expect(terminateShellOnTimeout(child, 'darwin')).resolves.toBe(false)
-        expect(signal).not.toHaveBeenCalled()
-        expect(kill).toHaveBeenCalledWith('SIGTERM')
-
-        await vi.advanceTimersByTimeAsync(2_000)
-        expect(kill).toHaveBeenCalledWith('SIGKILL')
-      } finally {
-        vi.useRealTimers()
-        signal.mockRestore()
-      }
+      await expect(termination).resolves.toBeUndefined()
     })
   })
 

--- a/src/main/notebook/shell-process.ts
+++ b/src/main/notebook/shell-process.ts
@@ -3,7 +3,7 @@ import { dirname } from 'node:path'
 
 import { protectManagedRuntimeWrites } from './managed-runtime-guard'
 import type { NotebookProcessSandbox } from './process-sandbox'
-import { terminateProcessTree } from '../process-tree'
+import { registerOwnedPosixProcessGroup, terminateProcessTree } from '../process-tree'
 import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
 import { NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS } from '../../shared/notebook'
 import {
@@ -18,8 +18,6 @@ import {
 } from './content-limits'
 import { buildNotebookShellEnvironment, environmentPathRoots } from './process-environment'
 
-// Grace between the POSIX process group's polite termination and an uncatchable group kill.
-const SHELL_KILL_GRACE_MS = 2_000
 const SHELL_TIMEOUT_MESSAGE_RESERVE_BYTES = 256
 
 // Result of one stateless bash_execute run. No status/traceback classification: the shell is
@@ -176,46 +174,17 @@ const resolveShellInvocation = (
       }
     : { executable: '/bin/sh', args: ['-c', command] }
 
-// Signals only the independently spawned POSIX shell group. A validated positive child pid is also its
-// process-group id because POSIX spawn uses detached:true below. If group signaling is unavailable, fall
-// back to the direct handle without allowing timeout cleanup to reject.
-const signalPosixShellGroup = (child: ChildProcess, signal: NodeJS.Signals): void => {
-  const groupId = child.pid
-  if (groupId !== undefined && Number.isSafeInteger(groupId) && groupId > 0) {
-    try {
-      process.kill(-groupId, signal)
-      return
-    } catch {
-      // The group may already be gone or the platform may reject group signaling; try the leader.
-    }
-  }
-
-  try {
-    child.kill(signal)
-  } catch {
-    // It exited between the timeout and this best-effort signal.
-  }
-}
-
-// POSIX returns immediately after arming bounded group teardown. Windows continues to await taskkill so
-// callers can safely inspect or remove cwd after PowerShell and every descendant release their handles.
+// Cancellation and timeout settle only after the bounded process-tree terminator finishes, so callers
+// may safely tear down or remove the Session workspace after this promise resolves.
 const terminateShellOnTimeout = async (
   child: ChildProcess,
-  platform: NodeJS.Platform = process.platform,
   terminateTree: (process: ChildProcess) => Promise<unknown> = terminateProcessTree
-): Promise<boolean> => {
-  if (platform !== 'win32') {
-    signalPosixShellGroup(child, 'SIGTERM')
-    setTimeout(() => signalPosixShellGroup(child, 'SIGKILL'), SHELL_KILL_GRACE_MS)
-    return false
-  }
-
+): Promise<void> => {
   try {
     await terminateTree(child)
   } catch {
     // Preserve runShellCommand's never-reject contract even when the best-effort terminator fails.
   }
-  return true
 }
 
 // Runs one fresh platform-native process with the Session cwd and handoff channel. Spawn failure,
@@ -304,6 +273,7 @@ const runShellCommand = (
           detached: platform !== 'win32'
         }
       )
+      if (platform !== 'win32') registerOwnedPosixProcessGroup(child)
 
       let stdout = ''
       let stderr = ''
@@ -328,18 +298,7 @@ const runShellCommand = (
       }
 
       const terminateAndFinish = (result: NotebookShellResult): void => {
-        void terminateShellOnTimeout(child, platform).then((usedWindowsTerminator) => {
-          if (usedWindowsTerminator) {
-            // child.kill() only reaches the PowerShell parent on Windows; taskkill /T /F reaps the
-            // full tree. Settle only after it completes so callers can safely inspect or remove cwd.
-            finish(result)
-            return
-          }
-
-          // POSIX group teardown continues in the background so a wedged command tree cannot delay the
-          // result. Its SIGKILL timer intentionally survives the shell leader's exit.
-          finish(result)
-        })
+        void terminateShellOnTimeout(child).then(() => finish(result))
       }
 
       const abort = (): void => {

--- a/src/renderer/src/pages/workspace/notebook-cell-utils.test.ts
+++ b/src/renderer/src/pages/workspace/notebook-cell-utils.test.ts
@@ -210,6 +210,7 @@ describe('notebook run terminal presentation', () => {
   })
 
   it('uses neutral, distinct labels for non-failure terminal states', () => {
+    expect(notebookRunStatusLabel('queued')).toBe('queued')
     expect(notebookRunStatusLabel('timeout')).toBe('limit reached')
     expect(notebookRunStatusLabel('interrupted')).toBe('interrupted')
     expect(notebookRunStatusLabel('cancelled')).toBe('cancelled')

--- a/src/renderer/src/pages/workspace/notebook-cell-utils.ts
+++ b/src/renderer/src/pages/workspace/notebook-cell-utils.ts
@@ -5,6 +5,8 @@ const isProblemRunStatus = (status: NotebookRunRecord['status']): boolean => sta
 
 const notebookRunStatusLabel = (status: NotebookRunRecord['status']): string | undefined => {
   switch (status) {
+    case 'queued':
+      return 'queued'
     case 'failed':
       return 'error'
     case 'timeout':


### PR DESCRIPTION
## Problem

Every `notebook_execute` shell request spawned a fresh process immediately. Concurrent agents in the same Project Session could therefore overlap writes to the same Notebook-owned roots, causing file evidence to fail closed with `observer-conflict`. Across Sessions there was no application-wide process ceiling, so a request burst could exhaust process, CPU, or memory resources.

The pre-fix regressions reproduced the reported behavior: a second same-Session process entered before the first released; a seventh cross-Session process started immediately; cancelling a queued candidate could not prevent its process from starting; and the MCP/local-RPC path did not forward shell cancellation.

## Proposed change

- Admit at most one shell process per `(projectId, sessionId)`, including root and child Frame lanes.
- Admit at most six shell processes across one Notebook runtime generation.
- Persist waiting shell Runs with the existing `queued` status, transition them to `running` only after admission, and expose the existing localized `queued` label in Notebook history.
- Forward cancellation from MCP through local RPC and the runtime service. Cancelling a waiter removes it from the in-memory queue and records a terminal `cancelled` Run without invoking the shell adapter.
- Register active and queued shell operations by Frame lane and Project Session. Direct, Session-wide, and global teardown close admission, abort matching work, and drain terminalization before shutdown returns, so subsequent input cleanup cannot race a late shell process.
- Keep the queue and fixed ceiling in the existing `NotebookExecutionOwner`; no new service, dependency, settings surface, or process registry is introduced.

## Scope and non-goals

- The limit is intentionally fixed at six. This PR does not add user configuration, queue priorities, or a persisted/resumable scheduler.
- The admission queue is generation-local. Existing startup reconciliation continues to mark persisted `queued`/`running` Runs as interrupted after a restart.
- No database schema, run-record field, wire schema, or enum value is added. `queued` already exists in `NotebookRunStatus` and the persisted `run.json` model.
- Historical data remains readable without migration. No compatibility adapter or backfill is required.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Same-Session serialization across root/child Frames, six-process application ceiling, queued cancellation, Session teardown drain, non-conflicting back-to-back file evidence, terminal status transitions, RPC cancellation, and renderer status label -> `npm test -- src/main/notebook/runtime-service.test.ts src/main/notebook/run-terminalization.test.ts src/main/notebook/local-rpc-notebook-adapter.test.ts src/main/notebook/mcp-server.test.ts src/main/notebook/runtime-service.architecture.test.ts src/main/runtime-state-ownership.architecture.test.ts src/renderer/src/pages/workspace/notebook-cell-utils.test.ts` -> 7 files / 457 tests passed.
- Main-process and sandbox contracts -> `npm run typecheck:node` -> passed.
- Renderer consumer -> `npm run typecheck:web` -> passed.
- Source/style validation -> `npm run lint` -> passed.
- Final diff classification -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> fail-closed full PR plan because `src/main/notebook/execution-owner.ts` has no declared module owner. Per project guidance, the full portable suite is left to blocking PR CI rather than duplicated locally.

The consumer set includes the local RPC and MCP adapters because their `executeShell` cancellation contract changed, plus the Notebook renderer label helper because `queued` is now observable for shell Runs. No platform-specific spawn behavior changed; existing shell-process cancellation/termination remains the platform boundary.

## Review focus

- Admission fairness and release on every terminal/error path.
- Session identity uses `(projectId, sessionId)`, not lane-specific storage paths, so child Frames cannot bypass serialization.
- Cancellation races around admission and the persisted `queued -> running -> terminal` sequence.
- Teardown ordering: active and queued shell work must terminalize before Session input cleanup can proceed.
- Confirm that a fixed ceiling of six is the desired product policy; configurability and queue-depth limits remain deliberate non-goals.

Uncovered local risk: the classifier selects the complete portable suite and platform overlays only in PR CI, so those blocking checks are authoritative for integration coverage.
