### PR TITLE
fix(artifacts): make finalization recovery retryable

### DIFF
--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -8,6 +8,7 @@ import {
   type ArtifactVersionFile
 } from '../../shared/artifact-provenance'
 import {
+  ARTIFACT_FINALIZATION_INVALID_PROOF,
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile,
   type ArtifactWriteSource
@@ -1307,6 +1308,46 @@ describe('artifact IPC handler registration', () => {
         artifactVersionCount: 1
       })
     )
+  })
+
+  it('returns invalid provenance proof as a terminal IPC failure result', async () => {
+    const repository = { finalizeRunArtifacts: vi.fn() } as unknown as ArtifactRepository
+    const provenance = {
+      finalizeRun: vi
+        .fn()
+        .mockRejectedValue(
+          new ArtifactFinalizationProofError(
+            'execution-snapshot-corrupt',
+            'Artifact Version provenance proof is invalid.'
+          )
+        )
+    }
+    const runRegistry = new ArtifactRunRegistry()
+    const claimId = runRegistry.register({
+      projectId: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-1',
+      promptMessageId: 'prompt-1',
+      artifactVersionIds: ['version-1']
+    })
+    const handlers = createArtifactHandlers(repository, runRegistry, {
+      provenance: provenance as never
+    })
+    registerArtifactIpcHandlers(repository, runRegistry, provenance as never, undefined, handlers)
+
+    await expect(
+      ipcHandlers.get('artifacts:finalize-run')?.({}, { claimId, messageId: 'message-1' })
+    ).resolves.toEqual({
+      ok: false,
+      code: ARTIFACT_FINALIZATION_INVALID_PROOF,
+      message: 'Artifact Version provenance proof is invalid.'
+    })
+    expect(repository.finalizeRunArtifacts).not.toHaveBeenCalled()
   })
 
   it('uses a legacy Version locator only to open the latest logical Artifact preview', async () => {

--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -1459,7 +1459,10 @@ describe('artifact handler edge cases', () => {
       size: 1,
       mtimeMs: 1
     }
-    const recoverPendingArtifacts = vi.fn().mockResolvedValue([recovered])
+    const recoverPendingArtifacts = vi.fn().mockResolvedValue({
+      artifacts: [recovered],
+      nativeRunIds: ['run-1']
+    })
     const repository = { reconcilePendingArtifactPaths } as unknown as ArtifactRepository
     const handlers = createArtifactHandlers(repository, new ArtifactRunRegistry(), {
       recoverPendingArtifacts
@@ -1477,6 +1480,38 @@ describe('artifact handler edge cases', () => {
     expect(reconcilePendingArtifactPaths).not.toHaveBeenCalled()
   })
 
+  it('does not bypass native recovery when its authoritative result is empty', async () => {
+    const reconcilePendingArtifactPaths = vi.fn().mockResolvedValue([
+      {
+        id: 'compatibility-artifact',
+        projectId: 'default-project',
+        sessionId: 'session-1',
+        name: 'a.txt',
+        path: '/p/session-1/a.txt',
+        fileUrl: 'file:///p/session-1/a.txt',
+        size: 1,
+        mtimeMs: 1
+      }
+    ])
+    const recoverPendingArtifacts = vi.fn().mockResolvedValue({
+      artifacts: [],
+      nativeRunIds: ['run-1']
+    })
+    const repository = { reconcilePendingArtifactPaths } as unknown as ArtifactRepository
+    const handlers = createArtifactHandlers(repository, new ArtifactRunRegistry(), {
+      recoverPendingArtifacts
+    })
+    const request = {
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      pendingPaths: ['/p/.pending/run-1/a.txt']
+    }
+
+    await expect(handlers.reconcilePendingArtifacts(request)).resolves.toEqual([])
+    expect(reconcilePendingArtifactPaths).not.toHaveBeenCalled()
+  })
+
   it('falls back to compatibility recovery for pending Artifacts without native Versions', async () => {
     const compatibilityArtifact = {
       id: 'legacy-artifact',
@@ -1489,7 +1524,7 @@ describe('artifact handler edge cases', () => {
       mtimeMs: 1
     }
     const reconcilePendingArtifactPaths = vi.fn().mockResolvedValue([compatibilityArtifact])
-    const recoverPendingArtifacts = vi.fn().mockResolvedValue([])
+    const recoverPendingArtifacts = vi.fn().mockResolvedValue(undefined)
     const repository = { reconcilePendingArtifactPaths } as unknown as ArtifactRepository
     const handlers = createArtifactHandlers(repository, new ArtifactRunRegistry(), {
       recoverPendingArtifacts
@@ -1505,5 +1540,53 @@ describe('artifact handler edge cases', () => {
       compatibilityArtifact
     ])
     expect(reconcilePendingArtifactPaths).toHaveBeenCalledWith(request)
+  })
+
+  it('preserves compatibility-only files when native recovery covers only some pending runs', async () => {
+    const nativeArtifact = {
+      id: 'version-1',
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      name: 'native.txt',
+      path: '/p/version-1/native.txt',
+      fileUrl: 'file:///p/version-1/native.txt',
+      size: 1,
+      mtimeMs: 1
+    }
+    const compatibilityArtifact = {
+      id: 'legacy-artifact',
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      name: 'legacy.txt',
+      path: '/p/session-1/legacy.txt',
+      fileUrl: 'file:///p/session-1/legacy.txt',
+      size: 1,
+      mtimeMs: 1
+    }
+    const reconcilePendingArtifactPaths = vi
+      .fn()
+      .mockResolvedValue([{ ...nativeArtifact, id: 'compatibility-native' }, compatibilityArtifact])
+    const repository = { reconcilePendingArtifactPaths } as unknown as ArtifactRepository
+    const handlers = createArtifactHandlers(repository, new ArtifactRunRegistry(), {
+      recoverPendingArtifacts: vi.fn().mockResolvedValue({
+        artifacts: [nativeArtifact],
+        nativeRunIds: ['run-native']
+      })
+    })
+    const request = {
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      pendingPaths: ['/p/.pending/run-native/native.txt', '/p/.pending/run-legacy/legacy.txt']
+    }
+
+    await expect(handlers.reconcilePendingArtifacts(request)).resolves.toEqual([
+      nativeArtifact,
+      compatibilityArtifact
+    ])
+    expect(reconcilePendingArtifactPaths).toHaveBeenCalledWith({
+      ...request,
+      pendingPaths: ['/p/.pending/run-legacy/legacy.txt']
+    })
   })
 })

--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -1583,7 +1583,7 @@ describe('artifact handler edge cases', () => {
     expect(reconcilePendingArtifactPaths).toHaveBeenCalledWith(request)
   })
 
-  it('preserves compatibility-only files when native recovery covers only some pending runs', async () => {
+  it('preserves same-named compatibility files when native recovery covers only some pending runs', async () => {
     const nativeArtifact = {
       id: 'version-1',
       projectId: 'default-project',
@@ -1598,9 +1598,9 @@ describe('artifact handler edge cases', () => {
       id: 'legacy-artifact',
       projectId: 'default-project',
       sessionId: 'session-1',
-      name: 'legacy.txt',
-      path: '/p/session-1/legacy.txt',
-      fileUrl: 'file:///p/session-1/legacy.txt',
+      name: 'native.txt',
+      path: '/p/session-1/native.txt',
+      fileUrl: 'file:///p/session-1/native.txt',
       size: 1,
       mtimeMs: 1
     }
@@ -1618,7 +1618,7 @@ describe('artifact handler edge cases', () => {
       projectId: 'default-project',
       sessionId: 'session-1',
       messageId: 'message-1',
-      pendingPaths: ['/p/.pending/run-native/native.txt', '/p/.pending/run-legacy/legacy.txt']
+      pendingPaths: ['/p/.pending/run-native/native.txt', '/p/.pending/run-legacy/native.txt']
     }
 
     await expect(handlers.reconcilePendingArtifacts(request)).resolves.toEqual([
@@ -1627,7 +1627,42 @@ describe('artifact handler edge cases', () => {
     ])
     expect(reconcilePendingArtifactPaths).toHaveBeenCalledWith({
       ...request,
-      pendingPaths: ['/p/.pending/run-legacy/legacy.txt']
+      pendingPaths: ['/p/.pending/run-legacy/native.txt']
+    })
+  })
+
+  it('returns an invalid recovery proof as a terminal IPC failure result', async () => {
+    const repository = {
+      reconcilePendingArtifactPaths: vi.fn()
+    } as unknown as ArtifactRepository
+    const proofError = Object.assign(new Error('Native Artifact finalization proof is invalid.'), {
+      code: ARTIFACT_FINALIZATION_INVALID_PROOF
+    })
+    const handlers = createArtifactHandlers(repository, new ArtifactRunRegistry(), {
+      recoverPendingArtifacts: vi.fn().mockRejectedValue(proofError)
+    })
+    registerArtifactIpcHandlers(
+      repository,
+      new ArtifactRunRegistry(),
+      undefined,
+      undefined,
+      handlers
+    )
+
+    await expect(
+      ipcHandlers.get('artifacts:reconcile-pending')?.(
+        {},
+        {
+          projectId: 'default-project',
+          sessionId: 'session-1',
+          messageId: 'message-1',
+          pendingPaths: ['/p/.pending/run-1/native.txt']
+        }
+      )
+    ).resolves.toEqual({
+      ok: false,
+      code: ARTIFACT_FINALIZATION_INVALID_PROOF,
+      message: 'Native Artifact finalization proof is invalid.'
     })
   })
 })

--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -991,6 +991,43 @@ describe('artifact IPC handlers', () => {
       versionIds: ['version-1', 'version-1']
     })
   })
+  it('evicts an abandoned Claim after its recovery window expires', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    const runRegistry = new ArtifactRunRegistry()
+    const claimId = runRegistry.register({
+      projectId: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-abandoned'
+    })
+
+    now.mockReturnValue(60 * 60 * 1_000)
+    expect(runRegistry.resolve(claimId).runId).toBe('run-abandoned')
+
+    now.mockReturnValue(60 * 60 * 1_000 + 1_000)
+    expect(() => runRegistry.resolve(claimId)).toThrow(/Artifact run claim not found/)
+    now.mockRestore()
+  })
+
+  it('evicts a finalized Claim after its idempotency window expires', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    const runRegistry = new ArtifactRunRegistry()
+    const claimId = runRegistry.register({
+      projectId: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-finalized'
+    })
+    runRegistry.markFinalized(claimId, 'message-1')
+
+    now.mockReturnValue(5 * 60 * 1_000)
+    expect(runRegistry.resolve(claimId).finalizedMessageId).toBe('message-1')
+
+    now.mockReturnValue(5 * 60 * 1_000 + 1_000)
+
+    expect(() => runRegistry.resolve(claimId)).toThrow(/Artifact run claim not found/)
+    now.mockRestore()
+  })
 })
 
 describe('artifact IPC handler registration', () => {
@@ -1407,6 +1444,66 @@ describe('artifact handler edge cases', () => {
     }
     await handlers.reconcilePendingArtifacts(request)
 
+    expect(reconcilePendingArtifactPaths).toHaveBeenCalledWith(request)
+  })
+
+  it('uses the Session recovery owner when pending Artifact recovery is configured', async () => {
+    const reconcilePendingArtifactPaths = vi.fn().mockResolvedValue([])
+    const recovered = {
+      id: 'version-1',
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      name: 'a.txt',
+      path: '/p/version-1/a.txt',
+      fileUrl: 'file:///p/version-1/a.txt',
+      size: 1,
+      mtimeMs: 1
+    }
+    const recoverPendingArtifacts = vi.fn().mockResolvedValue([recovered])
+    const repository = { reconcilePendingArtifactPaths } as unknown as ArtifactRepository
+    const handlers = createArtifactHandlers(repository, new ArtifactRunRegistry(), {
+      recoverPendingArtifacts
+    })
+    const request = {
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      pendingPaths: ['/p/.pending/run-1/a.txt']
+    }
+
+    await expect(handlers.reconcilePendingArtifacts(request)).resolves.toEqual([recovered])
+
+    expect(recoverPendingArtifacts).toHaveBeenCalledWith(request)
+    expect(reconcilePendingArtifactPaths).not.toHaveBeenCalled()
+  })
+
+  it('falls back to compatibility recovery for pending Artifacts without native Versions', async () => {
+    const compatibilityArtifact = {
+      id: 'legacy-artifact',
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      name: 'legacy.txt',
+      path: '/p/session-1/legacy.txt',
+      fileUrl: 'file:///p/session-1/legacy.txt',
+      size: 1,
+      mtimeMs: 1
+    }
+    const reconcilePendingArtifactPaths = vi.fn().mockResolvedValue([compatibilityArtifact])
+    const recoverPendingArtifacts = vi.fn().mockResolvedValue([])
+    const repository = { reconcilePendingArtifactPaths } as unknown as ArtifactRepository
+    const handlers = createArtifactHandlers(repository, new ArtifactRunRegistry(), {
+      recoverPendingArtifacts
+    })
+    const request = {
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      pendingPaths: ['/p/.pending/run-1/legacy.txt']
+    }
+
+    await expect(handlers.reconcilePendingArtifacts(request)).resolves.toEqual([
+      compatibilityArtifact
+    ])
     expect(reconcilePendingArtifactPaths).toHaveBeenCalledWith(request)
   })
 })

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -1,4 +1,5 @@
 import { shell } from 'electron'
+import { basename, dirname } from 'node:path'
 
 import { ipcMainHandle } from '../ipc-handler-registry'
 
@@ -92,7 +93,9 @@ type ArtifactHandlerDependencies = {
     sessionId: string,
     mutation: () => Promise<Result>
   ) => Promise<Result>
-  recoverPendingArtifacts?: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
+  recoverPendingArtifacts?: (
+    request: ReconcilePendingArtifactsRequest
+  ) => Promise<{ artifacts: ArtifactFile[]; nativeRunIds: string[] } | undefined>
   provenance?: Pick<
     ArtifactProvenanceRepository,
     | 'finalizeRun'
@@ -172,14 +175,31 @@ const createArtifactHandlers = (
       ),
     reconcilePendingArtifacts: (request) =>
       withDataRootWrite(async () => {
-        const recovered = await dependencies.recoverPendingArtifacts?.(request)
-        if (recovered && recovered.length > 0) return recovered
-        return repository.reconcilePendingArtifactPaths({
-          projectId: resolveProjectId(request),
-          sessionId: request.sessionId,
-          messageId: request.messageId,
-          pendingPaths: request.pendingPaths
-        })
+        const reconcileCompatibility = (pendingPaths: string[]): Promise<ArtifactFile[]> =>
+          repository.reconcilePendingArtifactPaths({
+            projectId: resolveProjectId(request),
+            sessionId: request.sessionId,
+            messageId: request.messageId,
+            pendingPaths
+          })
+        if (dependencies.recoverPendingArtifacts) {
+          const recovered = await dependencies.recoverPendingArtifacts(request)
+          if (recovered) {
+            const nativeRunIds = new Set(recovered.nativeRunIds)
+            const compatibilityPaths = request.pendingPaths.filter(
+              (pendingPath) => !nativeRunIds.has(basename(dirname(pendingPath)))
+            )
+            if (compatibilityPaths.length === 0) return recovered.artifacts
+
+            const compatibilityArtifacts = await reconcileCompatibility(compatibilityPaths)
+            const nativeNames = new Set(recovered.artifacts.map((artifact) => artifact.name))
+            return [
+              ...recovered.artifacts,
+              ...compatibilityArtifacts.filter((artifact) => !nativeNames.has(artifact.name))
+            ]
+          }
+        }
+        return reconcileCompatibility(request.pendingPaths)
       }),
     openFile: async (request) => {
       // Resolve through the repository first so shell.openPath never sees unmanaged locations.

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -4,6 +4,7 @@ import { basename, dirname } from 'node:path'
 import { ipcMainHandle } from '../ipc-handler-registry'
 
 import {
+  ARTIFACT_FINALIZATION_INVALID_PROOF,
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile,
   type ArtifactPreviewResult,
@@ -489,10 +490,18 @@ const registerArtifactIpcHandlers = (
       try {
         return { ok: true, artifacts: await handlers.finalizeRunArtifacts(request) }
       } catch (error) {
-        if (!(error instanceof ArtifactOwnershipPersistenceRaceError)) throw error
+        if (
+          !(error instanceof ArtifactOwnershipPersistenceRaceError) &&
+          !(error instanceof ArtifactFinalizationProofError)
+        ) {
+          throw error
+        }
         return {
           ok: false,
-          code: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+          code:
+            error instanceof ArtifactOwnershipPersistenceRaceError
+              ? ARTIFACT_OWNERSHIP_PERSISTENCE_RACE
+              : ARTIFACT_FINALIZATION_INVALID_PROOF,
           message: error.message
         }
       }

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -9,6 +9,7 @@ import {
   type ArtifactFile,
   type ArtifactPreviewResult,
   type FinalizeRunArtifactsResult,
+  type ReconcilePendingArtifactsResult,
   type ResolveArtifactVersionDescriptorsRequest
 } from '../../shared/artifacts'
 import type {
@@ -193,10 +194,10 @@ const createArtifactHandlers = (
             if (compatibilityPaths.length === 0) return recovered.artifacts
 
             const compatibilityArtifacts = await reconcileCompatibility(compatibilityPaths)
-            const nativeNames = new Set(recovered.artifacts.map((artifact) => artifact.name))
+            const nativePaths = new Set(recovered.artifacts.map((artifact) => artifact.path))
             return [
               ...recovered.artifacts,
-              ...compatibilityArtifacts.filter((artifact) => !nativeNames.has(artifact.name))
+              ...compatibilityArtifacts.filter((artifact) => !nativePaths.has(artifact.path))
             ]
           }
         }
@@ -509,8 +510,29 @@ const registerArtifactIpcHandlers = (
   )
   ipcMainHandle(
     'artifacts:reconcile-pending',
-    (_event, request: ReconcilePendingArtifactsRequest) =>
-      handlers.reconcilePendingArtifacts(request)
+    async (
+      _event,
+      request: ReconcilePendingArtifactsRequest
+    ): Promise<ReconcilePendingArtifactsResult> => {
+      try {
+        return await handlers.reconcilePendingArtifacts(request)
+      } catch (error) {
+        if (
+          typeof error !== 'object' ||
+          error === null ||
+          !('code' in error) ||
+          error.code !== ARTIFACT_FINALIZATION_INVALID_PROOF
+        ) {
+          throw error
+        }
+        return {
+          ok: false,
+          code: ARTIFACT_FINALIZATION_INVALID_PROOF,
+          message:
+            error instanceof Error ? error.message : 'Artifact finalization proof is invalid.'
+        }
+      }
+    }
   )
   ipcMainHandle('artifacts:open-file', (_event, request: OpenArtifactFileRequest) =>
     handlers.openFile(request)

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -92,6 +92,7 @@ type ArtifactHandlerDependencies = {
     sessionId: string,
     mutation: () => Promise<Result>
   ) => Promise<Result>
+  recoverPendingArtifacts?: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
   provenance?: Pick<
     ArtifactProvenanceRepository,
     | 'finalizeRun'
@@ -170,14 +171,16 @@ const createArtifactHandlers = (
         })
       ),
     reconcilePendingArtifacts: (request) =>
-      withDataRootWrite(() =>
-        repository.reconcilePendingArtifactPaths({
+      withDataRootWrite(async () => {
+        const recovered = await dependencies.recoverPendingArtifacts?.(request)
+        if (recovered && recovered.length > 0) return recovered
+        return repository.reconcilePendingArtifactPaths({
           projectId: resolveProjectId(request),
           sessionId: request.sessionId,
           messageId: request.messageId,
           pendingPaths: request.pendingPaths
         })
-      ),
+      }),
     openFile: async (request) => {
       // Resolve through the repository first so shell.openPath never sees unmanaged locations.
       const versionIdentity = parseArtifactVersionLocator(request.path)

--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -146,7 +146,8 @@ class ArtifactProvenanceFinalizationRecovery {
     appSessionId: string,
     durableSession?: PersistedChatSession,
     snapshot?: ArtifactProjectReconciliationSnapshot,
-    artifactRunIds?: readonly string[]
+    artifactRunIds?: readonly string[],
+    artifactVersionIds?: readonly string[]
   ): Promise<ArtifactFinalizationRecoveryResult> {
     this.validateProjectReconciliation(projectId, snapshot)
     const result: ArtifactFinalizationRecoveryResult = {
@@ -176,9 +177,13 @@ class ArtifactProvenanceFinalizationRecovery {
       })
     ).map(requireAgentArtifactVersion)
     const requestedRunIds = artifactRunIds ? new Set(artifactRunIds) : undefined
+    const requestedVersionIds = artifactVersionIds ? new Set(artifactVersionIds) : undefined
+    const isScopedRetry = requestedRunIds !== undefined || requestedVersionIds !== undefined
     const candidateVersions = allFinalizationVersions.filter(
       (version) =>
-        (!requestedRunIds || requestedRunIds.has(version.artifactRunId)) &&
+        (!isScopedRetry ||
+          requestedRunIds?.has(version.artifactRunId) ||
+          requestedVersionIds?.has(version.id)) &&
         (version.state === 'pending' ||
           (version.messageId !== null &&
             !isArtifactLinkedToDurableMessage(durableSession, version.messageId, version.id)))
@@ -193,7 +198,7 @@ class ArtifactProvenanceFinalizationRecovery {
     // Direct callers deliberately get a fresh scan. Startup supplies one opaque Project snapshot
     // to every Session, avoiding repeated scans without persisting stale repository state.
     const prepared = snapshot?.[artifactProjectReconciliationState]
-    const unfinishedCompatibilityPublications = requestedRunIds
+    const unfinishedCompatibilityPublications = isScopedRetry
       ? []
       : (prepared?.unfinishedCompatibilityPublications ??
         (await compatibilityRepository.listPendingRunPublications(projectId)))

--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -145,7 +145,8 @@ class ArtifactProvenanceFinalizationRecovery {
     projectId: string,
     appSessionId: string,
     durableSession?: PersistedChatSession,
-    snapshot?: ArtifactProjectReconciliationSnapshot
+    snapshot?: ArtifactProjectReconciliationSnapshot,
+    artifactRunIds?: readonly string[]
   ): Promise<ArtifactFinalizationRecoveryResult> {
     this.validateProjectReconciliation(projectId, snapshot)
     const result: ArtifactFinalizationRecoveryResult = {
@@ -174,11 +175,13 @@ class ArtifactProvenanceFinalizationRecovery {
         }
       })
     ).map(requireAgentArtifactVersion)
+    const requestedRunIds = artifactRunIds ? new Set(artifactRunIds) : undefined
     const candidateVersions = allFinalizationVersions.filter(
       (version) =>
-        version.state === 'pending' ||
-        (version.messageId !== null &&
-          !isArtifactLinkedToDurableMessage(durableSession, version.messageId, version.id))
+        (!requestedRunIds || requestedRunIds.has(version.artifactRunId)) &&
+        (version.state === 'pending' ||
+          (version.messageId !== null &&
+            !isArtifactLinkedToDurableMessage(durableSession, version.messageId, version.id)))
     )
     result.nativeFinalizationRunIds = [
       ...new Set(candidateVersions.map((version) => version.artifactRunId))
@@ -190,9 +193,10 @@ class ArtifactProvenanceFinalizationRecovery {
     // Direct callers deliberately get a fresh scan. Startup supplies one opaque Project snapshot
     // to every Session, avoiding repeated scans without persisting stale repository state.
     const prepared = snapshot?.[artifactProjectReconciliationState]
-    const unfinishedCompatibilityPublications =
-      prepared?.unfinishedCompatibilityPublications ??
-      (await compatibilityRepository.listPendingRunPublications(projectId))
+    const unfinishedCompatibilityPublications = requestedRunIds
+      ? []
+      : (prepared?.unfinishedCompatibilityPublications ??
+        (await compatibilityRepository.listPendingRunPublications(projectId)))
     const publicationByRunId = new Map(
       unfinishedCompatibilityPublications.map((publication) => [publication.runId, publication])
     )

--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -184,7 +184,8 @@ class ArtifactProvenanceFinalizationRecovery {
         (!isScopedRetry ||
           requestedRunIds?.has(version.artifactRunId) ||
           requestedVersionIds?.has(version.id)) &&
-        (version.state === 'pending' ||
+        (isScopedRetry ||
+          version.state === 'pending' ||
           (version.messageId !== null &&
             !isArtifactLinkedToDurableMessage(durableSession, version.messageId, version.id)))
     )

--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -38,6 +38,8 @@ type PreparedArtifactFinalizationContext = Pick<
 type ArtifactFinalizationRecoveryResult = {
   recoveredVersionIds: string[]
   recoveredMessageArtifacts: Array<{ messageId: string; artifacts: ArtifactVersionFile[] }>
+  nativeFinalizationRunIds: string[]
+  unresolvedNativeFinalizationRunIds: string[]
 }
 
 type ArtifactProvenanceFinalizationRecoveryOptions = {
@@ -148,7 +150,9 @@ class ArtifactProvenanceFinalizationRecovery {
     this.validateProjectReconciliation(projectId, snapshot)
     const result: ArtifactFinalizationRecoveryResult = {
       recoveredVersionIds: [],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     }
     const compatibilityRepository = this.options.compatibilityRepository
     if (
@@ -176,6 +180,10 @@ class ArtifactProvenanceFinalizationRecovery {
         (version.messageId !== null &&
           !isArtifactLinkedToDurableMessage(durableSession, version.messageId, version.id))
     )
+    result.nativeFinalizationRunIds = [
+      ...new Set(candidateVersions.map((version) => version.artifactRunId))
+    ]
+    const unresolvedNativeFinalizationRunIds = new Set(result.nativeFinalizationRunIds)
     // Native Session linkage proves only that immutable Provenance content is attached. A single
     // project scan adds the much narrower set whose compatibility publication is physically
     // unfinished, without replaying every historical finalized run or rescanning Sessions per run.
@@ -296,7 +304,9 @@ class ArtifactProvenanceFinalizationRecovery {
           artifacts: finalized
         })
       }
+      unresolvedNativeFinalizationRunIds.delete(artifactRunId)
     }
+    result.unresolvedNativeFinalizationRunIds = [...unresolvedNativeFinalizationRunIds]
     return result
   }
 }

--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/session-persistence'
 import {
   ArtifactFinalizationProofError,
+  ArtifactOwnershipPersistenceRaceError,
   ArtifactProvenanceMessageFinalizer,
   validateDurableMessageOwnership
 } from './provenance-message-finalization'
@@ -40,6 +41,7 @@ type ArtifactFinalizationRecoveryResult = {
   recoveredMessageArtifacts: Array<{ messageId: string; artifacts: ArtifactVersionFile[] }>
   nativeFinalizationRunIds: string[]
   unresolvedNativeFinalizationRunIds: string[]
+  invalidProofNativeFinalizationRunIds?: string[]
 }
 
 type ArtifactProvenanceFinalizationRecoveryOptions = {
@@ -193,6 +195,7 @@ class ArtifactProvenanceFinalizationRecovery {
       ...new Set(candidateVersions.map((version) => version.artifactRunId))
     ]
     const unresolvedNativeFinalizationRunIds = new Set(result.nativeFinalizationRunIds)
+    const invalidProofNativeFinalizationRunIds = new Set<string>()
     // Native Session linkage proves only that immutable Provenance content is attached. A single
     // project scan adds the much narrower set whose compatibility publication is physically
     // unfinished, without replaying every historical finalized run or rescanning Sessions per run.
@@ -254,7 +257,13 @@ class ArtifactProvenanceFinalizationRecovery {
           })
           proof = { messageId }
         }
-      } catch {
+      } catch (error) {
+        if (
+          error instanceof ArtifactFinalizationProofError &&
+          !(error instanceof ArtifactOwnershipPersistenceRaceError)
+        ) {
+          invalidProofNativeFinalizationRunIds.add(artifactRunId)
+        }
         // Leave the pending Version visible and retryable; an unproven marker is never guessed.
       }
       if (!proof) continue
@@ -284,7 +293,12 @@ class ArtifactProvenanceFinalizationRecovery {
           durableSession
         )
       } catch (error) {
-        if (error instanceof ArtifactFinalizationProofError) continue
+        if (error instanceof ArtifactFinalizationProofError) {
+          if (!(error instanceof ArtifactOwnershipPersistenceRaceError)) {
+            invalidProofNativeFinalizationRunIds.add(artifactRunId)
+          }
+          continue
+        }
         throw error
       }
       // Replay unconditionally after the durable Version commit: a bound marker may have survived a
@@ -317,6 +331,9 @@ class ArtifactProvenanceFinalizationRecovery {
       unresolvedNativeFinalizationRunIds.delete(artifactRunId)
     }
     result.unresolvedNativeFinalizationRunIds = [...unresolvedNativeFinalizationRunIds]
+    if (invalidProofNativeFinalizationRunIds.size > 0) {
+      result.invalidProofNativeFinalizationRunIds = [...invalidProofNativeFinalizationRunIds]
+    }
     return result
   }
 }

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -252,7 +252,9 @@ describe('artifact provenance repository', () => {
     ).resolves.toEqual({
       recoveredVersionIds: [],
       quarantinedVersionIds: [],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     })
     await expect(stat(stagingDirectory)).rejects.toMatchObject({ code: 'ENOENT' })
   })
@@ -1736,7 +1738,9 @@ describe('artifact provenance repository', () => {
     await expect(repository.reconcileSession('project-1', 'session-1')).resolves.toEqual({
       recoveredVersionIds: [versionId],
       quarantinedVersionIds: [corruptVersionId],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     })
     await expect(
       readFile(join(storageRoot, ...contentStorageKey.split('/')), 'utf8')
@@ -4482,7 +4486,9 @@ describe('artifact provenance repository', () => {
     ).resolves.toEqual({
       recoveredVersionIds: [version.versionId],
       quarantinedVersionIds: [],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     })
     await expect(
       client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
@@ -4555,7 +4561,9 @@ describe('artifact provenance repository', () => {
     ).resolves.toEqual({
       recoveredVersionIds: [version.versionId],
       quarantinedVersionIds: [],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     })
     await expect(
       client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
@@ -4629,7 +4637,9 @@ describe('artifact provenance repository', () => {
     ).resolves.toEqual({
       recoveredVersionIds: [],
       quarantinedVersionIds: [],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     })
     await expect(readFile(version.path)).resolves.toBeTruthy()
     await expect(
@@ -4642,7 +4652,9 @@ describe('artifact provenance repository', () => {
     ).resolves.toEqual({
       recoveredVersionIds: [version.versionId],
       quarantinedVersionIds: [],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     })
   })
 
@@ -4738,7 +4750,9 @@ describe('artifact provenance repository', () => {
     ).resolves.toEqual({
       recoveredVersionIds: [],
       quarantinedVersionIds: [version.versionId],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     })
     await expect(readFile(version.path)).rejects.toMatchObject({ code: 'ENOENT' })
     const quarantineRoot = join(

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -644,6 +644,7 @@ class ArtifactProvenanceRepository {
       removeOrphanStaging?: boolean
       projectReconciliation?: ArtifactProjectReconciliationSnapshot
       artifactRunIds?: string[]
+      artifactVersionIds?: string[]
     }
   ): Promise<ArtifactStorageReconciliationResult> {
     const projectId = assertSafeSegment(projectIdInput, 'project id')
@@ -672,7 +673,8 @@ class ArtifactProvenanceRepository {
       appSessionId,
       durableSession,
       options?.projectReconciliation,
-      options?.artifactRunIds
+      options?.artifactRunIds,
+      options?.artifactVersionIds
     )
     result.recoveredVersionIds.push(...finalizationResult.recoveredVersionIds)
     result.recoveredMessageArtifacts.push(...finalizationResult.recoveredMessageArtifacts)

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -123,6 +123,8 @@ type ArtifactStorageReconciliationResult = {
   recoveredVersionIds: string[]
   quarantinedVersionIds: string[]
   recoveredMessageArtifacts: Array<{ messageId: string; artifacts: ArtifactVersionFile[] }>
+  nativeFinalizationRunIds: string[]
+  unresolvedNativeFinalizationRunIds: string[]
 }
 
 type ProjectVersionWriteOperation = {
@@ -652,7 +654,9 @@ class ArtifactProvenanceRepository {
     const result: ArtifactStorageReconciliationResult = {
       recoveredVersionIds: [],
       quarantinedVersionIds: [],
-      recoveredMessageArtifacts: []
+      recoveredMessageArtifacts: [],
+      nativeFinalizationRunIds: [],
+      unresolvedNativeFinalizationRunIds: []
     }
     const unindexedSnapshot = await this.unindexedRecovery.prepareSession(projectId, appSessionId)
     const stagingResult = await this.stagingRecovery.reconcileSession(
@@ -670,6 +674,10 @@ class ArtifactProvenanceRepository {
     )
     result.recoveredVersionIds.push(...finalizationResult.recoveredVersionIds)
     result.recoveredMessageArtifacts.push(...finalizationResult.recoveredMessageArtifacts)
+    result.nativeFinalizationRunIds.push(...finalizationResult.nativeFinalizationRunIds)
+    result.unresolvedNativeFinalizationRunIds.push(
+      ...finalizationResult.unresolvedNativeFinalizationRunIds
+    )
 
     const unindexedResult = await this.unindexedRecovery.reconcileSession(unindexedSnapshot)
     result.recoveredVersionIds.push(...unindexedResult.recoveredVersionIds)

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -643,6 +643,7 @@ class ArtifactProvenanceRepository {
     options?: {
       removeOrphanStaging?: boolean
       projectReconciliation?: ArtifactProjectReconciliationSnapshot
+      artifactRunIds?: string[]
     }
   ): Promise<ArtifactStorageReconciliationResult> {
     const projectId = assertSafeSegment(projectIdInput, 'project id')
@@ -670,7 +671,8 @@ class ArtifactProvenanceRepository {
       projectId,
       appSessionId,
       durableSession,
-      options?.projectReconciliation
+      options?.projectReconciliation,
+      options?.artifactRunIds
     )
     result.recoveredVersionIds.push(...finalizationResult.recoveredVersionIds)
     result.recoveredMessageArtifacts.push(...finalizationResult.recoveredMessageArtifacts)

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -125,6 +125,7 @@ type ArtifactStorageReconciliationResult = {
   recoveredMessageArtifacts: Array<{ messageId: string; artifacts: ArtifactVersionFile[] }>
   nativeFinalizationRunIds: string[]
   unresolvedNativeFinalizationRunIds: string[]
+  invalidProofNativeFinalizationRunIds?: string[]
 }
 
 type ProjectVersionWriteOperation = {
@@ -682,6 +683,11 @@ class ArtifactProvenanceRepository {
     result.unresolvedNativeFinalizationRunIds.push(
       ...finalizationResult.unresolvedNativeFinalizationRunIds
     )
+    if (finalizationResult.invalidProofNativeFinalizationRunIds?.length) {
+      result.invalidProofNativeFinalizationRunIds = [
+        ...finalizationResult.invalidProofNativeFinalizationRunIds
+      ]
+    }
 
     const unindexedResult = await this.unindexedRecovery.reconcileSession(unindexedSnapshot)
     result.recoveredVersionIds.push(...unindexedResult.recoveredVersionIds)

--- a/src/main/artifacts/run-registry.ts
+++ b/src/main/artifacts/run-registry.ts
@@ -13,6 +13,8 @@ type ArtifactRunClaim = {
   runtimeSegmentId?: string
   promptMessageId?: string
   finalizedMessageId?: string
+  registeredAt: number
+  finalizedAt?: number
 }
 
 type RegisterArtifactRunClaimRequest = {
@@ -32,17 +34,32 @@ type RegisterArtifactRunClaimRequest = {
 
 // Keeps short-lived artifact run ownership in memory until the renderer finalizes a message.
 class ArtifactRunRegistry {
+  private static readonly finalizedClaimTtlMs = 5 * 60 * 1_000
+  private static readonly unfinalizedClaimTtlMs = 60 * 60 * 1_000
   private sequence = 0
   private readonly claims = new Map<string, ArtifactRunClaim>()
 
+  private pruneExpired(now: number): void {
+    for (const [claimId, claim] of this.claims) {
+      const expiresAt =
+        claim.finalizedAt !== undefined
+          ? claim.finalizedAt + ArtifactRunRegistry.finalizedClaimTtlMs
+          : claim.registeredAt + ArtifactRunRegistry.unfinalizedClaimTtlMs
+      if (now >= expiresAt) this.claims.delete(claimId)
+    }
+  }
+
   // Registers one generated run and returns an opaque claim id for renderer finalization.
   register(request: RegisterArtifactRunClaimRequest): string {
+    const now = Date.now()
+    this.pruneExpired(now)
     this.sequence += 1
-    const claimId = `artifact-claim-${Date.now()}-${this.sequence}`
+    const claimId = `artifact-claim-${now}-${this.sequence}`
 
     this.claims.set(claimId, {
       claimId,
       ...request,
+      registeredAt: now,
       artifactVersionIds: request.artifactVersionIds ? [...request.artifactVersionIds] : undefined
     })
 
@@ -51,6 +68,7 @@ class ArtifactRunRegistry {
 
   // Resolves an opaque claim id back to the runtime-owned project/session/run tuple.
   resolve(claimId: string): ArtifactRunClaim {
+    this.pruneExpired(Date.now())
     const claim = this.claims.get(claimId)
 
     if (!claim) {
@@ -62,6 +80,8 @@ class ArtifactRunRegistry {
 
   // Records the message that consumed a claim so finalize retries remain idempotent.
   markFinalized(claimId: string, messageId: string): void {
+    const now = Date.now()
+    this.pruneExpired(now)
     const claim = this.resolve(claimId)
 
     if (claim.finalizedMessageId && claim.finalizedMessageId !== messageId) {
@@ -72,7 +92,8 @@ class ArtifactRunRegistry {
 
     this.claims.set(claimId, {
       ...claim,
-      finalizedMessageId: messageId
+      finalizedMessageId: messageId,
+      finalizedAt: claim.finalizedAt ?? now
     })
   }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3694,7 +3694,9 @@ const createApplicationModules = async (
       ),
     codeReconstruction,
     withSessionMutation: (projectId, sessionId, mutation) =>
-      sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+      sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation),
+    recoverPendingArtifacts: (request) =>
+      sessionPersistenceCoordinator.retryArtifactFinalization(request)
   })
   artifactHandlersRef.current = artifactHandlers
   declareElectronAdapter('artifacts', () =>

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -56,6 +56,55 @@ describe('artifact finalization startup recovery', () => {
     await rm(storageRoot, { recursive: true, force: true })
   })
 
+  it('retries durable finalization in the current Session and remains idempotent', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version } = await prepareRecovery(compatibility)
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+    const request = {
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      messageId: 'message-1',
+      pendingPaths: [
+        join(
+          storageRoot,
+          'artifacts',
+          PROJECT_ID,
+          STORAGE_SESSION_ID,
+          '.pending',
+          RUN_ID,
+          'result.png'
+        )
+      ]
+    }
+
+    const finalized = await coordinator.retryArtifactFinalization(request)
+
+    expect(finalized).toEqual([
+      expect.objectContaining({
+        id: version.versionId,
+        artifactId: version.artifactId,
+        versionId: version.versionId,
+        projectId: PROJECT_ID,
+        sessionId: SESSION_ID
+      })
+    ])
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+    ).resolves.toMatchObject({ state: 'finalized', messageId: 'message-1' })
+    const durableSession = await sessions.loadSession(PROJECT_ID, SESSION_ID)
+    expect(durableSession?.messages[1].artifactIds).toBeUndefined()
+    expect(durableSession?.artifacts).toBeUndefined()
+
+    await expect(coordinator.retryArtifactFinalization(request)).resolves.toEqual(finalized)
+  })
+
   it('persists an inspectable Message snapshot with the recovered Session attachment', async () => {
     const compatibility = new ArtifactRepository(storageRoot)
     const { provenance, version } = await prepareRecovery(compatibility)

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -71,17 +71,8 @@ describe('artifact finalization startup recovery', () => {
       projectId: PROJECT_ID,
       sessionId: SESSION_ID,
       messageId: 'message-1',
-      pendingPaths: [
-        join(
-          storageRoot,
-          'artifacts',
-          PROJECT_ID,
-          STORAGE_SESSION_ID,
-          '.pending',
-          RUN_ID,
-          'result.png'
-        )
-      ]
+      pendingPaths: [],
+      artifactVersionIds: [version.versionId]
     }
 
     const recovery = await coordinator.retryArtifactFinalization(request)

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -84,7 +84,8 @@ describe('artifact finalization startup recovery', () => {
       ]
     }
 
-    const finalized = await coordinator.retryArtifactFinalization(request)
+    const recovery = await coordinator.retryArtifactFinalization(request)
+    const finalized = recovery?.artifacts
 
     expect(finalized).toEqual([
       expect.objectContaining({
@@ -102,7 +103,7 @@ describe('artifact finalization startup recovery', () => {
     expect(durableSession?.messages[1].artifactIds).toBeUndefined()
     expect(durableSession?.artifacts).toBeUndefined()
 
-    await expect(coordinator.retryArtifactFinalization(request)).resolves.toEqual(finalized)
+    await expect(coordinator.retryArtifactFinalization(request)).resolves.toEqual(recovery)
   })
 
   it('persists an inspectable Message snapshot with the recovered Session attachment', async () => {
@@ -210,6 +211,24 @@ describe('artifact finalization startup recovery', () => {
 
     expect(loaded.sessions[0].messages[1].artifactIds).toBeUndefined()
     expect(loaded.sessions[0].artifacts).toBeUndefined()
+    await expect(
+      coordinator.retryArtifactFinalization({
+        projectId: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1',
+        pendingPaths: [
+          join(
+            storageRoot,
+            'artifacts',
+            PROJECT_ID,
+            STORAGE_SESSION_ID,
+            '.pending',
+            RUN_ID,
+            'result.png'
+          )
+        ]
+      })
+    ).rejects.toThrow(/remains unresolved/u)
     await expect(
       compatibility.findRunFinalizationMarker(PROJECT_ID, RUN_ID)
     ).resolves.toMatchObject({

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -11,6 +11,7 @@ vi.mock('electron', () => ({
 }))
 
 import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import { ARTIFACT_FINALIZATION_INVALID_PROOF } from '../../shared/artifacts'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { createPngInlineSource } from '../artifacts/artifact-test-fixtures'
 import { ProvenanceMessageSnapshotRepository } from '../artifacts/provenance-message-snapshot'
@@ -290,7 +291,7 @@ describe('artifact finalization startup recovery', () => {
           )
         ]
       })
-    ).rejects.toThrow(/remains unresolved/u)
+    ).rejects.toMatchObject({ code: ARTIFACT_FINALIZATION_INVALID_PROOF })
     await expect(
       compatibility.findRunFinalizationMarker(PROJECT_ID, RUN_ID)
     ).resolves.toMatchObject({

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -97,6 +97,77 @@ describe('artifact finalization startup recovery', () => {
     await expect(coordinator.retryArtifactFinalization(request)).resolves.toEqual(recovery)
   })
 
+  it('replays an explicitly requested finalized Version that is already linked', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const { provenance, version } = await prepareRecovery(compatibility)
+    await client.artifactVersion.update({
+      where: { id: version.versionId },
+      data: { state: 'finalized', messageId: 'message-1' }
+    })
+    const linked = (await sessions.loadSession(PROJECT_ID, SESSION_ID))!
+    linked.messages[1] = {
+      ...linked.messages[1],
+      status: 'complete',
+      artifactIds: [version.versionId]
+    }
+    const graphMessage = linked.conversationGraph?.messages.find(
+      (message) => message.id === 'message-1'
+    )
+    if (graphMessage) {
+      graphMessage.status = 'complete'
+      graphMessage.artifactIds = [version.versionId]
+    }
+    linked.artifacts = [
+      {
+        id: version.versionId,
+        artifactId: version.artifactId,
+        versionId: version.versionId,
+        versionNumber: version.versionNumber,
+        kind: 'managed-file',
+        path: version.path,
+        fileUrl: version.fileUrl,
+        name: version.name,
+        mimeType: version.mimeType,
+        size: version.size,
+        createdAt: Date.parse(version.createdAt),
+        mtimeMs: version.mtimeMs,
+        sha256: version.checksum
+      }
+    ]
+    await sessions.saveSession(linked)
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+
+    await expect(
+      coordinator.retryArtifactFinalization({
+        projectId: PROJECT_ID,
+        sessionId: SESSION_ID,
+        messageId: 'message-1',
+        pendingPaths: [],
+        artifactVersionIds: [version.versionId]
+      })
+    ).resolves.toMatchObject({
+      artifacts: [expect.objectContaining({ versionId: version.versionId })],
+      nativeRunIds: [RUN_ID]
+    })
+    await expect(
+      compatibility.listPendingRunFiles({
+        projectId: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID
+      })
+    ).resolves.toEqual([])
+    await expect(
+      client.artifactLineage.findUniqueOrThrow({ where: { id: version.artifactId } })
+    ).resolves.toMatchObject({ currentVersionId: version.versionId })
+  })
+
   it('persists an inspectable Message snapshot with the recovered Session attachment', async () => {
     const compatibility = new ArtifactRepository(storageRoot)
     const { provenance, version } = await prepareRecovery(compatibility)

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -445,6 +445,7 @@ describe('Session persistence coordinator architecture', () => {
         'recoverInterruptedDelegatedWork',
         'replaceSessionMetadata',
         'repairProjectFiles',
+        'retryArtifactFinalization',
         'runSessionMutation',
         'saveManifest',
         'saveSession',
@@ -667,6 +668,7 @@ describe('Session persistence coordinator architecture', () => {
         'mutateSessionDetailsAuthority',
         'patchSessionRuntimeContext',
         'readSessionRuntimeContext',
+        'retryArtifactFinalization',
         'runSessionMutation',
         'saveSession',
         'saveSessionSpecialistBinding',
@@ -727,7 +729,7 @@ describe('Session persistence coordinator architecture', () => {
       expect(methods(owner, 'private')).not.toContain('enqueue')
     }
 
-    expect(expectedSchedulerRoute.size).toBe(34)
+    expect(expectedSchedulerRoute.size).toBe(35)
     const constructorSource = facade.members.filter(isConstructorDeclaration)[0].getText(facadeFile)
     expect(constructorSource).toContain('this.operationScheduler.runSession(')
     expect(constructorSource).toContain('this.operationScheduler.runGlobal(work)')
@@ -900,7 +902,7 @@ describe('Session persistence coordinator architecture', () => {
       ].sort()
     )
     expect(methods(reconciliationOwner, 'public')).toEqual(
-      ['reconcileLoadedSessions', 'repairFileProjection'].sort()
+      ['reconcileLoadedSessions', 'repairFileProjection', 'retryArtifactFinalization'].sort()
     )
     expect(methods(reconciliationOwner, 'private')).toEqual([])
     expect(methods(sideChatOwner, 'public')).toEqual(

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -404,6 +404,57 @@ describe('SessionPersistenceCoordinator', () => {
     ).rejects.toThrow(/remains unresolved/u)
   })
 
+  it('scopes an explicit Artifact retry so an unrelated native run cannot block it', async () => {
+    const session = createSession()
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn().mockResolvedValue({ status: 'found', session })
+    })
+    const reconcileSession = vi.fn(
+      async (
+        _projectId: string,
+        _sessionId: string,
+        _session: PersistedChatSession,
+        options?: { artifactRunIds?: string[] }
+      ) => {
+        if (!options?.artifactRunIds?.includes('run-legacy')) {
+          throw new Error('unrelated native recovery failed')
+        }
+        return {
+          recoveredMessageArtifacts: [],
+          nativeFinalizationRunIds: [],
+          unresolvedNativeFinalizationRunIds: []
+        }
+      }
+    )
+    const artifactStorage = {
+      prepareProjectReconciliation: vi
+        .fn()
+        .mockResolvedValue(createProjectReconciliationSnapshot()),
+      reconcileSession
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      artifactStorage
+    )
+    const request = {
+      projectId: session.projectId,
+      sessionId: session.id,
+      messageId: 'message-1',
+      pendingPaths: ['/artifacts/storage-session/.pending/run-legacy/result.txt']
+    }
+
+    await expect(coordinator.retryArtifactFinalization(request)).resolves.toBeUndefined()
+    expect(reconcileSession).toHaveBeenCalledWith(session.projectId, session.id, session, {
+      removeOrphanStaging: false,
+      artifactRunIds: ['run-legacy']
+    })
+    expect(artifactStorage.prepareProjectReconciliation).not.toHaveBeenCalled()
+  })
+
   it('resolves Message membership from the durable active Branch', async () => {
     const prompt = (id: string, createdAt: number): PersistedChatMessage => ({
       id,

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -365,6 +365,45 @@ const createProjectReconciliationSnapshot = (): ArtifactProjectReconciliationSna
   ({}) as ArtifactProjectReconciliationSnapshot
 
 describe('SessionPersistenceCoordinator', () => {
+  it('rejects a retry when any requested native Artifact run remains unresolved', async () => {
+    const session = createSession()
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn().mockResolvedValue({ status: 'found', session })
+    })
+    const artifactStorage = {
+      prepareProjectReconciliation: vi
+        .fn()
+        .mockResolvedValue(createProjectReconciliationSnapshot()),
+      reconcileSession: vi.fn().mockResolvedValue({
+        recoveredMessageArtifacts: [
+          { messageId: 'message-1', artifacts: [createRecoveredArtifact()] }
+        ],
+        nativeFinalizationRunIds: ['run-1', 'run-2'],
+        unresolvedNativeFinalizationRunIds: ['run-2']
+      })
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      artifactStorage
+    )
+
+    await expect(
+      coordinator.retryArtifactFinalization({
+        projectId: session.projectId,
+        sessionId: session.id,
+        messageId: 'message-1',
+        pendingPaths: [
+          '/artifacts/storage-session/.pending/run-1/a.txt',
+          '/artifacts/storage-session/.pending/run-2/b.txt'
+        ]
+      })
+    ).rejects.toThrow(/remains unresolved/u)
+  })
+
   it('resolves Message membership from the durable active Branch', async () => {
     const prompt = (id: string, createdAt: number): PersistedChatMessage => ({
       id,

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,4 +1,5 @@
 import type { ProjectFileSource, ProjectFilesChangedEvent } from '../../shared/project-files'
+import type { ArtifactFile, ReconcilePendingArtifactsRequest } from '../../shared/artifacts'
 import {
   type DelegationPolicy,
   type LoadAllSessionsResult,
@@ -817,6 +818,24 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         // Force the next save to validate Artifact finalization's binding before reusing topology.
         this.stateOwner.invalidateBindingTopology(projectId, sessionId)
       }
+    })
+  }
+
+  retryArtifactFinalization(request: ReconcilePendingArtifactsRequest): Promise<ArtifactFile[]> {
+    return this.operationScheduler.runSession(request.projectId, request.sessionId, async () => {
+      this.assertMutable(request.projectId, request.sessionId, 'mutate')
+      const authority = await this.repository.loadSessionWithDiagnostics(
+        request.projectId,
+        request.sessionId
+      )
+      if (authority.status !== 'found') {
+        throw new Error('Cannot retry Artifact finalization without a readable Session.')
+      }
+
+      return this.reconciliationOwner.retryArtifactFinalization(
+        authority.session,
+        request.messageId
+      )
     })
   }
 

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,5 +1,5 @@
 import type { ProjectFileSource, ProjectFilesChangedEvent } from '../../shared/project-files'
-import type { ArtifactFile, ReconcilePendingArtifactsRequest } from '../../shared/artifacts'
+import type { ReconcilePendingArtifactsRequest } from '../../shared/artifacts'
 import {
   type DelegationPolicy,
   type LoadAllSessionsResult,
@@ -66,6 +66,7 @@ import {
 import {
   SessionPersistenceReconciliationOwner,
   type ArtifactStorageReconciler,
+  type PendingArtifactFinalizationRecovery,
   type SessionPermissionGrantReconciliation,
   type SessionUploadPersistence
 } from './reconciliation-owner'
@@ -821,7 +822,9 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     })
   }
 
-  retryArtifactFinalization(request: ReconcilePendingArtifactsRequest): Promise<ArtifactFile[]> {
+  retryArtifactFinalization(
+    request: ReconcilePendingArtifactsRequest
+  ): Promise<PendingArtifactFinalizationRecovery | undefined> {
     return this.operationScheduler.runSession(request.projectId, request.sessionId, async () => {
       this.assertMutable(request.projectId, request.sessionId, 'mutate')
       const authority = await this.repository.loadSessionWithDiagnostics(
@@ -832,10 +835,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         throw new Error('Cannot retry Artifact finalization without a readable Session.')
       }
 
-      return this.reconciliationOwner.retryArtifactFinalization(
-        authority.session,
-        request.messageId
-      )
+      return this.reconciliationOwner.retryArtifactFinalization(authority.session, request)
     })
   }
 

--- a/src/main/session-persistence/reconciliation-owner.ts
+++ b/src/main/session-persistence/reconciliation-owner.ts
@@ -1,3 +1,5 @@
+import { basename, dirname } from 'node:path'
+
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
 import { artifactCreatedAtMs } from '../../shared/artifacts'
 import type { ProjectFileSource } from '../../shared/project-files'
@@ -58,9 +60,16 @@ type ArtifactStorageReconciler = {
           messageId: string
           artifacts: ArtifactVersionFile[]
         }>
+        nativeFinalizationRunIds?: string[]
+        unresolvedNativeFinalizationRunIds?: string[]
       }
     | undefined
   >
+}
+
+type PendingArtifactFinalizationRecovery = {
+  artifacts: ArtifactVersionFile[]
+  nativeRunIds: string[]
 }
 
 type SessionPersistenceReconciliationOwnerOptions = {
@@ -213,9 +222,9 @@ class SessionPersistenceReconciliationOwner {
 
   async retryArtifactFinalization(
     session: PersistedChatSession,
-    messageId: string
-  ): Promise<ArtifactVersionFile[]> {
-    if (!this.artifactStorage) return []
+    request: { messageId: string; pendingPaths: string[] }
+  ): Promise<PendingArtifactFinalizationRecovery | undefined> {
+    if (!this.artifactStorage) return undefined
 
     const projectReconciliation = await this.artifactStorage.prepareProjectReconciliation(
       session.projectId
@@ -229,9 +238,26 @@ class SessionPersistenceReconciliationOwner {
         projectReconciliation
       }
     )
-    return (artifactRecovery?.recoveredMessageArtifacts ?? []).flatMap((recovery) =>
-      recovery.messageId === messageId ? recovery.artifacts : []
+    const artifacts = (artifactRecovery?.recoveredMessageArtifacts ?? []).flatMap((recovery) =>
+      recovery.messageId === request.messageId ? recovery.artifacts : []
     )
+    const nativeFinalizationRunIds = artifactRecovery?.nativeFinalizationRunIds
+    if (!nativeFinalizationRunIds) {
+      return artifacts.length > 0 ? { artifacts, nativeRunIds: [] } : undefined
+    }
+
+    const requestedRunIds = new Set(
+      request.pendingPaths.map((pendingPath) => basename(dirname(pendingPath)))
+    )
+    const nativeRunIds = nativeFinalizationRunIds.filter((runId) => requestedRunIds.has(runId))
+    if (nativeRunIds.length === 0) return undefined
+
+    const unresolvedRunIds = new Set(artifactRecovery?.unresolvedNativeFinalizationRunIds ?? [])
+    if (nativeRunIds.some((runId) => unresolvedRunIds.has(runId))) {
+      throw new Error('Native Artifact finalization remains unresolved.')
+    }
+
+    return { artifacts, nativeRunIds }
   }
 
   async reconcileLoadedSessions(
@@ -381,6 +407,7 @@ const sessionKey = (projectId: string, sessionId: string): string => `${projectI
 export { SessionPersistenceReconciliationOwner }
 export type {
   ArtifactStorageReconciler,
+  PendingArtifactFinalizationRecovery,
   SessionPermissionGrantReconciliation,
   SessionUploadPersistence
 }

--- a/src/main/session-persistence/reconciliation-owner.ts
+++ b/src/main/session-persistence/reconciliation-owner.ts
@@ -54,6 +54,7 @@ type ArtifactStorageReconciler = {
       removeOrphanStaging?: boolean
       projectReconciliation?: ArtifactProjectReconciliationSnapshot
       artifactRunIds?: string[]
+      artifactVersionIds?: string[]
     }
   ): Promise<
     | {
@@ -223,7 +224,7 @@ class SessionPersistenceReconciliationOwner {
 
   async retryArtifactFinalization(
     session: PersistedChatSession,
-    request: { messageId: string; pendingPaths: string[] }
+    request: { messageId: string; pendingPaths: string[]; artifactVersionIds?: string[] }
   ): Promise<PendingArtifactFinalizationRecovery | undefined> {
     if (!this.artifactStorage) return undefined
 
@@ -236,7 +237,8 @@ class SessionPersistenceReconciliationOwner {
       session,
       {
         removeOrphanStaging: false,
-        artifactRunIds: requestedRunIds
+        artifactRunIds: requestedRunIds,
+        artifactVersionIds: request.artifactVersionIds
       }
     )
     const artifacts = (artifactRecovery?.recoveredMessageArtifacts ?? []).flatMap((recovery) =>
@@ -247,8 +249,7 @@ class SessionPersistenceReconciliationOwner {
       return artifacts.length > 0 ? { artifacts, nativeRunIds: [] } : undefined
     }
 
-    const requestedRunIdSet = new Set(requestedRunIds)
-    const nativeRunIds = nativeFinalizationRunIds.filter((runId) => requestedRunIdSet.has(runId))
+    const nativeRunIds = nativeFinalizationRunIds
     if (nativeRunIds.length === 0) return undefined
 
     const unresolvedRunIds = new Set(artifactRecovery?.unresolvedNativeFinalizationRunIds ?? [])

--- a/src/main/session-persistence/reconciliation-owner.ts
+++ b/src/main/session-persistence/reconciliation-owner.ts
@@ -53,6 +53,7 @@ type ArtifactStorageReconciler = {
     options?: {
       removeOrphanStaging?: boolean
       projectReconciliation?: ArtifactProjectReconciliationSnapshot
+      artifactRunIds?: string[]
     }
   ): Promise<
     | {
@@ -226,16 +227,16 @@ class SessionPersistenceReconciliationOwner {
   ): Promise<PendingArtifactFinalizationRecovery | undefined> {
     if (!this.artifactStorage) return undefined
 
-    const projectReconciliation = await this.artifactStorage.prepareProjectReconciliation(
-      session.projectId
-    )
+    const requestedRunIds = [
+      ...new Set(request.pendingPaths.map((pendingPath) => basename(dirname(pendingPath))))
+    ]
     const artifactRecovery = await this.artifactStorage.reconcileSession(
       session.projectId,
       session.id,
       session,
       {
         removeOrphanStaging: false,
-        projectReconciliation
+        artifactRunIds: requestedRunIds
       }
     )
     const artifacts = (artifactRecovery?.recoveredMessageArtifacts ?? []).flatMap((recovery) =>
@@ -246,10 +247,8 @@ class SessionPersistenceReconciliationOwner {
       return artifacts.length > 0 ? { artifacts, nativeRunIds: [] } : undefined
     }
 
-    const requestedRunIds = new Set(
-      request.pendingPaths.map((pendingPath) => basename(dirname(pendingPath)))
-    )
-    const nativeRunIds = nativeFinalizationRunIds.filter((runId) => requestedRunIds.has(runId))
+    const requestedRunIdSet = new Set(requestedRunIds)
+    const nativeRunIds = nativeFinalizationRunIds.filter((runId) => requestedRunIdSet.has(runId))
     if (nativeRunIds.length === 0) return undefined
 
     const unresolvedRunIds = new Set(artifactRecovery?.unresolvedNativeFinalizationRunIds ?? [])

--- a/src/main/session-persistence/reconciliation-owner.ts
+++ b/src/main/session-persistence/reconciliation-owner.ts
@@ -211,6 +211,29 @@ class SessionPersistenceReconciliationOwner {
     this.permissionGrants = options.permissionGrants
   }
 
+  async retryArtifactFinalization(
+    session: PersistedChatSession,
+    messageId: string
+  ): Promise<ArtifactVersionFile[]> {
+    if (!this.artifactStorage) return []
+
+    const projectReconciliation = await this.artifactStorage.prepareProjectReconciliation(
+      session.projectId
+    )
+    const artifactRecovery = await this.artifactStorage.reconcileSession(
+      session.projectId,
+      session.id,
+      session,
+      {
+        removeOrphanStaging: false,
+        projectReconciliation
+      }
+    )
+    return (artifactRecovery?.recoveredMessageArtifacts ?? []).flatMap((recovery) =>
+      recovery.messageId === messageId ? recovery.artifacts : []
+    )
+  }
+
   async reconcileLoadedSessions(
     input: ReconcileLoadedSessionsInput
   ): Promise<ReconcileLoadedSessionsOutcome> {

--- a/src/main/session-persistence/reconciliation-owner.ts
+++ b/src/main/session-persistence/reconciliation-owner.ts
@@ -1,7 +1,7 @@
 import { basename, dirname } from 'node:path'
 
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
-import { artifactCreatedAtMs } from '../../shared/artifacts'
+import { ARTIFACT_FINALIZATION_INVALID_PROOF, artifactCreatedAtMs } from '../../shared/artifacts'
 import type { ProjectFileSource } from '../../shared/project-files'
 import {
   materializeSessionConversationGraph,
@@ -64,6 +64,7 @@ type ArtifactStorageReconciler = {
         }>
         nativeFinalizationRunIds?: string[]
         unresolvedNativeFinalizationRunIds?: string[]
+        invalidProofNativeFinalizationRunIds?: string[]
       }
     | undefined
   >
@@ -254,6 +255,14 @@ class SessionPersistenceReconciliationOwner {
 
     const unresolvedRunIds = new Set(artifactRecovery?.unresolvedNativeFinalizationRunIds ?? [])
     if (nativeRunIds.some((runId) => unresolvedRunIds.has(runId))) {
+      const invalidProofRunIds = new Set(
+        artifactRecovery?.invalidProofNativeFinalizationRunIds ?? []
+      )
+      if (nativeRunIds.some((runId) => invalidProofRunIds.has(runId))) {
+        throw Object.assign(new Error('Native Artifact finalization proof is invalid.'), {
+          code: ARTIFACT_FINALIZATION_INVALID_PROOF
+        })
+      }
       throw new Error('Native Artifact finalization remains unresolved.')
     }
 

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -5,6 +5,7 @@ import {
   type AcpPermissionRequest
 } from '../../../../shared/acp'
 import {
+  ARTIFACT_FINALIZATION_INVALID_PROOF,
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile
 } from '../../../../shared/artifacts'
@@ -2731,7 +2732,10 @@ describe('workspace runtime events', () => {
     })
     const finalizeRunArtifacts = vi.fn().mockImplementation(async () => {
       operationOrder.push('finalize')
-      throw new Error('Artifact finalization message is not a Branch descendant of its prompt.')
+      throw Object.assign(
+        new Error('Artifact finalization message is not a Branch descendant of its prompt.'),
+        { code: ARTIFACT_FINALIZATION_INVALID_PROOF }
+      )
     })
 
     await applyWorkspaceRuntimeEvent(
@@ -2753,6 +2757,9 @@ describe('workspace runtime events', () => {
 
     expect(operationOrder).toEqual(['save', 'finalize'])
     expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
+    expect(useSessionStore.getState().sessions[0].error).toMatch(
+      /^Generated file finalization cannot be retried:/u
+    )
   })
 
   it('attempts the recoverable ownership persistence race at most twice', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -10,6 +10,7 @@ import {
   type AcpTurnTokenUsage
 } from '../../../../shared/acp'
 import {
+  ARTIFACT_FINALIZATION_INVALID_PROOF,
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile,
   type FinalizeRunArtifactsRequest
@@ -248,6 +249,12 @@ const finalizeRunArtifacts = async (
   throw error
 }
 
+const isArtifactFinalizationProofError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  error.code === ARTIFACT_FINALIZATION_INVALID_PROOF
+
 // Artifact finalization and auto-review both require the latest renderer-selected Message graph to be
 // durable before Main reads it. Persist explicitly instead of racing the asynchronous store saver.
 const saveSessionInRuntimeOrder = (session: PersistedChatSession): Promise<PersistedChatSession> =>
@@ -344,7 +351,13 @@ const finalizeArtifactEvent = async (
     await persistLatestSession()
     return true
   } catch (error) {
-    if (!artifactsFinalized) store.recordArtifactError(event.sessionId, getErrorText(error))
+    if (!artifactsFinalized) {
+      store.recordArtifactError(
+        event.sessionId,
+        getErrorText(error),
+        !isArtifactFinalizationProofError(error)
+      )
+    }
     throw error
   }
 }

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ARTIFACT_FINALIZATION_INVALID_PROOF } from '../../../../shared/artifacts'
 import {
   activateConversationBranch,
   createLinearConversationGraph,
@@ -404,6 +405,59 @@ describe('reconcilePendingArtifacts', () => {
       error: undefined,
       errorReportable: undefined,
       messages: [{ artifactIds: ['version-1'] }]
+    })
+  })
+
+  it('records an invalid native recovery proof as a terminal failure', async () => {
+    const nativePath =
+      '/data/artifacts/proj-1/.provenance/artifacts/artifact-1/versions/version-1/chart.png'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        id: 'session-1',
+        projectId: 'proj-1',
+        status: 'error',
+        error: 'Generated file finalization failed: disk temporarily unavailable',
+        errorReportable: true,
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'done',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['version-1'],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        artifacts: [
+          {
+            id: 'version-1',
+            artifactId: 'artifact-1',
+            versionId: 'version-1',
+            kind: 'managed-file',
+            path: nativePath,
+            name: 'chart.png'
+          }
+        ]
+      })
+    ])
+    const api = {
+      reconcilePendingArtifacts: vi.fn().mockResolvedValue({
+        ok: false,
+        code: ARTIFACT_FINALIZATION_INVALID_PROOF,
+        message: 'Native Artifact finalization proof is invalid.'
+      })
+    } as never
+
+    await expect(retryPendingArtifactFinalization('session-1', api)).rejects.toMatchObject({
+      code: ARTIFACT_FINALIZATION_INVALID_PROOF
+    })
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error:
+        'Generated file finalization cannot be retried: Native Artifact finalization proof is invalid.',
+      errorReportable: true
     })
   })
 

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -340,6 +340,73 @@ describe('reconcilePendingArtifacts', () => {
     })
   })
 
+  it('retries a native provenance Artifact by its durable Version identity', async () => {
+    const nativePath =
+      '/data/artifacts/proj-1/.provenance/artifacts/artifact-1/versions/version-1/chart.png'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        id: 'session-1',
+        projectId: 'proj-1',
+        status: 'error',
+        error: 'Generated file finalization failed: disk temporarily unavailable',
+        errorReportable: true,
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'done',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['version-1'],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        artifacts: [
+          {
+            id: 'version-1',
+            artifactId: 'artifact-1',
+            versionId: 'version-1',
+            kind: 'managed-file',
+            path: nativePath,
+            name: 'chart.png'
+          }
+        ]
+      })
+    ])
+    const finalized = {
+      id: 'version-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1',
+      runId: 'run-1',
+      projectId: 'proj-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      name: 'chart.png',
+      path: nativePath,
+      fileUrl: `file://${nativePath}`,
+      size: 3,
+      mtimeMs: 2
+    }
+    const api = { reconcilePendingArtifacts: vi.fn().mockResolvedValue([finalized]) }
+
+    await retryPendingArtifactFinalization('session-1', api)
+
+    expect(api.reconcilePendingArtifacts).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      pendingPaths: [],
+      artifactVersionIds: ['version-1']
+    })
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      error: undefined,
+      errorReportable: undefined,
+      messages: [{ artifactIds: ['version-1'] }]
+    })
+  })
+
   it('re-finalizes pending artifacts referenced only by an inactive conversation Branch', async () => {
     const pendingPath = '/data/artifacts/proj-1/session-1/.pending/run-1/report.md'
     const originalPrompt = {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -107,6 +107,9 @@ describe('reconcilePendingArtifacts', () => {
       createPersistedSession({
         id: 'session-1',
         projectId: 'proj-1',
+        status: 'error',
+        error: 'Generated file finalization failed: disk temporarily unavailable',
+        errorReportable: true,
         messages: [
           {
             id: 'message-1',
@@ -157,6 +160,11 @@ describe('reconcilePendingArtifacts', () => {
     const session = useSessionStore.getState().sessions.find((item) => item.id === 'session-1')
     expect(session?.messages[0].artifactIds).toEqual(['session-1:message-1:chart.png'])
     expect(session?.artifacts?.map((artifact) => artifact.path)).toEqual([finalized.path])
+    expect(session).toMatchObject({
+      status: 'idle',
+      error: undefined,
+      errorReportable: undefined
+    })
   })
 
   it('leaves messages without pending artifacts untouched', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -176,6 +176,57 @@ describe('reconcilePendingArtifacts', () => {
     expect(api.reconcilePendingArtifacts).not.toHaveBeenCalled()
   })
 
+  it('preserves already-published message artifacts when native recovery returns only new files', async () => {
+    const pendingPath = '/data/artifacts/proj-1/session-1/.pending/run-1/new.txt'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        id: 'session-1',
+        projectId: 'proj-1',
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'done',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['published-artifact', 'pending-artifact'],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        artifacts: [
+          {
+            id: 'published-artifact',
+            kind: 'managed-file',
+            path: '/data/artifacts/proj-1/session-1/message-1/published.txt',
+            name: 'published.txt'
+          },
+          { id: 'pending-artifact', kind: 'managed-file', path: pendingPath, name: 'new.txt' }
+        ]
+      })
+    ])
+    const finalized = {
+      id: 'version-1',
+      projectId: 'proj-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      name: 'new.txt',
+      path: '/data/artifacts/proj-1/session-1/version-1/new.txt',
+      fileUrl: 'file:///data/artifacts/proj-1/session-1/version-1/new.txt',
+      size: 3,
+      mtimeMs: 2
+    }
+
+    await reconcilePendingArtifacts({
+      reconcilePendingArtifacts: vi.fn().mockResolvedValue([finalized])
+    })
+
+    expect(useSessionStore.getState().sessions[0].messages[0].artifactIds).toEqual([
+      'published-artifact',
+      'version-1'
+    ])
+  })
+
   it('continues recovering later Messages when an earlier pending Artifact fails', async () => {
     const firstPath = '/data/artifacts/proj-1/session-1/.pending/run-1/first.txt'
     const secondPath = '/data/artifacts/proj-1/session-1/.pending/run-2/second.txt'

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -461,6 +461,61 @@ describe('reconcilePendingArtifacts', () => {
     })
   })
 
+  it('keeps native-only recovery unresolved when startup and manual retries return no Version', async () => {
+    const nativePath =
+      '/data/artifacts/proj-1/.provenance/artifacts/artifact-1/versions/version-1/chart.png'
+    const originalError = 'Generated file finalization failed: disk temporarily unavailable'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        id: 'session-1',
+        projectId: 'proj-1',
+        status: 'error',
+        error: originalError,
+        errorReportable: true,
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'done',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['version-1'],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        artifacts: [
+          {
+            id: 'version-1',
+            artifactId: 'artifact-1',
+            versionId: 'version-1',
+            kind: 'managed-file',
+            path: nativePath,
+            name: 'chart.png'
+          }
+        ]
+      })
+    ])
+    const api = { reconcilePendingArtifacts: vi.fn().mockResolvedValue([]) }
+
+    await reconcilePendingArtifacts(api)
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: originalError,
+      errorReportable: true
+    })
+    await expect(retryPendingArtifactFinalization('session-1', api)).rejects.toThrow(
+      /did not resolve all native Versions/u
+    )
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error:
+        'Generated file finalization failed: Artifact finalization did not resolve all native Versions.',
+      errorReportable: true
+    })
+  })
+
   it('keeps an unresolved compatibility reference when native recovery succeeds', async () => {
     const nativePath =
       '/data/artifacts/proj-1/.provenance/artifacts/artifact-1/versions/version-1/chart.png'

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -407,6 +407,72 @@ describe('reconcilePendingArtifacts', () => {
     })
   })
 
+  it('keeps an unresolved compatibility reference when native recovery succeeds', async () => {
+    const nativePath =
+      '/data/artifacts/proj-1/.provenance/artifacts/artifact-1/versions/version-1/chart.png'
+    const pendingPath = '/data/artifacts/proj-1/session-1/.pending/run-2/report.md'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        id: 'session-1',
+        projectId: 'proj-1',
+        status: 'error',
+        error: 'Generated file finalization failed: disk temporarily unavailable',
+        errorReportable: true,
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'done',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['version-1', 'pending-report'],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        artifacts: [
+          {
+            id: 'version-1',
+            artifactId: 'artifact-1',
+            versionId: 'version-1',
+            kind: 'managed-file',
+            path: nativePath,
+            name: 'chart.png'
+          },
+          {
+            id: 'pending-report',
+            kind: 'managed-file',
+            path: pendingPath,
+            name: 'report.md'
+          }
+        ]
+      })
+    ])
+    const finalizedNative = {
+      id: 'version-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1',
+      runId: 'run-1',
+      projectId: 'proj-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      name: 'chart.png',
+      path: nativePath,
+      fileUrl: `file://${nativePath}`,
+      size: 3,
+      mtimeMs: 2
+    }
+    const api = { reconcilePendingArtifacts: vi.fn().mockResolvedValue([finalizedNative]) }
+
+    await expect(retryPendingArtifactFinalization('session-1', api)).rejects.toThrow(
+      /did not resolve all pending files/u
+    )
+
+    expect(useSessionStore.getState().sessions[0].messages[0].artifactIds).toEqual(
+      expect.arrayContaining(['version-1', 'pending-report'])
+    )
+  })
+
   it('re-finalizes pending artifacts referenced only by an inactive conversation Branch', async () => {
     const pendingPath = '/data/artifacts/proj-1/session-1/.pending/run-1/report.md'
     const originalPrompt = {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -30,6 +30,7 @@ import {
   loadPersistedSession,
   loadPersistedSessions,
   reconcilePendingArtifacts,
+  retryPendingArtifactFinalization,
   saveSessionInOrder,
   type SessionPersistenceApi
 } from './session-persistence'
@@ -165,6 +166,60 @@ describe('reconcilePendingArtifacts', () => {
     await reconcilePendingArtifacts(api)
 
     expect(api.reconcilePendingArtifacts).not.toHaveBeenCalled()
+  })
+
+  it('clears the Artifact error after an explicit retry replaces every pending reference', async () => {
+    const pendingPath = '/data/artifacts/proj-1/session-1/.pending/run-1/chart.png'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        id: 'session-1',
+        projectId: 'proj-1',
+        status: 'error',
+        error: 'Generated file finalization failed: disk temporarily unavailable',
+        errorReportable: true,
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'done',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['pending-artifact'],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        artifacts: [
+          {
+            id: 'pending-artifact',
+            kind: 'managed-file',
+            path: pendingPath,
+            name: 'chart.png'
+          }
+        ]
+      })
+    ])
+    const finalized = {
+      id: 'version-1',
+      projectId: 'proj-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      name: 'chart.png',
+      path: '/data/artifacts/proj-1/session-1/version-1/chart.png',
+      fileUrl: 'file:///data/artifacts/proj-1/session-1/version-1/chart.png',
+      size: 3,
+      mtimeMs: 2
+    }
+    const api = { reconcilePendingArtifacts: vi.fn().mockResolvedValue([finalized]) }
+
+    await retryPendingArtifactFinalization('session-1', api)
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      error: undefined,
+      errorReportable: undefined,
+      messages: [{ artifactIds: ['version-1'] }]
+    })
   })
 
   it('re-finalizes pending artifacts referenced only by an inactive conversation Branch', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -168,6 +168,65 @@ describe('reconcilePendingArtifacts', () => {
     expect(api.reconcilePendingArtifacts).not.toHaveBeenCalled()
   })
 
+  it('continues recovering later Messages when an earlier pending Artifact fails', async () => {
+    const firstPath = '/data/artifacts/proj-1/session-1/.pending/run-1/first.txt'
+    const secondPath = '/data/artifacts/proj-1/session-1/.pending/run-2/second.txt'
+    useSessionStore.getState().hydrateSessions([
+      createPersistedSession({
+        id: 'session-1',
+        projectId: 'proj-1',
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'first',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['pending-first'],
+            createdAt: 1,
+            updatedAt: 1
+          },
+          {
+            id: 'message-2',
+            role: 'agent',
+            content: 'second',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: ['pending-second'],
+            createdAt: 2,
+            updatedAt: 2
+          }
+        ],
+        artifacts: [
+          { id: 'pending-first', kind: 'managed-file', path: firstPath, name: 'first.txt' },
+          { id: 'pending-second', kind: 'managed-file', path: secondPath, name: 'second.txt' }
+        ]
+      })
+    ])
+    const finalized = {
+      id: 'version-2',
+      projectId: 'proj-1',
+      sessionId: 'session-1',
+      messageId: 'message-2',
+      name: 'second.txt',
+      path: '/data/artifacts/proj-1/session-1/version-2/second.txt',
+      fileUrl: 'file:///data/artifacts/proj-1/session-1/version-2/second.txt',
+      size: 3,
+      mtimeMs: 3
+    }
+    const api = {
+      reconcilePendingArtifacts: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('first recovery failed'))
+        .mockResolvedValueOnce([finalized])
+    }
+
+    await reconcilePendingArtifacts(api)
+
+    expect(api.reconcilePendingArtifacts).toHaveBeenCalledTimes(2)
+    expect(useSessionStore.getState().sessions[0].messages[1].artifactIds).toEqual(['version-2'])
+  })
+
   it('clears the Artifact error after an explicit retry replaces every pending reference', async () => {
     const pendingPath = '/data/artifacts/proj-1/session-1/.pending/run-1/chart.png'
     useSessionStore.getState().hydrateSessions([

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -27,6 +27,7 @@ import {
 import { PENDING_UPLOAD_SESSION_ID } from '../../../../shared/uploads'
 import {
   getExternallyHydratedSessionAuthority,
+  isArtifactFinalizationError,
   isExternallyHydratedSession,
   toPersistedSession,
   useSessionStore
@@ -1006,7 +1007,11 @@ const reconcilePendingArtifacts = async (api: ArtifactReconcileApi): Promise<voi
       const current = useSessionStore
         .getState()
         .sessions.find((candidate) => candidate.id === session.id)
-      if (current && pendingArtifactRequests(current).length === 0) {
+      if (
+        current &&
+        isArtifactFinalizationError(current.error) &&
+        pendingArtifactRequests(current).length === 0
+      ) {
         useSessionStore.getState().clearArtifactError(session.id)
       }
     } catch (error) {

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -910,28 +910,47 @@ const isPendingArtifactPath = (path: string | undefined): path is string =>
   typeof path === 'string' && path.split(/[\\/]/).includes('.pending')
 
 const pendingArtifactRequests = (
-  session: ChatSession
-): Array<{ messageId: string; pendingPaths: string[] }> => {
+  session: ChatSession,
+  includeNativeVersions = false
+): Array<{ messageId: string; pendingPaths: string[]; artifactVersionIds?: string[] }> => {
   const artifactsById = new Map(
     (session.artifacts ?? []).map((artifact) => [artifact.id, artifact])
   )
   const messages = session.conversationGraph?.messages ?? session.messages
   return messages.flatMap((message) => {
-    const pendingPaths = (message.artifactIds ?? [])
-      .map((id) => artifactsById.get(id)?.path)
-      .filter(isPendingArtifactPath)
-    return pendingPaths.length > 0 ? [{ messageId: message.id, pendingPaths }] : []
+    const artifacts = (message.artifactIds ?? []).flatMap((id) => {
+      const artifact = artifactsById.get(id)
+      return artifact ? [artifact] : []
+    })
+    const pendingPaths = artifacts.map((artifact) => artifact.path).filter(isPendingArtifactPath)
+    const artifactVersionIds = includeNativeVersions
+      ? [
+          ...new Set(
+            artifacts.flatMap((artifact) => (artifact.versionId ? [artifact.versionId] : []))
+          )
+        ]
+      : []
+    return pendingPaths.length > 0 || artifactVersionIds.length > 0
+      ? [
+          {
+            messageId: message.id,
+            pendingPaths,
+            ...(artifactVersionIds.length > 0 ? { artifactVersionIds } : {})
+          }
+        ]
+      : []
   })
 }
 
 const reconcileSessionPendingArtifacts = async (
   session: ChatSession,
-  api: ArtifactReconcileApi
+  api: ArtifactReconcileApi,
+  includeNativeVersions = false
 ): Promise<void> => {
   if (session.isPending || !session.projectId) return
 
   let firstFailure: unknown
-  for (const request of pendingArtifactRequests(session)) {
+  for (const request of pendingArtifactRequests(session, includeNativeVersions)) {
     try {
       const finalized = await api.reconcilePendingArtifacts({
         projectId: session.projectId,
@@ -975,10 +994,10 @@ const retryPendingArtifactFinalization = async (
   if (!session) throw new Error('Session not found.')
 
   try {
-    if (pendingArtifactRequests(session).length === 0) {
+    if (pendingArtifactRequests(session, true).length === 0) {
       throw new Error('No pending Artifact references are available to retry.')
     }
-    await reconcileSessionPendingArtifacts(session, api)
+    await reconcileSessionPendingArtifacts(session, api, true)
     const current = useSessionStore
       .getState()
       .sessions.find((candidate) => candidate.id === sessionId)
@@ -1003,7 +1022,11 @@ const retryPendingArtifactFinalization = async (
 const reconcilePendingArtifacts = async (api: ArtifactReconcileApi): Promise<void> => {
   for (const session of useSessionStore.getState().sessions) {
     try {
-      await reconcileSessionPendingArtifacts(session, api)
+      await reconcileSessionPendingArtifacts(
+        session,
+        api,
+        isArtifactFinalizationError(session.error)
+      )
       const current = useSessionStore
         .getState()
         .sessions.find((candidate) => candidate.id === session.id)

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -990,6 +990,12 @@ const reconcilePendingArtifacts = async (api: ArtifactReconcileApi): Promise<voi
   for (const session of useSessionStore.getState().sessions) {
     try {
       await reconcileSessionPendingArtifacts(session, api)
+      const current = useSessionStore
+        .getState()
+        .sessions.find((candidate) => candidate.id === session.id)
+      if (current && pendingArtifactRequests(current).length === 0) {
+        useSessionStore.getState().clearArtifactError(session.id)
+      }
     } catch (error) {
       reportPersistenceError(error, 'artifact-reconcile')
     }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { ArtifactFile, ReconcilePendingArtifactsRequest } from '../../../../shared/artifacts'
+import {
+  ARTIFACT_FINALIZATION_INVALID_PROOF,
+  type ReconcilePendingArtifactsRequest,
+  type ReconcilePendingArtifactsResult
+} from '../../../../shared/artifacts'
 import {
   projectConversationMessage,
   resolveActiveConversationActivities,
@@ -901,8 +905,19 @@ const flushSessionPersistence = async (): Promise<void> => {
 
 // The one artifact command startup reconciliation needs; kept narrow so it is trivial to fake in tests.
 type ArtifactReconcileApi = {
-  reconcilePendingArtifacts: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
+  reconcilePendingArtifacts: (
+    request: ReconcilePendingArtifactsRequest
+  ) => Promise<ReconcilePendingArtifactsResult>
 }
+
+const invalidArtifactFinalizationProofError = (message: string): Error =>
+  Object.assign(new Error(message), { code: ARTIFACT_FINALIZATION_INVALID_PROOF })
+
+const isInvalidArtifactFinalizationProofError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  error.code === ARTIFACT_FINALIZATION_INVALID_PROOF
 
 // A crash between persisting a pending artifact reference and finalizing it strands the file in
 // `.pending/<run>/`. The path segment is stable across OSes, so detect it structurally.
@@ -959,11 +974,13 @@ const reconcileSessionPendingArtifacts = async (
   let firstFailure: unknown
   for (const request of pendingArtifactRequests(session, includeNativeVersions)) {
     try {
-      const finalized = await api.reconcilePendingArtifacts({
+      const result = await api.reconcilePendingArtifacts({
         projectId: session.projectId,
         sessionId: session.id,
         ...request
       })
+      if (!Array.isArray(result)) throw invalidArtifactFinalizationProofError(result.message)
+      const finalized = result
       if (finalized.length > 0) {
         const current = useSessionStore
           .getState()
@@ -1027,7 +1044,9 @@ const retryPendingArtifactFinalization = async (
     useSessionStore.getState().clearArtifactError(sessionId)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    useSessionStore.getState().recordArtifactError(sessionId, message)
+    useSessionStore
+      .getState()
+      .recordArtifactError(sessionId, message, !isInvalidArtifactFinalizationProofError(error))
     reportPersistenceError(error, 'artifact-reconcile')
     throw error
   }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -929,20 +929,26 @@ const reconcileSessionPendingArtifacts = async (
 ): Promise<void> => {
   if (session.isPending || !session.projectId) return
 
+  let firstFailure: unknown
   for (const request of pendingArtifactRequests(session)) {
-    const finalized = await api.reconcilePendingArtifacts({
-      projectId: session.projectId,
-      sessionId: session.id,
-      ...request
-    })
-    if (finalized.length > 0) {
-      useSessionStore.getState().replaceMessageArtifacts({
+    try {
+      const finalized = await api.reconcilePendingArtifacts({
+        projectId: session.projectId,
         sessionId: session.id,
-        messageId: request.messageId,
-        artifacts: finalized
+        ...request
       })
+      if (finalized.length > 0) {
+        useSessionStore.getState().replaceMessageArtifacts({
+          sessionId: session.id,
+          messageId: request.messageId,
+          artifacts: finalized
+        })
+      }
+    } catch (error) {
+      firstFailure ??= error
     }
   }
+  if (firstFailure) throw firstFailure
 }
 
 const retryPendingArtifactFinalization = async (

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -981,6 +981,12 @@ const reconcileSessionPendingArtifacts = async (
       })
       if (!Array.isArray(result)) throw invalidArtifactFinalizationProofError(result.message)
       const finalized = result
+      const recoveredVersionIds = new Set(
+        finalized.flatMap((artifact) => (artifact.versionId ? [artifact.versionId] : []))
+      )
+      if (request.artifactVersionIds?.some((versionId) => !recoveredVersionIds.has(versionId))) {
+        throw new Error('Artifact finalization did not resolve all native Versions.')
+      }
       if (finalized.length > 0) {
         const current = useSessionStore
           .getState()

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -908,6 +908,72 @@ type ArtifactReconcileApi = {
 const isPendingArtifactPath = (path: string | undefined): path is string =>
   typeof path === 'string' && path.split(/[\\/]/).includes('.pending')
 
+const pendingArtifactRequests = (
+  session: ChatSession
+): Array<{ messageId: string; pendingPaths: string[] }> => {
+  const artifactsById = new Map(
+    (session.artifacts ?? []).map((artifact) => [artifact.id, artifact])
+  )
+  const messages = session.conversationGraph?.messages ?? session.messages
+  return messages.flatMap((message) => {
+    const pendingPaths = (message.artifactIds ?? [])
+      .map((id) => artifactsById.get(id)?.path)
+      .filter(isPendingArtifactPath)
+    return pendingPaths.length > 0 ? [{ messageId: message.id, pendingPaths }] : []
+  })
+}
+
+const reconcileSessionPendingArtifacts = async (
+  session: ChatSession,
+  api: ArtifactReconcileApi
+): Promise<void> => {
+  if (session.isPending || !session.projectId) return
+
+  for (const request of pendingArtifactRequests(session)) {
+    const finalized = await api.reconcilePendingArtifacts({
+      projectId: session.projectId,
+      sessionId: session.id,
+      ...request
+    })
+    if (finalized.length > 0) {
+      useSessionStore.getState().replaceMessageArtifacts({
+        sessionId: session.id,
+        messageId: request.messageId,
+        artifacts: finalized
+      })
+    }
+  }
+}
+
+const retryPendingArtifactFinalization = async (
+  sessionId: string,
+  api: ArtifactReconcileApi = window.api.artifacts
+): Promise<void> => {
+  const session = useSessionStore
+    .getState()
+    .sessions.find((candidate) => candidate.id === sessionId)
+  if (!session) throw new Error('Session not found.')
+
+  try {
+    if (pendingArtifactRequests(session).length === 0) {
+      throw new Error('No pending Artifact references are available to retry.')
+    }
+    await reconcileSessionPendingArtifacts(session, api)
+    const current = useSessionStore
+      .getState()
+      .sessions.find((candidate) => candidate.id === sessionId)
+    if (current && pendingArtifactRequests(current).length > 0) {
+      throw new Error('Artifact finalization did not resolve all pending files.')
+    }
+    useSessionStore.getState().clearArtifactError(sessionId)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    useSessionStore.getState().recordArtifactError(sessionId, message)
+    reportPersistenceError(error, 'artifact-reconcile')
+    throw error
+  }
+}
+
 // Re-finalizes artifacts a prior crash left in `.pending` after the in-memory finalize claim was lost.
 // For each hydrated message still referencing a pending path, ask the main process to complete the
 // move (idempotent) and replace the message's stale references with the finalized files. Runs once at
@@ -916,38 +982,10 @@ const isPendingArtifactPath = (path: string | undefined): path is string =>
 // readable at its pending path is never dropped.
 const reconcilePendingArtifacts = async (api: ArtifactReconcileApi): Promise<void> => {
   for (const session of useSessionStore.getState().sessions) {
-    if (session.isPending || !session.projectId) continue
-
-    const artifactsById = new Map(
-      (session.artifacts ?? []).map((artifact) => [artifact.id, artifact])
-    )
-
-    const messages = session.conversationGraph?.messages ?? session.messages
-    for (const message of messages) {
-      const pendingPaths = (message.artifactIds ?? [])
-        .map((id) => artifactsById.get(id)?.path)
-        .filter(isPendingArtifactPath)
-
-      if (pendingPaths.length === 0) continue
-
-      try {
-        const finalized = await api.reconcilePendingArtifacts({
-          projectId: session.projectId,
-          sessionId: session.id,
-          messageId: message.id,
-          pendingPaths
-        })
-
-        if (finalized.length > 0) {
-          useSessionStore.getState().replaceMessageArtifacts({
-            sessionId: session.id,
-            messageId: message.id,
-            artifacts: finalized
-          })
-        }
-      } catch (error) {
-        reportPersistenceError(error, 'artifact-reconcile')
-      }
+    try {
+      await reconcileSessionPendingArtifacts(session, api)
+    } catch (error) {
+      reportPersistenceError(error, 'artifact-reconcile')
     }
   }
 }
@@ -1823,6 +1861,7 @@ export {
   loadPersistedSession,
   loadPersistedSessions,
   reconcilePendingArtifacts,
+  retryPendingArtifactFinalization,
   resetSessionPersistenceWriteFailuresForTests,
   deriveSessionCatalogRecovery,
   deleteSession,

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -938,10 +938,23 @@ const reconcileSessionPendingArtifacts = async (
         ...request
       })
       if (finalized.length > 0) {
+        const current = useSessionStore
+          .getState()
+          .sessions.find((candidate) => candidate.id === session.id)
+        const message = (current?.conversationGraph?.messages ?? current?.messages ?? []).find(
+          (candidate) => candidate.id === request.messageId
+        )
+        const artifactsById = new Map(
+          (current?.artifacts ?? []).map((artifact) => [artifact.id, artifact])
+        )
+        const preserveArtifactIds = (message?.artifactIds ?? []).filter(
+          (artifactId) => !isPendingArtifactPath(artifactsById.get(artifactId)?.path)
+        )
         useSessionStore.getState().replaceMessageArtifacts({
           sessionId: session.id,
           messageId: request.messageId,
-          artifacts: finalized
+          artifacts: finalized,
+          preserveArtifactIds
         })
       }
     } catch (error) {

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -909,6 +909,13 @@ type ArtifactReconcileApi = {
 const isPendingArtifactPath = (path: string | undefined): path is string =>
   typeof path === 'string' && path.split(/[\\/]/).includes('.pending')
 
+const pendingArtifactRunId = (path: string | undefined): string | undefined => {
+  if (!path) return undefined
+  const parts = path.split(/[\\/]/)
+  const pendingIndex = parts.lastIndexOf('.pending')
+  return pendingIndex >= 0 ? parts[pendingIndex + 1] : undefined
+}
+
 const pendingArtifactRequests = (
   session: ChatSession,
   includeNativeVersions = false
@@ -967,9 +974,22 @@ const reconcileSessionPendingArtifacts = async (
         const artifactsById = new Map(
           (current?.artifacts ?? []).map((artifact) => [artifact.id, artifact])
         )
-        const preserveArtifactIds = (message?.artifactIds ?? []).filter(
-          (artifactId) => !isPendingArtifactPath(artifactsById.get(artifactId)?.path)
+        const recoveredRunIds = new Set(
+          finalized.flatMap((artifact) => (artifact.runId ? [artifact.runId] : []))
         )
+        const recoveredCompatibilityNames = new Set(
+          finalized.flatMap((artifact) => (!artifact.versionId ? [artifact.name] : []))
+        )
+        const preserveArtifactIds = (message?.artifactIds ?? []).filter((artifactId) => {
+          const artifact = artifactsById.get(artifactId)
+          if (!isPendingArtifactPath(artifact?.path)) return true
+          const runId = pendingArtifactRunId(artifact.path)
+          const name = artifact.name ?? artifact.path.split(/[\\/]/).at(-1)
+          return (
+            (!runId || !recoveredRunIds.has(runId)) &&
+            (!name || !recoveredCompatibilityNames.has(name))
+          )
+        })
         useSessionStore.getState().replaceMessageArtifacts({
           sessionId: session.id,
           messageId: request.messageId,

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -602,6 +602,10 @@ const createPanelDefaults = (): PanelProps => ({
     compact: vi.fn()
   },
   workflows: {
+    artifactFinalization: {
+      running: false,
+      request: vi.fn()
+    },
     review: {
       disabled: false,
       running: false,
@@ -740,6 +744,57 @@ describe('ConversationPanel composer errors', () => {
     expect(alert?.querySelector('section')).not.toBeNull()
     expect(alert?.querySelector('.bg-status-failure-surface')).not.toBeNull()
     expect(alert?.className).not.toContain('bg-red-50')
+  })
+
+  it('offers an immediate retry when Artifact publication fails', () => {
+    const request = vi.fn()
+    const pendingPath = '/data/artifacts/project-a/artifact-session-1/.pending/run-1/report.md'
+    const activeSession: ChatSession = {
+      id: 'session-artifact-retry',
+      projectId: 'project-a',
+      title: 'Artifact retry',
+      cwd: '/workspace',
+      status: 'error',
+      error: 'Generated file finalization failed: disk temporarily unavailable',
+      errorReportable: true,
+      messages: [
+        {
+          id: 'message-1',
+          role: 'agent',
+          content: 'Created the report.',
+          status: 'complete',
+          eventIds: ['artifact-event-1'],
+          artifactIds: ['artifact-session-1:run-1:report.md'],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      artifacts: [
+        {
+          id: 'artifact-session-1:run-1:report.md',
+          kind: 'managed-file',
+          name: 'report.md',
+          path: pendingPath,
+          fileUrl: `file://${pendingPath}`,
+          size: 10,
+          mtimeMs: 1
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 2
+    }
+
+    renderPanel({
+      view: { activeSession },
+      workflows: { artifactFinalization: { request } }
+    })
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Retry Artifact publication"]'
+    )
+    expect(retry).not.toBeNull()
+    act(() => retry?.click())
+    expect(request).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -796,6 +796,28 @@ describe('ConversationPanel composer errors', () => {
     act(() => retry?.click())
     expect(request).toHaveBeenCalledOnce()
   })
+
+  it('does not offer retry when Artifact provenance proof is invalid', () => {
+    const activeSession: ChatSession = {
+      id: 'session-artifact-invalid-proof',
+      projectId: 'project-a',
+      title: 'Artifact proof failure',
+      cwd: '/workspace',
+      status: 'error',
+      error:
+        'Generated file finalization cannot be retried: Artifact run claim is missing complete provenance context.',
+      errorReportable: true,
+      messages: [],
+      createdAt: 1,
+      updatedAt: 2
+    }
+
+    renderPanel({ view: { activeSession } })
+
+    expect(
+      container.querySelector<HTMLButtonElement>('[aria-label="Retry Artifact publication"]')
+    ).toBeNull()
+  })
 })
 
 describe('ConversationPanel session loading presentation', () => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -78,6 +78,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { cn } from '@/lib/utils'
 import {
+  isArtifactFinalizationError,
   projectSessionActionability,
   useSessionStore,
   type ChatSession
@@ -369,6 +370,10 @@ type ConversationPanelSaveAsSkill = {
 }
 
 type ConversationPanelWorkflows = {
+  artifactFinalization: {
+    running: boolean
+    request: () => void
+  }
   review: ConversationPanelReview
   saveAsSkill: ConversationPanelSaveAsSkill
 }
@@ -733,6 +738,7 @@ const ConversationPanel = ({
   const isRunErrorReportable =
     !hasUnsupportedCodexAcpRunError &&
     (activeSession?.errorReportable ?? isReportableRunFailure(activeSession?.error))
+  const canRetryArtifactFinalization = isArtifactFinalizationError(activeSession?.error)
 
   const activeSpecialist = specialistId
     ? specialistItems.find((item) => item.kind === 'custom' && item.id === specialistId)
@@ -1131,16 +1137,38 @@ const ConversationPanel = ({
                             text and the reported text are always the same error. Shown only for an
                             unknown failure — a recognized one (app guidance or a known provider error)
                             keeps its message but is not a bug worth a GitHub issue. */}
-                        {isRunErrorReportable ? (
-                          <button
-                            type="button"
-                            onClick={openReportDialog}
-                            className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100 dark:border-red-800/50 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/40"
-                            aria-label={t('Report this error')}
-                          >
-                            <Flag className="size-3" strokeWidth={2.2} aria-hidden="true" />
-                            {t('Report error')}
-                          </button>
+                        {canRetryArtifactFinalization || isRunErrorReportable ? (
+                          <div className="flex shrink-0 items-center gap-1">
+                            {canRetryArtifactFinalization ? (
+                              <button
+                                type="button"
+                                onClick={workflows.artifactFinalization.request}
+                                disabled={workflows.artifactFinalization.running}
+                                className="inline-flex h-6 items-center gap-1 rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-800/50 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/40"
+                                aria-label={t('Retry Artifact publication')}
+                              >
+                                {workflows.artifactFinalization.running ? (
+                                  <Loader2
+                                    className="size-3 animate-spin"
+                                    strokeWidth={2.2}
+                                    aria-hidden="true"
+                                  />
+                                ) : null}
+                                {t('Retry Artifact publication')}
+                              </button>
+                            ) : null}
+                            {isRunErrorReportable ? (
+                              <button
+                                type="button"
+                                onClick={openReportDialog}
+                                className="inline-flex h-6 items-center gap-1 rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100 dark:border-red-800/50 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/40"
+                                aria-label={t('Report this error')}
+                              >
+                                <Flag className="size-3" strokeWidth={2.2} aria-hidden="true" />
+                                {t('Report error')}
+                              </button>
+                            ) : null}
+                          </div>
                         ) : null}
                       </div>
                     ) : null}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -78,7 +78,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { cn } from '@/lib/utils'
 import {
-  isArtifactFinalizationError,
+  isRetryableArtifactFinalizationError,
   projectSessionActionability,
   useSessionStore,
   type ChatSession
@@ -738,7 +738,7 @@ const ConversationPanel = ({
   const isRunErrorReportable =
     !hasUnsupportedCodexAcpRunError &&
     (activeSession?.errorReportable ?? isReportableRunFailure(activeSession?.error))
-  const canRetryArtifactFinalization = isArtifactFinalizationError(activeSession?.error)
+  const canRetryArtifactFinalization = isRetryableArtifactFinalizationError(activeSession?.error)
 
   const activeSpecialist = specialistId
     ? specialistItems.find((item) => item.kind === 'custom' && item.id === specialistId)

--- a/src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx
@@ -243,6 +243,74 @@ afterEach(async () => {
 // ---------------------------------------------------------------------------
 
 describe('WorkspacePage pending-switch broadcast', () => {
+  it('keeps Artifact retry disabled after switching Sessions while another retry is running', async () => {
+    setupBase()
+    const pendingSession = (id: string): ChatSession => {
+      const pendingPath = `/artifacts/storage-${id}/.pending/run-${id}/result.txt`
+      return createSession({
+        id,
+        title: id,
+        messages: [
+          {
+            id: `message-${id}`,
+            role: 'agent',
+            content: 'result',
+            status: 'complete',
+            eventIds: [],
+            artifactIds: [`artifact-${id}`],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        artifacts: [
+          {
+            id: `artifact-${id}`,
+            kind: 'managed-file',
+            name: 'result.txt',
+            path: pendingPath,
+            fileUrl: `file://${pendingPath}`,
+            size: 1,
+            mtimeMs: 1
+          }
+        ]
+      })
+    }
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [pendingSession('sess-a'), pendingSession('sess-b')],
+      selectedSessionId: 'sess-a'
+    })
+    useSpecialistStore.setState({ items: [], isLoaded: true, load: vi.fn() })
+    let finishReconciliation!: (artifacts: []) => void
+    const reconcilePendingArtifacts = vi.fn(
+      () =>
+        new Promise<[]>((resolve) => {
+          finishReconciliation = resolve
+        })
+    )
+    window.api = {
+      ...apiStub(),
+      artifacts: { reconcilePendingArtifacts }
+    } as never
+    await renderPage(root)
+
+    await act(async () => {
+      conversationProps.workflows.artifactFinalization.request()
+      await Promise.resolve()
+    })
+    expect(conversationProps.workflows.artifactFinalization.running).toBe(true)
+
+    act(() => useSessionStore.setState({ selectedSessionId: 'sess-b' }))
+
+    expect(conversationProps.view.activeSession?.id).toBe('sess-b')
+    expect(conversationProps.workflows.artifactFinalization.running).toBe(true)
+
+    await act(async () => {
+      finishReconciliation([])
+      await Promise.resolve()
+    })
+  })
+
   it('keeps Delegation read-only while a selected Session is temporarily missing', async () => {
     setupBase()
     useSettingsStore.setState({

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1325,7 +1325,7 @@ const WorkspacePage = ({
             }}
             workflows={{
               artifactFinalization: {
-                running: artifactFinalizationRetrySessionId === activeSession?.id,
+                running: artifactFinalizationRetrySessionId !== undefined,
                 request: requestArtifactFinalizationRetry
               },
               review: {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -9,7 +9,10 @@ import {
   useWorkspaceElicitation
 } from '@/lib/acp/useWorkspaceElicitation'
 import { usePreviewPersistence } from '@/lib/preview-persistence/preview-persistence'
-import { deleteSession } from '@/lib/session-persistence/session-persistence'
+import {
+  deleteSession,
+  retryPendingArtifactFinalization
+} from '@/lib/session-persistence/session-persistence'
 import { useMemoryStore } from '@/stores/memory-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
@@ -218,6 +221,8 @@ const WorkspacePage = ({
   // disabled as the first defense.
   const [isDownloadingProjectArtifacts, setIsDownloadingProjectArtifacts] = useState(false)
   const [isProjectDownloadOpen, setIsProjectDownloadOpen] = useState(false)
+  const [artifactFinalizationRetrySessionId, setArtifactFinalizationRetrySessionId] =
+    useState<string>()
   const [manualReviewRequests, setManualReviewRequests] = useState<
     Record<string, ManualReviewRequestState>
   >({})
@@ -1028,6 +1033,19 @@ const WorkspacePage = ({
     })()
   }
 
+  const requestArtifactFinalizationRetry = (): void => {
+    if (!activeSession || artifactFinalizationRetrySessionId) return
+    const sessionId = activeSession.id
+    setArtifactFinalizationRetrySessionId(sessionId)
+    void retryPendingArtifactFinalization(sessionId)
+      .catch(() => undefined)
+      .finally(() => {
+        setArtifactFinalizationRetrySessionId((current) =>
+          current === sessionId ? undefined : current
+        )
+      })
+  }
+
   const requestSaveAsSkill = (): void => {
     if (!activeSession || !saveAsSkillAvailability.enabled) return
     const graph = activeSession.conversationGraph
@@ -1306,6 +1324,10 @@ const WorkspacePage = ({
               compact: compactActiveContext
             }}
             workflows={{
+              artifactFinalization: {
+                running: artifactFinalizationRetrySessionId === activeSession?.id,
+                request: requestArtifactFinalizationRetry
+              },
               review: {
                 disabled: isRequestReviewDisabled,
                 running: isReviewBusy,

--- a/src/renderer/src/stores/session-store-run-output-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-output-helpers.ts
@@ -62,6 +62,7 @@ export type ReplaceMessageArtifactsInput = {
   sessionId: string
   messageId: string
   artifacts: ArtifactFile[]
+  preserveArtifactIds?: string[]
 }
 
 export type ReplaceMessageUploadsInput = {
@@ -524,11 +525,21 @@ export const projectMessageArtifacts = (
   const incomingArtifacts = input.artifacts.map((artifact) =>
     createPersistedArtifact(artifact, ownerTimestamp)
   )
-  const incomingArtifactIds = incomingArtifacts.map((artifact) => artifact.id)
+  const preservedArtifactIds = (artifactOwner?.artifactIds ?? []).filter((artifactId) =>
+    input.preserveArtifactIds?.includes(artifactId)
+  )
+  const incomingArtifactIds = appendUniqueStrings(
+    preservedArtifactIds,
+    incomingArtifacts.map((artifact) => artifact.id)
+  )
 
   if (!message) {
     if (!graphMessage || !session.conversationGraph) return session
-    const replacedArtifactIds = new Set(graphMessage.artifactIds ?? [])
+    const replacedArtifactIds = new Set(
+      (graphMessage.artifactIds ?? []).filter(
+        (artifactId) => !preservedArtifactIds.includes(artifactId)
+      )
+    )
     const preservedArtifacts = (session.artifacts ?? []).filter(
       (artifact) => !replacedArtifactIds.has(artifact.id)
     )
@@ -550,7 +561,9 @@ export const projectMessageArtifacts = (
     }
   }
 
-  const replacedArtifactIds = new Set(message.artifactIds ?? [])
+  const replacedArtifactIds = new Set(
+    (message.artifactIds ?? []).filter((artifactId) => !preservedArtifactIds.includes(artifactId))
+  )
   const preservedArtifacts = (session.artifacts ?? []).filter(
     (artifact) => !replacedArtifactIds.has(artifact.id)
   )

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -68,7 +68,7 @@ export type SessionRunProjectionActions = {
   replaceMessageArtifacts: (input: ReplaceMessageArtifactsInput) => void
   replaceMessageUploads: (input: ReplaceMessageUploadsInput) => void
   replaceMessagePdfContext: (input: ReplaceMessagePdfContextInput) => void
-  recordArtifactError: (sessionId: string, error: string) => void
+  recordArtifactError: (sessionId: string, error: string, retryable?: boolean) => void
   clearArtifactError: (sessionId: string) => void
   finishRun: (
     sessionId: string,
@@ -275,12 +275,12 @@ export const createSessionRunProjectionOwner = <
       }))
     },
 
-    recordArtifactError: (sessionId, error) => {
+    recordArtifactError: (sessionId, error, retryable = true) => {
       const message = error.trim()
       if (!sessionId || !message) return
       setSessionState((state) => ({
         sessions: projectSession(state.sessions, sessionId, (session) =>
-          projectArtifactError(session, message)
+          projectArtifactError(session, message, retryable)
         )
       }))
     },

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -20,7 +20,11 @@ import { projectSessionInteractionState } from './session-store-interaction-stat
 import type { ChatMessage, ChatSession, ToolActivity } from './session-store-persistence-owner'
 
 const ARTIFACT_ERROR_PREFIX = 'Generated file finalization failed'
+const TERMINAL_ARTIFACT_ERROR_PREFIX = 'Generated file finalization cannot be retried'
 export const isArtifactFinalizationError = (error: string | undefined): boolean =>
+  error?.startsWith(ARTIFACT_ERROR_PREFIX) === true ||
+  error?.startsWith(TERMINAL_ARTIFACT_ERROR_PREFIX) === true
+export const isRetryableArtifactFinalizationError = (error: string | undefined): boolean =>
   error?.startsWith(ARTIFACT_ERROR_PREFIX) ?? false
 const CONVERSATION_GRAPH_SYNC_ERROR =
   'Conversation history could not be finalized safely. Restart the app to restore the last saved conversation state, then report this issue.'
@@ -261,10 +265,14 @@ export const projectPermissionCleared = (
   )
 }
 
-export const projectArtifactError = (session: ChatSession, error: string): ChatSession => ({
+export const projectArtifactError = (
+  session: ChatSession,
+  error: string,
+  retryable = true
+): ChatSession => ({
   ...session,
   status: 'error',
-  error: `${ARTIFACT_ERROR_PREFIX}: ${error}`,
+  error: `${retryable ? ARTIFACT_ERROR_PREFIX : TERMINAL_ARTIFACT_ERROR_PREFIX}: ${error}`,
   errorReportable: true,
   updatedAt: Date.now()
 })

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -20,6 +20,8 @@ import { projectSessionInteractionState } from './session-store-interaction-stat
 import type { ChatMessage, ChatSession, ToolActivity } from './session-store-persistence-owner'
 
 const ARTIFACT_ERROR_PREFIX = 'Generated file finalization failed'
+export const isArtifactFinalizationError = (error: string | undefined): boolean =>
+  error?.startsWith(ARTIFACT_ERROR_PREFIX) ?? false
 const CONVERSATION_GRAPH_SYNC_ERROR =
   'Conversation history could not be finalized safely. Restart the app to restore the last saved conversation state, then report this issue.'
 
@@ -268,7 +270,7 @@ export const projectArtifactError = (session: ChatSession, error: string): ChatS
 })
 
 export const projectArtifactErrorCleared = (session: ChatSession): ChatSession => {
-  if (!session.error?.startsWith(ARTIFACT_ERROR_PREFIX)) return session
+  if (!isArtifactFinalizationError(session.error)) return session
   return {
     ...session,
     status: session.activeRun ? 'running' : 'idle',
@@ -285,7 +287,7 @@ export const projectFinishedRun = (
   contextWindowSample?: RunTerminalContextWindowSample,
   modelCallUsage?: readonly AcpModelCallUsage[]
 ): ChatSession => {
-  const keepArtifactError = session.error?.startsWith(ARTIFACT_ERROR_PREFIX) ?? false
+  const keepArtifactError = isArtifactFinalizationError(session.error)
   const now = Math.max(Date.now(), session.updatedAt + 1)
   const terminalPromptMessageId = promptMessageId ?? session.activeRun?.promptMessageId
   const messages = appendContextWindowSample(

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -108,6 +108,7 @@ const publicValueExports = [
   'createSessionStore',
   'getExternallyHydratedSessionAuthority',
   'isArtifactFinalizationError',
+  'isRetryableArtifactFinalizationError',
   'isExternallyHydratedSession',
   'isSessionWaitReason',
   'projectSessionActionability',

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -107,6 +107,7 @@ const publicValueExports = [
   'createInitialSessionState',
   'createSessionStore',
   'getExternallyHydratedSessionAuthority',
+  'isArtifactFinalizationError',
   'isExternallyHydratedSession',
   'isSessionWaitReason',
   'projectSessionActionability',

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -385,5 +385,8 @@ export const createSessionStore = (): SessionStoreApi =>
 
 export const useSessionStore = create<SessionStore>(createSessionStoreInitializer())
 
-export { isArtifactFinalizationError } from './session-store-run-terminal-helpers'
+export {
+  isArtifactFinalizationError,
+  isRetryableArtifactFinalizationError
+} from './session-store-run-terminal-helpers'
 export type { SessionStore, SessionStoreApi }

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -385,4 +385,5 @@ export const createSessionStore = (): SessionStoreApi =>
 
 export const useSessionStore = create<SessionStore>(createSessionStoreInitializer())
 
+export { isArtifactFinalizationError } from './session-store-run-terminal-helpers'
 export type { SessionStore, SessionStoreApi }

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -198,6 +198,17 @@ export type ReconcilePendingArtifactsRequest = ProjectIdScope & {
   artifactVersionIds?: string[]
 }
 
+// Success remains the historical bare array so an older main process can interoperate during a
+// renderer reload. Terminal proof rejection is explicit because Electron does not preserve custom
+// properties on rejected Error objects.
+export type ReconcilePendingArtifactsResult =
+  | ArtifactFile[]
+  | {
+      ok: false
+      code: typeof ARTIFACT_FINALIZATION_INVALID_PROOF
+      message: string
+    }
+
 // Internal repository list request after the app has resolved the logical project bucket.
 export type ListProjectMessageArtifactsRequest = ListMessageArtifactsRequest & {
   projectId: string

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -107,11 +107,13 @@ export type FinalizeRunArtifactsRequest = {
   messageId: string
 }
 
-// The only finalization failure the renderer may recover inside one event delivery. Other failures
-// remain rejected IPC calls so proof and compatibility errors cannot accidentally become retryable.
+// Ownership races may retry inside one event delivery. Invalid proof is returned only so the
+// renderer can keep that terminal failure from offering a manual retry; operational failures reject.
 export const ARTIFACT_OWNERSHIP_PERSISTENCE_RACE = 'ownership-persistence-race' as const
+export const ARTIFACT_FINALIZATION_INVALID_PROOF = 'invalid-proof' as const
 
-export type ArtifactFinalizationErrorCode = typeof ARTIFACT_OWNERSHIP_PERSISTENCE_RACE
+export type ArtifactFinalizationErrorCode =
+  typeof ARTIFACT_OWNERSHIP_PERSISTENCE_RACE | typeof ARTIFACT_FINALIZATION_INVALID_PROOF
 
 export type FinalizeRunArtifactsResult =
   | { ok: true; artifacts: ArtifactFile[] }
@@ -186,13 +188,14 @@ export type ResolveArtifactVersionDescriptorsRequest = {
   versionIds: string[]
 }
 
-// Renderer request to re-finalize pending artifacts after an operational failure or crash: the
-// persisted message still references `.pending/<run>/<file>` paths. Returns the message's finalized
-// files so the renderer can replace the stale pending references.
+// Renderer request to re-finalize artifacts after an operational failure or crash. Compatibility
+// files retain `.pending/<run>/<file>` paths; native provenance files retain immutable Version ids.
+// Returns the message's finalized files so the renderer can replace stale pending references.
 export type ReconcilePendingArtifactsRequest = ProjectIdScope & {
   sessionId: string
   messageId: string
   pendingPaths: string[]
+  artifactVersionIds?: string[]
 }
 
 // Internal repository list request after the app has resolved the logical project bucket.

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -186,9 +186,9 @@ export type ResolveArtifactVersionDescriptorsRequest = {
   versionIds: string[]
 }
 
-// Renderer request to re-finalize pending artifacts a crash left behind: the persisted message still
-// references `.pending/<run>/<file>` paths whose in-memory finalize claim was lost on restart. Returns
-// the message's finalized files so the renderer can replace the stale pending references.
+// Renderer request to re-finalize pending artifacts after an operational failure or crash: the
+// persisted message still references `.pending/<run>/<file>` paths. Returns the message's finalized
+// files so the renderer can replace the stale pending references.
 export type ReconcilePendingArtifactsRequest = ProjectIdScope & {
   sessionId: string
   messageId: string

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -1819,6 +1819,7 @@
     "Repair this agent before selecting it.": "Reparieren Sie diesen Agenten, bevor Sie ihn auswählen.",
     "Report environment": "Berichtsumgebung",
     "Report error": "Fehler melden",
+    "Retry Artifact publication": "Artifact-Veröffentlichung erneut versuchen",
     "Report this error": "Melden Sie diesen Fehler",
     "Repos you import from will appear here.": "Repos, aus denen Sie importieren, werden hier angezeigt.",
     "Repositories ({{count}})_one": "Repositorys ({{count}})",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1990,6 +1990,7 @@
     "Repair this agent before selecting it.": "Repare este agente antes de seleccionarlo.",
     "Report environment": "Entorno de informe",
     "Report error": "Informar error",
+    "Retry Artifact publication": "Reintentar la publicación del artefacto",
     "Report this error": "Informar este error",
     "Repos you import from will appear here.": "Los repositorios desde los que importa aparecerán aquí.",
     "Repositories ({{count}})_one": "Repositorio ({{count}})",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1990,6 +1990,7 @@
     "Repair this agent before selecting it.": "Réparez cet agent avant de le sélectionner.",
     "Report environment": "Environnement du rapport",
     "Report error": "Signaler une erreur",
+    "Retry Artifact publication": "Réessayer la publication de l’artefact",
     "Report this error": "Signaler cette erreur",
     "Repos you import from will appear here.": "Les dépôts à partir desquels vous importez apparaîtront ici.",
     "Repositories ({{count}})_one": "Dépôt ({{count}})",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1912,6 +1912,7 @@
     "Repair this agent before selecting it.": "このエージェントを選択する前に修復してください。",
     "Report environment": "レポート環境",
     "Report error": "エラーを報告する",
+    "Retry Artifact publication": "Artifact の公開を再試行",
     "Report this error": "このエラーを報告する",
     "Repos you import from will appear here.": "インポート元のリポジトリがここに表示されます。",
     "Repositories ({{count}})_other": "リポジトリ ({{count}})",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1922,6 +1922,7 @@
     "Repair this agent before selecting it.": "선택하기 전에 이 에이전트를 복구하세요.",
     "Report environment": "환경 보고",
     "Report error": "오류 신고",
+    "Retry Artifact publication": "아티팩트 게시 다시 시도",
     "Report this error": "이 오류를 보고하세요",
     "Repos you import from will appear here.": "가져온 저장소가 여기에 표시됩니다.",
     "Repositories ({{count}})_other": "저장소({{count}})",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1998,6 +1998,7 @@
     "Repair this agent before selecting it.": "Восстановите этот агент перед выбором.",
     "Report environment": "Отправить информацию об окружении",
     "Report error": "Отправить ошибку",
+    "Retry Artifact publication": "Повторить публикацию артефакта",
     "Report this error": "Отправить эту ошибку",
     "Repos you import from will appear here.": "Репозитории, которые вы импортируете, появятся здесь.",
     "Repositories ({{count}})_one": "Репозитории ({{count}})",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1988,6 +1988,7 @@
     "Repair this agent before selecting it.": "请先修复该智能体，然后再选择它。",
     "Report environment": "报告环境信息",
     "Report error": "报告错误",
+    "Retry Artifact publication": "重试发布 Artifact",
     "Report this error": "报告此错误",
     "Repos you import from will appear here.": "你导入过的仓库会显示在这里。",
     "Repositories ({{count}})_other": "仓库（{{count}}）",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1985,6 +1985,7 @@
     "Repair this agent before selecting it.": "請先修復該智能體，然後再選擇它。",
     "Report environment": "報告環境資訊",
     "Report error": "回報錯誤",
+    "Retry Artifact publication": "重試發佈 Artifact",
     "Report this error": "回報此錯誤",
     "Repos you import from will appear here.": "你匯入過的儲存庫會顯示在這裡。",
     "Repositories ({{count}})_other": "儲存庫（{{count}}）",

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -35,13 +35,13 @@ import type {
 } from './side-chat'
 import type { SourcePreviewLoadState } from './source-preview'
 import type {
-  ArtifactFile,
   ArtifactPreviewResult,
   FinalizeRunArtifactsRequest,
   FinalizeRunArtifactsResult,
   OpenArtifactFileRequest,
   ReadArtifactPreviewRequest,
   ReconcilePendingArtifactsRequest,
+  ReconcilePendingArtifactsResult,
   ResolveArtifactVersionDescriptorsRequest
 } from './artifacts'
 import type {
@@ -813,7 +813,7 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
   >()('artifacts', ['artifacts:read-preview']),
   'artifacts.reconcilePendingArtifacts': callable<
-    (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
+    (request: ReconcilePendingArtifactsRequest) => Promise<ReconcilePendingArtifactsResult>
   >()('artifacts', ['artifacts:reconcile-pending']),
   'artifacts.resolveVersionDescriptors': callable<
     (request: ResolveArtifactVersionDescriptorsRequest) => Promise<ArtifactVersionDescriptor[]>


### PR DESCRIPTION
## Problem

Artifact output is attached to a pending Message before finalization. Any operational finalization failure other than the ownership-persistence race marked the Session as `error`, but the UI only offered **Report error**. The durable marker could be reconciled on startup, so the user had to refresh or restart instead of retrying immediately.

Artifact run Claims also stayed in the process-local registry forever, so both finalized and abandoned unfinalized Claims accumulated without a bound. The original base also used unfinalized Claims to exclude runs from orphan discovery; #2067 removed that directory-scan consumer while this PR was in review, so the final patch does not reintroduce it.

## Proposed change

- Route the existing pending-Artifact reconciliation command through the Session persistence coordinator and the existing durable Provenance recovery owner.
- Add an idempotent **Retry Artifact publication** action for retryable Artifact finalization errors. Native files are selected by their already-persisted immutable Version ids; compatibility files retain their `.pending` paths. Replace pending Message references through the existing renderer store saver and clear the error only after every pending reference is resolved.
- Keep recovery failures isolated per Message so one failed pending Artifact does not prevent later Messages in the same Session from being attempted.
- Clear a persisted Artifact finalization error after startup recovery has resolved every pending reference, using the existing Session saver.
- Distinguish native recovery from “no native Version”: proof-rejected or partially recovered native runs remain fail-closed, while compatibility-only runs still use the historical fallback. Mixed native/compatibility Messages merge both projections without replacing native Version identity.
- Scope explicit recovery to the requested pending run IDs, and preserve already-published Message artifacts when merging newly recovered native Versions.
- Replay explicitly requested native Versions even when durable finalization and Message linkage already succeeded, so a failed compatibility publication/activation step can finish idempotently.
- Preserve unresolved compatibility references when another native or compatibility reference in the same Message recovers; only remove a pending reference when the returned run identity or compatibility filename proves that reference was resolved.
- Merge native and compatibility recovery results by final path identity rather than filename, so separate runs may publish distinct same-named files without dropping either result.
- Return invalid provenance proof as a terminal IPC failure kind so the UI does not offer a retry that cannot succeed.
- Preserve that terminal classification through the reconciliation IPC result; Electron does not retain custom fields on rejected `Error` objects, so successful historical responses remain bare arrays while proof rejection uses an explicit serializable failure result.
- Require every requested native Version id to appear in the recovery result before startup or manual retry may clear the Session error; an empty older-main response remains unresolved instead of becoming a false success.
- Keep the retry action disabled while any Session retry is running, including after the user switches Sessions.
- Lazily prune finalized Claims after a 5-minute idempotency window and unfinalized Claims after a 1-hour recovery window.
- Translate the new action in all eight renderer locales.

## Scope and non-goals

- No database or Session schema change.
- No new persisted field, status enum value, pending-operation table, provider protocol, or automatic retry loop.
- The existing reconciliation IPC request gains one optional `artifactVersionIds` field; reconciliation success keeps the historical bare array, while terminal failure may return the existing `invalid-proof` error-code variant. These are runtime-only contracts, not persisted state.
- Recovery also adds process-local candidate/unresolved/invalid-proof run metadata to an internal return value.
- Existing `.runs` markers, pending Message references, and Artifact Version states remain the durable recovery model.
- Historical compatibility-only pending files continue through the prior repository fallback.

## Acceptance criteria and validation

The initial regression tests were run before the fix and failed consistently for the reported reasons: the retry action was absent, an abandoned Claim remained excluded from the then-current orphan scan, and a finalized Claim never expired. The review follow-up regressions also failed before their fixes: an empty native result invoked compatibility recovery, an unresolved second native run returned a partial first-run result, switching Sessions made the globally blocked retry look enabled, native provenance references produced “No pending Artifact references are available to retry,” invalid proof still displayed a retry button, an already-linked finalized Version was skipped during explicit retry, a successful native recovery dropped an unresolved compatibility reference, same-named compatibility output was discarded by filename, reconciliation proof rejection lost its terminal classification across IPC, and an empty native-only result incorrectly cleared both startup and manual retry errors. After rebasing over #2067, the Claim tests directly verify the remaining registry-lifetime behavior.

Final evidence below was collected after the last material edit and again after rebasing onto the latest `origin/main`:

- Immediate, idempotent durable finalization; fail-closed proof handling; partial/mixed-run recovery; per-Message failure isolation; renderer error clearing; Claim TTLs; compatibility fallback; UI interaction; architecture boundaries -> `npm test -- src/main/artifacts/ipc.test.ts src/main/artifacts/provenance-repository.test.ts src/main/session-persistence/artifact-finalization-recovery.integration.test.ts src/main/session-persistence/coordinator.test.ts src/main/session-persistence/coordinator.architecture.test.ts src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx src/renderer/src/stores/session-store.architecture.test.ts` -> 9 files, 491 tests passed.
- Renderer locale completeness and binding terminology -> `npx vitest run src/renderer/src/i18n/resources.test.ts` -> 805 tests passed.
- Final startup error-clearing follow-up -> `npx vitest run src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/stores/session-store.architecture.test.ts` -> 2 files, 75 tests passed.
- Scoped-run and complete-Message attachment follow-up -> full relevant files (`provenance-repository`, coordinator, integration, renderer persistence, Session store) -> 5 files, 464 tests passed.
- Native Version retry, end-to-end terminal-proof classification, native-only empty-response protection, startup/delete protection, explicit finalized-Version replay, unresolved mixed-reference preservation, same-named native/compatibility output, store architecture, IPC, and recovery integration -> 10 focused files, 774 tests passed.
- Session persistence render + logic files after the empty-update CI regression fix -> 2 files, 85 tests passed.
- Main, sandbox, and renderer type contracts -> `npm run typecheck:node` and `npm run typecheck:web` -> passed.
- Changed TypeScript/TSX lint surface -> targeted `npx eslint ...` over every changed linted source/test -> no issues.
- `git diff --check` -> passed.

The impact classifier selects the complete PR Gate because `src/main/artifacts/ipc.ts` has no declared module owner. Per task instruction, the complete local `npm test` suite was not run; exact-head PR CI is authoritative for the full portable and platform-selected lanes. No platform-specific or E2E behavior changed, so those suites were not run locally.

## Review focus

- The main process finalizes existing durable Artifact state inside the Session scheduler lane, while the renderer remains the sole writer of the corresponding Session reference update.
- Native candidate and unresolved run identities prevent compatibility fallback from bypassing Provenance proof and prevent partial results from replacing a Message's complete pending set.
- Explicit retry may replay a finalized, linked Version because the compatibility publication/lineage activation boundary can still be incomplete; startup scanning remains limited to pending or unlinked Versions.
- A lost retry response remains safe: replay returns the same native Versions, and compatibility-only historical data retains its old fallback.
- The 5-minute finalized and 1-hour unfinalized TTLs bound process memory while the existing durable marker remains the recovery authority after an in-memory Claim expires.
