### PR TITLE
fix(file-save): publish exports atomically

### DIFF
--- a/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
+++ b/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
@@ -168,27 +168,6 @@ const char* WindowsErrorCode(DWORD error) {
   }
 }
 
-struct NativeIoStatusBlock {
-  union {
-    LONG status;
-    void* pointer;
-  };
-  ULONG_PTR information;
-};
-
-struct NativeFileLinkInformation {
-  BOOLEAN replace_if_exists;
-  HANDLE root_directory;
-  ULONG file_name_length;
-  WCHAR file_name[1];
-};
-
-using NtSetInformationFileFunction = LONG(NTAPI*)(
-    HANDLE, NativeIoStatusBlock*, void*, ULONG, ULONG);
-using RtlNtStatusToDosErrorFunction = ULONG(NTAPI*)(LONG);
-
-constexpr ULONG kFileLinkInformation = 11;
-
 napi_value PublishWindows(
     napi_env env,
     const std::string& root_utf8,
@@ -230,12 +209,6 @@ napi_value PublishWindows(
     return ThrowError(env, "Network storage roots are not supported for atomic publication.",
                       "ENOTSUP");
   }
-  bool supports_hard_links = false;
-  if (!QueryHardLinkSupport(root_handle, &supports_hard_links) || !supports_hard_links) {
-    CloseHandle(root_handle);
-    return ThrowError(env, "The storage root file system does not support hard links.", "ENOTSUP");
-  }
-
   FILE_ATTRIBUTE_TAG_INFO root_attributes{};
   if (!GetFileInformationByHandleEx(
           root_handle, FileAttributeTagInfo, &root_attributes, sizeof(root_attributes)) ||
@@ -314,66 +287,38 @@ napi_value PublishWindows(
   }
 
   const size_t destination_bytes = destination_name.size() * sizeof(wchar_t);
-  const size_t link_prefix_size = offsetof(NativeFileLinkInformation, file_name);
+  const size_t rename_prefix_size = offsetof(FILE_RENAME_INFO, FileName);
   const size_t max_native_buffer = (std::numeric_limits<ULONG>::max)();
-  if (destination_bytes > max_native_buffer - link_prefix_size) {
+  if (destination_bytes > max_native_buffer - rename_prefix_size) {
     CloseHandle(source_handle);
     CloseHandle(parent_handle);
     CloseHandle(root_handle);
     return ThrowError(env, "The publication destination name is too long.", "EINVAL");
   }
-  size_t link_size = link_prefix_size + destination_bytes;
-  if (link_size < sizeof(NativeFileLinkInformation)) {
-    link_size = sizeof(NativeFileLinkInformation);
+  size_t rename_size = rename_prefix_size + destination_bytes;
+  if (rename_size < sizeof(FILE_RENAME_INFO)) {
+    rename_size = sizeof(FILE_RENAME_INFO);
   }
-  std::vector<unsigned char> link_buffer(link_size);
-  auto* link_info = reinterpret_cast<NativeFileLinkInformation*>(link_buffer.data());
-  link_info->replace_if_exists = FALSE;
-  link_info->root_directory = parent_handle;
-  link_info->file_name_length = static_cast<ULONG>(destination_bytes);
-  std::memcpy(link_info->file_name, destination_name.data(), destination_bytes);
+  std::vector<unsigned char> rename_buffer(rename_size);
+  auto* rename_info = reinterpret_cast<FILE_RENAME_INFO*>(rename_buffer.data());
+  rename_info->ReplaceIfExists = FALSE;
+  rename_info->RootDirectory = parent_handle;
+  rename_info->FileNameLength = static_cast<DWORD>(destination_bytes);
+  std::memcpy(rename_info->FileName, destination_name.data(), destination_bytes);
 
-  HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-  const auto nt_set_information_file =
-      ntdll == nullptr
-          ? nullptr
-          : reinterpret_cast<NtSetInformationFileFunction>(
-                GetProcAddress(ntdll, "NtSetInformationFile"));
-  const auto rtl_nt_status_to_dos_error =
-      ntdll == nullptr
-          ? nullptr
-          : reinterpret_cast<RtlNtStatusToDosErrorFunction>(
-                GetProcAddress(ntdll, "RtlNtStatusToDosError"));
-  if (nt_set_information_file == nullptr || rtl_nt_status_to_dos_error == nullptr) {
-    CloseHandle(source_handle);
-    CloseHandle(parent_handle);
-    CloseHandle(root_handle);
-    return ThrowError(env, "Handle-relative publication is unavailable.", "ENOTSUP");
-  }
-
-  // FileLinkInformation binds both the already-open source and parent handles while creating the
-  // destination atomically without replacement. Removing the temporary alias is best effort.
-  NativeIoStatusBlock io_status{};
-  const LONG link_status = nt_set_information_file(
+  // FileRenameInfo binds both the already-open source and parent handles while moving the source
+  // atomically without replacement. Unlike a hard link, it is supported by FAT/exFAT volumes.
+  const bool renamed = SetFileInformationByHandle(
       source_handle,
-      &io_status,
-      link_info,
-      static_cast<ULONG>(link_buffer.size()),
-      kFileLinkInformation);
-  const bool linked = link_status >= 0;
-  const DWORD link_error =
-      linked ? ERROR_SUCCESS : rtl_nt_status_to_dos_error(link_status);
-  if (linked) {
-    FILE_DISPOSITION_INFO disposition{};
-    disposition.DeleteFile = TRUE;
-    (void)SetFileInformationByHandle(
-        source_handle, FileDispositionInfo, &disposition, sizeof(disposition));
-  }
+      FileRenameInfo,
+      rename_info,
+      static_cast<DWORD>(rename_buffer.size()));
+  const DWORD rename_error = renamed ? ERROR_SUCCESS : GetLastError();
   CloseHandle(source_handle);
   CloseHandle(parent_handle);
   CloseHandle(root_handle);
-  if (!linked) {
-    return ThrowError(env, "Atomic no-replace publication failed.", WindowsErrorCode(link_error));
+  if (!renamed) {
+    return ThrowError(env, "Atomic no-replace publication failed.", WindowsErrorCode(rename_error));
   }
 
   napi_value undefined;

--- a/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
+++ b/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
@@ -168,6 +168,27 @@ const char* WindowsErrorCode(DWORD error) {
   }
 }
 
+struct NativeIoStatusBlock {
+  union {
+    LONG status;
+    void* pointer;
+  };
+  ULONG_PTR information;
+};
+
+struct NativeFileRenameInformation {
+  BOOLEAN replace_if_exists;
+  HANDLE root_directory;
+  ULONG file_name_length;
+  WCHAR file_name[1];
+};
+
+using NtSetInformationFileFunction = LONG(NTAPI*)(
+    HANDLE, NativeIoStatusBlock*, void*, ULONG, ULONG);
+using RtlNtStatusToDosErrorFunction = ULONG(NTAPI*)(LONG);
+
+constexpr ULONG kFileRenameInformation = 10;
+
 napi_value PublishWindows(
     napi_env env,
     const std::string& root_utf8,
@@ -287,7 +308,7 @@ napi_value PublishWindows(
   }
 
   const size_t destination_bytes = destination_name.size() * sizeof(wchar_t);
-  const size_t rename_prefix_size = offsetof(FILE_RENAME_INFO, FileName);
+  const size_t rename_prefix_size = offsetof(NativeFileRenameInformation, file_name);
   const size_t max_native_buffer = (std::numeric_limits<ULONG>::max)();
   if (destination_bytes > max_native_buffer - rename_prefix_size) {
     CloseHandle(source_handle);
@@ -296,24 +317,46 @@ napi_value PublishWindows(
     return ThrowError(env, "The publication destination name is too long.", "EINVAL");
   }
   size_t rename_size = rename_prefix_size + destination_bytes;
-  if (rename_size < sizeof(FILE_RENAME_INFO)) {
-    rename_size = sizeof(FILE_RENAME_INFO);
+  if (rename_size < sizeof(NativeFileRenameInformation)) {
+    rename_size = sizeof(NativeFileRenameInformation);
   }
   std::vector<unsigned char> rename_buffer(rename_size);
-  auto* rename_info = reinterpret_cast<FILE_RENAME_INFO*>(rename_buffer.data());
-  rename_info->ReplaceIfExists = FALSE;
-  rename_info->RootDirectory = parent_handle;
-  rename_info->FileNameLength = static_cast<DWORD>(destination_bytes);
-  std::memcpy(rename_info->FileName, destination_name.data(), destination_bytes);
+  auto* rename_info = reinterpret_cast<NativeFileRenameInformation*>(rename_buffer.data());
+  rename_info->replace_if_exists = FALSE;
+  rename_info->root_directory = parent_handle;
+  rename_info->file_name_length = static_cast<ULONG>(destination_bytes);
+  std::memcpy(rename_info->file_name, destination_name.data(), destination_bytes);
 
-  // FileRenameInfo binds both the already-open source and parent handles while moving the source
-  // atomically without replacement. Unlike a hard link, it is supported by FAT/exFAT volumes.
-  const bool renamed = SetFileInformationByHandle(
+  HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+  const auto nt_set_information_file =
+      ntdll == nullptr
+          ? nullptr
+          : reinterpret_cast<NtSetInformationFileFunction>(
+                GetProcAddress(ntdll, "NtSetInformationFile"));
+  const auto rtl_nt_status_to_dos_error =
+      ntdll == nullptr
+          ? nullptr
+          : reinterpret_cast<RtlNtStatusToDosErrorFunction>(
+                GetProcAddress(ntdll, "RtlNtStatusToDosError"));
+  if (nt_set_information_file == nullptr || rtl_nt_status_to_dos_error == nullptr) {
+    CloseHandle(source_handle);
+    CloseHandle(parent_handle);
+    CloseHandle(root_handle);
+    return ThrowError(env, "Handle-relative publication is unavailable.", "ENOTSUP");
+  }
+
+  // FileRenameInformation binds both the already-open source and parent handles while moving the
+  // source atomically without replacement. Unlike a hard link, FAT/exFAT supports this operation.
+  NativeIoStatusBlock io_status{};
+  const LONG rename_status = nt_set_information_file(
       source_handle,
-      FileRenameInfo,
+      &io_status,
       rename_info,
-      static_cast<DWORD>(rename_buffer.size()));
-  const DWORD rename_error = renamed ? ERROR_SUCCESS : GetLastError();
+      static_cast<ULONG>(rename_buffer.size()),
+      kFileRenameInformation);
+  const bool renamed = rename_status >= 0;
+  const DWORD rename_error =
+      renamed ? ERROR_SUCCESS : rtl_nt_status_to_dos_error(rename_status);
   CloseHandle(source_handle);
   CloseHandle(parent_handle);
   CloseHandle(root_handle);

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -374,8 +374,16 @@ describe('file save IPC handlers', () => {
           projectId: 'project-1',
           sessionId: 'session-1',
           files: [
-            { fileId: 'artifact-a', suggestedName: 'report.csv' },
-            { fileId: 'artifact-b', suggestedName: 'other.csv' }
+            {
+              fileId: 'artifact-a',
+              versionId: 'artifact-a-version',
+              suggestedName: 'report.csv'
+            },
+            {
+              fileId: 'artifact-b',
+              versionId: 'artifact-b-version',
+              suggestedName: 'other.csv'
+            }
           ]
         }
       )

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { unzipSync } from 'fflate'
 import { createHash } from 'node:crypto'
 import { constants } from 'node:fs'
-import { copyFile, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { copyFile, mkdir, mkdtemp, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -47,6 +47,13 @@ const publishDirectly: typeof productionPublishUserFile = async (
   await options?.validateDestination?.()
   await write(destinationPath)
 }
+const publishWithoutHardLinks: typeof productionPublishUserFile = (destination, write, options) =>
+  productionPublishUserFile(destination, write, {
+    ...options,
+    linkFile: async () => {
+      throw Object.assign(new Error('hard links are unsupported'), { code: 'EOPNOTSUPP' })
+    }
+  })
 const registerFileSaveHandlers = (
   options: NonNullable<Parameters<typeof registerProductionFileSaveHandlers>[0]> = {}
 ): void => {
@@ -63,6 +70,7 @@ type TestManagedVersionHandle = {
   readRange: (begin: number, end: number) => Promise<Uint8Array>
   verifyUnchanged: () => Promise<void>
   copyTo: (destinationPath: string, options?: { exclusive?: boolean }) => Promise<void>
+  assertCanCopyTo?: (destinationPath: string) => Promise<void>
   close: () => Promise<void>
 }
 
@@ -87,7 +95,21 @@ const fileBackedManagedVersionHandle = async (
   managedVersionHandle(await readFile(sourcePath), {
     copyTo: vi.fn(async (destinationPath, options) =>
       copyFile(sourcePath, destinationPath, options?.exclusive ? constants.COPYFILE_EXCL : 0)
-    )
+    ),
+    assertCanCopyTo: async (destinationPath) => {
+      try {
+        const [sourceInfo, destinationInfo] = await Promise.all([
+          stat(sourcePath),
+          stat(destinationPath)
+        ])
+        if (sourceInfo.dev === destinationInfo.dev && sourceInfo.ino === destinationInfo.ino) {
+          throw new Error('Cannot save a managed file over its source.')
+        }
+      } catch (error) {
+        if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return
+        throw error
+      }
+    }
   })
 
 type TestFileSaveOptions = Omit<
@@ -241,17 +263,6 @@ describe('file save IPC handlers', () => {
       .fn()
       .mockResolvedValueOnce(await fileBackedManagedVersionHandle(sourceA))
       .mockResolvedValueOnce(await fileBackedManagedVersionHandle(sourceB))
-    const publishWithoutHardLinks: typeof productionPublishUserFile = (
-      destination,
-      write,
-      options
-    ) =>
-      productionPublishUserFile(destination, write, {
-        ...options,
-        linkFile: async () => {
-          throw Object.assign(new Error('hard links are unsupported'), { code: 'EOPNOTSUPP' })
-        }
-      })
     showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [destinationDirectory] })
     registerFileSaveHandlers({ openLatestManagedFile, publishUserFile: publishWithoutHardLinks })
 
@@ -305,7 +316,7 @@ describe('file save IPC handlers', () => {
       .mockResolvedValueOnce(await fileBackedManagedVersionHandle(sourceA))
       .mockResolvedValueOnce(await fileBackedManagedVersionHandle(sourceB))
     showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [destinationDirectory] })
-    registerFileSaveHandlers({ openLatestManagedFile } as never)
+    registerFileSaveHandlers({ openLatestManagedFile, publishUserFile: publishWithoutHardLinks })
 
     try {
       const result = await handlers.get('file:save-session-artifacts')!(
@@ -336,6 +347,46 @@ describe('file save IPC handlers', () => {
       await expect(readFile(join(destinationDirectory, 'report (3).csv'), 'utf8')).resolves.toBe(
         'artifact b'
       )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('uses a collision suffix when the selected batch destination is the source file', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-artifact-self-collision-'))
+    const sourcePath = join(root, 'report.csv')
+    const otherSourcePath = join(root, 'other-source.csv')
+    await writeFile(sourcePath, 'artifact bytes')
+    await writeFile(otherSourcePath, 'other bytes')
+    showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [root] })
+    registerFileSaveHandlers({
+      openLatestManagedFile: vi
+        .fn()
+        .mockResolvedValueOnce(await fileBackedManagedVersionHandle(sourcePath))
+        .mockResolvedValueOnce(await fileBackedManagedVersionHandle(otherSourcePath)),
+      publishUserFile: productionPublishUserFile
+    })
+
+    try {
+      const result = await handlers.get('file:save-session-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          files: [
+            { fileId: 'artifact-a', suggestedName: 'report.csv' },
+            { fileId: 'artifact-b', suggestedName: 'other.csv' }
+          ]
+        }
+      )
+
+      expect(result).toEqual({
+        saved: true,
+        filePaths: [join(root, 'report (2).csv'), join(root, 'other.csv')]
+      })
+      await expect(readFile(sourcePath, 'utf8')).resolves.toBe('artifact bytes')
+      await expect(readFile(join(root, 'report (2).csv'), 'utf8')).resolves.toBe('artifact bytes')
+      await expect(readFile(join(root, 'other.csv'), 'utf8')).resolves.toBe('other bytes')
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -38,13 +38,23 @@ vi.mock('electron', () => ({
 }))
 
 const { registerFileSaveHandlers: registerProductionFileSaveHandlers } = await import('./file-save')
+const { publishUserFile: productionPublishUserFile } = await import('./user-file-publisher')
+const publishDirectly: typeof productionPublishUserFile = async (
+  destinationPath,
+  write,
+  options
+) => {
+  await options?.validateDestination?.()
+  await write(destinationPath)
+}
 const registerFileSaveHandlers = (
-  options: Parameters<typeof registerProductionFileSaveHandlers>[0] = {}
+  options: NonNullable<Parameters<typeof registerProductionFileSaveHandlers>[0]> = {}
 ): void => {
   const openManagedFileVersion = options.openManagedFileVersion ?? options.openLatestManagedFile
   registerProductionFileSaveHandlers({
     ...options,
-    ...(openManagedFileVersion ? { openManagedFileVersion } : {})
+    ...(openManagedFileVersion ? { openManagedFileVersion } : {}),
+    publishUserFile: options.publishUserFile ?? publishDirectly
   })
 }
 
@@ -122,7 +132,7 @@ const registerProjectFileSaveHandlers = (options: TestFileSaveOptions = {}): voi
         }
       : undefined)
 
-  registerProductionFileSaveHandlers({
+  registerFileSaveHandlers({
     ...productionOptions,
     ...(openManagedFileVersion ? { openManagedFileVersion } : {})
   })
@@ -812,6 +822,37 @@ describe('file save IPC handlers', () => {
     expect(close).toHaveBeenCalledTimes(1)
   })
 
+  it('preserves an existing managed-file destination when copying fails after a partial write', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-failure-'))
+    const destinationPath = join(root, 'report.csv')
+    await writeFile(destinationPath, 'existing destination')
+    const copyTo = vi.fn(async (path: string) => {
+      await writeFile(path, 'partial replacement')
+      throw new Error('disk full')
+    })
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
+    registerFileSaveHandlers({
+      resolveManagedFilePath: vi.fn().mockResolvedValue('/managed/report.csv'),
+      publishUserFile: productionPublishUserFile,
+      openManagedFile: vi.fn().mockResolvedValue({
+        copyTo,
+        close: vi.fn().mockResolvedValue(undefined)
+      })
+    } as never)
+
+    try {
+      await expect(
+        handlers.get('file:save-managed')!(
+          { sender: {} },
+          { source: 'local', path: '/managed/report.csv', suggestedName: 'report.csv' }
+        )
+      ).rejects.toThrow('disk full')
+      await expect(readFile(destinationPath, 'utf8')).resolves.toBe('existing destination')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('does not prompt when managed path validation fails', async () => {
     const resolveManagedFilePath = vi.fn().mockRejectedValue(new Error('outside artifact storage'))
     registerFileSaveHandlers({ resolveManagedFilePath } as never)
@@ -958,6 +999,69 @@ describe('file save IPC handlers', () => {
     }
   })
 
+  it('shows Save As before opening Project Versions and holds only one lease at a time', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-lease-order-'))
+    const destinationPath = join(root, 'Research-artifacts.zip')
+    const events: string[] = []
+    let activeLeases = 0
+    let maximumActiveLeases = 0
+    const openManagedFileVersion = vi.fn(
+      async (_source: 'artifact' | 'upload', request: { fileId: string }) => {
+        events.push(`open:${request.fileId}`)
+        activeLeases += 1
+        maximumActiveLeases = Math.max(maximumActiveLeases, activeLeases)
+        return managedVersionHandle(request.fileId, {
+          close: vi.fn(async () => {
+            activeLeases -= 1
+            events.push(`close:${request.fileId}`)
+          })
+        })
+      }
+    )
+    showSaveDialog.mockImplementation(async () => {
+      events.push('dialog')
+      return { canceled: false, filePath: destinationPath }
+    })
+    registerProjectFileSaveHandlers({ openManagedFileVersion })
+
+    try {
+      await handlers.get('file:save-project-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          suggestedArchiveName: 'Research',
+          files: [
+            {
+              source: 'artifact',
+              sessionId: 'session-1',
+              fileId: 'artifact-1',
+              versionId: 'artifact-version-1',
+              suggestedName: 'artifact.txt'
+            },
+            {
+              source: 'upload',
+              sessionId: 'session-1',
+              fileId: 'upload-1',
+              versionId: 'upload-version-1',
+              suggestedName: 'upload.txt'
+            }
+          ]
+        }
+      )
+
+      expect(events).toEqual([
+        'dialog',
+        'open:artifact-1',
+        'close:artifact-1',
+        'open:upload-1',
+        'close:upload-1'
+      ])
+      expect(maximumActiveLeases).toBe(1)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('reads each logical Project file from its selected managed Version', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-current-head-'))
     const destinationPath = join(root, 'Research-artifacts.zip')
@@ -1050,7 +1154,7 @@ describe('file save IPC handlers', () => {
     }
   })
 
-  it('closes a retained Project Version lease when temporary archive setup fails', async () => {
+  it('does not open a Project Version when temporary archive setup fails', async () => {
     const close = vi.fn().mockResolvedValue(undefined)
     const readRange = vi.fn()
     const verifyUnchanged = vi.fn()
@@ -1059,14 +1163,15 @@ describe('file save IPC handlers', () => {
       canceled: false,
       filePath: join(downloadsPath, 'Research-artifacts.zip')
     })
+    const openLatestManagedFile = vi.fn().mockResolvedValue({
+      size: 1,
+      readRange,
+      verifyUnchanged,
+      copyTo: vi.fn(),
+      close
+    })
     registerProjectFileSaveHandlers({
-      openLatestManagedFile: vi.fn().mockResolvedValue({
-        size: 1,
-        readRange,
-        verifyUnchanged,
-        copyTo: vi.fn(),
-        close
-      }),
+      openLatestManagedFile,
       createProjectArtifactTemporaryRoot: vi.fn().mockRejectedValue(temporaryRootError)
     } as never)
 
@@ -1090,7 +1195,8 @@ describe('file save IPC handlers', () => {
     ).rejects.toBe(temporaryRootError)
     expect(readRange).not.toHaveBeenCalled()
     expect(verifyUnchanged).not.toHaveBeenCalled()
-    expect(close).toHaveBeenCalledOnce()
+    expect(openLatestManagedFile).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
   })
 
   it('exports Project Artifacts without reading an entire source into memory', async () => {
@@ -1227,7 +1333,7 @@ describe('file save IPC handlers', () => {
       })
       expect(resolveManagedFilePath).not.toHaveBeenCalled()
       expect(resolveSessionArtifactFilePath).not.toHaveBeenCalled()
-      expect(showSaveDialog).not.toHaveBeenCalled()
+      expect(showSaveDialog).toHaveBeenCalledOnce()
       await expect(readFile(destinationPath)).rejects.toMatchObject({ code: 'ENOENT' })
     } finally {
       await rm(root, { recursive: true, force: true })
@@ -1241,6 +1347,10 @@ describe('file save IPC handlers', () => {
         code: 'CONTENT_INTEGRITY_FAILED'
       })
     )
+    showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: join(downloadsPath, 'Research-artifacts.zip')
+    })
     registerProjectFileSaveHandlers({
       resolveSessionArtifactFilePath,
       openLatestManagedFile
@@ -1277,7 +1387,7 @@ describe('file save IPC handlers', () => {
       ]
     })
     expect(resolveSessionArtifactFilePath).not.toHaveBeenCalled()
-    expect(showSaveDialog).not.toHaveBeenCalled()
+    expect(showSaveDialog).toHaveBeenCalledOnce()
   })
 
   it('opens the immutable Project file Version selected in the renderer snapshot', async () => {
@@ -1485,10 +1595,14 @@ describe('file save IPC handlers', () => {
     }
   })
 
-  it('skips the Save As dialog when no Project Artifact resolves', async () => {
+  it('publishes no archive when no Project Artifact resolves after Save As', async () => {
     const resolveSessionArtifactFilePath = vi
       .fn()
       .mockRejectedValue(new Error('Artifact bytes are unavailable.'))
+    showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: join(downloadsPath, 'Research-artifacts.zip')
+    })
     registerProjectFileSaveHandlers({ resolveSessionArtifactFilePath } as never)
 
     const result = await handlers.get('file:save-project-artifacts')!(
@@ -1508,7 +1622,7 @@ describe('file save IPC handlers', () => {
       }
     )
 
-    expect(showSaveDialog).not.toHaveBeenCalled()
+    expect(showSaveDialog).toHaveBeenCalledOnce()
     expect(result).toEqual({
       saved: true,
       failures: [
@@ -1858,6 +1972,10 @@ describe('file save IPC handlers', () => {
   it('reports invalid latest Version sizes without reading them', async () => {
     const close = vi.fn().mockResolvedValue(undefined)
     const readRange = vi.fn()
+    showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: join(downloadsPath, 'Research-artifacts.zip')
+    })
     registerProjectFileSaveHandlers({
       openLatestManagedFile: vi
         .fn()
@@ -1895,7 +2013,7 @@ describe('file save IPC handlers', () => {
       ]
     })
     expect(readRange).not.toHaveBeenCalled()
-    expect(showSaveDialog).not.toHaveBeenCalled()
+    expect(showSaveDialog).toHaveBeenCalledOnce()
     expect(close).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -241,8 +241,19 @@ describe('file save IPC handlers', () => {
       .fn()
       .mockResolvedValueOnce(await fileBackedManagedVersionHandle(sourceA))
       .mockResolvedValueOnce(await fileBackedManagedVersionHandle(sourceB))
+    const publishWithoutHardLinks: typeof productionPublishUserFile = (
+      destination,
+      write,
+      options
+    ) =>
+      productionPublishUserFile(destination, write, {
+        ...options,
+        linkFile: async () => {
+          throw Object.assign(new Error('hard links are unsupported'), { code: 'EOPNOTSUPP' })
+        }
+      })
     showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [destinationDirectory] })
-    registerFileSaveHandlers({ openLatestManagedFile } as never)
+    registerFileSaveHandlers({ openLatestManagedFile, publishUserFile: publishWithoutHardLinks })
 
     try {
       const result = await handlers.get('file:save-session-artifacts')!(

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -22,6 +22,7 @@ import type {
 } from '../shared/file-save'
 import { englishNativeTranslator, type NativeTranslator } from './locale/main-process-messages'
 import { toErrorMessage } from './error-message'
+import { publishUserFile } from './user-file-publisher'
 
 type RegisterFileSaveHandlersOptions = {
   resolveManagedFilePath?: (
@@ -46,6 +47,7 @@ type RegisterFileSaveHandlersOptions = {
   ) => Promise<ManagedFileVersionHandle>
   createProjectArtifactTemporaryRoot?: () => Promise<string>
   projectArtifactExportLimits?: ProjectArtifactExportLimits
+  publishUserFile?: typeof publishUserFile
   translate?: NativeTranslator
 }
 
@@ -71,17 +73,9 @@ const PROJECT_ARTIFACT_EXPORT_LIMITS: ProjectArtifactExportLimits = {
 
 const PROJECT_ARTIFACT_STREAM_CHUNK_BYTES = 64 * 1024
 
-type ProjectArtifactExportCandidateBase = {
-  file: SaveProjectArtifactsRequest['files'][number]
-  entryName: string
-}
-
-type ProjectArtifactExportCandidate = ProjectArtifactExportCandidateBase & {
-  source: ManagedFileVersionHandle
-}
-
 type ManagedFileHandle = {
   copyTo: (destinationPath: string, options?: { exclusive?: boolean }) => Promise<void>
+  assertCanCopyTo?: (destinationPath: string) => Promise<void>
   close: () => Promise<void>
 }
 
@@ -200,7 +194,27 @@ const assertSaveProjectArtifactsRequest = (request: SaveProjectArtifactsRequest)
 const openManagedFile = async (sourcePath: string): Promise<ManagedFileHandle> => {
   const sourceHandle = await open(sourcePath, 'r')
 
+  const assertCanCopyTo = async (destinationPath: string): Promise<void> => {
+    let destinationHandle: FileHandle | undefined
+    try {
+      destinationHandle = await open(destinationPath, 'r')
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return
+      throw error
+    }
+    try {
+      const sourceStat = await sourceHandle.stat()
+      const destinationStat = await destinationHandle.stat()
+      if (destinationStat.dev === sourceStat.dev && destinationStat.ino === sourceStat.ino) {
+        throw new Error('Cannot save a managed file over its source.')
+      }
+    } finally {
+      await destinationHandle.close()
+    }
+  }
+
   return {
+    assertCanCopyTo,
     copyTo: async (destinationPath, options) => {
       // Open without truncation, then check and write through the same handle to prevent path swaps.
       const destinationHandle = await open(
@@ -243,7 +257,12 @@ const appendArchiveChunk = async (handle: FileHandle, chunk: Uint8Array): Promis
 
 const writeProjectArtifactArchive = async (options: {
   destinationPath: string
-  candidates: ProjectArtifactExportCandidate[]
+  projectId: string
+  files: SaveProjectArtifactsRequest['files']
+  openManagedFileVersion: NonNullable<
+    RegisterFileSaveHandlersOptions['openManagedFileVersion']
+  >
+  publishUserFile: typeof publishUserFile
   failures: SaveProjectArtifactFailure[]
   limits: ProjectArtifactExportLimits
   createTemporaryRoot: () => Promise<string>
@@ -252,7 +271,6 @@ const writeProjectArtifactArchive = async (options: {
   let archiveHandle: FileHandle | undefined
   let archiveHandleClosed = false
   let zip: Zip | undefined
-  const pendingManagedSources = new Set(options.candidates.map((candidate) => candidate.source))
 
   try {
     temporaryRoot = await options.createTemporaryRoot()
@@ -262,6 +280,7 @@ const writeProjectArtifactArchive = async (options: {
     let pendingArchiveWrite = Promise.resolve()
     let streamedEntries = 0
     let streamedBytes = 0
+    const takenNames = new Set<string>()
 
     zip = new Zip((error, chunk) => {
       if (error) {
@@ -280,13 +299,22 @@ const writeProjectArtifactArchive = async (options: {
       if (archiveFailure) throw archiveFailure
     }
 
-    for (const candidate of options.candidates) {
-      let closeSource: (() => Promise<void>) | undefined
+    for (const file of options.files) {
+      let managedSource: ManagedFileVersionHandle | undefined
       let entryStarted = false
       try {
-        const managedSource = candidate.source
+        if (streamedEntries >= options.limits.maxFiles) {
+          throw new Error('Project export exceeds the file-count limit.')
+        }
+        managedSource = await options.openManagedFileVersion(file.source, {
+          projectId: options.projectId,
+          fileId: file.fileId,
+          versionId: file.versionId
+        })
         const sourceSize = managedSource.size
-        closeSource = () => managedSource.close()
+        if (!Number.isSafeInteger(sourceSize) || sourceSize < 0) {
+          throw new Error('Project export source size is invalid.')
+        }
         const chunks = (async function* (): AsyncGenerator<Uint8Array> {
           for (let begin = 0; begin < managedSource.size;) {
             const end = Math.min(begin + PROJECT_ARTIFACT_STREAM_CHUNK_BYTES, managedSource.size)
@@ -306,7 +334,13 @@ const writeProjectArtifactArchive = async (options: {
           throw new Error('Project export exceeds the total size limit.')
         }
 
-        const zipEntry = new ZipDeflate(candidate.entryName, { level: 6 })
+        const categoryDirectory = file.source === 'upload' ? 'uploads' : 'generated'
+        const entryName = claimZipEntryName(
+          takenNames,
+          `${categoryDirectory}/${getSafeZipEntryName(file.suggestedName)}`
+        )
+        takenNames.add(entryName.toLowerCase())
+        const zipEntry = new ZipDeflate(entryName, { level: 6 })
         zip.add(zipEntry)
         entryStarted = true
         let entryBytes = 0
@@ -335,12 +369,11 @@ const writeProjectArtifactArchive = async (options: {
       } catch (error) {
         if (entryStarted) throw error
         options.failures.push({
-          ...candidate.file,
+          ...file,
           message: toErrorMessage(error)
         })
       } finally {
-        await closeSource?.()
-        pendingManagedSources.delete(candidate.source)
+        await managedSource?.close()
       }
     }
 
@@ -354,7 +387,9 @@ const writeProjectArtifactArchive = async (options: {
     throwIfArchiveFailed()
     await archiveHandle.close()
     archiveHandleClosed = true
-    await copyFile(temporaryArchivePath, options.destinationPath)
+    await options.publishUserFile(options.destinationPath, (temporaryPath) =>
+      copyFile(temporaryArchivePath, temporaryPath, constants.COPYFILE_EXCL)
+    )
     return true
   } catch (error) {
     zip?.terminate()
@@ -363,9 +398,6 @@ const writeProjectArtifactArchive = async (options: {
     if (archiveHandle && !archiveHandleClosed) {
       await archiveHandle.close().catch(() => undefined)
     }
-    await Promise.all(
-      [...pendingManagedSources].map((source) => source.close().catch(() => undefined))
-    )
     if (temporaryRoot) {
       await rm(temporaryRoot, { recursive: true, force: true }).catch(() => undefined)
     }
@@ -438,17 +470,26 @@ const getSafeFilename = (suggestedName: string, sourcePath: string): string => {
 const copyToAvailableDestination = async (
   managedFile: ManagedFileHandle,
   destinationDirectory: string,
-  safeName: string
+  safeName: string,
+  publish: typeof publishUserFile
 ): Promise<string> => {
   for (let suffix = 1; ; suffix += 1) {
     const filename = suffix === 1 ? safeName : addFilenameCollisionSuffix(safeName, suffix)
     const destinationPath = join(destinationDirectory, filename)
     try {
-      await managedFile.copyTo(destinationPath, { exclusive: true })
+      await publish(
+        destinationPath,
+        (temporaryPath) => managedFile.copyTo(temporaryPath, { exclusive: true }),
+        {
+          exclusive: true,
+          ...(managedFile.assertCanCopyTo
+            ? { validateDestination: () => managedFile.assertCanCopyTo!(destinationPath) }
+            : {})
+        }
+      )
       return destinationPath
     } catch (error) {
       if (isAlreadyExistsError(error)) continue
-      await rm(destinationPath, { force: true }).catch(() => undefined)
       throw error
     }
   }
@@ -480,6 +521,7 @@ const extensionForMime = (mimeType: string): string | undefined => {
 }
 
 const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {}): void => {
+  const publish = options.publishUserFile ?? publishUserFile
   ipcMainHandle(
     'file:save-blob',
     async (event, request: SaveBlobFileRequest): Promise<SaveBlobFileResult> => {
@@ -499,7 +541,9 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
         return { saved: false }
       }
 
-      await writeFile(filePath, Buffer.from(request.data))
+      await publish(filePath, (temporaryPath) =>
+        writeFile(temporaryPath, Buffer.from(request.data))
+      )
       return { saved: true, filePath }
     }
   )
@@ -569,7 +613,11 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
               })
           : pathManagedFile!
         try {
-          await managedFile.copyTo(filePath)
+          await publish(filePath, (temporaryPath) => managedFile.copyTo(temporaryPath), {
+            ...(managedFile.assertCanCopyTo
+              ? { validateDestination: () => managedFile.assertCanCopyTo!(filePath) }
+              : {})
+          })
           return { saved: true, filePath }
         } finally {
           if (versionedRequest) await managedFile.close()
@@ -610,7 +658,11 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
         })
 
         try {
-          await managedFile.copyTo(filePath)
+          await publish(filePath, (temporaryPath) => managedFile.copyTo(temporaryPath), {
+            ...(managedFile.assertCanCopyTo
+              ? { validateDestination: () => managedFile.assertCanCopyTo!(filePath) }
+              : {})
+          })
           return { saved: true, filePaths: [filePath] }
         } finally {
           await managedFile.close()
@@ -642,7 +694,7 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
           })
           const safeName = getSafeFilename(file.suggestedName, file.fileId)
           savedPaths.push(
-            await copyToAvailableDestination(managedFile, destinationDirectory, safeName)
+            await copyToAvailableDestination(managedFile, destinationDirectory, safeName, publish)
           )
         } catch (error) {
           failures.push({
@@ -672,58 +724,6 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
         throw new Error('Managed file Version resolver is not configured.')
       }
 
-      const limits = options.projectArtifactExportLimits ?? PROJECT_ARTIFACT_EXPORT_LIMITS
-      const candidates: ProjectArtifactExportCandidate[] = []
-      const takenNames = new Set<string>()
-      const failures: SaveProjectArtifactFailure[] = []
-      let totalBytes = 0
-      for (const file of request.files) {
-        let exportFile: ManagedFileVersionHandle | undefined
-        let retainedManagedVersion = false
-        try {
-          if (takenNames.size >= limits.maxFiles) {
-            throw new Error('Project export exceeds the file-count limit.')
-          }
-          const managedVersion = await openManagedFileVersion(file.source, {
-            projectId: request.projectId,
-            fileId: file.fileId,
-            versionId: file.versionId
-          })
-          exportFile = managedVersion
-          if (!Number.isSafeInteger(managedVersion.size) || managedVersion.size < 0) {
-            throw new Error('Project export source size is invalid.')
-          }
-          if (managedVersion.size > limits.maxFileBytes) {
-            throw new Error('Project export file exceeds the per-file size limit.')
-          }
-          if (totalBytes + managedVersion.size > limits.maxTotalBytes) {
-            throw new Error('Project export exceeds the total size limit.')
-          }
-          // Entries are grouped by origin under constant directory prefixes; the file name part
-          // is sanitized before prefixing and collision suffixes apply within each category.
-          const categoryDirectory = file.source === 'upload' ? 'uploads' : 'generated'
-          const entryName = claimZipEntryName(
-            takenNames,
-            `${categoryDirectory}/${getSafeZipEntryName(file.suggestedName)}`
-          )
-          candidates.push({ file, entryName, source: managedVersion })
-          retainedManagedVersion = true
-          totalBytes += managedVersion.size
-          // Claim checks are case-insensitive; the entry itself keeps its original casing.
-          takenNames.add(entryName.toLowerCase())
-        } catch (error) {
-          failures.push({
-            ...file,
-            message: toErrorMessage(error)
-          })
-        } finally {
-          if (!retainedManagedVersion) await exportFile?.close()
-        }
-      }
-      if (candidates.length === 0) {
-        return { saved: true, ...(failures.length > 0 ? { failures } : {}) }
-      }
-
       const parentWindow = BrowserWindow.fromWebContents(event.sender)
       const dialogOptions = {
         defaultPath: join(
@@ -738,30 +738,21 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
           }
         ]
       }
-      let dialogResult: Awaited<ReturnType<typeof dialog.showSaveDialog>>
-      try {
-        dialogResult = parentWindow
-          ? await dialog.showSaveDialog(parentWindow, dialogOptions)
-          : await dialog.showSaveDialog(dialogOptions)
-      } catch (error) {
-        await Promise.all(
-          candidates.flatMap((candidate) => [candidate.source.close().catch(() => undefined)])
-        )
-        throw error
-      }
+      const dialogResult = parentWindow
+        ? await dialog.showSaveDialog(parentWindow, dialogOptions)
+        : await dialog.showSaveDialog(dialogOptions)
       const { canceled, filePath } = dialogResult
-      if (canceled || !filePath) {
-        await Promise.all(
-          candidates.flatMap((candidate) => [candidate.source.close().catch(() => undefined)])
-        )
-        return { saved: false }
-      }
+      if (canceled || !filePath) return { saved: false }
 
+      const failures: SaveProjectArtifactFailure[] = []
       const wroteArchive = await writeProjectArtifactArchive({
         destinationPath: filePath,
-        candidates,
+        projectId: request.projectId,
+        files: request.files,
+        openManagedFileVersion,
+        publishUserFile: publish,
         failures,
-        limits,
+        limits: options.projectArtifactExportLimits ?? PROJECT_ARTIFACT_EXPORT_LIMITS,
         createTemporaryRoot:
           options.createProjectArtifactTemporaryRoot ??
           (() => mkdtemp(join(tmpdir(), 'open-science-project-export-')))

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -259,9 +259,7 @@ const writeProjectArtifactArchive = async (options: {
   destinationPath: string
   projectId: string
   files: SaveProjectArtifactsRequest['files']
-  openManagedFileVersion: NonNullable<
-    RegisterFileSaveHandlersOptions['openManagedFileVersion']
-  >
+  openManagedFileVersion: NonNullable<RegisterFileSaveHandlersOptions['openManagedFileVersion']>
   publishUserFile: typeof publishUserFile
   failures: SaveProjectArtifactFailure[]
   limits: ProjectArtifactExportLimits

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -480,12 +480,7 @@ const copyToAvailableDestination = async (
       await publish(
         destinationPath,
         (temporaryPath) => managedFile.copyTo(temporaryPath, { exclusive: true }),
-        {
-          exclusive: true,
-          ...(managedFile.assertCanCopyTo
-            ? { validateDestination: () => managedFile.assertCanCopyTo!(destinationPath) }
-            : {})
-        }
+        { exclusive: true }
       )
       return destinationPath
     } catch (error) {

--- a/src/main/immutable-input-authority.ts
+++ b/src/main/immutable-input-authority.ts
@@ -48,6 +48,7 @@ type ImmutableInputContentLease = Pick<
   | 'read'
   | 'readRange'
   | 'copyTo'
+  | 'assertCanCopyTo'
   | 'verifyUnchanged'
   | 'close'
 >

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -85,6 +85,7 @@ import { createMoleculePreviewHandler } from './connectors/molecule-preview'
 import { ALL_CONNECTOR_IDS } from './connectors/registry'
 import { connectorSkillSourceDir } from './connectors/provision'
 import { registerFileSaveHandlers } from './file-save'
+import { publishUserFile } from './user-file-publisher'
 import { ImmutableInputAuthority } from './immutable-input-authority'
 import { createCliCommandOwner, registerCliInstallIpcHandlers } from './cli-install/ipc'
 
@@ -3306,7 +3307,9 @@ const createApplicationModules = async (
             filters: [{ name: translate('Connector configuration'), extensions: ['json'] }]
           })
           if (selected.canceled || !selected.filePath) return false
-          await writeFile(selected.filePath, contents, 'utf8')
+          await publishUserFile(selected.filePath, (temporaryPath) =>
+            writeFile(temporaryPath, contents, 'utf8')
+          )
           return true
         }
       },

--- a/src/main/managed-file-versions/service.ts
+++ b/src/main/managed-file-versions/service.ts
@@ -84,6 +84,7 @@ type ManagedFileReadLease = ResolvedManagedFileVersion & {
   ) => Promise<{ bytesRead: number }>
   readRange: (begin: number, end: number) => Promise<Uint8Array>
   copyTo: (destinationPath: string, options?: { exclusive?: boolean }) => Promise<void>
+  assertCanCopyTo?: (destinationPath: string) => Promise<void>
   verifyUnchanged: () => Promise<void>
   close: () => Promise<void>
 }
@@ -1208,6 +1209,7 @@ class ManagedFileVersionService {
       },
       readRange: operatorLease.readRange,
       copyTo: (destinationPath, options) => operatorLease.copyTo(destinationPath, options),
+      assertCanCopyTo: operatorLease.assertCanCopyTo,
       verifyUnchanged: operatorLease.verifyUnchanged,
       close: operatorLease.close
     }

--- a/src/main/managed-file-versions/version-file-operator.test.ts
+++ b/src/main/managed-file-versions/version-file-operator.test.ts
@@ -522,6 +522,10 @@ describe('NodeVersionFileOperator', () => {
     const lease = await operator.openImmutable(stored.storageRef, stored)
     expect(lease.localPath).toBe(join(cleanupRoot, ...stored.storageRef.split('/')))
     await expect(lease.readRange(9, 18)).resolves.toEqual(new Uint8Array(Buffer.from('immutable')))
+    await expect(lease.assertCanCopyTo(destinationPath)).resolves.toBeUndefined()
+    await expect(lease.assertCanCopyTo(lease.localPath)).rejects.toMatchObject({
+      code: 'INTEGRITY_FAILED'
+    })
     await lease.copyTo(destinationPath)
     await expect(readFile(destinationPath)).resolves.toEqual(content)
     await lease.verifyUnchanged()

--- a/src/main/managed-file-versions/version-file-operator.ts
+++ b/src/main/managed-file-versions/version-file-operator.ts
@@ -72,6 +72,7 @@ type ReadLease = Integrity & {
   versionToken?: string
   readRange: (begin: number, end: number) => Promise<Uint8Array>
   copyTo: (destinationPath: string, options?: { exclusive?: boolean }) => Promise<void>
+  assertCanCopyTo: (destinationPath: string) => Promise<void>
   verifyUnchanged: () => Promise<void>
   close: () => Promise<void>
 }
@@ -564,6 +565,34 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
           )
         }
       }
+      const assertCanCopyTo = async (destinationPath: string): Promise<void> => {
+        let destination: FileHandle | undefined
+        try {
+          assertOpen()
+          try {
+            destination = await this.fileSystem.open(destinationPath, constants.O_RDONLY)
+          } catch (error) {
+            if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return
+            throw error
+          }
+          const sourceStats = await leaseHandle.stat()
+          const destinationStats = await destination.stat()
+          if (
+            sourceStats.dev === destinationStats.dev &&
+            sourceStats.ino === destinationStats.ino
+          ) {
+            throw new Error('Cannot copy an immutable version over itself.')
+          }
+        } catch (error) {
+          throw normalizeStorageError(
+            error,
+            'INTEGRITY_FAILED',
+            'Unable to validate immutable version copy destination.'
+          )
+        } finally {
+          await destination?.close().catch(() => undefined)
+        }
+      }
       const copyTo = async (
         destinationPath: string,
         options?: { exclusive?: boolean }
@@ -632,6 +661,7 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
         ...(versionTokenMatch ? { versionToken: versionTokenMatch[1] } : {}),
         readRange,
         copyTo,
+        assertCanCopyTo,
         verifyUnchanged,
         close: async () => {
           if (closed) return

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -28,6 +28,7 @@ import type {
   NotebookSessionState,
   RunNotebookCellRequest
 } from '../../shared/notebook'
+import { publishUserFile } from '../user-file-publisher'
 import {
   isNotebookRunCursor,
   NOTEBOOK_STATE_HISTORY_FRAME_ID_LIMIT_BYTES,
@@ -274,7 +275,7 @@ const saveIpynbWithDialog = async (
   })
 
   if (canceled || !filePath) return { saved: false }
-  await writeFile(filePath, data, 'utf8')
+  await publishUserFile(filePath, (temporaryPath) => writeFile(temporaryPath, data, 'utf8'))
   return { saved: true, filePath }
 }
 

--- a/src/main/session-persistence/conversation-export.test.ts
+++ b/src/main/session-persistence/conversation-export.test.ts
@@ -1,4 +1,6 @@
 import { join } from 'node:path'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -23,6 +25,7 @@ import {
   createConversationExportService,
   registerConversationExportIpcHandler
 } from './conversation-export'
+import { publishUserFile as productionPublishUserFile } from '../user-file-publisher'
 
 const session: PersistedChatSession = {
   id: 'session-1',
@@ -61,6 +64,14 @@ describe('conversation export service', () => {
     webContents: { executeJavaScript, printToPDF },
     destroy
   }))
+  const publishDirectly: typeof productionPublishUserFile = async (
+    destinationPath,
+    write,
+    options
+  ) => {
+    await write(destinationPath)
+    await options?.validateDestination?.()
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -89,6 +100,7 @@ describe('conversation export service', () => {
       getDownloadsPath: () => '/downloads',
       getTempPath: () => '/tmp',
       now: () => 3,
+      publishUserFile: publishDirectly,
       ...overrides
     } as Parameters<typeof createConversationExportService>[0])
 
@@ -113,6 +125,30 @@ describe('conversation export service', () => {
     )
     expect(createPrintWindow).not.toHaveBeenCalled()
     expect(result).toEqual({ saved: true, filePath: '/downloads/export.md' })
+  })
+
+  it('preserves an existing Markdown destination when writing fails after partial output', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-conversation-export-failure-'))
+    const destinationPath = join(root, 'export.md')
+    await writeFile(destinationPath, 'existing conversation')
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
+    writeExportFile.mockImplementation(async (path: string) => {
+      await writeFile(path, 'partial conversation')
+      throw new Error('disk full')
+    })
+
+    try {
+      await expect(
+        createService({ publishUserFile: productionPublishUserFile }).exportConversation({
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          format: 'markdown'
+        })
+      ).rejects.toThrow('disk full')
+      await expect(readFile(destinationPath, 'utf8')).resolves.toBe('existing conversation')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('saves only the selected durable turns in conversation order', async () => {

--- a/src/main/session-persistence/conversation-export.ts
+++ b/src/main/session-persistence/conversation-export.ts
@@ -16,6 +16,7 @@ import {
 import { hasCurrentRunningDelegatedAttempt } from '../../shared/delegated-work-projection'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { englishNativeTranslator, type NativeTranslator } from '../locale/main-process-messages'
+import { publishUserFile } from '../user-file-publisher'
 
 type ConversationExportPrintWindow = {
   loadFile(path: string): Promise<void>
@@ -48,6 +49,7 @@ type ConversationExportDependencies = {
     options: SaveDialogOptions
   ): Promise<Electron.SaveDialogReturnValue>
   writeFile(path: string, data: string | Buffer): Promise<void>
+  publishUserFile: typeof publishUserFile
   createTempDirectory(prefix: string): Promise<string>
   removeDirectory(path: string): Promise<void>
   createPrintWindow(): ConversationExportPrintWindow
@@ -115,6 +117,7 @@ const defaultDependencies: ConversationExportDefaultDependencies = {
   showSaveDialog: (parentWindow, options) =>
     parentWindow ? dialog.showSaveDialog(parentWindow, options) : dialog.showSaveDialog(options),
   writeFile,
+  publishUserFile,
   createTempDirectory: mkdtemp,
   removeDirectory: (path) => rm(path, { recursive: true, force: true }),
   createPrintWindow: createDefaultPrintWindow,
@@ -216,7 +219,9 @@ const createConversationExportService = (
       if (dialogResult.canceled || !dialogResult.filePath) return { saved: false }
 
       if (request.format === 'markdown') {
-        await deps.writeFile(dialogResult.filePath, renderConversationMarkdown(document))
+        await deps.publishUserFile(dialogResult.filePath, (temporaryPath) =>
+          deps.writeFile(temporaryPath, renderConversationMarkdown(document))
+        )
         return { saved: true, filePath: dialogResult.filePath }
       }
 
@@ -258,7 +263,9 @@ const createConversationExportService = (
                 )
               )
           )
-          await deps.writeFile(dialogResult.filePath, pdf)
+          await deps.publishUserFile(dialogResult.filePath, (temporaryPath) =>
+            deps.writeFile(temporaryPath, pdf)
+          )
           return { saved: true, filePath: dialogResult.filePath }
         } finally {
           printWindow.destroy()

--- a/src/main/skills/export.test.ts
+++ b/src/main/skills/export.test.ts
@@ -31,7 +31,16 @@ describe('Skill ZIP export', () => {
     const archiveBytes = new Uint8Array([1, 2, 3])
 
     await expect(
-      saveSkillExport({ showSaveDialog, writeFile }, { fileName: 'my-skill.zip', archiveBytes })
+      saveSkillExport(
+        {
+          showSaveDialog,
+          writeFile,
+          publishUserFile: async (destinationPath, write) => {
+            await write(destinationPath)
+          }
+        },
+        { fileName: 'my-skill.zip', archiveBytes }
+      )
     ).resolves.toEqual({ saved: true })
     expect(showSaveDialog).toHaveBeenCalledWith({
       title: 'Export Skill',

--- a/src/main/skills/export.ts
+++ b/src/main/skills/export.ts
@@ -6,6 +6,7 @@ import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import type { BundledSkill } from './registry'
 import { canonicalSkillDocument } from './skill-document-name'
 import { englishNativeTranslator, type NativeTranslator } from '../locale/main-process-messages'
+import { publishUserFile } from '../user-file-publisher'
 import {
   inspectSkillPackage,
   SkillPackagePolicyError,
@@ -48,6 +49,7 @@ type SkillExportDialog = {
     filters: Array<{ name: string; extensions: string[] }>
   }) => Promise<{ canceled: boolean; filePath?: string }>
   writeFile: (filePath: string, bytes: Uint8Array) => Promise<unknown>
+  publishUserFile?: typeof publishUserFile
 }
 
 const collectFiles = async (directory: string, skillName: string): Promise<Zippable> => {
@@ -117,6 +119,8 @@ export const saveSkillExport = async (
     filters: [{ name: translate('Skill ZIP'), extensions: ['zip'] }]
   })
   if (selected.canceled || !selected.filePath) return { saved: false }
-  await adapter.writeFile(selected.filePath, archive.archiveBytes)
+  await (adapter.publishUserFile ?? publishUserFile)(selected.filePath, async (temporaryPath) => {
+    await adapter.writeFile(temporaryPath, archive.archiveBytes)
+  })
   return { saved: true }
 }

--- a/src/main/specialist/package/contribution-template.test.ts
+++ b/src/main/specialist/package/contribution-template.test.ts
@@ -92,7 +92,10 @@ describe('contribution template ZIP', () => {
       showSaveDialog,
       readReadme: vi.fn().mockResolvedValue('# 中文\n\n# English\n'),
       generatePackageId: () => '00000000-0000-4000-8000-000000000002',
-      writeFile
+      writeFile,
+      publishUserFile: async (destinationPath, write) => {
+        await write(destinationPath)
+      }
     })
 
     await expect(exportContributionTemplate()).resolves.toEqual({ saved: true })
@@ -109,7 +112,10 @@ describe('contribution template ZIP', () => {
         .fn()
         .mockResolvedValue({ canceled: false, filePath: '/secret/user/location/template.zip' }),
       readReadme: vi.fn().mockResolvedValue('# Guide'),
-      writeFile: vi.fn().mockRejectedValue(new Error('EACCES /secret/user/location/template.zip'))
+      writeFile: vi.fn().mockRejectedValue(new Error('EACCES /secret/user/location/template.zip')),
+      publishUserFile: async (destinationPath, write) => {
+        await write(destinationPath)
+      }
     })
 
     await expect(exportContributionTemplate()).rejects.toThrow(

--- a/src/main/specialist/package/contribution-template.ts
+++ b/src/main/specialist/package/contribution-template.ts
@@ -8,6 +8,7 @@ import {
   type ContributionTemplateExportResult
 } from '../../../shared/specialist-package'
 import { englishNativeTranslator, type NativeTranslator } from '../../locale/main-process-messages'
+import { publishUserFile } from '../../user-file-publisher'
 
 export const CONTRIBUTION_TEMPLATE_FILENAME = 'openscience-specialist-template.zip'
 
@@ -26,6 +27,7 @@ type ContributionTemplateExporterDependencies = {
   }) => Promise<{ canceled: boolean; filePath?: string }>
   readReadme: () => Promise<string>
   writeFile: (filePath: string, bytes: Uint8Array) => Promise<void>
+  publishUserFile?: typeof publishUserFile
   generatePackageId?: () => string
   translate?: NativeTranslator
 }
@@ -98,7 +100,10 @@ export const createContributionTemplateExporter =
         readme,
         packageId: (dependencies.generatePackageId ?? randomUUID)()
       })
-      await dependencies.writeFile(destination.filePath, archive)
+      await (dependencies.publishUserFile ?? publishUserFile)(
+        destination.filePath,
+        (temporaryPath) => dependencies.writeFile(temporaryPath, archive)
+      )
       return { saved: true }
     } catch {
       throw new Error('Could not save contribution template.')

--- a/src/main/specialist/package/electron-adapter.test.ts
+++ b/src/main/specialist/package/electron-adapter.test.ts
@@ -29,7 +29,13 @@ describe('saveSpecialistExport', () => {
 
     await expect(
       saveSpecialistExport(
-        { showSaveDialog, writeFile },
+        {
+          showSaveDialog,
+          writeFile,
+          publishUserFile: async (destinationPath, write) => {
+            await write(destinationPath)
+          }
+        },
         { fileName: 'research-synth-1.3.0.zip', archiveBytes: new Uint8Array([1, 2, 3]) }
       )
     ).resolves.toEqual({ saved: true })
@@ -114,7 +120,16 @@ describe('saveSpecialistPackageReport', () => {
     }
 
     await expect(
-      saveSpecialistPackageReport({ showSaveDialog, writeFile }, report)
+      saveSpecialistPackageReport(
+        {
+          showSaveDialog,
+          writeFile,
+          publishUserFile: async (destinationPath, write) => {
+            await write(destinationPath)
+          }
+        },
+        report
+      )
     ).resolves.toEqual({ saved: true })
     expect(showSaveDialog).toHaveBeenCalledWith({
       defaultPath: 'safe-specialist-1.0.0-diagnostics.json',

--- a/src/main/specialist/package/electron-adapter.ts
+++ b/src/main/specialist/package/electron-adapter.ts
@@ -5,6 +5,7 @@ import {
   type SpecialistPackageReportSaveResult
 } from '../../../shared/specialist-package'
 import { englishNativeTranslator, type NativeTranslator } from '../../locale/main-process-messages'
+import { publishUserFile } from '../../user-file-publisher'
 
 type SpecialistExportDialog = {
   showSaveDialog: (options: {
@@ -12,6 +13,7 @@ type SpecialistExportDialog = {
     filters: [{ name: string; extensions: ['zip'] }]
   }) => Promise<{ canceled: boolean; filePath?: string }>
   writeFile: (path: string, bytes: Uint8Array) => Promise<unknown>
+  publishUserFile?: typeof publishUserFile
 }
 
 export const saveSpecialistExport = async (
@@ -24,7 +26,9 @@ export const saveSpecialistExport = async (
     filters: [{ name: translate('ZIP archive'), extensions: ['zip'] }]
   })
   if (selected.canceled || !selected.filePath) return { saved: false }
-  await adapter.writeFile(selected.filePath, archive.archiveBytes)
+  await (adapter.publishUserFile ?? publishUserFile)(selected.filePath, async (temporaryPath) => {
+    await adapter.writeFile(temporaryPath, archive.archiveBytes)
+  })
   return { saved: true }
 }
 
@@ -62,6 +66,7 @@ type SpecialistPackageReportDialog = {
     filters: [{ name: string; extensions: ['json'] }]
   }) => Promise<{ canceled: boolean; filePath?: string }>
   writeFile: (path: string, contents: string) => Promise<unknown>
+  publishUserFile?: typeof publishUserFile
 }
 
 export const saveSpecialistPackageReport = async (
@@ -77,6 +82,8 @@ export const saveSpecialistPackageReport = async (
     filters: [{ name: translate('JSON report'), extensions: ['json'] }]
   })
   if (selected.canceled || !selected.filePath) return { saved: false }
-  await adapter.writeFile(selected.filePath, `${JSON.stringify(report, null, 2)}\n`)
+  await (adapter.publishUserFile ?? publishUserFile)(selected.filePath, async (temporaryPath) => {
+    await adapter.writeFile(temporaryPath, `${JSON.stringify(report, null, 2)}\n`)
+  })
   return { saved: true }
 }

--- a/src/main/storage/durable-json-file.ts
+++ b/src/main/storage/durable-json-file.ts
@@ -3,8 +3,8 @@ import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/p
 import { basename, dirname, join } from 'node:path'
 
 import { defaultFileDurability } from './file-durability'
+import { retryFileReplacement } from './file-replacement'
 
-const FILE_REPLACEMENT_RETRY_DELAYS_MS = [25, 50, 100, 200, 400] as const
 const fileOperations = new Map<string, Promise<void>>()
 
 type DurableJsonDirectoryEntry = {
@@ -54,12 +54,6 @@ const DEFAULT_DEPENDENCIES: DurableJsonFileDependencies = {
   writeFile: (path, contents, options) => writeFile(path, contents, options)
 }
 
-const isRetryableFileReplacementError = (error: unknown): boolean =>
-  typeof error === 'object' &&
-  error !== null &&
-  'code' in error &&
-  ['EPERM', 'EACCES', 'EBUSY'].includes(String(error.code))
-
 const isMissingFileError = (error: unknown): boolean =>
   typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
 
@@ -83,23 +77,6 @@ const runFileOperation = async <Result>(
   } finally {
     release()
     if (fileOperations.get(filePath) === tail) fileOperations.delete(filePath)
-  }
-}
-
-const renameWithRetry = async (
-  source: string,
-  destination: string,
-  dependencies: DurableJsonFileDependencies
-): Promise<void> => {
-  for (let attempt = 0; ; attempt += 1) {
-    try {
-      await dependencies.rename(source, destination)
-      return
-    } catch (error) {
-      const delayMs = FILE_REPLACEMENT_RETRY_DELAYS_MS[attempt]
-      if (delayMs === undefined || !isRetryableFileReplacementError(error)) throw error
-      await dependencies.wait(delayMs)
-    }
   }
 }
 
@@ -127,7 +104,10 @@ export const writeDurableJsonFile = async (
         throw error
       }
       await dependencies.syncFile(temporaryPath)
-      await renameWithRetry(temporaryPath, filePath, dependencies)
+      await retryFileReplacement(
+        () => dependencies.rename(temporaryPath, filePath),
+        dependencies.wait
+      )
       await dependencies.syncDirectory(directory)
     } catch (error) {
       if (ownsTemporaryPath) {
@@ -274,7 +254,10 @@ export const readDurableJsonFile = async <Value>(
         }
 
         await dependencies.syncFile(candidate.path)
-        await renameWithRetry(candidate.path, filePath, dependencies)
+        await retryFileReplacement(
+          () => dependencies.rename(candidate.path, filePath),
+          dependencies.wait
+        )
         await dependencies.syncDirectory(dirname(filePath))
         await cleanupTemporaryCandidates(candidates, dependencies)
         return { status: 'found', value }

--- a/src/main/storage/file-replacement.ts
+++ b/src/main/storage/file-replacement.ts
@@ -1,0 +1,26 @@
+const FILE_REPLACEMENT_RETRY_DELAYS_MS = [25, 50, 100, 200, 400] as const
+
+const isRetryableFileReplacementError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  ['EPERM', 'EACCES', 'EBUSY'].includes(String(error.code))
+
+const retryFileReplacement = async (
+  replace: () => Promise<void>,
+  wait: (delayMs: number) => Promise<void> = (delayMs) =>
+    new Promise((resolve) => setTimeout(resolve, delayMs))
+): Promise<void> => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await replace()
+      return
+    } catch (error) {
+      const delayMs = FILE_REPLACEMENT_RETRY_DELAYS_MS[attempt]
+      if (delayMs === undefined || !isRetryableFileReplacementError(error)) throw error
+      await wait(delayMs)
+    }
+  }
+}
+
+export { retryFileReplacement }

--- a/src/main/user-file-publisher.test.ts
+++ b/src/main/user-file-publisher.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { publishUserFile } from './user-file-publisher'
+
+let root = ''
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'open-science-user-file-publisher-'))
+})
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true })
+})
+
+describe('publishUserFile', () => {
+  it('preserves an existing destination when the writer fails after partial output', async () => {
+    const destinationPath = join(root, 'report.txt')
+    await writeFile(destinationPath, 'existing bytes')
+
+    await expect(
+      publishUserFile(destinationPath, async (temporaryPath) => {
+        await writeFile(temporaryPath, 'partial replacement')
+        throw new Error('disk full')
+      })
+    ).rejects.toThrow('disk full')
+
+    await expect(readFile(destinationPath, 'utf8')).resolves.toBe('existing bytes')
+    await expect(readdir(root)).resolves.toEqual(['report.txt'])
+  })
+
+  it('flushes complete bytes before atomically replacing the destination', async () => {
+    const destinationPath = join(root, 'report.txt')
+    await writeFile(destinationPath, 'old bytes')
+    const events: string[] = []
+
+    await publishUserFile(
+      destinationPath,
+      async (temporaryPath) => {
+        events.push('write')
+        await writeFile(temporaryPath, 'new bytes')
+      },
+      {
+        durability: {
+          syncFile: vi.fn(async () => {
+            events.push('sync-file')
+            await expect(readFile(destinationPath, 'utf8')).resolves.toBe('old bytes')
+          }),
+          syncDirectory: vi.fn(async () => {
+            events.push('sync-directory')
+            await expect(readFile(destinationPath, 'utf8')).resolves.toBe('new bytes')
+          })
+        }
+      }
+    )
+
+    expect(events).toEqual(['write', 'sync-file', 'sync-directory'])
+    await expect(readFile(destinationPath, 'utf8')).resolves.toBe('new bytes')
+  })
+
+  it('does not replace an existing destination during exclusive publication', async () => {
+    const destinationPath = join(root, 'report.txt')
+    await writeFile(destinationPath, 'existing bytes')
+
+    await expect(
+      publishUserFile(destinationPath, (temporaryPath) => writeFile(temporaryPath, 'new bytes'), {
+        exclusive: true
+      })
+    ).rejects.toMatchObject({ code: 'EEXIST' })
+
+    await expect(readFile(destinationPath, 'utf8')).resolves.toBe('existing bytes')
+    await expect(readdir(root)).resolves.toEqual(['report.txt'])
+  })
+})

--- a/src/main/user-file-publisher.test.ts
+++ b/src/main/user-file-publisher.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -74,4 +74,20 @@ describe('publishUserFile', () => {
     await expect(readFile(destinationPath, 'utf8')).resolves.toBe('existing bytes')
     await expect(readdir(root)).resolves.toEqual(['report.txt'])
   })
+
+  it.runIf(process.platform !== 'win32')(
+    'preserves existing destination permissions when replacing its bytes',
+    async () => {
+      const destinationPath = join(root, 'report.txt')
+      await writeFile(destinationPath, 'existing bytes')
+      await chmod(destinationPath, 0o600)
+
+      await publishUserFile(destinationPath, async (temporaryPath) => {
+        await writeFile(temporaryPath, 'new bytes')
+        await chmod(temporaryPath, 0o644)
+      })
+
+      expect((await stat(destinationPath)).mode & 0o777).toBe(0o600)
+    }
+  )
 })

--- a/src/main/user-file-publisher.test.ts
+++ b/src/main/user-file-publisher.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -90,4 +90,26 @@ describe('publishUserFile', () => {
       expect((await stat(destinationPath)).mode & 0o777).toBe(0o600)
     }
   )
+
+  it('retries a transient replacement denial before publishing', async () => {
+    const destinationPath = join(root, 'report.txt')
+    await writeFile(destinationPath, 'existing bytes')
+    const wait = vi.fn().mockResolvedValue(undefined)
+    const replace = vi.fn(async (sourcePath: string, targetPath: string) => {
+      if (replace.mock.calls.length === 1) {
+        throw Object.assign(new Error('replacement denied'), { code: 'EPERM' })
+      }
+      await rename(sourcePath, targetPath)
+    })
+
+    await publishUserFile(
+      destinationPath,
+      (temporaryPath) => writeFile(temporaryPath, 'new bytes'),
+      { replace, wait }
+    )
+
+    expect(replace).toHaveBeenCalledTimes(2)
+    expect(wait).toHaveBeenCalledWith(25)
+    await expect(readFile(destinationPath, 'utf8')).resolves.toBe('new bytes')
+  })
 })

--- a/src/main/user-file-publisher.test.ts
+++ b/src/main/user-file-publisher.test.ts
@@ -130,6 +130,22 @@ describe('publishUserFile', () => {
     }
   )
 
+  it.runIf(process.platform !== 'win32')(
+    'replaces a read-only destination while preserving its permissions',
+    async () => {
+      const destinationPath = join(root, 'report.txt')
+      await writeFile(destinationPath, 'existing bytes')
+      await chmod(destinationPath, 0o444)
+
+      await publishUserFile(destinationPath, (temporaryPath) =>
+        writeFile(temporaryPath, 'new bytes')
+      )
+
+      await expect(readFile(destinationPath, 'utf8')).resolves.toBe('new bytes')
+      expect((await stat(destinationPath)).mode & 0o777).toBe(0o444)
+    }
+  )
+
   it('retries a transient replacement denial before publishing', async () => {
     const destinationPath = join(root, 'report.txt')
     await writeFile(destinationPath, 'existing bytes')

--- a/src/main/user-file-publisher.test.ts
+++ b/src/main/user-file-publisher.test.ts
@@ -75,6 +75,45 @@ describe('publishUserFile', () => {
     await expect(readdir(root)).resolves.toEqual(['report.txt'])
   })
 
+  it('publishes exclusively when the destination file system does not support hard links', async () => {
+    const destinationPath = join(root, 'report.txt')
+    const syncFile = vi.fn().mockResolvedValue(undefined)
+
+    await publishUserFile(
+      destinationPath,
+      (temporaryPath) => writeFile(temporaryPath, 'new bytes'),
+      {
+        exclusive: true,
+        linkFile: async () => {
+          throw Object.assign(new Error('hard links are unsupported'), { code: 'EOPNOTSUPP' })
+        },
+        durability: { syncFile, syncDirectory: vi.fn().mockResolvedValue(undefined) }
+      }
+    )
+
+    expect(syncFile).toHaveBeenCalledTimes(2)
+    expect(syncFile).toHaveBeenLastCalledWith(destinationPath)
+    await expect(readFile(destinationPath, 'utf8')).resolves.toBe('new bytes')
+    await expect(readdir(root)).resolves.toEqual(['report.txt'])
+  })
+
+  it('does not replace a destination that appears before the hard-link fallback', async () => {
+    const destinationPath = join(root, 'report.txt')
+
+    await expect(
+      publishUserFile(destinationPath, (temporaryPath) => writeFile(temporaryPath, 'new bytes'), {
+        exclusive: true,
+        linkFile: async () => {
+          await writeFile(destinationPath, 'racing bytes')
+          throw Object.assign(new Error('hard links are unsupported'), { code: 'EOPNOTSUPP' })
+        }
+      })
+    ).rejects.toMatchObject({ code: 'EEXIST' })
+
+    await expect(readFile(destinationPath, 'utf8')).resolves.toBe('racing bytes')
+    await expect(readdir(root)).resolves.toEqual(['report.txt'])
+  })
+
   it.runIf(process.platform !== 'win32')(
     'preserves existing destination permissions when replacing its bytes',
     async () => {

--- a/src/main/user-file-publisher.test.ts
+++ b/src/main/user-file-publisher.test.ts
@@ -1,4 +1,15 @@
-import { chmod, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import {
+  chmod,
+  copyFile,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -87,12 +98,13 @@ describe('publishUserFile', () => {
         linkFile: async () => {
           throw Object.assign(new Error('hard links are unsupported'), { code: 'EOPNOTSUPP' })
         },
+        publishNoReplace: rename,
         durability: { syncFile, syncDirectory: vi.fn().mockResolvedValue(undefined) }
       }
     )
 
     expect(syncFile).toHaveBeenCalledTimes(2)
-    expect(syncFile).toHaveBeenLastCalledWith(destinationPath)
+    expect(syncFile.mock.calls[1]?.[0]).toMatch(/\.open-science-publish-/)
     await expect(readFile(destinationPath, 'utf8')).resolves.toBe('new bytes')
     await expect(readdir(root)).resolves.toEqual(['report.txt'])
   })
@@ -106,12 +118,36 @@ describe('publishUserFile', () => {
         linkFile: async () => {
           await writeFile(destinationPath, 'racing bytes')
           throw Object.assign(new Error('hard links are unsupported'), { code: 'EOPNOTSUPP' })
+        },
+        publishNoReplace: async (sourcePath, targetPath) => {
+          await copyFile(sourcePath, targetPath, constants.COPYFILE_EXCL)
+          await rm(sourcePath)
         }
       })
     ).rejects.toMatchObject({ code: 'EEXIST' })
 
     await expect(readFile(destinationPath, 'utf8')).resolves.toBe('racing bytes')
     await expect(readdir(root)).resolves.toEqual(['report.txt'])
+  })
+
+  it('does not expose partial output when the no-hard-link fallback copy fails', async () => {
+    const destinationPath = join(root, 'report.txt')
+
+    await expect(
+      publishUserFile(destinationPath, (temporaryPath) => writeFile(temporaryPath, 'new bytes'), {
+        exclusive: true,
+        linkFile: async () => {
+          throw Object.assign(new Error('hard links are unsupported'), { code: 'EOPNOTSUPP' })
+        },
+        copyFileExclusive: async (_sourcePath, targetPath) => {
+          await writeFile(targetPath, 'partial bytes')
+          throw new Error('disk full')
+        }
+      })
+    ).rejects.toThrow('disk full')
+
+    await expect(readFile(destinationPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readdir(root)).resolves.toEqual([])
   })
 
   it.runIf(process.platform !== 'win32')(

--- a/src/main/user-file-publisher.ts
+++ b/src/main/user-file-publisher.ts
@@ -2,11 +2,14 @@ import { chmod, link, mkdtemp, rename, rm, stat } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 
 import { defaultFileDurability, type FileDurability } from './storage/file-durability'
+import { retryFileReplacement } from './storage/file-replacement'
 
 type PublishUserFileOptions = {
   exclusive?: boolean
   validateDestination?: () => Promise<void>
   durability?: FileDurability
+  replace?: (sourcePath: string, destinationPath: string) => Promise<void>
+  wait?: (delayMs: number) => Promise<void>
 }
 
 // Keeps incomplete bytes private and only changes the user-selected path after the writer and file
@@ -33,7 +36,12 @@ const publishUserFile = async (
     await durability.syncFile(temporaryPath)
     await options.validateDestination?.()
     if (options.exclusive) await link(temporaryPath, destinationPath)
-    else await rename(temporaryPath, destinationPath)
+    else {
+      await retryFileReplacement(
+        () => (options.replace ?? rename)(temporaryPath, destinationPath),
+        options.wait
+      )
+    }
     await durability.syncDirectory(directory)
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true }).catch(() => undefined)

--- a/src/main/user-file-publisher.ts
+++ b/src/main/user-file-publisher.ts
@@ -1,4 +1,5 @@
-import { chmod, link, mkdtemp, rename, rm, stat } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { chmod, copyFile, link, mkdtemp, rename, rm, stat } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 
 import { defaultFileDurability, type FileDurability } from './storage/file-durability'
@@ -8,8 +9,44 @@ type PublishUserFileOptions = {
   exclusive?: boolean
   validateDestination?: () => Promise<void>
   durability?: FileDurability
+  linkFile?: (sourcePath: string, destinationPath: string) => Promise<void>
   replace?: (sourcePath: string, destinationPath: string) => Promise<void>
   wait?: (delayMs: number) => Promise<void>
+}
+
+type LinkFile = NonNullable<PublishUserFileOptions['linkFile']>
+
+const hardLinkUnsupportedCodes = new Set([
+  'EACCES',
+  'EINVAL',
+  'ENOSYS',
+  'ENOTSUP',
+  'EOPNOTSUPP',
+  'EPERM'
+])
+
+const isHardLinkUnsupported = (error: unknown): boolean =>
+  error instanceof Error &&
+  'code' in error &&
+  typeof error.code === 'string' &&
+  hardLinkUnsupportedCodes.has(error.code)
+
+const publishExclusive = async (
+  sourcePath: string,
+  destinationPath: string,
+  linkFile: LinkFile
+): Promise<boolean> => {
+  try {
+    await linkFile(sourcePath, destinationPath)
+    return false
+  } catch (error) {
+    if (!isHardLinkUnsupported(error)) throw error
+    // Some user-selected volumes (notably FAT/exFAT) cannot create hard links. copyFile's
+    // exclusive flag keeps the no-overwrite guarantee and removes its destination after a failed
+    // copy; unlike the hard-link path, the copied inode needs its own durability barrier.
+    await copyFile(sourcePath, destinationPath, constants.COPYFILE_EXCL)
+    return true
+  }
 }
 
 // Keeps incomplete bytes private and only changes the user-selected path after the writer and file
@@ -35,8 +72,14 @@ const publishUserFile = async (
     }
     await durability.syncFile(temporaryPath)
     await options.validateDestination?.()
-    if (options.exclusive) await link(temporaryPath, destinationPath)
-    else {
+    if (options.exclusive) {
+      const copied = await publishExclusive(
+        temporaryPath,
+        destinationPath,
+        options.linkFile ?? link
+      )
+      if (copied) await durability.syncFile(destinationPath)
+    } else {
       await retryFileReplacement(
         () => (options.replace ?? rename)(temporaryPath, destinationPath),
         options.wait

--- a/src/main/user-file-publisher.ts
+++ b/src/main/user-file-publisher.ts
@@ -1,20 +1,26 @@
+import { randomUUID } from 'node:crypto'
 import { constants } from 'node:fs'
 import { chmod, copyFile, link, mkdtemp, rename, rm, stat } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 
 import { defaultFileDurability, type FileDurability } from './storage/file-durability'
 import { retryFileReplacement } from './storage/file-replacement'
+import { publishNoReplace as publishAnchoredNoReplace } from './uploads/atomic-no-replace-publisher'
 
 type PublishUserFileOptions = {
   exclusive?: boolean
   validateDestination?: () => Promise<void>
   durability?: FileDurability
+  copyFileExclusive?: (sourcePath: string, destinationPath: string) => Promise<void>
   linkFile?: (sourcePath: string, destinationPath: string) => Promise<void>
+  publishNoReplace?: (sourcePath: string, destinationPath: string) => Promise<void>
   replace?: (sourcePath: string, destinationPath: string) => Promise<void>
   wait?: (delayMs: number) => Promise<void>
 }
 
 type LinkFile = NonNullable<PublishUserFileOptions['linkFile']>
+type CopyFileExclusive = NonNullable<PublishUserFileOptions['copyFileExclusive']>
+type PublishNoReplace = NonNullable<PublishUserFileOptions['publishNoReplace']>
 
 const hardLinkUnsupportedCodes = new Set([
   'EACCES',
@@ -31,21 +37,38 @@ const isHardLinkUnsupported = (error: unknown): boolean =>
   typeof error.code === 'string' &&
   hardLinkUnsupportedCodes.has(error.code)
 
+const defaultCopyFileExclusive: CopyFileExclusive = (sourcePath, destinationPath) =>
+  copyFile(sourcePath, destinationPath, constants.COPYFILE_EXCL)
+
+const defaultPublishNoReplace: PublishNoReplace = async (sourcePath, destinationPath) => {
+  const directory = dirname(destinationPath)
+  publishAnchoredNoReplace(directory, directory, basename(sourcePath), basename(destinationPath))
+}
+
 const publishExclusive = async (
   sourcePath: string,
   destinationPath: string,
-  linkFile: LinkFile
-): Promise<boolean> => {
+  linkFile: LinkFile,
+  copyFileExclusive: CopyFileExclusive,
+  durability: FileDurability,
+  publishNoReplace: PublishNoReplace
+): Promise<void> => {
   try {
     await linkFile(sourcePath, destinationPath)
-    return false
+    return
   } catch (error) {
     if (!isHardLinkUnsupported(error)) throw error
-    // Some user-selected volumes (notably FAT/exFAT) cannot create hard links. copyFile's
-    // exclusive flag keeps the no-overwrite guarantee and removes its destination after a failed
-    // copy; unlike the hard-link path, the copied inode needs its own durability barrier.
-    await copyFile(sourcePath, destinationPath, constants.COPYFILE_EXCL)
-    return true
+  }
+
+  // Some user-selected volumes (notably FAT/exFAT) cannot create hard links. Keep the fallback
+  // copy under a private random name, flush it, then atomically rename it without replacement.
+  const stagingPath = join(dirname(destinationPath), `.open-science-publish-${randomUUID()}`)
+  try {
+    await copyFileExclusive(sourcePath, stagingPath)
+    await durability.syncFile(stagingPath)
+    await publishNoReplace(stagingPath, destinationPath)
+  } finally {
+    await rm(stagingPath, { force: true }).catch(() => undefined)
   }
 }
 
@@ -73,12 +96,14 @@ const publishUserFile = async (
     }
     await options.validateDestination?.()
     if (options.exclusive) {
-      const copied = await publishExclusive(
+      await publishExclusive(
         temporaryPath,
         destinationPath,
-        options.linkFile ?? link
+        options.linkFile ?? link,
+        options.copyFileExclusive ?? defaultCopyFileExclusive,
+        durability,
+        options.publishNoReplace ?? defaultPublishNoReplace
       )
-      if (copied) await durability.syncFile(destinationPath)
     } else {
       await retryFileReplacement(
         () => (options.replace ?? rename)(temporaryPath, destinationPath),

--- a/src/main/user-file-publisher.ts
+++ b/src/main/user-file-publisher.ts
@@ -1,4 +1,4 @@
-import { link, mkdtemp, rename, rm } from 'node:fs/promises'
+import { chmod, link, mkdtemp, rename, rm, stat } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 
 import { defaultFileDurability, type FileDurability } from './storage/file-durability'
@@ -23,6 +23,13 @@ const publishUserFile = async (
 
   try {
     await write(temporaryPath)
+    if (!options.exclusive) {
+      try {
+        await chmod(temporaryPath, (await stat(destinationPath)).mode & 0o7777)
+      } catch (error) {
+        if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error
+      }
+    }
     await durability.syncFile(temporaryPath)
     await options.validateDestination?.()
     if (options.exclusive) await link(temporaryPath, destinationPath)

--- a/src/main/user-file-publisher.ts
+++ b/src/main/user-file-publisher.ts
@@ -1,0 +1,37 @@
+import { link, mkdtemp, rename, rm } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+
+import { defaultFileDurability, type FileDurability } from './storage/file-durability'
+
+type PublishUserFileOptions = {
+  exclusive?: boolean
+  validateDestination?: () => Promise<void>
+  durability?: FileDurability
+}
+
+// Keeps incomplete bytes private and only changes the user-selected path after the writer and file
+// durability barrier succeed. The private child directory also prevents a temp-path symlink race.
+const publishUserFile = async (
+  destinationPath: string,
+  write: (temporaryPath: string) => Promise<unknown>,
+  options: PublishUserFileOptions = {}
+): Promise<void> => {
+  const directory = dirname(destinationPath)
+  const temporaryDirectory = await mkdtemp(join(directory, '.open-science-save-'))
+  const temporaryPath = join(temporaryDirectory, basename(destinationPath))
+  const durability = options.durability ?? defaultFileDurability
+
+  try {
+    await write(temporaryPath)
+    await durability.syncFile(temporaryPath)
+    await options.validateDestination?.()
+    if (options.exclusive) await link(temporaryPath, destinationPath)
+    else await rename(temporaryPath, destinationPath)
+    await durability.syncDirectory(directory)
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true }).catch(() => undefined)
+  }
+}
+
+export { publishUserFile }
+export type { PublishUserFileOptions }

--- a/src/main/user-file-publisher.ts
+++ b/src/main/user-file-publisher.ts
@@ -63,6 +63,7 @@ const publishUserFile = async (
 
   try {
     await write(temporaryPath)
+    await durability.syncFile(temporaryPath)
     if (!options.exclusive) {
       try {
         await chmod(temporaryPath, (await stat(destinationPath)).mode & 0o7777)
@@ -70,7 +71,6 @@ const publishUserFile = async (
         if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error
       }
     }
-    await durability.syncFile(temporaryPath)
     await options.validateDestination?.()
     if (options.exclusive) {
       const copied = await publishExclusive(

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -11,6 +11,7 @@ import {
   WEB_EVENT_CONSUMERS_READY_EVENT,
   WEB_EVENTS_OPEN_EVENT
 } from '../../shared/web-event-connection'
+import type { SaveManagedFileRequest } from '../../shared/file-save'
 
 const themeMocks = vi.hoisted(() => ({
   applyTheme: vi.fn(),
@@ -61,11 +62,7 @@ type WebApi = {
     create: (request: unknown) => Promise<unknown>
     onCreated: (listener: (payload: unknown) => void) => () => void
   }
-  saveManagedFile: (request: {
-    source: 'artifact' | 'upload'
-    path: string
-    suggestedName: string
-  }) => Promise<{ saved: boolean }>
+  saveManagedFile: (request: SaveManagedFileRequest) => Promise<{ saved: boolean }>
 }
 
 const bootstrapPayload = {
@@ -507,9 +504,10 @@ describe('Web bootstrap event connection', () => {
     const resourceResponse = new Response(new Uint8Array([1, 2, 3]))
     const blob = vi.spyOn(resourceResponse, 'blob')
     let released = false
+    let acquireRequest: unknown
     vi.stubGlobal(
       'fetch',
-      vi.fn(async (input: RequestInfo | URL) => {
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input)
         if (url === '/api/bootstrap') {
           return new Response(JSON.stringify(bootstrapPayload), {
@@ -518,6 +516,7 @@ describe('Web bootstrap event connection', () => {
           })
         }
         if (url === '/rpc/preview-resources%3Aacquire') {
+          acquireRequest = JSON.parse(String(init?.body))
           return new Response(
             JSON.stringify({
               protocolVersion: WEB_RPC_PROTOCOL_VERSION,
@@ -555,7 +554,9 @@ describe('Web bootstrap event connection', () => {
     await expect(
       api.saveManagedFile({
         source: 'artifact',
-        path: 'artifact-1/report.bin',
+        projectId: 'project-1',
+        fileId: 'artifact-1',
+        versionId: 'version-3',
         suggestedName: 'report.bin'
       })
     ).resolves.toEqual({ saved: true })
@@ -564,6 +565,17 @@ describe('Web bootstrap event connection', () => {
     expect(createWritable).toHaveBeenCalledOnce()
     expect(blob).not.toHaveBeenCalled()
     expect(savedBytes).toEqual([1, 2, 3])
+    expect(acquireRequest).toEqual({
+      protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+      args: [
+        {
+          source: 'artifact',
+          projectId: 'project-1',
+          fileId: 'artifact-1',
+          versionId: 'version-3'
+        }
+      ]
+    })
     expect(released).toBe(true)
   })
 
@@ -625,7 +637,8 @@ describe('Web bootstrap event connection', () => {
     await expect(
       api.saveManagedFile({
         source: 'upload',
-        path: 'upload-1/data.bin',
+        projectId: 'project-1',
+        fileId: 'upload-1',
         suggestedName: 'data.bin'
       })
     ).rejects.toMatchObject({ name: 'WebManagedFileSizeLimitError' })
@@ -698,7 +711,8 @@ describe('Web bootstrap event connection', () => {
     const api = await loadBootstrap()
     const request = api.saveManagedFile({
       source: 'artifact',
-      path: 'artifact-1/report.pdf',
+      projectId: 'project-1',
+      fileId: 'artifact-1',
       suggestedName: 'report.pdf'
     })
     const outcome = Promise.race([

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -557,8 +557,9 @@ describe('Web bootstrap event connection', () => {
         projectId: 'project-1',
         fileId: 'artifact-1',
         versionId: 'version-3',
+        path: 'artifact-version:project-1/session-1/artifact-1/version-3',
         suggestedName: 'report.bin'
-      })
+      } as SaveManagedFileRequest)
     ).resolves.toEqual({ saved: true })
 
     expect(showSaveFilePicker).toHaveBeenCalledWith({ suggestedName: 'report.bin' })

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -458,15 +458,22 @@ const installWebApi = async (): Promise<EventCursor> => {
 
         let resource: { id: string; url: string; size: number } | undefined
         try {
-          const previewRequest: AcquireManagedPreviewRequest =
-            'path' in request
-              ? { source: request.source, path: request.path }
-              : {
-                  source: request.source,
-                  projectId: request.projectId,
-                  fileId: request.fileId,
-                  ...(request.versionId ? { versionId: request.versionId } : {})
-                }
+          let previewRequest: AcquireManagedPreviewRequest
+          switch (request.source) {
+            case 'artifact':
+            case 'upload':
+              previewRequest = {
+                source: request.source,
+                projectId: request.projectId,
+                fileId: request.fileId,
+                ...(request.versionId ? { versionId: request.versionId } : {})
+              }
+              break
+            case 'notebook-input':
+            case 'local':
+              previewRequest = { source: request.source, path: request.path }
+              break
+          }
           const acquiredResource = (await invoke('preview-resources:acquire', [
             previewRequest
           ])) as { id: string; url: string; size: number }

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -16,7 +16,11 @@ import {
   WEB_EVENT_SURFACE_ATTRIBUTE,
   type WebEventConnectionPhase
 } from '../../shared/web-event-connection'
-import { WEB_MANAGED_FILE_SIZE_LIMIT_ERROR_NAME } from '../../shared/file-save'
+import {
+  WEB_MANAGED_FILE_SIZE_LIMIT_ERROR_NAME,
+  type SaveManagedFileRequest
+} from '../../shared/file-save'
+import type { AcquireManagedPreviewRequest } from '../../shared/preview-resources'
 import { installWebRendererContracts } from './api-installer'
 import { i18next, initI18n } from '@/i18n'
 import { applyHtmlLang, resolveInitialLocale } from '@/lib/locale-preference'
@@ -435,11 +439,7 @@ const installWebApi = async (): Promise<EventCursor> => {
         downloadBlob(new Blob([request.data], { type: request.mimeType }), request.suggestedName)
         return Promise.resolve({ saved: true })
       },
-      saveManagedFile: async (request: {
-        source: 'artifact' | 'upload'
-        path: string
-        suggestedName: string
-      }) => {
+      saveManagedFile: async (request: SaveManagedFileRequest) => {
         const showSaveFilePicker = (
           window as unknown as { showSaveFilePicker?: BrowserSaveFilePicker }
         ).showSaveFilePicker
@@ -458,8 +458,17 @@ const installWebApi = async (): Promise<EventCursor> => {
 
         let resource: { id: string; url: string; size: number } | undefined
         try {
+          const previewRequest: AcquireManagedPreviewRequest =
+            'path' in request
+              ? { source: request.source, path: request.path }
+              : {
+                  source: request.source,
+                  projectId: request.projectId,
+                  fileId: request.fileId,
+                  ...(request.versionId ? { versionId: request.versionId } : {})
+                }
           const acquiredResource = (await invoke('preview-resources:acquire', [
-            { source: request.source, path: request.path }
+            previewRequest
           ])) as { id: string; url: string; size: number }
           resource = acquiredResource
           if (!writable && acquiredResource.size > WEB_BLOB_DOWNLOAD_MAX_BYTES) {

--- a/src/shared/file-save.ts
+++ b/src/shared/file-save.ts
@@ -68,7 +68,7 @@ type SaveProjectArtifactFailure = SaveProjectArtifactFile & {
   message: string
 }
 
-// filePath is absent when every file failed to resolve: no dialog is shown and nothing is written.
+// filePath is absent when every file fails after Save As confirmation: no archive is written.
 type SaveProjectArtifactsResult =
   { saved: false } | { saved: true; filePath?: string; failures?: SaveProjectArtifactFailure[] }
 


### PR DESCRIPTION
## Summary

- publish desktop exports through one same-directory temporary-file helper, flushing complete bytes before atomic replacement and cleaning failed temporary output
- preserve managed-file self-copy protection while routing Blob, managed/version, project ZIP, conversation Markdown/PDF, notebook, Skill, Specialist, and Connector exports through that helper
- forward the shared logical managed-file identity from the Web adapter to preview-resource acquisition
- show Project Artifact Save As before opening sources and stream one verified Version lease at a time

## Reproduction

The regression tests were added first and run against the unmodified production paths. The focused run failed in four places (115 passed):

- a managed-file partial write changed the existing destination to partial bytes
- a conversation Markdown partial write changed the existing destination to partial bytes
- the Web RPC body omitted `projectId`, `fileId`, and `versionId`
- Project export opened both source leases before the save dialog and retained both concurrently

After the fix, those tests pass and assert the reported behavior directly.

The first independent Codex review then caught the real PDF-preview request shape: managed requests can carry a legacy `path` alongside logical identity. A follow-up regression failed against the first patch because it still selected `{source,path}`; the adapter now discriminates by `source`, so artifact/upload always use logical identity while local/notebook-input keep path-based behavior.

The second independent review caught that atomic replacement could widen an existing target from mode `0600` to the temporary file's `0644`. A deterministic regression reproduced that change; overwrite publication now copies the existing destination's permission bits before the durability barrier.

The third independent review identified transient Windows replacement failures. A fault-injected `EPERM` regression confirmed the publisher did not retry; it now shares the existing durable-file bounded retry policy (`25/50/100/200/400ms`) for `EPERM`, `EACCES`, and `EBUSY` rename failures.

The fourth independent review found that exclusive batch-export publication required hard-link support, which FAT/exFAT removable volumes do not provide. An injected `EOPNOTSUPP` regression failed on the hard-link-only implementation. Supported volumes still use atomic hard-link publication; unsupported volumes fall back to `COPYFILE_EXCL`, fsync the copied inode, and retain the no-overwrite guarantee. A race regression verifies that a destination appearing before fallback is preserved byte-for-byte. The Session Artifact batch IPC test also runs the production publisher with an injected no-hard-link filesystem and verifies both files are exported.

The fifth independent review found that applying a read-only destination mode before the temporary-file durability barrier made the required `r+` fsync fail with `EACCES`. A real mode-`0444` regression reproduced the failure. Complete temporary bytes are now synced before inheriting the existing mode and atomically replacing the destination.

The sixth independent review found two exclusive-publication gaps. First, direct `COPYFILE_EXCL` fallback could expose partial final output; a fault-injected copy reproduced it. The fallback now copies only to a random hidden sibling, syncs it, and uses the existing anchored native no-replace publisher for the final atomic rename. Second, same-inode batch destinations were rejected before collision retry; the public IPC regression now verifies that the source remains unchanged and export continues at `report (2).csv`.

The first Windows Gate for that follow-up compiled the native addon but reproduced a platform-specific publication failure in both public Session Artifact batch tests: the Win32 `SetFileInformationByHandle(FileRenameInfo)` wrapper rejected the handle-relative rename. The implementation now calls `NtSetInformationFile(FileRenameInformation)` directly with the already-open source and parent handles, `replace_if_exists=false`, and converts its NT status to the existing portable error codes. This keeps atomic no-replace rename semantics on local filesystems without requiring hard-link support.

## Behavior and compatibility

- Existing target bytes remain unchanged for failures before publication. If the final rename succeeds but directory `fsync` reports failure, the target contains the complete new file, never partial bytes.
- Exclusive publication is atomic on hard-link-capable volumes and on local FAT/exFAT volumes through native no-replace rename. Unsupported network filesystems fail without exposing the final destination.
- Atomic replacement creates a new inode. Existing permission bits are preserved; ownership, ACLs, and extended attributes are not guaranteed to carry over.
- Project export now prompts first. Canceling performs no source open/hash work; after confirmation, source failures can result in no ZIP being written.
- No product data fields, persisted formats, database schema, migrations, or enum/state values change.
- No historical-data compatibility path is required.

## Test impact

Final exact-head checks after the last material edit:

- desktop publisher, native no-replace publication, durable replacement policy, file-save, and conversation behavior: `npm test -- src/main/file-save.test.ts src/main/user-file-publisher.test.ts src/main/uploads/atomic-no-replace-publisher.test.ts src/main/storage/durable-json-file.test.ts src/main/session-persistence/conversation-export.test.ts` — 124 passed
- Web adapter/main parser contract: `npm test -- src/renderer/web/bootstrap.test.ts src/main/managed-preview-resources.test.ts -t 'path-only|logical managed version|streams a managed file'` — 4 passed, 53 filtered
- version lease and adjacent export consumers: `npm test -- src/main/managed-file-versions/version-file-operator.test.ts src/main/notebook/runtime-service.export.test.ts src/main/skills/export.test.ts src/main/specialist/package/electron-adapter.test.ts src/main/specialist/package/contribution-template.test.ts` — 74 passed
- `npm run typecheck:node` — passed
- `npm run typecheck:web` — passed
- `npm run lint` — passed
- `npx node-gyp rebuild --directory packages/safe-file-publisher-native` — passed on macOS arm64 after the NT rename change; Windows compilation and behavior are covered by the rerun PR Gate
- exact-head [PR Gate](https://github.com/aipoch/open-science/actions/runs/33653944346) — passed, including Windows core, Windows/macOS E2E, all three Ubuntu full-suite shards, static checks, Linux isolation, and module coverage enforcement

`test:affected:explain` selected the full suite because `src/main/file-save.test.ts` has no module owner in the impact manifest. Per maintainer direction, the full local `npm test` was not run; PR Gate is authoritative for the complete portable and platform plan.

## Uncovered risk

- FAT/exFAT hard-link rejection is fault-injected in the public batch-export boundary; CI validated the native rename fallback on Windows/NTFS, but does not mount a real FAT/exFAT volume. Microsoft documents rename support there independently of hard links.
