### PR TITLE
ci(dependabot): disable npm version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,5 @@
 version: 2
 updates:
-  # Track npm lockfile drift and open grouped update PRs weekly. Keeps transitive advisories moving
-  # while bounding routine update noise.
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 2
-    commit-message:
-      prefix: 'build(dependencies): update'
-    pull-request-branch-name:
-      prefix: build
-      template: '{prefix}/{group_name}'
-      branch-name-case: lowercase
-    groups:
-      npm-security-updates:
-        applies-to: security-updates
-        patterns:
-          - '*'
-      npm-production-dependencies:
-        applies-to: version-updates
-        dependency-type: production
-        patterns:
-          - '*'
-      npm-development-dependencies:
-        applies-to: version-updates
-        dependency-type: development
-        patterns:
-          - '*'
-
   # Keep the GitHub Actions used by the workflows current (checkout, setup-node, upload-artifact, ...).
   - package-ecosystem: github-actions
     directory: /

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -289,7 +289,7 @@ describe('PR Gate workflow', () => {
     })
   })
 
-  it('keeps Dependabot pull requests compatible with repository branch and title policy', () => {
+  it('disables npm updates while keeping GitHub Actions updates policy-compatible', () => {
     const npm = dependabot.updates.find(
       (update) => update['package-ecosystem'] === 'npm' && update.directory === '/'
     )
@@ -297,31 +297,7 @@ describe('PR Gate workflow', () => {
       (update) => update['package-ecosystem'] === 'github-actions' && update.directory === '/'
     )
 
-    expect(npm).toMatchObject({
-      'commit-message': { prefix: 'build(dependencies): update' },
-      'open-pull-requests-limit': 2,
-      'pull-request-branch-name': {
-        'branch-name-case': 'lowercase',
-        prefix: 'build',
-        template: '{prefix}/{group_name}'
-      },
-      groups: {
-        'npm-development-dependencies': {
-          'applies-to': 'version-updates',
-          'dependency-type': 'development',
-          patterns: ['*']
-        },
-        'npm-production-dependencies': {
-          'applies-to': 'version-updates',
-          'dependency-type': 'production',
-          patterns: ['*']
-        },
-        'npm-security-updates': {
-          'applies-to': 'security-updates',
-          patterns: ['*']
-        }
-      }
-    })
+    expect(npm).toBeUndefined()
     expect(actions).toMatchObject({
       'commit-message': { prefix: 'ci(dependencies): update' },
       'open-pull-requests-limit': 2,


### PR DESCRIPTION
## Problem

Dependabot npm version updates can group incompatible major upgrades into one pull request. PR #2109 demonstrates this by combining Prisma, i18next, parse5, pdfjs, and other major updates; its generated dependency set cannot be safely merged and consumes the full PR Gate matrix.

## Proposed change

- remove the npm ecosystem from `.github/dependabot.yml`;
- keep automated GitHub Actions updates unchanged;
- keep the PR Gate Dependency Review vulnerability regression check unchanged;
- add a contract assertion that npm updates remain disabled.

## Scope and non-goals

- No application code or dependency versions change.
- No historical-data compatibility impact.
- No new or changed enum/state values.
- No data persistence or migration impact.
- This does not remove Dependency Review or GitHub Actions update automation.

## Acceptance criteria and validation

All listed local checks ran after the last material edit:

- Dependabot policy and PR Gate contract -> `npx vitest run scripts/ci/pr-gate-workflow.test.ts scripts/ci/ci-integrity-workflow.test.ts` -> 2 files, 30 tests passed.
- Changed test lint -> `npx eslint scripts/ci/pr-gate-workflow.test.ts` -> passed.
- Formatting -> `npx prettier --check .github/dependabot.yml scripts/ci/pr-gate-workflow.test.ts` -> passed.
- Diff hygiene -> `git diff --check` -> passed.
- Impact selection -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> full plan because the CI contract test is a global gate input.

Per maintainer direction, the complete local `npm test` was not run; required PR CI is authoritative for the full suite and platform lanes.

## Review focus

Confirm that only npm Dependabot updates are disabled while GitHub Actions updates and Dependency Review remain intact.
