### PR TITLE
fix(storage): keep workspace ownership out of the artifact MCP bundle

### DIFF
--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -48,7 +48,8 @@ import {
   validateNewDataRoot
 } from './migration-service'
 import { readMigrationMarker } from './migration-marker'
-import { availableBytes, computeStorageUsage } from './usage'
+import { availableBytes } from './usage'
+import { computeStorageUsageWithOwnership } from './usage-ownership'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { MIGRATABLE_DATA_DIRS } from './data-directories'
 import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
@@ -311,7 +312,7 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
     return {
       ...status,
       canAutoSelectDataDrive,
-      usage: await computeStorageUsage(status.dataRoot),
+      usage: await computeStorageUsageWithOwnership(status.dataRoot),
       availableBytes: available
     }
   }

--- a/src/main/storage/managed-workspace-ownership-dir.ts
+++ b/src/main/storage/managed-workspace-ownership-dir.ts
@@ -1,0 +1,4 @@
+// Name of the directory holding managed-workspace ownership records. Kept in its own electron-free
+// module so pure-Node consumers (the storage usage scanner behind the artifact MCP server) can
+// reference it without importing the electron-bound ownership reader.
+export const MANAGED_WORKSPACE_OWNERSHIP_DIR = '.ownership'

--- a/src/main/storage/managed-workspace-ownership.integration.test.ts
+++ b/src/main/storage/managed-workspace-ownership.integration.test.ts
@@ -24,7 +24,7 @@ import {
   restoreManagedProjectWorkspacesActive,
   restoreManagedWorkspaceActive
 } from './managed-workspace-ownership'
-import { computeStorageUsage } from './usage'
+import { computeStorageUsageWithOwnership } from './usage-ownership'
 
 const roots: string[] = []
 
@@ -139,7 +139,7 @@ describe('managed workspace ownership', () => {
 
     await deletion.deleteSession('project-1', 'session-1')
 
-    const usage = await computeStorageUsage(dataRoot)
+    const usage = await computeStorageUsageWithOwnership(dataRoot)
     const workspace = usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]
 
     expect(workspace).toMatchObject({
@@ -180,7 +180,7 @@ describe('managed workspace ownership', () => {
       (_sessionIds, operation) => operation()
     )
 
-    const usage = await computeStorageUsage(dataRoot)
+    const usage = await computeStorageUsageWithOwnership(dataRoot)
     expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toEqual({
       name: 'legacy-workspace',
       bytes: 0
@@ -237,7 +237,7 @@ describe('managed workspace ownership', () => {
     await finalizeManagedWorkspaceOwnership(cwd, session.id, session.updatedAt, dataRoot)
     await rm(cwd, { recursive: true })
 
-    await expect(computeStorageUsage(dataRoot)).resolves.toMatchObject({
+    await expect(computeStorageUsageWithOwnership(dataRoot)).resolves.toMatchObject({
       categories: expect.arrayContaining([{ key: 'workspaces', bytes: 0 }])
     })
 
@@ -566,7 +566,7 @@ describe('managed workspace ownership', () => {
       }).deleteSession(session.projectId, session.id)
     ).rejects.toThrow('Session authority delete failed')
 
-    const usage = await computeStorageUsage(dataRoot)
+    const usage = await computeStorageUsageWithOwnership(dataRoot)
     expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
       projectId: 'project-1',
       sessionId: 'session-1',
@@ -600,7 +600,7 @@ describe('managed workspace ownership', () => {
       }).deleteSession(session.projectId, session.id)
     ).rejects.toThrow('Retention directory sync failed')
 
-    const usage = await computeStorageUsage(dataRoot)
+    const usage = await computeStorageUsageWithOwnership(dataRoot)
     expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
       retainedAfterDelete: false
     })
@@ -646,7 +646,7 @@ describe('managed workspace ownership', () => {
       }).deleteProjectSessions('project-1', (_sessionIds, operation) => operation())
     ).rejects.toThrow('Project Session authority delete failed')
 
-    const usage = await computeStorageUsage(dataRoot)
+    const usage = await computeStorageUsageWithOwnership(dataRoot)
     expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
       projectId: 'project-1',
       sessionId: 'session-1',
@@ -681,7 +681,7 @@ describe('managed workspace ownership', () => {
       }).deleteProjectSessions(session.projectId, (_sessionIds, operation) => operation())
     ).rejects.toThrow('Retention directory sync failed')
 
-    const usage = await computeStorageUsage(dataRoot)
+    const usage = await computeStorageUsageWithOwnership(dataRoot)
     expect(usage.categories.find(({ key }) => key === 'workspaces')?.children?.[0]).toMatchObject({
       retainedAfterDelete: false
     })

--- a/src/main/storage/managed-workspace-ownership.ts
+++ b/src/main/storage/managed-workspace-ownership.ts
@@ -1,4 +1,5 @@
 import { lstat, mkdir, readdir, rm } from 'node:fs/promises'
+import { MANAGED_WORKSPACE_OWNERSHIP_DIR } from './managed-workspace-ownership-dir'
 import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type { PersistedChatSession } from '../../shared/session-persistence'
@@ -10,7 +11,6 @@ import {
   writeDurableJsonFile
 } from './durable-json-file'
 
-const MANAGED_WORKSPACE_OWNERSHIP_DIR = '.ownership'
 const MANAGED_WORKSPACE_OWNERSHIP_VERSION = 1
 
 type ManagedWorkspaceOwnership = Readonly<{

--- a/src/main/storage/usage-ownership.ts
+++ b/src/main/storage/usage-ownership.ts
@@ -1,0 +1,9 @@
+import type { StorageUsage } from '../../shared/storage'
+import { readManagedWorkspaceOwnership } from './managed-workspace-ownership'
+import { computeStorageUsage } from './usage'
+
+// Settings-side storage usage enriched with managed-workspace ownership. Lives outside usage.ts so
+// the artifact MCP server's plain-Node bundle can keep importing usage.ts without pulling the
+// electron-dependent ownership chain into it.
+export const computeStorageUsageWithOwnership = async (dataRoot: string): Promise<StorageUsage> =>
+  computeStorageUsage(dataRoot, readManagedWorkspaceOwnership)

--- a/src/main/storage/usage.ts
+++ b/src/main/storage/usage.ts
@@ -8,10 +8,22 @@ import {
   type UsageChild
 } from '../../shared/storage'
 import { logicalEnvNameFromDirectory } from '../notebook/runtime-paths'
-import {
-  MANAGED_WORKSPACE_OWNERSHIP_DIR,
-  readManagedWorkspaceOwnership
-} from './managed-workspace-ownership'
+import { MANAGED_WORKSPACE_OWNERSHIP_DIR } from './managed-workspace-ownership-dir'
+
+// Ownership enrichment is injected by the electron-side wrapper (usage-ownership.ts) so this module
+// stays importable from the artifact MCP server's plain-Node bundle.
+export type StorageUsageOwnership = Readonly<{
+  workspaceId: string
+  projectId: string
+  sessionId?: string
+  createdAt: number
+  lastUsedAt: number
+  retainedAfterDelete: boolean
+}>
+export type StorageUsageOwnershipReader = (
+  workspacePath: string,
+  dataRoot: string
+) => Promise<StorageUsageOwnership | undefined>
 
 const isMissingPathError = (error: unknown): boolean => {
   const code = (error as NodeJS.ErrnoException)?.code
@@ -65,7 +77,10 @@ const fileSize = async (path: string, seen: Set<string>): Promise<number> => {
 // top-level directory so Settings can make those opaque UUID folders reachable without inventing
 // a Project/Session association that no longer exists. Empty directories remain visible; symlinks
 // are skipped rather than followed or offered as workspace roots.
-const workspaceUsage = async (dir: string): Promise<{ bytes: number; children: UsageChild[] }> => {
+const workspaceUsage = async (
+  dir: string,
+  readOwnership?: StorageUsageOwnershipReader
+): Promise<{ bytes: number; children: UsageChild[] }> => {
   let entries
   try {
     entries = await readdir(dir, { withFileTypes: true })
@@ -84,7 +99,7 @@ const workspaceUsage = async (dir: string): Promise<{ bytes: number; children: U
       if (entry.name === MANAGED_WORKSPACE_OWNERSHIP_DIR) {
         continue
       }
-      const ownership = await readManagedWorkspaceOwnership(path, join(dir, '..'))
+      const ownership = readOwnership ? await readOwnership(path, join(dir, '..')) : undefined
       children.push({
         name: entry.name,
         bytes: await dirSize(path, seen),
@@ -181,7 +196,10 @@ const runtimeUsage = async (dir: string): Promise<{ bytes: number; children: Usa
   return { bytes, children }
 }
 
-export const computeStorageUsage = async (dataRoot: string): Promise<StorageUsage> => {
+export const computeStorageUsage = async (
+  dataRoot: string,
+  readOwnership?: StorageUsageOwnershipReader
+): Promise<StorageUsage> => {
   const categories: StorageUsage['categories'] = []
   for (const key of STORAGE_USAGE_CATEGORY_KEYS) {
     const dir = join(dataRoot, key)
@@ -189,7 +207,7 @@ export const computeStorageUsage = async (dataRoot: string): Promise<StorageUsag
       const { bytes, children } = await runtimeUsage(dir)
       categories.push({ key, bytes, children })
     } else if (key === 'workspaces') {
-      const { bytes, children } = await workspaceUsage(dir)
+      const { bytes, children } = await workspaceUsage(dir, readOwnership)
       categories.push(children.length > 0 ? { key, bytes, children } : { key, bytes })
     } else if (key === 'execution-file-evidence') {
       const seen = new Set<string>()


### PR DESCRIPTION
## Problem

The Windows installer smoke in the v0.25.0 release run fails: the packaged artifact MCP server (launched under `ELECTRON_RUN_AS_NODE=1`, where the electron builtin does not exist) exits with `Cannot find module 'electron'`. The MCP entry may only statically import electron-free modules, and PR #2042 broke that contract: its `storage/managed-workspace-ownership.ts` statically imports `storage-root.ts`, which imports `app` from `electron` at the top level, and `storage/usage.ts` statically imports the ownership reader — putting the whole chain inside the MCP bundle (`mcp-server → repository → publication-owner → usage → managed-workspace-ownership → storage-root`).

## Proposed change

Cut the chain at `usage.ts` so the MCP-reachable surface stays pure Node:

- `usage.ts` — drop the static ownership import; the scanner and `availableBytes` remain electron-free, and ownership enrichment is injected through an optional `StorageUsageOwnershipReader` parameter on `computeStorageUsage`.
- New `managed-workspace-ownership-dir.ts` — the `.ownership` directory constant in its own electron-free module (single source of truth; the ownership module re-imports it).
- New `usage-ownership.ts` — electron-side wrapper `computeStorageUsageWithOwnership` that supplies the ownership reader; `command-owner.ts` consumes it so Settings usage keeps ownership enrichment.
- The ownership integration test asserts through the wrapper.

## Scope and non-goals

- No behavior change for Settings usage output, ownership records, or MCP `availableBytes` budgeting.
- `storage-root.ts`, `managed-workspace-ownership.ts` internals, and the ownership record format are untouched.

## Acceptance criteria and validation

- Static import-graph check from `artifacts/mcp-server.ts`: 53 modules reachable, zero top-level electron importers, `storage-root` unreachable (previously 63 modules, 1 electron importer).
- `npx vitest run src/main/storage/usage.test.ts src/main/storage/managed-workspace-ownership.integration.test.ts src/main/artifacts/mcp-server.test.ts src/main/acp/ipc.test.ts` — 110 passed, run after the last material edit.
- `npm run typecheck` and ESLint on the changed files pass.

## Review focus

- Whether any other MCP-reachable module gained an electron import in the v0.24.0..v0.25.0 window beyond this chain (checked: none).
