### PR TITLE
fix(session-state): normalize stale recovery combinations

### DIFF
--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -3192,6 +3192,25 @@ describe('normalizeSessionFile with activities', () => {
     expect(restored?.error).toBeUndefined()
   })
 
+  it.each(['approved', 'rejected'] as const)(
+    'does not restore a %s Plan as still waiting for approval',
+    (approval) => {
+      const restored = normalizeSessionFile({
+        ...(createSessionWithActivity(undefined) as PersistedChatSession),
+        activities: undefined,
+        status: 'waiting-plan-approval',
+        runtimeContext: {
+          version: 1,
+          revision: 4,
+          plan: { ...createRuntimePlan(), approval }
+        }
+      })
+
+      expect(restored?.status).toBe('idle')
+      expect(restored?.activeRun).toBeUndefined()
+    }
+  )
+
   it('drops unknown or damaged runtime context without losing the conversation', () => {
     const unknown = normalizeSessionFile({
       ...createSessionWithActivity(undefined),
@@ -3516,50 +3535,53 @@ describe('normalizeSessionFile with activities', () => {
     })
   })
 
-  it('discards stale app-restart recovery after the prompt has a successful completed response', () => {
-    const restored = normalizeSessionFile({
-      id: 'session-1',
-      projectId: 'project-a',
-      title: 'Completed session',
-      cwd: '/workspace',
-      status: 'idle',
-      resumeRecovery: {
-        kind: 'resume-required',
-        cause: 'app-restart',
-        promptMessageId: 'prompt-1'
-      },
-      messages: [
-        {
-          id: 'prompt-1',
-          role: 'user',
-          content: 'Complete the task',
-          status: 'complete',
-          interrupted: true,
-          eventIds: [],
-          createdAt: 5,
-          updatedAt: 5
+  it.each(['app-restart', 'cancelled', 'connection-lost'] as const)(
+    'discards stale %s recovery after the prompt has a successful completed response',
+    (cause) => {
+      const restored = normalizeSessionFile({
+        id: 'session-1',
+        projectId: 'project-a',
+        title: 'Completed session',
+        cwd: '/workspace',
+        status: 'idle',
+        resumeRecovery: {
+          kind: 'resume-required',
+          cause,
+          promptMessageId: 'prompt-1'
         },
-        {
-          id: 'response-1',
-          role: 'agent',
-          content: 'Task completed.',
-          status: 'complete',
-          responseToMessageId: 'prompt-1',
-          eventIds: [],
-          createdAt: 6,
-          completedAt: 7,
-          updatedAt: 7
-        }
-      ],
-      createdAt: 1,
-      updatedAt: 7
-    })
+        messages: [
+          {
+            id: 'prompt-1',
+            role: 'user',
+            content: 'Complete the task',
+            status: 'complete',
+            interrupted: true,
+            eventIds: [],
+            createdAt: 5,
+            updatedAt: 5
+          },
+          {
+            id: 'response-1',
+            role: 'agent',
+            content: 'Task completed.',
+            status: 'complete',
+            responseToMessageId: 'prompt-1',
+            eventIds: [],
+            createdAt: 6,
+            completedAt: 7,
+            updatedAt: 7
+          }
+        ],
+        createdAt: 1,
+        updatedAt: 7
+      })
 
-    expect(restored).toMatchObject({ status: 'idle' })
-    expect(restored?.resumeRecovery).toBeUndefined()
-    expect(restored?.error).toBeUndefined()
-    expect(restored?.messages[0]).toMatchObject({ id: 'prompt-1', interrupted: true })
-  })
+      expect(restored).toMatchObject({ status: 'idle' })
+      expect(restored?.resumeRecovery).toBeUndefined()
+      expect(restored?.error).toBeUndefined()
+      expect(restored?.messages[0]).toMatchObject({ id: 'prompt-1', interrupted: true })
+    }
+  )
 
   it('discards stale recovery when the canonical active Branch has a completed response', () => {
     const messages: PersistedChatMessage[] = [

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -2895,7 +2895,7 @@ const normalizeSessionAfterRestore = (
   const hasCompletedResponse =
     session.status === 'idle' &&
     session.error === undefined &&
-    session.resumeRecovery?.cause === 'app-restart' &&
+    session.resumeRecovery !== undefined &&
     latestRecoveredPromptResponse?.status === 'complete'
   if (options.reconcileCompletedRecovery && hasCompletedResponse) {
     return {
@@ -4207,9 +4207,12 @@ const sanitizeSession = (
   if (runtimeContext) sanitized.runtimeContext = runtimeContext
   const planHistoryProjections = sanitizePlanHistoryProjections(session.planHistoryProjections)
   if (planHistoryProjections) sanitized.planHistoryProjections = planHistoryProjections
-  if (sanitized.status === 'waiting-plan-approval' && runtimeContext?.plan === undefined) {
+  if (
+    sanitized.status === 'waiting-plan-approval' &&
+    runtimeContext?.plan?.approval !== 'pending'
+  ) {
     // Approval waiting is meaningful only with restorable main-owned Plan authority. A corrupt or
-    // unknown context must not leave the conversation permanently blocked with nothing to approve.
+    // settled context must not leave the conversation permanently blocked with nothing to approve.
     sanitized.status = 'idle'
     sanitized.activeRun = undefined
   }


### PR DESCRIPTION
## Problem

Two inconsistent persisted Session combinations survived restore normalization:

- `waiting-plan-approval` remained blocking even when Main-owned Plan authority was already `approved` or `rejected`.
- `resumeRecovery` remained visible after the exact Prompt had a completed response when the recovery cause was `cancelled` or `connection-lost`.

Both leave the renderer presenting an action that no longer has a live owner.

## Proposed change

- Preserve a Plan approval wait only when sanitized Plan authority is actually `pending`.
- Clear stale recovery for every recognized cause when the active Branch proves that the exact recovery Prompt completed successfully in an idle, error-free Session.
- Cover the repaired combinations with parameterized regression tests at the Session decode/restore boundary.

## Scope and non-goals

- No parallel state machine or new owner.
- No Session fields, enum values, envelope versions, Prisma/SQLite changes, or migration.
- No change to running-without-`activeRun` recovery, Permission/Elicitation ownership checks, history replay semantics, or Specialist binding command policy.

## Persisted data and historical compatibility

Existing inconsistent Session JSON is repaired when loaded. Files are not eagerly rewritten; a later normal save persists the normalized projection. Valid historical Sessions retain their current behavior.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Red reproductions become green; existing restore behavior remains intact | `vitest run src/shared/session-persistence.test.ts -t 'does not restore\|discards stale'` | 7 passed |
| Restore sanitizer plus Renderer/Workspace actionability boundaries | `vitest run src/shared/session-persistence.test.ts src/renderer/src/stores/session-store.test.ts src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx` | 398 passed |
| Main Session persistence owner/contracts/consumers | `npm run test:module -- session_persistence` | 9 files, 502 tests passed |
| Renderer Session owner/contracts/representative consumer | `npm run test:module -- session_renderer` | 5 files, 603 tests passed |
| Main/shared types | `npm run typecheck:node` | passed |
| Renderer/shared types | `npm run typecheck:web` | passed |
| Linted source | `npm run lint` | passed |
| Formatting and whitespace | `npx prettier --check src/shared/session-persistence.ts src/shared/session-persistence.test.ts`; `git diff --check` | passed |

`npm run test:affected:explain -- --base origin/main --head HEAD` selects the full portable suite because `src/shared/session-persistence.ts` has no module owner entry. Per the requested local test scope, the complete `npm test` was not run locally; exact-head PR CI is the remaining authority for that fallback and cross-platform coverage.

## Review focus

- Whether a settled Plan can legitimately retain `waiting-plan-approval` (the current Main-owned authority contract says no).
- Whether an exact completed response in an idle, error-free Session is sufficient to retire all recovery causes.
- Historical compatibility of load-time normalization without a persisted-format migration.
