### PR TITLE
fix(workspace): restore generated image previews

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -10,6 +10,10 @@ import type { ChatMessage } from '@/stores/session-store'
 
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
 
+const { artifactPreview } = vi.hoisted(() => ({
+  artifactPreview: vi.fn(() => null)
+}))
+
 // Keep the transcript row and markdown surface as thin wrappers so the test never loads Shiki.
 vi.mock('@/components/ui/message-scroller', () => ({
   MessageScrollerItem: ({ children }: PropsWithChildren): JSX.Element => <div>{children}</div>
@@ -21,7 +25,7 @@ vi.mock('@/components/streamdown/AgentMarkdown', () => ({
 }))
 
 vi.mock('./artifact-preview', () => ({
-  ArtifactPreview: () => null
+  ArtifactPreview: artifactPreview
 }))
 
 let container: HTMLDivElement
@@ -41,6 +45,7 @@ const createMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
 const noop = (): void => {}
 
 beforeEach(() => {
+  artifactPreview.mockClear()
   useSettingsStore.setState(createInitialSettingsState())
   container = document.createElement('div')
   document.body.appendChild(container)
@@ -330,6 +335,82 @@ describe('WorkspaceMessageItem file names', () => {
     expectSplitFileName(button, 'lon', 't', '.csv')
     expect(button?.querySelector('div[class*="px-1.5"]')).not.toBeNull()
     expect(button?.querySelector('span.text-text-000')?.className).toContain('ml-1')
+  })
+
+  it('reads the exact generated Artifact Version shown by the card', async () => {
+    const readPreview = vi.fn().mockResolvedValue({
+      content: '',
+      encoding: 'utf8',
+      size: 10,
+      truncated: false
+    })
+    ;(window as unknown as { api: unknown }).api = { artifacts: { readPreview } }
+
+    await renderMessageItem(createMessage({ id: 'm-assistant', role: 'agent', content: 'Done' }), [
+      {
+        id: 'version-1',
+        artifactId: 'artifact-1',
+        versionId: 'version-1',
+        kind: 'managed-file',
+        path: '/p/chart.png',
+        name: 'chart.png',
+        mimeType: 'image/png',
+        size: 10,
+        mtimeMs: 1,
+        resolvedProjectId: 'project-1',
+        resolvedSessionId: 'session-1'
+      }
+    ])
+
+    expect(readPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        fileId: 'artifact-1',
+        versionId: 'version-1'
+      })
+    )
+  })
+
+  it('forwards generated Artifact identity to the image preview', async () => {
+    ;(window as unknown as { api: unknown }).api = {
+      artifacts: {
+        readPreview: vi.fn().mockResolvedValue({
+          content: '',
+          encoding: 'utf8',
+          size: 10,
+          truncated: false
+        })
+      }
+    }
+    const artifact = {
+      id: 'version-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1',
+      kind: 'managed-file' as const,
+      path: '/p/chart.png',
+      name: 'chart.png',
+      mimeType: 'image/png',
+      size: 10,
+      mtimeMs: 1,
+      resolvedProjectId: 'project-1',
+      resolvedSessionId: 'session-1'
+    }
+
+    await renderMessageItem(createMessage({ id: 'm-assistant', role: 'agent', content: 'Done' }), [
+      artifact
+    ])
+
+    expect(artifactPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artifact,
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        managedFileId: 'artifact-1',
+        selectedVersionId: 'version-1'
+      }),
+      undefined
+    )
   })
 })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -880,6 +880,7 @@ const VisibleArtifactPreview = ({
         projectId: artifact.resolvedProjectId,
         ...(artifact.resolvedSessionId ? { sessionId: artifact.resolvedSessionId } : {}),
         fileId: artifact.artifactId,
+        ...(artifact.versionId ? { versionId: artifact.versionId } : {}),
         maxBytes: ARTIFACT_PREVIEW_BYTES,
         encoding: 'utf8'
       })
@@ -900,7 +901,17 @@ const VisibleArtifactPreview = ({
   }, [artifact, requestKey])
 
   const preview = previewState?.requestKey === requestKey ? previewState.preview : undefined
-  return <ArtifactPreview artifact={artifact} preview={preview} isVisible />
+  return (
+    <ArtifactPreview
+      artifact={artifact}
+      preview={preview}
+      projectId={artifact.resolvedProjectId}
+      sessionId={artifact.resolvedSessionId}
+      managedFileId={artifact.artifactId}
+      selectedVersionId={artifact.versionId}
+      isVisible
+    />
+  )
 }
 
 // Thumbnail button for one generated file; clicking it previews the file instead of opening it.
@@ -933,6 +944,7 @@ const ArtifactCard = ({
     projectId: artifact.resolvedProjectId,
     sessionId: artifact.resolvedSessionId,
     managedFileId: artifact.artifactId,
+    selectedVersionId: artifact.versionId,
     path: artifact.path,
     source: 'artifact',
     size: artifact.size,
@@ -957,7 +969,14 @@ const ArtifactCard = ({
           {publicationPending ? null : isNearViewport ? (
             <VisibleArtifactPreview artifact={artifact} requestKey={requestKey} />
           ) : (
-            <ArtifactPreview artifact={artifact} isVisible={false} />
+            <ArtifactPreview
+              artifact={artifact}
+              projectId={artifact.resolvedProjectId}
+              sessionId={artifact.resolvedSessionId}
+              managedFileId={artifact.artifactId}
+              selectedVersionId={artifact.versionId}
+              isVisible={false}
+            />
           )}
         </span>
         {missing ? (

--- a/src/renderer/src/pages/workspace/artifact-preview.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.interaction.test.tsx
@@ -91,4 +91,32 @@ describe('ArtifactPreview image lifecycle', () => {
 
     expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(1)
   })
+
+  it('recovers when the first image read races Artifact publication', async () => {
+    vi.mocked(window.api.previewResources.acquire)
+      .mockRejectedValueOnce(new Error('Managed file has no published version.'))
+      .mockResolvedValueOnce({
+        id: 'resource-chart-after-publication',
+        url: 'open-science-preview://resource/resource-chart-after-publication',
+        size: 2048,
+        mimeType: 'image/png',
+        version: 1
+      })
+    root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <ArtifactPreview
+          artifact={imageArtifact}
+          projectId="project-1"
+          sessionId="session-1"
+          managedFileId="artifact-chart"
+          selectedVersionId="version-chart"
+        />
+      )
+    })
+
+    await waitFor(() => expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull())
+  })
 })

--- a/src/renderer/src/pages/workspace/previews/useCachedPreviewImage.ts
+++ b/src/renderer/src/pages/workspace/previews/useCachedPreviewImage.ts
@@ -3,10 +3,13 @@ import { useEffect, useState } from 'react'
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 
 import { createManagedPreviewRequest } from './preview-file-reader'
+import { isManagedFilePublicationPendingError } from './preview-errors'
 import { createPreviewResourceKey } from './preview-resource-key'
 
 const MAX_CACHED_IMAGE_BYTES = 64 * 1024 * 1024
 const MAX_CACHED_IMAGE_COUNT = 32
+const PUBLICATION_RETRY_DELAY_MS = 200
+const PUBLICATION_RETRY_LIMIT = 4
 
 type CachedImage = { url: string; size: number; managedResourceId?: string }
 type CachedImageEntry = {
@@ -57,8 +60,21 @@ const prune = (): void => {
   }
 }
 
+const acquirePreviewResource = async (
+  item: PreviewImageItem,
+  retriesRemaining = PUBLICATION_RETRY_LIMIT
+): ReturnType<Window['api']['previewResources']['acquire']> => {
+  try {
+    return await window.api.previewResources.acquire(createManagedPreviewRequest(item))
+  } catch (error) {
+    if (retriesRemaining === 0 || !isManagedFilePublicationPendingError(error)) throw error
+    await new Promise<void>((resolve) => setTimeout(resolve, PUBLICATION_RETRY_DELAY_MS))
+    return acquirePreviewResource(item, retriesRemaining - 1)
+  }
+}
+
 const loadImage = async (item: PreviewImageItem): Promise<CachedImage> => {
-  const resource = await window.api.previewResources.acquire(createManagedPreviewRequest(item))
+  const resource = await acquirePreviewResource(item)
 
   const imageSize = Math.max(item.size ?? 0, resource.size)
   if (imageSize > MAX_CACHED_IMAGE_BYTES) {


### PR DESCRIPTION
## Problem

Generated image cards can remain on the generic file placeholder even though the PNG exists and is valid. The transcript card drops the managed Artifact identity before thumbnail acquisition, and the first acquisition can also race initial Artifact publication.

Production evidence showed the availability read at 22:24:18.001 and managed visibility at 22:24:18.226, a 225 ms publication window. The generated PNG and notebook copy had identical hashes.

## Proposed change

- Forward the existing project, Session, Artifact, and Artifact Version identity through generated-card preview reads and thumbnail rendering.
- Retry only the exact transient Managed file has no published version error, every 200 ms with a limit of four retries.
- Add regression coverage for exact-version propagation and recovery from the publication race.

## Scope and non-goals

- No schema, persisted-data, migration, new-state, or enum changes.
- No new fields or user interaction.
- Legacy records without a version ID retain the existing fallback behavior.
- No general polling or retry framework; permanent and unrelated errors still fail immediately.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Generated card reads the exact Artifact Version -> npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx src/renderer/src/pages/workspace/artifact-preview.interaction.test.tsx -> 26 passed.
- Generated image recovers from the initial publication race -> expanded workspace preview impact set -> 9 files, 83 passed.
- Renderer type safety -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -- --no-cache -> passed.
- Formatting and whitespace -> Prettier check plus git diff --check -> passed.

Before the production change, the regression tests were run twice and failed identically: 3 failed, 23 passed. The failures showed the missing version ID, missing thumbnail identity, and the absence of a retry after the publication-pending error.

The affected-test classifier selects full mode because the new focused test path is not declared in module-impact ownership. Per task scope, the complete local npm test suite was not run; PR Gate is authoritative for the exact head and remaining portable/platform coverage.

## Review focus

- Confirm the generated transcript card preserves the existing managed-file identity through both probes and image rendering.
- Confirm retries remain limited to the known publication-pending error and do not mask permanent failures.