### PR TITLE
fix(skills): support asset-heavy Skill bundles

### DIFF
--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -686,17 +686,18 @@ describe('fetchSkillFiles', () => {
     ).rejects.toThrow(/nesting exceeds/)
   })
 
-  it('rejects a directory with more files than the count limit', async () => {
-    // 300 files exceeds the structural cap (SKILL_IMPORT_LIMITS.maxFiles is 256).
-    const many = Object.fromEntries(
-      Array.from({ length: 300 }, (_, i) => [`f${i}.txt`, 'x'])
-    ) as Record<string, string>
+  it('downloads a large directory within the request budget', async () => {
+    // Asset-heavy Skills can legitimately exceed the old 256-file structural cap.
+    const many = {
+      'SKILL.md': '# Large Skill',
+      ...Object.fromEntries(Array.from({ length: 299 }, (_, i) => [`f${i}.txt`, 'x']))
+    }
     await expect(
       fetchSkillFiles(
         { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },
         fakeFetch(many)
       )
-    ).rejects.toThrow(/too many files/)
+    ).resolves.toHaveLength(300)
   })
 
   it('percent-encodes path segments in the contents URL', async () => {

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -149,6 +149,25 @@ describe('isImportableSkillArchivePath', () => {
     await expectMatchesPreview(archive, false)
   })
 
+  it('bounds ownership checks for long unrelated ZIP paths', async () => {
+    const archive = buildZip([
+      {
+        path: 'release/skills/ppt-master/SKILL.md',
+        content: Buffer.from('---\nname: ppt-master\ndescription: d\n---\nRun it.')
+      },
+      {
+        path: `${'x/'.repeat(32_760)}unsupported.bin`,
+        content: Buffer.from('unsupported'),
+        method: 99
+      }
+    ])
+    const startedAt = performance.now()
+
+    await expect(inspect(archive)).resolves.toBe(true)
+
+    expect(performance.now() - startedAt).toBeLessThan(250)
+  })
+
   it('finds a named Skill manifest without inflating unrelated large entries', async () => {
     const archive = buildZip([
       { path: 'paper-finder/assets/model.bin', content: Buffer.alloc(2 * 1024 * 1024), method: 0 },

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -133,6 +133,22 @@ describe('isImportableSkillArchivePath', () => {
     await expectMatchesPreview(archive, true)
   })
 
+  it('rejects an incomplete Skill under three wrapper directories', async () => {
+    const archive = buildZip([
+      {
+        path: 'release/skills/ppt-master/SKILL.md',
+        content: Buffer.from('---\nname: ppt-master\ndescription: d\n---\nRun it.')
+      },
+      {
+        path: 'release/skills/ppt-master/unsupported.bin',
+        content: Buffer.from('unsupported'),
+        method: 99
+      }
+    ])
+
+    await expectMatchesPreview(archive, false)
+  })
+
   it('finds a named Skill manifest without inflating unrelated large entries', async () => {
     const archive = buildZip([
       { path: 'paper-finder/assets/model.bin', content: Buffer.alloc(2 * 1024 * 1024), method: 0 },

--- a/src/main/skills/skill-archive-sniffer.test.ts
+++ b/src/main/skills/skill-archive-sniffer.test.ts
@@ -122,6 +122,17 @@ describe('isImportableSkillArchivePath', () => {
     ).resolves.toBe(true)
   })
 
+  it('classifies a Skill under three wrapper directories', async () => {
+    const archive = buildZip([
+      {
+        path: 'release/skills/ppt-master/SKILL.md',
+        content: Buffer.from('---\nname: ppt-master\ndescription: d\n---\nRun it.')
+      }
+    ])
+
+    await expectMatchesPreview(archive, true)
+  })
+
   it('finds a named Skill manifest without inflating unrelated large entries', async () => {
     const archive = buildZip([
       { path: 'paper-finder/assets/model.bin', content: Buffer.alloc(2 * 1024 * 1024), method: 0 },
@@ -201,7 +212,7 @@ describe('isImportableSkillArchivePath', () => {
     ])
     const deepManifest = buildZip([
       {
-        path: 'a/b/c/SKILL.md',
+        path: 'a/b/c/d/SKILL.md',
         content: Buffer.from('---\nname: Too Deep\ndescription: hidden\n---\nBody')
       }
     ])

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -681,7 +681,7 @@ const owningRoot = (
   if (roots.has('')) return ''
 
   const segments = path.split('/')
-  const maxSegments = Math.min(2, segments.length - (includeExactRoot ? 0 : 1))
+  const maxSegments = segments.length - (includeExactRoot ? 0 : 1)
   for (let length = 1; length <= maxSegments; length += 1) {
     const candidate = segments.slice(0, length).join('/')
     if (roots.has(candidate)) return candidate

--- a/src/main/skills/skill-archive-sniffer.ts
+++ b/src/main/skills/skill-archive-sniffer.ts
@@ -4,7 +4,11 @@ import { createInflateRaw } from 'node:zlib'
 
 import { parseSkillDocument } from './frontmatter'
 import { SKILL_IMPORT_LIMITS } from './import-limits'
-import { selectSkillManifestRoots, skillManifestRootPath } from './skill-bundle-paths'
+import {
+  MAX_SKILL_MANIFEST_ROOT_SEGMENTS,
+  selectSkillManifestRoots,
+  skillManifestRootPath
+} from './skill-bundle-paths'
 
 const EOCD_SIGNATURE = 0x06054b50
 const CENTRAL_SIGNATURE = 0x02014b50
@@ -681,7 +685,10 @@ const owningRoot = (
   if (roots.has('')) return ''
 
   const segments = path.split('/')
-  const maxSegments = segments.length - (includeExactRoot ? 0 : 1)
+  const maxSegments = Math.min(
+    MAX_SKILL_MANIFEST_ROOT_SEGMENTS,
+    segments.length - (includeExactRoot ? 0 : 1)
+  )
   for (let length = 1; length <= maxSegments; length += 1) {
     const candidate = segments.slice(0, length).join('/')
     if (roots.has(candidate)) return candidate

--- a/src/main/skills/skill-bundle-import-owner.ts
+++ b/src/main/skills/skill-bundle-import-owner.ts
@@ -464,9 +464,9 @@ export class SkillBundleImportOwner {
       }
       seen.add(target)
     }
-    for (const left of seen) {
-      for (const right of seen) {
-        if (left !== right && right.startsWith(left + sep)) {
+    for (const target of seen) {
+      for (let parent = dirname(target); parent !== root; parent = dirname(parent)) {
+        if (seen.has(parent)) {
           throw new Error('Conflicting file and directory at the same path in skill import.')
         }
       }

--- a/src/main/skills/skill-bundle-paths.ts
+++ b/src/main/skills/skill-bundle-paths.ts
@@ -1,9 +1,14 @@
+const MAX_SKILL_MANIFEST_ROOT_SEGMENTS = 3
+
 // A directly importable Skill root may be at the archive root or under at most three wrapper
 // directories. Keep this predicate shared by full discovery and prompt-time ZIP sniffing so the
 // prompt never advertises a package whose preview will later contain no candidates.
 const skillManifestRootPath = (path: string): string | undefined => {
   const segments = path.split('/')
-  if (segments.length > 4 || segments[segments.length - 1].toLowerCase() !== 'skill.md') {
+  if (
+    segments.length > MAX_SKILL_MANIFEST_ROOT_SEGMENTS + 1 ||
+    segments[segments.length - 1].toLowerCase() !== 'skill.md'
+  ) {
     return undefined
   }
   return segments.slice(0, -1).join('/')
@@ -33,4 +38,9 @@ const selectSkillManifestRoots = (paths: Iterable<string>): string[] => {
     .sort((left, right) => left.localeCompare(right))
 }
 
-export { isSkillManifestPath, selectSkillManifestRoots, skillManifestRootPath }
+export {
+  isSkillManifestPath,
+  MAX_SKILL_MANIFEST_ROOT_SEGMENTS,
+  selectSkillManifestRoots,
+  skillManifestRootPath
+}

--- a/src/main/skills/skill-bundle-paths.ts
+++ b/src/main/skills/skill-bundle-paths.ts
@@ -1,9 +1,9 @@
-// A directly importable Skill root may be at the archive root or under at most two wrapper
+// A directly importable Skill root may be at the archive root or under at most three wrapper
 // directories. Keep this predicate shared by full discovery and prompt-time ZIP sniffing so the
 // prompt never advertises a package whose preview will later contain no candidates.
 const skillManifestRootPath = (path: string): string | undefined => {
   const segments = path.split('/')
-  if (segments.length > 3 || segments[segments.length - 1].toLowerCase() !== 'skill.md') {
+  if (segments.length > 4 || segments[segments.length - 1].toLowerCase() !== 'skill.md') {
     return undefined
   }
   return segments.slice(0, -1).join('/')

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -789,6 +789,32 @@ describe('UserSkillRepository', () => {
     expect((await repo.previewZip(zip)).previews[0].alreadyImported).toBe(true)
   })
 
+  it('previews a three-level wrapped ppt-master-scale Skill bundle', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    // ppt-master v6.2.0 contains 12,941 files. Keep a small synthetic fixture at the same structural
+    // scale so the real release remains importable without checking a third-party archive into Git.
+    const zip = buildZip([
+      {
+        path: 'ppt-master/skills/ppt-master/SKILL.md',
+        content: Buffer.from('---\nname: ppt-master\ndescription: d\n---\nbody')
+      },
+      ...Array.from({ length: 12_940 }, (_, index) => ({
+        path: `ppt-master/skills/ppt-master/templates/icons/icon-${index}.svg`,
+        content: Buffer.alloc(0)
+      }))
+    ])
+
+    const { previews } = await repo.previewZip(zip)
+
+    expect(previews).toEqual([
+      expect.objectContaining({
+        name: 'ppt-master',
+        subPath: 'ppt-master/skills/ppt-master'
+      })
+    ])
+    expect(previews[0].files).toHaveLength(12_941)
+  })
+
   it('bounds cumulative preview content without making later bundle skills unimportable', async () => {
     const repo = new UserSkillRepository(await makeStorage())
     const largeBody = Buffer.alloc(3 * 1024 * 1024, 0x61)

--- a/src/main/skills/zip-extract.test.ts
+++ b/src/main/skills/zip-extract.test.ts
@@ -137,8 +137,7 @@ describe('extractZip', () => {
   })
 
   it('rejects a bundle with more files than the count limit', () => {
-    // 300 tiny STORE entries exceed SKILL_IMPORT_LIMITS.maxFiles (256).
-    const inputs: ZipInput[] = Array.from({ length: 300 }, (_, i) => ({
+    const inputs: ZipInput[] = Array.from({ length: SKILL_IMPORT_LIMITS.maxFiles + 1 }, (_, i) => ({
       path: `f${i}.txt`,
       content: Buffer.from('x', 'utf8'),
       method: 0 as const

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -1403,7 +1403,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(
       document.body.querySelector('[aria-label="Skill package usage"]')?.textContent
-    ).toContain('References: 1 / 253')
+    ).toContain(`References: 1 / ${SKILL_IMPORT_LIMITS.maxFiles - 3}`)
     expect(document.body.textContent).toContain('references/guide.md')
     expect(document.body.textContent).toContain('references/guides/deep.md')
     expect(document.body.textContent).toContain('scripts/run.sh')

--- a/src/shared/skill-import-limits.ts
+++ b/src/shared/skill-import-limits.ts
@@ -9,12 +9,12 @@ export const isSkillPackageBudgetedPath = (relativePath: string): boolean =>
 // GitHub download). Without them a zip bomb or a very large repository could exhaust memory or freeze
 // the app while the user imports a skill from settings. Lives in shared/ so the renderer can enforce
 // the same numbers on the upload picker as the main process enforces on extraction/download. The
-// limits are generous for a real skill (a SKILL.md plus a handful of reference files) and only trip on
-// abuse.
+// limits cover asset-heavy Skills while still rejecting archives whose structure or byte size is
+// pathological.
 export const SKILL_IMPORT_LIMITS = {
-  // Structural cap on the number of files in ONE skill: high enough for a mega-zip carrying several
-  // skills, low enough to reject a pathological archive. Total size is the real limit.
-  maxFiles: 256,
+  // Structural cap on the number of files in ONE skill. Large asset libraries can legitimately
+  // contain thousands of tiny files; byte limits remain the primary memory bound.
+  maxFiles: 16_384,
   // Maximum size of any single file (decompressed, for zip entries). Set high because real skills
   // legitimately bundle large reference assets (datasets, templates, model files) worth keeping.
   maxFileBytes: 50 * 1024 * 1024,
@@ -46,8 +46,7 @@ export const SKILL_IMPORT_LIMITS = {
   // unbounded number of import candidates.
   maxSkillsPerBundle: 256,
   // Structural cap on the number of entries in the OUTER bundle walk (loose files + nested archives),
-  // above the per-skill file cap since one bundle may hold many skills. Decompressed size
-  // (maxBundleBytes) is the real memory guard; this only rejects an archive with a pathological entry
-  // count.
-  maxBundleEntries: 4096
+  // above the per-skill cap so a bundle can carry multiple Skills. Decompressed size (maxBundleBytes)
+  // is the real memory guard; this only rejects an archive with a pathological entry count.
+  maxBundleEntries: 32_768
 } as const


### PR DESCRIPTION
## Problem

The published [ppt-master v6.2.0 Skill bundle](https://github.com/hugohe3/ppt-master/releases/download/v6.2.0/ppt-master-skill-v6.2.0.zip) is a valid asset-heavy Skill with 12,941 files, about 75.8 MiB decompressed content, and a three-directory wrapper around `SKILL.md`.

Import currently rejects it because one Skill is limited to 256 files, the outer bundle walk is limited to 4,096 entries, and manifests are only recognized beneath two wrapper directories. Raising those limits alone also exposes quadratic file/directory conflict validation: a local import of the real bundle took 57.3 seconds.

## Proposed change

- raise the per-Skill structural cap to 16,384 files;
- raise the outer bundle walk cap to 32,768 entries;
- recognize `SKILL.md` beneath three wrapper directories;
- keep prompt-time archive ownership checks aligned with, and bounded by, the same wrapper depth;
- replace all-pairs path conflict detection with bounded parent traversal;
- add a synthetic 12,941-file regression fixture matching the published bundle's structure, plus focused boundary coverage.

The existing 50 MiB per-file, 128 MiB per-Skill, 256 MiB bundle, depth, zip-slip, duplicate-path, and total-resource protections remain in place. The real bundle imports in about 2.1 seconds after the path-validation change.

## Scope and non-goals

- No database field, persisted-format, state enum, data-model, or UI-flow changes.
- Existing Skill directories remain forward-compatible and require no migration.
- A Skill imported above the old 256-file limit may not export, edit, or rematerialize after downgrading to an older app version.
- This PR supports importing the published release ZIP. It does not redesign direct GitHub repository import: the Contents API path retains its 512-request budget, so very large repositories require a separate bounded repository-archive transport change rather than a larger request allowance.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- ppt-master-scale archive recognition, renderer budget display, and existing import/path-safety behavior -> focused Vitest run across five affected files -> 252 passed
- Node and sandbox type safety -> `npm run typecheck:node` -> passed
- lint -> `npm run lint` -> passed

The regression test was added first and failed on the unfixed code because preview returned no importable Skill. The downloaded release also reproduced the outer-entry rejection before the fix and passed both preview and full import after it.

A second public-boundary regression uses the maximum-length ZIP entry name with unrelated path segments. It failed before the ownership-search bound at about 3.63 seconds and passed afterward in 11 milliseconds.

`npm run test:module -- user_skills_repository` could not start locally because this isolated worktree had no matching generated Prisma Client; no dependency installation was performed. PR CI remains authoritative for the complete module and platform test plan. The full local `npm test` suite was intentionally not run.

## Review focus

- whether 16,384 per Skill and 32,768 per outer bundle preserve an acceptable structural bound;
- the three-wrapper compatibility boundary;
- bounded ownership checks for attacker-controlled ZIP paths;
- equivalence of parent traversal to the previous ancestor/descendant conflict check;
- accepted downgrade behavior for newly imported asset-heavy Skills.
