### PR TITLE
fix(notebook): restore protected Windows REPL startup

### DIFF
--- a/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
+++ b/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
@@ -381,8 +381,13 @@ const windowsLaunch = (
     }),
     'utf8'
   ).toString('base64url')
-  const env = {
+  const env: NodeJS.ProcessEnv = {
     ...request.env,
+    // CreateProcessW requires this base while applying AppContainer security capabilities. Windows
+    // maps it to the profile's isolated Packages/.../AC directory for the sandboxed child.
+    ...(request.env.LOCALAPPDATA === undefined && process.env.LOCALAPPDATA
+      ? { LOCALAPPDATA: process.env.LOCALAPPDATA }
+      : {}),
     ...proxyEnvironment(request.gatewayPort, request.gatewayCredentials)
   }
   if (request.localRpcSocketPath) {

--- a/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
+++ b/packages/notebook-network-sandbox/src/windows-appcontainer.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   connectionProbeSpecification,
@@ -12,6 +12,8 @@ import {
   windowsLaunch,
   windowsStandardLaunch
 } from '../runtime/src/platform/windows-appcontainer.js'
+
+afterEach(() => vi.unstubAllEnvs())
 
 describe('Windows AppContainer network fence probe', () => {
   it('keeps PowerShell catch and finally clauses attached to the try statement', () => {
@@ -55,6 +57,35 @@ describe('Windows AppContainer launch', () => {
     const launch = windowsStandardLaunch(request)
 
     expect(launch.argv).toEqual([request.executable, ...request.args])
+  })
+
+  it('supplies the AppContainer-local data base when the command environment is isolated', () => {
+    const localAppData = join(tmpdir(), 'local-app-data')
+    const runtimeRoot = join(tmpdir(), 'runtime')
+    const appRoot = join(tmpdir(), 'app')
+    const workspaceRoot = join(tmpdir(), 'workspace')
+    vi.stubEnv('LOCALAPPDATA', localAppData)
+
+    const launch = windowsLaunch({
+      command: 'node repl_loop.js',
+      executable: join(runtimeRoot, 'node.exe'),
+      args: [join(appRoot, 'repl_loop.js')],
+      cwd: workspaceRoot,
+      gatewayPort: 49700,
+      gatewayCredentials: { username: 'command', password: 'secret' },
+      env: {},
+      filesystem: {
+        readOnlyRoots: [runtimeRoot, appRoot],
+        readWriteRoots: [workspaceRoot],
+        deniedReadRoots: [],
+        deniedWriteRoots: []
+      },
+      hostPath: 'C:\\resources\\notebook-sandbox-host.exe',
+      installationId: '0123456789abcdef01234567',
+      ownershipRoot: 'C:\\sandbox'
+    })
+
+    expect(launch.env.LOCALAPPDATA).toBe(localAppData)
   })
 
   it('launches a structured executable directly instead of through PowerShell', () => {

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -3266,14 +3266,19 @@ describe('NotebookKernelExecutor repl kind (real repl_loop.js)', () => {
     }
   })
 
-  it.runIf(process.platform === 'darwin')(
+  it.runIf(
+    process.platform === 'darwin' ||
+      (process.platform === 'win32' && process.env.OPEN_SCIENCE_WINDOWS_APP_CONTAINER_TEST === '1')
+  )(
     'executes the repl loop through the production network sandbox',
     async () => {
       cwdDir = await mkdtemp(join(tmpdir(), 'os-kernel-repl-sandbox-'))
       const inputRoot = `${cwdDir}-inputs`
       const inputPath = join(inputRoot, 'content')
+      const replLoopPath = join(inputRoot, 'repl_loop.js')
       await mkdir(inputRoot, { recursive: true })
       await writeFile(inputPath, 'verified input')
+      await writeFile(replLoopPath, await readFile(REPL_LOOP))
       const owner = new NotebookNetworkSandboxOwner({
         resourceRoot: resolve(
           import.meta.dirname,
@@ -3284,7 +3289,7 @@ describe('NotebookKernelExecutor repl kind (real repl_loop.js)', () => {
         requestDecision: async () => 'deny'
       })
       const executor = new NotebookKernelExecutor({
-        replLoopPath: REPL_LOOP,
+        replLoopPath,
         processSandbox: owner
       })
 
@@ -3375,6 +3380,41 @@ describe('NotebookKernelExecutor repl kind (real repl_loop.js)', () => {
       }
       expect(child.spawnfile).toBe(process.execPath)
       expect(child.spawnargs).toContain(REPL_LOOP)
+    } finally {
+      await executor.shutdown()
+    }
+  })
+
+  it('preserves the Windows repl main module without widening sandbox access', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-kernel-repl-windows-main-'))
+    const cleanup = vi.fn()
+    const wrap = vi.fn<NotebookProcessSandbox['wrap']>(async (invocation) => ({
+      executable: invocation.executable,
+      args: invocation.args,
+      env: invocation.env,
+      beginExecution: () => () => undefined,
+      annotateStderr: (stderr) => stderr,
+      cleanup
+    }))
+    const executor = new NotebookKernelExecutor({
+      replLoopPath: REPL_LOOP,
+      platform: 'win32',
+      processSandbox: { wrap }
+    })
+
+    try {
+      const result = await executor.execute({
+        ...baseRequest(cwdDir),
+        code: 'return 1',
+        kind: 'repl',
+        sessionId: 'session-1',
+        projectId: 'project-1'
+      })
+
+      expect(result.status, result.stderr || result.traceback).toBe('completed')
+      expect(wrap).toHaveBeenCalledWith(
+        expect.objectContaining({ args: ['--preserve-symlinks-main', REPL_LOOP] })
+      )
     } finally {
       await executor.shutdown()
     }

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -824,7 +824,9 @@ class NotebookKernelExecutor implements NotebookExecutor {
       // Run the control-plane loop as plain Node via the app binary (ELECTRON_RUN_AS_NODE set in env).
       command = process.execPath
       loopPath = this.replLoopPath
-      args = [loopPath]
+      // Node otherwise realpaths the main module before loading it. A Windows AppContainer can read
+      // the explicitly granted script but cannot enumerate its drive root or unrelated ancestors.
+      args = [...(this.platform === 'win32' ? ['--preserve-symlinks-main'] : []), loopPath]
     } else {
       // Data kernel (python/r). The loop SCRIPT is chosen by kind; the INTERPRETER is either resolved
       // by the Runtime Registry (a managed env bin, or an external/overlay interpreter for BYO) or,


### PR DESCRIPTION
## Problem

This is a protected-AppContainer follow-up to #2118.

The original v0.25.1 report says:

> Notebook kernel process exited with exit code 0.

#2118 identified and fixed that exact failure in the Windows standard-launch fallback: PowerShell did not transparently relay redirected stdin to the long-lived REPL child, so it observed EOF and exited cleanly before the first protocol frame. That fix landed on `main` after v0.25.1 and is preserved by this PR.

While exercising the same public Notebook REPL boundary through a ready production AppContainer, two additional protected-launch failures reproduced consistently:

1. The isolated kernel environment omitted `LOCALAPPDATA`, and AppContainer process creation failed with `0x800700CB` (`Notebook kernel process exited with exit code 1`).
2. After supplying that base, Node realpathed the REPL entry point through AppContainer-inaccessible drive ancestors and failed with `EPERM lstat 'C:\'` / `D:\`.

These are adjacent Windows startup failures, not a second explanation for the exact exit-code-0 report. #2118 explicitly left protected AppContainer launch behavior out of scope; this PR covers that path.

## Proposed change

- Supply `LOCALAPPDATA` only when constructing a protected Windows AppContainer launch whose isolated command environment omitted it. Windows maps it to the AppContainer-local profile for the child.
- Start only the Windows REPL loop with Node's `--preserve-symlinks-main`, avoiding main-module realpath traversal without widening filesystem ACLs.
- Make the existing production network-sandbox REPL test opt-in on Windows and run it against a script copied into its declared read-only input root.
- Add portable contract tests for the protected launch environment and Windows REPL arguments.

## Scope and non-goals

- No database/schema, data-model, persisted-format, migration, historical-compatibility, UI, or interaction changes.
- No new enum or state.
- No new durable external component. The existing AppContainer profile and ownership lifecycle are unchanged.
- Standard Windows launch behavior remains owned by #2118; non-Windows REPL launches are unchanged.

## Acceptance criteria and validation

All successful checks below ran after the last relevant material edit; the rebase-only conflict resolution preserved both PRs' tests.

- Combined Windows standard/protected launch behavior -> focused Windows tests after rebase -> 5 passed, 101 skipped.
- Protected Windows AppContainer REPL startup before the fix -> production sandbox boundary -> failed consistently in three runs with `exit code 1` and `0x800700CB`; after only the environment fix it progressed to the `EPERM lstat` failure.
- Protected Windows AppContainer REPL startup after both fixes -> opt-in production sandbox test plus focused contracts -> passed.
- Notebook/AppContainer consumers before rebase -> targeted five-file Vitest set -> 50 passed, 75 skipped.
- `notebook_network_sandbox` owner module before rebase -> all 12 files selected by `test:module` executed directly -> 77 passed, 13 skipped.
  - `npm run test:module -- notebook_network_sandbox` itself stopped before Vitest because the isolated worktree had no generated Prisma client; no dependency generation or full install was performed.
- Sandbox TypeScript contracts after rebase -> `npm run typecheck:sandbox` -> passed.
- Lint after rebase -> `npm run lint` -> passed.
- `npm run typecheck:node` passed before rebase. After rebasing onto current `main`, it is locally blocked by the existing Prisma generated client predating main's new `remoteCleanupDisposition` field; all reported errors are in unchanged compute files. PR Gate uses freshly generated dependencies and remains authoritative.

Per request, the full `npm test` suite was not run.

## Review focus

- Whether inheriting only `LOCALAPPDATA` at the protected AppContainer adapter is the narrowest correct boundary.
- Whether `--preserve-symlinks-main` should remain restricted to Windows REPL kernels.
- The separation between #2118's exact exit-code-0 standard-launch fix and this PR's protected-AppContainer failures.