### PR TITLE
perf(ci): disable install-time npm audit

### DIFF
--- a/.github/workflows/ci-integrity.yml
+++ b/.github/workflows/ci-integrity.yml
@@ -34,7 +34,7 @@ jobs:
           cache: npm
 
       - name: Install trusted parsing toolchain
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit
 
       - name: Resolve inspected revisions
         id: revisions

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,7 +34,7 @@ jobs:
           cache: npm
 
       - name: Install test dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit
 
       - name: Validate release tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/stage-runtime-bundle.yml
+++ b/.github/workflows/stage-runtime-bundle.yml
@@ -70,7 +70,7 @@ jobs:
       # staging-irrelevant postinstall (prisma generate + electron-builder native rebuild); staging only
       # needs these JS/WASM deps plus the micromamba fetched below.
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit
 
       # micromamba comes from the pinned official GitHub release asset (see fetch-micromamba.mjs), not
       # our CDN, so staging never depends on a chicken-and-egg CDN state. Fetch the RUNNER's native

--- a/scripts/ci/ci-integrity-workflow.test.ts
+++ b/scripts/ci/ci-integrity-workflow.test.ts
@@ -73,7 +73,7 @@ describe('CI Integrity workflow', () => {
       uses: 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020',
       with: { 'node-version': 22, cache: 'npm' }
     })
-    expect(step('Install trusted parsing toolchain').run).toBe('npm ci --ignore-scripts')
+    expect(step('Install trusted parsing toolchain').run).toBe('npm ci --ignore-scripts --no-audit')
   })
 
   it('fetches PR objects without checking out or executing the head revision', () => {

--- a/scripts/ci/npm-ci.mjs
+++ b/scripts/ci/npm-ci.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url'
 export const GITHUB_ELECTRON_MIRROR = 'https://github.com/electron/electron/releases/download/'
 export const GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR =
   'https://github.com/electron-userland/electron-builder-binaries/releases/download/'
+export const DEFAULT_NPM_CI_ARGS = ['--no-audit']
 
 export function shouldForceGitHubElectronMirrors(env = process.env) {
   return env.GITHUB_ACTIONS === 'true'
@@ -35,7 +36,7 @@ export function runNpmCi({
   platform = process.platform,
   spawn = spawnSync
 } = {}) {
-  const result = spawn(npmCiCommand(platform), ['ci', ...args], {
+  const result = spawn(npmCiCommand(platform), ['ci', ...DEFAULT_NPM_CI_ARGS, ...args], {
     env: npmCiEnv(env),
     stdio: 'inherit',
     shell: platform === 'win32'

--- a/scripts/ci/npm-ci.test.ts
+++ b/scripts/ci/npm-ci.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  DEFAULT_NPM_CI_ARGS,
   GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR,
   GITHUB_ELECTRON_MIRROR,
   npmCiCommand,
@@ -42,7 +43,7 @@ describe('npm ci Electron mirror policy', () => {
 
     expect(
       runNpmCi({
-        args: ['--no-audit'],
+        args: ['--prefer-offline'],
         env: { GITHUB_ACTIONS: 'true' },
         platform: 'linux',
         spawn
@@ -52,16 +53,17 @@ describe('npm ci Electron mirror policy', () => {
     expect(npmCiCommand('win32')).toBe('npm.cmd')
     expect(spawn).toHaveBeenCalledWith(
       'npm',
-      ['ci', '--no-audit'],
+      ['ci', '--no-audit', '--prefer-offline'],
       expect.objectContaining({
         env: expect.objectContaining({ ELECTRON_MIRROR: GITHUB_ELECTRON_MIRROR }),
         shell: false,
         stdio: 'inherit'
       })
     )
+    expect(DEFAULT_NPM_CI_ARGS).toEqual(['--no-audit'])
   })
 
-  it('routes Electron-installing workflow npm ci through the GitHub mirror helper', () => {
+  it('routes Electron-installing workflow npm ci through the GitHub mirror helper and disables audit for direct installs', () => {
     const workflowDir = join(process.cwd(), '.github', 'workflows')
     const leftover: string[] = []
     for (const name of readdirSync(workflowDir).filter((file) => file.endsWith('.yml'))) {
@@ -69,7 +71,7 @@ describe('npm ci Electron mirror policy', () => {
       for (const [lineNumber, line] of text.split('\n').entries()) {
         const match = line.match(/^\s+run:\s*(npm ci.*)$/)
         if (!match) continue
-        if (match[1].includes('--ignore-scripts')) continue
+        if (match[1].includes('--ignore-scripts') && match[1].includes('--no-audit')) continue
         leftover.push(`${name}:${lineNumber + 1}: ${match[1]}`)
       }
     }


### PR DESCRIPTION
## Problem

PR #2127 run 33820936407 restored the 447 MB npm cache in about five seconds, but the macOS dependency install took 372 seconds. The install log was silent for roughly 361 seconds before npm printed its audit-endpoint retirement notice; postinstall then completed in about three seconds. Five nearby successful macOS installs took 49–73 seconds.

The implicit best-effort audit request exhausted the 15-minute macOS E2E budget: accessibility was cancelled and visual regression never ran. The same implicit request exists in PR, nightly, release, certification, notarization, smoke, and publishing installs.

## Proposed change

- Make the shared CI npm wrapper pass `--no-audit` by default while preserving caller arguments.
- Add `--no-audit` to the three direct `npm ci --ignore-scripts` workflow installs.
- Extend the workflow inventory test so future direct installs must explicitly disable audit.

## Scope and non-goals

This does not relax dependency integrity or release security. `npm ci` still verifies the lockfile and package integrity hashes. GitHub Dependency Review remains the enforced high-severity PR gate, Dependabot remains enabled, and release certification, checksums, and provenance are unchanged.

No dependency, lockfile, timeout, cache architecture, application architecture, data model, persisted data, historical compatibility, state/enum, or UI changes are included. A dedicated vulnerability-audit job is intentionally not added; if needed later, it should be an explicit, observable, independently capped security gate rather than hidden inside installation.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- CI install policy and affected workflow contracts -> `npx vitest run scripts/ci/npm-ci.test.ts scripts/ci/ci-integrity-workflow.test.ts scripts/ci/runtime-certification-workflow.test.ts scripts/ci/release-workflows.test.ts scripts/windows-release-workflows.test.ts scripts/ci/pr-gate-workflow.test.ts` -> 61 passed
- changed JS/TS lint -> `npx eslint scripts/ci/npm-ci.mjs scripts/ci/npm-ci.test.ts scripts/ci/ci-integrity-workflow.test.ts` -> passed
- changed-file formatting -> `npx prettier --check ...` -> passed
- workflow install inventory -> every Actions `npm ci` routes through the shared no-audit wrapper or explicitly includes `--no-audit`
- final diff hygiene -> `git diff --check` -> passed

The dependency-aware planner selected no application modules for this workflow/tooling-only change. Per task direction, the complete local `npm test` suite was not run; exact-head PR CI is the final authority.

## Review focus

Confirm that disabling npm install-time advisory requests across PR and release-family workflows removes nondeterministic network latency without weakening the repository existing explicit dependency and release security controls.