### PR TITLE
fix(settings): reject provider request redirects

### DIFF
--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -18,6 +18,7 @@ import {
   providerRequestFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
+import { fetchProviderRequest } from './provider-fetch'
 
 const ALLOWED_PATHS = new Set(['/v1/messages', '/v1/messages/count_tokens'])
 const HOP_BY_HOP_HEADERS = new Set([
@@ -206,13 +207,16 @@ export class AnthropicProviderBridge {
     if (!baseUrl) throw new Error('The Anthropic provider target has no valid base URL.')
     let upstream: Response
     try {
-      upstream = await this.fetchImpl(`${baseUrl}${requestUrl.pathname}${requestUrl.search}`, {
-        method: 'POST',
-        headers: headersToForward,
-        body,
-        redirect: 'manual',
-        signal: request.signal
-      })
+      upstream = await fetchProviderRequest(
+        this.fetchImpl,
+        `${baseUrl}${requestUrl.pathname}${requestUrl.search}`,
+        {
+          method: 'POST',
+          headers: headersToForward,
+          body,
+          signal: request.signal
+        }
+      )
     } catch (error) {
       const origin = upstreamOrigin(baseUrl)
       this.diagnostics.error('anthropic provider request failed', {

--- a/src/main/settings/authenticated-provider-redirects.test.ts
+++ b/src/main/settings/authenticated-provider-redirects.test.ts
@@ -1,0 +1,192 @@
+import { createServer, type IncomingMessage, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { describe, expect, it } from 'vitest'
+
+import { listProviderModels } from './list-models'
+import { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
+import { ResponsesBridge } from './responses-bridge'
+import { validateProvider } from './validate'
+
+type CapturedRequest = Readonly<{
+  authorization?: string
+  apiKey?: string
+  path?: string
+}>
+
+const listen = async (server: Server): Promise<string> => {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address() as AddressInfo
+  return `http://127.0.0.1:${address.port}`
+}
+
+const close = async (server: Server): Promise<void> => {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  )
+}
+
+const capture = (request: IncomingMessage): CapturedRequest => ({
+  authorization: request.headers.authorization,
+  apiKey:
+    typeof request.headers['x-api-key'] === 'string' ? request.headers['x-api-key'] : undefined,
+  path: request.url
+})
+
+describe('authenticated provider redirect policy', () => {
+  it('does not follow a same-origin redirect during provider validation', async () => {
+    const redirected: CapturedRequest[] = []
+    const server = createServer((request, response) => {
+      request.resume()
+      if (request.url === '/v1/messages') {
+        response.writeHead(307, { location: '/redirected-validation' })
+        response.end()
+        return
+      }
+      redirected.push(capture(request))
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          usage: { input_tokens: 1, output_tokens: 1 }
+        })
+      )
+    })
+
+    const baseUrl = await listen(server)
+    try {
+      const result = await validateProvider({
+        type: 'custom',
+        baseUrl,
+        model: 'model-a',
+        key: 'validation-secret'
+      })
+
+      expect(redirected).toEqual([])
+      expect(result).toMatchObject({ ok: false, status: 307 })
+    } finally {
+      await close(server)
+    }
+  })
+
+  it('does not propagate model-list credentials across origins', async () => {
+    const redirected: CapturedRequest[] = []
+    const sink = createServer((request, response) => {
+      request.resume()
+      redirected.push(capture(request))
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ data: [{ id: 'redirected-model' }] }))
+    })
+    const sinkUrl = await listen(sink)
+    const source = createServer((request, response) => {
+      request.resume()
+      response.writeHead(307, { location: `${sinkUrl}/redirected-models` })
+      response.end()
+    })
+    const sourceUrl = await listen(source)
+
+    try {
+      const result = await listProviderModels({
+        url: `${sourceUrl}/v1/models`,
+        key: 'model-list-secret'
+      })
+
+      expect(redirected).toEqual([])
+      expect(result).toMatchObject({ ok: false, status: 307 })
+    } finally {
+      await Promise.all([close(source), close(sink)])
+    }
+  })
+
+  it('does not follow a same-origin redirect in the Responses bridge', async () => {
+    const redirected: CapturedRequest[] = []
+    const upstream = createServer((request, response) => {
+      request.resume()
+      if (request.url === '/v1/chat/completions') {
+        response.writeHead(307, { location: '/redirected-chat-completions' })
+        response.end()
+        return
+      }
+      redirected.push(capture(request))
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }))
+    })
+    const upstreamUrl = await listen(upstream)
+    const bridge = new ResponsesBridge({
+      baseUrl: `${upstreamUrl}/v1`,
+      key: 'responses-bridge-secret',
+      model: 'model-a'
+    })
+    const connection = await bridge.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'model-a', input: 'hello', stream: false }),
+        redirect: 'manual'
+      })
+
+      expect(redirected).toEqual([])
+      expect(response.status).toBe(307)
+    } finally {
+      await bridge.close()
+      await close(upstream)
+    }
+  })
+
+  it('does not follow a same-origin redirect in native Responses compatibility', async () => {
+    const redirected: CapturedRequest[] = []
+    const upstream = createServer((request, response) => {
+      request.resume()
+      if (request.url === '/v1/responses') {
+        response.writeHead(307, { location: '/redirected-responses' })
+        response.end()
+        return
+      }
+      redirected.push(capture(request))
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(
+        JSON.stringify({
+          id: 'response-a',
+          output: [],
+          usage: { input_tokens: 1, output_tokens: 1 }
+        })
+      )
+    })
+    const upstreamUrl = await listen(upstream)
+    const proxy = new NativeResponsesCompatibilityProxy({
+      baseUrl: `${upstreamUrl}/v1`,
+      key: 'native-responses-secret',
+      model: 'model-a'
+    })
+    const connection = await proxy.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'model-a', input: 'hello', stream: false }),
+        redirect: 'manual'
+      })
+
+      expect(redirected).toEqual([])
+      expect(response.status).toBe(307)
+    } finally {
+      await proxy.close()
+      await close(upstream)
+    }
+  })
+})

--- a/src/main/settings/chat-provider-compatibility.ts
+++ b/src/main/settings/chat-provider-compatibility.ts
@@ -6,6 +6,7 @@ import {
   writeProviderLoopbackJson as json,
   type ProviderLoopbackHttpRequest
 } from './provider-loopback-http-host'
+import { fetchProviderRequest } from './provider-fetch'
 import { chatToResponses, responsesToChat } from './xai-protocol'
 
 type Json = Record<string, unknown>
@@ -276,11 +277,10 @@ export class ChatProviderCompatibilityBridge {
     const headers: Record<string, string> = { 'content-type': 'application/json' }
     if (this.target.key) headers.authorization = `Bearer ${this.target.key}`
     if (this.target.wire === 'anthropic') headers['anthropic-version'] = '2023-06-01'
-    const upstream = await this.fetchImpl(this.target.endpoint, {
+    const upstream = await fetchProviderRequest(this.fetchImpl, this.target.endpoint, {
       method: 'POST',
       headers,
       body: JSON.stringify(upstreamBody),
-      redirect: 'manual',
       signal: request.signal
     })
     const payload = (await upstream.json()) as Json

--- a/src/main/settings/chat-skill-selector.ts
+++ b/src/main/settings/chat-skill-selector.ts
@@ -3,6 +3,7 @@ import { createLogger } from '../logger'
 import type { OfficialVendorId } from '../../shared/provider-registry'
 import type { CustomReasoningEffortTransport } from '../../shared/reasoning-effort'
 import { normalizeOpenAiChatModelStepUsage } from './openai-chat-usage'
+import { fetchProviderRequest } from './provider-fetch'
 import { resolveChatReasoningTransport } from './reasoning-transport'
 import {
   boundedSkillSelectorCatalog,
@@ -79,7 +80,7 @@ export async function selectChatSkills(input: {
       target.reasoningEffortTransport
     )
     const request = (withTool: boolean): Promise<Response> =>
-      fetchImpl(target.url, {
+      fetchProviderRequest(fetchImpl, target.url, {
         method: 'POST',
         headers: {
           'content-type': 'application/json',

--- a/src/main/settings/list-models.test.ts
+++ b/src/main/settings/list-models.test.ts
@@ -26,7 +26,7 @@ describe('listProviderModels', () => {
       )
 
     const result = await listProviderModels(
-      { url: 'https://api.deepseek.com/v1/models', key: 'sk-1' },
+      { url: 'https://api.deepseek.com/v1/models', vendorId: 'deepseek', key: 'sk-1' },
       { fetchImpl: fetchImpl as unknown as typeof fetch }
     )
 
@@ -34,7 +34,22 @@ describe('listProviderModels', () => {
     const [url, init] = fetchImpl.mock.calls[0]
     expect(url).toBe('https://api.deepseek.com/v1/models')
     expect((init.headers as Record<string, string>).authorization).toBe('Bearer sk-1')
-    expect((init.headers as Record<string, string>)['x-api-key']).toBe('sk-1')
+    expect((init.headers as Record<string, string>)['x-api-key']).toBeUndefined()
+  })
+
+  it('uses only x-api-key for the Anthropic model catalog', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(Response.json({ data: [{ id: 'claude-opus-5' }] }))
+
+    await expect(
+      listProviderModels(
+        { url: 'https://api.anthropic.com/v1/models', vendorId: 'anthropic', key: 'sk-ant-1' },
+        { fetchImpl: fetchImpl as unknown as typeof fetch }
+      )
+    ).resolves.toMatchObject({ ok: true })
+
+    const headers = fetchImpl.mock.calls[0][1].headers as Record<string, string>
+    expect(headers.authorization).toBeUndefined()
+    expect(headers['x-api-key']).toBe('sk-ant-1')
   })
 
   it('reports a non-2xx status without throwing', async () => {

--- a/src/main/settings/list-models.ts
+++ b/src/main/settings/list-models.ts
@@ -1,6 +1,8 @@
 import { ANTHROPIC_VERSION } from './validate'
 import { readBoundedResponseText } from './bounded-response'
 import { PROVIDER_RESOURCE_LIMITS } from './provider-resource-limits'
+import type { OfficialVendorId } from '../../shared/provider-registry'
+import { fetchProviderRequest } from './provider-fetch'
 
 // Fetches a provider's live model list from its dedicated model-list URL (from the registry). Both the
 // Anthropic and OpenAI model-list shapes are `{ data: [{ id }] }`, so one parser covers the compatible
@@ -19,7 +21,7 @@ export type ListModelsResult = {
 export type ListModelsTarget = {
   // Full model-list endpoint URL (e.g. https://api.deepseek.com/v1/models).
   url: string
-  // Plaintext key; sent as both bearer and x-api-key so either auth scheme is satisfied.
+  vendorId?: OfficialVendorId
   key?: string
 }
 
@@ -43,9 +45,8 @@ export const parseModelIds = (body: unknown): string[] => {
     .filter((id): id is string => typeof id === 'string' && id !== '')
 }
 
-// Requests the model catalog from a vendor's model-list URL. Sends both bearer and x-api-key auth so
-// it works against gateways that expect either. Returns ok=false (never throws) so the caller can fall
-// back to the bundled catalog and surface a message.
+// Requests the model catalog from a vendor's model-list URL. Returns ok=false (never throws) so the
+// caller can fall back to the bundled catalog and surface a message.
 export const listProviderModels = async (
   target: ListModelsTarget,
   { fetchImpl = fetch, timeoutMs = DEFAULT_LIST_TIMEOUT_MS }: ListModelsDeps = {}
@@ -61,15 +62,19 @@ export const listProviderModels = async (
   const headers: Record<string, string> = { 'anthropic-version': ANTHROPIC_VERSION }
 
   if (target.key) {
-    headers.authorization = `Bearer ${target.key}`
-    headers['x-api-key'] = target.key
+    if (target.vendorId === 'anthropic') headers['x-api-key'] = target.key
+    else headers.authorization = `Bearer ${target.key}`
   }
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
 
   try {
-    const response = await fetchImpl(url, { method: 'GET', headers, signal: controller.signal })
+    const response = await fetchProviderRequest(fetchImpl, url, {
+      method: 'GET',
+      headers,
+      signal: controller.signal
+    })
 
     if (response.status < 200 || response.status >= 300) {
       return {

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -30,6 +30,7 @@ import {
   providerRequestFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
+import { fetchProviderRequest } from './provider-fetch'
 import { normalizeOpenAiChatModelStepUsage } from './openai-chat-usage'
 
 // Responses payloads are intentionally open-ended across providers. Keep the compatibility boundary
@@ -594,7 +595,8 @@ export class NativeResponsesCompatibilityProxy {
     timer.unref?.()
     try {
       const resolvedKey = this.target.resolveKey ? await this.target.resolveKey() : this.target.key
-      const response = await this.fetchImpl(responsesUrl(this.target.baseUrl), {
+      const url = responsesUrl(this.target.baseUrl)
+      const response = await fetchProviderRequest(this.fetchImpl, url, {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
@@ -890,7 +892,7 @@ export class NativeResponsesCompatibilityProxy {
         this.options.responseHeaderTimeoutMs ?? DEFAULT_RESPONSE_HEADER_TIMEOUT_MS,
         'Native Responses upstream did not return response headers in time.'
       )
-      let upstream = await this.fetchImpl(responsesUrl(this.target.baseUrl), {
+      let upstream = await fetchProviderRequest(this.fetchImpl, responsesUrl(this.target.baseUrl), {
         method: 'POST',
         headers: headersToForward,
         body: upstreamRequestBody,
@@ -898,7 +900,7 @@ export class NativeResponsesCompatibilityProxy {
       })
       if (upstream.status === 401 && this.target.resolveKey) {
         const refreshedKey = await this.target.resolveKey(true)
-        upstream = await this.fetchImpl(responsesUrl(this.target.baseUrl), {
+        upstream = await fetchProviderRequest(this.fetchImpl, responsesUrl(this.target.baseUrl), {
           method: 'POST',
           headers: upstreamHeaders(request, refreshedKey),
           body: upstreamRequestBody,

--- a/src/main/settings/openai-provider-bridge.ts
+++ b/src/main/settings/openai-provider-bridge.ts
@@ -16,6 +16,7 @@ import {
   providerRequestFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
+import { fetchProviderRequest } from './provider-fetch'
 
 const WIRE_PATH = {
   'chat-completions': '/v1/chat/completions',
@@ -191,11 +192,10 @@ export class OpenAiProviderBridge {
       return
     }
 
-    const upstream = await this.fetchImpl(endpoint, {
+    const upstream = await fetchProviderRequest(this.fetchImpl, endpoint, {
       method: 'POST',
       headers: headersToForward,
       body,
-      redirect: 'manual',
       signal: request.signal
     })
     const headers = responseHeaders(upstream.headers)

--- a/src/main/settings/provider-fetch.ts
+++ b/src/main/settings/provider-fetch.ts
@@ -1,0 +1,7 @@
+// Provider requests carry credentials in headers or bodies. Keep redirects manual so fetch never
+// forwards those credentials to an endpoint that was not selected by the provider configuration.
+export const fetchProviderRequest = (
+  fetchImpl: typeof fetch,
+  input: string | URL | Request,
+  init?: RequestInit
+): Promise<Response> => fetchImpl(input, { ...init, redirect: 'manual' })

--- a/src/main/settings/provider-model-catalog-owner.ts
+++ b/src/main/settings/provider-model-catalog-owner.ts
@@ -49,7 +49,11 @@ export class ProviderModelCatalogOwner {
       }
     }
     const result = await listProviderModels(
-      { url: modelsUrl, key },
+      {
+        url: modelsUrl,
+        key,
+        ...(stored.type === 'official' && stored.vendorId ? { vendorId: stored.vendorId } : {})
+      },
       { fetchImpl: netFetchStandard }
     )
     if (!result.ok || !result.models) {

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -32,6 +32,7 @@ import {
   providerRequestFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
+import { fetchProviderRequest } from './provider-fetch'
 import type { SkillSelectorUsageObservation } from '../agent-framework'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
@@ -453,7 +454,7 @@ export class ResponsesBridge {
       })
       return
     }
-    const upstream = await this.fetchImpl(chatUrl(this.target.baseUrl), {
+    const upstream = await fetchProviderRequest(this.fetchImpl, chatUrl(this.target.baseUrl), {
       method: 'POST',
       headers,
       body: chatRequestBody,

--- a/src/main/settings/validate.ts
+++ b/src/main/settings/validate.ts
@@ -17,6 +17,7 @@ import { normalizeResponsesBaseUrl } from '../agent-framework/codex'
 import { ResponseBodyLimitError, readBoundedResponseText } from './bounded-response'
 import { PROVIDER_RESOURCE_LIMITS } from './provider-resource-limits'
 import { toErrorMessage } from '../error-message'
+import { fetchProviderRequest } from './provider-fetch'
 
 // Runs a real connectivity/auth probe for a provider and classifies the outcome into an actionable
 // category. Request construction and classification are pure so the branch matrix is unit-testable;
@@ -685,7 +686,7 @@ const validateCustomProvider = async (
   const timer = setTimeout(() => controller.abort(), timeoutMs)
 
   try {
-    const response = await fetchImpl(request.url, {
+    const response = await fetchProviderRequest(fetchImpl, request.url, {
       method: 'POST',
       headers: request.headers,
       body: request.body,

--- a/src/main/settings/xai-oauth-provider-bridge.ts
+++ b/src/main/settings/xai-oauth-provider-bridge.ts
@@ -8,6 +8,7 @@ import {
   writeProviderLoopbackJson as json,
   type ProviderLoopbackHttpRequest
 } from './provider-loopback-http-host'
+import { fetchProviderRequest } from './provider-fetch'
 import {
   anthropicToResponses,
   chatToResponses,
@@ -221,11 +222,10 @@ export class XaiOAuthProviderBridge {
     forceRefresh: boolean
   ): Promise<Response> {
     const token = await this.getAccessToken(forceRefresh)
-    return this.fetchImpl('https://api.x.ai/v1/responses', {
+    return fetchProviderRequest(this.fetchImpl, 'https://api.x.ai/v1/responses', {
       method: 'POST',
       headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
       body: JSON.stringify(body),
-      redirect: 'manual',
       signal: request.signal
     })
   }


### PR DESCRIPTION
## Problem

Authenticated provider validation, model-catalog, Responses bridge, and native Responses requests used fetch's default redirect behavior while sibling bridges used `redirect: 'manual'`. A redirect could therefore replay a request to an unapproved path. The baseline regression test demonstrated Bearer credentials reaching same-origin redirect targets and the custom `x-api-key` header reaching a cross-origin target.

The model-catalog request also sent the same credential in both `Authorization` and `x-api-key`, regardless of the vendor's required authentication scheme.

## Proposed change

- Route provider API fetches through one `fetchProviderRequest` boundary that always uses manual redirect handling.
- Stop on every 3xx response; no redirect destination is currently allowlisted.
- Send only `x-api-key` to Anthropic's model catalog and only Bearer authentication to the other current model-catalog vendors.
- Add real loopback HTTP regression coverage for all four reported request paths.

## Scope and non-goals

- No persisted-data, migration, state-enum, or renderer-interaction changes.
- `vendorId` is added only to the in-memory model-list request target so the request can select the correct header.
- No redirect allowlist is added because no current provider flow requires redirects.
- OAuth discovery/login and unauthenticated connectivity probes are outside this Provider API request boundary.

## Acceptance criteria and validation

The listed checks ran after the last material edit.

- Redirect refusal and credential non-propagation -> `vitest run src/main/settings/authenticated-provider-redirects.test.ts ...` -> 11 passed files, 1 conditionally skipped; 227 passed tests, 4 skipped.
- Provider validation and model-catalog auth selection -> the same targeted Vitest run includes `validate.test.ts`, `list-models.test.ts`, and `provider-accounts.test.ts` -> passed.
- Provider bridge owners and transport consumer -> the same targeted Vitest run includes all bridge suites, `responses-bridge.integration.test.ts`, and `provider-transport-owner.test.ts` -> passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Changed-file lint -> ESLint with the repository config over all 13 changed files -> passed.
- Whitespace/patch integrity -> `git diff --check` -> passed.

The affected-test explainer selected the full CI plan because the new regression test is not yet assigned to a module in `module-impact.json`. Per task scope, the complete local `npm test` suite was not run; PR CI is the final validation authority.

## Review focus

- Whether the Provider API boundary includes every credential-bearing bridge request without absorbing unrelated network traffic.
- Whether Anthropic-only `x-api-key` selection matches the current live model-catalog endpoints.
- Whether returning the original 3xx status provides sufficient diagnostics while guaranteeing no follow-up request.
