### PR TITLE
fix(session-plan): verify plan read-back through unpublished version read

### DIFF
--- a/src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
+++ b/src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
@@ -117,7 +117,7 @@ describe.runIf(process.platform === 'darwin' || process.platform === 'linux')(
           dataRoot: storageRoot,
           projectId,
           mcpEntryPath: '/mcp',
-          managedFileVersions: { openLatest, openVersion: vi.fn() }
+          managedFileVersions: { openLatest, openVersion: vi.fn(), openUnpublishedVersion: vi.fn() }
         },
         uploads: {
           repository: {

--- a/src/main/acp/runtime-base-composition.test.ts
+++ b/src/main/acp/runtime-base-composition.test.ts
@@ -101,7 +101,7 @@ describe('ACP Runtime base composition', () => {
         dataRoot: '/data',
         projectId: 'project-1',
         mcpEntryPath: '/mcp',
-        managedFileVersions: { openLatest, openVersion: vi.fn() }
+        managedFileVersions: { openLatest, openVersion: vi.fn(), openUnpublishedVersion: vi.fn() }
       },
       uploads: {
         repository: {

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -127,7 +127,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
   >
   managedFileVersions: Pick<
     import('../managed-file-versions/service').ManagedFileVersionService,
-    'openLatest' | 'openVersion'
+    'openLatest' | 'openVersion' | 'openUnpublishedVersion'
   >
   onSessionTurnStarted?: (sessionId: string, turnToken: string) => void
   onSessionTurnEnded?: (sessionId: string, turnToken: string) => void

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -26332,7 +26332,7 @@ describe('Specialist Skill scoping', () => {
         }
       }
     }
-    const openVersion = vi.fn(async () => {
+    const openUnpublishedVersion = vi.fn(async () => {
       const content = Buffer.from(serializedPlan)
       return {
         path: planPath,
@@ -26368,7 +26368,7 @@ describe('Specialist Skill scoping', () => {
         repository: new ArtifactRepository(root),
         runRegistry: new ArtifactRunRegistry(),
         provenance,
-        managedFileVersions: { openVersion } as never
+        managedFileVersions: { openUnpublishedVersion } as never
       },
       plan: {
         mcpEntryPath: '/unused',
@@ -26428,7 +26428,7 @@ describe('Specialist Skill scoping', () => {
           }
         })
       ).resolves.toMatchObject({ projection: { artifactVersionId: 'version-1' } })
-      expect(openVersion).toHaveBeenCalledWith(
+      expect(openUnpublishedVersion).toHaveBeenCalledWith(
         { source: 'artifact', projectId: 'project-1', fileId: 'artifact-1' },
         'version-1'
       )

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -323,7 +323,7 @@ type AcpRuntimeArtifactOptions = {
   >
   managedFileVersions?: Pick<
     import('../managed-file-versions/service').ManagedFileVersionService,
-    'openLatest' | 'openVersion'
+    'openLatest' | 'openVersion' | 'openUnpublishedVersion'
   >
 }
 

--- a/src/main/managed-file-versions/service.integration.test.ts
+++ b/src/main/managed-file-versions/service.integration.test.ts
@@ -2852,4 +2852,181 @@ describe('ManagedFileVersionService (SQLite + filesystem)', () => {
 
     await expect(service.auditActiveVersionIntegrity()).resolves.toEqual([])
   })
+
+  describe('openUnpublishedVersion', () => {
+    const createPendingAgentPlanFixture = async (): Promise<{
+      fileId: string
+      versionId: string
+      bytes: Buffer
+    }> => {
+      const fileId = 'plan-lineage-1'
+      const versionId = 'plan-pending-v1'
+      const bytes = Buffer.from('{"schema_version":1,"task_summary":"Analyze the dataset"}\n')
+      const storageKey = `artifacts/project-1/session-1/${fileId}/versions/${versionId}/content`
+      await mkdir(dirname(join(storageRoot, ...storageKey.split('/'))), { recursive: true })
+      await writeFile(join(storageRoot, ...storageKey.split('/')), bytes)
+      await client.artifactLineage.create({
+        data: {
+          id: fileId,
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          normalizedFilename: 'plan.json',
+          filename: 'plan.json'
+        }
+      })
+      await client.artifactVersion.create({
+        data: {
+          id: versionId,
+          artifactId: fileId,
+          versionNumber: 1,
+          filename: 'plan.json',
+          originKind: 'agent_generated',
+          basedOnVersionId: null,
+          artifactRunId: 'plan-run-1',
+          rootFrameId: 'frame-root',
+          agentFrameId: 'frame-agent',
+          messageBranchId: 'branch-1',
+          runtimeSegmentId: 'segment-1',
+          promptMessageId: 'message-1',
+          state: 'pending',
+          contentStorageKey: storageKey,
+          evidenceStorageKey: `${storageKey}/../evidence`,
+          evidenceJson: '{"schema_version":1}',
+          evidenceChecksum: checksum(Buffer.from('{"schema_version":1}')),
+          evidenceSchemaVersion: 1,
+          contentType: 'application/json',
+          sizeBytes: BigInt(bytes.byteLength),
+          checksum: checksum(bytes)
+        }
+      })
+      return { fileId, versionId, bytes }
+    }
+
+    it('reads a pending agent-generated version by id exactly as written', async () => {
+      const fixture = await createPendingAgentPlanFixture()
+      const service = new ManagedFileVersionService({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+      const identity = {
+        source: 'artifact' as const,
+        projectId: 'project-1',
+        fileId: fixture.fileId
+      }
+
+      // The published read path rejects this exact shape: the lineage head is unassigned until
+      // message finalization, and the version is not yet managed-visible.
+      await expect(service.openVersion(identity, fixture.versionId)).rejects.toMatchObject({
+        code: 'VERSION_NOT_FOUND'
+      })
+
+      const lease = await service.openUnpublishedVersion(identity, fixture.versionId)
+      try {
+        await expect(lease.readRange(0, lease.size)).resolves.toEqual(new Uint8Array(fixture.bytes))
+        expect(lease.version.checksum).toBe(checksum(fixture.bytes))
+        expect(lease.logicalFile.sessionId).toBe('session-1')
+        await lease.verifyUnchanged()
+      } finally {
+        await lease.close()
+      }
+    })
+
+    it('rejects an incomplete staging write for artifacts and uploads', async () => {
+      const artifactFixture = await createPendingAgentPlanFixture()
+      await client.artifactVersion.update({
+        where: { id: artifactFixture.versionId },
+        data: { state: 'staging' }
+      })
+      await client.uploadFile.create({
+        data: {
+          id: 'upload-file-1',
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          filename: 'notes.md',
+          originalFilename: 'notes.md'
+        }
+      })
+      const uploadBytes = Buffer.from('staging bytes\n')
+      const uploadKey =
+        'uploads/project-1/session-1/upload-file-1/versions/upload-staging-v1/content'
+      await mkdir(dirname(join(storageRoot, ...uploadKey.split('/'))), { recursive: true })
+      await writeFile(join(storageRoot, ...uploadKey.split('/')), uploadBytes)
+      await client.uploadVersion.create({
+        data: {
+          id: 'upload-staging-v1',
+          uploadFileId: 'upload-file-1',
+          versionNumber: 1,
+          state: 'staging',
+          originKind: 'legacy',
+          basedOnVersionId: null,
+          contentStorageKey: uploadKey,
+          filename: 'notes.md',
+          originalFilename: 'notes.md',
+          contentType: 'text/markdown',
+          sizeBytes: BigInt(uploadBytes.byteLength),
+          checksum: checksum(uploadBytes)
+        }
+      })
+      const service = new ManagedFileVersionService({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+
+      await expect(
+        service.openUnpublishedVersion(
+          { source: 'artifact', projectId: 'project-1', fileId: artifactFixture.fileId },
+          artifactFixture.versionId
+        )
+      ).rejects.toMatchObject({ code: 'VERSION_NOT_FOUND' })
+      await expect(
+        service.openUnpublishedVersion(
+          { source: 'upload', projectId: 'project-1', fileId: 'upload-file-1' },
+          'upload-staging-v1'
+        )
+      ).rejects.toMatchObject({ code: 'VERSION_NOT_FOUND' })
+    })
+
+    it('rejects a version owned by another file', async () => {
+      const other = await createFixture('artifact')
+      const fixture = await createPendingAgentPlanFixture()
+      const service = new ManagedFileVersionService({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+
+      await expect(
+        service.openUnpublishedVersion(
+          { source: 'artifact', projectId: 'project-1', fileId: fixture.fileId },
+          other.versionIds[0]
+        )
+      ).rejects.toMatchObject({ code: 'VERSION_NOT_IN_FILE' })
+    })
+
+    it('reads a finalized published version through the same path', async () => {
+      const fixture = await createPendingAgentPlanFixture()
+      const now = new Date('2026-09-01T00:00:00.000Z')
+      await client.artifactVersion.update({
+        where: { id: fixture.versionId },
+        data: { state: 'finalized', managedVisibleAt: now }
+      })
+      await client.artifactLineage.update({
+        where: { id: fixture.fileId },
+        data: { currentVersionId: fixture.versionId }
+      })
+      const service = new ManagedFileVersionService({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+
+      const lease = await service.openUnpublishedVersion(
+        { source: 'artifact', projectId: 'project-1', fileId: fixture.fileId },
+        fixture.versionId
+      )
+      try {
+        await expect(lease.readRange(0, lease.size)).resolves.toEqual(new Uint8Array(fixture.bytes))
+      } finally {
+        await lease.close()
+      }
+    })
+  })
 })

--- a/src/main/managed-file-versions/service.integration.test.ts
+++ b/src/main/managed-file-versions/service.integration.test.ts
@@ -3002,6 +3002,56 @@ describe('ManagedFileVersionService (SQLite + filesystem)', () => {
       ).rejects.toMatchObject({ code: 'VERSION_NOT_IN_FILE' })
     })
 
+    it('reports version identity before write state on both read paths', async () => {
+      // A legacy-origin staging version owned by another file: identity must win over state so
+      // the published path keeps its historical error precedence.
+      const owned = await createFixture('artifact')
+      await client.artifactLineage.create({
+        data: {
+          id: 'foreign-lineage',
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          normalizedFilename: 'foreign.json',
+          filename: 'foreign.json'
+        }
+      })
+      const foreignBytes = Buffer.from('foreign\n')
+      const foreignKey = 'artifacts/project-1/session-1/foreign-lineage/versions/foreign-v1/content'
+      await mkdir(dirname(join(storageRoot, ...foreignKey.split('/'))), { recursive: true })
+      await writeFile(join(storageRoot, ...foreignKey.split('/')), foreignBytes)
+      await client.artifactVersion.create({
+        data: {
+          id: 'foreign-v1',
+          artifactId: 'foreign-lineage',
+          versionNumber: 1,
+          filename: 'foreign.json',
+          originKind: 'legacy',
+          basedOnVersionId: null,
+          state: 'staging',
+          contentStorageKey: foreignKey,
+          contentType: 'application/json',
+          sizeBytes: BigInt(foreignBytes.byteLength),
+          checksum: checksum(foreignBytes)
+        }
+      })
+      const service = new ManagedFileVersionService({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+      const identity = {
+        source: 'artifact' as const,
+        projectId: 'project-1',
+        fileId: owned.fileId
+      }
+
+      await expect(service.openVersion(identity, 'foreign-v1')).rejects.toMatchObject({
+        code: 'VERSION_NOT_IN_FILE'
+      })
+      await expect(service.openUnpublishedVersion(identity, 'foreign-v1')).rejects.toMatchObject({
+        code: 'VERSION_NOT_IN_FILE'
+      })
+    })
+
     it('reads a finalized published version through the same path', async () => {
       const fixture = await createPendingAgentPlanFixture()
       const now = new Date('2026-09-01T00:00:00.000Z')

--- a/src/main/managed-file-versions/service.ts
+++ b/src/main/managed-file-versions/service.ts
@@ -500,6 +500,21 @@ class ManagedFileVersionService {
     return this.openVersionLease(await this.resolveRecord({ ...request, versionId }))
   }
 
+  /**
+   * Producer read-back of one exact version that may not be published yet: the lineage head may
+   * still be unassigned and an agent-generated version may not be managed-visible until message
+   * finalization. Intended for trusted main-process callers that hold the version id they just
+   * wrote (for example the Session Plan write-then-verify path); never expose over renderer IPC.
+   */
+  async openUnpublishedVersion(
+    request: ManagedFileIdentity,
+    versionId: string
+  ): Promise<ManagedFileReadLease> {
+    return this.openVersionLease(
+      await this.resolveRecord({ ...request, versionId }, { unpublished: true })
+    )
+  }
+
   async diffText(request: ManagedFileVersionDiffRequest): Promise<ManagedFileVersionDiffResult> {
     return this.diffVersion(request, request.versionId, request.requestId)
   }
@@ -550,32 +565,49 @@ class ManagedFileVersionService {
   }
 
   private async resolveRecord(
-    request: ManagedFileIdentity & { versionId?: string }
+    request: ManagedFileIdentity & { versionId?: string },
+    options: { unpublished?: boolean } = {}
   ): Promise<ResolvedManagedFileVersion> {
     this.assertIdentity(request)
     const client = await this.options.getClient()
     const logicalFile = await this.loadLogicalFile(client, request)
     await this.assertReadable(client, logicalFile)
     const headVersionId = logicalFile.currentVersionId
-    if (!headVersionId) {
-      throw new ManagedFileVersionError(
-        'VERSION_NOT_FOUND',
-        'Managed file has no published version.'
-      )
+    if (!options.unpublished) {
+      if (!headVersionId) {
+        throw new ManagedFileVersionError(
+          'VERSION_NOT_FOUND',
+          'Managed file has no published version.'
+        )
+      }
     }
     const versionId = request.versionId ?? headVersionId
+    if (!versionId) {
+      throw new ManagedFileVersionError('VERSION_NOT_FOUND', 'Managed file version was not found.')
+    }
     const version = await this.loadVersion(client, logicalFile, versionId)
     if (!version) {
       throw new ManagedFileVersionError('VERSION_NOT_FOUND', 'Managed file version was not found.')
     }
-    if (request.source === 'artifact' && !isManagedVisibleArtifactVersion(version)) {
-      operationError('VERSION_NOT_FOUND', 'Managed file version is not published.')
+    if (!options.unpublished) {
+      if (request.source === 'artifact' && !isManagedVisibleArtifactVersion(version)) {
+        operationError('VERSION_NOT_FOUND', 'Managed file version is not published.')
+      }
+      if (version.state !== COMPLETE_STATE[request.source]) {
+        operationError('VERSION_NOT_FOUND', 'Managed file version is not published.')
+      }
+    } else if (request.source === 'artifact') {
+      // Producer read-back still requires a committed write: a staging row's content is not yet
+      // owned by its write operation. 'pending' precedes message finalization; 'finalized' is the
+      // ordinary complete state.
+      if (version.state !== 'pending' && version.state !== 'finalized') {
+        operationError('VERSION_NOT_FOUND', 'Managed file version write has not completed.')
+      }
+    } else if (version.state !== COMPLETE_STATE.upload) {
+      operationError('VERSION_NOT_FOUND', 'Managed file version write has not completed.')
     }
     if (version.fileId !== logicalFile.id) {
       operationError('VERSION_NOT_IN_FILE', 'Managed file version belongs to another file.')
-    }
-    if (version.state !== COMPLETE_STATE[request.source]) {
-      operationError('VERSION_NOT_FOUND', 'Managed file version is not published.')
     }
     return { logicalFile, version }
   }

--- a/src/main/managed-file-versions/service.ts
+++ b/src/main/managed-file-versions/service.ts
@@ -589,6 +589,9 @@ class ManagedFileVersionService {
     if (!version) {
       throw new ManagedFileVersionError('VERSION_NOT_FOUND', 'Managed file version was not found.')
     }
+    if (version.fileId !== logicalFile.id) {
+      operationError('VERSION_NOT_IN_FILE', 'Managed file version belongs to another file.')
+    }
     if (!options.unpublished) {
       if (request.source === 'artifact' && !isManagedVisibleArtifactVersion(version)) {
         operationError('VERSION_NOT_FOUND', 'Managed file version is not published.')
@@ -605,9 +608,6 @@ class ManagedFileVersionService {
       }
     } else if (version.state !== COMPLETE_STATE.upload) {
       operationError('VERSION_NOT_FOUND', 'Managed file version write has not completed.')
-    }
-    if (version.fileId !== logicalFile.id) {
-      operationError('VERSION_NOT_IN_FILE', 'Managed file version belongs to another file.')
     }
     return { logicalFile, version }
   }

--- a/src/main/session-plan/production-plan-service.test.ts
+++ b/src/main/session-plan/production-plan-service.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { readManagedArtifactVersion } from './production-plan-service'
 
 describe('readManagedArtifactVersion', () => {
-  it('reads an exact published Artifact Version through a lease and closes it', async () => {
+  it('reads an exact Artifact Version, including an unpublished one, through a lease and closes it', async () => {
     const bytes = Buffer.from('{"schema_version":1}')
     const close = vi.fn().mockResolvedValue(undefined)
     const verifyUnchanged = vi.fn().mockResolvedValue(undefined)
-    const openVersion = vi.fn().mockResolvedValue({
+    const openUnpublishedVersion = vi.fn().mockResolvedValue({
       size: bytes.byteLength,
       logicalFile: { sessionId: 'session-1' },
       version: { checksum: 'a'.repeat(64) },
@@ -17,7 +17,7 @@ describe('readManagedArtifactVersion', () => {
     })
 
     await expect(
-      readManagedArtifactVersion({ openVersion } as never, {
+      readManagedArtifactVersion({ openUnpublishedVersion } as never, {
         projectId: 'project-1',
         sessionId: 'session-1',
         artifactId: 'artifact-1',
@@ -25,7 +25,7 @@ describe('readManagedArtifactVersion', () => {
       })
     ).resolves.toEqual({ content: '{"schema_version":1}', checksum: 'a'.repeat(64) })
 
-    expect(openVersion).toHaveBeenCalledWith(
+    expect(openUnpublishedVersion).toHaveBeenCalledWith(
       { source: 'artifact', projectId: 'project-1', fileId: 'artifact-1' },
       'version-2'
     )
@@ -35,7 +35,7 @@ describe('readManagedArtifactVersion', () => {
 
   it('rejects a Version owned by another Session and still closes its lease', async () => {
     const close = vi.fn().mockResolvedValue(undefined)
-    const openVersion = vi.fn().mockResolvedValue({
+    const openUnpublishedVersion = vi.fn().mockResolvedValue({
       size: 2,
       logicalFile: { sessionId: 'session-2' },
       version: { checksum: 'b'.repeat(64) },
@@ -45,7 +45,7 @@ describe('readManagedArtifactVersion', () => {
     })
 
     await expect(
-      readManagedArtifactVersion({ openVersion } as never, {
+      readManagedArtifactVersion({ openUnpublishedVersion } as never, {
         projectId: 'project-1',
         sessionId: 'session-1',
         artifactId: 'artifact-1',

--- a/src/main/session-plan/production-plan-service.ts
+++ b/src/main/session-plan/production-plan-service.ts
@@ -8,7 +8,7 @@ import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
 type ProductionPlanServiceDependencies = Readonly<{
   interactions?: SessionPlanInteractionOwner
   artifactTurns: Pick<ArtifactTurnOwner, 'handleForExecution' | 'write'>
-  managedFileVersions: Pick<ManagedFileVersionService, 'openVersion'>
+  managedFileVersions: Pick<ManagedFileVersionService, 'openUnpublishedVersion'>
   sessions: Pick<
     SessionPersistenceCoordinator,
     'readSessionRuntimeContext' | 'patchSessionRuntimeContext' | 'appendUserMessageToInteraction'
@@ -24,11 +24,14 @@ type PlanArtifactVersionRequest = {
   artifactVersionId: string
 }
 
+// The Plan document is read back while its Artifact Version is still pending message finalization
+// (write-then-verify after generate, and again during approval feedback), so this uses the
+// producer read instead of the published-version read.
 const readManagedArtifactVersion = async (
-  managedFileVersions: Pick<ManagedFileVersionService, 'openVersion'>,
+  managedFileVersions: Pick<ManagedFileVersionService, 'openUnpublishedVersion'>,
   request: PlanArtifactVersionRequest
 ): Promise<{ content: string; checksum: string }> => {
-  const lease = await managedFileVersions.openVersion(
+  const lease = await managedFileVersions.openUnpublishedVersion(
     { source: 'artifact', projectId: request.projectId, fileId: request.artifactId },
     request.artifactVersionId
   )


### PR DESCRIPTION
## Problem

`generate_plan` writes the plan json Artifact Version mid-turn and then reads it back to verify the bytes it just wrote landed intact (`PlanService.generate` write-then-verify). The read-back went through the managed-file-version **published** read (`openVersion`), which rejects any version before message finalization advances the lineage head and stamps `managedVisibleAt`. Mid-turn, an agent-generated version is `state = 'pending'`, the head is unassigned, and visibility is unset — so verification always failed with `Managed file has no published version`, and every `generate_plan` call errored.

The approval-feedback path (`respond` → `readDocument`) reads the same still-pending version and was broken the same way.

```mermaid
flowchart LR
    A["generate_plan (agent, mid-turn)"] -->|write| B["ArtifactVersion state=pending<br/>head unassigned, not managed-visible"]
    B -->|"read-back verify (was failing)"| C["published read: openVersion"]
    C -. VERSION_NOT_FOUND .-> A
    B -->|"read-back verify (fixed)"| D["producer read: openUnpublishedVersion"]
    D -->|ok| E["Session -> waiting-plan-approval"]
    F["message finalization"] -->|"head advances + managedVisibleAt"| B
```

## Proposed change

Add one producer read-back capability to `ManagedFileVersionService`:

- `openUnpublishedVersion(identity, versionId)` reads an exact version by id through the existing lease/`verifyUnchanged` integrity path, without the published gate. It still enforces the file-identity check (`VERSION_NOT_IN_FILE`) and a completed-write constraint (`staging` content is rejected; artifact allows `pending`/`finalized`, upload requires `ready`). It is intended for trusted main-process callers that hold a version id they just wrote and is never exposed over renderer IPC.
- The production Plan service routes its artifact reads through the producer read (`production-plan-service.ts`), covering both write-then-verify after generate and approval-time reads of the pending plan.
- The published `openVersion` path and its six other call sites (ipc, reviewer, provenance repository, conversation import, immutable-input authority) are unchanged except that version identity is now checked before write state — restoring the historical error precedence (`VERSION_NOT_IN_FILE` wins over `VERSION_NOT_FOUND`) that a refactor had inverted, pinned by a regression test.

## Scope and non-goals

- In scope: the producer read API, the Plan service wiring, the error-precedence restore.
- Non-goals (explicitly deferred): plan version-lineage redesign (same-name revisions forming one Artifact chain), approval-time diff of a new proposal against the previous version, preventing manual user edits of plan json, and any renderer/UI or prisma schema change.

## Acceptance criteria and validation

1. `generate_plan` write-then-verify succeeds for a pending agent-generated version with an unassigned lineage head.
2. Approval-time reads of the pending plan succeed.
3. `openVersion` still rejects the same pending version (`VERSION_NOT_FOUND`) until message finalization; afterwards it reads normally.
4. `staging` versions are rejected on the producer read for both artifacts and uploads; foreign-file versions report `VERSION_NOT_IN_FILE`.
5. All verification ran after the last material edit (`f7424e3a`):

| Behavior | Check | Result |
| --- | --- | --- |
| Producer read of pending / finalized versions, staging rejection, foreign-file identity, error precedence | `vitest run src/main/managed-file-versions/service.integration.test.ts` | 78 passed |
| Plan service wiring (`readManagedArtifactVersion` switches to producer read) | `vitest run src/main/session-plan/production-plan-service.test.ts` | 2 passed |
| Full portable suite | `vitest run` | 1363 files / 23526 tests passed |
| Node process typecheck | `npm run typecheck:node` | pass |
| Lint (full repo, after last edit) | `npm run lint` | pass |
| Multi-scenario live check (real SQLite + filesystem + real service composition) | throwaway harness, 4 scenarios | all passed, harness removed |

6. Uncovered risk: `openUnpublishedVersion` deliberately bypasses the managed-visible gate. It is currently callable by any main-process owner of the service instance; the convention (documented on the method, not mechanically enforced) is trusted producer-only use. Should a second consumer appear (e.g. approval-time diff), the boundary should be tightened to a narrow injected type.

## Review focus

- Is the producer-read boundary (checks retained: identity, completed-write; checks relaxed: publication) correctly scoped?
- Is routing the Plan service's reads through the producer path the right seam, vs. alternatives?
- The error-precedence restore in `resolveRecord`.
