### PR TITLE
fix(settings-errors): hide backend diagnostics in alerts

### DIFF
--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -453,6 +453,25 @@ describe('ConnectorsPanel (groups)', () => {
     expect(retryConnectorProjection).toHaveBeenCalledOnce()
   })
 
+  it('shows a safe Skill projection retry failure instead of backend details', async () => {
+    const diagnostic = 'EACCES: write /Users/researcher/private/generated-skill/SKILL.md'
+    useSettingsStore.setState({
+      skillProjectionStatus: 'degraded',
+      retryConnectorProjection: vi.fn().mockRejectedValue(new Error(diagnostic))
+    })
+    await act(async () => root.render(<ConnectorsPanel onNavigate={vi.fn()} />))
+
+    const retry = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Retry'
+    )
+    await act(async () => retry?.click())
+
+    expect(document.body.textContent).toContain(
+      'Could not refresh the Agent Skill documents for Connectors.'
+    )
+    expect(document.body.textContent).not.toContain(diagnostic)
+  })
+
   it('reports a rejected Connector access change after rollback', async () => {
     useSettingsStore.setState({
       setConnectorEnabled: vi.fn().mockRejectedValue(new Error('write failed'))
@@ -747,6 +766,32 @@ describe('ConnectorsPanel (groups)', () => {
     expect(document.body.textContent).toContain('Checking…')
 
     await act(async () => finishRetry())
+  })
+
+  it('shows a safe retry failure instead of backend details', async () => {
+    const diagnostic = 'spawn /Users/researcher/private/mcp-server ENOENT'
+    useSettingsStore.setState({
+      retryCustomServer: vi.fn().mockRejectedValue(new Error(diagnostic)),
+      customServers: [
+        {
+          id: 'offline-mcp',
+          name: 'offline-mcp',
+          displayName: 'Offline MCP',
+          transport: 'stdio',
+          enabled: true,
+          command: 'mcp',
+          availability: 'unavailable'
+        }
+      ]
+    })
+    act(() => root.render(<ConnectorsPanel onNavigate={vi.fn()} />))
+
+    await act(async () => clickButtonByText('Retry'))
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+      'Could not reconnect this Connector.'
+    )
+    expect(document.body.textContent).not.toContain(diagnostic)
   })
 
   it('directs invalid custom Connector configurations to Edit without offering Retry', () => {

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -296,10 +296,8 @@ export function ConnectorsPanel({
     setOperationError(null)
     try {
       await retryCustomServer(id)
-    } catch (error) {
-      setOperationError(
-        error instanceof Error ? error.message : 'Could not reconnect this Connector.'
-      )
+    } catch {
+      setOperationError('Could not reconnect this Connector.')
     } finally {
       setRetryingIds((current) => {
         const next = new Set(current)
@@ -315,12 +313,8 @@ export function ConnectorsPanel({
     setOperationError(null)
     try {
       await retryConnectorProjection()
-    } catch (error) {
-      setOperationError(
-        error instanceof Error
-          ? error.message
-          : 'Could not refresh the Agent Skill documents for Connectors.'
-      )
+    } catch {
+      setOperationError('Could not refresh the Agent Skill documents for Connectors.')
     } finally {
       setRetryingProjection(false)
     }
@@ -376,8 +370,8 @@ export function ConnectorsPanel({
     try {
       await removeCustomServer(removal.server.id)
       setRemoval(null)
-    } catch (error) {
-      setRemovalError(error instanceof Error ? error.message : 'Could not remove this Connector.')
+    } catch {
+      setRemovalError('Could not remove this Connector.')
     } finally {
       setRemoving(false)
     }
@@ -675,7 +669,13 @@ export function ConnectorsPanel({
             role="alert"
           >
             <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-            <span>{t(operationError)}</span>
+            <span>
+              {operationError === 'Could not reconnect this Connector.'
+                ? t('Could not reconnect this Connector.')
+                : operationError === 'Could not refresh the Agent Skill documents for Connectors.'
+                  ? t('Could not refresh the Agent Skill documents for Connectors.')
+                  : t(operationError)}
+            </span>
           </div>
         ) : null}
         {showFeatured
@@ -994,7 +994,7 @@ export function ConnectorsPanel({
                   className="mt-4 flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
                 >
                   <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-                  <span>{t(removalError)}</span>
+                  <span>{t('Could not remove this Connector.')}</span>
                 </div>
               ) : null}
             </div>

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -148,9 +148,8 @@ const NetworkPanel = ({
     try {
       await setPackageMirror(draft)
       onNavigate({ kind: 'list' })
-    } catch (error) {
-      // An IPC-supplied error message is passed through verbatim; only the fallback is translated.
-      setMessage(error instanceof Error ? error.message : t('Could not save the package mirror.'))
+    } catch {
+      setMessage('Could not save the package mirror.')
     } finally {
       setIsSaving(false)
     }
@@ -406,7 +405,7 @@ const NetworkPanel = ({
 
               {message ? (
                 <p className="text-xs text-destructive" role="alert">
-                  {message}
+                  {t('Could not save the package mirror.')}
                 </p>
               ) : null}
 

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -244,13 +244,15 @@ describe('RuntimesPanel', () => {
     expect(recheck?.disabled).toBe(false)
   })
 
-  it('shows discovery failures instead of rendering an empty registry and recovers on Recheck', async () => {
-    listEnvironments.mockRejectedValueOnce(new Error('runtime discovery unavailable'))
+  it('shows a safe discovery failure instead of backend details and recovers on Recheck', async () => {
+    const diagnostic = 'SQLITE_BUSY while reading /private/data/runtimes.db'
+    listEnvironments.mockRejectedValueOnce(new Error(diagnostic))
     await render()
 
-    expect(container.querySelector('[data-testid="runtimes-error"]')?.textContent).toContain(
-      'runtime discovery unavailable'
+    expect(container.querySelector('[data-testid="runtimes-error"]')?.textContent).toBe(
+      'Could not load runtimes.'
     )
+    expect(container.textContent).not.toContain(diagnostic)
     expect(container.textContent).not.toContain('Detecting runtimes…')
     expect(container.querySelectorAll('[data-testid="runtime-card"]')).toHaveLength(0)
 
@@ -267,9 +269,10 @@ describe('RuntimesPanel', () => {
     getEnablement.mockRejectedValueOnce(new Error('runtime enablement unavailable'))
     await render()
 
-    expect(container.querySelector('[data-testid="runtimes-error"]')?.textContent).toContain(
-      'runtime enablement unavailable'
+    expect(container.querySelector('[data-testid="runtimes-error"]')?.textContent).toBe(
+      'Could not load runtimes.'
     )
+    expect(container.textContent).not.toContain('runtime enablement unavailable')
     expect(container.querySelectorAll('[data-testid="runtime-card"]')).toHaveLength(0)
     expect(container.querySelector('[aria-label="Enable Python 3.12 (managed)"]')).toBeNull()
   })
@@ -284,9 +287,10 @@ describe('RuntimesPanel', () => {
     )
     await click(recheck ?? null)
 
-    expect(container.querySelector('[data-testid="runtimes-error"]')?.textContent).toContain(
-      'runtime recheck unavailable'
+    expect(container.querySelector('[data-testid="runtimes-error"]')?.textContent).toBe(
+      'Could not re-check runtimes.'
     )
+    expect(container.textContent).not.toContain('runtime recheck unavailable')
     expect(container.querySelectorAll('[data-testid="runtime-card"]')).toHaveLength(4)
     expect(container.textContent).toContain('System Python')
     expect(container.querySelector('[data-testid="runtime-packages-count"]')?.textContent).toBe('2')

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -186,8 +186,8 @@ const RuntimesPanel = ({
     setError(null)
     try {
       await recheckRuntimeSettings()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : t('Could not re-check runtimes.'))
+    } catch {
+      setError('Could not re-check runtimes.')
     }
   }
 
@@ -627,7 +627,11 @@ const RuntimesPanel = ({
         ) : null}
         {error !== null && (
           <p role="alert" className="text-sm text-destructive" data-testid="runtimes-error">
-            {error === 'Could not load runtimes.' ? t('Could not load runtimes.') : error}
+            {error === 'Could not load runtimes.'
+              ? t('Could not load runtimes.')
+              : error === 'Could not re-check runtimes.'
+                ? t('Could not re-check runtimes.')
+                : error}
           </p>
         )}
         {!loading && envs !== null ? (

--- a/src/renderer/src/pages/settings/network-panel-i18n.render.test.tsx
+++ b/src/renderer/src/pages/settings/network-panel-i18n.render.test.tsx
@@ -115,4 +115,26 @@ describe('NetworkPanel mirror view', () => {
     switchTo('zh-Hant')
     expect(placeholders()).toContain('/path/to/corp-ca-bundle.pem')
   })
+
+  it('translates a safe save failure without exposing backend details', async () => {
+    const diagnostic = 'EACCES: open /Users/researcher/private/ca-bundle.pem'
+    useSettingsStore.setState({
+      setPackageMirror: async () => {
+        throw new Error(diagnostic)
+      }
+    })
+    render(<NetworkPanel view={{ kind: 'mirror' }} onNavigate={noop} />)
+    switchTo('zh-Hans')
+
+    const save = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === '保存'
+    )
+    await act(async () => save?.click())
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('无法保存软件包镜像。')
+    expect(container.textContent).not.toContain(diagnostic)
+
+    switchTo('zh-Hant')
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('無法儲存套件鏡像。')
+  })
 })

--- a/src/renderer/src/stores/runtime-settings-store.test.ts
+++ b/src/renderer/src/stores/runtime-settings-store.test.ts
@@ -34,6 +34,19 @@ beforeEach(() => {
 })
 
 describe('runtime settings store', () => {
+  it('records a safe load error while preserving the original rejection', async () => {
+    const diagnostic = new Error('SQLITE_BUSY while reading /private/data/runtimes.db')
+    setRuntimeApi({
+      listEnvironments: vi.fn().mockRejectedValue(diagnostic),
+      getEnablement: vi.fn().mockResolvedValue(enablement),
+      getAgentEnvironmentCreationEnabled: vi.fn().mockResolvedValue(true)
+    })
+
+    await expect(useRuntimeSettingsStore.getState().load()).rejects.toBe(diagnostic)
+
+    expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
+  })
+
   it('retains discovery and package counts across later panel loads', async () => {
     const runtime = {
       listEnvironments: vi.fn().mockResolvedValue({ python: [python], r: [] }),

--- a/src/renderer/src/stores/runtime-settings-store.ts
+++ b/src/renderer/src/stores/runtime-settings-store.ts
@@ -133,7 +133,7 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
           set({
             loaded: true,
             busy: false,
-            error: error instanceof Error ? error.message : 'Could not load runtimes.'
+            error: 'Could not load runtimes.'
           })
         }
         throw error


### PR DESCRIPTION
## Summary

- replace raw renderer exception messages with stable translated error keys for Runtime, Connector retry/removal/Skill projection, and package mirror failures
- preserve Runtime rejection semantics while keeping backend paths and implementation details out of primary alerts
- add public rendering-boundary regressions using path-bearing diagnostics, including language switching after a mirror save failure

## Verification

- related Vitest suites and i18n guard: 922 passed
- npm run typecheck:web
- targeted ESLint and git diff --check

## Full-suite note

A non-sandbox npm test run completed with 23,509 passing tests and 4 unrelated existing failures: one WorkspaceMessageScroller preview-argument assertion, one session-persistence architecture count assertion, and two real-R image-capture assertions. Isolated reruns reproduced those failures outside the files changed here.