### PR TITLE
fix(codebuddy): preserve empty Windows command arguments

### DIFF
--- a/src/main/agent-framework/codebuddy.test.ts
+++ b/src/main/agent-framework/codebuddy.test.ts
@@ -161,6 +161,27 @@ describe('codebuddy framework', () => {
     expect(spawnedEnv?.DISABLE_ERROR_REPORTING).toBe('1')
   })
 
+  it('preserves an empty restricted tool set through the Windows command wrapper', () => {
+    const spawnProcess = vi.fn(() => ({}) as ChildProcessWithoutNullStreams)
+    const framework = createCodeBuddyFramework({
+      platform: 'win32',
+      sourceEnv: {},
+      spawnProcess
+    })
+
+    framework.spawn({
+      executablePath: 'C:\\runtime\\codebuddy.cmd',
+      env: {},
+      args: ['--tools', '']
+    })
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      '"C:\\runtime\\codebuddy.cmd"',
+      ['--acp', '--tools', '""'],
+      expect.objectContaining({ shell: true })
+    )
+  })
+
   it('keeps native Bash absent on Windows too', () => {
     const framework = createCodeBuddyFramework({ platform: 'win32' })
     const config = framework.prepareModelConfig(provider, {

--- a/src/main/agent-framework/codebuddy.ts
+++ b/src/main/agent-framework/codebuddy.ts
@@ -112,16 +112,13 @@ export const createCodeBuddyFramework = ({
 
   spawn(input: AgentSpawnInput): ChildProcessWithoutNullStreams {
     const needsShell = platform === 'win32' && /\.(cmd|bat)$/i.test(input.executablePath)
-    return spawnProcess(
-      needsShell ? `"${input.executablePath}"` : input.executablePath,
-      ['--acp', ...input.args],
-      {
-        env: { ...augmentedPathEnv(sourceEnv), ...input.env },
-        stdio: 'pipe',
-        windowsHide: true,
-        shell: needsShell
-      }
-    )
+    const args = ['--acp', ...input.args].map((arg) => (needsShell && arg === '' ? '""' : arg))
+    return spawnProcess(needsShell ? `"${input.executablePath}"` : input.executablePath, args, {
+      env: { ...augmentedPathEnv(sourceEnv), ...input.env },
+      stdio: 'pipe',
+      windowsHide: true,
+      shell: needsShell
+    })
   },
 
   async prepareDelegatedSpawn(


### PR DESCRIPTION
## Problem

On Windows, Side chat prepares CodeBuddy's restricted runtime with an empty `--tools` value. CodeBuddy is launched through its `.cmd` wrapper with `shell: true`; Node/Windows shell handling drops the empty argument, so CodeBuddy parses `--tools` without its required value, exits before ACP initialization, and surfaces `ACP connection closed`.

The supplied log shows two deterministic failures whose 48-byte stderr summary matches the exact CodeBuddy 2.138.0 reproduction: `error: option '--tools <value>' argument missing`.

## Proposed change

- Encode empty arguments as the shell-safe literal `""` only when spawning a Windows `.cmd`/`.bat` CodeBuddy executable.
- Add a regression test at the existing `spawnProcess` injection boundary. The test failed three consecutive times before the fix with the empty argument dropped, then passed after the fix.

## Scope and non-goals

- No renderer or interaction changes; the existing error surfaces remain unchanged.
- No architecture or data-model changes.
- No new data fields, enum/state values, persistence, schema, or migration.
- No historical-data compatibility work is required.
- Claude Code, OpenCode, Codex Responses/bridge, non-Windows CodeBuddy, non-empty arguments, subscription behavior, and process cleanup are unchanged.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Windows CodeBuddy empty restricted tool set and its Side chat caller chain -> `npx vitest run src/main/agent-framework/codebuddy.test.ts src/main/acp/restricted-inference-runner.test.ts src/main/side-chat/runtime-owner.test.ts src/main/agent-framework/native-shell-policy.test.ts` -> 4 files, 76 tests passed.
- Electron main and notebook sandbox types -> `npm run typecheck:node` -> passed.
- Linted source -> `npm run lint` -> passed with no warnings after formatting.
- Patch integrity -> `git diff --check` -> passed.

Per maintainer request, the complete local `npm test` suite was not run. The changed CodeBuddy owner is not declared in `module-impact.json`, so exact-head PR Gate is expected to fail closed to the broader authoritative CI plan. A packaged-app end-to-end test is not included; the report was reproduced directly with the pinned official CodeBuddy CLI on Windows, while the regression test covers the app-owned spawn boundary.

## Review focus

- Confirm that quoting only empty arguments on the Windows shell path is appropriately narrow.
- Confirm that the existing spawn injection boundary is sufficient regression coverage for the `.cmd` argument handoff.
