### PR TITLE
fix(window): keep Linux application menu visible

### DIFF
--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserWindowConstructorOptions } from 'electron'
 
 import {
   CLOSE_ACTIVE_PANE_CHANNEL,
@@ -102,6 +103,7 @@ type CloseEvent = { preventDefault: () => void; defaultPrevented: boolean }
 // currentWindow and lastWindow both point at the latest window; two describe blocks, one shared fake.
 let currentWindow: FakeBrowserWindow | undefined
 let lastWindow: FakeBrowserWindow | undefined
+let lastWindowOptions: BrowserWindowConstructorOptions | undefined
 let loadRendererDocument = (): Promise<void> => Promise.resolve()
 
 class FakeBrowserWindow {
@@ -199,7 +201,8 @@ vi.mock('electron', () => ({
   // isPackaged=true skips the dev title-suffix branch, keeping the fake focused on the open + close handlers.
   app: { isPackaged: true, getAppPath: () => '/app' },
   BrowserWindow: class {
-    constructor() {
+    constructor(options: BrowserWindowConstructorOptions) {
+      lastWindowOptions = options
       currentWindow = new FakeBrowserWindow()
       lastWindow = currentWindow
       return currentWindow as unknown as object
@@ -279,6 +282,23 @@ describe('window presentation', () => {
     for (const handler of window.handlers.get('ready-to-show') ?? []) handler({} as CloseEvent)
 
     expect(window.showMock).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['linux', false],
+    ['darwin', true],
+    ['win32', true]
+  ] as const)('sets %s menu auto-hide to %s', (platformName, autoHideMenuBar) => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: platformName })
+
+    try {
+      createMainWindow()
+    } finally {
+      Object.defineProperty(process, 'platform', platform!)
+    }
+
+    expect(lastWindowOptions?.autoHideMenuBar).toBe(autoHideMenuBar)
   })
 
   it('gives the find overlay a dedicated least-privilege preload', () => {

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -92,7 +92,7 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
   const e2eWindowMode = process.env[E2E_WINDOW_MODE_ENV]
   const window = new BrowserWindow({
     show: false,
-    autoHideMenuBar: true,
+    autoHideMenuBar: process.platform !== 'linux',
     ...(process.platform !== 'darwin' ? { icon } : {}),
     ...options,
     webPreferences: {


### PR DESCRIPTION
## Problem

The Linux desktop client starts its main `BrowserWindow` with `autoHideMenuBar: true`, the same setting used on macOS and Windows. In the reported Linux desktop environment this leaves the native application menu, including Session actions, absent after startup.

This occurs whenever the Electron main window is created on Linux. It is window-wide rather than page-specific: Home, Workspace, and Settings all run inside the same main window. If left unchanged, users cannot discover or use native menu actions through the visible application chrome.

## Proposed change

Keep the native application menu visible by default on Linux while preserving the existing auto-hide behavior on macOS and Windows.

This is a single window-construction option change. It adds no data fields, schema changes, data-model changes, enum states, persistence, migrations, or historical-data compatibility behavior. The only interaction change is that Linux renders the existing native menu bar by default.

## Scope and non-goals

- Covers the interactive main window shared by all renderer pages.
- Does not change hidden PDF export or reviewer rendering windows; they have no user interaction.
- Does not change renderer Session action menus. The Workspace sidebar menu remains hover/focus discoverable on desktop and always visible in mobile mode.
- Does not add a custom menu system or platform abstraction; those would be over-design for this platform option regression.

## Acceptance criteria and validation

Regression test added at the existing `BrowserWindow` construction boundary. Before the production fix, the focused test failed deterministically twice with `expected true to be false`, matching the reported hidden Linux menu.

Final checks ran after the last material edit:

- Linux menu visibility and unchanged macOS/Windows behavior -> `../../node_modules/.bin/vitest run src/main/windows.test.ts` -> passed, 77/77 tests.
- Changed source/test lint -> `../../node_modules/.bin/eslint src/main/windows.ts src/main/windows.test.ts` -> passed.
- Node typecheck -> `PATH="../../node_modules/.bin:$PATH" npm run typecheck:node` -> blocked by the linked worktree using a stale generated Prisma Client; all errors are unrelated existing `ComputeJob.remoteCleanupDisposition` generated-type mismatches. CI runs in a clean generated environment and remains authoritative.

Platform impact: Linux is included because the behavior is platform-specific. macOS and Windows are included as constructor-option regression cases to prove their existing auto-hide behavior is unchanged. No Web lane is needed because the Web UI has no Electron native menu.

## Review focus

Confirm that Linux alone should opt out of Electron menu auto-hide and that preserving the current behavior on macOS and Windows is intended.

Uncovered risk: desktop-environment global-menu integrations may relocate the native menu outside the window; this change controls Electron auto-hide but cannot override a distribution-specific global-menu shell policy.