### PR TITLE
fix(package-export): keep ZIP timestamps valid across time zones

### DIFF
--- a/src/main/skills/export.test.ts
+++ b/src/main/skills/export.test.ts
@@ -11,6 +11,7 @@ import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 const roots: string[] = []
 
 afterEach(async () => {
+  vi.unstubAllEnvs()
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
@@ -118,6 +119,28 @@ describe('Skill ZIP export', () => {
     expect(strFromU8(archive['SKILL.md']!)).not.toContain('displayName')
     expect(strFromU8(archive['SKILL.md']!)).toContain('name: Portable')
     expect(strFromU8(archive['SKILL.md']!)).toContain('Body.')
+  })
+
+  it('exports a Skill ZIP in a negative UTC timezone', async () => {
+    vi.stubEnv('TZ', 'America/Los_Angeles')
+    const root = await mkdtemp(join(tmpdir(), 'skill-export-negative-timezone-'))
+    roots.push(root)
+    await writeFile(join(root, 'SKILL.md'), '# Portable')
+
+    await expect(
+      buildSkillExportArchive({
+        id: 'personal-portable',
+        name: 'Portable',
+        displayName: 'Portable',
+        description: '',
+        source: 'personal',
+        updatedAt: '2026-08-07T00:00:00.000Z',
+        sourceDir: root
+      })
+    ).resolves.toEqual({
+      fileName: 'portable.zip',
+      archiveBytes: expect.any(Uint8Array)
+    })
   })
 
   it.each(['.hidden', '__MACOSX/metadata'])(

--- a/src/main/skills/export.ts
+++ b/src/main/skills/export.ts
@@ -94,7 +94,7 @@ const collectFiles = async (directory: string, skillName: string): Promise<Zippa
     if (totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
       throw new Error('Skill tree exceeds the total export size limit.')
     }
-    files[file.relativePath] = [bytes, { mtime: new Date('1980-01-01T00:00:00.000Z') }]
+    files[file.relativePath] = [bytes, { mtime: new Date(1980, 0, 1) }]
   }
   return files
 }

--- a/src/main/specialist/package/contribution-template.test.ts
+++ b/src/main/specialist/package/contribution-template.test.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { strFromU8, unzipSync } from 'fflate'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SpecialistPackageCatalogSnapshot } from '../../../shared/specialist-package'
 import {
@@ -20,6 +20,10 @@ const catalog: SpecialistPackageCatalogSnapshot = {
   connectorIds: [],
   protectedSpecialistIds: ['reviewer']
 }
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 describe('contribution template ZIP', () => {
   it('builds the fixed root package with valid application-generated metadata', () => {
@@ -141,5 +145,19 @@ describe('contribution template ZIP', () => {
 
     expect(first).toEqual(second)
     expect(Object.keys(unzipSync(first)).sort()).toEqual(['manifest.json', 'specialist.json'])
+  })
+
+  it('builds a deterministic Specialist ZIP in a negative UTC timezone', () => {
+    vi.stubEnv('TZ', 'UTC')
+    const utcArchive = buildDeterministicSpecialistZip({
+      'specialist.json': new TextEncoder().encode('{}\n')
+    })
+    vi.stubEnv('TZ', 'America/Los_Angeles')
+
+    expect(
+      buildDeterministicSpecialistZip({
+        'specialist.json': new TextEncoder().encode('{}\n')
+      })
+    ).toEqual(utcArchive)
   })
 })

--- a/src/main/specialist/package/contribution-template.ts
+++ b/src/main/specialist/package/contribution-template.ts
@@ -38,7 +38,7 @@ const assertValidAppVersion = (appVersion: string): void => {
 export const buildDeterministicSpecialistZip = (
   files: Readonly<Record<string, Uint8Array>>
 ): Uint8Array => {
-  const zipOptions = { mtime: new Date('1980-01-01T00:00:00.000Z') }
+  const zipOptions = { mtime: new Date(1980, 0, 1) }
   const entries: Zippable = {}
   for (const [path, bytes] of Object.entries(files).sort(([left], [right]) =>
     left.localeCompare(right)


### PR DESCRIPTION
## Problem

`fflate` serializes DOS ZIP timestamps through local `Date` fields. The fixed instant `1980-01-01T00:00:00.000Z` becomes December 31, 1979 in negative UTC zones, so Skill export and the shared Specialist ZIP writer throw `date not in range 1980-2099`.

This blocks Skill export, Specialist export and contribution templates, Marketplace package filtering/install preparation, and makes Specialist export previews report `canExport: false`.

## Proposed change

- Construct the ZIP minimum timestamp as local January 1, 1980 in both ZIP writers.
- Add public-boundary regressions for `America/Los_Angeles`.
- Verify the deterministic Specialist writer produces identical bytes in UTC and the negative UTC zone.

## Scope and non-goals

- No API, schema, architecture, interaction, data-model, field, enum, or state changes.
- No persistence or migration changes.
- Historical compatibility: existing ZIP inputs remain accepted unchanged; newly generated ZIP payload contents are unchanged apart from their deterministic entry timestamp metadata. No historical data migration is needed.
- No new dependency or test seam.

## Acceptance criteria and validation

All green checks below ran after the last material edit.

- Negative-UTC Skill and Specialist regressions -> `TZ=UTC npx vitest run src/main/skills/export.test.ts src/main/specialist/package/contribution-template.test.ts -t "negative UTC timezone"` -> 2 passed.
- Skill export, Settings consumer, Specialist export/preview, contribution template, Marketplace filtering/install preparation, and release certification -> `TZ=America/Los_Angeles npx vitest run src/main/skills/export.test.ts src/main/settings/skill-catalog.test.ts src/main/specialist/package/contribution-template.test.ts src/main/specialist/package/marketplace-zip.test.ts src/main/specialist/package/service.test.ts src/main/specialist/marketplace/service.test.ts src/main/specialist/package/release-certification.test.ts` -> 7 files and 121 tests passed.
- Main-process typing -> `npm run typecheck:node` -> passed.
- Repository lint -> `npm run lint` -> passed.

Before the production fix, the two new regressions failed with the reported `date not in range 1980-2099` error at the actual `buildSkillExportArchive` and `buildDeterministicSpecialistZip` boundaries. The complete local `npm test` suite was intentionally not run per maintainer direction; PR CI is the final portable and platform validation authority.

## Review focus

- The local-date construction matches the local accessors used by `fflate` and preserves cross-time-zone archive determinism.
- The two independent ZIP writers are both covered without exposing implementation-only seams.
- Remaining local risk: the focused verification ran on macOS; PR CI owns the Linux and Windows lanes.