### PR TITLE
fix(notebook): launch protected Windows kernels directly

### DIFF
--- a/packages/notebook-network-sandbox/runtime/src/notebook-runtime.ts
+++ b/packages/notebook-network-sandbox/runtime/src/notebook-runtime.ts
@@ -49,6 +49,8 @@ type NetworkAskCallback = (request: {
 
 type NetworkWrapRequest = Readonly<{
   command: string
+  executable?: string
+  args?: readonly string[]
   commandId: string
   shell?: string | WindowsShell
   cwd: string
@@ -226,6 +228,7 @@ const wrap = async (
     if (process.platform === 'win32') {
       const launchRequest = {
         command: request.command,
+        ...(request.executable ? { executable: request.executable, args: request.args ?? [] } : {}),
         ...(request.shell ? { shell: request.shell } : {}),
         gatewayPort: gateway.port,
         gatewayCredentials: credentials,

--- a/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
+++ b/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
@@ -16,6 +16,8 @@ type WindowsShell = Readonly<{ kind: 'powershell' | 'cmd'; path: string }>
 
 type WindowsLaunchRequest = Readonly<{
   command: string
+  executable?: string
+  args?: readonly string[]
   shell?: string | WindowsShell
   cwd: string
   gatewayPort: number
@@ -320,11 +322,13 @@ const windowsLaunch = (
     shell.kind === 'powershell'
       ? ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', request.command]
       : ['/d', '/s', '/c', request.command]
+  const executable = request.executable ?? shell.path
+  const args = request.executable ? [...(request.args ?? [])] : childArgs
   const layout = normalizeFilesystemLayout(request.filesystem)
   const specification = Buffer.from(
     JSON.stringify({
-      executable: shell.path,
-      arguments: childArgs,
+      executable,
+      arguments: args,
       cwd: request.cwd,
       readOnlyRoots: layout.readOnlyRoots,
       readWriteRoots: layout.readWriteRoots,

--- a/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
+++ b/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
@@ -30,6 +30,37 @@ type WindowsLaunchRequest = Readonly<{
   ownershipRoot: string
 }>
 
+const WINDOWS_BATCH_FILE = /\.(?:cmd|bat)$/i
+const CMD_META_CHARACTER = /([()\][%!^"`<>&|;, *?])/g
+
+// Ported from cross-spawn's Windows non-shell parser. Batch files require cmd.exe, while escaping
+// each token and asking the native host to preserve the resulting command line prevents cmd syntax
+// in an interpreter path or argument from becoming a second command.
+const escapeCmdCommand = (value: string): string => value.replace(CMD_META_CHARACTER, '^$1')
+
+const escapeCmdArgument = (value: string, doubleEscapeMetaCharacters: boolean): string => {
+  let escaped = value.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"').replace(/(?=(\\+?)?)\1$/, '$1$1')
+  escaped = `"${escaped}"`.replace(CMD_META_CHARACTER, '^$1')
+  return doubleEscapeMetaCharacters ? escaped.replace(CMD_META_CHARACTER, '^$1') : escaped
+}
+
+const windowsBatchInvocation = (
+  executable: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv
+): Readonly<{ executable: string; args: string[]; verbatimArguments: true }> => {
+  const command = [
+    escapeCmdCommand(executable),
+    // cmd.exe parses the invocation once and a batch file parses its expanded arguments again.
+    ...args.map((argument) => escapeCmdArgument(argument, true))
+  ].join(' ')
+  return {
+    executable: env.ComSpec ?? env.COMSPEC ?? 'cmd.exe',
+    args: ['/d', '/s', '/c', `"${command}"`],
+    verbatimArguments: true
+  }
+}
+
 type WindowsStandardLaunchRequest = Readonly<
   Pick<
     WindowsLaunchRequest,
@@ -322,13 +353,19 @@ const windowsLaunch = (
     shell.kind === 'powershell'
       ? ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', request.command]
       : ['/d', '/s', '/c', request.command]
-  const executable = request.executable ?? shell.path
-  const args = request.executable ? [...(request.args ?? [])] : childArgs
+  const directInvocation = request.executable
+    ? WINDOWS_BATCH_FILE.test(request.executable)
+      ? windowsBatchInvocation(request.executable, request.args ?? [], request.env)
+      : { executable: request.executable, args: [...(request.args ?? [])] }
+    : { executable: shell.path, args: childArgs }
   const layout = normalizeFilesystemLayout(request.filesystem)
   const specification = Buffer.from(
     JSON.stringify({
-      executable,
-      arguments: args,
+      executable: directInvocation.executable,
+      arguments: directInvocation.args,
+      ...('verbatimArguments' in directInvocation
+        ? { verbatimArguments: directInvocation.verbatimArguments }
+        : {}),
       cwd: request.cwd,
       readOnlyRoots: layout.readOnlyRoots,
       readWriteRoots: layout.readWriteRoots,

--- a/packages/notebook-network-sandbox/src/index.ts
+++ b/packages/notebook-network-sandbox/src/index.ts
@@ -123,6 +123,7 @@ class NotebookNetworkSandbox {
     try {
       wrapped = await this.#backend.wrap({
         command: command.command,
+        ...(command.executable ? { executable: command.executable, args: command.args ?? [] } : {}),
         commandId,
         ...(shell ? { shell } : {}),
         cwd: command.cwd,

--- a/packages/notebook-network-sandbox/src/types.ts
+++ b/packages/notebook-network-sandbox/src/types.ts
@@ -45,6 +45,10 @@ export type NotebookNetworkSandboxStatus =
 
 export type NotebookSandboxCommand = Readonly<{
   command: string
+  // Protected Windows launches use the exact process argv so PowerShell never has to initialize the
+  // AppContainer's working drive before the requested process can start.
+  executable?: string
+  args?: readonly string[]
   cwd: string
   env?: NodeJS.ProcessEnv
   shell?: string | Readonly<{ kind: 'powershell' | 'cmd'; path: string }>

--- a/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
+++ b/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
@@ -34,6 +34,37 @@ describe('Windows AppContainer elevation', () => {
 })
 
 describe('Windows AppContainer launch', () => {
+  it('launches a structured executable directly instead of through PowerShell', () => {
+    const launch = windowsLaunch({
+      command: "& 'D:\\runtime\\python.exe' 'D:\\app\\python_loop.py'",
+      executable: 'D:\\runtime\\python.exe',
+      args: ['D:\\app\\python_loop.py'],
+      cwd: 'D:\\workspace',
+      gatewayPort: 49700,
+      gatewayCredentials: { username: 'command', password: 'secret' },
+      env: {},
+      filesystem: {
+        readOnlyRoots: ['D:\\runtime', 'D:\\app\\python_loop.py'],
+        readWriteRoots: ['D:\\workspace'],
+        deniedReadRoots: [],
+        deniedWriteRoots: []
+      },
+      hostPath: 'C:\\resources\\notebook-sandbox-host.exe',
+      installationId: '0123456789abcdef01234567',
+      ownershipRoot: 'C:\\sandbox'
+    })
+
+    const specification = JSON.parse(
+      Buffer.from(launch.argv.at(-1)!, 'base64url').toString('utf8')
+    ) as { executable: string; arguments: string[]; cwd: string }
+
+    expect(specification).toMatchObject({
+      executable: 'D:\\runtime\\python.exe',
+      arguments: ['D:\\app\\python_loop.py'],
+      cwd: 'D:\\workspace'
+    })
+  })
+
   it('routes local RPC through the authenticated command gateway', () => {
     const launch = windowsLaunch({
       command: 'node repl_loop.js',

--- a/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
+++ b/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
@@ -36,16 +36,16 @@ describe('Windows AppContainer elevation', () => {
 describe('Windows AppContainer launch', () => {
   it('launches a structured executable directly instead of through PowerShell', () => {
     const launch = windowsLaunch({
-      command: "& 'D:\\runtime\\python.exe' 'D:\\app\\python_loop.py'",
-      executable: 'D:\\runtime\\python.exe',
-      args: ['D:\\app\\python_loop.py'],
-      cwd: 'D:\\workspace',
+      command: "& '/runtime/python.exe' '/app/python_loop.py'",
+      executable: '/runtime/python.exe',
+      args: ['/app/python_loop.py'],
+      cwd: '/workspace',
       gatewayPort: 49700,
       gatewayCredentials: { username: 'command', password: 'secret' },
       env: {},
       filesystem: {
-        readOnlyRoots: ['D:\\runtime', 'D:\\app\\python_loop.py'],
-        readWriteRoots: ['D:\\workspace'],
+        readOnlyRoots: ['/runtime', '/app/python_loop.py'],
+        readWriteRoots: ['/workspace'],
         deniedReadRoots: [],
         deniedWriteRoots: []
       },
@@ -59,9 +59,9 @@ describe('Windows AppContainer launch', () => {
     ) as { executable: string; arguments: string[]; cwd: string }
 
     expect(specification).toMatchObject({
-      executable: 'D:\\runtime\\python.exe',
-      arguments: ['D:\\app\\python_loop.py'],
-      cwd: 'D:\\workspace'
+      executable: '/runtime/python.exe',
+      arguments: ['/app/python_loop.py'],
+      cwd: '/workspace'
     })
   })
 

--- a/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
+++ b/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -64,6 +69,82 @@ describe('Windows AppContainer launch', () => {
       cwd: '/workspace'
     })
   })
+
+  it('launches a structured batch-file shim through cmd.exe', () => {
+    const launch = windowsLaunch({
+      command: "& 'C:\\runtime path\\python.bat' 'C:\\app path\\python_loop.py'",
+      executable: 'C:\\runtime path\\python.bat',
+      args: ['C:\\app path\\python_loop.py'],
+      cwd: 'C:\\workspace',
+      gatewayPort: 49700,
+      gatewayCredentials: { username: 'command', password: 'secret' },
+      env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+      filesystem: {
+        readOnlyRoots: ['/runtime', '/app/python_loop.py'],
+        readWriteRoots: ['/workspace'],
+        deniedReadRoots: [],
+        deniedWriteRoots: []
+      },
+      hostPath: 'C:\\resources\\notebook-sandbox-host.exe',
+      installationId: '0123456789abcdef01234567',
+      ownershipRoot: 'C:\\sandbox'
+    })
+
+    const specification = JSON.parse(
+      Buffer.from(launch.argv.at(-1)!, 'base64url').toString('utf8')
+    ) as { executable: string; arguments: string[]; verbatimArguments?: boolean }
+
+    expect(specification).toMatchObject({
+      executable: 'C:\\Windows\\System32\\cmd.exe',
+      arguments: ['/d', '/s', '/c', expect.stringContaining('python.bat')],
+      verbatimArguments: true
+    })
+  })
+
+  it.runIf(process.platform === 'win32')(
+    'preserves metacharacters when cmd.exe executes the generated batch invocation',
+    () => {
+      const root = mkdtempSync(join(tmpdir(), 'os-batch-launch-'))
+      const shim = join(root, 'python shim.cmd')
+      const helper = join(root, 'print-argument.js')
+      writeFileSync(helper, 'process.stdout.write(`[${process.argv[2]}]`)')
+      writeFileSync(shim, `@echo off\r\n"${process.execPath}" "${helper}" %*\r\n`)
+      try {
+        const launch = windowsLaunch({
+          command: 'unused',
+          executable: shim,
+          args: ['hello & goodbye'],
+          cwd: root,
+          gatewayPort: 49700,
+          gatewayCredentials: { username: 'command', password: 'secret' },
+          env: { ComSpec: process.env.ComSpec },
+          filesystem: {
+            readOnlyRoots: [root],
+            readWriteRoots: [root],
+            deniedReadRoots: [],
+            deniedWriteRoots: []
+          },
+          hostPath: 'C:\\resources\\notebook-sandbox-host.exe',
+          installationId: '0123456789abcdef01234567',
+          ownershipRoot: 'C:\\sandbox'
+        })
+        const specification = JSON.parse(
+          Buffer.from(launch.argv.at(-1)!, 'base64url').toString('utf8')
+        ) as { executable: string; arguments: string[]; verbatimArguments: boolean }
+
+        const result = spawnSync(specification.executable, specification.arguments, {
+          cwd: root,
+          encoding: 'utf8',
+          windowsVerbatimArguments: specification.verbatimArguments
+        })
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.trim()).toBe('[hello & goodbye]')
+      } finally {
+        rmSync(root, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('routes local RPC through the authenticated command gateway', () => {
     const launch = windowsLaunch({

--- a/packages/notebook-network-sandbox/vendor/windows-src/src/main.rs
+++ b/packages/notebook-network-sandbox/vendor/windows-src/src/main.rs
@@ -13,6 +13,8 @@ mod wfp;
 struct LaunchSpec {
     executable: String,
     arguments: Vec<String>,
+    #[serde(default)]
+    verbatim_arguments: bool,
     cwd: String,
     read_only_roots: Vec<String>,
     read_write_roots: Vec<String>,
@@ -53,6 +55,12 @@ fn quote_windows_argument(value: &str) -> String {
 }
 
 fn command_line(spec: &LaunchSpec) -> String {
+    if spec.verbatim_arguments {
+        return std::iter::once(quote_windows_argument(&spec.executable))
+            .chain(spec.arguments.iter().cloned())
+            .collect::<Vec<_>>()
+            .join(" ");
+    }
     std::iter::once(&spec.executable)
         .chain(spec.arguments.iter())
         .map(|argument| quote_windows_argument(argument))
@@ -2257,6 +2265,7 @@ mod tests {
         let spec = LaunchSpec {
             executable: "C:\\Program Files\\PowerShell\\pwsh.exe".into(),
             arguments: vec!["-Command".into(), "Write-Output \"hello\"\\".into()],
+            verbatim_arguments: false,
             cwd: "C:\\workspace".into(),
             read_only_roots: Vec::new(),
             read_write_roots: Vec::new(),
@@ -2266,6 +2275,29 @@ mod tests {
         assert_eq!(
             command_line(&spec),
             "\"C:\\Program Files\\PowerShell\\pwsh.exe\" -Command \"Write-Output \\\"hello\\\"\\\\\""
+        );
+    }
+
+    #[test]
+    fn windows_command_line_preserves_pre_escaped_batch_arguments() {
+        let spec = LaunchSpec {
+            executable: "C:\\Windows\\System32\\cmd.exe".into(),
+            arguments: vec![
+                "/d".into(),
+                "/s".into(),
+                "/c".into(),
+                "\"C:\\runtime^ path\\python.cmd ^\"C:\\app^ path\\loop.py^\"\"".into(),
+            ],
+            verbatim_arguments: true,
+            cwd: "C:\\workspace".into(),
+            read_only_roots: Vec::new(),
+            read_write_roots: Vec::new(),
+            denied_read_roots: Vec::new(),
+            denied_write_roots: Vec::new(),
+        };
+        assert_eq!(
+            command_line(&spec),
+            "C:\\Windows\\System32\\cmd.exe /d /s /c \"C:\\runtime^ path\\python.cmd ^\"C:\\app^ path\\loop.py^\"\""
         );
     }
 
@@ -2319,6 +2351,7 @@ mod tests {
         let spec = LaunchSpec {
             executable: "cmd.exe".into(),
             arguments: Vec::new(),
+            verbatim_arguments: false,
             cwd: workspace.to_string_lossy().into_owned(),
             read_only_roots: Vec::new(),
             read_write_roots: vec![workspace.to_string_lossy().into_owned()],

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -538,6 +538,58 @@ gate('NotebookKernelExecutor (fake loop)', () => {
     }
   })
 
+  it('annotates crash stderr before releasing its sandbox context', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-kernel-startup-sandbox-exit-'))
+    const crashingLoop = join(cwdDir, 'crashing_sandbox_loop.py')
+    await writeFile(
+      crashingLoop,
+      [
+        'import sys',
+        'sys.stderr.write("Permission denied: C:/hidden/credentials.txt\\n")',
+        'sys.stderr.flush()',
+        'raise SystemExit(25)'
+      ].join('\n')
+    )
+    let cleaned = false
+    const cleanup = vi.fn(() => {
+      cleaned = true
+    })
+    const annotateStderr = vi.fn((stderr: string) =>
+      cleaned ? stderr : `${stderr}<sandbox_violations>hidden path</sandbox_violations>`
+    )
+    const processSandbox: NotebookProcessSandbox = {
+      wrap: vi.fn(async (invocation) => ({
+        executable: invocation.executable,
+        args: invocation.args,
+        env: invocation.env,
+        beginExecution: () => () => undefined,
+        annotateStderr,
+        cleanup
+      }))
+    }
+    const executor = new NotebookKernelExecutor({
+      pythonLoopPath: crashingLoop,
+      processSandbox
+    })
+
+    try {
+      const result = await executor.execute({
+        ...baseRequest(cwdDir),
+        code: 'kernel exits in sandbox',
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        resolvedInterpreter: { command: python3 as string }
+      })
+
+      expect(result).toMatchObject({ status: 'failed' })
+      expect(result.stderr).toContain('<sandbox_violations>hidden path</sandbox_violations>')
+      expect(annotateStderr).toHaveBeenCalled()
+    } finally {
+      await executor.shutdown()
+    }
+    expect(cleanup).toHaveBeenCalledOnce()
+  })
+
   it('settles when a dead kernel descendant keeps its stdio pipes open', async () => {
     cwdDir = await mkdtemp(join(tmpdir(), 'os-kernel-descendant-stdio-'))
     const releaseFile = join(cwdDir, 'release-descendant')

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -509,6 +509,35 @@ gate('NotebookKernelExecutor (fake loop)', () => {
     }
   })
 
+  it('reports the exit code and stderr when a kernel exits before replying', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-kernel-startup-exit-'))
+    const crashingLoop = join(cwdDir, 'crashing_loop.py')
+    await writeFile(
+      crashingLoop,
+      [
+        'import sys',
+        'sys.stderr.write("PowerShell FileSystem provider initialization failed.\\n")',
+        'sys.stderr.flush()',
+        'raise SystemExit(23)'
+      ].join('\n')
+    )
+    const executor = new NotebookKernelExecutor({ pythonLoopPath: crashingLoop })
+
+    try {
+      const result = await executor.execute({
+        ...baseRequest(cwdDir),
+        code: 'import numpy',
+        resolvedInterpreter: { command: python3 as string }
+      })
+
+      expect(result).toMatchObject({ status: 'failed' })
+      expect(result.stderr).toContain('Notebook kernel process exited with exit code 23.')
+      expect(result.stderr).toContain('PowerShell FileSystem provider initialization failed.')
+    } finally {
+      await executor.shutdown()
+    }
+  })
+
   it('drops a kernel whose stdout exceeds the bounded protocol line', async () => {
     cwdDir = await makeDefaultEnvCwd('os-kernel-protocol-line-limit-')
     const terminated: string[] = []

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -538,6 +538,52 @@ gate('NotebookKernelExecutor (fake loop)', () => {
     }
   })
 
+  it('settles when a dead kernel descendant keeps its stdio pipes open', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-kernel-descendant-stdio-'))
+    const releaseFile = join(cwdDir, 'release-descendant')
+    const finishedFile = join(cwdDir, 'descendant-finished')
+    const descendantCode = [
+      'import os, time',
+      `release_file = ${JSON.stringify(releaseFile)}`,
+      `finished_file = ${JSON.stringify(finishedFile)}`,
+      'while not os.path.exists(release_file): time.sleep(0.01)',
+      `os.chdir(${JSON.stringify(tmpdir())})`,
+      'with open(finished_file, "w", encoding="utf-8") as marker: marker.write("done")'
+    ].join('\n')
+    const crashingLoop = join(cwdDir, 'crashing_loop_with_descendant.py')
+    await writeFile(
+      crashingLoop,
+      [
+        'import subprocess, sys',
+        `subprocess.Popen([sys.executable, "-c", ${JSON.stringify(descendantCode)}], stdout=sys.stdout, stderr=sys.stderr, close_fds=False)`,
+        'raise SystemExit(24)'
+      ].join('\n')
+    )
+    const executor = new NotebookKernelExecutor({ pythonLoopPath: crashingLoop })
+    const execution = executor.execute({
+      ...baseRequest(cwdDir),
+      code: 'kernel exits',
+      resolvedInterpreter: { command: python3 as string }
+    })
+
+    try {
+      const settledBeforeDescendant = await Promise.race([
+        execution.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 1_500))
+      ])
+
+      expect(settledBeforeDescendant).toBe(true)
+      await expect(execution).resolves.toMatchObject({ status: 'failed' })
+    } finally {
+      await writeFile(releaseFile, 'release')
+      await execution
+      await executor.shutdown()
+      for (let attempt = 0; attempt < 200 && !existsSync(finishedFile); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+    }
+  })
+
   it('drops a kernel whose stdout exceeds the bounded protocol line', async () => {
     cwdDir = await makeDefaultEnvCwd('os-kernel-protocol-line-limit-')
     const terminated: string[] = []

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -747,34 +747,44 @@ class NotebookKernelExecutor implements NotebookExecutor {
     // Process liveness follows exit, not close: a descendant may inherit stdio and keep those pipes
     // open after the kernel itself is dead. stderrTail is therefore the bounded data drained so far.
     child.on('exit', (code, signal) => {
-      // Stale exit: this proc was already replaced (dropped after a hard kill, or a respawn) before
-      // the event fired, so it must not touch the live proc or its pending run.
-      if (this.procs.get(key) !== proc) return
-      proc.alive = false
-      this.disarmIdleTimer(proc)
-      this.procs.delete(key)
-      proc.readline.close()
-      const pending = proc.pending
-      const terminationError =
-        pending?.timeout?.timedOut && pending.timeoutMs !== undefined
-          ? new NotebookExecutionTimeoutError(
-              `Notebook execution timed out after ${pending.timeoutMs}ms.`
-            )
-          : (() => {
-              const reason =
-                code !== null ? ` with exit code ${code}` : signal ? ` after signal ${signal}` : ''
-              const stderr = proc.annotateStderr(proc.stderrTail).trim()
-              return new Error(
-                `Notebook kernel process exited${reason}.` + (stderr ? `\n${stderr}` : '')
+      try {
+        // Stale exit: this proc was already replaced (dropped after a hard kill, or a respawn) before
+        // the event fired, so it must not touch the live proc or its pending run.
+        if (this.procs.get(key) !== proc) return
+        proc.alive = false
+        this.disarmIdleTimer(proc)
+        this.procs.delete(key)
+        proc.readline.close()
+        const pending = proc.pending
+        const terminationError =
+          pending?.timeout?.timedOut && pending.timeoutMs !== undefined
+            ? new NotebookExecutionTimeoutError(
+                `Notebook execution timed out after ${pending.timeoutMs}ms.`
               )
-            })()
-      proc.terminationError = terminationError
-      this.rejectPending(proc, terminationError)
-      // Unexpected exit of a still-live proc is a crash; surface it as a 'terminated' kernel status.
-      // Intentional teardown (shutdown/restart) and hard-timeout/idle drops clear the map first, so
-      // this only fires for a genuine crash (the stale-proc guard above returns early otherwise).
-      this.onTerminated?.(kind, env)
+            : (() => {
+                const reason =
+                  code !== null
+                    ? ` with exit code ${code}`
+                    : signal
+                      ? ` after signal ${signal}`
+                      : ''
+                const stderr = proc.annotateStderr(proc.stderrTail).trim()
+                return new Error(
+                  `Notebook kernel process exited${reason}.` + (stderr ? `\n${stderr}` : '')
+                )
+              })()
+        proc.terminationError = terminationError
+        this.rejectPending(proc, terminationError)
+        // Unexpected exit of a still-live proc is a crash; surface it as a 'terminated' kernel status.
+        // Intentional teardown (shutdown/restart) and hard-timeout/idle drops clear the map first, so
+        // this only fires for a genuine crash (the stale-proc guard above returns early otherwise).
+        this.onTerminated?.(kind, env)
+      } finally {
+        // Crash annotation above still needs the live filesystem policy and recorded violations.
+        spawned.cleanupSandbox()
+      }
     })
+    child.once('error', spawned.cleanupSandbox)
 
     // Register before piping buffered stdout: pipe() can synchronously flush data that already arrived
     // after spawn, and the overflow callback must be able to identify and drop this proc.
@@ -794,6 +804,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
     child: ChildProcessWithoutNullStreams
     beginSandboxExecution: () => () => void
     annotateStderr: (stderr: string) => string
+    cleanupSandbox: () => void
   }> {
     const figuresDir = this.ensureFiguresDir()
     // Control-plane REPL may omit a runtime root; package cache belongs to a managed runtime directory.
@@ -896,18 +907,20 @@ class NotebookKernelExecutor implements NotebookExecutor {
       tokenPipe.on('error', () => undefined)
       tokenPipe.end(request.mcpRpcToken)
     }
-    if (sandboxed) {
-      child.once('exit', sandboxed.cleanup)
-      child.once('error', sandboxed.cleanup)
+    try {
+      await new Promise<void>((resolve, reject) => {
+        child.once('spawn', resolve)
+        child.once('error', reject)
+      })
+    } catch (error) {
+      sandboxed?.cleanup()
+      throw error
     }
-    await new Promise<void>((resolve, reject) => {
-      child.once('spawn', resolve)
-      child.once('error', reject)
-    })
     return {
       child,
       beginSandboxExecution: sandboxed?.beginExecution ?? (() => () => undefined),
-      annotateStderr: sandboxed?.annotateStderr ?? ((stderr) => stderr)
+      annotateStderr: sandboxed?.annotateStderr ?? ((stderr) => stderr),
+      cleanupSandbox: sandboxed?.cleanup ?? (() => undefined)
     }
   }
 

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -744,8 +744,10 @@ class NotebookKernelExecutor implements NotebookExecutor {
       if (this.procs.get(key) !== proc) return
       this.rejectPending(proc, new Error('Notebook kernel stdin pipe failed.'))
     })
-    child.on('close', (code, signal) => {
-      // Stale close: this proc was already replaced (dropped after a hard kill, or a respawn) before
+    // Process liveness follows exit, not close: a descendant may inherit stdio and keep those pipes
+    // open after the kernel itself is dead. stderrTail is therefore the bounded data drained so far.
+    child.on('exit', (code, signal) => {
+      // Stale exit: this proc was already replaced (dropped after a hard kill, or a respawn) before
       // the event fired, so it must not touch the live proc or its pending run.
       if (this.procs.get(key) !== proc) return
       proc.alive = false

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -744,8 +744,8 @@ class NotebookKernelExecutor implements NotebookExecutor {
       if (this.procs.get(key) !== proc) return
       this.rejectPending(proc, new Error('Notebook kernel stdin pipe failed.'))
     })
-    child.on('exit', () => {
-      // Stale exit: this proc was already replaced (dropped after a hard kill, or a respawn) before
+    child.on('close', (code, signal) => {
+      // Stale close: this proc was already replaced (dropped after a hard kill, or a respawn) before
       // the event fired, so it must not touch the live proc or its pending run.
       if (this.procs.get(key) !== proc) return
       proc.alive = false
@@ -758,7 +758,14 @@ class NotebookKernelExecutor implements NotebookExecutor {
           ? new NotebookExecutionTimeoutError(
               `Notebook execution timed out after ${pending.timeoutMs}ms.`
             )
-          : new Error('Notebook kernel process exited.')
+          : (() => {
+              const reason =
+                code !== null ? ` with exit code ${code}` : signal ? ` after signal ${signal}` : ''
+              const stderr = proc.annotateStderr(proc.stderrTail).trim()
+              return new Error(
+                `Notebook kernel process exited${reason}.` + (stderr ? `\n${stderr}` : '')
+              )
+            })()
       proc.terminationError = terminationError
       this.rejectPending(proc, terminationError)
       // Unexpected exit of a still-live proc is a crash; surface it as a 'terminated' kernel status.

--- a/src/main/notebook/network-sandbox-owner.test.ts
+++ b/src/main/notebook/network-sandbox-owner.test.ts
@@ -117,6 +117,43 @@ describe('NotebookNetworkSandboxOwner', () => {
     ).toBe("& 'C:\\Program Files\\Python\\python.exe' 'O''Brien' '$(Write-Error injected)'")
   })
 
+  it('preserves the executable and arguments for a Windows sandbox launch', async () => {
+    const owner = new NotebookNetworkSandboxOwner({
+      resourceRoot: '/resources',
+      getSettings: async () => DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+      persistAlwaysAllow: vi.fn(),
+      requestDecision: vi.fn(),
+      platform: 'win32'
+    })
+
+    const wrapped = await owner.wrap({
+      executable: 'D:\\runtime\\python.exe',
+      args: ['D:\\app\\python_loop.py'],
+      env: { PATH: 'C:\\Windows\\System32' },
+      cwd: 'D:\\workspace',
+      commandText: 'python_loop.py',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      runtime: 'python',
+      filesystem: {
+        readOnlyRoots: ['D:\\runtime'],
+        readWriteRoots: ['D:\\workspace'],
+        deniedReadRoots: [],
+        deniedWriteRoots: []
+      }
+    })
+
+    expect(backend.wrap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "& 'D:\\runtime\\python.exe' 'D:\\app\\python_loop.py'",
+        executable: 'D:\\runtime\\python.exe',
+        args: ['D:\\app\\python_loop.py']
+      })
+    )
+
+    wrapped.cleanup()
+  })
+
   it('applies allow-once to every matching connection in the next command only', async () => {
     const requestDecision = vi.fn().mockResolvedValue('allowOnce')
     const persistAlwaysAllow = vi.fn()

--- a/src/main/notebook/network-sandbox-owner.ts
+++ b/src/main/notebook/network-sandbox-owner.ts
@@ -196,6 +196,9 @@ class NotebookNetworkSandboxOwner implements NotebookProcessSandbox {
     try {
       wrapped = await this.sandbox!.wrap({
         command: commandLine(invocation, this.platform),
+        ...(this.platform === 'win32'
+          ? { executable: invocation.executable, args: invocation.args }
+          : {}),
         cwd: invocation.cwd,
         env,
         ...(invocation.localRpcSocketPath


### PR DESCRIPTION
## Problem

On packaged Windows installs with the protected Notebook network sandbox ready, persistent kernels were launched through `powershell.exe -Command`. When the Notebook working directory was on a non-system drive such as `D:`, PowerShell could fail to initialize its FileSystem provider inside the AppContainer before Python started. The UI then reported only `Notebook kernel process exited.`, hiding the exit reason and stderr.

The production runtime differential was:

- managed Python launched directly in the AppContainer: NumPy and Matplotlib succeed;
- the same interpreter launched through the existing PowerShell wrapper: exits before Python starts with a missing FileSystem drive/provider error.

## Proposed change

- Carry an optional structured `executable` and `args` through the Notebook sandbox adapter.
- Use that exact argv for native executables in protected Windows AppContainer launches, avoiding the PowerShell bootstrap.
- Route `.cmd`/`.bat` interpreter shims through `cmd.exe` with pre-escaped, verbatim arguments; the native host preserves that prepared command line.
- Keep the existing command string for policy and diagnostic purposes.
- Include the exit code/signal plus the existing bounded, annotated stderr tail when a persistent kernel exits unexpectedly.
- Keep process liveness tied to the kernel's `exit` event, so a descendant that inherits stdio cannot leave a dead kernel registered while holding its pipes open.
- Annotate crash stderr before releasing the sandbox context that owns filesystem classifications and recorded violations.

## Scope and non-goals

- Direct or batch-shim argv behavior is limited to protected Windows AppContainer launches. Standard Windows execution and POSIX launch behavior are unchanged.
- No database schema, persisted-format, historical-data compatibility, state-enum, or renderer interaction changes.
- Existing execution-result persistence may store the richer error string through its current field; no new persistence path or field is introduced.
- `verbatimArguments` is an optional, default-false field in the internal transient host launch specification; it is neither persisted nor part of the user-facing data model.
- This does not attempt to repair syntactically escaped Python input such as `2 \\* np.pi`; such code remains an ordinary cell error and should not terminate the kernel.

## Acceptance criteria and validation

The original three report-focused regression tests were added before the launch fix and failed consistently for the reported reasons: the Windows launch spec selected PowerShell, the owner dropped structured argv, and an early kernel exit lost its exit code/stderr. They pass after the fix.

The first AI review identified that waiting for `close` could hang if a kernel descendant inherited stdio. A public executor-boundary regression was added and failed before the lifecycle correction: the execution remained unsettled after the direct kernel exited. It passes after restoring `exit` as the liveness boundary.

The next AI review identified two more regressions. Before fixing them, focused tests confirmed both failures: a batch interpreter remained the direct `CreateProcessW` target, and sandbox cleanup ran before crash stderr annotation. The fixes route batch shims through safely escaped `cmd.exe` argv and keep the sandbox context alive until annotation is complete. A Windows-only end-to-end test also executes a generated `.cmd` interpreter shim with a metacharacter-bearing argument.

Final evidence mapping (all listed checks ran after the last material edit):

- native argv, `.cmd`/`.bat` shims, early-exit diagnostics, annotation ordering, and inherited-stdio lifecycle -> focused Vitest set -> 7 passed, 110 skipped
- Notebook network sandbox owner/contract/consumer coverage -> `npx vitest run packages/notebook-network-sandbox/src` -> 76 passed, 13 skipped
- native host command-line construction -> `cargo test windows_command_line` -> 2 passed
- main-process and sandbox TypeScript contracts -> `npm run typecheck:node` -> passed
- lint and formatting -> `npm run lint`, `cargo fmt --check`, and `git diff --check` -> passed
- production-equivalent Windows AppContainer repro -> managed NumPy probe and the reported Matplotlib program both completed; the latter printed `saved sin_plot.png` and returned a figure

The full native-host test binary compiled and ran locally: 8 of 9 tests passed. Its unrelated ACL inheritance test could not modify the current user's temporary-directory ACL (`Access is denied`); both command-line tests pass independently.

The complete `kernel-executor.test.ts` file was also attempted locally earlier. 46 tests across the two requested files passed and 32 were skipped; 31 kernel tests could not enter their test bodies because Windows denied the existing symlink-based Python fixture with `EPERM`. The focused regressions use the installed managed interpreter and passed. The affected-test planner conservatively selected the full suite because `kernel-executor.test.ts` has no declared module owner; per the requested local-test scope, the complete `npm test` suite was left to PR CI.

The exact-head PR Gate passed Windows core, Windows E2E, Static, Linux isolation, macOS, and portable shards 1/2. Portable shard 3 failed in unrelated `runtime-service.test.ts` shell/session shutdown tests: asynchronous repository writes continued after their temporary Session directories were removed, producing `ENOENT` plus two shell-run assertion failures; Module coverage failed only because it merges the shard result. These tests do not exercise the changed kernel/AppContainer files. The prior scheduler-route count failure disappeared after `main` advanced. The latest AI review also raised a generic orphan-process risk that already exists on the branch base; the protected Windows path here is supervised by the native host Job Object. A local heartbeat reproduction showed that the suggested post-exit `killChildTracked` call cannot rediscover a descendant after the parent PID is gone, so a real generic fix requires a separate cross-platform process-ownership design rather than an ineffective change in this PR.

## Review focus

- Confirm native executables avoid PowerShell only in protected Windows mode.
- Confirm `.cmd`/`.bat` shims preserve their effective argv through `cmd.exe`, including metacharacters.
- Confirm kernel liveness settles on direct-process `exit` and crash diagnostics are annotated before sandbox cleanup without waiting for descendant-held pipes.
- Exact-head PR Gate and its Windows lane remain authoritative for the uncovered platform/test-fixture risk.

