### PR TITLE
fix(artifacts): resolve legacy previews by logical identity

### DIFF
--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -129,6 +129,7 @@ const createDependencies = () => {
     listArtifactGroups: vi.fn(),
     listFiles: vi.fn(),
     repairIndex: vi.fn(),
+    resolveFile: vi.fn(),
     searchArtifacts: vi.fn()
   }
   const project = {
@@ -282,7 +283,7 @@ const dispatchCommand = (
 }
 
 describe('Data and content application commands', () => {
-  it('owns exactly the 55 current data and content invoke channels', () => {
+  it('owns exactly the 58 current data and content invoke channels', () => {
     expect(registeredCommands()).toEqual(
       [
         'artifacts:finalize-run',
@@ -308,6 +309,7 @@ describe('Data and content application commands', () => {
         'project-files:list-artifact-groups',
         'project-files:list-files',
         'project-files:repair-index',
+        'project-files:resolve-file',
         'project-files:search-artifacts',
         'projects:create',
         'projects:update-archive',
@@ -462,6 +464,11 @@ describe('Data and content application commands', () => {
         key: 'projectFilesRepairIndex',
         args: [request('project-files-repair')],
         owner: deps.projectFiles.repairIndex
+      },
+      {
+        key: 'projectFilesResolveFile',
+        args: [request('project-files-resolve')],
+        owner: deps.projectFiles.resolveFile
       },
       {
         key: 'projectFilesSearchArtifacts',

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -239,6 +239,7 @@ const dataContentApplicationCommands = Object.freeze({
   ),
   projectFilesListFiles: projectFilesCommand('project-files:list-files', 'listFiles'),
   projectFilesRepairIndex: projectFilesCommand('project-files:repair-index', 'repairIndex'),
+  projectFilesResolveFile: projectFilesCommand('project-files:resolve-file', 'resolveFile'),
   projectFilesSearchArtifacts: projectFilesCommand(
     'project-files:search-artifacts',
     'searchArtifacts'
@@ -392,6 +393,7 @@ const dataContentApplicationCommandGroups = Object.freeze([
     dataContentApplicationCommands.projectFilesListArtifactGroups,
     dataContentApplicationCommands.projectFilesListFiles,
     dataContentApplicationCommands.projectFilesRepairIndex,
+    dataContentApplicationCommands.projectFilesResolveFile,
     dataContentApplicationCommands.projectFilesSearchArtifacts
   ] as const),
   defineApplicationCommandGroup('projects', [
@@ -555,6 +557,7 @@ const registerDataContentApplicationCommands = (
         dependencies.projectFiles.listArtifactGroups(args[0]),
       'project-files:list-files': ({ args }) => dependencies.projectFiles.listFiles(args[0]),
       'project-files:repair-index': ({ args }) => dependencies.projectFiles.repairIndex(args[0]),
+      'project-files:resolve-file': ({ args }) => dependencies.projectFiles.resolveFile(args[0]),
       'project-files:search-artifacts': ({ args }) =>
         dependencies.projectFiles.searchArtifacts(args[0])
     })

--- a/src/main/project-files/ipc.test.ts
+++ b/src/main/project-files/ipc.test.ts
@@ -40,6 +40,18 @@ describe('project files IPC handlers', () => {
       isIndexComplete: true
     }
     const filePage = { items: [], totalCount: 1 }
+    const resolvedFile = {
+      id: 'artifact-1',
+      source: 'artifact' as const,
+      sourceFileId: 'artifact-1',
+      sourceVersionId: 'version-2',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      name: 'report.md',
+      path: 'artifact-version:project-1/session-1/artifact-1/version-2',
+      size: 12,
+      sortAtMs: 2
+    }
     const groupPage = { items: [], totalCount: 1 }
     const artifactSearch = {
       primary: { items: [], totalCount: 0 },
@@ -49,6 +61,7 @@ describe('project files IPC handlers', () => {
     const repository = {
       getOverview: vi.fn().mockResolvedValue(overview),
       listFiles: vi.fn().mockResolvedValue(filePage),
+      resolveFile: vi.fn().mockResolvedValue(resolvedFile),
       listArtifactGroups: vi.fn().mockResolvedValue(groupPage),
       searchArtifacts: vi.fn().mockResolvedValue(artifactSearch)
     }
@@ -68,6 +81,14 @@ describe('project files IPC handlers', () => {
       limit: 24
     }
     const groupsRequest = { projectId: 'project-1', limit: 10 }
+    const resolveRequest = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      source: 'artifact' as const,
+      fileIdHint: 'legacy-artifact',
+      identityHint: 'legacy' as const,
+      name: 'report.md'
+    }
     const artifactSearchRequest = {
       primaryProjectId: 'project-1',
       otherProjectIds: ['project-2'],
@@ -82,9 +103,11 @@ describe('project files IPC handlers', () => {
     }
     await expect(handlers.getOverview(overviewRequest)).resolves.toBe(overview)
     await expect(handlers.listFiles(filesRequest)).resolves.toBe(filePage)
+    await expect(handlers.resolveFile(resolveRequest)).resolves.toBe(resolvedFile)
     await expect(handlers.listArtifactGroups(groupsRequest)).resolves.toBe(groupPage)
     await expect(handlers.searchArtifacts(artifactSearchRequest)).resolves.toBe(artifactSearch)
     expect(repository.listFiles).toHaveBeenCalledWith(filesRequest)
+    expect(repository.resolveFile).toHaveBeenCalledWith(resolveRequest)
     expect(repository.listArtifactGroups).toHaveBeenCalledWith(groupsRequest)
     expect(repository.getOverview).toHaveBeenCalledWith(overviewRequest)
     expect(repository.searchArtifacts).toHaveBeenCalledWith(artifactSearchRequest)
@@ -94,6 +117,7 @@ describe('project files IPC handlers', () => {
     const repository = {
       getOverview: vi.fn(),
       listFiles: vi.fn(),
+      resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
       searchArtifacts: vi.fn()
     }
@@ -113,6 +137,7 @@ describe('project files IPC handlers', () => {
     const repository = {
       getOverview: vi.fn(),
       listFiles: vi.fn(),
+      resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
       searchArtifacts: vi.fn()
     }
@@ -146,6 +171,10 @@ describe('project files IPC handlers', () => {
         order.push('files')
         return { items: [], totalCount: 0 }
       }),
+      resolveFile: vi.fn(async () => {
+        order.push('resolve')
+        return undefined
+      }),
       listArtifactGroups: vi.fn(async () => {
         order.push('groups')
         return { items: [], totalCount: 0 }
@@ -176,6 +205,13 @@ describe('project files IPC handlers', () => {
       collection: { kind: 'uploads' },
       limit: 20
     })
+    await handlers.resolveFile({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      source: 'artifact',
+      identityHint: 'legacy',
+      name: 'report.md'
+    })
     await handlers.listArtifactGroups({ projectId: 'project-1', limit: 10 })
     await handlers.searchArtifacts({
       primaryProjectId: 'project-1',
@@ -191,6 +227,8 @@ describe('project files IPC handlers', () => {
       'recover',
       'files',
       'recover',
+      'resolve',
+      'recover',
       'groups',
       'recover',
       'search',
@@ -200,7 +238,8 @@ describe('project files IPC handlers', () => {
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(1, ['project-1'])
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(2, ['project-1'])
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(3, ['project-1'])
-    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(4, ['project-1', 'project-2'])
+    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(4, ['project-1'])
+    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(5, ['project-1', 'project-2'])
     expect(recovery.recoverPendingDeletions).toHaveBeenCalledOnce()
   })
 })
@@ -223,6 +262,7 @@ describe('registerProjectFilesIpcHandlers', () => {
         isIndexComplete: true
       }),
       listFiles: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
+      resolveFile: vi.fn().mockResolvedValue(undefined),
       listArtifactGroups: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
       searchArtifacts: vi.fn().mockResolvedValue({
         primary: { items: [], totalCount: 0 },
@@ -242,6 +282,7 @@ describe('registerProjectFilesIpcHandlers', () => {
 
     expect(handlers.has('project-files:get-overview')).toBe(true)
     expect(handlers.has('project-files:list-files')).toBe(true)
+    expect(handlers.has('project-files:resolve-file')).toBe(true)
     expect(handlers.has('project-files:list-artifact-groups')).toBe(true)
     expect(handlers.has('project-files:search-artifacts')).toBe(true)
     expect(handlers.has('project-files:repair-index')).toBe(true)
@@ -258,6 +299,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     const injected: ProjectFilesHandlers = {
       getOverview: vi.fn().mockResolvedValue(overview),
       listFiles: vi.fn(),
+      resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
       searchArtifacts: vi.fn(),
       repairIndex: vi.fn()
@@ -284,6 +326,7 @@ describe('registerProjectFilesIpcHandlers', () => {
         isIndexComplete: true
       }),
       listFiles: vi.fn(),
+      resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
       searchArtifacts: vi.fn(),
       repairIndex: vi.fn()
@@ -316,6 +359,7 @@ describe('registerProjectFilesIpcHandlers', () => {
         }
       }),
       listFiles: vi.fn(),
+      resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
       searchArtifacts: vi.fn()
     }
@@ -344,6 +388,7 @@ describe('registerProjectFilesIpcHandlers', () => {
         order.push('files')
         return { items: [], totalCount: 0 }
       }),
+      resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
       searchArtifacts: vi.fn()
     }
@@ -374,6 +419,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     const localRepository: ProjectFilesQueryRepository = {
       getOverview: vi.fn(),
       listFiles: vi.fn(),
+      resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(async () => {
         order.push('groups')
         return { items: [], totalCount: 0 }
@@ -403,6 +449,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     const localRepository: ProjectFilesQueryRepository = {
       getOverview: vi.fn(),
       listFiles: vi.fn(),
+      resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
       searchArtifacts: vi.fn()
     }
@@ -438,10 +485,17 @@ describe('registerProjectFilesIpcHandlers', () => {
       collection: { kind: 'uploads' },
       limit: 1
     })
+    await invoke('project-files:resolve-file', {
+      projectId: 'p1',
+      sessionId: 'session-1',
+      source: 'artifact',
+      identityHint: 'legacy',
+      name: 'report.md'
+    })
     await invoke('project-files:list-artifact-groups', { projectId: 'p1', limit: 1 })
     await invoke('project-files:repair-index', { projectId: 'p1' })
 
-    expect(recoveryBackend.waitForProjectOperations).toHaveBeenCalledTimes(3)
+    expect(recoveryBackend.waitForProjectOperations).toHaveBeenCalledTimes(4)
     expect(recoveryBackend.recoverPendingDeletions).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/project-files/ipc.ts
+++ b/src/main/project-files/ipc.ts
@@ -7,6 +7,8 @@ import type {
   ListProjectFilesRequest,
   ProjectFilesOverview,
   ProjectFilesPage,
+  ProjectFileItem,
+  ResolveProjectFileRequest,
   SearchArtifactsRequest,
   SearchArtifactsResult
 } from '../../shared/project-files'
@@ -14,6 +16,7 @@ import type {
 type ProjectFilesQueryRepository = {
   getOverview(request: GetProjectFilesOverviewRequest): Promise<ProjectFilesOverview>
   listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage>
+  resolveFile(request: ResolveProjectFileRequest): Promise<ProjectFileItem | undefined>
   listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage>
   searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult>
 }
@@ -30,6 +33,7 @@ type ProjectFilesRecoveryBackend = {
 type ProjectFilesHandlers = {
   getOverview(request: GetProjectFilesOverviewRequest): Promise<ProjectFilesOverview>
   listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage>
+  resolveFile(request: ResolveProjectFileRequest): Promise<ProjectFileItem | undefined>
   listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage>
   searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult>
   repairIndex(request: { projectId: string }): Promise<void>
@@ -49,6 +53,10 @@ const createProjectFilesHandlers = (
   listFiles: async (request) => {
     await recoveryBackend.waitForProjectOperations([request.projectId])
     return repository.listFiles(request)
+  },
+  resolveFile: async (request) => {
+    await recoveryBackend.waitForProjectOperations([request.projectId])
+    return repository.resolveFile(request)
   },
   listArtifactGroups: async (request) => {
     await recoveryBackend.waitForProjectOperations([request.projectId])
@@ -87,6 +95,9 @@ const registerProjectFilesIpcHandlers = (
   )
   ipcMainHandle('project-files:list-files', (_event, request: ListProjectFilesRequest) =>
     handlers.listFiles(request)
+  )
+  ipcMainHandle('project-files:resolve-file', (_event, request: ResolveProjectFileRequest) =>
+    handlers.resolveFile(request)
   )
   ipcMainHandle(
     'project-files:list-artifact-groups',

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -1,3 +1,5 @@
+import type { ManagedFile } from '@prisma/client'
+
 import type {
   ArtifactGroupPage,
   GetProjectFilesOverviewRequest,
@@ -7,6 +9,7 @@ import type {
   ProjectFileItem,
   ProjectFilesOverview,
   ProjectFilesPage,
+  ResolveProjectFileRequest,
   SearchArtifactsRequest,
   SearchArtifactsResult
 } from '../../shared/project-files'
@@ -28,6 +31,7 @@ import {
   toProjectFileItem,
   toSafeCount
 } from './query-support'
+import { normalizeArtifactFilename } from '../artifacts/provenance-version-writer'
 
 type ProjectFilesIndexCompletenessReader = (projectId: string) => boolean
 
@@ -184,6 +188,82 @@ class ProjectFilesQueryOwner {
             })
           : undefined
     }
+  }
+
+  async resolveFile(request: ResolveProjectFileRequest): Promise<ProjectFileItem | undefined> {
+    requireIdentifier(request.projectId, 'projectId')
+    requireIdentifier(request.sessionId, 'sessionId')
+    if (request.source !== 'artifact' && request.source !== 'upload') {
+      throw new Error('Project file source is invalid.')
+    }
+    if (!request.name.trim() || request.name.length > 1024) {
+      throw new Error('Project file name is invalid.')
+    }
+    if (request.fileIdHint !== undefined) requireIdentifier(request.fileIdHint, 'fileIdHint')
+    if (request.identityHint !== 'logical' && request.identityHint !== 'legacy') {
+      throw new Error('Project file identity hint is invalid.')
+    }
+
+    const client = await this.getClient()
+    const normalizedName = normalizeArtifactFilename(request.name)
+    const queryArtifactByScopedName = async (): Promise<ManagedFile[]> => {
+      const lineage = await client.artifactLineage.findUnique({
+        where: {
+          projectId_sessionId_normalizedFilename: {
+            projectId: request.projectId,
+            sessionId: request.sessionId,
+            normalizedFilename: normalizedName
+          }
+        },
+        select: { id: true }
+      })
+      return lineage
+        ? await queryAuthoritativeFiles(client, {
+            projectIds: [request.projectId],
+            source: 'artifact',
+            sourceFileId: lineage.id,
+            sessionId: request.sessionId,
+            limit: 1
+          })
+        : []
+    }
+
+    // Logical ids remain authoritative across mentions. A path-only Artifact id is only a weak
+    // pre-adoption hint: resolve its Session-unique filename first so an identical id and filename
+    // already owned by another Session cannot capture the restored tab.
+    let rows =
+      request.source === 'artifact' && request.identityHint === 'legacy'
+        ? await queryArtifactByScopedName()
+        : request.fileIdHint
+          ? await queryAuthoritativeFiles(client, {
+              projectIds: [request.projectId],
+              source: request.source,
+              sourceFileId: request.fileIdHint,
+              limit: 1
+            })
+          : []
+    if (
+      rows.length === 0 &&
+      request.source === 'artifact' &&
+      request.identityHint === 'legacy' &&
+      request.fileIdHint
+    ) {
+      rows = await queryAuthoritativeFiles(client, {
+        projectIds: [request.projectId],
+        source: 'artifact',
+        sourceFileId: request.fileIdHint,
+        sessionId: request.sessionId,
+        limit: 1
+      })
+    }
+    const row = rows[0]
+    if (!row) return undefined
+    const origin = await client.fileOriginSession.findUnique({
+      where: {
+        projectId_sessionId: { projectId: row.projectId, sessionId: row.sessionId }
+      }
+    })
+    return toProjectFileItem(row, origin ?? undefined)
   }
 
   async searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult> {

--- a/src/main/project-files/query-support.ts
+++ b/src/main/project-files/query-support.ts
@@ -52,6 +52,7 @@ type CatalogCursor = { sortAtMs: string; seq: number }
 type AuthoritativeCatalogQuery = {
   projectIds: string[]
   source?: ProjectFileSource
+  sourceFileId?: string
   sessionId?: string
   search?: NormalizedSearch
   cursor?: CatalogCursor
@@ -304,6 +305,9 @@ const authoritativeCatalogPredicates = (
   const sourcePredicate = query.source
     ? Prisma.sql`AND file."source" = ${query.source}`
     : Prisma.empty
+  const sourceFilePredicate = query.sourceFileId
+    ? Prisma.sql`AND file."sourceFileId" = ${query.sourceFileId}`
+    : Prisma.empty
   const sessionPredicate = query.sessionId
     ? Prisma.sql`AND file."sessionId" = ${query.sessionId}`
     : Prisma.empty
@@ -321,6 +325,7 @@ const authoritativeCatalogPredicates = (
     : Prisma.empty
   return Prisma.sql`
     ${sourcePredicate}
+    ${sourceFilePredicate}
     ${sessionPredicate}
     ${filenamePredicate}
     ${excludedSessionsPredicate}

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -133,6 +133,127 @@ describe('ManagedFileIndexRepository', () => {
     })
   })
 
+  it('resolves a legacy preview id collision to the scoped Artifact logical identity', async () => {
+    // A legacy preview id can already belong to another Session after adoption; the filename is the
+    // scoped compatibility hint, while the authoritative catalog still decides visibility and head.
+    const otherArtifactPath = join(
+      storageRoot,
+      'artifacts',
+      'default-project',
+      'other-session',
+      'message-1',
+      'other.md'
+    )
+    await writeManagedFile(otherArtifactPath, 'other artifact\n')
+    await repository.syncSession(
+      createSession({
+        id: 'other-session',
+        artifacts: [
+          {
+            id: 'legacy-artifact-1',
+            kind: 'managed-file',
+            path: otherArtifactPath,
+            name: 'legacy.md',
+            mimeType: 'text/markdown'
+          }
+        ]
+      })
+    )
+    const artifactPath = join(
+      storageRoot,
+      'artifacts',
+      'default-project',
+      SESSION_ID,
+      'message-1',
+      'legacy.md'
+    )
+    await writeManagedFile(artifactPath, 'legacy artifact\n')
+    await repository.syncSession(
+      createSession({
+        artifacts: [
+          {
+            id: 'legacy-artifact-1',
+            kind: 'managed-file',
+            path: artifactPath,
+            name: 'legacy.md',
+            mimeType: 'text/markdown'
+          }
+        ]
+      })
+    )
+    const lineage = await client.artifactLineage.findUniqueOrThrow({
+      where: {
+        projectId_sessionId_normalizedFilename: {
+          projectId: PROJECT_ID,
+          sessionId: SESSION_ID,
+          normalizedFilename: 'legacy.md'
+        }
+      }
+    })
+
+    const resolved = await repository.resolveFile({
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      source: 'artifact',
+      fileIdHint: 'legacy-artifact-1',
+      identityHint: 'legacy',
+      name: 'LEGACY.md'
+    })
+
+    expect(lineage.id).not.toBe('legacy-artifact-1')
+    expect(resolved).toMatchObject({
+      id: lineage.id,
+      source: 'artifact',
+      sourceFileId: lineage.id,
+      sourceVersionId: lineage.currentVersionId,
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      name: 'legacy.md',
+      path: `artifact-version:${PROJECT_ID}/${SESSION_ID}/${lineage.id}/${lineage.currentVersionId}`
+    })
+  })
+
+  it('resolves a stable Artifact id when a legacy mention carries the viewing Session id', async () => {
+    const artifactPath = join(
+      storageRoot,
+      'artifacts',
+      'default-project',
+      SESSION_ID,
+      'message-1',
+      'report.md'
+    )
+    await writeManagedFile(artifactPath, 'source artifact\n')
+    await repository.syncSession(
+      createSession({
+        artifacts: [
+          {
+            id: 'artifact-1',
+            kind: 'managed-file',
+            path: artifactPath,
+            name: 'report.md',
+            mimeType: 'text/markdown'
+          }
+        ]
+      })
+    )
+
+    await expect(
+      repository.resolveFile({
+        projectId: PROJECT_ID,
+        sessionId: 'viewing-session',
+        source: 'artifact',
+        fileIdHint: 'artifact-1',
+        identityHint: 'logical',
+        name: 'report.md'
+      })
+    ).resolves.toMatchObject({
+      sourceFileId: 'artifact-1',
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      name: 'report.md'
+    })
+  })
+
   it('does not publish a legacy Artifact when its persisted checksum disagrees with the source', async () => {
     const artifactPath = join(
       storageRoot,

--- a/src/main/project-files/repository.ts
+++ b/src/main/project-files/repository.ts
@@ -5,9 +5,11 @@ import type {
   HostArtifactCatalogItem,
   ListArtifactGroupsRequest,
   ListProjectFilesRequest,
+  ProjectFileItem,
   ProjectFilesOverview,
   ProjectFilesPage,
   ProjectFileSource,
+  ResolveProjectFileRequest,
   SearchArtifactsRequest,
   SearchArtifactsResult
 } from '../../shared/project-files'
@@ -95,6 +97,10 @@ class ManagedFileIndexRepository {
 
   async listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage> {
     return this.queryOwner.listFiles(request)
+  }
+
+  async resolveFile(request: ResolveProjectFileRequest): Promise<ProjectFileItem | undefined> {
+    return this.queryOwner.resolveFile(request)
   }
 
   async readHostArtifactCatalog(request: {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -429,6 +429,7 @@ describe('preload bridge — public surface inventory', () => {
       'projectFiles.listFiles',
       'projectFiles.onChanged',
       'projectFiles.repairIndex',
+      'projectFiles.resolveFile',
       'projectFiles.searchArtifacts',
       'projects.create',
       'projects.delete',

--- a/src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx
+++ b/src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx
@@ -47,7 +47,11 @@ vi.mock('radix-ui', () => ({
 }))
 
 vi.mock('./PreviewFileSurface', () => ({
-  PreviewFileSurface: (props: { item: PreviewFileItem; provenanceEntry?: string }) => {
+  PreviewFileSurface: (props: {
+    item: PreviewFileItem
+    provenanceEntry?: string
+    retryResolutionEnabled?: boolean
+  }) => {
     previewSurfaceSpy(props)
     return <div data-testid="preview-surface">{props.item.title}</div>
   }
@@ -124,6 +128,9 @@ describe('FilePreviewDialog closing lifecycle', () => {
     )
     expect(container.querySelector('[data-testid="preview-surface"]')?.textContent).toBe(
       'report.pdf'
+    )
+    expect(previewSurfaceSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ retryResolutionEnabled: false })
     )
   })
 

--- a/src/renderer/src/pages/workspace/FilePreviewDialog.tsx
+++ b/src/renderer/src/pages/workspace/FilePreviewDialog.tsx
@@ -147,6 +147,7 @@ const FilePreviewDialog = ({
                   onPdfContextError={onPdfContextError}
                   tooltipClassName="z-[70]"
                   leaveGuardScope={dialogPreviewGuardScope(dialogItem.projectId, dialogItem.id)}
+                  retryResolutionEnabled={open}
                   {...annotationPort}
                 />
               ) : null}

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -54,12 +54,18 @@ vi.mock('./previews/PreviewFileContent', () => ({
     annotationVersionId?: string
     annotationBlockedByHistoricalVersion?: boolean
     annotationVersionPending?: boolean
+    onRetry?: () => Promise<void>
     onPdfReadingPositionChange?: (position: { pageNumber: number; pageCount: number }) => void
   }) => {
     previewContentSpy(props)
     return (
       <div data-testid="preview-content" data-path={props.item.path}>
         Preview content
+        {props.onRetry ? (
+          <button type="button" onClick={() => void props.onRetry?.()}>
+            Retry managed preview
+          </button>
+        ) : null}
       </div>
     )
   }
@@ -1766,6 +1772,347 @@ afterEach(() => {
 })
 
 describe('PreviewFileSurface Provenance entry', () => {
+  it('refreshes a restored path-only Artifact identity before retrying its preview', async () => {
+    const legacyPath = String.raw`C:\stale\report.md`
+    const legacyItem: PreviewFileItem = {
+      id: 'legacy-artifact-id',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      type: 'file',
+      title: legacyPath,
+      name: legacyPath,
+      path: legacyPath,
+      format: 'markdown',
+      source: 'artifact'
+    }
+    const resolveFile = vi.fn().mockResolvedValue({
+      id: 'canonical-artifact-id',
+      source: 'artifact',
+      sourceFileId: 'canonical-artifact-id',
+      sourceVersionId: 'version-3',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      name: 'report.md',
+      path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-3',
+      mimeType: 'text/markdown',
+      size: 42,
+      mtimeMs: 3,
+      sortAtMs: 3
+    })
+    window.api.projectFiles = { resolveFile } as unknown as typeof window.api.projectFiles
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(legacyItem)
+
+    await act(async () => {
+      root.render(<PreviewFileSurface item={legacyItem} onClose={vi.fn()} workbenchConnected />)
+      await Promise.resolve()
+    })
+
+    await click(
+      [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Retry managed preview'
+      ) ?? null
+    )
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(resolveFile).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      source: 'artifact',
+      fileIdHint: 'legacy-artifact-id',
+      identityHint: 'legacy',
+      name: 'report.md'
+    })
+    expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject({
+      id: 'legacy-artifact-id',
+      artifactId: 'canonical-artifact-id',
+      managedFileId: 'canonical-artifact-id',
+      path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-3'
+    })
+  })
+
+  it('does not pin a lineage-derived head while refreshing an unpinned Artifact', async () => {
+    const legacyItem: PreviewFileItem = {
+      ...item,
+      id: 'legacy-preview-id',
+      projectId: 'project-1',
+      managedFileId: undefined,
+      selectedVersionId: undefined,
+      versionNumber: undefined
+    }
+    const resolveFile = vi.fn().mockResolvedValue({
+      id: 'artifact-1',
+      source: 'artifact',
+      sourceFileId: 'artifact-1',
+      sourceVersionId: 'version-3',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      name: 'sin.png',
+      path: 'artifact-version:project-1/session-1/artifact-1/version-3',
+      mimeType: 'image/png',
+      size: 24,
+      mtimeMs: 3,
+      sortAtMs: 3
+    })
+    window.api.projectFiles = { resolveFile } as unknown as typeof window.api.projectFiles
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(legacyItem)
+
+    await act(async () => {
+      root.render(<PreviewFileSurface item={legacyItem} onClose={vi.fn()} workbenchConnected />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    await vi.waitFor(() =>
+      expect(previewContentSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          item: expect.objectContaining({ selectedVersionId: 'version-2' })
+        })
+      )
+    )
+
+    await click(
+      [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Retry managed preview'
+      ) ?? null
+    )
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject({
+      id: 'legacy-preview-id',
+      managedFileId: 'artifact-1',
+      path: 'artifact-version:project-1/session-1/artifact-1/version-3'
+    })
+    expect(usePreviewWorkbenchStore.getState().items[0]).not.toHaveProperty('selectedVersionId')
+    expect(usePreviewWorkbenchStore.getState().items[0]).not.toHaveProperty('versionNumber')
+  })
+
+  it('ignores a stale retry lookup after the user selects another Artifact version', async () => {
+    const legacyItem: PreviewFileItem = {
+      id: 'legacy-artifact-id',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'report.md',
+      name: 'report.md',
+      path: '/stale/report.md',
+      format: 'markdown',
+      source: 'artifact'
+    }
+    const resolvedFile = {
+      id: 'canonical-artifact-id',
+      source: 'artifact' as const,
+      sourceFileId: 'canonical-artifact-id',
+      sourceVersionId: 'version-3',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      name: 'report.md',
+      path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-3',
+      mimeType: 'text/markdown',
+      size: 42,
+      mtimeMs: 3,
+      sortAtMs: 3
+    }
+    let finishResolve: ((value: typeof resolvedFile) => void) | undefined
+    const resolveFile = vi.fn(
+      () =>
+        new Promise<typeof resolvedFile>((resolve) => {
+          finishResolve = resolve
+        })
+    )
+    window.api.projectFiles = { resolveFile } as unknown as typeof window.api.projectFiles
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(legacyItem)
+
+    await act(async () => {
+      root.render(<PreviewFileSurface item={legacyItem} onClose={vi.fn()} workbenchConnected />)
+      await Promise.resolve()
+    })
+    await click(
+      [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Retry managed preview'
+      ) ?? null
+    )
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertItem(
+        {
+          ...legacyItem,
+          artifactId: 'canonical-artifact-id',
+          managedFileId: 'canonical-artifact-id',
+          selectedVersionId: 'version-2',
+          versionNumber: 2,
+          path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-2'
+        },
+        true
+      )
+      await Promise.resolve()
+    })
+    await act(async () => {
+      finishResolve?.(resolvedFile)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject({
+      selectedVersionId: 'version-2',
+      versionNumber: 2,
+      path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-2'
+    })
+  })
+
+  it('ignores a stale retry lookup after the preview identity changes and returns', async () => {
+    const legacyItem: PreviewFileItem = {
+      id: 'legacy-artifact-id',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'report.md',
+      name: 'report.md',
+      path: '/stale/report.md',
+      format: 'markdown',
+      source: 'artifact'
+    }
+    const resolvedFile = {
+      id: 'canonical-artifact-id',
+      source: 'artifact' as const,
+      sourceFileId: 'canonical-artifact-id',
+      sourceVersionId: 'version-3',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      name: 'report.md',
+      path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-3',
+      size: 42,
+      sortAtMs: 3
+    }
+    let finishResolve: ((value: typeof resolvedFile) => void) | undefined
+    const resolveFile = vi.fn(
+      () =>
+        new Promise<typeof resolvedFile>((resolve) => {
+          finishResolve = resolve
+        })
+    )
+    window.api.projectFiles = { resolveFile } as unknown as typeof window.api.projectFiles
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(legacyItem)
+
+    await act(async () => {
+      root.render(<PreviewFileSurface item={legacyItem} onClose={vi.fn()} workbenchConnected />)
+      await Promise.resolve()
+    })
+    await click(
+      [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Retry managed preview'
+      ) ?? null
+    )
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertItem(
+        {
+          ...legacyItem,
+          artifactId: 'canonical-artifact-id',
+          managedFileId: 'canonical-artifact-id',
+          selectedVersionId: 'version-2',
+          versionNumber: 2,
+          path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-2'
+        },
+        true
+      )
+      await Promise.resolve()
+    })
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertItem(legacyItem, true)
+      await Promise.resolve()
+    })
+    await act(async () => {
+      finishResolve?.(resolvedFile)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject(legacyItem)
+    expect(usePreviewWorkbenchStore.getState().items[0]).not.toHaveProperty('artifactId')
+    expect(usePreviewWorkbenchStore.getState().items[0]).not.toHaveProperty('managedFileId')
+  })
+
+  it('ignores a retry lookup started before a retained preview closes and reopens', async () => {
+    const legacyItem: PreviewFileItem = {
+      id: 'legacy-artifact-id',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'report.md',
+      name: 'report.md',
+      path: '/stale/report.md',
+      format: 'markdown',
+      source: 'artifact'
+    }
+    const resolvedFile = {
+      id: 'canonical-artifact-id',
+      source: 'artifact' as const,
+      sourceFileId: 'canonical-artifact-id',
+      sourceVersionId: 'version-3',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      name: 'report.md',
+      path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-3',
+      size: 42,
+      sortAtMs: 3
+    }
+    let finishResolve: ((value: typeof resolvedFile) => void) | undefined
+    const resolveFile = vi.fn(
+      () =>
+        new Promise<typeof resolvedFile>((resolve) => {
+          finishResolve = resolve
+        })
+    )
+    window.api.projectFiles = { resolveFile } as unknown as typeof window.api.projectFiles
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(legacyItem)
+
+    await act(async () => {
+      root.render(<PreviewFileSurface item={legacyItem} onClose={vi.fn()} workbenchConnected />)
+      await Promise.resolve()
+    })
+    await click(
+      [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Retry managed preview'
+      ) ?? null
+    )
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().removeItem(legacyItem.id)
+      root.render(
+        <PreviewFileSurface
+          item={legacyItem}
+          onClose={vi.fn()}
+          workbenchConnected
+          retryResolutionEnabled={false}
+        />
+      )
+      await Promise.resolve()
+    })
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(legacyItem)
+      root.render(
+        <PreviewFileSurface
+          item={legacyItem}
+          onClose={vi.fn()}
+          workbenchConnected
+          retryResolutionEnabled
+        />
+      )
+      await Promise.resolve()
+    })
+    await act(async () => {
+      finishResolve?.(resolvedFile)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject(legacyItem)
+    expect(usePreviewWorkbenchStore.getState().items[0]).not.toHaveProperty('artifactId')
+    expect(usePreviewWorkbenchStore.getState().items[0]).not.toHaveProperty('managedFileId')
+  })
+
   it('keeps a default managed Artifact preview on its logical DB head', async () => {
     const managedArtifact = {
       ...item,

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -15,7 +15,15 @@ import {
   X
 } from 'lucide-react'
 import type { TFunction } from 'i18next'
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -46,8 +54,10 @@ import { LocalFileHeaderActions } from './LocalFileHeaderActions'
 import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
 import { usePdfContextAction, type PdfContextAction } from './use-pdf-context-action'
 import {
+  createProjectFileResolveRequest,
   createPreviewFileItemForArtifactVersion,
   createPreviewFileItemForManagedVersion,
+  refreshPreviewFileItemFromProjectFile,
   resolveArtifactVersionDescriptor
 } from './preview-file-item'
 import { PreviewFileContent } from './previews/PreviewFileContent'
@@ -71,6 +81,7 @@ type PreviewFileSurfaceProps = PreviewInteractionPort & {
   provenanceEntry?: 'menu' | 'leading' | 'trailing'
   leaveGuardScope?: string
   workbenchConnected?: boolean
+  retryResolutionEnabled?: boolean
   onItemChange?: (item: PreviewFileItem) => void
 }
 
@@ -567,6 +578,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
       provenanceEntry = 'menu',
       leaveGuardScope,
       workbenchConnected = false,
+      retryResolutionEnabled = true,
       onItemChange,
       activeAnnotations,
       onAddAnnotation,
@@ -608,6 +620,11 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
     const [pendingLeaveAction, setPendingLeaveAction] = useState<() => boolean | void>()
     const saveGenerationRef = useRef(0)
     const acceptedIdentityTransitionRef = useRef<string | undefined>(undefined)
+    const mountedRef = useRef(false)
+    const retryGenerationRef = useRef(0)
+    const retryInFlightRef = useRef<{ generation: number; operation: Promise<void> } | undefined>(
+      undefined
+    )
     const activeProjectId = usePreviewWorkbenchStore((state) => state.activeProjectId)
     const storedItem = usePreviewWorkbenchStore((state) =>
       workbenchConnected
@@ -623,6 +640,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
     const itemIdentityKey = `${sourceItem.projectId ?? ''}:${sourceItem.source ?? 'artifact'}:${sourceItem.id}:${sourceItem.managedFileId ?? ''}:${sourceItem.artifactId ?? ''}:${sourceItem.selectedVersionId ?? ''}:${sourceItem.path}`
     const previewItem = versionOverride?.key === itemIdentityKey ? versionOverride.item : sourceItem
     const projectId = previewItem.projectId ?? activeProjectId
+    const previewIdentityKey = `${previewItem.projectId ?? ''}:${previewItem.source ?? 'artifact'}:${previewItem.id}:${previewItem.managedFileId ?? ''}:${previewItem.artifactId ?? ''}:${previewItem.selectedVersionId ?? ''}:${previewItem.path}`
     const managedWorkflow = useManagedVersionWorkflow({
       item: previewItem,
       projectId,
@@ -738,6 +756,13 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
     )
     useImperativeHandle(ref, () => ({ requestLeave }), [requestLeave])
 
+    useEffect(() => {
+      mountedRef.current = true
+      return () => {
+        mountedRef.current = false
+      }
+    }, [])
+
     useEffect(
       () =>
         leaveGuardScope ? previewLeaveGuards.register(leaveGuardScope, guardLeave) : undefined,
@@ -815,9 +840,61 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
         // onItemChange and must not retain an origin-keyed override that can become stale.
         if (!onItemChange) setVersionOverride({ key: itemIdentityKey, item: nextItem })
       }
+      // Invalidate pending retry lookups synchronously; the following render will advance the
+      // generation again if the complete request or selected identity also changed.
+      retryGenerationRef.current += 1
       onApplied?.()
       return true
     }
+
+    const managedRetryRequest = createProjectFileResolveRequest(resolvedPreviewItem, projectId)
+    const retryGenerationKey = JSON.stringify([
+      retryResolutionEnabled,
+      previewIdentityKey,
+      managedRetryRequest?.projectId,
+      managedRetryRequest?.sessionId,
+      managedRetryRequest?.source,
+      managedRetryRequest?.fileIdHint,
+      managedRetryRequest?.identityHint,
+      managedRetryRequest?.name
+    ])
+    useLayoutEffect(() => {
+      retryGenerationRef.current += 1
+    }, [retryGenerationKey])
+    const retryManagedPreview = managedRetryRequest
+      ? (): Promise<void> => {
+          const requestedGeneration = retryGenerationRef.current
+          if (retryInFlightRef.current?.generation === requestedGeneration) {
+            return retryInFlightRef.current.operation
+          }
+          const operation = (async (): Promise<void> => {
+            try {
+              const file = await window.api.projectFiles.resolveFile(managedRetryRequest)
+              if (
+                !file ||
+                !retryResolutionEnabled ||
+                !mountedRef.current ||
+                retryGenerationRef.current !== requestedGeneration
+              ) {
+                return
+              }
+              // A retry repairs metadata for the same stable tab, so it must not prompt about an
+              // unrelated identity transition before the failed preview can remount.
+              applyVersionItem(refreshPreviewFileItemFromProjectFile(previewItem, file), true)
+            } catch {
+              // The runtime still remounts the original request so transient catalog failures do
+              // not turn Retry into a no-op.
+            }
+          })()
+          retryInFlightRef.current = { generation: requestedGeneration, operation }
+          void operation.finally(() => {
+            if (retryInFlightRef.current?.operation === operation) {
+              retryInFlightRef.current = undefined
+            }
+          })
+          return operation
+        }
+      : undefined
 
     const selectPreviewVersion = (versionId: string): void => {
       if (!lineage || !projectId) return
@@ -1207,6 +1284,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                   onUndoAnnotation={onUndoAnnotation}
                   onRedoAnnotation={onRedoAnnotation}
                   onAnnotationError={onAnnotationError}
+                  onRetry={retryManagedPreview}
                   onPdfReadingPositionChange={
                     readingContextBindingId ? reportPdfReadingPosition : undefined
                   }
@@ -1238,6 +1316,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
               onUndoAnnotation={onUndoAnnotation}
               onRedoAnnotation={onRedoAnnotation}
               onAnnotationError={onAnnotationError}
+              onRetry={retryManagedPreview}
               onPdfReadingPositionChange={
                 readingContextBindingId ? reportPdfReadingPosition : undefined
               }

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -352,6 +352,7 @@ describe('ProjectFilesView', () => {
 
         return { items, totalCount: items.length }
       }),
+      resolveFile: vi.fn().mockResolvedValue(undefined),
       listArtifactGroups: vi.fn(async (request) => {
         const groups = getLibrary().artifactGroups
         const query = request.search

--- a/src/renderer/src/pages/workspace/preview-file-item.test.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.test.ts
@@ -10,6 +10,8 @@ import {
   createPreviewFileItemFromPdfContext,
   createPreviewFileItemFromUpload,
   createPreviewFileItemForArtifactVersion,
+  createProjectFileResolveRequest,
+  refreshPreviewFileItemFromProjectFile,
   resolveArtifactVersionDescriptor
 } from './preview-file-item'
 
@@ -52,6 +54,110 @@ const createMentionPart = (overrides: Partial<ArtifactMentionPart> = {}): Artifa
 })
 
 describe('preview file item helpers', () => {
+  it.each([
+    [
+      'artifact',
+      createPreviewFileItem({
+        id: 'legacy-artifact-id',
+        sessionId: 'session-1',
+        path: '/legacy/report.md',
+        name: 'report.md'
+      }),
+      'legacy-artifact-id',
+      'legacy'
+    ],
+    [
+      'upload',
+      createPreviewFileItem({
+        id: 'upload:upload-1',
+        sessionId: 'session-1',
+        source: 'upload',
+        path: '/legacy/upload.md',
+        name: 'upload.md'
+      }),
+      'upload-1',
+      'logical'
+    ],
+    [
+      'upload without a namespaced tab id',
+      createPreviewFileItem({
+        id: 'legacy-upload-1',
+        sessionId: 'session-1',
+        source: 'upload',
+        path: '/legacy/upload.md',
+        name: 'upload.md'
+      }),
+      'legacy-upload-1',
+      'legacy'
+    ]
+  ] as const)(
+    'builds a logical Project Files lookup for a legacy %s retry',
+    (_, item, fileIdHint, identityHint) => {
+      expect(createProjectFileResolveRequest(item, 'project-1')).toEqual({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        source: item.source ?? 'artifact',
+        fileIdHint,
+        identityHint,
+        name: item.name
+      })
+    }
+  )
+
+  it('reduces a restored legacy Artifact path to a filename for retry lookup', () => {
+    const item = createPreviewFileItem({
+      id: 'legacy-artifact-id',
+      sessionId: 'session-1',
+      path: String.raw`C:\legacy\nested\report.md`,
+      name: String.raw`C:\legacy\nested\report.md`
+    })
+
+    expect(createProjectFileResolveRequest(item, 'project-1')).toEqual({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      source: 'artifact',
+      fileIdHint: 'legacy-artifact-id',
+      identityHint: 'legacy',
+      name: 'report.md'
+    })
+  })
+
+  it('refreshes a legacy preview with canonical identity without changing its selected Version', () => {
+    const legacyItem = createPreviewFileItem({
+      id: 'legacy-preview-id',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      path: '/legacy/report.md',
+      name: 'report.md',
+      selectedVersionId: 'artifact-version-1',
+      versionNumber: 1
+    })
+
+    expect(
+      refreshPreviewFileItemFromProjectFile(legacyItem, {
+        id: 'artifact-lineage-1',
+        source: 'artifact',
+        sourceFileId: 'artifact-lineage-1',
+        sourceVersionId: 'artifact-version-2',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        name: 'report.md',
+        path: 'artifact-version:project-1/session-1/artifact-lineage-1/artifact-version-2',
+        mimeType: 'text/markdown',
+        size: 24,
+        mtimeMs: 2,
+        sortAtMs: 2
+      })
+    ).toMatchObject({
+      id: 'legacy-preview-id',
+      artifactId: 'artifact-lineage-1',
+      managedFileId: 'artifact-lineage-1',
+      selectedVersionId: 'artifact-version-1',
+      versionNumber: 1,
+      path: 'artifact-version:project-1/session-1/artifact-lineage-1/artifact-version-1'
+    })
+  })
+
   it('does not replace an explicitly missing Artifact Version with the latest Version', () => {
     const latest = {
       id: 'artifact-version-2',

--- a/src/renderer/src/pages/workspace/preview-file-item.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.ts
@@ -1,6 +1,7 @@
 import type { PreviewFileItem, PreviewFileSource } from '@/stores/preview-workbench-store'
 import type { ChatSession } from '@/stores/session-store'
 import type { ArtifactFile } from '../../../../shared/artifacts'
+import type { ProjectFileItem, ResolveProjectFileRequest } from '../../../../shared/project-files'
 import type { MessagePart, SessionPdfBinding } from '../../../../shared/session-persistence'
 import { sessionPdfBindingToFileReference } from '../../../../shared/session-pdf-context'
 import {
@@ -82,6 +83,80 @@ export const createPreviewFileItem = ({
   if (originSession) item.originSession = originSession
 
   return item
+}
+
+// Builds the metadata-only lookup used before a managed preview retry. A restored upload keeps its
+// stable `upload:` tab id, while Artifact ids may need the main process's scoped filename fallback.
+export const createProjectFileResolveRequest = (
+  item: PreviewFileItem,
+  projectId: string | undefined
+): ResolveProjectFileRequest | undefined => {
+  const source = item.source ?? 'artifact'
+  if (!projectId || (source !== 'artifact' && source !== 'upload')) return undefined
+
+  const artifactLocator = source === 'artifact' ? parseArtifactVersionLocator(item.path) : undefined
+  const uploadLocator = source === 'upload' ? parseUploadVersionReference(item.path) : undefined
+  const uploadTabId = source === 'upload' && item.id.startsWith('upload:') ? item.id.slice(7) : ''
+  const logicalFileId =
+    source === 'artifact'
+      ? (item.managedFileId ?? item.artifactId ?? artifactLocator?.artifactId)
+      : (item.managedFileId ?? uploadLocator?.fileId ?? uploadTabId)
+  const fileIdHint = logicalFileId || item.id
+  // Old persisted Artifacts may have used their physical path as the display name. The database
+  // compatibility lookup is scoped by filename, so strip either POSIX or Windows directories.
+  const name =
+    source === 'artifact' && !logicalFileId
+      ? item.name.split(/[\\/]/u).at(-1) || item.name
+      : item.name
+
+  return {
+    projectId,
+    sessionId: item.sessionId,
+    source,
+    ...(fileIdHint ? { fileIdHint } : {}),
+    identityHint: logicalFileId ? 'logical' : 'legacy',
+    name
+  }
+}
+
+// Replaces a stale physical projection with the catalog's logical identity. Explicit history
+// selections stay pinned; an ordinary tab continues following the database head returned here.
+export const refreshPreviewFileItemFromProjectFile = (
+  item: PreviewFileItem,
+  file: ProjectFileItem
+): PreviewFileItem => {
+  const selectedVersionId = item.selectedVersionId
+  const path = selectedVersionId
+    ? file.source === 'artifact'
+      ? createArtifactVersionLocator({
+          projectId: file.projectId,
+          appSessionId: file.sessionId,
+          artifactId: file.sourceFileId,
+          versionId: selectedVersionId
+        })
+      : createUploadVersionReference(selectedVersionId, {
+          projectId: file.projectId,
+          sessionId: file.sessionId,
+          fileId: file.sourceFileId
+        })
+    : file.path
+
+  return createPreviewFileItem({
+    id: item.id,
+    projectId: file.projectId,
+    sessionId: file.sessionId,
+    path,
+    name: file.name,
+    mimeType: file.mimeType,
+    source: file.source === 'upload' ? 'upload' : undefined,
+    size: file.size,
+    mtimeMs: file.mtimeMs,
+    artifactId: file.source === 'artifact' ? file.sourceFileId : undefined,
+    managedFileId: file.sourceFileId,
+    selectedVersionId,
+    versionNumber: selectedVersionId ? item.versionNumber : undefined,
+    originSession: file.originSession
+  })
 }
 
 // Converts app-managed generated files into preview tabs and ignores unmanaged artifacts.

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act } from 'react'
+import { act, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -283,6 +283,7 @@ describe('PreviewFileContent', () => {
     item: PreviewFileItem,
     options: Omit<PreviewFileRendererProps, 'item'> & {
       downloadVersionContext?: PreviewDownloadVersionContext
+      onRetry?: () => Promise<void>
     } = {}
   ): Promise<void> => {
     root = createRoot(container)
@@ -441,6 +442,103 @@ describe('PreviewFileContent', () => {
 
     await vi.waitFor(() => expect(container.textContent).toContain('recovered preview'))
     expect(window.api.artifacts.readPreview).toHaveBeenCalledTimes(2)
+    consoleError.mockRestore()
+  })
+
+  it('waits for managed logical identity refresh before restarting a failed preview', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let finishIdentityRefresh: (() => void) | undefined
+    const onRetry = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishIdentityRefresh = resolve
+        })
+    )
+    vi.mocked(window.api.artifacts.readPreview)
+      .mockRejectedValueOnce(new Error('stale managed identity'))
+      .mockResolvedValueOnce({
+        content: 'logical preview',
+        encoding: 'utf8',
+        size: 15,
+        truncated: false
+      })
+
+    await renderFile(createFileItem({ format: 'text', name: 'notes.txt' }), { onRetry })
+    await vi.waitFor(() => expect(container.textContent).toContain("File couldn't be read"))
+    const retry = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Retry'
+    )
+
+    await act(async () => {
+      retry?.click()
+      retry?.click()
+      await Promise.resolve()
+    })
+
+    expect(onRetry).toHaveBeenCalledOnce()
+    expect(window.api.artifacts.readPreview).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      finishIdentityRefresh?.()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await vi.waitFor(() => expect(container.textContent).toContain('logical preview'))
+    expect(window.api.artifacts.readPreview).toHaveBeenCalledTimes(2)
+    consoleError.mockRestore()
+  })
+
+  it('retries with the refreshed logical identity instead of the stale physical path', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const legacyItem = createFileItem({
+      managedFileId: undefined,
+      path: '/stale/notes.txt',
+      format: 'text',
+      name: 'notes.txt'
+    })
+    const canonicalItem = {
+      ...legacyItem,
+      managedFileId: 'canonical-artifact-id',
+      path: 'artifact-version:project-1/session-1/canonical-artifact-id/version-3'
+    }
+    vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
+      content: 'logical preview',
+      encoding: 'utf8',
+      size: 15,
+      truncated: false
+    })
+    const RetryHarness = (): React.JSX.Element => {
+      const [currentItem, setCurrentItem] = useState(legacyItem)
+      return (
+        <PreviewFileContent
+          item={currentItem}
+          onRetry={async () => setCurrentItem(canonicalItem)}
+        />
+      )
+    }
+
+    root = createRoot(container)
+    await act(async () => root.render(<RetryHarness />))
+    await vi.waitFor(() => expect(container.textContent).toContain("File couldn't be read"))
+    const retry = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Retry'
+    )
+
+    await act(async () => {
+      retry?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await vi.waitFor(() => expect(container.textContent).toContain('logical preview'))
+    expect(window.api.previewResources.acquire).toHaveBeenCalledOnce()
+    expect(window.api.previewResources.acquire).toHaveBeenCalledWith({
+      source: 'artifact',
+      projectId: 'project-1',
+      fileId: 'canonical-artifact-id',
+      maxBytes: expect.any(Number)
+    })
     consoleError.mockRestore()
   })
 

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.tsx
@@ -7,6 +7,7 @@ import type { PreviewFileRendererProps } from './preview-types'
 export const PreviewFileContent = ({
   item,
   downloadVersionContext,
+  onRetry,
   annotationVersionId,
   annotationBlockedByHistoricalVersion,
   annotationVersionPending,
@@ -20,6 +21,7 @@ export const PreviewFileContent = ({
   onPdfReadingPositionChange
 }: PreviewFileRendererProps & {
   downloadVersionContext?: PreviewDownloadVersionContext
+  onRetry?: () => Promise<void>
 }): React.JSX.Element => {
   const content = renderPreviewFile({
     item,
@@ -37,7 +39,11 @@ export const PreviewFileContent = ({
   })
 
   return (
-    <PreviewRuntimeBoundary item={item} downloadVersionContext={downloadVersionContext}>
+    <PreviewRuntimeBoundary
+      item={item}
+      downloadVersionContext={downloadVersionContext}
+      onRetry={onRetry}
+    >
       {content ?? (
         <PreviewUnsupportedContent
           path={item.path}

--- a/src/renderer/src/pages/workspace/previews/preview-runtime.tsx
+++ b/src/renderer/src/pages/workspace/previews/preview-runtime.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useMemo, useState } from 'react'
+import { Fragment, useCallback, useMemo, useRef, useState } from 'react'
 
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 
@@ -10,14 +10,34 @@ import type { PreviewDownloadVersionContext } from './preview-runtime-context'
 const PreviewAttemptBoundary = ({
   item,
   downloadVersionContext,
+  onRetry,
   children
 }: {
   item: PreviewFileItem
   downloadVersionContext?: PreviewDownloadVersionContext
+  onRetry?: () => Promise<void>
   children: React.ReactNode
 }): React.JSX.Element => {
   const [attempt, setAttempt] = useState(0)
-  const retry = useCallback(() => setAttempt((current) => current + 1), [])
+  const retryPendingRef = useRef(false)
+  const retry = useCallback(() => {
+    if (retryPendingRef.current) return
+    const restart = (): void => setAttempt((current) => current + 1)
+    if (!onRetry) {
+      restart()
+      return
+    }
+    retryPendingRef.current = true
+    // Managed retries refresh their logical identity first. A lookup failure still remounts the
+    // renderer so transient read errors retain the existing retry behavior.
+    void Promise.resolve()
+      .then(onRetry)
+      .catch(() => undefined)
+      .finally(() => {
+        retryPendingRef.current = false
+        restart()
+      })
+  }, [onRetry])
   const runtime = useMemo(
     () => ({ attempt, item, retry, downloadVersionContext }),
     [attempt, downloadVersionContext, item, retry]
@@ -34,10 +54,12 @@ const PreviewAttemptBoundary = ({
 const PreviewRuntimeBoundary = ({
   item,
   downloadVersionContext,
+  onRetry,
   children
 }: {
   item: PreviewFileItem
   downloadVersionContext?: PreviewDownloadVersionContext
+  onRetry?: () => Promise<void>
   children: React.ReactNode
 }): React.JSX.Element => {
   const resourceKey = createPreviewResourceKey(item)
@@ -48,6 +70,7 @@ const PreviewRuntimeBoundary = ({
       key={boundaryKey}
       item={item}
       downloadVersionContext={downloadVersionContext}
+      onRetry={onRetry}
     >
       {children}
     </PreviewAttemptBoundary>

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -57,6 +57,17 @@ export type ProjectFilesPage = {
   totalCount: number
 }
 
+// Compatibility lookup for a restored preview tab. Hints identify metadata only; callers still
+// read file bytes through the returned logical sourceFileId/sourceVersionId pair.
+export type ResolveProjectFileRequest = {
+  projectId: string
+  sessionId: string
+  source: ProjectFileSource
+  fileIdHint?: string
+  identityHint: 'logical' | 'legacy'
+  name: string
+}
+
 // Bounded global-search projection. The primary Project is independently paged; Other Projects
 // deliberately return only a small combined sample so the command palette remains responsive.
 export type SearchArtifactsRequest = {

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -237,9 +237,11 @@ import type {
   GetProjectFilesOverviewRequest,
   ListArtifactGroupsRequest,
   ListProjectFilesRequest,
+  ProjectFileItem,
   ProjectFilesChangedEvent,
   ProjectFilesOverview,
   ProjectFilesPage,
+  ResolveProjectFileRequest,
   SearchArtifactsRequest,
   SearchArtifactsResult
 } from './project-files'
@@ -1302,6 +1304,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'projectFiles.listFiles': callable<
     (request: ListProjectFilesRequest) => Promise<ProjectFilesPage>
   >()('project-files', ['project-files:list-files']),
+  'projectFiles.resolveFile': callable<
+    (request: ResolveProjectFileRequest) => Promise<ProjectFileItem | undefined>
+  >()('project-files', ['project-files:resolve-file']),
   'projectFiles.onChanged': callable<
     (listener: AcpListener<ProjectFilesChangedEvent>) => RemoveListener
   >()('project-files', ['project-files:changed', EVENT]),

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -130,6 +130,7 @@ export const WEB_INVOKE_CHANNELS = {
   'projectFiles.listArtifactGroups': 'project-files:list-artifact-groups',
   'projectFiles.listFiles': 'project-files:list-files',
   'projectFiles.repairIndex': 'project-files:repair-index',
+  'projectFiles.resolveFile': 'project-files:resolve-file',
   'projectFiles.searchArtifacts': 'project-files:search-artifacts',
   'projects.create': 'projects:create',
   'projects.delete': 'projects:delete',


### PR DESCRIPTION
## Summary

- Re-resolve managed Artifact and Upload metadata through Project Files before a failed preview retries.
- Recover pre-logical-path Artifact tabs with a project-, session-, and normalized-filename Prisma lookup, including records whose display name fell back to a physical path.
- Refresh the existing stable preview tab with the canonical logical locator while preserving explicit history selections and following the database head for ordinary previews.
- Reject stale retry results after unmount, close and reopen, or identity and version transitions.

## Highlights

- Retry can reopen managed files that were already open before logical-path-only reads were enforced.
- Legacy Artifact ID collisions resolve to the lineage owned by the original project and session.
- Rapid close and reopen or A to B to A version transitions cannot apply an obsolete lookup result.

## Impact

- Adds the typed Project Files resolve contract across repository, IPC, application commands, preload, and renderer.
- Uses existing ArtifactLineage and authoritative managed-file projections; there is no schema change or migration.
- Does not restore path-only byte reads. Physical paths are used only to derive a legacy filename metadata hint.
- Upload logical identity, stable tab identity, and explicit historical version behavior remain unchanged.

## Test Results

- TDD regression: the missing-name legacy path test failed before basename normalization and passed after the fix.
- TDD race regressions: retained close to reopen and A to B to A tests failed with the reversible context key and passed with monotonic generations.
- `npx vitest run src/main/project-files/repository.test.ts src/main/project-files/ipc.test.ts src/main/data-content-application-commands.test.ts src/renderer/src/pages/workspace/preview-file-item.test.ts src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx src/preload/index.test.ts` - 8 files, 363 tests passed on the final rebased head.
- `npm run typecheck` - passed.
- `npm run lint` - passed.
- `npm run check:web-api-map` - passed.
- `git diff --check upstream/main..HEAD` - passed.
- Independent pre-merge review - Ready to merge, no Critical or Important findings after the race fix.

## Potential Issues

- A pre-final-rebase complete `npm test` run was not green: 23,582 tests passed and 5 failed. The Web bootstrap failure passed in isolation. The other four failures reproduced with identical assertions in a detached pure `upstream/main` worktree: one Windows kernel cancellation assertion, two Notebook network sandbox policy assertions, and the literature-review kernel running under system Python 3.9. PR Gate remains authoritative for the final head.
- No packaged Electron E2E was run locally for this metadata recovery path.

## Authors

- @roxi3906
