### PR TITLE
ci(supply-chain): add dependency governance guardrails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,22 @@
 version: 2
 updates:
   # Track npm lockfile drift and open grouped update PRs weekly. Keeps transitive advisories moving
-  # (the app ships native modules + spawns child processes, so a stale vulnerable dep reaches users).
+  # while bounding routine update noise.
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 2
     groups:
-      # Batch low-risk dev/tooling bumps into one PR to cut review noise.
-      dev-dependencies:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
+      production-dependencies:
+        applies-to: version-updates
+        dependency-type: production
+      development-dependencies:
+        applies-to: version-updates
         dependency-type: development
 
   # Keep the GitHub Actions used by the workflows current (checkout, setup-node, upload-artifact, ...).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,27 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 2
+    commit-message:
+      prefix: 'build(dependencies): update'
+    pull-request-branch-name:
+      prefix: build
+      template: '{prefix}/{group_name}'
+      branch-name-case: lowercase
     groups:
-      security-updates:
+      npm-security-updates:
         applies-to: security-updates
         patterns:
           - '*'
-      production-dependencies:
+      npm-production-dependencies:
         applies-to: version-updates
         dependency-type: production
-      development-dependencies:
+        patterns:
+          - '*'
+      npm-development-dependencies:
         applies-to: version-updates
         dependency-type: development
+        patterns:
+          - '*'
 
   # Keep the GitHub Actions used by the workflows current (checkout, setup-node, upload-artifact, ...).
   - package-ecosystem: github-actions
@@ -25,3 +35,18 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 2
+    commit-message:
+      prefix: 'ci(dependencies): update'
+    pull-request-branch-name:
+      prefix: ci
+      template: '{prefix}/{group_name}'
+      branch-name-case: lowercase
+    groups:
+      github-actions-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
+      github-actions-version-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -240,6 +240,16 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
+      - name: Review dependency changes
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          base-ref: ${{ needs.preflight.outputs.base }}
+          fail-on-severity: high
+          fail-on-scopes: runtime, development
+          head-ref: ${{ needs.preflight.outputs.head }}
+          license-check: false
+          show-openssf-scorecard: false
       - name: Validate pull request policy
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,6 +1014,8 @@
     },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
@@ -1385,7 +1387,9 @@
       }
     },
     "node_modules/@dotenvx/dotenvx/node_modules/undici": {
-      "version": "7.28.0",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1480,7 +1484,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1715,7 +1721,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.1",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2530,7 +2538,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2614,7 +2624,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2727,9 +2739,9 @@
       }
     },
     "node_modules/@file-viewer/renderer-spreadsheet/node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3961,7 +3973,9 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.2"
@@ -8649,7 +8663,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9464,7 +9480,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.41",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9526,14 +9544,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -9547,7 +9567,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -9565,11 +9587,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -9794,7 +9816,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -10852,9 +10876,9 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
-      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11085,7 +11109,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11431,7 +11457,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.385",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -12093,7 +12121,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12159,7 +12189,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12643,9 +12675,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -12657,6 +12689,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -12747,7 +12788,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13191,7 +13234,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14670,7 +14715,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -14759,7 +14806,9 @@
       }
     },
     "node_modules/jsdom/node_modules/undici": {
-      "version": "7.28.0",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15938,24 +15987,27 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
+      "version": "11.17.2",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.2.tgz",
+      "integrity": "sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.2.0",
+        "@mermaid-js/parser": "^1.2.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.3",
+        "cytoscape": "^3.34.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.20",
+        "dayjs": "^1.11.21",
         "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.45",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -16909,7 +16961,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -17077,7 +17131,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18082,7 +18138,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -18100,7 +18158,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -18404,7 +18462,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -18418,13 +18478,13 @@
       }
     },
     "node_modules/query-string": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.4.1.tgz",
-      "integrity": "sha512-lSyJeN3RuaG7DZGWThtYRhk96+kEyZ/+doZpERuWbjeFL+Ok3vEat/swU498rAI0NcVt5/RJp8UDuLz7FckxrA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.5.1.tgz",
+      "integrity": "sha512-/zO3RwuRCMTIcEgq6YMv4OrtEE1XzBG7w5N6zc6ydYnkWYOWsnLI/5894hYEzfESfMOT4cHCsRTIdxsSl1KjGg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "decode-uri-component": "^0.4.1",
+        "decode-uri-component": "^0.5.0",
         "filter-obj": "^5.1.0",
         "split-on-first": "^3.0.0"
       },
@@ -20242,7 +20302,9 @@
       }
     },
     "node_modules/shadcn/node_modules/undici": {
-      "version": "7.28.0",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20631,6 +20693,12 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -21528,7 +21596,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -21722,7 +21792,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -251,6 +251,25 @@ describe('PR Gate workflow', () => {
     })
   })
 
+  it('rejects newly introduced high-severity dependency vulnerabilities', () => {
+    const review = workflow.jobs.policy.steps?.find(
+      ({ name }) => name === 'Review dependency changes'
+    )
+
+    expect(review).toMatchObject({
+      if: "${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}",
+      uses: 'actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294',
+      with: {
+        'base-ref': '${{ needs.preflight.outputs.base }}',
+        'fail-on-severity': 'high',
+        'fail-on-scopes': 'runtime, development',
+        'head-ref': '${{ needs.preflight.outputs.head }}',
+        'license-check': false,
+        'show-openssf-scorecard': false
+      }
+    })
+  })
+
   it('pins every third-party action to an immutable commit', () => {
     for (const job of Object.values(workflow.jobs)) {
       for (const step of job.steps ?? []) {

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -41,8 +41,27 @@ type Workflow = {
   permissions?: Record<string, string>
 }
 
+type DependabotUpdate = {
+  'commit-message'?: { prefix?: string }
+  directory?: string
+  groups?: Record<
+    string,
+    { 'applies-to'?: string; 'dependency-type'?: string; patterns?: string[] }
+  >
+  'open-pull-requests-limit'?: number
+  'package-ecosystem'?: string
+  'pull-request-branch-name'?: {
+    'branch-name-case'?: string
+    prefix?: string
+    template?: string
+  }
+}
+
 const workflowText = readFileSync(join(process.cwd(), '.github/workflows/pr-gate.yml'), 'utf8')
 const workflow = load(workflowText) as Workflow
+const dependabot = load(readFileSync(join(process.cwd(), '.github/dependabot.yml'), 'utf8')) as {
+  updates: DependabotUpdate[]
+}
 const manifest = JSON.parse(
   readFileSync(join(process.cwd(), 'scripts/ci/change-impact.json'), 'utf8')
 ) as { bundleOrder: string[]; laneBundles: Record<string, string>; laneOrder: string[] }
@@ -266,6 +285,60 @@ describe('PR Gate workflow', () => {
         'head-ref': '${{ needs.preflight.outputs.head }}',
         'license-check': false,
         'show-openssf-scorecard': false
+      }
+    })
+  })
+
+  it('keeps Dependabot pull requests compatible with repository branch and title policy', () => {
+    const npm = dependabot.updates.find(
+      (update) => update['package-ecosystem'] === 'npm' && update.directory === '/'
+    )
+    const actions = dependabot.updates.find(
+      (update) => update['package-ecosystem'] === 'github-actions' && update.directory === '/'
+    )
+
+    expect(npm).toMatchObject({
+      'commit-message': { prefix: 'build(dependencies): update' },
+      'open-pull-requests-limit': 2,
+      'pull-request-branch-name': {
+        'branch-name-case': 'lowercase',
+        prefix: 'build',
+        template: '{prefix}/{group_name}'
+      },
+      groups: {
+        'npm-development-dependencies': {
+          'applies-to': 'version-updates',
+          'dependency-type': 'development',
+          patterns: ['*']
+        },
+        'npm-production-dependencies': {
+          'applies-to': 'version-updates',
+          'dependency-type': 'production',
+          patterns: ['*']
+        },
+        'npm-security-updates': {
+          'applies-to': 'security-updates',
+          patterns: ['*']
+        }
+      }
+    })
+    expect(actions).toMatchObject({
+      'commit-message': { prefix: 'ci(dependencies): update' },
+      'open-pull-requests-limit': 2,
+      'pull-request-branch-name': {
+        'branch-name-case': 'lowercase',
+        prefix: 'ci',
+        template: '{prefix}/{group_name}'
+      },
+      groups: {
+        'github-actions-security-updates': {
+          'applies-to': 'security-updates',
+          patterns: ['*']
+        },
+        'github-actions-version-updates': {
+          'applies-to': 'version-updates',
+          patterns: ['*']
+        }
       }
     })
   })


### PR DESCRIPTION
## Problem

The repository had no pull-request dependency-delta gate, and npm version updates were disabled by `open-pull-requests-limit: 0` despite the documented weekly-update intent. The current lockfile also reported 17 npm audit package nodes (12 high), including a reachable Mermaid path from untrusted Markdown.

## Proposed change

- refresh compatible lockfile versions for Mermaid, js-yaml, fast-uri, qs, undici, postcss, nanoid, browserslist, brace-expansion, xmldom, and related transitive packages;
- run the SHA-pinned GitHub Dependency Review action inside the existing PR policy bundle for both pull requests and merge groups;
- reject newly introduced high or critical vulnerabilities in runtime and development scopes;
- restore two weekly npm version-update PR slots and group production, development, and security updates separately;
- group npm and GitHub Actions updates under branch templates and commit prefixes that satisfy the repository's branch and Conventional Commit policy.

## Scope and non-goals

- No application data fields, architecture, UI interaction, data model, enum state, application persistence, migration, or historical-data compatibility changes.
- No raw `npm audit` merge gate: the five retained Electron/extract-zip and Prisma/deepmerge-ts package nodes would make a whole-tree audit gate fail the baseline without proving product exploitability.
- No forced Electron 44 upgrade or Prisma downgrade/major override.
- No new CodeQL, secret-scanning, SBOM, Semgrep, or OpenSSF Scorecard workflow. GitHub CodeQL default setup, secret scanning, and dependency-graph SPDX export already exist; Scorecard is reporting rather than the requested regression gate.
- Dependency Review license and Scorecard checks are disabled so this gate remains focused on new vulnerability regressions.

## Acceptance criteria and validation

Final evidence mapping; all listed local checks ran against the final material state:

- Compatible advisory remediation -> `npm audit --json` and `npm audit --omit=dev --json` -> expected nonzero exit with 5 high package nodes remaining, down from 17 total / 12 high; Mermaid, js-yaml, fast-uri, qs, undici, postcss, nanoid, browserslist, brace-expansion, xmldom, query-string, and decode-uri-component no longer appear.
- Real Mermaid compatibility -> direct jsdom-backed `mermaid.render` smoke for `graph TD` and `xychart-beta` -> both produced SVG with Mermaid 11.17.2.
- Renderer dependency integration -> `npm run build:e2e` -> passed; real Mermaid and xychart chunks were bundled.
- Markdown consumers and fallback behavior -> `npx vitest run src/renderer/src/components/streamdown/AgentMarkdown.test.tsx src/renderer/src/components/streamdown/AgentMarkdown.lazy-failure.test.tsx src/renderer/src/components/streamdown/StreamingBlock.streamdown.test.tsx` -> 3 files, 22 tests passed.
- PR/merge-group gate, Dependabot policy integration, and action pinning -> `npx vitest run scripts/ci/pr-gate-workflow.test.ts scripts/ci/ci-integrity-workflow.test.ts` -> 2 files, 30 tests passed.
- The three notebook shell-queue tests that failed under the first CI run's full-suite load -> focused `npx vitest run src/main/notebook/runtime-service.test.ts --testNamePattern ...` -> 3 tests passed; final-head PR CI remains authoritative.
- Changed TypeScript lint -> `npx eslint scripts/ci/pr-gate-workflow.test.ts` -> passed.
- Formatting/YAML syntax/diff hygiene -> Prettier check, js-yaml parse, and `git diff --check` -> passed.
- Dependabot schema -> GitHub's `.github/dependabot.yml` check -> passed on the final head.
- Final impact selection -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> full fallback because the lockfile and PR Gate are global gate inputs. Per maintainer direction, the full local `npm test` was not run; required PR CI is authoritative for the complete test set.

An independent security-boundary review confirmed the Mermaid source-to-sink path and the lockfile update as the narrowest compatible fix. A separate candidate review found that the first draft skipped merge groups; the final patch now reviews both pull-request and merge-group dependency deltas with preflight-validated base/head SHAs. No remaining concrete Mermaid version bypass was found. The first automated PR review also identified Dependabot branch-policy incompatibility; the final configuration uses grouped, lowercase `build/...` and `ci/...` templates plus Conventional Commit prefixes.

## Review focus

- The policy job remains part of the stable required `PR Gate`; Dependency Review adds no runner and normally adds only an API-backed step.
- Development scope is intentional because renderer-bundled dependencies such as Mermaid are declared in `devDependencies`.
- This PR changes a protected gate control-plane file, so `CI Integrity` is expected to require an explicit maintainer ruleset bypass after the other checks are reviewed.
- After merge, repository settings still need separate authorization to enable Dependabot security updates and secret-scanning push protection. The checked-in security grouping is inactive until Dependabot security updates are enabled.
