### PR TITLE
fix(notebook): preserve stdin in Windows standard launch

### DIFF
--- a/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
+++ b/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
@@ -64,7 +64,14 @@ const windowsBatchInvocation = (
 type WindowsStandardLaunchRequest = Readonly<
   Pick<
     WindowsLaunchRequest,
-    'command' | 'shell' | 'gatewayPort' | 'gatewayCredentials' | 'env' | 'localRpcSocketPath'
+    | 'command'
+    | 'executable'
+    | 'args'
+    | 'shell'
+    | 'gatewayPort'
+    | 'gatewayCredentials'
+    | 'env'
+    | 'localRpcSocketPath'
   >
 >
 
@@ -403,10 +410,16 @@ const windowsStandardLaunch = (
       : request.shell
         ? { kind: 'cmd', path: request.shell }
         : { kind: 'powershell', path: 'powershell.exe' }
+  // PowerShell does not transparently relay a redirected stdin stream to a long-lived native child:
+  // a Notebook loop can observe EOF and exit before the executor writes its first protocol frame.
+  // Preserve structured native invocations in standard mode just as protected mode does. Batch
+  // shims still need a command shell, so retain the existing serialized-command path for them.
   const argv =
-    shell.kind === 'powershell'
-      ? [shell.path, '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', request.command]
-      : [shell.path, '/d', '/s', '/c', request.command]
+    request.executable && !WINDOWS_BATCH_FILE.test(request.executable)
+      ? [request.executable, ...(request.args ?? [])]
+      : shell.kind === 'powershell'
+        ? [shell.path, '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', request.command]
+        : [shell.path, '/d', '/s', '/c', request.command]
   const env = {
     ...request.env,
     ...proxyEnvironment(request.gatewayPort, request.gatewayCredentials)

--- a/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
+++ b/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
@@ -1,4 +1,5 @@
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
+import { once } from 'node:events'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -8,7 +9,8 @@ import { describe, expect, it } from 'vitest'
 import {
   connectionProbeSpecification,
   windowsElevationScript,
-  windowsLaunch
+  windowsLaunch,
+  windowsStandardLaunch
 } from '../runtime/src/platform/windows-appcontainer.js'
 
 describe('Windows AppContainer network fence probe', () => {
@@ -39,6 +41,22 @@ describe('Windows AppContainer elevation', () => {
 })
 
 describe('Windows AppContainer launch', () => {
+  it('launches a structured standard-mode executable directly to preserve persistent stdio', () => {
+    const request = {
+      command:
+        "& 'D:\\Open Science\\open-science.exe' 'D:\\Open Science\\resources\\notebook\\repl_loop.js'",
+      executable: 'D:\\Open Science\\open-science.exe',
+      args: ['D:\\Open Science\\resources\\notebook\\repl_loop.js'],
+      gatewayPort: 49700,
+      gatewayCredentials: { username: 'command', password: 'secret' },
+      env: { ELECTRON_RUN_AS_NODE: '1' }
+    }
+
+    const launch = windowsStandardLaunch(request)
+
+    expect(launch.argv).toEqual([request.executable, ...request.args])
+  })
+
   it('launches a structured executable directly instead of through PowerShell', () => {
     const launch = windowsLaunch({
       command: "& '/runtime/python.exe' '/app/python_loop.py'",
@@ -100,6 +118,61 @@ describe('Windows AppContainer launch', () => {
       verbatimArguments: true
     })
   })
+
+  it.runIf(process.platform === 'win32')(
+    'keeps a standard-mode structured child alive for delayed stdin',
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), 'os-standard-launch-'))
+      const helper = join(root, 'persistent-loop.js')
+      writeFileSync(
+        helper,
+        "require('node:readline').createInterface({ input: process.stdin }).on('line', (line) => process.stdout.write(line + '\\n'))"
+      )
+      const quotePowerShell = (value: string): string => `'${value.replaceAll("'", "''")}'`
+      const request = {
+        command: `& ${quotePowerShell(process.execPath)} ${quotePowerShell(helper)}`,
+        executable: process.execPath,
+        args: [helper],
+        gatewayPort: 49700,
+        gatewayCredentials: { username: 'command', password: 'secret' },
+        env: process.env
+      }
+      const launch = windowsStandardLaunch(request)
+      const child = spawn(launch.argv[0]!, launch.argv.slice(1), {
+        cwd: root,
+        env: launch.env,
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+      let stdout = ''
+      child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString('utf8')))
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 300))
+        expect(child.exitCode).toBeNull()
+        child.stdin.write('delayed-frame\n')
+        await Promise.race([
+          new Promise<void>((resolve) => {
+            const check = (): void => {
+              if (stdout.includes('delayed-frame\n')) resolve()
+              else child.stdout.once('data', check)
+            }
+            check()
+          }),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('structured child did not answer stdin')), 2_000)
+          )
+        ])
+        expect(stdout).toContain('delayed-frame\n')
+      } finally {
+        if (child.exitCode === null) {
+          child.kill()
+          await once(child, 'exit')
+        }
+        rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+      }
+    },
+    5_000
+  )
 
   it.runIf(process.platform === 'win32')(
     'preserves metacharacters when cmd.exe executes the generated batch invocation',


### PR DESCRIPTION
## Problem

On packaged Windows builds, a Notebook kernel can fail during startup with:

> Notebook kernel process exited with exit code 0.

This is reproducible on Windows 10/11 x64 with Notebook protection enabled, particularly when the application and user data are located on different local drives.

When protected Notebook execution falls back to the Windows standard-launch path, a structured kernel invocation (`executable` plus `args`) is serialized into a PowerShell command. PowerShell does not transparently relay redirected stdin to a long-running native child in this scenario. The kernel can therefore observe EOF and exit before the executor writes its first protocol frame, producing the misleading exit-code-0 error.

## Proposed change

- Preserve structured native invocations in Windows standard mode by launching the executable and arguments directly.
- Keep the existing PowerShell or `cmd.exe` path for serialized commands and batch-file shims.
- Add a Windows regression test that delays the initial stdin write and verifies that the structured child remains alive and responds.
- Add a platform-independent assertion covering the generated direct argv.

## Scope and non-goals

This change is limited to Windows standard-mode launch planning in the Notebook network sandbox.

It does not change:

- protected AppContainer launch behavior;
- proxy environment construction;
- local RPC socket handling;
- batch-file execution through a command shell;
- Notebook protocol framing or kernel lifecycle management.

## Acceptance criteria and validation

The checks listed below were run after the last material code edit.

- Structured standard-mode launch preserves the executable and argument boundary
  - `npx vitest run packages/notebook-network-sandbox/src/windows-appcontainer.test.ts`
  - Passed: 8 tests

- A Windows structured child remains alive across delayed stdin and processes the first frame
  - Covered by the Windows-only regression test in `windows-appcontainer.test.ts`
  - Passed in the final-state targeted test run

- Sandbox TypeScript contracts remain valid
  - `npm run typecheck:sandbox`
  - Passed

- Changed files conform to repository formatting
  - `npx prettier --check packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts packages/notebook-network-sandbox/src/windows-appcontainer.test.ts`
  - Passed

A later rerun through the documented `npm test -- <path>` wrapper was blocked before test collection by a local `std-env` ESM/CJS dependency-loading error. The failure occurred while loading `vitest.config.ts`, not in the changed tests.

Broader local validation remains constrained by existing environment issues:

- repository-wide typecheck: unrelated missing `waitForMcpServers` export and `ajv` dependency;
- lint: local `acorn` dependency unavailable;
- broader Windows kernel tests: fixture setup encounters symlink `EPERM` without elevated developer-mode privileges.

Cross-version packaged Windows certification remains covered by CI/Nightly. Independent review is pending PR review.

## Review focus

Please focus on:

- whether direct argv launch is the correct boundary for structured non-batch executables;
- whether retaining shell execution for `.bat` and `.cmd` files preserves the intended compatibility behavior;
- whether the delayed-stdin regression test adequately represents the persistent Notebook kernel failure mode.