### PR TITLE
ci(release): align Zenodo with stable release notes

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -97,30 +97,39 @@ jobs:
           test -s artifacts/SHA256SUMS.txt
           test -s artifacts/RELEASE-CERTIFICATION.json
 
-      # API-only: this job has no checkout, so `gh release delete --cleanup-tag` fails
-      # before deleting anything. GitHub also will not move an existing `nightly` tag.
-      - name: Reset nightly release
+      # Keep one long-lived GitHub Release and only update its tag and assets. Zenodo archives newly
+      # published releases but ignores edits, so deleting and recreating this release would create a
+      # new Zenodo version on every scheduled run.
+      - name: Refresh nightly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          error_file="$RUNNER_TEMP/nightly-reset-error.log"
-          if release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/nightly" --jq .id 2>"$error_file"); then
-            gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"
+          error_file="$RUNNER_TEMP/nightly-refresh-error.log"
+          if ! release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/nightly" --jq .id 2>"$error_file"); then
+            cat "$error_file" >&2
+            echo "The long-lived nightly release is missing; refusing to create a new Zenodo-visible release." >&2
+            exit 1
+          fi
+
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/nightly" > /dev/null 2>"$error_file"; then
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly" \
+              -f sha="$SOURCE_SHA" -F force=true
           elif grep -Eq 'HTTP 404' "$error_file"; then
-            echo "No existing nightly release to delete."
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref='refs/tags/nightly' -f sha="$SOURCE_SHA"
           else
             cat "$error_file" >&2
             exit 1
           fi
 
-          if gh api --method DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly" 2>"$error_file"; then
-            echo "Deleted the nightly tag."
-          elif grep -Eq 'HTTP 404' "$error_file"; then
-            echo "No existing nightly tag to delete."
-          else
-            cat "$error_file" >&2
-            exit 1
-          fi
+          asset_file="$RUNNER_TEMP/nightly-assets.txt"
+          gh api --paginate "repos/$GITHUB_REPOSITORY/releases/$release_id/assets" \
+            --jq '.[].id' > "$asset_file"
+          while IFS= read -r asset_id; do
+            if [ -n "$asset_id" ]; then
+              gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"
+            fi
+          done < "$asset_file"
 
       - name: Publish nightly pre-release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -108,12 +108,14 @@ jobs:
           if ! release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/nightly" --jq .id 2>"$error_file"); then
             cat "$error_file" >&2
             echo "The long-lived nightly release is missing; refusing to create a new Zenodo-visible release." >&2
+            echo "Follow the recovery procedure in release-notes/README.md." >&2
             exit 1
           fi
 
           if ! gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/nightly" > /dev/null 2>"$error_file"; then
             cat "$error_file" >&2
             echo "The long-lived nightly tag is missing; refusing to publish without a retry marker." >&2
+            echo "Follow the recovery procedure in release-notes/README.md." >&2
             exit 1
           fi
 

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -97,9 +97,9 @@ jobs:
           test -s artifacts/SHA256SUMS.txt
           test -s artifacts/RELEASE-CERTIFICATION.json
 
-      # Keep one long-lived GitHub Release and only update its tag and assets. Zenodo archives newly
+      # Keep one long-lived GitHub Release and only update its assets and tag. Zenodo archives newly
       # published releases but ignores edits, so deleting and recreating this release would create a
-      # new Zenodo version on every scheduled run.
+      # new Zenodo version on every scheduled run. Advance the tag last so a failed upload is retried.
       - name: Refresh nightly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,14 +111,9 @@ jobs:
             exit 1
           fi
 
-          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/nightly" > /dev/null 2>"$error_file"; then
-            gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly" \
-              -f sha="$SOURCE_SHA" -F force=true
-          elif grep -Eq 'HTTP 404' "$error_file"; then
-            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
-              -f ref='refs/tags/nightly' -f sha="$SOURCE_SHA"
-          else
+          if ! gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/nightly" > /dev/null 2>"$error_file"; then
             cat "$error_file" >&2
+            echo "The long-lived nightly tag is missing; refusing to publish without a retry marker." >&2
             exit 1
           fi
 
@@ -151,3 +146,10 @@ jobs:
             artifacts/*.deb
             artifacts/SHA256SUMS.txt
             artifacts/RELEASE-CERTIFICATION.json
+
+      - name: Advance nightly tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly"
+          -f sha="$SOURCE_SHA" -F force=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,18 @@ jobs:
             artifacts/*.AppImage
             artifacts/*.deb
 
+      # Set the final body before GitHub emits the release event consumed by Zenodo. Updating the
+      # GitHub Release afterwards is too late because Zenodo archives the event payload it received.
+      - name: Resolve release notes
+        id: release_notes
+        run: |
+          path="release-notes/${GITHUB_REF_NAME#v}/en.md"
+          if [ ! -s "$path" ]; then
+            echo "Missing release notes: $path" >&2
+            exit 1
+          fi
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
       # Attach user-facing artifacts + checksums: installers (dmg/exe/AppImage/deb) and the mac
       # portable zips, plus the electron-updater feed files so the manually dispatched website mirror
       # can republish them to the CDN feed: win/linux latest.yml + latest-linux.yml, and the mac feeds.
@@ -152,7 +164,7 @@ jobs:
         with:
           draft: false
           prerelease: false
-          generate_release_notes: true
+          body_path: ${{ steps.release_notes.outputs.path }}
           files: |
             artifacts/*.dmg
             artifacts/*.zip

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -30,3 +30,17 @@ skipping AWS credentials, historical blockmap backfill, and every S3 write.
 For historical releases that predate this directory, the mirror workflow preserves the legacy path:
 it reads and condenses the GitHub Release body into English notes. A historical release therefore does
 not need a repository directory unless localized backfill is wanted.
+
+## Nightly release prerequisite
+
+Nightly publishing reuses one long-lived GitHub prerelease and moves its `nightly` tag only after the
+replacement assets upload successfully. The release and tag must both exist before enabling
+`.github/workflows/nightly-publish.yml`; do not delete or recreate the release during routine
+operation. Creating a GitHub Release while the Zenodo integration is enabled can archive another
+nightly version permanently.
+
+If only the tag is missing, restore it to the commit represented by the current nightly assets before
+rerunning the workflow. If the release is missing, disable the Zenodo integration before recreating
+the long-lived prerelease, verify that Zenodo did not archive it, and then re-enable the integration.
+The workflow intentionally fails closed in either case instead of attempting an unsafe automatic
+bootstrap.

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -16,8 +16,8 @@ release-notes/
     es.md
 ```
 
-The files contain the concise Markdown shown in the update dialog. Keep the full release notes in the
-GitHub Release body and link to them from the dialog as usual.
+The files contain the concise Markdown shown in the update dialog. `en.md` is also the authoritative
+GitHub Release body and Zenodo description, so it must be present before a stable tag is published.
 
 `en.md` is required because it is the fallback for missing translations and the compatibility source
 for electron-updater feeds used by older clients. The eight translated files are optional; when one is

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -199,7 +199,7 @@ describe('release and scheduled workflow topology', () => {
     const plan = publishWorkflow.jobs.plan
     const publish = publishWorkflow.jobs.publish
     const download = step(publish, 'Download prepared nightly artifacts')
-    const reset = step(publish, 'Reset nightly release')
+    const refresh = step(publish, 'Refresh nightly release')
     const release = step(publish, 'Publish nightly pre-release')
     const workflowRun = publishWorkflow.on?.workflow_run as {
       branches: string[]
@@ -245,14 +245,27 @@ describe('release and scheduled workflow topology', () => {
     expect(
       publish.steps?.some(({ run }) => run?.includes('release-certification-evidence.mjs'))
     ).toBe(false)
-    expect(reset.if).toBeUndefined()
-    expect(reset.run).toContain('repos/$GITHUB_REPOSITORY/releases/tags/nightly')
-    expect(reset.run).toContain('repos/$GITHUB_REPOSITORY/releases/$release_id')
-    expect(reset.run).toContain('repos/$GITHUB_REPOSITORY/git/refs/tags/nightly')
-    expect(reset.run).toContain("grep -Eq 'HTTP 404'")
-    expect(reset.run).not.toContain('--cleanup-tag')
-    expect(reset.run).not.toMatch(/\|\|\s*true/)
+    expect(refresh.if).toBeUndefined()
+    expect(refresh.run).toContain('repos/$GITHUB_REPOSITORY/releases/tags/nightly')
+    expect(refresh.run).toContain('refusing to create a new Zenodo-visible release')
+    expect(refresh.run).toContain('--method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly"')
+    expect(refresh.run).toContain('-F force=true')
+    expect(refresh.run).toContain('repos/$GITHUB_REPOSITORY/releases/$release_id/assets')
+    expect(refresh.run).toContain('repos/$GITHUB_REPOSITORY/releases/assets/$asset_id')
+    expect(refresh.run).not.toContain('DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"')
+    expect(refresh.run).not.toMatch(/\|\|\s*true/)
     expect(release.if).toBeUndefined()
+  })
+
+  it('publishes stable release notes as the GitHub and Zenodo description', () => {
+    const publish = workflow('release.yml').jobs.publish
+    const resolve = step(publish, 'Resolve release notes')
+    const release = step(publish, 'Publish GitHub Release')
+
+    expect(resolve.run).toContain('release-notes/${GITHUB_REF_NAME#v}/en.md')
+    expect(resolve.run).toContain('if [ ! -s "$path" ]')
+    expect(release.with?.body_path).toBe('${{ steps.release_notes.outputs.path }}')
+    expect(release.with).not.toHaveProperty('generate_release_notes')
   })
 
   it('dispatches the advisory Windows upgrade drill only after stable publication', () => {

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -201,6 +201,7 @@ describe('release and scheduled workflow topology', () => {
     const download = step(publish, 'Download prepared nightly artifacts')
     const refresh = step(publish, 'Refresh nightly release')
     const release = step(publish, 'Publish nightly pre-release')
+    const advance = step(publish, 'Advance nightly tag')
     const workflowRun = publishWorkflow.on?.workflow_run as {
       branches: string[]
       types: string[]
@@ -248,13 +249,20 @@ describe('release and scheduled workflow topology', () => {
     expect(refresh.if).toBeUndefined()
     expect(refresh.run).toContain('repos/$GITHUB_REPOSITORY/releases/tags/nightly')
     expect(refresh.run).toContain('refusing to create a new Zenodo-visible release')
-    expect(refresh.run).toContain('--method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly"')
-    expect(refresh.run).toContain('-F force=true')
+    expect(refresh.run).toContain('repos/$GITHUB_REPOSITORY/git/ref/tags/nightly')
+    expect(refresh.run).toContain('refusing to publish without a retry marker')
+    expect(refresh.run).not.toContain('--method PATCH')
+    expect(refresh.run).not.toContain('--method POST')
     expect(refresh.run).toContain('repos/$GITHUB_REPOSITORY/releases/$release_id/assets')
     expect(refresh.run).toContain('repos/$GITHUB_REPOSITORY/releases/assets/$asset_id')
     expect(refresh.run).not.toContain('DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"')
     expect(refresh.run).not.toMatch(/\|\|\s*true/)
     expect(release.if).toBeUndefined()
+    expect(advance.run).toContain('--method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly"')
+    expect(advance.run).toContain('-F force=true')
+    const publishSteps = publish.steps ?? []
+    expect(publishSteps.indexOf(refresh)).toBeLessThan(publishSteps.indexOf(release))
+    expect(publishSteps.indexOf(release)).toBeLessThan(publishSteps.indexOf(advance))
   })
 
   it('publishes stable release notes as the GitHub and Zenodo description', () => {


### PR DESCRIPTION
## Problem

Zenodo archives every newly published GitHub Release, including the rolling `nightly` prerelease. Stable records also capture the GitHub Release body at publication time, so later edits do not replace the already archived autogenerated notes.

## Proposed change

- Reuse the existing long-lived nightly GitHub Release instead of deleting and recreating it. Force-move the `nightly` tag, remove the previous assets, and upload the new build to the same Release ID.
- Fail closed when that long-lived Release is missing so automation cannot accidentally create another Zenodo-visible nightly record.
- Require `release-notes/<version>/en.md` for stable tags and pass it as `body_path` when the GitHub Release is first published, making the GitHub and Zenodo descriptions consistent.
- Update the release-note ownership documentation and workflow contract tests.

## Scope and non-goals

- No Zenodo API integration or token is added.
- No existing Zenodo record is modified or deleted.
- Nightly remains a public GitHub prerelease with the same tag and download surface.

## Historical compatibility

- The existing long-lived GitHub `nightly` Release is now a required external-state prerequisite. If it is deleted, publication fails rather than recreating a Zenodo-visible Release.
- Existing Zenodo nightly records `22252247` and `22260562` remain historical external data and require separate manual withdrawal/deletion or Zenodo support.

## New states or enum values

None.

## Persistence impact

No application persistence, database schema, or serialized format changes. The workflow deliberately preserves the GitHub Release ID while replacing its tag target and assets.

## Acceptance criteria and validation

Checks below ran after the final material edit:

- Stable/nightly workflow behavior -> `npx vitest run scripts/ci/release-workflows.test.ts scripts/windows-release-workflows.test.ts scripts/ci/ci-integrity-workflow.test.ts` -> 27 tests passed.
- Workflow syntax and action structure -> `actionlint .github/workflows/release.yml .github/workflows/nightly-publish.yml` -> passed.
- Changed-file formatting -> `npx prettier --check ...` -> passed.
- Changed TypeScript test lint -> `npx eslint scripts/ci/release-workflows.test.ts` -> passed.
- Test-impact explanation -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> full plan selected because the workflow contract test is a global gate input.

Per maintainer direction, the complete local `npm test` suite was not run. PR Gate is the authority for the complete portable and platform-specific checks.

## Review focus

- Confirm that preserving the Release ID prevents new Zenodo release events while retaining the rolling GitHub download surface.
- Confirm that force-moving the lightweight `nightly` ref and replacing assets remains safe under the existing serialized publication lock.
- Confirm that stable `body_path` is resolved and validated before the release event is emitted.

Uncovered locally: no real GitHub Release/tag mutation was performed; the first scheduled Nightly publication after merge remains the live external-system validation.
