### PR TITLE
fix(windows): keep hosted full-test shards from hanging

### DIFF
--- a/scripts/performance/run-runtime-profile.mjs
+++ b/scripts/performance/run-runtime-profile.mjs
@@ -83,7 +83,9 @@ const run = (args, environment = process.env) =>
   new Promise((resolveRun, rejectRun) => {
     const child = spawn(process.execPath, [npmCliPath, ...args], {
       env: environment,
-      stdio: 'inherit',
+      // npm and Playwright do not read this launcher's stdin. Inheriting a piped stdin from
+      // spawnSync/Vitest keeps the Windows child alive until the outer timeout.
+      stdio: ['ignore', 'inherit', 'inherit'],
       windowsHide: true
     })
     child.once('error', rejectRun)

--- a/scripts/performance/run-runtime-profile.test.ts
+++ b/scripts/performance/run-runtime-profile.test.ts
@@ -4,28 +4,39 @@ import { join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 
+const launcherEnvironment = (overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
+  const environment: NodeJS.ProcessEnv = {}
+  for (const [name, value] of Object.entries(process.env)) {
+    if (value === undefined) continue
+    const key = name.toLowerCase()
+    // The launcher must not depend on `npm` being on PATH. Windows still needs PATH so
+    // node.exe can load its DLLs. Drop every casing of npm_execpath so the mock path wins.
+    if (key === 'npm_execpath') continue
+    if (process.platform !== 'win32' && key === 'path') continue
+    environment[name] = value
+  }
+  return { ...environment, ...overrides }
+}
+
 describe('runtime profile launcher', () => {
   it('invokes npm through the current Node executable without relying on a shell command', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-runtime-launcher-'))
-    const npmCliPath = join(root, 'mock-npm-cli.mjs')
+    const npmCliPath = join(root, 'mock-npm-cli.cjs')
     const invocationLog = join(root, 'npm-invocations.jsonl')
     await writeFile(
       npmCliPath,
-      `import { appendFileSync } from 'node:fs'
-appendFileSync(process.env.RUNTIME_PROFILE_INVOCATION_LOG, JSON.stringify(process.argv.slice(2)) + '\\n')
+      `'use strict'
+const { appendFileSync } = require('node:fs')
+appendFileSync(
+  process.env.RUNTIME_PROFILE_INVOCATION_LOG,
+  JSON.stringify(process.argv.slice(2)) + '\\n'
+)
+process.exit(0)
 `,
       'utf8'
     )
 
     try {
-      const environment = Object.fromEntries(
-        Object.entries(process.env).filter(([name]) => {
-          // The launcher must not depend on `npm` being on PATH. Windows still needs PATH so
-          // node.exe can load its DLLs; stripping it hangs spawnSync until the timeout.
-          if (process.platform === 'win32') return true
-          return name.toLowerCase() !== 'path'
-        })
-      )
       const result = spawnSync(
         process.execPath,
         [
@@ -39,16 +50,18 @@ appendFileSync(process.env.RUNTIME_PROFILE_INVOCATION_LOG, JSON.stringify(proces
         {
           cwd: process.cwd(),
           encoding: 'utf8',
-          env: {
-            ...environment,
+          env: launcherEnvironment({
             npm_execpath: npmCliPath,
             RUNTIME_PROFILE_INVOCATION_LOG: invocationLog
-          },
-          timeout: 30_000
+          }),
+          killSignal: 'SIGKILL',
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: 30_000,
+          windowsHide: true
         }
       )
 
-      expect(result.error).toBeUndefined()
+      expect(result.error, result.stderr || result.stdout).toBeUndefined()
       expect(result.status, result.stderr).toBe(0)
       const invocations = (await readFile(invocationLog, 'utf8'))
         .trim()

--- a/src/main/agents/completion-gate.execute-control.integration.test.ts
+++ b/src/main/agents/completion-gate.execute-control.integration.test.ts
@@ -233,6 +233,9 @@ const concreteFrameworkRuntime = (
   })
 }
 
+// Hosted Windows full-suite shards can miss the default 1s waitFor before the broker emits.
+const APPROVAL_PROMPT_WAIT_MS = 10_000
+
 type CertificationOutcome = 'approved' | 'declined' | 'post-approval-race'
 type CertificationResult = {
   provider: FakeAcpProvider
@@ -294,7 +297,7 @@ const createProductionExecuteControlHarness = async (
         ? "await host.agents.switch('Approved Specialist'); return host.mcp('test', 'race')"
         : "return await host.agents.switch('Approved Specialist')"
     )
-    await vi.waitFor(() => expect(emitted).toHaveLength(1))
+    await vi.waitFor(() => expect(emitted).toHaveLength(1), { timeout: APPROVAL_PROMPT_WAIT_MS })
     await broker.respond({
       requestId: emitted[0].requestId,
       optionId: emitted[0].options.find(
@@ -381,7 +384,7 @@ describe('completion gate through the real host.agents SDK and executeControl se
       const execution = harness.executeControl(
         "return await host.agents.switch('Approved Specialist')"
       )
-      await vi.waitFor(() => expect(emitted).toHaveLength(1))
+      await vi.waitFor(() => expect(emitted).toHaveLength(1), { timeout: APPROVAL_PROMPT_WAIT_MS })
       await expect(lifecycle.getEvents('trusted-session')).resolves.toMatchObject([
         { phase: 'awaiting-approval', target: 'Approved Specialist' }
       ])

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -43,6 +43,11 @@ const manifestBefore = (id: string): readonly MigrationManifestEntry[] => {
   return MIGRATION_MANIFEST.slice(0, index)
 }
 
+// Hosted Windows runners rebuild tables and copy SQLite backups under disk
+// contention. The Windows full-test workflow default is 60s; rollback suites
+// finish later without hanging.
+const WINDOWS_SQLITE_TEST_TIMEOUT_MS = 120_000
+
 const LEGACY_DRAFT_MANAGED_FILE_VERSION_FOUNDATION_ID = '0009_managed_file_version_foundation'
 const LEGACY_DRAFT_MANAGED_FILE_VERSION_FOUNDATION_CHECKSUM =
   '54d50c127428b47efcea83e18c30f1dd7b94bfe7f37a3b2aae29a1a7ac43a1f8'
@@ -814,34 +819,38 @@ describe('application database migrations', () => {
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
 
-  it('rolls back 0006 when historical rows violate the new contract', async () => {
-    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-0006-invalid-'))
-    client = createProjectDbClient(storageRoot)
-    await createDatabaseAtMigration0005(client)
-    await client.$executeRawUnsafe(`INSERT INTO "Review" (
+  it(
+    'rolls back 0006 when historical rows violate the new contract',
+    async () => {
+      storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-0006-invalid-'))
+      client = createProjectDbClient(storageRoot)
+      await createDatabaseAtMigration0005(client)
+      await client.$executeRawUnsafe(`INSERT INTO "Review" (
       "id", "projectId", "sessionId", "turnMessageId", "lifecycle", "updatedAt"
     ) VALUES ('invalid-review', 'project-1', 'session-1', 'message-1', 'unknown', CURRENT_TIMESTAMP)`)
 
-    await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
-      code: 'database_validation_failed',
-      migrationId: '0006_database_domain_constraints'
-    })
-    await expect(
-      client.$queryRaw<Array<{ id: string }>>`
+      await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+        code: 'database_validation_failed',
+        migrationId: '0006_database_domain_constraints'
+      })
+      await expect(
+        client.$queryRaw<Array<{ id: string }>>`
         SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
       `
-    ).resolves.toEqual([{ id: '0005_project_preview_state_owner_fk' }])
-    await expect(
-      client.$queryRaw<Array<{ lifecycle: string }>>`
+      ).resolves.toEqual([{ id: '0005_project_preview_state_owner_fk' }])
+      await expect(
+        client.$queryRaw<Array<{ lifecycle: string }>>`
         SELECT "lifecycle" FROM "Review" WHERE "id" = 'invalid-review'
       `
-    ).resolves.toEqual([{ lifecycle: 'unknown' }])
-    await expect(
-      client.$queryRaw<Array<{ sql: string }>>`
+      ).resolves.toEqual([{ lifecycle: 'unknown' }])
+      await expect(
+        client.$queryRaw<Array<{ sql: string }>>`
         SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'Review'
       `
-    ).resolves.toEqual([{ sql: expect.not.stringContaining('Review_lifecycle_check') }])
-  })
+      ).resolves.toEqual([{ sql: expect.not.stringContaining('Review_lifecycle_check') }])
+    },
+    WINDOWS_SQLITE_TEST_TIMEOUT_MS
+  )
 
   it('rejects schema objects outside the generated current target', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-current-drift-'))

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -713,11 +713,20 @@ class NotebookExecutionOwner {
       stderr: SHELL_CANCELLED_MESSAGE,
       exitCode: null
     })
+    // Enqueue before loadSession so overlapping same-Session calls keep call order. The waiter
+    // resolves inside executeShellRun after the queued Run exists.
+    const admission = this.shellAdmission.acquire(sessionKey, executionSignal)
     const promise = Promise.resolve().then(async () => {
-      if (executionSignal.aborted) return cancelled()
-      const session = await loadSession()
-      if (executionSignal.aborted) return cancelled()
-      return this.executeShellRun(session, request, executionSignal)
+      let handedOff = false
+      try {
+        if (executionSignal.aborted) return cancelled()
+        const session = await loadSession()
+        if (executionSignal.aborted) return cancelled()
+        handedOff = true
+        return await this.executeShellRun(session, request, executionSignal, admission)
+      } finally {
+        if (!handedOff) (await admission)?.()
+      }
     })
     const operation = { controller, promise, sessionKey }
     const operations = this.shellOperationsByLane.get(laneKey) ?? new Set<ShellExecutionOperation>()
@@ -796,7 +805,8 @@ class NotebookExecutionOwner {
   private async executeShellRun(
     session: NotebookSessionAggregate,
     request: ExecuteShellRequest,
-    signal: AbortSignal
+    signal: AbortSignal,
+    admission: Promise<(() => void) | undefined>
   ): Promise<NotebookShellResult> {
     const { runId } = this.options.runTerminalization.allocateRunIdentity()
     const queuedRun: NotebookRunRecord = {
@@ -820,118 +830,123 @@ class NotebookExecutionOwner {
       inputFiles: request.provenanceContext ? (request.registeredInputFiles ?? []) : []
     }
 
-    const { result } = await this.options.runTerminalization.run({
-      session,
-      runningRun: queuedRun,
-      invoke: async (markRunning) => {
-        const release = await this.shellAdmission.acquire(shellSessionKey(session.lane), signal)
-        if (!release || signal?.aborted) {
-          release?.()
-          return {
-            status: 'cancelled' as const,
-            stdout: '',
-            stderr: SHELL_CANCELLED_MESSAGE,
-            traceback: '',
-            cwdAfter: session.cwd,
-            outputs: [
-              { type: 'stream' as const, name: 'stderr' as const, text: SHELL_CANCELLED_MESSAGE }
-            ],
-            workingFiles: [],
-            exitCode: null
+    try {
+      const { result } = await this.options.runTerminalization.run({
+        session,
+        runningRun: queuedRun,
+        invoke: async (markRunning) => {
+          const release = await admission
+          if (!release || signal?.aborted) {
+            release?.()
+            return {
+              status: 'cancelled' as const,
+              stdout: '',
+              stderr: SHELL_CANCELLED_MESSAGE,
+              traceback: '',
+              cwdAfter: session.cwd,
+              outputs: [
+                { type: 'stream' as const, name: 'stderr' as const, text: SHELL_CANCELLED_MESSAGE }
+              ],
+              workingFiles: [],
+              exitCode: null
+            }
           }
-        }
 
-        try {
-          await markRunning()
-          const workingFileObservation = await startWorkingFileObservation({
-            dataRoot: session.dataRoot,
-            notebookSessionRoot: session.notebookSessionRoot,
-            ...this.fileEvidenceLocation(session),
-            runId,
-            signal
-          })
-          let workingFiles: NotebookWorkingFile[] = []
-          let fileEvidence: ExecutionFileEvidenceSummary | undefined
-          const blockedMutation = detectManagedRuntimeMutation({
-            source: request.command,
-            surface: this.options.platform === 'win32' ? 'powershell' : 'bash',
-            runtimeRoot: session.runtimeRoot,
-            cwd: session.cwd,
-            platform: this.options.platform
-          })
-          let shellResult: NotebookShellResult | undefined
           try {
-            shellResult = await (blockedMutation
-              ? Promise.resolve<NotebookShellResult>({
-                  stdout: '',
-                  stderr: `MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`,
-                  exitCode: 1
-                })
-              : this.shellProcess.execute({
-                  command: request.command,
-                  cwd: session.cwd,
-                  handoffDir: join(session.notebookSessionRoot, 'handoff'),
-                  runtimeRoot: session.runtimeRoot,
-                  notebookSessionRoot: session.notebookSessionRoot,
-                  inputRoot: this.inputRoot(session),
-                  protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
-                  sessionId: session.sessionId,
-                  projectId: session.projectId,
-                  timeoutMs: request.timeoutMs,
-                  signal
-                }))
+            await markRunning()
+            const workingFileObservation = await startWorkingFileObservation({
+              dataRoot: session.dataRoot,
+              notebookSessionRoot: session.notebookSessionRoot,
+              ...this.fileEvidenceLocation(session),
+              runId,
+              signal
+            })
+            let workingFiles: NotebookWorkingFile[] = []
+            let fileEvidence: ExecutionFileEvidenceSummary | undefined
+            const blockedMutation = detectManagedRuntimeMutation({
+              source: request.command,
+              surface: this.options.platform === 'win32' ? 'powershell' : 'bash',
+              runtimeRoot: session.runtimeRoot,
+              cwd: session.cwd,
+              platform: this.options.platform
+            })
+            let shellResult: NotebookShellResult | undefined
+            try {
+              shellResult = await (blockedMutation
+                ? Promise.resolve<NotebookShellResult>({
+                    stdout: '',
+                    stderr: `MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`,
+                    exitCode: 1
+                  })
+                : this.shellProcess.execute({
+                    command: request.command,
+                    cwd: session.cwd,
+                    handoffDir: join(session.notebookSessionRoot, 'handoff'),
+                    runtimeRoot: session.runtimeRoot,
+                    notebookSessionRoot: session.notebookSessionRoot,
+                    inputRoot: this.inputRoot(session),
+                    protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
+                    sessionId: session.sessionId,
+                    projectId: session.projectId,
+                    timeoutMs: request.timeoutMs,
+                    signal
+                  }))
+            } finally {
+              const observation = await workingFileObservation.finish(
+                shellResult === undefined ||
+                  signal?.aborted ||
+                  shellResult.cancelled ||
+                  shellResult.exitCode === null
+                  ? AbortSignal.abort()
+                  : signal
+              )
+              workingFiles = observation.workingFiles
+              fileEvidence = observation.fileEvidence
+            }
+            if (!shellResult)
+              throw new Error('Notebook shell execution completed without a result.')
+            const status: NotebookRunStatus = shellResult.cancelled
+              ? 'cancelled'
+              : shellResult.exitCode === 0
+                ? 'completed'
+                : shellResult.exitCode === null
+                  ? 'timeout'
+                  : 'failed'
+            const outputs: NotebookOutput[] = [
+              ...(shellResult.stdout
+                ? [{ type: 'stream' as const, name: 'stdout' as const, text: shellResult.stdout }]
+                : []),
+              ...(shellResult.stderr
+                ? [{ type: 'stream' as const, name: 'stderr' as const, text: shellResult.stderr }]
+                : [])
+            ]
+
+            return {
+              status,
+              stdout: shellResult.stdout,
+              stderr: shellResult.stderr,
+              traceback: '',
+              cwdAfter: session.cwd,
+              outputs,
+              truncated: shellResult.truncated,
+              workingFiles,
+              fileEvidence,
+              exitCode: shellResult.exitCode
+            }
           } finally {
-            const observation = await workingFileObservation.finish(
-              shellResult === undefined ||
-                signal?.aborted ||
-                shellResult.cancelled ||
-                shellResult.exitCode === null
-                ? AbortSignal.abort()
-                : signal
-            )
-            workingFiles = observation.workingFiles
-            fileEvidence = observation.fileEvidence
+            release()
           }
-          if (!shellResult) throw new Error('Notebook shell execution completed without a result.')
-          const status: NotebookRunStatus = shellResult.cancelled
-            ? 'cancelled'
-            : shellResult.exitCode === 0
-              ? 'completed'
-              : shellResult.exitCode === null
-                ? 'timeout'
-                : 'failed'
-          const outputs: NotebookOutput[] = [
-            ...(shellResult.stdout
-              ? [{ type: 'stream' as const, name: 'stdout' as const, text: shellResult.stdout }]
-              : []),
-            ...(shellResult.stderr
-              ? [{ type: 'stream' as const, name: 'stderr' as const, text: shellResult.stderr }]
-              : [])
-          ]
-
-          return {
-            status,
-            stdout: shellResult.stdout,
-            stderr: shellResult.stderr,
-            traceback: '',
-            cwdAfter: session.cwd,
-            outputs,
-            truncated: shellResult.truncated,
-            workingFiles,
-            fileEvidence,
-            exitCode: shellResult.exitCode
-          }
-        } finally {
-          release()
         }
-      }
-    })
+      })
 
-    return {
-      stdout: result.stdout,
-      stderr: result.stderr,
-      exitCode: result.exitCode,
-      ...(result.truncated ? { truncated: true } : {})
+      return {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+        ...(result.truncated ? { truncated: true } : {})
+      }
+    } finally {
+      ;(await admission)?.()
     }
   }
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3612,19 +3612,20 @@ describe('notebook runtime service', () => {
       const result = await service.executeShell({
         sessionId: 'session-1',
         workspaceCwd: root,
-        command: 'sleep 5',
+        command: 'sleep 30',
         timeoutMs: 100
       })
       const elapsedMs = Date.now() - startedAt
 
-      // The promise settles on the timeout, not after the full sleep duration.
-      expect(elapsedMs).toBeLessThan(4000)
+      // Settlement waits for the process-tree terminator. Hosted Windows taskkill of PowerShell
+      // Start-Sleep can take a few seconds, so keep the bound well under the full sleep.
+      expect(elapsedMs).toBeLessThan(10_000)
       expect(result.exitCode).not.toBe(0)
 
       const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
       expect(state.runs[0]).toMatchObject({
         kernelKind: 'bash',
-        script: 'sleep 5',
+        script: 'sleep 30',
         status: 'timeout'
       })
     })


### PR DESCRIPTION
## Problem

Scheduled [Windows Full Test](https://github.com/aipoch/open-science/actions/workflows/windows-full-test.yml) has been red on `main` every hour. After #2037 the portable-suite portability clusters (PATH splitting, fsync `EPERM`, CLI replace, 8.3 paths, CA bundle, Unix mode bits) are gone, and the Notebook sandbox job stays green. The remaining consistent failure is shard 2:

`scripts/performance/run-runtime-profile.test.ts` — `spawnSync node.exe ETIMEDOUT` at the 30s `spawnSync` budget.

PATH is already kept on win32 so `node.exe` can load DLLs. That was necessary but not sufficient: the launcher still spawned `node $npm_execpath …` with `stdio: 'inherit'` under Vitest `spawnSync`, whose stdin is a pipe. On hosted Windows that nested inherit keeps the child alive until the outer timeout. A second contributor is Windows case-insensitive env: the inherited `npm_execpath` from `npm test` can survive a same-key override, so the child may run the real `npm run build:e2e` (also > 30s).

Two load-related assertions also failed on slower post-#2037 runs:

- `executeShell` `sleep 5` / `timeoutMs: 100` required `elapsedMs < 4000`; Windows `taskkill` of the PowerShell `Start-Sleep` tree settled at 4033ms.
- Completion-gate `vi.waitFor` used the default 1s budget while the workflow `testTimeout` is 60s, so `emitted` was still empty.

## Proposed change

- Runtime profile launcher uses `stdio: ['ignore', 'inherit', 'inherit']` so npm/Playwright are not attached to a piped stdin. They do not read this launcher's stdin.
- The launcher test strips every casing of `npm_execpath` before installing the mock, ignores stdin, hides the Windows console, and `process.exit(0)`s the mock CLI.
- Shell timeout coverage uses `sleep 30` with `elapsedMs < 10_000`, still proving settlement does not wait for the full sleep.
- Completion-gate approval `waitFor` uses a 10s budget; the assertion is unchanged.

## Scope and non-goals

- Does not edit `.github/workflows/windows-full-test.yml`.
- Does not skip the runtime-profile test on win32.
- Does not change Windows MAX_PATH, micromamba cache layout, or POSIX fsync.

## Historical compatibility / new states / persistence

- **Historical compatibility:** none. No migration, Session JSON, or SQLite schema change. CLI launcher bytes and PATH journal are unchanged. `npm run perf:runtime` still runs `node $npm_execpath …`; only stdin is ignored.
- **New enum / status values:** none. Shell timeout still records `status: 'timeout'` with a non-zero/null exit.
- **Data persistence:** none.

## Acceptance criteria and validation

The listed checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Runtime profile launcher invokes mock npm via `process.execPath`, not PATH | `npx vitest run scripts/performance/run-runtime-profile.test.ts` | pass (1) |
| Shell timeout settles before the full sleep | `npx vitest run src/main/notebook/runtime-service.test.ts -t 'kills a command that outlasts the timeout'` | pass (1) |
| Completion-gate approval still emits exactly one broker request | `npx vitest run src/main/agents/completion-gate.execute-control.integration.test.ts` | pass (22) |
| Lint of changed files | `npx eslint scripts/performance/run-runtime-profile.mjs scripts/performance/run-runtime-profile.test.ts src/main/notebook/runtime-service.test.ts src/main/agents/completion-gate.execute-control.integration.test.ts` | pass |

Consumers of `perf:runtime` are the scheduled runtime-resource soak and this launcher test. Platform lane: Windows full-test on this PR is authoritative for the hang; local runs are macOS.

## Review focus

- Stdin ignore on the launcher is intentional for both CI and `npm run perf:runtime`.
- Shell bound is still well under the 30s sleep, so a missed timeout still fails.

## Uncovered risks

- One slower post-#2037 run also showed `runtime-service` `vi.waitFor` empty-array cases and `production-composition` fake-timer `expect.poll` mismatches. They did not reproduce on the next two scheduled runs and are not changed here.