### PR TITLE
test(session-persistence): count the concurrency-limit scheduler route

### DIFF
--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -731,7 +731,7 @@ describe('Session persistence coordinator architecture', () => {
       expect(methods(owner, 'private')).not.toContain('enqueue')
     }
 
-    expect(expectedSchedulerRoute.size).toBe(35)
+    expect(expectedSchedulerRoute.size).toBe(36)
     const constructorSource = facade.members.filter(isConstructorDeclaration)[0].getText(facadeFile)
     expect(constructorSource).toContain('this.operationScheduler.runSession(')
     expect(constructorSource).toContain('this.operationScheduler.runGlobal(work)')


### PR DESCRIPTION
## Problem

PR Gate for [#2070](https://github.com/aipoch/open-science/pull/2070) failed `src/main/session-persistence/coordinator.architecture.test.ts` with `expected 36 to be 35`.

[#2077](https://github.com/aipoch/open-science/pull/2077) added `setSessionComputeConcurrencyLimit` to the coordinator scheduler-route inventory and did not update the size lock. Later PRs, including #2070, inherited the failing assertion.

## Proposed change

Update the architecture inventory size lock from 35 to 36 so it matches the current scheduler routes, including the concurrency-limit operation.

## Scope and non-goals

- Test-only. No production, schema, or scheduler behavior changes.
- Does not change #2070 or #2077.

## Acceptance criteria and validation

- `npx vitest run src/main/session-persistence/coordinator.architecture.test.ts` → 8 passed.