### PR TITLE
refactor(architecture): remove runtime import cycles

### DIFF
--- a/src/main/agents/agents-mutations.ts
+++ b/src/main/agents/agents-mutations.ts
@@ -25,7 +25,7 @@
 // (later slice). Ordinary mutations do not request a system permission card.
 
 import type { ConnectorReadModel, SkillCatalogReadModel } from './agents-service'
-import { applyNameOrIdFilter } from './agents-service'
+import { applyNameOrIdFilter } from './name-or-id-filter'
 import type { SpecialistService } from '../specialist/service'
 import type {
   CreateSpecialistInput,

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -40,6 +40,7 @@ import type {
   SpecialistDeleteResult
 } from '../../shared/specialist-package'
 import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
+import { applyNameOrIdFilter } from './name-or-id-filter'
 
 // The minimal read surface this adapter needs from the settings/connectors catalog. Keeping it
 // narrow avoids pulling the whole SettingsService into the SDK contract and lets tests stub it.
@@ -469,37 +470,4 @@ export const projectConnectorsFromStored = (
   return [...bundled, ...custom]
 }
 
-// ---------------------------------------------------------------------------
-// name-or-id resolution (shared by the catalog reads AND the mutation module)
-// ---------------------------------------------------------------------------
-
-type Nameable = { id: string; name?: string; displayName?: string }
-
-export function applyNameOrIdFilter<T extends Nameable>(
-  entries: T[],
-  nameOrId: unknown,
-  method: string
-): T[] {
-  const ref = asString(nameOrId)
-  if (!ref) return entries
-
-  // 1. Exact stable ID wins.
-  const byId = entries.filter((entry) => entry.id === ref)
-  if (byId.length > 0) return byId
-
-  // 2. Otherwise match a unique immutable public name. Display labels are never references.
-  const byName = entries.filter((entry) => entry.name === ref)
-  if (byName.length === 0) {
-    throw agentsPublicError(
-      `No catalog entry matches "${ref}". Use the stable id from listSkills()/listConnectors().`
-    )
-  }
-  if (byName.length > 1) {
-    // Ambiguous immutable name: instruct the caller to use the stable id instead of guessing.
-    const ids = byName.map((entry) => entry.id).join(', ')
-    throw agentsPublicError(
-      `Multiple catalog entries match name "${ref}" (${ids}). Use the stable id from ${method} instead.`
-    )
-  }
-  return byName
-}
+export { applyNameOrIdFilter }

--- a/src/main/agents/name-or-id-filter.ts
+++ b/src/main/agents/name-or-id-filter.ts
@@ -1,0 +1,29 @@
+import { agentsPublicError } from './agents-error'
+
+type Nameable = { id: string; name?: string; displayName?: string }
+
+export const applyNameOrIdFilter = <T extends Nameable>(
+  entries: T[],
+  nameOrId: unknown,
+  method: string
+): T[] => {
+  const ref = typeof nameOrId === 'string' ? nameOrId : undefined
+  if (!ref) return entries
+
+  const byId = entries.filter((entry) => entry.id === ref)
+  if (byId.length > 0) return byId
+
+  const byName = entries.filter((entry) => entry.name === ref)
+  if (byName.length === 0) {
+    throw agentsPublicError(
+      `No catalog entry matches "${ref}". Use the stable id from listSkills()/listConnectors().`
+    )
+  }
+  if (byName.length > 1) {
+    const ids = byName.map((entry) => entry.id).join(', ')
+    throw agentsPublicError(
+      `Multiple catalog entries match name "${ref}" (${ids}). Use the stable id from ${method} instead.`
+    )
+  }
+  return byName
+}

--- a/src/main/compute/compute-job-workflow-owner.ts
+++ b/src/main/compute/compute-job-workflow-owner.ts
@@ -28,11 +28,10 @@ import {
   type ComputeJobRepository,
   UnencryptedComputeJobPersistenceApprovalRequiredError
 } from './job-repository'
-import { getJobHarvestDir } from './harvest-engine'
 import { validateHarvestConfig } from './harvest-classifier'
 import type { ComputeHostRepository } from './repository'
 import { GLOB_CHARS, SHELL_UNSAFE_CHARS } from './remote-path-security'
-import { workspaceRelativePath } from './workspace-path'
+import { getJobHarvestDir, workspaceRelativePath } from './workspace-path'
 
 const COMMAND_PREVIEW_MAX_LEN = 120
 const JOB_MAX_TIMEOUT_SECONDS = 7 * 24 * 3600

--- a/src/main/compute/harvest-engine.ts
+++ b/src/main/compute/harvest-engine.ts
@@ -56,7 +56,7 @@ import {
 } from '../notebook/working-file-observer'
 import { withDataRootWrite } from '../storage/migration-state'
 import { toErrorMessage } from '../error-message'
-import { workspaceRelativePath } from './workspace-path'
+import { getJobHarvestDir, workspaceRelativePath } from './workspace-path'
 import { createLogger, errorLogFields } from '../logger'
 
 const MIB_BYTES = 1024 * 1024
@@ -125,30 +125,6 @@ const pathExists = async (path: string): Promise<boolean> =>
     () => true,
     () => false
   )
-// ---------------------------------------------------------------------------
-// Public path helper
-// ---------------------------------------------------------------------------
-
-/**
- * Returns the local harvest directory for a job:
- *   <storageRoot>/notebooks/<project>/<sessionId>/hpc/<jobId>/
- *
- * This is inside the session workspace (alongside ./handoff, ./data) so the
- * agent's data kernel can directly open('hpc/<jobId>/out.result') (design §4).
- * Delegates path-segment validation to getNotebookSessionRoot which rejects
- * traversal attempts.
- */
-export const getJobHarvestDir = (
-  storageRoot: string,
-  project: string,
-  sessionId: string,
-  jobId: string
-): string => {
-  // getNotebookSessionRoot validates project and sessionId (throws on traversal).
-  const workspaceCwd = getNotebookSessionRoot(storageRoot, project, sessionId)
-  return join(workspaceCwd, 'hpc', jobId)
-}
-
 // ---------------------------------------------------------------------------
 // Remote enumeration
 // ---------------------------------------------------------------------------
@@ -800,3 +776,5 @@ const harvestJobUnchecked = async (
   const updatedJob = await finalize(harvestError, JSON.stringify(leftOnRemote))
   if (deps.broadcast) await notify(updatedJob)
 }
+
+export { getJobHarvestDir }

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -47,9 +47,8 @@ import { ComputeConnectionError, type ComputeConnectionBroker } from './connecti
 import { dispatchJob } from './job-dispatcher'
 import { EnabledComputeHostsRegistry, enabledComputeHostsRegistry } from './enabled-hosts-registry'
 import { deleteComputeHost, type DeleteComputeHostOptions } from './compute-host-deletion-owner'
-import { getJobHarvestDir } from './harvest-engine'
 import { SessionCacheOwner } from './session-cache-owner'
-import { workspaceRelativePath } from './workspace-path'
+import { getJobHarvestDir, workspaceRelativePath } from './workspace-path'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import {
   createComputePermissionGrantAdapter,

--- a/src/main/compute/job-notifier.ts
+++ b/src/main/compute/job-notifier.ts
@@ -28,8 +28,7 @@ import { join } from 'node:path'
 import type { ComputeJob, JobSummary } from '../../shared/compute'
 import type { ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
-import { getJobHarvestDir } from './harvest-engine'
-import { workspaceRelativePath } from './workspace-path'
+import { getJobHarvestDir, workspaceRelativePath } from './workspace-path'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/main/compute/workspace-path.ts
+++ b/src/main/compute/workspace-path.ts
@@ -1,4 +1,14 @@
-import { posix, relative, sep } from 'node:path'
+import { join, posix, relative, sep } from 'node:path'
+
+import { getNotebookSessionRoot } from '../notebook/repository'
+
+/** Returns the validated local output directory inside a Session workspace for one Compute Job. */
+export const getJobHarvestDir = (
+  storageRoot: string,
+  project: string,
+  sessionId: string,
+  jobId: string
+): string => join(getNotebookSessionRoot(storageRoot, project, sessionId), 'hpc', jobId)
 
 /** Returns a workspace-relative logical path, independent of the host filesystem separator. */
 export const workspaceRelativePath = (workspaceCwd: string, path: string): string =>

--- a/src/main/immutable-input-authority.ts
+++ b/src/main/immutable-input-authority.ts
@@ -4,10 +4,10 @@ import { chmod, lstat, mkdir, realpath, rename, rm, stat } from 'node:fs/promise
 import { join, sep } from 'node:path'
 
 import type { NotebookRunInputFile } from '../shared/notebook'
-import {
-  ManagedFileVersionError,
-  type ManagedFileReadLease,
-  type ManagedFileVersionService
+import { ManagedFileVersionError } from './managed-file-versions/error'
+import type {
+  ManagedFileReadLease,
+  ManagedFileVersionService
 } from './managed-file-versions/service'
 import { getNotebookInputRoot } from './notebook/input-staging'
 

--- a/src/main/managed-file-versions/diff-task.ts
+++ b/src/main/managed-file-versions/diff-task.ts
@@ -5,7 +5,7 @@ import {
   MANAGED_DIFF_MAX_OUTPUT_LINES,
   type ManagedFileVersionDiffLine
 } from '../../shared/managed-file-versions'
-import { ManagedFileVersionError } from './service'
+import { ManagedFileVersionError } from './error'
 
 type DiffTask = { requestId: string; before: string; after: string }
 type WorkerLike = {

--- a/src/main/managed-file-versions/error.ts
+++ b/src/main/managed-file-versions/error.ts
@@ -1,0 +1,13 @@
+import type { ManagedFileVersionErrorCode } from '../../shared/managed-file-versions'
+
+export class ManagedFileVersionError extends Error {
+  readonly name = 'ManagedFileVersionError'
+
+  constructor(
+    readonly code: ManagedFileVersionErrorCode,
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options)
+  }
+}

--- a/src/main/managed-file-versions/ipc.ts
+++ b/src/main/managed-file-versions/ipc.ts
@@ -10,7 +10,7 @@ import type {
   SaveTextEditResult
 } from '../../shared/managed-file-versions'
 import { ipcMainHandle } from '../ipc-handler-registry'
-import { ManagedFileVersionError } from './service'
+import { ManagedFileVersionError } from './error'
 
 type ManagedFileVersionIpcService = {
   inspect(request: ManagedFileVersionInspectRequest): Promise<ManagedFileVersionInspectResult>

--- a/src/main/managed-file-versions/service.ts
+++ b/src/main/managed-file-versions/service.ts
@@ -19,6 +19,7 @@ import {
   type SaveTextEditResult
 } from '../../shared/managed-file-versions'
 import { ManagedTextDiffTaskRunner } from './diff-task'
+import { ManagedFileVersionError } from './error'
 import {
   NodeVersionFileOperator,
   VersionFileOperatorError,
@@ -147,18 +148,6 @@ type AdoptedLegacyArtifact = {
 
 type WriteOperationRecord = Prisma.ManagedFileVersionWriteOperationGetPayload<object>
 type LegacyArtifactVersionRecord = Prisma.ArtifactVersionGetPayload<object>
-
-class ManagedFileVersionError extends Error {
-  readonly name = 'ManagedFileVersionError'
-
-  constructor(
-    readonly code: ManagedFileVersionErrorCode,
-    message: string,
-    options?: ErrorOptions
-  ) {
-    super(message, options)
-  }
-}
 
 const operationError = (code: ManagedFileVersionErrorCode, message: string): never => {
   throw new ManagedFileVersionError(code, message)

--- a/src/main/notebook/micromamba.ts
+++ b/src/main/notebook/micromamba.ts
@@ -1,7 +1,7 @@
 import { statSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { PROD_SESSION_DIR_NAME } from '../session-persistence/repository'
+import { PROD_SESSION_DIR_NAME } from '../session-persistence/paths'
 import {
   DEFAULT_MAX_CACHE_RELATIVE_PATH,
   selectMicromambaCache,

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path'
 import { Transform, type TransformCallback } from 'node:stream'
 import { finished } from 'node:stream/promises'
 
-import { PROD_SESSION_DIR_NAME } from '../session-persistence/repository'
+import { PROD_SESSION_DIR_NAME } from '../session-persistence/paths'
 import type { OptionalProjectIdScope } from '../../shared/project-scope'
 import type { RuntimeTargetReceipt } from '../../shared/notebook-runtime'
 import type {

--- a/src/main/runtime-import-cycle.architecture.test.ts
+++ b/src/main/runtime-import-cycle.architecture.test.ts
@@ -1,0 +1,149 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, extname, relative, resolve } from 'node:path'
+
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isExportDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isStringLiteralLike,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type Node
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = resolve(__dirname, '../..')
+const mainRoot = resolve(projectRoot, 'src/main')
+const sourceExtensions = ['.ts', '.tsx', '.mts', '.cts'] as const
+
+const productionSources = (): string[] => {
+  const files: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (
+        sourceExtensions.includes(extname(path) as (typeof sourceExtensions)[number]) &&
+        !/\.(?:test|spec)(?:-support|-harness)?\.[cm]?tsx?$/.test(entry.name) &&
+        !entry.name.endsWith('.d.ts')
+      ) {
+        files.push(path)
+      }
+    }
+  }
+  visit(mainRoot)
+  return files.sort()
+}
+
+const runtimeImportSpecifiers = (path: string): string[] => {
+  const specifiers: string[] = []
+  const sourceFile = createSourceFile(
+    path,
+    readFileSync(path, 'utf8'),
+    ScriptTarget.Latest,
+    true,
+    extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+  const visit = (node: Node): void => {
+    if (isImportDeclaration(node) && isStringLiteralLike(node.moduleSpecifier)) {
+      const clause = node.importClause
+      const hasRuntimeBinding =
+        clause === undefined ||
+        (!clause.isTypeOnly &&
+          (clause.name !== undefined ||
+            clause.namedBindings === undefined ||
+            !('elements' in clause.namedBindings) ||
+            clause.namedBindings.elements.some((element) => !element.isTypeOnly)))
+      if (hasRuntimeBinding) specifiers.push(node.moduleSpecifier.text)
+    } else if (
+      isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      isStringLiteralLike(node.moduleSpecifier) &&
+      !node.isTypeOnly &&
+      (!node.exportClause ||
+        !('elements' in node.exportClause) ||
+        node.exportClause.elements.some((element) => !element.isTypeOnly))
+    ) {
+      specifiers.push(node.moduleSpecifier.text)
+    } else if (isCallExpression(node)) {
+      const [argument] = node.arguments
+      const isRequire = isIdentifier(node.expression) && node.expression.text === 'require'
+      const isDynamicImport = node.expression.kind === SyntaxKind.ImportKeyword
+      if ((isRequire || isDynamicImport) && argument && isStringLiteralLike(argument)) {
+        specifiers.push(argument.text)
+      }
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return specifiers
+}
+
+const resolveRelativeImport = (source: string, specifier: string): string | undefined => {
+  if (!specifier.startsWith('.')) return undefined
+  const base = resolve(dirname(source), specifier.replace(/\.[cm]?js$/, ''))
+  const candidates = [
+    ...sourceExtensions.map((extension) => `${base}${extension}`),
+    ...sourceExtensions.map((extension) => resolve(base, `index${extension}`))
+  ]
+  return candidates.find((candidate) => existsSync(candidate))
+}
+
+const runtimeImportGraph = (): Map<string, readonly string[]> => {
+  const sources = productionSources()
+  const sourceSet = new Set(sources)
+  return new Map(
+    sources.map((source) => [
+      source,
+      [
+        ...new Set(
+          runtimeImportSpecifiers(source)
+            .map((specifier) => resolveRelativeImport(source, specifier))
+            .filter((target): target is string => target !== undefined && sourceSet.has(target))
+        )
+      ].sort()
+    ])
+  )
+}
+
+const canonicalCycle = (cycle: readonly string[]): string => {
+  const nodes = cycle.slice(0, -1).map((path) => relative(projectRoot, path).replaceAll('\\', '/'))
+  const rotations = nodes.map((_, index) => [...nodes.slice(index), ...nodes.slice(0, index)])
+  const canonical = rotations.sort((left, right) => left.join().localeCompare(right.join()))[0]
+  return [...canonical, canonical[0]].join(' -> ')
+}
+
+const runtimeImportCycles = (): string[] => {
+  const graph = runtimeImportGraph()
+  const visited = new Set<string>()
+  const active = new Set<string>()
+  const stack: string[] = []
+  const cycles = new Set<string>()
+
+  const visit = (source: string): void => {
+    visited.add(source)
+    active.add(source)
+    stack.push(source)
+    for (const target of graph.get(source) ?? []) {
+      if (!visited.has(target)) visit(target)
+      else if (active.has(target)) {
+        cycles.add(canonicalCycle([...stack.slice(stack.indexOf(target)), target]))
+      }
+    }
+    stack.pop()
+    active.delete(source)
+  }
+
+  for (const source of graph.keys()) if (!visited.has(source)) visit(source)
+  return [...cycles].sort()
+}
+
+describe('main-process runtime import architecture', () => {
+  it('keeps production runtime dependencies acyclic', () => {
+    expect(runtimeImportCycles()).toEqual([])
+  })
+})

--- a/src/main/session-persistence/paths.ts
+++ b/src/main/session-persistence/paths.ts
@@ -1,0 +1,12 @@
+import { join } from 'node:path'
+
+// Production storage lives under ~/.open-science; dev builds use an isolated sibling directory.
+export const PROD_SESSION_DIR_NAME = '.open-science'
+export const DEV_SESSION_DIR_NAME = '.open-science-project'
+
+// Builds the app-owned session directory in the user's home folder. Kept pure (no electron) so it
+// stays unit-testable; the dev/prod choice is applied by the main-only resolveStorageRoot helper.
+export const getSessionPersistenceDir = (
+  homePath: string,
+  dirName: string = PROD_SESSION_DIR_NAME
+): string => join(homePath, dirName)

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -247,17 +247,6 @@ const projectIncompleteSummaries = (
     .sort((left, right) => right.updatedAt - left.updatedAt || left.id.localeCompare(right.id))
 }
 
-// Production storage lives under ~/.open-science; dev builds use an isolated sibling directory.
-export const PROD_SESSION_DIR_NAME = '.open-science'
-export const DEV_SESSION_DIR_NAME = '.open-science-project'
-
-// Builds the app-owned session directory in the user's home folder. Kept pure (no electron) so it
-// stays unit-testable; the dev/prod choice is applied by the main-only resolveStorageRoot helper.
-const getSessionPersistenceDir = (
-  homePath: string,
-  dirName: string = PROD_SESSION_DIR_NAME
-): string => join(homePath, dirName)
-
 // Rejects path segments that could escape the sessions tree. Real session/project ids are id-like, so
 // this only guards against corrupt or malicious values before they become file paths.
 const assertSafeSegment = (segment: unknown): string => {
@@ -1701,6 +1690,7 @@ const isMissingFileError = (error: unknown): boolean =>
   'code' in error &&
   (error as { code?: unknown }).code === 'ENOENT'
 
-export { SessionRepository, getSessionPersistenceDir }
+export { DEV_SESSION_DIR_NAME, PROD_SESSION_DIR_NAME, getSessionPersistenceDir } from './paths'
+export { SessionRepository }
 export type { ProjectSessionDeletionState, ProjectSessionLoadDiagnostics, SessionLoadDiagnostic }
 export type { SessionLoadDiagnostics, SessionScanMetrics }

--- a/src/main/storage-root.ts
+++ b/src/main/storage-root.ts
@@ -7,7 +7,7 @@ import {
   DEV_SESSION_DIR_NAME,
   PROD_SESSION_DIR_NAME,
   getSessionPersistenceDir
-} from './session-persistence/repository'
+} from './session-persistence/paths'
 import { MIGRATABLE_DATA_DIRS } from './storage/data-directories'
 
 const resolveE2eStorageRoot = (): string | undefined => {


### PR DESCRIPTION
## Problem

The Electron main-process production import graph contained four runtime value-import cycles:

- Session repository → Session data paths → data path → storage root → Session repository
- Agents service ↔ Agents mutations
- Managed File Version service ↔ diff task
- harvest engine ↔ job notifier

The current code happened to defer access to the partially initialized exports, but that made
startup order, isolated module loading, and future bundling behavior implicit dependencies.

## Proposed change

- Move Session directory constants and `getSessionPersistenceDir` to a leaf path module.
- Move `applyNameOrIdFilter` to a pure Agents helper module.
- Move `ManagedFileVersionError` to a dedicated error module.
- Move `getJobHarvestDir` to the existing Compute workspace-path module.
- Keep the former repository/service/harvest-engine exports as compatibility re-exports.
- Add a TypeScript-AST architecture test that scans main-process production modules, includes only
  runtime relative import edges, and rejects cycles without adding a dependency.

## Scope and non-goals

This is a structural refactor only. It does not change user interaction, IPC behavior, database or
data models, persisted formats or paths, state enums, or historical-data compatibility. No migration
is required.

## Acceptance criteria and validation

The architecture test was run repeatedly before the production changes and failed deterministically
with exactly the four cycles above. After the last material edit:

- Runtime import graph → `npm test -- src/main/runtime-import-cycle.architecture.test.ts` → 1 test passed.
- Storage/Session path behavior → `npm test -- src/main/storage/data-path.test.ts src/main/session-persistence/data-path-roundtrip.test.ts src/main/session-persistence/repository.test.ts` → 106 tests passed.
- Agents catalog and mutation behavior → `npm test -- src/main/agents/agents-service.test.ts src/main/agents/agents-mutations.test.ts` → 51 tests passed.
- Managed File Version and Compute behavior → `npm test -- src/main/managed-file-versions/diff-task.test.ts src/main/managed-file-versions/ipc.test.ts src/main/managed-file-versions/service.integration.test.ts src/main/compute/harvest-engine.test.ts src/main/compute/job-notifier.test.ts src/main/compute/job-notifier.integration.test.ts` → 172 tests passed.
- Notebook consumers of the Session path constant → `npm test -- src/main/notebook/micromamba.test.ts src/main/notebook/provisioner.startup.test.ts` → 39 tests passed.
- Main-process types → `npm run typecheck:node` → passed.
- Lint → `npm run lint` → passed.

The dependency-aware explain command selected the full plan because the changed Agents file has no
registered module owner. Per maintainer direction, the full local `npm test` suite was not run; the PR
Gate is the final full-suite authority.

Uncovered pre-existing issue: the unrelated `package-manager.test.ts` case “kills the child and
reports failure when onChild (PID recording) throws” fails with `RUNTIME_CHILD_UNCONFIRMED`. The same
focused failure reproduces on the unmodified main checkout and is not caused by this import-only
change.

## Review focus

- Confirm each moved definition has exactly one leaf owner and that production consumers use it.
- Confirm compatibility re-exports preserve existing import surfaces and class identity.
- Confirm the architecture test excludes type-only imports and test-only modules while detecting
  runtime imports, re-exports, `require()`, and dynamic imports.
