### PR TITLE
fix(windows): retry full-test cleanup and raise shard timeout

### DIFF
--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -60,7 +60,7 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode == 'full') }}
     runs-on: windows-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -82,8 +82,9 @@ jobs:
       - name: Test complete suite shard
         # SQLite-heavy integration suites contend heavily for Windows disk I/O when Vitest uses
         # every available core, and hosted-runner disk latency occasionally exceeds the default
-        # per-test/hook budgets. Keep files serial and use bounded 60-second budgets; the 25-minute
-        # job timeout remains the backstop for a real hang.
+        # per-test/hook budgets. Keep files serial and use bounded 60-second budgets; individual
+        # tests still fail at that bound. The 35-minute job timeout covers checkout, npm ci, and a
+        # slow serial suite without treating a still-progressing shard as a hang.
         run: npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
 
   notebook_sandbox:

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -76,7 +76,8 @@ describe('release and scheduled workflow topology', () => {
     )
     expect(job).toMatchObject({
       needs: 'plan',
-      if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode == 'full') }}"
+      if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode == 'full') }}",
+      'timeout-minutes': 35
     })
     expect(sandbox).toMatchObject({
       needs: 'plan',

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -109,7 +109,8 @@ describe('post-merge Windows validation', () => {
     expect(job).toMatchObject({
       needs: 'plan',
       if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode == 'full') }}",
-      'runs-on': 'windows-latest'
+      'runs-on': 'windows-latest',
+      'timeout-minutes': 35
     })
     expect(job['continue-on-error']).toBeUndefined()
     expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])

--- a/src/main/agent-framework/claude-code-memory.integration.test.ts
+++ b/src/main/agent-framework/claude-code-memory.integration.test.ts
@@ -4,9 +4,9 @@ import {
   readFileSync,
   readdirSync,
   realpathSync,
-  rmSync,
   writeFileSync
 } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -127,7 +127,7 @@ const runMemoryProbe = async (memoryFlag: '0' | '1'): Promise<MemoryProbeResult>
       }
     }
 
-    for await (const message of query({
+    const session = query({
       prompt: 'Reply with OK.',
       options: {
         cwd: canonicalCwd,
@@ -139,8 +139,13 @@ const runMemoryProbe = async (memoryFlag: '0' | '1'): Promise<MemoryProbeResult>
         systemPrompt: { type: 'preset', preset: 'claude_code' },
         tools: []
       }
-    })) {
-      if (message.type === 'result') break
+    })
+    try {
+      for await (const message of session) {
+        if (message.type === 'result') break
+      }
+    } finally {
+      session.close()
     }
 
     expect(requestBodies).toHaveLength(1)
@@ -156,10 +161,12 @@ const runMemoryProbe = async (memoryFlag: '0' | '1'): Promise<MemoryProbeResult>
   }
 }
 
-afterEach(() => {
-  for (const root of temporaryRoots.splice(0)) {
-    rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
-  }
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 }))
+  )
 })
 
 describe('Claude Code ACP memory isolation', () => {

--- a/src/main/agent-framework/claude-code-memory.integration.test.ts
+++ b/src/main/agent-framework/claude-code-memory.integration.test.ts
@@ -157,7 +157,9 @@ const runMemoryProbe = async (memoryFlag: '0' | '1'): Promise<MemoryProbeResult>
 }
 
 afterEach(() => {
-  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+  }
 })
 
 describe('Claude Code ACP memory isolation', () => {

--- a/src/main/agents/completion-gate.execute-control.integration.test.ts
+++ b/src/main/agents/completion-gate.execute-control.integration.test.ts
@@ -119,7 +119,7 @@ const createExecuteControlHarness = async (
     close: async () => {
       await service.shutdownAll()
       await server.close()
-      await rm(root, { recursive: true, force: true })
+      await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
     }
   }
 }

--- a/src/main/artifacts/provenance-test-fixtures.ts
+++ b/src/main/artifacts/provenance-test-fixtures.ts
@@ -84,7 +84,7 @@ export const createProvenanceTestFixture = async (): Promise<{
       try {
         await client.$disconnect()
       } finally {
-        await rm(storageRoot, { recursive: true, force: true })
+        await rm(storageRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
       }
     }
   }

--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -94,6 +94,10 @@ type ExactMethodInventory = [PublicMethod] extends [ListedMethod]
   : false
 const exactMethodInventory: ExactMethodInventory = true
 
+// Hosted Windows runners rebuild the application schema under disk contention.
+// The Windows full-test workflow default is 60s; write-identity suites finish later without hanging.
+const WINDOWS_SQLITE_TEST_TIMEOUT_MS = 120_000
+
 describe('artifact provenance public write contract', () => {
   it('captures constructor, method, and runtime value exports without private placement', async () => {
     const { repository } = await fixture()
@@ -162,26 +166,30 @@ describe('artifact provenance allocation and write identity', () => {
     }
   })
 
-  it('returns the original immutable Version for an exact operation retry and rejects reuse', async () => {
-    const { client, repository, stagePng } = await fixture()
-    const request = createArtifactVersionRequest({
-      writeOperationId: 'stable-operation',
-      writeRequestChecksum: '3'.repeat(64)
-    })
-    await stagePng('original bytes')
-    const first = await repository.createVersion(request)
-    await stagePng('changed pending bytes')
+  it(
+    'returns the original immutable Version for an exact operation retry and rejects reuse',
+    async () => {
+      const { client, repository, stagePng } = await fixture()
+      const request = createArtifactVersionRequest({
+        writeOperationId: 'stable-operation',
+        writeRequestChecksum: '3'.repeat(64)
+      })
+      await stagePng('original bytes')
+      const first = await repository.createVersion(request)
+      await stagePng('changed pending bytes')
 
-    const retried = await repository.createVersion(request)
+      const retried = await repository.createVersion(request)
 
-    expect(retried).toMatchObject({ versionId: first.versionId, versionNumber: 1 })
-    await expect(readFile(retried.path)).resolves.toEqual(createPngBytes('original bytes'))
-    await expect(client.artifactVersion.count()).resolves.toBe(1)
-    await expect(
-      repository.createVersion({ ...request, writeRequestChecksum: '4'.repeat(64) })
-    ).rejects.toThrow(/write operation.*different request/i)
-    await expect(client.artifactVersion.count()).resolves.toBe(1)
-  })
+      expect(retried).toMatchObject({ versionId: first.versionId, versionNumber: 1 })
+      await expect(readFile(retried.path)).resolves.toEqual(createPngBytes('original bytes'))
+      await expect(client.artifactVersion.count()).resolves.toBe(1)
+      await expect(
+        repository.createVersion({ ...request, writeRequestChecksum: '4'.repeat(64) })
+      ).rejects.toThrow(/write operation.*different request/i)
+      await expect(client.artifactVersion.count()).resolves.toBe(1)
+    },
+    WINDOWS_SQLITE_TEST_TIMEOUT_MS
+  )
 
   it('diffs a generated text Version against its published or same-run predecessor', async () => {
     const value = await fixture()

--- a/src/main/compute/compute-integration.test-support.ts
+++ b/src/main/compute/compute-integration.test-support.ts
@@ -27,7 +27,7 @@ export const createMigratedComputeTestDatabase = async (
     await migrateApplicationDatabase(client)
   } catch (error) {
     await client.$disconnect()
-    await rm(storageRoot, { recursive: true, force: true })
+    await rm(storageRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
     throw error
   }
 
@@ -45,7 +45,7 @@ export const createMigratedComputeTestDatabase = async (
       try {
         await client.$disconnect()
       } finally {
-        await rm(storageRoot, { recursive: true, force: true })
+        await rm(storageRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
       }
     }
   }

--- a/src/main/compute/prisma-client.test.ts
+++ b/src/main/compute/prisma-client.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
   disconnect = undefined
 
   if (storageRoot) {
-    await rm(storageRoot, { recursive: true, force: true })
+    await rm(storageRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
     storageRoot = undefined
   }
 })

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3678,13 +3678,14 @@ describe('notebook runtime service', () => {
           )} ${quoteForShell(marker)} & descendant_pid=$!; printf '%s' "$descendant_pid" > ${quoteForShell(
             descendantPidPath
           )}; wait "$descendant_pid" # ${marker}`,
-          timeoutMs: 2_000
+          timeoutMs: 5_000
         })
 
         // Start the execution first, then require the descendant to be observable well before the
         // timeout. This prevents a loaded runner from taking the process-tree snapshot before the
-        // fixture has spawned the process that the cleanup contract is meant to cover.
-        const readinessDeadline = Date.now() + 1_500
+        // fixture has spawned the process that the cleanup contract is meant to cover. Coverage
+        // shards on Ubuntu can spend more than 1.5s before the descendant writes its pid.
+        const readinessDeadline = Date.now() + 4_000
         let descendantPid: number | undefined
         while (descendantPid === undefined && Date.now() < readinessDeadline) {
           try {

--- a/src/main/reviewer/repository.test.ts
+++ b/src/main/reviewer/repository.test.ts
@@ -24,7 +24,7 @@ afterEach(async () => {
   client = undefined
 
   if (storageRoot) {
-    await rm(storageRoot, { recursive: true, force: true })
+    await rm(storageRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
     storageRoot = undefined
   }
 })
@@ -80,7 +80,11 @@ const checks = (): NewCheck[] => [
   }
 ]
 
-describe('review repository (integration)', () => {
+// Hosted Windows runners rebuild the application schema under disk contention.
+// The Windows full-test workflow default is 60s; this suite finishes later without hanging.
+const WINDOWS_SQLITE_TEST_TIMEOUT_MS = 120_000
+
+describe('review repository (integration)', { timeout: WINDOWS_SQLITE_TEST_TIMEOUT_MS }, () => {
   it('round-trips a review with its unified checks by session', async () => {
     const repository = await createRepository()
 


### PR DESCRIPTION
## Problem

Scheduled [Windows Full Test](https://github.com/aipoch/open-science/actions/workflows/windows-full-test.yml) is still red after #2104. The `spawnSync` hang is gone, and the Notebook sandbox job stays green. Remaining failures on `main` are:

1. `claude-code-memory.integration.test.ts` and `completion-gate.execute-control.integration.test.ts` fail in `afterEach`/`close` with `EBUSY` while deleting temp trees. The assertions already passed.
2. SQLite-heavy suites (`provenance-write-contract`, `reviewer/repository`) exceed the workflow's 60s `--testTimeout` on slow hosted disks, then pass on a later run of the same SHA.
3. Slow serial shards are cancelled at the 25-minute job timeout while still progressing. One cancelled 2/3 finished `compute/prisma-client.test.ts` in 35s immediately before cancellation.

The same SHA (`87fba82d`) failed then passed, so these are hosted-Windows flakes rather than a product regression. Adding more Vitest shards would not fix `EBUSY` or `expect.poll` flakes, and each extra shard still pays `npm ci`.

## Proposed change

- Retry temp-dir removal with Node `maxRetries` on the failing Claude Code / completion-gate cleanups and the shared SQLite fixture dispose paths.
- Give the failing SQLite suites the existing 120s Windows budget used by migration tests.
- Raise the Windows full-test job timeout from 25 to 35 minutes. Individual tests still fail at 60s (or 120s where annotated); the job timeout now covers checkout, `npm ci`, and a slow serial suite.

## Scope and non-goals

- Does not add a fourth Vitest shard.
- Does not skip tests on win32.
- Does not change `production-composition` `expect.poll` (unreproduced on later green runs of the same SHA).
- No schema, persistence, UI, or production runtime change.

## Acceptance criteria and validation

The listed checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Affected suites | `npx vitest run` on the changed workflow, fixture, and integration files | pass (124) |
| Lint of changed files | `npx eslint --cache` on the 9 TypeScript files | pass |
| Full portable suite | `npm test` | 1366 files passed, 23686 tests passed, 226 skipped |

Windows full-test on this PR is the authoritative hosted-runner signal.

## Review focus

- `maxRetries` on `rm`/`rmSync` matches existing Windows cleanup in sandbox and responses-bridge tests.
- 35 minutes is suite duration, not a hang bound: cancelled jobs were still emitting passing tests.