### PR TITLE
docs(readme): add Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Download](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 #1 BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Platforms macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![License](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Download](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 #1 BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Platforms macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![License](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](LICENSE)

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -2,6 +2,7 @@
 
 [![Download](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 Platz 1 bei BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Plattformen macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![Lizenz](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -2,7 +2,7 @@
 
 [![Download](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 Platz 1 bei BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Plattformen macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![Lizenz](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -2,7 +2,7 @@
 
 [![Descargar](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Versión](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 N.º 1 en BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Plataformas macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![Licencia](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -2,6 +2,7 @@
 
 [![Descargar](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Versión](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 N.º 1 en BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Plataformas macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![Licencia](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -2,6 +2,7 @@
 
 [![Télécharger](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 N° 1 sur BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Plateformes macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![Licence](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -2,7 +2,7 @@
 
 [![Télécharger](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 N° 1 sur BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Plateformes macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![Licence](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -2,7 +2,7 @@
 
 [![ダウンロード](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![バージョン](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 BiomniBench-DA Public 50で第1位](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![対応プラットフォーム macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![ライセンス](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -2,6 +2,7 @@
 
 [![ダウンロード](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![バージョン](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 BiomniBench-DA Public 50で第1位](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![対応プラットフォーム macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![ライセンス](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -2,6 +2,7 @@
 
 [![다운로드](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![버전](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 BiomniBench-DA Public 50 1위](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![지원 플랫폼 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![라이선스](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -2,7 +2,7 @@
 
 [![다운로드](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![버전](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 BiomniBench-DA Public 50 1위](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![지원 플랫폼 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![라이선스](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -2,6 +2,7 @@
 
 [![Скачать](https://img.shields.io/badge/Скачать-последний%20выпуск-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Версия](https://img.shields.io/github/v/release/aipoch/open-science?label=Версия&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 № 1 в BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Платформы macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![Лицензия](https://img.shields.io/badge/Лицензия-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -2,7 +2,7 @@
 
 [![Скачать](https://img.shields.io/badge/Скачать-последний%20выпуск-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![Версия](https://img.shields.io/github/v/release/aipoch/open-science?label=Версия&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 № 1 в BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![Платформы macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![Лицензия](https://img.shields.io/badge/Лицензия-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/zh-Hans/README.md
+++ b/docs/zh-Hans/README.md
@@ -2,6 +2,7 @@
 
 [![下载](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![版本](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 BiomniBench-DA Public 50 第一名](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![支持平台 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![许可证](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/zh-Hans/README.md
+++ b/docs/zh-Hans/README.md
@@ -2,7 +2,7 @@
 
 [![下载](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![版本](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 BiomniBench-DA Public 50 第一名](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![支持平台 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![许可证](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/zh-Hant/README.md
+++ b/docs/zh-Hant/README.md
@@ -2,7 +2,7 @@
 
 [![下載](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![版本](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 BiomniBench-DA Public 50 第一名](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![支援平台 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![授權條款](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)

--- a/docs/zh-Hant/README.md
+++ b/docs/zh-Hant/README.md
@@ -2,6 +2,7 @@
 
 [![下載](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
 [![版本](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
+[![DOI](https://zenodo.org/badge/1287804060.svg)](https://doi.org/10.5281/zenodo.22252246)
 [![🏆 BiomniBench-DA Public 50 第一名](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
 [![支援平台 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
 [![授權條款](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)


### PR DESCRIPTION
## Problem
The Zenodo DOI badge did not match the existing `for-the-badge` styling in the README badge area.

## Proposed change
Replace the native Zenodo SVG badge with the provided blue Shields.io `for-the-badge` badge, preserving the DOI link, and synchronize it across every README indexed by the root README.

## Scope and non-goals
Documentation-only change. Updated 9 files: `README.md`, `docs/de/README.md`, `docs/es/README.md`, `docs/fr/README.md`, `docs/ja/README.md`, `docs/ko/README.md`, `docs/ru/README.md`, `docs/zh-Hans/README.md`, and `docs/zh-Hant/README.md`. No application code or Zenodo integration settings changed.

## Acceptance criteria and validation
- Badge used once in each README:
  `[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)`
- Prettier 3.7.4 passed for all 9 README files after the final edit.
- `git diff --check` passed.
- Final README language-index/file-set gate passed.
- Shields.io badge endpoint returned HTTP 200; DOI target resolved successfully.
- PR title and both Conventional Commit subjects comply with repository policy. The full policy runner was attempted but hit a local Windows `spawnSync git EPERM` limitation; no policy violation was reported.

## Review focus
Confirm the badge's `for-the-badge` appearance, blue color, exact DOI target, and synchronization across all indexed README translations.

## Evidence and uncovered risks
All listed checks ran after the final material edit. No known uncovered risk for this documentation-only change.