### PR TITLE
test(workspace): expect generated text preview version identity

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3603,6 +3603,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       projectId: 'default',
       sessionId: 'session-1',
       fileId: 'managed-artifact-1',
+      versionId: 'artifact-version-1',
       maxBytes: 1,
       encoding: 'base64'
     })
@@ -3611,6 +3612,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       projectId: 'default',
       sessionId: 'session-1',
       fileId: 'managed-artifact-1',
+      versionId: 'artifact-version-1',
       maxBytes: 32 * 1024,
       encoding: 'utf8'
     })


### PR DESCRIPTION
## Problem

PR Gate for [#2082](https://github.com/aipoch/open-science/pull/2082) failed `WorkspaceMessageScroller.interaction.test.tsx` after merge.

The generated text thumbnail now reads the exact Artifact Version (`versionId`) on both the one-byte availability probe and the bounded utf8 preview. The scroller viewport test still expected the pre-#2082 request shape without `versionId`.

## Proposed change

Expect `versionId: 'artifact-version-1'` on both generated-card `artifacts.readPreview` calls in the viewport-gated text thumbnail test.

## Scope and non-goals

- Test-only. No production preview-read changes.
- Does not change #2082.

## Acceptance criteria and validation

- `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx` → 55 passed.