### PR TITLE
fix(notebook): align local RPC and working file contracts

### DIFF
--- a/src/main/notebook/local-rpc-server.delegated-work.test.ts
+++ b/src/main/notebook/local-rpc-server.delegated-work.test.ts
@@ -297,7 +297,8 @@ describe('authenticated delegatedWorkCall route', () => {
     })
     const call = async (
       params: Record<string, unknown>,
-      method = 'delegatedWorkCall'
+      method = 'delegatedWorkCall',
+      expectedStatus = 400
     ): Promise<unknown> => {
       const response = await fetch(connection.endpoint, {
         method: 'POST',
@@ -307,11 +308,11 @@ describe('authenticated delegatedWorkCall route', () => {
         },
         body: JSON.stringify({ method, params })
       })
-      expect(response.status).toBe(500)
+      expect(response.status).toBe(expectedStatus)
       return response.json()
     }
 
-    await expect(call({ value: 'done' }, 'delegatedOutputCall')).resolves.toEqual({
+    await expect(call({ value: 'done' }, 'delegatedOutputCall', 500)).resolves.toEqual({
       error: 'host.submit_output is not configured.'
     })
     await expect(
@@ -581,7 +582,7 @@ describe('authenticated delegatedWorkCall route', () => {
         })
       })
 
-      expect(response.status).toBe(500)
+      expect(response.status).toBe(400)
     }
 
     expect(readHostArtifactCatalog).not.toHaveBeenCalled()
@@ -718,7 +719,8 @@ describe('authenticated delegatedWorkCall route', () => {
           }
         })
       })
-      expect(response.status).toBe(500)
+      // A catalog integrity failure remains a server error, unlike a rejected caller-owned input.
+      expect(response.status).toBe(identity === 'collision' ? 500 : 403)
       if (identity === 'artifact-1') {
         await expect(response.json()).resolves.toEqual({
           error: expect.stringMatching(/version_id\/versionId.*not artifact_id.*omit inputs/i)
@@ -777,7 +779,7 @@ describe('authenticated delegatedWorkCall route', () => {
         body: JSON.stringify({ method: 'delegatedWorkCall', params: { request } })
       })
 
-      expect(response.status).toBe(500)
+      expect(response.status).toBe(400)
       await expect(response.json()).resolves.toEqual({ error })
     }
     expect(delegate).not.toHaveBeenCalled()
@@ -1089,7 +1091,7 @@ describe('authenticated delegatedWorkCall route', () => {
       })
     })
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({
       error:
         'delegate context was removed; include all goals, background, constraints, and deliverables in task and retry'

--- a/src/main/notebook/local-rpc-server.errors.test.ts
+++ b/src/main/notebook/local-rpc-server.errors.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { fetchLocalRpc } from '../local-rpc-transport'
+import { NotebookLocalRpcServer } from './local-rpc-server'
+import type { NotebookRpcConnection } from './mcp-server'
+
+let server: NotebookLocalRpcServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+const call = (connection: NotebookRpcConnection, body: unknown): Promise<Response> =>
+  fetchLocalRpc(
+    connection,
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${connection.token}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    },
+    'Notebook RPC error contract'
+  )
+
+describe.each(['tcp', 'pipe'] as const)('Notebook RPC error status over %s', (transport) => {
+  it.each(
+    [null, [], {}, { method: 42 }, { method: 'state', params: [] }].map((body) => ({ body }))
+  )('rejects malformed request envelopes: $body', async ({ body }) => {
+    const state = vi.fn()
+    server = new NotebookLocalRpcServer({ state } as never, { transport })
+    const connection = await server.ensureStarted()
+
+    expect((await call(connection, body)).status).toBe(400)
+    expect(state).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown methods independently of runtime params and capability scope', async () => {
+    server = new NotebookLocalRpcServer({} as never, { transport })
+    const connections = [
+      await server.ensureStarted(),
+      await server.issueSessionConnection('session', 'project', 'root-frame-session'),
+      await server.issueControlConnection('session', 'project', 'root-frame-session')
+    ]
+    for (const connection of connections) {
+      const response = await call(connection, { method: 'unknown' })
+      expect(response.status).toBe(404)
+      await expect(response.json()).resolves.toEqual({
+        error: 'Unknown notebook RPC method: unknown'
+      })
+    }
+  })
+
+  it('reports input-schema failures as 400 before calling the Memory owner', async () => {
+    const searchForAgent = vi.fn()
+    server = new NotebookLocalRpcServer({} as never, {
+      transport,
+      memoryService: {
+        searchForAgent,
+        listCategoriesForAgent: vi.fn(),
+        rememberForAgent: vi.fn()
+      }
+    })
+    const connection = await server.issueControlConnection(
+      'session',
+      'project',
+      'root-frame-session'
+    )
+    const response = await call(connection, { method: 'memorySearch', params: { query: 42 } })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining('query')
+    })
+    expect(searchForAgent).not.toHaveBeenCalled()
+  })
+
+  it('reports an unowned Notebook input lease as 403', async () => {
+    server = new NotebookLocalRpcServer({} as never, { transport })
+    const connection = await server.issueSessionConnection(
+      'session',
+      'project',
+      'root-frame-session'
+    )
+    const response = await call(connection, {
+      method: 'resolveNotebookInput',
+      params: {
+        inputRunLeaseId: 'stale-lease',
+        sourceKind: 'upload-version',
+        inputFileVersionId: 'version'
+      }
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Notebook input resolution requires an active run lease.'
+    })
+  })
+
+  it.each([
+    new Error('owner failed'),
+    new SyntaxError('internal JSON failed'),
+    z.string().safeParse(42).error!
+  ])('keeps unexpected owner errors at 500: %s', async (error) => {
+    const state = vi.fn().mockRejectedValue(error)
+    server = new NotebookLocalRpcServer({ state } as never, { transport })
+    const connection = await server.ensureStarted()
+    const response = await call(connection, {
+      method: 'state',
+      params: { sessionId: 'session', workspaceCwd: process.cwd() }
+    })
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: error.message })
+    expect(state).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/notebook/local-rpc-server.lineage.test.ts
+++ b/src/main/notebook/local-rpc-server.lineage.test.ts
@@ -88,14 +88,14 @@ describe('lineageCall RPC', () => {
         options: {},
         ...forged
       })
-      expect(attempt.response.status).toBe(500)
+      expect(attempt.response.status).toBe(400)
       expect(attempt.payload).toEqual({ error: 'host.lineage RPC params are invalid.' })
     }
 
     await expect(
       callLineage(control, control.token, { op: 'clear', version_id: 'version-1' })
     ).resolves.toMatchObject({
-      response: { status: 500 },
+      response: { status: 400 },
       payload: { error: 'Unknown host.lineage operation.' }
     })
   })

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -32,7 +32,7 @@ describe('mcpCall RPC', () => {
       body: JSON.stringify({ method: 'settingsCall', params: { workspaceCwd: process.cwd() } })
     })
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(404)
     await expect(response.json()).resolves.toEqual({
       error: 'Unknown notebook RPC method: settingsCall'
     })
@@ -161,7 +161,7 @@ describe('mcpCall RPC', () => {
       })
     })
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({
       error: 'mcpCall requires string server and method names.'
     })
@@ -554,7 +554,7 @@ describe('computeCall RPC', () => {
     expect(parsed.error_code).toBe('approval_denied')
   })
 
-  it('returns 500 for unknown op', async () => {
+  it('returns 400 for unknown op', async () => {
     const fakeCompute = { callCommand: async () => ({}) }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',
@@ -566,7 +566,7 @@ describe('computeCall RPC', () => {
       headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
       body: JSON.stringify({ method: 'computeCall', params: { op: 'unknown_op' } })
     })
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(400)
     const body = (await res.json()) as { error: string }
     expect(body.error).toMatch(/unknown computecall op/i)
   })
@@ -956,7 +956,7 @@ describe('computeCall RPC', () => {
     })
   })
 
-  it('returns 500 for unknown details mode', async () => {
+  it('returns 400 for unknown details mode', async () => {
     const fakeCompute = {
       callCommand: async () => ({}),
       list: async () => [],
@@ -977,7 +977,7 @@ describe('computeCall RPC', () => {
         params: { op: 'details', provider_id: 'ssh:biowulf', mode: 'zap' }
       })
     })
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(400)
     const body = (await res.json()) as { error: string }
     expect(body.error).toMatch(/unknown details mode/i)
   })

--- a/src/main/notebook/local-rpc-server.skill-import.test.ts
+++ b/src/main/notebook/local-rpc-server.skill-import.test.ts
@@ -95,7 +95,7 @@ describe('NotebookLocalRpcServer Skill import bridge', () => {
         }
       })
     })
-    expect(mixedSourceResponse.status).toBe(500)
+    expect(mixedSourceResponse.status).toBe(400)
     expect(request).toHaveBeenCalledOnce()
   })
 

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -452,6 +452,29 @@ describe('notebook local RPC server', () => {
     }
   })
 
+  it('reports malformed authenticated JSON as a bad request', async () => {
+    const server = new NotebookLocalRpcServer({} as never, {
+      transport: 'tcp',
+      token: 'secret-token'
+    })
+    const connection = await server.ensureStarted()
+
+    try {
+      const response = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer secret-token',
+          'content-type': 'application/json'
+        },
+        body: '{'
+      })
+
+      expect(response.status).toBe(400)
+    } finally {
+      await server.close()
+    }
+  })
+
   it('rejects an authenticated request body above the local RPC budget', async () => {
     const server = new NotebookLocalRpcServer({} as never, {
       transport: 'tcp',
@@ -587,7 +610,7 @@ describe('notebook local RPC server', () => {
       )
       await expect(
         call({ source: { path: 'plot.png' }, options: {}, projectId: 'forged' })
-      ).resolves.toMatchObject({ status: 500 })
+      ).resolves.toMatchObject({ status: 400 })
       release()
       connection.release()
       expect(discard).toHaveBeenCalledWith('run-1')
@@ -724,7 +747,7 @@ describe('notebook local RPC server', () => {
         'Notebook RPC request validation test'
       )
 
-      expect(response.status).toBe(500)
+      expect(response.status).toBe(400)
       await expect(response.json()).resolves.toEqual({
         error: expect.stringContaining('Invalid notebook RPC params for execute')
       })
@@ -2681,7 +2704,7 @@ describe('notebook local RPC server', () => {
         writeRequestChecksum: 'a'.repeat(64),
         filename: 'bypass.txt'
       })
-      expect(bypass.status).toBe(500)
+      expect(bypass.status).toBe(400)
       await expect(bypass.json()).resolves.toEqual({
         error: 'Artifact Version creation requires a write reservation.'
       })

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -334,11 +334,6 @@ type NotebookLocalRpcServerOptions = {
   }
 }
 
-type NotebookRpcPayload = {
-  method?: unknown
-  params?: unknown
-}
-
 type ArtifactRpcCapability = Omit<ArtifactRpcCapabilityBinding, 'allowedMethods'> & {
   allowedMethods: Set<ArtifactRpcMethod>
   expiresAt: number
@@ -421,6 +416,16 @@ class RpcHttpError extends Error {
   }
 }
 
+// Only wrap synchronous request parsers, never an owner/service call: an internal schema or JSON
+// failure must remain a server error rather than being blamed on the caller.
+const parseRpcParams = <Result>(parse: () => Result): Result => {
+  try {
+    return parse()
+  } catch (error) {
+    throw new RpcHttpError(400, error instanceof Error ? error.message : String(error))
+  }
+}
+
 const ARTIFACT_RPC_METHODS = new Set<ArtifactRpcMethod>([
   'artifactReserveWrite',
   'artifactReleaseWrite',
@@ -462,6 +467,16 @@ const DELEGATED_CONTROL_RPC_METHODS = new Set([
 ])
 const SKILL_IMPORT_RPC_METHODS = new Set(['skillImport'])
 const PLAN_RPC_METHODS = new Set(['planCall'])
+
+const RPC_METHODS = new Set<string>([
+  ...NOTEBOOK_LOCAL_RPC_METHODS,
+  ...CONTROL_RPC_METHODS,
+  ...ARTIFACT_RPC_METHODS,
+  ...SKILL_IMPORT_RPC_METHODS,
+  ...PLAN_RPC_METHODS,
+  'delegatedOutputCall',
+  'resolveNotebookInput'
+])
 
 const isArtifactRpcMethod = (method: string): method is ArtifactRpcMethod =>
   ARTIFACT_RPC_METHODS.has(method as ArtifactRpcMethod)
@@ -1000,8 +1015,8 @@ class NotebookLocalRpcServer {
     requestOrRequests: DurableDelegateRequest | readonly DurableDelegateRequest[],
     caller: AuthenticatedDelegateCaller
   ): Promise<DurableDelegateRequest | readonly DurableDelegateRequest[]> {
-    const requests = assertDelegateRequestShape(requestOrRequests)
-    assertDelegateInputShape(requests)
+    const requests = parseRpcParams(() => assertDelegateRequestShape(requestOrRequests))
+    parseRpcParams(() => assertDelegateInputShape(requests))
     const bareIdentityLookups = new Map<string, Promise<string>>()
     const canonicalizeBareIdentity = (identity: string): Promise<string> => {
       const pending = bareIdentityLookups.get(identity)
@@ -1021,7 +1036,7 @@ class NotebookLocalRpcServer {
           item.projectId !== caller.session.projectId ||
           item.sessionId !== caller.session.sessionId
         ) {
-          throw new Error(DELEGATION_INPUT_UNAVAILABLE_MESSAGE)
+          throw new RpcHttpError(403, DELEGATION_INPUT_UNAVAILABLE_MESSAGE)
         }
         return item.source === 'upload'
           ? createUploadVersionReference(item.versionId, {
@@ -1577,10 +1592,25 @@ class NotebookLocalRpcServer {
         writeJson(response, 401, { error: 'Invalid notebook RPC token.' })
         return
       }
-      const payload = await readBoundedJsonBody<NotebookRpcPayload>(request, this.requestBytes)
+      let payload: unknown
+      try {
+        payload = await readBoundedJsonBody(request, this.requestBytes)
+      } catch (error) {
+        if (error instanceof SyntaxError) throw new RpcHttpError(400, error.message)
+        throw error
+      }
       activeRequest.bodyComplete = true
-      const method = typeof payload.method === 'string' ? payload.method : ''
+      if (!isRecord(payload) || typeof payload.method !== 'string' || !payload.method.trim()) {
+        throw new RpcHttpError(400, 'Notebook RPC payload must include a non-empty method string.')
+      }
+      const method = payload.method
       activeRequest.method = method
+      if (!RPC_METHODS.has(method)) {
+        throw new RpcHttpError(404, `Unknown notebook RPC method: ${method}`)
+      }
+      if (payload.params !== undefined && !isRecord(payload.params)) {
+        throw new RpcHttpError(400, 'Notebook RPC params must be an object.')
+      }
       let params = isRecord(payload.params) ? payload.params : {}
       if (method === 'hostSdkHelp') delete params.view_image_available
       let hostCapabilities: HostCapabilityProjection | undefined
@@ -1627,7 +1657,7 @@ class NotebookLocalRpcServer {
                 ? new Set(['op', 'version_id', 'options'])
                 : new Set(['op', 'version_id'])
             if (Object.keys(params).some((key) => !allowedKeys.has(key))) {
-              throw new Error('host.lineage RPC params are invalid.')
+              throw new RpcHttpError(400, 'host.lineage RPC params are invalid.')
             }
           }
           if (method === 'framesCall' && !sessionBinding.isControl) {
@@ -1676,7 +1706,7 @@ class NotebookLocalRpcServer {
               throw new RpcHttpError(403, 'host.viewImage requires a trusted execution workspace.')
             }
             if (Object.keys(params).some((key) => key !== 'source' && key !== 'options')) {
-              throw new Error('host.viewImage RPC params are invalid.')
+              throw new RpcHttpError(400, 'host.viewImage RPC params are invalid.')
             }
           }
           if (
@@ -1964,10 +1994,10 @@ class NotebookLocalRpcServer {
     if (MEMORY_RPC_METHODS.has(method)) {
       if (!this.memoryService) throw new Error('Memory service is not configured.')
       if (typeof params.sessionId !== 'string') {
-        throw new Error('Memory RPC requires a trusted session binding.')
+        throw new RpcHttpError(403, 'Memory RPC requires a trusted session binding.')
       }
       if (typeof params.projectId !== 'string') {
-        throw new Error('Memory RPC requires a trusted project binding.')
+        throw new RpcHttpError(403, 'Memory RPC requires a trusted project binding.')
       }
       const context: MemoryAgentContext = {
         projectId: params.projectId,
@@ -1980,20 +2010,24 @@ class NotebookLocalRpcServer {
       }
       if (method === 'memorySearch') {
         return this.memoryService.searchForAgent(
-          memoryAgentSearchRequestSchema.parse({
-            query: params.query,
-            categoryIds: params.categoryIds,
-            limit: params.limit
-          }),
+          parseRpcParams(() =>
+            memoryAgentSearchRequestSchema.parse({
+              query: params.query,
+              categoryIds: params.categoryIds,
+              limit: params.limit
+            })
+          ),
           context
         )
       }
       return this.memoryService.rememberForAgent(
-        memoryAgentRememberRequestSchema.parse({
-          categoryId: params.categoryId,
-          content: params.content,
-          analysis: params.analysis
-        }),
+        parseRpcParams(() =>
+          memoryAgentRememberRequestSchema.parse({
+            categoryId: params.categoryId,
+            content: params.content,
+            analysis: params.analysis
+          })
+        ),
         context
       )
     }
@@ -2007,7 +2041,7 @@ class NotebookLocalRpcServer {
       }
       const request = params as CreateArtifactVersionRequest
       if (!request.resourceReservationId) {
-        throw new Error('Artifact Version creation requires a write reservation.')
+        throw new RpcHttpError(400, 'Artifact Version creation requires a write reservation.')
       }
       return this.artifactProvenance.createVersion(request, signal)
     }
@@ -2054,7 +2088,8 @@ class NotebookLocalRpcServer {
         typeof params.turnToken !== 'string' ||
         typeof params.attachmentUri !== 'string'
       ) {
-        throw new Error(
+        throw new RpcHttpError(
+          400,
           'Skill import RPC params must include sessionId and exactly one supported source.'
         )
       }
@@ -2073,7 +2108,7 @@ class NotebookLocalRpcServer {
         typeof params.sessionId !== 'string' ||
         !['generate', 'approve', 'reject', 'updateStepStatus'].includes(String(params.operation))
       ) {
-        throw new Error('Session Plan RPC params are invalid.')
+        throw new RpcHttpError(400, 'Session Plan RPC params are invalid.')
       }
       return this.planService.call({
         projectId: params.projectId,
@@ -2086,7 +2121,7 @@ class NotebookLocalRpcServer {
 
     if (method === 'requestUserInput') {
       const request = sanitizeAgentUserChoiceRequest(params)
-      if (!request) throw new Error('Invalid user choice request.')
+      if (!request) throw new RpcHttpError(400, 'Invalid user choice request.')
       if (params.caller_role === 'delegate') {
         if (!this.delegatedWorkService?.requestUserInput) {
           throw new Error('Delegated user input is not configured.')
@@ -2131,14 +2166,14 @@ class NotebookLocalRpcServer {
       const projectId = typeof params.projectId === 'string' ? params.projectId : ''
       const sessionId = typeof params.sessionId === 'string' ? params.sessionId : ''
       if (!projectId || !sessionId) {
-        throw new Error('Host Artifact reads require a session-bound Project scope.')
+        throw new RpcHttpError(403, 'Host Artifact reads require a session-bound Project scope.')
       }
       const context = { projectId, sessionId }
       if (params.op === 'list') return this.hostArtifacts.list(params.options, context)
       if (params.op === 'path') {
         return this.hostArtifacts.resolvePath(params.version_id, context)
       }
-      throw new Error('Unknown host Artifact operation.')
+      throw new RpcHttpError(400, 'Unknown host Artifact operation.')
     }
 
     if (method === 'lineageCall') {
@@ -2146,14 +2181,14 @@ class NotebookLocalRpcServer {
       const projectId = typeof params.projectId === 'string' ? params.projectId : ''
       const sessionId = typeof params.sessionId === 'string' ? params.sessionId : ''
       if (!projectId || !sessionId) {
-        throw new Error('Host Lineage reads require a session-bound Project scope.')
+        throw new RpcHttpError(403, 'Host Lineage reads require a session-bound Project scope.')
       }
       const context = { projectId, sessionId }
       if (params.op === 'graph') {
         return this.hostLineage.graph(params.version_id, params.options, context)
       }
       if (params.op === 'get') return this.hostLineage.get(params.version_id, context)
-      throw new Error('Unknown host.lineage operation.')
+      throw new RpcHttpError(400, 'Unknown host.lineage operation.')
     }
 
     if (method === 'framesCall') {
@@ -2161,12 +2196,12 @@ class NotebookLocalRpcServer {
       const projectId = typeof params.projectId === 'string' ? params.projectId : ''
       const sessionId = typeof params.sessionId === 'string' ? params.sessionId : ''
       if (!projectId || !sessionId) {
-        throw new Error('Host Frame reads require a session-bound Project scope.')
+        throw new RpcHttpError(403, 'Host Frame reads require a session-bound Project scope.')
       }
       const context = { projectId, sessionId }
       if (params.op === 'list') return this.hostFrames.list(params.options, context)
       if (params.op === 'get') return this.hostFrames.get(params.frame_id, params.options, context)
-      throw new Error('Unknown host Frame operation.')
+      throw new RpcHttpError(400, 'Unknown host Frame operation.')
     }
 
     if (method === 'sessionsCall') {
@@ -2174,12 +2209,15 @@ class NotebookLocalRpcServer {
       const projectId = typeof params.projectId === 'string' ? params.projectId : ''
       const sessionId = typeof params.sessionId === 'string' ? params.sessionId : ''
       if (!projectId || !sessionId) {
-        throw new Error('Host Session diagnostics require a session-bound Project scope.')
+        throw new RpcHttpError(
+          403,
+          'Host Session diagnostics require a session-bound Project scope.'
+        )
       }
       const context = { projectId, sessionId, callerRole: 'main' as const }
       if (params.op === 'list') return this.hostSessions.list(params.options, context)
       if (params.op === 'inspect') return this.hostSessions.inspect(params.session_id, context)
-      throw new Error('Unknown host Session operation.')
+      throw new RpcHttpError(400, 'Unknown host Session operation.')
     }
 
     if (method === 'llmCall') {
@@ -2249,19 +2287,20 @@ class NotebookLocalRpcServer {
         (sourceKind !== 'upload-version' && sourceKind !== 'artifact-version') ||
         typeof inputFileVersionId !== 'string'
       ) {
-        throw new Error(
+        throw new RpcHttpError(
+          400,
           'Notebook input resolution requires sessionId, inputRunLeaseId, sourceKind and inputFileVersionId.'
         )
       }
       const leases = this.activeInputRunLeases.get(sessionId)
       if (!leases || leases.size === 0) {
-        throw new Error('Notebook input resolution requires an active run lease.')
+        throw new RpcHttpError(403, 'Notebook input resolution requires an active run lease.')
       }
       const lease = [...leases].find(
         (candidate) => this.inputRunLeaseIds.get(candidate) === inputRunLeaseId
       )
       if (!lease) {
-        throw new Error('Notebook input resolution does not match an active run lease.')
+        throw new RpcHttpError(403, 'Notebook input resolution does not match an active run lease.')
       }
       const registered = lease
         .getRunInputFiles()
@@ -2270,7 +2309,10 @@ class NotebookLocalRpcServer {
             input.sourceKind === sourceKind && input.inputFileVersionId === inputFileVersionId
         )
       if (!registered) {
-        throw new Error(`Notebook input is not registered for this run: ${inputFileVersionId}`)
+        throw new RpcHttpError(
+          403,
+          `Notebook input is not registered for this run: ${inputFileVersionId}`
+        )
       }
       return {
         path: await lease.resolve({ sourceKind, inputFileVersionId })
@@ -2283,7 +2325,7 @@ class NotebookLocalRpcServer {
     if (method === 'mcpCall') {
       if (!this.connectorService) throw new Error('Connector service is not configured.')
       if (typeof params.server !== 'string' || typeof params.method !== 'string') {
-        throw new Error('mcpCall requires string server and method names.')
+        throw new RpcHttpError(400, 'mcpCall requires string server and method names.')
       }
       const server = params.server
       const toolMethod = params.method
@@ -2398,7 +2440,7 @@ class NotebookLocalRpcServer {
           })
           return { ok: true }
         }
-        throw new Error(`Unknown details mode: ${mode}`)
+        throw new RpcHttpError(400, `Unknown details mode: ${mode}`)
       }
 
       // op='download' — agent-initiated file download to session-cache (design.md §5).
@@ -2557,7 +2599,7 @@ class NotebookLocalRpcServer {
         return this.computeService.getSessionConcurrencyStatus(sessionId)
       }
 
-      throw new Error(`Unknown computeCall op: ${op}`)
+      throw new RpcHttpError(400, `Unknown computeCall op: ${op}`)
     }
 
     // agentsCall: host.agents control-plane SDK (issue 02). Routes operations to the AgentsService
@@ -2729,7 +2771,7 @@ class NotebookLocalRpcServer {
           params.frame_ids.length === 0 ||
           params.frame_ids.some((candidate) => typeof candidate !== 'string' || !candidate.trim())
         ) {
-          throw new Error('host.stop_child requires one or more frame ids.')
+          throw new RpcHttpError(400, 'host.stop_child requires one or more frame ids.')
         }
         return this.delegatedWorkService.stopChildren(caller, params.frame_ids as string[])
       }
@@ -2742,7 +2784,7 @@ class NotebookLocalRpcServer {
         const message = typeof params.message === 'string' ? params.message : ''
         const rawOptions = params.options === undefined ? {} : params.options
         if (!rawOptions || typeof rawOptions !== 'object' || Array.isArray(rawOptions)) {
-          throw new Error('host.send_frame_message options must be an object.')
+          throw new RpcHttpError(400, 'host.send_frame_message options must be an object.')
         }
         const messageOptions = rawOptions as Record<string, unknown>
         if (
@@ -2750,19 +2792,25 @@ class NotebookLocalRpcServer {
           messageOptions.kind !== 'info' &&
           messageOptions.kind !== 'question'
         )
-          throw new Error('host.send_frame_message kind must be info or question.')
+          throw new RpcHttpError(400, 'host.send_frame_message kind must be info or question.')
         if (
           messageOptions.request_id !== undefined &&
           typeof messageOptions.request_id !== 'string'
         )
-          throw new Error('host.send_frame_message request_id must be a string.')
+          throw new RpcHttpError(400, 'host.send_frame_message request_id must be a string.')
         if (
           messageOptions.reply_to_message_id !== undefined &&
           typeof messageOptions.reply_to_message_id !== 'string'
         )
-          throw new Error('host.send_frame_message reply_to_message_id must be a string.')
+          throw new RpcHttpError(
+            400,
+            'host.send_frame_message reply_to_message_id must be a string.'
+          )
         if (!target || !message.trim()) {
-          throw new Error('host.send_frame_message requires a target Frame and non-empty message.')
+          throw new RpcHttpError(
+            400,
+            'host.send_frame_message requires a target Frame and non-empty message.'
+          )
         }
         return this.delegatedWorkService.sendMessage(caller, target, message, {
           ...(messageOptions.kind ? { kind: messageOptions.kind as 'info' | 'question' } : {}),
@@ -2778,7 +2826,10 @@ class NotebookLocalRpcServer {
         const selector = typeof params.selector === 'string' ? params.selector : ''
         const rawOptions = params.options === undefined ? {} : params.options
         if (!selector || !rawOptions || typeof rawOptions !== 'object' || Array.isArray(rawOptions))
-          throw new Error('host.message_receipt requires a selector and options object.')
+          throw new RpcHttpError(
+            400,
+            'host.message_receipt requires a selector and options object.'
+          )
         const timeout = (rawOptions as Record<string, unknown>).timeout_seconds
         return this.delegatedWorkService.messageReceipt(
           caller,
@@ -2791,7 +2842,10 @@ class NotebookLocalRpcServer {
           throw new Error('host.resolve_message is unavailable.')
         const messageId = typeof params.message_id === 'string' ? params.message_id : ''
         if (!messageId || params.action !== 'acknowledge_uncertain')
-          throw new Error('host.resolve_message requires message_id and acknowledge_uncertain.')
+          throw new RpcHttpError(
+            400,
+            'host.resolve_message requires message_id and acknowledge_uncertain.'
+          )
         return this.delegatedWorkService.resolveMessage(caller, messageId, {
           action: 'acknowledge_uncertain'
         })
@@ -2801,10 +2855,12 @@ class NotebookLocalRpcServer {
           if (!this.delegatedWorkService.collect) {
             throw new Error('host.collect is not configured.')
           }
-          const call = parseCollectRpcCall({
-            selectors: params.selectors ?? params.frame_ids,
-            options: params.options
-          })
+          const call = parseRpcParams(() =>
+            parseCollectRpcCall({
+              selectors: params.selectors ?? params.frame_ids,
+              options: params.options
+            })
+          )
           return this.delegatedWorkService.collect(caller, call.selectors, call.options)
         }
         if (
@@ -2812,7 +2868,7 @@ class NotebookLocalRpcServer {
           (!Array.isArray(params.frame_ids) ||
             params.frame_ids.some((id) => typeof id !== 'string'))
         ) {
-          throw new Error(`host.${op} frame_ids must be an array of strings.`)
+          throw new RpcHttpError(400, `host.${op} frame_ids must be an array of strings.`)
         }
         const frameIds = params.frame_ids as readonly string[] | undefined
         if (op === 'children') {
@@ -2822,8 +2878,8 @@ class NotebookLocalRpcServer {
           return this.delegatedWorkService.children(caller, frameIds)
         }
       }
-      if (op !== 'delegate') throw new Error('Delegated Work operation is invalid.')
-      const call = parseDelegateRpcCall(params)
+      if (op !== 'delegate') throw new RpcHttpError(400, 'Delegated Work operation is invalid.')
+      const call = parseRpcParams(() => parseDelegateRpcCall(params))
       const request = await this.canonicalizeDelegationInputs(call.request, caller)
       return this.delegatedWorkService.delegate(caller, request, call.options)
     }
@@ -2861,7 +2917,9 @@ class NotebookLocalRpcServer {
         }
       }
     }
-    const handler = resolveNotebookLocalRpcHandler(this.service, method, trustedParams)
+    const handler = parseRpcParams(() =>
+      resolveNotebookLocalRpcHandler(this.service, method, trustedParams)
+    )
 
     const projectId =
       typeof params.sessionId === 'string'

--- a/src/main/notebook/repository.test.ts
+++ b/src/main/notebook/repository.test.ts
@@ -707,7 +707,7 @@ describe('notebook run repository', () => {
           {
             path: join(root, 'notebooks', 'default-project', 'session-1', 'data', 'processed.csv'),
             relativePath: 'data/processed.csv',
-            kind: 'processed-data',
+            kind: 'other',
             size: 123,
             mtimeMs: 200,
             createdByRunId: 'run-1'
@@ -734,7 +734,7 @@ describe('notebook run repository', () => {
       workingFiles: [
         {
           relativePath: 'data/processed.csv',
-          kind: 'processed-data',
+          kind: 'other',
           size: 123
         }
       ]

--- a/src/main/notebook/run-document-data-paths.test.ts
+++ b/src/main/notebook/run-document-data-paths.test.ts
@@ -50,7 +50,7 @@ const buildDocument = (): NotebookRunDocument => ({
         {
           path: `${ROOT}/notebooks/default-project/session-1/data/processed.csv`,
           relativePath: 'data/processed.csv',
-          kind: 'processed-data',
+          kind: 'other',
           size: 123,
           mtimeMs: 200,
           createdByRunId: 'run-1'

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1340,7 +1340,7 @@ describe('notebook runtime service', () => {
               {
                 path: join(root, 'notebooks', 'default-project', 'session-1', 'data', 'result.csv'),
                 relativePath: 'data/result.csv',
-                kind: 'processed-data',
+                kind: 'other',
                 size: 12,
                 mtimeMs: 200
               }
@@ -1406,7 +1406,7 @@ describe('notebook runtime service', () => {
       workingFiles: [
         {
           relativePath: 'data/result.csv',
-          kind: 'processed-data'
+          kind: 'other'
         }
       ],
       environmentCapture: {
@@ -2903,7 +2903,7 @@ describe('notebook runtime service', () => {
     const writtenFile = {
       path: join(root, 'notebooks', 'default-project', 'session-1', 'handoff', 'data.json'),
       relativePath: 'handoff/data.json',
-      kind: 'raw-data' as const
+      kind: 'other' as const
     }
     const fileEvidence = {
       schemaVersion: 1 as const,

--- a/src/main/notebook/working-file-observer.test.ts
+++ b/src/main/notebook/working-file-observer.test.ts
@@ -72,6 +72,34 @@ afterEach(async () => {
 })
 
 describe('working-file evidence', () => {
+  it('reports unclassified data and handoff changes without observing other workspace directories', async () => {
+    const { sessionRoot, dataRoot } = await createRoots()
+    const paths = [
+      'data/raw/input.csv',
+      'data/processed/result.csv',
+      'handoff/transfer.csv',
+      'cache/cached.csv',
+      'scripts/analysis.py',
+      'work/intermediate.csv',
+      'outputs/result.csv'
+    ]
+    for (const path of paths) {
+      await mkdir(join(sessionRoot, ...path.split('/').slice(0, -1)), { recursive: true })
+    }
+    const observation = await startWorkingFileObservation(
+      { dataRoot, notebookSessionRoot: sessionRoot },
+      { watchDirectory: watcherUnavailable }
+    )
+    for (const path of paths) await writeFile(join(sessionRoot, ...path.split('/')), 'content')
+
+    const { workingFiles } = await observation.finish()
+    expect(workingFiles.map(({ relativePath, kind }) => ({ relativePath, kind }))).toEqual([
+      { relativePath: 'data/processed/result.csv', kind: 'other' },
+      { relativePath: 'data/raw/input.csv', kind: 'other' },
+      { relativePath: 'handoff/transfer.csv', kind: 'other' }
+    ])
+  })
+
   it('normalizes persisted paths across operating systems', () => {
     expect(
       toPortableNotebookRelativePath(
@@ -427,6 +455,7 @@ describe('working-file evidence', () => {
         {
           path: resolve(output),
           relativePath: 'data/result.csv',
+          kind: 'other',
           change: 'created',
           generationId: 'generation-1',
           checksum

--- a/src/shared/notebook.test.ts
+++ b/src/shared/notebook.test.ts
@@ -1,13 +1,20 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, expectTypeOf } from 'vitest'
 import {
   notebookEnvironmentApplicationCommandContracts,
   parseNotebookLanguage,
   parseOptionalNotebookLanguage,
   type NotebookOutput,
+  type NotebookWorkingFile,
+  type NotebookWorkingFileKind,
   type NotebookCell
 } from './notebook'
 
 describe('shared notebook types', () => {
+  it('advertises only the unclassified working-file kind emitted by the runtime', () => {
+    expectTypeOf<NotebookWorkingFileKind>().toEqualTypeOf<'other'>()
+    expectTypeOf<NotebookWorkingFile['kind']>().toEqualTypeOf<'other'>()
+  })
+
   it('parses only python and r as NotebookLanguage', () => {
     expect(parseNotebookLanguage('python')).toBe('python')
     expect(parseNotebookLanguage('r')).toBe('r')

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -347,9 +347,9 @@ export const parseNotebookInputPreviewKey = (key: string): NotebookInputPreviewI
   }
 }
 
-// Classifies files that are created inside the notebook session workspace.
-export type NotebookWorkingFileKind =
-  'raw-data' | 'processed-data' | 'cache' | 'script' | 'intermediate' | 'other'
+// Observation reports unclassified changes under data/ and handoff/, not scientific file roles.
+// Historical JSON is read permissively; this contract describes current runtime output.
+export type NotebookWorkingFileKind = 'other'
 
 // Keeps raw streams separate while also preserving a display-ready plain text projection.
 export type NotebookTextOutput = {


### PR DESCRIPTION
## Problem

Local RPC reports many malformed requests and unknown methods as HTTP 500, preventing callers from distinguishing invalid input from server failures. Working File's six-value kind union also advertises classifications that the observer has never emitted.

## Proposed change

- Reuse the existing RPC HTTP error type at request validation boundaries: invalid JSON/envelopes/schema/parameters return 400; unknown top-level methods return 404; ownership failures return 403. Preserve existing authentication 401 and resource-limit 413 handling.
- Keep unexpected owner/service errors at 500, including internal Zod/JSON failures. Preserve existing JSON error payload shapes.
- Narrow `NotebookWorkingFileKind` to the runtime-supported `other` value and align current-output fixtures. Lock down the existing data/handoff observation boundary without adding cache, scripts, work, or outputs observation.

## Scope and non-goals

- No new fields, enum states, database changes, migrations, persistence-format changes, or user interactions.
- Historical records with older kind literals remain permissively readable and are not rewritten. The type narrowing removes five unsupported compile-time alternatives only.
- No generic downstream service/domain error taxonomy, new watcher coverage, or provider lifecycle/history/subscription changes.

## Acceptance criteria and validation

Tests were exercised against the unfixed production code before accepting the fix: the final RPC test set produced **31 failures / 161 passes**, with unexpected 500 responses instead of 400/403/404. Working File's type assertions produced exactly two TS2344 errors against the old union. Earlier minimal RPC repros were also repeated. Restoring the production fix made these regressions pass. The observer directory test characterizes existing behavior rather than claiming a runtime observation regression.

Final checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| RPC status, authentication, capability, limits and existing routes over TCP/pipe | `npm test -- src/main/notebook/local-rpc-server` | 15 files, 192 passed |
| Shared contract, observer, persistence and transport consumers | `npm test -- src/shared/notebook.test.ts src/main/notebook/working-file-observer.test.ts src/main/notebook/repository.test.ts src/main/notebook/run-document-data-paths.test.ts src/main/notebook/runtime-service.test.ts src/main/storage/normalize-legacy-paths.test.ts src/main/notebook/local-rpc-notebook-adapter.test.ts src/main/notebook/mcp-server.test.ts src/main/local-rpc-transport.test.ts` | 485 passed, 6 skipped, 5 failures detailed below |
| Isolated Shell concurrency rerun | `npm test -- src/main/notebook/runtime-service.test.ts -t "admits at most six shell processes across Sessions"` | Passed |
| New observation contract and strengthened kind assertion | `npm test -- src/main/notebook/working-file-observer.test.ts -t "unclassified\|freezes a created generation"` | 2 passed |
| Output presentation and representative Agent consumers | `npm test -- src/renderer/src/pages/workspace/NotebookRunOutputs.render.test.tsx src/main/acp/codex-completion-handoff.integration.test.ts src/main/acp/opencode-immediate-handoff.integration.test.ts src/main/acp/claude-turn-adapter.test.ts src/main/acp/opencode-turn-adapter.test.ts src/main/acp/codex-turn-adapter.test.ts` | 6 files, 45 passed |
| Main, sandbox and shared types | `npm run typecheck:node` | Passed |
| Renderer/preload types | `npm run typecheck:web` | Passed |
| Coding rules | `npm run lint` | Passed |

Local limitations: four existing observer tests failed while creating directory symlink fixtures with Windows EPERM, before exercising production behavior. One Shell concurrency test timed out in the aggregate run and passed when rerun alone. These failures are not presented as an all-green aggregate run. No complete local `npm test` was run, per maintainer direction; exact-head CI remains authoritative for complete portable and platform coverage.

Independent Standards and Spec reviews found no blocking issues and confirmed the impact mapping covers the final diff. The shared Notebook RPC composition remains provider-neutral for Claude Code, OpenCode, Codex Responses and Codex Bridge. No provider protocol, history replay, lifecycle, or subscription implementation changed; representative consumers are included, not claimed as exhaustive provider E2E coverage. No migration or UI interaction checks are required because those behaviors are unchanged.

## Review focus

- Request parsing ends before owner execution, so internal failures are not misclassified as caller errors.
- Known-method registry covers existing routes and authentication still precedes method validation.
- Working File type narrowing describes current output without altering historical storage or evidence scope.
