### PR TITLE
fix(files): resolve the diff module by absolute path for the eval worker

### DIFF
--- a/src/main/managed-file-versions/diff-task.test.ts
+++ b/src/main/managed-file-versions/diff-task.test.ts
@@ -1,7 +1,9 @@
+import { createRequire } from 'node:module'
+
 import { describe, expect, it } from 'vitest'
 
 import { ManagedFileVersionError } from './service'
-import { ManagedTextDiffTaskRunner } from './diff-task'
+import { ManagedTextDiffTaskRunner, resolveDiffModulePath } from './diff-task'
 
 describe('ManagedTextDiffTaskRunner', () => {
   it('returns line numbers and intra-line segments for a replacement', async () => {
@@ -953,5 +955,34 @@ describe('ManagedTextDiffTaskRunner', () => {
       maxYoungGenerationSizeMb: 8,
       stackSizeMb: 2
     })
+  })
+
+  it('resolves the diff module through an absolute path the worker can require', async () => {
+    const diffModulePath = resolveDiffModulePath()
+    expect(diffModulePath).toMatch(/^\/|^[A-Za-z]:[\\/]/)
+    // The path must be requirable on its own, without help from the process CWD.
+    const resolved = createRequire(diffModulePath)('diff') as typeof import('diff')
+    expect(typeof resolved.diffLines).toBe('function')
+    expect(typeof resolved.diffChars).toBe('function')
+    expect(typeof resolved.diffArrays).toBe('function')
+  })
+
+  it('keeps diffing when the process runs from a CWD without node_modules', async () => {
+    // Regression guard for packaged launches (Finder/Dock sets CWD=/): an eval worker's bare
+    // require('diff') resolves from the CWD and used to fail there with CONTENT_INTEGRITY_FAILED.
+    const previousCwd = process.cwd()
+    try {
+      process.chdir('/')
+      const lines = await new ManagedTextDiffTaskRunner().run({
+        requestId: 'diff-from-root-cwd',
+        before: 'one\ntwo\n',
+        after: 'one\ntwo changed\n'
+      })
+      expect(lines).toEqual(
+        expect.arrayContaining([expect.objectContaining({ kind: 'removed', oldLineNumber: 2 })])
+      )
+    } finally {
+      process.chdir(previousCwd)
+    }
   })
 })

--- a/src/main/managed-file-versions/diff-task.test.ts
+++ b/src/main/managed-file-versions/diff-task.test.ts
@@ -959,7 +959,9 @@ describe('ManagedTextDiffTaskRunner', () => {
 
   it('resolves the diff module through an absolute path the worker can require', async () => {
     const diffModulePath = resolveDiffModulePath()
+    expect(diffModulePath).toBeDefined()
     expect(diffModulePath).toMatch(/^\/|^[A-Za-z]:[\\/]/)
+    if (!diffModulePath) throw new Error('Expected resolveDiffModulePath() to return a path.')
     // The path must be requirable on its own, without help from the process CWD.
     const resolved = createRequire(diffModulePath)('diff') as typeof import('diff')
     expect(typeof resolved.diffLines).toBe('function')

--- a/src/main/managed-file-versions/diff-task.ts
+++ b/src/main/managed-file-versions/diff-task.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import { Worker } from 'node:worker_threads'
 
 import {
@@ -5,6 +6,7 @@ import {
   MANAGED_DIFF_MAX_OUTPUT_LINES,
   type ManagedFileVersionDiffLine
 } from '../../shared/managed-file-versions'
+import { createLogger } from '../logger'
 import { ManagedFileVersionError } from './error'
 
 type DiffTask = { requestId: string; before: string; after: string }
@@ -29,10 +31,25 @@ const DIFF_WORKER_RESOURCE_LIMITS: DiffWorkerResourceLimits = {
   maxYoungGenerationSizeMb: 8,
   stackSizeMb: 2
 }
+const diffLog = createLogger('managed-file-versions')
+
+// An eval worker has no referencing file, so a bare require('diff') inside it resolves from the
+// process CWD. A packaged app launched from Finder or Dock runs with CWD=/, where that resolution
+// fails and every diff rejects with CONTENT_INTEGRITY_FAILED. Resolve the module here — anchored
+// to this bundle, which sits next to the packaged node_modules — and hand the worker an absolute
+// path. Falls back to the bare specifier where resolution is unavailable.
+const resolveDiffModulePath = (): string | undefined => {
+  try {
+    return createRequire(import.meta.url).resolve('diff')
+  } catch {
+    return undefined
+  }
+}
+const DIFF_MODULE_PATH = resolveDiffModulePath()
 
 const WORKER_SOURCE = String.raw`
 const { parentPort, workerData } = require('node:worker_threads')
-const { diffArrays, diffChars, diffLines } = require('diff')
+const { diffArrays, diffChars, diffLines } = require(workerData.diffModulePath || 'diff')
 const LINE_ALIGNMENT_MAX_LINES = 400
 const LINE_ALIGNMENT_MAX_CHARACTERS = 50000
 const LINE_ALIGNMENT_MAX_EDIT_LENGTH = 1000
@@ -575,7 +592,8 @@ class ManagedTextDiffTaskRunner {
           before: task.before,
           after: task.after,
           maxOutputLines: MANAGED_DIFF_MAX_OUTPUT_LINES,
-          maxOutputBytes: MANAGED_DIFF_MAX_OUTPUT_BYTES
+          maxOutputBytes: MANAGED_DIFF_MAX_OUTPUT_BYTES,
+          diffModulePath: DIFF_MODULE_PATH
         }
       })
     return new Promise((resolve, reject) => {
@@ -626,6 +644,8 @@ class ManagedTextDiffTaskRunner {
       })
       worker.once('error', (error: Error) => {
         if (!clear()) return
+        // The renderer only sees a generic failure, so keep the underlying cause observable here.
+        diffLog.warn('diff worker failed', { requestId: task.requestId, error: String(error) })
         reject(
           new ManagedFileVersionError('CONTENT_INTEGRITY_FAILED', 'Diff task failed.', {
             cause: error
@@ -634,6 +654,7 @@ class ManagedTextDiffTaskRunner {
       })
       worker.once('exit', (code: number) => {
         if (code === 0 || !clear()) return
+        diffLog.warn('diff worker exited unexpectedly', { requestId: task.requestId, code })
         reject(
           new ManagedFileVersionError('CONTENT_INTEGRITY_FAILED', 'Diff task exited unexpectedly.')
         )
@@ -651,4 +672,4 @@ class ManagedTextDiffTaskRunner {
   }
 }
 
-export { ManagedTextDiffTaskRunner }
+export { ManagedTextDiffTaskRunner, resolveDiffModulePath }


### PR DESCRIPTION
## Problem

In the packaged app, comparing an editable managed file against its source version always fails with "Diff could not be loaded." — deterministically, for every user, regardless of file size or change size. Editing and saving versions keep working; only the compare button is affected.

Reproduced on the installed v0.25.1 against real data: `managedFileVersions.diffText` returns `{ code: "CONTENT_INTEGRITY_FAILED", message: "Diff task failed." }` while `inspect` reports `canDiff: true`.

## Root cause

The diff worker runs from an inline source with `eval: true` (`src/main/managed-file-versions/diff-task.ts`). An eval worker has no referencing file, so its bare `require('diff')` resolves from the **process CWD**:

- Dev and tests (`npm run dev`, vitest, e2e) run from the repo root → CWD contains `node_modules/diff` → resolution succeeds → every test stays green.
- A packaged app launched from Finder/Dock/Spotlight runs with CWD=`/` (LaunchServices never goes through a shell) → resolution fails with `Cannot find module 'diff'` → worker `error` event → `CONTENT_INTEGRITY_FAILED` envelope → the renderer's generic "Diff could not be loaded."

The failure was invisible in `main.log` because the envelope path returns normally (IPC rejection diagnostics only log handler rejections), which made this hard to diagnose from the field.

## Fix

- Resolve `diff` in the main process via `createRequire(import.meta.url).resolve('diff')` — anchored to the bundle location, which sits next to the packaged `node_modules` — and pass the absolute path to the worker through `workerData.diffModulePath`. The worker requires that path, falling back to the bare specifier when resolution is unavailable (same behavior as before in dev).
- Log worker `error`/`exit` failures under the `managed-file-versions` scope so future causes are observable in `main.log`.

## Verification

- New regression tests in `diff-task.test.ts`:
  - the resolved path is absolute and requirable standalone;
  - a diff succeeds with `process.chdir('/')` (verified RED when the fix is reverted, GREEN with it).
- Full `npx vitest run` passes; eslint clean.
- End-to-end against the installed app: extracted the bundled worker source and confirmed `Cannot find module 'diff'` at CWD=/ and success at CWD=repo. After the fix, an Electron instance launched with CWD=/ against a copy of real production data returns `ok: true` (63-line diff) for both user-edit versions that previously failed.

## Out of scope (found during the investigation, not addressed here)

- Diff output budget: the worker emits every non-blank context line, so any editable file above ~20k lines exceeds `MANAGED_DIFF_MAX_OUTPUT_LINES` (20000) no matter how small the change — while the edit budget is 2 MiB. Hunk collapsing would fix this.
- The renderer collapses every non-cancelled diff error into one generic sentence; surfacing the error code would aid diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)