### PR TITLE
fix(notebook): allow automatic package mirrors

### DIFF
--- a/src/main/notebook/mirror-probe.test.ts
+++ b/src/main/notebook/mirror-probe.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+  buildNotebookNetworkPolicy,
+  domainPatternMatches
+} from '../../shared/notebook-network'
+import {
+  MIRROR_CANDIDATES,
   effectiveMirrorAsync,
   type MirrorCandidate,
   pickFastestMirror,
@@ -49,6 +55,28 @@ const probeFrom =
 afterEach(() => resetAutoMirrorCache())
 
 describe('pickFastestMirror', () => {
+  it('keeps every automatic package mirror reachable through the default network policy', () => {
+    const policy = buildNotebookNetworkPolicy(DEFAULT_NOTEBOOK_NETWORK_SETTINGS)
+    const automaticMirrorHosts = MIRROR_CANDIDATES.flatMap((candidate) =>
+      [
+        candidate.probeUrl,
+        candidate.biocondaProbeUrl,
+        candidate.mirror.condaChannel,
+        candidate.mirror.pypiIndex,
+        candidate.mirror.cranMirror
+      ]
+        .filter((url): url is string => Boolean(url))
+        .map((url) => new URL(url).hostname)
+    )
+
+    expect(
+      automaticMirrorHosts.filter(
+        (hostname) =>
+          !policy.allowedDomains.some((pattern) => domainPatternMatches(pattern, hostname))
+      )
+    ).toEqual([])
+  })
+
   it('returns the fastest candidate whose conda-forge and bioconda channels respond', async () => {
     const result = await pickFastestMirror({
       candidates,

--- a/src/main/notebook/mirror-probe.ts
+++ b/src/main/notebook/mirror-probe.ts
@@ -1,55 +1,15 @@
-import type { PackageMirror } from '../../shared/mirror'
+import {
+  AUTOMATIC_PACKAGE_MIRROR_CANDIDATES,
+  type AutomaticPackageMirrorCandidate,
+  type PackageMirror
+} from '../../shared/mirror'
 import { netFetchStandard } from '../skills/net-fetch'
-import { CURATED_MIRRORS, effectiveMirror } from './mirror'
+import { effectiveMirror } from './mirror'
 
 // A candidate mirror bundle + cheap URLs to measure both required conda channels. Public endpoints
 // only (no secrets). The repodata URLs are HEAD-ed so no body is downloaded.
-export type MirrorCandidate = {
-  name: string
-  mirror: PackageMirror
-  probeUrl: string
-  biocondaProbeUrl: string
-}
-
-const condaRepodata = (base: string): string =>
-  `${base}anaconda/cloud/conda-forge/noarch/repodata.json`
-const biocondaRepodata = (base: string): string =>
-  `${base}anaconda/cloud/bioconda/noarch/repodata.json`
-
-export const MIRROR_CANDIDATES: MirrorCandidate[] = [
-  {
-    name: 'public',
-    mirror: {},
-    probeUrl: 'https://conda.anaconda.org/conda-forge/noarch/repodata.json',
-    biocondaProbeUrl: 'https://conda.anaconda.org/bioconda/noarch/repodata.json'
-  },
-  {
-    name: 'tuna',
-    mirror: { ...CURATED_MIRRORS.cn },
-    probeUrl: condaRepodata('https://mirrors.tuna.tsinghua.edu.cn/'),
-    biocondaProbeUrl: biocondaRepodata('https://mirrors.tuna.tsinghua.edu.cn/')
-  },
-  {
-    name: 'ustc',
-    mirror: {
-      condaChannel: 'https://mirrors.ustc.edu.cn/anaconda/cloud/conda-forge/',
-      pypiIndex: 'https://mirrors.ustc.edu.cn/pypi/web/simple',
-      cranMirror: 'https://mirrors.ustc.edu.cn/CRAN/'
-    },
-    probeUrl: condaRepodata('https://mirrors.ustc.edu.cn/'),
-    biocondaProbeUrl: biocondaRepodata('https://mirrors.ustc.edu.cn/')
-  },
-  {
-    name: 'aliyun',
-    mirror: {
-      condaChannel: 'https://mirrors.aliyun.com/anaconda/cloud/conda-forge/',
-      pypiIndex: 'https://mirrors.aliyun.com/pypi/simple',
-      cranMirror: 'https://mirrors.aliyun.com/CRAN/'
-    },
-    probeUrl: condaRepodata('https://mirrors.aliyun.com/'),
-    biocondaProbeUrl: biocondaRepodata('https://mirrors.aliyun.com/')
-  }
-]
+export type MirrorCandidate = AutomaticPackageMirrorCandidate
+export const MIRROR_CANDIDATES = AUTOMATIC_PACKAGE_MIRROR_CANDIDATES
 
 // Measures one URL's latency (ms), rejecting on error/timeout. Injectable so the selection logic is
 // testable without network.

--- a/src/main/notebook/mirror.ts
+++ b/src/main/notebook/mirror.ts
@@ -1,16 +1,6 @@
-import type { PackageMirror } from '../../shared/mirror'
+import { CURATED_MIRRORS, type PackageMirror } from '../../shared/mirror'
 
-export { MIRROR_HELP_URL } from '../../shared/mirror'
-
-// Curated public mirror table (region-auto default, D10). Centralized here rather than scattered so
-// it is easy to audit and later move to a build var. Public endpoints only — no secrets.
-export const CURATED_MIRRORS = {
-  cn: {
-    condaChannel: 'https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge/',
-    pypiIndex: 'https://pypi.tuna.tsinghua.edu.cn/simple',
-    cranMirror: 'https://mirrors.tuna.tsinghua.edu.cn/CRAN/'
-  }
-} as const
+export { CURATED_MIRRORS, MIRROR_HELP_URL } from '../../shared/mirror'
 
 // Cheap locale heuristic: a Chinese locale gets the CN mirror default; everyone else uses public
 // hosts (empty overrides). A more precise speed-based pick is future work (spec §9, §16).

--- a/src/shared/mirror.ts
+++ b/src/shared/mirror.ts
@@ -9,6 +9,79 @@ export type PackageMirror = {
   caBundle?: string
 }
 
+export type AutomaticPackageMirrorCandidate = Readonly<{
+  name: string
+  mirror: PackageMirror
+  probeUrl: string
+  biocondaProbeUrl: string
+}>
+
+const condaRepodata = (base: string): string =>
+  `${base}anaconda/cloud/conda-forge/noarch/repodata.json`
+const biocondaRepodata = (base: string): string =>
+  `${base}anaconda/cloud/bioconda/noarch/repodata.json`
+
+export const CURATED_MIRRORS = {
+  cn: {
+    condaChannel: 'https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge/',
+    pypiIndex: 'https://pypi.tuna.tsinghua.edu.cn/simple',
+    cranMirror: 'https://mirrors.tuna.tsinghua.edu.cn/CRAN/'
+  }
+} as const
+
+// This catalog is the source of truth for mirrors selected without an explicit user setting.
+// Notebook network policy derives its trusted package-registry hosts from the same URLs.
+export const AUTOMATIC_PACKAGE_MIRROR_CANDIDATES: readonly AutomaticPackageMirrorCandidate[] = [
+  {
+    name: 'public',
+    mirror: {},
+    probeUrl: 'https://conda.anaconda.org/conda-forge/noarch/repodata.json',
+    biocondaProbeUrl: 'https://conda.anaconda.org/bioconda/noarch/repodata.json'
+  },
+  {
+    name: 'tuna',
+    mirror: { ...CURATED_MIRRORS.cn },
+    probeUrl: condaRepodata('https://mirrors.tuna.tsinghua.edu.cn/'),
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.tuna.tsinghua.edu.cn/')
+  },
+  {
+    name: 'ustc',
+    mirror: {
+      condaChannel: 'https://mirrors.ustc.edu.cn/anaconda/cloud/conda-forge/',
+      pypiIndex: 'https://mirrors.ustc.edu.cn/pypi/web/simple',
+      cranMirror: 'https://mirrors.ustc.edu.cn/CRAN/'
+    },
+    probeUrl: condaRepodata('https://mirrors.ustc.edu.cn/'),
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.ustc.edu.cn/')
+  },
+  {
+    name: 'aliyun',
+    mirror: {
+      condaChannel: 'https://mirrors.aliyun.com/anaconda/cloud/conda-forge/',
+      pypiIndex: 'https://mirrors.aliyun.com/pypi/simple',
+      cranMirror: 'https://mirrors.aliyun.com/CRAN/'
+    },
+    probeUrl: condaRepodata('https://mirrors.aliyun.com/'),
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.aliyun.com/')
+  }
+]
+
+export const AUTOMATIC_PACKAGE_MIRROR_DOMAINS = [
+  ...new Set(
+    AUTOMATIC_PACKAGE_MIRROR_CANDIDATES.flatMap((candidate) =>
+      [
+        candidate.probeUrl,
+        candidate.biocondaProbeUrl,
+        candidate.mirror.condaChannel,
+        candidate.mirror.pypiIndex,
+        candidate.mirror.cranMirror
+      ]
+        .filter((url): url is string => Boolean(url))
+        .map((url) => new URL(url).hostname)
+    )
+  )
+]
+
 // "View available mirrors" help link target: the TUNA Anaconda mirror help page, which lists the
 // real conda channel mirror source addresses (…/anaconda/cloud/conda-forge/ etc.) plus the matching
 // pip/CRAN mirrors — consistent with the CN region default in main/notebook/mirror.ts. Lives in

--- a/src/shared/notebook-network.ts
+++ b/src/shared/notebook-network.ts
@@ -69,6 +69,7 @@ export const OPEN_SCIENCE_DOMAIN_GROUPS: readonly OpenScienceDomainGroup[] = Obj
       'anaconda.org',
       '*.anaconda.org',
       '*.conda.io',
+      ...AUTOMATIC_PACKAGE_MIRROR_DOMAINS,
       'cran.r-project.org',
       'cloud.r-project.org',
       'bioconductor.org',
@@ -304,3 +305,4 @@ export const buildNotebookNetworkPolicy = (
     deniedDomainReasons: {}
   }
 }
+import { AUTOMATIC_PACKAGE_MIRROR_DOMAINS } from './mirror'


### PR DESCRIPTION
## Problem

Notebook package management can automatically select TUNA, USTC, or Aliyun mirrors, but the locked package-registry network policy allows only the public registry hosts. The sandbox therefore returns `OPEN_SCIENCE_NETWORK_DOMAIN_BLOCKED` for an application-selected mirror. The reported conda and pip failures are two manifestations of this same policy mismatch, not filesystem path denials.

## Proposed change

- Make the shared automatic mirror catalog the single source of truth for mirror selection and trusted package-registry hosts.
- Derive the locked package-registry network domains from every probe, conda, pip, and CRAN URL in that catalog.
- Add a regression test that requires every automatic mirror URL to match the default Notebook network policy.

## Scope and non-goals

- User-configured custom mirrors still require the existing network approval flow.
- No schema, persisted data, historical compatibility, new state or enum values, architecture boundary, or UI interaction changes.
- No dependency changes.

## Acceptance criteria and validation

Final checks ran after the last material edit:

- automatic mirror selection and policy reachability -> `npx vitest run src/main/notebook/mirror-probe.test.ts src/main/notebook/mirror.test.ts src/shared/notebook-network.test.ts` -> 26 passed
- main and sandbox TypeScript contracts -> `npm run typecheck:node` -> passed
- linted source -> `npm run lint` -> passed
- final diff hygiene -> `git diff --check` -> passed

The regression test was first run against the unfixed code and failed with the exact blocked TUNA hosts from the report, plus the equivalent USTC and Aliyun candidates. After deriving policy domains from the shared catalog it passes.

The affected-test planner falls back to the complete suite because these files do not have module ownership entries. Per task direction, the complete local `npm test` was not run; exact-head PR CI is the final authority for the portable and platform suites.

## Review focus

Confirm that every mirror selected from the application-owned automatic catalog is trusted as part of the locked registry group while arbitrary user-configured mirrors remain subject to explicit approval.