### PR TITLE
feat(task-api): add session configuration controls

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -222,12 +222,14 @@ open-science run --project <project-id> --prompt-file ./task.md \
   --compute-host ssh:cluster-a --compute-host ssh:cluster-b --wait --json
 ```
 
-On a new Session, the explicit list enables and selects those hosts. With `--session`, an explicit
-list replaces the selected target pool and enables any newly named hosts without disabling other
-Available hosts. Omitting every `--compute-host` preserves both access and selection. The CLI does
-not provide a clear-selection flag; SDK and Task API callers can explicitly send an empty
-`computeHostIds` array to clear Selected while preserving Enabled hosts. JSON output uses the
-server's compatibility-named
+On a new Session, `--enable-compute-host` adds Available hosts, `--compute-host` enables and selects
+its explicit list, and `--clear-compute-hosts` overrides Project defaults with empty Enabled and
+Selected lists. With `--session`, `--compute-host` replaces the selected target pool and enables any
+newly named hosts without disabling other Available hosts. Existing-Session runs reject
+`--enable-compute-host` and `--clear-compute-hosts`; use `session config update` for those access
+changes. Omitting every Compute Host option preserves both access and selection. SDK and Task API
+callers can explicitly send an empty `computeHostIds` array to clear Selected while preserving
+Enabled hosts. JSON output uses the server's compatibility-named
 `preferredComputeHostIds` authority result, not a copy inferred from the command line.
 
 When the selection is non-empty, the agent is instructed to run tool-backed task work on one of

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -182,6 +182,27 @@ newly created Sessions and provider Sessions that are set up again after the upd
 rebuild an already attached Session. Project list, create, and update output reports only the boolean
 `hasAgentContext`; Agent Context contents are not returned through the public Task API or CLI output.
 
+### Project Session defaults
+
+Inspect or update the configuration copied into each newly created Session:
+
+```bash
+open-science project session-defaults show <project-id> --json
+open-science project session-defaults update <project-id> \
+  --provider anthropic --model claude-sonnet-4-5 --reasoning-effort high \
+  --approval-profile auto --auto-review --memory --delegation allow \
+  --enable-compute-host ssh:cluster-a --compute-host ssh:cluster-a --json
+```
+
+Updates use the Project's current `updatedAt` value as a compare-and-swap revision. They fail on a
+concurrent Project edit instead of overwriting it. Use the corresponding `--clear-*` option to
+remove an optional default, or `--clear-compute-hosts` to remove both enabled and selected Compute
+Hosts. Omitted options are preserved.
+
+The precedence for a new Session is explicit `run` options, then Project Session defaults, then
+application settings, then the provider-owned default. Defaults are snapshotted into the new
+Session; changing them never rewrites an existing Session.
+
 ## Run a task
 
 Provide a prompt directly, read it from a UTF-8 file, or pipe it through stdin:
@@ -305,9 +326,55 @@ open-science plan revise <session-id> --feedback "Split the validation step" --j
 Version/revision matching prevents a stale automation client from deciding a newer Plan. Approval
 continues the parked Run; feedback asks the live Plan interaction for a revision.
 
+## Session configuration
+
+Read the persisted and effective configuration, including referenced provider, model, Specialist,
+and Compute Host availability:
+
+```bash
+open-science session config show <session-id> --json
+```
+
+Update an idle Session with the revision returned by `show`:
+
+```bash
+open-science session config update <session-id> --revision 7 \
+  --provider openai --provider-default-model --reasoning-effort medium \
+  --approval-profile ask --no-auto-review --memory --delegation deny \
+  --clear-compute-hosts --json
+```
+
+The Main provider, model, and reasoning effort are one compound configuration. A provider change
+must therefore include either `--model` or `--provider-default-model`. An update affects future
+turns only and is rejected while root-agent, subagent, or Notebook work is active. Reviewer work
+does not block the update. Stale revisions fail with `session_revision_conflict`; invalid or
+unavailable references fail with `invalid_configuration`.
+
+## Agent routing settings
+
+Inspect or atomically update the global Agent framework plus Reviewer and Subagent model routing:
+
+```bash
+open-science settings agent-routing show --json
+open-science settings agent-routing update --framework codex \
+  --reviewer-provider openai --reviewer-model gpt-5 \
+  --subagent-inherit --json
+```
+
+Use `--reviewer-inherit` or `--subagent-inherit` to follow the applicable Main model. Fixed routes
+require both provider and model; reasoning effort is optional. The command validates all three
+settings against the target framework before saving them together. It returns identifiers and
+availability only, never provider credentials.
+
+A framework change applies to new Sessions and future Reviewer work. Existing idle Sessions migrate
+lazily on their next turn, replaying their visible transcript when a fresh provider Session is
+needed. In-flight Main, Reviewer, and Subagent work remains pinned to the runtime generation and
+model snapshot admitted at its start. Reviewer and Subagent route changes affect only future work.
+
 ### Session persistence and compatibility
 
-The controls use the Session JSON authority; they do not add a Prisma/SQLite migration:
+Session configuration continues to use the Session JSON authority; it does not add a Session
+schema migration:
 
 - Session JSON stores `delegationPolicy` with values `allow` or `deny`. Historical Session files
   that omit it, and malformed values, restore as `allow`.
@@ -316,7 +383,11 @@ The controls use the Session JSON authority; they do not add a Prisma/SQLite mig
 - Plan artifacts/approval/continuation continue under runtimeContext.plan; delegated attempts,
   messages, and questions continue under runtimeContext.delegatedWork.
 
-No Session or Run status enum is added. Existing waiting-plan-approval remains the durable Session
+Project Session defaults add one `sessionDefaults` JSON-text column to the Project table. Existing
+rows migrate to `{}` and therefore retain prior behavior. Agent routing reuses the existing Settings
+JSON fields.
+
+No persistent enum value is added. Existing waiting-plan-approval remains the durable Session
 status, while a public Run remains running and carries an attention discriminant.
 
 ## Machine-readable output

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -22,6 +22,34 @@ const result = await client.waitForRun(run.id)
 console.log(result.output)
 ```
 
+Session, Project-default, and global Agent-routing configuration use the same authenticated local
+API:
+
+```js
+const configuration = await client.getSessionConfiguration(run.sessionId)
+await client.updateSessionConfiguration(run.sessionId, {
+  expectedRevision: configuration.revision,
+  memoryEnabled: false
+})
+
+const defaults = await client.getProjectSessionDefaults('systematic-review')
+await client.updateProjectSessionDefaults('systematic-review', {
+  expectedUpdatedAt: defaults.updatedAt,
+  patch: { permissionProfile: 'auto' }
+})
+
+await client.updateAgentRouting({
+  framework: 'codex',
+  reviewer: { mode: 'inherit' },
+  subagent: { mode: 'inherit' }
+})
+```
+
+Session updates use `revision`; Project-default updates use `updatedAt`. Both reject stale writes.
+Project defaults are copied only when a Session is created, with precedence `startRun` request,
+Project defaults, application settings, then provider default. Agent-routing updates are atomic and
+never return provider credentials.
+
 SDK requests have a 30-second default deadline that remains active while the response body is being
 consumed. Override the client default with `requestTimeoutMs`, or pass `{ signal, timeoutMs }` as the
 final options argument to an individual request method. `downloadArtifact` keeps the deadline active

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -37,10 +37,16 @@ Commands:
   project list
   project create <name> [--description <text>] [--agent-context <text> | --agent-context-file <path>]
   project update <id-or-name> [--name <name>] [--description <text>] [--agent-context <text> | --agent-context-file <path> | --clear-agent-context]
+  project session-defaults show <id-or-name>
+  project session-defaults update <id-or-name> [session options]
   run --project <id-or-name> (--prompt <text> | --prompt-file <path>) [--compute-host <provider-id>] [--wait]
   run status <run-id>
   run cancel <run-id>
   session status <session-id>
+  session config show <session-id>
+  session config update <session-id> --revision <number> [session options]
+  settings agent-routing show
+  settings agent-routing update [routing options]
   plan show <session-id>
   plan approve <session-id> --artifact-version <id> --revision <number>
   plan reject <session-id> --artifact-version <id> --revision <number>
@@ -63,13 +69,26 @@ Options:
   --agent-context-file <path>  Read Project Agent Context from a UTF-8 file
   --clear-agent-context  Clear a Project's persistent Agent Context
   --approval-profile <profile>  ask, auto, or full (default: ask)
+  --provider <provider-id>  Configured Main provider
+  --model <model-id>       Main model
+  --provider-default-model Use the provider-owned default model
+  --reasoning-effort <effort>  default, low, medium, high, xhigh, or max
   --skill <id>           Force-load a skill for this run (repeatable)
   --compute-host <provider-id>  Select a Compute Host execution target (repeatable)
+  --enable-compute-host <provider-id>  Enable a Compute Host without selecting it (repeatable)
+  --clear-compute-hosts    Clear enabled and selected Compute Hosts
   --plan-first           Require an approved Plan before execution
   --auto-review          Enable automatic review for this Session
   --no-auto-review       Disable automatic review for this Session
+  --memory               Enable Memory for this Session
+  --no-memory            Disable Memory for this Session
   --specialist <id-or-name>  Bind a new Session to a Specialist
   --delegation <policy>  allow or deny new delegated children
+  --framework <id>       claude-code, opencode, codex, or codebuddy
+  --reviewer-inherit | --reviewer-provider <id> --reviewer-model <id> [--reviewer-effort <effort>]
+  --subagent-inherit | --subagent-provider <id> --subagent-model <id> [--subagent-effort <effort>]
+  --clear-provider | --clear-approval-profile | --clear-auto-review | --clear-memory
+  --clear-delegation | --clear-specialist  Clear one Project Session default
   --wait                 Wait for the run to finish
   --return-on-attention  With --wait, return when the Plan needs approval
   --timeout-ms <ms>      Stop waiting after this many milliseconds
@@ -96,6 +115,16 @@ const VALUE_OPTIONS = {
   '--prompt': 'prompt',
   '--prompt-file': 'promptFile',
   '--approval-profile': 'approvalProfile',
+  '--provider': 'provider',
+  '--model': 'model',
+  '--reasoning-effort': 'reasoningEffort',
+  '--framework': 'framework',
+  '--reviewer-provider': 'reviewerProvider',
+  '--reviewer-model': 'reviewerModel',
+  '--reviewer-effort': 'reviewerEffort',
+  '--subagent-provider': 'subagentProvider',
+  '--subagent-model': 'subagentModel',
+  '--subagent-effort': 'subagentEffort',
   '--specialist': 'specialist',
   '--delegation': 'delegation',
   '--artifact-version': 'artifactVersion',
@@ -109,8 +138,8 @@ const VALUE_OPTIONS = {
   '--output': 'output'
 }
 
-const TASK_COMMANDS = new Set(['project', 'run', 'session', 'plan', 'artifacts'])
-const GROUP_COMMANDS = new Set(['codex', 'project', 'session', 'plan', 'artifacts'])
+const TASK_COMMANDS = new Set(['project', 'run', 'session', 'settings', 'plan', 'artifacts'])
+const GROUP_COMMANDS = new Set(['codex', 'project', 'session', 'settings', 'plan', 'artifacts'])
 
 export class CliUsageError extends Error {
   constructor(message) {
@@ -156,6 +185,26 @@ export const parseCliArgs = (argv) => {
     else if (arg === '--wait') options.wait = true
     else if (arg === '--return-on-attention') options.returnOnAttention = true
     else if (arg === '--plan-first') options.planFirst = true
+    else if (arg === '--provider-default-model') options.providerDefaultModel = true
+    else if (arg === '--clear-compute-hosts') options.clearComputeHosts = true
+    else if (arg === '--memory') {
+      if (options.memoryEnabled === false) {
+        throw new CliUsageError('Use only one of --memory or --no-memory.')
+      }
+      options.memoryEnabled = true
+    } else if (arg === '--no-memory') {
+      if (options.memoryEnabled === true) {
+        throw new CliUsageError('Use only one of --memory or --no-memory.')
+      }
+      options.memoryEnabled = false
+    } else if (arg === '--reviewer-inherit') options.reviewerInherit = true
+    else if (arg === '--subagent-inherit') options.subagentInherit = true
+    else if (arg === '--clear-provider') options.clearProvider = true
+    else if (arg === '--clear-approval-profile') options.clearApprovalProfile = true
+    else if (arg === '--clear-auto-review') options.clearAutoReview = true
+    else if (arg === '--clear-memory') options.clearMemory = true
+    else if (arg === '--clear-delegation') options.clearDelegation = true
+    else if (arg === '--clear-specialist') options.clearSpecialist = true
     else if (arg === '--auto-review') {
       if (options.autoReviewEnabled === false) {
         throw new CliUsageError('Use only one of --auto-review or --no-auto-review.')
@@ -176,6 +225,10 @@ export const parseCliArgs = (argv) => {
       const value = args.shift()
       if (!value) throw new CliUsageError('--compute-host requires a value.')
       options.computeHosts = [...(options.computeHosts ?? []), value]
+    } else if (arg === '--enable-compute-host') {
+      const value = args.shift()
+      if (!value) throw new CliUsageError('--enable-compute-host requires a value.')
+      options.enabledComputeHosts = [...(options.enabledComputeHosts ?? []), value]
     } else if (arg === '-h' || arg === '--help') options.help = true
     else if (Object.hasOwn(VALUE_OPTIONS, arg)) {
       const value = args.shift()
@@ -203,12 +256,48 @@ export const parseCliArgs = (argv) => {
   if (options.revision !== undefined) {
     const revision = Number(options.revision)
     if (!Number.isInteger(revision) || revision < 0) {
-      throw new CliUsageError(`Invalid Plan revision: ${options.revision}`)
+      throw new CliUsageError(`Invalid revision: ${options.revision}`)
     }
     options.revision = revision
   }
   if (options.delegation && !['allow', 'deny'].includes(options.delegation)) {
     throw new CliUsageError(`Invalid delegation policy: ${options.delegation}`)
+  }
+  for (const [label, value] of [
+    ['--reasoning-effort', options.reasoningEffort],
+    ['--reviewer-effort', options.reviewerEffort],
+    ['--subagent-effort', options.subagentEffort]
+  ]) {
+    if (
+      value !== undefined &&
+      !['default', 'low', 'medium', 'high', 'xhigh', 'max'].includes(value)
+    ) {
+      throw new CliUsageError(`Invalid ${label}: ${value}`)
+    }
+  }
+  if (
+    options.framework !== undefined &&
+    !['claude-code', 'opencode', 'codex', 'codebuddy'].includes(options.framework)
+  ) {
+    throw new CliUsageError(`Invalid framework: ${options.framework}`)
+  }
+  if (options.model !== undefined && options.providerDefaultModel) {
+    throw new CliUsageError('Use only one of --model or --provider-default-model.')
+  }
+  if (
+    options.provider !== undefined &&
+    options.model === undefined &&
+    !options.providerDefaultModel
+  ) {
+    throw new CliUsageError('--provider requires --model or --provider-default-model.')
+  }
+  if (
+    options.clearComputeHosts &&
+    (options.computeHosts !== undefined || options.enabledComputeHosts !== undefined)
+  ) {
+    throw new CliUsageError(
+      'Use only one of Compute Host selection options or --clear-compute-hosts.'
+    )
   }
   if (options.json && options.jsonl) {
     throw new CliUsageError('Use only one of --json or --jsonl.')
@@ -285,22 +374,74 @@ export const parseCliArgs = (argv) => {
     }
     if (positionals.length > 0) throw new CliUsageError('codex login accepts no arguments.')
   }
+  const sessionConfigAction = command === 'session' && subcommand === 'config' && positionals[0]
+  const projectDefaultsAction =
+    command === 'project' && subcommand === 'session-defaults' && positionals[0]
+  const agentRoutingAction =
+    command === 'settings' && subcommand === 'agent-routing' && positionals[0]
+  const isSessionConfigUpdate = sessionConfigAction === 'update'
+  const isProjectDefaultsUpdate = projectDefaultsAction === 'update'
+  const isAgentRoutingUpdate = agentRoutingAction === 'update'
+  const isRun = command === 'run' && !subcommand
   const runOnlyOptions = [
     ['--plan-first', options.planFirst],
-    ['--auto-review/--no-auto-review', options.autoReviewEnabled !== undefined],
-    ['--specialist', options.specialist !== undefined],
-    ['--delegation', options.delegation !== undefined],
-    ['--compute-host', options.computeHosts !== undefined]
+    ['--skill', options.skills !== undefined]
   ]
   for (const [label, present] of runOnlyOptions) {
-    if (present && (command !== 'run' || subcommand)) {
+    if (present && !isRun) {
       throw new CliUsageError(`${label} requires run.`)
     }
   }
+  const sessionOptionPresent =
+    options.provider !== undefined ||
+    options.model !== undefined ||
+    options.providerDefaultModel ||
+    options.reasoningEffort !== undefined ||
+    options.approvalProfile !== undefined ||
+    options.autoReviewEnabled !== undefined ||
+    options.memoryEnabled !== undefined ||
+    options.delegation !== undefined ||
+    options.computeHosts !== undefined ||
+    options.enabledComputeHosts !== undefined ||
+    options.clearComputeHosts
+  if (sessionOptionPresent && !isRun && !isSessionConfigUpdate && !isProjectDefaultsUpdate) {
+    throw new CliUsageError(
+      'Session configuration options require run or a defaults/config update.'
+    )
+  }
+  if (options.specialist !== undefined && !isRun && !isProjectDefaultsUpdate) {
+    throw new CliUsageError('--specialist requires run or project session-defaults update.')
+  }
+  const projectClearPresent =
+    options.clearProvider ||
+    options.clearApprovalProfile ||
+    options.clearAutoReview ||
+    options.clearMemory ||
+    options.clearDelegation ||
+    options.clearSpecialist
+  if (projectClearPresent && !isProjectDefaultsUpdate) {
+    throw new CliUsageError(
+      'Project default clear options require project session-defaults update.'
+    )
+  }
+  const routingPresent =
+    options.framework !== undefined ||
+    options.reviewerProvider !== undefined ||
+    options.reviewerModel !== undefined ||
+    options.reviewerEffort !== undefined ||
+    options.reviewerInherit ||
+    options.subagentProvider !== undefined ||
+    options.subagentModel !== undefined ||
+    options.subagentEffort !== undefined ||
+    options.subagentInherit
+  if (routingPresent && !isAgentRoutingUpdate) {
+    throw new CliUsageError('Agent routing options require settings agent-routing update.')
+  }
   if (
     command !== 'plan' &&
+    !isSessionConfigUpdate &&
     (options.artifactVersion !== undefined ||
-      options.revision !== undefined ||
+      (options.revision !== undefined && !isSessionConfigUpdate) ||
       options.feedback !== undefined)
   ) {
     throw new CliUsageError('Plan response options require a plan command.')
@@ -1116,6 +1257,64 @@ const streamRunEvents = async (eventStream, runRef, options, deps, signal) => {
   }
 }
 
+const agentConfigurationPatch = (options) => {
+  const present =
+    options.provider !== undefined ||
+    options.model !== undefined ||
+    options.providerDefaultModel ||
+    options.reasoningEffort !== undefined
+  if (!present) return undefined
+  return {
+    ...(options.provider !== undefined ? { providerId: options.provider } : {}),
+    ...(options.model !== undefined
+      ? { model: options.model }
+      : options.providerDefaultModel
+        ? { model: null }
+        : {}),
+    ...(options.reasoningEffort !== undefined ? { reasoningEffort: options.reasoningEffort } : {})
+  }
+}
+
+const computeHostsPatch = (options, current = { enabled: [], selected: [] }) => {
+  if (options.clearComputeHosts) return { enabled: [], selected: [] }
+  if (options.computeHosts === undefined && options.enabledComputeHosts === undefined) {
+    return undefined
+  }
+  const selected = options.computeHosts ?? current.selected
+  const enabled = [...(options.enabledComputeHosts ?? current.enabled), ...selected].filter(
+    (value, index, values) => values.indexOf(value) === index
+  )
+  return { enabled, selected }
+}
+
+const modelRouting = (options, prefix) => {
+  const inherit = options[`${prefix}Inherit`]
+  const providerId = options[`${prefix}Provider`]
+  const model = options[`${prefix}Model`]
+  const reasoningEffort = options[`${prefix}Effort`]
+  if (inherit) {
+    if (providerId !== undefined || model !== undefined || reasoningEffort !== undefined) {
+      throw new CliUsageError(
+        `--${prefix}-inherit cannot be combined with fixed ${prefix} routing options.`
+      )
+    }
+    return { mode: 'inherit' }
+  }
+  if (providerId === undefined && model === undefined && reasoningEffort === undefined) {
+    return undefined
+  }
+  if (!providerId || !model) {
+    throw new CliUsageError(
+      `--${prefix}-provider and --${prefix}-model are required for fixed routing.`
+    )
+  }
+  return { mode: 'fixed', providerId, model, reasoningEffort: reasoningEffort ?? 'default' }
+}
+
+const assertNoClearConflict = (clear, present, label) => {
+  if (clear && present) throw new CliUsageError(`Cannot set and clear ${label} together.`)
+}
+
 export const runTaskCommand = async (parsed, dependencies = {}) => {
   const deps = { ...TASK_DEPS, ...dependencies }
   const { command, subcommand, positionals = [], options } = parsed
@@ -1164,10 +1363,160 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
     )
     return
   }
+  if (command === 'project' && subcommand === 'session-defaults') {
+    const action = positionals[0]
+    const selector = positionals.slice(1).join(' ').trim()
+    if (!selector) throw new CliUsageError('Project id or name is required.')
+    const project = await resolveCliProject(client, selector)
+    const current = await client.getProjectSessionDefaults(project.id)
+    if (action === 'show') {
+      outputValue(current, options, deps)
+      return
+    }
+    if (action !== 'update') {
+      throw new CliUsageError('Use project session-defaults show or update.')
+    }
+    const agent = agentConfigurationPatch(options)
+    assertNoClearConflict(options.clearProvider, agent !== undefined, 'the provider default')
+    assertNoClearConflict(
+      options.clearApprovalProfile,
+      options.approvalProfile !== undefined,
+      'the approval profile default'
+    )
+    assertNoClearConflict(
+      options.clearAutoReview,
+      options.autoReviewEnabled !== undefined,
+      'the auto-review default'
+    )
+    assertNoClearConflict(
+      options.clearMemory,
+      options.memoryEnabled !== undefined,
+      'the Memory default'
+    )
+    assertNoClearConflict(
+      options.clearDelegation,
+      options.delegation !== undefined,
+      'the delegation default'
+    )
+    assertNoClearConflict(
+      options.clearSpecialist,
+      options.specialist !== undefined,
+      'the Specialist default'
+    )
+    const computeHosts = computeHostsPatch(options, current.configured.computeHosts)
+    const patch = {
+      ...(options.clearProvider
+        ? { agentConfiguration: null }
+        : agent
+          ? { agentConfiguration: agent }
+          : {}),
+      ...(options.clearApprovalProfile
+        ? { permissionProfile: null }
+        : options.approvalProfile !== undefined
+          ? { permissionProfile: options.approvalProfile }
+          : {}),
+      ...(options.clearAutoReview
+        ? { autoReviewEnabled: null }
+        : options.autoReviewEnabled !== undefined
+          ? { autoReviewEnabled: options.autoReviewEnabled }
+          : {}),
+      ...(options.clearMemory
+        ? { memoryEnabled: null }
+        : options.memoryEnabled !== undefined
+          ? { memoryEnabled: options.memoryEnabled }
+          : {}),
+      ...(options.clearDelegation
+        ? { delegationPolicy: null }
+        : options.delegation !== undefined
+          ? { delegationPolicy: options.delegation }
+          : {}),
+      ...(options.clearSpecialist
+        ? { specialistId: null }
+        : options.specialist !== undefined
+          ? { specialistId: options.specialist }
+          : {}),
+      ...(computeHosts !== undefined
+        ? { computeHosts: options.clearComputeHosts ? null : computeHosts }
+        : {})
+    }
+    if (Object.keys(patch).length === 0) {
+      throw new CliUsageError('Project Session defaults update requires at least one field.')
+    }
+    outputValue(
+      await client.updateProjectSessionDefaults(project.id, {
+        expectedUpdatedAt: current.updatedAt,
+        patch
+      }),
+      options,
+      deps
+    )
+    return
+  }
   if (command === 'session' && subcommand === 'status') {
     const sessionId = positionals[0]
     if (!sessionId) throw new CliUsageError('Session id is required.')
     outputValue(await client.getSession(sessionId), options, deps)
+    return
+  }
+  if (command === 'session' && subcommand === 'config') {
+    const action = positionals[0]
+    const sessionId = positionals[1]
+    if (!sessionId) throw new CliUsageError('Session id is required.')
+    if (action === 'show') {
+      outputValue(await client.getSessionConfiguration(sessionId), options, deps)
+      return
+    }
+    if (action !== 'update') throw new CliUsageError('Use session config show or update.')
+    if (options.revision === undefined) throw new CliUsageError('--revision is required.')
+    const current = await client.getSessionConfiguration(sessionId)
+    const computeHosts = computeHostsPatch(options, current.persisted.computeHosts)
+    const patch = {
+      ...(agentConfigurationPatch(options)
+        ? { agentConfiguration: agentConfigurationPatch(options) }
+        : {}),
+      ...(options.approvalProfile !== undefined
+        ? { permissionProfile: options.approvalProfile }
+        : {}),
+      ...(options.autoReviewEnabled !== undefined
+        ? { autoReviewEnabled: options.autoReviewEnabled }
+        : {}),
+      ...(options.memoryEnabled !== undefined ? { memoryEnabled: options.memoryEnabled } : {}),
+      ...(options.delegation !== undefined ? { delegationPolicy: options.delegation } : {}),
+      ...(computeHosts !== undefined ? { computeHosts } : {})
+    }
+    if (Object.keys(patch).length === 0) {
+      throw new CliUsageError('Session configuration update requires at least one field.')
+    }
+    outputValue(
+      await client.updateSessionConfiguration(sessionId, {
+        expectedRevision: options.revision,
+        ...patch
+      }),
+      options,
+      deps
+    )
+    return
+  }
+  if (command === 'settings' && subcommand === 'agent-routing') {
+    const action = positionals[0]
+    if (action === 'show') {
+      outputValue(await client.getAgentRouting(), options, deps)
+      return
+    }
+    if (action !== 'update') {
+      throw new CliUsageError('Use settings agent-routing show or update.')
+    }
+    const reviewer = modelRouting(options, 'reviewer')
+    const subagent = modelRouting(options, 'subagent')
+    const request = {
+      ...(options.framework !== undefined ? { framework: options.framework } : {}),
+      ...(reviewer ? { reviewer } : {}),
+      ...(subagent ? { subagent } : {})
+    }
+    if (Object.keys(request).length === 0) {
+      throw new CliUsageError('Agent routing update requires at least one field.')
+    }
+    outputValue(await client.updateAgentRouting(request), options, deps)
     return
   }
   if (command === 'plan') {
@@ -1262,6 +1611,13 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
           : {}),
         ...(options.specialist ? { specialist: options.specialist } : {}),
         ...(options.delegation ? { delegationPolicy: options.delegation } : {}),
+        ...(agentConfigurationPatch(options)
+          ? { agentConfiguration: agentConfigurationPatch(options) }
+          : {}),
+        ...(options.memoryEnabled !== undefined ? { memoryEnabled: options.memoryEnabled } : {}),
+        ...(options.enabledComputeHosts !== undefined
+          ? { enabledComputeHostIds: options.enabledComputeHosts }
+          : {}),
         ...(options.computeHosts !== undefined ? { computeHostIds: options.computeHosts } : {})
       })
       runRef.current = { runId: started.id, sessionId: started.sessionId }

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -383,6 +383,16 @@ export const parseCliArgs = (argv) => {
   const isProjectDefaultsUpdate = projectDefaultsAction === 'update'
   const isAgentRoutingUpdate = agentRoutingAction === 'update'
   const isRun = command === 'run' && !subcommand
+  if (isRun && options.session && options.enabledComputeHosts !== undefined) {
+    throw new CliUsageError(
+      '--enable-compute-host cannot update an existing Session; use session config update.'
+    )
+  }
+  if (isRun && options.session && options.clearComputeHosts) {
+    throw new CliUsageError(
+      '--clear-compute-hosts cannot update an existing Session; use session config update.'
+    )
+  }
   const runOnlyOptions = [
     ['--plan-first', options.planFirst],
     ['--skill', options.skills !== undefined]
@@ -1615,10 +1625,16 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
           ? { agentConfiguration: agentConfigurationPatch(options) }
           : {}),
         ...(options.memoryEnabled !== undefined ? { memoryEnabled: options.memoryEnabled } : {}),
-        ...(options.enabledComputeHosts !== undefined
-          ? { enabledComputeHostIds: options.enabledComputeHosts }
-          : {}),
-        ...(options.computeHosts !== undefined ? { computeHostIds: options.computeHosts } : {})
+        ...(options.clearComputeHosts
+          ? { enabledComputeHostIds: [], computeHostIds: [] }
+          : {
+              ...(options.enabledComputeHosts !== undefined
+                ? { enabledComputeHostIds: options.enabledComputeHosts }
+                : {}),
+              ...(options.computeHosts !== undefined
+                ? { computeHostIds: options.computeHosts }
+                : {})
+            })
       })
       runRef.current = { runId: started.id, sessionId: started.sessionId }
       for (const event of runRef.pending.splice(0)) {

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -235,6 +235,168 @@ describe('task CLI', () => {
     )
   })
 
+  it('parses Session, Project-default, and Agent-routing configuration commands', () => {
+    expect(() => parseCliArgs(['run', '--provider', 'provider-1'])).toThrow(
+      '--provider requires --model or --provider-default-model.'
+    )
+    expect(
+      parseCliArgs([
+        'session',
+        'config',
+        'update',
+        'session-1',
+        '--revision',
+        '4',
+        '--provider',
+        'provider-1',
+        '--provider-default-model',
+        '--reasoning-effort',
+        'high',
+        '--no-memory',
+        '--enable-compute-host',
+        'ssh:alpha',
+        '--compute-host',
+        'ssh:alpha'
+      ])
+    ).toMatchObject({
+      command: 'session',
+      subcommand: 'config',
+      positionals: ['update', 'session-1'],
+      options: {
+        revision: 4,
+        provider: 'provider-1',
+        providerDefaultModel: true,
+        reasoningEffort: 'high',
+        memoryEnabled: false,
+        enabledComputeHosts: ['ssh:alpha'],
+        computeHosts: ['ssh:alpha']
+      }
+    })
+    expect(
+      parseCliArgs([
+        'project',
+        'session-defaults',
+        'update',
+        'Research',
+        '--clear-provider',
+        '--clear-specialist'
+      ])
+    ).toMatchObject({
+      command: 'project',
+      subcommand: 'session-defaults',
+      positionals: ['update', 'Research'],
+      options: { clearProvider: true, clearSpecialist: true }
+    })
+    expect(
+      parseCliArgs([
+        'settings',
+        'agent-routing',
+        'update',
+        '--framework',
+        'codex',
+        '--reviewer-inherit',
+        '--subagent-provider',
+        'provider-1',
+        '--subagent-model',
+        'model-1'
+      ])
+    ).toMatchObject({
+      command: 'settings',
+      subcommand: 'agent-routing',
+      positionals: ['update'],
+      options: {
+        framework: 'codex',
+        reviewerInherit: true,
+        subagentProvider: 'provider-1',
+        subagentModel: 'model-1'
+      }
+    })
+    expect(() =>
+      parseCliArgs([
+        'session',
+        'config',
+        'update',
+        'session-1',
+        '--revision',
+        '4',
+        '--clear-compute-hosts',
+        '--enable-compute-host',
+        'ssh:alpha'
+      ])
+    ).toThrow('Use only one of Compute Host selection options or --clear-compute-hosts.')
+  })
+
+  it('dispatches atomic configuration updates with their concurrency tokens', async () => {
+    const client = {
+      listProjects: vi.fn(listProjects),
+      getProjectSessionDefaults: vi.fn().mockResolvedValue({
+        projectId: 'project-1',
+        updatedAt: 10,
+        configured: { computeHosts: { enabled: [], selected: [] } }
+      }),
+      updateProjectSessionDefaults: vi.fn().mockResolvedValue({ projectId: 'project-1' }),
+      getSessionConfiguration: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        revision: 4,
+        persisted: { computeHosts: { enabled: ['ssh:alpha'], selected: [] } }
+      }),
+      updateSessionConfiguration: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+      updateAgentRouting: vi.fn().mockResolvedValue({ configured: {} })
+    }
+    const deps = { connect: vi.fn().mockResolvedValue(client), log: vi.fn(), stdinIsTTY: true }
+
+    await runTaskCommand(
+      parseCliArgs([
+        'project',
+        'session-defaults',
+        'update',
+        'Research',
+        '--approval-profile',
+        'auto',
+        '--clear-memory'
+      ]),
+      deps
+    )
+    expect(client.updateProjectSessionDefaults).toHaveBeenCalledWith('project-1', {
+      expectedUpdatedAt: 10,
+      patch: { permissionProfile: 'auto', memoryEnabled: null }
+    })
+
+    await runTaskCommand(
+      parseCliArgs([
+        'session',
+        'config',
+        'update',
+        'session-1',
+        '--revision',
+        '4',
+        '--compute-host',
+        'ssh:alpha'
+      ]),
+      deps
+    )
+    expect(client.updateSessionConfiguration).toHaveBeenCalledWith('session-1', {
+      expectedRevision: 4,
+      computeHosts: { enabled: ['ssh:alpha'], selected: ['ssh:alpha'] }
+    })
+
+    await runTaskCommand(
+      parseCliArgs([
+        'settings',
+        'agent-routing',
+        'update',
+        '--framework',
+        'codex',
+        '--reviewer-inherit'
+      ]),
+      deps
+    )
+    expect(client.updateAgentRouting).toHaveBeenCalledWith({
+      framework: 'codex',
+      reviewer: { mode: 'inherit' }
+    })
+  })
+
   it('sends Compute hosts only when the repeatable flag is present and prints authority JSON', async () => {
     const authorityRun = {
       id: 'run-compute',
@@ -1330,8 +1492,7 @@ describe('task CLI', () => {
       'notebook',
       'notebook-env',
       'reviewer',
-      'runtime',
-      'settings'
+      'runtime'
     ]) {
       await expect(runCli([command])).rejects.toThrow(`Unknown command: ${command}`)
     }

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -324,6 +324,12 @@ describe('task CLI', () => {
         'ssh:alpha'
       ])
     ).toThrow('Use only one of Compute Host selection options or --clear-compute-hosts.')
+    expect(() =>
+      parseCliArgs(['run', '--session', 'session-1', '--enable-compute-host', 'ssh:alpha'])
+    ).toThrow('--enable-compute-host cannot update an existing Session; use session config update.')
+    expect(() => parseCliArgs(['run', '--session', 'session-1', '--clear-compute-hosts'])).toThrow(
+      '--clear-compute-hosts cannot update an existing Session; use session config update.'
+    )
   })
 
   it('dispatches atomic configuration updates with their concurrency tokens', async () => {
@@ -435,6 +441,37 @@ describe('task CLI', () => {
       computeHostIds: ['ssh:alpha', 'ssh:beta', 'ssh:alpha']
     })
     expect(JSON.parse(log.mock.calls[0][0]).preferredComputeHostIds).toEqual(['ssh:authority'])
+  })
+
+  it('clears inherited Compute Host access and selection for a new Session', async () => {
+    const client = {
+      listProjects,
+      startRun: vi
+        .fn()
+        .mockResolvedValue({ id: 'run-1', sessionId: 'session-1', status: 'running' })
+    }
+
+    await runTaskCommand(
+      {
+        command: 'run',
+        options: {
+          project: 'project-1',
+          prompt: 'Run locally.',
+          clearComputeHosts: true,
+          wait: false,
+          json: true,
+          jsonl: false
+        }
+      },
+      { connect: vi.fn().mockResolvedValue(client), log: vi.fn(), stdinIsTTY: true }
+    )
+
+    expect(client.startRun).toHaveBeenCalledWith({
+      project: 'project-1',
+      prompt: 'Run locally.',
+      enabledComputeHostIds: [],
+      computeHostIds: []
+    })
   })
 
   it('parses application update output and rejects positional arguments', () => {

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -59,8 +59,14 @@ describe('OpenScienceClient', () => {
         'listProjects',
         'createProject',
         'updateProject',
+        'getProjectSessionDefaults',
+        'updateProjectSessionDefaults',
         'listSessions',
         'getSession',
+        'getSessionConfiguration',
+        'updateSessionConfiguration',
+        'getAgentRouting',
+        'updateAgentRouting',
         'getSessionPlan',
         'respondSessionPlan',
         'startRun',
@@ -74,6 +80,45 @@ describe('OpenScienceClient', () => {
         'throwResponseError'
       ].sort()
     )
+  })
+
+  it('uses versioned endpoints for Session, Project-default, and Agent-routing configuration', async () => {
+    const fetch = vi.fn().mockImplementation(async () => response(200, { data: { ok: true } }))
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'secret-token',
+      fetch
+    })
+
+    await client.getProjectSessionDefaults('project/1')
+    await client.updateProjectSessionDefaults('project/1', {
+      expectedUpdatedAt: 2,
+      patch: { memoryEnabled: false }
+    })
+    await client.getSessionConfiguration('session/1')
+    await client.updateSessionConfiguration('session/1', {
+      expectedRevision: 3,
+      memoryEnabled: false
+    })
+    await client.getAgentRouting()
+    await client.updateAgentRouting({ framework: 'codex' })
+
+    expect(fetch.mock.calls.map(([url]) => url)).toEqual([
+      'http://127.0.0.1:44100/api/v1/projects/project%2F1/session-defaults',
+      'http://127.0.0.1:44100/api/v1/projects/project%2F1/session-defaults',
+      'http://127.0.0.1:44100/api/v1/sessions/session%2F1/config',
+      'http://127.0.0.1:44100/api/v1/sessions/session%2F1/config',
+      'http://127.0.0.1:44100/api/v1/settings/agent-routing',
+      'http://127.0.0.1:44100/api/v1/settings/agent-routing'
+    ])
+    expect(fetch.mock.calls.map(([, options]) => options?.method ?? 'GET')).toEqual([
+      'GET',
+      'PATCH',
+      'GET',
+      'PATCH',
+      'GET',
+      'PATCH'
+    ])
   })
 
   it('starts and waits for a run through the authenticated versioned API', async () => {

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -18,6 +18,19 @@ export type ProjectSessionDefaults = {
   specialistId?: string
   computeHosts?: ComputeHosts
 }
+export type ProjectSessionDefaultsPatch = {
+  agentConfiguration?: {
+    providerId?: string
+    model?: string | null
+    reasoningEffort?: ReasoningEffort
+  } | null
+  permissionProfile?: PermissionProfile | null
+  autoReviewEnabled?: boolean | null
+  memoryEnabled?: boolean | null
+  delegationPolicy?: DelegationPolicy | null
+  specialistId?: string | null
+  computeHosts?: ComputeHosts | null
+}
 export type ModelRouting =
   | { mode: 'inherit' }
   | {
@@ -293,7 +306,7 @@ export class OpenScienceClient {
     projectId: string,
     request: {
       expectedUpdatedAt: number
-      patch: Partial<{ [Key in keyof ProjectSessionDefaults]: ProjectSessionDefaults[Key] | null }>
+      patch: ProjectSessionDefaultsPatch
     },
     options?: RequestOptions
   ): ReturnType<OpenScienceClient['getProjectSessionDefaults']>

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,6 +1,31 @@
 export type PermissionProfile = 'ask' | 'auto' | 'full'
 export type DelegationPolicy = 'allow' | 'deny'
 export type TurnIntent = 'plan-first'
+export type ReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+export type AgentFramework = 'claude-code' | 'opencode' | 'codex' | 'codebuddy'
+export type AgentConfiguration = {
+  providerId: string
+  model?: string
+  reasoningEffort: ReasoningEffort
+}
+export type ComputeHosts = { enabled: string[]; selected: string[] }
+export type ProjectSessionDefaults = {
+  agentConfiguration?: AgentConfiguration
+  permissionProfile?: PermissionProfile
+  autoReviewEnabled?: boolean
+  memoryEnabled?: boolean
+  delegationPolicy?: DelegationPolicy
+  specialistId?: string
+  computeHosts?: ComputeHosts
+}
+export type ModelRouting =
+  | { mode: 'inherit' }
+  | {
+      mode: 'fixed'
+      providerId: string
+      model: string
+      reasoningEffort: ReasoningEffort
+    }
 export type RequestOptions = {
   idempotencyKey?: string
   signal?: AbortSignal
@@ -166,6 +191,47 @@ export type Session = {
   artifactCount: number
 }
 
+export type SessionConfiguration = {
+  sessionId: string
+  projectId: string
+  revision: number
+  cwd: string
+  specialistId?: string
+  persisted: {
+    agentConfiguration?: AgentConfiguration
+    permissionProfile?: PermissionProfile
+    autoReviewEnabled?: boolean
+    memoryEnabled?: boolean
+    delegationPolicy?: DelegationPolicy
+    computeHosts: ComputeHosts
+  }
+  effective: {
+    agentConfiguration?: AgentConfiguration
+    permissionProfile: PermissionProfile
+    autoReviewEnabled: boolean
+    memoryEnabled: boolean
+    delegationPolicy: DelegationPolicy
+    computeHosts: ComputeHosts
+  }
+  availability: {
+    agentConfiguration?: { available: boolean; reason?: string }
+    specialist?: { available: boolean; reason?: string }
+    computeHosts: Record<string, { available: boolean; reason?: string }>
+  }
+}
+
+export type AgentRouting = {
+  configured: { framework: AgentFramework; reviewer: ModelRouting; subagent: ModelRouting }
+  effective: {
+    reviewer:
+      | { source: 'application_main'; providerId?: string; model?: string }
+      | ({ source: 'fixed' } & Omit<Extract<ModelRouting, { mode: 'fixed' }>, 'mode'>)
+    subagent:
+      | { source: 'session_main' }
+      | ({ source: 'fixed' } & Omit<Extract<ModelRouting, { mode: 'fixed' }>, 'mode'>)
+  }
+}
+
 export type Artifact = {
   id: string
   kind: 'workspace-file' | 'external-file' | 'managed-file'
@@ -210,8 +276,55 @@ export class OpenScienceClient {
     },
     options?: RequestOptions
   ): Promise<Project>
+  getProjectSessionDefaults(
+    projectId: string,
+    options?: RequestOptions
+  ): Promise<{
+    projectId: string
+    updatedAt: number
+    configured: ProjectSessionDefaults
+    availability: {
+      agentConfiguration?: { available: boolean; reason?: string }
+      specialist?: { available: boolean; reason?: string }
+      computeHosts: Record<string, { available: boolean; reason?: string }>
+    }
+  }>
+  updateProjectSessionDefaults(
+    projectId: string,
+    request: {
+      expectedUpdatedAt: number
+      patch: Partial<{ [Key in keyof ProjectSessionDefaults]: ProjectSessionDefaults[Key] | null }>
+    },
+    options?: RequestOptions
+  ): ReturnType<OpenScienceClient['getProjectSessionDefaults']>
   listSessions(projectId?: string, options?: RequestOptions): Promise<Session[]>
   getSession(sessionId: string, options?: RequestOptions): Promise<Session>
+  getSessionConfiguration(
+    sessionId: string,
+    options?: RequestOptions
+  ): Promise<SessionConfiguration>
+  updateSessionConfiguration(
+    sessionId: string,
+    request: {
+      expectedRevision: number
+      agentConfiguration?: {
+        providerId?: string
+        model?: string | null
+        reasoningEffort?: ReasoningEffort
+      }
+      permissionProfile?: PermissionProfile
+      autoReviewEnabled?: boolean
+      memoryEnabled?: boolean
+      delegationPolicy?: DelegationPolicy
+      computeHosts?: ComputeHosts
+    },
+    options?: RequestOptions
+  ): Promise<SessionConfiguration>
+  getAgentRouting(options?: RequestOptions): Promise<AgentRouting>
+  updateAgentRouting(
+    request: { framework?: AgentFramework; reviewer?: ModelRouting; subagent?: ModelRouting },
+    options?: RequestOptions
+  ): Promise<AgentRouting>
   getSessionPlan(sessionId: string, options?: RequestOptions): Promise<SessionPlan | null>
   respondSessionPlan(
     sessionId: string,
@@ -236,7 +349,10 @@ export class OpenScienceClient {
       autoReviewEnabled?: boolean
       specialist?: string
       delegationPolicy?: DelegationPolicy
+      agentConfiguration?: Partial<AgentConfiguration> & { model?: string | null }
+      memoryEnabled?: boolean
       computeHostIds?: string[]
+      enabledComputeHostIds?: string[]
     },
     options?: RequestOptions
   ): Promise<Run>

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -203,6 +203,21 @@ export class OpenScienceClient {
     })
   }
 
+  getProjectSessionDefaults(projectId, options) {
+    return this.request(
+      `/api/v1/projects/${encodeURIComponent(projectId)}/session-defaults`,
+      options
+    )
+  }
+
+  updateProjectSessionDefaults(projectId, request, options) {
+    return this.request(`/api/v1/projects/${encodeURIComponent(projectId)}/session-defaults`, {
+      ...options,
+      method: 'PATCH',
+      body: request
+    })
+  }
+
   listSessions(projectId, options) {
     const query = projectId ? `?project=${encodeURIComponent(projectId)}` : ''
     return this.request(`/api/v1/sessions${query}`, options)
@@ -210,6 +225,30 @@ export class OpenScienceClient {
 
   getSession(sessionId, options) {
     return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, options)
+  }
+
+  getSessionConfiguration(sessionId, options) {
+    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/config`, options)
+  }
+
+  updateSessionConfiguration(sessionId, request, options) {
+    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/config`, {
+      ...options,
+      method: 'PATCH',
+      body: request
+    })
+  }
+
+  getAgentRouting(options) {
+    return this.request('/api/v1/settings/agent-routing', options)
+  }
+
+  updateAgentRouting(request, options) {
+    return this.request('/api/v1/settings/agent-routing', {
+      ...options,
+      method: 'PATCH',
+      body: request
+    })
   }
 
   getSessionPlan(sessionId, options) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Project {
   name             String
   description      String               @default("")
   agentContext     String               @default("")
+  sessionDefaults  String               @default("{}")
   isExample        Boolean              @default(false)
   pinned           Boolean              @default(false)
   archivedAt       DateTime?

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -108,6 +108,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0026_compute_job_remote_cleanup',
     checksum: 'c9c0dff928daa4eafe5b8910c4202ddba83f740e92cb243a4fa0dc8e323cba7b'
+  },
+  {
+    id: '0027_project_session_defaults',
+    checksum: 'af7f3740a6032de71789e25567ee6605f961ee0dea3b89df2b47f9a589e738c7'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -74,10 +74,6 @@ describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
     expect(MIGRATION_MANIFEST.slice(-5).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
-        id: '0022_memory_global_content_unique',
-        checksum: '0f02a6cace6991db4377da8a2f8d52dad221cb2fede595bf11bab90c64737ac8'
-      },
-      {
         id: '0023_compute_job_operation',
         checksum: 'c625e336996c7dd1eba64da8ccd306104ccd68cf219e60ee2c3889749f86b079'
       },
@@ -92,6 +88,10 @@ describe('packaged database migration ledger smoke', () => {
       {
         id: '0026_compute_job_remote_cleanup',
         checksum: 'c9c0dff928daa4eafe5b8910c4202ddba83f740e92cb243a4fa0dc8e323cba7b'
+      },
+      {
+        id: '0027_project_session_defaults',
+        checksum: 'af7f3740a6032de71789e25567ee6605f961ee0dea3b89df2b47f9a589e738c7'
       }
     ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
@@ -129,7 +129,7 @@ describe('packaged database migration ledger smoke', () => {
       }
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
       )
 
       await migrateApplicationDatabase(client)
@@ -165,7 +165,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await rebuildComputeJobWithoutAnalysisConstraints(client, false)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
       )
       await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
         "id", "providerId", "shape", "sessionId", "projectId", "status", "intent",
@@ -199,7 +199,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await client.$executeRawUnsafe('DROP INDEX "MemoryEntry_global_contentKey_key"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
       )
       await client.memoryEntry.createMany({
         data: [
@@ -297,7 +297,7 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
 
@@ -373,7 +373,8 @@ describe('packaged database migration ledger smoke', () => {
            '0023_compute_job_operation',
            '0024_compute_job_file_evidence',
            '0025_managed_file_version_foundation',
-           '0026_compute_job_remote_cleanup'
+           '0026_compute_job_remote_cleanup',
+           '0027_project_session_defaults'
          )`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -384,7 +384,6 @@ const createAcpRuntime = ({
           projectId: DEFAULT_ARTIFACT_PROJECT_ID,
           mcpEntryPath,
           memoryTools: !delegatedNotebookConnection,
-          isMemoryEnabled: () => memory?.isEnabled?.() ?? Promise.resolve(false),
           getRpcConnection: ({ sessionId, projectId, memoryTools }) =>
             delegatedNotebookConnection
               ? Promise.resolve(delegatedNotebookConnection)

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -94,6 +94,7 @@ const createFakeRuntime = (options: {
   beginProviderTurnObservation: ReturnType<typeof vi.fn>
   captureSessionModel: ReturnType<typeof vi.fn>
   setPermissionProfile: ReturnType<typeof vi.fn>
+  setMemoryEnabled: ReturnType<typeof vi.fn>
   respondToPermission: ReturnType<typeof vi.fn>
   requestUserInput: ReturnType<typeof vi.fn>
   disableLiteratureContext: ReturnType<typeof vi.fn>
@@ -166,6 +167,7 @@ const createFakeRuntime = (options: {
     appliedModel: `${sessionId}:applied`
   }))
   const setPermissionProfile = vi.fn(async () => snapshot)
+  const setMemoryEnabled = vi.fn()
   const respondToPermission = vi.fn((response: AcpPermissionResponse) => {
     options.callbacks.onPermissionSettled?.(
       response.requestId,
@@ -301,6 +303,7 @@ const createFakeRuntime = (options: {
     beginProviderTurnObservation,
     captureSessionModel,
     setPermissionProfile,
+    setMemoryEnabled,
     respondToPermission,
     requestUserInput,
     disableLiteratureContext,
@@ -332,6 +335,7 @@ const createFakeRuntime = (options: {
     beginProviderTurnObservation,
     captureSessionModel,
     setPermissionProfile,
+    setMemoryEnabled,
     respondToPermission,
     requestUserInput,
     disableLiteratureContext,
@@ -1097,6 +1101,9 @@ describe('AcpRuntimeCoordinator', () => {
       profile: 'ask'
     })
     expect(delegated.setPermissionProfile).toHaveBeenCalledWith('session-1', 'ask')
+
+    coordinator.setMemoryEnabled('session-1', false)
+    expect(created[0].setMemoryEnabled).toHaveBeenCalledWith('session-1', false)
 
     await coordinator.cancelPrompt({ sessionId: 'session-1' })
     expect(delegated.stopSession).not.toHaveBeenCalled()

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1334,6 +1334,10 @@ class AcpRuntimeCoordinator {
     return this.getState()
   }
 
+  setMemoryEnabled(sessionId: string, enabled: boolean): void {
+    this.runtimeForSession(sessionId).setMemoryEnabled(sessionId, enabled)
+  }
+
   async revokePermissionGrant(request: AcpRevokePermissionGrantRequest): Promise<AcpRuntimeState> {
     await this.runtimeForSession(request.sessionId).revokePermissionGrant(request)
     return this.getState()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -5649,6 +5649,23 @@ describe('ACP runtime session management', () => {
     expect(reconfigure.mock.calls.map(([request]) => request.memoryEnabled)).toEqual([false, false])
   })
 
+  it('updates Memory on an attached Session without replacing its provider Session', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['remote-session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', memoryEnabled: true })
+
+    runtime.setMemoryEnabled(session.sessionId, false)
+
+    expect(runtime.isSessionMemoryEnabled(session.sessionId)).toBe(false)
+    expect(fakeAgent.newSessions).toHaveLength(1)
+    expect(fakeAgent.resumedSessions).toEqual([])
+  })
+
   it('adds the hidden Plan mode context only to the requested turn and preserves user Messages', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1'])
@@ -21732,6 +21749,7 @@ describe('ACP runtime session management', () => {
         getSnapshot: () => runtime.getSnapshot(),
         resumeSession: (request) => runtime.resumeSession(request),
         setPermissionProfile: (request) => runtime.setPermissionProfile(request),
+        setMemoryEnabled: (sessionId, enabled) => runtime.setMemoryEnabled(sessionId, enabled),
         sendPrompt: (request) => runtime.sendPrompt(request),
         sendPromptObserved: async (request, onProviderPromptAccepted) => {
           onProviderPromptAccepted()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -833,6 +833,13 @@ class AcpRuntime {
     return this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().memoryEnabled ?? false
   }
 
+  setMemoryEnabled(sessionId: string, enabled: boolean): void {
+    const aggregate = this.sessionRegistry.lookup(sessionId)?.aggregate
+    if (!aggregate) throw new Error(`ACP session not found: ${sessionId}`)
+    aggregate.setMemoryEnabled(enabled)
+    this.emitState()
+  }
+
   liveSessionProjectId(sessionId: string): string | undefined {
     return this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().projectId
   }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -336,7 +336,6 @@ type AcpRuntimeNotebookOptions = {
   mcpEntryPath: string
   mcpCommand?: string
   memoryTools?: boolean
-  isMemoryEnabled?: () => Promise<boolean>
   getRpcConnection?: (binding: {
     sessionId: string
     projectId: string

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -32,90 +32,6 @@ const createOwner = (
   })
 
 describe('ACP session capability owner', () => {
-  it.each([
-    { globalEnabled: true, sessionEnabled: true, expected: '1' },
-    { globalEnabled: true, sessionEnabled: false, expected: '0' },
-    { globalEnabled: false, sessionEnabled: true, expected: '0' },
-    { globalEnabled: false, sessionEnabled: false, expected: '0' }
-  ])(
-    'enables Memory tools only when global=$globalEnabled and session=$sessionEnabled',
-    async ({ globalEnabled, sessionEnabled, expected }) => {
-      const getRpcConnection = vi.fn(async () => ({
-        endpoint: 'http://127.0.0.1:1',
-        token: 'notebook'
-      }))
-      const owner = createOwner({
-        artifacts: undefined,
-        skillImport: undefined,
-        notebook: {
-          projectId: 'project',
-          mcpEntryPath: '/app/main.js',
-          isMemoryEnabled: async () => globalEnabled,
-          getRpcConnection
-        }
-      })
-
-      const provision = await owner.provision({
-        stableAppSessionId: 'session-1',
-        framework: opencodeFramework,
-        nativeMcpEnabled: true,
-        bridgeMcpAliasesEnabled: false,
-        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-        sessionCwd: '/workspace',
-        projectId: 'project',
-        memoryEnabled: sessionEnabled
-      })
-      const notebook = provision.mcpServers.find(
-        (server) => server.name === 'open_science_notebook'
-      )
-
-      expect(notebook && 'env' in notebook ? notebook.env : []).toContainEqual({
-        name: 'OPEN_SCIENCE_NOTEBOOK_MEMORY_TOOLS',
-        value: expected
-      })
-      expect(getRpcConnection).toHaveBeenCalledWith(
-        expect.objectContaining({ memoryTools: expected === '1' })
-      )
-    }
-  )
-
-  it('fails closed without blocking capability provisioning when the global Memory gate cannot be read', async () => {
-    const getRpcConnection = vi.fn(async () => ({
-      endpoint: 'http://127.0.0.1:1',
-      token: 'notebook'
-    }))
-    const owner = createOwner({
-      artifacts: undefined,
-      skillImport: undefined,
-      notebook: {
-        projectId: 'project',
-        mcpEntryPath: '/app/main.js',
-        isMemoryEnabled: async () => {
-          throw new Error('settings unavailable')
-        },
-        getRpcConnection
-      }
-    })
-
-    const provision = await owner.provision({
-      stableAppSessionId: 'session-1',
-      framework: opencodeFramework,
-      nativeMcpEnabled: true,
-      bridgeMcpAliasesEnabled: false,
-      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-      sessionCwd: '/workspace',
-      projectId: 'project',
-      memoryEnabled: true
-    })
-    const notebook = provision.mcpServers.find((server) => server.name === 'open_science_notebook')
-
-    expect(notebook && 'env' in notebook ? notebook.env : []).toContainEqual({
-      name: 'OPEN_SCIENCE_NOTEBOOK_MEMORY_TOOLS',
-      value: '0'
-    })
-    expect(getRpcConnection).toHaveBeenCalledWith(expect.objectContaining({ memoryTools: false }))
-  })
-
   it('marks delegated Notebook MCP processes as ineligible for memory tools', async () => {
     const owner = createOwner({
       artifacts: undefined,
@@ -1155,7 +1071,8 @@ describe('ACP session capability owner', () => {
         bridgeMcpAliasesEnabled,
         policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
         sessionCwd: '/workspace',
-        projectId: 'project'
+        projectId: 'project',
+        memoryEnabled: false
       })
 
       expect(built.descriptor.controlRpcMethods).toEqual(
@@ -1182,6 +1099,11 @@ describe('ACP session capability owner', () => {
       expect(built.descriptor.transport).toBe('stdio')
       expect(built.descriptor.modelFacingMcpServerNames).toContain(artifactServerName)
       expect(built.descriptor.modelFacingMcpServerNames).toContain(notebookServerName)
+      const notebook = built.mcpServers.find((server) => server.name === notebookServerName)
+      expect(notebook && 'env' in notebook ? notebook.env : []).toContainEqual({
+        name: 'OPEN_SCIENCE_NOTEBOOK_MEMORY_TOOLS',
+        value: '1'
+      })
     }
   )
 

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -133,7 +133,6 @@ export type SessionCapabilityNotebookOptions = {
   mcpEntryPath: string
   mcpCommand?: string
   memoryTools?: boolean
-  isMemoryEnabled?: () => Promise<boolean>
   getRpcConnection?: (binding: {
     sessionId: string
     projectId: string
@@ -569,14 +568,7 @@ export class AcpSessionCapabilityOwner {
     const skillImportAllowed = policyAllowsSessionCapability(request.policy, 'skill-import')
     const planAllowed = policyAllowsSessionCapability(request.policy, 'plan')
     const hostMessageAllowed = policyAllowsSessionCapability(request.policy, 'host-message')
-    let memoryToolsEnabled = false
-    if ((this.options.notebook?.memoryTools ?? true) && request.memoryEnabled !== false) {
-      try {
-        memoryToolsEnabled = (await this.options.notebook?.isMemoryEnabled?.()) !== false
-      } catch (error) {
-        safeLogError('Memory capability gate read failed', diagnosticErrorFields(error))
-      }
-    }
+    const memoryToolsEnabled = this.options.notebook?.memoryTools ?? true
     const literatureAllowed =
       policyAllowsSessionCapability(request.policy, 'literature') &&
       Boolean(this.options.literature) &&

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -27,6 +27,7 @@ describe('ACP Task Agent port', () => {
       | 'createSession'
       | 'resumeSession'
       | 'setPermissionProfile'
+      | 'setMemoryEnabled'
       | 'prompt'
       | 'cancelPrompt'
     >()
@@ -49,6 +50,7 @@ describe('ACP Task Agent port', () => {
         contextReset: true
       })),
       setPermissionProfile: vi.fn(async () => undefined),
+      setMemoryEnabled: vi.fn(),
       sendPrompt: vi.fn(async () => undefined),
       sendPromptObserved: vi.fn(async () => undefined),
       cancelPrompt: vi.fn(async () => undefined)
@@ -125,6 +127,7 @@ describe('ACP Task Agent port', () => {
       contextReset: true
     })
     await port.setPermissionProfile('session-stable', 'full')
+    await port.setMemoryEnabled('session-stable', false)
     await port.prompt({
       sessionId: 'session-stable',
       promptMessageId: 'persisted-prompt',
@@ -176,6 +179,7 @@ describe('ACP Task Agent port', () => {
       sessionId: 'session-stable',
       profile: 'full'
     })
+    expect(runtime.setMemoryEnabled).toHaveBeenCalledWith('session-stable', false)
     expect(runtime.sendPrompt).toHaveBeenCalledWith({
       sessionId: 'session-stable',
       text: 'Continue the research.',
@@ -194,6 +198,7 @@ describe('ACP Task Agent port', () => {
       getSnapshot: vi.fn(() => ({ sessionIds: [] })),
       resumeSession: vi.fn(async () => ({ sessionId: 'session-legacy' })),
       setPermissionProfile: vi.fn(async () => undefined),
+      setMemoryEnabled: vi.fn(),
       sendPrompt: vi.fn(async () => undefined),
       sendPromptObserved: vi.fn(async () => undefined),
       cancelPrompt: vi.fn(async () => undefined)
@@ -255,6 +260,7 @@ describe('ACP Task Agent port', () => {
         getSnapshot: () => ({ sessionIds: [] }),
         resumeSession: vi.fn(),
         setPermissionProfile: vi.fn(),
+        setMemoryEnabled: vi.fn(),
         sendPrompt,
         sendPromptObserved: sendPrompt,
         cancelPrompt: vi.fn()
@@ -297,6 +303,7 @@ describe('ACP Task Agent port', () => {
         getSnapshot: () => ({ sessionIds: [] }),
         resumeSession: vi.fn(),
         setPermissionProfile: vi.fn(),
+        setMemoryEnabled: vi.fn(),
         sendPrompt,
         sendPromptObserved: sendPrompt,
         cancelPrompt: vi.fn()

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -63,12 +63,15 @@ const createAcpTaskAgentPort = (
       : operation(),
   listAttachedSessionIds: async () => [...runtime.getSnapshot().sessionIds],
   createSession: async (request) => {
-    const agentTarget = await resolveDefaultSessionAgentTarget?.()
+    const agentTarget = request.agentConfiguration
+      ? await resolveSessionAgentTarget?.({ agentConfiguration: request.agentConfiguration })
+      : await resolveDefaultSessionAgentTarget?.()
     const response = await createSessionWorkflow.create({
       projectId: request.projectId,
       permissionProfile: request.permissionProfile,
       ...(request.cwd ? { cwd: request.cwd } : {}),
       ...(request.specialistId ? { specialistId: request.specialistId } : {}),
+      ...(request.memoryEnabled !== undefined ? { memoryEnabled: request.memoryEnabled } : {}),
       ...(agentTarget ? { agentTarget } : {})
     })
     return {

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -17,6 +17,7 @@ type AcpTaskAgentRuntime = {
   getSnapshot(): { sessionIds: string[] }
   resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
   setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<unknown>
+  setMemoryEnabled(sessionId: string, enabled: boolean): void
   sendPrompt(request: AcpPromptRequest): Promise<unknown>
   sendPromptObserved(
     request: AcpPromptRequest,
@@ -106,6 +107,7 @@ const createAcpTaskAgentPort = (
   },
   setPermissionProfile: (sessionId, profile) =>
     runtime.setPermissionProfile({ sessionId, profile }).then(() => undefined),
+  setMemoryEnabled: async (sessionId, enabled) => runtime.setMemoryEnabled(sessionId, enabled),
   prompt: async (request, observer) => {
     const acpRequest = toAcpPromptRequest(request)
     const tracked = notifications?.trackPrompt(acpRequest)

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -272,7 +272,7 @@ describe('application command composition', () => {
     expect(composition.task.commandNames()).not.toContain('reviewer:abort-fix-loop')
   })
 
-  it('exposes only the nineteen Task commands and no transport-wide capability', async () => {
+  it('exposes only the twenty Task commands and no transport-wide capability', async () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
@@ -287,6 +287,7 @@ describe('application command composition', () => {
       'sessions:settle-task-completion',
       'sessions:fail-task-run',
       'sessions:set-delegation-policy',
+      'sessions:update-configuration',
       'acp:get-plan-projection',
       'acp:respond-plan',
       'reviewer:abort',

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -272,13 +272,15 @@ describe('application command composition', () => {
     expect(composition.task.commandNames()).not.toContain('reviewer:abort-fix-loop')
   })
 
-  it('exposes only the seventeen Task commands and no transport-wide capability', async () => {
+  it('exposes only the nineteen Task commands and no transport-wide capability', async () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
       'projects:list',
       'projects:create',
       'projects:update',
+      'settings:get-settings',
+      'settings:set-agent-routing',
       'sessions:load-all',
       'sessions:save-session',
       'sessions:stage-task-completion',

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -272,13 +272,14 @@ describe('application command composition', () => {
     expect(composition.task.commandNames()).not.toContain('reviewer:abort-fix-loop')
   })
 
-  it('exposes only the twenty Task commands and no transport-wide capability', async () => {
+  it('exposes only the twenty-one Task commands and no transport-wide capability', async () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
       'projects:list',
       'projects:create',
       'projects:update',
+      'projects:update-session-defaults',
       'settings:get-settings',
       'settings:set-agent-routing',
       'sessions:load-all',

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -136,6 +136,7 @@ const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
 ])
 
 const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
+  'projects:update-session-defaults',
   'reviewer:abort',
   'settings:set-agent-routing',
   'sessions:fail-task-run',
@@ -148,6 +149,7 @@ const TASK_COMMAND_NAMES = Object.freeze([
   'projects:list',
   'projects:create',
   'projects:update',
+  'projects:update-session-defaults',
   'settings:get-settings',
   'settings:set-agent-routing',
   'sessions:load-all',

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -137,6 +137,7 @@ const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
 
 const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
   'reviewer:abort',
+  'settings:set-agent-routing',
   'sessions:fail-task-run',
   'sessions:settle-task-completion',
   'sessions:stage-task-completion'
@@ -146,6 +147,8 @@ const TASK_COMMAND_NAMES = Object.freeze([
   'projects:list',
   'projects:create',
   'projects:update',
+  'settings:get-settings',
+  'settings:set-agent-routing',
   'sessions:load-all',
   'sessions:save-session',
   'sessions:stage-task-completion',

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -140,7 +140,8 @@ const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
   'settings:set-agent-routing',
   'sessions:fail-task-run',
   'sessions:settle-task-completion',
-  'sessions:stage-task-completion'
+  'sessions:stage-task-completion',
+  'sessions:update-configuration'
 ])
 
 const TASK_COMMAND_NAMES = Object.freeze([
@@ -155,6 +156,7 @@ const TASK_COMMAND_NAMES = Object.freeze([
   'sessions:settle-task-completion',
   'sessions:fail-task-run',
   'sessions:set-delegation-policy',
+  'sessions:update-configuration',
   'acp:get-plan-projection',
   'acp:respond-plan',
   'reviewer:abort',

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -256,7 +256,7 @@ describe('production application command wiring', () => {
     expect(occurrences(ipcSource, 'applicationCommands')).toBe(2)
     expect(indexSource).toContain('applicationCommands,')
     expect(startup).toContain('applicationCommands,')
-    expect(startup).toContain('taskControls, computePreferences }')
+    expect(startup).toContain('taskControls, computePreferences, detectActiveSessions }')
     expect(compact(ipcSource)).toContain(
       "computePreferences: Pick<SessionEnabledComputeHostsOwner, 'withReservation' | 'set'>"
     )
@@ -269,7 +269,7 @@ describe('production application command wiring', () => {
       "Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>"
     )
     expect(compact(webServiceSource)).toContain(
-      '{ commands: applicationCommands.task, agent: taskAgent, controls: taskControls, computePreferences }'
+      '{ commands: applicationCommands.task, agent: taskAgent, controls: taskControls, computePreferences, detectActiveSessions }'
     )
     expect(webServiceSource).toContain('localWeb: applicationCommands.localWeb')
     expect(webServiceSource).toContain('remoteWeb: applicationCommands.remoteWeb')

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -91,6 +91,14 @@ class SessionEnabledComputeHostsOwner {
     return this.options.registry.getSelected(sessionId)
   }
 
+  validate(providerIds: readonly string[]): Promise<string[]> {
+    return this.enqueueWrite(() => this.validateProviderIds(providerIds))
+  }
+
+  listAvailable(): Promise<readonly string[]> {
+    return this.enqueue(() => this.options.listHostIds())
+  }
+
   async withReservation<Result>(
     providerIds: readonly string[],
     operation: (providerIds: string[]) => Promise<Result>

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -248,6 +248,7 @@ const WRAPPED_COMMAND_KEYS = [
   'projectCreate',
   'projectDelete',
   'projectUpdate',
+  'projectUpdateSessionDefaults',
   'sessionDelete',
   'sessionEditDetails',
   'sessionExportConversation',
@@ -327,6 +328,7 @@ describe('Data and content application commands', () => {
         'projects:list-deletion-cleanup',
         'projects:retry-deletion-cleanup',
         'projects:update',
+        'projects:update-session-defaults',
         'sessions:delete-session',
         'sessions:edit-details',
         'sessions:export-conversation',
@@ -1110,6 +1112,42 @@ describe('Data and content application commands', () => {
       )
     }
     expect(deps.sessions.updateSessionConfiguration).toHaveBeenCalledOnce()
+  })
+
+  it('keeps Project Session defaults behind the Task-only validated command', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const request = {
+      id: deps.project.id,
+      expectedUpdatedAt: deps.project.updatedAt,
+      sessionDefaults: { memoryEnabled: false }
+    }
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.projectUpdate,
+        invocation([request] as const)
+      )
+    ).rejects.toThrow(
+      'Project Session defaults must be changed through the Task configuration API.'
+    )
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.projectUpdateSessionDefaults,
+        invocation([request] as const, callerContext)
+      )
+    ).rejects.toThrow(
+      'Channel only available from Task automation: projects:update-session-defaults'
+    )
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.projectUpdateSessionDefaults,
+        invocation([request] as const, createTaskCallerContext())
+      )
+    ).resolves.toBe(deps.project)
+    expect(deps.projects.update).toHaveBeenCalledOnce()
+    expect(deps.projects.update).toHaveBeenCalledWith(request)
   })
 
   it('preserves configuration revision conflicts across the Task command boundary', async () => {

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -177,6 +177,7 @@ const createDependencies = () => {
     settleTaskCompletion: vi.fn(async () => session),
     failTaskRun: vi.fn(async () => session),
     setDelegationPolicy: vi.fn(async () => session),
+    updateSessionConfiguration: vi.fn(async () => session),
     deleteSession: vi.fn(async (): Promise<SessionDeletionResult> => ({
       status: 'deleted',
       runtimeDetached: true
@@ -262,6 +263,7 @@ const WRAPPED_COMMAND_KEYS = [
   'sessionSettleTaskCompletion',
   'sessionFailTaskRun',
   'sessionSetDelegationPolicy',
+  'sessionUpdateConfiguration',
   'sessionUnlinkPdfContext',
   'uploadStageLocalFile',
   'uploadStageLocalPath'
@@ -342,6 +344,7 @@ describe('Data and content application commands', () => {
         'sessions:settle-task-completion',
         'sessions:fail-task-run',
         'sessions:set-delegation-policy',
+        'sessions:update-configuration',
         'uploads:abort-transfer',
         'uploads:append-transfer',
         'uploads:begin-transfer',
@@ -1068,6 +1071,62 @@ describe('Data and content application commands', () => {
         ] as const)
       )
     ).rejects.toMatchObject({ code: 'invalid-command-result' })
+  })
+
+  it('allows only Task automation to atomically update authoritative Session configuration', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const configured = {
+      ...deps.session,
+      revision: 5,
+      memoryEnabled: false,
+      delegationPolicy: 'deny' as const,
+      enabledComputeHosts: ['ssh:alpha'],
+      selectedComputeHosts: ['ssh:alpha']
+    }
+    deps.sessions.updateSessionConfiguration.mockResolvedValueOnce(configured)
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionUpdateConfiguration,
+        invocation([configured, 4] as const, createTaskCallerContext())
+      )
+    ).resolves.toEqual(configured)
+    expect(deps.sessions.updateSessionConfiguration).toHaveBeenCalledWith(configured, 4)
+    expect(deps.events.publish).toHaveBeenCalledWith('session:updated', {
+      session: configured,
+      originClientId: 'web:headless-task-api'
+    })
+
+    for (const rejectedCaller of [electronCaller, callerContext, remoteCaller]) {
+      await expect(
+        router.dispatcher.invoke(
+          dataContentApplicationCommands.sessionUpdateConfiguration,
+          invocation([configured, 5] as const, rejectedCaller)
+        )
+      ).rejects.toThrow(
+        'Channel only available from Task automation: sessions:update-configuration'
+      )
+    }
+    expect(deps.sessions.updateSessionConfiguration).toHaveBeenCalledOnce()
+  })
+
+  it('preserves configuration revision conflicts across the Task command boundary', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    deps.sessions.updateSessionConfiguration.mockRejectedValueOnce(
+      new SessionRevisionConflictError(4, 5)
+    )
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionUpdateConfiguration,
+        invocation([{ ...deps.session, revision: 4 }, 4] as const, createTaskCallerContext())
+      )
+    ).rejects.toMatchObject({ code: 'session-revision-conflict' })
+    expect(deps.events.publish).not.toHaveBeenCalled()
   })
 
   it('sanitizes the complete authoritative Session result instead of passing malformed fields', async () => {

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -110,6 +110,10 @@ type SessionApplicationCommandOwner = Omit<SessionPersistenceHandlers, 'deleteSe
   editDetails(
     request: SessionPersistence.EditSessionDetailsRequest
   ): Promise<SessionPersistence.PersistedChatSession>
+  updateSessionConfiguration(
+    session: SessionPersistence.PersistedChatSession,
+    expectedRevision: number
+  ): Promise<SessionPersistence.PersistedChatSession>
   deleteSession(
     request: SessionPersistence.DeleteSessionRequest
   ): Promise<SessionPersistence.SessionDeletionResult>
@@ -367,6 +371,14 @@ const dataContentApplicationCommands = Object.freeze({
     'sessions:set-delegation-policy',
     SessionPersistence.sessionApplicationCommandContracts.setDelegationPolicy
   ),
+  sessionUpdateConfiguration: defineApplicationCommand<
+    'sessions:update-configuration',
+    readonly [session: SessionPersistence.PersistedChatSession, expectedRevision: number],
+    SessionPersistence.PersistedChatSession
+  >(
+    'sessions:update-configuration',
+    SessionPersistence.sessionApplicationCommandContracts.updateConfiguration
+  ),
   uploadAbortTransfer: uploadCommand('uploads:abort-transfer', 'abortTransfer'),
   uploadAppendTransfer: uploadCommand('uploads:append-transfer', 'appendTransfer'),
   uploadBeginTransfer: uploadCommand('uploads:begin-transfer', 'beginTransfer'),
@@ -447,7 +459,8 @@ const dataContentApplicationCommandGroups = Object.freeze([
     dataContentApplicationCommands.sessionStageTaskCompletion,
     dataContentApplicationCommands.sessionSettleTaskCompletion,
     dataContentApplicationCommands.sessionFailTaskRun,
-    dataContentApplicationCommands.sessionSetDelegationPolicy
+    dataContentApplicationCommands.sessionSetDelegationPolicy,
+    dataContentApplicationCommands.sessionUpdateConfiguration
   ] as const),
   defineApplicationCommandGroup('uploads', [
     dataContentApplicationCommands.uploadAbortTransfer,
@@ -489,6 +502,15 @@ const assertSessionDelegationPolicyCaller = (
   const { callerContext } = invocation
   if (!canMutateSessionDelegationPolicy(callerContext)) {
     throw new Error(`Channel only available from current human or Task automation: ${name}`)
+  }
+}
+
+const assertTaskCaller = (
+  invocation: ApplicationInvocation<readonly unknown[]>,
+  name: string
+): void => {
+  if (invocation.callerContext.surface !== 'task') {
+    throw new Error(`Channel only available from Task automation: ${name}`)
   }
 }
 
@@ -778,6 +800,32 @@ const registerDataContentApplicationCommands = (
           publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.sessionUpdated, {
             session,
             originClientId: MAIN_DELEGATION_POLICY_LIFECYCLE_CLIENT_ID
+          })
+          return session
+        })
+      },
+      'sessions:update-configuration': (invocation) => {
+        assertTaskCaller(invocation, dataContentApplicationCommands.sessionUpdateConfiguration.name)
+        const originClientId = invocation.callerContext.lifecycleClientId
+        return dependencies.withDataRootWrite(async () => {
+          let session: SessionPersistence.PersistedChatSession
+          try {
+            session = await dependencies.sessions.updateSessionConfiguration(
+              invocation.args[0],
+              invocation.args[1]
+            )
+          } catch (error) {
+            if (SessionPersistence.isSessionRevisionConflictError(error)) {
+              throw new ApplicationCommandError(
+                SessionPersistence.SESSION_REVISION_CONFLICT_ERROR_CODE,
+                error instanceof Error ? error.message : 'Session revision conflict.'
+              )
+            }
+            throw error
+          }
+          publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.sessionUpdated, {
+            session,
+            originClientId
           })
           return session
         })

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -297,6 +297,11 @@ const dataContentApplicationCommands = Object.freeze({
     'update',
     Projects.projectApplicationCommandContracts.update
   ),
+  projectUpdateSessionDefaults: projectCommand(
+    'projects:update-session-defaults',
+    'update',
+    Projects.projectApplicationCommandContracts.update
+  ),
   sessionDelete: sessionCommand(
     'sessions:delete-session',
     'deleteSession',
@@ -440,7 +445,8 @@ const dataContentApplicationCommandGroups = Object.freeze([
     dataContentApplicationCommands.projectList,
     dataContentApplicationCommands.projectListDeletionCleanup,
     dataContentApplicationCommands.projectRetryDeletionCleanup,
-    dataContentApplicationCommands.projectUpdate
+    dataContentApplicationCommands.projectUpdate,
+    dataContentApplicationCommands.projectUpdateSessionDefaults
   ] as const),
   defineApplicationCommandGroup('sessions', [
     dataContentApplicationCommands.sessionDelete,
@@ -632,10 +638,29 @@ const registerDataContentApplicationCommands = (
         }),
       'projects:update': ({ args }) =>
         dependencies.withDataRootWrite(async () => {
+          if (args[0].sessionDefaults !== undefined) {
+            throw new Error(
+              'Project Session defaults must be changed through the Task configuration API.'
+            )
+          }
           const project = await dependencies.projects.update(args[0])
           publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectUpdated, project)
           return project
+        }),
+      'projects:update-session-defaults': (invocation) => {
+        assertTaskCaller(
+          invocation,
+          dataContentApplicationCommands.projectUpdateSessionDefaults.name
+        )
+        return dependencies.withDataRootWrite(async () => {
+          if (invocation.args[0].sessionDefaults === undefined) {
+            throw new Error('Project Session defaults are required.')
+          }
+          const project = await dependencies.projects.update(invocation.args[0])
+          publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.projectUpdated, project)
+          return project
         })
+      }
     })
     scope.registerGroup(dataContentApplicationCommandGroups[6], {
       'sessions:delete-session': async ({ args }) => {

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -17,7 +17,7 @@ const COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID = '0021_compute_job_analysis_con
 const MEMORY_GLOBAL_CONTENT_UNIQUE_MIGRATION_ID = '0022_memory_global_content_unique'
 const COMPUTE_JOB_OPERATION_MIGRATION_ID = '0023_compute_job_operation'
 const COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID = '0024_compute_job_file_evidence'
-const CURRENT_MIGRATION_ID = '0026_compute_job_remote_cleanup'
+const CURRENT_MIGRATION_ID = '0027_project_session_defaults'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -307,7 +307,7 @@ describe('agent memory project scope migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "fileEvidence"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "producerRunId"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
       SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
@@ -317,6 +317,7 @@ describe('agent memory project scope migration', () => {
       COMPUTE_JOB_OPERATION_MIGRATION_ID,
       COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID,
       '0025_managed_file_version_foundation',
+      '0026_compute_job_remote_cleanup',
       CURRENT_MIGRATION_ID
     )
 
@@ -331,6 +332,7 @@ describe('agent memory project scope migration', () => {
         COMPUTE_JOB_OPERATION_MIGRATION_ID,
         COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID,
         '0025_managed_file_version_foundation',
+        '0026_compute_job_remote_cleanup',
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -213,7 +213,8 @@ describe('application database (integration)', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
 
@@ -1260,7 +1261,8 @@ describe('application database (integration)', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
 

--- a/src/main/database/compute-job-operation-migration.test.ts
+++ b/src/main/database/compute-job-operation-migration.test.ts
@@ -24,7 +24,7 @@ describe('Compute Job operation migration', () => {
     await migrateApplicationDatabase(client)
     await client.$executeRawUnsafe(`DROP TABLE "ComputeJobOperation"`)
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
     )
     const [{ sql: computeJobSqlBefore }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
       `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
@@ -40,7 +40,7 @@ describe('Compute Job operation migration', () => {
       client.$queryRawUnsafe<Array<{ id: string }>>(
         `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1`
       )
-    ).resolves.toEqual([{ id: '0026_compute_job_remote_cleanup' }])
+    ).resolves.toEqual([{ id: '0027_project_session_defaults' }])
   })
 
   it('adds a constrained operation sidecar without rebuilding historical ComputeJob rows', async () => {

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -73,10 +73,11 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ],
       from: '0015_session_model_call_usage',
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -165,10 +165,11 @@ describe('database JSON constraints migration', () => {
           '0023_compute_job_operation',
           '0024_compute_job_file_evidence',
           '0025_managed_file_version_foundation',
-          '0026_compute_job_remote_cleanup'
+          '0026_compute_job_remote_cleanup',
+          '0027_project_session_defaults'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0026_compute_job_remote_cleanup'
+        to: '0027_project_session_defaults'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
       await expect(

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -118,7 +118,8 @@ describe('database startup logging', () => {
               '0023_compute_job_operation',
               '0024_compute_job_file_evidence',
               '0025_managed_file_version_foundation',
-              '0026_compute_job_remote_cleanup'
+              '0026_compute_job_remote_cleanup',
+              '0027_project_session_defaults'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -6,6 +6,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "name" TEXT NOT NULL,
     "description" TEXT NOT NULL DEFAULT '',
     "agentContext" TEXT NOT NULL DEFAULT '',
+    "sessionDefaults" TEXT NOT NULL DEFAULT '{}',
     "isExample" BOOLEAN NOT NULL DEFAULT false,
     "pinned" BOOLEAN NOT NULL DEFAULT false,
     "archivedAt" DATETIME,

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -402,10 +402,11 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ],
       from: null,
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -418,8 +419,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0026_compute_job_remote_cleanup',
-      to: '0026_compute_job_remote_cleanup'
+      from: '0027_project_session_defaults',
+      to: '0027_project_session_defaults'
     })
   })
 
@@ -487,7 +488,7 @@ describe('application database migrations', () => {
       'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
     )
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
     )
     await removeComputeAnalysisSchema(client, true)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
@@ -512,7 +513,8 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
     await expect(
@@ -592,7 +594,8 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -637,7 +640,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -661,7 +664,7 @@ describe('application database migrations', () => {
     await removeComputeAnalysisSchema(client, true)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup')`)
+      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`)
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: [
@@ -685,10 +688,11 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -765,10 +769,11 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     await expect(
       client.$queryRaw<
@@ -891,7 +896,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0026_compute_job_remote_cleanup'
+      migrationId: '0027_project_session_defaults'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -908,7 +913,7 @@ describe('application database migrations', () => {
     ).resolves.toEqual({
       adoptedLegacy: false,
       applied: ['0027_test_suffix'],
-      from: '0026_compute_job_remote_cleanup',
+      from: '0027_project_session_defaults',
       to: '0027_test_suffix'
     })
     await expect(
@@ -942,6 +947,7 @@ describe('application database migrations', () => {
       { id: '0024_compute_job_file_evidence' },
       { id: '0025_managed_file_version_foundation' },
       { id: '0026_compute_job_remote_cleanup' },
+      { id: '0027_project_session_defaults' },
       { id: '0027_test_suffix' }
     ])
   })
@@ -1020,10 +1026,11 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     expect(backupEvents).toEqual([
       {
@@ -1103,7 +1110,8 @@ describe('application database migrations', () => {
       { id: '0023_compute_job_operation' },
       { id: '0024_compute_job_file_evidence' },
       { id: '0025_managed_file_version_foundation' },
-      { id: '0026_compute_job_remote_cleanup' }
+      { id: '0026_compute_job_remote_cleanup' },
+      { id: '0027_project_session_defaults' }
     ])
   })
 
@@ -1223,6 +1231,7 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults',
         '0027_test_suffix'
       ],
       to: '0027_test_suffix'
@@ -1480,7 +1489,8 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
     await expect(
@@ -1603,7 +1613,8 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1678,7 +1689,8 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
     await expect(
@@ -1756,7 +1768,8 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -1868,7 +1881,8 @@ describe('application database migrations', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ]
     })
     await expect(
@@ -2001,7 +2015,7 @@ describe('application database migrations', () => {
     client = createProjectDbClient(storageRoot)
     await migrateApplicationDatabase(client)
 
-    const firstId = '0026_test_batch_start'
+    const firstId = '0028_test_batch_start'
     const firstStatements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
     const firstVerifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
     const first = {
@@ -2012,7 +2026,7 @@ describe('application database migrations', () => {
       backupOnApply: 'required' as const,
       backupRetention: 'retain' as const
     }
-    const secondId = '0027_test_batch_failure'
+    const secondId = '0029_test_batch_failure'
     const secondStatements = [
       `CREATE TABLE "MigrationSuffixProbe" ("id" TEXT NOT NULL PRIMARY KEY)`
     ] as const
@@ -2386,8 +2400,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0025_managed_file_version_foundation.backup',
       'open-science.db.before-0026_compute_job_remote_cleanup.backup',
+      'open-science.db.before-0027_project_session_defaults.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)
@@ -2724,7 +2738,7 @@ describe('application database migrations', () => {
     client = createProjectDbClient(storageRoot)
     await migrateApplicationDatabase(client)
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-        WHERE "id" IN ('0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup')`)
+        WHERE "id" IN ('0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`)
     await client.$executeRawUnsafe('DROP TABLE "VisionEvidence"')
     await removeComputePasswordAuthSchema(client)
     await removeComputeAnalysisSchema(client, true)
@@ -2738,7 +2752,7 @@ describe('application database migrations', () => {
         MIGRATION_MANIFEST.findIndex(({ id }) => id === '0009_vision_evidence')
       ).map(({ id }) => id),
       from: '0008_database_json_constraints',
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -2794,9 +2808,13 @@ describe('application database migrations', () => {
       `
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup'],
+      applied: [
+        '0025_managed_file_version_foundation',
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
+      ],
       from: '0024_compute_job_file_evidence',
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     await expect(
       client.$queryRaw<Array<{ uploadVersionId: string }>>`

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -51,6 +51,7 @@ import {
   managedFileVersionFoundationMigration
 } from './migrations/0025-managed-file-version-foundation'
 import { computeJobRemoteCleanupMigration } from './migrations/0026-compute-job-remote-cleanup'
+import { projectSessionDefaultsMigration } from './migrations/0027-project-session-defaults'
 import {
   applySqliteMigrationOperations,
   type SqliteMigrationOperation
@@ -347,6 +348,12 @@ const COMPUTE_JOB_REMOTE_CLEANUP_CHECKSUM = checksumMigrationPayload(
   computeJobRemoteCleanupMigration.verifiers,
   computeJobRemoteCleanupMigration.operations
 )
+const PROJECT_SESSION_DEFAULTS_CHECKSUM = checksumMigrationPayload(
+  projectSessionDefaultsMigration.id,
+  projectSessionDefaultsMigration.statements,
+  projectSessionDefaultsMigration.verifiers,
+  projectSessionDefaultsMigration.operations
+)
 const COMPUTE_JOB_SENSITIVE_DATA_ENCRYPTION_CHECKSUM = checksumMigrationPayload(
   computeJobSensitiveDataEncryptionMigration.id,
   computeJobSensitiveDataEncryptionMigration.statements,
@@ -608,6 +615,12 @@ const MIGRATION_MANIFEST = [
   {
     ...computeJobRemoteCleanupMigration,
     checksum: COMPUTE_JOB_REMOTE_CLEANUP_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...projectSessionDefaultsMigration,
+    checksum: PROJECT_SESSION_DEFAULTS_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }

--- a/src/main/database/migrations/0027-project-session-defaults.ts
+++ b/src/main/database/migrations/0027-project-session-defaults.ts
@@ -1,0 +1,19 @@
+/* Immutable 0027 migration snapshot. Do not regenerate after release. */
+
+const projectSessionDefaultsMigration = {
+  id: '0027_project_session_defaults',
+  statements: [
+    `ALTER TABLE "Project" ADD COLUMN "sessionDefaults" TEXT NOT NULL DEFAULT '{}'`
+  ] as const,
+  operations: [] as const,
+  verifiers: [
+    {
+      kind: 'column-exists',
+      version: 1,
+      table: 'Project',
+      column: 'sessionDefaults'
+    }
+  ] as const
+}
+
+export { projectSessionDefaultsMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -85,10 +85,11 @@ describe('notification attention metadata migration', () => {
         '0023_compute_job_operation',
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
-        '0026_compute_job_remote_cleanup'
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults'
       ],
       from: '0006_database_domain_constraints',
-      to: '0026_compute_job_remote_cleanup'
+      to: '0027_project_session_defaults'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)

--- a/src/main/database/project-session-defaults-migration.test.ts
+++ b/src/main/database/project-session-defaults-migration.test.ts
@@ -10,11 +10,11 @@ import { MIGRATION_MANIFEST, migrateApplicationDatabase } from './migration-serv
 import { visionEvidenceMigration } from './migrations/0009-vision-evidence'
 import { applySqliteMigrationOperations } from './sqlite-schema-migrations'
 
-const createDatabaseAtMigration0025 = async (client: PrismaClient): Promise<void> => {
-  const migration0026Index = MIGRATION_MANIFEST.findIndex(
-    (migration) => migration.id === '0026_compute_job_remote_cleanup'
+const createDatabaseAtMigration0026 = async (client: PrismaClient): Promise<void> => {
+  const migration0027Index = MIGRATION_MANIFEST.findIndex(
+    (migration) => migration.id === '0027_project_session_defaults'
   )
-  const prefix = MIGRATION_MANIFEST.slice(0, migration0026Index)
+  const prefix = MIGRATION_MANIFEST.slice(0, migration0027Index)
   await client.$executeRawUnsafe('PRAGMA foreign_keys = OFF')
   for (const migration of prefix) {
     for (const statement of migration.statements) await client.$executeRawUnsafe(statement)
@@ -44,7 +44,7 @@ const createDatabaseAtMigration0025 = async (client: PrismaClient): Promise<void
   }
 }
 
-describe('Compute Job remote cleanup migration', () => {
+describe('Project Session defaults migration', () => {
   let storageRoot: string | undefined
   let client: ReturnType<typeof createProjectDbClient> | undefined
 
@@ -53,33 +53,27 @@ describe('Compute Job remote cleanup migration', () => {
     if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
   })
 
-  it('keeps historical Jobs pending until remote cleanup is explicitly settled', async () => {
-    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-job-cleanup-migration-'))
+  it('adds an empty JSON object for historical Projects without rewriting related tables', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-project-defaults-migration-'))
     const databasePath = join(storageRoot, 'open-science.db')
     client = createProjectDbClient(storageRoot)
-    await createDatabaseAtMigration0025(client)
-    await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
-      "id", "providerId", "shape", "sessionId", "projectId", "intent", "command",
-      "commandHash", "status"
-    ) VALUES (
-      'historical-job', 'ssh:retired-host', 'direct_ssh', 'session-1', 'project-1',
-      'completed research', 'true', 'hash', 'success'
-    )`)
+    await createDatabaseAtMigration0026(client)
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Project" ("id", "name", "updatedAt") VALUES ('historical-project', 'Historical', CURRENT_TIMESTAMP)`
+    )
 
     await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toMatchObject({
-      applied: ['0026_compute_job_remote_cleanup', '0027_project_session_defaults'],
-      from: '0025_managed_file_version_foundation',
+      applied: ['0027_project_session_defaults'],
+      from: '0026_compute_job_remote_cleanup',
       to: '0027_project_session_defaults'
     })
     await expect(
-      client.$queryRawUnsafe<Array<{ remoteCleanupDisposition: string }>>(
-        `SELECT "remoteCleanupDisposition" FROM "ComputeJob" WHERE "id" = 'historical-job'`
+      client.$queryRawUnsafe<Array<{ sessionDefaults: string }>>(
+        `SELECT "sessionDefaults" FROM "Project" WHERE "id" = 'historical-project'`
       )
-    ).resolves.toEqual([{ remoteCleanupDisposition: 'pending' }])
+    ).resolves.toEqual([{ sessionDefaults: '{}' }])
     await expect(
-      client.$executeRawUnsafe(
-        `UPDATE "ComputeJob" SET "remoteCleanupDisposition" = 'corrupt' WHERE "id" = 'historical-job'`
-      )
-    ).rejects.toThrow(/CHECK constraint failed/)
+      client.$queryRawUnsafe<Array<{ table: string }>>(`PRAGMA foreign_key_list("Session")`)
+    ).resolves.toContainEqual(expect.objectContaining({ table: 'Project' }))
   })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -615,7 +615,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               permissionApprovalPresence,
               taskAgent,
               taskControls,
-              computePreferences
+              computePreferences,
+              detectActiveSessions
             })
             remoteAccess.attachWebController(webController)
             registerRemoteAccessIpcHandlers(remoteAccess)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4109,6 +4109,8 @@ const createApplicationModules = async (
         settleTaskCompletion: (request) =>
           sessionPersistenceCoordinator.settleTaskCompletion(request),
         failTaskRun: (request) => sessionPersistenceCoordinator.failTaskRun(request),
+        updateSessionConfiguration: (session, expectedRevision) =>
+          sessionPersistenceCoordinator.updateSessionConfiguration(session, expectedRevision),
         saveSession: async (session, options, authority) => {
           const result = authority
             ? await sessionPersistenceHandlers.saveSession(session, options, authority)

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -253,6 +253,45 @@ describe('notebook local RPC server', () => {
     }
   })
 
+  it('uses the current Session gate when Memory is enabled after capability issue', async () => {
+    let memoryEnabled = false
+    const memorySearch = vi.fn(async () => [])
+    const server = new NotebookLocalRpcServer({} as never, {
+      transport: 'tcp',
+      isMemoryEnabledForSession: async () => memoryEnabled,
+      memoryService: {
+        listCategoriesForAgent: vi.fn(async () => []),
+        searchForAgent: memorySearch,
+        rememberForAgent: vi.fn()
+      }
+    })
+    const connection = await server.issueSessionConnection(
+      'session-toggle',
+      'project-1',
+      'root-frame-session-toggle',
+      false
+    )
+    const request = (): Promise<Response> =>
+      fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ method: 'memorySearch', params: { query: 'remembered' } })
+      })
+
+    try {
+      expect((await request()).status).toBe(403)
+      memoryEnabled = true
+      expect((await request()).status).toBe(200)
+      expect(memorySearch).toHaveBeenCalledOnce()
+    } finally {
+      connection.release?.()
+      await server.close()
+    }
+  })
+
   it('rejects Memory RPC when the current Main-owned Session gate is disabled', async () => {
     const memorySearch = vi.fn(async () => [])
     const server = new NotebookLocalRpcServer({} as never, {

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -1626,15 +1626,15 @@ class NotebookLocalRpcServer {
           if (sessionBinding.allowedMethods && !sessionBinding.allowedMethods.has(method)) {
             throw new RpcHttpError(403, `Notebook RPC capability does not allow ${method}.`)
           }
-          if (MEMORY_RPC_METHODS.has(method) && sessionBinding.memoryTools !== true) {
-            throw new RpcHttpError(403, 'Memory is disabled for this Session.')
-          }
-          if (MEMORY_RPC_METHODS.has(method) && this.isMemoryEnabledForSession) {
-            let memoryEnabled = false
-            try {
-              memoryEnabled = await this.isMemoryEnabledForSession(sessionBinding.sessionId)
-            } catch (error) {
-              log.warn('Memory Session gate read failed', errorLogFields(error))
+          if (MEMORY_RPC_METHODS.has(method)) {
+            let memoryEnabled = sessionBinding.memoryTools === true
+            if (this.isMemoryEnabledForSession) {
+              memoryEnabled = false
+              try {
+                memoryEnabled = await this.isMemoryEnabledForSession(sessionBinding.sessionId)
+              } catch (error) {
+                log.warn('Memory Session gate read failed', errorLogFields(error))
+              }
             }
             if (!memoryEnabled) {
               throw new RpcHttpError(403, 'Memory is disabled for this Session.')

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -89,6 +89,7 @@ describe('project repository', () => {
         id: 'project-1',
         name: 'Research',
         description: 'A project',
+        sessionDefaults: {},
         isExample: false,
         createdAt: 1710000000000,
         updatedAt: 1710000000100
@@ -148,6 +149,7 @@ describe('project repository', () => {
     await repository.update({
       id: 'project-1',
       name: '  Renamed  ',
+      sessionDefaults: { memoryEnabled: false, permissionProfile: 'auto' },
       expectedUpdatedAt: 1710000000100
     })
 
@@ -157,7 +159,11 @@ describe('project repository', () => {
         deletedAt: null,
         updatedAt: new Date(1710000000100)
       },
-      data: { name: 'Renamed', updatedAt: expect.any(Date) }
+      data: {
+        name: 'Renamed',
+        sessionDefaults: '{"permissionProfile":"auto","memoryEnabled":false}',
+        updatedAt: expect.any(Date)
+      }
     })
     expect(project.update).not.toHaveBeenCalled()
   })

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -8,6 +8,7 @@ import type {
   UpdateProjectRequest
 } from '../../shared/projects'
 import { PROJECT_NAME_MAX_LENGTH } from '../../shared/projects'
+import { projectSessionDefaultsSchema } from '../../shared/session-configuration'
 import { MEMORY_SETTINGS_ID } from '../../shared/memory'
 import { migrationSqlExecutor } from '../database/migration-sql-executor'
 
@@ -35,6 +36,7 @@ const toProject = (row: PrismaProject): Project => ({
   description: row.description,
   // An empty Agent Context is omitted on the wire, matching the optional shared schema field.
   ...(row.agentContext ? { agentContext: row.agentContext } : {}),
+  sessionDefaults: projectSessionDefaultsSchema.parse(JSON.parse(row.sessionDefaults ?? '{}')),
   isExample: row.isExample,
   ...(row.pinned ? { pinned: true } : {}),
   ...(row.archivedAt ? { archivedAt: row.archivedAt.getTime() } : {}),
@@ -96,6 +98,7 @@ class ProjectRepository {
       name?: string
       description?: string
       agentContext?: string
+      sessionDefaults?: string
       pinned?: boolean
       updatedAt?: Date
     } = {}
@@ -118,6 +121,12 @@ class ProjectRepository {
       data.agentContext = request.agentContext.trim()
     }
 
+    if (request.sessionDefaults !== undefined) {
+      data.sessionDefaults = JSON.stringify(
+        projectSessionDefaultsSchema.parse(request.sessionDefaults)
+      )
+    }
+
     if (!Number.isSafeInteger(request.expectedUpdatedAt) || request.expectedUpdatedAt <= 0) {
       throw new Error('Project update timestamp is invalid.')
     }
@@ -128,7 +137,8 @@ class ProjectRepository {
       request.pinned !== undefined &&
       request.name === undefined &&
       request.description === undefined &&
-      request.agentContext === undefined
+      request.agentContext === undefined &&
+      request.sessionDefaults === undefined
     ) {
       // Prisma's @updatedAt automation also runs for administrative changes. Updating only the pin
       // column in SQL avoids both a fake activity bump and a read/write race that could restore an

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -468,6 +468,7 @@ describe('Session persistence coordinator architecture', () => {
         'submitStructuredOutput',
         'transitionAttempt',
         'updateArchive',
+        'updateSessionConfiguration',
         'updateQuestionDraft'
       ].sort()
     )
@@ -683,6 +684,7 @@ describe('Session persistence coordinator architecture', () => {
         'stageTaskCompletion',
         'setSessionDelegationPolicy',
         'setSessionEnabledComputeHosts',
+        'updateSessionConfiguration',
         'updateArchive'
       ],
       runSessionThenGlobalIfNeeded: ['deleteSession'],
@@ -737,7 +739,7 @@ describe('Session persistence coordinator architecture', () => {
       expect(methods(owner, 'private')).not.toContain('enqueue')
     }
 
-    expect(expectedSchedulerRoute.size).toBe(39)
+    expect(expectedSchedulerRoute.size).toBe(40)
     const constructorSource = facade.members.filter(isConstructorDeclaration)[0].getText(facadeFile)
     expect(constructorSource).toContain('this.operationScheduler.runSession(')
     expect(constructorSource).toContain('this.operationScheduler.runGlobal(work)')
@@ -886,7 +888,8 @@ describe('Session persistence coordinator architecture', () => {
         'setDelegationPolicy',
         'setEnabledComputeHosts',
         'settleTaskCompletion',
-        'stageTaskCompletion'
+        'stageTaskCompletion',
+        'updateSessionConfiguration'
       ].sort()
     )
     expect(methods(stateOwner, 'private')).toEqual(

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../shared/conversation-graph'
 import {
   materializeSessionConversationGraph,
+  SessionRevisionConflictError,
   type PersistedArtifact,
   type PersistedChatMessage,
   type PersistedChatSession,
@@ -2089,6 +2090,72 @@ describe('SessionPersistenceCoordinator', () => {
     expect(onDelegationPolicyUpdated).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ id: 'session-1', delegationPolicy: 'deny' })
     )
+  })
+
+  it('updates Main-owned Session configuration in one revision-checked commit', async () => {
+    let durable = createSession({
+      revision: 4,
+      title: 'Authoritative title',
+      memoryEnabled: true,
+      delegationPolicy: 'allow',
+      enabledComputeHosts: ['ssh:old'],
+      selectedComputeHosts: ['ssh:old']
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session, expectedRevision) => {
+        const revision = expectedRevision ?? session.revision ?? 0
+        if (revision !== durable.revision) {
+          throw new SessionRevisionConflictError(revision, durable.revision ?? 0)
+        }
+        durable = structuredClone({ ...session, revision: revision + 1 })
+        return durable
+      })
+    })
+    const onDelegationPolicyUpdated = vi.fn()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onDelegationPolicyUpdated
+    )
+    const candidate = createSession({
+      ...durable,
+      title: 'Untrusted replacement title',
+      permissionProfile: 'full',
+      memoryEnabled: false,
+      delegationPolicy: 'deny',
+      enabledComputeHosts: ['ssh:new'],
+      selectedComputeHosts: ['ssh:new']
+    })
+
+    await expect(coordinator.updateSessionConfiguration(candidate, 4)).resolves.toMatchObject({
+      revision: 5,
+      title: 'Authoritative title',
+      permissionProfile: 'full',
+      memoryEnabled: false,
+      delegationPolicy: 'deny',
+      enabledComputeHosts: ['ssh:new'],
+      selectedComputeHosts: ['ssh:new']
+    })
+    expect(repository.saveSession).toHaveBeenCalledOnce()
+    expect(onDelegationPolicyUpdated).toHaveBeenCalledOnce()
+
+    await expect(coordinator.updateSessionConfiguration(candidate, 4)).rejects.toMatchObject({
+      code: 'session-revision-conflict',
+      expectedRevision: 4,
+      actualRevision: 5
+    })
   })
 
   it('preserves main-owned delegation policy on an ordinary existing-Session save', async () => {

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -2158,6 +2158,32 @@ describe('SessionPersistenceCoordinator', () => {
     })
   })
 
+  it('rejects a configuration update after a Run wins the Session lane', async () => {
+    const durable = createSession({
+      revision: 5,
+      status: 'running',
+      activeRun: { promptMessageId: 'prompt-1', startedAt: 3 }
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      }))
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.updateSessionConfiguration(
+        { ...durable, memoryEnabled: false, status: 'idle', activeRun: undefined },
+        5
+      )
+    ).rejects.toMatchObject({
+      code: 'session-configuration-busy',
+      sessionId: durable.id
+    })
+    expect(repository.saveSession).not.toHaveBeenCalled()
+  })
+
   it('preserves main-owned delegation policy on an ordinary existing-Session save', async () => {
     let durable = createSession({ delegationPolicy: 'deny' })
     const repository = createSessionRepository({

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -791,6 +791,16 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     )
   }
 
+  updateSessionConfiguration(
+    session: PersistedChatSession,
+    expectedRevision: number
+  ): Promise<PersistedChatSession> {
+    return this.operationScheduler.runSession(session.projectId, session.id, async () => {
+      await assertSessionIdentityOwnership(this.repository, this.stateOwner, session)
+      return this.stateOwner.updateSessionConfiguration(session, expectedRevision)
+    })
+  }
+
   setSessionComputeConcurrencyLimit(
     projectId: string,
     sessionId: string,

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -7,6 +7,7 @@ import {
   materializeSessionConversationGraph,
   normalizeDelegationPolicy,
   sanitizeSessionRuntimeContext,
+  SessionConfigurationBusyError,
   sessionRevision,
   type DelegationPolicy,
   type PersistedChatMessage,
@@ -480,6 +481,12 @@ class SessionPersistenceStateOwner {
     const loaded = await loadAuthority(this.options.repository, session.projectId, session.id)
     if (loaded.status !== 'found') {
       throw new Error(`Cannot update configuration for a ${loaded.status} Session.`)
+    }
+    if (
+      loaded.session.activeRun ||
+      (loaded.session.status !== 'idle' && loaded.session.status !== 'error')
+    ) {
+      throw new SessionConfigurationBusyError(session.id)
     }
     const durableSession: PersistedChatSession = {
       ...loaded.session,

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -472,6 +472,42 @@ class SessionPersistenceStateOwner {
     return persisted
   }
 
+  async updateSessionConfiguration(
+    session: PersistedChatSession,
+    expectedRevision: number
+  ): Promise<PersistedChatSession> {
+    this.options.assertMutable(session.projectId, session.id, 'mutate')
+    const loaded = await loadAuthority(this.options.repository, session.projectId, session.id)
+    if (loaded.status !== 'found') {
+      throw new Error(`Cannot update configuration for a ${loaded.status} Session.`)
+    }
+    const durableSession: PersistedChatSession = {
+      ...loaded.session,
+      agentConfiguration: session.agentConfiguration,
+      permissionProfile: session.permissionProfile,
+      autoReviewEnabled: session.autoReviewEnabled,
+      memoryEnabled: session.memoryEnabled,
+      delegationPolicy: session.delegationPolicy,
+      enabledComputeHosts: session.enabledComputeHosts
+        ? [...session.enabledComputeHosts]
+        : undefined,
+      selectedComputeHosts: session.selectedComputeHosts
+        ? [...session.selectedComputeHosts]
+        : undefined,
+      updatedAt: Math.max(loaded.session.updatedAt + 1, session.updatedAt)
+    }
+    const persisted = await saveSessionWithRevision(
+      this.options.repository,
+      durableSession,
+      expectedRevision
+    )
+    this.recordSession(persisted)
+    if (persisted.delegationPolicy !== loaded.session.delegationPolicy) {
+      this.options.notifyDelegationPolicyUpdated?.(persisted)
+    }
+    return persisted
+  }
+
   async setEnabledComputeHosts(
     projectId: string,
     sessionId: string,

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -54,6 +54,37 @@ afterEach(async () => {
 })
 
 describe('settings repository', () => {
+  it('commits framework, Reviewer, and Subagent routing as one validated mutation', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+    const fixed = {
+      mode: 'fixed' as const,
+      providerId: 'provider-a',
+      model: 'model-a',
+      reasoningEffort: 'high' as const
+    }
+
+    await repository.setAgentRouting(
+      { framework: 'opencode', reviewer: fixed, subagent: fixed },
+      (candidate) => candidate
+    )
+    await expect(repository.getSettings()).resolves.toMatchObject({
+      agentFrameworkId: 'opencode',
+      reviewerModel: fixed,
+      subagentModel: fixed
+    })
+
+    await expect(
+      repository.setAgentRouting({ framework: 'codex', reviewer: { mode: 'inherit' } }, () => {
+        throw new Error('routing is unavailable')
+      })
+    ).rejects.toThrow('routing is unavailable')
+    await expect(repository.getSettings()).resolves.toMatchObject({
+      agentFrameworkId: 'opencode',
+      reviewerModel: fixed,
+      subagentModel: fixed
+    })
+  })
+
   it('defaults legacy and malformed Subagent model settings to dynamic inheritance', () => {
     expect(sanitizeSettings({ providers: [] }).subagentModel).toEqual({ mode: 'inherit' })
     expect(

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -6,7 +6,8 @@ import type {
   ClaudeInfo,
   ProjectFilesFilterPreference,
   ProviderDeletionScenarioModelHandling,
-  ReasoningEffort
+  ReasoningEffort,
+  SetAgentRoutingRequest
 } from '../../shared/settings'
 import {
   CLAUDE_ISOLATED_PROVIDER_ID,
@@ -449,6 +450,24 @@ class SettingsRepository {
 
   async setAgentFramework(id: AgentFrameworkId): Promise<StoredSettings> {
     return this.mutate((settings) => ({ ...settings, agentFrameworkId: id }))
+  }
+
+  async setAgentRouting(
+    request: SetAgentRoutingRequest,
+    validate: (candidate: StoredSettings) => StoredSettings
+  ): Promise<StoredSettings> {
+    return this.mutate((settings) =>
+      validate({
+        ...settings,
+        ...(request.framework !== undefined ? { agentFrameworkId: request.framework } : {}),
+        ...(request.reviewer !== undefined
+          ? { reviewerModel: structuredClone(request.reviewer) }
+          : {}),
+        ...(request.subagent !== undefined
+          ? { subagentModel: structuredClone(request.subagent) }
+          : {})
+      })
+    )
   }
 
   async setReasoningEffort(effort: ReasoningEffort): Promise<StoredSettings> {

--- a/src/main/settings/reviewer-model-owner.ts
+++ b/src/main/settings/reviewer-model-owner.ts
@@ -4,6 +4,7 @@ import type { AgentBackendResolver, ExplicitAgentBackendTarget } from './backend
 import type { ProviderAccountsModule } from './provider-accounts'
 import { providerRuntimeValidationTarget } from './provider-validation-state'
 import type { SettingsRepository } from './repository'
+import type { StoredSettings } from './types'
 
 type ReviewerModelOwnerOptions = {
   repository: SettingsRepository
@@ -24,40 +25,43 @@ class ReviewerModelOwner {
       configuration.mode === 'fixed'
         ? (await this.options.backendResolver.captureConfiguredSelection()).frameworkId
         : undefined
-    await this.options.repository.setReviewerModel(configuration, (settings, candidate) => {
-      if (candidate.mode === 'inherit') return
-      const provider = settings.providers.find((entry) => entry.id === candidate.providerId)
-      const validationFailed = provider ? providerValidationFailed(provider) : false
-      if (!provider || validationFailed) {
-        throw new Error(
-          'The selected Reviewer model is no longer available. Refresh the model catalog.'
-        )
-      }
-      const framework = getAgentFramework(
-        frameworkId ?? settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+    await this.options.repository.setReviewerModel(configuration, (settings, candidate) =>
+      this.validate(settings, candidate, frameworkId)
+    )
+  }
+
+  validate(
+    settings: StoredSettings,
+    candidate: ReviewerModelConfiguration,
+    frameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+  ): ReviewerModelConfiguration {
+    if (candidate.mode === 'inherit') return candidate
+    const provider = settings.providers.find((entry) => entry.id === candidate.providerId)
+    const validationFailed = provider ? providerValidationFailed(provider) : false
+    if (!provider || validationFailed) {
+      throw new Error(
+        'The selected Reviewer model is no longer available. Refresh the model catalog.'
       )
-      const target = this.options.providers.resolveRuntimeTarget(
-        provider,
-        { kind: 'required', model: candidate.model },
-        framework
+    }
+    const framework = getAgentFramework(frameworkId)
+    const target = this.options.providers.resolveRuntimeTarget(
+      provider,
+      { kind: 'required', model: candidate.model },
+      framework
+    )
+    if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+      throw new Error(
+        'The selected Reviewer model is no longer available. Refresh the model catalog.'
       )
-      if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
-        throw new Error(
-          'The selected Reviewer model is no longer available. Refresh the model catalog.'
-        )
-      }
-      if (
-        !target.frameworkCompatible ||
-        (framework.id === 'codex' && !target.modelBridgeSupported)
-      ) {
-        throw new Error(
-          'The selected Reviewer model is not available for the active Agent Framework. Refresh the model catalog.'
-        )
-      }
-      return target.reasoningEffortProfile.supported
-        ? candidate
-        : { ...candidate, reasoningEffort: 'default' }
-    })
+    }
+    if (!target.frameworkCompatible || (framework.id === 'codex' && !target.modelBridgeSupported)) {
+      throw new Error(
+        'The selected Reviewer model is not available for the active Agent Framework. Refresh the model catalog.'
+      )
+    }
+    return target.reasoningEffortProfile.supported
+      ? candidate
+      : { ...candidate, reasoningEffort: 'default' }
   }
 
   async admit(): Promise<ReviewerModelAdmission> {

--- a/src/main/settings/runtime-application-commands.test.ts
+++ b/src/main/settings/runtime-application-commands.test.ts
@@ -29,6 +29,7 @@ const expectedChannels = [
   'settings:delete-provider',
   'settings:set-active-provider',
   'settings:set-agent-framework',
+  'settings:set-agent-routing',
   'settings:set-reasoning-effort',
   'settings:login-shared-claude',
   'settings:logout-shared-claude',
@@ -113,7 +114,7 @@ describe('Settings runtime application commands', () => {
     expect(workflowMethod('setActiveProvider')).toHaveBeenCalledWith({ id: 'provider-1' })
   })
 
-  it('delegates the five remote-safe mutations through the runtime workflow', async () => {
+  it('delegates the six remote-safe mutations through the runtime workflow', async () => {
     const { dependencies, workflowMethod } = createDependencies()
     const router = createApplicationCommandRouter()
     registerRuntimeSettingsApplicationCommands(router.registrar, dependencies)
@@ -135,6 +136,24 @@ describe('Settings runtime application commands', () => {
       invocation([{ id: 'opencode' }] as const, 'remote')
     )
     await router.dispatcher.invoke(
+      settingsRuntimeApplicationCommands.setAgentRouting,
+      invocation(
+        [
+          {
+            framework: 'codex',
+            reviewer: { mode: 'inherit' },
+            subagent: {
+              mode: 'fixed',
+              providerId: 'provider-2',
+              model: 'model-1',
+              reasoningEffort: 'high'
+            }
+          }
+        ] as const,
+        'remote'
+      )
+    )
+    await router.dispatcher.invoke(
       settingsRuntimeApplicationCommands.setReasoningEffort,
       invocation([{ effort: 'high' }] as const, 'remote')
     )
@@ -149,6 +168,16 @@ describe('Settings runtime application commands', () => {
       model: 'model-1'
     })
     expect(workflowMethod('setAgentFramework')).toHaveBeenCalledWith({ id: 'opencode' })
+    expect(workflowMethod('setAgentRouting')).toHaveBeenCalledWith({
+      framework: 'codex',
+      reviewer: { mode: 'inherit' },
+      subagent: {
+        mode: 'fixed',
+        providerId: 'provider-2',
+        model: 'model-1',
+        reasoningEffort: 'high'
+      }
+    })
     expect(workflowMethod('setReasoningEffort')).toHaveBeenCalledWith({ effort: 'high' })
   })
 

--- a/src/main/settings/runtime-application-commands.test.ts
+++ b/src/main/settings/runtime-application-commands.test.ts
@@ -90,7 +90,7 @@ const createDependencies = (): Readonly<{
 }
 
 describe('Settings runtime application commands', () => {
-  it('installs the exact 20-command inventory and dispatches a remote-safe selection', async () => {
+  it('installs the exact 21-command inventory and keeps Task-only routing off renderer IPC', async () => {
     const { dependencies, workflowMethod } = createDependencies()
     const selected = { activeProviderId: 'provider-1' }
     workflowMethod('setActiveProvider').mockResolvedValue(selected)
@@ -103,7 +103,12 @@ describe('Settings runtime application commands', () => {
     expect(settingsRuntimeApplicationCommandGroup.commands.map((command) => command.name)).toEqual(
       expectedChannels
     )
-    expect(settingsChannels).toEqual(expect.arrayContaining([...expectedChannels]))
+    expect(settingsChannels).toEqual(
+      expect.arrayContaining(
+        expectedChannels.filter((channel) => channel !== 'settings:set-agent-routing')
+      )
+    )
+    expect(settingsChannels).not.toContain('settings:set-agent-routing')
     expect(router.dispatcher.commandNames()).toEqual([...expectedChannels].sort())
     await expect(
       router.dispatcher.invoke(

--- a/src/main/settings/runtime-application-commands.ts
+++ b/src/main/settings/runtime-application-commands.ts
@@ -6,7 +6,11 @@ import {
   type ApplicationCommandRegistrar
 } from '../application-command-router'
 import type { CallerContext } from '../caller-context'
-import { readIsolatedClaudeToken, readReasoningEffort } from './transport-validation'
+import {
+  readAgentRouting,
+  readIsolatedClaudeToken,
+  readReasoningEffort
+} from './transport-validation'
 import type { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
 import type { RuntimeSettingsWorkflows } from './workflows/runtime'
 
@@ -26,6 +30,7 @@ type RuntimeSettingsCommandWorkflows = Pick<
   | 'logoutXaiOAuth'
   | 'setActiveProvider'
   | 'setAgentFramework'
+  | 'setAgentRouting'
   | 'setReasoningEffort'
   | 'uninstallRuntime'
   | 'upsertProvider'
@@ -82,6 +87,11 @@ const settingsRuntimeApplicationCommands = Object.freeze({
     WorkflowArgs<'setAgentFramework'>,
     WorkflowResult<'setAgentFramework'>
   >('settings:set-agent-framework'),
+  setAgentRouting: defineApplicationCommand<
+    'settings:set-agent-routing',
+    WorkflowArgs<'setAgentRouting'>,
+    WorkflowResult<'setAgentRouting'>
+  >('settings:set-agent-routing'),
   setReasoningEffort: defineApplicationCommand<
     'settings:set-reasoning-effort',
     WorkflowArgs<'setReasoningEffort'>,
@@ -153,6 +163,7 @@ const settingsRuntimeApplicationCommandGroup = defineApplicationCommandGroup('se
   settingsRuntimeApplicationCommands.deleteProvider,
   settingsRuntimeApplicationCommands.setActiveProvider,
   settingsRuntimeApplicationCommands.setAgentFramework,
+  settingsRuntimeApplicationCommands.setAgentRouting,
   settingsRuntimeApplicationCommands.setReasoningEffort,
   settingsRuntimeApplicationCommands.loginSharedClaude,
   settingsRuntimeApplicationCommands.logoutSharedClaude,
@@ -227,6 +238,10 @@ const registerRuntimeSettingsApplicationCommands = (
       'settings:set-agent-framework': ({ args }) =>
         dependencies.snapshotCommits.currentSnapshotAfter(
           dependencies.workflows.setAgentFramework(args[0])
+        ),
+      'settings:set-agent-routing': ({ args }) =>
+        dependencies.snapshotCommits.currentSnapshotAfter(
+          dependencies.workflows.setAgentRouting(readAgentRouting(args[0]))
         ),
       'settings:set-reasoning-effort': ({ args }) =>
         dependencies.snapshotCommits.currentSnapshotAfter(

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -5713,6 +5713,46 @@ describe('SettingsService: Subagent model', () => {
 })
 
 describe('SettingsService: Reviewer model', () => {
+  it('validates a compound Agent routing update against its target framework before committing', async () => {
+    const service = createService()
+    const created = await service.upsertProvider({
+      type: 'custom',
+      name: 'Routing gateway',
+      apiEndpoints: ['anthropic'],
+      baseUrl: 'https://routing.example/v1',
+      model: 'routing-model',
+      key: 'secret'
+    })
+    const provider = created.providers.find((candidate) => candidate.name === 'Routing gateway')!
+    const fixed = {
+      mode: 'fixed' as const,
+      providerId: provider.id,
+      model: 'routing-model',
+      reasoningEffort: 'high' as const
+    }
+
+    await expect(
+      service.setAgentRouting({
+        framework: 'claude-code',
+        reviewer: fixed,
+        subagent: fixed
+      })
+    ).resolves.toMatchObject({
+      agentFrameworkId: 'claude-code',
+      reviewerModel: fixed,
+      subagentModel: fixed
+    })
+
+    await expect(service.setAgentRouting({ framework: 'codex' })).rejects.toThrow(
+      'not available for the active Agent Framework'
+    )
+    await expect(service.getSettingsView()).resolves.toMatchObject({
+      agentFrameworkId: 'claude-code',
+      reviewerModel: fixed,
+      subagentModel: fixed
+    })
+  })
+
   it('atomically validates and saves a fixed Reviewer target', async () => {
     const service = createService()
     const created = await service.upsertProvider({

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -50,6 +50,7 @@ import type {
   SetSkillsEnabledRequest,
   SetToolPermissionRequest,
   SettingsSnapshot,
+  SetAgentRoutingRequest,
   AppIconVariant,
   SkillDetailView,
   SkillView,
@@ -89,10 +90,11 @@ import type { RuntimeEnablement } from '../../shared/notebook-runtime'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import { resolveStorageRoot } from '../storage-root'
-import type {
-  AgentModelChangeTarget,
-  AgentFrameworkId,
-  ResolvedAgentBackend
+import {
+  DEFAULT_AGENT_FRAMEWORK_ID,
+  type AgentModelChangeTarget,
+  type AgentFrameworkId,
+  type ResolvedAgentBackend
 } from '../agent-framework'
 import type { ClaudeDetectDeps } from './claude-detect'
 import type { OpencodeDetectDeps } from './opencode-detect'
@@ -467,6 +469,33 @@ class SettingsService {
 
   async setAgentFramework(id: AgentFrameworkId): Promise<SettingsSnapshot> {
     await this.repository.setAgentFramework(id)
+    return this.getSettingsView()
+  }
+
+  async setAgentRouting(request: SetAgentRoutingRequest): Promise<SettingsSnapshot> {
+    if (
+      request.framework === undefined &&
+      request.reviewer === undefined &&
+      request.subagent === undefined
+    ) {
+      throw new Error('Agent routing update requires at least one field.')
+    }
+    await this.repository.setAgentRouting(request, (candidate) => {
+      const frameworkId = candidate.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+      return {
+        ...candidate,
+        reviewerModel: this.scenarioModels.reviewer.validate(
+          candidate,
+          candidate.reviewerModel ?? { mode: 'inherit' },
+          frameworkId
+        ),
+        subagentModel: this.scenarioModels.subagent.validate(
+          candidate,
+          candidate.subagentModel ?? { mode: 'inherit' },
+          frameworkId
+        )
+      }
+    })
     return this.getSettingsView()
   }
 

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -360,6 +360,7 @@ describe('Settings backend ownership architecture', () => {
       'setActiveProvider',
       'setAgentEnvironmentCreationEnabled',
       'setAgentFramework',
+      'setAgentRouting',
       'setAppIconVariant',
       'setClaudeInfo',
       'setClosePreference',
@@ -490,7 +491,7 @@ describe('Settings backend ownership architecture', () => {
         provisionedConnectorSkillNames publishHostSkill refreshProviderModels registeredHelperCatalog rememberCodexAutoHttpsFallback removeCustomServer removeDeviceCredential removeGitHubToken removeNotebookNetwork
         removeManualInterpreter resolveActiveModelChangeTarget resolveActiveReasoningEffort
         resolveAdmittedSubagentBackend resolveAgentBackend resolveDeviceOAuthCredential resolveExplicitAgentBackend resolveSkillDocument resolveSubagentExecutionModel saveCustomServerOAuthState saveGitHubToken
-        scanRepoSkills setActiveProvider setAgentEnvironmentCreationEnabled setAgentFramework setAppIconVariant setClosePreference
+        scanRepoSkills setActiveProvider setAgentEnvironmentCreationEnabled setAgentFramework setAgentRouting setAppIconVariant setClosePreference
         setComputeBookmarks setConnectorAutoAllow setConnectorEnabled
         setConversationSkillImportEnabled setCustomServerAuthenticator setCustomServerEnabled
         setDataRoot setDefaultPermissionProfile setDeviceCredentialAuthenticator setEnvironmentEnabled setInstallAuthorized

--- a/src/main/settings/subagent-model-owner.ts
+++ b/src/main/settings/subagent-model-owner.ts
@@ -14,6 +14,7 @@ import type { AgentBackendResolutionContext, AgentBackendResolver } from './back
 import type { ProviderAccountsModule } from './provider-accounts'
 import { providerRuntimeValidationTarget } from './provider-validation-state'
 import type { SettingsRepository } from './repository'
+import type { StoredSettings } from './types'
 
 type InheritedSubagentModel = Readonly<{
   providerId?: string
@@ -35,38 +36,43 @@ class SubagentModelOwner {
   constructor(private readonly options: SubagentModelOwnerOptions) {}
 
   async set(configuration: SubagentModelConfiguration): Promise<void> {
-    await this.options.repository.setSubagentModel(configuration, (settings, candidate) => {
-      if (candidate.mode === 'inherit') return
-      const provider = settings.providers.find((entry) => entry.id === candidate.providerId)
-      const validationFailed = provider ? providerValidationFailed(provider) : false
-      if (!provider || validationFailed) {
-        throw new Error(
-          'The selected Subagent model is no longer available. Refresh the model catalog.'
-        )
-      }
-      const framework = getAgentFramework(settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
-      const target = this.options.providers.resolveRuntimeTarget(
-        provider,
-        { kind: 'required', model: candidate.model },
-        framework
+    await this.options.repository.setSubagentModel(configuration, (settings, candidate) =>
+      this.validate(settings, candidate)
+    )
+  }
+
+  validate(
+    settings: StoredSettings,
+    candidate: SubagentModelConfiguration,
+    frameworkId = settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+  ): SubagentModelConfiguration {
+    if (candidate.mode === 'inherit') return candidate
+    const provider = settings.providers.find((entry) => entry.id === candidate.providerId)
+    const validationFailed = provider ? providerValidationFailed(provider) : false
+    if (!provider || validationFailed) {
+      throw new Error(
+        'The selected Subagent model is no longer available. Refresh the model catalog.'
       )
-      if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
-        throw new Error(
-          'The selected Subagent model is no longer available. Refresh the model catalog.'
-        )
-      }
-      if (
-        !target.frameworkCompatible ||
-        (framework.id === 'codex' && !target.modelBridgeSupported)
-      ) {
-        throw new Error(
-          'The selected Subagent model is not available for the active Agent Framework. Refresh the model catalog.'
-        )
-      }
-      return target.reasoningEffortProfile.supported
-        ? candidate
-        : { ...candidate, reasoningEffort: 'default' }
-    })
+    }
+    const framework = getAgentFramework(frameworkId)
+    const target = this.options.providers.resolveRuntimeTarget(
+      provider,
+      { kind: 'required', model: candidate.model },
+      framework
+    )
+    if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+      throw new Error(
+        'The selected Subagent model is no longer available. Refresh the model catalog.'
+      )
+    }
+    if (!target.frameworkCompatible || (framework.id === 'codex' && !target.modelBridgeSupported)) {
+      throw new Error(
+        'The selected Subagent model is not available for the active Agent Framework. Refresh the model catalog.'
+      )
+    }
+    return target.reasoningEffortProfile.supported
+      ? candidate
+      : { ...candidate, reasoningEffort: 'default' }
   }
 
   async admit(

--- a/src/main/settings/transport-validation.ts
+++ b/src/main/settings/transport-validation.ts
@@ -4,6 +4,7 @@ import {
   type AppIconVariant,
   type ProjectFilesFilterPreference,
   type ReasoningEffort,
+  type SetAgentRoutingRequest,
   type ReviewerModelConfiguration,
   type SessionDetailsModelConfiguration,
   type SubagentModelConfiguration,
@@ -79,6 +80,33 @@ const readSubagentModel = (request: unknown): SubagentModelConfiguration =>
 
 const readReviewerModel = (request: unknown): ReviewerModelConfiguration =>
   readModelConfiguration(request, 'Reviewer')
+
+const readAgentRouting = (request: unknown): SetAgentRoutingRequest => {
+  if (typeof request !== 'object' || request === null || Array.isArray(request)) {
+    throw new Error('Invalid Agent routing update.')
+  }
+  const value = request as Record<string, unknown>
+  if (!Object.keys(value).every((key) => ['framework', 'reviewer', 'subagent'].includes(key))) {
+    throw new Error('Invalid Agent routing update.')
+  }
+  if (
+    value.framework !== undefined &&
+    !['claude-code', 'opencode', 'codex', 'codebuddy'].includes(String(value.framework))
+  ) {
+    throw new Error(`Unknown Agent Framework: ${String(value.framework)}`)
+  }
+  return {
+    ...(value.framework !== undefined
+      ? { framework: value.framework as SetAgentRoutingRequest['framework'] }
+      : {}),
+    ...(value.reviewer !== undefined
+      ? { reviewer: readModelConfiguration({ configuration: value.reviewer }, 'Reviewer') }
+      : {}),
+    ...(value.subagent !== undefined
+      ? { subagent: readModelConfiguration({ configuration: value.subagent }, 'Subagent') }
+      : {})
+  }
+}
 
 const readSessionDetailsModel = (request: unknown): SessionDetailsModelConfiguration => {
   const configuration = readField(request, 'configuration')
@@ -220,6 +248,7 @@ const readGitHubToken = (request: unknown): string => {
 
 export {
   readAppIconVariant,
+  readAgentRouting,
   readClosePreference,
   readConversationSkillImportEnabled,
   readDefaultPermissionProfile,

--- a/src/main/settings/workflows/runtime.ts
+++ b/src/main/settings/workflows/runtime.ts
@@ -6,6 +6,7 @@ import {
   type ProviderDeletionScenarioModelHandling,
   type SetActiveProviderRequest,
   type SetAgentFrameworkRequest,
+  type SetAgentRoutingRequest,
   type SetReasoningEffortRequest,
   type UpsertProviderRequest
 } from '../../../shared/settings'
@@ -23,6 +24,7 @@ type RuntimeSettingsWorkflowStore = Pick<
   | 'deleteProvider'
   | 'setActiveProvider'
   | 'setAgentFramework'
+  | 'setAgentRouting'
   | 'setReasoningEffort'
   | 'loginClaudeShared'
   | 'logoutClaudeShared'
@@ -117,6 +119,17 @@ class RuntimeSettingsWorkflows {
   ): Promise<Awaited<ReturnType<RuntimeSettingsWorkflowStore['setAgentFramework']>>> {
     const snapshot = await this.settings.setAgentFramework(request.id)
     this.effects.requestAgentFrameworkSwitch()
+    return snapshot
+  }
+
+  async setAgentRouting(
+    request: SetAgentRoutingRequest
+  ): Promise<Awaited<ReturnType<RuntimeSettingsWorkflowStore['setAgentRouting']>>> {
+    const before = await this.settings.getSettingsView()
+    const snapshot = await this.settings.setAgentRouting(request)
+    if (snapshot.agentFrameworkId !== before.agentFrameworkId) {
+      this.effects.requestAgentFrameworkSwitch()
+    }
     return snapshot
   }
 

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -9,7 +9,11 @@ import type { AcpRuntimeEvent } from '../../shared/acp'
 import { ComputeHostPreferenceValidationError } from '../../shared/compute'
 import type { Project } from '../../shared/projects'
 import type { SettingsSnapshot } from '../../shared/settings'
-import { normalizeSessionFile, type PersistedChatSession } from '../../shared/session-persistence'
+import {
+  normalizeSessionFile,
+  SessionConfigurationBusyError,
+  type PersistedChatSession
+} from '../../shared/session-persistence'
 import type { TaskRun } from '../../shared/task-api'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
@@ -302,6 +306,24 @@ describe('TaskRunner', () => {
       })
     ).rejects.toMatchObject({ code: 'session_busy' })
     expect(save).not.toHaveBeenCalled()
+  })
+
+  it('maps an authoritative concurrent-start rejection to session_busy', async () => {
+    const current = { ...session, revision: 3 }
+    const updateConfiguration = vi.fn(async (): Promise<PersistedChatSession> => {
+      throw new SessionConfigurationBusyError(current.id)
+    })
+    const runner = createRunner({
+      sessions: { list: async () => [current], updateConfiguration }
+    })
+
+    await expect(
+      runner.updateSessionConfiguration(current.id, {
+        expectedRevision: 3,
+        memoryEnabled: false
+      })
+    ).rejects.toMatchObject({ code: 'session_busy' })
+    expect(updateConfiguration).toHaveBeenCalledOnce()
   })
 
   it('requires an explicit model decision when changing providers', async () => {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1101,6 +1101,27 @@ describe('TaskRunner', () => {
     })
   })
 
+  it('rejects enabled Compute Host changes while resuming an existing Session', async () => {
+    const save = vi.fn(async (value: PersistedChatSession) => value)
+    const runner = createRunner({
+      sessions: { list: async () => [session], save }
+    })
+
+    await expect(
+      runner.startRun({
+        project: project.id,
+        sessionId: session.id,
+        prompt: 'Continue with changed host access.',
+        enabledComputeHostIds: ['ssh:alpha']
+      })
+    ).rejects.toMatchObject({
+      code: 'invalid_request',
+      message:
+        'Provider, model, reasoning effort, memory, and enabled Compute Hosts must be changed with session config update before resuming an existing Session.'
+    })
+    expect(save).not.toHaveBeenCalled()
+  })
+
   it('rejects a cwd that conflicts with an existing Session workspace', async () => {
     const existingRoot = await mkdtemp(join(tmpdir(), 'open-science-task-existing-cwd-'))
     const requestedRoot = await mkdtemp(join(tmpdir(), 'open-science-task-requested-cwd-'))

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -166,6 +166,7 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
         updatedAt: request.updatedAt
       })
     },
+    updateConfiguration: async (value) => save(value),
     setDelegationPolicy: async () => undefined
   }
   const defaultAgent: TaskAgentPort = {
@@ -227,14 +228,14 @@ describe('TaskRunner', () => {
         reasoningEffort: 'default'
       }
     }
-    const save = vi.fn(async (value: PersistedChatSession) => {
+    const updateConfiguration = vi.fn(async (value: PersistedChatSession) => {
       current = { ...value, revision: (value.revision ?? 0) + 1 }
       return current
     })
     const validate = vi.fn(async (providerIds: readonly string[]) => [...new Set(providerIds)])
     const setMemoryEnabled = vi.fn(async () => undefined)
     const runner = createRunner({
-      sessions: { list: async () => [current], save },
+      sessions: { list: async () => [current], updateConfiguration },
       settings: { get: async () => configuredSettings },
       agent: {
         listAttachedSessionIds: async () => [session.id],
@@ -273,7 +274,7 @@ describe('TaskRunner', () => {
         computeHosts: { 'ssh:alpha': { available: true } }
       }
     })
-    expect(save).toHaveBeenCalledOnce()
+    expect(updateConfiguration).toHaveBeenCalledWith(expect.any(Object), 4)
     expect(setMemoryEnabled).toHaveBeenCalledWith(session.id, false)
     expect(validate).toHaveBeenCalledWith(['ssh:alpha', 'ssh:alpha'])
   })
@@ -887,6 +888,7 @@ describe('TaskRunner', () => {
     const sessions: TaskRunnerOverrides['sessions'] = {
       list: async () => [session],
       save: async (value) => value,
+      updateConfiguration: async (value) => value,
       setDelegationPolicy: async () => undefined
     }
     const runner = createRunner({ projects, sessions })
@@ -4051,6 +4053,7 @@ describe('TaskRunner', () => {
         }
         return value
       },
+      updateConfiguration: async (value) => value,
       setDelegationPolicy: async () => undefined
     }
     const runJournal = {
@@ -4123,6 +4126,7 @@ describe('TaskRunner', () => {
         durableSession = structuredClone(value)
         return value
       },
+      updateConfiguration: async (value) => value,
       setDelegationPolicy: async () => undefined
     }
     const runJournal = {
@@ -4192,6 +4196,7 @@ describe('TaskRunner', () => {
         durableSession = structuredClone(value)
         return value
       },
+      updateConfiguration: async (value) => value,
       setDelegationPolicy: async () => undefined
     }
     const runJournal = {
@@ -4468,6 +4473,7 @@ describe('TaskRunner', () => {
         durableSession = structuredClone(persisted)
         return persisted
       },
+      updateConfiguration: async (value) => value,
       setDelegationPolicy: async () => undefined
     }
     const runJournal = {
@@ -4559,6 +4565,7 @@ describe('TaskRunner', () => {
         durableSession = structuredClone(persisted)
         return persisted
       },
+      updateConfiguration: async (value) => value,
       setDelegationPolicy: async () => undefined
     }
     const runJournal = {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import { ComputeHostPreferenceValidationError } from '../../shared/compute'
 import type { Project } from '../../shared/projects'
+import type { SettingsSnapshot } from '../../shared/settings'
 import { normalizeSessionFile, type PersistedChatSession } from '../../shared/session-persistence'
 import type { TaskRun } from '../../shared/task-api'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
@@ -48,6 +49,43 @@ const session: PersistedChatSession = {
   messages: [],
   createdAt: 1,
   updatedAt: 2
+}
+
+const settings: SettingsSnapshot = {
+  claude: {},
+  opencode: {},
+  codebuddy: {},
+  codex: {},
+  claudeManaged: false,
+  opencodeManaged: false,
+  codebuddyManaged: false,
+  codexManaged: false,
+  providers: [],
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [],
+  reasoningEffort: 'default',
+  notificationsEnabled: true,
+  conversationSkillImportEnabled: true,
+  appIconVariant: 'light'
+}
+
+const configuredSettings: SettingsSnapshot = {
+  ...settings,
+  activeProviderId: 'provider-1',
+  activeModel: 'model-1',
+  providers: [
+    {
+      id: 'provider-1',
+      type: 'custom',
+      name: 'Test provider',
+      apiEndpoints: ['anthropic'],
+      model: 'model-1',
+      models: ['model-1', 'model-2'],
+      supportsImageInput: false,
+      hasKey: true,
+      needsKey: false
+    }
+  ]
 }
 
 class RetainedRunEventPayload {}
@@ -150,6 +188,7 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
       finalizeRun: async () => ({ ok: true, artifacts: [] })
     },
     runtimeEvents: { subscribe: () => () => undefined },
+    settings: { get: async () => settings },
     specialists: { resolve: async (reference) => ({ id: reference }) },
     reviewer: { review: async () => ({ started: true }) },
     computePreferences: {
@@ -174,6 +213,267 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
   })
 }
 describe('TaskRunner', () => {
+  it('updates an idle Session configuration atomically with revision and availability checks', async () => {
+    let current: PersistedChatSession = {
+      ...session,
+      revision: 4,
+      agentConfiguration: {
+        providerId: 'provider-1',
+        model: 'model-1',
+        reasoningEffort: 'default'
+      }
+    }
+    const save = vi.fn(async (value: PersistedChatSession) => {
+      current = { ...value, revision: (value.revision ?? 0) + 1 }
+      return current
+    })
+    const validate = vi.fn(async (providerIds: readonly string[]) => [...new Set(providerIds)])
+    const runner = createRunner({
+      sessions: { list: async () => [current], save },
+      settings: { get: async () => configuredSettings },
+      computePreferences: {
+        withReservation: async (providerIds, operation) => operation([...new Set(providerIds)]),
+        set: async () => current,
+        validate,
+        listAvailable: async () => ['ssh:alpha']
+      }
+    })
+
+    await expect(
+      runner.updateSessionConfiguration(session.id, {
+        expectedRevision: 4,
+        agentConfiguration: { model: 'model-2', reasoningEffort: 'high' },
+        permissionProfile: 'full',
+        memoryEnabled: false,
+        computeHosts: { enabled: ['ssh:alpha'], selected: ['ssh:alpha'] }
+      })
+    ).resolves.toMatchObject({
+      revision: 5,
+      persisted: {
+        agentConfiguration: {
+          providerId: 'provider-1',
+          model: 'model-2',
+          reasoningEffort: 'high'
+        },
+        permissionProfile: 'full',
+        memoryEnabled: false,
+        computeHosts: { enabled: ['ssh:alpha'], selected: ['ssh:alpha'] }
+      },
+      availability: {
+        agentConfiguration: { available: true },
+        computeHosts: { 'ssh:alpha': { available: true } }
+      }
+    })
+    expect(save).toHaveBeenCalledOnce()
+    expect(validate).toHaveBeenCalledWith(['ssh:alpha', 'ssh:alpha'])
+  })
+
+  it('rejects stale or active Session configuration updates without persisting them', async () => {
+    const current = { ...session, revision: 3 }
+    const save = vi.fn(async (value: PersistedChatSession) => value)
+    const staleRunner = createRunner({ sessions: { list: async () => [current], save } })
+
+    await expect(
+      staleRunner.updateSessionConfiguration(session.id, {
+        expectedRevision: 2,
+        memoryEnabled: false
+      })
+    ).rejects.toMatchObject({ code: 'session_revision_conflict' })
+
+    const busyRunner = createRunner({
+      sessions: { list: async () => [current], save },
+      isSessionBusy: () => true
+    })
+    await expect(
+      busyRunner.updateSessionConfiguration(session.id, {
+        expectedRevision: 3,
+        memoryEnabled: false
+      })
+    ).rejects.toMatchObject({ code: 'session_busy' })
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('requires an explicit model decision when changing providers', async () => {
+    const current = {
+      ...session,
+      revision: 3,
+      agentConfiguration: {
+        providerId: 'provider-1',
+        model: 'model-1',
+        reasoningEffort: 'default' as const
+      }
+    }
+    const save = vi.fn(async (value: PersistedChatSession) => value)
+    const runner = createRunner({
+      sessions: { list: async () => [current], save },
+      settings: { get: async () => configuredSettings }
+    })
+
+    await expect(
+      runner.updateSessionConfiguration(session.id, {
+        expectedRevision: 3,
+        agentConfiguration: { providerId: 'provider-2' }
+      })
+    ).rejects.toMatchObject({ code: 'invalid_configuration' })
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('persists Project Session defaults without rewriting existing Sessions', async () => {
+    let currentProject: Project = { ...project, updatedAt: 7 }
+    const update = vi.fn(async (request: Parameters<NonNullable<TaskProjectPort['update']>>[0]) => {
+      currentProject = {
+        ...currentProject,
+        sessionDefaults: request.sessionDefaults,
+        updatedAt: 8
+      }
+      return currentProject
+    })
+    const save = vi.fn(async (value: PersistedChatSession) => value)
+    const runner = createRunner({
+      projects: {
+        list: async () => [currentProject],
+        create: async (request) => ({ ...currentProject, ...request }),
+        update
+      },
+      sessions: { list: async () => [session], save },
+      settings: { get: async () => configuredSettings },
+      specialists: { resolve: async () => ({ id: 'specialist-id' }) },
+      computePreferences: {
+        withReservation: async (providerIds, operation) => operation([...new Set(providerIds)]),
+        set: async () => session,
+        validate: async (providerIds) => [...new Set(providerIds)],
+        listAvailable: async () => ['ssh:alpha']
+      }
+    })
+
+    await expect(
+      runner.updateProjectSessionDefaults(project.id, {
+        expectedUpdatedAt: 7,
+        patch: {
+          agentConfiguration: {
+            providerId: 'provider-1',
+            model: 'model-2',
+            reasoningEffort: 'high'
+          },
+          permissionProfile: 'auto',
+          memoryEnabled: false,
+          specialistId: 'specialist-name',
+          computeHosts: { enabled: ['ssh:alpha'], selected: ['ssh:alpha'] }
+        }
+      })
+    ).resolves.toMatchObject({
+      updatedAt: 8,
+      configured: {
+        agentConfiguration: {
+          providerId: 'provider-1',
+          model: 'model-2',
+          reasoningEffort: 'high'
+        },
+        permissionProfile: 'auto',
+        memoryEnabled: false,
+        specialistId: 'specialist-id',
+        computeHosts: { enabled: ['ssh:alpha'], selected: ['ssh:alpha'] }
+      }
+    })
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: project.id, expectedUpdatedAt: 7 })
+    )
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('snapshots Project defaults into only new Sessions with explicit Run values winning', async () => {
+    const defaultedProject: Project = {
+      ...project,
+      sessionDefaults: {
+        agentConfiguration: {
+          providerId: 'provider-1',
+          model: 'model-1',
+          reasoningEffort: 'low'
+        },
+        permissionProfile: 'full',
+        autoReviewEnabled: true,
+        memoryEnabled: false,
+        delegationPolicy: 'deny',
+        computeHosts: {
+          enabled: ['ssh:alpha', 'ssh:beta'],
+          selected: ['ssh:alpha']
+        }
+      }
+    }
+    const created: Array<Parameters<TaskRunnerDependencies['agent']['createSession']>[0]> = []
+    const saved: PersistedChatSession[] = []
+    const ids = ['user-defaults', 'run-defaults', 'agent-defaults']
+    const runner = createRunner({
+      projects: {
+        list: async () => [defaultedProject],
+        create: async (request) => ({ ...defaultedProject, ...request })
+      },
+      settings: { get: async () => configuredSettings },
+      sessions: {
+        list: async () => [],
+        save: async (value) => {
+          saved.push(structuredClone(value))
+          return value
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async (request) => {
+          created.push(request)
+          return {
+            sessionId: 'session-defaults',
+            agentConfiguration: request.agentConfiguration
+          }
+        },
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async (_request, observer) => {
+          await observer?.onPromptAdmitted?.()
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      prompt: 'Use the configured defaults.',
+      permissionProfile: 'auto',
+      memoryEnabled: true,
+      agentConfiguration: { model: 'model-2' },
+      computeHostIds: ['ssh:beta']
+    })
+    await runner.waitForRun(started.id)
+
+    expect(created).toEqual([
+      {
+        projectId: project.id,
+        permissionProfile: 'auto',
+        agentConfiguration: {
+          providerId: 'provider-1',
+          model: 'model-2',
+          reasoningEffort: 'low'
+        }
+      }
+    ])
+    expect(saved).toContainEqual(
+      expect.objectContaining({
+        permissionProfile: 'auto',
+        autoReviewEnabled: true,
+        memoryEnabled: true,
+        delegationPolicy: 'deny',
+        enabledComputeHosts: ['ssh:alpha', 'ssh:beta'],
+        selectedComputeHosts: ['ssh:beta'],
+        agentConfiguration: {
+          providerId: 'provider-1',
+          model: 'model-2',
+          reasoningEffort: 'low'
+        }
+      })
+    )
+  })
+
   it('resolves only the active Task Run that owns a Session and prompt', async () => {
     let finishPrompt: (() => void) | undefined
     const prompt = new Promise<void>((resolve) => {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -434,7 +434,7 @@ describe('TaskRunner', () => {
     expect(save).not.toHaveBeenCalled()
   })
 
-  it('snapshots Project defaults into only new Sessions with explicit Run values winning', async () => {
+  it('snapshots Project defaults into only new Sessions with explicit Run overrides and additions', async () => {
     const defaultedProject: Project = {
       ...project,
       sessionDefaults: {
@@ -495,6 +495,7 @@ describe('TaskRunner', () => {
       permissionProfile: 'auto',
       memoryEnabled: true,
       agentConfiguration: { model: 'model-2' },
+      enabledComputeHostIds: ['ssh:gamma'],
       computeHostIds: ['ssh:beta']
     })
     await runner.waitForRun(started.id)
@@ -516,13 +517,28 @@ describe('TaskRunner', () => {
         autoReviewEnabled: true,
         memoryEnabled: true,
         delegationPolicy: 'deny',
-        enabledComputeHosts: ['ssh:alpha', 'ssh:beta'],
+        enabledComputeHosts: ['ssh:alpha', 'ssh:beta', 'ssh:gamma'],
         selectedComputeHosts: ['ssh:beta'],
         agentConfiguration: {
           providerId: 'provider-1',
           model: 'model-2',
           reasoningEffort: 'low'
         }
+      })
+    )
+
+    const cleared = await runner.startRun({
+      project: project.id,
+      prompt: 'Override the configured Compute Host defaults.',
+      enabledComputeHostIds: [],
+      computeHostIds: []
+    })
+    await runner.waitForRun(cleared.id)
+
+    expect(saved).toContainEqual(
+      expect.objectContaining({
+        enabledComputeHosts: [],
+        selectedComputeHosts: []
       })
     )
   })

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -283,6 +283,61 @@ describe('TaskRunner', () => {
     expect(validate).toHaveBeenCalledWith(['ssh:alpha', 'ssh:alpha'])
   })
 
+  it('keeps a committed configuration update when its attached runtime detaches', async () => {
+    let current: PersistedChatSession = { ...session, revision: 4, memoryEnabled: true }
+    const updateConfiguration = vi.fn(async (value: PersistedChatSession) => {
+      current = { ...value, revision: 5 }
+      return current
+    })
+    const listAttachedSessionIds = vi
+      .fn<() => Promise<string[]>>()
+      .mockResolvedValueOnce([session.id])
+      .mockResolvedValueOnce([])
+    const runner = createRunner({
+      sessions: { list: async () => [current], updateConfiguration },
+      agent: {
+        listAttachedSessionIds,
+        setMemoryEnabled: async () => {
+          throw new Error(`ACP session not found: ${session.id}`)
+        }
+      }
+    })
+
+    await expect(
+      runner.updateSessionConfiguration(session.id, {
+        expectedRevision: 4,
+        memoryEnabled: false
+      })
+    ).resolves.toMatchObject({ revision: 5, persisted: { memoryEnabled: false } })
+    expect(updateConfiguration).toHaveBeenCalledOnce()
+    expect(listAttachedSessionIds).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports a runtime synchronization failure while the Session remains attached', async () => {
+    let current: PersistedChatSession = { ...session, revision: 4, memoryEnabled: true }
+    const updateConfiguration = vi.fn(async (value: PersistedChatSession) => {
+      current = { ...value, revision: 5 }
+      return current
+    })
+    const runner = createRunner({
+      sessions: { list: async () => [current], updateConfiguration },
+      agent: {
+        listAttachedSessionIds: async () => [session.id],
+        setMemoryEnabled: async () => {
+          throw new Error('runtime synchronization failed')
+        }
+      }
+    })
+
+    await expect(
+      runner.updateSessionConfiguration(session.id, {
+        expectedRevision: 4,
+        memoryEnabled: false
+      })
+    ).rejects.toThrow('runtime synchronization failed')
+    expect(updateConfiguration).toHaveBeenCalledOnce()
+  })
+
   it('rejects stale or active Session configuration updates without persisting them', async () => {
     const current = { ...session, revision: 3 }
     const save = vi.fn(async (value: PersistedChatSession) => value)

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -17,6 +17,7 @@ import type { TaskRunJournalEntry } from './task-run-journal'
 import {
   TASK_RUN_DISPOSAL_BUDGET_MS,
   TaskRunner,
+  type TaskAgentPort,
   type TaskPreviewResourcePort,
   type TaskProjectPort,
   type TaskRunnerDependencies,
@@ -90,7 +91,8 @@ const configuredSettings: SettingsSnapshot = {
 
 class RetainedRunEventPayload {}
 
-type TaskRunnerOverrides = Omit<Partial<TaskRunnerDependencies>, 'sessions'> & {
+type TaskRunnerOverrides = Omit<Partial<TaskRunnerDependencies>, 'agent' | 'sessions'> & {
+  agent?: Partial<TaskAgentPort>
   sessions?: Omit<
     Partial<TaskSessionPort>,
     'save' | 'stageCompletion' | 'settleCompletion' | 'failRun'
@@ -166,6 +168,16 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
     },
     setDelegationPolicy: async () => undefined
   }
+  const defaultAgent: TaskAgentPort = {
+    withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+    listAttachedSessionIds: async () => [],
+    createSession: async () => ({ sessionId: 'session-created' }),
+    resumeSession: async (request) => ({ sessionId: request.sessionId }),
+    setPermissionProfile: async () => undefined,
+    setMemoryEnabled: async () => undefined,
+    cancelPrompt: async () => undefined,
+    prompt: async () => undefined
+  }
   return new TaskRunner({
     projects: {
       list: async () => [project],
@@ -174,15 +186,6 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
     previewResources: {
       acquire: async () => ({ id: 'resource-1', url: 'preview://resource-1', size: 0 }),
       release: async () => undefined
-    },
-    agent: {
-      withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
-      listAttachedSessionIds: async () => [],
-      createSession: async () => ({ sessionId: 'session-created' }),
-      resumeSession: async (request) => ({ sessionId: request.sessionId }),
-      setPermissionProfile: async () => undefined,
-      cancelPrompt: async () => undefined,
-      prompt: async () => undefined
     },
     artifacts: {
       finalizeRun: async () => ({ ok: true, artifacts: [] })
@@ -201,6 +204,7 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
     createId: () => 'generated-id',
     now: () => 1,
     ...overrides,
+    agent: { ...defaultAgent, ...overrides.agent },
     sessions: {
       ...defaultSessions,
       ...overrides.sessions,
@@ -228,9 +232,14 @@ describe('TaskRunner', () => {
       return current
     })
     const validate = vi.fn(async (providerIds: readonly string[]) => [...new Set(providerIds)])
+    const setMemoryEnabled = vi.fn(async () => undefined)
     const runner = createRunner({
       sessions: { list: async () => [current], save },
       settings: { get: async () => configuredSettings },
+      agent: {
+        listAttachedSessionIds: async () => [session.id],
+        setMemoryEnabled
+      },
       computePreferences: {
         withReservation: async (providerIds, operation) => operation([...new Set(providerIds)]),
         set: async () => current,
@@ -265,6 +274,7 @@ describe('TaskRunner', () => {
       }
     })
     expect(save).toHaveBeenCalledOnce()
+    expect(setMemoryEnabled).toHaveBeenCalledWith(session.id, false)
     expect(validate).toHaveBeenCalledWith(['ssh:alpha', 'ssh:alpha'])
   })
 

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -308,6 +308,26 @@ describe('TaskRunner', () => {
     expect(save).not.toHaveBeenCalled()
   })
 
+  it('reports availability for the persisted Agent configuration instead of its fallback', async () => {
+    const pinned = {
+      ...session,
+      agentConfiguration: {
+        providerId: 'provider-removed',
+        model: 'model-removed',
+        reasoningEffort: 'high' as const
+      }
+    }
+    const runner = createRunner({
+      sessions: { list: async () => [pinned] },
+      settings: { get: async () => configuredSettings }
+    })
+
+    await expect(runner.getSessionConfiguration(pinned.id)).resolves.toMatchObject({
+      persisted: { agentConfiguration: pinned.agentConfiguration },
+      availability: { agentConfiguration: { available: false } }
+    })
+  })
+
   it('maps an authoritative concurrent-start rejection to session_busy', async () => {
     const current = { ...session, revision: 3 }
     const updateConfiguration = vi.fn(async (): Promise<PersistedChatSession> => {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -30,7 +30,29 @@ import {
   type Project,
   type UpdateProjectRequest
 } from '../../shared/projects'
-import type { AgentFrameworkId, SessionAgentConfiguration } from '../../shared/settings'
+import { buildConfiguredModelCatalog } from '../../shared/configured-model-catalog'
+import {
+  projectSessionDefaultsSchema,
+  sessionAgentConfigurationSchema,
+  sessionAgentConfigurationPatchSchema,
+  updateProjectSessionDefaultsRequestSchema,
+  updateSessionConfigurationRequestSchema,
+  type ProjectSessionDefaults,
+  type ProjectSessionDefaultsPatch,
+  type SessionAgentConfigurationPatch,
+  type SessionComputeHosts,
+  type UpdateProjectSessionDefaultsRequest,
+  type UpdateSessionConfigurationRequest
+} from '../../shared/session-configuration'
+import {
+  resolveSelectableConfiguration,
+  resolveSessionAgentConfiguration
+} from '../../shared/session-agent-configuration'
+import type {
+  AgentFrameworkId,
+  SessionAgentConfiguration,
+  SettingsSnapshot
+} from '../../shared/settings'
 import {
   materializeSessionConversationGraph,
   type DelegationPolicy,
@@ -49,6 +71,7 @@ import type {
   StartTaskRunRequest,
   TaskApiErrorCode,
   TaskProject,
+  TaskProjectSessionDefaults,
   TaskRun,
   TaskRunStatus,
   TaskRunIdentity,
@@ -56,6 +79,7 @@ import type {
   TaskRunProgressPhase,
   TaskRunReview,
   TaskSessionSummary,
+  TaskSessionConfiguration,
   UpdateTaskProjectRequest
 } from '../../shared/task-api'
 import { ArchiveAvailabilityError, archiveAvailabilityMessage } from '../archive/availability-error'
@@ -86,6 +110,13 @@ type TaskComputePreferencePort = {
     operation: (providerIds: string[]) => Promise<Result>
   ): Promise<Result>
   set(sessionId: string, providerIds: readonly string[]): Promise<PersistedChatSession>
+  validate?(providerIds: readonly string[]): Promise<string[]>
+  listAvailable?(): Promise<readonly string[]>
+  project?(session: PersistedChatSession): void
+}
+
+type TaskSettingsPort = {
+  get(): Promise<SettingsSnapshot>
 }
 
 type TaskPreviewResourcePort = {
@@ -113,6 +144,8 @@ type TaskAgentCreateSessionRequest = {
   permissionProfile: PermissionProfileId
   cwd?: string
   specialistId?: string
+  memoryEnabled?: boolean
+  agentConfiguration?: SessionAgentConfiguration
 }
 
 type TaskAgentResumeSessionRequest = {
@@ -192,6 +225,8 @@ type TaskRunnerDependencies = {
   specialists: TaskSpecialistPort
   reviewer: TaskReviewerPort
   computePreferences: TaskComputePreferencePort
+  settings: TaskSettingsPort
+  isSessionBusy?: (projectId: string, sessionId: string) => boolean
   runWithLifecycleContext<Result>(operation: () => Result): Result
   runJournal?: TaskRunJournal
   createId: () => string
@@ -571,6 +606,101 @@ const projectTaskProjection = (project: Project): TaskProject => ({
   hasAgentContext: Boolean(project.agentContext?.trim())
 })
 
+const taskModelCatalog = (
+  settings: SettingsSnapshot
+): ReturnType<typeof buildConfiguredModelCatalog> => {
+  const framework = settings.agentFrameworks.find(
+    (candidate) => candidate.id === settings.agentFrameworkId
+  )
+  return buildConfiguredModelCatalog({
+    providers: settings.providers,
+    activeProviderId: settings.activeProviderId,
+    claudeSubscriptionProviderId: settings.claudeSubscriptionProviderId,
+    includeAllClaudeSubscriptions: true,
+    frameworkId: settings.agentFrameworkId,
+    frameworkEndpoints: framework?.supportedApiTypes ?? ['anthropic']
+  })
+}
+
+const validateTaskAgentConfiguration = (
+  configuration: SessionAgentConfiguration,
+  settings: SettingsSnapshot
+): SessionAgentConfiguration => {
+  const resolved = resolveSelectableConfiguration(
+    taskModelCatalog(settings),
+    configuration.providerId,
+    configuration.model,
+    configuration.reasoningEffort
+  )
+  if (!resolved) {
+    throw new TaskRunnerError(
+      'invalid_configuration',
+      'The provider, model, and reasoning effort are not available for the active Agent Framework.'
+    )
+  }
+  return resolved
+}
+
+const effectiveTaskAgentConfiguration = (
+  session: Pick<PersistedChatSession, 'agentBackendId' | 'agentModel' | 'agentConfiguration'>,
+  settings: SettingsSnapshot
+): SessionAgentConfiguration | undefined => {
+  const resolution = resolveSessionAgentConfiguration({
+    session,
+    catalog: taskModelCatalog(settings),
+    activeProviderId: settings.activeProviderId,
+    activeModel: settings.activeModel,
+    activeReasoningEffort: settings.reasoningEffort
+  })
+  return resolution.configuration
+}
+
+const mergeAgentConfigurationPatch = (
+  current: SessionAgentConfiguration | undefined,
+  patch: SessionAgentConfigurationPatch
+): SessionAgentConfiguration => {
+  if (
+    patch.providerId !== undefined &&
+    patch.providerId !== current?.providerId &&
+    patch.model === undefined
+  ) {
+    throw new TaskRunnerError(
+      'invalid_configuration',
+      'A provider change requires an explicit model or provider-default model reset.'
+    )
+  }
+  const providerId = patch.providerId ?? current?.providerId
+  if (!providerId) {
+    throw new TaskRunnerError(
+      'invalid_configuration',
+      'Provider is required when the Session has no effective agent configuration.'
+    )
+  }
+  const model = patch.model === null ? undefined : (patch.model ?? current?.model)
+  return {
+    providerId,
+    ...(model ? { model } : {}),
+    reasoningEffort: patch.reasoningEffort ?? current?.reasoningEffort ?? 'default'
+  }
+}
+
+const computeHostsFromSession = (session: PersistedChatSession): SessionComputeHosts => ({
+  enabled: [...(session.enabledComputeHosts ?? [])],
+  selected: [...(session.selectedComputeHosts ?? session.enabledComputeHosts ?? [])]
+})
+
+const applyProjectDefaultsPatch = (
+  current: ProjectSessionDefaults,
+  patch: ProjectSessionDefaultsPatch
+): ProjectSessionDefaults => {
+  const next: Record<string, unknown> = { ...current }
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) delete next[key]
+    else next[key] = value
+  }
+  return projectSessionDefaultsSchema.parse(next)
+}
+
 class TaskRunnerError extends Error {
   constructor(
     readonly code: TaskApiErrorCode,
@@ -804,6 +934,202 @@ class TaskRunner {
     return summarizeSession(await this.findSession(sessionId))
   }
 
+  async getSessionConfiguration(sessionId: string): Promise<TaskSessionConfiguration> {
+    const [session, settings, availableComputeHosts] = await Promise.all([
+      this.findSession(sessionId),
+      this.dependencies.settings.get(),
+      this.dependencies.computePreferences.listAvailable?.() ?? Promise.resolve([])
+    ])
+    const effectiveAgentConfiguration = effectiveTaskAgentConfiguration(session, settings)
+    const computeHosts = computeHostsFromSession(session)
+    return {
+      sessionId: session.id,
+      projectId: session.projectId,
+      revision: session.revision ?? 0,
+      cwd: session.cwd,
+      ...(session.specialistId ? { specialistId: session.specialistId } : {}),
+      persisted: {
+        ...(session.agentConfiguration ? { agentConfiguration: session.agentConfiguration } : {}),
+        ...(session.permissionProfile ? { permissionProfile: session.permissionProfile } : {}),
+        ...(session.autoReviewEnabled !== undefined
+          ? { autoReviewEnabled: session.autoReviewEnabled }
+          : {}),
+        ...(session.memoryEnabled !== undefined ? { memoryEnabled: session.memoryEnabled } : {}),
+        ...(session.delegationPolicy ? { delegationPolicy: session.delegationPolicy } : {}),
+        computeHosts
+      },
+      effective: {
+        ...(effectiveAgentConfiguration ? { agentConfiguration: effectiveAgentConfiguration } : {}),
+        permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+        autoReviewEnabled: session.autoReviewEnabled === true,
+        memoryEnabled: session.memoryEnabled !== false,
+        delegationPolicy: session.delegationPolicy ?? 'allow',
+        computeHosts
+      },
+      availability: {
+        ...(effectiveAgentConfiguration
+          ? {
+              agentConfiguration: this.agentConfigurationAvailability(
+                effectiveAgentConfiguration,
+                settings
+              )
+            }
+          : {}),
+        ...(session.specialistId
+          ? { specialist: await this.specialistAvailability(session.specialistId) }
+          : {}),
+        computeHosts: this.computeAvailability(computeHosts, availableComputeHosts)
+      }
+    }
+  }
+
+  async updateSessionConfiguration(
+    sessionId: string,
+    request: UpdateSessionConfigurationRequest
+  ): Promise<TaskSessionConfiguration> {
+    const parsed = updateSessionConfigurationRequestSchema.safeParse(request)
+    if (
+      !request ||
+      typeof request !== 'object' ||
+      !Number.isSafeInteger(request.expectedRevision) ||
+      request.expectedRevision < 0 ||
+      !parsed.success ||
+      Object.keys(parsed.data).length === 1
+    ) {
+      throw new TaskRunnerError('invalid_request', 'Invalid Session configuration update.')
+    }
+    const session = await this.findSession(sessionId)
+    if ((session.revision ?? 0) !== request.expectedRevision) {
+      throw new TaskRunnerError(
+        'session_revision_conflict',
+        `Session revision conflict: expected ${request.expectedRevision}, actual ${session.revision ?? 0}.`
+      )
+    }
+    if (
+      this.activeRunBySession.has(session.id) ||
+      this.dependencies.isSessionBusy?.(session.projectId, session.id) === true ||
+      (session.status !== 'idle' && session.status !== 'error')
+    ) {
+      throw new TaskRunnerError('session_busy', `Session has active work: ${session.id}`)
+    }
+    const settings = await this.dependencies.settings.get()
+    const patch = parsed.data
+    const agentConfiguration = patch.agentConfiguration
+      ? validateTaskAgentConfiguration(
+          mergeAgentConfigurationPatch(
+            session.agentConfiguration ?? effectiveTaskAgentConfiguration(session, settings),
+            patch.agentConfiguration
+          ),
+          settings
+        )
+      : session.agentConfiguration
+    if (patch.computeHosts) {
+      await this.validateComputeHosts([
+        ...patch.computeHosts.enabled,
+        ...patch.computeHosts.selected
+      ])
+    }
+    const next: PersistedChatSession = {
+      ...session,
+      ...(patch.agentConfiguration ? { agentConfiguration } : {}),
+      ...(patch.permissionProfile !== undefined
+        ? { permissionProfile: patch.permissionProfile }
+        : {}),
+      ...(patch.autoReviewEnabled !== undefined
+        ? { autoReviewEnabled: patch.autoReviewEnabled }
+        : {}),
+      ...(patch.memoryEnabled !== undefined ? { memoryEnabled: patch.memoryEnabled } : {}),
+      ...(patch.delegationPolicy !== undefined ? { delegationPolicy: patch.delegationPolicy } : {}),
+      ...(patch.computeHosts
+        ? {
+            enabledComputeHosts: [...new Set(patch.computeHosts.enabled)],
+            selectedComputeHosts: [...new Set(patch.computeHosts.selected)]
+          }
+        : {}),
+      updatedAt: Math.max(session.updatedAt + 1, this.dependencies.now())
+    }
+    try {
+      const persisted = await this.dependencies.sessions.save(next)
+      this.dependencies.computePreferences.project?.(persisted)
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === 'session-revision-conflict'
+      ) {
+        throw new TaskRunnerError(
+          'session_revision_conflict',
+          error instanceof Error ? error.message : 'Session revision conflict.'
+        )
+      }
+      throw error
+    }
+    return this.getSessionConfiguration(sessionId)
+  }
+
+  async getProjectSessionDefaults(projectId: string): Promise<TaskProjectSessionDefaults> {
+    const project = await this.resolveProject(projectId)
+    return this.projectSessionDefaultsProjection(project)
+  }
+
+  async updateProjectSessionDefaults(
+    projectId: string,
+    request: UpdateProjectSessionDefaultsRequest
+  ): Promise<TaskProjectSessionDefaults> {
+    const parsed = updateProjectSessionDefaultsRequestSchema.safeParse(request)
+    if (!parsed.success || Object.keys(parsed.data.patch).length === 0) {
+      throw new TaskRunnerError('invalid_request', 'Invalid Project Session defaults update.')
+    }
+    const project = await this.resolveProject(projectId)
+    const patch: ProjectSessionDefaultsPatch = { ...parsed.data.patch }
+    if (typeof patch.specialistId === 'string') {
+      try {
+        patch.specialistId = (await this.dependencies.specialists.resolve(patch.specialistId)).id
+      } catch (error) {
+        throw new TaskRunnerError('specialist_not_found', toErrorMessage(error))
+      }
+    }
+    const settings = await this.dependencies.settings.get()
+    if (patch.agentConfiguration) {
+      patch.agentConfiguration = validateTaskAgentConfiguration(
+        mergeAgentConfigurationPatch(
+          project.sessionDefaults?.agentConfiguration ??
+            effectiveTaskAgentConfiguration({}, settings),
+          patch.agentConfiguration
+        ),
+        settings
+      )
+    }
+    const defaults = applyProjectDefaultsPatch(project.sessionDefaults ?? {}, patch)
+    if (defaults.computeHosts) {
+      await this.validateComputeHosts([
+        ...defaults.computeHosts.enabled,
+        ...defaults.computeHosts.selected
+      ])
+    }
+    try {
+      const updated = await this.dependencies.projects.update?.({
+        id: project.id,
+        expectedUpdatedAt: parsed.data.expectedUpdatedAt,
+        sessionDefaults: defaults
+      })
+      if (!updated) throw new Error('Task Project update is unavailable.')
+      return this.projectSessionDefaultsProjection(updated)
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message === 'Project changed elsewhere.' || error.message === 'Project not found.')
+      ) {
+        throw new TaskRunnerError(
+          'project_conflict',
+          'Project changed elsewhere. Refresh it and try again.'
+        )
+      }
+      throw error
+    }
+  }
+
   async listArtifacts(sessionId: string): Promise<PersistedArtifact[]> {
     return [...((await this.findSession(sessionId)).artifacts ?? [])]
   }
@@ -889,6 +1215,27 @@ class TaskRunner {
     ) {
       throw new TaskRunnerError('invalid_request', 'Compute Host ids must be non-empty strings.')
     }
+    if (
+      request.enabledComputeHostIds !== undefined &&
+      (!Array.isArray(request.enabledComputeHostIds) ||
+        request.enabledComputeHostIds.some(
+          (providerId) => typeof providerId !== 'string' || !providerId.trim()
+        ))
+    ) {
+      throw new TaskRunnerError(
+        'invalid_request',
+        'Enabled Compute Host ids must be non-empty strings.'
+      )
+    }
+    if (
+      request.agentConfiguration !== undefined &&
+      !sessionAgentConfigurationPatchSchema.safeParse(request.agentConfiguration).success
+    ) {
+      throw new TaskRunnerError('invalid_request', 'Invalid Session agent configuration.')
+    }
+    if (request.memoryEnabled !== undefined && typeof request.memoryEnabled !== 'boolean') {
+      throw new TaskRunnerError('invalid_request', 'Memory must be a boolean.')
+    }
     const prompt = typeof request.prompt === 'string' ? request.prompt.trim() : ''
     if (!prompt) throw new TaskRunnerError('invalid_request', 'Prompt is required.')
     const cwd =
@@ -915,6 +1262,15 @@ class TaskRunner {
         `Session ${existing.id} does not belong to project ${project.id}.`
       )
     }
+    if (
+      existing &&
+      (request.agentConfiguration !== undefined || request.memoryEnabled !== undefined)
+    ) {
+      throw new TaskRunnerError(
+        'invalid_request',
+        'Provider, model, reasoning effort, and memory must be changed with session config update before resuming an existing Session.'
+      )
+    }
     if (existing && cwd !== undefined) {
       const existingCwd = await canonicalizeTaskWorkingDirectory(existing.cwd)
       if (cwd !== existingCwd) {
@@ -932,6 +1288,72 @@ class TaskRunner {
         'session_busy',
         `Session is waiting for Plan approval: ${existing.id}`
       )
+    }
+    if (!existing) {
+      const settings = await this.dependencies.settings.get()
+      const defaults = project.sessionDefaults ?? {}
+      const selectedComputeHosts = request.computeHostIds ?? defaults.computeHosts?.selected
+      const configuredEnabledComputeHosts =
+        request.enabledComputeHostIds ?? defaults.computeHosts?.enabled
+      const enabledComputeHosts =
+        configuredEnabledComputeHosts !== undefined || selectedComputeHosts !== undefined
+          ? [
+              ...new Set([
+                ...(configuredEnabledComputeHosts ?? []),
+                ...(selectedComputeHosts ?? [])
+              ])
+            ]
+          : undefined
+      const candidateAgentConfiguration = request.agentConfiguration
+        ? mergeAgentConfigurationPatch(
+            defaults.agentConfiguration ?? effectiveTaskAgentConfiguration({}, settings),
+            request.agentConfiguration
+          )
+        : defaults.agentConfiguration
+      normalizedRequest = {
+        ...normalizedRequest,
+        permissionProfile:
+          request.permissionProfile ??
+          defaults.permissionProfile ??
+          settings.defaultPermissionProfile ??
+          DEFAULT_PERMISSION_PROFILE,
+        autoReviewEnabled: request.autoReviewEnabled ?? defaults.autoReviewEnabled ?? false,
+        memoryEnabled: request.memoryEnabled ?? defaults.memoryEnabled ?? true,
+        delegationPolicy: request.delegationPolicy ?? defaults.delegationPolicy ?? 'allow',
+        ...(request.specialist !== undefined
+          ? { specialist: request.specialist }
+          : defaults.specialistId
+            ? { specialist: defaults.specialistId }
+            : {}),
+        ...(candidateAgentConfiguration
+          ? {
+              agentConfiguration: validateTaskAgentConfiguration(
+                candidateAgentConfiguration,
+                settings
+              )
+            }
+          : {}),
+        ...(enabledComputeHosts !== undefined
+          ? { enabledComputeHostIds: enabledComputeHosts }
+          : {}),
+        ...(selectedComputeHosts !== undefined ? { computeHostIds: selectedComputeHosts } : {})
+      }
+      if (normalizedRequest.enabledComputeHostIds !== undefined) {
+        const enabled = new Set(normalizedRequest.enabledComputeHostIds)
+        const invalidSelection = normalizedRequest.computeHostIds?.find(
+          (providerId) => !enabled.has(providerId)
+        )
+        if (invalidSelection) {
+          throw new TaskRunnerError(
+            'invalid_configuration',
+            `Selected Compute Host is not enabled: ${invalidSelection}`
+          )
+        }
+        await this.validateComputeHosts(
+          [...normalizedRequest.enabledComputeHostIds, ...(normalizedRequest.computeHostIds ?? [])],
+          'invalid_request'
+        )
+      }
     }
     const userMessageId = this.dependencies.createId()
     const runId = this.dependencies.createId()
@@ -1011,9 +1433,9 @@ class TaskRunner {
           existing.id,
           async () => acceptPrepared(await prepare())
         )
-      } else if (request.computeHostIds !== undefined) {
+      } else if (normalizedRequest.computeHostIds !== undefined) {
         accepted = await this.dependencies.computePreferences.withReservation(
-          request.computeHostIds,
+          normalizedRequest.computeHostIds,
           async (computeHostIds) => {
             normalizedRequest = { ...normalizedRequest, computeHostIds }
             return acceptPrepared(await prepare(normalizedRequest))
@@ -1253,9 +1675,7 @@ class TaskRunner {
         !existing.agentConfiguration &&
         !existing.agentBackendId
       ) {
-        if (request.permissionProfile && request.permissionProfile !== existing.permissionProfile) {
-          await this.dependencies.agent.setPermissionProfile(existing.id, request.permissionProfile)
-        }
+        await this.dependencies.agent.setPermissionProfile(existing.id, permissionProfile)
         sessionInfo = {
           sessionId: existing.id,
           cwd: existing.cwd,
@@ -1284,11 +1704,25 @@ class TaskRunner {
         })
       }
     } else {
+      const parsedAgentConfiguration =
+        request.agentConfiguration === undefined
+          ? undefined
+          : sessionAgentConfigurationSchema.safeParse(request.agentConfiguration)
+      if (parsedAgentConfiguration && !parsedAgentConfiguration.success) {
+        throw new TaskRunnerError(
+          'invalid_configuration',
+          'A new Session requires a complete agent configuration.'
+        )
+      }
       sessionInfo = await this.dependencies.agent.createSession({
         projectId: project.id,
         permissionProfile,
         ...(request.cwd ? { cwd: request.cwd } : {}),
-        ...(specialistId ? { specialistId } : {})
+        ...(specialistId ? { specialistId } : {}),
+        ...(request.memoryEnabled === false ? { memoryEnabled: request.memoryEnabled } : {}),
+        ...(parsedAgentConfiguration?.success
+          ? { agentConfiguration: parsedAgentConfiguration.data }
+          : {})
       })
     }
 
@@ -1334,6 +1768,7 @@ class TaskRunner {
           status: 'running',
           permissionProfile,
           autoReviewEnabled,
+          memoryEnabled: existing.memoryEnabled ?? true,
           delegationPolicy,
           specialistId,
           agentFrameworkId: sessionInfo.frameworkId ?? existing.agentFrameworkId,
@@ -1354,6 +1789,7 @@ class TaskRunner {
           status: 'running',
           permissionProfile,
           autoReviewEnabled,
+          memoryEnabled: request.memoryEnabled ?? true,
           delegationPolicy,
           specialistId,
           agentFrameworkId: sessionInfo.frameworkId,
@@ -1361,10 +1797,12 @@ class TaskRunner {
           providerSessionId: sessionInfo.providerSessionId,
           providerContinuityToken: sessionInfo.providerContinuityToken,
           agentConfiguration: sessionInfo.agentConfiguration,
-          ...(request.computeHostIds !== undefined
+          ...(request.enabledComputeHostIds !== undefined || request.computeHostIds !== undefined
             ? {
-                enabledComputeHosts: request.computeHostIds,
-                selectedComputeHosts: request.computeHostIds
+                enabledComputeHosts: [
+                  ...new Set(request.enabledComputeHostIds ?? request.computeHostIds ?? [])
+                ],
+                selectedComputeHosts: [...new Set(request.computeHostIds ?? [])]
               }
             : {}),
           messages: [userMessage],
@@ -2122,6 +2560,97 @@ class TaskRunner {
     const project = projects.find((candidate) => candidate.id === normalized)
     if (project) return project
     throw new TaskRunnerError('project_not_found', `Project not found: ${normalized}`)
+  }
+
+  private agentConfigurationAvailability(
+    configuration: SessionAgentConfiguration,
+    settings: SettingsSnapshot
+  ): { available: boolean; reason?: string } {
+    try {
+      validateTaskAgentConfiguration(configuration, settings)
+      return { available: true }
+    } catch (error) {
+      return { available: false, reason: toErrorMessage(error) }
+    }
+  }
+
+  private async specialistAvailability(
+    specialistId: string
+  ): Promise<{ available: boolean; reason?: string }> {
+    try {
+      await this.dependencies.specialists.resolve(specialistId)
+      return { available: true }
+    } catch (error) {
+      return { available: false, reason: toErrorMessage(error) }
+    }
+  }
+
+  private computeAvailability(
+    computeHosts: SessionComputeHosts,
+    availableProviderIds: readonly string[]
+  ): Record<string, { available: boolean; reason?: string }> {
+    const available = new Set(availableProviderIds)
+    return Object.fromEntries(
+      [...new Set([...computeHosts.enabled, ...computeHosts.selected])].map((providerId) => [
+        providerId,
+        available.has(providerId)
+          ? { available: true }
+          : { available: false, reason: 'Compute Host is not registered.' }
+      ])
+    )
+  }
+
+  private async validateComputeHosts(
+    providerIds: readonly string[],
+    errorCode: 'invalid_request' | 'invalid_configuration' = 'invalid_configuration'
+  ): Promise<string[]> {
+    try {
+      if (this.dependencies.computePreferences.validate) {
+        return await this.dependencies.computePreferences.validate(providerIds)
+      }
+      return await this.dependencies.computePreferences.withReservation(
+        providerIds,
+        async (validated) => validated
+      )
+    } catch (error) {
+      if (error instanceof ComputeHostPreferenceValidationError) {
+        throw new TaskRunnerError(errorCode, error.message)
+      }
+      throw error
+    }
+  }
+
+  private async projectSessionDefaultsProjection(
+    project: Project
+  ): Promise<TaskProjectSessionDefaults> {
+    const defaults = project.sessionDefaults ?? {}
+    const [settings, availableComputeHosts, specialist] = await Promise.all([
+      this.dependencies.settings.get(),
+      this.dependencies.computePreferences.listAvailable?.() ?? Promise.resolve([]),
+      defaults.specialistId
+        ? this.specialistAvailability(defaults.specialistId)
+        : Promise.resolve(undefined)
+    ])
+    return {
+      projectId: project.id,
+      updatedAt: project.updatedAt,
+      configured: defaults,
+      availability: {
+        ...(defaults.agentConfiguration
+          ? {
+              agentConfiguration: this.agentConfigurationAvailability(
+                defaults.agentConfiguration,
+                settings
+              )
+            }
+          : {}),
+        ...(specialist ? { specialist } : {}),
+        computeHosts: this.computeAvailability(
+          defaults.computeHosts ?? { enabled: [], selected: [] },
+          availableComputeHosts
+        )
+      }
+    }
   }
 
   private async findSession(sessionId: string): Promise<PersistedChatSession> {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1282,11 +1282,13 @@ class TaskRunner {
     }
     if (
       existing &&
-      (request.agentConfiguration !== undefined || request.memoryEnabled !== undefined)
+      (request.agentConfiguration !== undefined ||
+        request.memoryEnabled !== undefined ||
+        request.enabledComputeHostIds !== undefined)
     ) {
       throw new TaskRunnerError(
         'invalid_request',
-        'Provider, model, reasoning effort, and memory must be changed with session config update before resuming an existing Session.'
+        'Provider, model, reasoning effort, memory, and enabled Compute Hosts must be changed with session config update before resuming an existing Session.'
       )
     }
     if (existing && cwd !== undefined) {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1315,7 +1315,16 @@ class TaskRunner {
       const defaults = project.sessionDefaults ?? {}
       const selectedComputeHosts = request.computeHostIds ?? defaults.computeHosts?.selected
       const configuredEnabledComputeHosts =
-        request.enabledComputeHostIds ?? defaults.computeHosts?.enabled
+        request.enabledComputeHostIds === undefined
+          ? defaults.computeHosts?.enabled
+          : request.enabledComputeHostIds.length === 0
+            ? []
+            : [
+                ...new Set([
+                  ...(defaults.computeHosts?.enabled ?? []),
+                  ...request.enabledComputeHostIds
+                ])
+              ]
       const enabledComputeHosts =
         configuredEnabledComputeHosts !== undefined || selectedComputeHosts !== undefined
           ? [

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -947,6 +947,7 @@ class TaskRunner {
       this.dependencies.computePreferences.listAvailable?.() ?? Promise.resolve([])
     ])
     const effectiveAgentConfiguration = effectiveTaskAgentConfiguration(session, settings)
+    const availabilityAgentConfiguration = session.agentConfiguration ?? effectiveAgentConfiguration
     const computeHosts = computeHostsFromSession(session)
     return {
       sessionId: session.id,
@@ -973,10 +974,10 @@ class TaskRunner {
         computeHosts
       },
       availability: {
-        ...(effectiveAgentConfiguration
+        ...(availabilityAgentConfiguration
           ? {
               agentConfiguration: this.agentConfigurationAvailability(
-                effectiveAgentConfiguration,
+                availabilityAgentConfiguration,
                 settings
               )
             }

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -191,6 +191,7 @@ type TaskAgentPort = {
   createSession(request: TaskAgentCreateSessionRequest): Promise<TaskAgentSession>
   resumeSession(request: TaskAgentResumeSessionRequest): Promise<TaskAgentSession>
   setPermissionProfile(sessionId: string, profile: PermissionProfileId): Promise<void>
+  setMemoryEnabled(sessionId: string, enabled: boolean): Promise<void>
   prompt(request: TaskAgentPromptRequest, observer?: TaskAgentPromptObserver): Promise<void>
   cancelPrompt(sessionId: string): Promise<void>
 }
@@ -1065,6 +1066,12 @@ class TaskRunner {
       }
       throw error
     }
+    if (
+      patch.memoryEnabled !== undefined &&
+      (await this.dependencies.agent.listAttachedSessionIds()).includes(session.id)
+    ) {
+      await this.dependencies.agent.setMemoryEnabled(session.id, patch.memoryEnabled)
+    }
     return this.getSessionConfiguration(sessionId)
   }
 
@@ -1676,6 +1683,10 @@ class TaskRunner {
         !existing.agentBackendId
       ) {
         await this.dependencies.agent.setPermissionProfile(existing.id, permissionProfile)
+        await this.dependencies.agent.setMemoryEnabled(
+          existing.id,
+          existing.memoryEnabled !== false
+        )
         sessionInfo = {
           sessionId: existing.id,
           cwd: existing.cwd,

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1082,7 +1082,13 @@ class TaskRunner {
       patch.memoryEnabled !== undefined &&
       (await this.dependencies.agent.listAttachedSessionIds()).includes(session.id)
     ) {
-      await this.dependencies.agent.setMemoryEnabled(session.id, patch.memoryEnabled)
+      try {
+        await this.dependencies.agent.setMemoryEnabled(session.id, patch.memoryEnabled)
+      } catch (error) {
+        if ((await this.dependencies.agent.listAttachedSessionIds()).includes(session.id)) {
+          throw error
+        }
+      }
     }
     return this.getSessionConfiguration(sessionId)
   }

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -101,6 +101,10 @@ type TaskSessionPort = {
   stageCompletion(request: StageTaskSessionCompletionRequest): Promise<PersistedChatSession>
   settleCompletion(request: SettleTaskSessionCompletionRequest): Promise<PersistedChatSession>
   failRun(request: FailTaskSessionRunRequest): Promise<PersistedChatSession>
+  updateConfiguration(
+    session: PersistedChatSession,
+    expectedRevision: number
+  ): Promise<PersistedChatSession>
   setDelegationPolicy(projectId: string, sessionId: string, policy: DelegationPolicy): Promise<void>
 }
 
@@ -1050,7 +1054,10 @@ class TaskRunner {
       updatedAt: Math.max(session.updatedAt + 1, this.dependencies.now())
     }
     try {
-      const persisted = await this.dependencies.sessions.save(next)
+      const persisted = await this.dependencies.sessions.updateConfiguration(
+        next,
+        request.expectedRevision
+      )
       this.dependencies.computePreferences.project?.(persisted)
     } catch (error) {
       if (

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -54,6 +54,7 @@ import type {
   SettingsSnapshot
 } from '../../shared/settings'
 import {
+  isSessionConfigurationBusyError,
   materializeSessionConversationGraph,
   type DelegationPolicy,
   type FailTaskSessionRunRequest,
@@ -1060,6 +1061,9 @@ class TaskRunner {
       )
       this.dependencies.computePreferences.project?.(persisted)
     } catch (error) {
+      if (isSessionConfigurationBusyError(error)) {
+        throw new TaskRunnerError('session_busy', error.message)
+      }
       if (
         typeof error === 'object' &&
         error !== null &&

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -16,6 +16,7 @@ import type {
   SettleTaskSessionCompletionRequest,
   StageTaskSessionCompletionRequest
 } from '../../shared/session-persistence'
+import type { SettingsSnapshot } from '../../shared/settings'
 import { ApplicationEventHub } from '../application-events'
 import type { ApplicationEventSource } from '../application-events'
 import type { ApplicationCommandComposition } from '../application-command-composition'
@@ -24,6 +25,24 @@ import { FileTaskRunJournal } from '../tasks/task-run-journal'
 import { createWebServiceController, type WebServiceControllerDeps } from './index'
 
 type StartOptions = Parameters<WebServiceControllerDeps['startServer']>[0]
+
+const taskSettings: SettingsSnapshot = {
+  claude: {},
+  opencode: {},
+  codebuddy: {},
+  codex: {},
+  claudeManaged: false,
+  opencodeManaged: false,
+  codebuddyManaged: false,
+  codexManaged: false,
+  providers: [],
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [],
+  reasoningEffort: 'default',
+  notificationsEnabled: true,
+  conversationSkillImportEnabled: true,
+  appIconVariant: 'light'
+}
 
 // Builds a controller over fully faked I/O so the idempotency + attached logic is exercised without
 // Electron, the network, or the filesystem. `startServer` echoes the requested port and records the
@@ -123,6 +142,7 @@ describe('createWebServiceController', () => {
         commandNames: () => [],
         invoke: vi.fn(async (name, invocation) => {
           if (name === 'projects:list') return [project]
+          if (name === 'settings:get-settings') return taskSettings
           if (name === 'sessions:load-all') return { sessions, manifest: { version: 1 } }
           if (name === 'sessions:save-session') {
             const durable = {
@@ -326,6 +346,7 @@ describe('createWebServiceController', () => {
     const taskInvoke = vi.fn(async (name, invocation) => {
       callerSignals.push(invocation.callerLease.signal)
       if (name === 'projects:list') return [project]
+      if (name === 'settings:get-settings') return taskSettings
       if (name === 'sessions:load-all') return { sessions, manifest: { version: 1 } }
       if (name === 'sessions:save-session') {
         sessions.splice(0, sessions.length, invocation.args[0])
@@ -381,6 +402,7 @@ describe('createWebServiceController', () => {
         commandNames: () => [],
         invoke: vi.fn(async (name, invocation) => {
           if (name === 'projects:list') return [project]
+          if (name === 'settings:get-settings') return taskSettings
           if (name === 'sessions:load-all') return { sessions, manifest: { version: 1 } }
           if (name === 'sessions:save-session') {
             const durable = invocation.args[0] as PersistedChatSession

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -165,6 +165,7 @@ describe('createWebServiceController', () => {
         createSession: vi.fn(async () => ({ sessionId: 'session-compute' })),
         resumeSession: vi.fn(async (request) => ({ sessionId: request.sessionId })),
         setPermissionProfile: vi.fn(async () => undefined),
+        setMemoryEnabled: vi.fn(async () => undefined),
         cancelPrompt: vi.fn(async () => undefined),
         prompt: vi.fn(async () => undefined)
       },
@@ -366,6 +367,7 @@ describe('createWebServiceController', () => {
         createSession: vi.fn(async () => ({ sessionId: 'session-created' })),
         resumeSession: vi.fn(async (request) => ({ sessionId: request.sessionId })),
         setPermissionProfile: vi.fn(async () => undefined),
+        setMemoryEnabled: vi.fn(async () => undefined),
         cancelPrompt: vi.fn(async () => undefined),
         prompt: vi.fn(async () => undefined)
       }
@@ -456,6 +458,7 @@ describe('createWebServiceController', () => {
       createSession: vi.fn(async () => ({ sessionId: 'session-restart' })),
       resumeSession: vi.fn(async (request) => ({ sessionId: request.sessionId })),
       setPermissionProfile: vi.fn(async () => undefined),
+      setMemoryEnabled: vi.fn(async () => undefined),
       cancelPrompt: vi.fn(async () => undefined),
       prompt: vi.fn(async () => undefined)
     }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -3746,8 +3746,34 @@ describe('startWebHttpServer', () => {
       updateProject: vi
         .fn()
         .mockResolvedValue({ id: 'project-1', name: 'Research', hasAgentContext: true }),
+      getProjectSessionDefaults: vi.fn().mockResolvedValue({
+        projectId: 'project/1',
+        updatedAt: 7,
+        configured: {}
+      }),
+      updateProjectSessionDefaults: vi.fn().mockResolvedValue({
+        projectId: 'project/1',
+        updatedAt: 8,
+        configured: { memoryEnabled: false }
+      }),
       listSessions: vi.fn().mockResolvedValue([{ id: 'session/1', title: 'Review' }]),
       getSession: vi.fn().mockResolvedValue({ id: 'session/1', title: 'Review' }),
+      getSessionConfiguration: vi.fn().mockResolvedValue({
+        sessionId: 'session/1',
+        revision: 3,
+        persisted: { computeHosts: { enabled: [], selected: [] } }
+      }),
+      updateSessionConfiguration: vi.fn().mockResolvedValue({
+        sessionId: 'session/1',
+        revision: 4,
+        persisted: { memoryEnabled: false, computeHosts: { enabled: [], selected: [] } }
+      }),
+      getAgentRouting: vi.fn().mockResolvedValue({
+        configured: { framework: 'claude-code' }
+      }),
+      updateAgentRouting: vi.fn().mockResolvedValue({
+        configured: { framework: 'codex' }
+      }),
       getSessionPlan: vi.fn().mockResolvedValue({
         artifactVersionId: 'plan-version',
         revision: 2,
@@ -3896,6 +3922,27 @@ describe('startWebHttpServer', () => {
       agentContext: 'Prefer Python.'
     })
 
+    const projectDefaults = await fetch(`${base}/api/v1/projects/project%2F1/session-defaults`, {
+      headers
+    })
+    expect(await projectDefaults.json()).toMatchObject({ data: { updatedAt: 7 } })
+    const updatedProjectDefaults = await fetch(
+      `${base}/api/v1/projects/project%2F1/session-defaults`,
+      {
+        method: 'PATCH',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          expectedUpdatedAt: 7,
+          patch: { memoryEnabled: false }
+        })
+      }
+    )
+    expect(await updatedProjectDefaults.json()).toMatchObject({ data: { updatedAt: 8 } })
+    expect(tasks.updateProjectSessionDefaults).toHaveBeenCalledWith('project/1', {
+      expectedUpdatedAt: 7,
+      patch: { memoryEnabled: false }
+    })
+
     const sessions = await fetch(`${base}/api/v1/sessions?project=project-1`, {
       headers
     })
@@ -3905,6 +3952,35 @@ describe('startWebHttpServer', () => {
     const session = await fetch(`${base}/api/v1/sessions/session%2F1`, { headers })
     expect(await session.json()).toEqual({ data: { id: 'session/1', title: 'Review' } })
     expect(tasks.getSession).toHaveBeenCalledWith('session/1')
+
+    const sessionConfiguration = await fetch(`${base}/api/v1/sessions/session%2F1/config`, {
+      headers
+    })
+    expect(await sessionConfiguration.json()).toMatchObject({ data: { revision: 3 } })
+    const updatedSessionConfiguration = await fetch(`${base}/api/v1/sessions/session%2F1/config`, {
+      method: 'PATCH',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ expectedRevision: 3, memoryEnabled: false })
+    })
+    expect(await updatedSessionConfiguration.json()).toMatchObject({ data: { revision: 4 } })
+    expect(tasks.updateSessionConfiguration).toHaveBeenCalledWith('session/1', {
+      expectedRevision: 3,
+      memoryEnabled: false
+    })
+
+    const agentRouting = await fetch(`${base}/api/v1/settings/agent-routing`, { headers })
+    expect(await agentRouting.json()).toMatchObject({
+      data: { configured: { framework: 'claude-code' } }
+    })
+    const updatedAgentRouting = await fetch(`${base}/api/v1/settings/agent-routing`, {
+      method: 'PATCH',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ framework: 'codex' })
+    })
+    expect(await updatedAgentRouting.json()).toMatchObject({
+      data: { configured: { framework: 'codex' } }
+    })
+    expect(tasks.updateAgentRouting).toHaveBeenCalledWith({ framework: 'codex' })
 
     const plan = await fetch(`${base}/api/v1/sessions/session%2F1/plan`, { headers })
     expect(await plan.json()).toEqual({

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -46,6 +46,9 @@ import type {
   CreateTaskProjectRequest,
   StartTaskRunRequest,
   TaskPlanResponseRequest,
+  UpdateProjectSessionDefaultsRequest,
+  UpdateSessionConfigurationRequest,
+  UpdateTaskAgentRoutingRequest,
   UpdateTaskProjectRequest
 } from '../../shared/task-api'
 import { TASK_EVENT_STREAM_PROTOCOL_VERSION } from '../../shared/task-api'
@@ -143,7 +146,20 @@ type WebServerOptions = {
     | 'releaseArtifact'
     | 'runWithCallerContext'
   > &
-    Partial<Pick<HeadlessTaskApi, 'getSessionPlan' | 'respondSessionPlan' | 'resolveActiveRun'>>
+    Partial<
+      Pick<
+        HeadlessTaskApi,
+        | 'getSessionPlan'
+        | 'respondSessionPlan'
+        | 'resolveActiveRun'
+        | 'getProjectSessionDefaults'
+        | 'updateProjectSessionDefaults'
+        | 'getSessionConfiguration'
+        | 'updateSessionConfiguration'
+        | 'getAgentRouting'
+        | 'updateAgentRouting'
+      >
+    >
   onShutdownRequest?: () => void
   bootstrap: {
     appName: string
@@ -600,8 +616,10 @@ const readJsonBody = async (
 
 const taskErrorStatus = (error: TaskApiError): number => {
   if (error.code === 'invalid_request') return 400
+  if (error.code === 'invalid_configuration') return 400
   if (
     error.code === 'session_busy' ||
+    error.code === 'session_revision_conflict' ||
     error.code === 'project_conflict' ||
     error.code === 'session_archived' ||
     error.code === 'project_archived'
@@ -982,6 +1000,42 @@ const handleTaskApiRequest = async (
         })
         return true
       }
+      const projectSessionDefaultsMatch = url.pathname.match(
+        /^\/api\/v1\/projects\/([^/]+)\/session-defaults$/
+      )
+      if (
+        projectSessionDefaultsMatch &&
+        request.method === 'GET' &&
+        tasks.getProjectSessionDefaults
+      ) {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.getProjectSessionDefaults(
+            decodeURIComponent(projectSessionDefaultsMatch[1])
+          )
+        })
+        return true
+      }
+      if (
+        projectSessionDefaultsMatch &&
+        request.method === 'PATCH' &&
+        tasks.updateProjectSessionDefaults
+      ) {
+        const body = (await readJsonBody(
+          request,
+          response,
+          requestBodyBudgetRegistry,
+          requestBodyClientId
+        )) as UpdateProjectSessionDefaultsRequest
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.updateProjectSessionDefaults(
+            decodeURIComponent(projectSessionDefaultsMatch[1]),
+            body
+          )
+        })
+        return true
+      }
       const projectMatch = url.pathname.match(/^\/api\/v1\/projects\/([^/]+)$/)
       if (projectMatch && request.method === 'PATCH') {
         const body = (await readJsonBody(
@@ -1001,6 +1055,30 @@ const handleTaskApiRequest = async (
         json(response, 200, {
           data: await tasks.listSessions(url.searchParams.get('project') ?? undefined)
         })
+        return true
+      }
+      if (
+        url.pathname === '/api/v1/settings/agent-routing' &&
+        request.method === 'GET' &&
+        tasks.getAgentRouting
+      ) {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data: await tasks.getAgentRouting() })
+        return true
+      }
+      if (
+        url.pathname === '/api/v1/settings/agent-routing' &&
+        request.method === 'PATCH' &&
+        tasks.updateAgentRouting
+      ) {
+        const body = (await readJsonBody(
+          request,
+          response,
+          requestBodyBudgetRegistry,
+          requestBodyClientId
+        )) as UpdateTaskAgentRoutingRequest
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data: await tasks.updateAgentRouting(body) })
         return true
       }
       if (url.pathname === '/api/v1/runs' && request.method === 'POST') {
@@ -1069,6 +1147,30 @@ const handleTaskApiRequest = async (
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, {
           data: await tasks.listArtifacts(decodeURIComponent(sessionArtifactsMatch[1]))
+        })
+        return true
+      }
+      const sessionConfigMatch = url.pathname.match(/^\/api\/v1\/sessions\/([^/]+)\/config$/)
+      if (sessionConfigMatch && request.method === 'GET' && tasks.getSessionConfiguration) {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.getSessionConfiguration(decodeURIComponent(sessionConfigMatch[1]))
+        })
+        return true
+      }
+      if (sessionConfigMatch && request.method === 'PATCH' && tasks.updateSessionConfiguration) {
+        const body = (await readJsonBody(
+          request,
+          response,
+          requestBodyBudgetRegistry,
+          requestBodyClientId
+        )) as UpdateSessionConfigurationRequest
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.updateSessionConfiguration(
+            decodeURIComponent(sessionConfigMatch[1]),
+            body
+          )
         })
         return true
       }

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -77,7 +77,8 @@ const createWebServiceController = (
     permissionApprovalPresence,
     taskAgent,
     taskControls,
-    computePreferences
+    computePreferences,
+    detectActiveSessions
   }: {
     applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
     requestQuit: () => void
@@ -87,6 +88,7 @@ const createWebServiceController = (
     taskAgent: TaskAgentPort
     taskControls?: TaskControlPorts
     computePreferences: TaskComputePreferencePort
+    detectActiveSessions?: () => ReadonlyArray<{ projectId: string; sessionId: string }>
   },
   deps: Partial<WebServiceControllerDeps> = {}
 ): WebServiceController => {
@@ -114,7 +116,8 @@ const createWebServiceController = (
       commands: applicationCommands.task,
       agent: taskAgent,
       controls: taskControls,
-      computePreferences
+      computePreferences,
+      detectActiveSessions
     },
     {
       runJournal: createTaskRunJournal(getConfigRoot()),

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -69,6 +69,7 @@ const createAgent = (overrides: Partial<TaskAgentMock> = {}): TaskAgentMock => (
     sessionId: request.sessionId
   })),
   setPermissionProfile: vi.fn<TaskAgentPort['setPermissionProfile']>(async () => undefined),
+  setMemoryEnabled: vi.fn<TaskAgentPort['setMemoryEnabled']>(async () => undefined),
   prompt: vi.fn<TaskAgentPort['prompt']>(async () => undefined),
   cancelPrompt: vi.fn<TaskAgentPort['cancelPrompt']>(async () => undefined),
   ...overrides
@@ -873,6 +874,7 @@ describe('HeadlessTaskApi adapter', () => {
       cwd: '/workspace/attached',
       status: 'idle',
       permissionProfile: 'ask',
+      memoryEnabled: false,
       messages: [],
       createdAt: 1,
       updatedAt: 1
@@ -923,6 +925,7 @@ describe('HeadlessTaskApi adapter', () => {
 
     expect(agent.listAttachedSessionIds).toHaveBeenCalledOnce()
     expect(agent.setPermissionProfile).toHaveBeenCalledWith(existing.id, 'auto')
+    expect(agent.setMemoryEnabled).toHaveBeenCalledWith(existing.id, false)
     expect(agent.prompt).toHaveBeenCalledWith(
       {
         sessionId: existing.id,

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -237,6 +237,53 @@ const createComputePreferenceHarness = (
 }
 
 describe('HeadlessTaskApi adapter', () => {
+  it('routes Session configuration updates through the Task-only atomic command', async () => {
+    const existing: PersistedChatSession = {
+      id: 'session-config',
+      projectId: project.id,
+      title: 'Configurable Session',
+      cwd: '/workspace',
+      status: 'idle',
+      revision: 4,
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    let durable = existing
+    const invoke = vi.fn(
+      async (channel: string, _callerContext: CallerContext, args: unknown[]) => {
+        if (channel === 'sessions:load-all') {
+          return { sessions: [durable], manifest: { version: 1 } }
+        }
+        if (channel === 'sessions:update-configuration') {
+          durable = { ...(args[0] as PersistedChatSession), revision: 5 }
+          return durable
+        }
+        throw new Error(`Unexpected Task command: ${channel}`)
+      }
+    )
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
+
+    await expect(
+      api.updateSessionConfiguration(existing.id, {
+        expectedRevision: 4,
+        memoryEnabled: false,
+        delegationPolicy: 'deny'
+      })
+    ).resolves.toMatchObject({
+      revision: 5,
+      persisted: { memoryEnabled: false, delegationPolicy: 'deny' }
+    })
+    expect(invoke).toHaveBeenCalledWith('sessions:update-configuration', taskCallerContext(), [
+      expect.objectContaining({
+        id: existing.id,
+        memoryEnabled: false,
+        delegationPolicy: 'deny'
+      }),
+      4
+    ])
+  })
+
   it('creates a new Session when persistence and Task share one Compute preference owner', async () => {
     const durableSessions = new Map<string, PersistedChatSession>()
     const registry = new EnabledComputeHostsRegistry()

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -237,6 +237,32 @@ const createComputePreferenceHarness = (
 }
 
 describe('HeadlessTaskApi adapter', () => {
+  it('routes Project Session defaults through the Task-only persistence command', async () => {
+    const invoke = vi.fn(
+      async (channel: string, _callerContext: CallerContext, args: unknown[]) => {
+        if (channel === 'projects:list') return [project]
+        if (channel === 'projects:update-session-defaults') {
+          return { ...project, ...(args[0] as object), updatedAt: 2 }
+        }
+        throw new Error(`Unexpected Task command: ${channel}`)
+      }
+    )
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
+
+    await api.updateProjectSessionDefaults(project.id, {
+      expectedUpdatedAt: project.updatedAt,
+      patch: { memoryEnabled: false }
+    })
+
+    expect(invoke).toHaveBeenCalledWith('projects:update-session-defaults', taskCallerContext(), [
+      {
+        id: project.id,
+        expectedUpdatedAt: project.updatedAt,
+        sessionDefaults: { memoryEnabled: false }
+      }
+    ])
+  })
+
   it('routes Session configuration updates through the Task-only atomic command', async () => {
     const existing: PersistedChatSession = {
       id: 'session-config',

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -35,6 +35,24 @@ const taskCallerContext = (): ReturnType<typeof expect.objectContaining> =>
     actionOrigin: 'automation'
   })
 
+const taskSettings = {
+  claude: {},
+  opencode: {},
+  codebuddy: {},
+  codex: {},
+  claudeManaged: false,
+  opencodeManaged: false,
+  codebuddyManaged: false,
+  codexManaged: false,
+  providers: [],
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [],
+  reasoningEffort: 'default',
+  notificationsEnabled: true,
+  conversationSkillImportEnabled: true,
+  appIconVariant: 'light'
+}
+
 type TaskAgentMock = {
   [Method in Exclude<keyof TaskAgentPort, 'withSessionAvailable'>]: MockedFunction<
     TaskAgentPort[Method]
@@ -64,6 +82,7 @@ const commandsFrom = (
     commandNames: () => [],
     invoke: async (channel, invocation) => {
       const args = [...invocation.args]
+      if (channel === 'settings:get-settings') return taskSettings
       try {
         const result = await invoke(channel, invocation.callerContext, args)
         if (channel === 'sessions:load-all') {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -10,16 +10,23 @@ import type { Project } from '../../shared/projects'
 import type { ReviewRunResult, ReviewWithChecks } from '../../shared/reviewer'
 import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
 import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
+import type { SettingsSnapshot } from '../../shared/settings'
 import type {
   AcquiredTaskArtifact,
   CreateTaskProjectRequest,
   StartTaskRunRequest,
   TaskProject,
+  TaskAgentRouting,
+  TaskProjectSessionDefaults,
   TaskPlanResponseRequest,
   TaskRun,
   TaskRunProgressEvent,
   TaskRunReview,
   TaskSessionSummary,
+  TaskSessionConfiguration,
+  UpdateProjectSessionDefaultsRequest,
+  UpdateSessionConfigurationRequest,
+  UpdateTaskAgentRoutingRequest,
   UpdateTaskProjectRequest
 } from '../../shared/task-api'
 import { createApplicationCommandClient } from '../application-command-client'
@@ -44,6 +51,7 @@ type TaskApiPorts = {
   agent: TaskAgentPort
   controls?: TaskControlPorts
   computePreferences?: TaskComputePreferencePort
+  detectActiveSessions?: () => ReadonlyArray<{ projectId: string; sessionId: string }>
 }
 
 type TaskApiDependencies = {
@@ -90,6 +98,9 @@ class HeadlessTaskApi {
         setDelegationPolicy: async (projectId, sessionId, policy) => {
           await this.invoke('sessions:set-delegation-policy', projectId, sessionId, policy)
         }
+      },
+      settings: {
+        get: () => this.invoke('settings:get-settings') as Promise<SettingsSnapshot>
       },
       agent: {
         withSessionAvailable: (projectId, sessionId, operation) =>
@@ -150,10 +161,23 @@ class HeadlessTaskApi {
         },
         set: async () => {
           throw new Error('Task Compute preference control is unavailable.')
-        }
+        },
+        validate: async (providerIds) => {
+          if (providerIds.length > 0) {
+            throw new Error('Task Compute preference control is unavailable.')
+          }
+          return []
+        },
+        listAvailable: async () => [],
+        project: () => undefined
       },
       runWithLifecycleContext: (operation) =>
         this.callerContexts.run(TASK_CALLER_CONTEXT, operation),
+      isSessionBusy: (projectId, sessionId) =>
+        this.ports
+          .detectActiveSessions?.()
+          .some((session) => session.projectId === projectId && session.sessionId === sessionId) ===
+        true,
       runJournal: dependencies.runJournal,
       createId: dependencies.createId ?? randomUUID,
       now: dependencies.now ?? Date.now
@@ -194,6 +218,49 @@ class HeadlessTaskApi {
 
   getSession(sessionId: string): Promise<TaskSessionSummary> {
     return this.runner.getSession(sessionId)
+  }
+
+  getSessionConfiguration(sessionId: string): Promise<TaskSessionConfiguration> {
+    return this.runner.getSessionConfiguration(sessionId)
+  }
+
+  updateSessionConfiguration(
+    sessionId: string,
+    request: UpdateSessionConfigurationRequest
+  ): Promise<TaskSessionConfiguration> {
+    return this.runner.updateSessionConfiguration(sessionId, request)
+  }
+
+  getProjectSessionDefaults(projectId: string): Promise<TaskProjectSessionDefaults> {
+    return this.runner.getProjectSessionDefaults(projectId)
+  }
+
+  updateProjectSessionDefaults(
+    projectId: string,
+    request: UpdateProjectSessionDefaultsRequest
+  ): Promise<TaskProjectSessionDefaults> {
+    return this.runner.updateProjectSessionDefaults(projectId, request)
+  }
+
+  async getAgentRouting(): Promise<TaskAgentRouting> {
+    return this.projectAgentRouting(
+      (await this.invoke('settings:get-settings')) as SettingsSnapshot
+    )
+  }
+
+  async updateAgentRouting(request: UpdateTaskAgentRoutingRequest): Promise<TaskAgentRouting> {
+    try {
+      const snapshot = (await this.invoke(
+        'settings:set-agent-routing',
+        request
+      )) as SettingsSnapshot
+      return this.projectAgentRouting(snapshot)
+    } catch (error) {
+      throw new TaskRunnerError(
+        'invalid_configuration',
+        error instanceof Error ? error.message : 'Agent routing update failed.'
+      )
+    }
   }
 
   async getSessionPlan(sessionId: string): Promise<ActivePlanProjection | null> {
@@ -280,6 +347,42 @@ class HeadlessTaskApi {
       return Promise.reject(new Error('Caller authorization is no longer current.'))
     }
     return operation()
+  }
+
+  private projectAgentRouting(settings: SettingsSnapshot): TaskAgentRouting {
+    const reviewer = settings.reviewerModel ?? { mode: 'inherit' as const }
+    const subagent = settings.subagentModel ?? { mode: 'inherit' as const }
+    return {
+      configured: {
+        framework: settings.agentFrameworkId,
+        reviewer,
+        subagent
+      },
+      effective: {
+        reviewer:
+          reviewer.mode === 'inherit'
+            ? {
+                source: 'application_main',
+                ...(settings.activeProviderId ? { providerId: settings.activeProviderId } : {}),
+                ...(settings.activeModel ? { model: settings.activeModel } : {})
+              }
+            : {
+                source: 'fixed',
+                providerId: reviewer.providerId,
+                model: reviewer.model,
+                reasoningEffort: reviewer.reasoningEffort
+              },
+        subagent:
+          subagent.mode === 'inherit'
+            ? { source: 'session_main' }
+            : {
+                source: 'fixed',
+                providerId: subagent.providerId,
+                model: subagent.model,
+                reasoningEffort: subagent.reasoningEffort
+              }
+      }
+    }
   }
 
   private resolveSpecialist(reference: string): Promise<{ id: string }> {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -77,7 +77,13 @@ class HeadlessTaskApi {
       projects: {
         list: () => this.invoke('projects:list') as Promise<Project[]>,
         create: (request) => this.invoke('projects:create', request) as Promise<Project>,
-        update: (request) => this.invoke('projects:update', request) as Promise<Project>
+        update: (request) =>
+          this.invoke(
+            request.sessionDefaults === undefined
+              ? 'projects:update'
+              : 'projects:update-session-defaults',
+            request
+          ) as Promise<Project>
       },
       sessions: {
         list: async () => {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -115,6 +115,8 @@ class HeadlessTaskApi {
           this.withCurrentCaller(() => this.ports.agent.resumeSession(request)),
         setPermissionProfile: (sessionId, profile) =>
           this.withCurrentCaller(() => this.ports.agent.setPermissionProfile(sessionId, profile)),
+        setMemoryEnabled: (sessionId, enabled) =>
+          this.withCurrentCaller(() => this.ports.agent.setMemoryEnabled(sessionId, enabled)),
         prompt: (request, observer) =>
           this.withCurrentCaller(() => this.ports.agent.prompt(request, observer)),
         cancelPrompt: (sessionId) =>

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -95,6 +95,12 @@ class HeadlessTaskApi {
           this.invoke('sessions:settle-task-completion', request) as Promise<PersistedChatSession>,
         failRun: (request) =>
           this.invoke('sessions:fail-task-run', request) as Promise<PersistedChatSession>,
+        updateConfiguration: (session, expectedRevision) =>
+          this.invoke(
+            'sessions:update-configuration',
+            session,
+            expectedRevision
+          ) as Promise<PersistedChatSession>,
         setDelegationPolicy: async (projectId, sessionId, policy) => {
           await this.invoke('sessions:set-delegation-policy', projectId, sessionId, policy)
         }

--- a/src/shared/projects.ts
+++ b/src/shared/projects.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
+import { projectSessionDefaultsSchema } from './session-configuration'
 
 // Shared project types crossing the main <-> renderer IPC boundary.
 //
@@ -19,6 +20,7 @@ export const projectSchema = z
     // Agent Context. The DB column is NOT NULL DEFAULT ''. Capped because it is injected verbatim
     // into every agent session's system prompt.
     agentContext: z.string().max(16000).optional(),
+    sessionDefaults: projectSessionDefaultsSchema.optional(),
     isExample: z.boolean(),
     // Optional on the wire for compatibility with older persisted payloads; absence means unpinned.
     pinned: z.boolean().optional(),
@@ -45,6 +47,7 @@ export const updateProjectRequestSchema = z
     description: z.string().max(PROJECT_DESCRIPTION_MAX_LENGTH).optional(),
     expectedUpdatedAt: z.number().int().positive(),
     agentContext: z.string().max(16000).optional(),
+    sessionDefaults: projectSessionDefaultsSchema.optional(),
     pinned: z.boolean().optional()
   })
   .strict()

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -290,6 +290,7 @@ import type {
   SetNetworkProxyRequest,
   SetNotebookNetworkRequest,
   SetAgentFrameworkRequest,
+  SetAgentRoutingRequest,
   SetConversationSkillImportEnabledRequest,
   SetNotificationsEnabledRequest,
   SetShowNotificationContentRequest,
@@ -1866,6 +1867,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'settings.setAgentFramework': callable<
     (request: SetAgentFrameworkRequest) => Promise<SettingsSnapshot>
   >()('settings', ['settings:set-agent-framework']),
+  'settings.setAgentRouting': callable<
+    (request: SetAgentRoutingRequest) => Promise<SettingsSnapshot>
+  >()('settings', ['settings:set-agent-routing']),
   'settings.setAppIconVariant': callable<
     (request: SetAppIconVariantRequest) => Promise<SettingsSnapshot>
   >()('settings', ['settings:set-app-icon-variant', LOCAL]),

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -290,7 +290,6 @@ import type {
   SetNetworkProxyRequest,
   SetNotebookNetworkRequest,
   SetAgentFrameworkRequest,
-  SetAgentRoutingRequest,
   SetConversationSkillImportEnabledRequest,
   SetNotificationsEnabledRequest,
   SetShowNotificationContentRequest,
@@ -1867,9 +1866,6 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'settings.setAgentFramework': callable<
     (request: SetAgentFrameworkRequest) => Promise<SettingsSnapshot>
   >()('settings', ['settings:set-agent-framework']),
-  'settings.setAgentRouting': callable<
-    (request: SetAgentRoutingRequest) => Promise<SettingsSnapshot>
-  >()('settings', ['settings:set-agent-routing']),
   'settings.setAppIconVariant': callable<
     (request: SetAppIconVariantRequest) => Promise<SettingsSnapshot>
   >()('settings', ['settings:set-app-icon-variant', LOCAL]),

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -39,7 +39,10 @@ const TASK_RUN_REQUEST_FIELDS = {
   autoReviewEnabled: true,
   specialist: true,
   delegationPolicy: true,
-  computeHostIds: true
+  computeHostIds: true,
+  agentConfiguration: true,
+  memoryEnabled: true,
+  enabledComputeHostIds: true
 } as const satisfies Record<keyof StartTaskRunRequest, true>
 
 const permissionPaths = [
@@ -264,10 +267,13 @@ describe('renderer surface compatibility matrix', () => {
       )
     ).toBe(false)
     expect(Object.keys(TASK_RUN_REQUEST_FIELDS).sort()).toEqual([
+      'agentConfiguration',
       'autoReviewEnabled',
       'computeHostIds',
       'cwd',
       'delegationPolicy',
+      'enabledComputeHostIds',
+      'memoryEnabled',
       'permissionProfile',
       'project',
       'prompt',

--- a/src/shared/session-configuration.test.ts
+++ b/src/shared/session-configuration.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  updateProjectSessionDefaultsRequestSchema,
+  updateSessionConfigurationRequestSchema
+} from './session-configuration'
+
+describe('Session configuration contracts', () => {
+  it('keeps selected Compute Hosts inside the enabled set', () => {
+    expect(
+      updateSessionConfigurationRequestSchema.safeParse({
+        expectedRevision: 1,
+        computeHosts: { enabled: ['ssh:alpha'], selected: ['ssh:beta'] }
+      }).success
+    ).toBe(false)
+  })
+
+  it('allows Project defaults to be explicitly cleared without adding Session null states', () => {
+    expect(
+      updateProjectSessionDefaultsRequestSchema.parse({
+        expectedUpdatedAt: 1,
+        patch: {
+          agentConfiguration: null,
+          memoryEnabled: null,
+          computeHosts: null
+        }
+      })
+    ).toMatchObject({
+      patch: { agentConfiguration: null, memoryEnabled: null, computeHosts: null }
+    })
+    expect(
+      updateSessionConfigurationRequestSchema.safeParse({
+        expectedRevision: 1,
+        memoryEnabled: null
+      }).success
+    ).toBe(false)
+  })
+
+  it('rejects unknown fields at both mutation boundaries', () => {
+    expect(
+      updateSessionConfigurationRequestSchema.safeParse({
+        expectedRevision: 1,
+        futureOption: true
+      }).success
+    ).toBe(false)
+    expect(
+      updateProjectSessionDefaultsRequestSchema.safeParse({
+        expectedUpdatedAt: 1,
+        patch: { futureOption: true }
+      }).success
+    ).toBe(false)
+  })
+})

--- a/src/shared/session-configuration.ts
+++ b/src/shared/session-configuration.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod'
+
+import { PERMISSION_PROFILE_IDS } from './permission-profiles'
+
+const reasoningEffortSchema = z.enum(['default', 'low', 'medium', 'high', 'xhigh', 'max'])
+const delegationPolicySchema = z.enum(['allow', 'deny'])
+const nonEmptyStringSchema = z.string().trim().min(1)
+const permissionProfileIdSchema = z.enum(PERMISSION_PROFILE_IDS)
+
+export const sessionAgentConfigurationSchema = z
+  .object({
+    providerId: nonEmptyStringSchema,
+    model: nonEmptyStringSchema.optional(),
+    reasoningEffort: reasoningEffortSchema
+  })
+  .strict()
+
+export const sessionComputeHostsSchema = z
+  .object({
+    enabled: z.array(nonEmptyStringSchema),
+    selected: z.array(nonEmptyStringSchema)
+  })
+  .strict()
+  .superRefine(({ enabled, selected }, context) => {
+    const enabledIds = new Set(enabled)
+    for (const providerId of selected) {
+      if (!enabledIds.has(providerId)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Selected Compute Host is not enabled: ${providerId}`
+        })
+      }
+    }
+  })
+
+export const projectSessionDefaultsSchema = z
+  .object({
+    agentConfiguration: sessionAgentConfigurationSchema.optional(),
+    permissionProfile: permissionProfileIdSchema.optional(),
+    autoReviewEnabled: z.boolean().optional(),
+    memoryEnabled: z.boolean().optional(),
+    delegationPolicy: delegationPolicySchema.optional(),
+    specialistId: nonEmptyStringSchema.optional(),
+    computeHosts: sessionComputeHostsSchema.optional()
+  })
+  .strict()
+
+export const sessionAgentConfigurationPatchSchema = z
+  .object({
+    providerId: nonEmptyStringSchema.optional(),
+    model: nonEmptyStringSchema.nullable().optional(),
+    reasoningEffort: reasoningEffortSchema.optional()
+  })
+  .strict()
+
+export const sessionConfigurationPatchSchema = z
+  .object({
+    agentConfiguration: sessionAgentConfigurationPatchSchema.optional(),
+    permissionProfile: permissionProfileIdSchema.optional(),
+    autoReviewEnabled: z.boolean().optional(),
+    memoryEnabled: z.boolean().optional(),
+    delegationPolicy: delegationPolicySchema.optional(),
+    computeHosts: sessionComputeHostsSchema.optional()
+  })
+  .strict()
+
+export const updateSessionConfigurationRequestSchema = sessionConfigurationPatchSchema
+  .extend({ expectedRevision: z.number().int().nonnegative() })
+  .strict()
+
+export const projectSessionDefaultsPatchSchema = z
+  .object({
+    agentConfiguration: sessionAgentConfigurationPatchSchema.nullable().optional(),
+    permissionProfile: permissionProfileIdSchema.nullable().optional(),
+    autoReviewEnabled: z.boolean().nullable().optional(),
+    memoryEnabled: z.boolean().nullable().optional(),
+    delegationPolicy: delegationPolicySchema.nullable().optional(),
+    specialistId: nonEmptyStringSchema.nullable().optional(),
+    computeHosts: sessionComputeHostsSchema.nullable().optional()
+  })
+  .strict()
+
+export const updateProjectSessionDefaultsRequestSchema = z
+  .object({
+    expectedUpdatedAt: z.number().int().positive(),
+    patch: projectSessionDefaultsPatchSchema
+  })
+  .strict()
+
+export type SessionAgentConfigurationValue = z.infer<typeof sessionAgentConfigurationSchema>
+export type SessionComputeHosts = z.infer<typeof sessionComputeHostsSchema>
+export type ProjectSessionDefaults = z.infer<typeof projectSessionDefaultsSchema>
+export type SessionAgentConfigurationPatch = z.infer<typeof sessionAgentConfigurationPatchSchema>
+export type SessionConfigurationPatch = z.infer<typeof sessionConfigurationPatchSchema>
+export type UpdateSessionConfigurationRequest = z.infer<
+  typeof updateSessionConfigurationRequestSchema
+>
+export type ProjectSessionDefaultsPatch = z.infer<typeof projectSessionDefaultsPatchSchema>
+export type UpdateProjectSessionDefaultsRequest = z.infer<
+  typeof updateProjectSessionDefaultsRequestSchema
+>

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -4734,6 +4734,20 @@ const saveSessionArgsCodec: RuntimeCodec<
   }
 })
 
+const updateSessionConfigurationArgsCodec: RuntimeCodec<
+  readonly [session: PersistedChatSession, expectedRevision: number]
+> = Object.freeze({
+  parse: (value) => {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw new Error('Invalid Session configuration update arguments.')
+    }
+    return [
+      persistedChatSessionCodec.parse(value[0]),
+      z.number().int().nonnegative().parse(value[1])
+    ]
+  }
+})
+
 // Runtime-validated contracts for Electron-facing Session commands. Request schemas double as wire
 // types, while Session-bearing commands share the recursive persistence codec above.
 export const sessionApplicationCommandContracts = Object.freeze({
@@ -4766,6 +4780,10 @@ export const sessionApplicationCommandContracts = Object.freeze({
     persistedChatSessionCodec
   ),
   save: defineApplicationCommandContract(saveSessionArgsCodec, persistedChatSessionCodec),
+  updateConfiguration: defineApplicationCommandContract(
+    updateSessionConfigurationArgsCodec,
+    persistedChatSessionCodec
+  ),
   editDetails: defineApplicationCommandContract(
     validationCodec(z.tuple([editSessionDetailsRequestSchema])),
     persistedChatSessionCodec

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -942,6 +942,26 @@ export const isSessionRevisionConflictError = (
     error.code === SESSION_REVISION_CONFLICT_ERROR_CODE) ||
   (error instanceof Error && error.message.includes('Session revision conflict:'))
 
+export class SessionConfigurationBusyError extends Error {
+  readonly code = 'session-configuration-busy' as const
+
+  constructor(readonly sessionId: string) {
+    super(`Session has active work: ${sessionId}`)
+    this.name = 'SessionConfigurationBusyError'
+  }
+}
+
+export const isSessionConfigurationBusyError = (
+  error: unknown
+): error is Readonly<{ code: SessionConfigurationBusyError['code']; message: string }> =>
+  error instanceof SessionConfigurationBusyError ||
+  (typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'session-configuration-busy' &&
+    'message' in error &&
+    typeof error.message === 'string')
+
 // Restored interrupted sessions carry this error verbatim; the renderer keys its resume banner off it.
 export const INTERRUPTED_SESSION_ERROR = 'Session was interrupted before the app closed.'
 export const INTERRUPTED_TURN_ERROR = 'This turn was interrupted. Resume to continue.'

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -433,6 +433,12 @@ export const DEFAULT_REVIEWER_MODEL_CONFIGURATION: ReviewerModelConfiguration = 
   mode: 'inherit'
 })
 
+export type SetAgentRoutingRequest = Readonly<{
+  framework?: AgentFrameworkId
+  reviewer?: ReviewerModelConfiguration
+  subagent?: SubagentModelConfiguration
+}>
+
 export type SessionDetailsModelConfiguration =
   | Readonly<{ mode: 'inherit'; reasoningEffort: ReasoningEffort }>
   | Readonly<{

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -2,8 +2,21 @@ import type { ArtifactFile } from './artifacts'
 import type { PermissionProfileId } from './permission-profiles'
 import type { CreateProjectRequest, Project, UpdateProjectRequest } from './projects'
 import type { ReviewLifecycle, ReviewOutcome, ReviewRunNotStartedReason } from './reviewer'
+import type {
+  ProjectSessionDefaults,
+  SessionAgentConfigurationPatch,
+  SessionAgentConfigurationValue,
+  SessionComputeHosts,
+  UpdateProjectSessionDefaultsRequest,
+  UpdateSessionConfigurationRequest
+} from './session-configuration'
 import type { DelegationPolicy, PersistedSessionStatus } from './session-persistence'
 import type { ActivePlanProjection } from './session-plan/contract'
+import type {
+  AgentFrameworkId,
+  ReviewerModelConfiguration,
+  SubagentModelConfiguration
+} from './settings'
 
 export const TASK_EVENT_STREAM_PROTOCOL_VERSION = 1 as const
 
@@ -46,8 +59,12 @@ export type StartTaskRunRequest = {
   // Accepts an immutable Specialist ID or its stable Profile name. displayName is presentation-only.
   specialist?: string
   delegationPolicy?: DelegationPolicy
+  agentConfiguration?: SessionAgentConfigurationPatch
+  memoryEnabled?: boolean
   /** Selected execution-target provider IDs for this Session. Omit to preserve. */
   computeHostIds?: string[]
+  /** Enabled execution targets; selected ids must be a subset. Used by Project defaults. */
+  enabledComputeHostIds?: string[]
 }
 
 export type TaskRunAttention = { kind: 'plan-approval'; plan: ActivePlanProjection }
@@ -108,9 +125,88 @@ export type TaskSessionSummary = {
   artifactCount: number
 }
 
-export type TaskProject = Omit<Project, 'agentContext'> & {
+export type TaskProject = Omit<Project, 'agentContext' | 'sessionDefaults'> & {
   hasAgentContext: boolean
 }
+
+export type TaskReferenceAvailability = Readonly<{
+  available: boolean
+  reason?: string
+}>
+
+export type TaskSessionConfiguration = Readonly<{
+  sessionId: string
+  projectId: string
+  revision: number
+  cwd: string
+  specialistId?: string
+  persisted: Readonly<{
+    agentConfiguration?: SessionAgentConfigurationValue
+    permissionProfile?: PermissionProfileId
+    autoReviewEnabled?: boolean
+    memoryEnabled?: boolean
+    delegationPolicy?: DelegationPolicy
+    computeHosts: SessionComputeHosts
+  }>
+  effective: Readonly<{
+    agentConfiguration?: SessionAgentConfigurationValue
+    permissionProfile: PermissionProfileId
+    autoReviewEnabled: boolean
+    memoryEnabled: boolean
+    delegationPolicy: DelegationPolicy
+    computeHosts: SessionComputeHosts
+  }>
+  availability: Readonly<{
+    agentConfiguration?: TaskReferenceAvailability
+    specialist?: TaskReferenceAvailability
+    computeHosts: Readonly<Record<string, TaskReferenceAvailability>>
+  }>
+}>
+
+export type TaskProjectSessionDefaults = Readonly<{
+  projectId: string
+  updatedAt: number
+  configured: ProjectSessionDefaults
+  availability: Readonly<{
+    agentConfiguration?: TaskReferenceAvailability
+    specialist?: TaskReferenceAvailability
+    computeHosts: Readonly<Record<string, TaskReferenceAvailability>>
+  }>
+}>
+
+export type TaskAgentRouting = Readonly<{
+  configured: Readonly<{
+    framework: AgentFrameworkId
+    reviewer: ReviewerModelConfiguration
+    subagent: SubagentModelConfiguration
+  }>
+  effective: Readonly<{
+    reviewer:
+      | Readonly<{ source: 'application_main'; providerId?: string; model?: string }>
+      | Readonly<{
+          source: 'fixed'
+          providerId: string
+          model: string
+          reasoningEffort: SessionAgentConfigurationValue['reasoningEffort']
+        }>
+    subagent:
+      | Readonly<{ source: 'session_main' }>
+      | Readonly<{
+          source: 'fixed'
+          providerId: string
+          model: string
+          reasoningEffort: SessionAgentConfigurationValue['reasoningEffort']
+        }>
+  }>
+}>
+
+export type UpdateTaskAgentRoutingRequest = Readonly<{
+  framework?: AgentFrameworkId
+  reviewer?: ReviewerModelConfiguration
+  subagent?: SubagentModelConfiguration
+}>
+
+export type { UpdateProjectSessionDefaultsRequest, UpdateSessionConfigurationRequest }
 
 export type CreateTaskProjectRequest = Pick<
   CreateProjectRequest,
@@ -136,6 +232,8 @@ export type TaskApiErrorCode =
   | 'project_conflict'
   | 'session_not_found'
   | 'session_busy'
+  | 'session_revision_conflict'
+  | 'invalid_configuration'
   | 'session_archived'
   | 'project_archived'
   | 'run_not_found'

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -252,7 +252,6 @@ export const WEB_INVOKE_CHANNELS = {
   'settings.scanRepoSkills': 'settings:scan-repo-skills',
   'settings.setActiveProvider': 'settings:set-active-provider',
   'settings.setAgentFramework': 'settings:set-agent-framework',
-  'settings.setAgentRouting': 'settings:set-agent-routing',
   'settings.setAppIconVariant': 'settings:set-app-icon-variant',
   'settings.setClosePreference': 'settings:set-close-preference',
   'settings.setConnectorAutoAllow': 'settings:set-connector-auto-allow',

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -252,6 +252,7 @@ export const WEB_INVOKE_CHANNELS = {
   'settings.scanRepoSkills': 'settings:scan-repo-skills',
   'settings.setActiveProvider': 'settings:set-active-provider',
   'settings.setAgentFramework': 'settings:set-agent-framework',
+  'settings.setAgentRouting': 'settings:set-agent-routing',
   'settings.setAppIconVariant': 'settings:set-app-icon-variant',
   'settings.setClosePreference': 'settings:set-close-preference',
   'settings.setConnectorAutoAllow': 'settings:set-connector-auto-allow',


### PR DESCRIPTION
## Problem

The headless Task API and CLI expose only fragments of the configuration already used by Sessions,
cannot reproduce the desktop application's global Agent routing, and require repeated flags for
every new Session in a Project.

- Closes #2115
- Closes #2116
- Closes #2117

## Proposed change

### #2115 — Session configuration

This occurs when automation needs to inspect or change a Session without submitting a prompt. The
old CLI omits Main provider/model/effort, Memory, revision, and the complete enabled/selected Compute
Host state. Leaving it unchanged forces callers to infer sticky state or send a turn merely to alter
configuration.

Add `session config show/update` plus matching HTTP and SDK methods. `show` separates persisted and
effective values, includes immutable `cwd` and Specialist identity, and reports reference
availability. `update` uses Session revision CAS, validates provider/model/effort as one compound
target, blocks unsafe Main/Subagent/Notebook activity with `session_busy`, and affects future turns
only. Reviewer work is not retargeted and therefore is not a blocker. The same mutable fields are
accepted when `run` creates a Session; no empty Session lifecycle is added.

This changes the public API and CLI interaction, but reuses the existing Session JSON data model and
does not add a Session database field.

### #2116 — application Agent routing

This occurs when a headless operator needs to reproduce the desktop Agent Framework, Reviewer, and
Subagent routing. Without it, automation cannot configure these application-wide settings and must
open the GUI.

Add `settings agent-routing show/update` plus matching HTTP and SDK methods. Framework and optional
fixed/inherited Reviewer/Subagent routes are validated against the target framework and persisted in
one Settings repository mutation. Output contains identifiers and effective routing only, never
credentials. Existing runtime-generation isolation remains responsible for pinning admitted work;
the update affects future Session, Reviewer, and delegated-work admissions.

This changes the public API and CLI interaction and adds one atomic Settings command. It reuses the
existing Settings JSON fields and routing unions.

### #2117 — Project Session defaults

This occurs when a Project repeatedly creates Sessions with the same model, policy, Specialist, or
Compute Hosts. Without defaults, every invocation must repeat flags and omission can silently produce
different new-Session behavior.

Add `project session-defaults show/update` plus matching HTTP and SDK methods. A new Session resolves
each field using explicit run options, Project defaults, application defaults, then provider
defaults. The resolved configuration is snapshotted into that Session; later Project edits never
rewrite existing Sessions. Updates reuse Project `updatedAt` optimistic concurrency, explicit clear
operations, compound model validation, immutable Specialist resolution, and Compute Host
availability checks.

This adds one Project data-model field and migration: `Project.sessionDefaults`, stored as validated
JSON text with default `{}`. No desktop UI is added.

These three issues are worth handling together because Project inheritance depends on the same
Session validation/persistence contract and all three share one narrow headless configuration
surface. The implementation avoids full Settings parity, provider/credential management, a generic
inheritance engine, a new Session lifecycle, and per-Session Reviewer/Subagent overrides.

## Scope and non-goals

- No Agent Framework Project default; it remains application-wide.
- No provider creation, credentials, runtime installation, or connector configuration.
- No mutable Session `cwd` or Specialist binding.
- No change to turn-only Plan First, forced Skills, wait, timeout, or output controls.
- No renderer workflow or preload API expansion; the command is available only to the restricted
  Task dispatcher.
- No database-level JSON `CHECK`: application Zod validation is the existing boundary, and avoiding a
  table rebuild keeps the migration and foreign-key risk minimal.

## Persistence, compatibility, and states

- **Historical data:** existing Session JSON remains valid and keeps the established fallbacks.
  Migration `0027_project_session_defaults` gives every existing Project `{}`, preserving previous
  new-Session behavior. Existing Settings JSON already supports the routing fields.
- **Persistence:** Session configuration remains in Session JSON; Project defaults persist in the new
  `Project.sessionDefaults` JSON-text column; Agent routing remains in Settings JSON.
- **Enums/states:** no persistent Session, Run, Project, or Settings enum value is added. The public
  API adds structured error codes `session_revision_conflict` and `invalid_configuration`.

## Acceptance criteria and validation

All listed local checks ran after the final material edit. Per request, the complete `npm test` suite
was not run locally; the exact-head classifier selects the full PR Gate plan, so CI is authoritative
for the complete portable and platform suites.

| Behavior / risk | Command | Result |
| --- | --- | --- |
| Session/default/routing schemas, Task runner, Task API, Settings command/repository, Project repository, CLI and SDK contracts | `npx vitest run src/shared/session-configuration.test.ts src/shared/renderer-surface-matrix.test.ts src/main/tasks/task-runner.test.ts src/main/web-service/task-api.test.ts src/main/settings/repository.test.ts src/main/settings/runtime-application-commands.test.ts src/main/projects/repository.test.ts packages/open-science/cli.test.ts packages/open-science/client.test.ts` | 9 files, 310 tests passed |
| Preload/renderer interface inventory after keeping the new command Task-only | `npx vitest run src/preload/index.test.ts src/preload/electron-renderer-contract-adapter.test.ts src/shared/renderer-contract.test.ts src/shared/renderer-contract-catalog.test.ts src/shared/renderer-surface-inventory.test.ts src/shared/renderer-surface-matrix.test.ts src/shared/web-rpc-contract.test.ts` | 7 files, 150 tests passed |
| Atomic target-framework routing validation | `npx vitest run src/main/settings/service.test.ts -t "compound Agent routing"` | 1 passed |
| Project migration, historical row default, FK retention, ledger and schema generation | `npx vitest run src/main/database/*migration*.test.ts scripts/database-migration-ledger-smoke.test.ts scripts/generate-database-schema.test.ts scripts/check-prisma-client.test.ts` | 12 files, 113 tests passed |
| Authenticated versioned HTTP routes and encoded IDs | `npx vitest run src/main/web-service/http-server.test.ts -t "serves the versioned task API without exposing internal RPC channels"` | 1 passed |
| Main/preload/sandbox and renderer TypeScript contracts | `npm run typecheck` | passed |
| Repository lint policy | `npm run lint` | passed |
| Checked-in database target schema | `npm run db:schema:check` | passed |
| Generated Web API map | `npm run check:web-api-map` | passed |
| Published CLI/SDK package contents | `npm run check:cli-package` | passed |
| Exact-head impact selection | `npm run test:affected:explain -- --base origin/main --head HEAD` | full PR Gate selected |
| CI-discovered contract baselines after the Task-only surface correction | `npx vitest run src/main/web-service/controller.test.ts src/main/application-command-wiring.test.ts src/main/settings/runtime-application-commands.test.ts src/main/application-command-composition.test.ts src/main/settings/settings-backend.architecture.test.ts src/main/database/database-startup-logging.test.ts src/main/database/application-database.integration.test.ts` | 7 files, 82 tests passed after rebase |
| Unrelated Notebook concurrency timeout diagnosis | `npx vitest run src/main/notebook/runtime-service.test.ts -t "admits at most six shell processes across Sessions"` | 1 passed, 255 skipped; failed CI shard rerun passed |
| Complete PR validation | [PR Gate run 33757303153](https://github.com/aipoch/open-science/actions/runs/33757303153) attempt 2 | all required portable, coverage, static, policy, Windows, macOS, CodeQL, and AI review checks passed |

Per request, complete portable Vitest coverage and cross-platform packaging were left to PR CI and
passed. Live provider admissions were not exercised; their existing runtime-generation ownership is
unchanged.

## Review focus

- CAS and busy-state ordering prevents partial Session writes.
- Provider changes require an explicit model or provider-default reset.
- Enabled/selected Compute Hosts retain subset semantics across explicit run options and Project
  inheritance.
- Project migration adds only the defaulted column and preserves Session foreign keys.
- Settings routing validates the complete candidate before its single repository commit.
