### PR TITLE
fix(skills): support helper validation without audit hooks

### DIFF
--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -212,6 +212,22 @@ describe('validateNotebookHelperExports', () => {
     await expect(
       validateNotebookHelperExports(
         'figure-composer',
+        'int = 1\nclass FigureComposer(int):\n    pass\n',
+        ['FigureComposer'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'class FigureComposer:\n    int = 1\n    class Nested(int):\n        pass\n',
+        ['FigureComposer'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
         'LEFT, RIGHT = (1,)\ndef compose_figure():\n    return None\n',
         ['compose_figure'],
         { python: legacyPython }

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -156,7 +156,7 @@ describe('validateNotebookHelperExports', () => {
     await expect(
       validateNotebookHelperExports(
         'figure-composer',
-        'def compose_figure():\n    return None\n',
+        'META_GREY = "#888888"\ndef compose_figure():\n    return None\n',
         ['compose_figure'],
         { python: legacyPython }
       )
@@ -169,6 +169,22 @@ describe('validateNotebookHelperExports', () => {
         { python: legacyPython }
       )
     ).rejects.toThrow('missing or non-callable exports: compose_figure')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'def compose_figure():\n    return None\ncompose_figure = 1\n',
+        ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('missing or non-callable exports: compose_figure')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'open("validation-side-effect", "w")\ndef compose_figure():\n    return None\n',
+        ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
   })
 
   it('validates UTF-8 helper source when the interpreter defaults stdin to a legacy encoding', async () => {

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -152,6 +152,17 @@ describe('validateNotebookHelperExports', () => {
       ...python,
       baseArgs: [...python.baseArgs, '-c', 'import sys; del sys.addaudithook; exec(sys.argv[-1])']
     }
+    const futureSource =
+      'from __future__ import annotations\ndef compose_figure(value: MissingType):\n    return value\n'
+
+    await expect(
+      validateNotebookHelperExports('figure-composer', futureSource, ['compose_figure'], { python })
+    ).resolves.toBeUndefined()
+    await expect(
+      validateNotebookHelperExports('figure-composer', futureSource, ['compose_figure'], {
+        python: legacyPython
+      })
+    ).resolves.toBeUndefined()
 
     await expect(
       validateNotebookHelperExports(

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -156,7 +156,7 @@ describe('validateNotebookHelperExports', () => {
     await expect(
       validateNotebookHelperExports(
         'figure-composer',
-        'META_GREY = "#888888"\ndef compose_figure():\n    return None\n',
+        'META_GREY = "#888888"\nLEFT, RIGHT = (1, 2)\ndef compose_figure(value: int = 1) -> str:\n    return str(value)\n',
         ['compose_figure'],
         { python: legacyPython }
       )
@@ -198,6 +198,22 @@ describe('validateNotebookHelperExports', () => {
         'figure-composer',
         'class FigureComposer:\n    output = open("validation-side-effect", "w")\n',
         ['FigureComposer'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'class FigureComposer:\n    __slots__ = (1,)\n',
+        ['FigureComposer'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'LEFT, RIGHT = (1,)\ndef compose_figure():\n    return None\n',
+        ['compose_figure'],
         { python: legacyPython }
       )
     ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -180,6 +180,14 @@ describe('validateNotebookHelperExports', () => {
     await expect(
       validateNotebookHelperExports(
         'figure-composer',
+        'class ComposerBase:\n    def __init_subclass__(cls):\n        raise RuntimeError()\nclass FigureComposer(ComposerBase):\n    pass\n',
+        ['FigureComposer'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
         'def another_export():\n    return None\n',
         ['compose_figure'],
         { python: legacyPython }

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -146,6 +146,31 @@ describe('resolvePythonCommand', () => {
 })
 
 describe('validateNotebookHelperExports', () => {
+  it('validates definition-only helpers when Python predates audit hooks', async () => {
+    const python = await resolvePythonCommand()
+    const legacyPython = {
+      ...python,
+      baseArgs: [...python.baseArgs, '-c', 'import sys; del sys.addaudithook; exec(sys.argv[-1])']
+    }
+
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'def compose_figure():\n    return None\n',
+        ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).resolves.toBeUndefined()
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'def another_export():\n    return None\n',
+        ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('missing or non-callable exports: compose_figure')
+  })
+
   it('validates UTF-8 helper source when the interpreter defaults stdin to a legacy encoding', async () => {
     const python = await resolvePythonCommand()
 

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -188,6 +188,22 @@ describe('validateNotebookHelperExports', () => {
     await expect(
       validateNotebookHelperExports(
         'figure-composer',
+        'import json as json_module\nfrom math import sqrt as compose_figure\n',
+        ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).resolves.toBeUndefined()
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'import pathlib\ndef compose_figure():\n    return None\n',
+        ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
         'def another_export():\n    return None\n',
         ['compose_figure'],
         { python: legacyPython }

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -146,181 +146,25 @@ describe('resolvePythonCommand', () => {
 })
 
 describe('validateNotebookHelperExports', () => {
-  it('validates definition-only helpers when Python predates audit hooks', async () => {
+  it('validates trusted bundled helpers when Python lacks audit hooks', async () => {
     const python = await resolvePythonCommand()
     const legacyPython = {
       ...python,
       baseArgs: [...python.baseArgs, '-c', 'import sys; del sys.addaudithook; exec(sys.argv[-1])']
     }
-    const futureSource =
-      'from __future__ import annotations\ndef compose_figure(value: MissingType):\n    return value\n'
+    const source = 'def compose_figure():\n    return None\n'
 
-    await expect(
-      validateNotebookHelperExports('figure-composer', futureSource, ['compose_figure'], { python })
-    ).resolves.toBeUndefined()
-    await expect(
-      validateNotebookHelperExports('figure-composer', futureSource, ['compose_figure'], {
-        python: legacyPython
-      })
-    ).resolves.toBeUndefined()
-
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'META_GREY = "#888888"\nLEFT, RIGHT = (1, 2)\ndef compose_figure(value: int = 1) -> str:\n    return str(value)\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).resolves.toBeUndefined()
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'class FigureComposer:\n    def compose(self):\n        return None\n',
-        ['FigureComposer'],
-        { python: legacyPython }
-      )
-    ).resolves.toBeUndefined()
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'class ComposerBase:\n    pass\nclass FigureComposer(ComposerBase):\n    pass\n',
-        ['FigureComposer'],
-        { python: legacyPython }
-      )
-    ).resolves.toBeUndefined()
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'class ComposerBase:\n    def __init_subclass__(cls):\n        raise RuntimeError()\nclass FigureComposer(ComposerBase):\n    pass\n',
-        ['FigureComposer'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'import json as json_module\nfrom math import sqrt as compose_figure\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).resolves.toBeUndefined()
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'import collections\nfrom collections import OrderedDict\ndef compose_figure(value: OrderedDict = OrderedDict, other: collections.OrderedDict = collections.OrderedDict):\n    return value or other\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).resolves.toBeUndefined()
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'import pathlib\ndef compose_figure():\n    return None\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'def another_export():\n    return None\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('missing or non-callable exports: compose_figure')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'def compose_figure():\n    return None\ncompose_figure = 1\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('missing or non-callable exports: compose_figure')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'open("validation-side-effect", "w")\ndef compose_figure():\n    return None\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'class FigureComposer:\n    output = open("validation-side-effect", "w")\n',
-        ['FigureComposer'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'class FigureComposer:\n    __slots__ = (1,)\n',
-        ['FigureComposer'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'int = 1\nclass FigureComposer(int):\n    pass\n',
-        ['FigureComposer'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'class FigureComposer:\n    int = 1\n    class Nested(int):\n        pass\n',
-        ['FigureComposer'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
-    await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'LEFT, RIGHT = (1,)\ndef compose_figure():\n    return None\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
-  })
-
-  it('matches Python runtime bindings created by future imports', async () => {
-    const python = await resolvePythonCommand()
-    const legacyPython = {
-      ...python,
-      baseArgs: [...python.baseArgs, '-c', 'import sys; del sys.addaudithook; exec(sys.argv[-1])']
-    }
-
-    const source =
-      'from __future__ import annotations\ndef compose_figure(value=annotations):\n    return value\n'
-
-    await expect(
-      validateNotebookHelperExports('figure-composer', source, ['compose_figure'], { python })
-    ).resolves.toBeUndefined()
     await expect(
       validateNotebookHelperExports('figure-composer', source, ['compose_figure'], {
-        python: legacyPython
+        python: legacyPython,
+        trustedSource: true
       })
     ).resolves.toBeUndefined()
-  })
-
-  it('accepts the same safe built-in references on legacy Python', async () => {
-    const python = await resolvePythonCommand()
-    const legacyPython = {
-      ...python,
-      baseArgs: [...python.baseArgs, '-c', 'import sys; del sys.addaudithook; exec(sys.argv[-1])']
-    }
-
     await expect(
-      validateNotebookHelperExports(
-        'figure-composer',
-        'def compose_figure(value: callable = range):\n    return value\n',
-        ['compose_figure'],
-        { python: legacyPython }
-      )
-    ).resolves.toBeUndefined()
+      validateNotebookHelperExports('external-helper', source, ['compose_figure'], {
+        python: legacyPython
+      })
+    ).rejects.toThrow('external helper validation requires Python audit-hook support')
   })
 
   it('validates UTF-8 helper source when the interpreter defaults stdin to a legacy encoding', async () => {

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -196,6 +196,14 @@ describe('validateNotebookHelperExports', () => {
     await expect(
       validateNotebookHelperExports(
         'figure-composer',
+        'import collections\nfrom collections import OrderedDict\ndef compose_figure(value: OrderedDict = OrderedDict, other: collections.OrderedDict = collections.OrderedDict):\n    return value or other\n',
+        ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).resolves.toBeUndefined()
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
         'import pathlib\ndef compose_figure():\n    return None\n',
         ['compose_figure'],
         { python: legacyPython }

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -164,6 +164,14 @@ describe('validateNotebookHelperExports', () => {
     await expect(
       validateNotebookHelperExports(
         'figure-composer',
+        'class FigureComposer:\n    def compose(self):\n        return None\n',
+        ['FigureComposer'],
+        { python: legacyPython }
+      )
+    ).resolves.toBeUndefined()
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
         'def another_export():\n    return None\n',
         ['compose_figure'],
         { python: legacyPython }
@@ -182,6 +190,14 @@ describe('validateNotebookHelperExports', () => {
         'figure-composer',
         'open("validation-side-effect", "w")\ndef compose_figure():\n    return None\n',
         ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'class FigureComposer:\n    output = open("validation-side-effect", "w")\n',
+        ['FigureComposer'],
         { python: legacyPython }
       )
     ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -286,6 +286,43 @@ describe('validateNotebookHelperExports', () => {
     ).rejects.toThrow('legacy helper validation requires side-effect-free definitions')
   })
 
+  it('matches Python runtime bindings created by future imports', async () => {
+    const python = await resolvePythonCommand()
+    const legacyPython = {
+      ...python,
+      baseArgs: [...python.baseArgs, '-c', 'import sys; del sys.addaudithook; exec(sys.argv[-1])']
+    }
+
+    const source =
+      'from __future__ import annotations\ndef compose_figure(value=annotations):\n    return value\n'
+
+    await expect(
+      validateNotebookHelperExports('figure-composer', source, ['compose_figure'], { python })
+    ).resolves.toBeUndefined()
+    await expect(
+      validateNotebookHelperExports('figure-composer', source, ['compose_figure'], {
+        python: legacyPython
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('accepts the same safe built-in references on legacy Python', async () => {
+    const python = await resolvePythonCommand()
+    const legacyPython = {
+      ...python,
+      baseArgs: [...python.baseArgs, '-c', 'import sys; del sys.addaudithook; exec(sys.argv[-1])']
+    }
+
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
+        'def compose_figure(value: callable = range):\n    return value\n',
+        ['compose_figure'],
+        { python: legacyPython }
+      )
+    ).resolves.toBeUndefined()
+  })
+
   it('validates UTF-8 helper source when the interpreter defaults stdin to a legacy encoding', async () => {
     const python = await resolvePythonCommand()
 

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -172,6 +172,14 @@ describe('validateNotebookHelperExports', () => {
     await expect(
       validateNotebookHelperExports(
         'figure-composer',
+        'class ComposerBase:\n    pass\nclass FigureComposer(ComposerBase):\n    pass\n',
+        ['FigureComposer'],
+        { python: legacyPython }
+      )
+    ).resolves.toBeUndefined()
+    await expect(
+      validateNotebookHelperExports(
+        'figure-composer',
         'def another_export():\n    return None\n',
         ['compose_figure'],
         { python: legacyPython }

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -180,11 +180,81 @@ if hasattr(sys, "addaudithook"):
 else:
     # Python < 3.8 cannot audit validation-time host access, so never execute staged source there.
     tree = ast.parse(request["source"], filename="<registered-helper>")
-    definitions = {
-        node.name for node in tree.body
-        if isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef))
-    }
-    missing = [name for name in request["exports"] if name not in definitions]
+
+    def is_literal(expression):
+        try:
+            ast.literal_eval(expression)
+            return True
+        except (SyntaxError, TypeError, ValueError):
+            return False
+
+    def is_static_function(node):
+        arguments = (
+            list(getattr(node.args, "posonlyargs", ()))
+            + list(node.args.args)
+            + list(node.args.kwonlyargs)
+        )
+        if node.args.vararg is not None:
+            arguments.append(node.args.vararg)
+        if node.args.kwarg is not None:
+            arguments.append(node.args.kwarg)
+        defaults = list(node.args.defaults) + [
+            default for default in node.args.kw_defaults if default is not None
+        ]
+        annotations = [argument.annotation for argument in arguments] + [node.returns]
+        return (
+            not node.decorator_list
+            and all(is_literal(default) for default in defaults)
+            and all(annotation is None or is_literal(annotation) for annotation in annotations)
+        )
+
+    def assignment_names(target):
+        if isinstance(target, ast.Name):
+            return [target.id]
+        if isinstance(target, (ast.List, ast.Tuple)):
+            names = []
+            for element in target.elts:
+                nested_names = assignment_names(element)
+                if nested_names is None:
+                    return None
+                names.extend(nested_names)
+            return names
+        return None
+
+    bindings = {}
+    unsafe = []
+    for index, node in enumerate(tree.body):
+        if index == 0 and isinstance(node, ast.Expr):
+            try:
+                if isinstance(ast.literal_eval(node.value), str):
+                    continue
+            except (SyntaxError, TypeError, ValueError):
+                pass
+        if isinstance(node, ast.Pass):
+            continue
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(node):
+            bindings[node.name] = True
+            continue
+        if isinstance(node, ast.Assign) and is_literal(node.value):
+            names = []
+            for target in node.targets:
+                target_names = assignment_names(target)
+                if target_names is None:
+                    names = None
+                    break
+                names.extend(target_names)
+            if names is not None:
+                for name in names:
+                    bindings[name] = False
+                continue
+        unsafe.append(type(node).__name__)
+
+    if unsafe:
+        raise TypeError(
+            "legacy helper validation requires side-effect-free definitions: "
+            + ", ".join(unsafe)
+        )
+    missing = [name for name in request["exports"] if not bindings.get(name, False)]
 if missing:
     raise TypeError("missing or non-callable exports: " + ", ".join(missing))
 `

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -146,12 +146,12 @@ export const resolvePythonCommand = async (
 }
 
 const CALLABLE_HELPER_VALIDATOR = String.raw`
-import __future__, ast, base64, builtins, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics, sys
+import base64, builtins, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics, sys
 
 allowed_modules = {
     module.__name__: module
     for module in (
-        __future__, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics
+        collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics
     )
 }
 
@@ -165,290 +165,20 @@ def deny(event, args):
         raise PermissionError("host access is unavailable during helper validation")
 
 request = json.loads(base64.b64decode(sys.stdin.read()).decode("utf-8"))
+if hasattr(sys, "addaudithook"):
+    sys.addaudithook(deny)
+elif not request.get("trustedSource", False):
+    raise PermissionError("external helper validation requires Python audit-hook support")
 safe_names = (
     "__build_class__", "abs", "all", "any", "bool", "bytes", "callable", "dict", "enumerate",
     "Exception", "float", "int", "isinstance", "len", "list", "map", "max", "min", "object",
     "range", "repr", "reversed", "set", "slice", "sorted", "str", "sum", "tuple", "ValueError", "zip"
 )
-if hasattr(sys, "addaudithook"):
-    sys.addaudithook(deny)
-    safe_builtins = {name: getattr(builtins, name) for name in safe_names}
-    safe_builtins["__import__"] = restricted_import
-    namespace = {"__builtins__": safe_builtins, "__name__": "__open_science_helper_validation__"}
-    exec(compile(request["source"], "<registered-helper>", "exec"), namespace, namespace)
-    missing = [name for name in request["exports"] if name not in namespace or not callable(namespace[name])]
-else:
-    # Python < 3.8 cannot audit validation-time host access, so never execute staged source there.
-    compile(request["source"], "<registered-helper>", "exec")
-    tree = ast.parse(request["source"], filename="<registered-helper>")
-    postpone_annotations = any(
-        isinstance(node, ast.ImportFrom)
-        and node.module == "__future__"
-        and any(alias.name == "annotations" for alias in node.names)
-        for node in tree.body
-    )
-
-    def is_literal(expression):
-        try:
-            ast.literal_eval(expression)
-            return True
-        except (SyntaxError, TypeError, ValueError):
-            return False
-
-    def is_static_function(node, visible_bindings=None, postpone_annotation_evaluation=False):
-        if visible_bindings is None:
-            visible_bindings = {}
-        arguments = (
-            list(getattr(node.args, "posonlyargs", ()))
-            + list(node.args.args)
-            + list(node.args.kwonlyargs)
-        )
-        if node.args.vararg is not None:
-            arguments.append(node.args.vararg)
-        if node.args.kwarg is not None:
-            arguments.append(node.args.kwarg)
-        defaults = list(node.args.defaults) + [
-            default for default in node.args.kw_defaults if default is not None
-        ]
-        annotations = [argument.annotation for argument in arguments] + [node.returns]
-
-        def static_reference(expression):
-            if isinstance(expression, ast.Name):
-                if expression.id in visible_bindings:
-                    return True, visible_bindings[expression.id]
-                if expression.id in safe_names:
-                    return True, getattr(builtins, expression.id)
-                return False, None
-            if isinstance(expression, ast.Attribute):
-                found, value = static_reference(expression.value)
-                if not found:
-                    return False, None
-                try:
-                    return True, getattr(value, expression.attr)
-                except Exception:
-                    return False, None
-            return False, None
-
-        def is_static_value(expression):
-            return is_literal(expression) or static_reference(expression)[0]
-
-        return (
-            not node.decorator_list
-            and all(is_static_value(default) for default in defaults)
-            and all(
-                annotation is None
-                or postpone_annotation_evaluation
-                or is_static_value(annotation)
-                for annotation in annotations
-            )
-        )
-
-    def bind_literal_target(target, value):
-        if isinstance(target, ast.Name):
-            return {target.id: value}
-        if isinstance(target, (ast.List, ast.Tuple)):
-            try:
-                values = list(value)
-            except TypeError:
-                return None
-            starred = [
-                index for index, element in enumerate(target.elts)
-                if isinstance(element, ast.Starred)
-            ]
-            if len(starred) > 1:
-                return None
-            if not starred and len(values) != len(target.elts):
-                return None
-            if starred and len(values) < len(target.elts) - 1:
-                return None
-
-            bindings = {}
-            for index, element in enumerate(target.elts):
-                if isinstance(element, ast.Starred):
-                    trailing = len(target.elts) - index - 1
-                    nested_value = values[index:len(values) - trailing if trailing else None]
-                    element = element.value
-                elif starred and index > starred[0]:
-                    nested_value = values[len(values) - (len(target.elts) - index)]
-                else:
-                    nested_value = values[index]
-                nested_bindings = bind_literal_target(element, nested_value)
-                if nested_bindings is None:
-                    return None
-                bindings.update(nested_bindings)
-            return bindings
-        return None
-
-    def literal_assignment_bindings(node):
-        if not isinstance(node, ast.Assign):
-            return None
-        try:
-            value = ast.literal_eval(node.value)
-        except (SyntaxError, TypeError, ValueError):
-            return None
-        bindings = {}
-        for target in node.targets:
-            target_bindings = bind_literal_target(target, value)
-            if target_bindings is None:
-                return None
-            bindings.update(target_bindings)
-        return bindings
-
-    def static_import_bindings(node):
-        bindings = {}
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                module = allowed_modules.get(alias.name)
-                if module is None:
-                    return None
-                bindings[alias.asname or alias.name] = module
-            return bindings
-        if not isinstance(node, ast.ImportFrom) or node.level != 0:
-            return None
-        # Future statements set compiler flags and still emit IMPORT_FROM/STORE_NAME,
-        # so their imported names (including aliases) are runtime bindings too.
-        module = allowed_modules.get(node.module)
-        if module is None:
-            return None
-        for alias in node.names:
-            if alias.name == "*":
-                names = getattr(module, "__all__", None)
-                if names is None:
-                    names = [name for name in dir(module) if not name.startswith("_")]
-                for name in names:
-                    try:
-                        bindings[name] = getattr(module, name)
-                    except AttributeError:
-                        return None
-                continue
-            try:
-                bindings[alias.asname or alias.name] = getattr(module, alias.name)
-            except AttributeError:
-                return None
-        return bindings
-
-    def is_docstring(node):
-        if not isinstance(node, ast.Expr):
-            return False
-        try:
-            return isinstance(ast.literal_eval(node.value), str)
-        except (SyntaxError, TypeError, ValueError):
-            return False
-
-    static_base_types = {
-        name: getattr(builtins, name)
-        for name in (
-            "bytes", "dict", "Exception", "float", "int", "list", "object", "set", "str",
-            "tuple", "ValueError"
-        )
-    }
-
-    def callable_placeholder(*args, **kwargs):
-        return None
-
-    static_classes_with_init_subclass = set()
-
-    def build_static_class(node, visible_bindings=None):
-        if node.decorator_list or node.keywords:
-            return None
-        if visible_bindings is None:
-            visible_bindings = {}
-        bases = []
-        for base in node.bases:
-            if not isinstance(base, ast.Name):
-                return None
-            if base.id in visible_bindings:
-                base_type = visible_bindings[base.id]
-                if not isinstance(base_type, type):
-                    return None
-            else:
-                base_type = static_base_types.get(base.id)
-                if base_type is None:
-                    return None
-            if base_type in static_classes_with_init_subclass:
-                return None
-            bases.append(base_type)
-        if not bases:
-            bases.append(object)
-
-        namespace = {
-            "__module__": "__open_science_helper_validation__",
-            "__qualname__": node.name,
-        }
-        local_bindings = dict(visible_bindings)
-        for index, member in enumerate(node.body):
-            if index == 0 and is_docstring(member):
-                namespace["__doc__"] = ast.literal_eval(member.value)
-                continue
-            if isinstance(member, ast.Pass):
-                continue
-            if (
-                isinstance(member, (ast.AsyncFunctionDef, ast.FunctionDef))
-                and is_static_function(member, local_bindings, postpone_annotations)
-            ):
-                namespace[member.name] = callable_placeholder
-                local_bindings[member.name] = callable_placeholder
-                continue
-            if isinstance(member, ast.ClassDef):
-                nested_class = build_static_class(member, local_bindings)
-                if nested_class is None:
-                    return None
-                namespace[member.name] = nested_class
-                local_bindings[member.name] = nested_class
-                continue
-            class_bindings = literal_assignment_bindings(member)
-            if class_bindings is not None:
-                namespace.update(class_bindings)
-                local_bindings.update(class_bindings)
-                continue
-            imported_bindings = static_import_bindings(member)
-            if imported_bindings is None:
-                return None
-            namespace.update(imported_bindings)
-            local_bindings.update(imported_bindings)
-
-        try:
-            static_class = type(node.name, tuple(bases), namespace)
-        except Exception:
-            return None
-        if "__init_subclass__" in namespace:
-            static_classes_with_init_subclass.add(static_class)
-        return static_class
-
-    bindings = {}
-    unsafe = []
-    for index, node in enumerate(tree.body):
-        if index == 0 and is_docstring(node):
-            continue
-        if isinstance(node, ast.Pass):
-            continue
-        if (
-            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
-            and is_static_function(node, bindings, postpone_annotations)
-        ):
-            bindings[node.name] = callable_placeholder
-            continue
-        if isinstance(node, ast.ClassDef):
-            static_class = build_static_class(node, bindings)
-            if static_class is not None:
-                bindings[node.name] = static_class
-                continue
-        assignment_bindings = literal_assignment_bindings(node)
-        if assignment_bindings is not None:
-            bindings.update(assignment_bindings)
-            continue
-        imported_bindings = static_import_bindings(node)
-        if imported_bindings is not None:
-            bindings.update(imported_bindings)
-            continue
-        unsafe.append(type(node).__name__)
-
-    if unsafe:
-        raise TypeError(
-            "legacy helper validation requires side-effect-free definitions: "
-            + ", ".join(unsafe)
-        )
-    missing = [name for name in request["exports"] if not callable(bindings.get(name))]
+safe_builtins = {name: getattr(builtins, name) for name in safe_names}
+safe_builtins["__import__"] = restricted_import
+namespace = {"__builtins__": safe_builtins, "__name__": "__open_science_helper_validation__"}
+exec(compile(request["source"], "<registered-helper>", "exec"), namespace, namespace)
+missing = [name for name in request["exports"] if name not in namespace or not callable(namespace[name])]
 if missing:
     raise TypeError("missing or non-callable exports: " + ", ".join(missing))
 `
@@ -457,7 +187,7 @@ export const validateNotebookHelperExports = async (
   helperId: string,
   source: string,
   exports: readonly string[],
-  deps: { python?: PythonCommand; env?: NodeJS.ProcessEnv } = {}
+  deps: { python?: PythonCommand; env?: NodeJS.ProcessEnv; trustedSource?: boolean } = {}
 ): Promise<void> => {
   const python = deps.python ?? (await resolvePythonCommand())
   await new Promise<void>((resolveValidation, rejectValidation) => {
@@ -499,6 +229,11 @@ export const validateNotebookHelperExports = async (
         )
       )
     })
-    child.stdin.end(Buffer.from(JSON.stringify({ source, exports }), 'utf8').toString('base64'))
+    child.stdin.end(
+      Buffer.from(
+        JSON.stringify({ source, exports, trustedSource: deps.trustedSource ?? false }),
+        'utf8'
+      ).toString('base64')
+    )
   })
 }

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -291,18 +291,24 @@ else:
     def callable_placeholder(*args, **kwargs):
         return None
 
-    def build_static_class(node, shadowed_names=()):
+    def build_static_class(node, visible_bindings=None):
         if node.decorator_list or node.keywords:
             return None
+        if visible_bindings is None:
+            visible_bindings = {}
         bases = []
         for base in node.bases:
-            if (
-                not isinstance(base, ast.Name)
-                or base.id not in static_base_types
-                or base.id in shadowed_names
-            ):
+            if not isinstance(base, ast.Name):
                 return None
-            bases.append(static_base_types[base.id])
+            if base.id in visible_bindings:
+                base_type = visible_bindings[base.id]
+                if not isinstance(base_type, type):
+                    return None
+            else:
+                base_type = static_base_types.get(base.id)
+                if base_type is None:
+                    return None
+            bases.append(base_type)
         if not bases:
             bases.append(object)
 
@@ -310,7 +316,7 @@ else:
             "__module__": "__open_science_helper_validation__",
             "__qualname__": node.name,
         }
-        local_shadowed_names = set(shadowed_names)
+        local_bindings = dict(visible_bindings)
         for index, member in enumerate(node.body):
             if index == 0 and is_docstring(member):
                 namespace["__doc__"] = ast.literal_eval(member.value)
@@ -319,20 +325,20 @@ else:
                 continue
             if isinstance(member, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(member):
                 namespace[member.name] = callable_placeholder
-                local_shadowed_names.add(member.name)
+                local_bindings[member.name] = callable_placeholder
                 continue
             if isinstance(member, ast.ClassDef):
-                nested_class = build_static_class(member, local_shadowed_names)
+                nested_class = build_static_class(member, local_bindings)
                 if nested_class is None:
                     return None
                 namespace[member.name] = nested_class
-                local_shadowed_names.add(member.name)
+                local_bindings[member.name] = nested_class
                 continue
             class_bindings = literal_assignment_bindings(member)
             if class_bindings is None:
                 return None
             namespace.update(class_bindings)
-            local_shadowed_names.update(class_bindings)
+            local_bindings.update(class_bindings)
 
         try:
             return type(node.name, tuple(bases), namespace)
@@ -347,15 +353,16 @@ else:
         if isinstance(node, ast.Pass):
             continue
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(node):
-            bindings[node.name] = True
+            bindings[node.name] = callable_placeholder
             continue
-        if isinstance(node, ast.ClassDef) and build_static_class(node, bindings) is not None:
-            bindings[node.name] = True
-            continue
+        if isinstance(node, ast.ClassDef):
+            static_class = build_static_class(node, bindings)
+            if static_class is not None:
+                bindings[node.name] = static_class
+                continue
         assignment_bindings = literal_assignment_bindings(node)
         if assignment_bindings is not None:
-            for name in assignment_bindings:
-                bindings[name] = False
+            bindings.update(assignment_bindings)
             continue
         unsafe.append(type(node).__name__)
 
@@ -364,7 +371,7 @@ else:
             "legacy helper validation requires side-effect-free definitions: "
             + ", ".join(unsafe)
         )
-    missing = [name for name in request["exports"] if not bindings.get(name, False)]
+    missing = [name for name in request["exports"] if not callable(bindings.get(name))]
 if missing:
     raise TypeError("missing or non-callable exports: " + ", ".join(missing))
 `

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -188,7 +188,9 @@ else:
         except (SyntaxError, TypeError, ValueError):
             return False
 
-    def is_static_function(node):
+    def is_static_function(node, visible_bindings=None):
+        if visible_bindings is None:
+            visible_bindings = {}
         arguments = (
             list(getattr(node.args, "posonlyargs", ()))
             + list(node.args.args)
@@ -203,20 +205,34 @@ else:
         ]
         annotations = [argument.annotation for argument in arguments] + [node.returns]
 
-        def is_static_annotation(annotation):
-            return is_literal(annotation) or (
-                isinstance(annotation, ast.Name)
-                and annotation.id in {
+        def static_reference(expression):
+            if isinstance(expression, ast.Name):
+                if expression.id in visible_bindings:
+                    return True, visible_bindings[expression.id]
+                if expression.id in {
                     "bool", "bytes", "dict", "Exception", "float", "int", "list", "object",
                     "set", "str", "tuple", "ValueError"
-                }
-            )
+                }:
+                    return True, getattr(builtins, expression.id)
+                return False, None
+            if isinstance(expression, ast.Attribute):
+                found, value = static_reference(expression.value)
+                if not found:
+                    return False, None
+                try:
+                    return True, getattr(value, expression.attr)
+                except Exception:
+                    return False, None
+            return False, None
+
+        def is_static_value(expression):
+            return is_literal(expression) or static_reference(expression)[0]
 
         return (
             not node.decorator_list
-            and all(is_literal(default) for default in defaults)
+            and all(is_static_value(default) for default in defaults)
             and all(
-                annotation is None or is_static_annotation(annotation)
+                annotation is None or is_static_value(annotation)
                 for annotation in annotations
             )
         )
@@ -358,7 +374,10 @@ else:
                 continue
             if isinstance(member, ast.Pass):
                 continue
-            if isinstance(member, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(member):
+            if (
+                isinstance(member, (ast.AsyncFunctionDef, ast.FunctionDef))
+                and is_static_function(member, local_bindings)
+            ):
                 namespace[member.name] = callable_placeholder
                 local_bindings[member.name] = callable_placeholder
                 continue
@@ -395,7 +414,10 @@ else:
             continue
         if isinstance(node, ast.Pass):
             continue
-        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(node):
+        if (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and is_static_function(node, bindings)
+        ):
             bindings[node.name] = callable_placeholder
             continue
         if isinstance(node, ast.ClassDef):

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -305,6 +305,8 @@ else:
             return bindings
         if not isinstance(node, ast.ImportFrom) or node.level != 0:
             return None
+        # Future statements set compiler flags and still emit IMPORT_FROM/STORE_NAME,
+        # so their imported names (including aliases) are runtime bindings too.
         module = allowed_modules.get(node.module)
         if module is None:
             return None

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -221,32 +221,66 @@ else:
             return names
         return None
 
+    def literal_assignment_names(node):
+        if not isinstance(node, ast.Assign) or not is_literal(node.value):
+            return None
+        names = []
+        for target in node.targets:
+            target_names = assignment_names(target)
+            if target_names is None:
+                return None
+            names.extend(target_names)
+        return names
+
+    def is_docstring(node):
+        if not isinstance(node, ast.Expr):
+            return False
+        try:
+            return isinstance(ast.literal_eval(node.value), str)
+        except (SyntaxError, TypeError, ValueError):
+            return False
+
+    def is_static_class(node):
+        if node.decorator_list or node.keywords:
+            return False
+        if node.bases and not (
+            len(node.bases) == 1
+            and isinstance(node.bases[0], ast.Name)
+            and node.bases[0].id == "object"
+        ):
+            return False
+        for index, member in enumerate(node.body):
+            if index == 0 and is_docstring(member):
+                continue
+            if isinstance(member, ast.Pass):
+                continue
+            if isinstance(member, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(member):
+                continue
+            if isinstance(member, ast.ClassDef) and is_static_class(member):
+                continue
+            if literal_assignment_names(member) is not None:
+                continue
+            return False
+        return True
+
     bindings = {}
     unsafe = []
     for index, node in enumerate(tree.body):
-        if index == 0 and isinstance(node, ast.Expr):
-            try:
-                if isinstance(ast.literal_eval(node.value), str):
-                    continue
-            except (SyntaxError, TypeError, ValueError):
-                pass
+        if index == 0 and is_docstring(node):
+            continue
         if isinstance(node, ast.Pass):
             continue
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(node):
             bindings[node.name] = True
             continue
-        if isinstance(node, ast.Assign) and is_literal(node.value):
-            names = []
-            for target in node.targets:
-                target_names = assignment_names(target)
-                if target_names is None:
-                    names = None
-                    break
-                names.extend(target_names)
-            if names is not None:
-                for name in names:
-                    bindings[name] = False
-                continue
+        if isinstance(node, ast.ClassDef) and is_static_class(node):
+            bindings[node.name] = True
+            continue
+        names = literal_assignment_names(node)
+        if names is not None:
+            for name in names:
+                bindings[name] = False
+            continue
         unsafe.append(type(node).__name__)
 
     if unsafe:

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -291,12 +291,16 @@ else:
     def callable_placeholder(*args, **kwargs):
         return None
 
-    def build_static_class(node):
+    def build_static_class(node, shadowed_names=()):
         if node.decorator_list or node.keywords:
             return None
         bases = []
         for base in node.bases:
-            if not isinstance(base, ast.Name) or base.id not in static_base_types:
+            if (
+                not isinstance(base, ast.Name)
+                or base.id not in static_base_types
+                or base.id in shadowed_names
+            ):
                 return None
             bases.append(static_base_types[base.id])
         if not bases:
@@ -306,6 +310,7 @@ else:
             "__module__": "__open_science_helper_validation__",
             "__qualname__": node.name,
         }
+        local_shadowed_names = set(shadowed_names)
         for index, member in enumerate(node.body):
             if index == 0 and is_docstring(member):
                 namespace["__doc__"] = ast.literal_eval(member.value)
@@ -314,17 +319,20 @@ else:
                 continue
             if isinstance(member, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(member):
                 namespace[member.name] = callable_placeholder
+                local_shadowed_names.add(member.name)
                 continue
             if isinstance(member, ast.ClassDef):
-                nested_class = build_static_class(member)
+                nested_class = build_static_class(member, local_shadowed_names)
                 if nested_class is None:
                     return None
                 namespace[member.name] = nested_class
+                local_shadowed_names.add(member.name)
                 continue
             class_bindings = literal_assignment_bindings(member)
             if class_bindings is None:
                 return None
             namespace.update(class_bindings)
+            local_shadowed_names.update(class_bindings)
 
         try:
             return type(node.name, tuple(bases), namespace)
@@ -341,7 +349,7 @@ else:
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(node):
             bindings[node.name] = True
             continue
-        if isinstance(node, ast.ClassDef) and build_static_class(node) is not None:
+        if isinstance(node, ast.ClassDef) and build_static_class(node, bindings) is not None:
             bindings[node.name] = True
             continue
         assignment_bindings = literal_assignment_bindings(node)

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -146,12 +146,12 @@ export const resolvePythonCommand = async (
 }
 
 const CALLABLE_HELPER_VALIDATOR = String.raw`
-import ast, base64, builtins, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics, sys
+import __future__, ast, base64, builtins, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics, sys
 
 allowed_modules = {
     module.__name__: module
     for module in (
-        collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics
+        __future__, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics
     )
 }
 
@@ -179,7 +179,14 @@ if hasattr(sys, "addaudithook"):
     missing = [name for name in request["exports"] if name not in namespace or not callable(namespace[name])]
 else:
     # Python < 3.8 cannot audit validation-time host access, so never execute staged source there.
+    compile(request["source"], "<registered-helper>", "exec")
     tree = ast.parse(request["source"], filename="<registered-helper>")
+    postpone_annotations = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == "annotations" for alias in node.names)
+        for node in tree.body
+    )
 
     def is_literal(expression):
         try:
@@ -188,7 +195,7 @@ else:
         except (SyntaxError, TypeError, ValueError):
             return False
 
-    def is_static_function(node, visible_bindings=None):
+    def is_static_function(node, visible_bindings=None, postpone_annotation_evaluation=False):
         if visible_bindings is None:
             visible_bindings = {}
         arguments = (
@@ -232,7 +239,9 @@ else:
             not node.decorator_list
             and all(is_static_value(default) for default in defaults)
             and all(
-                annotation is None or is_static_value(annotation)
+                annotation is None
+                or postpone_annotation_evaluation
+                or is_static_value(annotation)
                 for annotation in annotations
             )
         )
@@ -376,7 +385,7 @@ else:
                 continue
             if (
                 isinstance(member, (ast.AsyncFunctionDef, ast.FunctionDef))
-                and is_static_function(member, local_bindings)
+                and is_static_function(member, local_bindings, postpone_annotations)
             ):
                 namespace[member.name] = callable_placeholder
                 local_bindings[member.name] = callable_placeholder
@@ -416,7 +425,7 @@ else:
             continue
         if (
             isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
-            and is_static_function(node, bindings)
+            and is_static_function(node, bindings, postpone_annotations)
         ):
             bindings[node.name] = callable_placeholder
             continue

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -146,7 +146,7 @@ export const resolvePythonCommand = async (
 }
 
 const CALLABLE_HELPER_VALIDATOR = String.raw`
-import base64, builtins, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics, sys
+import ast, base64, builtins, collections, datetime, decimal, fractions, functools, itertools, json, math, re, statistics, sys
 
 allowed_modules = {
     module.__name__: module
@@ -164,18 +164,27 @@ def deny(event, args):
     if event == "open" or event == "import" or event.startswith(("socket.", "subprocess.", "os.system", "os.exec", "os.spawn")):
         raise PermissionError("host access is unavailable during helper validation")
 
-sys.addaudithook(deny)
 request = json.loads(base64.b64decode(sys.stdin.read()).decode("utf-8"))
-safe_names = (
-    "__build_class__", "abs", "all", "any", "bool", "bytes", "callable", "dict", "enumerate",
-    "Exception", "float", "int", "isinstance", "len", "list", "map", "max", "min", "object",
-    "range", "repr", "reversed", "set", "slice", "sorted", "str", "sum", "tuple", "ValueError", "zip"
-)
-safe_builtins = {name: getattr(builtins, name) for name in safe_names}
-safe_builtins["__import__"] = restricted_import
-namespace = {"__builtins__": safe_builtins, "__name__": "__open_science_helper_validation__"}
-exec(compile(request["source"], "<registered-helper>", "exec"), namespace, namespace)
-missing = [name for name in request["exports"] if name not in namespace or not callable(namespace[name])]
+if hasattr(sys, "addaudithook"):
+    sys.addaudithook(deny)
+    safe_names = (
+        "__build_class__", "abs", "all", "any", "bool", "bytes", "callable", "dict", "enumerate",
+        "Exception", "float", "int", "isinstance", "len", "list", "map", "max", "min", "object",
+        "range", "repr", "reversed", "set", "slice", "sorted", "str", "sum", "tuple", "ValueError", "zip"
+    )
+    safe_builtins = {name: getattr(builtins, name) for name in safe_names}
+    safe_builtins["__import__"] = restricted_import
+    namespace = {"__builtins__": safe_builtins, "__name__": "__open_science_helper_validation__"}
+    exec(compile(request["source"], "<registered-helper>", "exec"), namespace, namespace)
+    missing = [name for name in request["exports"] if name not in namespace or not callable(namespace[name])]
+else:
+    # Python < 3.8 cannot audit validation-time host access, so never execute staged source there.
+    tree = ast.parse(request["source"], filename="<registered-helper>")
+    definitions = {
+        node.name for node in tree.body
+        if isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef))
+    }
+    missing = [name for name in request["exports"] if name not in definitions]
 if missing:
     raise TypeError("missing or non-callable exports: " + ", ".join(missing))
 `

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -291,6 +291,8 @@ else:
     def callable_placeholder(*args, **kwargs):
         return None
 
+    static_classes_with_init_subclass = set()
+
     def build_static_class(node, visible_bindings=None):
         if node.decorator_list or node.keywords:
             return None
@@ -308,6 +310,8 @@ else:
                 base_type = static_base_types.get(base.id)
                 if base_type is None:
                     return None
+            if base_type in static_classes_with_init_subclass:
+                return None
             bases.append(base_type)
         if not bases:
             bases.append(object)
@@ -341,9 +345,12 @@ else:
             local_bindings.update(class_bindings)
 
         try:
-            return type(node.name, tuple(bases), namespace)
+            static_class = type(node.name, tuple(bases), namespace)
         except Exception:
             return None
+        if "__init_subclass__" in namespace:
+            static_classes_with_init_subclass.add(static_class)
+        return static_class
 
     bindings = {}
     unsafe = []

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -202,35 +202,75 @@ else:
             default for default in node.args.kw_defaults if default is not None
         ]
         annotations = [argument.annotation for argument in arguments] + [node.returns]
+
+        def is_static_annotation(annotation):
+            return is_literal(annotation) or (
+                isinstance(annotation, ast.Name)
+                and annotation.id in {
+                    "bool", "bytes", "dict", "Exception", "float", "int", "list", "object",
+                    "set", "str", "tuple", "ValueError"
+                }
+            )
+
         return (
             not node.decorator_list
             and all(is_literal(default) for default in defaults)
-            and all(annotation is None or is_literal(annotation) for annotation in annotations)
+            and all(
+                annotation is None or is_static_annotation(annotation)
+                for annotation in annotations
+            )
         )
 
-    def assignment_names(target):
+    def bind_literal_target(target, value):
         if isinstance(target, ast.Name):
-            return [target.id]
+            return {target.id: value}
         if isinstance(target, (ast.List, ast.Tuple)):
-            names = []
-            for element in target.elts:
-                nested_names = assignment_names(element)
-                if nested_names is None:
+            try:
+                values = list(value)
+            except TypeError:
+                return None
+            starred = [
+                index for index, element in enumerate(target.elts)
+                if isinstance(element, ast.Starred)
+            ]
+            if len(starred) > 1:
+                return None
+            if not starred and len(values) != len(target.elts):
+                return None
+            if starred and len(values) < len(target.elts) - 1:
+                return None
+
+            bindings = {}
+            for index, element in enumerate(target.elts):
+                if isinstance(element, ast.Starred):
+                    trailing = len(target.elts) - index - 1
+                    nested_value = values[index:len(values) - trailing if trailing else None]
+                    element = element.value
+                elif starred and index > starred[0]:
+                    nested_value = values[len(values) - (len(target.elts) - index)]
+                else:
+                    nested_value = values[index]
+                nested_bindings = bind_literal_target(element, nested_value)
+                if nested_bindings is None:
                     return None
-                names.extend(nested_names)
-            return names
+                bindings.update(nested_bindings)
+            return bindings
         return None
 
-    def literal_assignment_names(node):
-        if not isinstance(node, ast.Assign) or not is_literal(node.value):
+    def literal_assignment_bindings(node):
+        if not isinstance(node, ast.Assign):
             return None
-        names = []
+        try:
+            value = ast.literal_eval(node.value)
+        except (SyntaxError, TypeError, ValueError):
+            return None
+        bindings = {}
         for target in node.targets:
-            target_names = assignment_names(target)
-            if target_names is None:
+            target_bindings = bind_literal_target(target, value)
+            if target_bindings is None:
                 return None
-            names.extend(target_names)
-        return names
+            bindings.update(target_bindings)
+        return bindings
 
     def is_docstring(node):
         if not isinstance(node, ast.Expr):
@@ -240,28 +280,56 @@ else:
         except (SyntaxError, TypeError, ValueError):
             return False
 
-    def is_static_class(node):
+    static_base_types = {
+        name: getattr(builtins, name)
+        for name in (
+            "bytes", "dict", "Exception", "float", "int", "list", "object", "set", "str",
+            "tuple", "ValueError"
+        )
+    }
+
+    def callable_placeholder(*args, **kwargs):
+        return None
+
+    def build_static_class(node):
         if node.decorator_list or node.keywords:
-            return False
-        if node.bases and not (
-            len(node.bases) == 1
-            and isinstance(node.bases[0], ast.Name)
-            and node.bases[0].id == "object"
-        ):
-            return False
+            return None
+        bases = []
+        for base in node.bases:
+            if not isinstance(base, ast.Name) or base.id not in static_base_types:
+                return None
+            bases.append(static_base_types[base.id])
+        if not bases:
+            bases.append(object)
+
+        namespace = {
+            "__module__": "__open_science_helper_validation__",
+            "__qualname__": node.name,
+        }
         for index, member in enumerate(node.body):
             if index == 0 and is_docstring(member):
+                namespace["__doc__"] = ast.literal_eval(member.value)
                 continue
             if isinstance(member, ast.Pass):
                 continue
             if isinstance(member, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(member):
+                namespace[member.name] = callable_placeholder
                 continue
-            if isinstance(member, ast.ClassDef) and is_static_class(member):
+            if isinstance(member, ast.ClassDef):
+                nested_class = build_static_class(member)
+                if nested_class is None:
+                    return None
+                namespace[member.name] = nested_class
                 continue
-            if literal_assignment_names(member) is not None:
-                continue
-            return False
-        return True
+            class_bindings = literal_assignment_bindings(member)
+            if class_bindings is None:
+                return None
+            namespace.update(class_bindings)
+
+        try:
+            return type(node.name, tuple(bases), namespace)
+        except Exception:
+            return None
 
     bindings = {}
     unsafe = []
@@ -273,12 +341,12 @@ else:
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and is_static_function(node):
             bindings[node.name] = True
             continue
-        if isinstance(node, ast.ClassDef) and is_static_class(node):
+        if isinstance(node, ast.ClassDef) and build_static_class(node) is not None:
             bindings[node.name] = True
             continue
-        names = literal_assignment_names(node)
-        if names is not None:
-            for name in names:
+        assignment_bindings = literal_assignment_bindings(node)
+        if assignment_bindings is not None:
+            for name in assignment_bindings:
                 bindings[name] = False
             continue
         unsafe.append(type(node).__name__)

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -272,6 +272,37 @@ else:
             bindings.update(target_bindings)
         return bindings
 
+    def static_import_bindings(node):
+        bindings = {}
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                module = allowed_modules.get(alias.name)
+                if module is None:
+                    return None
+                bindings[alias.asname or alias.name] = module
+            return bindings
+        if not isinstance(node, ast.ImportFrom) or node.level != 0:
+            return None
+        module = allowed_modules.get(node.module)
+        if module is None:
+            return None
+        for alias in node.names:
+            if alias.name == "*":
+                names = getattr(module, "__all__", None)
+                if names is None:
+                    names = [name for name in dir(module) if not name.startswith("_")]
+                for name in names:
+                    try:
+                        bindings[name] = getattr(module, name)
+                    except AttributeError:
+                        return None
+                continue
+            try:
+                bindings[alias.asname or alias.name] = getattr(module, alias.name)
+            except AttributeError:
+                return None
+        return bindings
+
     def is_docstring(node):
         if not isinstance(node, ast.Expr):
             return False
@@ -339,10 +370,15 @@ else:
                 local_bindings[member.name] = nested_class
                 continue
             class_bindings = literal_assignment_bindings(member)
-            if class_bindings is None:
+            if class_bindings is not None:
+                namespace.update(class_bindings)
+                local_bindings.update(class_bindings)
+                continue
+            imported_bindings = static_import_bindings(member)
+            if imported_bindings is None:
                 return None
-            namespace.update(class_bindings)
-            local_bindings.update(class_bindings)
+            namespace.update(imported_bindings)
+            local_bindings.update(imported_bindings)
 
         try:
             static_class = type(node.name, tuple(bases), namespace)
@@ -370,6 +406,10 @@ else:
         assignment_bindings = literal_assignment_bindings(node)
         if assignment_bindings is not None:
             bindings.update(assignment_bindings)
+            continue
+        imported_bindings = static_import_bindings(node)
+        if imported_bindings is not None:
+            bindings.update(imported_bindings)
             continue
         unsafe.append(type(node).__name__)
 

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -165,13 +165,13 @@ def deny(event, args):
         raise PermissionError("host access is unavailable during helper validation")
 
 request = json.loads(base64.b64decode(sys.stdin.read()).decode("utf-8"))
+safe_names = (
+    "__build_class__", "abs", "all", "any", "bool", "bytes", "callable", "dict", "enumerate",
+    "Exception", "float", "int", "isinstance", "len", "list", "map", "max", "min", "object",
+    "range", "repr", "reversed", "set", "slice", "sorted", "str", "sum", "tuple", "ValueError", "zip"
+)
 if hasattr(sys, "addaudithook"):
     sys.addaudithook(deny)
-    safe_names = (
-        "__build_class__", "abs", "all", "any", "bool", "bytes", "callable", "dict", "enumerate",
-        "Exception", "float", "int", "isinstance", "len", "list", "map", "max", "min", "object",
-        "range", "repr", "reversed", "set", "slice", "sorted", "str", "sum", "tuple", "ValueError", "zip"
-    )
     safe_builtins = {name: getattr(builtins, name) for name in safe_names}
     safe_builtins["__import__"] = restricted_import
     namespace = {"__builtins__": safe_builtins, "__name__": "__open_science_helper_validation__"}
@@ -216,10 +216,7 @@ else:
             if isinstance(expression, ast.Name):
                 if expression.id in visible_bindings:
                     return True, visible_bindings[expression.id]
-                if expression.id in {
-                    "bool", "bytes", "dict", "Exception", "float", "int", "list", "object",
-                    "set", "str", "tuple", "ValueError"
-                }:
+                if expression.id in safe_names:
                     return True, getattr(builtins, expression.id)
                 return False, None
             if isinstance(expression, ast.Attribute):

--- a/src/main/skills/registered-helper-catalog.ts
+++ b/src/main/skills/registered-helper-catalog.ts
@@ -256,7 +256,9 @@ const preparePackage = async (entry: RegisteredSkillPackage): Promise<PreparedHe
       entry.packageRoot,
       descriptor.implementation
     )
-    await validateNotebookHelperExports(descriptor.id, source, descriptor.exports)
+    await validateNotebookHelperExports(descriptor.id, source, descriptor.exports, {
+      trustedSource: entry.origin === 'builtin'
+    })
     loaded.push({ descriptor, bytes, digest: sourceDigest(bytes) })
   }
   const generation = generationDigest(skillId, entry.origin, loaded)


### PR DESCRIPTION
## Problem

On Windows, a Python runtime without `sys.addaudithook` causes an otherwise valid Skill import to fail during promoted-catalog validation:

`INVALID_REGISTERED_HELPER: helper "figure-composer" failed isolated callable export validation: AttributeError: module 'sys' has no attribute 'addaudithook'`

The imported repository does not supply `figure-composer`. Promotion validates the merged catalog, including the application-bundled helper. A URL pinned to the reporter's older repository commit is parsed and fetched with that ref, so changing the ref cannot remove this built-in validation failure.

## Proposed change

- Mark helper source as trusted only when its catalog origin is `builtin`.
- Keep audit-hook-protected validation unchanged whenever the Python runtime provides `sys.addaudithook`.
- When the hook is unavailable, allow only trusted application-bundled helper source through the existing restricted-builtins/import environment.
- Reject personal or imported helper source before executing it when audit-hook protection is unavailable.
- Add focused regression coverage that simulates the missing hook. Before the fix it failed three consecutive runs with the exact reported `figure-composer` `AttributeError`; after the fix the trusted built-in validates, while external source remains fail-closed.

## Scope and non-goals

- No database or persisted-format changes.
- No historical-data migration or compatibility handling.
- No new fields, statuses, or enum values.
- No architecture, data-model, or UI interaction changes.
- No changes to GitHub token, rate-limit, commit-ref, or download behavior.
- No attempt to build a second Python interpreter for legacy runtimes; external helper validation still requires audit-hook support.

This is intentionally narrower than a general legacy-Python fallback. Application-bundled helper code is already part of the trusted app distribution, while imported and personal code retains the audit boundary.

## Acceptance criteria and validation

All listed checks ran after the final material edit and after rebasing onto the latest `origin/main`:

- Missing audit hook and trust boundary -> `npm test -- src/main/notebook/python-command.test.ts` -> 12 passed.
- Registered helper generation and isolated validation -> `npm test -- src/main/skills/registered-helper-catalog.test.ts` -> 33 passed.
- Skill catalog promotion, rollback, and bundled helper execution -> `npm test -- src/main/settings/skill-catalog.registered-helpers.test.ts` -> 4 passed.
- GitHub ref parsing/pinning and import behavior -> `npm test -- src/main/skills/github-import.test.ts` -> 37 passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed.
- Formatting -> `npx prettier --check src/main/notebook/python-command.ts src/main/notebook/python-command.test.ts src/main/skills/registered-helper-catalog.ts` -> passed.
- Patch whitespace -> `git diff --check` -> passed.

The two suites that launch a real Notebook kernel were run outside the outer agent sandbox because nested macOS `sandbox-exec` is rejected there. Both pass in their intended execution environment. PR CI remains the final cross-platform authority; no full local `npm test` was run.

## Review focus

- Only catalog entries whose origin is `builtin` may set `trustedSource`.
- External and personal helper source must fail before `exec` when the runtime lacks `sys.addaudithook`.
- The existing audited validation behavior must remain unchanged on supported Python runtimes.

Fixes #2093
