### PR TITLE
fix(acp): recover finalized Claude model call usage

### DIFF
--- a/src/main/acp/backend-generation-owner.test.ts
+++ b/src/main/acp/backend-generation-owner.test.ts
@@ -4,6 +4,26 @@ import { claudeCodeFramework, codexFramework } from '../agent-framework'
 import { AcpBackendGenerationOwner } from './backend-generation-owner'
 
 describe('AcpBackendGenerationOwner', () => {
+  it('publishes the Claude transcript root without provider credentials', () => {
+    const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
+    const attempt = owner.prepare(
+      { epoch: 1, assertCurrent: vi.fn() },
+      {
+        framework: claudeCodeFramework,
+        executablePath: '/bin/claude',
+        env: {
+          CLAUDE_CONFIG_DIR: '/profiles/app-claude',
+          ANTHROPIC_AUTH_TOKEN: 'provider-secret'
+        }
+      }
+    )
+
+    const view = attempt.publish()
+
+    expect(view.adapter.claudeConfigDir).toBe('/profiles/app-claude')
+    expect(JSON.stringify(view)).not.toContain('provider-secret')
+  })
+
   it('publishes one immutable secret-free behavior view atomically', () => {
     const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
     const sessionOptions = { settingSources: ['user'] }

--- a/src/main/acp/backend-generation-owner.ts
+++ b/src/main/acp/backend-generation-owner.ts
@@ -33,6 +33,7 @@ export type AcpBackendGenerationView = Readonly<{
     supportsImageInput: boolean
   }>
   adapter: Readonly<{
+    claudeConfigDir?: string
     codexHome?: string
     nativeMcpEnabled: boolean
     bridgeMcpAliasesEnabled: boolean
@@ -68,6 +69,10 @@ const deepFreeze = <T>(value: T): T => {
 }
 
 const generationView = (backend: ResolvedAgentBackend): AcpBackendGenerationView => {
+  const claudeConfigDir =
+    backend.framework.id === 'claude-code' && backend.env.CLAUDE_CONFIG_DIR?.trim()
+      ? backend.env.CLAUDE_CONFIG_DIR
+      : undefined
   const codexHome =
     backend.framework.id === 'codex' && typeof backend.env.CODEX_HOME === 'string'
       ? backend.env.CODEX_HOME
@@ -103,6 +108,7 @@ const generationView = (backend: ResolvedAgentBackend): AcpBackendGenerationView
       supportsImageInput: backend.supportsImageInput === true
     }),
     adapter: Object.freeze({
+      ...(claudeConfigDir ? { claudeConfigDir } : {}),
       ...(codexHome ? { codexHome } : {}),
       nativeMcpEnabled: backend.framework.id !== 'codex' || !bridgeMcpAliasesEnabled,
       bridgeMcpAliasesEnabled

--- a/src/main/acp/claude-transcript-reader.test.ts
+++ b/src/main/acp/claude-transcript-reader.test.ts
@@ -1,0 +1,101 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  getSessionMessages,
+  type SessionKey,
+  type SessionStore
+} from '@anthropic-ai/claude-agent-sdk'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createClaudeTranscriptReader } from './claude-transcript-reader'
+
+const sessionId = '11111111-1111-4111-8111-111111111111'
+
+describe('Claude transcript reader', () => {
+  let root: string | undefined
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true })
+    root = undefined
+  })
+
+  it('reads the provider Session through the SDK transcript boundary', async () => {
+    root = await mkdtemp(join(tmpdir(), 'open-science-claude-transcript-'))
+    const configDir = join(root, 'claude')
+    const cwd = join(root, 'workspace')
+    let resolvedKey: SessionKey | undefined
+    const captureStore: SessionStore = {
+      append: async () => undefined,
+      load: async (key) => {
+        resolvedKey = key
+        return null
+      }
+    }
+    await getSessionMessages(sessionId, { dir: cwd, sessionStore: captureStore })
+    if (!resolvedKey) throw new Error('Claude SDK did not resolve a Session key.')
+
+    const projectDir = join(configDir, 'projects', resolvedKey.projectKey)
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(
+      join(projectDir, `${sessionId}.jsonl`),
+      [
+        {
+          type: 'user',
+          uuid: 'user-1',
+          parentUuid: null,
+          sessionId,
+          message: { role: 'user', content: 'hello' }
+        },
+        {
+          type: 'assistant',
+          uuid: 'assistant-1',
+          parentUuid: 'user-1',
+          sessionId,
+          parent_tool_use_id: null,
+          message: {
+            role: 'assistant',
+            id: 'minimax-call-1',
+            content: [{ type: 'text', text: 'done' }],
+            usage: {
+              input_tokens: 10,
+              cache_read_input_tokens: 2,
+              cache_creation_input_tokens: 0,
+              output_tokens: 1
+            }
+          }
+        }
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join('\n'),
+      'utf8'
+    )
+
+    const messages = await createClaudeTranscriptReader(configDir)({
+      providerSessionId: sessionId,
+      cwd
+    })
+
+    expect(messages).toHaveLength(2)
+    expect(messages[1]).toMatchObject({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: {
+        id: 'minimax-call-1',
+        usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 1 }
+      }
+    })
+  })
+
+  it('returns no messages when Claude has no transcript for the Session', async () => {
+    root = await mkdtemp(join(tmpdir(), 'open-science-claude-transcript-'))
+
+    await expect(
+      createClaudeTranscriptReader(join(root, 'claude'))({
+        providerSessionId: sessionId,
+        cwd: join(root, 'workspace')
+      })
+    ).resolves.toEqual([])
+  })
+})

--- a/src/main/acp/claude-transcript-reader.ts
+++ b/src/main/acp/claude-transcript-reader.ts
@@ -1,0 +1,75 @@
+import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+
+import type { SessionKey, SessionStore, SessionStoreEntry } from '@anthropic-ai/claude-agent-sdk'
+
+import type { ClaudeTranscriptReader } from './claude-turn-adapter'
+
+const nodeRequire = createRequire(import.meta.url)
+const { getSessionMessages } = nodeRequire(
+  '@anthropic-ai/claude-agent-sdk'
+) as typeof import('@anthropic-ai/claude-agent-sdk')
+
+const isMissingFile = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'ENOENT'
+
+const transcriptPath = (configDir: string, key: SessionKey): string => {
+  if (key.subpath) throw new Error('Claude subagent transcripts are not model-call sources.')
+  const projectsRoot = resolve(configDir, 'projects')
+  const path = resolve(projectsRoot, key.projectKey, `${key.sessionId}.jsonl`)
+  const fromProjectsRoot = relative(projectsRoot, path)
+  if (
+    fromProjectsRoot === '..' ||
+    fromProjectsRoot.startsWith(`..${sep}`) ||
+    isAbsolute(fromProjectsRoot)
+  ) {
+    throw new Error('Claude transcript path escapes its configured project store.')
+  }
+  return path
+}
+
+const parseTranscriptEntries = (text: string): SessionStoreEntry[] =>
+  text
+    .split(/\r?\n/u)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      const value: unknown = JSON.parse(line)
+      if (
+        typeof value !== 'object' ||
+        value === null ||
+        Array.isArray(value) ||
+        typeof (value as { type?: unknown }).type !== 'string'
+      ) {
+        throw new Error('Claude transcript contains a malformed entry.')
+      }
+      return value as SessionStoreEntry
+    })
+
+const createReadOnlyClaudeSessionStore = (configDir: string): SessionStore => ({
+  append: async () => {
+    throw new Error('Claude transcript recovery is read-only.')
+  },
+  load: async (key) => {
+    try {
+      return parseTranscriptEntries(await readFile(transcriptPath(configDir, key), 'utf8'))
+    } catch (error) {
+      if (isMissingFile(error)) return null
+      throw error
+    }
+  }
+})
+
+const createClaudeTranscriptReader = (configDir: string): ClaudeTranscriptReader => {
+  const sessionStore = createReadOnlyClaudeSessionStore(configDir)
+  return ({ providerSessionId, cwd }) =>
+    getSessionMessages(providerSessionId, {
+      dir: cwd,
+      sessionStore
+    })
+}
+
+export { createClaudeTranscriptReader }

--- a/src/main/acp/claude-turn-adapter.test.ts
+++ b/src/main/acp/claude-turn-adapter.test.ts
@@ -233,7 +233,7 @@ describe('Claude Code turn adapter', () => {
     )
   })
 
-  it('recovers finalized calls when live MiniMax-M3 messages contain provisional zero usage', async () => {
+  it('recovers finalized calls after a transient incomplete MiniMax-M3 transcript read', async () => {
     const transcriptMessages = [
       ['minimax-call-1', 32_837, 128, 116],
       ['minimax-call-2', 1_195, 33_024, 66],
@@ -255,7 +255,7 @@ describe('Claude Code turn adapter', () => {
     })
     const readTranscriptMessages = vi
       .fn()
-      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new SyntaxError('Unexpected end of JSON input'))
       .mockResolvedValue(transcriptMessages)
     const adapter = createClaudeCodeTurnAdapter({ readTranscriptMessages })
     const probe = await adapter.begin({

--- a/src/main/acp/claude-turn-adapter.test.ts
+++ b/src/main/acp/claude-turn-adapter.test.ts
@@ -234,27 +234,29 @@ describe('Claude Code turn adapter', () => {
   })
 
   it('recovers finalized calls when live MiniMax-M3 messages contain provisional zero usage', async () => {
-    const readTranscriptMessages = vi.fn(async () =>
-      [
-        ['minimax-call-1', 32_837, 128, 116],
-        ['minimax-call-2', 1_195, 33_024, 66],
-        ['minimax-call-3', 898, 34_176, 23]
-      ].flatMap(([id, inputTokens, cachedReadTokens, outputTokens]) => {
-        const message = {
-          id,
-          usage: {
-            input_tokens: inputTokens,
-            cache_read_input_tokens: cachedReadTokens,
-            cache_creation_input_tokens: 0,
-            output_tokens: outputTokens
-          }
+    const transcriptMessages = [
+      ['minimax-call-1', 32_837, 128, 116],
+      ['minimax-call-2', 1_195, 33_024, 66],
+      ['minimax-call-3', 898, 34_176, 23]
+    ].flatMap(([id, inputTokens, cachedReadTokens, outputTokens]) => {
+      const message = {
+        id,
+        usage: {
+          input_tokens: inputTokens,
+          cache_read_input_tokens: cachedReadTokens,
+          cache_creation_input_tokens: 0,
+          output_tokens: outputTokens
         }
-        return [
-          { type: 'assistant', parent_tool_use_id: null, message },
-          { type: 'assistant', parent_tool_use_id: null, message }
-        ]
-      })
-    )
+      }
+      return [
+        { type: 'assistant', parent_tool_use_id: null, message },
+        { type: 'assistant', parent_tool_use_id: null, message }
+      ]
+    })
+    const readTranscriptMessages = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValue(transcriptMessages)
     const adapter = createClaudeCodeTurnAdapter({ readTranscriptMessages })
     const probe = await adapter.begin({
       providerSessionId: 'provider-session-1',
@@ -328,6 +330,7 @@ describe('Claude Code turn adapter', () => {
       providerSessionId: 'provider-session-1',
       cwd: '/workspace'
     })
+    expect(readTranscriptMessages).toHaveBeenCalledTimes(2)
   })
 
   it('rejects conflicting usage replayed under the same provider call id', async () => {

--- a/src/main/acp/claude-turn-adapter.test.ts
+++ b/src/main/acp/claude-turn-adapter.test.ts
@@ -1,7 +1,7 @@
 import type { PromptResponse } from '@agentclientprotocol/sdk'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { claudeCodeTurnAdapter } from './claude-turn-adapter'
+import { claudeCodeTurnAdapter, createClaudeCodeTurnAdapter } from './claude-turn-adapter'
 
 describe('Claude Code turn adapter', () => {
   it('returns generic ACP usage and the matching terminal SDK model-turn count', async () => {
@@ -110,7 +110,8 @@ describe('Claude Code turn adapter', () => {
   })
 
   it('publishes exact top-level calls only when Claude count and aggregate usage prove coverage', async () => {
-    const probe = await claudeCodeTurnAdapter.begin({
+    const readTranscriptMessages = vi.fn(async () => [])
+    const probe = await createClaudeCodeTurnAdapter({ readTranscriptMessages }).begin({
       providerSessionId: 'provider-session-1',
       cwd: '/workspace'
     })
@@ -180,6 +181,7 @@ describe('Claude Code turn adapter', () => {
         }
       ]
     })
+    expect(readTranscriptMessages).not.toHaveBeenCalled()
   })
 
   it('publishes exact calls from repeated provider messages that omit the parent tool id', async () => {
@@ -229,6 +231,103 @@ describe('Claude Code turn adapter', () => {
     expect(result.modelCalls?.map((call) => call.sourceInvocationId)).toEqual(
       Array.from({ length: 7 }, (_, index) => `provider-call-${index + 1}`)
     )
+  })
+
+  it('recovers finalized calls when live MiniMax-M3 messages contain provisional zero usage', async () => {
+    const readTranscriptMessages = vi.fn(async () =>
+      [
+        ['minimax-call-1', 32_837, 128, 116],
+        ['minimax-call-2', 1_195, 33_024, 66],
+        ['minimax-call-3', 898, 34_176, 23]
+      ].flatMap(([id, inputTokens, cachedReadTokens, outputTokens]) => {
+        const message = {
+          id,
+          usage: {
+            input_tokens: inputTokens,
+            cache_read_input_tokens: cachedReadTokens,
+            cache_creation_input_tokens: 0,
+            output_tokens: outputTokens
+          }
+        }
+        return [
+          { type: 'assistant', parent_tool_use_id: null, message },
+          { type: 'assistant', parent_tool_use_id: null, message }
+        ]
+      })
+    )
+    const adapter = createClaudeCodeTurnAdapter({ readTranscriptMessages })
+    const probe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+
+    for (const id of ['minimax-call-1', 'minimax-call-2', 'minimax-call-3']) {
+      const observation = {
+        sessionId: 'provider-session-1',
+        message: {
+          type: 'assistant',
+          parent_tool_use_id: null,
+          message: {
+            id,
+            usage: {
+              input_tokens: 0,
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+              output_tokens: 0
+            }
+          }
+        }
+      }
+      probe.observe?.(observation)
+      probe.observe?.(observation)
+    }
+    probe.observe?.({
+      sessionId: 'provider-session-1',
+      message: { type: 'result', num_turns: 3, origin: { kind: 'human' } }
+    })
+
+    const result = await probe.finalize({
+      response: {
+        stopReason: 'end_turn',
+        usage: {
+          inputTokens: 34_930,
+          cachedReadTokens: 67_328,
+          cachedWriteTokens: 0,
+          outputTokens: 205
+        }
+      } as PromptResponse
+    })
+
+    expect(result.modelCalls).toEqual([
+      {
+        sourceInvocationId: 'minimax-call-1',
+        inputTokens: 32_837,
+        cacheTokens: 128,
+        cachedReadTokens: 128,
+        cachedWriteTokens: 0,
+        outputTokens: 116
+      },
+      {
+        sourceInvocationId: 'minimax-call-2',
+        inputTokens: 1_195,
+        cacheTokens: 33_024,
+        cachedReadTokens: 33_024,
+        cachedWriteTokens: 0,
+        outputTokens: 66
+      },
+      {
+        sourceInvocationId: 'minimax-call-3',
+        inputTokens: 898,
+        cacheTokens: 34_176,
+        cachedReadTokens: 34_176,
+        cachedWriteTokens: 0,
+        outputTokens: 23
+      }
+    ])
+    expect(readTranscriptMessages).toHaveBeenCalledWith({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
   })
 
   it('rejects conflicting usage replayed under the same provider call id', async () => {

--- a/src/main/acp/claude-turn-adapter.ts
+++ b/src/main/acp/claude-turn-adapter.ts
@@ -105,6 +105,14 @@ type ClaudeCodeTurnAdapterOptions = Readonly<{
   readTranscriptMessages?: ClaudeTranscriptReader
 }>
 
+// Persistent Claude SDK queries can expose their result roughly 100 ms before the matching
+// Assistant transcript rows are readable. Keep retries bounded and only pay this delay after the
+// live usage has already failed exact coverage.
+const CLAUDE_TRANSCRIPT_RECOVERY_DELAYS_MS = [0, 50, 100, 200] as const
+
+const waitForClaudeTranscript = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds))
+
 const recoverClaudeModelCalls = async (
   readTranscriptMessages: ClaudeTranscriptReader | undefined,
   input: Readonly<{
@@ -115,43 +123,52 @@ const recoverClaudeModelCalls = async (
     turnUsage: AcpTurnTokenUsage | undefined
   }>
 ): Promise<readonly AcpProviderModelCallUsage[] | undefined> => {
-  if (!readTranscriptMessages || input.observedCalls.length !== input.modelTurnCount) {
+  if (
+    !readTranscriptMessages ||
+    !input.turnUsage ||
+    input.modelTurnCount <= 0 ||
+    input.observedCalls.length !== input.modelTurnCount
+  ) {
     return undefined
   }
   const invocationIds = input.observedCalls.map((call) => call.sourceInvocationId)
   if (invocationIds.some((id) => !id)) return undefined
 
-  let messages: readonly unknown[]
-  try {
-    messages = await readTranscriptMessages({
-      providerSessionId: input.providerSessionId,
-      cwd: input.cwd
-    })
-  } catch {
-    return undefined
-  }
-
   const expectedIds = new Set(invocationIds as string[])
-  const recoveredById = new Map<string, AcpProviderModelCallUsage>()
-  for (const value of messages) {
-    if (typeof value !== 'object' || value === null || Array.isArray(value)) continue
-    const message = value as Record<string, unknown>
-    if (message.type !== 'assistant') continue
-    const call = toClaudeModelStepUsage(message)
-    const id = call?.sourceInvocationId
-    if (!call || !id || !expectedIds.has(id)) continue
-    const previous = recoveredById.get(id)
-    if (previous && !sameClaudeModelCallUsage(previous, call)) return undefined
-    recoveredById.set(id, call)
-  }
+  for (const delayMs of CLAUDE_TRANSCRIPT_RECOVERY_DELAYS_MS) {
+    if (delayMs > 0) await waitForClaudeTranscript(delayMs)
+    let messages: readonly unknown[]
+    try {
+      messages = await readTranscriptMessages({
+        providerSessionId: input.providerSessionId,
+        cwd: input.cwd
+      })
+    } catch {
+      return undefined
+    }
 
-  const recovered = (invocationIds as string[]).flatMap((id) => {
-    const call = recoveredById.get(id)
-    return call ? [call] : []
-  })
-  return hasExactClaudeCallCoverage(recovered, input.modelTurnCount, input.turnUsage)
-    ? recovered
-    : undefined
+    const recoveredById = new Map<string, AcpProviderModelCallUsage>()
+    for (const value of messages) {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) continue
+      const message = value as Record<string, unknown>
+      if (message.type !== 'assistant') continue
+      const call = toClaudeModelStepUsage(message)
+      const id = call?.sourceInvocationId
+      if (!call || !id || !expectedIds.has(id)) continue
+      const previous = recoveredById.get(id)
+      if (previous && !sameClaudeModelCallUsage(previous, call)) return undefined
+      recoveredById.set(id, call)
+    }
+
+    const recovered = (invocationIds as string[]).flatMap((id) => {
+      const call = recoveredById.get(id)
+      return call ? [call] : []
+    })
+    if (hasExactClaudeCallCoverage(recovered, input.modelTurnCount, input.turnUsage)) {
+      return recovered
+    }
+  }
+  return undefined
 }
 
 // ARD-24 owns Runtime probe selection and lifecycle wiring; this leaf only provides the

--- a/src/main/acp/claude-turn-adapter.ts
+++ b/src/main/acp/claude-turn-adapter.ts
@@ -94,10 +94,72 @@ const hasExactClaudeCallCoverage = (
   )
 }
 
+type ClaudeTranscriptReader = (
+  input: Readonly<{
+    providerSessionId: string
+    cwd: string
+  }>
+) => Promise<readonly unknown[]>
+
+type ClaudeCodeTurnAdapterOptions = Readonly<{
+  readTranscriptMessages?: ClaudeTranscriptReader
+}>
+
+const recoverClaudeModelCalls = async (
+  readTranscriptMessages: ClaudeTranscriptReader | undefined,
+  input: Readonly<{
+    providerSessionId: string
+    cwd: string
+    observedCalls: readonly AcpProviderModelCallUsage[]
+    modelTurnCount: number
+    turnUsage: AcpTurnTokenUsage | undefined
+  }>
+): Promise<readonly AcpProviderModelCallUsage[] | undefined> => {
+  if (!readTranscriptMessages || input.observedCalls.length !== input.modelTurnCount) {
+    return undefined
+  }
+  const invocationIds = input.observedCalls.map((call) => call.sourceInvocationId)
+  if (invocationIds.some((id) => !id)) return undefined
+
+  let messages: readonly unknown[]
+  try {
+    messages = await readTranscriptMessages({
+      providerSessionId: input.providerSessionId,
+      cwd: input.cwd
+    })
+  } catch {
+    return undefined
+  }
+
+  const expectedIds = new Set(invocationIds as string[])
+  const recoveredById = new Map<string, AcpProviderModelCallUsage>()
+  for (const value of messages) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) continue
+    const message = value as Record<string, unknown>
+    if (message.type !== 'assistant') continue
+    const call = toClaudeModelStepUsage(message)
+    const id = call?.sourceInvocationId
+    if (!call || !id || !expectedIds.has(id)) continue
+    const previous = recoveredById.get(id)
+    if (previous && !sameClaudeModelCallUsage(previous, call)) return undefined
+    recoveredById.set(id, call)
+  }
+
+  const recovered = (invocationIds as string[]).flatMap((id) => {
+    const call = recoveredById.get(id)
+    return call ? [call] : []
+  })
+  return hasExactClaudeCallCoverage(recovered, input.modelTurnCount, input.turnUsage)
+    ? recovered
+    : undefined
+}
+
 // ARD-24 owns Runtime probe selection and lifecycle wiring; this leaf only provides the
 // side-effect-free Claude interpretation module for that serialized executor cutover.
-export const claudeCodeTurnAdapter: AcpProviderTurnAdapter = {
-  begin: ({ providerSessionId }) => {
+export const createClaudeCodeTurnAdapter = (
+  options: ClaudeCodeTurnAdapterOptions = {}
+): AcpProviderTurnAdapter => ({
+  begin: ({ providerSessionId, cwd }) => {
     let modelTurnCount = 0
     let lastModelStepUsage: AcpModelStepTokenUsage | undefined
     let modelCalls: AcpProviderModelCallUsage[] = []
@@ -156,7 +218,7 @@ export const claudeCodeTurnAdapter: AcpProviderTurnAdapter = {
         const nextCount = modelTurnCount + (message.num_turns as number)
         if (Number.isSafeInteger(nextCount)) modelTurnCount = nextCount
       },
-      finalize: ({ response }) => {
+      finalize: async ({ response }) => {
         if (closed) return {}
         const finalModelTurnCount = modelTurnCount
         const finalLastModelStepUsage = lastModelStepUsage
@@ -164,18 +226,34 @@ export const claudeCodeTurnAdapter: AcpProviderTurnAdapter = {
         const finalModelCallsTrusted = modelCallsTrusted
         close()
         const turnUsage = toAcpTurnTokenUsage(response.usage)
+        const exactLiveCalls =
+          finalModelCallsTrusted &&
+          hasExactClaudeCallCoverage(finalModelCalls, finalModelTurnCount, turnUsage)
+            ? finalModelCalls
+            : undefined
+        const exactModelCalls =
+          exactLiveCalls ??
+          (await recoverClaudeModelCalls(options.readTranscriptMessages, {
+            providerSessionId,
+            cwd,
+            observedCalls: finalModelCalls,
+            modelTurnCount: finalModelTurnCount,
+            turnUsage
+          }))
+        const exactLastModelStepUsage = exactModelCalls?.at(-1) ?? finalLastModelStepUsage
         const result: AcpProviderTurnResult = {
           ...(turnUsage ? { turnUsage } : {}),
           ...(finalModelTurnCount > 0 ? { modelTurnCount: finalModelTurnCount } : {}),
-          ...(finalLastModelStepUsage ? { lastModelStepUsage: finalLastModelStepUsage } : {}),
-          ...(finalModelCallsTrusted &&
-          hasExactClaudeCallCoverage(finalModelCalls, finalModelTurnCount, turnUsage)
-            ? { modelCalls: finalModelCalls }
-            : {})
+          ...(exactLastModelStepUsage ? { lastModelStepUsage: exactLastModelStepUsage } : {}),
+          ...(exactModelCalls ? { modelCalls: exactModelCalls } : {})
         }
         return result
       },
       cancel: close
     }
   }
-}
+})
+
+export const claudeCodeTurnAdapter = createClaudeCodeTurnAdapter()
+
+export type { ClaudeTranscriptReader }

--- a/src/main/acp/claude-turn-adapter.ts
+++ b/src/main/acp/claude-turn-adapter.ts
@@ -144,7 +144,7 @@ const recoverClaudeModelCalls = async (
         cwd: input.cwd
       })
     } catch {
-      return undefined
+      continue
     }
 
     const recoveredById = new Map<string, AcpProviderModelCallUsage>()

--- a/src/main/acp/provider-prompt-executor.test.ts
+++ b/src/main/acp/provider-prompt-executor.test.ts
@@ -1,10 +1,16 @@
 import type { ActiveSession, PromptResponse, SessionNotification } from '@agentclientprotocol/sdk'
 import { describe, expect, it, vi } from 'vitest'
 
-const { claudeBegin } = vi.hoisted(() => ({ claudeBegin: vi.fn() }))
+const { claudeBegin, createClaudeAdapter } = vi.hoisted(() => ({
+  claudeBegin: vi.fn(),
+  createClaudeAdapter: vi.fn()
+}))
 
 vi.mock('./claude-turn-adapter', () => ({
-  claudeCodeTurnAdapter: { begin: (...args: unknown[]) => claudeBegin(...args) }
+  createClaudeCodeTurnAdapter: (...args: unknown[]) => {
+    createClaudeAdapter(...args)
+    return { begin: (...beginArgs: unknown[]) => claudeBegin(...beginArgs) }
+  }
 }))
 
 import {
@@ -90,7 +96,12 @@ const setup = (
   const routeNotification = vi.fn()
   const report = vi.fn()
   const executor = new AcpProviderPromptExecutor({
-    backendGeneration: { openCodeUsageApi: () => undefined }
+    backendGeneration: {
+      openCodeUsageApi: () => undefined,
+      current: {
+        adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false }
+      }
+    }
   })
   claudeBegin.mockImplementation((input) => adapter.begin(input))
   return {
@@ -118,6 +129,36 @@ const setup = (
 }
 
 describe('AcpProviderPromptExecutor', () => {
+  it('gives the Claude adapter a transcript reader for the active config root', async () => {
+    const executor = new AcpProviderPromptExecutor({
+      backendGeneration: {
+        openCodeUsageApi: () => undefined,
+        current: {
+          adapter: {
+            claudeConfigDir: '/profiles/app-claude',
+            nativeMcpEnabled: true,
+            bridgeMcpAliasesEnabled: false
+          }
+        }
+      }
+    })
+    claudeBegin.mockResolvedValue({
+      finalize: () => ({}),
+      cancel: () => undefined
+    })
+
+    const probe = await executor.beginObservation({
+      providerSessionId: 'provider-1',
+      cwd: '/workspace',
+      frameworkId: 'claude-code'
+    })
+
+    expect(createClaudeAdapter).toHaveBeenCalledWith({
+      readTranscriptMessages: expect.any(Function)
+    })
+    await probe.cancel()
+  })
+
   it('captures one OpenCode generation API for both usage snapshots', async () => {
     const api = { baseUrl: 'https://usage.example/v1', authorization: 'Bearer generation-1' }
     const openCodeUsageApi = vi.fn(() => api)
@@ -145,7 +186,12 @@ describe('AcpProviderPromptExecutor', () => {
       nextUpdate: vi.fn(async () => stop(response))
     } as unknown as ProviderPromptExecutionInput['session']
     const executor = new AcpProviderPromptExecutor({
-      backendGeneration: { openCodeUsageApi },
+      backendGeneration: {
+        openCodeUsageApi,
+        current: {
+          adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false }
+        }
+      },
       opencodeUsageFetch: fetchImpl
     })
 

--- a/src/main/acp/provider-prompt-executor.ts
+++ b/src/main/acp/provider-prompt-executor.ts
@@ -8,7 +8,8 @@ import type {
 import { toAcpTurnTokenUsage } from '../../shared/acp'
 import type { AgentFrameworkId } from '../../shared/settings'
 import type { AcpBackendGenerationOwner } from './backend-generation-owner'
-import { claudeCodeTurnAdapter } from './claude-turn-adapter'
+import { createClaudeTranscriptReader } from './claude-transcript-reader'
+import { createClaudeCodeTurnAdapter } from './claude-turn-adapter'
 import { codeBuddyTurnAdapter } from './codebuddy-turn-adapter'
 import { createCodexTurnAdapter } from './codex-turn-adapter'
 import { AcpOpenCodeTurnAdapter } from './opencode-turn-adapter'
@@ -37,7 +38,8 @@ type ProviderPromptExecutionInput = Readonly<{
 }>
 
 type AcpProviderPromptExecutorOptions = Readonly<{
-  backendGeneration: Pick<AcpBackendGenerationOwner, 'openCodeUsageApi'>
+  backendGeneration: Pick<AcpBackendGenerationOwner, 'openCodeUsageApi'> &
+    Readonly<{ current: Pick<AcpBackendGenerationOwner['current'], 'adapter'> }>
   opencodeUsageFetch?: typeof fetch
 }>
 
@@ -321,7 +323,12 @@ class AcpProviderPromptExecutor {
   }
 
   private adapterFor(frameworkId: AgentFrameworkId): AcpProviderTurnAdapter {
-    if (frameworkId === 'claude-code') return claudeCodeTurnAdapter
+    if (frameworkId === 'claude-code') {
+      const configDir = this.options.backendGeneration.current.adapter.claudeConfigDir
+      return createClaudeCodeTurnAdapter({
+        ...(configDir ? { readTranscriptMessages: createClaudeTranscriptReader(configDir) } : {})
+      })
+    }
     if (frameworkId === 'codex') return createCodexTurnAdapter()
     if (frameworkId === 'codebuddy') return codeBuddyTurnAdapter
 


### PR DESCRIPTION
## Problem

Claude Code can emit provisional zero token usage in live Assistant SDK messages when a turn runs through MiniMax-M3. The provider result still reports the correct aggregate usage and turn count, so Open Science persists Turn history but omits Calls because the zero-valued rows fail exact reconciliation.

Real provider reproduction confirmed that Claude writes finalized per-invocation usage to the same Session transcript before the prompt completes.

## Proposed change

- expose the active Claude config directory in the secret-free backend adapter view
- read the finalized Session transcript through the Claude SDK SessionStore boundary only when live call details fail exact reconciliation
- match only invocation ids observed during the current prompt, deduplicate repeated transcript fragments, and retain the existing fail-closed count and token-total checks
- preserve the fast path without transcript I/O when live call details are already exact

## Scope and non-goals

- no database, schema, persisted-field, enum, or renderer changes
- no historical Session backfill
- no synthesized or partial call rows
- no behavior changes for OpenCode, Codex, or CodeBuddy
- missing, malformed, late, or inconsistent transcripts keep the existing Calls unavailable behavior

## Acceptance criteria and validation

All listed checks ran against the final commit.

- MiniMax-M3 provisional-zero regression and exact-call recovery -> npm test -- --run src/main/acp/claude-turn-adapter.test.ts src/main/acp/claude-transcript-reader.test.ts src/main/acp/backend-generation-owner.test.ts src/main/acp/provider-prompt-executor.test.ts -> 4 files, 33 tests passed
- Node adapter and SDK SessionStore types -> npx tsc --noEmit -p tsconfig.node.json --composite false -> passed
- changed ACP source and tests -> targeted npx eslint invocation -> passed
- committed patch whitespace -> git diff --check HEAD^ HEAD -> passed

An Electron production build also passed before the final test-only assertion adjustment. PR CI remains authoritative for complete portable and platform coverage.

## Review focus

- whether filtering transcript rows to invocation ids observed during the current prompt is sufficiently strict
- whether the read-only SessionStore adapter preserves the expected Claude config-directory isolation on every platform
- whether fallback failures retain enough aggregate usage while still refusing inexact call rows
