### PR TITLE
fix(ipc): clean up renderer lifecycle listeners

### DIFF
--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -103,7 +103,11 @@ describe('createIpcHandlerRegistry', () => {
     }
 
     expect(sender.listenerCount('render-process-gone')).toBe(0)
-    expect(sender.listenerCount('destroyed')).toBe(0)
+    expect(sender.listenerCount('destroyed')).toBeLessThanOrEqual(1)
+    sender.emit('destroyed')
+    expect(() => nativeHandlers.get('projects:list')?.({ sender })).toThrow(
+      'Caller lease is no longer current.'
+    )
   })
 
   it('renews a crashed WebContents lease but keeps destroyed terminal', () => {

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'node:events'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ApplicationCallerLease } from './application-command-router'
@@ -84,6 +86,24 @@ describe('createIpcHandlerRegistry', () => {
 
     staleNavigationListener?.({ isMainFrame: true, isSameDocument: false })
     expect(replacement.signal.aborted).toBe(false)
+  })
+
+  it('does not retain renderer lifecycle listeners across main-frame navigations', () => {
+    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
+    const registry = createIpcHandlerRegistry({
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+        nativeHandlers.set(channel, handler)
+    } as never)
+    const sender = Object.assign(new EventEmitter(), { id: 42 })
+    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
+
+    for (let navigation = 0; navigation < 11; navigation += 1) {
+      nativeHandlers.get('projects:list')?.({ sender })
+      sender.emit('did-start-navigation', { isMainFrame: true, isSameDocument: false })
+    }
+
+    expect(sender.listenerCount('render-process-gone')).toBe(0)
+    expect(sender.listenerCount('destroyed')).toBe(0)
   })
 
   it('renews a crashed WebContents lease but keeps destroyed terminal', () => {

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -71,6 +71,7 @@ const createIpcHandlerRegistry = (
   const registeredChannels = new Set<string>()
   let activeCallerLeaseEpoch = createCallerLeaseEpoch()
   const destroyedNativeCallers = new WeakSet<object>()
+  const destructionBoundNativeCallers = new WeakSet<object>()
 
   const callerLeaseEpochForRegistration = (): CallerLeaseEpoch => {
     if (activeCallerLeaseEpoch.disposed) activeCallerLeaseEpoch = createCallerLeaseEpoch()
@@ -95,6 +96,15 @@ const createIpcHandlerRegistry = (
       once?: (name: string, listener: () => void) => unknown
       removeListener?: (name: string, listener: (...args: never[]) => void) => unknown
     }
+    if (!destructionBoundNativeCallers.has(sender) && lifecycleSender.once) {
+      destructionBoundNativeCallers.add(sender)
+      lifecycleSender.once('destroyed', () => {
+        destroyedNativeCallers.add(sender)
+        const currentLease = activeCallerLeaseEpoch.nativeCallers.get(sender)
+        activeCallerLeaseEpoch.nativeCallers.delete(sender)
+        currentLease?.release()
+      })
+    }
     const releaseCurrentLease = (): void => {
       if (epoch.nativeCallers.get(sender) !== ownedLease) return
       epoch.nativeCallers.delete(sender)
@@ -107,17 +117,11 @@ const createIpcHandlerRegistry = (
       if (!details.isMainFrame || details.isSameDocument) return
       releaseCurrentLease()
     }
-    const releaseOnDestroyed = (): void => {
-      destroyedNativeCallers.add(sender)
-      releaseCurrentLease()
-    }
     const removeLifecycleBindings = (): void => {
       lifecycleSender.removeListener?.('did-start-navigation', releaseOnMainFrameNavigation)
-      lifecycleSender.removeListener?.('destroyed', releaseOnDestroyed)
       lifecycleSender.removeListener?.('render-process-gone', releaseCurrentLease)
     }
     lifecycleSender.on?.('did-start-navigation', releaseOnMainFrameNavigation)
-    lifecycleSender.once?.('destroyed', releaseOnDestroyed)
     lifecycleSender.once?.('render-process-gone', releaseCurrentLease)
     ownedLease.lease.signal.addEventListener('abort', removeLifecycleBindings, { once: true })
     if (ownedLease.lease.signal.aborted) removeLifecycleBindings()

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -107,17 +107,20 @@ const createIpcHandlerRegistry = (
       if (!details.isMainFrame || details.isSameDocument) return
       releaseCurrentLease()
     }
-    const removeNavigationBinding = (): void => {
-      lifecycleSender.removeListener?.('did-start-navigation', releaseOnMainFrameNavigation)
-    }
-    lifecycleSender.on?.('did-start-navigation', releaseOnMainFrameNavigation)
-    ownedLease.lease.signal.addEventListener('abort', removeNavigationBinding, { once: true })
-    lifecycleSender.once?.('destroyed', () => {
+    const releaseOnDestroyed = (): void => {
       destroyedNativeCallers.add(sender)
       releaseCurrentLease()
-    })
+    }
+    const removeLifecycleBindings = (): void => {
+      lifecycleSender.removeListener?.('did-start-navigation', releaseOnMainFrameNavigation)
+      lifecycleSender.removeListener?.('destroyed', releaseOnDestroyed)
+      lifecycleSender.removeListener?.('render-process-gone', releaseCurrentLease)
+    }
+    lifecycleSender.on?.('did-start-navigation', releaseOnMainFrameNavigation)
+    lifecycleSender.once?.('destroyed', releaseOnDestroyed)
     lifecycleSender.once?.('render-process-gone', releaseCurrentLease)
-    if (ownedLease.lease.signal.aborted) removeNavigationBinding()
+    ownedLease.lease.signal.addEventListener('abort', removeLifecycleBindings, { once: true })
+    if (ownedLease.lease.signal.aborted) removeLifecycleBindings()
     return ownedLease
   }
 


### PR DESCRIPTION
## Problem

Repeated main-frame navigations release the Electron caller lease but leave that document's `render-process-gone` and `destroyed` listeners attached to the same `WebContents`. After 11 navigation/invocation cycles, Node emits `MaxListenersExceededWarning`, matching the reported symptom.

## Proposed change

Keep one terminal `destroyed` listener per `WebContents` across renderer documents, and remove the per-document `did-start-navigation` and `render-process-gone` bindings whenever that document's caller lease aborts. Keep lease invalidation and late-invocation rejection unchanged. Add a regression test that drives the public IPC handler boundary with a real `EventEmitter` sender through 11 main-frame navigations, verifies the per-document listeners do not accumulate, then destroys the sender and verifies a late IPC call is rejected.

## Scope and non-goals

- No IPC contract, data model, schema, persisted format, enum, or user interaction changes.
- No historical-data compatibility work is required.
- Adds one process-local `WeakSet` solely to deduplicate the terminal listener; it is neither persisted nor exposed.
- Do not raise `setMaxListeners()`; stale listeners are removed at their owner boundary.

## Acceptance criteria and validation

The completed local checks below ran after the last material edit.

- Reproduction on unfixed code: `npm test -- src/main/ipc-handler-registry.test.ts -t 'does not retain renderer lifecycle listeners across main-frame navigations'` -> failed consistently 3/3 times with 11 retained `render-process-gone` listeners and the matching warning.
- Review regression on the first fix: the same test rejected the first cleanup-only fix because destruction after navigation no longer made the sender terminal.
- Final regression and owner behavior: `npm test -- src/main/ipc-handler-registry.test.ts` -> 10 passed.
- Lint: `npm run lint` -> passed.
- Impact explanation: `npm run test:affected:explain -- --base origin/main --head HEAD` -> fail-closed full Vitest plan because the shared IPC registry test has no module owner; complete portable coverage is delegated to PR Gate as requested.
- Final Node typecheck: delegated to PR Gate Static checks because the post-review local rerun stalled without a diagnostic; no local pass is claimed for the final head.

Included locally: the changed IPC registry owner and lifecycle behavior. Excluded locally: renderer/Web surfaces, platform lanes, and the full portable suite because no contract, UI, platform-specific, or persisted behavior changed; required PR CI remains authoritative.

## Review focus

Confirm that the one WebContents-scoped terminal listener survives document lease aborts, while per-document navigation and renderer-exit listeners are cleaned up without weakening caller-lease invalidation.