### PR TITLE
fix(workspace): stack Artifact error actions below message

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -792,7 +792,15 @@ describe('ConversationPanel composer errors', () => {
     const retry = container.querySelector<HTMLButtonElement>(
       '[aria-label="Retry Artifact publication"]'
     )
+    const report = container.querySelector<HTMLButtonElement>('[aria-label="Report this error"]')
+    const error = Array.from(container.querySelectorAll('span')).find(
+      (element) => element.textContent === activeSession.error
+    )
     expect(retry).not.toBeNull()
+    expect(report).not.toBeNull()
+    expect(error?.parentElement?.classList.contains('flex-col')).toBe(true)
+    expect(retry?.parentElement?.classList.contains('flex-wrap')).toBe(true)
+    expect(retry?.parentElement?.classList.contains('self-end')).toBe(true)
     act(() => retry?.click())
     expect(request).toHaveBeenCalledOnce()
   })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1133,14 +1133,14 @@ const ConversationPanel = ({
                       <span className="min-w-0 break-words">{resolvedActionError}</span>
                     ) : null}
                     {activeSession?.status === 'error' ? (
-                      <div className="flex items-start gap-2">
-                        <span className="min-w-0 flex-1 break-words">{resolvedRunError}</span>
-                        {/* The button sits on the failure row beside the run's own error, so the shown
-                            text and the reported text are always the same error. Shown only for an
-                            unknown failure — a recognized one (app guidance or a known provider error)
-                            keeps its message but is not a bug worth a GitHub issue. */}
+                      <div className="flex flex-col items-stretch gap-2">
+                        <span className="min-w-0 break-words">{resolvedRunError}</span>
+                        {/* Actions stay with the run's own error, so the shown and reported text are
+                            always the same error. Shown only for an unknown failure — a recognized one
+                            (app guidance or a known provider error) keeps its message but is not a bug
+                            worth a GitHub issue. */}
                         {canRetryArtifactFinalization || isRunErrorReportable ? (
-                          <div className="flex shrink-0 items-center gap-1">
+                          <div className="flex flex-wrap items-center justify-end gap-1 self-end">
                             {canRetryArtifactFinalization ? (
                               <button
                                 type="button"


### PR DESCRIPTION
## Problem

When an Artifact publication failure is both retryable and reportable, the long error text shares one horizontal row with two non-shrinking action buttons. The buttons squeeze the message into a narrow column, especially at narrower widths and in locales with longer labels.

## Proposed change

- Give the run error message its own row.
- Keep Retry Artifact publication and Report error together in a right-aligned action row.
- Allow the action group to wrap between buttons when space is constrained.
- Extend the existing ConversationPanel public render-boundary test with the layout contract.

## Scope and non-goals

This changes presentation only. It adds no persisted fields, historical-data compatibility path, state or enum values, architecture changes, or data-model changes. Button behavior and error classification are unchanged. No new production test seam or dependency is introduced.

## Acceptance criteria and validation

The regression assertion was run before the fix and failed because the error row lacked the required vertical layout. After the final material edit:

- Artifact error layout and existing ConversationPanel interactions -> npx vitest run src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -> 136 passed
- Changed renderer files lint -> npx eslint src/renderer/src/pages/workspace/ConversationPanel.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -> passed
- Changed renderer files formatting and diff whitespace -> npx prettier --check ... and git diff --check -> passed
- Web type safety -> npm run typecheck:web -> blocked before checking this diff by a shared stale Prisma Client; all reported errors are existing remoteCleanupDisposition mismatches in unchanged src/main/compute files

The complete npm test suite was intentionally not run; PR CI is the final validation authority.

## Review focus

Please confirm that the separate wrapping action row preserves readable errors without changing retry or reporting behavior.