### PR TITLE
fix(pdf-context): preserve logical file identity

### DIFF
--- a/e2e/workspace-files.spec.ts
+++ b/e2e/workspace-files.spec.ts
@@ -16,6 +16,26 @@ const SCRIPT_NAME = 'analysis.sh'
 const SCRIPT_CONTENT = '#!/bin/bash\n# stable\necho "old"\n'
 const SCRIPT_VERSION_TWO_CONTENT = '#!/bin/bash\n# stable\necho "new"\n'
 
+const createTwoPagePdf = (): Buffer => {
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> >>'
+  ]
+  const offsets: number[] = []
+  let body = '%PDF-1.4\n'
+  for (const [index, object] of objects.entries()) {
+    offsets.push(Buffer.byteLength(body))
+    body += `${index + 1} 0 obj\n${object}\nendobj\n`
+  }
+  const xrefOffset = Buffer.byteLength(body)
+  const xref = offsets.map((offset) => `${String(offset).padStart(10, '0')} 00000 n `).join('\n')
+  return Buffer.from(
+    `${body}xref\n0 ${objects.length + 1}\n0000000000 65535 f \n${xref}\ntrailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`
+  )
+}
+
 const createProject = async (page: Page): Promise<void> => {
   await page.getByRole('button', { name: 'New project' }).click()
   const dialog = page.getByRole('dialog', { name: 'New project' })
@@ -188,6 +208,29 @@ test('edits uploaded Markdown versions and keeps diff navigation coherent', asyn
 
   await preview.getByRole('button', { name: `Close preview of ${FILE_NAME}` }).click()
   await expect(preview).toBeHidden()
+})
+
+test('links a multi-page PDF upload as Reading context in a new project', async ({ app }) => {
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await createProject(page)
+
+  await page.locator('input[type="file"][multiple]').setInputFiles({
+    name: 'paper.pdf',
+    mimeType: 'application/pdf',
+    buffer: createTwoPagePdf()
+  })
+  await expect(page.getByTestId('automatic-reading-suggestion')).toContainText(
+    '1 PDF will be linked when sent'
+  )
+
+  await page.getByRole('textbox', { name: 'Ask anything' }).fill('Summarize the attached paper.')
+  await page.getByRole('button', { name: 'Send message' }).click()
+
+  await expect(page.getByTestId('pdf-context-bar')).toContainText('paper.pdf')
+  await expect(page.getByRole('button', { name: 'Page 1 of 2' })).toBeVisible()
+  await expect(page.getByText('PDF context Version is unavailable in this Project.')).toHaveCount(0)
+  await expect(page.getByText('Managed file reference requires a logical identity.')).toHaveCount(0)
 })
 
 test('shows structured text replacements with character-level highlights', async ({ app }) => {

--- a/src/main/session-persistence/pdf-context-owner.test.ts
+++ b/src/main/session-persistence/pdf-context-owner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import type { NotebookRunInputFile } from '../../shared/notebook'
 import type { SessionRuntimeContext } from '../../shared/session-persistence'
+import { ImmutableInputAuthority } from '../immutable-input-authority'
 import { inspectPdfPageCount, MAX_AUTO_EXTRACT_PDF_BYTES } from '../uploads/attachment-media'
 import { SessionPdfContextOwner } from './pdf-context-owner'
 
@@ -80,14 +81,28 @@ describe('SessionPdfContextOwner', () => {
       harness.owner.filterCandidates({
         projectId: 'project-1',
         sources: [
-          { sourceKind: 'artifact-version', sourceVersionId: 'single-page' },
-          { sourceKind: 'artifact-version', sourceVersionId: 'multi-page' },
-          { sourceKind: 'artifact-version', sourceVersionId: 'notes' },
-          { sourceKind: 'artifact-version', sourceVersionId: 'missing' }
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'single-page',
+            sourceVersionId: 'single-page'
+          },
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'multi-page',
+            sourceVersionId: 'multi-page'
+          },
+          { sourceKind: 'artifact-version', sourceFileId: 'notes', sourceVersionId: 'notes' },
+          { sourceKind: 'artifact-version', sourceFileId: 'missing', sourceVersionId: 'missing' }
         ]
       })
     ).resolves.toEqual({
-      sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'multi-page' }],
+      sources: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'multi-page',
+          sourceVersionId: 'multi-page'
+        }
+      ],
       pendingAttachmentIds: []
     })
   })
@@ -125,13 +140,20 @@ describe('SessionPdfContextOwner', () => {
       projectId: 'project-1',
       sessionId: 'session-1',
       expectedRevision: 4,
-      sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+      sources: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-1',
+          sourceVersionId: 'version-1'
+        }
+      ]
     })
 
     expect(harness.resolveVersion).toHaveBeenCalledWith({
       projectId: 'project-1',
       sourceKind: 'artifact-version',
-      inputFileVersionId: 'version-1'
+      inputFileVersionId: 'version-1',
+      expectedSourceFileId: 'artifact-1'
     })
     expect(harness.patchSessionRuntimeContext).toHaveBeenCalledWith({
       projectId: 'project-1',
@@ -155,6 +177,78 @@ describe('SessionPdfContextOwner', () => {
     expect(context.pdfContext?.bindings[0]?.bindingId).toEqual(expect.any(String))
   })
 
+  it('links a newly finalized upload through its complete immutable Version identity', async () => {
+    const openVersion = vi.fn().mockResolvedValue({
+      path: '/managed/paper.pdf',
+      size: input.sizeBytes,
+      logicalFile: {
+        source: 'upload',
+        id: 'upload-1',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        displayName: input.filename,
+        currentVersionId: input.inputFileVersionId
+      },
+      version: {
+        id: input.inputFileVersionId,
+        fileId: 'upload-1',
+        versionNumber: 1,
+        contentStorageKey: input.storageKey,
+        filename: input.filename,
+        originalFilename: input.filename,
+        contentType: input.contentType,
+        sizeBytes: BigInt(input.sizeBytes),
+        checksum: input.checksum,
+        createdAt: new Date('2026-09-03T00:00:00.000Z')
+      },
+      verifyUnchanged: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined)
+    })
+    const readSessionRuntimeContext = vi.fn(async () => ({ version: 1 as const, revision: 0 }))
+    const patchSessionRuntimeContext = vi.fn(async (request) => ({
+      version: 1 as const,
+      revision: request.expectedRevision + 1,
+      ...request.patch
+    }))
+    const owner = new SessionPdfContextOwner({
+      inputs: new ImmutableInputAuthority({
+        storageRoot: '/storage',
+        managedFileVersions: { openVersion }
+      } as never),
+      sessions: { readSessionRuntimeContext, patchSessionRuntimeContext }
+    })
+    const source = {
+      sourceKind: 'upload-version' as const,
+      sourceFileId: 'upload-1',
+      sourceVersionId: input.inputFileVersionId
+    }
+
+    await expect(
+      owner.link({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        expectedRevision: 0,
+        sources: [source],
+        excludeSinglePage: true
+      })
+    ).resolves.toMatchObject({
+      revision: 1,
+      pdfContext: {
+        bindings: [
+          expect.objectContaining({
+            sourceKind: 'upload-version',
+            sourceFileId: 'upload-1',
+            sourceVersionId: input.inputFileVersionId
+          })
+        ]
+      }
+    })
+    expect(openVersion).toHaveBeenCalledWith(
+      { source: 'upload', projectId: 'project-1', fileId: 'upload-1' },
+      input.inputFileVersionId
+    )
+  })
+
   it('rejects unavailable and non-PDF versions without mutating the Session', async () => {
     const unavailable = setup(null)
     await expect(
@@ -162,7 +256,13 @@ describe('SessionPdfContextOwner', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         expectedRevision: 4,
-        sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'missing' }]
+        sources: [
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'missing'
+          }
+        ]
       })
     ).rejects.toThrow('unavailable')
     expect(unavailable.patchSessionRuntimeContext).not.toHaveBeenCalled()
@@ -173,7 +273,13 @@ describe('SessionPdfContextOwner', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         expectedRevision: 4,
-        sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+        sources: [
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'version-1'
+          }
+        ]
       })
     ).rejects.toThrow('Only PDF')
     expect(nonPdf.patchSessionRuntimeContext).not.toHaveBeenCalled()
@@ -186,7 +292,13 @@ describe('SessionPdfContextOwner', () => {
     await expect(
       harness.owner.filterCandidates({
         projectId: 'project-1',
-        sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+        sources: [
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'version-1'
+          }
+        ]
       })
     ).resolves.toEqual({ sources: [], pendingAttachmentIds: [] })
     expect(inspectPdfPageCount).not.toHaveBeenCalled()
@@ -196,7 +308,13 @@ describe('SessionPdfContextOwner', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         expectedRevision: 4,
-        sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+        sources: [
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'version-1'
+          }
+        ]
       })
     ).rejects.toThrow('exceeding the automatic extraction limit')
     expect(harness.patchSessionRuntimeContext).not.toHaveBeenCalled()
@@ -233,7 +351,13 @@ describe('SessionPdfContextOwner', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         expectedRevision: 4,
-        sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+        sources: [
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'version-1'
+          }
+        ]
       })
     ).resolves.toEqual({ context: current, changed: false })
     expect(harness.patchSessionRuntimeContext).not.toHaveBeenCalled()
@@ -294,7 +418,13 @@ describe('SessionPdfContextOwner', () => {
       projectId: 'project-1',
       sessionId: 'session-1',
       expectedRevision: 4,
-      sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }],
+      sources: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-1',
+          sourceVersionId: 'version-1'
+        }
+      ],
       excludeSinglePage: true
     })
     expect(unchanged.pdfContext).toBeUndefined()
@@ -307,7 +437,13 @@ describe('SessionPdfContextOwner', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         expectedRevision: 4,
-        sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+        sources: [
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'version-1'
+          }
+        ]
       })
     ).rejects.toThrow('multi-page')
   })
@@ -363,8 +499,16 @@ describe('SessionPdfContextOwner', () => {
       sessionId: 'session-1',
       expectedRevision: 4,
       sources: [
-        { sourceKind: 'artifact-version', sourceVersionId: 'single-page' },
-        { sourceKind: 'artifact-version', sourceVersionId: 'version-3' }
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'single-page',
+          sourceVersionId: 'single-page'
+        },
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'version-3',
+          sourceVersionId: 'version-3'
+        }
       ],
       excludeSinglePage: true
     })

--- a/src/main/session-persistence/pdf-context-owner.ts
+++ b/src/main/session-persistence/pdf-context-owner.ts
@@ -61,7 +61,8 @@ class SessionPdfContextOwner {
       const input = await this.options.inputs.resolveVersion({
         projectId: request.projectId,
         sourceKind: source.sourceKind,
-        inputFileVersionId: source.sourceVersionId
+        inputFileVersionId: source.sourceVersionId,
+        expectedSourceFileId: source.sourceFileId
       })
       if (
         !input ||
@@ -144,7 +145,8 @@ class SessionPdfContextOwner {
       const input = await this.options.inputs.resolveVersion({
         projectId: request.projectId,
         sourceKind: source.sourceKind,
-        inputFileVersionId: source.sourceVersionId
+        inputFileVersionId: source.sourceVersionId,
+        expectedSourceFileId: source.sourceFileId
       })
       if (!input) throw new Error('PDF context Version is unavailable in this Project.')
       if (!isPdf(input.filename, input.contentType)) {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2063,6 +2063,7 @@ describe('workspace agent message sending', () => {
     const replacementSelection = {
       kind: 'version' as const,
       sourceKind: 'artifact-version' as const,
+      sourceFileId: 'artifact-2',
       sourceVersionId: 'version-2',
       previewItemId: 'artifact:version-2'
     }
@@ -2130,6 +2131,7 @@ describe('workspace agent message sending', () => {
     const selection = {
       kind: 'version' as const,
       sourceKind: 'artifact-version' as const,
+      sourceFileId: 'artifact-1',
       sourceVersionId: 'version-1',
       previewItemId: 'artifact:version-1'
     }
@@ -2997,7 +2999,13 @@ describe('workspace agent message sending', () => {
         readingPosition: { pageNumber: 7, pageCount: 14 }
       },
       pdfReadingPosition: { pageNumber: 7, pageCount: 14 },
-      pendingPdfContextVersions: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-2' }]
+      pendingPdfContextVersions: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-2',
+          sourceVersionId: 'version-2'
+        }
+      ]
     })
 
     await vi.waitFor(() => expect(runtime.sendPrompt).toHaveBeenCalledOnce())
@@ -3072,7 +3080,13 @@ describe('workspace agent message sending', () => {
           linkPdfContext,
           saveSession: vi.fn(async (session: PersistedChatSession) => session),
           filterPdfContextCandidates: vi.fn().mockResolvedValue({
-            sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'artifact-version-2' }],
+            sources: [
+              {
+                sourceKind: 'artifact-version',
+                sourceFileId: 'artifact-2',
+                sourceVersionId: 'artifact-version-2'
+              }
+            ],
             pendingAttachmentIds: [stagedPdf.id]
           })
         }
@@ -3093,7 +3107,11 @@ describe('workspace agent message sending', () => {
       attachments: [stagedPdf],
       pendingPdfContextAttachmentIds: [stagedPdf.id],
       pendingPdfContextVersions: [
-        { sourceKind: 'artifact-version', sourceVersionId: 'artifact-version-2' }
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-2',
+          sourceVersionId: 'artifact-version-2'
+        }
       ],
       pdfReadingPosition: readingPosition,
       cwd: '/workspace/project',
@@ -3107,8 +3125,16 @@ describe('workspace agent message sending', () => {
       sessionId: 'transport-session-1',
       expectedRevision: 0,
       sources: [
-        { sourceKind: 'upload-version', sourceVersionId: 'pdf-version-1' },
-        { sourceKind: 'artifact-version', sourceVersionId: 'artifact-version-2' }
+        {
+          sourceKind: 'upload-version',
+          sourceFileId: 'pdf-upload-1',
+          sourceVersionId: 'pdf-version-1'
+        },
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-2',
+          sourceVersionId: 'artifact-version-2'
+        }
       ],
       excludeSinglePage: true
     })
@@ -3117,6 +3143,18 @@ describe('workspace agent message sending', () => {
       activeBindingId: stagedBinding.bindingId,
       readingPosition
     })
+    expect(runtime.sendPrompt.mock.calls[0]?.[4]).toEqual([
+      expect.objectContaining({
+        source: 'upload',
+        sourceFileId: 'pdf-upload-1',
+        versionId: 'pdf-version-1'
+      }),
+      expect.objectContaining({
+        source: 'artifact',
+        sourceFileId: 'artifact-2',
+        versionId: 'artifact-version-2'
+      })
+    ])
   })
 
   it('does not append a prompt when attachment finalization fails', async () => {
@@ -4028,7 +4066,13 @@ describe('workspace agent message sending', () => {
           saveSession,
           linkPdfContext,
           filterPdfContextCandidates: vi.fn().mockResolvedValue({
-            sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'artifact-version-2' }],
+            sources: [
+              {
+                sourceKind: 'artifact-version',
+                sourceFileId: 'artifact-2',
+                sourceVersionId: 'artifact-version-2'
+              }
+            ],
             pendingAttachmentIds: [stagedPdf.id]
           })
         }
@@ -4053,7 +4097,11 @@ describe('workspace agent message sending', () => {
         attachments: [stagedPdf],
         pendingPdfContextAttachmentIds: [stagedPdf.id],
         pendingPdfContextVersions: [
-          { sourceKind: 'artifact-version', sourceVersionId: 'artifact-version-2' }
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-2',
+            sourceVersionId: 'artifact-version-2'
+          }
         ],
         pdfReadingPosition: readingPosition,
         cwd: '/workspace/project',
@@ -4077,8 +4125,16 @@ describe('workspace agent message sending', () => {
       sessionId: 'transport-session-1',
       expectedRevision: 3,
       sources: [
-        { sourceKind: 'upload-version', sourceVersionId: 'pdf-version-1' },
-        { sourceKind: 'artifact-version', sourceVersionId: 'artifact-version-2' }
+        {
+          sourceKind: 'upload-version',
+          sourceFileId: 'pdf-upload-1',
+          sourceVersionId: 'pdf-version-1'
+        },
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-2',
+          sourceVersionId: 'artifact-version-2'
+        }
       ],
       excludeSinglePage: true
     })
@@ -4561,7 +4617,11 @@ describe('workspace agent message sending', () => {
         projectId: 'project-1',
         delegationPolicy: 'deny',
         pendingPdfContextVersions: [
-          { sourceKind: 'artifact-version', sourceVersionId: 'version-1' }
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'version-1'
+          }
         ]
       },
       { awaitPendingPreparation: true }

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -402,6 +402,7 @@ const finalizedPdfContextSources = ({
   }
   return selected.map((attachment) => ({
     sourceKind: 'upload-version',
+    sourceFileId: attachment!.id,
     sourceVersionId: attachment!.versionId!
   }))
 }
@@ -427,7 +428,11 @@ const filterPendingPdfContext = async (
     const attachment = request.attachments.find((candidate) => candidate.id === attachmentId)
     if (!attachment) throw new Error('The staged PDF is no longer attached to this message.')
     if (attachment.versionId) {
-      versions.push({ sourceKind: 'upload-version', sourceVersionId: attachment.versionId })
+      versions.push({
+        sourceKind: 'upload-version',
+        sourceFileId: attachment.id,
+        sourceVersionId: attachment.versionId
+      })
       continue
     }
     pendingAttachments.push({
@@ -734,7 +739,11 @@ const sendWorkspaceMessage = async (
         ...(pdfContext
           ? {
               pendingPdfContextVersions: pdfContext.bindings.map(
-                ({ sourceKind, sourceVersionId }) => ({ sourceKind, sourceVersionId })
+                ({ sourceKind, sourceFileId, sourceVersionId }) => ({
+                  sourceKind,
+                  sourceFileId,
+                  sourceVersionId
+                })
               ),
               pdfReadingPosition: pdfContext.readingPosition
             }

--- a/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.test.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.test.ts
@@ -212,7 +212,13 @@ describe('branchWorkspaceSessionFromMessage', () => {
       projectId: 'project-1',
       sessionId: 'branched-session',
       expectedRevision: 0,
-      sources: [{ sourceKind: 'upload-version', sourceVersionId: 'version-1' }]
+      sources: [
+        {
+          sourceKind: 'upload-version',
+          sourceFileId: 'file-1',
+          sourceVersionId: 'version-1'
+        }
+      ]
     })
     expect(
       useSessionStore.getState().sessions.find((session) => session.id === 'branched-session')

--- a/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts
@@ -98,7 +98,11 @@ export const branchWorkspaceSessionFromMessage = async (
         ...new Map(
           pdfContext.bindings.map((binding) => [
             `${binding.sourceKind}:${binding.sourceVersionId}`,
-            { sourceKind: binding.sourceKind, sourceVersionId: binding.sourceVersionId }
+            {
+              sourceKind: binding.sourceKind,
+              sourceFileId: binding.sourceFileId,
+              sourceVersionId: binding.sourceVersionId
+            }
           ])
         ).values()
       ]

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1550,6 +1550,7 @@ const ConversationPanel = ({
                                 ? [
                                     {
                                       sourceKind: binding.sourceKind,
+                                      sourceFileId: binding.sourceFileId,
                                       sourceVersionId: binding.sourceVersionId
                                     }
                                   ]

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -2149,7 +2149,13 @@ describe('PreviewFileSurface PDF context action matrix', () => {
       projectId: 'project-1',
       sessionId: 'active-session',
       expectedRevision: 3,
-      sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+      sources: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-1',
+          sourceVersionId: 'version-1'
+        }
+      ]
     })
     // Linking is "Read with agent": the composer takes focus so the user can ask immediately.
     expect(focusListener).toHaveBeenCalled()
@@ -2177,6 +2183,7 @@ describe('PreviewFileSurface PDF context action matrix', () => {
 
     expect(onLinkReadingContext).toHaveBeenCalledWith({
       sourceKind: 'artifact-version',
+      sourceFileId: 'artifact-1',
       sourceVersionId: 'version-1'
     })
     expect(direct.linkPdfContext).not.toHaveBeenCalled()
@@ -2227,7 +2234,13 @@ describe('PreviewFileSurface PDF context action matrix', () => {
       projectId: 'project-1',
       sessionId: 'active-session',
       expectedRevision: 3,
-      sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+      sources: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-1',
+          sourceVersionId: 'version-1'
+        }
+      ]
     })
   })
 
@@ -2310,6 +2323,7 @@ describe('PreviewFileSurface PDF context action matrix', () => {
     expect(usePreviewWorkbenchStore.getState().pendingPdfContextByProject['project-1']).toEqual({
       kind: 'version',
       sourceKind: 'artifact-version',
+      sourceFileId: 'artifact-1',
       sourceVersionId: 'version-1',
       previewItemId: 'artifact-1'
     })
@@ -2343,6 +2357,7 @@ describe('PreviewFileSurface PDF context action matrix', () => {
     expect(usePreviewWorkbenchStore.getState().pendingPdfContextByProject['project-1']).toEqual({
       kind: 'version',
       sourceKind: 'artifact-version',
+      sourceFileId: 'artifact-1',
       sourceVersionId: 'version-1',
       previewItemId: 'artifact-1'
     })
@@ -2355,6 +2370,7 @@ describe('PreviewFileSurface PDF context action matrix', () => {
       ...pdfItem,
       id: 'upload-1',
       artifactId: undefined,
+      managedFileId: 'upload-1',
       selectedVersionId: undefined,
       source: 'upload',
       path: 'upload-version:project-1/source-session/upload-version-1'
@@ -2367,7 +2383,13 @@ describe('PreviewFileSurface PDF context action matrix', () => {
 
     expect(linkPdfContext).toHaveBeenCalledWith(
       expect.objectContaining({
-        sources: [{ sourceKind: 'upload-version', sourceVersionId: 'upload-version-1' }]
+        sources: [
+          {
+            sourceKind: 'upload-version',
+            sourceFileId: 'upload-1',
+            sourceVersionId: 'upload-version-1'
+          }
+        ]
       })
     )
   })
@@ -2528,6 +2550,7 @@ describe('PreviewFileSurface PDF context action matrix', () => {
         sources: [
           {
             sourceKind: 'upload-version',
+            sourceFileId: 'upload-1',
             sourceVersionId: 'notebook-upload-version-1'
           }
         ]

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -1268,7 +1268,13 @@ describe('PreviewPanel', () => {
     expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-1')
     expect(linkPdfContext).toHaveBeenCalledWith(
       expect.objectContaining({
-        sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-1' }]
+        sources: [
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'item-1',
+            sourceVersionId: 'version-1'
+          }
+        ]
       })
     )
     expect(focusListener).toHaveBeenCalled()
@@ -1326,6 +1332,7 @@ describe('PreviewPanel', () => {
     await vi.waitFor(() =>
       expect(onLinkReadingContext).toHaveBeenCalledWith({
         sourceKind: 'artifact-version',
+        sourceFileId: 'item-1',
         sourceVersionId: 'version-1'
       })
     )

--- a/src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx
+++ b/src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx
@@ -84,7 +84,13 @@ describe('ReadingContextPicker', () => {
       totalCount: 3
     })
     const filterPdfContextCandidates = vi.fn().mockResolvedValue({
-      sources: [{ sourceKind: 'artifact-version', sourceVersionId: 'version-multi' }],
+      sources: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-1',
+          sourceVersionId: 'version-multi'
+        }
+      ],
       pendingAttachmentIds: []
     })
     vi.stubGlobal('api', {
@@ -112,8 +118,16 @@ describe('ReadingContextPicker', () => {
     expect(filterPdfContextCandidates).toHaveBeenCalledWith({
       projectId: 'project-1',
       sources: [
-        { sourceKind: 'artifact-version', sourceVersionId: 'version-multi' },
-        { sourceKind: 'upload-version', sourceVersionId: 'version-single' }
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-1',
+          sourceVersionId: 'version-multi'
+        },
+        {
+          sourceKind: 'upload-version',
+          sourceFileId: 'upload-1',
+          sourceVersionId: 'version-single'
+        }
       ]
     })
 
@@ -121,6 +135,7 @@ describe('ReadingContextPicker', () => {
     await waitFor(() =>
       expect(onSelect).toHaveBeenCalledWith({
         sourceKind: 'artifact-version',
+        sourceFileId: 'artifact-1',
         sourceVersionId: 'version-multi'
       })
     )

--- a/src/renderer/src/pages/workspace/ReadingContextPicker.tsx
+++ b/src/renderer/src/pages/workspace/ReadingContextPicker.tsx
@@ -32,6 +32,7 @@ const toSource = (file: ProjectFileItem): SessionPdfContextSource | undefined =>
   file.sourceVersionId
     ? {
         sourceKind: file.source === 'upload' ? 'upload-version' : 'artifact-version',
+        sourceFileId: file.sourceFileId,
         sourceVersionId: file.sourceVersionId
       }
     : undefined

--- a/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
@@ -478,6 +478,7 @@ describe('WorkspacePage image attachment gating', () => {
     const manualSelection = {
       kind: 'version' as const,
       sourceKind: 'artifact-version' as const,
+      sourceFileId: 'artifact-9',
       sourceVersionId: 'version-9',
       previewItemId: 'other-preview'
     }

--- a/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.test.ts
@@ -278,6 +278,7 @@ describe('docToPdfContextSources', () => {
       name: `${id}.pdf`,
       path: `/${id}.pdf`,
       source,
+      sourceFileId: `file-${id}`,
       mimeType: 'application/pdf; charset=binary',
       versionId: `version-${id}`
     })
@@ -301,9 +302,21 @@ describe('docToPdfContextSources', () => {
         ]
       })
     ).toEqual([
-      { sourceKind: 'artifact-version', sourceVersionId: 'version-one' },
-      { sourceKind: 'upload-version', sourceVersionId: 'version-two' },
-      { sourceKind: 'artifact-version', sourceVersionId: 'version-three' }
+      {
+        sourceKind: 'artifact-version',
+        sourceFileId: 'file-one',
+        sourceVersionId: 'version-one'
+      },
+      {
+        sourceKind: 'upload-version',
+        sourceFileId: 'file-two',
+        sourceVersionId: 'version-two'
+      },
+      {
+        sourceKind: 'artifact-version',
+        sourceFileId: 'file-three',
+        sourceVersionId: 'version-three'
+      }
     ])
   })
 })

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -238,6 +238,7 @@ export const docToPdfContextSources = (doc: ComposerDoc): SessionPdfContextSourc
   for (const reference of docToArtifactRefs(doc)) {
     if (
       reference.source === 'linked-folder' ||
+      !reference.sourceFileId ||
       !reference.versionId ||
       (reference.mimeType?.split(';', 1)[0]?.trim().toLowerCase() !== 'application/pdf' &&
         !reference.name.toLowerCase().endsWith('.pdf'))
@@ -246,6 +247,7 @@ export const docToPdfContextSources = (doc: ComposerDoc): SessionPdfContextSourc
     }
     const source: SessionPdfContextSource = {
       sourceKind: reference.source === 'upload' ? 'upload-version' : 'artifact-version',
+      sourceFileId: reference.sourceFileId,
       sourceVersionId: reference.versionId
     }
     const identity = `${source.sourceKind}:${source.sourceVersionId}`

--- a/src/renderer/src/pages/workspace/preview-file-item.test.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.test.ts
@@ -285,6 +285,8 @@ describe('preview file item helpers', () => {
       projectId: 'project-1',
       sessionId: 'source-session',
       source: 'upload',
+      managedFileId: 'upload-1',
+      selectedVersionId: 'upload-version-2',
       path: 'upload-version:project-1/source-session/upload-version-2',
       format: 'pdf'
     })

--- a/src/renderer/src/pages/workspace/preview-file-item.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.ts
@@ -234,7 +234,8 @@ export const createPreviewFileItemFromPdfContext = (
     size: context.sizeBytes,
     source: isArtifact ? undefined : 'upload',
     artifactId: isArtifact ? context.sourceFileId : undefined,
-    selectedVersionId: isArtifact ? context.sourceVersionId : undefined
+    managedFileId: context.sourceFileId,
+    selectedVersionId: context.sourceVersionId
   })
 }
 

--- a/src/renderer/src/pages/workspace/use-pdf-context-action.ts
+++ b/src/renderer/src/pages/workspace/use-pdf-context-action.ts
@@ -15,15 +15,15 @@ import {
 } from '@/stores/preview-workbench-store'
 import { useSessionStore } from '@/stores/session-store'
 import { parseNotebookInputPreviewKey } from '../../../../shared/notebook'
-import { MAX_SESSION_PDF_CONTEXTS } from '../../../../shared/session-persistence'
+import {
+  MAX_SESSION_PDF_CONTEXTS,
+  type SessionPdfContextSource
+} from '../../../../shared/session-persistence'
 import { PENDING_UPLOAD_SESSION_ID, parseUploadVersionReference } from '../../../../shared/uploads'
 
 import { requestComposerFocus } from './composer-focus-events'
 
-export type PdfContextTarget = {
-  sourceKind: 'artifact-version' | 'upload-version'
-  sourceVersionId: string
-}
+export type PdfContextTarget = SessionPdfContextSource
 
 // A managed PDF is linkable once it has immutable Version identity; local files never are.
 export const resolvePdfContextTarget = (item: PreviewFileItem): PdfContextTarget | undefined => {
@@ -33,6 +33,7 @@ export const resolvePdfContextTarget = (item: PreviewFileItem): PdfContextTarget
       const identity = parseNotebookInputPreviewKey(item.path)
       return {
         sourceKind: identity.sourceKind,
+        sourceFileId: identity.sourceFileId,
         sourceVersionId: identity.inputFileVersionId
       }
     } catch {
@@ -41,12 +42,14 @@ export const resolvePdfContextTarget = (item: PreviewFileItem): PdfContextTarget
   }
   if (item.source === 'upload') {
     const identity = parseUploadVersionReference(item.path)
-    return identity
-      ? { sourceKind: 'upload-version', sourceVersionId: identity.versionId }
+    const sourceFileId = item.managedFileId ?? identity?.fileId
+    return identity && sourceFileId
+      ? { sourceKind: 'upload-version', sourceFileId, sourceVersionId: identity.versionId }
       : undefined
   }
-  return item.selectedVersionId
-    ? { sourceKind: 'artifact-version', sourceVersionId: item.selectedVersionId }
+  const sourceFileId = item.managedFileId ?? item.artifactId
+  return item.selectedVersionId && sourceFileId
+    ? { sourceKind: 'artifact-version', sourceFileId, sourceVersionId: item.selectedVersionId }
     : undefined
 }
 
@@ -188,6 +191,7 @@ export const usePdfContextAction = (
           : {
               kind: 'version',
               sourceKind: pdfContextTarget!.sourceKind,
+              sourceFileId: pdfContextTarget!.sourceFileId,
               sourceVersionId: pdfContextTarget!.sourceVersionId,
               previewItemId: item!.id
             }

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -162,10 +162,12 @@ describe('workspace composer controller', () => {
   it('starts a Reading mutation for a newly selected Session after the previous Session settles', async () => {
     const sourceA = {
       sourceKind: 'upload-version' as const,
+      sourceFileId: 'upload-a',
       sourceVersionId: 'version-a'
     }
     const sourceB = {
       sourceKind: 'upload-version' as const,
+      sourceFileId: 'upload-b',
       sourceVersionId: 'version-b'
     }
     const bindingB = {
@@ -231,6 +233,7 @@ describe('workspace composer controller', () => {
   it('undoes and redoes Reading changes while coalescing rapid async mutations', async () => {
     const source = {
       sourceKind: 'upload-version' as const,
+      sourceFileId: 'upload-1',
       sourceVersionId: 'version-1'
     }
     const binding = {
@@ -309,10 +312,12 @@ describe('workspace composer controller', () => {
   it('does not retain Reading undo entries when a coalesced link mutation fails', async () => {
     const sourceA = {
       sourceKind: 'upload-version' as const,
+      sourceFileId: 'upload-a',
       sourceVersionId: 'version-a'
     }
     const sourceB = {
       sourceKind: 'upload-version' as const,
+      sourceFileId: 'upload-b',
       sourceVersionId: 'version-b'
     }
     const failedLink = deferred<never>()
@@ -347,6 +352,7 @@ describe('workspace composer controller', () => {
   it('removes the Reading redo entry when a link fails after an in-flight undo', async () => {
     const source = {
       sourceKind: 'upload-version' as const,
+      sourceFileId: 'upload-a',
       sourceVersionId: 'version-a'
     }
     const failedLink = deferred<never>()
@@ -378,6 +384,7 @@ describe('workspace composer controller', () => {
   it('does not retain a Reading undo entry when unlink fails', async () => {
     const source = {
       sourceKind: 'upload-version' as const,
+      sourceFileId: 'upload-a',
       sourceVersionId: 'version-a'
     }
     const binding = {
@@ -669,6 +676,7 @@ describe('workspace composer controller', () => {
             name: 'paper.pdf',
             path: '/paper.pdf',
             source: 'artifact',
+            sourceFileId: 'paper',
             mimeType: 'application/pdf',
             versionId: 'paper-version'
           }
@@ -678,12 +686,20 @@ describe('workspace composer controller', () => {
 
     expect(hook.result.current.lifecycle.captureSend()).toMatchObject({
       pendingPdfContextVersions: [
-        { sourceKind: 'artifact-version', sourceVersionId: 'paper-version' }
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'paper',
+          sourceVersionId: 'paper-version'
+        }
       ]
     })
     expect(hook.result.current.lifecycle.captureSend(false)).toMatchObject({
       pendingPdfContextVersions: [
-        { sourceKind: 'artifact-version', sourceVersionId: 'paper-version' }
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'paper',
+          sourceVersionId: 'paper-version'
+        }
       ]
     })
   })

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -85,6 +85,7 @@ export type ComposerSendSnapshot = {
   pendingPdfContextAttachmentIds?: string[]
   pendingPdfContextVersions?: Array<{
     sourceKind: 'artifact-version' | 'upload-version'
+    sourceFileId: string
     sourceVersionId: string
   }>
 }
@@ -213,8 +214,9 @@ const useWorkspaceComposerController = ({
   )
   const durableReadingSources = useMemo(
     () =>
-      durableReadingBindings.map(({ sourceKind, sourceVersionId }) => ({
+      durableReadingBindings.map(({ sourceKind, sourceFileId, sourceVersionId }) => ({
         sourceKind,
+        sourceFileId,
         sourceVersionId
       })),
     [durableReadingBindings]
@@ -436,7 +438,11 @@ const useWorkspaceComposerController = ({
       }
       const currentSources = (
         readingMutationRuntimeRef.current?.runtimeContext.pdfContext?.bindings ?? []
-      ).map(({ sourceKind, sourceVersionId }) => ({ sourceKind, sourceVersionId }))
+      ).map(({ sourceKind, sourceFileId, sourceVersionId }) => ({
+        sourceKind,
+        sourceFileId,
+        sourceVersionId
+      }))
       if (samePdfContextSources(uniqueSources, currentSources)) return Promise.resolve()
 
       const operationSessionId = activeSession.id
@@ -486,7 +492,11 @@ const useWorkspaceComposerController = ({
           const currentBindings =
             readingMutationRuntimeRef.current?.runtimeContext.pdfContext?.bindings ?? []
           readingContextSourcesRef.current = currentBindings.map(
-            ({ sourceKind, sourceVersionId }) => ({ sourceKind, sourceVersionId })
+            ({ sourceKind, sourceFileId, sourceVersionId }) => ({
+              sourceKind,
+              sourceFileId,
+              sourceVersionId
+            })
           )
           setError(error instanceof Error ? error.message : String(error))
           throw error
@@ -919,6 +929,7 @@ const useWorkspaceComposerController = ({
           ? [
               {
                 sourceKind: pendingPdfContextSelection.sourceKind,
+                sourceFileId: pendingPdfContextSelection.sourceFileId,
                 sourceVersionId: pendingPdfContextSelection.sourceVersionId
               }
             ]

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -401,7 +401,11 @@ describe('workspace message queue controller', () => {
     const queued = admission('queued with new Reading PDFs')
     queued.snapshot.pendingPdfContextAttachmentIds = ['upload-1']
     queued.snapshot.pendingPdfContextVersions = [
-      { sourceKind: 'artifact-version', sourceVersionId: 'version-1' }
+      {
+        sourceKind: 'artifact-version',
+        sourceFileId: 'artifact-1',
+        sourceVersionId: 'version-1'
+      }
     ]
 
     act(() => hook.result.current.lifecycle.enqueue(queued))
@@ -413,7 +417,11 @@ describe('workspace message queue controller', () => {
       expect.objectContaining({
         pendingPdfContextAttachmentIds: ['upload-1'],
         pendingPdfContextVersions: [
-          { sourceKind: 'artifact-version', sourceVersionId: 'version-1' }
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'version-1'
+          }
         ]
       })
     )
@@ -1588,7 +1596,11 @@ describe('workspace message queue controller', () => {
     const queued = admission('read these papers')
     queued.snapshot.pendingPdfContextAttachmentIds = ['upload-1']
     queued.snapshot.pendingPdfContextVersions = [
-      { sourceKind: 'artifact-version', sourceVersionId: 'version-1' }
+      {
+        sourceKind: 'artifact-version',
+        sourceFileId: 'artifact-1',
+        sourceVersionId: 'version-1'
+      }
     ]
     act(() => hook.result.current.lifecycle.enqueue(queued))
 
@@ -1614,7 +1626,11 @@ describe('workspace message queue controller', () => {
       expect.objectContaining({
         pendingPdfContextAttachmentIds: ['upload-1'],
         pendingPdfContextVersions: [
-          { sourceKind: 'artifact-version', sourceVersionId: 'version-1' }
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-1',
+            sourceVersionId: 'version-1'
+          }
         ]
       })
     )

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -92,6 +92,7 @@ export type PendingPdfContextSelection =
   | {
       kind: 'version'
       sourceKind: 'artifact-version' | 'upload-version'
+      sourceFileId: string
       sourceVersionId: string
       previewItemId: string
     }

--- a/src/shared/session-pdf-context.ts
+++ b/src/shared/session-pdf-context.ts
@@ -17,6 +17,7 @@ export const sessionPdfBindingToFileReference = (
   context.sourceKind === 'artifact-version'
     ? {
         id: context.sourceFileId,
+        sourceFileId: context.sourceFileId,
         name: context.name,
         source: 'artifact',
         path: createArtifactVersionLocator({
@@ -34,6 +35,7 @@ export const sessionPdfBindingToFileReference = (
       }
     : {
         id: context.sourceFileId,
+        sourceFileId: context.sourceFileId,
         name: context.name,
         source: 'upload',
         path: createUploadVersionReference(context.sourceVersionId, {

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -151,6 +151,7 @@ export type MessagePdfContextSnapshot = SessionPdfContext &
 
 export type SessionPdfContextSource = Readonly<{
   sourceKind: SessionPdfBinding['sourceKind']
+  sourceFileId: string
   sourceVersionId: string
 }>
 
@@ -4566,6 +4567,7 @@ export type OpenSessionRecoveryFolderRequest = {
 const sessionPdfContextSourceSchema = z
   .object({
     sourceKind: z.enum(['artifact-version', 'upload-version']),
+    sourceFileId: z.string().min(1),
     sourceVersionId: z.string().min(1)
   })
   .strict()


### PR DESCRIPTION
## Problem

Uploading a multi-page PDF in a newly created Project could link the immutable Version without its managed logical file identity. The main-process resolver now requires both values, so the send failed with `PDF context Version is unavailable in this Project.` A second projection gap dropped the same identity when the linked PDF was materialized for the agent and preview.

The regression escaped earlier CI because unit tests mocked `ImmutableInputAuthority.resolveVersion`, while the workspace E2E suite had no new-Project PDF upload journey. The earlier full portable and Electron lanes therefore exercised the files independently but not this public boundary.

## Proposed change

- Carry `sourceFileId` with `sourceVersionId` through PDF selection, queued/new-session sends, branching, context linking, agent file references, and preview reconstruction.
- Resolve PDF Versions against the expected logical file identity instead of a Version id alone.
- Add a real `SessionPdfContextOwner -> ImmutableInputAuthority` regression test; it failed consistently on the pre-fix code with the reported unavailable-Version error.
- Add a workspace Electron journey for new Project -> upload a two-page PDF -> send -> linked Reading context -> rendered PDF preview.

## Scope and non-goals

- No database fields, migrations, persisted-format changes, new enum/status values, data-model changes, or user interaction changes.
- The IPC request contract now requires an already-existing managed file id; this is transport identity, not new persisted data.
- Historical Session PDF bindings already persist `sourceFileId` and remain compatible. Legacy mention records that never stored a logical file id remain readable as attachments but are not auto-promoted into Reading context because their immutable identity cannot be proven.
- No fallback from a Version id to "latest" bytes was added.

## Acceptance criteria and validation

All listed checks ran against the final source state after the last material edit:

- PDF owner and renderer/queue consumers -> `../../node_modules/.bin/vitest run <13 targeted files>` -> 13 files, 737 tests passed.
- Module manifest/architecture guards -> `../../node_modules/.bin/vitest run src/main/session-persistence/coordinator.architecture.test.ts scripts/ci/validate-module-impact.test.ts` -> 2 files, 18 tests passed.
- Node contracts -> `npm run typecheck:node -- --pretty false` -> passed.
- Renderer contracts -> `npm run typecheck:web -- --pretty false` -> passed.
- Lint -> `../../node_modules/.bin/eslint --cache .` -> passed.
- Production Electron bundle -> `node --max-old-space-size=4096 ../../node_modules/electron-vite/bin/electron-vite.js build` -> passed.
- New-Project PDF upload journey -> `../../node_modules/.bin/playwright test e2e/workspace-files.spec.ts --grep 'links a multi-page PDF upload as Reading context in a new project'` -> 1 passed.

Per maintainer instruction, the full local `npm test` suite was not run; PR CI is authoritative for the complete portable and platform matrix.

## Review focus

- Confirm every transition preserves the `(sourceKind, sourceFileId, sourceVersionId)` identity tuple.
- Confirm legacy references without `sourceFileId` fail closed instead of resolving unrelated/latest bytes.
- Confirm the Electron journey covers the exact new-Project upload path reported by the user.
