### PR TITLE
fix(task-api): preserve lifecycle and run identity

### DIFF
--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -7,6 +7,7 @@ export type RequestOptions = {
   timeoutMs?: number
 }
 export type RunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
+export type RunFailureCode = 'process_restarted'
 export type RunProgressPhase =
   | 'accepted'
   | 'session-ready'
@@ -130,6 +131,7 @@ export type Run = {
   completedAt?: number
   output?: string
   error?: string
+  failureCode?: RunFailureCode
   artifacts: Artifact[]
   attention?: RunAttention
   review?: {
@@ -155,6 +157,8 @@ export type Session = {
   autoReviewEnabled: boolean
   specialistId?: string
   delegationPolicy: DelegationPolicy
+  pinned: boolean
+  archivedAt?: number
   createdAt: number
   updatedAt: number
   output?: string

--- a/src/main/archive/availability-error.ts
+++ b/src/main/archive/availability-error.ts
@@ -1,0 +1,18 @@
+type ArchiveAvailabilityErrorCode = 'project-archived' | 'session-archived'
+
+const messages: Record<ArchiveAvailabilityErrorCode, string> = {
+  'project-archived': 'Restore this archived Project before continuing.',
+  'session-archived': 'Restore this archived Session before continuing.'
+}
+
+const archiveAvailabilityMessage = (code: ArchiveAvailabilityErrorCode): string => messages[code]
+
+class ArchiveAvailabilityError extends Error {
+  constructor(readonly code: ArchiveAvailabilityErrorCode) {
+    super(archiveAvailabilityMessage(code))
+    this.name = 'ArchiveAvailabilityError'
+  }
+}
+
+export { ArchiveAvailabilityError, archiveAvailabilityMessage }
+export type { ArchiveAvailabilityErrorCode }

--- a/src/main/archive/coordinator.ts
+++ b/src/main/archive/coordinator.ts
@@ -3,6 +3,7 @@ import type {
   PersistedChatSession,
   UpdateSessionArchiveRequest
 } from '../../shared/session-persistence'
+import { ArchiveAvailabilityError } from './availability-error'
 
 type ProjectArchiveRepository = {
   get(id: string): Promise<Project | null>
@@ -57,7 +58,7 @@ class ArchiveCoordinator {
     this.assertProjectDeletionAvailable(projectId)
     if (!project) throw new Error('Project not found.')
     if (project.archivedAt !== undefined) {
-      throw new Error('Restore this archived Project before continuing.')
+      throw new ArchiveAvailabilityError('project-archived')
     }
     return project
   }

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -1125,8 +1125,7 @@ describe('Data and content application commands', () => {
 
     expect(deps.sessions.saveSession).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'idle', revision: 0, createdAt: 0 }),
-      undefined,
-      { taskRunCommit: false }
+      undefined
     )
     const savedSession = (
       deps.sessions.saveSession.mock.calls as unknown as Array<readonly [Record<string, unknown>]>

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -1125,12 +1125,32 @@ describe('Data and content application commands', () => {
 
     expect(deps.sessions.saveSession).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'idle', revision: 0, createdAt: 0 }),
-      undefined
+      undefined,
+      { taskRunCommit: false }
     )
     const savedSession = (
       deps.sessions.saveSession.mock.calls as unknown as Array<readonly [Record<string, unknown>]>
     )[0]?.[0]
     expect(savedSession?.runtimeContext).toBeUndefined()
+  })
+
+  it('grants Task callers authority to advance the Task Run commit witness', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    await dispatchCommand(
+      router,
+      'sessionSave',
+      [{ ...deps.session, taskRunCommitId: 'run-1' }],
+      createTaskCallerContext()
+    ).result
+
+    expect(deps.sessions.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ taskRunCommitId: 'run-1' }),
+      undefined,
+      { taskRunCommit: true }
+    )
   })
 
   it('normalizes graph-only Session arguments and results without preserving incomplete objects', async () => {

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -678,11 +678,12 @@ const registerDataContentApplicationCommands = (
         return dependencies.withDataRootWrite(async () => {
           let result: Awaited<ReturnType<SessionPersistenceHandlers['saveSession']>>
           try {
-            result = await dependencies.sessions.saveSession(
-              invocation.args[0],
-              invocation.args[1],
-              { taskRunCommit: invocation.callerContext.surface === 'task' }
-            )
+            result =
+              invocation.callerContext.surface === 'task'
+                ? await dependencies.sessions.saveSession(invocation.args[0], invocation.args[1], {
+                    taskRunCommit: true
+                  })
+                : await dependencies.sessions.saveSession(invocation.args[0], invocation.args[1])
           } catch (error) {
             if (SessionPersistence.isSessionRevisionConflictError(error)) {
               throw new ApplicationCommandError(

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -678,7 +678,11 @@ const registerDataContentApplicationCommands = (
         return dependencies.withDataRootWrite(async () => {
           let result: Awaited<ReturnType<SessionPersistenceHandlers['saveSession']>>
           try {
-            result = await dependencies.sessions.saveSession(invocation.args[0], invocation.args[1])
+            result = await dependencies.sessions.saveSession(
+              invocation.args[0],
+              invocation.args[1],
+              { taskRunCommit: invocation.callerContext.surface === 'task' }
+            )
           } catch (error) {
             if (SessionPersistence.isSessionRevisionConflictError(error)) {
               throw new ApplicationCommandError(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1315,7 +1315,7 @@ const createApplicationModules = async (
         ? sessionEnabledComputeHostsOwnerRef.current.reconcileSession(session)
         : session
     },
-    saveSession: async (session, options) => {
+    saveSession: async (session, options, authority) => {
       const created =
         (await sessionRepository.loadSession(session.projectId, session.id)) === undefined
       let durableSession = created
@@ -1324,10 +1324,10 @@ const createApplicationModules = async (
               throw new Error('Session enabled Compute Host ownership is not initialized.')
             }
             return sessionEnabledComputeHostsOwnerRef.current.createSession(session, (candidate) =>
-              sessionPersistenceCoordinator.saveSession(candidate, options)
+              sessionPersistenceCoordinator.saveSession(candidate, options, authority)
             )
           })()
-        : await sessionPersistenceCoordinator.saveSession(session, options)
+        : await sessionPersistenceCoordinator.saveSession(session, options, authority)
       // Flush any approved host.agents.switch binding stashed while this session was not yet durable,
       // so the approved target survives a restart before the next message (the in-memory binding
       // alone does not persist across restart).
@@ -4102,8 +4102,8 @@ const createApplicationModules = async (
           return context
         },
         editDetails: (request) => sessionDetailsOwner.edit(request),
-        saveSession: async (session, options) => {
-          const result = await sessionPersistenceHandlers.saveSession(session, options)
+        saveSession: async (session, options, authority) => {
+          const result = await sessionPersistenceHandlers.saveSession(session, options, authority)
           sessionDetailsOwner.afterSessionSaved(result.session)
           return result
         },

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1318,16 +1318,18 @@ const createApplicationModules = async (
     saveSession: async (session, options, authority) => {
       const created =
         (await sessionRepository.loadSession(session.projectId, session.id)) === undefined
+      const save = (candidate: PersistedChatSession): Promise<PersistedChatSession> =>
+        authority
+          ? sessionPersistenceCoordinator.saveSession(candidate, options, authority)
+          : sessionPersistenceCoordinator.saveSession(candidate, options)
       let durableSession = created
         ? await (() => {
             if (!sessionEnabledComputeHostsOwnerRef.current) {
               throw new Error('Session enabled Compute Host ownership is not initialized.')
             }
-            return sessionEnabledComputeHostsOwnerRef.current.createSession(session, (candidate) =>
-              sessionPersistenceCoordinator.saveSession(candidate, options, authority)
-            )
+            return sessionEnabledComputeHostsOwnerRef.current.createSession(session, save)
           })()
-        : await sessionPersistenceCoordinator.saveSession(session, options, authority)
+        : await save(session)
       // Flush any approved host.agents.switch binding stashed while this session was not yet durable,
       // so the approved target survives a restart before the next message (the in-memory binding
       // alone does not persist across restart).
@@ -4103,7 +4105,9 @@ const createApplicationModules = async (
         },
         editDetails: (request) => sessionDetailsOwner.edit(request),
         saveSession: async (session, options, authority) => {
-          const result = await sessionPersistenceHandlers.saveSession(session, options, authority)
+          const result = authority
+            ? await sessionPersistenceHandlers.saveSession(session, options, authority)
+            : await sessionPersistenceHandlers.saveSession(session, options)
           sessionDetailsOwner.afterSessionSaved(result.session)
           return result
         },

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -1825,6 +1825,32 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durable).toMatchObject({ title: 'Renderer rename', archivedAt: 10 })
   })
 
+  it('lets only Task-owned saves advance the Task Run commit witness', async () => {
+    let durable = createSession({ taskRunCommitId: 'committed-run' })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await coordinator.saveSession(
+      createSession({ title: 'Renderer rename', taskRunCommitId: 'forged-run' })
+    )
+    expect(durable).toMatchObject({ title: 'Renderer rename', taskRunCommitId: 'committed-run' })
+
+    await coordinator.saveSession(
+      { ...durable, taskRunCommitId: 'next-run' },
+      {},
+      { taskRunCommit: true }
+    )
+    expect(durable.taskRunCommitId).toBe('next-run')
+  })
+
   it('updates delegation policy through its dedicated durable Session owner', async () => {
     const previousUpdatedAt = Date.now() + 10_000
     let durable = createSession({ delegationPolicy: 'allow', updatedAt: previousUpdatedAt })

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -48,7 +48,8 @@ import {
   type AppendUserMessageToInteractionCommand,
   type PatchSessionRuntimeContextCommand,
   type SessionMetadata,
-  type SessionMetadataSnapshot
+  type SessionMetadataSnapshot,
+  type SessionSaveAuthority
 } from './state-owner'
 import {
   SessionSideChatPersistenceOwner,
@@ -731,11 +732,16 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
   // incomplete state rather than silently presenting stale metadata as complete.
   saveSession(
     session: PersistedChatSession,
-    options: SaveSessionOptions = {}
+    options: SaveSessionOptions = {},
+    authority: SessionSaveAuthority = { taskRunCommit: false }
   ): Promise<PersistedChatSession> {
     return this.operationScheduler.runSession(session.projectId, session.id, async () => {
       await assertSessionIdentityOwnership(this.repository, this.stateOwner, session)
-      return this.stateOwner.saveSession(session, sanitizeRendererSaveSessionOptions(options))
+      return this.stateOwner.saveSession(
+        session,
+        sanitizeRendererSaveSessionOptions(options),
+        authority
+      )
     })
   }
 

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -12,6 +12,7 @@ import type {
   UpdateSessionArchiveRequest
 } from '../../shared/session-persistence'
 import type { SessionDeletionReceipt } from '../artifacts/provenance-message-snapshot'
+import { ArchiveAvailabilityError } from '../archive/availability-error'
 import type { ManagedFileSoftDeleteToken } from '../project-files/repository'
 import type { Logger } from '../logger'
 import { startDiagnosticOperation } from '../diagnostics/operation'
@@ -194,7 +195,7 @@ class SessionPersistenceDeletionOwner {
     }
     if (loaded.status === 'missing') return
     if (loaded.session.archivedAt !== undefined) {
-      throw new Error('Restore this archived Session before continuing.')
+      throw new ArchiveAvailabilityError('session-archived')
     }
   }
 

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -28,6 +28,7 @@ import { ReviewRepository } from '../reviewer/repository'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { withDataRootWrite } from '../storage/migration-state'
 import type { SessionMetadataSnapshot } from './coordinator'
+import type { SessionSaveAuthority } from './state-owner'
 import { MainMessageAttributionAuthority } from './message-attribution-authority'
 import { canReconcileSessionAbsences, withProjectDeletionRecoveryStatus } from './catalog-authority'
 import { sanitizeRendererSaveSessionOptions } from './renderer-save-options'
@@ -39,7 +40,8 @@ type SessionPersistenceBackend = {
   loadOne: (request: LoadSessionRequest) => Promise<PersistedChatSession | undefined>
   saveSession: (
     session: PersistedChatSession,
-    options?: SaveSessionOptions
+    options?: SaveSessionOptions,
+    authority?: SessionSaveAuthority
   ) => Promise<{ created: boolean; session: PersistedChatSession }>
   setDelegationPolicy?: (
     projectId: string,
@@ -58,7 +60,8 @@ type SessionPersistenceHandlers = {
   loadOne: (request: LoadSessionRequest) => Promise<PersistedChatSession | undefined>
   saveSession: (
     session: PersistedChatSession,
-    options?: SaveSessionOptions
+    options?: SaveSessionOptions,
+    authority?: SessionSaveAuthority
   ) => Promise<{ created: boolean; session: PersistedChatSession }>
   setDelegationPolicy: (
     projectId: string,
@@ -177,15 +180,15 @@ const createSessionPersistenceHandlersWithAttributionAuthority = (
       return repository.loadUsage()
     },
     loadOne: (request) => repository.loadOne(request),
-    saveSession: async (session, options) => {
+    saveSession: async (session, options, authority) => {
       const durable = await repository.loadOne({
         projectId: session.projectId,
         sessionId: session.id
       })
       const authorized = messageAttributionAuthority.authorizeSessionProjection(session, durable)
       return options
-        ? repository.saveSession(authorized, options)
-        : repository.saveSession(authorized)
+        ? repository.saveSession(authorized, options, authority)
+        : repository.saveSession(authorized, undefined, authority)
     },
     setDelegationPolicy: (projectId, sessionId, policy) => {
       if (!repository.setDelegationPolicy) {
@@ -222,9 +225,11 @@ const coordinateSessionPersistenceWithProjectDeletions = (
 ): SessionPersistenceBackend => {
   const coordinated: SessionPersistenceBackend = {
     ...repository,
-    saveSession: async (session, options) => {
+    saveSession: async (session, options, authority) => {
       await projectDeletion.waitForProjectOperations([session.projectId])
-      return options ? repository.saveSession(session, options) : repository.saveSession(session)
+      return options
+        ? repository.saveSession(session, options, authority)
+        : repository.saveSession(session, undefined, authority)
     },
     deleteSession: async (projectId, sessionId) => {
       await projectDeletion.waitForProjectOperations([projectId])

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -186,9 +186,10 @@ const createSessionPersistenceHandlersWithAttributionAuthority = (
         sessionId: session.id
       })
       const authorized = messageAttributionAuthority.authorizeSessionProjection(session, durable)
+      if (authority) return repository.saveSession(authorized, options, authority)
       return options
-        ? repository.saveSession(authorized, options, authority)
-        : repository.saveSession(authorized, undefined, authority)
+        ? repository.saveSession(authorized, options)
+        : repository.saveSession(authorized)
     },
     setDelegationPolicy: (projectId, sessionId, policy) => {
       if (!repository.setDelegationPolicy) {
@@ -227,9 +228,8 @@ const coordinateSessionPersistenceWithProjectDeletions = (
     ...repository,
     saveSession: async (session, options, authority) => {
       await projectDeletion.waitForProjectOperations([session.projectId])
-      return options
-        ? repository.saveSession(session, options, authority)
-        : repository.saveSession(session, undefined, authority)
+      if (authority) return repository.saveSession(session, options, authority)
+      return options ? repository.saveSession(session, options) : repository.saveSession(session)
     },
     deleteSession: async (projectId, sessionId) => {
       await projectDeletion.waitForProjectOperations([projectId])

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -35,6 +35,10 @@ type SessionMetadataSnapshot = Readonly<{
   isComplete: boolean
 }>
 
+type SessionSaveAuthority = Readonly<{
+  taskRunCommit: boolean
+}>
+
 type PatchSessionRuntimeContextCommand = Readonly<{
   projectId: string
   sessionId: string
@@ -573,9 +577,10 @@ class SessionPersistenceStateOwner {
 
   async saveSession(
     session: PersistedChatSession,
-    options: SaveSessionOptions = {}
+    options: SaveSessionOptions = {},
+    authority: SessionSaveAuthority = { taskRunCommit: false }
   ): Promise<PersistedChatSession> {
-    return this.saveSessionWithAuthority(session, options)
+    return this.saveSessionWithAuthority(session, options, authority)
   }
 
   async saveSessionSpecialistBinding(
@@ -595,7 +600,8 @@ class SessionPersistenceStateOwner {
 
   private async saveSessionWithAuthority(
     session: PersistedChatSession,
-    options: MainSaveSessionOptions = {}
+    options: MainSaveSessionOptions = {},
+    saveAuthority: SessionSaveAuthority = { taskRunCommit: false }
   ): Promise<PersistedChatSession> {
     this.options.assertMutable(session.projectId, session.id, 'save')
     const { projectId, id: sessionId } = session
@@ -615,6 +621,13 @@ class SessionPersistenceStateOwner {
     const rendererOwnedSession: PersistedChatSession = { ...submittedSession }
     delete rendererOwnedSession.runtimeContext
     delete rendererOwnedSession.archivedAt
+    const taskRunCommitId =
+      saveAuthority.taskRunCommit && rendererOwnedSession.taskRunCommitId
+        ? rendererOwnedSession.taskRunCommitId
+        : authority?.taskRunCommitId
+    // This witness participates in Task's cross-file commit protocol. Whole-Session saves from
+    // renderer/web surfaces may preserve it, but only the Task surface may advance it.
+    delete rendererOwnedSession.taskRunCommitId
     const specialistBindingOwnedByCaller =
       options.conflictRebaseFields?.includes('specialistId') === true &&
       options.conflictRebaseFields.includes('specialistBindingPending')
@@ -666,6 +679,7 @@ class SessionPersistenceStateOwner {
       ...mainOwnedSessionDetails,
       ...(authority?.runtimeContext ? { runtimeContext: authority.runtimeContext } : {}),
       ...(authority?.archivedAt ? { archivedAt: authority.archivedAt } : {}),
+      ...(taskRunCommitId ? { taskRunCommitId } : {}),
       ...(authority && !specialistBindingOwnedByCaller
         ? {
             specialistId: authority.specialistId,
@@ -793,5 +807,6 @@ export type {
   AppendUserMessageToInteractionCommand,
   PatchSessionRuntimeContextCommand,
   SessionMetadata,
-  SessionMetadataSnapshot
+  SessionMetadataSnapshot,
+  SessionSaveAuthority
 }

--- a/src/main/tasks/task-run-journal.ts
+++ b/src/main/tasks/task-run-journal.ts
@@ -10,14 +10,19 @@ import {
 const TASK_RUN_JOURNAL_FILE = 'task-runs.json'
 const TASK_RUN_JOURNAL_VERSION = 1 as const
 
+export type TaskRunJournalEntry = TaskRun & {
+  promptMessageId?: string
+  sessionCommitStatus?: Exclude<TaskRunStatus, 'running'>
+}
+
 type TaskRunJournalDocument = {
   version: typeof TASK_RUN_JOURNAL_VERSION
-  runs: TaskRun[]
+  runs: TaskRunJournalEntry[]
 }
 
 export type TaskRunJournal = {
-  load(): Promise<TaskRun[]>
-  replace(runs: readonly TaskRun[]): Promise<void>
+  load(): Promise<TaskRunJournalEntry[]>
+  replace(runs: readonly TaskRunJournalEntry[]): Promise<void>
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -32,7 +37,7 @@ const isStringArray = (value: unknown): value is string[] =>
 const TASK_RUN_STATUSES = new Set<TaskRunStatus>(['running', 'completed', 'failed', 'cancelled'])
 const TASK_RUN_FAILURE_CODES = new Set<TaskRunFailureCode>(['process_restarted'])
 
-const decodeRun = (value: unknown): TaskRun => {
+const decodeRun = (value: unknown): TaskRunJournalEntry => {
   if (!isRecord(value)) throw new Error('Task Run journal contains a non-object Run.')
   if (
     typeof value.id !== 'string' ||
@@ -51,15 +56,20 @@ const decodeRun = (value: unknown): TaskRun => {
     (value.failureCode !== undefined &&
       (typeof value.failureCode !== 'string' ||
         !TASK_RUN_FAILURE_CODES.has(value.failureCode as TaskRunFailureCode))) ||
+    (value.promptMessageId !== undefined && typeof value.promptMessageId !== 'string') ||
+    (value.sessionCommitStatus !== undefined &&
+      value.sessionCommitStatus !== 'completed' &&
+      value.sessionCommitStatus !== 'cancelled' &&
+      value.sessionCommitStatus !== 'failed') ||
     !Array.isArray(value.artifacts) ||
     !isStringArray(value.preferredComputeHostIds)
   ) {
     throw new Error('Task Run journal contains an invalid Run.')
   }
-  return value as TaskRun
+  return value as TaskRunJournalEntry
 }
 
-const decodeDocument = (contents: string): TaskRun[] => {
+const decodeDocument = (contents: string): TaskRunJournalEntry[] => {
   const value = JSON.parse(contents) as unknown
   if (!isRecord(value)) throw new Error('Task Run journal must contain an object.')
   if (
@@ -82,12 +92,12 @@ export class FileTaskRunJournal implements TaskRunJournal {
     this.filePath = join(configRoot, TASK_RUN_JOURNAL_FILE)
   }
 
-  async load(): Promise<TaskRun[]> {
+  async load(): Promise<TaskRunJournalEntry[]> {
     const result = await readDurableJsonFile(this.filePath, decodeDocument)
     return result.status === 'found' ? result.value : []
   }
 
-  async replace(runs: readonly TaskRun[]): Promise<void> {
+  async replace(runs: readonly TaskRunJournalEntry[]): Promise<void> {
     const document: TaskRunJournalDocument = {
       version: TASK_RUN_JOURNAL_VERSION,
       runs: runs.map((run) => structuredClone(run))

--- a/src/main/tasks/task-run-journal.ts
+++ b/src/main/tasks/task-run-journal.ts
@@ -1,0 +1,97 @@
+import { join } from 'node:path'
+
+import type { TaskRun, TaskRunFailureCode, TaskRunStatus } from '../../shared/task-api'
+import {
+  DurableJsonRecoveryBarrierError,
+  readDurableJsonFile,
+  writeDurableJsonFile
+} from '../storage/durable-json-file'
+
+const TASK_RUN_JOURNAL_FILE = 'task-runs.json'
+const TASK_RUN_JOURNAL_VERSION = 1 as const
+
+type TaskRunJournalDocument = {
+  version: typeof TASK_RUN_JOURNAL_VERSION
+  runs: TaskRun[]
+}
+
+export type TaskRunJournal = {
+  load(): Promise<TaskRun[]>
+  replace(runs: readonly TaskRun[]): Promise<void>
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isOptionalFiniteNumber = (value: unknown): value is number | undefined =>
+  value === undefined || (typeof value === 'number' && Number.isFinite(value))
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+
+const TASK_RUN_STATUSES = new Set<TaskRunStatus>(['running', 'completed', 'failed', 'cancelled'])
+const TASK_RUN_FAILURE_CODES = new Set<TaskRunFailureCode>(['process_restarted'])
+
+const decodeRun = (value: unknown): TaskRun => {
+  if (!isRecord(value)) throw new Error('Task Run journal contains a non-object Run.')
+  if (
+    typeof value.id !== 'string' ||
+    typeof value.sessionId !== 'string' ||
+    typeof value.projectId !== 'string' ||
+    typeof value.cwd !== 'string' ||
+    typeof value.status !== 'string' ||
+    !TASK_RUN_STATUSES.has(value.status as TaskRunStatus) ||
+    typeof value.startedAt !== 'number' ||
+    !Number.isFinite(value.startedAt) ||
+    !isOptionalFiniteNumber(value.cancelRequestedAt) ||
+    !isOptionalFiniteNumber(value.cancelledAt) ||
+    !isOptionalFiniteNumber(value.completedAt) ||
+    (value.output !== undefined && typeof value.output !== 'string') ||
+    (value.error !== undefined && typeof value.error !== 'string') ||
+    (value.failureCode !== undefined &&
+      (typeof value.failureCode !== 'string' ||
+        !TASK_RUN_FAILURE_CODES.has(value.failureCode as TaskRunFailureCode))) ||
+    !Array.isArray(value.artifacts) ||
+    !isStringArray(value.preferredComputeHostIds)
+  ) {
+    throw new Error('Task Run journal contains an invalid Run.')
+  }
+  return value as TaskRun
+}
+
+const decodeDocument = (contents: string): TaskRun[] => {
+  const value = JSON.parse(contents) as unknown
+  if (!isRecord(value)) throw new Error('Task Run journal must contain an object.')
+  if (
+    typeof value.version === 'number' &&
+    Number.isInteger(value.version) &&
+    value.version > TASK_RUN_JOURNAL_VERSION
+  ) {
+    throw new DurableJsonRecoveryBarrierError('Unsupported Task Run journal version.')
+  }
+  if (value.version !== TASK_RUN_JOURNAL_VERSION || !Array.isArray(value.runs)) {
+    throw new Error('Task Run journal has an invalid format.')
+  }
+  return value.runs.map(decodeRun)
+}
+
+export class FileTaskRunJournal implements TaskRunJournal {
+  private readonly filePath: string
+
+  constructor(configRoot: string) {
+    this.filePath = join(configRoot, TASK_RUN_JOURNAL_FILE)
+  }
+
+  async load(): Promise<TaskRun[]> {
+    const result = await readDurableJsonFile(this.filePath, decodeDocument)
+    return result.status === 'found' ? result.value : []
+  }
+
+  async replace(runs: readonly TaskRun[]): Promise<void> {
+    const document: TaskRunJournalDocument = {
+      version: TASK_RUN_JOURNAL_VERSION,
+      runs: runs.map((run) => structuredClone(run))
+    }
+    await writeDurableJsonFile(this.filePath, `${JSON.stringify(document, null, 2)}\n`)
+  }
+}

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -10,6 +10,7 @@ import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
 import { ComputeHostPreferenceValidationError } from '../../shared/compute'
 import type { Project } from '../../shared/projects'
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { TaskRun } from '../../shared/task-api'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
 import {
@@ -3393,5 +3394,61 @@ describe('TaskRunner', () => {
       status: 'failed',
       error: expect.stringContaining('Task Run terminal state could not be persisted.')
     })
+  })
+
+  it('excludes a failed initial Run from snapshots queued behind its rejected write', async () => {
+    let releaseFirstWrite: (() => void) | undefined
+    let markFirstWriteStarted: (() => void) | undefined
+    let finishPrompt: (() => void) | undefined
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      markFirstWriteStarted = resolve
+    })
+    const firstWriteGate = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve
+    })
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const snapshots: (readonly TaskRun[])[] = []
+    let writeCount = 0
+    let sessionCount = 0
+    const ids = ['user-1', 'run-1', 'user-2', 'run-2']
+    const runner = createRunner({
+      runJournal: {
+        load: async () => [],
+        replace: async (runs) => {
+          writeCount += 1
+          if (writeCount === 1) {
+            markFirstWriteStarted?.()
+            await firstWriteGate
+            throw new Error('initial journal write failed')
+          }
+          snapshots.push(structuredClone(runs))
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: `session-${++sessionCount}` }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => promptGate
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const rejectedStart = runner.startRun({ project: project.id, prompt: 'First Run.' })
+    await firstWriteStarted
+    const acceptedStart = runner.startRun({ project: project.id, prompt: 'Second Run.' })
+    await vi.waitFor(() => expect(() => runner.getRun('run-2')).not.toThrow())
+    releaseFirstWrite?.()
+
+    await expect(rejectedStart).rejects.toThrow('initial journal write failed')
+    const accepted = await acceptedStart
+    expect(snapshots[0]?.map(({ id }) => id)).toEqual(['run-2'])
+
+    finishPrompt?.()
+    await runner.waitForRun(accepted.id)
   })
 })

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -13,7 +13,7 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
 import {
-  TASK_REVIEW_DISPOSAL_BUDGET_MS,
+  TASK_RUN_DISPOSAL_BUDGET_MS,
   TaskRunner,
   type TaskPreviewResourcePort,
   type TaskProjectPort,
@@ -1232,7 +1232,7 @@ describe('TaskRunner', () => {
       })
 
       expect(review.mock.calls[0]?.[2].aborted).toBe(true)
-      await vi.advanceTimersByTimeAsync(TASK_REVIEW_DISPOSAL_BUDGET_MS)
+      await vi.advanceTimersByTimeAsync(TASK_RUN_DISPOSAL_BUDGET_MS)
       expect(disposed).toBe(true)
     } finally {
       vi.useRealTimers()
@@ -3372,5 +3372,26 @@ describe('TaskRunner', () => {
       expect.objectContaining({ code: 'run_not_found' })
     )
     expect(runner.getRun(latestRunId)).toMatchObject({ status: 'completed' })
+  })
+
+  it('does not report completion when the terminal Run record cannot be persisted', async () => {
+    let writes = 0
+    const runner = createRunner({
+      runJournal: {
+        load: async () => [],
+        replace: async () => {
+          writes += 1
+          if (writes > 1) throw new Error('disk full')
+        }
+      }
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Persist this Run.' })
+
+    await expect(runner.waitForRun(started.id)).rejects.toThrow('disk full')
+    expect(runner.getRun(started.id)).toMatchObject({
+      status: 'failed',
+      error: expect.stringContaining('Task Run terminal state could not be persisted.')
+    })
   })
 })

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -3470,6 +3470,35 @@ describe('TaskRunner', () => {
     })
   })
 
+  it('recovers a terminal persistence fallback without stale Session commit metadata', async () => {
+    let writes = 0
+    let durableRuns: TaskRunJournalEntry[] = []
+    const runJournal = {
+      load: async () => structuredClone(durableRuns),
+      replace: async (runs: readonly TaskRunJournalEntry[]) => {
+        writes += 1
+        if (writes === 3) throw new Error('terminal write failed once')
+        durableRuns = runs.map((run) => structuredClone(run))
+      }
+    }
+    const runner = createRunner({ runJournal })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Fallback durably.' })
+    await expect(runner.waitForRun(started.id)).resolves.toMatchObject({
+      status: 'failed',
+      error: expect.stringContaining('Task Run terminal state could not be persisted.')
+    })
+
+    const recoveredRunner = createRunner({ runJournal })
+    await recoveredRunner.initialize()
+
+    expect(recoveredRunner.getRun(started.id)).toMatchObject({
+      status: 'failed',
+      error: expect.stringContaining('Task Run terminal state could not be persisted.')
+    })
+    expect(durableRuns.find((run) => run.id === started.id)?.sessionCommitStatus).toBeUndefined()
+  })
+
   it('recovers a completed Run when the Session commit precedes automatic review', async () => {
     let durableSession: PersistedChatSession | undefined
     let durableRuns: TaskRun[] = []

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -3451,7 +3451,15 @@ describe('TaskRunner', () => {
 
   it('does not report completion when the terminal Run record cannot be persisted', async () => {
     let writes = 0
+    let durableSession: PersistedChatSession | undefined
     const runner = createRunner({
+      sessions: {
+        list: async () => (durableSession ? [structuredClone(durableSession)] : []),
+        save: async (value) => {
+          durableSession = structuredClone(value)
+          return value
+        }
+      },
       runJournal: {
         load: async () => [],
         replace: async () => {
@@ -3468,6 +3476,10 @@ describe('TaskRunner', () => {
       status: 'failed',
       error: expect.stringContaining('Task Run terminal state could not be persisted.')
     })
+    await expect(runner.listSessions()).resolves.toEqual([
+      expect.objectContaining({ id: started.sessionId, status: 'error' })
+    ])
+    expect(durableSession?.activeRun).toBeUndefined()
   })
 
   it('recovers a terminal persistence fallback without stale Session commit metadata', async () => {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -3240,7 +3240,7 @@ describe('TaskRunner', () => {
         load: async () => [],
         replace: async () => {
           journalWriteCount += 1
-          if (journalWriteCount === 2) {
+          if (journalWriteCount === 3) {
             markQueuedWriteStarted?.()
             await queuedWriteGate
           }
@@ -3499,6 +3499,404 @@ describe('TaskRunner', () => {
     expect(runner.getRun(latestRunId)).toMatchObject({ status: 'completed' })
   })
 
+  it('persists a new Run identity before its running Session', async () => {
+    let markInitialSessionSaveStarted: (() => void) | undefined
+    let releaseInitialSessionSave: (() => void) | undefined
+    const initialSessionSaveStarted = new Promise<void>((resolve) => {
+      markInitialSessionSaveStarted = resolve
+    })
+    const initialSessionSaveGate = new Promise<void>((resolve) => {
+      releaseInitialSessionSave = resolve
+    })
+    let blockInitialSessionSave = true
+    let durableRuns: TaskRunJournalEntry[] = []
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (value) => {
+          if (blockInitialSessionSave && value.status === 'running') {
+            blockInitialSessionSave = false
+            markInitialSessionSaveStarted?.()
+            await initialSessionSaveGate
+          }
+          return value
+        }
+      },
+      runJournal: {
+        load: async () => [],
+        replace: async (runs) => {
+          durableRuns = runs.map((run) => structuredClone(run))
+        }
+      },
+      createId: (() => {
+        const ids = ['ordered-prompt', 'ordered-run']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const starting = runner.startRun({ project: project.id, prompt: 'Persist in order.' })
+    await initialSessionSaveStarted
+    const runWasDurableBeforeSession = durableRuns.some(
+      (run) => run.id === 'ordered-run' && run.status === 'running'
+    )
+    releaseInitialSessionSave?.()
+    const started = await starting
+    await runner.waitForRun(started.id)
+
+    expect(runWasDurableBeforeSession).toBe(true)
+  })
+
+  it('keeps the Run identity when the initial Session save reports a post-commit failure', async () => {
+    let durableSession: PersistedChatSession | undefined
+    let rejectCommittedSave = true
+    let durableRuns: TaskRunJournalEntry[] = []
+    const sessions: TaskSessionPort = {
+      list: async () =>
+        durableSession ? [normalizeSessionFile(structuredClone(durableSession))!] : [],
+      save: async (value) => {
+        durableSession = structuredClone(value)
+        if (rejectCommittedSave && value.status === 'running') {
+          rejectCommittedSave = false
+          throw new Error('Session projection failed after commit.')
+        }
+        return value
+      },
+      setDelegationPolicy: async () => undefined
+    }
+    const runJournal = {
+      load: async () => structuredClone(durableRuns),
+      replace: async (runs: readonly TaskRunJournalEntry[]) => {
+        durableRuns = runs.map((run) => structuredClone(run))
+      }
+    }
+    const runner = createRunner({
+      sessions,
+      runJournal,
+      createId: (() => {
+        const ids = ['post-commit-prompt', 'post-commit-run']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    await expect(
+      runner.startRun({ project: project.id, prompt: 'Keep the durable identity.' })
+    ).rejects.toThrow('Session projection failed after commit.')
+
+    expect(durableRuns).toContainEqual(
+      expect.objectContaining({
+        id: 'post-commit-run',
+        status: 'failed',
+        error: 'Session projection failed after commit.'
+      })
+    )
+    expect(durableSession).toMatchObject({
+      status: 'error',
+      taskRunCommitId: 'post-commit-run',
+      error: 'Session projection failed after commit.'
+    })
+
+    const recoveredRunner = createRunner({ sessions, runJournal })
+    await recoveredRunner.initialize()
+    expect(recoveredRunner.getRun('post-commit-run')).toMatchObject({
+      status: 'failed',
+      error: 'Session projection failed after commit.'
+    })
+  })
+
+  it('recovers a post-commit Session failure before its compensation save completes', async () => {
+    let markCompensationStarted: (() => void) | undefined
+    let releaseCompensation: (() => void) | undefined
+    const compensationStarted = new Promise<void>((resolve) => {
+      markCompensationStarted = resolve
+    })
+    const compensationGate = new Promise<void>((resolve) => {
+      releaseCompensation = resolve
+    })
+    let durableSession: PersistedChatSession | undefined
+    let rejectCommittedSave = true
+    let blockCompensation = true
+    let durableRuns: TaskRunJournalEntry[] = []
+    const sessions: TaskSessionPort = {
+      list: async () =>
+        durableSession ? [normalizeSessionFile(structuredClone(durableSession))!] : [],
+      save: async (value) => {
+        if (rejectCommittedSave && value.status === 'running') {
+          durableSession = structuredClone(value)
+          rejectCommittedSave = false
+          throw new Error('Session projection failed after commit.')
+        }
+        if (blockCompensation && value.taskRunCommitId === 'crash-window-run') {
+          blockCompensation = false
+          markCompensationStarted?.()
+          await compensationGate
+        }
+        durableSession = structuredClone(value)
+        return value
+      },
+      setDelegationPolicy: async () => undefined
+    }
+    const runJournal = {
+      load: async () => structuredClone(durableRuns),
+      replace: async (runs: readonly TaskRunJournalEntry[]) => {
+        durableRuns = runs.map((run) => structuredClone(run))
+      }
+    }
+    const runner = createRunner({
+      sessions,
+      runJournal,
+      createId: (() => {
+        const ids = ['crash-window-prompt', 'crash-window-run']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const starting = runner.startRun({
+      project: project.id,
+      prompt: 'Recover the compensation window.'
+    })
+    await compensationStarted
+
+    expect(durableRuns).toContainEqual(
+      expect.objectContaining({
+        id: 'crash-window-run',
+        status: 'running',
+        sessionCommitStatus: 'failed',
+        error: 'Session projection failed after commit.'
+      })
+    )
+
+    const recoveredRunner = createRunner({ sessions, runJournal })
+    await recoveredRunner.initialize()
+    expect(recoveredRunner.getRun('crash-window-run')).toMatchObject({
+      status: 'failed',
+      failureCode: 'process_restarted',
+      error: 'Run interrupted because Open Science restarted.'
+    })
+    expect(durableSession).toMatchObject({
+      status: 'error',
+      taskRunCommitId: 'crash-window-run'
+    })
+
+    releaseCompensation?.()
+    await expect(starting).rejects.toThrow('Session projection failed after commit.')
+  })
+
+  it('terminates in memory and repairs the Session after its compensation save fails', async () => {
+    let durableSession: PersistedChatSession | undefined
+    let rejectCommittedSave = true
+    let rejectCompensationSave = true
+    let durableRuns: TaskRunJournalEntry[] = []
+    const sessions: TaskSessionPort = {
+      list: async () =>
+        durableSession ? [normalizeSessionFile(structuredClone(durableSession))!] : [],
+      save: async (value) => {
+        if (rejectCommittedSave && value.status === 'running') {
+          durableSession = structuredClone(value)
+          rejectCommittedSave = false
+          throw new Error('Session projection failed after commit.')
+        }
+        if (rejectCompensationSave && value.taskRunCommitId === 'compensation-failure-run') {
+          rejectCompensationSave = false
+          throw new Error('Session compensation save failed.')
+        }
+        durableSession = structuredClone(value)
+        return value
+      },
+      setDelegationPolicy: async () => undefined
+    }
+    const runJournal = {
+      load: async () => structuredClone(durableRuns),
+      replace: async (runs: readonly TaskRunJournalEntry[]) => {
+        durableRuns = runs.map((run) => structuredClone(run))
+      }
+    }
+    const runner = createRunner({
+      sessions,
+      runJournal,
+      createId: (() => {
+        const ids = ['compensation-failure-prompt', 'compensation-failure-run']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    await expect(
+      runner.startRun({ project: project.id, prompt: 'Fail the compensation save.' })
+    ).rejects.toThrow('Session projection failed after commit.')
+
+    expect(runner.getRun('compensation-failure-run')).toMatchObject({
+      status: 'failed',
+      error: 'Session projection failed after commit.'
+    })
+    expect(durableRuns).toContainEqual(
+      expect.objectContaining({
+        id: 'compensation-failure-run',
+        status: 'failed',
+        sessionCommitStatus: 'failed'
+      })
+    )
+
+    const recoveredRunner = createRunner({ sessions, runJournal })
+    await recoveredRunner.initialize()
+    expect(recoveredRunner.getRun('compensation-failure-run')).toMatchObject({
+      status: 'failed',
+      error: 'Session projection failed after commit.'
+    })
+    expect(durableSession).toMatchObject({
+      status: 'error',
+      taskRunCommitId: 'compensation-failure-run'
+    })
+  })
+
+  it('persists a witness for the recovered Session when an interrupted Run is restored', async () => {
+    let durableSession = normalizeSessionFile({
+      ...session,
+      status: 'running',
+      activeRun: { promptMessageId: 'interrupted-prompt', startedAt: 2 },
+      messages: [
+        {
+          id: 'interrupted-prompt',
+          role: 'user',
+          content: 'Resume after restart.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    })!
+    let durableRuns: TaskRunJournalEntry[] = [
+      {
+        id: 'interrupted-run',
+        sessionId: session.id,
+        projectId: project.id,
+        cwd: session.cwd,
+        status: 'running',
+        startedAt: 2,
+        artifacts: [],
+        preferredComputeHostIds: [],
+        promptMessageId: 'interrupted-prompt'
+      }
+    ]
+    let failureWasStagedBeforeSessionSave = false
+    const runner = createRunner({
+      sessions: {
+        list: async () => [structuredClone(durableSession)],
+        save: async (value) => {
+          failureWasStagedBeforeSessionSave = durableRuns.some(
+            (run) =>
+              run.id === 'interrupted-run' &&
+              run.status === 'running' &&
+              run.sessionCommitStatus === 'failed'
+          )
+          durableSession = normalizeSessionFile(value)!
+          return durableSession
+        }
+      },
+      runJournal: {
+        load: async () => structuredClone(durableRuns),
+        replace: async (runs) => {
+          durableRuns = runs.map((run) => structuredClone(run))
+        }
+      }
+    })
+
+    await runner.initialize()
+
+    expect(runner.getRun('interrupted-run')).toMatchObject({
+      status: 'failed',
+      failureCode: 'process_restarted'
+    })
+    expect(durableSession).toMatchObject({
+      status: 'error',
+      taskRunCommitId: 'interrupted-run',
+      error: 'Session was interrupted before the app closed.'
+    })
+    expect(durableSession.activeRun).toBeUndefined()
+    expect(failureWasStagedBeforeSessionSave).toBe(true)
+  })
+
+  it('does not overwrite newer Session activity while reconciling an interrupted Run', async () => {
+    const interruptedSession = normalizeSessionFile({
+      ...session,
+      status: 'running',
+      activeRun: { promptMessageId: 'old-prompt', startedAt: 2 },
+      messages: [
+        {
+          id: 'old-prompt',
+          role: 'user',
+          content: 'Old work.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    })!
+    const newerSession: PersistedChatSession = {
+      ...session,
+      status: 'running',
+      activeRun: { promptMessageId: 'new-prompt', startedAt: 4 },
+      messages: [
+        ...interruptedSession.messages,
+        {
+          id: 'new-prompt',
+          role: 'user',
+          content: 'New work.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 4,
+          updatedAt: 4
+        }
+      ],
+      updatedAt: 4
+    }
+    let reads = 0
+    const journalSnapshots: TaskRunJournalEntry[][] = []
+    let durableRuns: TaskRunJournalEntry[] = [
+      {
+        id: 'old-run',
+        sessionId: session.id,
+        projectId: project.id,
+        cwd: session.cwd,
+        status: 'running',
+        startedAt: 2,
+        artifacts: [],
+        preferredComputeHostIds: [],
+        promptMessageId: 'old-prompt'
+      }
+    ]
+    const save = vi.fn(async (value: PersistedChatSession) => value)
+    const runner = createRunner({
+      sessions: {
+        list: async () => structuredClone(reads++ === 0 ? [interruptedSession] : [newerSession]),
+        save
+      },
+      runJournal: {
+        load: async () => structuredClone(durableRuns),
+        replace: async (runs) => {
+          durableRuns = runs.map((run) => structuredClone(run))
+          journalSnapshots.push(structuredClone(durableRuns))
+        }
+      }
+    })
+
+    await runner.initialize()
+
+    expect(save).not.toHaveBeenCalled()
+    expect(runner.getRun('old-run')).toMatchObject({
+      status: 'failed',
+      failureCode: 'process_restarted'
+    })
+    expect(journalSnapshots[0]).toContainEqual(
+      expect.objectContaining({
+        id: 'old-run',
+        status: 'running',
+        sessionCommitStatus: 'failed'
+      })
+    )
+    expect(durableRuns[0]?.sessionCommitStatus).toBeUndefined()
+  })
+
   it('does not report completion when the terminal Run record cannot be persisted', async () => {
     let writes = 0
     let durableSession: PersistedChatSession | undefined
@@ -3514,7 +3912,7 @@ describe('TaskRunner', () => {
         load: async () => [],
         replace: async () => {
           writes += 1
-          if (writes > 1) throw new Error('disk full')
+          if (writes > 2) throw new Error('disk full')
         }
       }
     })
@@ -3539,7 +3937,7 @@ describe('TaskRunner', () => {
       load: async () => structuredClone(durableRuns),
       replace: async (runs: readonly TaskRunJournalEntry[]) => {
         writes += 1
-        if (writes === 3) throw new Error('terminal write failed once')
+        if (writes === 4) throw new Error('terminal write failed once')
         durableRuns = runs.map((run) => structuredClone(run))
       }
     }
@@ -3845,7 +4243,7 @@ describe('TaskRunner', () => {
         load: async () => [],
         replace: async (runs) => {
           journalWriteCount += 1
-          if (journalWriteCount === 3) throw new Error('cancel journal failed')
+          if (journalWriteCount === 4) throw new Error('cancel journal failed')
           durableRuns = runs.map((run) => structuredClone(run))
         }
       },

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -13,6 +13,7 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { TaskRun } from '../../shared/task-api'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
+import type { TaskRunJournalEntry } from './task-run-journal'
 import {
   TASK_RUN_DISPOSAL_BUDGET_MS,
   TaskRunner,
@@ -3172,6 +3173,79 @@ describe('TaskRunner', () => {
     await expect(cancellation).resolves.toMatchObject({ status: 'cancelled' })
   })
 
+  it('waits for a queued Session commit marker before dispatching cancellation', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let markQueuedWriteStarted: (() => void) | undefined
+    let releaseQueuedWrite: (() => void) | undefined
+    const queuedWriteStarted = new Promise<void>((resolve) => {
+      markQueuedWriteStarted = resolve
+    })
+    const queuedWriteGate = new Promise<void>((resolve) => {
+      releaseQueuedWrite = resolve
+    })
+    let journalWriteCount = 0
+    const cancelPrompt = vi.fn(async () => undefined)
+    const runner = createRunner({
+      runJournal: {
+        load: async () => [],
+        replace: async () => {
+          journalWriteCount += 1
+          if (journalWriteCount === 2) {
+            markQueuedWriteStarted?.()
+            await queuedWriteGate
+          }
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-queued-marker-cancel' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'queued-plan-event',
+            timestamp: 10,
+            kind: 'plan',
+            level: 'info',
+            sessionId: 'session-queued-marker-cancel',
+            text: 'Queue another journal write.',
+            planProjection: {
+              artifactId: 'queued-plan',
+              artifactVersionId: 'queued-plan-version',
+              artifactChecksum: 'queued-plan-checksum',
+              revision: 1,
+              approval: 'pending',
+              lifecycle: 'awaiting_approval'
+            } as never
+          })
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: (() => {
+        const ids = ['queued-user', 'queued-run', 'queued-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Queue completion.' })
+    await queuedWriteStarted
+    const cancellation = runner.cancelRun(started.id)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(cancelPrompt).not.toHaveBeenCalled()
+
+    releaseQueuedWrite?.()
+
+    await expect(cancellation).resolves.toMatchObject({ status: 'cancelled' })
+    expect(cancelPrompt).toHaveBeenCalledOnce()
+  })
+
   it('keeps a real Prompt failure when cancellation is requested afterward', async () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     let finalizationStarted: (() => void) | undefined
@@ -3394,6 +3468,327 @@ describe('TaskRunner', () => {
       status: 'failed',
       error: expect.stringContaining('Task Run terminal state could not be persisted.')
     })
+  })
+
+  it('recovers a completed Run when the Session commit precedes automatic review', async () => {
+    let durableSession: PersistedChatSession | undefined
+    let durableRuns: TaskRun[] = []
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let markReviewStarted: (() => void) | undefined
+    let releaseReview: (() => void) | undefined
+    const reviewStarted = new Promise<void>((resolve) => {
+      markReviewStarted = resolve
+    })
+    const reviewGate = new Promise<void>((resolve) => {
+      releaseReview = resolve
+    })
+    const sessions: TaskSessionPort = {
+      list: async () => (durableSession ? [structuredClone(durableSession)] : []),
+      save: async (value) => {
+        durableSession = structuredClone(value)
+        return value
+      },
+      setDelegationPolicy: async () => undefined
+    }
+    const runJournal = {
+      load: async () => structuredClone(durableRuns),
+      replace: async (runs: readonly TaskRun[]) => {
+        durableRuns = runs.map((run) => structuredClone(run))
+      }
+    }
+    const ids = ['recovery-user', 'recovery-run', 'recovery-agent']
+    const runner = createRunner({
+      sessions,
+      runJournal,
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-review-recovery' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'recovery-message-event',
+            timestamp: 10,
+            kind: 'message',
+            level: 'info',
+            sessionId: 'session-review-recovery',
+            role: 'assistant',
+            text: 'Durable response.'
+          })
+        }
+      },
+      reviewer: {
+        review: async () => {
+          markReviewStarted?.()
+          await reviewGate
+          return { started: true }
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      prompt: 'Commit before review.',
+      autoReviewEnabled: true
+    })
+    await reviewStarted
+
+    expect(durableSession).toMatchObject({ status: 'idle', activeRun: undefined })
+    expect(durableRuns).toContainEqual(expect.objectContaining({ status: 'running' }))
+    expect(runner.getRun(started.id)).toMatchObject({ status: 'running', output: undefined })
+
+    const recoveredRunner = createRunner({ sessions, runJournal })
+    await recoveredRunner.initialize()
+
+    expect(recoveredRunner.getRun(started.id)).toMatchObject({
+      status: 'completed',
+      output: 'Durable response.'
+    })
+
+    releaseReview?.()
+    await runner.waitForRun(started.id)
+    await recoveredRunner.dispose()
+  })
+
+  it('recovers the original failure when the failed Session commit precedes terminalization', async () => {
+    let durableSession: PersistedChatSession | undefined
+    let durableRuns: TaskRunJournalEntry[] = []
+    let markTerminalWriteStarted: (() => void) | undefined
+    let releaseTerminalWrite: (() => void) | undefined
+    const terminalWriteStarted = new Promise<void>((resolve) => {
+      markTerminalWriteStarted = resolve
+    })
+    const terminalWriteGate = new Promise<void>((resolve) => {
+      releaseTerminalWrite = resolve
+    })
+    let terminalWriteBlocked = false
+    const sessions: TaskSessionPort = {
+      list: async () => (durableSession ? [structuredClone(durableSession)] : []),
+      save: async (value) => {
+        durableSession = structuredClone(value)
+        return value
+      },
+      setDelegationPolicy: async () => undefined
+    }
+    const runJournal = {
+      load: async () => structuredClone(durableRuns),
+      replace: async (runs: readonly TaskRunJournalEntry[]) => {
+        if (
+          !terminalWriteBlocked &&
+          runs.some((run) => run.id === 'failure-run' && run.status === 'failed')
+        ) {
+          terminalWriteBlocked = true
+          markTerminalWriteStarted?.()
+          await terminalWriteGate
+        }
+        durableRuns = runs.map((run) => structuredClone(run))
+      }
+    }
+    const ids = ['failure-user', 'failure-run', 'failure-agent']
+    const runner = createRunner({
+      sessions,
+      runJournal,
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-failure-recovery' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => {
+          throw new Error('provider failed')
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Fail durably.' })
+    await terminalWriteStarted
+
+    expect(durableSession).toMatchObject({ status: 'error', error: 'provider failed' })
+    expect(durableRuns).toContainEqual(
+      expect.objectContaining({
+        id: started.id,
+        status: 'running',
+        sessionCommitStatus: 'failed',
+        error: 'provider failed'
+      })
+    )
+
+    const recoveredRunner = createRunner({ sessions, runJournal })
+    await recoveredRunner.initialize()
+
+    expect(recoveredRunner.getRun(started.id)).toMatchObject({
+      status: 'failed',
+      error: 'provider failed',
+      failureCode: undefined
+    })
+
+    releaseTerminalWrite?.()
+    await runner.waitForRun(started.id)
+    await recoveredRunner.dispose()
+  })
+
+  it('does not recover a staged completion before its Session commit', async () => {
+    const runner = createRunner({
+      sessions: {
+        list: async () => [
+          {
+            ...session,
+            status: 'running',
+            activeRun: { promptMessageId: 'staged-prompt', startedAt: 2 }
+          }
+        ]
+      },
+      runJournal: {
+        load: async () => [
+          {
+            id: 'staged-run',
+            sessionId: session.id,
+            projectId: project.id,
+            cwd: session.cwd,
+            status: 'running',
+            startedAt: 2,
+            completedAt: 3,
+            output: 'Not committed yet.',
+            artifacts: [],
+            preferredComputeHostIds: [],
+            promptMessageId: 'staged-prompt',
+            sessionCommitStatus: 'completed'
+          }
+        ],
+        replace: async () => undefined
+      }
+    })
+
+    await runner.initialize()
+
+    expect(runner.getRun('staged-run')).toMatchObject({
+      status: 'failed',
+      failureCode: 'process_restarted'
+    })
+  })
+
+  it('clears stale attention when recovering a committed cancellation', async () => {
+    const runner = createRunner({
+      sessions: {
+        list: async () => [{ ...session, status: 'idle', activeRun: undefined }]
+      },
+      runJournal: {
+        load: async () => [
+          {
+            id: 'cancelled-run',
+            sessionId: session.id,
+            projectId: project.id,
+            cwd: session.cwd,
+            status: 'running',
+            startedAt: 2,
+            completedAt: 3,
+            cancelledAt: 3,
+            artifacts: [],
+            preferredComputeHostIds: [],
+            promptMessageId: 'cancelled-prompt',
+            sessionCommitStatus: 'cancelled',
+            attention: { kind: 'plan-approval', plan: {} as never }
+          }
+        ],
+        replace: async () => undefined
+      }
+    })
+
+    await runner.initialize()
+
+    expect(runner.getRun('cancelled-run')).toMatchObject({
+      status: 'cancelled',
+      attention: undefined
+    })
+  })
+
+  it('rolls back a staged cancellation when its journal write fails', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let markReviewStarted: (() => void) | undefined
+    let releaseReview: (() => void) | undefined
+    const reviewStarted = new Promise<void>((resolve) => {
+      markReviewStarted = resolve
+    })
+    const reviewGate = new Promise<void>((resolve) => {
+      releaseReview = resolve
+    })
+    let journalWriteCount = 0
+    let durableRuns: TaskRunJournalEntry[] = []
+    let sessionCount = 0
+    const ids = ['cancel-user', 'cancel-run', 'cancel-agent', 'next-user', 'next-run', 'next-agent']
+    const runner = createRunner({
+      runJournal: {
+        load: async () => [],
+        replace: async (runs) => {
+          journalWriteCount += 1
+          if (journalWriteCount === 3) throw new Error('cancel journal failed')
+          durableRuns = runs.map((run) => structuredClone(run))
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: `session-${++sessionCount}` }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async (request) => {
+          emitEvent?.({
+            id: `${request.sessionId}-message`,
+            timestamp: 10,
+            kind: 'message',
+            level: 'info',
+            sessionId: request.sessionId,
+            role: 'assistant',
+            text: 'Durable response.'
+          })
+        }
+      },
+      reviewer: {
+        review: async () => {
+          markReviewStarted?.()
+          await reviewGate
+          return { started: true }
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const first = await runner.startRun({
+      project: project.id,
+      prompt: 'Review before cancellation.',
+      autoReviewEnabled: true
+    })
+    await reviewStarted
+    await expect(runner.cancelRun(first.id)).rejects.toThrow('cancel journal failed')
+
+    const next = await runner.startRun({ project: project.id, prompt: 'Persist another Run.' })
+    await runner.waitForRun(next.id)
+
+    expect(durableRuns.find((run) => run.id === first.id)).toMatchObject({
+      status: 'running',
+      sessionCommitStatus: 'completed'
+    })
+
+    releaseReview?.()
+    await expect(runner.waitForRun(first.id)).resolves.toMatchObject({ status: 'completed' })
   })
 
   it('excludes a failed initial Run from snapshots queued behind its rejected write', async () => {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -9,7 +9,7 @@ import type { AcpRuntimeEvent } from '../../shared/acp'
 import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
 import { ComputeHostPreferenceValidationError } from '../../shared/compute'
 import type { Project } from '../../shared/projects'
-import type { PersistedChatSession } from '../../shared/session-persistence'
+import { normalizeSessionFile, type PersistedChatSession } from '../../shared/session-persistence'
 import type { TaskRun } from '../../shared/task-api'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
@@ -3127,26 +3127,53 @@ describe('TaskRunner', () => {
     expect(cancelPrompt).not.toHaveBeenCalled()
   })
 
-  it('observes cancellation accepted while the final Session save is draining', async () => {
+  it('recovers cancellation accepted while the final Session save is draining', async () => {
     let finalSaveStarted: (() => void) | undefined
     let releaseFinalSave: (() => void) | undefined
+    let terminalWriteStarted: (() => void) | undefined
+    let releaseTerminalWrite: (() => void) | undefined
     const finalSaveStart = new Promise<void>((resolve) => {
       finalSaveStarted = resolve
     })
     const finalSaveGate = new Promise<void>((resolve) => {
       releaseFinalSave = resolve
     })
+    const terminalWriteStart = new Promise<void>((resolve) => {
+      terminalWriteStarted = resolve
+    })
+    const terminalWriteGate = new Promise<void>((resolve) => {
+      releaseTerminalWrite = resolve
+    })
     let saveCount = 0
+    let durableSession: PersistedChatSession | undefined
+    let durableRuns: TaskRunJournalEntry[] = []
+    let terminalWriteBlocked = false
     const cancelPrompt = vi.fn(async () => undefined)
     const runner = createRunner({
       sessions: {
-        list: async () => [],
-        save: async () => {
+        list: async () => (durableSession ? [normalizeSessionFile(durableSession)!] : []),
+        save: async (session) => {
           saveCount += 1
           if (saveCount === 2) {
             finalSaveStarted?.()
             await finalSaveGate
           }
+          durableSession = { ...session, revision: (session.revision ?? 0) + 1 }
+          return durableSession
+        }
+      },
+      runJournal: {
+        load: async () => structuredClone(durableRuns),
+        replace: async (runs) => {
+          if (
+            !terminalWriteBlocked &&
+            runs.some((run) => run.id === 'save-run' && run.status === 'cancelled')
+          ) {
+            terminalWriteBlocked = true
+            terminalWriteStarted?.()
+            await terminalWriteGate
+          }
+          durableRuns = runs.map((run) => structuredClone(run))
         }
       },
       agent: {
@@ -3170,7 +3197,30 @@ describe('TaskRunner', () => {
     await vi.waitFor(() => expect(cancelPrompt).toHaveBeenCalledOnce())
     releaseFinalSave?.()
 
+    await terminalWriteStart
+    expect(durableRuns).toContainEqual(
+      expect.objectContaining({
+        id: started.id,
+        status: 'running',
+        sessionCommitStatus: 'cancelled'
+      })
+    )
+    const recoveredRunner = createRunner({
+      sessions: {
+        list: async () => (durableSession ? [normalizeSessionFile(durableSession)!] : [])
+      },
+      runJournal: {
+        load: async () => structuredClone(durableRuns),
+        replace: async () => undefined
+      }
+    })
+    await recoveredRunner.initialize()
+    expect(recoveredRunner.getRun(started.id)).toMatchObject({ status: 'cancelled' })
+
+    releaseTerminalWrite?.()
     await expect(cancellation).resolves.toMatchObject({ status: 'cancelled' })
+    expect(cancelPrompt).toHaveBeenCalledOnce()
+    await recoveredRunner.dispose()
   })
 
   it('waits for a queued Session commit marker before dispatching cancellation', async () => {
@@ -3524,10 +3574,11 @@ describe('TaskRunner', () => {
       releaseReview = resolve
     })
     const sessions: TaskSessionPort = {
-      list: async () => (durableSession ? [structuredClone(durableSession)] : []),
+      list: async () => (durableSession ? [normalizeSessionFile(durableSession)!] : []),
       save: async (value) => {
-        durableSession = structuredClone(value)
-        return value
+        const persisted = { ...value, revision: (value.revision ?? 0) + 1 }
+        durableSession = structuredClone(persisted)
+        return persisted
       },
       setDelegationPolicy: async () => undefined
     }
@@ -3584,6 +3635,7 @@ describe('TaskRunner', () => {
     await reviewStarted
 
     expect(durableSession).toMatchObject({ status: 'idle', activeRun: undefined })
+    expect(durableSession?.taskRunCommitId).toBe(started.id)
     expect(durableRuns).toContainEqual(expect.objectContaining({ status: 'running' }))
     expect(runner.getRun(started.id)).toMatchObject({ status: 'running', output: undefined })
 
@@ -3613,10 +3665,11 @@ describe('TaskRunner', () => {
     })
     let terminalWriteBlocked = false
     const sessions: TaskSessionPort = {
-      list: async () => (durableSession ? [structuredClone(durableSession)] : []),
+      list: async () => (durableSession ? [normalizeSessionFile(durableSession)!] : []),
       save: async (value) => {
-        durableSession = structuredClone(value)
-        return value
+        const persisted = { ...value, revision: (value.revision ?? 0) + 1 }
+        durableSession = structuredClone(persisted)
+        return persisted
       },
       setDelegationPolicy: async () => undefined
     }
@@ -3656,6 +3709,7 @@ describe('TaskRunner', () => {
     await terminalWriteStarted
 
     expect(durableSession).toMatchObject({ status: 'error', error: 'provider failed' })
+    expect(durableSession?.taskRunCommitId).toBe(started.id)
     expect(durableRuns).toContainEqual(
       expect.objectContaining({
         id: started.id,
@@ -3679,16 +3733,27 @@ describe('TaskRunner', () => {
     await recoveredRunner.dispose()
   })
 
-  it('does not recover a staged completion before its Session commit', async () => {
+  it('does not recover a staged completion after an unrelated startup Session save', async () => {
+    const normalizedSession = normalizeSessionFile({
+      ...session,
+      status: 'running',
+      activeRun: { promptMessageId: 'staged-prompt', startedAt: 2 },
+      messages: [
+        {
+          id: 'staged-prompt',
+          role: 'user',
+          content: 'Finish this work.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    })!
+    const startupSession = { ...normalizedSession, status: 'idle' as const, revision: 1 }
     const runner = createRunner({
       sessions: {
-        list: async () => [
-          {
-            ...session,
-            status: 'running',
-            activeRun: { promptMessageId: 'staged-prompt', startedAt: 2 }
-          }
-        ]
+        list: async () => [startupSession]
       },
       runJournal: {
         load: async () => [
@@ -3722,7 +3787,14 @@ describe('TaskRunner', () => {
   it('clears stale attention when recovering a committed cancellation', async () => {
     const runner = createRunner({
       sessions: {
-        list: async () => [{ ...session, status: 'idle', activeRun: undefined }]
+        list: async () => [
+          normalizeSessionFile({
+            ...session,
+            status: 'idle',
+            activeRun: undefined,
+            taskRunCommitId: 'cancelled-run'
+          })!
+        ]
       },
       runJournal: {
         load: async () => [

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1913,6 +1913,9 @@ class TaskRunner {
       const persistenceMessage = 'Task Run terminal state could not be persisted.'
       run.status = 'failed'
       run.terminalStatus = 'failed'
+      run.sessionCommit = undefined
+      run.attention = undefined
+      run.cancelledAt = undefined
       run.error = run.error ? `${run.error}\n\n${persistenceMessage}` : persistenceMessage
       log.error(persistenceMessage, { error: toErrorMessage(error), runId: run.id })
       await this.persistRuns()

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -47,6 +47,7 @@ import type {
   TaskApiErrorCode,
   TaskProject,
   TaskRun,
+  TaskRunStatus,
   TaskRunIdentity,
   TaskRunProgressEvent,
   TaskRunProgressPhase,
@@ -54,7 +55,12 @@ import type {
   TaskSessionSummary,
   UpdateTaskProjectRequest
 } from '../../shared/task-api'
+import { ArchiveAvailabilityError, archiveAvailabilityMessage } from '../archive/availability-error'
 import { toErrorMessage } from '../error-message'
+import { createLogger } from '../logger'
+import type { TaskRunJournal } from './task-run-journal'
+
+const log = createLogger('task-runner')
 
 type TaskProjectPort = {
   list(): Promise<Project[]>
@@ -181,6 +187,7 @@ type TaskRunnerDependencies = {
   reviewer: TaskReviewerPort
   computePreferences: TaskComputePreferencePort
   runWithLifecycleContext<Result>(operation: () => Result): Result
+  runJournal?: TaskRunJournal
   createId: () => string
   now: () => number
 }
@@ -205,6 +212,7 @@ type MutableTaskRun = TaskRun & {
   progressPhase: TaskRunProgressPhase
   providerAccepted: boolean
   firstVisibleOutput: boolean
+  terminalStatus?: Exclude<TaskRunStatus, 'running'>
   heartbeatTimer?: ReturnType<typeof setTimeout>
   reviewAbortController?: AbortController
   cancellation?: {
@@ -230,8 +238,9 @@ class PartialTaskCompletionError extends Error {
 }
 
 const MAX_RETAINED_RUNS = 200
+const PROCESS_RESTARTED_MESSAGE = 'Run interrupted because Open Science restarted.'
 const TASK_RUN_HEARTBEAT_INTERVAL_MS = 10_000
-export const TASK_REVIEW_DISPOSAL_BUDGET_MS = 1000
+export const TASK_RUN_DISPOSAL_BUDGET_MS = 1000
 const VISIBLE_PROVIDER_EVENT_KINDS = new Set<AcpRuntimeEvent['kind']>([
   'message',
   'thought',
@@ -342,10 +351,16 @@ const cloneRun = (run: MutableTaskRun): TaskRun => ({
   completedAt: run.completedAt,
   output: run.output,
   error: run.error,
+  failureCode: run.failureCode,
   artifacts: [...run.artifacts],
   attention: run.attention,
   review: run.review,
   preferredComputeHostIds: [...run.preferredComputeHostIds]
+})
+
+const cloneRunForJournal = (run: MutableTaskRun): TaskRun => ({
+  ...cloneRun(run),
+  status: run.terminalStatus ?? run.status
 })
 
 const createTitle = (prompt: string): string => {
@@ -486,6 +501,8 @@ const summarizeSession = (session: PersistedChatSession): TaskSessionSummary => 
   autoReviewEnabled: session.autoReviewEnabled === true,
   specialistId: session.specialistId,
   delegationPolicy: session.delegationPolicy === 'deny' ? 'deny' : 'allow',
+  pinned: session.pinned === true,
+  archivedAt: session.archivedAt,
   createdAt: session.createdAt,
   updatedAt: session.updatedAt,
   output: [...session.messages].reverse().find((message) => message.role === 'agent')?.content,
@@ -566,6 +583,8 @@ class TaskRunner {
   private readonly activeRunBySession = new Map<string, string>()
   private readonly progressListeners = new Set<(event: TaskRunProgressEvent) => void>()
   private readonly unsubscribeEvents: () => void
+  private initialization: Promise<void> | undefined
+  private journalWriteTail = Promise.resolve()
   private disposed = false
   private disposal: Promise<void> | undefined
 
@@ -573,6 +592,11 @@ class TaskRunner {
     this.unsubscribeEvents = dependencies.runtimeEvents.subscribe((event) =>
       this.captureEvent(event)
     )
+  }
+
+  initialize(): Promise<void> {
+    if (!this.initialization) this.initialization = this.restoreRuns()
+    return this.initialization
   }
 
   dispose(): Promise<void> {
@@ -587,13 +611,16 @@ class TaskRunner {
       activeReviewCompletions.push(run.completion)
     }
     this.progressListeners.clear()
-    const settleReviews = Promise.allSettled(activeReviewCompletions).then(() => undefined)
+    const settleBackgroundWork = Promise.allSettled([
+      ...activeReviewCompletions,
+      this.journalWriteTail
+    ]).then(() => undefined)
     let timer: ReturnType<typeof setTimeout> | undefined
     const deadline = new Promise<void>((resolve) => {
-      timer = setTimeout(resolve, TASK_REVIEW_DISPOSAL_BUDGET_MS)
+      timer = setTimeout(resolve, TASK_RUN_DISPOSAL_BUDGET_MS)
       timer.unref?.()
     })
-    this.disposal = Promise.race([settleReviews, deadline]).finally(() => {
+    this.disposal = Promise.race([settleBackgroundWork, deadline]).finally(() => {
       if (timer) clearTimeout(timer)
     })
     return this.disposal
@@ -607,7 +634,7 @@ class TaskRunner {
   resolveActiveRun(sessionId: string, promptMessageId?: string): TaskRunIdentity | undefined {
     const runId = this.activeRunBySession.get(sessionId)
     const run = runId ? this.runs.get(runId) : undefined
-    if (!run || run.status !== 'running') return undefined
+    if (!run || run.status !== 'running' || run.terminalStatus) return undefined
     if (promptMessageId !== undefined && promptMessageId !== run.promptMessageId) return undefined
     return { runId: run.id, sessionId: run.sessionId, projectId: run.projectId }
   }
@@ -759,6 +786,7 @@ class TaskRunner {
   }
 
   async startRun(request: StartTaskRunRequest): Promise<TaskRun> {
+    await this.initialize()
     if (!request || typeof request !== 'object') {
       throw new TaskRunnerError('invalid_request', 'Run request must be an object.')
     }
@@ -819,12 +847,18 @@ class TaskRunner {
     let normalizedRequest: StartTaskRunRequest = cwd === undefined ? request : { ...request, cwd }
 
     const project = await this.resolveProject(request.project)
+    if (project.archivedAt !== undefined) {
+      throw new TaskRunnerError('project_archived', archiveAvailabilityMessage('project-archived'))
+    }
     const sessions = await this.dependencies.sessions.list()
     const existing = request.sessionId
       ? sessions.find((session) => session.id === request.sessionId)
       : undefined
     if (request.sessionId && !existing) {
       throw new TaskRunnerError('session_not_found', `Session not found: ${request.sessionId}`)
+    }
+    if (existing?.archivedAt !== undefined) {
+      throw new TaskRunnerError('session_archived', archiveAvailabilityMessage('session-archived'))
     }
     if (existing && existing.projectId !== project.id) {
       throw new TaskRunnerError(
@@ -882,6 +916,12 @@ class TaskRunner {
       if (error instanceof ComputeHostPreferenceValidationError) {
         throw new TaskRunnerError('invalid_request', error.message)
       }
+      if (error instanceof ArchiveAvailabilityError) {
+        throw new TaskRunnerError(
+          error.code === 'project-archived' ? 'project_archived' : 'session_archived',
+          error.message
+        )
+      }
       throw error
     }
     const session = prepared.session
@@ -906,6 +946,22 @@ class TaskRunner {
 
     this.pruneRuns()
     this.runs.set(runId, run)
+    try {
+      await this.persistRuns()
+    } catch (error) {
+      this.runs.delete(runId)
+      this.releaseSession(session.id, runId)
+      await this.dependencies.sessions
+        .save({
+          ...session,
+          status: 'error',
+          activeRun: undefined,
+          error: 'Task Run identity could not be persisted.',
+          updatedAt: this.dependencies.now()
+        })
+        .catch(() => undefined)
+      throw error
+    }
     this.publishProgress(run, 'accepted')
     this.publishProgress(run, 'session-ready')
     this.scheduleHeartbeat(run)
@@ -939,6 +995,10 @@ class TaskRunner {
     const run = this.runs.get(runId)
     if (!run) throw new TaskRunnerError('run_not_found', `Run not found: ${runId}`)
     if (run.status !== 'running') return cloneRun(run)
+    if (run.terminalStatus) {
+      await run.completion
+      return cloneRun(run)
+    }
 
     const existingCancellation = run.cancellation
     if (existingCancellation) {
@@ -1319,13 +1379,14 @@ class TaskRunner {
       const cancellation = run.cancellation
       if (cancellation) await cancellation.dispatch.catch(() => undefined)
       if (cancellationAtPromptFailure?.accepted === true) {
-        run.status = 'cancelled'
         run.attention = undefined
         const cancelledAt = this.dependencies.now()
         run.completedAt = cancelledAt
         run.cancelledAt = cancelledAt
         this.stopHeartbeat(run)
-        this.publishProgress(run, 'cancelled')
+        await this.persistTerminalRun(run, 'cancelled').finally(() =>
+          this.publishProgress(run, run.status === 'failed' ? 'failed' : 'cancelled')
+        )
       } else {
         await this.failRun(
           run,
@@ -1420,14 +1481,16 @@ class TaskRunner {
     if (terminalCancellation) await terminalCancellation.dispatch.catch(() => undefined)
     const terminalCancellationAccepted = terminalCancellation?.accepted === true
     if (terminalCancellationAccepted) run.attention = undefined
-    run.status = terminalCancellationAccepted ? 'cancelled' : 'completed'
+    const terminalStatus = terminalCancellationAccepted ? 'cancelled' : 'completed'
     run.output = completed!.output
     run.artifacts = completed!.artifacts
     const completedAt = this.dependencies.now()
     run.completedAt = completedAt
     if (terminalCancellationAccepted) run.cancelledAt = completedAt
     this.stopHeartbeat(run)
-    this.publishProgress(run, terminalCancellationAccepted ? 'cancelled' : 'completed')
+    await this.persistTerminalRun(run, terminalStatus).finally(() =>
+      this.publishProgress(run, run.status === 'failed' ? 'failed' : terminalStatus)
+    )
   }
 
   private async failRun(
@@ -1447,15 +1510,14 @@ class TaskRunner {
       ...(runtimeError?.providerError ? { errorReportable: false } : {}),
       updatedAt: this.dependencies.now()
     }
-    run.status = 'failed'
     run.attention = undefined
     run.error = message
     run.output = completed?.output
     run.artifacts = completed?.artifacts ?? []
     run.completedAt = this.dependencies.now()
     this.stopHeartbeat(run)
-    this.publishProgress(run, 'failed')
     if (persistSession) await this.dependencies.sessions.save(failed).catch(() => undefined)
+    await this.persistTerminalRun(run, 'failed').finally(() => this.publishProgress(run, 'failed'))
   }
 
   private async completeSession(
@@ -1563,7 +1625,8 @@ class TaskRunner {
   private captureEvent(event: AcpRuntimeEvent): void {
     if (!event.sessionId) return
     for (const run of this.runs.values()) {
-      if (run.status !== 'running' || run.sessionId !== event.sessionId) continue
+      if (run.status !== 'running' || run.terminalStatus || run.sessionId !== event.sessionId)
+        continue
       if (event.promptMessageId !== undefined && event.promptMessageId !== run.promptMessageId) {
         continue
       }
@@ -1573,6 +1636,7 @@ class TaskRunner {
           event.planProjection.lifecycle === 'awaiting_approval'
             ? { kind: 'plan-approval', plan: event.planProjection }
             : undefined
+        void this.persistRunsBestEffort()
       }
       if (
         run.providerAccepted &&
@@ -1637,6 +1701,71 @@ class TaskRunner {
     for (const run of completed) {
       this.runs.delete(run.id)
       if (this.runs.size < MAX_RETAINED_RUNS) return
+    }
+  }
+
+  private async restoreRuns(): Promise<void> {
+    const journal = this.dependencies.runJournal
+    if (!journal) return
+    const loadedRuns = await journal.load()
+    const storedRuns = loadedRuns.slice(-MAX_RETAINED_RUNS)
+    let normalized = false
+    for (const stored of storedRuns) {
+      const snapshot = structuredClone(stored)
+      if (snapshot.status === 'running') {
+        snapshot.status = 'failed'
+        snapshot.failureCode = 'process_restarted'
+        snapshot.error = PROCESS_RESTARTED_MESSAGE
+        snapshot.completedAt = this.dependencies.now()
+        normalized = true
+      }
+      const run: MutableTaskRun = {
+        ...snapshot,
+        completion: Promise.resolve(),
+        promptMessageId: '',
+        progressPhase: snapshot.status,
+        providerAccepted: false,
+        firstVisibleOutput: true
+      }
+      this.runs.set(run.id, run)
+    }
+    if (normalized || loadedRuns.length !== storedRuns.length) await this.persistRuns()
+  }
+
+  private persistRuns(): Promise<void> {
+    const journal = this.dependencies.runJournal
+    if (!journal) return Promise.resolve()
+    const snapshot = [...this.runs.values()].map(cloneRunForJournal)
+    const write = this.journalWriteTail.then(() => journal.replace(snapshot))
+    this.journalWriteTail = write.catch(() => undefined)
+    return write
+  }
+
+  private async persistRunsBestEffort(): Promise<void> {
+    try {
+      await this.persistRuns()
+    } catch (error) {
+      log.error('Failed to persist Task Run state.', { error: toErrorMessage(error) })
+    }
+  }
+
+  private async persistTerminalRun(
+    run: MutableTaskRun,
+    status: Exclude<TaskRunStatus, 'running'>
+  ): Promise<void> {
+    run.terminalStatus = status
+    try {
+      await this.persistRuns()
+      run.status = status
+    } catch (error) {
+      const persistenceMessage = 'Task Run terminal state could not be persisted.'
+      run.status = 'failed'
+      run.terminalStatus = 'failed'
+      run.error = run.error ? `${run.error}\n\n${persistenceMessage}` : persistenceMessage
+      log.error(persistenceMessage, { error: toErrorMessage(error), runId: run.id })
+      await this.persistRuns()
+    } finally {
+      run.terminalStatus = undefined
     }
   }
 

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1614,10 +1614,13 @@ class TaskRunner {
         const persistenceMessage = 'Task Run terminal state could not be persisted.'
         run.error = `${run.error}\n\n${persistenceMessage}`
         log.error(persistenceMessage, { error: toErrorMessage(error), runId: run.id })
-        await this.persistTerminalRun(run, 'failed').finally(() =>
-          this.publishProgress(run, 'failed')
-        )
-        await this.dependencies.sessions.save(failed).catch(() => undefined)
+        try {
+          await this.persistTerminalRun(run, 'failed').finally(() =>
+            this.publishProgress(run, 'failed')
+          )
+        } finally {
+          await this.dependencies.sessions.save(failed).catch(() => undefined)
+        }
         return
       } finally {
         if (run.sessionCommitBarrier === sessionCommitBarrier) {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -391,6 +391,19 @@ const cloneRunForJournal = (run: MutableTaskRun): TaskRunJournalEntry => {
   }
 }
 
+const sessionOwnsTaskRunPrompt = (
+  session: PersistedChatSession,
+  run: Pick<TaskRunJournalEntry, 'id' | 'sessionId' | 'projectId' | 'promptMessageId'>
+): boolean =>
+  run.promptMessageId !== undefined &&
+  session.id === run.sessionId &&
+  session.projectId === run.projectId &&
+  (session.activeRun?.promptMessageId === run.promptMessageId ||
+    (session.status === 'error' &&
+      session.activeRun === undefined &&
+      session.resumeRecovery?.cause === 'app-restart' &&
+      session.resumeRecovery.promptMessageId === run.promptMessageId))
+
 const createTitle = (prompt: string): string => {
   const normalized = prompt.trim().replace(/\s+/g, ' ')
   return normalized.length <= 60 ? normalized : `${normalized.slice(0, 57)}...`
@@ -915,30 +928,92 @@ class TaskRunner {
     const userMessageId = this.dependencies.createId()
     const runId = this.dependencies.createId()
     if (existing) this.reserveSession(existing.id, runId)
-    let prepared: Awaited<ReturnType<TaskRunner['prepareSession']>>
+    type PreparedSession = Awaited<ReturnType<TaskRunner['prepareSession']>>
+    let accepted: { prepared: PreparedSession; session: PersistedChatSession; run: MutableTaskRun }
     try {
       const prepare = (
         requestForPreparation = normalizedRequest
       ): ReturnType<TaskRunner['prepareSession']> =>
         this.prepareSession(project, existing, requestForPreparation, prompt, userMessageId)
+      const acceptPrepared = async (prepared: PreparedSession): Promise<typeof accepted> => {
+        let session = prepared.session
+        this.reserveSession(session.id, runId)
+        const run = {
+          id: runId,
+          sessionId: session.id,
+          projectId: project.id,
+          cwd: session.cwd,
+          status: 'running' as const,
+          startedAt: this.dependencies.now(),
+          artifacts: [],
+          preferredComputeHostIds: [
+            ...(session.selectedComputeHosts ?? session.enabledComputeHosts ?? [])
+          ],
+          eventAccumulator: createTaskRunEventAccumulator(),
+          promptMessageId: session.activeRun!.promptMessageId,
+          progressPhase: 'accepted' as const,
+          providerAccepted: false,
+          firstVisibleOutput: false,
+          completion: Promise.resolve()
+        } satisfies MutableTaskRun
+
+        this.pruneRuns()
+        this.runs.set(runId, run)
+        try {
+          await this.persistRuns()
+        } catch (error) {
+          this.runs.delete(runId)
+          this.releaseSession(session.id, runId)
+          await this.dependencies.sessions
+            .save({
+              ...session,
+              status: 'error',
+              activeRun: undefined,
+              error: 'Task Run identity could not be persisted.',
+              updatedAt: this.dependencies.now()
+            })
+            .catch(() => undefined)
+          throw error
+        }
+        if (prepared.persistBeforeRunStart) {
+          try {
+            session = await this.dependencies.sessions.save(session)
+          } catch (error) {
+            await this.failUnpublishedRunAfterSessionSave(run, error)
+            this.releaseSession(session.id, runId)
+            throw error
+          }
+          run.cwd = session.cwd
+          run.preferredComputeHostIds = [
+            ...(session.selectedComputeHosts ?? session.enabledComputeHosts ?? [])
+          ]
+          try {
+            await this.persistRuns()
+          } catch (error) {
+            await this.failUnpublishedRunAfterSessionSave(run, error)
+            this.releaseSession(session.id, runId)
+            throw error
+          }
+        }
+        return { prepared, session, run }
+      }
       if (existing) {
-        prepared = await this.dependencies.agent.withSessionAvailable(
+        accepted = await this.dependencies.agent.withSessionAvailable(
           project.id,
           existing.id,
-          prepare
+          async () => acceptPrepared(await prepare())
         )
       } else if (request.computeHostIds !== undefined) {
-        prepared = await this.dependencies.computePreferences.withReservation(
+        accepted = await this.dependencies.computePreferences.withReservation(
           request.computeHostIds,
           async (computeHostIds) => {
             normalizedRequest = { ...normalizedRequest, computeHostIds }
-            return prepare(normalizedRequest)
+            return acceptPrepared(await prepare(normalizedRequest))
           }
         )
       } else {
-        prepared = await prepare()
+        accepted = await acceptPrepared(await prepare())
       }
-      this.reserveSession(prepared.session.id, runId)
     } catch (error) {
       if (existing) this.releaseSession(existing.id, runId)
       if (error instanceof ComputeHostPreferenceValidationError) {
@@ -952,44 +1027,7 @@ class TaskRunner {
       }
       throw error
     }
-    const session = prepared.session
-    const run = {
-      id: runId,
-      sessionId: session.id,
-      projectId: project.id,
-      cwd: session.cwd,
-      status: 'running' as const,
-      startedAt: this.dependencies.now(),
-      artifacts: [],
-      preferredComputeHostIds: [
-        ...(session.selectedComputeHosts ?? session.enabledComputeHosts ?? [])
-      ],
-      eventAccumulator: createTaskRunEventAccumulator(),
-      promptMessageId: session.activeRun!.promptMessageId,
-      progressPhase: 'accepted' as const,
-      providerAccepted: false,
-      firstVisibleOutput: false,
-      completion: Promise.resolve()
-    } satisfies MutableTaskRun
-
-    this.pruneRuns()
-    this.runs.set(runId, run)
-    try {
-      await this.persistRuns()
-    } catch (error) {
-      this.runs.delete(runId)
-      this.releaseSession(session.id, runId)
-      await this.dependencies.sessions
-        .save({
-          ...session,
-          status: 'error',
-          activeRun: undefined,
-          error: 'Task Run identity could not be persisted.',
-          updatedAt: this.dependencies.now()
-        })
-        .catch(() => undefined)
-      throw error
-    }
+    const { prepared, session, run } = accepted
     this.publishProgress(run, 'accepted')
     this.publishProgress(run, 'session-ready')
     this.scheduleHeartbeat(run)
@@ -1072,6 +1110,76 @@ class TaskRunner {
     return cloneRun(run)
   }
 
+  private async failUnpublishedRunAfterSessionSave(
+    run: MutableTaskRun,
+    failure: unknown
+  ): Promise<void> {
+    const message = toErrorMessage(failure)
+    run.progressPhase = 'failed'
+    run.error = message
+    run.completedAt = this.dependencies.now()
+    run.attention = undefined
+    run.eventAccumulator = undefined
+    try {
+      await this.persistSessionCommit(
+        run,
+        {
+          status: 'failed',
+          completedAt: run.completedAt,
+          error: message,
+          artifacts: [...run.artifacts]
+        },
+        false
+      )
+    } catch (error) {
+      log.error('Failed to stage a Task Run after its Session save reported an error.', {
+        error: toErrorMessage(error),
+        runId: run.id
+      })
+    }
+
+    let session: PersistedChatSession | undefined
+    try {
+      session = (await this.dependencies.sessions.list()).find((candidate) =>
+        sessionOwnsTaskRunPrompt(candidate, run)
+      )
+    } catch (error) {
+      log.error('Failed to verify a Session after its save reported an error.', {
+        error: toErrorMessage(error),
+        runId: run.id
+      })
+      run.status = 'failed'
+      await this.persistRunsBestEffort()
+      return
+    }
+    if (!session) {
+      run.sessionCommit = undefined
+      run.status = 'failed'
+      await this.persistRunsBestEffort()
+      return
+    }
+    try {
+      await this.dependencies.sessions.save({
+        ...session,
+        status: 'error',
+        activeRun: undefined,
+        taskRunCommitId: run.id,
+        error: message,
+        updatedAt: this.dependencies.now()
+      })
+    } catch (error) {
+      log.error('Failed to reconcile a Session after its save reported an error.', {
+        error: toErrorMessage(error),
+        runId: run.id
+      })
+      run.status = 'failed'
+      await this.persistRunsBestEffort()
+      return
+    }
+    run.status = 'failed'
+    await this.persistRunsBestEffort()
+  }
+
   private reserveSession(sessionId: string, runId: string): void {
     const activeRunId = this.activeRunBySession.get(sessionId)
     if (activeRunId && activeRunId !== runId) {
@@ -1095,6 +1203,7 @@ class TaskRunner {
   ): Promise<{
     session: PersistedChatSession
     persistOnPromptAdmission: boolean
+    persistBeforeRunStart: boolean
     historyPreamble?: string
     contextReset?: boolean
     resumeFallback?: TaskAgentPromptRequest['resumeFallback']
@@ -1290,15 +1399,13 @@ class TaskRunner {
     }
 
     const persistOnPromptAdmission = existing !== undefined
-    const committedSession = persistOnPromptAdmission
-      ? sessionToCommit
-      : await this.dependencies.sessions.save(sessionToCommit)
     const previousHistoryPreamble = existing
       ? createHistoryPreamble(selectTaskHistoryMessages(existing))
       : undefined
     return {
-      session: committedSession,
+      session: sessionToCommit,
       persistOnPromptAdmission,
+      persistBeforeRunStart: existing === undefined,
       historyPreamble: contextReset ? previousHistoryPreamble : undefined,
       contextReset,
       resumeFallback:
@@ -1823,13 +1930,17 @@ class TaskRunner {
     const loadedRuns = await journal.load()
     const storedRuns = loadedRuns.slice(-MAX_RETAINED_RUNS)
     const sessions = storedRuns.some(
-      (run) => run.status === 'running' && run.sessionCommitStatus && run.promptMessageId
+      (run) => (run.status === 'running' || run.status === 'failed') && run.promptMessageId
     )
       ? await this.dependencies.sessions.list()
       : []
+    const interrupted: MutableTaskRun[] = []
+    const terminalSessionRepairs: MutableTaskRun[] = []
     let normalized = false
     for (const stored of storedRuns) {
       const snapshot = structuredClone(stored)
+      let interruptedSession: PersistedChatSession | undefined
+      let recoveryCommit: MutableTaskRun['sessionCommit']
       if (snapshot.status === 'running') {
         const committedSession = snapshot.promptMessageId
           ? sessions.find(
@@ -1844,24 +1955,96 @@ class TaskRunner {
           snapshot.status = snapshot.sessionCommitStatus
           if (snapshot.status !== 'completed') snapshot.attention = undefined
         } else {
-          snapshot.status = 'failed'
           snapshot.failureCode = 'process_restarted'
           snapshot.error = PROCESS_RESTARTED_MESSAGE
           snapshot.completedAt = this.dependencies.now()
+          snapshot.attention = undefined
+          interruptedSession = sessions.find((session) =>
+            sessionOwnsTaskRunPrompt(session, snapshot)
+          )
+          if (interruptedSession) {
+            recoveryCommit = {
+              status: 'failed',
+              completedAt: snapshot.completedAt,
+              output: snapshot.output,
+              error: snapshot.error,
+              failureCode: snapshot.failureCode,
+              artifacts: [...snapshot.artifacts]
+            }
+          } else {
+            snapshot.status = 'failed'
+          }
         }
         normalized = true
       }
       const run: MutableTaskRun = {
         ...snapshot,
+        ...(recoveryCommit ? { sessionCommit: recoveryCommit } : {}),
         completion: Promise.resolve(),
         promptMessageId: snapshot.promptMessageId ?? '',
-        progressPhase: snapshot.status,
+        progressPhase: snapshot.status === 'running' ? 'failed' : snapshot.status,
         providerAccepted: false,
         firstVisibleOutput: true
       }
       this.runs.set(run.id, run)
+      if (interruptedSession) interrupted.push(run)
+      if (
+        snapshot.status === 'failed' &&
+        sessions.some(
+          (session) =>
+            session.taskRunCommitId !== snapshot.id && sessionOwnsTaskRunPrompt(session, snapshot)
+        )
+      ) {
+        terminalSessionRepairs.push(run)
+      }
     }
+    if (
+      !normalized &&
+      loadedRuns.length === storedRuns.length &&
+      terminalSessionRepairs.length === 0
+    ) {
+      return
+    }
+
+    // Stage interrupted failures before committing their Session projection. A restart during this
+    // reconciliation can then retry the exact prompt, while a committed Session witness promotes the
+    // staged failure on the next restore.
     if (normalized || loadedRuns.length !== storedRuns.length) await this.persistRuns()
+    if (interrupted.length === 0 && terminalSessionRepairs.length === 0) return
+
+    const currentSessions = await this.dependencies.sessions.list()
+    for (const run of interrupted) {
+      const current = currentSessions.find((session) => sessionOwnsTaskRunPrompt(session, run))
+      if (!current) {
+        run.sessionCommit = undefined
+        run.status = 'failed'
+        continue
+      }
+      await this.dependencies.sessions.save({
+        ...current,
+        status: 'error',
+        activeRun: undefined,
+        taskRunCommitId: run.id,
+        error: current.error ?? PROCESS_RESTARTED_MESSAGE,
+        updatedAt: this.dependencies.now()
+      })
+      run.status = 'failed'
+    }
+    for (const run of terminalSessionRepairs) {
+      const current = currentSessions.find(
+        (session) => session.taskRunCommitId !== run.id && sessionOwnsTaskRunPrompt(session, run)
+      )
+      if (!current) continue
+      await this.dependencies.sessions.save({
+        ...current,
+        status: 'error',
+        activeRun: undefined,
+        taskRunCommitId: run.id,
+        error: current.error ?? run.error ?? PROCESS_RESTARTED_MESSAGE,
+        updatedAt: this.dependencies.now()
+      })
+    }
+    if (interrupted.length > 0) await this.persistRuns()
   }
 
   private persistRuns(): Promise<void> {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1027,12 +1027,6 @@ class TaskRunner {
       await run.completion
       return cloneRun(run)
     }
-    const sessionCommitBarrier = run.sessionCommitBarrier
-    if (sessionCommitBarrier) {
-      await sessionCommitBarrier
-      return this.cancelRun(runId)
-    }
-
     const existingCancellation = run.cancellation
     if (existingCancellation) {
       await existingCancellation.dispatch
@@ -1047,7 +1041,11 @@ class TaskRunner {
     }
     run.cancellation = cancellation
     cancellation.dispatch = Promise.resolve()
-      .then(() => this.dependencies.agent.cancelPrompt(run.sessionId))
+      .then(async () => {
+        const sessionCommitBarrier = run.sessionCommitBarrier
+        if (sessionCommitBarrier) await sessionCommitBarrier
+        await this.dependencies.agent.cancelPrompt(run.sessionId)
+      })
       .then(async () => {
         if (run.sessionCommit && run.sessionCommit.status !== 'failed') {
           const cancelledAt = this.dependencies.now()
@@ -1486,6 +1484,7 @@ class TaskRunner {
     }
     const sessionCommitStatus =
       sessionCommitCancellation?.accepted === true ? 'cancelled' : 'completed'
+    completed!.session = { ...completed!.session, taskRunCommitId: run.id }
     const sessionCommitAt = this.dependencies.now()
     const sessionCommit: NonNullable<MutableTaskRun['sessionCommit']> = {
       status: sessionCommitStatus,
@@ -1583,6 +1582,7 @@ class TaskRunner {
       ...(completed?.session ?? session),
       status: 'error',
       activeRun: undefined,
+      taskRunCommitId: run.id,
       error: message,
       ...(runtimeError?.providerError ? { errorReportable: false } : {}),
       updatedAt: this.dependencies.now()
@@ -1835,7 +1835,9 @@ class TaskRunner {
           ? sessions.find(
               (session) =>
                 session.id === snapshot.sessionId &&
-                session.activeRun?.promptMessageId !== snapshot.promptMessageId
+                session.activeRun?.promptMessageId !== snapshot.promptMessageId &&
+                session.taskRunCommitId === snapshot.id &&
+                session.status === (snapshot.sessionCommitStatus === 'failed' ? 'error' : 'idle')
             )
           : undefined
         if (snapshot.sessionCommitStatus && committedSession) {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -58,7 +58,7 @@ import type {
 import { ArchiveAvailabilityError, archiveAvailabilityMessage } from '../archive/availability-error'
 import { toErrorMessage } from '../error-message'
 import { createLogger } from '../logger'
-import type { TaskRunJournal } from './task-run-journal'
+import type { TaskRunJournal, TaskRunJournalEntry } from './task-run-journal'
 
 const log = createLogger('task-runner')
 
@@ -213,6 +213,16 @@ type MutableTaskRun = TaskRun & {
   providerAccepted: boolean
   firstVisibleOutput: boolean
   terminalStatus?: Exclude<TaskRunStatus, 'running'>
+  sessionCommitBarrier?: Promise<void>
+  sessionCommit?: {
+    status: Exclude<TaskRunStatus, 'running'>
+    completedAt: number
+    output?: string
+    error?: string
+    failureCode?: TaskRun['failureCode']
+    artifacts: ArtifactFile[]
+    attention?: TaskRun['attention']
+  }
   heartbeatTimer?: ReturnType<typeof setTimeout>
   reviewAbortController?: AbortController
   cancellation?: {
@@ -358,10 +368,28 @@ const cloneRun = (run: MutableTaskRun): TaskRun => ({
   preferredComputeHostIds: [...run.preferredComputeHostIds]
 })
 
-const cloneRunForJournal = (run: MutableTaskRun): TaskRun => ({
-  ...cloneRun(run),
-  status: run.terminalStatus ?? run.status
-})
+const cloneRunForJournal = (run: MutableTaskRun): TaskRunJournalEntry => {
+  const sessionCommit = run.sessionCommit
+  return {
+    ...cloneRun(run),
+    status: run.terminalStatus ?? run.status,
+    promptMessageId: run.promptMessageId,
+    ...(sessionCommit
+      ? {
+          sessionCommitStatus: sessionCommit.status,
+          completedAt: sessionCommit.completedAt,
+          ...(sessionCommit.status === 'cancelled'
+            ? { cancelledAt: sessionCommit.completedAt }
+            : {}),
+          output: sessionCommit.output,
+          error: sessionCommit.error,
+          failureCode: sessionCommit.failureCode,
+          artifacts: [...sessionCommit.artifacts],
+          attention: sessionCommit.attention
+        }
+      : {})
+  }
+}
 
 const createTitle = (prompt: string): string => {
   const normalized = prompt.trim().replace(/\s+/g, ' ')
@@ -999,6 +1027,11 @@ class TaskRunner {
       await run.completion
       return cloneRun(run)
     }
+    const sessionCommitBarrier = run.sessionCommitBarrier
+    if (sessionCommitBarrier) {
+      await sessionCommitBarrier
+      return this.cancelRun(runId)
+    }
 
     const existingCancellation = run.cancellation
     if (existingCancellation) {
@@ -1015,7 +1048,16 @@ class TaskRunner {
     run.cancellation = cancellation
     cancellation.dispatch = Promise.resolve()
       .then(() => this.dependencies.agent.cancelPrompt(run.sessionId))
-      .then(() => {
+      .then(async () => {
+        if (run.sessionCommit && run.sessionCommit.status !== 'failed') {
+          const cancelledAt = this.dependencies.now()
+          await this.persistSessionCommit(run, {
+            ...run.sessionCommit,
+            status: 'cancelled',
+            completedAt: cancelledAt,
+            attention: undefined
+          })
+        }
         run.reviewAbortController?.abort()
         cancellation.accepted = true
       })
@@ -1438,6 +1480,41 @@ class TaskRunner {
       return
     }
 
+    const sessionCommitCancellation = run.cancellation
+    if (sessionCommitCancellation) {
+      await sessionCommitCancellation.dispatch.catch(() => undefined)
+    }
+    const sessionCommitStatus =
+      sessionCommitCancellation?.accepted === true ? 'cancelled' : 'completed'
+    const sessionCommitAt = this.dependencies.now()
+    const sessionCommit: NonNullable<MutableTaskRun['sessionCommit']> = {
+      status: sessionCommitStatus,
+      completedAt: sessionCommitAt,
+      output: completed!.output,
+      artifacts: completed!.artifacts,
+      attention: sessionCommitStatus === 'completed' ? run.attention : undefined
+    }
+    this.stopHeartbeat(run)
+    let releaseSessionCommitBarrier: (() => void) | undefined
+    const sessionCommitBarrier = new Promise<void>((resolve) => {
+      releaseSessionCommitBarrier = resolve
+    })
+    run.sessionCommitBarrier = sessionCommitBarrier
+    try {
+      await this.persistSessionCommit(run, sessionCommit)
+    } catch (error) {
+      const persistenceMessage = 'Task Run terminal state could not be persisted.'
+      log.error(persistenceMessage, { error: toErrorMessage(error), runId: run.id })
+      await this.failRun(run, acceptedSession, completed, new Error(persistenceMessage))
+      run.eventAccumulator = undefined
+      return
+    } finally {
+      if (run.sessionCommitBarrier === sessionCommitBarrier) {
+        run.sessionCommitBarrier = undefined
+      }
+      releaseSessionCommitBarrier?.()
+    }
+
     try {
       await this.dependencies.sessions.save(completed!.session)
     } catch (error) {
@@ -1516,7 +1593,40 @@ class TaskRunner {
     run.artifacts = completed?.artifacts ?? []
     run.completedAt = this.dependencies.now()
     this.stopHeartbeat(run)
-    if (persistSession) await this.dependencies.sessions.save(failed).catch(() => undefined)
+    if (persistSession) {
+      const failedCommit: NonNullable<MutableTaskRun['sessionCommit']> = {
+        status: 'failed',
+        completedAt: run.completedAt,
+        output: run.output,
+        error: run.error,
+        failureCode: run.failureCode,
+        artifacts: run.artifacts,
+        attention: undefined
+      }
+      let releaseSessionCommitBarrier: (() => void) | undefined
+      const sessionCommitBarrier = new Promise<void>((resolve) => {
+        releaseSessionCommitBarrier = resolve
+      })
+      run.sessionCommitBarrier = sessionCommitBarrier
+      try {
+        await this.persistSessionCommit(run, failedCommit, false)
+      } catch (error) {
+        const persistenceMessage = 'Task Run terminal state could not be persisted.'
+        run.error = `${run.error}\n\n${persistenceMessage}`
+        log.error(persistenceMessage, { error: toErrorMessage(error), runId: run.id })
+        await this.persistTerminalRun(run, 'failed').finally(() =>
+          this.publishProgress(run, 'failed')
+        )
+        await this.dependencies.sessions.save(failed).catch(() => undefined)
+        return
+      } finally {
+        if (run.sessionCommitBarrier === sessionCommitBarrier) {
+          run.sessionCommitBarrier = undefined
+        }
+        releaseSessionCommitBarrier?.()
+      }
+      await this.dependencies.sessions.save(failed).catch(() => undefined)
+    }
     await this.persistTerminalRun(run, 'failed').finally(() => this.publishProgress(run, 'failed'))
   }
 
@@ -1709,20 +1819,37 @@ class TaskRunner {
     if (!journal) return
     const loadedRuns = await journal.load()
     const storedRuns = loadedRuns.slice(-MAX_RETAINED_RUNS)
+    const sessions = storedRuns.some(
+      (run) => run.status === 'running' && run.sessionCommitStatus && run.promptMessageId
+    )
+      ? await this.dependencies.sessions.list()
+      : []
     let normalized = false
     for (const stored of storedRuns) {
       const snapshot = structuredClone(stored)
       if (snapshot.status === 'running') {
-        snapshot.status = 'failed'
-        snapshot.failureCode = 'process_restarted'
-        snapshot.error = PROCESS_RESTARTED_MESSAGE
-        snapshot.completedAt = this.dependencies.now()
+        const committedSession = snapshot.promptMessageId
+          ? sessions.find(
+              (session) =>
+                session.id === snapshot.sessionId &&
+                session.activeRun?.promptMessageId !== snapshot.promptMessageId
+            )
+          : undefined
+        if (snapshot.sessionCommitStatus && committedSession) {
+          snapshot.status = snapshot.sessionCommitStatus
+          if (snapshot.status !== 'completed') snapshot.attention = undefined
+        } else {
+          snapshot.status = 'failed'
+          snapshot.failureCode = 'process_restarted'
+          snapshot.error = PROCESS_RESTARTED_MESSAGE
+          snapshot.completedAt = this.dependencies.now()
+        }
         normalized = true
       }
       const run: MutableTaskRun = {
         ...snapshot,
         completion: Promise.resolve(),
-        promptMessageId: '',
+        promptMessageId: snapshot.promptMessageId ?? '',
         progressPhase: snapshot.status,
         providerAccepted: false,
         firstVisibleOutput: true
@@ -1748,6 +1875,30 @@ class TaskRunner {
     } catch (error) {
       log.error('Failed to persist Task Run state.', { error: toErrorMessage(error) })
     }
+  }
+
+  private persistSessionCommit(
+    run: MutableTaskRun,
+    commit: NonNullable<MutableTaskRun['sessionCommit']>,
+    rollbackToPrevious = true
+  ): Promise<void> {
+    const journal = this.dependencies.runJournal
+    const previous = run.sessionCommit
+    if (!journal) {
+      run.sessionCommit = commit
+      return Promise.resolve()
+    }
+    const write = this.journalWriteTail.then(async () => {
+      run.sessionCommit = commit
+      try {
+        await journal.replace([...this.runs.values()].map(cloneRunForJournal))
+      } catch (error) {
+        run.sessionCommit = rollbackToPrevious ? previous : undefined
+        throw error
+      }
+    })
+    this.journalWriteTail = write.catch(() => undefined)
+    return write
   }
 
   private async persistTerminalRun(

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1735,8 +1735,9 @@ class TaskRunner {
   private persistRuns(): Promise<void> {
     const journal = this.dependencies.runJournal
     if (!journal) return Promise.resolve()
-    const snapshot = [...this.runs.values()].map(cloneRunForJournal)
-    const write = this.journalWriteTail.then(() => journal.replace(snapshot))
+    const write = this.journalWriteTail.then(() =>
+      journal.replace([...this.runs.values()].map(cloneRunForJournal))
+    )
     this.journalWriteTail = write.catch(() => undefined)
     return write
   }

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 
 const { log } = vi.hoisted(() => ({
@@ -10,6 +14,7 @@ import { ApplicationEventHub } from '../application-events'
 import type { ApplicationEventSource } from '../application-events'
 import type { ApplicationCommandComposition } from '../application-command-composition'
 import type { TaskAgentPort, TaskComputePreferencePort } from '../tasks/task-runner'
+import { FileTaskRunJournal } from '../tasks/task-run-journal'
 import { createWebServiceController, type WebServiceControllerDeps } from './index'
 
 type StartOptions = Parameters<WebServiceControllerDeps['startServer']>[0]
@@ -68,6 +73,10 @@ const makeController = (
     loadWebToken: async () => 'tok-123',
     writeState,
     removeState,
+    createTaskRunJournal: () => ({
+      load: async () => [],
+      replace: async () => undefined
+    }),
     appInfo: () => ({
       appPath: '/fake/app',
       appName: 'Open Science',
@@ -346,6 +355,139 @@ describe('createWebServiceController', () => {
     const restartedTasks = h.lastOptions().tasks!
     expect(restartedTasks).toBe(firstTasks)
     expect(restartedTasks.getRun(run.id)).toMatchObject({ id: run.id, sessionId: run.sessionId })
+  })
+
+  it('recovers a terminal Task run after the Web service controller is reconstructed', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'open-science-task-runs-'))
+    const project = {
+      id: 'project-restart',
+      name: 'Project',
+      description: '',
+      isExample: false,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const sessions: unknown[] = []
+    const applicationCommands = {
+      localWeb: { commandNames: () => [], invoke: vi.fn() },
+      remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() },
+      task: {
+        commandNames: () => [],
+        invoke: vi.fn(async (name, invocation) => {
+          if (name === 'projects:list') return [project]
+          if (name === 'sessions:load-all') return { sessions, manifest: { version: 1 } }
+          if (name === 'sessions:save-session') {
+            sessions.splice(0, sessions.length, invocation.args[0])
+            return invocation.args[0]
+          }
+          throw new Error(`Unexpected Task command: ${name}`)
+        })
+      }
+    } satisfies Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
+    const taskAgent: TaskAgentPort = {
+      withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+      listAttachedSessionIds: vi.fn(async () => []),
+      createSession: vi.fn(async () => ({ sessionId: 'session-restart' })),
+      resumeSession: vi.fn(async (request) => ({ sessionId: request.sessionId })),
+      setPermissionProfile: vi.fn(async () => undefined),
+      cancelPrompt: vi.fn(async () => undefined),
+      prompt: vi.fn(async () => undefined)
+    }
+    const controllers: ReturnType<typeof makeController>[] = []
+
+    try {
+      const first = makeController(
+        {
+          resolveConfigRoot: () => configRoot,
+          createTaskRunJournal: (root) => new FileTaskRunJournal(root)
+        },
+        vi.fn(),
+        applicationCommands,
+        { taskAgent }
+      )
+      controllers.push(first)
+      await first.controller.ensureStarted(44100, { attached: false })
+      const started = await first.lastOptions().tasks!.startRun({
+        project: project.id,
+        prompt: 'Research across a restart.'
+      })
+      await vi.waitFor(() => {
+        expect(first.lastOptions().tasks!.getRun(started.id).status).toBe('completed')
+      })
+      const terminal = first.lastOptions().tasks!.getRun(started.id)
+      expect(terminal.status).toBe('completed')
+      await first.controller.dispose()
+
+      const second = makeController(
+        {
+          resolveConfigRoot: () => configRoot,
+          createTaskRunJournal: (root) => new FileTaskRunJournal(root)
+        },
+        vi.fn(),
+        applicationCommands,
+        { taskAgent }
+      )
+      controllers.push(second)
+      await second.controller.ensureStarted(44101, { attached: false })
+
+      expect(second.lastOptions().tasks!.getRun(started.id)).toMatchObject({
+        id: started.id,
+        sessionId: started.sessionId,
+        projectId: project.id,
+        status: 'completed'
+      })
+    } finally {
+      await Promise.all(
+        controllers.map(({ controller }) => controller.dispose().catch(() => undefined))
+      )
+      await rm(configRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('marks a recorded running Task as failed when the process restarts', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'open-science-task-runs-'))
+    const journal = new FileTaskRunJournal(configRoot)
+    await journal.replace([
+      {
+        id: 'run-interrupted',
+        sessionId: 'session-interrupted',
+        projectId: 'project-interrupted',
+        cwd: configRoot,
+        status: 'running',
+        startedAt: 10,
+        artifacts: [],
+        preferredComputeHostIds: []
+      }
+    ])
+    const h = makeController({
+      resolveConfigRoot: () => configRoot,
+      createTaskRunJournal: (root) => new FileTaskRunJournal(root)
+    })
+
+    try {
+      await h.controller.ensureStarted(44100, { attached: false })
+      const tasks = h.lastOptions().tasks!
+
+      expect(tasks.getRun('run-interrupted')).toMatchObject({
+        status: 'failed',
+        failureCode: 'process_restarted',
+        error: 'Run interrupted because Open Science restarted.'
+      })
+      await expect(tasks.cancelRun('run-interrupted')).resolves.toMatchObject({
+        status: 'failed',
+        failureCode: 'process_restarted'
+      })
+      await expect(journal.load()).resolves.toEqual([
+        expect.objectContaining({
+          id: 'run-interrupted',
+          status: 'failed',
+          failureCode: 'process_restarted'
+        })
+      ])
+    } finally {
+      await h.controller.dispose().catch(() => undefined)
+      await rm(configRoot, { recursive: true, force: true })
+    }
   })
 
   it('terminal dispose is idempotent, releases Task once, and rejects later starts', async () => {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -4027,6 +4027,20 @@ describe('startWebHttpServer', () => {
       }
     })
 
+    for (const [code, message] of [
+      ['session_archived', 'Restore this archived Session before continuing.'],
+      ['project_archived', 'Restore this archived Project before continuing.']
+    ] as const) {
+      tasks.startRun.mockRejectedValueOnce(new TaskApiError(code, message))
+      const archived = await fetch(`${base}/api/v1/runs`, {
+        method: 'POST',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify({ project: 'project-1', sessionId: 'session-1', prompt: 'Again' })
+      })
+      expect(archived.status).toBe(409)
+      expect(await archived.json()).toEqual({ error: { code, message } })
+    }
+
     tasks.startRun.mockRejectedValueOnce(
       new TaskApiError('project_not_found', 'Project not found: missing')
     )

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -600,7 +600,14 @@ const readJsonBody = async (
 
 const taskErrorStatus = (error: TaskApiError): number => {
   if (error.code === 'invalid_request') return 400
-  if (error.code === 'session_busy' || error.code === 'project_conflict') return 409
+  if (
+    error.code === 'session_busy' ||
+    error.code === 'project_conflict' ||
+    error.code === 'session_archived' ||
+    error.code === 'project_archived'
+  ) {
+    return 409
+  }
   return 404
 }
 

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../logger'
 import type { ApplicationEventSource } from '../application-events'
 import type { PermissionApprovalPresence } from '../permission-approval-presence'
 import type { TaskControlPorts } from '../tasks/task-control-ports'
+import { FileTaskRunJournal, type TaskRunJournal } from '../tasks/task-run-journal'
 import type { TaskAgentPort, TaskComputePreferencePort } from '../tasks/task-runner'
 import { resolveConfigRoot } from '../storage-root'
 import { loadOrCreateWebToken } from './auth'
@@ -48,6 +49,7 @@ export type WebServiceControllerDeps = {
   loadWebToken: (configRoot: string) => Promise<string>
   writeState: (configRoot: string, state: Omit<WebServiceState, 'configRoot'>) => Promise<unknown>
   removeState: (configRoot: string) => Promise<void>
+  createTaskRunJournal: (configRoot: string) => TaskRunJournal
   appInfo: () => {
     appPath: string
     appName: string
@@ -93,6 +95,7 @@ const createWebServiceController = (
   const loadWebToken = deps.loadWebToken ?? loadOrCreateWebToken
   const writeState = deps.writeState ?? writeWebServiceState
   const removeState = deps.removeState ?? removeWebServiceState
+  const createTaskRunJournal = deps.createTaskRunJournal ?? ((root) => new FileTaskRunJournal(root))
   const appInfo =
     deps.appInfo ??
     (() => ({
@@ -114,6 +117,7 @@ const createWebServiceController = (
       computePreferences
     },
     {
+      runJournal: createTaskRunJournal(getConfigRoot()),
       subscribeEvents: (listener) =>
         applicationEvents.subscribe((event) => {
           for (const runtimeEvent of projectTaskRuntimeEvents(event)) listener(runtimeEvent)
@@ -174,6 +178,7 @@ const createWebServiceController = (
 
   const start = async (port: number, attached: boolean): Promise<{ port: number; url: string }> => {
     const configRoot = getConfigRoot()
+    await tasks.initialize()
     const token = await loadWebToken(configRoot)
     const info = appInfo()
     const server = await startServer({

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -587,6 +587,115 @@ describe('HeadlessTaskApi adapter', () => {
     await api.dispose()
   })
 
+  it('exposes durable lifecycle state without hiding archived Sessions', async () => {
+    const archivedSession: PersistedChatSession = {
+      id: 'session-archived',
+      projectId: project.id,
+      title: 'Archived research',
+      cwd: '/workspace/archived',
+      status: 'idle',
+      pinned: true,
+      archivedAt: 30,
+      messages: [],
+      createdAt: 1,
+      updatedAt: 30
+    }
+    const activeSession: PersistedChatSession = {
+      id: 'session-active',
+      projectId: project.id,
+      title: 'Active research',
+      cwd: '/workspace/active',
+      status: 'idle',
+      messages: [],
+      createdAt: 2,
+      updatedAt: 20
+    }
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') {
+        return { sessions: [archivedSession, activeSession], manifest: { version: 1 } }
+      }
+      throw new Error(`Unexpected Task command: ${channel}`)
+    })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
+
+    try {
+      await expect(api.listSessions(project.id)).resolves.toEqual([
+        expect.objectContaining({ id: archivedSession.id, pinned: true, archivedAt: 30 }),
+        expect.objectContaining({ id: activeSession.id, pinned: false, archivedAt: undefined })
+      ])
+      await expect(api.getSession(archivedSession.id)).resolves.toMatchObject({
+        pinned: true,
+        archivedAt: 30
+      })
+    } finally {
+      await api.dispose()
+    }
+  })
+
+  it.each([
+    {
+      name: 'Project',
+      code: 'project_archived',
+      projects: [{ ...project, archivedAt: 40 }],
+      sessions: [] as PersistedChatSession[],
+      request: { project: project.id, prompt: 'Research this.' },
+      admissionMessage: 'Restore this archived Project before continuing.'
+    },
+    {
+      name: 'Session',
+      code: 'session_archived',
+      projects: [project],
+      sessions: [
+        {
+          id: 'session-archived',
+          projectId: project.id,
+          title: 'Archived research',
+          cwd: '/workspace/archived',
+          status: 'idle' as const,
+          archivedAt: 40,
+          messages: [],
+          createdAt: 1,
+          updatedAt: 40
+        }
+      ],
+      request: {
+        project: project.id,
+        sessionId: 'session-archived',
+        prompt: 'Continue this research.'
+      },
+      admissionMessage: 'Restore this archived Session before continuing.'
+    }
+  ])('reports archived $name admission as a stable Task conflict', async (fixture) => {
+    const invoke = vi.fn(
+      async (channel: string, _callerContext: CallerContext, args: unknown[]) => {
+        if (channel === 'projects:list') return fixture.projects
+        if (channel === 'sessions:load-all') {
+          return { sessions: fixture.sessions, manifest: { version: 1 } }
+        }
+        if (channel === 'sessions:save-session') return args[0]
+        throw new Error(`Unexpected Task command: ${channel}`)
+      }
+    )
+    const api = new HeadlessTaskApi({
+      commands: commandsFrom(invoke),
+      agent: createAgent({
+        withSessionAvailable: async () => {
+          throw new Error(fixture.admissionMessage)
+        }
+      })
+    })
+
+    try {
+      await expect(api.startRun(fixture.request)).rejects.toMatchObject({
+        code: fixture.code,
+        message: fixture.admissionMessage
+      })
+    } finally {
+      await api.dispose()
+    }
+  })
+
   it('maps public query and artifact commands to the compatibility façade', async () => {
     const session: PersistedChatSession = {
       id: 'session-query',

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -27,6 +27,7 @@ import type { ApplicationCommandByNameDispatcher } from '../application-command-
 import { createTaskCallerContext, type CallerContext } from '../caller-context'
 import type { PlanResponseResult } from '../session-plan/plan-service'
 import type { TaskControlPorts } from '../tasks/task-control-ports'
+import type { TaskRunJournal } from '../tasks/task-run-journal'
 import {
   TaskRunner,
   TaskRunnerError,
@@ -49,6 +50,7 @@ type TaskApiDependencies = {
   createId: () => string
   now: () => number
   subscribeEvents: (listener: (event: AcpRuntimeEvent) => void) => () => void
+  runJournal: TaskRunJournal
 }
 
 class HeadlessTaskApi {
@@ -144,9 +146,14 @@ class HeadlessTaskApi {
       },
       runWithLifecycleContext: (operation) =>
         this.callerContexts.run(TASK_CALLER_CONTEXT, operation),
+      runJournal: dependencies.runJournal,
       createId: dependencies.createId ?? randomUUID,
       now: dependencies.now ?? Date.now
     } satisfies TaskRunnerDependencies)
+  }
+
+  initialize(): Promise<void> {
+    return this.runner.initialize()
   }
 
   async dispose(): Promise<void> {

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -785,6 +785,9 @@ export type PersistedChatSession = {
   activities?: PersistedToolActivity[]
   activityGroups?: PersistedActivityGroup[]
   activeRun?: PersistedActiveRun
+  // Main-owned witness for the latest terminal Task Run whose Session projection was committed.
+  // Historical files omit it; Task Run recovery then fails closed.
+  taskRunCommitId?: string
   // Survives renderer/app restarts so a failed Resume remains retryable without reconstructing the
   // state from an error string or re-sending the interrupted prompt.
   resumeRecovery?: PersistedSessionResumeRecovery
@@ -4099,6 +4102,7 @@ const sanitizeSession = (
     updatedAt: asNumber(session.updatedAt) ?? 0
   }
   const activeRun = sanitizeActiveRun(session.activeRun)
+  const taskRunCommitId = asString(session.taskRunCommitId)
   const resumeRecovery = sanitizeSessionResumeRecovery(session.resumeRecovery)
   const branchSource = sanitizeSessionBranchSource(session.branchSource)
   const pendingHistoryReplay =
@@ -4156,6 +4160,7 @@ const sanitizeSession = (
   }
 
   if (activeRun) sanitized.activeRun = activeRun
+  if (taskRunCommitId) sanitized.taskRunCommitId = taskRunCommitId
   if (resumeRecovery) sanitized.resumeRecovery = resumeRecovery
   if (branchSource) sanitized.branchSource = branchSource
   if (pendingHistoryReplay) sanitized.pendingHistoryReplay = pendingHistoryReplay

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -9,6 +9,8 @@ export const TASK_EVENT_STREAM_PROTOCOL_VERSION = 1 as const
 
 export type TaskRunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 
+export type TaskRunFailureCode = 'process_restarted'
+
 export type TaskRunProgressPhase =
   | 'accepted'
   | 'session-ready'
@@ -80,6 +82,7 @@ export type TaskRun = {
   completedAt?: number
   output?: string
   error?: string
+  failureCode?: TaskRunFailureCode
   artifacts: ArtifactFile[]
   attention?: TaskRunAttention
   review?: TaskRunReview
@@ -96,6 +99,8 @@ export type TaskSessionSummary = {
   autoReviewEnabled: boolean
   specialistId?: string
   delegationPolicy: DelegationPolicy
+  pinned: boolean
+  archivedAt?: number
   createdAt: number
   updatedAt: number
   output?: string
@@ -131,6 +136,8 @@ export type TaskApiErrorCode =
   | 'project_conflict'
   | 'session_not_found'
   | 'session_busy'
+  | 'session_archived'
+  | 'project_archived'
   | 'run_not_found'
   | 'artifact_not_found'
   | 'specialist_not_found'


### PR DESCRIPTION
## Problem

Task Session summaries did not expose archive lifecycle state, so clients could not distinguish active and archived Sessions before starting work. Archived Session and Project admission failures also escaped as unstable internal errors.

Task Run identity and terminal state lived only in process memory. Restarting the application made previous run IDs indistinguishable from unknown IDs and discarded output, error, artifact, attention, and review projections.

## Proposed change

- expose pinned and archivedAt on Task Session summaries
- return stable session_archived and project_archived errors as HTTP 409 conflicts
- persist a bounded, versioned Task-owned Run journal under the configuration root using the existing durable JSON writer
- restore terminal Runs after restart and normalize interrupted running records to failed with failureCode process_restarted
- coordinate completed, cancelled, and failed Run journal markers with an atomic Session-side taskRunCommitId witness so committed results survive restart without promoting staged results
- keep taskRunCommitId Main-owned: renderer/web whole-Session saves preserve it, while only the Task caller surface may advance it
- persist the initial Run identity before a new running Session, then reconcile Session save failures without deleting a possibly committed identity
- serialize journal snapshot capture and make cancellation-marker updates atomic on write failure
- publish terminal status only after persistence; report terminal persistence failure as failed without retaining stale Session-commit metadata
- attempt failed Session cleanup even when both terminal journal writes fail, while preserving the journal error
- synchronize the npm SDK declarations with the additive response fields

## Scope and non-goals

- listSessions continues to return archived Sessions; no implicit filtering was introduced
- no Prisma schema or SessionRun changes
- no historical Run backfill for versions that did not write the journal
- no provider-process resume and no WebSocket event replay
- TaskRunStatus is unchanged; process interruption uses the existing failed status

## Compatibility and persistence

Existing Session JSON already carries pinned and archivedAt. This change adds one optional Main-owned Session JSON field, taskRunCommitId, as the cross-file commit witness; historical Sessions require no migration and safely fail closed when the witness is absent. Ordinary renderer/web saves cannot clear or forge the durable witness.

A missing task-runs.json is treated as an empty journal. The journal uses format version 1 and retains approximately the existing 200-Run in-memory window. Optional internal prompt/Session-commit correlation fields remain backward-compatible with earlier version-1 entries. Future unsupported journal versions fail closed rather than being overwritten.

New protocol enum values are session_archived, project_archived, and TaskRunFailureCode process_restarted. No TaskRunStatus value was added.

## Acceptance criteria and validation

Regression tests were first observed failing for missing lifecycle fields, archived admission, HTTP conflict mapping, Run identity loss after controller reconstruction, false completion after terminal persistence failure, serialized snapshot capture, and restart misclassification when a completed Session was committed before its Run journal terminalization. Additional crash-window tests reproduced startup normalization falsely confirming a staged result, cancellation changing completed to cancelled while the final Session save was draining, a new running Session preceding its Run identity, and post-commit Session save failures across compensation and restart windows.

Final local evidence after rebasing onto the latest main:

- Task lifecycle, runner, HTTP/controller, archive/session owner, and architecture behavior -> focused Vitest set -> 7 files and 377 tests passed
- latest Task Run/Session witness, caller authority, cancellation, startup recovery, and persistence IPC paths -> focused Vitest set -> 6 files and 486 tests passed
- npm SDK and CLI consumers -> npm run test:cli -> 87 passed and 4 skipped
- Node and sandbox TypeScript surfaces -> npm run typecheck:node -> passed
- changed files -> ESLint and Prettier checks -> passed
- generated Web API map and package contents -> npm run check:web-api-map and npm run check:cli-package -> passed

The repository impact classifier selects the full PR CI plan because the new Task journal owner is not yet represented in module-impact.json. Per maintainer direction, the complete npm test suite was not run locally and PR CI is authoritative.

## Review focus

- additive Task API and SDK contract shape
- archive conflict semantics and admission race handling
- completed/cancelled/failed Session-to-Run commit ordering across process exits
- Main-owned taskRunCommitId authority across Task versus renderer/web saves
- cancellation races while journal writes queue or Session saves drain
- compatibility with prompt-admission lifecycle changes already on main
- restart normalization and the boundary between Task Run recovery and provider execution recovery
