### PR TITLE
fix(compute): persist session concurrency limits

### DIFF
--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -284,6 +284,9 @@ describe('Compute service architecture', () => {
       projectBarriers
     )
     const runtimeStart = source.indexOf('const jobPoller = createComputeJobRuntime', jobBarriers)
+    const projectRuntimeReady = source.indexOf(
+      'projectRuntimeQuiescenceRef.current = new ProjectRuntimeQuiescenceOwner'
+    )
     const backgroundRecovery = source.indexOf(
       'const projectDeletionRecovery = new ProjectDeletionRecoveryLoop',
       runtimeStart
@@ -311,7 +314,8 @@ describe('Compute service architecture', () => {
 
     expect(projectBarriers).toBeGreaterThan(-1)
     expect(jobBarriers).toBeGreaterThan(projectBarriers)
-    expect(runtimeStart).toBeGreaterThan(jobBarriers)
+    expect(projectRuntimeReady).toBeGreaterThan(jobBarriers)
+    expect(runtimeStart).toBeGreaterThan(projectRuntimeReady)
     expect(backgroundRecovery).toBeGreaterThan(runtimeStart)
     expect(projectOrphanRecovery).toBeGreaterThan(-1)
     expect(backgroundOrphanRecovery).toBeGreaterThan(backgroundRecovery)
@@ -324,7 +328,10 @@ describe('Compute service architecture', () => {
   it('gives Compute Job shutdown the transport cancellation budget', () => {
     const source = readSource(computePaths.mainIpc)
     const runtimeStart = source.indexOf('const jobPoller = createComputeJobRuntime')
-    const runtimeEnd = source.indexOf('const agentComputeService', runtimeStart)
+    const runtimeEnd = source.indexOf(
+      'const projectDeletionRecovery = new ProjectDeletionRecoveryLoop',
+      runtimeStart
+    )
     const runtimeRegistration = source.slice(runtimeStart, runtimeEnd)
 
     expect(runtimeStart).toBeGreaterThan(-1)

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -339,6 +339,25 @@ describe('Compute service architecture', () => {
     expect(runtimeRegistration).toContain('disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS')
   })
 
+  it('persists Session concurrency limits inside the data-root write boundary', () => {
+    const source = readSource(computePaths.mainIpc)
+    const persistenceStart = source.indexOf('const sessionLimitPersistence = {')
+    const persistenceEnd = source.indexOf(
+      'const computeIpcModule = createComputeIpcModule',
+      persistenceStart
+    )
+    const persistence = source.slice(persistenceStart, persistenceEnd)
+    const writeBoundary = persistence.indexOf('withDataRootWrite(')
+    const sessionMutation = persistence.indexOf(
+      'sessionPersistenceCoordinator.setSessionComputeConcurrencyLimit'
+    )
+
+    expect(persistenceStart).toBeGreaterThan(-1)
+    expect(persistenceEnd).toBeGreaterThan(persistenceStart)
+    expect(writeBoundary).toBeGreaterThan(-1)
+    expect(sessionMutation).toBeGreaterThan(writeBoundary)
+  })
+
   it('awaits Compute Job barrier rollback when a new Project deletion aborts', () => {
     const source = readSource(computePaths.mainIpc)
     const abortStart = source.indexOf('abortProjectDeletion: async (projectId) => {')

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -279,8 +279,8 @@ export class ComputeService {
     this.jobWorkflow.handleJobUpdated(job)
   }
 
-  startQueueReconciliation = (): void => {
-    this.concurrencyManager?.startQueueReconciliation()
+  startQueueReconciliation = async (): Promise<void> => {
+    await this.concurrencyManager?.startQueueReconciliation()
   }
 
   stopQueueReconciliation = async (): Promise<void> => {

--- a/src/main/compute/concurrency-integration.test.ts
+++ b/src/main/compute/concurrency-integration.test.ts
@@ -156,12 +156,102 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       { createPoller: () => poller }
     )
 
-    runtime.start()
+    await runtime.start()
 
     await vi.waitFor(async () => {
       expect((await jobRepo.get('persisted-queued-job'))?.status).toBe('submitted')
     })
     expect(poller.start).toHaveBeenCalledOnce()
+    await runtime.stop()
+  })
+
+  it('restores the session limit before reconciling persisted queued jobs', async () => {
+    const providerId = computeProviderId('test-host')
+    const durableSessionLimits = new Map<string, number>()
+    const sessionLimitPersistence = {
+      load: async () => [...durableSessionLimits.entries()],
+      save: async (sessionId: string, limit: number) => {
+        durableSessionLimits.set(sessionId, limit)
+      }
+    }
+    const initialManager = new ConcurrencyManager(
+      jobRepo,
+      hostRepo,
+      vi.fn(async () => undefined),
+      undefined,
+      undefined,
+      undefined,
+      sessionLimitPersistence
+    )
+    const initialService = new ComputeService({
+      runner: makeFakeRunner(),
+      repository: hostRepo,
+      approvalBroker: makeFakeBroker(),
+      scpRunner: makeFakeScp(),
+      jobRepository: jobRepo,
+      storageRoot,
+      concurrencyManager: initialManager
+    })
+    await initialService.setSessionConcurrencyLimit('session-cold-start', 1)
+    for (let index = 0; index < 10; index += 1) {
+      await jobRepo.create({
+        allowUnencryptedPersistence: true,
+        id: `persisted-queued-job-${index}`,
+        providerId,
+        shape: 'direct_ssh',
+        sessionId: 'session-cold-start',
+        projectId: 'project-1',
+        intent: 'resume persisted queue',
+        command: 'echo resumed',
+        commandHash: `hash-${index}`,
+        timeoutSeconds: 60,
+        remoteWorkdir: `~/.openscience/jobs/persisted-queued-job-${index}`,
+        initialStatus: 'queued'
+      })
+    }
+
+    const restartedManager = new ConcurrencyManager(
+      jobRepo,
+      hostRepo,
+      vi.fn(async () => undefined),
+      undefined,
+      undefined,
+      undefined,
+      sessionLimitPersistence
+    )
+    const restartedService = new ComputeService({
+      runner: makeFakeRunner(),
+      repository: hostRepo,
+      approvalBroker: makeFakeBroker(),
+      scpRunner: makeFakeScp(),
+      jobRepository: jobRepo,
+      storageRoot,
+      concurrencyManager: restartedManager
+    })
+    const runtime = createComputeJobRuntime(
+      {
+        computeService: restartedService,
+        hostRepository: hostRepo,
+        jobRepository: jobRepo,
+        connectionBroker: {} as ComputeConnectionBroker,
+        storageRoot
+      },
+      {
+        createPoller: () => ({
+          start: vi.fn(),
+          stop: vi.fn(async () => undefined),
+          pause: vi.fn(async () => undefined),
+          resume: vi.fn()
+        })
+      }
+    )
+
+    await runtime.start()
+    await restartedManager.reconcileQueuedJobs()
+
+    const jobs = await jobRepo.findBySession('session-cold-start')
+    expect(jobs.filter((job) => job.status === 'submitted')).toHaveLength(1)
+    expect(jobs.filter((job) => job.status === 'queued')).toHaveLength(9)
     await runtime.stop()
   })
 
@@ -223,11 +313,11 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       { createPoller: () => poller }
     )
 
-    runtime.start()
+    const starting = runtime.start()
     await startupScanStarted
     const stopping = runtime.stop()
     releaseStartupScan?.()
-    await stopping
+    await Promise.all([starting, stopping])
 
     expect((await jobRepo.get('queued-during-runtime-stop'))?.status).toBe('queued')
     expect(dispatchQueuedJob).not.toHaveBeenCalled()

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -100,6 +100,24 @@ describe('ConcurrencyManager', () => {
       )
       expect(durableManager['sessionLimits'].has('session-1')).toBe(false)
     })
+
+    it('projects an already-persisted limit without writing the Session again', async () => {
+      const save = vi.fn(async () => undefined)
+      const durableManager = new ConcurrencyManager(
+        jobRepo,
+        hostRepo,
+        dispatchJob,
+        onJobUpdated,
+        undefined,
+        undefined,
+        { load: async () => [], save }
+      )
+
+      await durableManager.projectPersistedSessionLimit('session-1', 2)
+
+      expect(durableManager['sessionLimits'].get('session-1')).toBe(2)
+      expect(save).not.toHaveBeenCalled()
+    })
   })
 
   describe('setProviderLimit', () => {

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -78,6 +78,28 @@ describe('ConcurrencyManager', () => {
       await manager.setSessionLimit('session-1', 7)
       expect(manager['sessionLimits'].get('session-1')).toBe(7)
     })
+
+    it('does not change the live limit when durable persistence fails', async () => {
+      const durableManager = new ConcurrencyManager(
+        jobRepo,
+        hostRepo,
+        dispatchJob,
+        onJobUpdated,
+        undefined,
+        undefined,
+        {
+          load: async () => [],
+          save: async () => {
+            throw new Error('Session write failed')
+          }
+        }
+      )
+
+      await expect(durableManager.setSessionLimit('session-1', 5)).rejects.toThrow(
+        'Session write failed'
+      )
+      expect(durableManager['sessionLimits'].has('session-1')).toBe(false)
+    })
   })
 
   describe('setProviderLimit', () => {
@@ -135,6 +157,29 @@ describe('ConcurrencyManager', () => {
       )
       expect(hostRepo.updateConcurrencyLimit).not.toHaveBeenCalled()
     })
+  })
+
+  it('keeps queued reconciliation stopped when durable limits cannot be restored', async () => {
+    const durableManager = new ConcurrencyManager(
+      jobRepo,
+      hostRepo,
+      dispatchJob,
+      onJobUpdated,
+      undefined,
+      undefined,
+      {
+        load: async () => {
+          throw new Error('Session catalog unavailable')
+        },
+        save: async () => undefined
+      }
+    )
+
+    await expect(durableManager.startQueueReconciliation()).rejects.toThrow(
+      'Session catalog unavailable'
+    )
+    await durableManager.reconcileQueuedJobs()
+    expect(jobRepo.findQueuedJobs).not.toHaveBeenCalled()
   })
 
   describe('enqueue - global queue limit', () => {

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -208,6 +208,62 @@ describe('ConcurrencyManager', () => {
     expect(jobRepo.findQueuedJobs).not.toHaveBeenCalled()
   })
 
+  it('queues new admissions when durable limits cannot be restored', async () => {
+    const durableManager = new ConcurrencyManager(
+      jobRepo,
+      hostRepo,
+      dispatchJob,
+      onJobUpdated,
+      undefined,
+      undefined,
+      {
+        load: async () => {
+          throw new Error('Session catalog unavailable')
+        },
+        save: async () => undefined
+      }
+    )
+    vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
+    vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
+    vi.mocked(hostRepo.get).mockResolvedValue({ concurrencyLimit: 10 } as ComputeHost)
+    const commit = vi.fn(async () => undefined)
+
+    await expect(durableManager.startQueueReconciliation()).rejects.toThrow(
+      'Session catalog unavailable'
+    )
+    await expect(
+      durableManager.admit({ sessionId: 'session-1', providerId: 'ssh:cluster-a' }, commit)
+    ).resolves.toBe('queued')
+    expect(commit).toHaveBeenCalledWith('queued')
+  })
+
+  it('does not hold the admission lock while loading durable limits', async () => {
+    const managerRef: { current?: ConcurrencyManager } = {}
+    const durableManager = new ConcurrencyManager(
+      jobRepo,
+      hostRepo,
+      dispatchJob,
+      onJobUpdated,
+      undefined,
+      undefined,
+      {
+        load: async () => {
+          await managerRef.current?.clearProjectedSessionLimits(['deleted-session'])
+          return [['session-1', 1]]
+        },
+        save: async () => undefined
+      }
+    )
+    managerRef.current = durableManager
+
+    await expect(
+      Promise.race([
+        durableManager.startQueueReconciliation().then(() => 'restored' as const),
+        new Promise<'timed_out'>((resolve) => setTimeout(() => resolve('timed_out'), 100))
+      ])
+    ).resolves.toBe('restored')
+  })
+
   describe('enqueue - global queue limit', () => {
     it('returns queue_full when global queue >= 100', async () => {
       vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(100)

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -118,6 +118,14 @@ describe('ConcurrencyManager', () => {
       expect(durableManager['sessionLimits'].get('session-1')).toBe(2)
       expect(save).not.toHaveBeenCalled()
     })
+
+    it('clears projected limits when their Sessions are deleted', async () => {
+      await manager.projectPersistedSessionLimit('session-1', 2)
+
+      await manager.clearProjectedSessionLimits(['session-1'])
+
+      expect(manager['sessionLimits'].has('session-1')).toBe(false)
+    })
   })
 
   describe('setProviderLimit', () => {

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -203,7 +203,8 @@ export class ConcurrencyManager {
     commit: (status: 'submitted' | 'queued') => Promise<void>
   ): Promise<'submitted' | 'queued' | 'queue_full'> {
     return this.runExclusive(async () => {
-      const shouldQueue = await this.overActiveLimits(params.sessionId, params.providerId)
+      const shouldQueue =
+        this.queueStopped || (await this.overActiveLimits(params.sessionId, params.providerId))
       if (!shouldQueue) {
         await commit('submitted')
         return 'submitted'
@@ -234,7 +235,9 @@ export class ConcurrencyManager {
   }): Promise<'can_dispatch' | 'should_queue' | 'queue_full'> {
     const { sessionId, providerId } = params
 
-    if (!(await this.overActiveLimits(sessionId, providerId))) return 'can_dispatch'
+    if (!this.queueStopped && !(await this.overActiveLimits(sessionId, providerId))) {
+      return 'can_dispatch'
+    }
     const globalQueuedCount = await this.jobRepository.countQueuedJobs()
     return globalQueuedCount >= GLOBAL_QUEUE_LIMIT ? 'queue_full' : 'should_queue'
   }
@@ -246,22 +249,23 @@ export class ConcurrencyManager {
 
   async startQueueReconciliation(): Promise<void> {
     const lifecycleRevision = ++this.queueLifecycleRevision
+    const restoredLimits = await this.sessionLimitPersistence?.load()
+    let limits: Map<string, number> | undefined
+    if (restoredLimits) {
+      limits = new Map<string, number>()
+      for (const [sessionId, limit] of restoredLimits) {
+        if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+          throw new Error(
+            `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
+          )
+        }
+        limits.set(sessionId, limit)
+      }
+    }
     let shouldReconcile = false
     await this.runExclusive(async () => {
-      const restoredLimits = await this.sessionLimitPersistence?.load()
       if (lifecycleRevision !== this.queueLifecycleRevision) return
-      if (restoredLimits) {
-        const limits = new Map<string, number>()
-        for (const [sessionId, limit] of restoredLimits) {
-          if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
-            throw new Error(
-              `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
-            )
-          }
-          limits.set(sessionId, limit)
-        }
-        this.sessionLimits = limits
-      }
+      if (limits) this.sessionLimits = limits
       this.queueStopped = false
       shouldReconcile = true
     })

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -122,6 +122,12 @@ export class ConcurrencyManager {
     }
   }
 
+  async clearProjectedSessionLimits(sessionIds: readonly string[]): Promise<void> {
+    await this.runExclusive(async () => {
+      for (const sessionId of sessionIds) this.sessionLimits.delete(sessionId)
+    })
+  }
+
   // Provider limits are durable host configuration. Own the production mutation here so it shares
   // the same lock as admission and queued-job promotion; raising the ceiling then wakes the FIFO queue.
   async setProviderLimit(providerId: string, limit: number): Promise<void> {

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -27,16 +27,21 @@ const TERMINAL_JOB_STATUSES: ReadonlySet<ComputeJob['status']> = new Set([
 
 type DispatchQueuedJob = (jobId: string, onJobUpdated: (job: ComputeJob) => void) => Promise<void>
 
+type SessionConcurrencyLimitPersistence = {
+  load(): Promise<readonly (readonly [sessionId: string, limit: number])[]>
+  save(sessionId: string, limit: number): Promise<void>
+}
+
 // Enforces session-level and provider-level concurrency limits for compute jobs.
-// Stores session limits in memory, decides whether jobs should queue or dispatch,
-// and automatically dispatches queued jobs when slots become available.
+// Restores durable session limits into memory, decides whether jobs should queue or dispatch, and
+// automatically dispatches queued jobs when slots become available.
 export class ConcurrencyManager {
-  // In-memory storage of session limits: sessionId -> limit
   private sessionLimits: Map<string, number> = new Map()
 
   private reconciliationRequested: boolean = false
   private reconciliationTask: Promise<void> | undefined
-  private queueStopped = false
+  private queueStopped: boolean
+  private queueLifecycleRevision = 0
 
   // In-process serialization lock for admit(). The decision (read counts → pick status) and the
   // job-row commit must be atomic: without this, two concurrent submitJob calls could both read the
@@ -55,9 +60,16 @@ export class ConcurrencyManager {
     private readonly dispatchJob: DispatchQueuedJob,
     private readonly publishJobUpdated: (job: ComputeJob) => void = () => undefined,
     lifecycle?: ComputeJobLifecycle,
-    private readonly dispatchTracker: Pick<DispatchTracker, 'begin' | 'end'> = sharedDispatchTracker
+    private readonly dispatchTracker: Pick<
+      DispatchTracker,
+      'begin' | 'end'
+    > = sharedDispatchTracker,
+    private readonly sessionLimitPersistence?: SessionConcurrencyLimitPersistence
   ) {
     this.lifecycle = lifecycle ?? new ComputeJobLifecycle(jobRepository, this.handleJobUpdated)
+    // A production manager with durable Session limits fails closed until startup restoration has
+    // completed. Isolated callers without persistence retain the existing immediately-active seam.
+    this.queueStopped = sessionLimitPersistence !== undefined
   }
 
   // Owns the complete update policy used by ComputeService: publish every persisted projection, then
@@ -68,8 +80,8 @@ export class ConcurrencyManager {
     if (TERMINAL_JOB_STATUSES.has(job.status)) this.requestQueueReconciliation()
   }
 
-  // Session limits are process-local by design. Serialize updates with admissions so a limit saved by
-  // the caller cannot be followed by a late admission made against the previous value.
+  // Serialize the durable write and live projection with admissions so a successful setting cannot
+  // be followed by a late admission made against the previous value.
   async setSessionLimit(sessionId: string, limit: number): Promise<void> {
     if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
       throw new Error(
@@ -79,6 +91,7 @@ export class ConcurrencyManager {
 
     let previousLimit: number | undefined
     await this.runExclusive(async () => {
+      await this.sessionLimitPersistence?.save(sessionId, limit)
       previousLimit = this.sessionLimits.get(sessionId)
       this.sessionLimits.set(sessionId, limit)
     })
@@ -204,12 +217,32 @@ export class ConcurrencyManager {
     await this.reconcileQueuedJobs()
   }
 
-  startQueueReconciliation(): void {
-    this.queueStopped = false
-    this.requestQueueReconciliation()
+  async startQueueReconciliation(): Promise<void> {
+    const lifecycleRevision = ++this.queueLifecycleRevision
+    let shouldReconcile = false
+    await this.runExclusive(async () => {
+      const restoredLimits = await this.sessionLimitPersistence?.load()
+      if (lifecycleRevision !== this.queueLifecycleRevision) return
+      if (restoredLimits) {
+        const limits = new Map<string, number>()
+        for (const [sessionId, limit] of restoredLimits) {
+          if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+            throw new Error(
+              `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
+            )
+          }
+          limits.set(sessionId, limit)
+        }
+        this.sessionLimits = limits
+      }
+      this.queueStopped = false
+      shouldReconcile = true
+    })
+    if (shouldReconcile) this.requestQueueReconciliation()
   }
 
   async stopQueueReconciliation(): Promise<void> {
+    this.queueLifecycleRevision += 1
     this.queueStopped = true
     this.reconciliationRequested = false
     await this.reconciliationTask
@@ -338,3 +371,5 @@ export class ConcurrencyManager {
     return JSON.stringify([projectId, sessionId])
   }
 }
+
+export type { SessionConcurrencyLimitPersistence }

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -101,6 +101,27 @@ export class ConcurrencyManager {
     }
   }
 
+  // Projects a limit that was already committed through Session persistence. Session creation uses
+  // this path so inherited limits become authoritative in the current process without writing the
+  // same Session a second time.
+  async projectPersistedSessionLimit(sessionId: string, limit: number): Promise<void> {
+    if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+      throw new Error(
+        `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
+      )
+    }
+
+    let previousLimit: number | undefined
+    await this.runExclusive(async () => {
+      previousLimit = this.sessionLimits.get(sessionId)
+      this.sessionLimits.set(sessionId, limit)
+    })
+
+    if (previousLimit !== undefined && limit > previousLimit) {
+      this.requestQueueReconciliation()
+    }
+  }
+
   // Provider limits are durable host configuration. Own the production mutation here so it shares
   // the same lock as admission and queued-job promotion; raising the ceiling then wakes the FIFO queue.
   async setProviderLimit(providerId: string, limit: number): Promise<void> {

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -37,7 +37,7 @@ import type { TaskNotificationService } from '../notifications/task-notification
 import { buildComputeApprovalBroadcast } from '../notifications/electron-wiring'
 import { ComputeApprovalBroker, type ComputeApprovalContext } from './compute-approval-broker'
 import { ComputeService, type ArtifactResolver } from './compute-service'
-import { ConcurrencyManager } from './concurrency-manager'
+import { ConcurrencyManager, type SessionConcurrencyLimitPersistence } from './concurrency-manager'
 import { ComputeHostRepository } from './repository'
 import { ComputeJobRepository } from './job-repository'
 import { ComputeJobOperationRepository } from './compute-job-operation-repository'
@@ -243,7 +243,8 @@ const createComputeHandlers = (
   hostLifecycle?: ComputeHostLifecycle,
   authenticationDependencies?: ComputeAuthenticationDependencies,
   sessionCacheOwner?: SessionCacheOwner,
-  operationRepository?: ComputeJobOperationRepository
+  operationRepository?: ComputeJobOperationRepository,
+  sessionLimitPersistence?: SessionConcurrencyLimitPersistence
 ): ComputeHandlers => {
   const permissionGrants = permissionGrantRegistry
     ? createComputePermissionGrantAdapter(permissionGrantRegistry, legacyComputeGrants)
@@ -347,7 +348,10 @@ const createComputeHandlers = (
               onJobUpdated: handleJobUpdated,
               storageRoot
             }),
-          onJobUpdated
+          onJobUpdated,
+          undefined,
+          undefined,
+          sessionLimitPersistence
         )
       : undefined
   const service =
@@ -628,7 +632,8 @@ const createComputeIpcModule = (
   >,
   permissionGrantRegistry?: PermissionGrantRegistry,
   legacyComputeGrants?: LegacyComputeGrantPort,
-  hostLifecycle?: ComputeHostLifecycle
+  hostLifecycle?: ComputeHostLifecycle,
+  sessionLimitPersistence?: SessionConcurrencyLimitPersistence
 ): ComputeIpcModule => {
   const operationRepository = createDefaultComputeJobOperationRepository()
   const storageRoot = resolveStorageRoot()
@@ -657,7 +662,8 @@ const createComputeIpcModule = (
     hostLifecycle,
     undefined,
     sessionCacheOwner,
-    operationRepository
+    operationRepository,
+    sessionLimitPersistence
   )
   const jobDeletionOwner = createComputeJobDeletionOwner({
     jobRepository,

--- a/src/main/compute/job-runtime.test.ts
+++ b/src/main/compute/job-runtime.test.ts
@@ -55,7 +55,7 @@ describe('createComputeJobRuntime', () => {
 
     pollerDeps?.onJobUpdated?.(job)
     await pollerDeps?.harvestFn?.(job)
-    runtime.start()
+    await runtime.start()
     await runtime.stop()
 
     expect(handleJobUpdated).toHaveBeenCalledWith(job)
@@ -76,6 +76,42 @@ describe('createComputeJobRuntime', () => {
       resume: expect.any(Function)
     })
     expect(unbind).toHaveBeenCalledOnce()
+  })
+
+  it('keeps queued promotion stopped when Session limit restoration fails', async () => {
+    const start = vi.fn()
+    const stop = vi.fn(async () => undefined)
+    const startQueueReconciliation = vi.fn(async () => {
+      throw new Error('Session catalog unavailable')
+    })
+    const runtime = createComputeJobRuntime(
+      {
+        computeService: {
+          handleJobUpdated: vi.fn(),
+          handleJobCancellationConfirmed: vi.fn(async () => undefined),
+          startQueueReconciliation,
+          stopQueueReconciliation: vi.fn(async () => undefined)
+        },
+        hostRepository: {} as ComputeHostRepository,
+        jobRepository: {} as ComputeJobRepository,
+        connectionBroker: {} as ComputeConnectionBroker,
+        storageRoot: '/data'
+      },
+      {
+        createPoller: () => ({
+          start,
+          stop,
+          pause: vi.fn(async () => undefined),
+          resume: vi.fn()
+        })
+      }
+    )
+
+    await expect(runtime.start()).resolves.toBeUndefined()
+    expect(start).toHaveBeenCalledOnce()
+    expect(startQueueReconciliation).toHaveBeenCalledOnce()
+    await runtime.stop()
+    expect(stop).toHaveBeenCalledOnce()
   })
 
   it('waits for already-started polling work when the runtime stops', async () => {
@@ -104,7 +140,7 @@ describe('createComputeJobRuntime', () => {
       storageRoot: '/data'
     })
 
-    runtime.start()
+    await runtime.start()
     await vi.waitFor(() => expect(findTerminalUnharvested).toHaveBeenCalledOnce())
 
     let stopped = false
@@ -240,7 +276,7 @@ describe('createComputeJobRuntime', () => {
       { harvest }
     )
 
-    runtime.start()
+    await runtime.start()
     await vi.waitFor(() => {
       expect(harvest).toHaveBeenCalledOnce()
       expect(run).toHaveBeenCalledOnce()

--- a/src/main/compute/job-runtime.test.ts
+++ b/src/main/compute/job-runtime.test.ts
@@ -204,6 +204,49 @@ describe('createComputeJobRuntime', () => {
     expect(events).toEqual(['reconciliation-stopping', 'reconciliation-stopped', 'poller-stopped'])
   })
 
+  it('does not reopen queue reconciliation when stop overlaps poller startup', async () => {
+    let releasePollerStart!: () => void
+    const pollerStart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releasePollerStart = resolve
+        })
+    )
+    const startQueueReconciliation = vi.fn(async () => undefined)
+    const stopQueueReconciliation = vi.fn(async () => undefined)
+    const runtime = createComputeJobRuntime(
+      {
+        computeService: {
+          handleJobUpdated: vi.fn(),
+          handleJobCancellationConfirmed: vi.fn(async () => undefined),
+          startQueueReconciliation,
+          stopQueueReconciliation
+        },
+        hostRepository: {} as ComputeHostRepository,
+        jobRepository: {} as ComputeJobRepository,
+        connectionBroker: {} as ComputeConnectionBroker,
+        storageRoot: '/data'
+      },
+      {
+        createPoller: () => ({
+          start: pollerStart,
+          stop: vi.fn(async () => undefined),
+          pause: vi.fn(async () => undefined),
+          resume: vi.fn()
+        })
+      }
+    )
+
+    const starting = runtime.start()
+    await vi.waitFor(() => expect(pollerStart).toHaveBeenCalledOnce())
+    const stopping = runtime.stop()
+    await vi.waitFor(() => expect(stopQueueReconciliation).toHaveBeenCalledOnce())
+    releasePollerStart()
+    await Promise.all([starting, stopping])
+
+    expect(startQueueReconciliation).not.toHaveBeenCalled()
+  })
+
   it('cancels in-flight polling and harvest work when the runtime stops', async () => {
     const runningJob = {
       job_id: 'job-running',

--- a/src/main/compute/job-runtime.ts
+++ b/src/main/compute/job-runtime.ts
@@ -6,13 +6,13 @@ import type { ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
 import type { ComputeService } from './compute-service'
 import type { ComputeConnectionBroker } from './connection-broker'
-import { createLogger } from '../logger'
+import { createLogger, errorLogFields } from '../logger'
 import { ComputeJobCancellationReaper } from './compute-job-cancellation-owner'
 import type { ComputeJobOperationRepository } from './compute-job-operation-repository'
 
 const log = createLogger('compute-integrity')
 
-type ComputeJobRuntime = { start(): void; stop(): Promise<void> }
+type ComputeJobRuntime = { start(): void | Promise<void>; stop(): Promise<void> }
 
 type ComputeJobRuntimeDeps = {
   computeService: Pick<
@@ -107,15 +107,26 @@ export const createComputeJobRuntime = (
     }
   }
   const unbindDeletionRuntime = deps.jobDeletionOwner?.bindRuntime(deletionRuntime)
+  let startTask: Promise<void> | undefined
   return {
     start: () => {
-      poller.start()
-      cancellationReaper?.start()
-      deps.computeService.startQueueReconciliation()
+      startTask ??= (async () => {
+        await Promise.all([poller.start(), cancellationReaper?.start()])
+        try {
+          await deps.computeService.startQueueReconciliation()
+        } catch (error) {
+          log.warn(
+            'compute queue reconciliation remains stopped after Session limit restoration failed',
+            errorLogFields(error)
+          )
+        }
+      })()
+      return startTask
     },
     stop: async () => {
       unbindDeletionRuntime?.()
       await deps.computeService.stopQueueReconciliation()
+      await startTask
       await Promise.all([poller.stop(), cancellationReaper?.stop()])
     }
   }

--- a/src/main/compute/job-runtime.ts
+++ b/src/main/compute/job-runtime.ts
@@ -108,10 +108,13 @@ export const createComputeJobRuntime = (
   }
   const unbindDeletionRuntime = deps.jobDeletionOwner?.bindRuntime(deletionRuntime)
   let startTask: Promise<void> | undefined
+  let stopRequested = false
   return {
     start: () => {
+      if (stopRequested) return
       startTask ??= (async () => {
         await Promise.all([poller.start(), cancellationReaper?.start()])
+        if (stopRequested) return
         try {
           await deps.computeService.startQueueReconciliation()
         } catch (error) {
@@ -124,6 +127,7 @@ export const createComputeJobRuntime = (
       return startTask
     },
     stop: async () => {
+      stopRequested = true
       unbindDeletionRuntime?.()
       await deps.computeService.stopQueueReconciliation()
       await startTask

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -205,6 +205,34 @@ describe('SessionEnabledComputeHostsOwner', () => {
     expect(projectSessionConcurrencyLimit).toHaveBeenCalledWith('session-1', 2)
   })
 
+  it('rejects an invalid concurrency limit before committing a new Session', async () => {
+    const projectSessionConcurrencyLimit = vi.fn(async () => {
+      throw new Error('Session concurrency limit must be an integer in the range 1..500 (got 0).')
+    })
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry: new EnabledComputeHostsRegistry(),
+      hostExists: async () => true,
+      listHostIds: async () => [],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
+      },
+      withDataRootWrite: passthroughDataRootWrite,
+      projectSessionConcurrencyLimit
+    })
+    const commit = vi.fn(async (candidate: PersistedChatSession) => candidate)
+
+    await expect(
+      owner.createSession(createSession({ computeConcurrencyLimit: 0 }), commit)
+    ).rejects.toThrow(/integer in the range 1\.\.500/)
+
+    expect(commit).not.toHaveBeenCalled()
+    expect(projectSessionConcurrencyLimit).not.toHaveBeenCalled()
+  })
+
   it('replaces the derived cache from a complete Session catalog', async () => {
     const registry = new EnabledComputeHostsRegistry()
     registry.set('stale-session', ['ssh:old'])

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -371,7 +371,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
   it('clears deleted Sessions from the cache', async () => {
     const registry = new EnabledComputeHostsRegistry()
     registry.set('session-1', ['ssh:cluster'])
-    const owner = new SessionEnabledComputeHostsOwner({
+    const clearSessionConcurrencyLimits = vi.fn(async () => undefined)
+    const options = {
       registry,
       hostExists: async () => true,
       listHostIds: async () => ['ssh:cluster'],
@@ -382,12 +383,15 @@ describe('SessionEnabledComputeHostsOwner', () => {
         },
         pruneSessionEnabledComputeHosts: async () => createPruneResult()
       },
+      clearSessionConcurrencyLimits,
       withDataRootWrite: passthroughDataRootWrite
-    })
+    }
+    const owner = new SessionEnabledComputeHostsOwner(options)
 
     await owner.clear(['session-1'])
 
     expect(owner.get('session-1')).toEqual([])
+    expect(clearSessionConcurrencyLimits).toHaveBeenCalledWith(['session-1'])
   })
 
   it('serializes Session deletion cache clears after in-flight reconciliation', async () => {

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -181,6 +181,30 @@ describe('SessionEnabledComputeHostsOwner', () => {
     expect(commit).toHaveBeenCalledTimes(1)
   })
 
+  it('projects a persisted concurrency limit before first Session creation completes', async () => {
+    const projectSessionConcurrencyLimit = vi.fn(async () => undefined)
+    const options = {
+      registry: new EnabledComputeHostsRegistry(),
+      hostExists: async () => true,
+      listHostIds: async () => [],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
+      },
+      withDataRootWrite: passthroughDataRootWrite,
+      projectSessionConcurrencyLimit
+    }
+    const owner = new SessionEnabledComputeHostsOwner(options)
+    const session = createSession({ computeConcurrencyLimit: 2 })
+
+    await owner.createSession(session, async (candidate) => candidate)
+
+    expect(projectSessionConcurrencyLimit).toHaveBeenCalledWith('session-1', 2)
+  })
+
   it('replaces the derived cache from a complete Session catalog', async () => {
     const registry = new EnabledComputeHostsRegistry()
     registry.set('stale-session', ['ssh:old'])

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -38,6 +38,7 @@ type SessionEnabledComputeHostsOwnerOptions = Readonly<{
   hostExists(providerId: string): Promise<boolean>
   listHostIds(): Promise<readonly string[]>
   sessionAuthority: SessionEnabledComputeHostsAuthority
+  projectSessionConcurrencyLimit?(sessionId: string, limit: number): Promise<void>
   withDataRootWrite<Result>(operation: () => Promise<Result>): Promise<Result>
 }>
 
@@ -307,6 +308,15 @@ class SessionEnabledComputeHostsOwner {
           ? { selectedComputeHosts }
           : {})
       })
+      if (durableSession.computeConcurrencyLimit !== undefined) {
+        if (!this.options.projectSessionConcurrencyLimit) {
+          throw new Error('Session concurrency ownership is not initialized.')
+        }
+        await this.options.projectSessionConcurrencyLimit(
+          durableSession.id,
+          durableSession.computeConcurrencyLimit
+        )
+      }
       this.project(durableSession)
       return durableSession
     })

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -43,6 +43,14 @@ type SessionEnabledComputeHostsOwnerOptions = Readonly<{
   withDataRootWrite<Result>(operation: () => Promise<Result>): Promise<Result>
 }>
 
+const validateSessionConcurrencyLimit = (limit: number | undefined): void => {
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 500)) {
+    throw new Error(
+      `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
+    )
+  }
+}
+
 class SessionEnabledComputeHostsOwner {
   private queue: Promise<unknown> = Promise.resolve()
   private readonly reservationCounts = new Map<string, number>()
@@ -290,6 +298,7 @@ class SessionEnabledComputeHostsOwner {
     commit: (session: PersistedChatSession) => Promise<PersistedChatSession>
   ): Promise<PersistedChatSession> {
     return this.enqueueWrite(async () => {
+      validateSessionConcurrencyLimit(session.computeConcurrencyLimit)
       const enabledComputeHosts = await this.validateProviderIds(session.enabledComputeHosts ?? [])
       const selectedComputeHosts = await this.validateProviderIds(
         session.selectedComputeHosts ?? enabledComputeHosts

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -39,6 +39,7 @@ type SessionEnabledComputeHostsOwnerOptions = Readonly<{
   listHostIds(): Promise<readonly string[]>
   sessionAuthority: SessionEnabledComputeHostsAuthority
   projectSessionConcurrencyLimit?(sessionId: string, limit: number): Promise<void>
+  clearSessionConcurrencyLimits?(sessionIds: readonly string[]): Promise<void>
   withDataRootWrite<Result>(operation: () => Promise<Result>): Promise<Result>
 }>
 
@@ -143,6 +144,7 @@ class SessionEnabledComputeHostsOwner {
 
   clear(sessionIds: readonly string[]): Promise<void> {
     return this.enqueue(async () => {
+      await this.options.clearSessionConcurrencyLimits?.(sessionIds)
       for (const sessionId of sessionIds) this.options.registry.clear(sessionId)
     })
   }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1846,14 +1846,16 @@ const createApplicationModules = async (
       )
     },
     save: async (sessionId: string, limit: number): Promise<void> => {
-      const projectId = await sessionPersistenceCoordinator.sessionProjectId(sessionId)
-      if (!projectId)
-        throw new Error(`Cannot persist concurrency for missing Session ${sessionId}.`)
-      const session = await sessionPersistenceCoordinator.setSessionComputeConcurrencyLimit(
-        projectId,
-        sessionId,
-        limit
-      )
+      const session = await withDataRootWrite(async () => {
+        const projectId = await sessionPersistenceCoordinator.sessionProjectId(sessionId)
+        if (!projectId)
+          throw new Error(`Cannot persist concurrency for missing Session ${sessionId}.`)
+        return sessionPersistenceCoordinator.setSessionComputeConcurrencyLimit(
+          projectId,
+          sessionId,
+          limit
+        )
+      })
       applicationEvents.publish('session:updated', {
         session,
         originClientId: MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID
@@ -1912,6 +1914,11 @@ const createApplicationModules = async (
       const concurrencyManager = computeIpcModule.handlers.concurrencyManager
       if (!concurrencyManager) throw new Error('Session concurrency ownership is not initialized.')
       await concurrencyManager.projectPersistedSessionLimit(sessionId, limit)
+    },
+    clearSessionConcurrencyLimits: async (sessionIds) => {
+      const concurrencyManager = computeIpcModule.handlers.concurrencyManager
+      if (!concurrencyManager) throw new Error('Session concurrency ownership is not initialized.')
+      await concurrencyManager.clearProjectedSessionLimits(sessionIds)
     },
     withDataRootWrite
   })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1945,77 +1945,6 @@ const createApplicationModules = async (
   await jobDeletionOwner.restoreOrphanJobDeletionBarriers(isComputeJobOwnerLive)
   composition.phase('deletion-barriers')
   const dataRoot = resolveDataRoot()
-  // Start the JobPoller wired to the shared broadcaster so every state/tail change is pushed to all
-  // renderer windows via 'compute:job-updated' (Phase 3d, design.md §9 + §15.3). The dispatcher
-  // (inside ComputeService) uses the same hook, so submitted→running/error transitions broadcast too.
-  // Phase 3b: harvestFn drives automatic harvest on terminal transitions; broadcast + storageRoot
-  // wire the compute_done notification emitter for all three terminal outcomes (issue 06).
-  await modules.add(
-    {
-      computeService,
-      connectionBroker,
-      jobDeletionOwner,
-      hostRepository,
-      jobRepository,
-      operationRepository,
-      storageRoot: dataRoot
-    },
-    (dependencies) => {
-      const jobPoller = createComputeJobRuntime(dependencies)
-      return {
-        name: 'compute-job-runtime',
-        capability: undefined,
-        start: async () => {
-          try {
-            const owners = await jobRepository.listOwners()
-            const jobs = (
-              await Promise.all(owners.map((owner) => jobRepository.findByOwner(owner)))
-            ).flat()
-            for (const [index, job] of jobs.entries()) {
-              if (
-                job.status !== 'error' ||
-                hasImmutableExecutionFileEvidenceReference(job.file_evidence)
-              ) {
-                continue
-              }
-              const fileEvidence = await recoverPublishedComputeJobFileEvidence({
-                storageRoot: dataRoot,
-                projectId: job.project_id,
-                sessionId: job.session_id,
-                jobId: job.job_id,
-                producerRunId: job.producer_run_id
-              })
-              if (!fileEvidence) continue
-              const updated = await jobRepository.update(job.job_id, { fileEvidence })
-              jobs[index] = updated
-              await settleComputeJobFileEvidence({
-                storageRoot: dataRoot,
-                projectId: job.project_id,
-                sessionId: job.session_id,
-                jobId: job.job_id,
-                producerRunId: job.producer_run_id,
-                fileEvidence
-              }).catch((error) =>
-                createLogger('compute:file-evidence').warn(
-                  'Recovered Compute Job file-evidence receipt remains for reconciliation.',
-                  { jobId: job.job_id, ...errorLogFields(error) }
-                )
-              )
-            }
-            await reconcileComputeJobFileEvidence(dataRoot, jobs)
-          } catch (error) {
-            createLogger('compute:file-evidence').warn(
-              'Compute Job file-evidence startup reconciliation failed closed.',
-              diagnosticErrorFields(error)
-            )
-          }
-          await jobPoller.start()
-        },
-        disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
-        dispose: () => jobPoller.stop()
-      }
-    }
-  )
   // The Notebook RPC receives only this Session-admitted facade, never the unrestricted service
   // used by Settings and internal runtimes.
   const agentComputeService = new AgentComputeService(computeService, hostsRegistry)
@@ -2868,6 +2797,75 @@ const createApplicationModules = async (
     sideChatLog.error('durable Side chat hydration failed', diagnosticErrorFields(error))
   }
   composition.phase('side-chat')
+  // Start the JobPoller wired to the shared broadcaster only after Project runtime quiescence and
+  // Side Chat recovery are available. Queue startup loads the Session catalog, which may first need
+  // to finish a pending Project deletion through those owners before restoring concurrency limits.
+  await modules.add(
+    {
+      computeService,
+      connectionBroker,
+      jobDeletionOwner,
+      hostRepository,
+      jobRepository,
+      operationRepository,
+      storageRoot: dataRoot
+    },
+    (dependencies) => {
+      const jobPoller = createComputeJobRuntime(dependencies)
+      return {
+        name: 'compute-job-runtime',
+        capability: undefined,
+        start: async () => {
+          try {
+            const owners = await jobRepository.listOwners()
+            const jobs = (
+              await Promise.all(owners.map((owner) => jobRepository.findByOwner(owner)))
+            ).flat()
+            for (const [index, job] of jobs.entries()) {
+              if (
+                job.status !== 'error' ||
+                hasImmutableExecutionFileEvidenceReference(job.file_evidence)
+              ) {
+                continue
+              }
+              const fileEvidence = await recoverPublishedComputeJobFileEvidence({
+                storageRoot: dataRoot,
+                projectId: job.project_id,
+                sessionId: job.session_id,
+                jobId: job.job_id,
+                producerRunId: job.producer_run_id
+              })
+              if (!fileEvidence) continue
+              const updated = await jobRepository.update(job.job_id, { fileEvidence })
+              jobs[index] = updated
+              await settleComputeJobFileEvidence({
+                storageRoot: dataRoot,
+                projectId: job.project_id,
+                sessionId: job.session_id,
+                jobId: job.job_id,
+                producerRunId: job.producer_run_id,
+                fileEvidence
+              }).catch((error) =>
+                createLogger('compute:file-evidence').warn(
+                  'Recovered Compute Job file-evidence receipt remains for reconciliation.',
+                  { jobId: job.job_id, ...errorLogFields(error) }
+                )
+              )
+            }
+            await reconcileComputeJobFileEvidence(dataRoot, jobs)
+          } catch (error) {
+            createLogger('compute:file-evidence').warn(
+              'Compute Job file-evidence startup reconciliation failed closed.',
+              diagnosticErrorFields(error)
+            )
+          }
+          await jobPoller.start()
+        },
+        disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
+        dispose: () => jobPoller.stop()
+      }
+    }
+  )
   // Recovery quiesces every runtime owner, so do not start its first attempt until ACP, Delegation,
   // Notebook, Side Chat, and the composed quiescence boundary are all initialized. The bounded
   // durable barrier restoration above still runs early enough to block admission during startup.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1908,6 +1908,11 @@ const createApplicationModules = async (
     hostExists: async (providerId) => (await hostRepository.get(providerId)) !== null,
     listHostIds: async () => (await hostRepository.list()).map((host) => host.providerId),
     sessionAuthority: sessionPersistenceCoordinator,
+    projectSessionConcurrencyLimit: async (sessionId, limit) => {
+      const concurrencyManager = computeIpcModule.handlers.concurrencyManager
+      if (!concurrencyManager) throw new Error('Session concurrency ownership is not initialized.')
+      await concurrencyManager.projectPersistedSessionLimit(sessionId, limit)
+    },
     withDataRootWrite
   })
   sessionEnabledComputeHostsOwnerRef.current = sessionEnabledComputeHostsOwner

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1833,6 +1833,33 @@ const createApplicationModules = async (
   const computeArtifactResolver = createComputeArtifactResolver(resolveDataRoot(), (path) =>
     artifactRepository.resolveManagedFilePath({ path })
   )
+  const sessionLimitPersistence = {
+    load: async (): Promise<readonly (readonly [string, number])[]> => {
+      const catalog = await loadAllSessions()
+      if (!canReconcileSessionAbsences(catalog)) {
+        throw new Error('Session concurrency limits could not be restored authoritatively.')
+      }
+      return catalog.sessions.flatMap((session) =>
+        session.computeConcurrencyLimit === undefined
+          ? []
+          : [[session.id, session.computeConcurrencyLimit] as const]
+      )
+    },
+    save: async (sessionId: string, limit: number): Promise<void> => {
+      const projectId = await sessionPersistenceCoordinator.sessionProjectId(sessionId)
+      if (!projectId)
+        throw new Error(`Cannot persist concurrency for missing Session ${sessionId}.`)
+      const session = await sessionPersistenceCoordinator.setSessionComputeConcurrencyLimit(
+        projectId,
+        sessionId,
+        limit
+      )
+      applicationEvents.publish('session:updated', {
+        session,
+        originClientId: MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID
+      })
+    }
+  }
   const computeIpcModule = createComputeIpcModule(
     undefined,
     undefined,
@@ -1861,7 +1888,8 @@ const createApplicationModules = async (
           }
         }
       }
-    }
+    },
+    sessionLimitPersistence
   )
   surfaceAdapters = beforeAcpAdapters
   const {
@@ -1976,7 +2004,7 @@ const createApplicationModules = async (
               diagnosticErrorFields(error)
             )
           }
-          jobPoller.start()
+          await jobPoller.start()
         },
         disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
         dispose: () => jobPoller.stop()

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -452,6 +452,7 @@ describe('Session persistence coordinator architecture', () => {
         'saveSideChatProjection',
         'sessionMetadataSnapshot',
         'sessionProjectId',
+        'setSessionComputeConcurrencyLimit',
         'setSessionDelegationPolicy',
         'setSessionDeletionHandlers',
         'setSessionEnabledComputeHosts',
@@ -671,6 +672,7 @@ describe('Session persistence coordinator architecture', () => {
         'saveSession',
         'saveSessionSpecialistBinding',
         'saveSideChatProjection',
+        'setSessionComputeConcurrencyLimit',
         'setSessionDelegationPolicy',
         'setSessionEnabledComputeHosts',
         'updateArchive'
@@ -727,7 +729,7 @@ describe('Session persistence coordinator architecture', () => {
       expect(methods(owner, 'private')).not.toContain('enqueue')
     }
 
-    expect(expectedSchedulerRoute.size).toBe(34)
+    expect(expectedSchedulerRoute.size).toBe(35)
     const constructorSource = facade.members.filter(isConstructorDeclaration)[0].getText(facadeFile)
     expect(constructorSource).toContain('this.operationScheduler.runSession(')
     expect(constructorSource).toContain('this.operationScheduler.runGlobal(work)')
@@ -871,6 +873,7 @@ describe('Session persistence coordinator architecture', () => {
         'saveSession',
         'saveSessionSpecialistBinding',
         'sessionProjectId',
+        'setComputeConcurrencyLimit',
         'setDelegationPolicy',
         'setEnabledComputeHosts'
       ].sort()
@@ -960,6 +963,7 @@ describe('Session persistence coordinator architecture', () => {
       saveSideChatProjection: ['sideChatOwner.saveProjection'],
       sessionMetadataSnapshot: ['stateOwner.metadataSnapshot'],
       sessionProjectId: ['stateOwner.sessionProjectId'],
+      setSessionComputeConcurrencyLimit: ['stateOwner.setComputeConcurrencyLimit'],
       setSessionDelegationPolicy: ['stateOwner.setDelegationPolicy'],
       setSessionEnabledComputeHosts: ['stateOwner.setEnabledComputeHosts'],
       readChildren: ['delegatedWorkOwner.readChildren'],

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -1794,6 +1794,52 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durable.delegationPolicy).toBe('deny')
   })
 
+  it('persists Compute concurrency through its dedicated Session owner', async () => {
+    const previousUpdatedAt = Date.now() + 10_000
+    let durable = createSession({ updatedAt: previousUpdatedAt })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session, expectedRevision) => {
+        durable = structuredClone({
+          ...session,
+          revision: (expectedRevision ?? session.revision ?? 0) + 1
+        })
+        return durable
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.setSessionComputeConcurrencyLimit('project-1', 'session-1', 2)
+    ).resolves.toMatchObject({ computeConcurrencyLimit: 2 })
+
+    expect(durable.computeConcurrencyLimit).toBe(2)
+    expect(durable.updatedAt).toBeGreaterThan(previousUpdatedAt)
+  })
+
+  it('preserves Main-owned Compute concurrency on an ordinary existing-Session save', async () => {
+    let durable = createSession({ computeConcurrencyLimit: 2 })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await coordinator.saveSession(
+      createSession({ title: 'Renderer rename', computeConcurrencyLimit: 9 })
+    )
+
+    expect(durable).toMatchObject({ title: 'Renderer rename', computeConcurrencyLimit: 2 })
+  })
+
   it('updates enabled Compute Hosts through the durable Session owner', async () => {
     const previousUpdatedAt = Date.now() + 10_000
     let durable = createSession({

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -762,6 +762,16 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     )
   }
 
+  setSessionComputeConcurrencyLimit(
+    projectId: string,
+    sessionId: string,
+    limit: number
+  ): Promise<PersistedChatSession> {
+    return this.operationScheduler.runSession(projectId, sessionId, () =>
+      this.stateOwner.setComputeConcurrencyLimit(projectId, sessionId, limit)
+    )
+  }
+
   setSessionEnabledComputeHosts(
     projectId: string,
     sessionId: string,

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -489,6 +489,30 @@ class SessionPersistenceStateOwner {
     return persisted
   }
 
+  async setComputeConcurrencyLimit(
+    projectId: string,
+    sessionId: string,
+    limit: number
+  ): Promise<PersistedChatSession> {
+    if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+      throw new Error(
+        `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
+      )
+    }
+    this.options.assertMutable(projectId, sessionId, 'mutate')
+    const loaded = await loadAuthority(this.options.repository, projectId, sessionId)
+    if (loaded.status !== 'found') {
+      throw new Error(`Cannot update Compute concurrency for a ${loaded.status} Session.`)
+    }
+    const persisted = await saveSessionWithRevision(this.options.repository, {
+      ...loaded.session,
+      computeConcurrencyLimit: limit,
+      updatedAt: Math.max(loaded.session.updatedAt + 1, Date.now())
+    })
+    this.recordSession(persisted)
+    return persisted
+  }
+
   async pruneEnabledComputeHosts(
     sessions: readonly PersistedChatSession[],
     validProviderIds: ReadonlySet<string>
@@ -607,6 +631,7 @@ class SessionPersistenceStateOwner {
       delete rendererOwnedSession.specialistBindingPending
     }
     if (authority) delete rendererOwnedSession.delegationPolicy
+    if (authority) delete rendererOwnedSession.computeConcurrencyLimit
     const permissionOwnedStatus =
       authority?.runtimeContext?.permission?.state === 'pending'
         ? 'waiting-permission'
@@ -661,6 +686,7 @@ class SessionPersistenceStateOwner {
               : undefined
           }
         : {}),
+      ...(authority ? { computeConcurrencyLimit: authority.computeConcurrencyLimit } : {}),
       ...(mainOwnedStatus ? { status: mainOwnedStatus } : {}),
       // Merging unchanged Main-owned authority is storage maintenance, not conversation activity.
       // Preserve the newest real activity time so opening a lazily loaded Session cannot move it into

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -471,6 +471,7 @@ describe('useLifecycleSync', () => {
         session: {
           ...toPersistedSession(source),
           enabledComputeHosts: ['ssh:lab'],
+          computeConcurrencyLimit: 2,
           updatedAt: source.updatedAt + 1
         }
       })
@@ -478,6 +479,7 @@ describe('useLifecycleSync', () => {
 
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       enabledComputeHosts: ['ssh:lab'],
+      computeConcurrencyLimit: 2,
       messages: [expect.objectContaining({ content: 'Keep this live prompt' })]
     })
   })

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -2744,9 +2744,10 @@ describe('renderer session persistence bridge', () => {
   })
 
   it('rebases an explicit Session save over a disjoint concurrent main-process update', async () => {
-    const base = createPersistedSession({ revision: 8 })
+    const base = createPersistedSession({ revision: 8, computeConcurrencyLimit: 1 })
     const submitted = createPersistedSession({
       revision: 8,
+      computeConcurrencyLimit: 2,
       messages: [
         {
           id: 'message-1',
@@ -2762,6 +2763,7 @@ describe('renderer session persistence bridge', () => {
     })
     const latest = createPersistedSession({
       revision: 9,
+      computeConcurrencyLimit: 3,
       runtimeContext: {
         version: 1,
         revision: 1,
@@ -2810,6 +2812,7 @@ describe('renderer session persistence bridge', () => {
     await expect(explicitSave).resolves.toMatchObject({
       revision: 10,
       messages: submitted.messages,
+      computeConcurrencyLimit: latest.computeConcurrencyLimit,
       runtimeContext: latest.runtimeContext
     })
     await expect(laterSave).resolves.toMatchObject({
@@ -2820,6 +2823,7 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession.mock.calls[1][0]).toMatchObject({
       revision: 9,
       messages: submitted.messages,
+      computeConcurrencyLimit: latest.computeConcurrencyLimit,
       runtimeContext: latest.runtimeContext
     })
     expect(saveSession.mock.calls[2][0]).toMatchObject({

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -151,6 +151,7 @@ const MAIN_OWNED_SESSION_FIELDS = new Set<keyof PersistedChatSession>([
   'delegationPolicy',
   'enabledComputeHosts',
   'selectedComputeHosts',
+  'computeConcurrencyLimit',
   'specialistId',
   'specialistBindingPending'
 ])

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -497,6 +497,9 @@ export const createSessionMessageGraphOwner = <
       ...(source.selectedComputeHosts
         ? { selectedComputeHosts: [...source.selectedComputeHosts] }
         : {}),
+      ...(source.computeConcurrencyLimit !== undefined
+        ? { computeConcurrencyLimit: source.computeConcurrencyLimit }
+        : {}),
       ...(nextSpecialistId ? { specialistId: nextSpecialistId } : {}),
       messages,
       activities: sourceActivities.map((activity) => copySnapshotActivity(activity, sessionId)),

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -616,6 +616,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
           revision: Math.max(sessionRevision(current), sessionRevision(session)),
           enabledComputeHosts: session.enabledComputeHosts && [...session.enabledComputeHosts],
           selectedComputeHosts: session.selectedComputeHosts && [...session.selectedComputeHosts],
+          computeConcurrencyLimit: session.computeConcurrencyLimit,
           updatedAt: Math.max(current.updatedAt, session.updatedAt)
         }
         markExternallyHydratedSession(projected, session)

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -7207,6 +7207,7 @@ describe('truncateSessionFromMessage', () => {
         ...toPersistedSession(source),
         enabledComputeHosts: ['ssh:lab', 'ssh:available'],
         selectedComputeHosts: ['ssh:lab'],
+        computeConcurrencyLimit: 2,
         updatedAt: source.updatedAt + 1
       },
       mode: 'compute-host-access-authority'
@@ -7215,7 +7216,8 @@ describe('truncateSessionFromMessage', () => {
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       title: 'Newer local title',
       enabledComputeHosts: ['ssh:lab', 'ssh:available'],
-      selectedComputeHosts: ['ssh:lab']
+      selectedComputeHosts: ['ssh:lab'],
+      computeConcurrencyLimit: 2
     })
   })
 })

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -6044,6 +6044,7 @@ describe('branchInNewSession', () => {
               autoReviewEnabled: true,
               memoryEnabled: false,
               enabledComputeHosts: ['ssh:build'],
+              computeConcurrencyLimit: 2,
               filesRevision: 7,
               artifacts: [
                 {
@@ -6109,6 +6110,7 @@ describe('branchInNewSession', () => {
       delegationPolicy: 'deny',
       memoryEnabled: false,
       enabledComputeHosts: ['ssh:build'],
+      computeConcurrencyLimit: 2,
       branchSource: {
         sessionId: 'source-session',
         agentFrameId: sourceFrame?.id,

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -85,6 +85,24 @@ describe('Session file envelope versions', () => {
     expect(normalizeSessionFile({ ...legacySession(), revision: '7' })?.revision).toBe(0)
   })
 
+  it('restores a valid Compute concurrency limit and keeps historical Sessions unlimited', () => {
+    expect(normalizeSessionFile(legacySession())?.computeConcurrencyLimit).toBeUndefined()
+    expect(
+      normalizeSessionFile({ ...legacySession(), computeConcurrencyLimit: 1 })
+        ?.computeConcurrencyLimit
+    ).toBe(1)
+    expect(
+      normalizeSessionFile({ ...legacySession(), computeConcurrencyLimit: 500 })
+        ?.computeConcurrencyLimit
+    ).toBe(500)
+  })
+
+  it.each([0, 501, 1.5, '1'])('rejects malformed Compute concurrency limit %j', (limit) => {
+    expect(
+      normalizeSessionFile({ ...legacySession(), computeConcurrencyLimit: limit })
+    ).toBeUndefined()
+  })
+
   it('redacts credentials while decoding a historical Session file', () => {
     const activity = normalizeSessionFile(
       createSessionWithActivity({

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -749,6 +749,9 @@ export type PersistedChatSession = {
   // enabled hosts. An explicit empty array distinguishes the new Available-only state from legacy
   // Session files where a missing field means every enabled host was selected.
   selectedComputeHosts?: string[]
+  // Durable Session-level Compute concurrency limit. Historical Sessions omit it and continue to
+  // use only their Compute Host ceilings.
+  computeConcurrencyLimit?: number
   // Pins the conversation to a dedicated section at the top of the sidebar. Absent (older files) or
   // non-true restores as unpinned; only an explicit true keeps it pinned across restarts.
   pinned?: boolean
@@ -4117,6 +4120,15 @@ const sanitizeSession = (
   const selectedComputeHosts = selectedComputeHostCandidates.filter((providerId) =>
     enabledComputeHostSet.has(providerId)
   )
+  const computeConcurrencyLimit = asNumber(session.computeConcurrencyLimit)
+  if (
+    session.computeConcurrencyLimit !== undefined &&
+    (!Number.isInteger(computeConcurrencyLimit) ||
+      (computeConcurrencyLimit ?? 0) < 1 ||
+      (computeConcurrencyLimit ?? 0) > 500)
+  ) {
+    return undefined
+  }
 
   if (activeRun) sanitized.activeRun = activeRun
   if (resumeRecovery) sanitized.resumeRecovery = resumeRecovery
@@ -4153,6 +4165,9 @@ const sanitizeSession = (
   if (enabledComputeHosts.length > 0) sanitized.enabledComputeHosts = enabledComputeHosts
   if (hasSelectedComputeHosts || enabledComputeHosts.length > 0) {
     sanitized.selectedComputeHosts = selectedComputeHosts
+  }
+  if (computeConcurrencyLimit !== undefined) {
+    sanitized.computeConcurrencyLimit = computeConcurrencyLimit
   }
   // Specialist ID: accept any non-empty string. The main process validates it against SpecialistService
   // at send time; the sanitizer only ensures the value is safe to re-persist.


### PR DESCRIPTION
## Problem

Session-level Compute concurrency limits were stored only in a process-local `Map`, while queued Compute jobs are durable and are restored immediately during application startup. If a Session limit was set to 1, ten jobs remained queued, and the app restarted, the restored queue could promote all ten jobs up to the Compute Host ceiling because the Session limit had disappeared.

That can cause unexpected local/cluster resource use, quota consumption, or cost. This is worth fixing rather than treating as speculative hardening: durable queued work must be restored with the admission policy that constrained it.

## Proposed change

- Persist the optional `computeConcurrencyLimit` on the existing Session JSON model.
- Persist a changed limit before updating the manager's live projection.
- Restore all Session limits before enabling durable queue promotion.
- Fail closed when the Session catalog cannot be loaded authoritatively; polling of already-submitted/running jobs continues.
- Preserve the Main-owned limit when a stale renderer Session snapshot is saved or merged through the existing Compute authority lifecycle event.

## Scope and non-goals

- Data model: adds one optional field to `PersistedChatSession`.
- Persistence: uses the existing Session JSON repository and revision flow.
- Historical compatibility: older Session files without the field remain valid and mean unlimited at the Session level. There is no backfill, and limits configured before this fix cannot be recovered after a restart because they were never persisted.
- Schema/architecture: no Prisma/database schema or migration; no new persistence subsystem.
- State: no enum or lifecycle state additions.
- Interaction: no UI or IPC contract behavior change for callers; the existing limit-setting behavior becomes durable.
- Non-goal: adding an explicit unset/reset-limit operation.

## Acceptance criteria and validation

- Regression boundary: a limit of 1 is persisted, ten durable queued jobs survive a simulated restart, startup restores the limit before reconciliation, and only one job is submitted.
- Before the production fix, the regression test failed stably in four runs with `expected 1, received 10`, matching the report.
- Persistence failure leaves the live limit unchanged.
- Restoration failure keeps queued promotion stopped while the runtime poller starts.
- Missing historical fields restore as unlimited; malformed persisted limits are rejected.
- Stale whole-Session renderer saves cannot overwrite the Main-owned limit.

Local validation after rebasing onto current `origin/main`:

- `rtk npm run test:module -- compute_service` — 1148 passed, 6 skipped
- `rtk npm run test:module -- session_persistence` — 494 passed
- `rtk npm run test:module -- session_renderer` — 599 passed
- `rtk npm run typecheck:node`
- `rtk npm run typecheck:web`
- `rtk npm run lint`
- Prettier check and `git diff --check`

The full `npm run test` was intentionally not run; PR CI remains the full-suite authority.

## Review focus

- Startup ordering and fail-closed queue behavior in `ConcurrencyManager` / `createComputeJobRuntime`.
- Main ownership and stale renderer-save protection for `computeConcurrencyLimit`.
- Compatibility semantics for Session files that predate the new optional field.
