### PR TITLE
fix(tasks): admit Task turns before persistence

### DIFF
--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -557,11 +557,12 @@ describe('AcpPromptTurnWorkflow', () => {
     const harness = createHarness()
     const callbackEntered = deferred<void>()
     const releaseCallback = deferred<void>()
-    const onPromptAdmitted = vi.fn(async () => {
+    const onPromptAdmitted = vi.fn(async (): Promise<AcpPromptRequest['provenanceContext']> => {
       harness.journal.push('persist')
       expect(harness.owner.current('s1')).toMatchObject({ kind: 'prompt' })
       callbackEntered.resolve()
       await releaseCallback.promise
+      return undefined
     })
 
     const turn = harness.workflow.run(request(), { kind: 'user' }, onPromptAdmitted)
@@ -582,6 +583,29 @@ describe('AcpPromptTurnWorkflow', () => {
     await expect(turn).resolves.toEqual({ stopReason: 'end_turn' })
     expect(harness.journal.indexOf('persist')).toBeLessThan(harness.journal.indexOf('start'))
     expect(harness.journal.indexOf('persist')).toBeLessThan(harness.journal.indexOf('execute'))
+  })
+
+  it('uses provenance returned by prompt admission for the provider turn', async () => {
+    const harness = createHarness()
+    const admittedProvenance = {
+      promptMessageId: 'message-1',
+      rootFrameId: 'root-frame-2',
+      agentFrameId: 'agent-frame-2',
+      messageBranchId: 'branch-2',
+      runtimeSegmentId: 'runtime-segment-2'
+    }
+    const onPromptAdmitted = async (): Promise<AcpPromptRequest['provenanceContext']> =>
+      admittedProvenance
+
+    await expect(
+      harness.workflow.run(request(), { kind: 'user' }, onPromptAdmitted)
+    ).resolves.toEqual({ stopReason: 'end_turn' })
+
+    expect(harness.artifacts.open).toHaveBeenCalledWith(
+      's1',
+      expect.any(String),
+      admittedProvenance
+    )
   })
 
   it('releases prompt ownership when the admitted callback rejects', async () => {

--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -54,6 +54,7 @@ type Harness = {
     cancellationCheckpoint: Mock<AcpSessionInteractionOwner['cancellationCheckpoint']>
     captureTerminal: Mock<AcpSessionInteractionOwner['captureTerminal']>
     settle: Mock<AcpSessionInteractionOwner['settle']>
+    updatePromptProvenance: Mock<AcpSessionInteractionOwner['updatePromptProvenance']>
     release: Mock<AcpSessionInteractionOwner['release']>
     supersede: Mock<AcpSessionInteractionOwner['supersede']>
   }
@@ -201,6 +202,9 @@ const createHarness = (
       owner.captureTerminal(...args)
     ),
     settle: vi.fn((...args: Parameters<typeof owner.settle>) => owner.settle(...args)),
+    updatePromptProvenance: vi.fn((...args: Parameters<typeof owner.updatePromptProvenance>) =>
+      owner.updatePromptProvenance(...args)
+    ),
     release: vi.fn((scope: Parameters<typeof owner.release>[0]) => owner.release(scope)),
     supersede: vi.fn((scope: Parameters<typeof owner.supersede>[0]) => owner.supersede(scope))
   }
@@ -586,7 +590,14 @@ describe('AcpPromptTurnWorkflow', () => {
   })
 
   it('uses provenance returned by prompt admission for the provider turn', async () => {
-    const harness = createHarness()
+    let activeInteractionProvenance: AcpPromptRequest['provenanceContext']
+    const harness = createHarness({
+      onPromptStarted: () => {
+        const current = harness.owner.current('s1')
+        activeInteractionProvenance =
+          current?.kind === 'prompt' ? current.provenanceContext : undefined
+      }
+    })
     const admittedProvenance = {
       promptMessageId: 'message-1',
       rootFrameId: 'root-frame-2',
@@ -606,6 +617,7 @@ describe('AcpPromptTurnWorkflow', () => {
       expect.any(String),
       admittedProvenance
     )
+    expect(activeInteractionProvenance).toEqual(admittedProvenance)
   })
 
   it('releases prompt ownership when the admitted callback rejects', async () => {

--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -553,6 +553,52 @@ describe('AcpPromptTurnWorkflow', () => {
     ])
   })
 
+  it('awaits the admitted callback after interaction activation and before prompt start', async () => {
+    const harness = createHarness()
+    const callbackEntered = deferred<void>()
+    const releaseCallback = deferred<void>()
+    const onPromptAdmitted = vi.fn(async () => {
+      harness.journal.push('persist')
+      expect(harness.owner.current('s1')).toMatchObject({ kind: 'prompt' })
+      callbackEntered.resolve()
+      await releaseCallback.promise
+    })
+
+    const turn = harness.workflow.run(request(), { kind: 'user' }, onPromptAdmitted)
+    await callbackEntered.promise
+
+    expect(harness.journal).toEqual([
+      'reserve',
+      'compaction:preempt',
+      'preflight',
+      'authorize',
+      'activate',
+      'admit',
+      'persist'
+    ])
+    expect(harness.executor).not.toHaveBeenCalled()
+
+    releaseCallback.resolve()
+    await expect(turn).resolves.toEqual({ stopReason: 'end_turn' })
+    expect(harness.journal.indexOf('persist')).toBeLessThan(harness.journal.indexOf('start'))
+    expect(harness.journal.indexOf('persist')).toBeLessThan(harness.journal.indexOf('execute'))
+  })
+
+  it('releases prompt ownership when the admitted callback rejects', async () => {
+    const harness = createHarness()
+    const failure = new Error('Session persistence failed')
+
+    await expect(
+      harness.workflow.run(request(), { kind: 'user' }, async () => {
+        throw failure
+      })
+    ).rejects.toBe(failure)
+
+    expect(harness.owner.current('s1')).toBeUndefined()
+    expect(harness.executor).not.toHaveBeenCalled()
+    expect(harness.journal).not.toContain('start')
+  })
+
   it('activates a framework-owned current Session before provider dispatch', async () => {
     const frameworkBeforePromptDispatch = vi.fn(async () => undefined)
     const beforePromptDispatch = vi.fn<
@@ -730,7 +776,8 @@ describe('AcpPromptTurnWorkflow', () => {
     const authorization = deferred<TurnSkillHandle>()
     const staleSkill = skillHandle()
     const harness = createHarness({ authorize: () => authorization.promise })
-    const stale = harness.workflow.run(request(), { kind: 'user' })
+    const onPromptAdmitted = vi.fn(async () => undefined)
+    const stale = harness.workflow.run(request(), { kind: 'user' }, onPromptAdmitted)
     await vi.waitFor(() => expect(harness.authorize).toHaveBeenCalledOnce())
     const staleReservation = harness.interactions.reservePrompt.mock.results[0].value
     const replacement = harness.owner.activatePrompt(
@@ -743,6 +790,7 @@ describe('AcpPromptTurnWorkflow', () => {
     expect(staleSkill.close).toHaveBeenCalledWith('failed')
     expect(harness.interactions.release).toHaveBeenCalledWith(staleReservation)
     expect(harness.owner.current('s1')).toBe(replacement)
+    expect(onPromptAdmitted).not.toHaveBeenCalled()
     expect(harness.preparation).not.toHaveBeenCalled()
     expect(harness.finalizer).not.toHaveBeenCalled()
   })

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -159,6 +159,7 @@ type AcpPromptTurnWorkflowOptions = Readonly<{
     | 'release'
     | 'reservePrompt'
     | 'settle'
+    | 'updatePromptProvenance'
   >
   skills: Pick<AcpTurnSkillOwner, 'authorize'>
   preparation: Pick<AcpPromptPreparationOwner, 'prepare'>
@@ -275,6 +276,7 @@ class AcpPromptTurnWorkflow {
       // rejected commit releases ownership below without publishing prompt start or dispatching.
       const admittedProvenanceContext = await onPromptAdmitted?.()
       if (admittedProvenanceContext) {
+        this.options.interactions.updatePromptProvenance(interaction, admittedProvenanceContext)
         admittedRequest = { ...request, provenanceContext: admittedProvenanceContext }
       }
       this.options.registry.select(admittedRequest.sessionId)

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -192,7 +192,7 @@ class AcpPromptTurnWorkflow {
   async run(
     request: AcpPromptRequest,
     mode: AcpPromptTurnMode,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): Promise<PromptResponse> {
     let activeSession = this.activeSession(request.sessionId)
     if (!activeSession) throw new Error(`ACP session not found: ${request.sessionId}`)
@@ -266,15 +266,19 @@ class AcpPromptTurnWorkflow {
     }
 
     let interaction: AcpPromptSessionInteractionScope | undefined
+    let admittedRequest = request
     try {
       interaction = this.options.interactions.activatePrompt(reservation)
       const admittedPlan = this.options.plan.admit(request, interaction, plan)
       plan = admittedPlan instanceof Promise ? await admittedPlan : admittedPlan
       // Admission-dependent state may commit only while this interaction owns the Session. A
       // rejected commit releases ownership below without publishing prompt start or dispatching.
-      await onPromptAdmitted?.()
-      this.options.registry.select(request.sessionId)
-      this.options.recordAdmittedPrompt(request)
+      const admittedProvenanceContext = await onPromptAdmitted?.()
+      if (admittedProvenanceContext) {
+        admittedRequest = { ...request, provenanceContext: admittedProvenanceContext }
+      }
+      this.options.registry.select(admittedRequest.sessionId)
+      this.options.recordAdmittedPrompt(admittedRequest)
     } catch (error) {
       skill.close(rejectedSkillOutcome)
       this.options.interactions.release(interaction ?? reservation)
@@ -290,7 +294,7 @@ class AcpPromptTurnWorkflow {
       textLength: request.text?.length ?? 0
     })
     return this.executeTurn({
-      request,
+      request: admittedRequest,
       connectionGeneration: this.options.environment.connectionGeneration?.() ?? 0,
       mode,
       session: activeSession,

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -189,7 +189,11 @@ type AcpPromptTurnWorkflowOptions = Readonly<{
 class AcpPromptTurnWorkflow {
   constructor(private readonly options: AcpPromptTurnWorkflowOptions) {}
 
-  async run(request: AcpPromptRequest, mode: AcpPromptTurnMode): Promise<PromptResponse> {
+  async run(
+    request: AcpPromptRequest,
+    mode: AcpPromptTurnMode,
+    onPromptAdmitted?: () => Promise<void>
+  ): Promise<PromptResponse> {
     let activeSession = this.activeSession(request.sessionId)
     if (!activeSession) throw new Error(`ACP session not found: ${request.sessionId}`)
     this.assertSessionIdle(request.sessionId)
@@ -266,6 +270,9 @@ class AcpPromptTurnWorkflow {
       interaction = this.options.interactions.activatePrompt(reservation)
       const admittedPlan = this.options.plan.admit(request, interaction, plan)
       plan = admittedPlan instanceof Promise ? await admittedPlan : admittedPlan
+      // Admission-dependent state may commit only while this interaction owns the Session. A
+      // rejected commit releases ownership below without publishing prompt start or dispatching.
+      await onPromptAdmitted?.()
       this.options.registry.select(request.sessionId)
       this.options.recordAdmittedPrompt(request)
     } catch (error) {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -179,9 +179,11 @@ const createFakeRuntime = (options: {
   const shutdownForUpdateGate = vi.fn(async () => ({ reaped: true }))
   const runPrompt = async (
     { sessionId }: { sessionId: string },
-    promptAttemptId?: string
+    promptAttemptId?: string,
+    onPromptAdmitted?: () => Promise<void>
   ): Promise<unknown> => {
     await options.beforePromptStart?.()
+    await onPromptAdmitted?.()
     const turnToken = `turn-${++turnSequence}`
     snapshot = {
       ...snapshot,
@@ -1200,13 +1202,19 @@ describe('AcpRuntimeCoordinator', () => {
       )
       const session = await coordinator.createSession()
       const onProviderPromptAccepted = vi.fn()
+      const onPromptAdmitted = vi.fn(async () => undefined)
 
       await coordinator.sendPromptObserved(
         { sessionId: session.sessionId, text: 'Research this.' },
-        onProviderPromptAccepted
+        onProviderPromptAccepted,
+        onPromptAdmitted
       )
 
+      expect(onPromptAdmitted).toHaveBeenCalledOnce()
       expect(onProviderPromptAccepted).toHaveBeenCalledOnce()
+      expect(onPromptAdmitted.mock.invocationCallOrder[0]).toBeLessThan(
+        onProviderPromptAccepted.mock.invocationCallOrder[0]
+      )
     }
   )
 

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type {
   AcpPermissionRequest,
   AcpPermissionResponse,
+  AcpPromptRequest,
   AcpRuntimeEvent,
   AcpStateSnapshot,
   AcpStateUpdate
@@ -180,7 +181,7 @@ const createFakeRuntime = (options: {
   const runPrompt = async (
     { sessionId }: { sessionId: string },
     promptAttemptId?: string,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): Promise<unknown> => {
     await options.beforePromptStart?.()
     await onPromptAdmitted?.()
@@ -1196,13 +1197,19 @@ describe('AcpRuntimeCoordinator', () => {
   ] as const)(
     'observes provider acceptance through %s without changing completion',
     async (_route, frameworkId) => {
-      const coordinator = new AcpRuntimeCoordinator(
-        (callbacks) =>
-          createFakeRuntime({ frameworkId, sessionIds: ['session-1'], callbacks }).runtime
-      )
+      let created!: ReturnType<typeof createFakeRuntime>
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        created = createFakeRuntime({ frameworkId, sessionIds: ['session-1'], callbacks })
+        return created.runtime
+      })
       const session = await coordinator.createSession()
       const onProviderPromptAccepted = vi.fn()
-      const onPromptAdmitted = vi.fn(async () => undefined)
+      const admittedProvenance = {
+        promptMessageId: 'prompt-1',
+        messageBranchId: 'branch-2',
+        runtimeSegmentId: 'runtime-segment-2'
+      }
+      const onPromptAdmitted = vi.fn(async () => admittedProvenance)
 
       await coordinator.sendPromptObserved(
         { sessionId: session.sessionId, text: 'Research this.' },
@@ -1215,6 +1222,7 @@ describe('AcpRuntimeCoordinator', () => {
       expect(onPromptAdmitted.mock.invocationCallOrder[0]).toBeLessThan(
         onProviderPromptAccepted.mock.invocationCallOrder[0]
       )
+      expect(created.sendPrompt.mock.calls[0]?.[0].provenanceContext).toEqual(admittedProvenance)
     }
   )
 

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -844,15 +844,22 @@ class AcpRuntimeCoordinator {
 
   sendPromptObserved(
     request: AcpPromptRequest,
-    onProviderPromptAccepted: () => void
+    onProviderPromptAccepted: () => void,
+    onPromptAdmitted?: () => Promise<void>
   ): ReturnType<AcpRuntime['sendPrompt']> {
-    return this.sendObservedPrompt(request, observePromptAcceptance(onProviderPromptAccepted))
+    return this.sendObservedPrompt(
+      request,
+      observePromptAcceptance(onProviderPromptAccepted),
+      undefined,
+      onPromptAdmitted
+    )
   }
 
   private sendObservedPrompt(
     request: AcpPromptRequest,
     acceptance?: PromptAcceptance,
-    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void
+    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void,
+    onPromptAdmitted?: () => Promise<void>
   ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> =>
@@ -864,7 +871,8 @@ class AcpRuntimeCoordinator {
           undefined,
           true,
           undefined,
-          onApplicationPromptAdmitted
+          onApplicationPromptAdmitted,
+          onPromptAdmitted
         ).finally(() => this.delegatedWork?.wakeMessages?.(request.sessionId))
       )
     const admission = this.promptAdmissionGuard?.(request.sessionId)
@@ -1014,7 +1022,8 @@ class AcpRuntimeCoordinator {
     pinnedRuntime?: AcpRuntime,
     retainAsLatestUserPrompt = operation === 'sendPrompt',
     attribution?: MessageAttribution,
-    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void
+    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void,
+    onPromptAdmitted?: () => Promise<void>
   ): ReturnType<AcpRuntime['sendPrompt']> {
     let dispatchStarted = false
     const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> => {
@@ -1026,7 +1035,8 @@ class AcpRuntimeCoordinator {
         pinnedRuntime,
         retainAsLatestUserPrompt,
         attribution,
-        onApplicationPromptAdmitted
+        onApplicationPromptAdmitted,
+        onPromptAdmitted
       )
     }
     if (!this.promptDispatchAdmissionGuard) return dispatch()
@@ -1046,7 +1056,8 @@ class AcpRuntimeCoordinator {
     pinnedRuntime?: AcpRuntime,
     retainAsLatestUserPrompt = operation === 'sendPrompt',
     attribution?: MessageAttribution,
-    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void
+    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void,
+    onPromptAdmitted?: () => Promise<void>
   ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     const owner = pinnedRuntime ?? this.findRuntimeForSession(request.sessionId)
@@ -1113,9 +1124,15 @@ class AcpRuntimeCoordinator {
           'ACP prompt start was superseded before provider dispatch'
         )
       }
-      return operation === 'sendApplicationPrompt'
-        ? runtime.sendApplicationPrompt(taskRequest, attribution!, attempt.id)
-        : runtime[operation](taskRequest, attempt.id)
+      if (operation === 'sendApplicationPrompt') {
+        return runtime.sendApplicationPrompt(taskRequest, attribution!, attempt.id)
+      }
+      if (operation === 'sendPrompt') {
+        return onPromptAdmitted
+          ? runtime.sendPrompt(taskRequest, attempt.id, onPromptAdmitted)
+          : runtime.sendPrompt(taskRequest, attempt.id)
+      }
+      return runtime.sendAppContinuation(taskRequest, attempt.id)
     })
     onApplicationPromptAdmitted?.(prompt)
     return prompt

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -845,7 +845,7 @@ class AcpRuntimeCoordinator {
   sendPromptObserved(
     request: AcpPromptRequest,
     onProviderPromptAccepted: () => void,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): ReturnType<AcpRuntime['sendPrompt']> {
     return this.sendObservedPrompt(
       request,
@@ -859,7 +859,7 @@ class AcpRuntimeCoordinator {
     request: AcpPromptRequest,
     acceptance?: PromptAcceptance,
     onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> =>
@@ -1023,7 +1023,7 @@ class AcpRuntimeCoordinator {
     retainAsLatestUserPrompt = operation === 'sendPrompt',
     attribution?: MessageAttribution,
     onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): ReturnType<AcpRuntime['sendPrompt']> {
     let dispatchStarted = false
     const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> => {
@@ -1057,7 +1057,7 @@ class AcpRuntimeCoordinator {
     retainAsLatestUserPrompt = operation === 'sendPrompt',
     attribution?: MessageAttribution,
     onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     const owner = pinnedRuntime ?? this.findRuntimeForSession(request.sessionId)
@@ -1113,6 +1113,13 @@ class AcpRuntimeCoordinator {
           })
           .catch(() => undefined)
       : undefined
+    const admitPrompt = onPromptAdmitted
+      ? async (): Promise<AcpPromptRequest['provenanceContext']> => {
+          const provenanceContext = await onPromptAdmitted()
+          if (provenanceContext) taskRequest.provenanceContext = provenanceContext
+          return provenanceContext
+        }
+      : undefined
     const prompt = Promise.resolve(settlementStart).then((leaseId) => {
       settlementLeaseId = leaseId
       if (
@@ -1128,8 +1135,8 @@ class AcpRuntimeCoordinator {
         return runtime.sendApplicationPrompt(taskRequest, attribution!, attempt.id)
       }
       if (operation === 'sendPrompt') {
-        return onPromptAdmitted
-          ? runtime.sendPrompt(taskRequest, attempt.id, onPromptAdmitted)
+        return admitPrompt
+          ? runtime.sendPrompt(taskRequest, attempt.id, admitPrompt)
           : runtime.sendPrompt(taskRequest, attempt.id)
       }
       return runtime.sendAppContinuation(taskRequest, attempt.id)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1438,7 +1438,7 @@ class AcpRuntime {
   async sendPrompt(
     request: AcpPromptRequest,
     promptAttemptId?: string,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): Promise<PromptResponse> {
     if (
       request.referencedArtifacts?.some(
@@ -1501,7 +1501,7 @@ class AcpRuntime {
           promptAttemptId?: string
         }>
       | Readonly<{ kind: 'app-continuation'; promptAttemptId?: string }>,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): Promise<PromptResponse> {
     return withDataRootWrite(async () => {
       let response: PromptResponse | undefined

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1435,7 +1435,11 @@ class AcpRuntime {
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
-  async sendPrompt(request: AcpPromptRequest, promptAttemptId?: string): Promise<PromptResponse> {
+  async sendPrompt(
+    request: AcpPromptRequest,
+    promptAttemptId?: string,
+    onPromptAdmitted?: () => Promise<void>
+  ): Promise<PromptResponse> {
     if (
       request.referencedArtifacts?.some(
         (reference) =>
@@ -1445,10 +1449,14 @@ class AcpRuntime {
       await this.enableLiteratureContext(request.sessionId)
     }
     return this.withOperationLease(() =>
-      this.runPromptTurn(request, {
-        kind: 'user',
-        ...(promptAttemptId === undefined ? {} : { promptAttemptId })
-      })
+      this.runPromptTurn(
+        request,
+        {
+          kind: 'user',
+          ...(promptAttemptId === undefined ? {} : { promptAttemptId })
+        },
+        onPromptAdmitted
+      )
     )
   }
 
@@ -1492,12 +1500,13 @@ class AcpRuntime {
           attribution: MessageAttribution
           promptAttemptId?: string
         }>
-      | Readonly<{ kind: 'app-continuation'; promptAttemptId?: string }>
+      | Readonly<{ kind: 'app-continuation'; promptAttemptId?: string }>,
+    onPromptAdmitted?: () => Promise<void>
   ): Promise<PromptResponse> {
     return withDataRootWrite(async () => {
       let response: PromptResponse | undefined
       try {
-        response = await this.promptTurnWorkflow.run(request, intent)
+        response = await this.promptTurnWorkflow.run(request, intent, onPromptAdmitted)
         return response
       } finally {
         this.schedulePendingAppContinuation(request.sessionId, response?.stopReason)

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -101,6 +101,9 @@ interface AcpSessionInteractionTerminalFacts {
 interface ActiveSessionInteraction {
   readonly scope: AcpSessionInteractionScope
   readonly abortController: AbortController
+  readonly promptProvenance?: {
+    value: AcpPromptRequest['provenanceContext']
+  }
   cancelled: boolean
   modelTurnCount: number
   readonly referencedSessionIds: Set<string>
@@ -353,11 +356,16 @@ export class AcpSessionInteractionOwner {
     }
 
     const abortController = new AbortController()
+    const promptProvenance = {
+      value: cloneProvenanceContext(request.provenanceContext)
+    }
     const scope: AcpPromptSessionInteractionScope = Object.freeze({
       sessionId: request.sessionId,
       kind: 'prompt',
       promptMessageId: request.promptMessageId,
-      provenanceContext: cloneProvenanceContext(request.provenanceContext),
+      get provenanceContext() {
+        return promptProvenance.value
+      },
       ...(request.memoryEnabled !== undefined ? { memoryEnabled: request.memoryEnabled } : {}),
       turnToken: request.turnToken ?? randomUUID(),
       sequence: ++this.sequence,
@@ -367,6 +375,7 @@ export class AcpSessionInteractionOwner {
     this.pendingPromptReservations.set(request.sessionId, {
       scope,
       abortController,
+      promptProvenance,
       cancelled: false,
       modelTurnCount: 0,
       referencedSessionIds: new Set(request.referencedSessionIds ?? [])
@@ -390,6 +399,17 @@ export class AcpSessionInteractionOwner {
     return scope
   }
 
+  updatePromptProvenance(
+    scope: AcpPromptSessionInteractionScope,
+    provenanceContext: AcpPromptRequest['provenanceContext']
+  ): void {
+    const active = this.activeInteractions.get(scope.sessionId)
+    if (active?.scope !== scope || !active.promptProvenance) {
+      throw new Error('ACP prompt interaction is no longer active')
+    }
+    active.promptProvenance.value = cloneProvenanceContext(provenanceContext)
+  }
+
   claim<Request extends AcpSessionInteractionRequest>(request: Request): ScopeFor<Request> {
     if (
       this.activeInteractions.has(request.sessionId) ||
@@ -399,6 +419,10 @@ export class AcpSessionInteractionOwner {
     }
 
     const abortController = new AbortController()
+    const promptProvenance =
+      request.kind === 'prompt'
+        ? { value: cloneProvenanceContext(request.provenanceContext) }
+        : undefined
     const base = {
       sessionId: request.sessionId,
       sequence: ++this.sequence,
@@ -410,7 +434,9 @@ export class AcpSessionInteractionOwner {
             ...base,
             kind: request.kind,
             promptMessageId: request.promptMessageId,
-            provenanceContext: cloneProvenanceContext(request.provenanceContext),
+            get provenanceContext() {
+              return promptProvenance?.value
+            },
             turnToken: request.turnToken ?? randomUUID()
           }
         : { ...base, kind: request.kind }
@@ -418,6 +444,7 @@ export class AcpSessionInteractionOwner {
     this.activeInteractions.set(request.sessionId, {
       scope,
       abortController,
+      ...(promptProvenance ? { promptProvenance } : {}),
       cancelled: false,
       modelTurnCount: 0,
       referencedSessionIds: new Set(

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 
-import type { AgentTurnProvenanceContext } from '../../shared/acp'
+import type { AcpPromptRequest, AgentTurnProvenanceContext } from '../../shared/acp'
 import type { TaskAgentPort } from '../tasks/task-runner'
 import {
   materializeSessionAgentConfiguration,
@@ -283,7 +283,11 @@ describe('ACP Task Agent port', () => {
     const onProviderPromptAccepted = vi.fn()
     const onPromptAdmitted = vi.fn(async () => undefined)
     const sendPrompt = vi.fn(
-      async (_request, onAccepted?: () => void, onAdmitted?: () => Promise<void>) => {
+      async (
+        _request,
+        onAccepted?: () => void,
+        onAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
+      ) => {
         await onAdmitted?.()
         onAccepted?.()
       }

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -281,9 +281,13 @@ describe('ACP Task Agent port', () => {
 
   it('forwards provider acceptance through the provider-neutral Task prompt observer', async () => {
     const onProviderPromptAccepted = vi.fn()
-    const sendPrompt = vi.fn(async (_request, onAccepted?: () => void) => {
-      onAccepted?.()
-    })
+    const onPromptAdmitted = vi.fn(async () => undefined)
+    const sendPrompt = vi.fn(
+      async (_request, onAccepted?: () => void, onAdmitted?: () => Promise<void>) => {
+        await onAdmitted?.()
+        onAccepted?.()
+      }
+    )
     const port = createAcpTaskAgentPort(
       {
         getSnapshot: () => ({ sessionIds: [] }),
@@ -303,9 +307,10 @@ describe('ACP Task Agent port', () => {
         provenanceContext: taskProvenanceContext('prompt-1'),
         text: 'Research this.'
       },
-      { onProviderPromptAccepted }
+      { onPromptAdmitted, onProviderPromptAccepted }
     )
 
+    expect(onPromptAdmitted).toHaveBeenCalledOnce()
     expect(onProviderPromptAccepted).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -21,7 +21,7 @@ type AcpTaskAgentRuntime = {
   sendPromptObserved(
     request: AcpPromptRequest,
     onProviderPromptAccepted: () => void,
-    onPromptAdmitted?: () => Promise<void>
+    onPromptAdmitted?: () => Promise<AcpPromptRequest['provenanceContext']>
   ): Promise<unknown>
   cancelPrompt(request: { sessionId: string }): Promise<unknown>
 }

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -20,7 +20,8 @@ type AcpTaskAgentRuntime = {
   sendPrompt(request: AcpPromptRequest): Promise<unknown>
   sendPromptObserved(
     request: AcpPromptRequest,
-    onProviderPromptAccepted: () => void
+    onProviderPromptAccepted: () => void,
+    onPromptAdmitted?: () => Promise<void>
   ): Promise<unknown>
   cancelPrompt(request: { sessionId: string }): Promise<unknown>
 }
@@ -106,8 +107,12 @@ const createAcpTaskAgentPort = (
     const acpRequest = toAcpPromptRequest(request)
     const tracked = notifications?.trackPrompt(acpRequest)
     try {
-      if (observer?.onProviderPromptAccepted) {
-        await runtime.sendPromptObserved(acpRequest, observer.onProviderPromptAccepted)
+      if (observer?.onProviderPromptAccepted || observer?.onPromptAdmitted) {
+        await runtime.sendPromptObserved(
+          acpRequest,
+          observer.onProviderPromptAccepted ?? (() => undefined),
+          observer.onPromptAdmitted
+        )
       } else {
         await runtime.sendPrompt(acpRequest)
       }

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1706,6 +1706,50 @@ describe('TaskRunner', () => {
     })
   })
 
+  it('cleans up an admitted Task turn when Session persistence commits before rejecting', async () => {
+    const existing: PersistedChatSession = {
+      ...session,
+      messages: []
+    }
+    let durableSession = existing
+    const save = vi.fn(async (candidate: PersistedChatSession) => {
+      durableSession = candidate
+      throw new Error('index unavailable after durable commit')
+    })
+    const runner = createRunner({
+      sessions: { list: async () => [existing], save },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [existing.id],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async (_request, observer) => {
+          await observer?.onPromptAdmitted?.()
+        }
+      }
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Task API prompt'
+    })
+    const failed = await runner.waitForRun(started.id)
+
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(durableSession).toMatchObject({
+      status: 'error',
+      activeRun: undefined,
+      error: 'index unavailable after durable commit'
+    })
+    expect(failed).toMatchObject({
+      status: 'failed',
+      error: 'index unavailable after durable commit'
+    })
+  })
+
   it('rejects a new authored turn while a restored Plan awaits approval', async () => {
     const existing: PersistedChatSession = {
       ...session,

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1711,6 +1711,68 @@ describe('TaskRunner', () => {
     })
   })
 
+  it('persists detached provider rebinding without a Task turn when admission rejects', async () => {
+    const existing: PersistedChatSession = {
+      ...session,
+      revision: 1,
+      providerSessionId: 'provider-session-old',
+      providerContinuityToken: 'continuity-old',
+      messages: []
+    }
+    let durableSession = structuredClone(existing)
+    const save = vi.fn(async (candidate: PersistedChatSession) => {
+      durableSession = {
+        ...structuredClone(candidate),
+        revision: (candidate.revision ?? 0) + 1
+      }
+      return structuredClone(durableSession)
+    })
+    const runner = createRunner({
+      sessions: { list: async () => [structuredClone(durableSession)], save },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession: async () => ({
+          sessionId: existing.id,
+          frameworkId: 'opencode',
+          backendId: 'opencode:provider-new',
+          providerSessionId: 'provider-session-new',
+          providerContinuityToken: 'continuity-new',
+          contextReset: true
+        }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => {
+          throw new Error('An ACP interaction is already running for this session')
+        }
+      }
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Task API prompt'
+    })
+    const failed = await runner.waitForRun(started.id)
+
+    expect(save).toHaveBeenCalledOnce()
+    expect(durableSession).toMatchObject({
+      status: existing.status,
+      messages: existing.messages,
+      providerSessionId: 'provider-session-new',
+      providerContinuityToken: 'continuity-new',
+      agentFrameworkId: 'opencode',
+      agentBackendId: 'opencode:provider-new',
+      pendingHistoryReplay: { kind: 'all' }
+    })
+    expect(durableSession).not.toHaveProperty('activeRun')
+    expect(failed).toMatchObject({
+      status: 'failed',
+      error: 'An ACP interaction is already running for this session'
+    })
+  })
+
   it('cleans up an admitted Task turn when Session persistence commits before rejecting', async () => {
     let durableSession: PersistedChatSession = {
       ...session,
@@ -2007,8 +2069,10 @@ describe('TaskRunner', () => {
     ])
     const promptRuntimeSegmentId = prompts[0]?.provenanceContext.runtimeSegmentId
     expect(
-      savedSessions[0]?.conversationGraph?.runtimeSegments.some(
-        ({ id }) => id === promptRuntimeSegmentId
+      savedSessions.some(
+        (saved) =>
+          saved.activeRun?.promptMessageId === 'new-user' &&
+          saved.conversationGraph?.runtimeSegments.some(({ id }) => id === promptRuntimeSegmentId)
       )
     ).toBe(true)
   })
@@ -2196,14 +2260,15 @@ describe('TaskRunner', () => {
       })
     ])
     expect(prompts[0]?.historyPreamble).not.toContain('Delete the duplicates')
-    expect(saved[0]).not.toHaveProperty('resumeRecovery')
-    expect(saved[0].pendingHistoryReplay).toEqual({
+    const admitted = saved.find(({ activeRun }) => activeRun?.promptMessageId === 'new-user')
+    expect(admitted).not.toHaveProperty('resumeRecovery')
+    expect(admitted?.pendingHistoryReplay).toEqual({
       kind: 'before-message',
       messageId: 'interrupted-user'
     })
     expect(saved.at(-1)).not.toHaveProperty('pendingHistoryReplay')
     expect(
-      saved[0]?.messages.filter((message) => message.content === 'Delete the duplicates')
+      admitted?.messages.filter((message) => message.content === 'Delete the duplicates')
     ).toHaveLength(1)
   })
 

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -751,7 +751,9 @@ describe('TaskRunner', () => {
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async (_request, observer) => observer?.onPromptAdmitted?.()
+        prompt: async (_request, observer) => {
+          await observer?.onPromptAdmitted?.()
+        }
       }
     })
 
@@ -1304,7 +1306,9 @@ describe('TaskRunner', () => {
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async (_request, observer) => observer?.onPromptAdmitted?.()
+        prompt: async (_request, observer) => {
+          await observer?.onPromptAdmitted?.()
+        }
       },
       reviewer: { review },
       createId: () => ids.shift() ?? 'generated-id'
@@ -1707,20 +1711,26 @@ describe('TaskRunner', () => {
   })
 
   it('cleans up an admitted Task turn when Session persistence commits before rejecting', async () => {
-    const existing: PersistedChatSession = {
+    let durableSession: PersistedChatSession = {
       ...session,
+      revision: 1,
       messages: []
     }
-    let durableSession = existing
     const save = vi.fn(async (candidate: PersistedChatSession) => {
-      durableSession = candidate
+      if (candidate.revision !== durableSession.revision) {
+        throw new Error('Session revision conflict')
+      }
+      durableSession = {
+        ...structuredClone(candidate),
+        revision: (candidate.revision ?? 0) + 1
+      }
       throw new Error('index unavailable after durable commit')
     })
     const runner = createRunner({
-      sessions: { list: async () => [existing], save },
+      sessions: { list: async () => [structuredClone(durableSession)], save },
       agent: {
         withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
-        listAttachedSessionIds: async () => [existing.id],
+        listAttachedSessionIds: async () => [durableSession.id],
         createSession: async () => ({ sessionId: 'unused' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
@@ -1733,7 +1743,7 @@ describe('TaskRunner', () => {
 
     const started = await runner.startRun({
       project: project.id,
-      sessionId: existing.id,
+      sessionId: durableSession.id,
       prompt: 'Task API prompt'
     })
     const failed = await runner.waitForRun(started.id)
@@ -2023,7 +2033,9 @@ describe('TaskRunner', () => {
         resumeSession,
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async (_request, observer) => observer?.onPromptAdmitted?.()
+        prompt: async (_request, observer) => {
+          await observer?.onPromptAdmitted?.()
+        }
       },
       createId: () => ids.shift() ?? 'generated-id'
     })
@@ -2072,7 +2084,9 @@ describe('TaskRunner', () => {
         resumeSession,
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async (_request, observer) => observer?.onPromptAdmitted?.()
+        prompt: async (_request, observer) => {
+          await observer?.onPromptAdmitted?.()
+        }
       },
       createId: () => ids.shift() ?? 'generated-id'
     })

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -93,6 +93,7 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
         throw new Error('Unexpected Compute preference update.')
       }
     },
+    runWithLifecycleContext: (operation) => operation(),
     createId: () => 'generated-id',
     now: () => 1,
     ...overrides,

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1750,6 +1750,69 @@ describe('TaskRunner', () => {
     })
   })
 
+  it('rebases an admitted Task turn onto concurrent Session metadata edits', async () => {
+    let durableSession: PersistedChatSession = {
+      ...session,
+      revision: 1,
+      messages: []
+    }
+    const list = vi.fn(async () => [structuredClone(durableSession)])
+    const save = vi.fn(async (candidate: PersistedChatSession) => {
+      if (candidate.revision !== durableSession.revision) {
+        throw new Error('Session revision conflict')
+      }
+      durableSession = {
+        ...structuredClone(candidate),
+        revision: (candidate.revision ?? 0) + 1
+      }
+      return structuredClone(durableSession)
+    })
+    const runner = createRunner({
+      sessions: { list, save },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [durableSession.id],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async (_request, observer) => {
+          durableSession = {
+            ...durableSession,
+            title: 'Renamed concurrently',
+            description: 'Keep this edit',
+            revision: 2,
+            updatedAt: 3
+          }
+          await observer?.onPromptAdmitted?.()
+        }
+      },
+      createId: (() => {
+        const ids = ['task-user', 'task-run', 'unused-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: durableSession.id,
+      prompt: 'Task API prompt'
+    })
+    const completed = await runner.waitForRun(started.id)
+
+    expect(completed.status).toBe('completed')
+    expect(list).toHaveBeenCalledTimes(2)
+    expect(durableSession).toMatchObject({
+      title: 'Renamed concurrently',
+      description: 'Keep this edit'
+    })
+    expect(durableSession.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'task-user', content: 'Task API prompt' })
+      ])
+    )
+  })
+
   it('rejects a new authored turn while a restored Plan awaits approval', async () => {
     const existing: PersistedChatSession = {
       ...session,

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -751,7 +751,7 @@ describe('TaskRunner', () => {
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async () => undefined
+        prompt: async (_request, observer) => observer?.onPromptAdmitted?.()
       }
     })
 
@@ -1304,7 +1304,7 @@ describe('TaskRunner', () => {
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async () => undefined
+        prompt: async (_request, observer) => observer?.onPromptAdmitted?.()
       },
       reviewer: { review },
       createId: () => ids.shift() ?? 'generated-id'
@@ -1659,6 +1659,53 @@ describe('TaskRunner', () => {
     }
   })
 
+  it('does not persist a Task turn when ACP rejects admission for an active desktop turn', async () => {
+    const existing: PersistedChatSession = {
+      ...session,
+      status: 'running',
+      messages: [
+        {
+          id: 'desktop-prompt',
+          role: 'user',
+          content: 'Desktop prompt',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      activeRun: { promptMessageId: 'desktop-prompt', startedAt: 1 }
+    }
+    const save = vi.fn(async () => undefined)
+    const runner = createRunner({
+      sessions: { list: async () => [existing], save },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [existing.id],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => {
+          throw new Error('An ACP interaction is already running for this session')
+        }
+      }
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Task API prompt'
+    })
+    const failed = await runner.waitForRun(started.id)
+
+    expect(save).not.toHaveBeenCalled()
+    expect(failed).toMatchObject({
+      status: 'failed',
+      error: 'An ACP interaction is already running for this session'
+    })
+  })
+
   it('rejects a new authored turn while a restored Plan awaits approval', async () => {
     const existing: PersistedChatSession = {
       ...session,
@@ -1796,7 +1843,8 @@ describe('TaskRunner', () => {
         },
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async (request) => {
+        prompt: async (request, observer) => {
+          await observer?.onPromptAdmitted?.()
           prompts.push(request)
         }
       },
@@ -1868,7 +1916,7 @@ describe('TaskRunner', () => {
         resumeSession,
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async () => undefined
+        prompt: async (_request, observer) => observer?.onPromptAdmitted?.()
       },
       createId: () => ids.shift() ?? 'generated-id'
     })
@@ -1917,7 +1965,7 @@ describe('TaskRunner', () => {
         resumeSession,
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async () => undefined
+        prompt: async (_request, observer) => observer?.onPromptAdmitted?.()
       },
       createId: () => ids.shift() ?? 'generated-id'
     })
@@ -2002,7 +2050,8 @@ describe('TaskRunner', () => {
         }),
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async (request) => {
+        prompt: async (request, observer) => {
+          await observer?.onPromptAdmitted?.()
           prompts.push(request)
         }
       },
@@ -2078,7 +2127,8 @@ describe('TaskRunner', () => {
         resumeSession: async () => ({ sessionId: 'unused' }),
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async (request) => {
+        prompt: async (request, observer) => {
+          await observer?.onPromptAdmitted?.()
           prompts.push(request)
         }
       },
@@ -2146,7 +2196,8 @@ describe('TaskRunner', () => {
         resumeSession: async () => ({ sessionId: 'unused' }),
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
-        prompt: async (request) => {
+        prompt: async (request, observer) => {
+          await observer?.onPromptAdmitted?.()
           prompts.push(request)
           throw new Error('provider rejected prompt')
         }

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -367,6 +367,57 @@ const createUserMessage = (
   updatedAt: now
 })
 
+const rebaseTaskTurnOntoLatestSession = (
+  latest: PersistedChatSession,
+  prepared: PersistedChatSession,
+  contextReset: boolean
+): PersistedChatSession => {
+  const activeRun = prepared.activeRun
+  const promptMessageId = activeRun?.promptMessageId
+  const userMessage = prepared.messages.find((message) => message.id === promptMessageId)
+  if (!activeRun || !userMessage) {
+    throw new Error('Task prompt admission is missing its prepared user message.')
+  }
+
+  let rebased: PersistedChatSession = {
+    ...latest,
+    cwd: prepared.cwd,
+    status: 'running',
+    permissionProfile: prepared.permissionProfile,
+    autoReviewEnabled: prepared.autoReviewEnabled,
+    delegationPolicy: prepared.delegationPolicy,
+    specialistId: prepared.specialistId,
+    agentFrameworkId: prepared.agentFrameworkId,
+    agentBackendId: prepared.agentBackendId,
+    providerSessionId: prepared.providerSessionId,
+    providerContinuityToken: prepared.providerContinuityToken,
+    agentConfiguration: prepared.agentConfiguration,
+    messages: [...latest.messages.filter((message) => message.id !== userMessage.id), userMessage],
+    activeRun,
+    error: undefined,
+    updatedAt: prepared.updatedAt
+  }
+  delete rebased.resumeRecovery
+
+  const currentGraph = materializeSessionConversationGraph(latest).conversationGraph
+  const graphWithRuntime = ensureConversationRuntimeSegment(currentGraph, {
+    id: `runtime-segment-${promptMessageId}`,
+    frameworkId: rebased.agentFrameworkId ?? 'claude-code',
+    providerId: rebased.agentConfiguration?.providerId,
+    backendId: rebased.agentBackendId,
+    model: rebased.agentModel,
+    startedAt: activeRun.startedAt,
+    forceNew: contextReset
+  })
+  if (graphWithRuntime.runtimeSegments.length !== currentGraph.runtimeSegments.length) {
+    rebased = materializeSessionConversationGraph({
+      ...rebased,
+      conversationGraph: graphWithRuntime
+    })
+  }
+  return rebased
+}
+
 const toPersistedArtifact = (
   artifact: ArtifactFile,
   fallbackCreatedAt?: number
@@ -1163,11 +1214,24 @@ class TaskRunner {
                     run.projectId,
                     session.id,
                     async () => {
+                      const latestSession = (await this.dependencies.sessions.list()).find(
+                        (candidate) => candidate.id === session.id
+                      )
+                      if (!latestSession || latestSession.projectId !== run.projectId) {
+                        throw new Error(
+                          `Session not found for Task prompt admission: ${session.id}`
+                        )
+                      }
+                      const sessionToSave = rebaseTaskTurnOntoLatestSession(
+                        latestSession,
+                        session,
+                        contextReset === true
+                      )
                       // Once the durable save starts it may commit the Session before a derived
                       // projection rejects. Retain the admitted aggregate so failure cleanup can
                       // clear that partially committed active run.
-                      admittedSession = session
-                      return this.dependencies.sessions.save(session)
+                      admittedSession = sessionToSave
+                      return this.dependencies.sessions.save(sessionToSave)
                     }
                   )
                 }

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -131,6 +131,7 @@ type TaskAgentPromptRequest = {
 }
 
 type TaskAgentPromptObserver = {
+  onPromptAdmitted?: () => Promise<void>
   onProviderPromptAccepted?: () => void
 }
 
@@ -862,7 +863,8 @@ class TaskRunner {
       prompt,
       prepared.historyPreamble,
       prepared.contextReset,
-      prepared.resumeFallback
+      prepared.resumeFallback,
+      prepared.persistOnPromptAdmission
     ).finally(() => this.releaseSession(session.id, runId))
     return cloneRun(run)
   }
@@ -939,6 +941,7 @@ class TaskRunner {
     userMessageId: string
   ): Promise<{
     session: PersistedChatSession
+    persistOnPromptAdmission: boolean
     historyPreamble?: string
     contextReset?: boolean
     resumeFallback?: TaskAgentPromptRequest['resumeFallback']
@@ -1099,12 +1102,16 @@ class TaskRunner {
       }
     }
 
-    const committedSession = await this.dependencies.sessions.save(sessionToCommit)
+    const persistOnPromptAdmission = existing !== undefined
+    const committedSession = persistOnPromptAdmission
+      ? sessionToCommit
+      : await this.dependencies.sessions.save(sessionToCommit)
     const previousHistoryPreamble = existing
       ? createHistoryPreamble(selectTaskHistoryMessages(existing))
       : undefined
     return {
       session: committedSession,
+      persistOnPromptAdmission,
       historyPreamble: contextReset ? previousHistoryPreamble : undefined,
       contextReset,
       resumeFallback:
@@ -1121,10 +1128,14 @@ class TaskRunner {
     prompt: string,
     historyPreamble?: string,
     contextReset?: boolean,
-    resumeFallback?: TaskAgentPromptRequest['resumeFallback']
+    resumeFallback?: TaskAgentPromptRequest['resumeFallback'],
+    persistOnPromptAdmission = false
   ): Promise<void> {
     let promptError: unknown
     let cancellationAtPromptFailure: MutableTaskRun['cancellation'] = undefined
+    let admittedSession: PersistedChatSession | undefined = persistOnPromptAdmission
+      ? undefined
+      : session
     try {
       this.publishProgress(run, 'prompt-dispatched')
       const promptMessageId = session.activeRun!.promptMessageId
@@ -1145,6 +1156,17 @@ class TaskRunner {
           ...(resumeFallback ? { resumeFallback } : {})
         },
         {
+          ...(persistOnPromptAdmission
+            ? {
+                onPromptAdmitted: async () => {
+                  admittedSession = await this.dependencies.agent.withSessionAvailable(
+                    run.projectId,
+                    session.id,
+                    () => this.dependencies.sessions.save(session)
+                  )
+                }
+              }
+            : {}),
           onProviderPromptAccepted: () => {
             if (run.status !== 'running' || run.providerAccepted) return
             run.providerAccepted = true
@@ -1157,8 +1179,32 @@ class TaskRunner {
       cancellationAtPromptFailure = run.cancellation
     }
 
+    if (!admittedSession) {
+      const cancellation = run.cancellation
+      if (cancellation) await cancellation.dispatch.catch(() => undefined)
+      if (cancellationAtPromptFailure?.accepted === true) {
+        run.status = 'cancelled'
+        run.attention = undefined
+        const cancelledAt = this.dependencies.now()
+        run.completedAt = cancelledAt
+        run.cancelledAt = cancelledAt
+        this.stopHeartbeat(run)
+        this.publishProgress(run, 'cancelled')
+      } else {
+        await this.failRun(
+          run,
+          session,
+          undefined,
+          promptError ?? new Error('Task Agent prompt completed without admission.'),
+          false
+        )
+      }
+      run.eventAccumulator = undefined
+      return
+    }
+
     const acceptedSession =
-      promptError === undefined ? consumePendingHistoryReplay(session) : session
+      promptError === undefined ? consumePendingHistoryReplay(admittedSession) : admittedSession
 
     let completed: CompletedTaskSession | undefined
     let completionError: unknown
@@ -1240,7 +1286,8 @@ class TaskRunner {
     run: MutableTaskRun,
     session: PersistedChatSession,
     completed: CompletedTaskSession | undefined,
-    failure: unknown
+    failure: unknown,
+    persistSession = true
   ): Promise<void> {
     const runtimeError = run.eventAccumulator?.runtimeError
     const message = runtimeError?.text?.trim() || toErrorMessage(failure)
@@ -1260,7 +1307,7 @@ class TaskRunner {
     run.completedAt = this.dependencies.now()
     this.stopHeartbeat(run)
     this.publishProgress(run, 'failed')
-    await this.dependencies.sessions.save(failed).catch(() => undefined)
+    if (persistSession) await this.dependencies.sessions.save(failed).catch(() => undefined)
   }
 
   private async completeSession(

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1,6 +1,7 @@
 import { constants } from 'node:fs'
 import { access, realpath, stat } from 'node:fs/promises'
 import { isAbsolute } from 'node:path'
+import { isDeepStrictEqual } from 'node:util'
 
 import type { AcpRuntimeEvent, AgentTurnProvenanceContext } from '../../shared/acp'
 import { ComputeHostPreferenceValidationError } from '../../shared/compute'
@@ -1070,6 +1071,40 @@ class TaskRunner {
         ...(request.cwd ? { cwd: request.cwd } : {}),
         ...(specialistId ? { specialistId } : {})
       })
+    }
+
+    if (existing) {
+      const cwd = sessionInfo.cwd ?? existing.cwd
+      const agentFrameworkId = sessionInfo.frameworkId ?? existing.agentFrameworkId
+      const agentBackendId = sessionInfo.backendId ?? existing.agentBackendId
+      const providerSessionId = sessionInfo.providerSessionId ?? existing.providerSessionId
+      const providerContinuityToken = sessionInfo.providerContinuityToken
+      const agentConfiguration = sessionInfo.agentConfiguration ?? existing.agentConfiguration
+      const persistedPermissionProfile = request.permissionProfile ?? existing.permissionProfile
+      const needsHistoryReplay = sessionInfo.contextReset === true && !existing.pendingHistoryReplay
+      const setupChanged =
+        cwd !== existing.cwd ||
+        persistedPermissionProfile !== existing.permissionProfile ||
+        agentFrameworkId !== existing.agentFrameworkId ||
+        agentBackendId !== existing.agentBackendId ||
+        providerSessionId !== existing.providerSessionId ||
+        providerContinuityToken !== existing.providerContinuityToken ||
+        !isDeepStrictEqual(agentConfiguration, existing.agentConfiguration) ||
+        needsHistoryReplay
+      if (setupChanged) {
+        existing = await this.dependencies.sessions.save({
+          ...existing,
+          cwd,
+          permissionProfile: persistedPermissionProfile,
+          agentFrameworkId,
+          agentBackendId,
+          providerSessionId,
+          providerContinuityToken,
+          agentConfiguration,
+          ...(needsHistoryReplay ? { pendingHistoryReplay: { kind: 'all' } } : {}),
+          updatedAt: now
+        })
+      }
     }
 
     const userMessage = createUserMessage(userMessageId, prompt, now, request.turnIntent)

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1162,7 +1162,13 @@ class TaskRunner {
                   admittedSession = await this.dependencies.agent.withSessionAvailable(
                     run.projectId,
                     session.id,
-                    () => this.dependencies.sessions.save(session)
+                    async () => {
+                      // Once the durable save starts it may commit the Session before a derived
+                      // projection rejects. Retain the admitted aggregate so failure cleanup can
+                      // clear that partially committed active run.
+                      admittedSession = session
+                      return this.dependencies.sessions.save(session)
+                    }
                   )
                 }
               }

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1339,6 +1339,18 @@ class TaskRunner {
       return
     }
 
+    const sessionAtAdmission = admittedSession
+    return this.dependencies.runWithLifecycleContext(() =>
+      this.finalizeAdmittedRun(run, sessionAtAdmission, promptError, cancellationAtPromptFailure)
+    )
+  }
+
+  private async finalizeAdmittedRun(
+    run: MutableTaskRun,
+    admittedSession: PersistedChatSession,
+    promptError: unknown,
+    cancellationAtPromptFailure: MutableTaskRun['cancellation']
+  ): Promise<void> {
     const acceptedSession =
       promptError === undefined ? consumePendingHistoryReplay(admittedSession) : admittedSession
 

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -179,6 +179,7 @@ type TaskRunnerDependencies = {
   specialists: TaskSpecialistPort
   reviewer: TaskReviewerPort
   computePreferences: TaskComputePreferencePort
+  runWithLifecycleContext<Result>(operation: () => Result): Result
   createId: () => string
   now: () => number
 }
@@ -1172,6 +1173,16 @@ class TaskRunner {
     }
   }
 
+  private withLifecycleSessionAvailable<Result>(
+    projectId: string,
+    sessionId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    return this.dependencies.runWithLifecycleContext(() =>
+      this.dependencies.agent.withSessionAvailable(projectId, sessionId, operation)
+    )
+  }
+
   private async executeRun(
     run: MutableTaskRun,
     session: PersistedChatSession,
@@ -1211,40 +1222,34 @@ class TaskRunner {
           ...(persistOnPromptAdmission
             ? {
                 onPromptAdmitted: async () => {
-                  return this.dependencies.agent.withSessionAvailable(
-                    run.projectId,
-                    session.id,
-                    async () => {
-                      const latestSession = (await this.dependencies.sessions.list()).find(
-                        (candidate) => candidate.id === session.id
-                      )
-                      if (!latestSession || latestSession.projectId !== run.projectId) {
-                        throw new Error(
-                          `Session not found for Task prompt admission: ${session.id}`
-                        )
-                      }
-                      const sessionToSave = rebaseTaskTurnOntoLatestSession(
-                        latestSession,
-                        session,
-                        contextReset === true
-                      )
-                      // Once the durable save starts it may commit the Session before a derived
-                      // projection rejects. Retain the admitted aggregate so failure cleanup can
-                      // clear that partially committed active run.
-                      admittedSession = sessionToSave
-                      try {
-                        const saved = await this.dependencies.sessions.save(sessionToSave)
-                        admittedSession = saved
-                        return getActiveConversationContext(
-                          materializeSessionConversationGraph(saved).conversationGraph,
-                          promptMessageId
-                        )
-                      } catch (error) {
-                        admissionPersistenceError = error
-                        throw error
-                      }
+                  return this.withLifecycleSessionAvailable(run.projectId, session.id, async () => {
+                    const latestSession = (await this.dependencies.sessions.list()).find(
+                      (candidate) => candidate.id === session.id
+                    )
+                    if (!latestSession || latestSession.projectId !== run.projectId) {
+                      throw new Error(`Session not found for Task prompt admission: ${session.id}`)
                     }
-                  )
+                    const sessionToSave = rebaseTaskTurnOntoLatestSession(
+                      latestSession,
+                      session,
+                      contextReset === true
+                    )
+                    // Once the durable save starts it may commit the Session before a derived
+                    // projection rejects. Retain the admitted aggregate so failure cleanup can
+                    // clear that partially committed active run.
+                    admittedSession = sessionToSave
+                    try {
+                      const saved = await this.dependencies.sessions.save(sessionToSave)
+                      admittedSession = saved
+                      return getActiveConversationContext(
+                        materializeSessionConversationGraph(saved).conversationGraph,
+                        promptMessageId
+                      )
+                    } catch (error) {
+                      admissionPersistenceError = error
+                      throw error
+                    }
+                  })
                 }
               }
             : {}),
@@ -1261,15 +1266,13 @@ class TaskRunner {
     }
 
     if (admissionPersistenceError !== undefined) {
-      await this.dependencies.agent
-        .withSessionAvailable(run.projectId, session.id, async () => {
-          const latestSession = (await this.dependencies.sessions.list()).find(
-            (candidate) => candidate.id === session.id && candidate.projectId === run.projectId
-          )
-          if (latestSession?.activeRun?.promptMessageId !== run.promptMessageId) return
-          await this.failRun(run, latestSession, undefined, admissionPersistenceError)
-        })
-        .catch(() => undefined)
+      await this.withLifecycleSessionAvailable(run.projectId, session.id, async () => {
+        const latestSession = (await this.dependencies.sessions.list()).find(
+          (candidate) => candidate.id === session.id && candidate.projectId === run.projectId
+        )
+        if (latestSession?.activeRun?.promptMessageId !== run.promptMessageId) return
+        await this.failRun(run, latestSession, undefined, admissionPersistenceError)
+      }).catch(() => undefined)
       if (run.status === 'running') {
         await this.failRun(run, session, undefined, admissionPersistenceError, false)
       }

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -131,7 +131,7 @@ type TaskAgentPromptRequest = {
 }
 
 type TaskAgentPromptObserver = {
-  onPromptAdmitted?: () => Promise<void>
+  onPromptAdmitted?: () => Promise<AgentTurnProvenanceContext | undefined>
   onProviderPromptAccepted?: () => void
 }
 
@@ -1183,6 +1183,7 @@ class TaskRunner {
     persistOnPromptAdmission = false
   ): Promise<void> {
     let promptError: unknown
+    let admissionPersistenceError: unknown
     let cancellationAtPromptFailure: MutableTaskRun['cancellation'] = undefined
     let admittedSession: PersistedChatSession | undefined = persistOnPromptAdmission
       ? undefined
@@ -1210,7 +1211,7 @@ class TaskRunner {
           ...(persistOnPromptAdmission
             ? {
                 onPromptAdmitted: async () => {
-                  admittedSession = await this.dependencies.agent.withSessionAvailable(
+                  return this.dependencies.agent.withSessionAvailable(
                     run.projectId,
                     session.id,
                     async () => {
@@ -1231,7 +1232,17 @@ class TaskRunner {
                       // projection rejects. Retain the admitted aggregate so failure cleanup can
                       // clear that partially committed active run.
                       admittedSession = sessionToSave
-                      return this.dependencies.sessions.save(sessionToSave)
+                      try {
+                        const saved = await this.dependencies.sessions.save(sessionToSave)
+                        admittedSession = saved
+                        return getActiveConversationContext(
+                          materializeSessionConversationGraph(saved).conversationGraph,
+                          promptMessageId
+                        )
+                      } catch (error) {
+                        admissionPersistenceError = error
+                        throw error
+                      }
                     }
                   )
                 }
@@ -1247,6 +1258,23 @@ class TaskRunner {
     } catch (error) {
       promptError = error
       cancellationAtPromptFailure = run.cancellation
+    }
+
+    if (admissionPersistenceError !== undefined) {
+      await this.dependencies.agent
+        .withSessionAvailable(run.projectId, session.id, async () => {
+          const latestSession = (await this.dependencies.sessions.list()).find(
+            (candidate) => candidate.id === session.id && candidate.projectId === run.projectId
+          )
+          if (latestSession?.activeRun?.promptMessageId !== run.promptMessageId) return
+          await this.failRun(run, latestSession, undefined, admissionPersistenceError)
+        })
+        .catch(() => undefined)
+      if (run.status === 'running') {
+        await this.failRun(run, session, undefined, admissionPersistenceError, false)
+      }
+      run.eventAccumulator = undefined
+      return
     }
 
     if (!admittedSession) {

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -777,16 +777,17 @@ describe('HeadlessTaskApi adapter', () => {
       location: 'remote',
       isAuthorizationCurrent: () => authorizationCurrent
     })
-    const invoke = vi.fn(
-      async (channel: string, _callerContext: CallerContext, args: unknown[]) => {
-        if (channel === 'projects:list') return [project]
-        if (channel === 'sessions:load-all') {
-          return { sessions: [existing], manifest: { version: 1 } }
-        }
-        if (channel === 'sessions:save-session') return args[0]
-        throw new Error(`Unexpected RPC channel: ${channel}`)
+    const invoke = vi.fn(async (channel: string, callerContext: CallerContext, args: unknown[]) => {
+      if (!callerContext.isAuthorizationCurrent()) {
+        throw new Error('Caller authorization is no longer current.')
       }
-    )
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') {
+        return { sessions: [existing], manifest: { version: 1 } }
+      }
+      if (channel === 'sessions:save-session') return args[0]
+      throw new Error(`Unexpected RPC channel: ${channel}`)
+    })
     const agent = createAgent({
       listAttachedSessionIds: vi.fn(async () => [existing.id]),
       prompt: vi.fn(async (_request, observer) => {
@@ -873,7 +874,7 @@ describe('HeadlessTaskApi adapter', () => {
     expect(invoke.mock.calls.every(([channel]) => !String(channel).startsWith('acp:'))).toBe(true)
   })
 
-  it('keeps the captured request caller across asynchronous run façade calls', async () => {
+  it('uses the request caller before admission and the Task caller for admitted lifecycle work', async () => {
     let finishPrompt: (() => void) | undefined
     const promptGate = new Promise<void>((resolve) => {
       finishPrompt = resolve
@@ -908,8 +909,14 @@ describe('HeadlessTaskApi adapter', () => {
     finishPrompt?.()
     await api.waitForRun(run.id)
 
-    expect(invoke).toHaveBeenCalled()
-    expect(invoke.mock.calls.every(([, callerContext]) => callerContext === context)).toBe(true)
+    expect(invoke).toHaveBeenCalledWith('projects:list', context, [])
+    expect(invoke).toHaveBeenCalledWith('sessions:load-all', context, [])
+    expect(invoke).toHaveBeenCalledWith('sessions:save-session', context, [
+      expect.objectContaining({ status: 'running' })
+    ])
+    expect(invoke).toHaveBeenCalledWith('sessions:save-session', taskCallerContext(), [
+      expect.objectContaining({ status: 'idle' })
+    ])
     expect(agent.createSession).toHaveBeenCalledWith({
       projectId: project.id,
       permissionProfile: 'ask'
@@ -1071,7 +1078,7 @@ describe('HeadlessTaskApi adapter', () => {
         }
         if (channel === 'sessions:save-session') return args[0]
         if (channel === 'reviewer:run') {
-          expect(callerContext).toBe(context)
+          expect(callerContext).toEqual(taskCallerContext())
           authorizationCurrent = false
           return { started: true }
         }

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -698,7 +698,8 @@ describe('HeadlessTaskApi adapter', () => {
     })
     const agent = createAgent({
       listAttachedSessionIds: vi.fn(async () => [existing.id]),
-      prompt: vi.fn(async () => {
+      prompt: vi.fn(async (_request, observer) => {
+        await observer?.onPromptAdmitted?.()
         emitEvent?.({
           id: 'artifact-event',
           timestamp: 10,
@@ -748,7 +749,10 @@ describe('HeadlessTaskApi adapter', () => {
         },
         text: 'Continue research.'
       },
-      { onProviderPromptAccepted: expect.any(Function) }
+      {
+        onPromptAdmitted: expect.any(Function),
+        onProviderPromptAccepted: expect.any(Function)
+      }
     )
     expect(invoke.mock.calls.every(([channel]) => !String(channel).startsWith('acp:'))).toBe(true)
     expect(invoke).toHaveBeenCalledWith('artifacts:finalize-run', taskCallerContext(), [

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -760,6 +760,67 @@ describe('HeadlessTaskApi adapter', () => {
     ])
   })
 
+  it('keeps deferred Session admission alive after remote authorization expires', async () => {
+    const existing: PersistedChatSession = {
+      id: 'session-admission-context',
+      projectId: project.id,
+      title: 'Admission context',
+      cwd: '/workspace/admission-context',
+      status: 'idle',
+      permissionProfile: 'ask',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    let authorizationCurrent = true
+    const context = createTaskCallerContext({
+      location: 'remote',
+      isAuthorizationCurrent: () => authorizationCurrent
+    })
+    const invoke = vi.fn(
+      async (channel: string, _callerContext: CallerContext, args: unknown[]) => {
+        if (channel === 'projects:list') return [project]
+        if (channel === 'sessions:load-all') {
+          return { sessions: [existing], manifest: { version: 1 } }
+        }
+        if (channel === 'sessions:save-session') return args[0]
+        throw new Error(`Unexpected RPC channel: ${channel}`)
+      }
+    )
+    const agent = createAgent({
+      listAttachedSessionIds: vi.fn(async () => [existing.id]),
+      prompt: vi.fn(async (_request, observer) => {
+        authorizationCurrent = false
+        await observer?.onPromptAdmitted?.()
+        observer?.onProviderPromptAccepted?.()
+      })
+    })
+    const ids = ['admission-user', 'admission-run', 'admission-agent']
+    const api = new HeadlessTaskApi(
+      { commands: commandsFrom(invoke), agent },
+      { createId: () => ids.shift() ?? 'generated-id' }
+    )
+
+    const run = await api.runWithCallerContext(context, () =>
+      api.startRun({
+        project: project.id,
+        sessionId: existing.id,
+        prompt: 'Continue after admission.'
+      })
+    )
+
+    await expect(api.waitForRun(run.id)).resolves.toMatchObject({ status: 'completed' })
+    expect(invoke).toHaveBeenCalledWith('sessions:save-session', taskCallerContext(), [
+      expect.objectContaining({
+        id: existing.id,
+        status: 'running',
+        activeRun: expect.objectContaining({ promptMessageId: 'admission-user' })
+      })
+    ])
+    expect(authorizationCurrent).toBe(false)
+    await api.dispose()
+  })
+
   it('resumes a detached session through the direct Agent port with its durable binding', async () => {
     const existing: PersistedChatSession = {
       id: 'session-detached',

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -142,6 +142,8 @@ class HeadlessTaskApi {
           throw new Error('Task Compute preference control is unavailable.')
         }
       },
+      runWithLifecycleContext: (operation) =>
+        this.callerContexts.run(TASK_CALLER_CONTEXT, operation),
       createId: dependencies.createId ?? randomUUID,
       now: dependencies.now ?? Date.now
     } satisfies TaskRunnerDependencies)


### PR DESCRIPTION
## Problem

`TaskRunner` persisted a replacement user message, `status: running`, and a new `activeRun` before the shared ACP runtime admitted the prompt. If the Session was already running from Desktop, Remote Web, or another `TaskRunner`, ACP rejected the prompt only after those writes. Task failure cleanup then persisted `status: error`, overwriting the original turn's durable presentation state.

The regression was reproduced before the fix with an existing running Session and ACP's shared busy error. It failed deterministically on two runs because the rejected Task attempt saved the Session twice.

## Proposed change

- Extend the existing transient Task prompt observer with one awaited admission callback.
- Invoke it in the shared ACP prompt-turn workflow after interaction ownership is activated and Plan admission succeeds, but before prompt-start publication or provider dispatch.
- For existing Sessions, persist the Task-authored turn only from that callback and retain the final archive/deletion availability check around the save.
- If ACP rejects before admission, fail the Task Run without writing the Session.
- Release ACP interaction ownership without provider dispatch when the admitted persistence callback rejects.

## Scope and non-goals

- No persisted fields, schema changes, migrations, data-relationship changes, or new enum/status values.
- No historical Session compatibility work is required; existing Session JSON is read unchanged.
- No renderer interaction or provider protocol payload changes.
- New Sessions keep their existing initial persistence behavior because ACP needs their durable identity before prompt dispatch.
- The Task API lifecycle remains asynchronous: a cross-surface conflict produces a failed Task Run instead of a new immediate HTTP conflict response.
- No database or distributed lock is introduced; the existing shared ACP interaction owner remains the global runtime authority.

## ACP compatibility

The admission hook is above framework dispatch in the shared runtime path. Claude Code, OpenCode, Codex Responses, and Codex Bridge therefore use the same ordering and cleanup contract. Framework adapters, wire requests, history replay, subscription behavior, models, transports, and platform-specific process behavior are unchanged.

## Acceptance criteria and validation

- Rejected cross-surface admission performs zero Session writes and preserves the original message graph, `activeRun`, and display status.
- Admitted persistence runs while ACP owns the Session and before prompt start/provider dispatch.
- Persistence rejection releases ACP ownership and never reaches the provider.
- Provider rejection after successful admission retains the existing error-persistence behavior.

Final checks after the last material edit:

- `npm test -- src/main/tasks/task-runner.test.ts` — 61 passed.
- `npm test -- src/main/acp/prompt-turn-workflow.test.ts src/main/acp/task-agent-port.test.ts src/main/acp/runtime-coordinator.test.ts` — 153 passed.
- `npm test -- src/main/web-service/task-api.test.ts src/main/web-service/controller.test.ts` — 40 passed.
- `npm run typecheck:node` — passed.
- `npm run lint` — passed.
- `npm run test:affected:explain -- --base origin/main --head HEAD` — selected the full Vitest suite because the changed ACP test path has no module owner; the PR Gate is authoritative for that fail-closed plan. Per maintainer direction, the full suite was not run locally.

## Review focus

- Confirm the callback boundary is the correct shared admission owner: interaction active, provider not started.
- Confirm pre-admission failure cannot reach any Session save path.
- Confirm existing-session archive/deletion checks remain atomic with the admitted save.
