### PR TITLE
fix(workspace): enforce bounded export snapshots

### DIFF
--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -38,7 +38,15 @@ vi.mock('electron', () => ({
 }))
 
 const { registerFileSaveHandlers: registerProductionFileSaveHandlers } = await import('./file-save')
-const registerFileSaveHandlers = registerProductionFileSaveHandlers
+const registerFileSaveHandlers = (
+  options: Parameters<typeof registerProductionFileSaveHandlers>[0] = {}
+): void => {
+  const openManagedFileVersion = options.openManagedFileVersion ?? options.openLatestManagedFile
+  registerProductionFileSaveHandlers({
+    ...options,
+    ...(openManagedFileVersion ? { openManagedFileVersion } : {})
+  })
+}
 
 type TestManagedVersionHandle = {
   size: number
@@ -91,7 +99,8 @@ type TestFileSaveOptions = Omit<
 // latest-version lease boundary without restoring a path fallback in the handler itself.
 const registerProjectFileSaveHandlers = (options: TestFileSaveOptions = {}): void => {
   const { resolveManagedFilePath, resolveSessionArtifactFilePath, ...productionOptions } = options
-  const openLatestManagedFile =
+  const openManagedFileVersion =
+    options.openManagedFileVersion ??
     options.openLatestManagedFile ??
     (resolveSessionArtifactFilePath || resolveManagedFilePath
       ? async (source: 'artifact' | 'upload', request: { projectId: string; fileId: string }) => {
@@ -115,7 +124,7 @@ const registerProjectFileSaveHandlers = (options: TestFileSaveOptions = {}): voi
 
   registerProductionFileSaveHandlers({
     ...productionOptions,
-    ...(openLatestManagedFile ? { openLatestManagedFile } : {})
+    ...(openManagedFileVersion ? { openManagedFileVersion } : {})
   })
 }
 
@@ -146,13 +155,20 @@ describe('file save IPC handlers', () => {
         {
           projectId: 'project-1',
           sessionId: 'session-1',
-          files: [{ fileId: 'artifact-report', suggestedName: 'report.csv' }]
+          files: [
+            {
+              fileId: 'artifact-report',
+              versionId: 'artifact-report-version',
+              suggestedName: 'report.csv'
+            }
+          ]
         }
       )
 
       expect(openLatestManagedFile).toHaveBeenCalledWith('artifact', {
         projectId: 'project-1',
-        fileId: 'artifact-report'
+        fileId: 'artifact-report',
+        versionId: 'artifact-report-version'
       })
       expect(showSaveDialog).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -165,6 +181,42 @@ describe('file save IPC handlers', () => {
     } finally {
       await rm(root, { recursive: true, force: true })
     }
+  })
+
+  it('opens the immutable Session Artifact Version selected in the renderer snapshot', async () => {
+    const copyTo = vi.fn().mockResolvedValue(undefined)
+    const close = vi.fn().mockResolvedValue(undefined)
+    const openLatestManagedFile = vi.fn()
+    const openManagedFileVersion = vi.fn().mockResolvedValue({ copyTo, close })
+    showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: join(downloadsPath, 'report.csv')
+    })
+    registerFileSaveHandlers({ openLatestManagedFile, openManagedFileVersion } as never)
+
+    await handlers.get('file:save-session-artifacts')!(
+      { sender: {} },
+      {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        files: [
+          {
+            fileId: 'artifact-report',
+            versionId: 'artifact-version-1',
+            suggestedName: 'report.csv'
+          }
+        ]
+      }
+    )
+
+    expect(openManagedFileVersion).toHaveBeenCalledWith('artifact', {
+      projectId: 'project-1',
+      fileId: 'artifact-report',
+      versionId: 'artifact-version-1'
+    })
+    expect(openLatestManagedFile).not.toHaveBeenCalled()
+    expect(copyTo).toHaveBeenCalledWith(join(downloadsPath, 'report.csv'))
+    expect(close).toHaveBeenCalledOnce()
   })
 
   it('exports multiple selected Session Artifacts after choosing one destination folder', async () => {
@@ -189,8 +241,8 @@ describe('file save IPC handlers', () => {
           projectId: 'project-1',
           sessionId: 'session-1',
           files: [
-            { fileId: 'artifact-a', suggestedName: 'a.csv' },
-            { fileId: 'artifact-b', suggestedName: 'b.png' }
+            { fileId: 'artifact-a', versionId: 'artifact-a-version', suggestedName: 'a.csv' },
+            { fileId: 'artifact-b', versionId: 'artifact-b-version', suggestedName: 'b.png' }
           ]
         }
       )
@@ -241,8 +293,8 @@ describe('file save IPC handlers', () => {
           projectId: 'project-1',
           sessionId: 'session-1',
           files: [
-            { fileId: 'artifact-a', suggestedName: 'report.csv' },
-            { fileId: 'artifact-b', suggestedName: 'report.csv' }
+            { fileId: 'artifact-a', versionId: 'artifact-a-version', suggestedName: 'report.csv' },
+            { fileId: 'artifact-b', versionId: 'artifact-b-version', suggestedName: 'report.csv' }
           ]
         }
       )
@@ -288,8 +340,8 @@ describe('file save IPC handlers', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         files: [
-          { fileId: 'artifact-a', suggestedName: 'a.csv' },
-          { fileId: 'artifact-b', suggestedName: 'b.csv' }
+          { fileId: 'artifact-a', versionId: 'artifact-a-version', suggestedName: 'a.csv' },
+          { fileId: 'artifact-b', versionId: 'artifact-b-version', suggestedName: 'b.csv' }
         ]
       }
     )
@@ -300,6 +352,7 @@ describe('file save IPC handlers', () => {
       failures: [
         {
           fileId: 'artifact-b',
+          versionId: 'artifact-b-version',
           suggestedName: 'b.csv',
           message: 'disk full'
         }
@@ -327,8 +380,12 @@ describe('file save IPC handlers', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         files: [
-          { fileId: 'artifact-missing', suggestedName: 'missing.csv' },
-          { fileId: 'artifact-b', suggestedName: 'b.csv' }
+          {
+            fileId: 'artifact-missing',
+            versionId: 'artifact-missing-version',
+            suggestedName: 'missing.csv'
+          },
+          { fileId: 'artifact-b', versionId: 'artifact-b-version', suggestedName: 'b.csv' }
         ]
       }
     )
@@ -339,6 +396,7 @@ describe('file save IPC handlers', () => {
       failures: [
         {
           fileId: 'artifact-missing',
+          versionId: 'artifact-missing-version',
           suggestedName: 'missing.csv',
           message: 'Artifact no longer exists'
         }
@@ -431,19 +489,21 @@ describe('file save IPC handlers', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         files: [
-          { fileId: 'artifact-a', suggestedName: 'a.csv' },
-          { fileId: 'artifact-b', suggestedName: 'b.csv' }
+          { fileId: 'artifact-a', versionId: 'artifact-a-version', suggestedName: 'a.csv' },
+          { fileId: 'artifact-b', versionId: 'artifact-b-version', suggestedName: 'b.csv' }
         ]
       }
     )
 
     expect(openLatestManagedFile).toHaveBeenNthCalledWith(1, 'artifact', {
       projectId: 'project-1',
-      fileId: 'artifact-a'
+      fileId: 'artifact-a',
+      versionId: 'artifact-a-version'
     })
     expect(openLatestManagedFile).toHaveBeenNthCalledWith(2, 'artifact', {
       projectId: 'project-1',
-      fileId: 'artifact-b'
+      fileId: 'artifact-b',
+      versionId: 'artifact-b-version'
     })
   })
 
@@ -468,19 +528,21 @@ describe('file save IPC handlers', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         files: [
-          { fileId: 'artifact-a', suggestedName: 'a.csv' },
-          { fileId: 'artifact-b', suggestedName: 'b.csv' }
+          { fileId: 'artifact-a', versionId: 'artifact-a-version', suggestedName: 'a.csv' },
+          { fileId: 'artifact-b', versionId: 'artifact-b-version', suggestedName: 'b.csv' }
         ]
       }
     )
 
     expect(openLatestManagedFile).toHaveBeenNthCalledWith(1, 'artifact', {
       projectId: 'project-1',
-      fileId: 'artifact-a'
+      fileId: 'artifact-a',
+      versionId: 'artifact-a-version'
     })
     expect(openLatestManagedFile).toHaveBeenNthCalledWith(2, 'artifact', {
       projectId: 'project-1',
-      fileId: 'artifact-b'
+      fileId: 'artifact-b',
+      versionId: 'artifact-b-version'
     })
     expect(resolveManagedFilePath).not.toHaveBeenCalled()
     expect(first.close).toHaveBeenCalledOnce()
@@ -854,18 +916,21 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'report.csv'
             },
             {
               source: 'upload',
               sessionId: 'session-2',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'report.csv'
             },
             {
               source: 'artifact',
               sessionId: 'session-2',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'notes.txt'
             }
           ]
@@ -893,7 +958,7 @@ describe('file save IPC handlers', () => {
     }
   })
 
-  it('reads each logical Project file from the current managed-file head', async () => {
+  it('reads each logical Project file from its selected managed Version', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-current-head-'))
     const destinationPath = join(root, 'Research-artifacts.zip')
     const resolveManagedFilePath = vi.fn().mockRejectedValue(new Error('stale path used'))
@@ -936,12 +1001,14 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'artifact-file-1',
+              versionId: 'artifact-file-1-version',
               suggestedName: 'report.csv'
             },
             {
               source: 'upload',
               sessionId: 'session-2',
               fileId: 'upload-file-1',
+              versionId: 'upload-file-1-version',
               suggestedName: 'data.csv'
             }
           ]
@@ -950,8 +1017,22 @@ describe('file save IPC handlers', () => {
 
       expect(result).toEqual({ saved: true, filePath: destinationPath })
       expect(openLatestManagedFile.mock.calls).toEqual([
-        ['artifact', { projectId: 'project-1', fileId: 'artifact-file-1' }],
-        ['upload', { projectId: 'project-1', fileId: 'upload-file-1' }]
+        [
+          'artifact',
+          {
+            projectId: 'project-1',
+            fileId: 'artifact-file-1',
+            versionId: 'artifact-file-1-version'
+          }
+        ],
+        [
+          'upload',
+          {
+            projectId: 'project-1',
+            fileId: 'upload-file-1',
+            versionId: 'upload-file-1-version'
+          }
+        ]
       ])
       expect(resolveManagedFilePath).not.toHaveBeenCalled()
       expect(resolveSessionArtifactFilePath).not.toHaveBeenCalled()
@@ -1000,6 +1081,7 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'artifact-file-1',
+              versionId: 'artifact-file-1-version',
               suggestedName: 'report.csv'
             }
           ]
@@ -1032,6 +1114,7 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'report.csv'
             }
           ]
@@ -1073,6 +1156,7 @@ describe('file save IPC handlers', () => {
                 source: 'artifact',
                 sessionId: 'session-1',
                 fileId: 'test-file-id',
+                versionId: 'test-file-id-version',
                 suggestedName: 'report.csv'
               }
             ]
@@ -1121,6 +1205,7 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'artifact-file-1',
+              versionId: 'artifact-file-1-version',
               suggestedName: 'report.csv'
             }
           ]
@@ -1134,6 +1219,7 @@ describe('file save IPC handlers', () => {
             source: 'artifact',
             sessionId: 'session-1',
             fileId: 'artifact-file-1',
+            versionId: 'artifact-file-1-version',
             suggestedName: 'report.csv',
             message: 'Managed version storage is unavailable.'
           }
@@ -1170,6 +1256,7 @@ describe('file save IPC handlers', () => {
             source: 'artifact',
             sessionId: 'session-1',
             fileId: 'artifact-file-1',
+            versionId: 'artifact-file-1-version',
             suggestedName: 'report.csv'
           }
         ]
@@ -1183,6 +1270,7 @@ describe('file save IPC handlers', () => {
           source: 'artifact',
           sessionId: 'session-1',
           fileId: 'artifact-file-1',
+          versionId: 'artifact-file-1-version',
           suggestedName: 'report.csv',
           message: 'Managed file version content is unavailable or corrupt.'
         }
@@ -1192,18 +1280,23 @@ describe('file save IPC handlers', () => {
     expect(showSaveDialog).not.toHaveBeenCalled()
   })
 
-  it('does not let a stale Project version hint bypass latest resolution', async () => {
+  it('opens the immutable Project file Version selected in the renderer snapshot', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-version-'))
+    const destinationPath = join(root, 'Research-artifacts.zip')
     const resolveSessionArtifactFilePath = vi.fn()
     const openLatestManagedFile = vi.fn()
-    const openManagedFileVersion = vi.fn()
+    const openManagedFileVersion = vi
+      .fn()
+      .mockResolvedValue(managedVersionHandle('selected artifact version'))
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
     registerProjectFileSaveHandlers({
       resolveSessionArtifactFilePath,
       openLatestManagedFile,
       openManagedFileVersion
     } as never)
 
-    await expect(
-      handlers.get('file:save-project-artifacts')!(
+    try {
+      await handlers.get('file:save-project-artifacts')!(
         { sender: {} },
         {
           projectId: 'project-1',
@@ -1219,11 +1312,20 @@ describe('file save IPC handlers', () => {
           ]
         }
       )
-    ).rejects.toThrow('Invalid Project Artifact save request.')
+      expect(openManagedFileVersion).toHaveBeenCalledWith('artifact', {
+        projectId: 'project-1',
+        fileId: 'artifact-file-1',
+        versionId: 'artifact-version-1'
+      })
+      const entries = unzipSync(new Uint8Array(await readFile(destinationPath)))
+      expect(Buffer.from(entries['generated/report.csv']!).toString('utf8')).toBe(
+        'selected artifact version'
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
     expect(openLatestManagedFile).not.toHaveBeenCalled()
-    expect(openManagedFileVersion).not.toHaveBeenCalled()
     expect(resolveSessionArtifactFilePath).not.toHaveBeenCalled()
-    expect(showSaveDialog).not.toHaveBeenCalled()
   })
 
   it('applies collision suffixes within each source category only', async () => {
@@ -1257,18 +1359,21 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'report.csv'
             },
             {
               source: 'upload',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'report.csv'
             },
             {
               source: 'artifact',
               sessionId: 'session-2',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'report.csv'
             }
           ]
@@ -1313,12 +1418,14 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'report.csv'
             },
             {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'gone.csv'
             }
           ]
@@ -1333,6 +1440,7 @@ describe('file save IPC handlers', () => {
             source: 'artifact',
             sessionId: 'session-1',
             fileId: 'test-file-id',
+            versionId: 'test-file-id-version',
             suggestedName: 'gone.csv',
             message: 'Artifact bytes are unavailable.'
           }
@@ -1364,6 +1472,7 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'report.csv'
             }
           ]
@@ -1392,6 +1501,7 @@ describe('file save IPC handlers', () => {
             source: 'artifact',
             sessionId: 'session-1',
             fileId: 'test-file-id',
+            versionId: 'test-file-id-version',
             suggestedName: 'gone.csv'
           }
         ]
@@ -1406,6 +1516,7 @@ describe('file save IPC handlers', () => {
           source: 'artifact',
           sessionId: 'session-1',
           fileId: 'test-file-id',
+          versionId: 'test-file-id-version',
           suggestedName: 'gone.csv',
           message: 'Artifact bytes are unavailable.'
         }
@@ -1440,12 +1551,14 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'small.txt'
             },
             {
               source: 'upload',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'big.txt'
             }
           ]
@@ -1460,6 +1573,7 @@ describe('file save IPC handlers', () => {
             source: 'upload',
             sessionId: 'session-1',
             fileId: 'test-file-id',
+            versionId: 'test-file-id-version',
             suggestedName: 'big.txt',
             message: 'Project export file exceeds the per-file size limit.'
           }
@@ -1500,12 +1614,14 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'first.txt'
             },
             {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'second.txt'
             }
           ]
@@ -1520,6 +1636,7 @@ describe('file save IPC handlers', () => {
             source: 'artifact',
             sessionId: 'session-1',
             fileId: 'test-file-id',
+            versionId: 'test-file-id-version',
             suggestedName: 'second.txt',
             message: 'Project export exceeds the total size limit.'
           }
@@ -1560,12 +1677,14 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'first.txt'
             },
             {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'second.txt'
             }
           ]
@@ -1580,6 +1699,7 @@ describe('file save IPC handlers', () => {
             source: 'artifact',
             sessionId: 'session-1',
             fileId: 'test-file-id',
+            versionId: 'test-file-id-version',
             suggestedName: 'second.txt',
             message: 'Project export exceeds the file-count limit.'
           }
@@ -1617,12 +1737,14 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: '..\\..\\evil.exe'
             },
             {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'nested/dir/notes.txt'
             }
           ]
@@ -1673,6 +1795,7 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: '__proto__'
             }
           ]
@@ -1716,6 +1839,7 @@ describe('file save IPC handlers', () => {
                 source: 'artifact',
                 sessionId: 'session-1',
                 fileId: 'test-file-id',
+                versionId: 'test-file-id-version',
                 suggestedName: 'report.csv'
               }
             ]
@@ -1750,6 +1874,7 @@ describe('file save IPC handlers', () => {
             source: 'artifact',
             sessionId: 'session-1',
             fileId: 'test-file-id',
+            versionId: 'test-file-id-version',
             suggestedName: 'fifo.csv'
           }
         ]
@@ -1763,6 +1888,7 @@ describe('file save IPC handlers', () => {
           source: 'artifact',
           sessionId: 'session-1',
           fileId: 'test-file-id',
+          versionId: 'test-file-id-version',
           suggestedName: 'fifo.csv',
           message: 'Project export source size is invalid.'
         }
@@ -1780,6 +1906,7 @@ describe('file save IPC handlers', () => {
       source: 'artifact',
       sessionId: 'session-1',
       fileId: 'test-file-id',
+      versionId: 'test-file-id-version',
       suggestedName: `${index}.txt`
     }))
 
@@ -1821,6 +1948,7 @@ describe('file save IPC handlers', () => {
                 source: 'artifact',
                 sessionId: 'session-1',
                 fileId: 'test-file-id',
+                versionId: 'test-file-id-version',
                 suggestedName: 'report.csv'
               }
             ]
@@ -1861,12 +1989,14 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'A.csv'
             },
             {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'a.csv'
             }
           ]
@@ -1903,6 +2033,7 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'a<b>.csv'
             }
           ]
@@ -1941,6 +2072,7 @@ describe('file save IPC handlers', () => {
               source: 'artifact',
               sessionId: 'session-1',
               fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
               suggestedName: 'exact.bin'
             }
           ]
@@ -1962,6 +2094,7 @@ describe('file save IPC handlers', () => {
       source: 'artifact',
       sessionId: 'session-1',
       fileId: 'artifact-file-1',
+      versionId: 'artifact-file-1-version',
       suggestedName: 'report.csv'
     }
 
@@ -1992,6 +2125,16 @@ describe('file save IPC handlers', () => {
           projectId: 'project-1',
           suggestedArchiveName: 'Research',
           files: [{ ...baseFile, fileId: undefined }]
+        }
+      )
+    ).rejects.toThrow('Invalid Project Artifact save request.')
+    await expect(
+      handlers.get('file:save-project-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          suggestedArchiveName: 'Research',
+          files: [{ ...baseFile, versionId: undefined }]
         }
       )
     ).rejects.toThrow('Invalid Project Artifact save request.')
@@ -2233,6 +2376,7 @@ describe('assertSaveSessionArtifactsRequest logical identity validation', () => 
     { identity: {}, label: 'missing file id' },
     { identity: { fileId: 42 }, label: 'numeric file id' },
     { identity: { fileId: '   ' }, label: 'blank file id' },
+    { identity: { fileId: 'artifact-1' }, label: 'missing version id' },
     { identity: { fileId: 'artifact-1', versionId: 42 }, label: 'numeric version id' },
     { identity: { fileId: 'artifact-1', versionId: '' }, label: 'blank version id' },
     { identity: { versionId: 'artifact-v1' }, label: 'version without file id' }

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -151,12 +151,13 @@ const assertSaveSessionArtifactsRequest: (
         file === null ||
         typeof file.fileId !== 'string' ||
         file.fileId.trim().length === 0 ||
+        typeof file.versionId !== 'string' ||
+        file.versionId.trim().length === 0 ||
         typeof file.suggestedName !== 'string'
       ) {
         return true
       }
       if ('path' in file && file.path !== undefined) return true
-      if ('versionId' in file && file.versionId !== undefined) return true
       return false
     })
   ) {
@@ -186,7 +187,8 @@ const assertSaveProjectArtifactsRequest = (request: SaveProjectArtifactsRequest)
         return true
       }
       if (typeof file.fileId !== 'string' || file.fileId.trim().length === 0) return true
-      if ('path' in file || ('versionId' in file && file.versionId !== undefined)) return true
+      if (typeof file.versionId !== 'string' || file.versionId.trim().length === 0) return true
+      if ('path' in file) return true
       return false
     })
   ) {
@@ -582,9 +584,9 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
     'file:save-session-artifacts',
     async (event, request: SaveSessionArtifactsRequest): Promise<SaveSessionArtifactsResult> => {
       assertSaveSessionArtifactsRequest(request)
-      const openLatestManagedFile = options.openLatestManagedFile
-      if (!openLatestManagedFile) {
-        throw new Error('Latest managed file resolver is not configured.')
+      const openManagedFileVersion = options.openManagedFileVersion
+      if (!openManagedFileVersion) {
+        throw new Error('Managed file Version resolver is not configured.')
       }
       const parentWindow = BrowserWindow.fromWebContents(event.sender)
 
@@ -601,9 +603,10 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
 
         if (canceled || !filePath) return { saved: false }
 
-        const managedFile = await openLatestManagedFile('artifact', {
+        const managedFile = await openManagedFileVersion('artifact', {
           projectId: request.projectId,
-          fileId: file.fileId
+          fileId: file.fileId,
+          versionId: file.versionId
         })
 
         try {
@@ -632,9 +635,10 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
       for (const file of request.files) {
         let managedFile: ManagedFileHandle | undefined
         try {
-          managedFile = await openLatestManagedFile('artifact', {
+          managedFile = await openManagedFileVersion('artifact', {
             projectId: request.projectId,
-            fileId: file.fileId
+            fileId: file.fileId,
+            versionId: file.versionId
           })
           const safeName = getSafeFilename(file.suggestedName, file.fileId)
           savedPaths.push(
@@ -663,9 +667,9 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
     'file:save-project-artifacts',
     async (event, request: SaveProjectArtifactsRequest): Promise<SaveProjectArtifactsResult> => {
       assertSaveProjectArtifactsRequest(request)
-      const openLatestManagedFile = options.openLatestManagedFile
-      if (!openLatestManagedFile) {
-        throw new Error('Latest managed file resolver is not configured.')
+      const openManagedFileVersion = options.openManagedFileVersion
+      if (!openManagedFileVersion) {
+        throw new Error('Managed file Version resolver is not configured.')
       }
 
       const limits = options.projectArtifactExportLimits ?? PROJECT_ARTIFACT_EXPORT_LIMITS
@@ -680,9 +684,10 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
           if (takenNames.size >= limits.maxFiles) {
             throw new Error('Project export exceeds the file-count limit.')
           }
-          const managedVersion = await openLatestManagedFile(file.source, {
+          const managedVersion = await openManagedFileVersion(file.source, {
             projectId: request.projectId,
-            fileId: file.fileId
+            fileId: file.fileId,
+            versionId: file.versionId
           })
           exportFile = managedVersion
           if (!Number.isSafeInteger(managedVersion.size) || managedVersion.size < 0) {

--- a/src/main/managed-preview-resources.test.ts
+++ b/src/main/managed-preview-resources.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rename, rm, stat, truncate, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { deflateSync } from 'node:zlib'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -38,6 +39,41 @@ describe('ManagedPreviewResources', () => {
       modifiedAtMs: value.mtimeMs,
       changedAtMs: value.ctimeMs
     }
+  }
+
+  const crc32 = (bytes: Buffer): number => {
+    let crc = 0xffffffff
+    for (const byte of bytes) {
+      crc ^= byte
+      for (let bit = 0; bit < 8; bit += 1) {
+        crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0)
+      }
+    }
+    return (crc ^ 0xffffffff) >>> 0
+  }
+
+  const pngChunk = (type: string, data: Buffer): Buffer => {
+    const typeBytes = Buffer.from(type, 'ascii')
+    const chunk = Buffer.alloc(12 + data.byteLength)
+    chunk.writeUInt32BE(data.byteLength, 0)
+    typeBytes.copy(chunk, 4)
+    data.copy(chunk, 8)
+    chunk.writeUInt32BE(crc32(Buffer.concat([typeBytes, data])), 8 + data.byteLength)
+    return chunk
+  }
+
+  const createCompressedPng = (width: number, height: number): Buffer => {
+    const ihdr = Buffer.alloc(13)
+    ihdr.writeUInt32BE(width, 0)
+    ihdr.writeUInt32BE(height, 4)
+    ihdr.set([1, 0, 0, 0, 0], 8)
+    const rowBytes = 1 + Math.ceil(width / 8)
+    return Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      pngChunk('IHDR', ihdr),
+      pngChunk('IDAT', deflateSync(Buffer.alloc(rowBytes * height))),
+      pngChunk('IEND', Buffer.alloc(0))
+    ])
   }
 
   it('registers the preview scheme for streaming and cross-scheme capability fetches', () => {
@@ -87,6 +123,20 @@ describe('ManagedPreviewResources', () => {
       total: 10,
       data: new Uint8Array(Buffer.from('2345'))
     })
+  })
+
+  it('rejects an ordinary image preview above the decoded pixel budget before minting a URL', async () => {
+    const filePath = await createFile(createCompressedPng(5_000, 5_000), 'large.png')
+    const createId = vi.fn(() => 'unsafe-image-resource')
+    const resources = new ManagedPreviewResources({
+      resolvePath: async () => filePath,
+      createId
+    })
+
+    await expect(
+      resources.acquire(17, { source: 'local', path: filePath, mimeType: 'image/png' })
+    ).rejects.toThrow(/16,000,000.*pixel/i)
+    expect(createId).not.toHaveBeenCalled()
   })
 
   it('reads a logical managed version through its trusted lease and closes it on release', async () => {

--- a/src/main/managed-preview-resources.ts
+++ b/src/main/managed-preview-resources.ts
@@ -13,8 +13,15 @@ import type {
   ReleaseManagedPreviewRequest
 } from '../shared/preview-resources'
 import type { ManagedFileReadLease } from './managed-file-versions/service'
+import {
+  exceedsDecodedImagePixelLimit,
+  isPixelLimitedRasterMimeType,
+  MAX_DECODED_IMAGE_PIXELS,
+  readRasterImageDimensions
+} from './raster-image-safety'
 
 const MAX_PREVIEW_RANGE_BYTES = 1024 * 1024
+const MAX_IMAGE_HEADER_BYTES = 1024 * 1024
 const MAX_RELEASED_RESOURCE_TOMBSTONES = 1024
 const PREVIEW_SCHEME = 'open-science-preview'
 const MANAGED_PREVIEW_SCHEME = {
@@ -251,12 +258,59 @@ class ManagedPreviewResources {
         throw new Error('Managed preview file changed after admission.')
       }
 
+      const mimeType = inferMimeType(filePath, request.mimeType)
+      if (isPixelLimitedRasterMimeType(mimeType)) {
+        const headerLength = Math.min(fileSnapshot.size, MAX_IMAGE_HEADER_BYTES)
+        let header: Buffer
+        if (trustedLease) {
+          const bytes = await trustedLease.readRange(0, headerLength)
+          if (bytes.byteLength !== headerLength) {
+            throw new Error('Image preview changed while reading its dimensions.')
+          }
+          header = Buffer.from(bytes)
+          await trustedLease.verifyUnchanged()
+        } else {
+          const fileHandle = await open(filePath, 'r')
+          try {
+            const before = snapshotFileStat(await fileHandle.stat({ bigint: true }))
+            if (
+              before.size !== fileSnapshot.size ||
+              before.mtimeNs !== fileSnapshot.mtimeNs ||
+              before.dev !== fileSnapshot.dev ||
+              before.ino !== fileSnapshot.ino
+            ) {
+              throw new Error('Image preview changed before reading its dimensions.')
+            }
+            header = Buffer.allocUnsafe(headerLength)
+            if (headerLength > 0) await readExactRange(fileHandle, header, 0)
+            const after = snapshotFileStat(await fileHandle.stat({ bigint: true }))
+            if (
+              after.size !== fileSnapshot.size ||
+              after.mtimeNs !== fileSnapshot.mtimeNs ||
+              after.dev !== fileSnapshot.dev ||
+              after.ino !== fileSnapshot.ino
+            ) {
+              throw new Error('Image preview changed while reading its dimensions.')
+            }
+          } finally {
+            await fileHandle.close()
+          }
+        }
+        const dimensions = readRasterImageDimensions(header, mimeType)
+        if (!dimensions) throw new Error('Could not read image preview dimensions safely.')
+        if (exceedsDecodedImagePixelLimit(dimensions)) {
+          throw new Error(
+            `Image preview exceeds the ${MAX_DECODED_IMAGE_PIXELS.toLocaleString('en-US')}-pixel limit.`
+          )
+        }
+      }
+
       const id = this.createId()
       const resource: ManagedPreviewResource = {
         id,
         url: `${PREVIEW_SCHEME}://${id}/${encodeURIComponent(basename(filePath))}`,
         size: fileSnapshot.size,
-        mimeType: inferMimeType(filePath, request.mimeType),
+        mimeType,
         version: fileSnapshot.version
       }
 

--- a/src/main/raster-image-safety.ts
+++ b/src/main/raster-image-safety.ts
@@ -1,0 +1,123 @@
+export const MAX_DECODED_IMAGE_PIXELS = 16_000_000
+
+export type RasterImageMimeType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
+export type RasterImageDimensions = { width: number; height: number }
+
+const JPEG_START_OF_FRAME_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf
+])
+
+const readPngDimensions = (bytes: Buffer): RasterImageDimensions | undefined => {
+  if (
+    bytes.length < 33 ||
+    !bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) ||
+    bytes.readUInt32BE(8) !== 13 ||
+    bytes.toString('ascii', 12, 16) !== 'IHDR'
+  ) {
+    return undefined
+  }
+  return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) }
+}
+
+const readJpegDimensions = (bytes: Buffer): RasterImageDimensions | undefined => {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8 || bytes[2] !== 0xff) {
+    return undefined
+  }
+  let offset = 2
+  while (offset < bytes.length) {
+    if (bytes[offset] !== 0xff) return undefined
+    while (offset < bytes.length && bytes[offset] === 0xff) offset += 1
+    if (offset >= bytes.length) return undefined
+
+    const marker = bytes[offset]
+    offset += 1
+    if (
+      marker === 0x00 ||
+      marker === 0x01 ||
+      marker === 0xd8 ||
+      marker === 0xd9 ||
+      marker === 0xda ||
+      (marker >= 0xd0 && marker <= 0xd7)
+    ) {
+      return undefined
+    }
+    if (offset + 2 > bytes.length) return undefined
+
+    const segmentLength = bytes.readUInt16BE(offset)
+    if (segmentLength < 2 || offset + segmentLength > bytes.length) return undefined
+    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
+      if (segmentLength < 11) return undefined
+      const samplePrecision = bytes[offset + 2]
+      const componentCount = bytes[offset + 7]
+      if (samplePrecision === 0 || componentCount < 1 || segmentLength !== 8 + 3 * componentCount) {
+        return undefined
+      }
+      return {
+        width: bytes.readUInt16BE(offset + 5),
+        height: bytes.readUInt16BE(offset + 3)
+      }
+    }
+    offset += segmentLength
+  }
+  return undefined
+}
+
+const readGifDimensions = (bytes: Buffer): RasterImageDimensions | undefined => {
+  const signature = bytes.toString('ascii', 0, 6)
+  if (bytes.length < 10 || (signature !== 'GIF87a' && signature !== 'GIF89a')) return undefined
+  return { width: bytes.readUInt16LE(6), height: bytes.readUInt16LE(8) }
+}
+
+const readWebpDimensions = (bytes: Buffer): RasterImageDimensions | undefined => {
+  if (
+    bytes.length < 25 ||
+    bytes.toString('ascii', 0, 4) !== 'RIFF' ||
+    bytes.toString('ascii', 8, 12) !== 'WEBP'
+  ) {
+    return undefined
+  }
+  const chunk = bytes.toString('ascii', 12, 16)
+  if (chunk === 'VP8X' && bytes.length >= 30) {
+    return {
+      width: bytes.readUIntLE(24, 3) + 1,
+      height: bytes.readUIntLE(27, 3) + 1
+    }
+  }
+  if (
+    chunk === 'VP8 ' &&
+    bytes.length >= 30 &&
+    bytes[23] === 0x9d &&
+    bytes[24] === 0x01 &&
+    bytes[25] === 0x2a
+  ) {
+    return {
+      width: bytes.readUInt16LE(26) & 0x3fff,
+      height: bytes.readUInt16LE(28) & 0x3fff
+    }
+  }
+  if (chunk === 'VP8L' && bytes[20] === 0x2f) {
+    return {
+      width: 1 + bytes[21] + ((bytes[22] & 0x3f) << 8),
+      height: 1 + (bytes[22] >> 6) + (bytes[23] << 2) + ((bytes[24] & 0x0f) << 10)
+    }
+  }
+  return undefined
+}
+
+export const isPixelLimitedRasterMimeType = (value: string): value is RasterImageMimeType =>
+  value === 'image/png' || value === 'image/jpeg' || value === 'image/gif' || value === 'image/webp'
+
+export const readRasterImageDimensions = (
+  bytes: Buffer,
+  mimeType: RasterImageMimeType
+): RasterImageDimensions | undefined => {
+  if (mimeType === 'image/png') return readPngDimensions(bytes)
+  if (mimeType === 'image/jpeg') return readJpegDimensions(bytes)
+  if (mimeType === 'image/gif') return readGifDimensions(bytes)
+  return readWebpDimensions(bytes)
+}
+
+export const exceedsDecodedImagePixelLimit = (size: RasterImageDimensions): boolean =>
+  size.width < 1 ||
+  size.height < 1 ||
+  size.width > Math.floor(MAX_DECODED_IMAGE_PIXELS / size.height)

--- a/src/main/session-persistence/conversation-export.test.ts
+++ b/src/main/session-persistence/conversation-export.test.ts
@@ -75,7 +75,9 @@ describe('conversation export service', () => {
     printToPDF.mockResolvedValue(Buffer.from('pdf'))
   })
 
-  const createService = (): ReturnType<typeof createConversationExportService> =>
+  const createService = (
+    overrides: Record<string, unknown> = {}
+  ): ReturnType<typeof createConversationExportService> =>
     createConversationExportService({
       loadSession,
       isSessionActive,
@@ -86,8 +88,9 @@ describe('conversation export service', () => {
       createPrintWindow,
       getDownloadsPath: () => '/downloads',
       getTempPath: () => '/tmp',
-      now: () => 3
-    })
+      now: () => 3,
+      ...overrides
+    } as Parameters<typeof createConversationExportService>[0])
 
   it('loads the durable session and saves normalized Markdown', async () => {
     const result = await createService().exportConversation({
@@ -217,6 +220,92 @@ describe('conversation export service', () => {
     expect(destroy).toHaveBeenCalledOnce()
     expect(removeDirectory).toHaveBeenCalledWith('/tmp/open-science-conversation-export-test')
     expect(result).toEqual({ saved: true, filePath: '/downloads/export.pdf' })
+  })
+
+  it('rejects oversized message and image selections before opening Save As', async () => {
+    loadSession.mockResolvedValue({
+      ...session,
+      messages: [
+        ...session.messages,
+        {
+          ...session.messages[0],
+          id: 'message-2',
+          images: [{ id: 'image-1', mimeType: 'image/png', data: 'AAAAAA' }]
+        }
+      ]
+    })
+    const exportLimits = {
+      maxMessages: 1,
+      maxImageBase64Bytes: 5,
+      maxHtmlBytes: 1_000_000,
+      pdfPrintTimeoutMs: 1_000
+    }
+
+    await expect(
+      createService({ exportLimits }).exportConversation({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        format: 'pdf'
+      })
+    ).rejects.toThrow(/select fewer conversation turns/i)
+    await expect(
+      createService({ exportLimits: { ...exportLimits, maxMessages: 10 } }).exportConversation({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        format: 'pdf'
+      })
+    ).rejects.toThrow(/select fewer conversation turns/i)
+    expect(showSaveDialog).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized rendered HTML before creating a print window', async () => {
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: '/downloads/export.pdf' })
+
+    await expect(
+      createService({
+        exportLimits: {
+          maxMessages: 10,
+          maxImageBase64Bytes: 1_000_000,
+          maxHtmlBytes: 100,
+          pdfPrintTimeoutMs: 1_000
+        }
+      }).exportConversation({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        format: 'pdf'
+      })
+    ).rejects.toThrow(/select fewer conversation turns/i)
+    expect(createPrintWindow).not.toHaveBeenCalled()
+  })
+
+  it('times out PDF printing and destroys the hidden window', async () => {
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: '/downloads/export.pdf' })
+    printToPDF.mockReturnValue(new Promise(() => undefined))
+    const exportPromise = createService({
+      exportLimits: {
+        maxMessages: 10,
+        maxImageBase64Bytes: 1_000_000,
+        maxHtmlBytes: 1_000_000,
+        pdfPrintTimeoutMs: 5
+      }
+    }).exportConversation({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      format: 'pdf'
+    })
+
+    const outcome = await Promise.race([
+      exportPromise.then(
+        () => 'resolved',
+        (error: unknown) => error
+      ),
+      new Promise<'still-pending'>((resolve) => setTimeout(() => resolve('still-pending'), 50))
+    ])
+
+    expect(outcome).toBeInstanceOf(Error)
+    expect((outcome as Error).message).toMatch(/timed out/i)
+    expect(destroy).toHaveBeenCalledOnce()
+    expect(removeDirectory).toHaveBeenCalledWith('/tmp/open-science-conversation-export-test')
   })
 
   it('destroys the print window when PDF generation fails', async () => {

--- a/src/main/session-persistence/conversation-export.ts
+++ b/src/main/session-persistence/conversation-export.ts
@@ -9,6 +9,7 @@ import {
   renderConversationHtml,
   renderConversationMarkdown,
   sanitizeExportFilename,
+  selectConversationExportMessages,
   type ExportConversationRequest,
   type ExportConversationResult
 } from '../../shared/conversation-export'
@@ -23,6 +24,20 @@ type ConversationExportPrintWindow = {
     printToPDF(options: Electron.PrintToPDFOptions): Promise<Buffer>
   }
   destroy(): void
+}
+
+type ConversationExportLimits = {
+  maxMessages: number
+  maxImageBase64Bytes: number
+  maxHtmlBytes: number
+  pdfPrintTimeoutMs: number
+}
+
+const DEFAULT_CONVERSATION_EXPORT_LIMITS: ConversationExportLimits = {
+  maxMessages: 2000,
+  maxImageBase64Bytes: 32 * 1024 * 1024,
+  maxHtmlBytes: 64 * 1024 * 1024,
+  pdfPrintTimeoutMs: 120_000
 }
 
 type ConversationExportDependencies = {
@@ -40,6 +55,7 @@ type ConversationExportDependencies = {
   getTempPath(): string
   now(): number
   translate: NativeTranslator
+  exportLimits: ConversationExportLimits
 }
 
 type ConversationExportRequiredDependencies = Pick<
@@ -105,8 +121,28 @@ const defaultDependencies: ConversationExportDefaultDependencies = {
   getDownloadsPath: () => app.getPath('downloads'),
   getTempPath: () => app.getPath('temp'),
   now: Date.now,
-  translate: englishNativeTranslator
+  translate: englishNativeTranslator,
+  exportLimits: DEFAULT_CONVERSATION_EXPORT_LIMITS
 }
+
+const printToPdfWithTimeout = (
+  print: Promise<Buffer>,
+  timeoutMs: number,
+  timeoutError: () => Error
+): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(timeoutError()), timeoutMs)
+    void print.then(
+      (pdf) => {
+        clearTimeout(timeout)
+        resolve(pdf)
+      },
+      (error: unknown) => {
+        clearTimeout(timeout)
+        reject(error)
+      }
+    )
+  })
 
 const createConversationExportService = (
   dependencies: ConversationExportRequiredDependencies &
@@ -133,6 +169,29 @@ const createConversationExportService = (
         throw new Error('Wait for the conversation to finish before exporting it.')
       }
       if (session.messages.length === 0) throw new Error('Conversation has no messages to export.')
+
+      const selectedMessages = selectConversationExportMessages(
+        session.messages,
+        request.selectedPromptMessageIds
+      )
+      const exceedsMessageBudget = selectedMessages.length > deps.exportLimits.maxMessages
+      const imageBase64Bytes =
+        request.format === 'pdf'
+          ? selectedMessages.reduce(
+              (total, message) =>
+                total +
+                (message.images ?? []).reduce(
+                  (messageTotal, image) => messageTotal + Buffer.byteLength(image.data, 'ascii'),
+                  0
+                ),
+              0
+            )
+          : 0
+      if (exceedsMessageBudget || imageBase64Bytes > deps.exportLimits.maxImageBase64Bytes) {
+        throw new Error(
+          deps.translate('Conversation export is too large. Select fewer conversation turns.')
+        )
+      }
 
       const document = createConversationExportDocument(
         session,
@@ -161,11 +220,16 @@ const createConversationExportService = (
         return { saved: true, filePath: dialogResult.filePath }
       }
 
+      const html = renderConversationHtml(document)
+      if (Buffer.byteLength(html, 'utf8') > deps.exportLimits.maxHtmlBytes) {
+        throw new Error(
+          deps.translate('Conversation export is too large. Select fewer conversation turns.')
+        )
+      }
       const tempDirectory = await deps.createTempDirectory(
         join(deps.getTempPath(), 'open-science-conversation-export-')
       )
       try {
-        const html = renderConversationHtml(document)
         const htmlPath = join(tempDirectory, 'conversation.html')
         await deps.writeFile(htmlPath, html)
 
@@ -175,16 +239,25 @@ const createConversationExportService = (
           await printWindow.webContents.executeJavaScript(
             'document.fonts ? document.fonts.ready.then(() => true) : true'
           )
-          const pdf = await printWindow.webContents.printToPDF({
-            pageSize: 'A4',
-            printBackground: true,
-            margins: {
-              top: 0.2,
-              bottom: 0.2,
-              left: 0.2,
-              right: 0.2
-            }
-          })
+          const pdf = await printToPdfWithTimeout(
+            printWindow.webContents.printToPDF({
+              pageSize: 'A4',
+              printBackground: true,
+              margins: {
+                top: 0.2,
+                bottom: 0.2,
+                left: 0.2,
+                right: 0.2
+              }
+            }),
+            deps.exportLimits.pdfPrintTimeoutMs,
+            () =>
+              new Error(
+                deps.translate(
+                  'Conversation PDF export timed out. Select fewer conversation turns.'
+                )
+              )
+          )
           await deps.writeFile(dialogResult.filePath, pdf)
           return { saved: true, filePath: dialogResult.filePath }
         } finally {
@@ -208,6 +281,7 @@ const registerConversationExportIpcHandler = (service: ConversationExportService
 export { createConversationExportService, registerConversationExportIpcHandler }
 export type {
   ConversationExportDependencies,
+  ConversationExportLimits,
   ConversationExportPrintWindow,
   ConversationExportService
 }

--- a/src/main/uploads/attachment-media.ts
+++ b/src/main/uploads/attachment-media.ts
@@ -5,6 +5,12 @@ import { pathToFileURL } from 'node:url'
 
 import type { Sharp } from 'sharp'
 import { ResourceBudgetExceededError } from '../resource-budget'
+import {
+  exceedsDecodedImagePixelLimit,
+  MAX_DECODED_IMAGE_PIXELS,
+  readRasterImageDimensions,
+  type RasterImageDimensions
+} from '../raster-image-safety'
 
 import { joinPdfTextItems } from '../../shared/pdf-text'
 
@@ -33,7 +39,7 @@ export const MAX_IMAGE_LONG_EDGE = 1568
 // Keep the cheap PNG/JPEG header preflight in front of sharp's decoder-side pixel limit so
 // malformed or oversized inputs fail before native decoding and allocation. 16 MP is at most
 // ~64 MiB at four bytes per pixel, which bounds processing independently of compressed size.
-export const MAX_DECODED_IMAGE_PIXELS = 16_000_000
+export { MAX_DECODED_IMAGE_PIXELS }
 
 // A conversation replays its full history every turn, so inlined image payloads accumulate across
 // turns even though each image is individually capped. Once the running base64 total nears the
@@ -221,69 +227,11 @@ const detectedImageMimeType = (bytes: Buffer): 'image/png' | 'image/jpeg' | unde
     : undefined
 }
 
-type ImageDimensions = { width: number; height: number }
-
-const JPEG_START_OF_FRAME_MARKERS = new Set([
-  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf
-])
-
-const declaredPngDimensions = (bytes: Buffer): ImageDimensions | undefined => {
-  if (
-    bytes.length < 33 ||
-    bytes.readUInt32BE(8) !== 13 ||
-    bytes.toString('ascii', 12, 16) !== 'IHDR'
-  ) {
-    return undefined
-  }
-  return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) }
-}
-
-const declaredJpegDimensions = (bytes: Buffer): ImageDimensions | undefined => {
-  let offset = 2
-  while (offset < bytes.length) {
-    if (bytes[offset] !== 0xff) return undefined
-    while (offset < bytes.length && bytes[offset] === 0xff) offset += 1
-    if (offset >= bytes.length) return undefined
-
-    const marker = bytes[offset]
-    offset += 1
-    if (
-      marker === 0x00 ||
-      marker === 0x01 ||
-      marker === 0xd8 ||
-      marker === 0xd9 ||
-      marker === 0xda ||
-      (marker >= 0xd0 && marker <= 0xd7)
-    ) {
-      return undefined
-    }
-    if (offset + 2 > bytes.length) return undefined
-
-    const segmentLength = bytes.readUInt16BE(offset)
-    if (segmentLength < 2 || offset + segmentLength > bytes.length) return undefined
-    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
-      if (segmentLength < 11) return undefined
-      const samplePrecision = bytes[offset + 2]
-      const componentCount = bytes[offset + 7]
-      if (samplePrecision === 0 || componentCount < 1 || segmentLength !== 8 + 3 * componentCount) {
-        return undefined
-      }
-      return {
-        width: bytes.readUInt16BE(offset + 5),
-        height: bytes.readUInt16BE(offset + 3)
-      }
-    }
-    offset += segmentLength
-  }
-  return undefined
-}
-
 const declaredImageDimensions = (
   bytes: Buffer,
   mimeType: 'image/png' | 'image/jpeg'
-): ImageDimensions => {
-  const dimensions =
-    mimeType === 'image/png' ? declaredPngDimensions(bytes) : declaredJpegDimensions(bytes)
+): RasterImageDimensions => {
+  const dimensions = readRasterImageDimensions(bytes, mimeType)
   if (!dimensions) {
     throw new ImageContentError(
       'IMAGE_DECODE_FAILED',
@@ -293,12 +241,8 @@ const declaredImageDimensions = (
   return dimensions
 }
 
-const assertImagePixelLimit = (size: ImageDimensions): void => {
-  if (
-    size.width < 1 ||
-    size.height < 1 ||
-    size.width > Math.floor(MAX_DECODED_IMAGE_PIXELS / size.height)
-  ) {
+const assertImagePixelLimit = (size: RasterImageDimensions): void => {
+  if (exceedsDecodedImagePixelLimit(size)) {
     throw new ImageContentError(
       'IMAGE_PROCESSING_FAILED',
       `Decoded image exceeds the ${MAX_DECODED_IMAGE_PIXELS}-pixel processing limit.`
@@ -392,7 +336,7 @@ const processImageBytes = async (
     width: Math.max(1, Math.round(croppedSize.width * scale)),
     height: Math.max(1, Math.round(croppedSize.height * scale))
   }
-  const prepare = (size: ImageDimensions = outputSize): Sharp => {
+  const prepare = (size: RasterImageDimensions = outputSize): Sharp => {
     let pipeline = source.clone().autoOrient()
     if (crop) {
       pipeline = pipeline.extract({

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -172,6 +172,31 @@ describe('preview persistence projections', () => {
     expect(JSON.stringify(persisted)).not.toContain('https://example.com/private-paper')
   })
 
+  it('persists the 100 most recently used file tabs in their display order', () => {
+    const items = Array.from({ length: 101 }, (_, index) =>
+      createStoredFileItem({
+        id: `file-${index}`,
+        path: `/workspace/project/file-${index}.md`,
+        name: `file-${index}.md`,
+        title: `file-${index}.md`,
+        updatedAt: index === 50 ? 0 : index + 1
+      })
+    )
+    usePreviewWorkbenchStore.setState({
+      panelState: 'open',
+      activeItemId: 'file-100',
+      items
+    })
+
+    const persisted = toPersistedPreviewState(usePreviewWorkbenchStore.getState())
+
+    expect(persisted.items).toHaveLength(100)
+    expect(persisted.items.map((item) => item.id)).toEqual(
+      items.filter((item) => item.id !== 'file-50').map((item) => item.id)
+    )
+    expect(persisted.activeItemId).toBe('file-100')
+  })
+
   it('round-trips the one durable Session Subagents Preview and selected Frame', () => {
     usePreviewWorkbenchStore.setState({
       panelState: 'collapsed',

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 
 import {
   PREVIEW_STATE_VERSION,
+  MAX_PERSISTED_PREVIEW_ITEMS,
   createEmptyPersistedPreviewState,
   normalizePersistedPreviewState,
   type PersistedPreviewState,
@@ -347,35 +348,40 @@ const createPreviewSaveScheduler = (
 
 // Projects the live store slice down to its durable subset: file previews plus the one Session-scoped
 // Subagents selection. Other tool tabs and external source URLs remain runtime-only.
-const getPersistedActiveItemId = (state: PreviewStoreState): string | undefined =>
-  state.items.find((item) => item.id === state.activeItemId)?.type === 'source'
-    ? undefined
-    : state.activeItemId
-
-const toPersistedPreviewState = (state: PreviewStoreState): PersistedPreviewState => ({
-  version: PREVIEW_STATE_VERSION,
-  panelState: state.panelState,
-  activeItemId: getPersistedActiveItemId(state),
-  ...(() => {
-    const item = state.items.find(
-      (candidate) => candidate.type === 'tool' && candidate.toolKind === 'subagents'
-    )
-    return item?.type === 'tool' && item.selectedAgentFrameId
+const toPersistedPreviewState = (state: PreviewStoreState): PersistedPreviewState => {
+  const fileItems = state.items.filter((item) => item.type === 'file')
+  const retainedIds = new Set(
+    [...fileItems]
+      .sort((left, right) => right.updatedAt - left.updatedAt)
+      .slice(0, MAX_PERSISTED_PREVIEW_ITEMS)
+      .map((item) => item.id)
+  )
+  const retainedFileItems = fileItems.filter((item) => retainedIds.has(item.id))
+  const subagentsItem = state.items.find(
+    (candidate) => candidate.type === 'tool' && candidate.toolKind === 'subagents'
+  )
+  const subagents =
+    subagentsItem?.type === 'tool' && subagentsItem.selectedAgentFrameId
       ? {
-          subagents: {
-            id: item.id,
-            sessionId: item.sessionId,
-            title: item.title,
-            type: 'tool' as const,
-            toolKind: 'subagents' as const,
-            selectedAgentFrameId: item.selectedAgentFrameId
-          }
+          id: subagentsItem.id,
+          sessionId: subagentsItem.sessionId,
+          title: subagentsItem.title,
+          type: 'tool' as const,
+          toolKind: 'subagents' as const,
+          selectedAgentFrameId: subagentsItem.selectedAgentFrameId
         }
-      : {}
-  })(),
-  items: state.items
-    .filter((item) => item.type === 'file')
-    .map((item) => ({
+      : undefined
+  const activeItemId =
+    retainedIds.has(state.activeItemId ?? '') || subagents?.id === state.activeItemId
+      ? state.activeItemId
+      : undefined
+
+  return {
+    version: PREVIEW_STATE_VERSION,
+    panelState: state.panelState,
+    activeItemId,
+    ...(subagents ? { subagents } : {}),
+    items: retainedFileItems.map((item) => ({
       id: item.id,
       sessionId: item.sessionId,
       title: item.title,
@@ -392,7 +398,8 @@ const toPersistedPreviewState = (state: PreviewStoreState): PersistedPreviewStat
       ...(item.versionNumber !== undefined ? { versionNumber: item.versionNumber } : {}),
       ...(item.originSession ? { originSession: item.originSession } : {})
     }))
-})
+  }
+}
 
 // Rebuilds the store's restore payload and repairs upload paths that changed after staging.
 const toRestoredSlice = (

--- a/src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.render.test.tsx
@@ -184,12 +184,14 @@ describe('DownloadProjectArtifactsDialog', () => {
           source: 'artifact',
           sessionId: 'session-1',
           fileId: 'report',
+          versionId: 'report-version-1',
           suggestedName: 'report.csv'
         },
         {
           source: 'upload',
           sessionId: 'session-1',
           fileId: 'dataset',
+          versionId: 'dataset-version-1',
           suggestedName: 'dataset.csv'
         }
       ]
@@ -197,7 +199,7 @@ describe('DownloadProjectArtifactsDialog', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('exports only the latest logical identity without a path or Version hint', async () => {
+  it('exports the immutable Version shown in the Project Files snapshot without a path', async () => {
     listFiles.mockResolvedValue({ items: [files[0]!], totalCount: 1 })
     await renderDialog()
 
@@ -214,6 +216,7 @@ describe('DownloadProjectArtifactsDialog', () => {
           source: 'artifact',
           sessionId: 'session-1',
           fileId: 'report',
+          versionId: 'report-version-1',
           suggestedName: 'report.csv'
         }
       ]

--- a/src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.tsx
+++ b/src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.tsx
@@ -169,6 +169,7 @@ const DownloadProjectArtifactsDialog = ({
           source: file.source,
           sessionId: file.sessionId,
           fileId: file.sourceFileId,
+          versionId: file.sourceVersionId,
           suggestedName: file.name
         }))
       })

--- a/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx
@@ -25,7 +25,7 @@ const artifacts: ProjectFileItem[] = [
     id: 'artifact-1',
     source: 'artifact',
     sourceFileId: 'artifact-1',
-    sourceVersionId: 'artifact-1',
+    sourceVersionId: 'artifact-version-1',
     projectId: 'project-1',
     sessionId: 'session-1',
     name: 'report.csv',
@@ -38,7 +38,7 @@ const artifacts: ProjectFileItem[] = [
     id: 'artifact-2',
     source: 'artifact',
     sourceFileId: 'artifact-2',
-    sourceVersionId: 'artifact-2',
+    sourceVersionId: 'artifact-version-2',
     projectId: 'project-1',
     sessionId: 'session-1',
     name: 'figure.png',
@@ -126,7 +126,13 @@ describe('DownloadSessionArtifactsDialog', () => {
     expect(saveSessionArtifacts).toHaveBeenCalledWith({
       projectId: 'project-1',
       sessionId: 'session-1',
-      files: [{ fileId: 'artifact-1', suggestedName: 'report.csv' }]
+      files: [
+        {
+          fileId: 'artifact-1',
+          versionId: 'artifact-version-1',
+          suggestedName: 'report.csv'
+        }
+      ]
     })
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.tsx
+++ b/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.tsx
@@ -136,6 +136,7 @@ const DownloadSessionArtifactsDialog = ({
         sessionId: session.id,
         files: selectedArtifacts.map((artifact) => ({
           fileId: artifact.sourceFileId,
+          versionId: artifact.sourceVersionId,
           suggestedName: artifact.name
         }))
       })

--- a/src/renderer/src/stores/preview-workbench-store.test.ts
+++ b/src/renderer/src/stores/preview-workbench-store.test.ts
@@ -26,6 +26,39 @@ describe('preview workbench store', () => {
     useSessionStore.setState({ sessions: [] })
   })
 
+  it('refreshes a file tab recency timestamp when it becomes active', () => {
+    const store = usePreviewWorkbenchStore.getState()
+    store.upsertAndActivateItem({
+      id: 'file-1',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'one.md',
+      path: '/one.md',
+      format: 'markdown',
+      name: 'one.md'
+    })
+    store.upsertAndActivateItem({
+      id: 'file-2',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'two.md',
+      path: '/two.md',
+      format: 'markdown',
+      name: 'two.md'
+    })
+    const previousTimestamp = usePreviewWorkbenchStore
+      .getState()
+      .items.find((item) => item.id === 'file-1')?.updatedAt
+    vi.advanceTimersByTime(1_000)
+
+    store.activateItem('file-1')
+
+    expect(
+      usePreviewWorkbenchStore.getState().items.find((item) => item.id === 'file-1')?.updatedAt
+    ).toBe(Date.now())
+    expect(Date.now()).toBeGreaterThan(previousTimestamp ?? 0)
+  })
+
   it('does not switch, remove, collapse, or close a dialog when its active draft rejects leaving', () => {
     const store = usePreviewWorkbenchStore.getState()
     store.activateProject('project-a')

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -616,7 +616,12 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
     if (!get().items.some((item) => item.id === itemId)) return
     if (get().activeItemId === itemId) return
     previewLeaveGuards.request(activeWorkbenchGuardScope(get()), () =>
-      set({ activeItemId: itemId })
+      set((state) => ({
+        activeItemId: itemId,
+        items: state.items.map((item) =>
+          item.id === itemId ? { ...item, updatedAt: Date.now() } : item
+        )
+      }))
     )
   },
 

--- a/src/shared/conversation-export.ts
+++ b/src/shared/conversation-export.ts
@@ -229,7 +229,7 @@ export const createConversationExportTurns = (
   })
 }
 
-const selectConversationExportMessages = (
+export const selectConversationExportMessages = (
   messages: readonly PersistedChatMessage[],
   selectedPromptMessageIds?: readonly string[]
 ): PersistedChatMessage[] => {

--- a/src/shared/file-save.ts
+++ b/src/shared/file-save.ts
@@ -32,6 +32,7 @@ type SaveManagedFileResult = SaveBlobFileResult
 
 type SaveSessionArtifactFile = {
   fileId: string
+  versionId: string
   suggestedName: string
 }
 
@@ -52,6 +53,7 @@ type SaveProjectArtifactFile = {
   source: 'artifact' | 'upload'
   sessionId: string
   fileId: string
+  versionId: string
   suggestedName: string
 }
 

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -40,6 +40,8 @@
     "Task needs attention": "Aufgabe erfordert Aufmerksamkeit"
   },
   "native": {
+    "Conversation export is too large. Select fewer conversation turns.": "Der Konversationsexport ist zu groß. Wählen Sie weniger Konversationsrunden aus.",
+    "Conversation PDF export timed out. Select fewer conversation turns.": "Beim PDF-Export der Konversation wurde das Zeitlimit überschritten. Wählen Sie weniger Konversationsrunden aus.",
     "Open Web UI": "Web-UI öffnen",
     "Copy URL": "URL kopieren",
     "Show": "Anzeigen",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -40,6 +40,8 @@
     "Export Connector configuration": "Exportar configuración del conector"
   },
   "native": {
+    "Conversation export is too large. Select fewer conversation turns.": "La exportación de la conversación es demasiado grande. Seleccione menos turnos de conversación.",
+    "Conversation PDF export timed out. Select fewer conversation turns.": "Se agotó el tiempo de espera de la exportación de la conversación a PDF. Seleccione menos turnos de conversación.",
     "Open Web UI": "Abrir interfaz de usuario web",
     "Copy URL": "Copiar URL",
     "Show": "Mostrar",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -40,6 +40,8 @@
     "Export Connector configuration": "Exporter la configuration du connecteur"
   },
   "native": {
+    "Conversation export is too large. Select fewer conversation turns.": "L’exportation de la conversation est trop volumineuse. Sélectionnez moins de tours de conversation.",
+    "Conversation PDF export timed out. Select fewer conversation turns.": "L’exportation PDF de la conversation a expiré. Sélectionnez moins de tours de conversation.",
     "Open Web UI": "Ouvrir l'interface Web",
     "Copy URL": "Copier l'URL",
     "Show": "Afficher",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -40,6 +40,8 @@
     "Export Connector configuration": "コネクタ構成をエクスポート"
   },
   "native": {
+    "Conversation export is too large. Select fewer conversation turns.": "会話のエクスポートが大きすぎます。選択する会話ターンを減らしてください。",
+    "Conversation PDF export timed out. Select fewer conversation turns.": "会話の PDF エクスポートがタイムアウトしました。選択する会話ターンを減らしてください。",
     "Open Web UI": "Web UI を開く",
     "Copy URL": "URL をコピー",
     "Show": "表示",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -40,6 +40,8 @@
     "Export Connector configuration": "커넥터 구성 내보내기"
   },
   "native": {
+    "Conversation export is too large. Select fewer conversation turns.": "대화 내보내기 용량이 너무 큽니다. 더 적은 대화 턴을 선택하세요.",
+    "Conversation PDF export timed out. Select fewer conversation turns.": "대화 PDF 내보내기 시간이 초과되었습니다. 더 적은 대화 턴을 선택하세요.",
     "Open Web UI": "Web UI 열기",
     "Copy URL": "URL 복사",
     "Show": "표시",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -40,6 +40,8 @@
     "Export Connector configuration": "Экспорт конфигурации коннектора"
   },
   "native": {
+    "Conversation export is too large. Select fewer conversation turns.": "Экспорт беседы слишком велик. Выберите меньше реплик беседы.",
+    "Conversation PDF export timed out. Select fewer conversation turns.": "Время экспорта беседы в PDF истекло. Выберите меньше реплик беседы.",
     "Open Web UI": "Открыть веб-интерфейс",
     "Copy URL": "Копировать URL",
     "Show": "Показать",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -40,6 +40,8 @@
     "Export Connector configuration": "导出连接器配置"
   },
   "native": {
+    "Conversation export is too large. Select fewer conversation turns.": "对话导出内容过大。请选择较少的对话轮次。",
+    "Conversation PDF export timed out. Select fewer conversation turns.": "对话 PDF 导出超时。请选择较少的对话轮次。",
     "Open Web UI": "打开 Web 界面",
     "Copy URL": "复制 URL",
     "Show": "显示",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -40,6 +40,8 @@
     "Export Connector configuration": "匯出連接器設定"
   },
   "native": {
+    "Conversation export is too large. Select fewer conversation turns.": "對話匯出內容過大。請選擇較少的對話輪次。",
+    "Conversation PDF export timed out. Select fewer conversation turns.": "對話 PDF 匯出逾時。請選擇較少的對話輪次。",
     "Open Web UI": "開啟 Web 介面",
     "Copy URL": "複製 URL",
     "Show": "顯示",

--- a/src/shared/preview-state.test.ts
+++ b/src/shared/preview-state.test.ts
@@ -189,6 +189,28 @@ describe('normalizePersistedPreviewState item sanitization', () => {
     expect(stringTitle.items[0]?.title).toBe(validItem.name)
     expect(badPath.items).toEqual([])
   })
+
+  it('drops oversized required strings and omits oversized optional strings', () => {
+    const state = normalizePersistedPreviewState({
+      items: [
+        { ...validItem, id: 'i'.repeat(513) },
+        { ...validItem, path: `/${'p'.repeat(8192)}` },
+        {
+          ...validItem,
+          title: 't'.repeat(1025),
+          source: 's'.repeat(257),
+          mimeType: 'm'.repeat(257),
+          managedFileId: 'f'.repeat(513)
+        }
+      ]
+    })
+
+    expect(state.items).toHaveLength(1)
+    expect(state.items[0]).toMatchObject({ title: validItem.name })
+    expect(state.items[0]).not.toHaveProperty('source')
+    expect(state.items[0]).not.toHaveProperty('mimeType')
+    expect(state.items[0]).not.toHaveProperty('managedFileId')
+  })
 })
 
 describe('normalizePersistedPreviewState top-level normalization', () => {
@@ -255,5 +277,24 @@ describe('normalizePersistedPreviewState top-level normalization', () => {
     const state = normalizePersistedPreviewState({ items: [validItem], activeItemId: 123 })
 
     expect(state.activeItemId).toBeUndefined()
+  })
+
+  it('keeps only the most recent 100 serialized items', () => {
+    const items = Array.from({ length: 101 }, (_, index) => ({
+      ...validItem,
+      id: `item-${index}`,
+      path: `/project/report-${index}.md`,
+      name: `report-${index}.md`
+    }))
+
+    const state = normalizePersistedPreviewState({
+      items,
+      activeItemId: 'item-100'
+    })
+
+    expect(state.items).toHaveLength(100)
+    expect(state.items[0]?.id).toBe('item-1')
+    expect(state.items.at(-1)?.id).toBe('item-100')
+    expect(state.activeItemId).toBe('item-100')
   })
 })

--- a/src/shared/preview-state.ts
+++ b/src/shared/preview-state.ts
@@ -6,6 +6,12 @@
 import type { ProjectFileOriginSession } from './project-files'
 
 export const PREVIEW_STATE_VERSION = 1
+export const MAX_PERSISTED_PREVIEW_ITEMS = 100
+
+const MAX_PREVIEW_ID_LENGTH = 512
+const MAX_PREVIEW_LABEL_LENGTH = 1024
+const MAX_PREVIEW_PATH_LENGTH = 8192
+const MAX_PREVIEW_METADATA_LENGTH = 256
 
 export type PersistedPreviewPanelState = 'open' | 'collapsed'
 
@@ -72,8 +78,8 @@ export type DeletePreviewStateRequest = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
-const asString = (value: unknown): string | undefined =>
-  typeof value === 'string' ? value : undefined
+const asBoundedString = (value: unknown, maxLength: number): string | undefined =>
+  typeof value === 'string' && value.length <= maxLength ? value : undefined
 
 const asNonNegativeNumber = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
@@ -88,8 +94,8 @@ const sanitizeOriginSession = (value: unknown): ProjectFileOriginSession | undef
   }
 
   const origin: ProjectFileOriginSession = { state: value.state }
-  const title = asString(value.title)
-  const deletedAt = asString(value.deletedAt)
+  const title = asBoundedString(value.title, MAX_PREVIEW_LABEL_LENGTH)
+  const deletedAt = asBoundedString(value.deletedAt, MAX_PREVIEW_METADATA_LENGTH)
   if (title) origin.title = title
   if (deletedAt) origin.deletedAt = deletedAt
   return origin
@@ -106,28 +112,28 @@ export const createEmptyPersistedPreviewState = (): PersistedPreviewState => ({
 const sanitizePreviewFileItem = (value: unknown): PersistedPreviewFileItem | undefined => {
   if (!isRecord(value)) return undefined
 
-  const id = asString(value.id)
-  const sessionId = asString(value.sessionId)
-  const path = asString(value.path)
-  const name = asString(value.name)
+  const id = asBoundedString(value.id, MAX_PREVIEW_ID_LENGTH)
+  const sessionId = asBoundedString(value.sessionId, MAX_PREVIEW_ID_LENGTH)
+  const path = asBoundedString(value.path, MAX_PREVIEW_PATH_LENGTH)
+  const name = asBoundedString(value.name, MAX_PREVIEW_LABEL_LENGTH)
 
   if (!id || !sessionId || !path || !name) return undefined
 
   const item: PersistedPreviewFileItem = {
     id,
     sessionId,
-    title: asString(value.title) ?? name,
+    title: asBoundedString(value.title, MAX_PREVIEW_LABEL_LENGTH) ?? name,
     path,
-    format: asString(value.format) ?? 'unknown',
+    format: asBoundedString(value.format, MAX_PREVIEW_METADATA_LENGTH) ?? 'unknown',
     name
   }
-  const source = asString(value.source)
-  const mimeType = asString(value.mimeType)
+  const source = asBoundedString(value.source, MAX_PREVIEW_METADATA_LENGTH)
+  const mimeType = asBoundedString(value.mimeType, MAX_PREVIEW_METADATA_LENGTH)
   const size = asNonNegativeNumber(value.size)
   const mtimeMs = asNonNegativeNumber(value.mtimeMs)
-  const artifactId = asString(value.artifactId)
-  const managedFileId = asString(value.managedFileId)
-  const selectedVersionId = asString(value.selectedVersionId)
+  const artifactId = asBoundedString(value.artifactId, MAX_PREVIEW_ID_LENGTH)
+  const managedFileId = asBoundedString(value.managedFileId, MAX_PREVIEW_ID_LENGTH)
+  const selectedVersionId = asBoundedString(value.selectedVersionId, MAX_PREVIEW_ID_LENGTH)
   const versionNumber = asPositiveInteger(value.versionNumber)
   const originSession = sanitizeOriginSession(value.originSession)
 
@@ -150,14 +156,14 @@ const sanitizeSubagentsPreviewItem = (
   if (!isRecord(value) || value.type !== 'tool' || value.toolKind !== 'subagents') {
     return undefined
   }
-  const id = asString(value.id)
-  const sessionId = asString(value.sessionId)
-  const selectedAgentFrameId = asString(value.selectedAgentFrameId)
+  const id = asBoundedString(value.id, MAX_PREVIEW_ID_LENGTH)
+  const sessionId = asBoundedString(value.sessionId, MAX_PREVIEW_ID_LENGTH)
+  const selectedAgentFrameId = asBoundedString(value.selectedAgentFrameId, MAX_PREVIEW_ID_LENGTH)
   if (!id || !sessionId || !selectedAgentFrameId) return undefined
   return {
     id,
     sessionId,
-    title: asString(value.title) ?? 'Subagents',
+    title: asBoundedString(value.title, MAX_PREVIEW_LABEL_LENGTH) ?? 'Subagents',
     type: 'tool',
     toolKind: 'subagents',
     selectedAgentFrameId
@@ -168,18 +174,21 @@ const sanitizeSubagentsPreviewItem = (
 export const normalizePersistedPreviewState = (value: unknown): PersistedPreviewState => {
   if (!isRecord(value)) return createEmptyPersistedPreviewState()
 
-  const items = Array.isArray(value.items)
-    ? value.items
+  const serializedItems = Array.isArray(value.items)
+    ? value.items.slice(-MAX_PERSISTED_PREVIEW_ITEMS)
+    : []
+  const items = serializedItems.length
+    ? serializedItems
         .map(sanitizePreviewFileItem)
         .filter((item): item is PersistedPreviewFileItem => !!item)
     : []
   const subagents =
     sanitizeSubagentsPreviewItem(value.subagents) ??
-    (Array.isArray(value.items)
-      ? value.items.map(sanitizeSubagentsPreviewItem).find(Boolean)
+    (serializedItems.length
+      ? serializedItems.map(sanitizeSubagentsPreviewItem).find(Boolean)
       : undefined)
   const panelState: PersistedPreviewPanelState = value.panelState === 'open' ? 'open' : 'collapsed'
-  const requestedActiveItemId = asString(value.activeItemId)
+  const requestedActiveItemId = asBoundedString(value.activeItemId, MAX_PREVIEW_ID_LENGTH)
   // Keep the active id only when it still points at a persisted item.
   const activeItemId = [...items, ...(subagents ? [subagents] : [])].some(
     (item) => item.id === requestedActiveItemId


### PR DESCRIPTION
## Problem

Five related workspace resource-boundary concerns were reviewed against the current implementation and reproduced before changing production code.

1. **Batch Artifact downloads were not snapshots.** Project Files already provides an immutable `sourceVersionId`, but the Project and Session download dialogs sent only `fileId`. If a file gained a new Version while a dialog remained open, main opened the latest Version at export time. A ZIP could therefore contain Versions from different points in time. This is a real correctness bug and is worth fixing.
2. **Preview persistence grew without bounds.** Runtime tabs append over long-lived use, every file tab was serialized on each change, and normalization accepted unlimited arrays and strings. The cost grows with usage and repeats on every persistence comparison/write. This is worth bounding, but replacing the store or limiting live tabs would be over-design.
3. **Ordinary raster previews had no decoded-pixel admission.** A small compressed PNG/JPEG/GIF/WebP could declare a very large decoded canvas and still receive a renderer capability URL. A valid 5000×5000 PNG reproduced this at only a small compressed size. Browser/GPU decode can then cause a large renderer memory spike. This is worth fixing at the existing main-process preview boundary.
4. **Conversation PDF export had no aggregate or time budget.** It selected all messages and Base64 images, built one HTML string, created a hidden window, awaited `printToPDF`, and returned one PDF Buffer. Oversized conversations were accepted and a never-settling print promise left export pending indefinitely. Simple limits and a print timeout are worth adding; a background job system is not.
5. **Resource identities looked duplicated, but a global redesign is not justified here.** Single-file download and preview boundaries already use discriminated logical identities for Artifact/Upload sources and paths only for local/notebook-input sources. The concrete failure was the batch request omitting `versionId`. This PR aligns that boundary without adding another locator shape or rewriting internal display/compatibility models.

## Proposed change

- Require `versionId` on every Session/Project batch export item, send `sourceVersionId` from both dialogs, validate it in main, and use only `openManagedFileVersion`.
- Keep all live preview tabs, but persist the 100 most recently used file tabs in existing display order. Refresh existing `updatedAt` when a tab becomes active. Normalize historical/untrusted state to at most 100 items and bound IDs, labels, paths, and metadata strings.
- Extract the existing 16,000,000 decoded-pixel limit and PNG/JPEG header readers into a main-process helper, add bounded GIF/WebP dimension readers, and reject unsafe or unrecognized supported raster files before minting a preview URL. Admission reads at most 1 MiB and re-verifies the file/Version lease.
- Limit conversation export to 2,000 selected messages, 32 MiB of selected PDF Base64 image data, and 64 MiB of rendered HTML. Time out `printToPDF` after 120 seconds, destroy the hidden window, and clean up the temporary directory. Errors direct users to select fewer turns.

## Scope and non-goals

- No database migration, preview schema-version bump, new dependency, new state framework, cancellation API, background export job, or final-target atomic-write redesign.
- No global replacement of internal `path` display/compatibility fields.
- TIFF/PDF retain their existing specialized admission paths. SVG and AVIF behavior is unchanged in this PR.
- Full `npm test` was intentionally not run, per maintainer direction; exact-head PR CI remains authoritative for the complete suite and platform lanes.

## Historical compatibility, state, and persistence

- **Historical compatibility:** existing persisted preview JSON still loads under schema Version 1, but only its last 100 serialized entries are considered; oversized required identity/name/path fields cause that entry to be dropped, while oversized optional metadata is omitted. Existing external callers of the transient batch IPC contract that omit `versionId` now fail closed instead of silently exporting latest content. There is no persisted Artifact-request migration.
- **New enum/state values:** none.
- **Persistence impact:** file-tab persistence changes from unbounded to an LRU-selected maximum of 100. Runtime tabs remain unbounded for the current process. Existing runtime `updatedAt` supplies recency and is not added to persisted JSON. No database column or stored schema version changes.

## Acceptance criteria and validation

All listed checks ran against the final material implementation after the last production edit.

- Exact batch Version snapshot → targeted dialog and main IPC tests → passed.
- Preview LRU projection and untrusted-state bounds → shared normalizer, persistence, and store tests → passed.
- Raster decoded-pixel admission, including a valid compressed 25 MP PNG → managed preview and attachment-media tests → passed.
- Conversation message/image/HTML budgets and PDF timeout cleanup → shared and main conversation export tests → passed.
- Native translation coverage → renderer i18n resource guard → passed.
- Combined Test Impact Set: 13 files, 1,105 tests → passed.
- `tsc --noEmit -p tsconfig.node.json --composite false` → passed.
- `tsc --noEmit -p tsconfig.web.json --composite false` → passed.
- `eslint .` → passed.
- Worktree-local CodeGraph refresh and post-change call-path review → completed.

Uncovered risks: Electron cannot cancel Chromium's underlying `printToPDF` operation; after timeout this PR destroys the owned hidden window and ignores any late settlement. Full portable and platform suites are delegated to PR Gate as requested.

## Review focus

- Confirm the batch IPC compatibility choice to reject missing Versions rather than resolving latest.
- Confirm the persisted-preview truncation policy for historical state.
- Review the bounded header parsers and lease re-verification before capability minting.
- Review the conversation limits and timeout cleanup path.
