### PR TITLE
fix(workspace): guard absent managed-file version API

### DIFF
--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -315,12 +315,11 @@ describe('PreviewFileSurface managed text versions', () => {
       .mockResolvedValue({ ok: true, value: managedInspect })
   })
 
-  it('stays read-only when the Web runtime omits managed operations', async () => {
+  it('stays read-only when the Web runtime omits the managed-file namespace', async () => {
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: {
-        artifacts: window.api.artifacts,
-        managedFileVersions: {}
+        artifacts: window.api.artifacts
       }
     })
 

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
@@ -113,7 +113,7 @@ const useManagedVersionWorkflow = ({
 
   useEffect(() => {
     let active = true
-    if (!identity || !requestKey || typeof window.api.managedFileVersions.inspect !== 'function')
+    if (!identity || !requestKey || typeof window.api.managedFileVersions?.inspect !== 'function')
       return
     const leaveDiffMode = (): void =>
       resetDiff((current) => (current === 'diff' ? 'view' : current))


### PR DESCRIPTION
## Summary

- guard the managed-file version capability check when Remote Web omits the entire Electron-only namespace
- keep managed-file previews visible and read-only when version inspection is unavailable
- tighten the existing public `PreviewFileSurface` regression fixture to match the real Remote Web API shape

Closes #2101.

## Reproduction before the fix

The existing public UI regression test was changed first so `window.api` omitted `managedFileVersions`, matching the Remote Web API installer rather than supplying an empty namespace.

The exact test was run three times against otherwise untouched production code. All three runs failed at `useManagedVersionWorkflow.ts:116` with:

```text
TypeError: Cannot read properties of undefined (reading 'inspect')
```

This matches the externally reported failure and activates the path using a managed upload preview item. No test seam was added.

## Fix

Use optional chaining only at the existing capability boundary:

```ts
typeof window.api.managedFileVersions?.inspect !== 'function'
```

The Remote Web RPC surface remains unchanged. No stubs or local file operations are exposed remotely.

## Impact assessment

- Architecture: unchanged
- Interaction: prevents the full-page crash; existing read-only preview remains visible and Electron-only edit/diff controls remain hidden
- Data fields or schema: none
- Data model or relationships: unchanged
- New enum/state values: none
- Persistence or migrations: none
- Historical-data compatibility: not applicable; no persisted representation changes

Adding Remote Web managed-file RPCs, a generalized capability registry, or a new fallback state machine would be unnecessary for this defect.

## Validation

- `npm test -- src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx -t 'stays read-only when the Web runtime omits the managed-file namespace'`
- `npm test -- src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx` — 91 passed
- `npm test -- src/renderer/web/api-installer.test.ts -t 'installs Web event subscriptions and omits Electron-only event adapters'`
- `npm run test:module -- project_files_view` — 237 passed
- `npm run typecheck:web`
- `npm run lint`

The affected-test explainer conservatively selected the full suite because `useManagedVersionWorkflow.ts` has no declared module owner. Per maintainer direction, the complete suite is left to PR CI.
