### PR TITLE
fix(settings): block stale configured model fallback

### DIFF
--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -411,16 +411,19 @@ export class AgentRuntimeManager {
     const activeModel = activeProvider
       ? providers.resolveActiveModel(activeProvider, settings.activeModel)
       : undefined
+    const configuredModelAvailable =
+      settings.activeModel === undefined || activeModel === settings.activeModel
     const activeEndpoints = activeProvider
       ? providers.resolveProviderApiEndpoints(activeProvider, activeModel)
       : undefined
-    const activeProviderCompatible = activeProvider
-      ? isProviderUsableByFramework(
-          { apiEndpoints: activeEndpoints, type: activeProvider.type },
-          framework
-        ) &&
-        (framework.id !== 'codex' || isModelBridgeSupported(activeProvider, activeModel))
-      : false
+    const activeProviderCompatible =
+      activeProvider && configuredModelAvailable
+        ? isProviderUsableByFramework(
+            { apiEndpoints: activeEndpoints, type: activeProvider.type },
+            framework
+          ) &&
+          (framework.id !== 'codex' || isModelBridgeSupported(activeProvider, activeModel))
+        : false
     const activeProviderKeyUsable =
       activeProvider && activeProvider.lastValidatedAt !== undefined
         ? await providers.isProviderKeyUsable(activeProvider)

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -556,7 +556,7 @@ describe('ProviderAccountsModule', () => {
 
     const target = module.resolveRuntimeTarget(
       stored,
-      { kind: 'configured', requestedModel: 'unavailable-model' },
+      { kind: 'configured', requestedModel: 'lab-model' },
       getAgentFramework('codex')
     )
 
@@ -890,6 +890,45 @@ describe('ProviderAccountsModule', () => {
         })
       ]
     })
+  })
+
+  it('refuses to resolve a configured model removed by a catalog refresh', async () => {
+    await module.upsertProvider({
+      type: 'official',
+      name: 'DeepSeek',
+      vendorId: 'deepseek',
+      key: 'key'
+    })
+    const providerId = (await repository.getSettings()).providers[0].id
+    await module.setActiveProvider(providerId, 'deepseek-v4-pro')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(Response.json({ data: [{ id: 'replacement-model' }] }))
+    )
+
+    await expect(module.refreshProviderModels({ providerId })).resolves.toMatchObject({
+      ok: true,
+      models: ['replacement-model']
+    })
+    const settings = await repository.getSettings()
+    const provider = settings.providers[0]
+    expect(settings.activeModel).toBe('deepseek-v4-pro')
+
+    let outcome: string
+    try {
+      const target = module.resolveRuntimeTarget(
+        provider,
+        { kind: 'configured', requestedModel: settings.activeModel },
+        getAgentFramework('codex')
+      )
+      outcome = `resolved ${target.effectiveModel}`
+    } catch (error) {
+      outcome = error instanceof Error ? error.message : String(error)
+    }
+
+    expect(outcome).toBe(
+      'The configured model is no longer available from provider "DeepSeek": "deepseek-v4-pro". Pick another model in Settings → Model.'
+    )
   })
 
   it('does not recreate a provider deleted while its model catalog refresh is pending', async () => {

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -503,7 +503,7 @@ class ProviderAccountsModule {
   }
 
   // Produces an ephemeral backend input without mutating selection or entering authentication;
-  // configured fallback rules remain, while an explicit required model must match exactly.
+  // a persisted or explicitly required model must still exist in the current catalog.
   resolveRuntimeTarget(
     storedProvider: StoredProvider,
     selection: RuntimeProviderModelSelection,

--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -53,7 +53,7 @@ describe('ProviderRuntimeProjectionOwner', () => {
 
     const target = owner.resolveRuntimeTarget(
       provider,
-      { kind: 'configured', requestedModel: 'unavailable-model' },
+      { kind: 'configured', requestedModel: 'lab-model' },
       getAgentFramework('codex')
     )
     const view = owner.toProviderView(provider)

--- a/src/main/settings/provider-runtime-projection.ts
+++ b/src/main/settings/provider-runtime-projection.ts
@@ -23,6 +23,7 @@ import {
   resolveProviderReasoningEffortProfile
 } from '../../shared/provider-reasoning-effort'
 import type { ReasoningEffortProfile } from '../../shared/reasoning-effort'
+import { buildConfiguredModelUnavailableMessage } from '../../shared/run-error-classification'
 import type { AgentFrameworkId } from '../agent-framework'
 import { isOfficialOpenAiResponsesBase } from '../agent-framework/codex'
 import { hardenKeyMask, tryDecryptKey } from './crypto'
@@ -125,6 +126,16 @@ class ProviderRuntimeProjectionOwner {
     framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
   ): ProviderRuntimeTarget {
     const availableModels = this.availableModels(storedProvider)
+    if (
+      selection.kind === 'configured' &&
+      selection.requestedModel &&
+      availableModels.length > 0 &&
+      !availableModels.includes(selection.requestedModel)
+    ) {
+      throw new Error(
+        buildConfiguredModelUnavailableMessage(selection.requestedModel, storedProvider.name)
+      )
+    }
     if (
       selection.kind === 'required' &&
       availableModels.length > 0 &&

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1966,6 +1966,28 @@ describe('SettingsService: preflight & spawn config', () => {
     })
   })
 
+  it('closes the provider gate when the configured model leaves the catalog', async () => {
+    const service = createService()
+    await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
+    const created = (
+      await service.upsertProvider({
+        type: 'official',
+        name: 'DeepSeek',
+        vendorId: 'deepseek',
+        key: 'k'
+      })
+    ).providers[0]
+    await service.setActiveProvider(created.id, 'deepseek-v4-pro')
+    const stored = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({
+      ...stored,
+      fetchedModels: ['replacement-model'],
+      lastValidatedAt: 1
+    })
+
+    await expect(service.getPreflight()).resolves.toMatchObject({ activeProviderReady: false })
+  })
+
   it('closes the provider gate when the active shared Claude session is signed out', async () => {
     const claudeSharedAuth: ClaudeSharedAuthControllerPort = {
       getStatus: vi.fn().mockResolvedValue({
@@ -5327,7 +5349,7 @@ describe('SettingsService: reasoning effort', () => {
     )
   })
 
-  it('uses one effective catalog model for both the backend and its effort profile', async () => {
+  it('fails closed before resolving effort when the configured model leaves the catalog', async () => {
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
     await repository.setAgentFramework('opencode')
     const service = createService(undefined, {
@@ -5347,13 +5369,9 @@ describe('SettingsService: reasoning effort', () => {
     const stored = (await repository.getSettings()).providers[0]
     await repository.upsertProvider({ ...stored, fetchedModels: ['claude-opus-5'] })
 
-    const backend = await resolveActiveBackend(service)
-    const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
-    const agentProviderId = opencodeTransportProviderId(provider.id, 'claude-opus-5')
-
-    expect(backend.sessionModel).toBe(`${agentProviderId}/claude-opus-5`)
-    expect(backend.sessionEffort).toBe('max')
-    expect(content.model).toBe(`${agentProviderId}/claude-opus-5`)
+    await expect(resolveActiveBackend(service)).rejects.toThrow(
+      'The configured model is no longer available from provider "Anthropic": "claude-haiku-4-5-20251001". Pick another model in Settings → Model.'
+    )
   })
 
   it('surfaces sessionEffort on the Claude backend too (the early-return path)', async () => {

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -4,6 +4,7 @@ import { describePromptError } from '../main/acp/prompt-error'
 import { buildUnsupportedCodexAcpVersionMessage } from './codex-runtime'
 import {
   buildActiveModelIncompatibleMessage,
+  buildConfiguredModelUnavailableMessage,
   CLAUDE_EXECUTABLE_MISSING_MESSAGE,
   CODEX_BRIDGE_UNSUPPORTED_MESSAGE,
   IMAGE_REPLAY_UNSUPPORTED_MESSAGE,
@@ -162,6 +163,9 @@ describe('isReportableRunFailure (text tier)', () => {
     expect(isReportableRunFailure(NO_ACTIVE_PROVIDER_MESSAGE)).toBe(false)
     expect(isReportableRunFailure(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)).toBe(false)
     expect(isReportableRunFailure(CLAUDE_EXECUTABLE_MISSING_MESSAGE)).toBe(false)
+    expect(
+      isReportableRunFailure(buildConfiguredModelUnavailableMessage('old-model', 'Provider'))
+    ).toBe(false)
   })
 
   it('does not report an unsupported Codex ACP version', () => {

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -87,6 +87,13 @@ export const CLAUDE_EXECUTABLE_MISSING_MESSAGE =
   'Claude executable is not configured. Complete onboarding in settings.'
 export const CODEX_BRIDGE_UNSUPPORTED_MESSAGE =
   'The active model is not supported over the Codex Chat Completions bridge. Pick another model in Settings → Model.'
+export const CONFIGURED_MODEL_UNAVAILABLE_PREFIX =
+  'The configured model is no longer available from provider'
+export const buildConfiguredModelUnavailableMessage = (
+  model: string,
+  providerName: string
+): string =>
+  `${CONFIGURED_MODEL_UNAVAILABLE_PREFIX} "${providerName}": "${model}". Pick another model in Settings → Model.`
 // The model↔framework mismatch message interpolates the framework name, so the classifier matches on
 // this leading, framework-independent phrase. It also covers the resume-path RESUME_MODEL_INCOMPATIBLE
 // wording (both begin here), so either surfacing is recognized.
@@ -159,6 +166,7 @@ export const isExpectedRunFailure = (error: string | null | undefined): boolean 
   if (message.startsWith(PROVIDER_RESOURCE_NOT_FOUND_PREFIX)) return true
   // The actionable provider connection reminder produced for Claude Code connection failures.
   if (message.startsWith(PROVIDER_CONNECTION_FAILED_PREFIX)) return true
+  if (message.startsWith(CONFIGURED_MODEL_UNAVAILABLE_PREFIX)) return true
   // Model↔framework incompatibility raised at spawn/createSession. The main-side message names the
   // framework (`…compatible with Codex.`) while the resume path rewords it to a generic form; both
   // share this leading phrase, so one prefix covers the createSession path (which is not reworded) and


### PR DESCRIPTION
## Summary

- Refuse to run when a persisted configured model is absent from the latest non-empty provider catalog, instead of silently selecting the vendor list first item.
- Keep the saved selection visible for recovery, mark provider preflight as not ready, and return an actionable Settings error.
- Treat the app-authored configuration error as expected and add regressions for catalog refresh, runtime projection, and preflight.

## Reproduction evidence

- On the unpatched base, the runtime regression expected a configured-model-unavailable error but received: resolved replacement-model.
- On the unpatched base, the preflight regression expected activeProviderReady false but received true.
- Both regressions pass after this change.

## Test plan

- 168 focused settings, runtime, error-classification, and model-selection tests pass.
- npm run typecheck passes.
- ESLint, Prettier, and git diff --check pass.
- Full npm test: 23,707 passed, 3 failed. The shell concurrency timeout passes when rerun alone. Two unchanged real-R ggplot image-capture tests still fail alone on this machine, indicating a local R graphics-stack issue unrelated to this diff.