### PR TITLE
fix(provider-transport): bound successful response bodies

### DIFF
--- a/src/main/settings/bounded-response.ts
+++ b/src/main/settings/bounded-response.ts
@@ -9,21 +9,25 @@ class ResponseBodyLimitError extends Error {
   }
 }
 
-const readBoundedResponseText = async (
+const DEFAULT_MAX_PROVIDER_RESPONSE_BYTES = 64 * 1024 * 1024
+const DEFAULT_MAX_PROVIDER_SSE_LINE_BYTES = 8 * 1024 * 1024
+const DEFAULT_MAX_PROVIDER_SSE_EVENT_BYTES = 8 * 1024 * 1024
+
+const consumeBoundedResponseBody = async (
   response: Response,
   maxBytes: number,
-  label: string
-): Promise<string> => {
+  label: string,
+  consume: (chunk: Uint8Array) => void
+): Promise<void> => {
   const declaredLength = response.headers.get('content-length')
   if (declaredLength && /^\d+$/u.test(declaredLength) && Number(declaredLength) > maxBytes) {
     await response.body?.cancel().catch(() => undefined)
     throw new ResponseBodyLimitError(label, maxBytes)
   }
 
-  if (!response.body) return ''
+  if (!response.body) return
 
   const reader = response.body.getReader()
-  const chunks: Buffer[] = []
   let observedBytes = 0
 
   try {
@@ -33,16 +37,48 @@ const readBoundedResponseText = async (
 
       observedBytes += value.byteLength
       if (observedBytes > maxBytes) {
-        await reader.cancel().catch(() => undefined)
         throw new ResponseBodyLimitError(label, maxBytes)
       }
-      chunks.push(Buffer.from(value))
+      consume(value)
     }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined)
+    throw error
   } finally {
     reader.releaseLock()
   }
-
-  return Buffer.concat(chunks, observedBytes).toString('utf8')
 }
 
-export { ResponseBodyLimitError, readBoundedResponseText }
+const readBoundedResponseBytes = async (
+  response: Response,
+  maxBytes: number,
+  label: string,
+  onActivity?: () => void
+): Promise<Buffer> => {
+  const chunks: Buffer[] = []
+  let observedBytes = 0
+  await consumeBoundedResponseBody(response, maxBytes, label, (chunk) => {
+    onActivity?.()
+    observedBytes += chunk.byteLength
+    chunks.push(Buffer.from(chunk))
+  })
+  return Buffer.concat(chunks, observedBytes)
+}
+
+const readBoundedResponseText = async (
+  response: Response,
+  maxBytes: number,
+  label: string,
+  onActivity?: () => void
+): Promise<string> =>
+  new TextDecoder().decode(await readBoundedResponseBytes(response, maxBytes, label, onActivity))
+
+export {
+  DEFAULT_MAX_PROVIDER_RESPONSE_BYTES,
+  DEFAULT_MAX_PROVIDER_SSE_EVENT_BYTES,
+  DEFAULT_MAX_PROVIDER_SSE_LINE_BYTES,
+  ResponseBodyLimitError,
+  consumeBoundedResponseBody,
+  readBoundedResponseBytes,
+  readBoundedResponseText
+}

--- a/src/main/settings/chat-provider-compatibility.test.ts
+++ b/src/main/settings/chat-provider-compatibility.test.ts
@@ -9,6 +9,41 @@ afterEach(async () => {
 })
 
 describe('ChatProviderCompatibilityBridge', () => {
+  it('rejects an oversized successful JSON response before reading its body', async () => {
+    let cancelBody: ReturnType<typeof vi.spyOn> | undefined
+    const upstream = vi.fn<typeof fetch>(async () => {
+      const response = Response.json(
+        { id: 'resp_oversized', output: [], usage: { input_tokens: 1, output_tokens: 1 } },
+        { headers: { 'content-length': String(64 * 1024 * 1024 + 1) } }
+      )
+      cancelBody = vi.spyOn(response.body!, 'cancel')
+      return response
+    })
+    const bridge = new ChatProviderCompatibilityBridge(
+      {
+        wire: 'responses',
+        endpoint: 'https://provider.example/v1/responses',
+        model: 'upstream-model'
+      },
+      upstream
+    )
+    bridges.push(bridge)
+    const connection = await bridge.start()
+
+    const response = await fetch(`${connection.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${connection.token}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hello' }] })
+    })
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toMatchObject({ error: { type: 'api_error' } })
+    expect(cancelBody).toHaveBeenCalledOnce()
+  })
+
   it('adapts Chat Completions tool calls to a Responses-only provider', async () => {
     const upstream = vi.fn<typeof fetch>(async () =>
       Response.json({

--- a/src/main/settings/chat-provider-compatibility.ts
+++ b/src/main/settings/chat-provider-compatibility.ts
@@ -1,5 +1,6 @@
 import type { ServerResponse } from 'node:http'
 
+import { DEFAULT_MAX_PROVIDER_RESPONSE_BYTES, readBoundedResponseText } from './bounded-response'
 import {
   ProviderLoopbackHttpHost,
   ProviderLoopbackRequestError,
@@ -283,7 +284,13 @@ export class ChatProviderCompatibilityBridge {
       body: JSON.stringify(upstreamBody),
       signal: request.signal
     })
-    const payload = (await upstream.json()) as Json
+    const payload = JSON.parse(
+      await readBoundedResponseText(
+        upstream,
+        DEFAULT_MAX_PROVIDER_RESPONSE_BYTES,
+        'Provider compatibility response'
+      )
+    ) as Json
     if (!upstream.ok) {
       json(response, upstream.status, payload)
       return

--- a/src/main/settings/chat-skill-selector.ts
+++ b/src/main/settings/chat-skill-selector.ts
@@ -2,6 +2,7 @@ import type { SkillSelectorUsageObservation } from '../agent-framework'
 import { createLogger } from '../logger'
 import type { OfficialVendorId } from '../../shared/provider-registry'
 import type { CustomReasoningEffortTransport } from '../../shared/reasoning-effort'
+import { DEFAULT_MAX_PROVIDER_RESPONSE_BYTES, readBoundedResponseText } from './bounded-response'
 import { normalizeOpenAiChatModelStepUsage } from './openai-chat-usage'
 import { fetchProviderRequest } from './provider-fetch'
 import { resolveChatReasoningTransport } from './reasoning-transport'
@@ -53,6 +54,7 @@ export async function selectChatSkills(input: {
   target: ChatSkillSelectorTarget
   fetchImpl: typeof fetch
   timeoutMs: number
+  maxResponseBytes?: number
   signal?: AbortSignal
   observeUsage?: (observation: SkillSelectorUsageObservation) => void
 }): Promise<ChatSkillSelectorInput[]> {
@@ -142,7 +144,13 @@ export async function selectChatSkills(input: {
       response: Response
     ): Promise<{ selected: ChatSkillSelectorInput[]; mode: 'function' | 'json' } | undefined> => {
       if (!response.ok) return undefined
-      const completion = (await response.json()) as JsonObject
+      const completion = JSON.parse(
+        await readBoundedResponseText(
+          response,
+          input.maxResponseBytes ?? DEFAULT_MAX_PROVIDER_RESPONSE_BYTES,
+          'Chat Skill selector response'
+        )
+      ) as JsonObject
       const usage = normalizeOpenAiChatModelStepUsage(completion.usage)
       if (usage) {
         observeUsage?.({

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -24,6 +24,101 @@ afterEach(() => {
 })
 
 describe('native Responses compatibility', () => {
+  it.each([
+    ['JSON', 'application/json', JSON.stringify({ id: 'response', output: [] })],
+    ['binary', 'application/octet-stream', 'binary']
+  ])(
+    'rejects an oversized successful %s response before reading its body',
+    async (_, type, body) => {
+      let cancelBody: ReturnType<typeof vi.spyOn> | undefined
+      const fetchImpl = vi.fn(async () => {
+        const response = new Response(body, {
+          status: 200,
+          headers: {
+            'content-type': type,
+            'content-length': String(64 * 1024 * 1024 + 1)
+          }
+        })
+        cancelBody = vi.spyOn(response.body!, 'cancel')
+        return response
+      })
+      const proxy = new NativeResponsesCompatibilityProxy(
+        { baseUrl: 'https://provider.example.test/v1', model: 'model-a' },
+        fetchImpl
+      )
+      const connection = await proxy.start()
+
+      try {
+        const response = await fetch(`${connection.baseUrl}/responses`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${connection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({ input: 'hello', stream: false })
+        })
+
+        expect(response.status).toBe(502)
+        await expect(response.json()).resolves.toMatchObject({ error: { type: 'api_error' } })
+        expect(cancelBody).toHaveBeenCalledOnce()
+      } finally {
+        await proxy.close()
+      }
+    }
+  )
+
+  it.each([
+    ['response', ['data: 123\n\n', 'unused'], 10, 16, 24],
+    ['line', ['12345678', '12345678', '12345678', '12345678'], 64, 16, 64],
+    ['event', ['data: 123456\n', 'data: 123456\n', '\n'], 64, 16, 24]
+  ])(
+    'cancels an SSE response whose current %s exceeds its limit while chunks remain active',
+    async (_, chunks, maxResponseBytes, maxSseLineBytes, maxSseEventBytes) => {
+      let cancelled = false
+      let index = 0
+      const encoder = new TextEncoder()
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                const chunk = chunks[index++]
+                if (chunk === undefined) controller.close()
+                else controller.enqueue(encoder.encode(chunk))
+              },
+              cancel() {
+                cancelled = true
+              }
+            }),
+            { status: 200, headers: { 'content-type': 'text/event-stream' } }
+          )
+      )
+      const proxy = new NativeResponsesCompatibilityProxy(
+        { baseUrl: 'https://provider.example.test/v1', model: 'model-a' },
+        fetchImpl,
+        { maxResponseBytes, maxSseLineBytes, maxSseEventBytes }
+      )
+      const connection = await proxy.start()
+
+      try {
+        const response = await fetch(`${connection.baseUrl}/responses`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${connection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({ input: 'hello', stream: true })
+        })
+
+        expect(response.status).toBe(502)
+        await expect(response.json()).resolves.toMatchObject({ error: { type: 'api_error' } })
+        expect(cancelled).toBe(true)
+      } finally {
+        await proxy.close()
+      }
+    }
+  )
+
   it('retargets endpoint, credential, and model without replacing the loopback connection', async () => {
     const fetchImpl = vi.fn(async () =>
       Response.json({ id: 'response', output: [], usage: { input_tokens: 1, output_tokens: 1 } })

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -32,6 +32,15 @@ import {
 } from './provider-error-replay'
 import { fetchProviderRequest } from './provider-fetch'
 import { normalizeOpenAiChatModelStepUsage } from './openai-chat-usage'
+import {
+  consumeBoundedResponseBody,
+  DEFAULT_MAX_PROVIDER_RESPONSE_BYTES,
+  DEFAULT_MAX_PROVIDER_SSE_EVENT_BYTES,
+  DEFAULT_MAX_PROVIDER_SSE_LINE_BYTES,
+  readBoundedResponseBytes,
+  readBoundedResponseText,
+  ResponseBodyLimitError
+} from './bounded-response'
 
 // Responses payloads are intentionally open-ended across providers. Keep the compatibility boundary
 // permissive, then validate the fields this module rewrites before touching them.
@@ -50,6 +59,9 @@ type NativeResponsesCompatibilityTarget = {
 }
 
 type NativeResponsesCompatibilityOptions = {
+  maxResponseBytes?: number
+  maxSseEventBytes?: number
+  maxSseLineBytes?: number
   responseHeaderTimeoutMs?: number
   skillSelectorTimeoutMs?: number
   streamIdleTimeoutMs?: number
@@ -77,6 +89,8 @@ const log = createLogger('native-responses-compatibility')
 const DEFAULT_RESPONSE_HEADER_TIMEOUT_MS = 2 * 60_000
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 5 * 60_000
 const MAX_REPLAY_ERROR_BODY_BYTES = 256 * 1024
+const responseLimit = (value: number | undefined, fallback: number): number =>
+  Math.max(1, Math.floor(value ?? fallback))
 const SAFE_NETWORK_ERROR_CODES = new Set([
   'EAI_AGAIN',
   'ECONNREFUSED',
@@ -461,35 +475,72 @@ const streamResponse = async (
   upstream: Response,
   response: ServerResponse,
   aliases: NativeResponsesToolAliases,
-  onActivity: () => void
+  onActivity: () => void,
+  limits: Readonly<{ responseBytes: number; eventBytes: number; lineBytes: number }>
 ): Promise<NativeResponsesStreamSummary | undefined> => {
   if (!upstream.body) throw new Error('native Responses upstream returned no body')
-  response.writeHead(upstream.status, copyResponseHeaders(upstream))
   const decoder = new TextDecoder()
   let buffered = ''
+  let bufferedBytes = 0
+  let eventBytes = 0
+  let pendingEvent: string[] = []
+  let headersWritten = false
   const observer = streamSummaryObserver(aliases)
-  for await (const chunk of upstream.body) {
-    onActivity()
-    buffered += decoder.decode(chunk, { stream: true })
-    const lines = buffered.split('\n')
-    buffered = lines.pop() ?? ''
-    for (const line of lines) response.write(`${rewriteSseLine(line, aliases, observer.observe)}\n`)
+
+  const writeHeaders = (): void => {
+    if (headersWritten) return
+    response.writeHead(upstream.status, copyResponseHeaders(upstream))
+    headersWritten = true
   }
+  const flushEvent = (): void => {
+    if (pendingEvent.length === 0) return
+    writeHeaders()
+    response.write(pendingEvent.join(''))
+    pendingEvent = []
+    eventBytes = 0
+  }
+  const consumeLine = (line: string, newline: boolean): void => {
+    const lineBytes = Buffer.byteLength(line, 'utf8')
+    if (lineBytes > limits.lineBytes) {
+      throw new ResponseBodyLimitError('Native Responses upstream SSE line', limits.lineBytes)
+    }
+    const boundary = line === '' || line === '\r'
+    if (!boundary) {
+      eventBytes += lineBytes + (newline ? 1 : 0)
+      if (eventBytes > limits.eventBytes) {
+        throw new ResponseBodyLimitError('Native Responses upstream SSE event', limits.eventBytes)
+      }
+    }
+    pendingEvent.push(rewriteSseLine(line, aliases, observer.observe) + (newline ? '\n' : ''))
+    if (boundary) flushEvent()
+  }
+
+  await consumeBoundedResponseBody(
+    upstream,
+    limits.responseBytes,
+    'Native Responses upstream SSE response',
+    (chunk) => {
+      onActivity()
+      buffered += decoder.decode(chunk, { stream: true })
+      const lines = buffered.split('\n')
+      if (lines.length === 1) {
+        bufferedBytes += chunk.byteLength
+        if (bufferedBytes > limits.lineBytes) {
+          throw new ResponseBodyLimitError('Native Responses upstream SSE line', limits.lineBytes)
+        }
+        return
+      }
+      buffered = lines.pop() ?? ''
+      bufferedBytes = Buffer.byteLength(buffered, 'utf8')
+      for (const line of lines) consumeLine(line, true)
+    }
+  )
   buffered += decoder.decode()
-  if (buffered) response.write(rewriteSseLine(buffered, aliases, observer.observe))
+  if (buffered) consumeLine(buffered, false)
+  flushEvent()
+  writeHeaders()
   response.end()
   return observer.summary()
-}
-
-const readResponseText = async (upstream: Response, onActivity: () => void): Promise<string> => {
-  if (!upstream.body) throw new Error('native Responses upstream returned no body')
-  const decoder = new TextDecoder()
-  let body = ''
-  for await (const chunk of upstream.body) {
-    onActivity()
-    body += decoder.decode(chunk, { stream: true })
-  }
-  return body + decoder.decode()
 }
 
 const namespaceToolDeclarations = (tools: ResponsesBridgeNamespacedTool[]): JsonObject[] => {
@@ -641,7 +692,13 @@ export class NativeResponsesCompatibilityProxy {
         })
         return []
       }
-      const payload = (await response.json()) as JsonObject
+      const payload = JSON.parse(
+        await readBoundedResponseText(
+          response,
+          responseLimit(this.options.maxResponseBytes, DEFAULT_MAX_PROVIDER_RESPONSE_BYTES),
+          'Native Responses Skill selection response'
+        )
+      ) as JsonObject
       const usage = normalizeOpenAiChatModelStepUsage(payload.usage)
       if (usage) {
         observeUsage?.({
@@ -966,7 +1023,20 @@ export class NativeResponsesCompatibilityProxy {
         response.end(snapshot.body)
       } else if (responseType === 'event-stream') {
         armStreamIdleTimeout()
-        const summary = await streamResponse(upstream, response, aliases, armStreamIdleTimeout)
+        const summary = await streamResponse(upstream, response, aliases, armStreamIdleTimeout, {
+          responseBytes: responseLimit(
+            this.options.maxResponseBytes,
+            DEFAULT_MAX_PROVIDER_RESPONSE_BYTES
+          ),
+          lineBytes: responseLimit(
+            this.options.maxSseLineBytes,
+            DEFAULT_MAX_PROVIDER_SSE_LINE_BYTES
+          ),
+          eventBytes: responseLimit(
+            this.options.maxSseEventBytes,
+            DEFAULT_MAX_PROVIDER_SSE_EVENT_BYTES
+          )
+        })
         log.info('native Responses compatibility stream completed', {
           requestId,
           ...(summary ?? { terminalEventType: 'missing' })
@@ -974,14 +1044,26 @@ export class NativeResponsesCompatibilityProxy {
       } else if (responseType === 'json') {
         armStreamIdleTimeout()
         const payload = restoreNativeResponsesPayload(
-          JSON.parse(await readResponseText(upstream, armStreamIdleTimeout)),
+          JSON.parse(
+            await readBoundedResponseText(
+              upstream,
+              responseLimit(this.options.maxResponseBytes, DEFAULT_MAX_PROVIDER_RESPONSE_BYTES),
+              'Native Responses upstream JSON response',
+              armStreamIdleTimeout
+            )
+          ),
           aliases
         )
         response.writeHead(upstream.status, copyResponseHeaders(upstream))
         response.end(JSON.stringify(payload))
       } else {
+        const body = await readBoundedResponseBytes(
+          upstream,
+          responseLimit(this.options.maxResponseBytes, DEFAULT_MAX_PROVIDER_RESPONSE_BYTES),
+          'Native Responses upstream binary response'
+        )
         response.writeHead(upstream.status, copyResponseHeaders(upstream))
-        response.end(Buffer.from(await upstream.arrayBuffer()))
+        response.end(body)
       }
       log.info('native Responses compatibility request completed', {
         requestId,

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -8,6 +8,132 @@ import { inputToMessages, responsesToChatRequest, toolsToChat } from './response
 import { selectExplicitConnectorSkills } from './skill-selector-routing'
 
 describe('Responses-compatible bridge conversion', () => {
+  it('accepts a successful JSON response with a UTF-8 BOM', async () => {
+    const upstreamFetch = vi.fn(
+      async () =>
+        new Response(
+          `\uFEFF${JSON.stringify({
+            id: 'chat-with-bom',
+            model: 'model-a',
+            choices: [{ message: { role: 'assistant', content: 'ok' } }]
+          })}`,
+          { headers: { 'content-type': 'application/json' } }
+        )
+    )
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', model: 'model-a' },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'model-a', input: 'hello', stream: false })
+      })
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toMatchObject({
+        id: 'chat-with-bom',
+        output: [{ content: [{ text: 'ok' }] }]
+      })
+    } finally {
+      await bridge.close()
+    }
+  })
+
+  it('rejects an oversized successful JSON response before reading its body', async () => {
+    let cancelBody: ReturnType<typeof vi.spyOn> | undefined
+    const upstreamFetch = vi.fn(async () => {
+      const upstream = Response.json(
+        {
+          id: 'chat-oversized',
+          model: 'model-a',
+          choices: [{ message: { role: 'assistant', content: 'too large' } }]
+        },
+        { headers: { 'content-length': String(64 * 1024 * 1024 + 1) } }
+      )
+      cancelBody = vi.spyOn(upstream.body!, 'cancel')
+      return upstream
+    })
+    const { ResponsesBridge } = await import('./responses-bridge')
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', model: 'model-a' },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'model-a', input: 'hello', stream: false })
+      })
+
+      expect(response.status).toBe(502)
+      await expect(response.json()).resolves.toMatchObject({ error: { type: 'api_error' } })
+      expect(cancelBody).toHaveBeenCalledOnce()
+    } finally {
+      await bridge.close()
+    }
+  })
+
+  it('fails and cancels a streaming upstream that exceeds the limit after a stop frame', async () => {
+    let cancelled = false
+    const terminalFrame = new TextEncoder().encode(
+      `data: ${JSON.stringify({
+        id: 'chat-oversized-stream',
+        choices: [{ delta: { content: 'done' }, finish_reason: 'stop' }]
+      })}\n\n`
+    )
+    const upstreamFetch = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(terminalFrame)
+              controller.enqueue(new TextEncoder().encode('x'))
+            },
+            cancel() {
+              cancelled = true
+            }
+          }),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+    )
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', model: 'model-a' },
+      upstreamFetch,
+      { maxResponseBytes: terminalFrame.byteLength }
+    )
+    const connection = await bridge.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'model-a', input: 'hello', stream: true })
+      })
+      const body = await response.text()
+
+      expect(body).toContain('response.failed')
+      expect(body).not.toContain('response.completed')
+      expect(cancelled).toBe(true)
+    } finally {
+      await bridge.close()
+    }
+  })
+
   const legacyReviewerMarker = '<open_science_reviewer_session>'
   it('maps instructions, messages, function calls, and tool results to Chat Completions', () => {
     const request = responsesToChatRequest({
@@ -1921,6 +2047,39 @@ describe('Responses bridge Skill selector', () => {
     { name: 'statistics', description: 'Analyze numerical data.', path: '/private/stats/SKILL.md' },
     { name: 'writing', description: 'Improve prose.', path: '/private/writing/SKILL.md' }
   ]
+
+  it('fails open and cancels an oversized successful selector response', async () => {
+    let cancelBody: ReturnType<typeof vi.spyOn> | undefined
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', model: 'model-a' },
+      vi.fn(async () => {
+        const response = Response.json(
+          {
+            choices: [
+              {
+                message: {
+                  tool_calls: [
+                    {
+                      function: {
+                        name: 'select_skills',
+                        arguments: JSON.stringify({ skill_names: ['mcp-pubmed'] })
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          { headers: { 'content-length': String(64 * 1024 * 1024 + 1) } }
+        )
+        cancelBody = vi.spyOn(response.body!, 'cancel')
+        return response
+      })
+    )
+
+    await expect(bridge.selectSkills('find biomedical papers', catalog)).resolves.toEqual([])
+    expect(cancelBody).toHaveBeenCalledOnce()
+  })
 
   it('sends only current text plus names and descriptions and returns canonical bounded results', async () => {
     let upstreamUrl = ''

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -34,6 +34,11 @@ import {
 } from './provider-error-replay'
 import { fetchProviderRequest } from './provider-fetch'
 import type { SkillSelectorUsageObservation } from '../agent-framework'
+import {
+  DEFAULT_MAX_PROVIDER_RESPONSE_BYTES,
+  readBoundedResponseText,
+  ResponseBodyLimitError
+} from './bounded-response'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
 // at the boundary before values reach the upstream request.
@@ -81,6 +86,7 @@ export type ResponsesBridgeSkillCandidate = ChatSkillSelectorCandidate
 export type ResponsesBridgeSkillInput = ChatSkillSelectorInput
 
 export type ResponsesBridgeOptions = {
+  maxResponseBytes?: number
   skillSelectorTimeoutMs?: number
   skillSelectorFailureMode?: 'empty' | 'throw'
   reasoningCacheMaxEntries?: number
@@ -139,9 +145,10 @@ export class ResponsesBridge {
           return
         }
         const bridgeError = error instanceof ResponsesProtocolError ? error : undefined
-        json(response, bridgeError?.status ?? 400, {
+        const responseLimitError = error instanceof ResponseBodyLimitError
+        json(response, bridgeError?.status ?? (responseLimitError ? 502 : 400), {
           error: {
-            type: bridgeError?.type ?? 'invalid_request_error',
+            type: bridgeError?.type ?? (responseLimitError ? 'api_error' : 'invalid_request_error'),
             message: error instanceof Error ? error.message : String(error)
           }
         })
@@ -171,6 +178,7 @@ export class ResponsesBridge {
         },
         fetchImpl: this.fetchImpl,
         timeoutMs: this.options.skillSelectorTimeoutMs ?? 15_000,
+        maxResponseBytes: this.options.maxResponseBytes ?? DEFAULT_MAX_PROVIDER_RESPONSE_BYTES,
         ...(signal ? { signal } : {}),
         ...(observeUsage ? { observeUsage } : {})
       })
@@ -487,12 +495,19 @@ export class ResponsesBridge {
         upstream,
         response,
         String(body.model ?? ''),
-        namespacedTools
+        namespacedTools,
+        this.options.maxResponseBytes ?? DEFAULT_MAX_PROVIDER_RESPONSE_BYTES
       )
       this.cacheReasoning(promptCacheKey, reasoning, callIds)
       return
     }
-    const completion = (await upstream.json()) as JsonObject
+    const completion = JSON.parse(
+      await readBoundedResponseText(
+        upstream,
+        this.options.maxResponseBytes ?? DEFAULT_MAX_PROVIDER_RESPONSE_BYTES,
+        'Chat Completions upstream response'
+      )
+    ) as JsonObject
     const message = (completion.choices?.[0]?.message ?? {}) as JsonObject
     const result = completionToResponse(completion, namespacedTools)
     const outputItems = Array.isArray(result.output) ? (result.output as JsonObject[]) : []

--- a/src/main/settings/responses-response-adapter.ts
+++ b/src/main/settings/responses-response-adapter.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto'
 
 import { createLogger } from '../logger'
+import { consumeBoundedResponseBody, DEFAULT_MAX_PROVIDER_RESPONSE_BYTES } from './bounded-response'
 import type { ResponsesBridgeNamespacedTool } from './responses-protocol-types'
 
 // Upstream protocol payloads are open-ended and validated at this response seam.
@@ -228,7 +229,8 @@ export const streamChatToResponses = async (
   upstream: Response,
   response: ResponsesStreamWriter,
   model: string,
-  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = []
+  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = [],
+  maxResponseBytes = DEFAULT_MAX_PROVIDER_RESPONSE_BYTES
 ): Promise<{ reasoning: string; callIds: string[] }> => {
   if (!upstream.body) throw new Error('Chat Completions upstream returned no body')
   response.writeHead(200, {
@@ -355,12 +357,17 @@ export const streamChatToResponses = async (
 
   let streamError: unknown
   try {
-    for await (const chunk of upstream.body) {
-      buffered += decoder.decode(chunk, { stream: true })
-      const records = buffered.split(/\r?\n\r?\n/)
-      buffered = records.pop() ?? ''
-      for (const record of records) handleRecord(record)
-    }
+    await consumeBoundedResponseBody(
+      upstream,
+      maxResponseBytes,
+      'Chat Completions upstream SSE response',
+      (chunk) => {
+        buffered += decoder.decode(chunk, { stream: true })
+        const records = buffered.split(/\r?\n\r?\n/)
+        buffered = records.pop() ?? ''
+        for (const record of records) handleRecord(record)
+      }
+    )
     buffered += decoder.decode()
     if (buffered.trim()) handleRecord(buffered)
   } catch (error) {
@@ -407,10 +414,6 @@ export const streamChatToResponses = async (
         message: streamError.message
       })
     })
-  } else if (terminalFinishReason === 'stop' || terminalFinishReason === 'tool_calls') {
-    writeEvent(response, 'response.completed', sequence++, {
-      response: responseEnvelope(responseId, model, output, usage)
-    })
   } else if (streamError) {
     log.warn('bridge stream error', {
       model,
@@ -421,6 +424,10 @@ export const streamChatToResponses = async (
         type: 'upstream_error',
         message: 'Upstream stream ended before completion'
       })
+    })
+  } else if (terminalFinishReason === 'stop' || terminalFinishReason === 'tool_calls') {
+    writeEvent(response, 'response.completed', sequence++, {
+      response: responseEnvelope(responseId, model, output, usage)
     })
   } else if (terminalFinishReason) {
     log.warn('bridge stream incomplete', { model, finishReason: terminalFinishReason })

--- a/src/main/settings/xai-oauth-provider-bridge.test.ts
+++ b/src/main/settings/xai-oauth-provider-bridge.test.ts
@@ -21,6 +21,35 @@ const responsesPayload = {
 }
 
 describe('xAI OAuth provider bridge', () => {
+  it('rejects an oversized successful response before reading its body', async () => {
+    let cancelBody: ReturnType<typeof vi.spyOn> | undefined
+    const upstream = vi.fn<typeof fetch>(async () => {
+      const response = Response.json(responsesPayload, {
+        headers: { 'content-length': String(64 * 1024 * 1024 + 1) }
+      })
+      cancelBody = vi.spyOn(response.body!, 'cancel')
+      return response
+    })
+    const bridge = createXaiOAuthProviderBridge(
+      [{ id: 'active', model: 'grok-4.6' }],
+      'active',
+      'openai',
+      vi.fn(async () => 'access-token'),
+      upstream
+    )
+    bridges.push(bridge)
+    const connection = await bridge.start()
+
+    const response = await fetch(`${connection.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${connection.token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'Hello' }] })
+    })
+
+    expect(response.status).toBe(502)
+    expect(cancelBody).toHaveBeenCalledOnce()
+  })
+
   it('serves Anthropic messages, local token counts, streams, and a forced 401 refresh', async () => {
     const getAccessToken = vi
       .fn<(forceRefresh?: boolean) => Promise<string>>()

--- a/src/main/settings/xai-oauth-provider-bridge.ts
+++ b/src/main/settings/xai-oauth-provider-bridge.ts
@@ -2,6 +2,7 @@ import type { ServerResponse } from 'node:http'
 import { createLogger } from '../logger'
 import { netFetchStandard } from '../skills/net-fetch'
 
+import { DEFAULT_MAX_PROVIDER_RESPONSE_BYTES, readBoundedResponseText } from './bounded-response'
 import {
   ProviderLoopbackHttpHost,
   ProviderLoopbackRequestError,
@@ -159,7 +160,13 @@ export class XaiOAuthProviderBridge {
         : chatToResponses(body, this.target.model)
     let upstream = await this.request(upstreamBody, request, false)
     if (upstream.status === 401) upstream = await this.request(upstreamBody, request, true)
-    const payload = (await upstream.json()) as Record<string, unknown>
+    const payload = JSON.parse(
+      await readBoundedResponseText(
+        upstream,
+        DEFAULT_MAX_PROVIDER_RESPONSE_BYTES,
+        'xAI Responses upstream response'
+      )
+    ) as Record<string, unknown>
     if (!upstream.ok) {
       log.info('loopback upstream error', {
         wire: this.wire,


### PR DESCRIPTION
## Summary

- cap provider success responses at 64 MiB with Content-Length preflight and observed-byte accounting
- cap native Responses SSE lines and events at 8 MiB, canceling the upstream body on overflow
- apply the shared bounded reader to Responses, compatibility, xAI OAuth, and Skill-selector JSON paths
- preserve controlled 502 or protocol-level stream failures without changing persisted settings or renderer UI

## Reproduction

Regression tests first demonstrated that the previous implementation:

- returned 200 for oversized successful JSON and binary responses
- consumed oversized SSE lines/events instead of canceling the upstream body
- completed Responses SSE, Skill selection, and xAI compatibility calls after their configured response budget was exceeded

## Tests

- provider bridge regression suite: 110 passed
- Responses response-adapter suite: 9 passed
- npm run typecheck:node
- ESLint on changed files
- git diff --check
- full npm test: 23,686 passed, 3 unrelated existing Notebook/R failures
  - shell admission timeout passes when rerun alone
  - two real-R TIFF capture assertions remain reproducible when rerun alone
