### PR TITLE
fix(pdf-context): route follow-up PDF uploads into Reading

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -3157,6 +3157,119 @@ describe('workspace agent message sending', () => {
     ])
   })
 
+  it('limits eligible follow-up PDFs to the remaining Reading capacity', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Existing prompt',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+    const binding = (index: number): SessionPdfContext['bindings'][number] => ({
+      version: 1,
+      bindingId: `binding-${index}`,
+      sourceKind: 'upload-version',
+      sourceFileId: `pdf-upload-${index}`,
+      sourceVersionId: `pdf-version-${index}`,
+      sourceSessionId: 'transport-session-1',
+      name: `paper-${index}.pdf`,
+      mimeType: 'application/pdf',
+      sizeBytes: 42,
+      checksum: String(index).repeat(64),
+      linkedAt: index
+    })
+    const existingContext: SessionPdfContext = {
+      version: 1,
+      bindings: [binding(1), binding(2)]
+    }
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        runtimeContext: { version: 1, revision: 2, pdfContext: existingContext }
+      }))
+    }))
+    const stagedPdf = createAttachment({
+      id: 'pdf-upload-3',
+      name: 'staged-paper.pdf',
+      originalName: 'staged-paper.pdf',
+      path: '/uploads/.pending/staged-paper.pdf',
+      mimeType: 'application/pdf'
+    })
+    const finalizedPdf = createAttachment({
+      ...stagedPdf,
+      sessionId: 'transport-session-1',
+      path: 'upload-version:project-1/transport-session-1/pdf-version-3',
+      versionId: 'pdf-version-3',
+      versionNumber: 1,
+      checksum: '3'.repeat(64)
+    })
+    const linkedContext: SessionPdfContext = {
+      version: 1,
+      bindings: [...existingContext.bindings, binding(3)]
+    }
+    const linkPdfContext = vi.fn().mockResolvedValue({
+      version: 1,
+      revision: 3,
+      pdfContext: linkedContext
+    })
+    vi.stubGlobal('window', {
+      api: {
+        uploads: { finalizeSession: vi.fn().mockResolvedValue([finalizedPdf]) },
+        sessions: {
+          linkPdfContext,
+          saveSession: vi.fn(async (session: PersistedChatSession) => session),
+          filterPdfContextCandidates: vi.fn().mockResolvedValue({
+            sources: [
+              {
+                sourceKind: 'artifact-version',
+                sourceFileId: 'artifact-4',
+                sourceVersionId: 'artifact-version-4'
+              }
+            ],
+            pendingAttachmentIds: [stagedPdf.id]
+          })
+        }
+      }
+    })
+    const runtime = {
+      state: createSnapshot(['transport-session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'Compare these papers',
+      attachments: [stagedPdf],
+      pendingPdfContextAttachmentIds: [stagedPdf.id],
+      pendingPdfContextVersions: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'artifact-4',
+          sourceVersionId: 'artifact-version-4'
+        }
+      ],
+      pdfContext: existingContext,
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+
+    await vi.waitFor(() => expect(runtime.sendPrompt).toHaveBeenCalledOnce())
+    expect(linkPdfContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sources: [
+          {
+            sourceKind: 'upload-version',
+            sourceFileId: stagedPdf.id,
+            sourceVersionId: finalizedPdf.versionId
+          }
+        ]
+      })
+    )
+  })
+
   it('keeps an ineligible follow-up PDF as an ordinary attachment', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -3157,6 +3157,87 @@ describe('workspace agent message sending', () => {
     ])
   })
 
+  it('keeps an ineligible follow-up PDF as an ordinary attachment', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Existing prompt',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+    const stagedPdf = createAttachment({
+      id: 'oversized-pdf',
+      name: 'oversized.pdf',
+      originalName: 'oversized.pdf',
+      path: '/uploads/.pending/oversized.pdf',
+      mimeType: 'application/pdf',
+      size: 50 * 1024 * 1024 + 1
+    })
+    const finalizedPdf = createAttachment({
+      ...stagedPdf,
+      sessionId: 'transport-session-1',
+      path: 'upload-version:project-1/transport-session-1/oversized-version',
+      versionId: 'oversized-version',
+      versionNumber: 1,
+      checksum: 'a'.repeat(64)
+    })
+    const filterPdfContextCandidates = vi.fn().mockResolvedValue({
+      sources: [],
+      pendingAttachmentIds: []
+    })
+    const linkPdfContext = vi
+      .fn()
+      .mockRejectedValue(new Error('PDF context files must be 50 MB or smaller.'))
+    vi.stubGlobal('window', {
+      api: {
+        uploads: { finalizeSession: vi.fn().mockResolvedValue([finalizedPdf]) },
+        sessions: {
+          filterPdfContextCandidates,
+          linkPdfContext,
+          saveSession: vi.fn(async (session: PersistedChatSession) => session)
+        }
+      }
+    })
+    const runtime = {
+      state: createSnapshot(['transport-session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+    }
+
+    const sent = await sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'Keep this available as an attachment',
+      attachments: [stagedPdf],
+      pendingPdfContextAttachmentIds: [stagedPdf.id],
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+
+    expect(sent).toBeDefined()
+    expect(filterPdfContextCandidates).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      sources: [],
+      pendingAttachments: [
+        {
+          attachmentId: stagedPdf.id,
+          path: stagedPdf.path,
+          name: stagedPdf.name,
+          mimeType: stagedPdf.mimeType
+        }
+      ]
+    })
+    expect(linkPdfContext).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(runtime.sendPrompt).toHaveBeenCalledOnce())
+    expect(runtime.sendPrompt.mock.calls[0]?.[2]).toEqual([
+      expect.objectContaining({
+        id: stagedPdf.id,
+        versionId: finalizedPdf.versionId
+      })
+    ])
+  })
+
   it('does not append a prompt when attachment finalization fails', async () => {
     const attachment = createAttachment()
     useSessionStore.getState().appendUserMessage({

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -5,6 +5,7 @@ import { withPdfContext as withPdf } from '../../../../shared/session-pdf-contex
 import type { ActivePlanProjection } from '../../../../shared/session-plan/contract'
 import {
   collectSessionReferences,
+  MAX_SESSION_PDF_CONTEXTS,
   type DelegationPolicy,
   type MessageAttribution,
   type MessagePdfContextSnapshot,
@@ -584,7 +585,7 @@ const startPendingPrompt = (
           attachments
         }),
         ...eligiblePendingPdfContext.versions
-      ]
+      ].slice(0, Math.max(0, MAX_SESSION_PDF_CONTEXTS - (pdfContext?.bindings.length ?? 0)))
       if (pdfContextSources.length > 0) {
         pdfContext = await linkPdfContextForSend({
           sessionId: created.sessionId,
@@ -922,7 +923,7 @@ const sendWorkspaceMessage = async (
           attachments: promptAttachments
         }),
         ...eligiblePendingPdfContext.versions
-      ]
+      ].slice(0, Math.max(0, MAX_SESSION_PDF_CONTEXTS - (pdfContext?.bindings.length ?? 0)))
       if (pdfContextSources.length > 0) {
         pdfContext = await linkPdfContextForSend({
           sessionId,

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -904,6 +904,12 @@ const sendWorkspaceMessage = async (
     if (!prepared) return undefined
     let promptAttachments
     try {
+      const eligiblePendingPdfContext = await filterPendingPdfContext({
+        attachments: effectiveAttachments,
+        pendingPdfContextAttachmentIds: input.pendingPdfContextAttachmentIds,
+        pendingPdfContextVersions: input.pendingPdfContextVersions,
+        projectId
+      })
       promptAttachments = await finalizeWorkspaceAttachments({
         sessionId,
         attachments: effectiveAttachments,
@@ -912,10 +918,10 @@ const sendWorkspaceMessage = async (
       })
       const pdfContextSources = [
         ...finalizedPdfContextSources({
-          attachmentIds: input.pendingPdfContextAttachmentIds ?? [],
+          attachmentIds: eligiblePendingPdfContext.attachmentIds,
           attachments: promptAttachments
         }),
-        ...(input.pendingPdfContextVersions ?? [])
+        ...eligiblePendingPdfContext.versions
       ]
       if (pdfContextSources.length > 0) {
         pdfContext = await linkPdfContextForSend({
@@ -928,7 +934,8 @@ const sendWorkspaceMessage = async (
       }
       if (
         pdfContext &&
-        (input.pendingPdfContextAttachmentIds?.length || input.pendingPdfContextVersions?.length)
+        (eligiblePendingPdfContext.attachmentIds.length > 0 ||
+          eligiblePendingPdfContext.versions.length > 0)
       ) {
         lifecycle.onPdfContextLinked?.(sessionId, pdfContext)
       }

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -997,6 +997,55 @@ describe('ConversationPanel composer intake', () => {
     expect(container.textContent).toContain('paper.pdf')
   })
 
+  it('shows automatic Reading follow-ups alongside linked PDF context', () => {
+    const dismissAutomaticReading = vi.fn()
+    renderPanel({
+      view: {
+        activeSession: {
+          id: 'session-1',
+          projectId: 'project-1',
+          title: 'Reading session',
+          cwd: '/workspace',
+          status: 'idle',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      },
+      composer: {
+        view: {
+          readingContext: {
+            bindings: [
+              {
+                version: 1,
+                bindingId: 'binding-1',
+                sourceKind: 'artifact-version',
+                sourceFileId: 'artifact-1',
+                sourceVersionId: 'version-1',
+                sourceSessionId: 'source-session',
+                name: 'first.pdf',
+                mimeType: 'application/pdf',
+                sizeBytes: 12,
+                checksum: 'checksum-1',
+                linkedAt: 1
+              }
+            ],
+            automaticAttachmentCount: 1
+          }
+        },
+        actions: { dismissAutomaticReading }
+      }
+    })
+
+    expect(container.querySelector('[data-testid="pdf-context-bar"]')).not.toBeNull()
+    const suggestion = container.querySelector('[data-testid="automatic-reading-suggestion"]')
+    expect(suggestion?.textContent).toContain('1 PDF will be linked when sent')
+    act(() =>
+      suggestion?.querySelector<HTMLButtonElement>('[aria-label="Keep as attachments"]')?.click()
+    )
+    expect(dismissAutomaticReading).toHaveBeenCalledOnce()
+  })
+
   it('shows linked PDF context as a single-line chip that opens its preview', () => {
     const open = vi.fn()
     const unlink = vi.fn()

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1665,10 +1665,14 @@ const ConversationPanel = ({
                           </TooltipProvider>
                         </div>
                       </div>
-                    ) : pdfContext.automaticAttachmentCount > 0 ? (
+                    ) : null}
+                    {pdfContext.automaticAttachmentCount > 0 ? (
                       <div
                         data-testid="automatic-reading-suggestion"
-                        className="-mx-3 -mt-2 flex min-h-9 items-center gap-2 rounded-t-2xl border-b border-border-200 bg-primary/[0.05] px-2 py-1"
+                        className={cn(
+                          '-mx-3 flex min-h-9 items-center gap-2 border-b border-border-200 bg-primary/[0.05] px-2 py-1',
+                          pdfContext.bindings.length === 0 && '-mt-2 rounded-t-2xl'
+                        )}
                       >
                         <Link2
                           className="size-4 shrink-0 text-primary"

--- a/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx
@@ -532,6 +532,70 @@ describe('WorkspacePage image attachment gating', () => {
     expect(usePreviewWorkbenchStore.getState().items).toEqual([])
   })
 
+  it('routes a follow-up PDF into Reading when the active Session already has PDF context', async () => {
+    setActiveProviderImageSupport(false)
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        createSession({
+          runtimeContext: {
+            version: 1,
+            revision: 1,
+            pdfContext: {
+              version: 1,
+              bindings: [
+                {
+                  version: 1,
+                  bindingId: 'binding-1',
+                  sourceKind: 'upload-version',
+                  sourceFileId: 'pdf-1',
+                  sourceVersionId: 'pdf-version-1',
+                  sourceSessionId: 'sess-a',
+                  name: 'first.pdf',
+                  mimeType: 'application/pdf',
+                  sizeBytes: 3,
+                  checksum: 'a'.repeat(64),
+                  linkedAt: 1
+                }
+              ]
+            }
+          }
+        })
+      ],
+      selectedSessionId: 'sess-a'
+    })
+    const staged = {
+      id: 'pdf-2',
+      sessionId: '.pending',
+      name: 'second.pdf',
+      originalName: 'second.pdf',
+      path: '/uploads/.pending/second.pdf',
+      mimeType: 'application/pdf',
+      size: 3
+    } satisfies UploadedAttachment
+    stageLocalFile.mockResolvedValueOnce(staged)
+    runtime.sendMessage.mockResolvedValue({ sessionId: 'sess-a' })
+
+    await renderPage()
+    await act(async () => {
+      conversationProps.composer.actions.stageFiles([pdfFile('second.pdf')])
+    })
+    await act(async () => {
+      await vi.waitFor(() => expect(conversationProps.composer.view.attachments).toEqual([staged]))
+    })
+    await act(async () => {
+      conversationProps.conversation.actions.submit.draft({ forcedSkillIds: [] })
+    })
+    await act(async () => {
+      await vi.waitFor(() => expect(runtime.sendMessage).toHaveBeenCalledOnce())
+    })
+
+    expect(runtime.sendMessage.mock.calls[0][0]).toMatchObject({
+      attachments: [staged],
+      pendingPdfContextAttachmentIds: ['pdf-2']
+    })
+  })
+
   it('allows explicitly linking a staged PDF from the preview surface', async () => {
     setActiveProviderImageSupport(false)
     useSessionStore.setState(createInitialSessionState())

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import type { TextAnnotation } from '../../../../shared/annotations'
+import type { SessionPdfContext } from '../../../../shared/session-persistence'
 import type { CustomizePrefillIntent } from '@/stores/navigation-store'
 import {
   createInitialPreviewWorkbenchState,
@@ -711,6 +712,73 @@ describe('workspace composer controller', () => {
     const snapshot = hook.result.current.lifecycle.captureSend(false)
     expect(snapshot).not.toHaveProperty('pdfContext')
     expect(snapshot.pendingPdfContextAttachmentIds).toEqual([staged.id])
+  })
+
+  it('does not let an unverified automatic PDF displace an immutable Reading candidate', async () => {
+    const staged = {
+      id: 'upload-pdf-3',
+      sessionId: '.pending',
+      name: 'unverified.pdf',
+      originalName: 'unverified.pdf',
+      path: '/uploads/.pending/unverified.pdf',
+      mimeType: 'application/pdf',
+      size: 3
+    } satisfies UploadedAttachment
+    const binding = (index: number): SessionPdfContext['bindings'][number] => ({
+      version: 1 as const,
+      bindingId: `binding-${index}`,
+      sourceKind: 'upload-version' as const,
+      sourceFileId: `upload-pdf-${index}`,
+      sourceVersionId: `version-${index}`,
+      sourceSessionId: 'session-a',
+      name: `paper-${index}.pdf`,
+      mimeType: 'application/pdf' as const,
+      sizeBytes: 3,
+      checksum: String(index).repeat(64),
+      linkedAt: index
+    })
+    const hook = renderController(uploads(vi.fn().mockResolvedValue(staged)), undefined, [], {
+      id: 'session-a',
+      projectId: 'project',
+      runtimeContext: {
+        revision: 1,
+        pdfContext: { version: 1, bindings: [binding(1), binding(2)] }
+      }
+    })
+    mounted.push(hook)
+
+    act(() => {
+      hook.result.current.actions.stageFiles([
+        new File(['pdf'], staged.name, { type: staged.mimeType })
+      ])
+      hook.result.current.actions.changeDoc({
+        nodes: [
+          { type: 'text', text: 'Compare with ' },
+          {
+            type: 'artifact',
+            id: 'paper-3',
+            name: 'paper-3.pdf',
+            path: '/paper-3.pdf',
+            source: 'artifact',
+            sourceFileId: 'paper-3',
+            mimeType: 'application/pdf',
+            versionId: 'version-3'
+          }
+        ]
+      })
+    })
+    await flushAsyncWork()
+
+    expect(hook.result.current.lifecycle.captureSend()).toMatchObject({
+      pendingPdfContextAttachmentIds: [staged.id],
+      pendingPdfContextVersions: [
+        {
+          sourceKind: 'artifact-version',
+          sourceFileId: 'paper-3',
+          sourceVersionId: 'version-3'
+        }
+      ]
+    })
   })
 
   it('adds an immutable PDF mentioned with @ as a send-time Reading candidate', () => {

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -663,6 +663,56 @@ describe('workspace composer controller', () => {
     ).toBeUndefined()
   })
 
+  it('keeps automatic staged Reading when a branch excludes inherited context', async () => {
+    const staged = {
+      id: 'upload-pdf-2',
+      sessionId: '.pending',
+      name: 'follow-up.pdf',
+      originalName: 'follow-up.pdf',
+      path: '/uploads/.pending/follow-up.pdf',
+      mimeType: 'application/pdf',
+      size: 3
+    } satisfies UploadedAttachment
+    const hook = renderController(uploads(vi.fn().mockResolvedValue(staged)), undefined, [], {
+      id: 'session-a',
+      projectId: 'project',
+      runtimeContext: {
+        revision: 1,
+        pdfContext: {
+          version: 1,
+          bindings: [
+            {
+              version: 1,
+              bindingId: 'binding-1',
+              sourceKind: 'upload-version',
+              sourceFileId: 'upload-pdf-1',
+              sourceVersionId: 'version-1',
+              sourceSessionId: 'session-a',
+              name: 'first.pdf',
+              mimeType: 'application/pdf',
+              sizeBytes: 3,
+              checksum: 'a'.repeat(64),
+              linkedAt: 1
+            }
+          ]
+        }
+      }
+    })
+    mounted.push(hook)
+
+    act(() =>
+      hook.result.current.actions.stageFiles([
+        new File(['pdf'], staged.name, { type: staged.mimeType })
+      ])
+    )
+    await flushAsyncWork()
+
+    expect(hook.result.current.view.readingContext.automaticAttachmentCount).toBe(1)
+    const snapshot = hook.result.current.lifecycle.captureSend(false)
+    expect(snapshot).not.toHaveProperty('pdfContext')
+    expect(snapshot.pendingPdfContextAttachmentIds).toEqual([staged.id])
+  })
+
   it('adds an immutable PDF mentioned with @ as a send-time Reading candidate', () => {
     const hook = renderController()
     mounted.push(hook)

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -313,11 +313,11 @@ const useWorkspaceComposerController = ({
       : undefined
   const automaticStagedReadingContexts = useMemo(
     () =>
-      !activeSession &&
+      (!activeSession || durableReadingBindings.length > 0) &&
       !pendingPdfContextSelection &&
       transfers.length === 0 &&
       attachments.length >= 1 &&
-      attachments.length <= 3 &&
+      attachments.length <= MAX_SESSION_PDF_CONTEXTS - durableReadingBindings.length &&
       attachments.every(
         (attachment) =>
           getPreviewFormatForFile({ name: attachment.name, mimeType: attachment.mimeType }) ===
@@ -325,7 +325,13 @@ const useWorkspaceComposerController = ({
       )
         ? attachments
         : [],
-    [activeSession, attachments, pendingPdfContextSelection, transfers.length]
+    [
+      activeSession,
+      attachments,
+      durableReadingBindings.length,
+      pendingPdfContextSelection,
+      transfers.length
+    ]
   )
   const versionReadingContextItem = usePreviewWorkbenchStore((state) => {
     if (pendingPdfContextSelection?.kind !== 'version') return undefined

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -947,15 +947,7 @@ const useWorkspaceComposerController = ({
           occupied.add(identity)
           return true
         })
-        .slice(
-          0,
-          Math.max(
-            0,
-            MAX_SESSION_PDF_CONTEXTS -
-              includedDurableBindings.length -
-              pendingPdfContextAttachmentIds.length
-          )
-        )
+        .slice(0, Math.max(0, MAX_SESSION_PDF_CONTEXTS - includedDurableBindings.length))
       return {
         draftKey: activeDraftKeyRef.current,
         version: versionsRef.current[activeDraftKeyRef.current] ?? 0,

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -917,13 +917,11 @@ const useWorkspaceComposerController = ({
     (includeReadingContext = true): ComposerSendSnapshot => {
       clearPastedTextUndo()
       clearUndo()
-      const pendingPdfContextAttachmentIds = includeReadingContext
-        ? stagedReadingContext
-          ? [stagedReadingContext.id]
-          : automaticReadingEnabledRef.current
-            ? automaticStagedReadingContexts.map(({ id }) => id)
-            : []
-        : []
+      const pendingPdfContextAttachmentIds = stagedReadingContext
+        ? [stagedReadingContext.id]
+        : automaticReadingEnabledRef.current
+          ? automaticStagedReadingContexts.map(({ id }) => id)
+          : []
       const includedDurableBindings = includeReadingContext ? durableReadingBindings : []
       const occupied = new Set(
         includedDurableBindings.map(


### PR DESCRIPTION
## Problem

After a conversation has already entered PDF Reading, uploading another PDF leaves the follow-up file as a generic attachment. The composer excludes every active Session from automatic Reading intake, so the send request omits the staged upload from `pendingPdfContextAttachmentIds` and the literature reader cannot index it for comparison.

## Proposed change

- Allow automatic staged-PDF Reading intake when the active Session already has durable PDF context.
- Preserve the existing behavior for active Sessions without Reading context.
- Respect the remaining three-document Reading limit instead of using an independent attachment count.
- Add a WorkspacePage boundary regression test for uploading a second PDF into an existing Reading Session.

## Scope and non-goals

- No schema, persisted-format, data-model, enum, or i18n changes.
- No immediate pending Reading chip or attachment-display redesign; the upload becomes a durable Reading binding when sent.
- No partial automatic selection for mixed batches or batches larger than the remaining Reading capacity.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Follow-up PDF routing -> targeted WorkspacePage regression test -> passed; before the fix it failed twice with `pendingPdfContextAttachmentIds` received as `undefined` instead of `["pdf-2"]`.
- Workspace Page owner and contracts -> `npm run test:module -- workspace_page` -> 30 files, 748 tests passed.
- Composer neighboring behavior -> `npm test -- src/renderer/src/pages/workspace/workspace-composer-controller.test.ts` -> 61 tests passed.
- Follow-up upload finalization and durable PDF-context linking -> targeted `useWorkspaceAgentRuntime.test.ts` case -> passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.
- Final impact explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> selected only `workspace_page` plus its `renderer_state` overlay; this exactly matches the executed module suite.

The changed implementation remains inside the `workspace_page` owner module and does not change its public interface. No platform, database, migration, or persistence lane is implicated. Full portable and platform coverage remains with PR CI.

## Review focus

Please verify that extending automatic Reading only for Sessions with an existing durable PDF binding is the intended boundary, and that all-or-nothing intake when the remaining capacity is insufficient remains appropriately conservative.
