### PR TITLE
fix(settings): surface provider errors and bound persistence

### DIFF
--- a/src/main/settings/document-codec.test.ts
+++ b/src/main/settings/document-codec.test.ts
@@ -39,6 +39,28 @@ describe('settings document codec', () => {
     expect(settings.providers.at(-1)?.id).toBe(`provider-${PROVIDER_RESOURCE_LIMITS.providers - 1}`)
   })
 
+  it('preserves a Codex provider that follows the non-Codex provider cap', () => {
+    const providers = [
+      ...Array.from({ length: PROVIDER_RESOURCE_LIMITS.providers }, (_, index) => ({
+        id: `provider-${index}`,
+        type: 'custom',
+        name: `Provider ${index}`
+      })),
+      {
+        id: 'builtin-codex-shared',
+        type: 'codex-shared',
+        name: 'Legacy Codex'
+      }
+    ]
+
+    const settings = sanitizeSettings({ providers })
+
+    expect(settings.providers).toHaveLength(PROVIDER_RESOURCE_LIMITS.providers)
+    expect(settings.providers).toContainEqual(
+      expect.objectContaining({ id: CODEX_SUBSCRIPTION_PROVIDER_ID, type: 'codex-isolated' })
+    )
+  })
+
   it('preserves current durable settings families and drops retired Runtime selections', () => {
     const dataRoot = resolve('portable-settings-data')
     const settings = sanitizeSettings({

--- a/src/main/settings/document-codec.test.ts
+++ b/src/main/settings/document-codec.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { CODEX_SUBSCRIPTION_PROVIDER_ID, SETTINGS_FILE_VERSION } from '../../shared/settings'
 import { sanitizeSettings } from './document-codec'
+import { PROVIDER_RESOURCE_LIMITS } from './provider-resource-limits'
 
 describe('settings document codec', () => {
   it('exposes one pure document boundary', async () => {
@@ -20,6 +21,22 @@ describe('settings document codec', () => {
       version: SETTINGS_FILE_VERSION,
       providers: []
     })
+  })
+
+  it('bounds providers and keeps the first valid record for duplicate IDs', () => {
+    const providers = Array.from(
+      { length: PROVIDER_RESOURCE_LIMITS.providers + 1 },
+      (_, index) => ({ id: `provider-${index}`, type: 'custom', name: `Provider ${index}` })
+    )
+    providers.splice(1, 0, { id: 'provider-0', type: 'custom', name: 'Duplicate' })
+
+    const settings = sanitizeSettings({ providers })
+
+    expect(settings.providers).toHaveLength(PROVIDER_RESOURCE_LIMITS.providers)
+    expect(settings.providers.filter(({ id }) => id === 'provider-0')).toEqual([
+      expect.objectContaining({ name: 'Provider 0' })
+    ])
+    expect(settings.providers.at(-1)?.id).toBe(`provider-${PROVIDER_RESOURCE_LIMITS.providers - 1}`)
   })
 
   it('preserves current durable settings families and drops retired Runtime selections', () => {

--- a/src/main/settings/document-codec.ts
+++ b/src/main/settings/document-codec.ts
@@ -178,23 +178,34 @@ const sanitizeRuntimeEnablement = (
 const sanitizeSettings = (value: unknown): StoredSettings => {
   if (!isRecord(value)) return createEmptySettings()
 
+  const legacyActiveProviderId = asString(value.activeProviderId)
   const sanitizedProviders: StoredProvider[] = []
   const sanitizedProviderIds = new Set<string>()
+  let selectedCodexProvider: StoredProvider | undefined
   if (Array.isArray(value.providers)) {
     for (const candidate of value.providers) {
       const provider = sanitizeProvider(candidate)
-      if (!provider || sanitizedProviderIds.has(provider.id)) continue
+      if (!provider) continue
+      if (isCodexSubscriptionProvider(provider.type)) {
+        if (
+          !selectedCodexProvider ||
+          (provider.id === legacyActiveProviderId &&
+            selectedCodexProvider.id !== legacyActiveProviderId)
+        ) {
+          selectedCodexProvider = provider
+        }
+        continue
+      }
+      if (
+        sanitizedProviders.length >= PROVIDER_RESOURCE_LIMITS.providers ||
+        sanitizedProviderIds.has(provider.id)
+      ) {
+        continue
+      }
       sanitizedProviderIds.add(provider.id)
       sanitizedProviders.push(provider)
-      if (sanitizedProviders.length >= PROVIDER_RESOURCE_LIMITS.providers) break
     }
   }
-  const legacyActiveProviderId = asString(value.activeProviderId)
-  const codexProviders = sanitizedProviders.filter((provider) =>
-    isCodexSubscriptionProvider(provider.type)
-  )
-  const selectedCodexProvider =
-    codexProviders.find((provider) => provider.id === legacyActiveProviderId) ?? codexProviders[0]
   const migratedCodexProvider = selectedCodexProvider
     ? {
         ...selectedCodexProvider,
@@ -212,8 +223,11 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
     delete migratedCodexProvider.expiresAt
   }
 
+  const nonCodexProviderLimit = PROVIDER_RESOURCE_LIMITS.providers - (migratedCodexProvider ? 1 : 0)
   const migratedProviders = [
-    ...sanitizedProviders.filter((provider) => !isCodexSubscriptionProvider(provider.type)),
+    ...sanitizedProviders
+      .filter((provider) => provider.id !== migratedCodexProvider?.id)
+      .slice(0, nonCodexProviderLimit),
     ...(migratedCodexProvider ? [migratedCodexProvider] : [])
   ]
   const providerIds = new Set<string>()

--- a/src/main/settings/document-codec.ts
+++ b/src/main/settings/document-codec.ts
@@ -37,6 +37,7 @@ import {
   sanitizePackageMirror,
   sanitizeProvider
 } from './record-codec'
+import { PROVIDER_RESOURCE_LIMITS } from './provider-resource-limits'
 import { isRecord } from '../value-guards'
 
 // Checks for plain JSON objects so untrusted settings payloads can be sanitized safely.
@@ -177,11 +178,17 @@ const sanitizeRuntimeEnablement = (
 const sanitizeSettings = (value: unknown): StoredSettings => {
   if (!isRecord(value)) return createEmptySettings()
 
-  const sanitizedProviders = Array.isArray(value.providers)
-    ? value.providers
-        .map(sanitizeProvider)
-        .filter((provider): provider is StoredProvider => !!provider)
-    : []
+  const sanitizedProviders: StoredProvider[] = []
+  const sanitizedProviderIds = new Set<string>()
+  if (Array.isArray(value.providers)) {
+    for (const candidate of value.providers) {
+      const provider = sanitizeProvider(candidate)
+      if (!provider || sanitizedProviderIds.has(provider.id)) continue
+      sanitizedProviderIds.add(provider.id)
+      sanitizedProviders.push(provider)
+      if (sanitizedProviders.length >= PROVIDER_RESOURCE_LIMITS.providers) break
+    }
+  }
   const legacyActiveProviderId = asString(value.activeProviderId)
   const codexProviders = sanitizedProviders.filter((provider) =>
     isCodexSubscriptionProvider(provider.type)
@@ -205,10 +212,18 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
     delete migratedCodexProvider.expiresAt
   }
 
-  const providers = [
+  const migratedProviders = [
     ...sanitizedProviders.filter((provider) => !isCodexSubscriptionProvider(provider.type)),
     ...(migratedCodexProvider ? [migratedCodexProvider] : [])
   ]
+  const providerIds = new Set<string>()
+  const providers = migratedProviders.filter((provider) => {
+    if (providerIds.has(provider.id) || providerIds.size >= PROVIDER_RESOURCE_LIMITS.providers) {
+      return false
+    }
+    providerIds.add(provider.id)
+    return true
+  })
   const visionModel = sanitizeVisionModel(value.visionModel)
   const settings: StoredSettings = {
     version: SETTINGS_FILE_VERSION,

--- a/src/main/settings/document-store.test.ts
+++ b/src/main/settings/document-store.test.ts
@@ -1,4 +1,12 @@
-import { mkdtemp, readFile, readdir, rename as renameFile, rm, writeFile } from 'node:fs/promises'
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rename as renameFile,
+  rm,
+  stat as statFile,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -6,7 +14,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const faults = vi.hoisted(() => ({
   failReadOnceWith: undefined as Error | undefined,
-  renameFailuresRemaining: 0
+  renameFailuresRemaining: 0,
+  reportedSize: undefined as number | undefined
 }))
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
@@ -28,6 +37,10 @@ vi.mock('node:fs/promises', async (importOriginal) => {
         })
       }
       await actual.rename(source, destination)
+    }),
+    stat: vi.fn(async (...args: Parameters<typeof actual.stat>) => {
+      const result = await actual.stat(...args)
+      return faults.reportedSize === undefined ? result : { ...result, size: faults.reportedSize }
     })
   }
 })
@@ -39,6 +52,7 @@ let storageRoot: string | undefined
 afterEach(async () => {
   faults.failReadOnceWith = undefined
   faults.renameFailuresRemaining = 0
+  faults.reportedSize = undefined
   vi.clearAllMocks()
   if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
   storageRoot = undefined
@@ -57,6 +71,20 @@ describe('settings document store', () => {
     await expect(
       store.mutate((settings) => ({ ...settings, notificationsEnabled: false }))
     ).resolves.toMatchObject({ providers: [], notificationsEnabled: false })
+  })
+
+  it('rejects an oversized settings document before reading its contents', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    const settingsPath = join(storageRoot, 'settings.json')
+    await writeFile(settingsPath, '{"version":2,"providers":[]}\n', 'utf8')
+    faults.reportedSize = 128 * 1024 * 1024 + 1
+    vi.mocked(readFile).mockClear()
+
+    await expect(new SettingsDocumentStore(storageRoot).read()).rejects.toThrow(
+      'settings.json exceeds the 134217728 byte read limit.'
+    )
+    expect(readFile).not.toHaveBeenCalled()
+    expect(statFile).toHaveBeenCalledWith(settingsPath)
   })
 
   it('migrates a version 1 settings document through the registered pipeline', async () => {

--- a/src/main/settings/document-store.ts
+++ b/src/main/settings/document-store.ts
@@ -9,6 +9,7 @@ import {
 import { sanitizeSettings } from './document-codec'
 import { createEmptySettings, type StoredSettings } from './types'
 import { isRecord } from '../value-guards'
+import { SETTINGS_RESOURCE_LIMITS } from './settings-resource-limits'
 
 const SETTINGS_FILE = 'settings.json'
 
@@ -58,7 +59,14 @@ class SettingsDocumentStore {
   }
 
   async read(): Promise<StoredSettings> {
-    const result = await readDurableJsonFile(this.path, decodeSettingsDocument)
+    const result = await readDurableJsonFile(
+      this.path,
+      decodeSettingsDocument,
+      {},
+      {
+        maxBytes: SETTINGS_RESOURCE_LIMITS.documentBytes
+      }
+    )
     return result.status === 'found' ? result.value : createEmptySettings()
   }
 
@@ -76,7 +84,13 @@ class SettingsDocumentStore {
   }
 
   private async write(settings: StoredSettings): Promise<void> {
-    await writeDurableJsonFile(this.path, `${JSON.stringify(settings, null, 2)}\n`)
+    const contents = `${JSON.stringify(settings, null, 2)}\n`
+    if (Buffer.byteLength(contents, 'utf8') > SETTINGS_RESOURCE_LIMITS.documentBytes) {
+      throw new Error(
+        `Settings document exceeds the ${SETTINGS_RESOURCE_LIMITS.documentBytes} byte limit.`
+      )
+    }
+    await writeDurableJsonFile(this.path, contents)
   }
 }
 

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -161,6 +161,7 @@ describe('ProviderAccountsModule', () => {
   })
 
   it.each([
+    ['id', 'p'.repeat(129), 'Provider ID must not exceed 128 characters.'],
     ['name', 'n'.repeat(129), 'Provider name must not exceed 128 characters.'],
     [
       'baseUrl',

--- a/src/main/settings/provider-resource-limits.ts
+++ b/src/main/settings/provider-resource-limits.ts
@@ -3,6 +3,7 @@ import { SETTINGS_RESOURCE_LIMITS, assertCharacterLimit } from './settings-resou
 
 const PROVIDER_RESOURCE_LIMITS = Object.freeze({
   providers: 64,
+  idCharacters: 128,
   nameCharacters: 128,
   baseUrlCharacters: 2_048,
   modelIdCharacters: 512,

--- a/src/main/settings/provider-resource-limits.ts
+++ b/src/main/settings/provider-resource-limits.ts
@@ -13,7 +13,8 @@ const PROVIDER_RESOURCE_LIMITS = Object.freeze({
   validationResponseBytes: 1024 * 1024
 })
 
-const assertProviderDraftLimits = (draft: ProviderDraft): void => {
+const assertProviderDraftLimits = (draft: ProviderDraft & { id?: string }): void => {
+  assertCharacterLimit(draft.id, PROVIDER_RESOURCE_LIMITS.idCharacters, 'Provider ID')
   assertCharacterLimit(draft.name, PROVIDER_RESOURCE_LIMITS.nameCharacters, 'Provider name')
   assertCharacterLimit(draft.baseUrl, PROVIDER_RESOURCE_LIMITS.baseUrlCharacters, 'Base URL')
   assertCharacterLimit(draft.model, PROVIDER_RESOURCE_LIMITS.modelIdCharacters, 'Model ID')

--- a/src/main/settings/record-codec.test.ts
+++ b/src/main/settings/record-codec.test.ts
@@ -6,6 +6,7 @@ import {
   sanitizeComputeGrant,
   sanitizeProvider
 } from './record-codec'
+import { PROVIDER_RESOURCE_LIMITS } from './provider-resource-limits'
 
 describe('settings record codec', () => {
   it('keeps the private owner interface explicit', async () => {
@@ -65,6 +66,38 @@ describe('settings record codec', () => {
     expect(
       sanitizeComputeGrant({ projectId: 'p1', operation: 42, providerId: 'c1' })
     ).toBeUndefined()
+  })
+
+  it('applies provider field and fetched-model limits while decoding', () => {
+    expect(
+      sanitizeProvider({
+        id: 'provider-1',
+        type: 'custom',
+        name: 'n'.repeat(PROVIDER_RESOURCE_LIMITS.nameCharacters + 1)
+      })
+    ).toBeUndefined()
+
+    const provider = sanitizeProvider({
+      id: 'provider-1',
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'u'.repeat(PROVIDER_RESOURCE_LIMITS.baseUrlCharacters + 1),
+      model: 'm'.repeat(PROVIDER_RESOURCE_LIMITS.modelIdCharacters + 1),
+      fetchedModels: [
+        ...Array.from(
+          { length: PROVIDER_RESOURCE_LIMITS.fetchedModels + 1 },
+          (_, index) => `model-${index}`
+        ),
+        'x'.repeat(PROVIDER_RESOURCE_LIMITS.modelIdCharacters + 1)
+      ]
+    })
+
+    expect(provider).not.toHaveProperty('baseUrl')
+    expect(provider).not.toHaveProperty('model')
+    expect(provider?.fetchedModels).toHaveLength(PROVIDER_RESOURCE_LIMITS.fetchedModels)
+    expect(provider?.fetchedModels).not.toContain(
+      'x'.repeat(PROVIDER_RESOURCE_LIMITS.modelIdCharacters + 1)
+    )
   })
 
   it.each([

--- a/src/main/settings/record-codec.ts
+++ b/src/main/settings/record-codec.ts
@@ -24,6 +24,8 @@ import type {
   StoredProvider
 } from './types'
 import { isRecord } from '../value-guards'
+import { PROVIDER_RESOURCE_LIMITS } from './provider-resource-limits'
+import { characterCount } from './settings-resource-limits'
 
 const log = createLogger('settings.repository')
 
@@ -123,7 +125,14 @@ export const sanitizeProvider = (value: unknown): StoredProvider | undefined => 
   const id = asString(value.id)
   const type = asString(value.type) as ProviderType | undefined
   const name = asString(value.name)
-  if (!id || !type || name === undefined) return undefined
+  if (
+    !id ||
+    !type ||
+    name === undefined ||
+    characterCount(id) > PROVIDER_RESOURCE_LIMITS.idCharacters ||
+    characterCount(name) > PROVIDER_RESOURCE_LIMITS.nameCharacters
+  )
+    return undefined
   if (!PROVIDER_TYPES.has(type)) {
     log.warn('dropping stored provider with unknown type', { id, type })
     return undefined
@@ -161,11 +170,20 @@ export const sanitizeProvider = (value: unknown): StoredProvider | undefined => 
   const codexTransport = asString(value.codexTransport)
   const codexAutoUseHttps = asBoolean(value.codexAutoUseHttps)
   // Keep only non-empty model ids from persisted discovery results.
-  const fetchedModels = Array.isArray(value.fetchedModels)
-    ? value.fetchedModels.filter(
-        (entry): entry is string => typeof entry === 'string' && entry !== ''
+  let fetchedModels: string[] | undefined
+  if (Array.isArray(value.fetchedModels)) {
+    fetchedModels = []
+    for (const entry of value.fetchedModels) {
+      if (
+        typeof entry !== 'string' ||
+        entry === '' ||
+        characterCount(entry) > PROVIDER_RESOURCE_LIMITS.modelIdCharacters
       )
-    : undefined
+        continue
+      fetchedModels.push(entry)
+      if (fetchedModels.length >= PROVIDER_RESOURCE_LIMITS.fetchedModels) break
+    }
+  }
 
   // Migrate the removed scalar apiType to the explicit endpoint array.
   const rawEndpoints = Array.isArray(value.apiEndpoints) ? value.apiEndpoints : []
@@ -185,8 +203,10 @@ export const sanitizeProvider = (value: unknown): StoredProvider | undefined => 
           ? [legacyApiType]
           : []
 
-  if (baseUrl) provider.baseUrl = baseUrl
-  if (model) provider.model = model
+  if (baseUrl && characterCount(baseUrl) <= PROVIDER_RESOURCE_LIMITS.baseUrlCharacters)
+    provider.baseUrl = baseUrl
+  if (model && characterCount(model) <= PROVIDER_RESOURCE_LIMITS.modelIdCharacters)
+    provider.model = model
   if (type === 'custom') {
     if (contextWindow !== undefined) provider.contextWindow = contextWindow
     if (maxInputTokens !== undefined) provider.maxInputTokens = maxInputTokens

--- a/src/main/settings/settings-resource-limits.ts
+++ b/src/main/settings/settings-resource-limits.ts
@@ -1,5 +1,6 @@
 const SETTINGS_RESOURCE_LIMITS = Object.freeze({
-  credentialBytes: 16 * 1024
+  credentialBytes: 16 * 1024,
+  documentBytes: 128 * 1024 * 1024
 })
 
 const characterCount = (value: string): number => Array.from(value).length

--- a/src/main/storage/durable-json-file.test.ts
+++ b/src/main/storage/durable-json-file.test.ts
@@ -155,6 +155,19 @@ describe('durable JSON file publication', () => {
 })
 
 describe('durable JSON file recovery', () => {
+  it('rejects an oversized primary before reading it', async () => {
+    const filePath = join('config', 'settings.json')
+    const dependencies = createDependencies({
+      stat: vi.fn().mockResolvedValue({ mtimeMs: 1, size: 11 }),
+      readFile: vi.fn().mockResolvedValue('{"ok":true}')
+    })
+
+    await expect(
+      readDurableJsonFile(filePath, JSON.parse, dependencies, { maxBytes: 10 })
+    ).rejects.toThrow('settings.json exceeds the 10 byte read limit.')
+    expect(dependencies.readFile).not.toHaveBeenCalled()
+  })
+
   it('keeps a valid primary authoritative and removes recognized temps', async () => {
     const root = await mkdtemp(join(tmpdir(), 'durable-json-primary-'))
     roots.push(root)

--- a/src/main/storage/durable-json-file.test.ts
+++ b/src/main/storage/durable-json-file.test.ts
@@ -204,6 +204,28 @@ describe('durable JSON file recovery', () => {
     await expect(readFile(temporaryPath, 'utf8')).resolves.toBe(futureContents)
   })
 
+  it('preserves an oversized recovery temp when a valid primary exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-primary-oversized-temp-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const temporaryPath = `${filePath}.1700000000000-1.tmp`
+    const primaryContents = '{"ok":true}\n'
+    const oversizedContents = '{"future":"settings that exceed the current limit"}\n'
+    await writeFile(filePath, primaryContents, 'utf8')
+    await writeFile(temporaryPath, oversizedContents, 'utf8')
+
+    await expect(
+      readDurableJsonFile(
+        filePath,
+        JSON.parse,
+        {},
+        { maxBytes: Buffer.byteLength(primaryContents) }
+      )
+    ).rejects.toThrow('settings.json.1700000000000-1.tmp exceeds')
+    await expect(readFile(filePath, 'utf8')).resolves.toBe(primaryContents)
+    await expect(readFile(temporaryPath, 'utf8')).resolves.toBe(oversizedContents)
+  })
+
   it('does not treat an unrelated tmp file as publication residue', async () => {
     const root = await mkdtemp(join(tmpdir(), 'durable-json-unrelated-temp-'))
     roots.push(root)

--- a/src/main/storage/durable-json-file.ts
+++ b/src/main/storage/durable-json-file.ts
@@ -14,6 +14,11 @@ type DurableJsonDirectoryEntry = {
 
 type DurableJsonFileStat = {
   mtimeMs: number
+  size: number
+}
+
+type DurableJsonReadOptions = {
+  maxBytes?: number
 }
 
 type DurableJsonWriteOptions = {
@@ -211,11 +216,12 @@ const cleanupTemporaryCandidates = async (
 const assertNoRecoveryBarrier = async <Value>(
   candidates: readonly TemporaryCandidate[],
   decode: (contents: string) => Value,
-  dependencies: DurableJsonFileDependencies
+  dependencies: DurableJsonFileDependencies,
+  readContents: (path: string) => Promise<string> = dependencies.readFile
 ): Promise<void> => {
   for (const candidate of candidates) {
     try {
-      decode(await dependencies.readFile(candidate.path))
+      decode(await readContents(candidate.path))
     } catch (error) {
       if (error instanceof DurableJsonRecoveryBarrierError) throw error
     }
@@ -225,21 +231,31 @@ const assertNoRecoveryBarrier = async <Value>(
 export const readDurableJsonFile = async <Value>(
   filePath: string,
   decode: (contents: string) => Value,
-  dependencyOverrides: Partial<DurableJsonFileDependencies> = {}
+  dependencyOverrides: Partial<DurableJsonFileDependencies> = {},
+  options: DurableJsonReadOptions = {}
 ): Promise<DurableJsonReadResult<Value>> => {
   const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides }
+  const readContents = async (path: string): Promise<string> => {
+    if (options.maxBytes !== undefined) {
+      const { size } = await dependencies.stat(path)
+      if (size > options.maxBytes) {
+        throw new Error(`${basename(path)} exceeds the ${options.maxBytes} byte read limit.`)
+      }
+    }
+    return dependencies.readFile(path)
+  }
   return runFileOperation(filePath, async () => {
     let primaryContents: string
     try {
-      primaryContents = await dependencies.readFile(filePath)
+      primaryContents = await readContents(filePath)
     } catch (error) {
       if (!isMissingFileError(error)) throw error
       const candidates = await listTemporaryCandidates(filePath, dependencies)
-      await assertNoRecoveryBarrier(candidates, decode, dependencies)
+      await assertNoRecoveryBarrier(candidates, decode, dependencies, readContents)
       for (const candidate of candidates) {
         let candidateContents: string
         try {
-          candidateContents = await dependencies.readFile(candidate.path)
+          candidateContents = await readContents(candidate.path)
         } catch (candidateReadError) {
           if (isMissingFileError(candidateReadError)) continue
           throw candidateReadError
@@ -267,7 +283,7 @@ export const readDurableJsonFile = async <Value>(
 
     const value = decode(primaryContents)
     const candidates = await listTemporaryCandidates(filePath, dependencies)
-    await assertNoRecoveryBarrier(candidates, decode, dependencies)
+    await assertNoRecoveryBarrier(candidates, decode, dependencies, readContents)
     await cleanupTemporaryCandidates(candidates, dependencies)
     return { status: 'found', value }
   })

--- a/src/main/storage/durable-json-file.ts
+++ b/src/main/storage/durable-json-file.ts
@@ -235,11 +235,13 @@ export const readDurableJsonFile = async <Value>(
   options: DurableJsonReadOptions = {}
 ): Promise<DurableJsonReadResult<Value>> => {
   const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides }
-  const readContents = async (path: string): Promise<string> => {
+  const readContents = async (path: string, recoveryCandidate = false): Promise<string> => {
     if (options.maxBytes !== undefined) {
       const { size } = await dependencies.stat(path)
       if (size > options.maxBytes) {
-        throw new Error(`${basename(path)} exceeds the ${options.maxBytes} byte read limit.`)
+        const message = `${basename(path)} exceeds the ${options.maxBytes} byte read limit.`
+        if (recoveryCandidate) throw new DurableJsonRecoveryBarrierError(message)
+        throw new Error(message)
       }
     }
     return dependencies.readFile(path)
@@ -251,11 +253,13 @@ export const readDurableJsonFile = async <Value>(
     } catch (error) {
       if (!isMissingFileError(error)) throw error
       const candidates = await listTemporaryCandidates(filePath, dependencies)
-      await assertNoRecoveryBarrier(candidates, decode, dependencies, readContents)
+      await assertNoRecoveryBarrier(candidates, decode, dependencies, (path) =>
+        readContents(path, true)
+      )
       for (const candidate of candidates) {
         let candidateContents: string
         try {
-          candidateContents = await readContents(candidate.path)
+          candidateContents = await readContents(candidate.path, true)
         } catch (candidateReadError) {
           if (isMissingFileError(candidateReadError)) continue
           throw candidateReadError
@@ -283,7 +287,9 @@ export const readDurableJsonFile = async <Value>(
 
     const value = decode(primaryContents)
     const candidates = await listTemporaryCandidates(filePath, dependencies)
-    await assertNoRecoveryBarrier(candidates, decode, dependencies, readContents)
+    await assertNoRecoveryBarrier(candidates, decode, dependencies, (path) =>
+      readContents(path, true)
+    )
     await cleanupTemporaryCandidates(candidates, dependencies)
     return { status: 'found', value }
   })

--- a/src/renderer/src/pages/settings/ProvidersPanel.race.test.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.race.test.tsx
@@ -63,6 +63,46 @@ const render = (): void => {
 }
 
 describe('ProvidersPanel: unexpected command failures', () => {
+  it('shows a deletion failure instead of leaving an unhandled rejection', async () => {
+    const deleteProvider = vi.fn().mockRejectedValue(new Error('settings write failed'))
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      providers: [
+        {
+          id: 'provider-1',
+          type: 'custom',
+          name: 'Gateway one',
+          models: ['model-1'],
+          model: 'model-1',
+          hasKey: true,
+          needsKey: false,
+          supportsImageInput: false
+        },
+        {
+          id: 'provider-2',
+          type: 'custom',
+          name: 'Gateway two',
+          models: ['model-2'],
+          model: 'model-2',
+          hasKey: true,
+          needsKey: false,
+          supportsImageInput: false
+        }
+      ],
+      activeProviderId: 'provider-1',
+      deleteProvider: deleteProvider as never
+    })
+    render()
+
+    const deleteButtons = document.body.querySelectorAll<HTMLButtonElement>('[aria-label="Delete"]')
+    await act(async () => deleteButtons[1]?.click())
+
+    expect(deleteProvider).toHaveBeenCalledWith('provider-2')
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      'Could not delete the provider.'
+    )
+  })
+
   it('localizes a connection-test failure and keeps transport details out of the alert', async () => {
     useSettingsStore.setState({
       ...useSettingsStore.getState(),

--- a/src/renderer/src/pages/settings/ProvidersPanel.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.tsx
@@ -35,6 +35,7 @@ type ProvidersPanelProps = {
 type ProviderActionError = {
   action:
     | 'test'
+    | 'delete'
     | 'codex-sign-in'
     | 'codex-sign-out'
     | 'codex-reimport'
@@ -55,6 +56,8 @@ const providerErrorCopy = (error: ProviderPanelError, t: TFunction): string => {
   switch (error.action) {
     case 'test':
       return t('Could not test the provider connection.')
+    case 'delete':
+      return t('Could not delete the provider.')
     case 'codex-sign-in':
       return t('Could not sign in to Codex.')
     case 'codex-sign-out':
@@ -395,6 +398,15 @@ const ProvidersPanel = ({
     }
   }
 
+  const handleDelete = async (providerId: string): Promise<void> => {
+    setProviderTestError(undefined)
+    try {
+      await deleteProvider(providerId)
+    } catch (error) {
+      setProviderTestError({ action: 'delete', detail: errorDetail(error) })
+    }
+  }
+
   return (
     <div className="space-y-5 p-5">
       {/* Main model selection and reasoning effort share one section and one row, mirroring the
@@ -437,7 +449,7 @@ const ProvidersPanel = ({
           claudeSubscriptionProviderId={claudeSubscriptionProviderId}
           busyProviderId={busyProviderId}
           onEdit={onEditProvider}
-          onDelete={(provider) => void deleteProvider(provider.id)}
+          onDelete={(provider) => void handleDelete(provider.id)}
           onTest={(provider) => void handleTest(provider)}
           isCodexLoginPending={isCodexLoginPending}
           onCancelCodexLogin={() => void cancelCodexLogin()}

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1574,6 +1574,41 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('section[aria-label="Providers"]')).not.toBeNull()
   })
 
+  it('shows an error when refreshing a provider model catalog rejects', async () => {
+    const provider: ProviderView = {
+      id: 'anthropic-provider',
+      type: 'official',
+      vendorId: 'anthropic',
+      name: 'Anthropic',
+      models: ['claude-sonnet-4-5'],
+      model: 'claude-sonnet-4-5',
+      maskedKey: 'sk-…test',
+      hasKey: true,
+      needsKey: false,
+      supportsImageInput: true
+    }
+    useSettingsStore.setState({ providers: [provider], activeProviderId: provider.id })
+    const refreshProviderModels = vi.fn().mockRejectedValue(new Error('transport failed'))
+    useSettingsStore.setState({ refreshProviderModels: refreshProviderModels as never })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () => {
+      useSettingsStore.setState({ providers: [provider], activeProviderId: provider.id })
+    })
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Edit"]')?.click()
+    )
+    const refresh = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Refresh from vendor'
+    )
+    await act(async () => refresh?.click())
+
+    expect(refreshProviderModels).toHaveBeenCalledWith(provider.id)
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toBe(
+      'Could not refresh models from the vendor.'
+    )
+  })
+
   it('opens Usage as a standalone history-driven settings panel', async () => {
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -1056,6 +1056,9 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                 : t('request failed')
             })
       )
+    } catch {
+      setStatusOk(false)
+      setStatusMessage(t('Could not refresh models from the vendor.'))
     } finally {
       setIsRefreshingModels(false)
     }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -815,6 +815,8 @@
     "Could not switch to this folder.": "Zu diesem Ordner konnte nicht gewechselt werden.",
     "Could not switch to {{name}}": "Konnte nicht zu {{name}} wechseln",
     "Could not test the provider connection.": "Die Verbindung zum Anbieter konnte nicht getestet werden.",
+    "Could not delete the provider.": "Der Anbieter konnte nicht gelöscht werden.",
+    "Could not refresh models from the vendor.": "Die Modelle des Anbieters konnten nicht aktualisiert werden.",
     "Could not update project pin.": "Projekt-Pin konnte nicht aktualisiert werden.",
     "Could not update the command-line tool.": "Das Befehlszeilentool konnte nicht aktualisiert werden.",
     "Couldn't fetch models: {{reason}}. Using the bundled list.": "Modelle konnten nicht abgerufen werden: {{reason}}. Stattdessen wird die integrierte Liste verwendet.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -872,6 +872,8 @@
     "Could not switch to this folder.": "No se pudo cambiar a esta carpeta.",
     "Could not switch to {{name}}": "No se pudo cambiar a {{name}}",
     "Could not test the provider connection.": "No se pudo probar la conexión del proveedor.",
+    "Could not delete the provider.": "No se pudo eliminar el proveedor.",
+    "Could not refresh models from the vendor.": "No se pudieron actualizar los modelos del proveedor.",
     "Could not update project pin.": "No se pudo actualizar el pin del proyecto.",
     "Could not update the command-line tool.": "No se pudo actualizar la herramienta de línea de comandos.",
     "Could not check the command-line tool.": "No se pudo comprobar la herramienta de línea de comandos.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -872,6 +872,8 @@
     "Could not switch to this folder.": "Impossible de basculer vers ce dossier.",
     "Could not switch to {{name}}": "Impossible de passer à {{name}}",
     "Could not test the provider connection.": "Impossible de tester la connexion du fournisseur.",
+    "Could not delete the provider.": "Impossible de supprimer le fournisseur.",
+    "Could not refresh models from the vendor.": "Impossible d’actualiser les modèles du fournisseur.",
     "Could not update project pin.": "Impossible de mettre à jour le code PIN du projet.",
     "Could not update the command-line tool.": "Impossible de mettre à jour l'outil de ligne de commande.",
     "Could not check the command-line tool.": "Impossible de vérifier l'outil de ligne de commande.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -825,6 +825,8 @@
     "Could not switch to this folder.": "このフォルダーに切り替えられませんでした。",
     "Could not switch to {{name}}": "{{name}} に切り替えられませんでした",
     "Could not test the provider connection.": "プロバイダー接続をテストできませんでした。",
+    "Could not delete the provider.": "プロバイダーを削除できませんでした。",
+    "Could not refresh models from the vendor.": "プロバイダーのモデルを更新できませんでした。",
     "Could not update project pin.": "プロジェクトピンを更新できませんでした。",
     "Could not update the command-line tool.": "コマンドラインツールを更新できませんでした。",
     "Could not check the command-line tool.": "コマンドラインツールを確認できませんでした。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -844,6 +844,8 @@
     "Could not switch to this folder.": "이 폴더로 전환할 수 없습니다.",
     "Could not switch to {{name}}": "{{name}}로 전환할 수 없습니다.",
     "Could not test the provider connection.": "모델 제공업체 연결을 테스트할 수 없습니다.",
+    "Could not delete the provider.": "모델 제공업체를 삭제할 수 없습니다.",
+    "Could not refresh models from the vendor.": "모델 제공업체의 모델을 새로 고칠 수 없습니다.",
     "Could not update project pin.": "프로젝트 고정을 업데이트할 수 없습니다.",
     "Could not update the command-line tool.": "명령줄 도구를 업데이트할 수 없습니다.",
     "Could not check the command-line tool.": "명령줄 도구를 확인할 수 없습니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -866,6 +866,8 @@
     "Could not switch to this folder.": "Не удалось переключиться на эту папку.",
     "Could not switch to {{name}}": "Не удалось переключиться на {{name}}",
     "Could not test the provider connection.": "Не удалось протестировать соединение с поставщиком.",
+    "Could not delete the provider.": "Не удалось удалить поставщика.",
+    "Could not refresh models from the vendor.": "Не удалось обновить модели поставщика.",
     "Could not update project pin.": "Не удалось изменить закрепление проекта.",
     "Could not update the command-line tool.": "Не удалось обновить инструмент командной строки.",
     "Could not check the command-line tool.": "Не удалось проверить инструмент командной строки.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -911,6 +911,8 @@
     "Could not switch to this folder.": "无法切换到该文件夹。",
     "Could not switch to {{name}}": "无法切换到 {{name}}",
     "Could not test the provider connection.": "无法测试模型服务商连接。",
+    "Could not delete the provider.": "无法删除模型服务商。",
+    "Could not refresh models from the vendor.": "无法刷新模型服务商的模型。",
     "Could not update project pin.": "无法更新项目置顶状态。",
     "Could not update the command-line tool.": "无法更新命令行工具。",
     "Could not check the command-line tool.": "无法检查命令行工具。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -910,6 +910,8 @@
     "Could not switch to this folder.": "無法切換到該資料夾。",
     "Could not switch to {{name}}": "無法切換到 {{name}}",
     "Could not test the provider connection.": "無法測試模型服務商連線。",
+    "Could not delete the provider.": "無法刪除模型服務商。",
+    "Could not refresh models from the vendor.": "無法重新整理模型服務商的模型。",
     "Could not update project pin.": "無法更新專案置頂狀態。",
     "Could not update the command-line tool.": "無法更新命令列工具。",
     "Could not check the command-line tool.": "無法檢查命令列工具。",


### PR DESCRIPTION
## Problem

Provider deletion and vendor-model refresh calls could reject without visible feedback, leaving users with an unchanged or ambiguous Settings surface and an unhandled Promise rejection. Separately, `settings.json` was read and decoded without matching the Provider limits enforced on writes, so a corrupt or locally modified document could retain oversized fields, unbounded collections, and duplicate Provider identities.

## Proposed change

- Catch rejected Provider deletion and model refresh operations at their existing UI boundaries and show localized inline errors.
- Add an optional pre-read byte budget to durable JSON reads and apply a 128 MiB read/write limit to `settings.json`.
- Reapply Provider identity, name, URL, model ID, Provider-count, and fetched-model limits while decoding.
- Keep the first valid Provider for each ID and stop after 64 unique valid Providers; stop each fetched catalog after 2,000 valid model IDs.

## Scope and non-goals

- No persisted fields or settings schema-version changes.
- No IPC, renderer contract, or domain-model changes.
- One component-local action discriminator, `delete`, is added for presentation only; it is not persisted.
- Historical valid settings remain compatible. Corrupt duplicate IDs are deterministically first-wins, over-limit collection entries and optional fields are dropped, and documents over 128 MiB are rejected rather than migrated or silently truncated.
- The generic durable reader only gains an optional limit. Existing consumers retain their current behavior unless they opt in.

## Acceptance criteria and validation

The regression tests were first run twice against the unmodified implementation. Both runs failed on the reported symptoms: no delete alert, no refresh alert plus an unhandled rejection, all 66 Providers retained, oversized Provider fields/catalogs retained, and an oversized durable read proceeding to `readFile`.

All commands below ran after the last material edit:

- Provider delete and refresh feedback -> `npx vitest run src/renderer/src/pages/settings/ProvidersPanel.race.test.tsx src/renderer/src/pages/settings/SettingsPage.render.test.tsx` -> passed as part of 161 focused tests.
- Settings byte, collection, duplicate-ID, and field limits -> `npx vitest run src/main/settings/document-store.test.ts src/main/storage/durable-json-file.test.ts src/main/settings/record-codec.test.ts src/main/settings/document-codec.test.ts` -> passed as part of 161 focused tests.
- Settings Provider owner/contracts/consumers -> exact test list emitted by `test:module settings_provider_accounts` -> 22 files, 438 tests passed.
- Settings Repository owner/contracts/consumers -> exact test list emitted by `test:module settings_repository` -> 20 files, 744 tests passed.
- Renderer translations -> `npx vitest run src/renderer/src/i18n/resources.test.ts` -> 805 tests passed.
- Main process types -> `npm run typecheck:node` -> passed.
- Renderer/Web types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.
- Exact-head impact explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> selected full mode because `settings-resource-limits.ts` has no declared module owner; the full local suite was intentionally not run per maintainer direction and remains covered by PR CI.

The two module wrappers themselves stopped at their worktree-local Prisma preflight. The exact emitted test files were run directly instead; tests that bind localhost were rerun outside the sandbox after the sandbox-only `listen EPERM` failure.

Uncovered local risk: Windows-specific file behavior and the complete portable suite are delegated to required PR CI.

## Review focus

- Whether 128 MiB leaves sufficient room for legitimate Provider catalogs while bounding corrupt Settings documents.
- Whether first-valid-record wins is the preferred recovery policy for duplicate historical Provider IDs.
- Whether the optional durable-reader limit preserves recovery semantics for existing consumers.
