### PR TITLE
fix(provider-validation): scope results to model targets

### DIFF
--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -17,7 +17,11 @@ import type {
   Preflight,
   ValidateProviderResult
 } from '../../shared/settings'
-import { isProviderUsableByFramework } from '../../shared/settings'
+import {
+  isProviderUsableByFramework,
+  preferredEndpoint,
+  requiresChatCompletionsBridge
+} from '../../shared/settings'
 import {
   buildUnsupportedCodexAcpVersionMessage,
   isSupportedCodexAcpVersion,
@@ -428,6 +432,21 @@ export class AgentRuntimeManager {
       activeProvider && activeProvider.lastValidatedAt !== undefined
         ? await providers.isProviderKeyUsable(activeProvider)
         : false
+    const activeValidationTarget = activeProvider
+      ? {
+          model: activeModel,
+          endpoint: preferredEndpoint(
+            activeEndpoints ?? [],
+            activeProvider.type === 'xai-subscription'
+              ? (['responses'] as const)
+              : framework.id === 'codex'
+                ? (['anthropic', 'openai', 'responses'] as const)
+                : requiresChatCompletionsBridge({ apiEndpoints: activeEndpoints }, framework)
+                  ? (activeEndpoints ?? [])
+                  : framework.supportedApiTypes
+          )
+        }
+      : undefined
 
     return computePreflight({
       settings,
@@ -438,7 +457,8 @@ export class AgentRuntimeManager {
       agentFrameworkId,
       isProviderKeyUsable: (provider) =>
         provider.id === activeProvider?.id && activeProviderKeyUsable,
-      activeProviderCompatible
+      activeProviderCompatible,
+      activeValidationTarget
     })
   }
 

--- a/src/main/settings/document-codec.ts
+++ b/src/main/settings/document-codec.ts
@@ -219,6 +219,7 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
   // Legacy shared validation describes the global home, not the app-owned isolated profile.
   if (selectedCodexProvider?.type === 'codex-shared' && migratedCodexProvider) {
     delete migratedCodexProvider.lastValidatedAt
+    delete migratedCodexProvider.lastValidatedTarget
     delete migratedCodexProvider.lastValidationFailure
     delete migratedCodexProvider.expiresAt
   }

--- a/src/main/settings/preflight.test.ts
+++ b/src/main/settings/preflight.test.ts
@@ -111,6 +111,26 @@ describe('computePreflight', () => {
     expect(run({ settings }).activeProviderReady).toBe(false)
   })
 
+  it('is not provider-ready when only another model target was validated', () => {
+    const validatedForAnotherModel = {
+      ...customProvider,
+      lastValidatedTarget: { model: 'model-a', endpoint: 'anthropic' as const }
+    } as StoredProvider & {
+      lastValidatedTarget: { model: string; endpoint: 'anthropic' }
+    }
+    const settings = baseSettings({
+      providers: [validatedForAnotherModel],
+      activeModel: 'model-b'
+    })
+
+    expect(
+      run({
+        settings,
+        activeValidationTarget: { model: 'model-b', endpoint: 'anthropic' }
+      }).activeProviderReady
+    ).toBe(false)
+  })
+
   it('is not provider-ready when the latest validation failed after an earlier success', () => {
     const settings = baseSettings({
       providers: [

--- a/src/main/settings/preflight.ts
+++ b/src/main/settings/preflight.ts
@@ -1,6 +1,8 @@
 import {
   providerValidationFailed,
+  providerValidationSucceeded,
   type AgentFrameworkId,
+  type ProviderValidationTarget,
   type Preflight
 } from '../../shared/settings'
 import type { StoredProvider, StoredSettings } from './types'
@@ -24,6 +26,7 @@ export type PreflightInput = {
   // Whether the active provider can actually drive the selected framework (endpoint + provider-type
   // compatibility). Resolved by the caller, which has the vendor registry to derive official apiTypes.
   activeProviderCompatible: boolean
+  activeValidationTarget?: ProviderValidationTarget
 }
 
 // Applies the design's gating rules: the selected framework's binary must be present, and an active
@@ -37,7 +40,8 @@ const computePreflight = ({
   codexPathExists,
   agentFrameworkId,
   isProviderKeyUsable,
-  activeProviderCompatible
+  activeProviderCompatible,
+  activeValidationTarget
 }: PreflightInput): Preflight => {
   const claudeReady = Boolean(settings.claude?.resolvedPath) && claudePathExists
   const opencodeReady = Boolean(settings.opencodePath) && opencodePathExists
@@ -59,8 +63,10 @@ const computePreflight = ({
   // incompatible pair (e.g. OpenCode + a Codex-only provider) is never marked ready.
   const activeProviderReady = Boolean(
     activeProvider &&
-    activeProvider.lastValidatedAt !== undefined &&
-    !providerValidationFailed(activeProvider) &&
+    (activeValidationTarget
+      ? providerValidationSucceeded(activeProvider, activeValidationTarget)
+      : activeProvider.lastValidatedAt !== undefined &&
+        !providerValidationFailed(activeProvider)) &&
     isProviderKeyUsable(activeProvider) &&
     activeProviderCompatible
   )

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -12,6 +12,7 @@ import type { ResolvedProvider } from './provider-env'
 import type { StoredSettings } from './types'
 import { getAgentFramework } from '../agent-framework'
 import { codexSubscriptionStorageDir } from '../agent-framework/codex'
+import { buildConfiguredModelCatalog } from '../../shared/configured-model-catalog'
 
 vi.mock('electron', () => ({
   net: {
@@ -650,6 +651,59 @@ describe('ProviderAccountsModule', () => {
     const stored = (await repository.getSettings()).providers[0]
     expect(stored.lastValidatedAt).toBeTypeOf('number')
     expect(stored.lastValidationFailure).toBeUndefined()
+  })
+
+  it('keeps another model selectable after a model-specific validation failure', async () => {
+    await module.upsertProvider({
+      type: 'custom',
+      name: 'Lab gateway',
+      baseUrl: 'https://lab.example/v1',
+      model: 'model-a',
+      key: 'secret-key',
+      apiEndpoints: ['anthropic']
+    })
+    const providerId = (await repository.getSettings()).providers[0].id
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'text', text: 'pong' }],
+              usage: { input_tokens: 1, output_tokens: 1 }
+            }),
+            { status: 200 }
+          )
+        )
+        .mockResolvedValueOnce(new Response('', { status: 404 }))
+    )
+
+    await expect(module.validateProvider({ providerId, model: 'model-a' })).resolves.toMatchObject({
+      ok: true,
+      category: 'ok'
+    })
+
+    await expect(module.validateProvider({ providerId, model: 'model-b' })).resolves.toMatchObject({
+      ok: false,
+      category: 'model-not-found'
+    })
+
+    const stored = (await repository.getSettings()).providers[0]
+    expect(stored.lastValidatedAt).toBeTypeOf('number')
+    expect(stored.lastValidatedTarget).toEqual({ model: 'model-a', endpoint: 'anthropic' })
+    expect(stored.lastValidationFailure?.target).toEqual({
+      model: 'model-b',
+      endpoint: 'anthropic'
+    })
+    const catalog = buildConfiguredModelCatalog({
+      providers: [module.toProviderView(stored)],
+      frameworkId: 'claude-code',
+      frameworkEndpoints: ['anthropic']
+    })
+    expect(catalog.map((entry) => entry.model)).toEqual(['model-a'])
   })
 
   it('coalesces shared Claude status reads and invalidates them across logout and login', async () => {

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -3,6 +3,7 @@ import type {
   ProviderDraft,
   ProviderDeletionScenarioModelHandling,
   ProviderView,
+  ProviderValidationTarget,
   RefreshProviderModelsRequest,
   RefreshProviderModelsResult,
   UpsertProviderRequest,
@@ -22,6 +23,7 @@ import {
   isProviderUsableByFramework,
   isXaiSubscriptionProvider,
   providerEndpoints,
+  preferredEndpoint,
   requiresChatCompletionsBridge,
   xaiSubscriptionProviderIdentity
 } from '../../shared/settings'
@@ -60,6 +62,10 @@ import { XaiProviderAccountOwner } from './xai-provider-account-owner'
 import { ProviderModelCatalogOwner } from './provider-model-catalog-owner'
 import { assertProviderCapacity, assertProviderDraftLimits } from './provider-resource-limits'
 import { assertProviderModelLimit } from './provider-resource-limits'
+import {
+  buildProviderValidationPatch,
+  targetForValidationResult
+} from './provider-validation-state'
 type ProviderAccountsModuleOptions = {
   repository: SettingsRepository
   storageRoot: string
@@ -256,6 +262,8 @@ class ProviderAccountsModule {
 
     if (existing?.lastValidatedAt !== undefined && !credentialsChanged)
       provider.lastValidatedAt = existing.lastValidatedAt
+    if (existing?.lastValidatedTarget !== undefined && !credentialsChanged)
+      provider.lastValidatedTarget = existing.lastValidatedTarget
     const preserveValidationFailure =
       !credentialsChanged ||
       (provider.type === 'claude-shared' && provider.disconnectedAt !== undefined)
@@ -416,6 +424,13 @@ class ProviderAccountsModule {
         ? undefined
         : await this.auth.validateProviderAuth(resolved.provider, settings, storedValidationTarget)
     const usesCompatibilityTransport = requiresChatCompletionsBridge(resolved.provider, framework)
+    const validationFrameworkEndpoints = isXaiSubscriptionProvider(resolved.provider.type)
+      ? (['responses'] as const)
+      : framework.id === 'codebuddy' && usesCompatibilityTransport
+        ? providerEndpoints(resolved.provider)
+        : framework.id === 'codex'
+          ? undefined
+          : framework.supportedApiTypes
     const result =
       incompatibility ??
       xaiAuthResult ??
@@ -426,13 +441,7 @@ class ProviderAccountsModule {
         requireNativeResponsesCompatibility:
           !isXaiSubscriptionProvider(resolved.provider.type) &&
           requiresNativeResponsesCompatibility(resolved.provider, framework),
-        frameworkEndpoints: isXaiSubscriptionProvider(resolved.provider.type)
-          ? ['responses']
-          : framework.id === 'codebuddy' && usesCompatibilityTransport
-            ? providerEndpoints(resolved.provider)
-            : framework.id === 'codex'
-              ? undefined
-              : framework.supportedApiTypes
+        frameworkEndpoints: validationFrameworkEndpoints
       }))
 
     if (!resolved.storedId) return result
@@ -451,20 +460,18 @@ class ProviderAccountsModule {
       return { ...result, applied: false }
     }
 
-    const validationPatch = result.ok
-      ? {
-          lastValidatedAt: Date.now(),
-          lastValidationFailure: undefined
-        }
-      : {
-          lastValidatedAt: undefined,
-          lastValidationFailure: {
-            at: Date.now(),
-            category: result.category,
-            status: result.status,
-            message: result.message
-          }
-        }
+    const validationTarget: ProviderValidationTarget | undefined =
+      isCodexSubscriptionProvider(resolved.provider.type) ||
+      resolved.provider.type === 'claude-isolated'
+        ? undefined
+        : targetForValidationResult(result, {
+            model: resolved.provider.model,
+            endpoint: preferredEndpoint(
+              resolved.provider.apiEndpoints ?? ['anthropic'],
+              validationFrameworkEndpoints ?? ['anthropic', 'openai', 'responses']
+            )
+          })
+    const validationPatch = buildProviderValidationPatch(stored, result, validationTarget)
 
     if (stored.type === 'claude-shared') {
       if (storedValidationTarget?.type !== 'claude-shared') {

--- a/src/main/settings/provider-auth-lifecycle.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.test.ts
@@ -148,6 +148,7 @@ describe('ProviderAuthLifecycleOwner', () => {
     await owner.loginClaudeShared()
     const reconnected = (await repository.getSettings()).providers[0]
     await expect(owner.isProviderKeyUsable(reconnected)).resolves.toBe(true)
+    expect(reconnected.lastValidatedTarget).toEqual({ endpoint: 'anthropic' })
     expect(claudeSharedAuth.getStatus).toHaveBeenCalledTimes(2)
   })
 

--- a/src/main/settings/provider-auth-lifecycle.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.test.ts
@@ -152,6 +152,21 @@ describe('ProviderAuthLifecycleOwner', () => {
     expect(claudeSharedAuth.getStatus).toHaveBeenCalledTimes(2)
   })
 
+  it('classifies a missing shared Claude login as a provider-wide auth failure', async () => {
+    vi.mocked(claudeSharedAuth.getStatus).mockResolvedValueOnce({
+      supported: true,
+      authenticated: false,
+      message: 'Not signed in.'
+    })
+    const settings = await repository.getSettings()
+    const provider = settings.providers[0]
+    const projection = new ProviderRuntimeProjectionOwner()
+
+    await expect(
+      owner.validateProviderAuth(projection.resolveProvider(provider), settings, provider)
+    ).resolves.toMatchObject({ ok: false, category: 'auth' })
+  })
+
   it('cancels the matching authentication owners before cleanup completes', async () => {
     await owner.cleanupProviderBeforeDelete('builtin-codex-subscription')
     expect(codexAuth.cancelLogin).toHaveBeenCalledOnce()

--- a/src/main/settings/provider-auth-lifecycle.ts
+++ b/src/main/settings/provider-auth-lifecycle.ts
@@ -583,10 +583,11 @@ class ProviderAuthLifecycleOwner {
       checkedAt: Date.now()
     }
     if (!status.authenticated) {
-      return this.claudeSharedAuthValidationResult(
+      const result = this.claudeSharedAuthValidationResult(
         status,
         'Not signed in. Sign in via browser OAuth in the Settings card to connect your Claude subscription.'
       )
+      return status.supported ? { ...result, category: 'auth' } : result
     }
     return this.options.runClaudeSubscriptionProbe(provider, settings)
   }

--- a/src/main/settings/provider-auth-lifecycle.ts
+++ b/src/main/settings/provider-auth-lifecycle.ts
@@ -34,6 +34,10 @@ import {
 } from './claude-shared-auth'
 import { encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey } from './crypto'
 import { getAppClaudeConfigDir, type ResolvedProvider } from './provider-env'
+import {
+  buildProviderValidationPatch,
+  targetForValidationResult
+} from './provider-validation-state'
 import type { SettingsRepository } from './repository'
 import type { SystemProxyEnvironment } from './system-proxy'
 import type { StoredProvider, StoredSettings } from './types'
@@ -224,9 +228,14 @@ class ProviderAuthLifecycleOwner {
       return this.repository.updateCodexIsolatedValidationIfIdentityMatches(
         provider,
         result.ok
-          ? { lastValidatedAt: Date.now(), lastValidationFailure: undefined }
+          ? {
+              lastValidatedAt: Date.now(),
+              lastValidatedTarget: undefined,
+              lastValidationFailure: undefined
+            }
           : {
               lastValidatedAt: undefined,
+              lastValidatedTarget: undefined,
               lastValidationFailure: {
                 at: Date.now(),
                 category: result.category,
@@ -307,33 +316,26 @@ class ProviderAuthLifecycleOwner {
     )
     if (!provider) return { ...result, applied: false }
 
-    if (result.ok) {
-      result = await this.options.runClaudeSubscriptionProbe(
-        this.options.resolveProvider(
-          provider,
-          settings.activeProviderId === provider.id ? settings.activeModel : undefined
-        ),
-        settings
-      )
-    }
+    const resolvedTarget = this.options.resolveProvider(
+      provider,
+      settings.activeProviderId === provider.id ? settings.activeModel : undefined
+    )
+    const probeStarted = result.ok
+    if (probeStarted)
+      result = await this.options.runClaudeSubscriptionProbe(resolvedTarget, settings)
+    const validationTarget = probeStarted
+      ? targetForValidationResult(result, {
+          model: resolvedTarget.model,
+          endpoint: 'anthropic'
+        })
+      : undefined
+    const validationPatch = buildProviderValidationPatch(provider, result, validationTarget)
     const applied = await this.repository.updateClaudeIsolatedValidationIfKeyMatches(
       provider.keyRef,
-      result.ok
-        ? {
-            expiresAt: Date.now() + SETUP_TOKEN_LIFETIME_MS,
-            lastValidatedAt: Date.now(),
-            lastValidationFailure: undefined
-          }
-        : {
-            expiresAt: undefined,
-            lastValidatedAt: undefined,
-            lastValidationFailure: {
-              at: Date.now(),
-              category: result.category,
-              status: result.status,
-              message: result.message
-            }
-          }
+      {
+        expiresAt: result.ok ? Date.now() + SETUP_TOKEN_LIFETIME_MS : undefined,
+        ...validationPatch
+      }
     )
     return { ...result, applied }
   }
@@ -357,6 +359,7 @@ class ProviderAuthLifecycleOwner {
         ...provider,
         expiresAt: undefined,
         lastValidatedAt: undefined,
+        lastValidatedTarget: undefined,
         lastValidationFailure: undefined
       })
     }
@@ -394,26 +397,21 @@ class ProviderAuthLifecycleOwner {
     if (result.ok) {
       result = await this.options.runClaudeSubscriptionProbe(resolvedTarget, settings)
     }
+    const validationTarget = authStatus.authenticated
+      ? targetForValidationResult(result, {
+          model: resolvedTarget.model,
+          endpoint: 'anthropic'
+        })
+      : undefined
+    const validationPatch = buildProviderValidationPatch(targetProvider, result, validationTarget)
     const applied = await this.repository.updateClaudeSharedValidationIfUnchanged(
       targetProvider,
       loginTarget.claudeSubscriptionProviderId,
       resolvedTarget.model,
-      result.ok
-        ? {
-            disconnectedAt: undefined,
-            lastValidatedAt: Date.now(),
-            lastValidationFailure: undefined
-          }
-        : {
-            disconnectedAt: authStatus.authenticated ? undefined : targetProvider.disconnectedAt,
-            lastValidatedAt: undefined,
-            lastValidationFailure: {
-              at: Date.now(),
-              category: result.category,
-              status: result.status,
-              message: result.message
-            }
-          }
+      {
+        disconnectedAt: authStatus.authenticated ? undefined : targetProvider.disconnectedAt,
+        ...validationPatch
+      }
     )
 
     return { ...result, applied }
@@ -431,6 +429,7 @@ class ProviderAuthLifecycleOwner {
         ...provider,
         disconnectedAt,
         lastValidatedAt: undefined,
+        lastValidatedTarget: undefined,
         lastValidationFailure: {
           at: disconnectedAt,
           category: 'auth',

--- a/src/main/settings/provider-runtime-projection.ts
+++ b/src/main/settings/provider-runtime-projection.ts
@@ -108,6 +108,7 @@ class ProviderRuntimeProjectionOwner {
       hasKey,
       needsKey,
       lastValidatedAt: provider.lastValidatedAt,
+      lastValidatedTarget: provider.lastValidatedTarget,
       lastValidationFailure: provider.lastValidationFailure,
       ...(provider.expiresAt !== undefined ? { expiresAt: provider.expiresAt } : {})
     }

--- a/src/main/settings/provider-validation-state.ts
+++ b/src/main/settings/provider-validation-state.ts
@@ -1,0 +1,78 @@
+import {
+  preferredEndpoint,
+  providerValidationTargetMatches,
+  type AgentFrameworkId,
+  type ChatApiEndpoint,
+  type ProviderType,
+  type ProviderValidationTarget,
+  type ValidateProviderResult
+} from '../../shared/settings'
+import type { StoredProvider } from './types'
+
+type ProviderValidationPatch = Pick<
+  StoredProvider,
+  'lastValidatedAt' | 'lastValidatedTarget' | 'lastValidationFailure'
+>
+
+export const providerRuntimeValidationTarget = (
+  target: {
+    providerType: ProviderType
+    effectiveModel?: string
+    apiEndpoints: readonly ChatApiEndpoint[]
+    needsChatResponsesBridge: boolean
+  },
+  framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+): ProviderValidationTarget => ({
+  model: target.effectiveModel,
+  endpoint: preferredEndpoint(
+    target.apiEndpoints,
+    target.providerType === 'xai-subscription'
+      ? ['responses']
+      : framework.id === 'codex' || target.needsChatResponsesBridge
+        ? target.apiEndpoints
+        : framework.supportedApiTypes
+  )
+})
+
+export const targetForValidationResult = (
+  result: ValidateProviderResult,
+  target: ProviderValidationTarget
+): ProviderValidationTarget | undefined =>
+  !result.ok && ['auth', 'bad-url', 'network', 'timeout', 'server-error'].includes(result.category)
+    ? undefined
+    : target
+
+export const buildProviderValidationPatch = (
+  provider: StoredProvider,
+  result: ValidateProviderResult,
+  target: ProviderValidationTarget | undefined,
+  at = Date.now()
+): ProviderValidationPatch => {
+  const sameFailureTarget =
+    provider.lastValidationFailure?.target === undefined ||
+    target === undefined ||
+    providerValidationTargetMatches(provider.lastValidationFailure.target, target)
+  const sameSuccessTarget =
+    provider.lastValidatedTarget === undefined ||
+    target === undefined ||
+    providerValidationTargetMatches(provider.lastValidatedTarget, target)
+
+  return result.ok
+    ? {
+        lastValidatedAt: at,
+        lastValidatedTarget: target,
+        ...(sameFailureTarget ? { lastValidationFailure: undefined } : {})
+      }
+    : {
+        ...(sameSuccessTarget
+          ? { lastValidatedAt: undefined, lastValidatedTarget: undefined }
+          : {}),
+        lastValidationFailure: {
+          at,
+          category: result.category,
+          status: result.status,
+          message: result.message,
+          target
+        }
+      }
+}

--- a/src/main/settings/record-codec.ts
+++ b/src/main/settings/record-codec.ts
@@ -3,6 +3,7 @@ import type {
   ClaudeInfo,
   ProviderType,
   ProviderValidationFailure,
+  ProviderValidationTarget,
   ValidationCategory
 } from '../../shared/settings'
 import { isCodexSubscriptionProvider } from '../../shared/settings'
@@ -116,7 +117,24 @@ const sanitizeValidationFailure = (value: unknown): ProviderValidationFailure | 
   const message = asString(value.message)
   if (status !== undefined) failure.status = status
   if (message) failure.message = message
+  const target = sanitizeValidationTarget(value.target)
+  if (target) failure.target = target
   return failure
+}
+
+const sanitizeValidationTarget = (value: unknown): ProviderValidationTarget | undefined => {
+  if (!isRecord(value)) return undefined
+  const model = asString(value.model)
+  const endpoint = asString(value.endpoint)
+  if (!model && endpoint !== 'anthropic' && endpoint !== 'openai' && endpoint !== 'responses') {
+    return undefined
+  }
+  return {
+    ...(model ? { model } : {}),
+    ...(endpoint === 'anthropic' || endpoint === 'openai' || endpoint === 'responses'
+      ? { endpoint }
+      : {})
+  }
 }
 
 // Rebuild one provider from known fields and durable credential references only.
@@ -163,6 +181,7 @@ export const sanitizeProvider = (value: unknown): StoredProvider | undefined => 
   const keyMask = asString(value.keyMask)
   const accountEmail = asString(value.accountEmail)
   const lastValidatedAt = asNumber(value.lastValidatedAt)
+  const lastValidatedTarget = sanitizeValidationTarget(value.lastValidatedTarget)
   const lastValidationFailure = sanitizeValidationFailure(value.lastValidationFailure)
   const expiresAt = asNumber(value.expiresAt)
   const disconnectedAt = asNumber(value.disconnectedAt)
@@ -227,6 +246,7 @@ export const sanitizeProvider = (value: unknown): StoredProvider | undefined => 
   if (keyMask) provider.keyMask = keyMask
   if (accountEmail && type === 'xai-subscription') provider.accountEmail = accountEmail
   if (lastValidatedAt !== undefined) provider.lastValidatedAt = lastValidatedAt
+  if (lastValidatedTarget) provider.lastValidatedTarget = lastValidatedTarget
   if (lastValidationFailure) provider.lastValidationFailure = lastValidationFailure
   if (expiresAt !== undefined) provider.expiresAt = expiresAt
   if (disconnectedAt !== undefined && type === 'claude-shared') {

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -941,21 +941,29 @@ describe('settings repository', () => {
 
     await repository.upsertProvider(
       provider({
+        lastValidatedAt: 1716999999999,
+        lastValidatedTarget: { model: 'model-a', endpoint: 'anthropic' },
         lastValidationFailure: {
           at: 1717000000000,
-          category: 'auth',
-          status: 401,
-          message: 'nope'
+          category: 'model-not-found',
+          status: 404,
+          message: 'nope',
+          target: { model: 'model-b', endpoint: 'anthropic' }
         }
       })
     )
 
     const reloaded = await new SettingsRepository(root).getSettings()
+    expect(reloaded.providers[0].lastValidatedTarget).toEqual({
+      model: 'model-a',
+      endpoint: 'anthropic'
+    })
     expect(reloaded.providers[0].lastValidationFailure).toEqual({
       at: 1717000000000,
-      category: 'auth',
-      status: 401,
-      message: 'nope'
+      category: 'model-not-found',
+      status: 404,
+      message: 'nope',
+      target: { model: 'model-b', endpoint: 'anthropic' }
     })
   })
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -161,6 +161,7 @@ class SettingsRepository {
 
       const provider = { ...current }
       delete provider.lastValidatedAt
+      delete provider.lastValidatedTarget
       delete provider.lastValidationFailure
       const providers = [...settings.providers]
       providers[index] = provider
@@ -173,7 +174,8 @@ class SettingsRepository {
 
   async updateCodexIsolatedValidationIfIdentityMatches(
     expectedProvider: Pick<StoredProvider, 'id' | 'type' | 'codexAuthMode'>,
-    patch: Pick<StoredProvider, 'lastValidatedAt' | 'lastValidationFailure'>
+    patch: Pick<StoredProvider, 'lastValidatedAt' | 'lastValidationFailure'> &
+      Partial<Pick<StoredProvider, 'lastValidatedTarget'>>
   ): Promise<boolean> {
     let applied = false
 
@@ -221,7 +223,10 @@ class SettingsRepository {
   // first paste) it is created with the fixed id/name, mirroring codex's single subscription record.
   async upsertClaudeIsolatedProvider(
     patch: Partial<
-      Pick<StoredProvider, 'keyRef' | 'keyMask' | 'lastValidatedAt' | 'lastValidationFailure'>
+      Pick<
+        StoredProvider,
+        'keyRef' | 'keyMask' | 'lastValidatedAt' | 'lastValidatedTarget' | 'lastValidationFailure'
+      >
     >
   ): Promise<StoredSettings> {
     const identity = claudeIsolatedProviderIdentity()
@@ -275,7 +280,8 @@ class SettingsRepository {
   // replacement token as verified.
   async updateClaudeIsolatedValidationIfKeyMatches(
     expectedKeyRef: string | undefined,
-    patch: Pick<StoredProvider, 'expiresAt' | 'lastValidatedAt' | 'lastValidationFailure'>
+    patch: Pick<StoredProvider, 'expiresAt' | 'lastValidatedAt' | 'lastValidationFailure'> &
+      Partial<Pick<StoredProvider, 'lastValidatedTarget'>>
   ): Promise<boolean> {
     let applied = false
 
@@ -299,7 +305,8 @@ class SettingsRepository {
     expectedProvider: StoredProvider,
     expectedPreferredMode: ClaudeSubscriptionProviderId | undefined,
     expectedResolvedModel: string | undefined,
-    patch: Pick<StoredProvider, 'disconnectedAt' | 'lastValidatedAt' | 'lastValidationFailure'>
+    patch: Pick<StoredProvider, 'disconnectedAt' | 'lastValidatedAt' | 'lastValidationFailure'> &
+      Partial<Pick<StoredProvider, 'lastValidatedTarget'>>
   ): Promise<boolean> {
     let applied = false
 

--- a/src/main/settings/reviewer-model-owner.ts
+++ b/src/main/settings/reviewer-model-owner.ts
@@ -2,6 +2,7 @@ import { providerValidationFailed, type ReviewerModelConfiguration } from '../..
 import { DEFAULT_AGENT_FRAMEWORK_ID, getAgentFramework } from '../agent-framework'
 import type { AgentBackendResolver, ExplicitAgentBackendTarget } from './backend-resolver'
 import type { ProviderAccountsModule } from './provider-accounts'
+import { providerRuntimeValidationTarget } from './provider-validation-state'
 import type { SettingsRepository } from './repository'
 
 type ReviewerModelOwnerOptions = {
@@ -40,6 +41,11 @@ class ReviewerModelOwner {
         { kind: 'required', model: candidate.model },
         framework
       )
+      if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+        throw new Error(
+          'The selected Reviewer model is no longer available. Refresh the model catalog.'
+        )
+      }
       if (
         !target.frameworkCompatible ||
         (framework.id === 'codex' && !target.modelBridgeSupported)
@@ -70,6 +76,17 @@ class ReviewerModelOwner {
       throw new Error('The configured Reviewer model provider validation failed.')
     }
     const { frameworkId } = await this.options.backendResolver.captureConfiguredSelection()
+    const framework = getAgentFramework(frameworkId)
+    if (provider) {
+      const target = this.options.providers.resolveRuntimeTarget(
+        provider,
+        { kind: 'required', model: configuration.model },
+        framework
+      )
+      if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+        throw new Error('The configured Reviewer model provider validation failed.')
+      }
+    }
     return Object.freeze({
       model: configuration.model,
       fixedTarget: Object.freeze({

--- a/src/main/settings/session-details-model-owner.test.ts
+++ b/src/main/settings/session-details-model-owner.test.ts
@@ -6,9 +6,9 @@ import { SessionDetailsModelOwner } from './session-details-model-owner'
 import type { SettingsRepository } from './repository'
 import type { ProviderAccountsModule } from './provider-accounts'
 import type { AgentBackendResolver } from './backend-resolver'
-import type { StoredSettings } from './types'
+import type { StoredProvider, StoredSettings } from './types'
 
-const provider = {
+const provider: StoredProvider = {
   id: 'provider-a',
   type: 'custom' as const,
   name: 'Provider A',
@@ -17,7 +17,8 @@ const provider = {
 }
 
 const createOwner = (
-  configuration: SessionDetailsModelConfiguration
+  configuration: SessionDetailsModelConfiguration,
+  providerPatch: Partial<StoredProvider> = {}
 ): {
   owner: SessionDetailsModelOwner
   repository: SettingsRepository
@@ -25,7 +26,7 @@ const createOwner = (
 } => {
   let settings = {
     version: 2,
-    providers: [provider],
+    providers: [{ ...provider, ...providerPatch }],
     agentFrameworkId: 'opencode' as const,
     sessionDetailsModel: configuration
   } satisfies StoredSettings
@@ -38,9 +39,14 @@ const createOwner = (
     })
   } as unknown as SettingsRepository
   const providers = {
-    resolveRuntimeTarget: vi.fn(() => ({
+    resolveRuntimeTarget: vi.fn((_provider, selection) => ({
+      providerId: provider.id,
+      providerType: provider.type,
+      effectiveModel: selection.kind === 'required' ? selection.model : provider.model,
+      apiEndpoints: ['openai'],
       frameworkCompatible: true,
       modelBridgeSupported: true,
+      needsChatResponsesBridge: false,
       reasoningEffortProfile: { supported: false }
     }))
   } as unknown as ProviderAccountsModule
@@ -137,5 +143,39 @@ describe('SessionDetailsModelOwner', () => {
     await expect(owner.admit(session({ agentFrameworkId: 'opencode' }))).rejects.toThrow(
       'no complete Main model target'
     )
+  })
+
+  it('applies a targeted validation failure only to its matching model', async () => {
+    const failure = {
+      at: 20,
+      category: 'model-not-found' as const,
+      target: { model: 'model-b', endpoint: 'openai' as const }
+    }
+    const { owner } = createOwner(
+      {
+        mode: 'fixed',
+        providerId: 'provider-a',
+        model: 'model-a',
+        reasoningEffort: 'low'
+      },
+      { lastValidationFailure: failure }
+    )
+
+    await expect(
+      owner.set({
+        mode: 'fixed',
+        providerId: 'provider-a',
+        model: 'model-a',
+        reasoningEffort: 'low'
+      })
+    ).resolves.toBeUndefined()
+    await expect(
+      owner.set({
+        mode: 'fixed',
+        providerId: 'provider-a',
+        model: 'model-b',
+        reasoningEffort: 'low'
+      })
+    ).rejects.toThrow('no longer available')
   })
 })

--- a/src/main/settings/session-details-model-owner.ts
+++ b/src/main/settings/session-details-model-owner.ts
@@ -8,6 +8,7 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 import { DEFAULT_AGENT_FRAMEWORK_ID, getAgentFramework } from '../agent-framework'
 import type { AgentBackendResolver, ExplicitAgentBackendTarget } from './backend-resolver'
 import type { ProviderAccountsModule } from './provider-accounts'
+import { providerRuntimeValidationTarget } from './provider-validation-state'
 import type { SettingsRepository } from './repository'
 import type { StoredSettings } from './types'
 
@@ -56,6 +57,11 @@ class SessionDetailsModelOwner {
         { kind: 'required', model: candidate.model },
         framework
       )
+      if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+        throw new Error(
+          'The selected Session details model is no longer available. Refresh the model catalog.'
+        )
+      }
       if (
         !target.frameworkCompatible ||
         (framework.id === 'codex' && !target.modelBridgeSupported)
@@ -95,6 +101,9 @@ class SessionDetailsModelOwner {
       { kind: 'required', model },
       framework
     )
+    if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+      throw new Error('The Session details model provider is unavailable.')
+    }
     if (!target.frameworkCompatible || (framework.id === 'codex' && !target.modelBridgeSupported)) {
       throw new Error('The Session details model is unavailable for its Agent Framework.')
     }

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -719,6 +719,7 @@ describe('Settings backend ownership architecture', () => {
       'keyMask',
       'keyRef',
       'lastValidatedAt',
+      'lastValidatedTarget',
       'lastValidationFailure',
       'maxInputTokens',
       'maxOutputTokens',

--- a/src/main/settings/subagent-model-owner.ts
+++ b/src/main/settings/subagent-model-owner.ts
@@ -1,4 +1,4 @@
-import type { SubagentModelConfiguration } from '../../shared/settings'
+import { providerValidationFailed, type SubagentModelConfiguration } from '../../shared/settings'
 import type { ResolvedSubagentModelSnapshot } from '../../shared/session-persistence'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import { createDelegateExecutionBackendLease } from '../delegation/execution-backend-lease'
@@ -12,6 +12,7 @@ import {
 } from '../agent-framework'
 import type { AgentBackendResolutionContext, AgentBackendResolver } from './backend-resolver'
 import type { ProviderAccountsModule } from './provider-accounts'
+import { providerRuntimeValidationTarget } from './provider-validation-state'
 import type { SettingsRepository } from './repository'
 
 type InheritedSubagentModel = Readonly<{
@@ -37,10 +38,7 @@ class SubagentModelOwner {
     await this.options.repository.setSubagentModel(configuration, (settings, candidate) => {
       if (candidate.mode === 'inherit') return
       const provider = settings.providers.find((entry) => entry.id === candidate.providerId)
-      const validationFailed =
-        provider?.lastValidationFailure !== undefined &&
-        (provider.lastValidatedAt === undefined ||
-          provider.lastValidationFailure.at >= provider.lastValidatedAt)
+      const validationFailed = provider ? providerValidationFailed(provider) : false
       if (!provider || validationFailed) {
         throw new Error(
           'The selected Subagent model is no longer available. Refresh the model catalog.'
@@ -52,6 +50,11 @@ class SubagentModelOwner {
         { kind: 'required', model: candidate.model },
         framework
       )
+      if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+        throw new Error(
+          'The selected Subagent model is no longer available. Refresh the model catalog.'
+        )
+      }
       if (
         !target.frameworkCompatible ||
         (framework.id === 'codex' && !target.modelBridgeSupported)
@@ -100,12 +103,20 @@ class SubagentModelOwner {
     const provider = settings.providers.find(
       (candidate) => candidate.id === configuration.providerId
     )
-    const validationFailed =
-      provider?.lastValidationFailure !== undefined &&
-      (provider.lastValidatedAt === undefined ||
-        provider.lastValidationFailure.at >= provider.lastValidatedAt)
+    const validationFailed = provider ? providerValidationFailed(provider) : false
     if (validationFailed) {
       throw new Error('The configured Subagent model provider validation failed.')
+    }
+    if (provider) {
+      const framework = getAgentFramework(frameworkId)
+      const target = this.options.providers.resolveRuntimeTarget(
+        provider,
+        { kind: 'required', model: configuration.model },
+        framework
+      )
+      if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+        throw new Error('The configured Subagent model provider validation failed.')
+      }
     }
 
     const backend = await this.options.backendResolver.resolveExplicitTarget({

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -9,6 +9,7 @@ import type {
   ProjectFilesFilterPreference,
   ProviderType,
   ProviderValidationFailure,
+  ProviderValidationTarget,
   ReasoningEffort,
   ReviewerModelConfiguration,
   SessionDetailsModelConfiguration,
@@ -80,8 +81,10 @@ export type StoredProvider = {
   accountEmail?: string
   keyRef?: string
   keyMask?: string
-  // Timestamp of the last successful connectivity/key check on the provider's first model.
+  // Timestamp of the last successful connectivity/key check.
   lastValidatedAt?: number
+  // Non-secret model/protocol fingerprint for the last successful target probe.
+  lastValidatedTarget?: ProviderValidationTarget
   // Estimated expiry of a stored credential, used to surface "expires <date>" on the Settings card.
   // Only set for credential types that have a known bounded lifetime: today that is the Claude
   // `claude setup-token` (Anthropic documents a one-year lifetime) and a codex subscription sign-in

--- a/src/main/settings/vision-model-owner.ts
+++ b/src/main/settings/vision-model-owner.ts
@@ -4,6 +4,7 @@ import { providerValidationFailed, type VisionModelConfiguration } from '../../s
 import { DEFAULT_AGENT_FRAMEWORK_ID, getAgentFramework } from '../agent-framework'
 import type { AgentBackendResolver, ExplicitAgentBackendTarget } from './backend-resolver'
 import type { ProviderAccountsModule } from './provider-accounts'
+import { providerRuntimeValidationTarget } from './provider-validation-state'
 import type { SettingsRepository } from './repository'
 
 type VisionModelOwnerOptions = Readonly<{
@@ -37,6 +38,11 @@ class VisionModelOwner {
         { kind: 'required', model: candidate.model },
         framework
       )
+      if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+        throw new Error(
+          'The selected Vision model is no longer available. Refresh the model catalog.'
+        )
+      }
       if (
         !target.frameworkCompatible ||
         (framework.id === 'codex' && !target.modelBridgeSupported)
@@ -69,6 +75,9 @@ class VisionModelOwner {
       { kind: 'required', model: configuration.model },
       framework
     )
+    if (providerValidationFailed(provider, providerRuntimeValidationTarget(target, framework))) {
+      throw new Error('The configured Vision model provider is unavailable.')
+    }
     if (
       !target.frameworkCompatible ||
       (framework.id === 'codex' && !target.modelBridgeSupported) ||

--- a/src/main/settings/xai-provider-account-owner.ts
+++ b/src/main/settings/xai-provider-account-owner.ts
@@ -39,6 +39,7 @@ export class XaiProviderAccountOwner {
               }
               if (clearValidation) {
                 delete updated.lastValidatedAt
+                delete updated.lastValidatedTarget
                 delete updated.lastValidationFailure
               }
               await this.repository.upsertProvider(updated)
@@ -52,6 +53,7 @@ export class XaiProviderAccountOwner {
               delete withoutCredential.keyRef
               delete withoutCredential.accountEmail
               delete withoutCredential.lastValidatedAt
+              delete withoutCredential.lastValidatedTarget
               delete withoutCredential.lastValidationFailure
               await this.repository.upsertProvider(withoutCredential)
             })

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -4,10 +4,12 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
+  AgentFrameworkId,
+  ChatApiEndpoint,
   ClaudeSubscriptionProviderId,
-  ProviderValidationTarget,
   ProviderView
 } from '../../../../shared/settings'
+import { defaultVendorModel } from '../../../../shared/provider-registry'
 import { ProviderList } from './ProviderList'
 
 let container: HTMLDivElement
@@ -65,7 +67,9 @@ const renderList = (
     onCancelXaiLogin?: () => void
     onLogoutXai?: () => void
     claudeSubscriptionProviderId?: ClaudeSubscriptionProviderId
-    activeValidationTarget?: ProviderValidationTarget
+    activeModel?: string
+    agentFrameworkId?: AgentFrameworkId
+    frameworkEndpoints?: readonly ChatApiEndpoint[]
   } = {}
 ): void => {
   act(() => {
@@ -73,7 +77,9 @@ const renderList = (
       <ProviderList
         providers={providers}
         activeProviderId={activeId}
-        activeValidationTarget={callbacks.activeValidationTarget}
+        activeModel={callbacks.activeModel}
+        agentFrameworkId={callbacks.agentFrameworkId}
+        frameworkEndpoints={callbacks.frameworkEndpoints}
         busyProviderId={busyId}
         onEdit={noop}
         onDelete={noop}
@@ -236,7 +242,7 @@ describe('ProviderList', () => {
       ],
       'p1',
       undefined,
-      { activeValidationTarget: { model: 'model-b', endpoint: 'anthropic' } }
+      { activeModel: 'model-b' }
     )
 
     expect(container.querySelector('[aria-label="Connection verified"]')).toBeNull()
@@ -246,17 +252,37 @@ describe('ProviderList', () => {
     renderList(
       [
         provider({
+          apiEndpoints: ['anthropic', 'openai'],
           lastValidatedTarget: { model: 'claude-sonnet-4-5', endpoint: 'anthropic' }
         })
       ],
       'p1',
       undefined,
       {
-        activeValidationTarget: { model: 'claude-sonnet-4-5', endpoint: 'openai' }
+        activeModel: 'claude-sonnet-4-5',
+        agentFrameworkId: 'opencode',
+        frameworkEndpoints: ['openai']
       }
     )
 
     expect(container.querySelector('[aria-label="Connection verified"]')).toBeNull()
+  })
+
+  it('matches an official provider validation against its default effective model', () => {
+    const model = defaultVendorModel('anthropic')
+    renderList(
+      [
+        provider({
+          type: 'official',
+          vendorId: 'anthropic',
+          model: undefined,
+          lastValidatedTarget: { model, endpoint: 'anthropic' }
+        })
+      ],
+      'p1'
+    )
+
+    expect(container.querySelector('[aria-label="Connection verified"]')).not.toBeNull()
   })
 
   it('shows a testing state (and no check/warning) while a provider is being validated', () => {

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -3,7 +3,11 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ClaudeSubscriptionProviderId, ProviderView } from '../../../../shared/settings'
+import type {
+  ClaudeSubscriptionProviderId,
+  ProviderValidationTarget,
+  ProviderView
+} from '../../../../shared/settings'
 import { ProviderList } from './ProviderList'
 
 let container: HTMLDivElement
@@ -61,7 +65,7 @@ const renderList = (
     onCancelXaiLogin?: () => void
     onLogoutXai?: () => void
     claudeSubscriptionProviderId?: ClaudeSubscriptionProviderId
-    activeModel?: string
+    activeValidationTarget?: ProviderValidationTarget
   } = {}
 ): void => {
   act(() => {
@@ -69,7 +73,7 @@ const renderList = (
       <ProviderList
         providers={providers}
         activeProviderId={activeId}
-        activeModel={callbacks.activeModel}
+        activeValidationTarget={callbacks.activeValidationTarget}
         busyProviderId={busyId}
         onEdit={noop}
         onDelete={noop}
@@ -232,7 +236,24 @@ describe('ProviderList', () => {
       ],
       'p1',
       undefined,
-      { activeModel: 'model-b' }
+      { activeValidationTarget: { model: 'model-b', endpoint: 'anthropic' } }
+    )
+
+    expect(container.querySelector('[aria-label="Connection verified"]')).toBeNull()
+  })
+
+  it('does not mark the active provider verified for a different protocol target', () => {
+    renderList(
+      [
+        provider({
+          lastValidatedTarget: { model: 'claude-sonnet-4-5', endpoint: 'anthropic' }
+        })
+      ],
+      'p1',
+      undefined,
+      {
+        activeValidationTarget: { model: 'claude-sonnet-4-5', endpoint: 'openai' }
+      }
     )
 
     expect(container.querySelector('[aria-label="Connection verified"]')).toBeNull()

--- a/src/renderer/src/pages/settings/ProviderList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.render.test.tsx
@@ -61,6 +61,7 @@ const renderList = (
     onCancelXaiLogin?: () => void
     onLogoutXai?: () => void
     claudeSubscriptionProviderId?: ClaudeSubscriptionProviderId
+    activeModel?: string
   } = {}
 ): void => {
   act(() => {
@@ -68,6 +69,7 @@ const renderList = (
       <ProviderList
         providers={providers}
         activeProviderId={activeId}
+        activeModel={callbacks.activeModel}
         busyProviderId={busyId}
         onEdit={noop}
         onDelete={noop}
@@ -217,6 +219,23 @@ describe('ProviderList', () => {
 
     expect(container.querySelector('[aria-label="Connection verified"]')).not.toBeNull()
     expect(container.textContent).not.toContain('Test failed')
+  })
+
+  it('does not mark the active provider verified for a different model target', () => {
+    renderList(
+      [
+        provider({
+          model: 'model-b',
+          models: ['model-a', 'model-b'],
+          lastValidatedTarget: { model: 'model-a', endpoint: 'anthropic' }
+        })
+      ],
+      'p1',
+      undefined,
+      { activeModel: 'model-b' }
+    )
+
+    expect(container.querySelector('[aria-label="Connection verified"]')).toBeNull()
   })
 
   it('shows a testing state (and no check/warning) while a provider is being validated', () => {

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -18,6 +18,7 @@ import type {
   ChatApiEndpoint,
   ClaudeSubscriptionProviderId,
   ProviderValidationFailure,
+  ProviderValidationTarget,
   ProviderView
 } from '../../../../shared/settings'
 import {
@@ -27,6 +28,7 @@ import {
   isXaiSubscriptionProvider,
   providerEndpoints,
   providerValidationFailed,
+  providerValidationTargetMatches,
   resolveCodexSubscriptionType,
   selectClaudeSubscriptionProvider
 } from '../../../../shared/settings'
@@ -43,7 +45,7 @@ type ProviderListProps = {
   // Provider that sources the currently selected model. Not shown as an "active provider"; used only
   // to keep the in-use provider from being deleted (which would leave no selectable model).
   activeProviderId: string | undefined
-  activeModel?: string
+  activeValidationTarget?: ProviderValidationTarget
   claudeSubscriptionProviderId?: ClaudeSubscriptionProviderId
   busyProviderId?: string
   onEdit: (provider: ProviderView) => void
@@ -143,7 +145,7 @@ const describeType = (provider: ProviderView, t: TFunction): string => {
 const ProviderList = ({
   providers,
   activeProviderId,
-  activeModel,
+  activeValidationTarget,
   claudeSubscriptionProviderId,
   busyProviderId,
   onEdit,
@@ -216,14 +218,15 @@ const ProviderList = ({
             ? provider.lastValidationFailure
             : undefined
           // A passing test shows a green check. Suppressed while a test is in flight.
-          const validationMatchesActiveModel =
+          const validationMatchesActiveTarget =
             !isActiveSource ||
             provider.lastValidatedTarget === undefined ||
-            provider.lastValidatedTarget.model === activeModel
+            (activeValidationTarget !== undefined &&
+              providerValidationTargetMatches(provider.lastValidatedTarget, activeValidationTarget))
           const isVerified =
             !failure &&
             !isBusy &&
-            validationMatchesActiveModel &&
+            validationMatchesActiveTarget &&
             provider.lastValidatedAt !== undefined
           const isCodexSubscription = isCodexSubscriptionProvider(provider.type)
           const isXaiSubscription = isXaiSubscriptionProvider(provider.type)

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -43,6 +43,7 @@ type ProviderListProps = {
   // Provider that sources the currently selected model. Not shown as an "active provider"; used only
   // to keep the in-use provider from being deleted (which would leave no selectable model).
   activeProviderId: string | undefined
+  activeModel?: string
   claudeSubscriptionProviderId?: ClaudeSubscriptionProviderId
   busyProviderId?: string
   onEdit: (provider: ProviderView) => void
@@ -142,6 +143,7 @@ const describeType = (provider: ProviderView, t: TFunction): string => {
 const ProviderList = ({
   providers,
   activeProviderId,
+  activeModel,
   claudeSubscriptionProviderId,
   busyProviderId,
   onEdit,
@@ -208,13 +210,21 @@ const ProviderList = ({
         {displayedProviders.map((provider) => {
           const isActiveSource = provider.id === activeProviderId
           const isBusy = provider.id === busyProviderId
-          // A failed test flags the provider as unverified: it shows a warning here and is excluded
-          // from the model pickers until a later test passes.
-          const failure = providerValidationFailed(provider)
+          // Show the latest failed test on the provider card. Targeted failures only exclude the
+          // matching model/protocol from pickers; provider-wide failures still exclude everything.
+          const failure = providerValidationFailed(provider, provider.lastValidationFailure?.target)
             ? provider.lastValidationFailure
             : undefined
           // A passing test shows a green check. Suppressed while a test is in flight.
-          const isVerified = !failure && !isBusy && provider.lastValidatedAt !== undefined
+          const validationMatchesActiveModel =
+            !isActiveSource ||
+            provider.lastValidatedTarget === undefined ||
+            provider.lastValidatedTarget.model === activeModel
+          const isVerified =
+            !failure &&
+            !isBusy &&
+            validationMatchesActiveModel &&
+            provider.lastValidatedAt !== undefined
           const isCodexSubscription = isCodexSubscriptionProvider(provider.type)
           const isXaiSubscription = isXaiSubscriptionProvider(provider.type)
           const codexSubscriptionType = isCodexSubscription

--- a/src/renderer/src/pages/settings/ProviderList.tsx
+++ b/src/renderer/src/pages/settings/ProviderList.tsx
@@ -15,10 +15,10 @@ import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
 import type {
+  AgentFrameworkId,
   ChatApiEndpoint,
   ClaudeSubscriptionProviderId,
   ProviderValidationFailure,
-  ProviderValidationTarget,
   ProviderView
 } from '../../../../shared/settings'
 import {
@@ -26,13 +26,15 @@ import {
   isClaudeSubscriptionProvider,
   isCodexSubscriptionProvider,
   isXaiSubscriptionProvider,
+  preferredEndpoint,
   providerEndpoints,
   providerValidationFailed,
   providerValidationTargetMatches,
+  requiresChatCompletionsBridge,
   resolveCodexSubscriptionType,
   selectClaudeSubscriptionProvider
 } from '../../../../shared/settings'
-import { getOfficialVendor } from '../../../../shared/provider-registry'
+import { defaultVendorModel, getOfficialVendor } from '../../../../shared/provider-registry'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useDateTimeFormat } from '@/hooks/useDateTimeFormat'
 import { ProviderKindIcon } from './provider-icons'
@@ -45,7 +47,9 @@ type ProviderListProps = {
   // Provider that sources the currently selected model. Not shown as an "active provider"; used only
   // to keep the in-use provider from being deleted (which would leave no selectable model).
   activeProviderId: string | undefined
-  activeValidationTarget?: ProviderValidationTarget
+  activeModel?: string
+  agentFrameworkId?: AgentFrameworkId
+  frameworkEndpoints?: readonly ChatApiEndpoint[]
   claudeSubscriptionProviderId?: ClaudeSubscriptionProviderId
   busyProviderId?: string
   onEdit: (provider: ProviderView) => void
@@ -125,6 +129,8 @@ const ENDPOINT_PATHS: Record<ChatApiEndpoint, string> = {
   responses: '/v1/responses'
 }
 
+const DEFAULT_FRAMEWORK_ENDPOINTS = ['anthropic'] as const
+
 // Human label for a provider type badge: the vendor name for official providers, else a type name.
 // Vendor names and the Codex identity are proper nouns and stay as the registry supplies them.
 const describeType = (provider: ProviderView, t: TFunction): string => {
@@ -145,7 +151,9 @@ const describeType = (provider: ProviderView, t: TFunction): string => {
 const ProviderList = ({
   providers,
   activeProviderId,
-  activeValidationTarget,
+  activeModel,
+  agentFrameworkId = 'claude-code',
+  frameworkEndpoints = DEFAULT_FRAMEWORK_ENDPOINTS,
   claudeSubscriptionProviderId,
   busyProviderId,
   onEdit,
@@ -217,12 +225,32 @@ const ProviderList = ({
           const failure = providerValidationFailed(provider, provider.lastValidationFailure?.target)
             ? provider.lastValidationFailure
             : undefined
+          const providerRoutes = providerEndpoints(provider)
+          const effectiveModel =
+            activeModel ??
+            provider.model ??
+            (provider.vendorId ? defaultVendorModel(provider.vendorId) : undefined)
+          const activeValidationTarget = {
+            model: effectiveModel,
+            endpoint: preferredEndpoint(
+              providerRoutes,
+              isXaiSubscriptionProvider(provider.type)
+                ? (['responses'] as const)
+                : agentFrameworkId === 'codex'
+                  ? (['anthropic', 'openai', 'responses'] as const)
+                  : requiresChatCompletionsBridge(
+                        { apiEndpoints: providerRoutes },
+                        { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
+                      )
+                    ? providerRoutes
+                    : frameworkEndpoints
+            )
+          }
           // A passing test shows a green check. Suppressed while a test is in flight.
           const validationMatchesActiveTarget =
             !isActiveSource ||
             provider.lastValidatedTarget === undefined ||
-            (activeValidationTarget !== undefined &&
-              providerValidationTargetMatches(provider.lastValidatedTarget, activeValidationTarget))
+            providerValidationTargetMatches(provider.lastValidatedTarget, activeValidationTarget)
           const isVerified =
             !failure &&
             !isBusy &&
@@ -237,7 +265,6 @@ const ProviderList = ({
           // removing it would leave no model to run, so its delete action stays disabled.
           const canDelete = !isActiveSource && displayedProviders.length > 1
           // The chat endpoint(s) this provider speaks; defaults to Anthropic when unset (older/custom).
-          const providerRoutes = providerEndpoints(provider)
           const endpoint = {
             path: providerRoutes.map((route) => ENDPOINT_PATHS[route]).join(' · '),
             full:

--- a/src/renderer/src/pages/settings/ProvidersPanel.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.tsx
@@ -24,11 +24,7 @@ import {
   CLAUDE_ISOLATED_PROVIDER_ID,
   CLAUDE_SHARED_PROVIDER_ID,
   isClaudeSubscriptionProvider,
-  isCodexSubscriptionProvider,
-  isXaiSubscriptionProvider,
-  preferredEndpoint,
-  providerEndpoints,
-  requiresChatCompletionsBridge
+  isCodexSubscriptionProvider
 } from '../../../../shared/settings'
 import { DiagnosticDetails } from '@/components/diagnostic-details'
 import { errorDetail } from '@/lib/error-detail'
@@ -164,27 +160,6 @@ const ProvidersPanel = ({
   // first wins. When the manual paste wins we cancel the background browser login, and this flag
   // stops that cancelled login's rejection from surfacing a spurious error over the paste's success.
   const manualClaudePasteWonRef = useRef(false)
-
-  const activeProvider = providers.find((provider) => provider.id === activeProviderId)
-  const activeProviderEndpoints = activeProvider ? providerEndpoints(activeProvider) : []
-  const activeValidationTarget = activeProvider
-    ? {
-        model: activeModel,
-        endpoint: preferredEndpoint(
-          activeProviderEndpoints,
-          isXaiSubscriptionProvider(activeProvider.type)
-            ? (['responses'] as const)
-            : agentFrameworkId === 'codex'
-              ? (['anthropic', 'openai', 'responses'] as const)
-              : requiresChatCompletionsBridge(
-                    { apiEndpoints: activeProviderEndpoints },
-                    { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
-                  )
-                ? activeProviderEndpoints
-                : frameworkEndpoints
-        )
-      }
-    : undefined
 
   // A pending sign-in lives in the main process for up to five minutes. This panel unmounts when
   // Settings closes (or the user switches panels), and an orphaned flow would have no cancel
@@ -540,7 +515,9 @@ const ProvidersPanel = ({
         <ProviderList
           providers={visibleProviders}
           activeProviderId={activeProviderId}
-          activeValidationTarget={activeValidationTarget}
+          activeModel={activeModel}
+          agentFrameworkId={agentFrameworkId}
+          frameworkEndpoints={frameworkEndpoints}
           claudeSubscriptionProviderId={claudeSubscriptionProviderId}
           busyProviderId={busyProviderId}
           onEdit={onEditProvider}

--- a/src/renderer/src/pages/settings/ProvidersPanel.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.tsx
@@ -14,7 +14,7 @@ import {
   dialogPanelClassName,
   dialogTitleClassName
 } from '@/components/ui/dialog-chrome'
-import { useSettingsStore } from '@/stores/settings-store'
+import { selectFrameworkApiEndpoints, useSettingsStore } from '@/stores/settings-store'
 import type {
   ProviderView,
   ValidateProviderResult,
@@ -24,7 +24,11 @@ import {
   CLAUDE_ISOLATED_PROVIDER_ID,
   CLAUDE_SHARED_PROVIDER_ID,
   isClaudeSubscriptionProvider,
-  isCodexSubscriptionProvider
+  isCodexSubscriptionProvider,
+  isXaiSubscriptionProvider,
+  preferredEndpoint,
+  providerEndpoints,
+  requiresChatCompletionsBridge
 } from '../../../../shared/settings'
 import { DiagnosticDetails } from '@/components/diagnostic-details'
 import { errorDetail } from '@/lib/error-detail'
@@ -112,6 +116,7 @@ const ProvidersPanel = ({
     (state) => state.claudeSubscriptionProviderId
   )
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
   const subagentModel = useSettingsStore((state) => state.subagentModel)
   const reviewerModel = useSettingsStore((state) => state.reviewerModel)
   const sessionDetailsModel = useSettingsStore((state) => state.sessionDetailsModel)
@@ -159,6 +164,27 @@ const ProvidersPanel = ({
   // first wins. When the manual paste wins we cancel the background browser login, and this flag
   // stops that cancelled login's rejection from surfacing a spurious error over the paste's success.
   const manualClaudePasteWonRef = useRef(false)
+
+  const activeProvider = providers.find((provider) => provider.id === activeProviderId)
+  const activeProviderEndpoints = activeProvider ? providerEndpoints(activeProvider) : []
+  const activeValidationTarget = activeProvider
+    ? {
+        model: activeModel,
+        endpoint: preferredEndpoint(
+          activeProviderEndpoints,
+          isXaiSubscriptionProvider(activeProvider.type)
+            ? (['responses'] as const)
+            : agentFrameworkId === 'codex'
+              ? (['anthropic', 'openai', 'responses'] as const)
+              : requiresChatCompletionsBridge(
+                    { apiEndpoints: activeProviderEndpoints },
+                    { id: agentFrameworkId, supportedApiTypes: frameworkEndpoints }
+                  )
+                ? activeProviderEndpoints
+                : frameworkEndpoints
+        )
+      }
+    : undefined
 
   // A pending sign-in lives in the main process for up to five minutes. This panel unmounts when
   // Settings closes (or the user switches panels), and an orphaned flow would have no cancel
@@ -514,7 +540,7 @@ const ProvidersPanel = ({
         <ProviderList
           providers={visibleProviders}
           activeProviderId={activeProviderId}
-          activeModel={activeModel}
+          activeValidationTarget={activeValidationTarget}
           claudeSubscriptionProviderId={claudeSubscriptionProviderId}
           busyProviderId={busyProviderId}
           onEdit={onEditProvider}

--- a/src/renderer/src/pages/settings/ProvidersPanel.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.tsx
@@ -107,6 +107,7 @@ const ProvidersPanel = ({
   const { t } = useTranslation()
   const providers = useSettingsStore((state) => state.providers)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
+  const activeModel = useSettingsStore((state) => state.activeModel)
   const claudeSubscriptionProviderId = useSettingsStore(
     (state) => state.claudeSubscriptionProviderId
   )
@@ -513,6 +514,7 @@ const ProvidersPanel = ({
         <ProviderList
           providers={visibleProviders}
           activeProviderId={activeProviderId}
+          activeModel={activeModel}
           claudeSubscriptionProviderId={claudeSubscriptionProviderId}
           busyProviderId={busyProviderId}
           onEdit={onEditProvider}

--- a/src/shared/configured-model-catalog.test.ts
+++ b/src/shared/configured-model-catalog.test.ts
@@ -67,6 +67,24 @@ describe('configured model catalog', () => {
     ])
   })
 
+  it('excludes only the model target whose validation reported it missing', () => {
+    const failedTargetProvider = provider('multi-model', ['model-a', 'model-b'], {
+      lastValidationFailure: {
+        at: 11,
+        category: 'model-not-found',
+        target: { model: 'model-b', endpoint: 'openai' }
+      }
+    } as Partial<ProviderView>)
+
+    const entries = buildConfiguredModelCatalog({
+      providers: [failedTargetProvider],
+      frameworkId: 'opencode',
+      frameworkEndpoints: ['openai']
+    })
+
+    expect(entries.map((entry) => entry.model)).toEqual(['model-a'])
+  })
+
   it('checks each official model against its documented protocol', () => {
     const entries = buildConfiguredModelCatalog({
       providers: [

--- a/src/shared/configured-model-catalog.ts
+++ b/src/shared/configured-model-catalog.ts
@@ -8,9 +8,11 @@ import {
   isClaudeSubscriptionProvider,
   isCodexSubscriptionProvider,
   isProviderUsableByFramework,
+  preferredEndpoint,
   isXaiSubscriptionProvider,
   providerEndpoints,
   providerValidationFailed,
+  requiresChatCompletionsBridge,
   selectClaudeSubscriptionProvider,
   type AgentFrameworkId,
   type ChatApiEndpoint,
@@ -91,7 +93,8 @@ export const buildConfiguredModelInventory = (
         (!isClaudeSubscriptionProvider(provider.type) ||
           input.includeAllClaudeSubscriptions === true ||
           provider.id === selectedClaudeProvider?.id) &&
-        !providerValidationFailed(provider)
+        (!providerValidationFailed(provider) ||
+          provider.lastValidationFailure?.target !== undefined)
     )
     .flatMap((provider) =>
       (provider.models.length > 0 ? provider.models : provider.model ? [provider.model] : ['']).map(
@@ -120,23 +123,40 @@ export const buildConfiguredModelCatalog = (
     frameworkEndpoints: readonly ChatApiEndpoint[]
   }>
 ): readonly ConfiguredModelCatalogEntry[] => {
-  return buildConfiguredModelInventory(input).map((entry) => {
+  return buildConfiguredModelInventory(input).flatMap((entry) => {
     const provider = input.providers.find((candidate) => candidate.id === entry.providerId)!
     const model = entry.model
     const apiEndpoints = configuredModelApiEndpoints(provider, model)
+    const usesCompatibilityTransport = requiresChatCompletionsBridge(
+      { apiEndpoints },
+      { id: input.frameworkId, supportedApiTypes: input.frameworkEndpoints }
+    )
+    const validationEndpoint = preferredEndpoint(
+      apiEndpoints,
+      provider.type === 'xai-subscription'
+        ? (['responses'] as const)
+        : input.frameworkId === 'codex'
+          ? (['anthropic', 'openai', 'responses'] as const)
+          : usesCompatibilityTransport
+            ? apiEndpoints
+            : input.frameworkEndpoints
+    )
+    if (providerValidationFailed(provider, { model, endpoint: validationEndpoint })) return []
     const frameworkCompatible = isProviderUsableByFramework(
       { apiEndpoints, type: provider.type },
       { id: input.frameworkId, supportedApiTypes: input.frameworkEndpoints }
     )
     const bridgeSupported = input.frameworkId !== 'codex' || isModelBridgeSupported(provider, model)
-    return Object.freeze({
-      ...entry,
-      selectable: frameworkCompatible && bridgeSupported,
-      ...(!frameworkCompatible
-        ? { unavailableReason: 'framework-incompatible' as const }
-        : !bridgeSupported
-          ? { unavailableReason: 'model-bridge-unsupported' as const }
-          : {})
-    })
+    return [
+      Object.freeze({
+        ...entry,
+        selectable: frameworkCompatible && bridgeSupported,
+        ...(!frameworkCompatible
+          ? { unavailableReason: 'framework-incompatible' as const }
+          : !bridgeSupported
+            ? { unavailableReason: 'model-bridge-unsupported' as const }
+            : {})
+      })
+    ]
   })
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -279,13 +279,18 @@ export type ClaudeDetectResult = {
   }
 }
 
-// A recorded failed validation, kept so the list can flag a provider as unverified and say why
-// (e.g. "auth failed"). Cleared whenever a later validation of the same credentials succeeds.
+// Non-secret fingerprint for a concrete model/protocol probe. Provider-auth-only checks omit it.
+export type ProviderValidationTarget = {
+  model?: string
+  endpoint?: ChatApiEndpoint
+}
+
 export type ProviderValidationFailure = {
   at: number
   category: ValidationCategory
   status?: number
   message?: string
+  target?: ProviderValidationTarget
 }
 
 // Renderer-facing provider view: masked and stripped of every secret field.
@@ -325,9 +330,10 @@ export type ProviderView = {
   hasKey: boolean
   // True when a stored key could not be decrypted and must be re-entered before use.
   needsKey: boolean
-  // Timestamp of the last successful connectivity/key check (a single ping on the provider's first
-  // model). Codex per-model bridge compatibility is NOT a runtime probe — it's a static registry mark.
+  // Timestamp of the last successful connectivity/key check.
   lastValidatedAt?: number
+  // The model and protocol exercised by lastValidatedAt. Absent on legacy/provider-auth-only checks.
+  lastValidatedTarget?: ProviderValidationTarget
   // Present when the most recent validation failed and no later one has succeeded. Drives the
   // "unverified" warning in the provider list.
   lastValidationFailure?: ProviderValidationFailure
@@ -345,16 +351,43 @@ export type XaiOAuthDeviceAuthorization = {
   intervalSeconds: number
 }
 
-// True when a provider's most recent validation failed (and no later one succeeded). A failed
-// provider is flagged in the settings list and excluded from the model pickers, so it can't be
-// picked as a model source until it passes a test. Shared by main and renderer for one rule.
-export const providerValidationFailed = (provider: {
-  lastValidatedAt?: number
-  lastValidationFailure?: ProviderValidationFailure
-}): boolean =>
+// Applies a targeted failure only to the model/protocol it probed; provider-level failures still
+// apply everywhere. Shared by main and renderer so every selection surface uses the same rule.
+export const providerValidationTargetMatches = (
+  left: ProviderValidationTarget,
+  right: ProviderValidationTarget
+): boolean => left.model === right.model && left.endpoint === right.endpoint
+
+export const providerValidationFailed = (
+  provider: {
+    lastValidatedAt?: number
+    lastValidatedTarget?: ProviderValidationTarget
+    lastValidationFailure?: ProviderValidationFailure
+  },
+  target?: ProviderValidationTarget
+): boolean =>
   provider.lastValidationFailure !== undefined &&
+  (provider.lastValidationFailure.target === undefined ||
+    (target !== undefined &&
+      providerValidationTargetMatches(provider.lastValidationFailure.target, target))) &&
   (provider.lastValidatedAt === undefined ||
+    (target !== undefined &&
+      provider.lastValidatedTarget !== undefined &&
+      !providerValidationTargetMatches(provider.lastValidatedTarget, target)) ||
     provider.lastValidationFailure.at >= provider.lastValidatedAt)
+
+export const providerValidationSucceeded = (
+  provider: {
+    lastValidatedAt?: number
+    lastValidatedTarget?: ProviderValidationTarget
+    lastValidationFailure?: ProviderValidationFailure
+  },
+  target: ProviderValidationTarget
+): boolean =>
+  provider.lastValidatedAt !== undefined &&
+  (provider.lastValidatedTarget === undefined ||
+    providerValidationTargetMatches(provider.lastValidatedTarget, target)) &&
+  !providerValidationFailed(provider, target)
 
 // The agent backends the app can drive over ACP. Persisted settings and the UI reference these ids;
 // the main-process AgentFramework registry is keyed by the same union.


### PR DESCRIPTION
## Summary

- persist the model and API endpoint exercised by successful and target-specific provider validation
- keep authentication/connectivity failures provider-wide while model and protocol failures only affect the matching target
- apply the scoped result consistently to preflight, model catalogs, scenario model admission, and the provider status UI
- preserve legacy provider-level records and invalidate target records when credentials or endpoint configuration changes

## Reproduction

The regression tests were added and run before the fix:

- validating model A and selecting unvalidated model B left preflight ready (expected false, received true)
- a model-not-found result for model B removed model A from the configured catalog (expected model-a, received an empty catalog)

Both cases pass after the implementation.

## Test plan

- npx vitest run src/main/settings/provider-accounts.test.ts src/main/settings/provider-auth-lifecycle.test.ts src/main/settings/xai-provider-account-owner.test.ts src/main/settings/provider-runtime-projection.test.ts src/main/settings/agent-runtime-manager.test.ts src/main/settings/preflight.test.ts src/main/settings/repository.test.ts src/main/settings/settings-backend.architecture.test.ts src/main/settings/provider-runtime-projection.architecture.test.ts src/main/settings/provider-auth-lifecycle.architecture.test.ts src/main/settings/session-details-model-owner.test.ts src/shared/configured-model-catalog.test.ts src/shared/settings.test.ts src/renderer/src/pages/settings/ProviderList.render.test.tsx
- npx vitest run src/main/settings/service.test.ts -t "SettingsService: (Subagent|Reviewer|Vision) model"
- npm run typecheck
- ESLint on changed files
- git diff --check