### PR TITLE
fix(workspace): avoid replaying finalized artifact claims

### DIFF
--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3677,6 +3677,46 @@ describe('workspace runtime events', () => {
     expect(reconcilePendingArtifacts).toHaveBeenCalledOnce()
     expect(finalizeRunArtifacts).not.toHaveBeenCalled()
   })
+
+  it('records native artifact reconciliation failures for retry', async () => {
+    const nativePendingArtifact = createArtifactFile({
+      id: 'native-version-reconcile-failure',
+      artifactId: 'native-artifact-reconcile-failure',
+      versionId: 'native-version-reconcile-failure',
+      versionNumber: 1,
+      path: '/Users/example/.open-science/managed/native-version-reconcile-failure/result.txt'
+    })
+    useSessionStore.getState().attachRunArtifacts({
+      sessionId: 'transport-session-1',
+      runId: 'run-native-reconcile-failure',
+      eventId: 'native-reconcile-failure-event',
+      artifacts: [nativePendingArtifact]
+    })
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-before-native-reconcile-failure', kind: 'stop' })
+    )
+
+    await expect(
+      applyWorkspaceRuntimeEvent(
+        createEvent({
+          id: 'native-reconcile-failure-event',
+          kind: 'artifact',
+          runId: 'run-native-reconcile-failure',
+          artifactClaimId: 'native-reconcile-failure-claim',
+          artifacts: [nativePendingArtifact]
+        }),
+        {
+          reconcilePendingArtifacts: vi.fn().mockRejectedValue(new Error('reconcile failed')),
+          saveSession: vi.fn().mockResolvedValue(undefined)
+        }
+      )
+    ).rejects.toThrow('reconcile failed')
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: expect.stringContaining('Generated file finalization failed')
+    })
+  })
 })
 
 describe('loop guard: suppressNextAutoReview', () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3546,6 +3546,13 @@ describe('workspace runtime events', () => {
 
     await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-finalize', kind: 'stop' }))
     await applyWorkspaceRuntimeEvent(artifactEvent, { finalizeRunArtifacts, saveSession })
+    useSessionStore
+      .getState()
+      .recordArtifactError(
+        'transport-session-1',
+        'Artifact run claim not found: artifact-claim-expired',
+        true
+      )
     await applyWorkspaceRuntimeEvent(artifactEvent, { finalizeRunArtifacts, saveSession })
 
     expect(finalizeRunArtifacts).toHaveBeenCalledOnce()

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3665,7 +3665,14 @@ describe('workspace runtime events', () => {
       ]
     })
     await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-native-replay', kind: 'stop' }))
-    useSessionStore.getState().recordArtifactError('transport-session-1', 'unrelated claim failed')
+    ;(
+      useSessionStore.getState().recordArtifactError as (
+        sessionId: string,
+        error: string,
+        retryable: boolean,
+        eventId: string
+      ) => void
+    )('transport-session-1', 'current claim failed', true, 'native-pending-event')
     const messageId = useSessionStore.getState().sessions[0].messages[1].id
     const finalizedArtifact = {
       ...nativePendingArtifact,
@@ -3691,7 +3698,45 @@ describe('workspace runtime events', () => {
 
     expect(reconcilePendingArtifacts).toHaveBeenCalledOnce()
     expect(finalizeRunArtifacts).not.toHaveBeenCalled()
-    expect(useSessionStore.getState().sessions[0].error).toContain('unrelated claim failed')
+    expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
+  })
+
+  it('does not clear an artifact error owned by another event', async () => {
+    const finalizedArtifact = createArtifactFile({
+      id: 'transport-session-1:message-1:result.txt',
+      sessionId: 'transport-session-1',
+      messageId: 'message-1',
+      runId: undefined,
+      path: '/Users/example/.open-science/artifacts/default-project/transport-session-1/message-1/result.txt'
+    })
+    const artifactEvent = createEvent({
+      id: 'replayed-finalized-event',
+      kind: 'artifact',
+      runId: 'run-finalized',
+      artifactClaimId: 'expired-finalized-claim',
+      artifacts: [createArtifactFile({ runId: 'run-finalized' })]
+    })
+    const finalizeRunArtifacts = vi.fn().mockResolvedValue([finalizedArtifact])
+    const dependencies = {
+      finalizeRunArtifacts,
+      saveSession: vi.fn().mockResolvedValue(undefined)
+    }
+
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-owned-error', kind: 'stop' }))
+    await applyWorkspaceRuntimeEvent(artifactEvent, dependencies)
+    ;(
+      useSessionStore.getState().recordArtifactError as (
+        sessionId: string,
+        error: string,
+        retryable: boolean,
+        eventId: string
+      ) => void
+    )('transport-session-1', 'sibling claim failed', true, 'sibling-artifact-event')
+
+    await applyWorkspaceRuntimeEvent(artifactEvent, dependencies)
+
+    expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
+    expect(useSessionStore.getState().sessions[0].error).toContain('sibling claim failed')
   })
 
   it('records native artifact reconciliation failures for retry', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3628,6 +3628,48 @@ describe('workspace runtime events', () => {
       secondFinalizedArtifact.id
     ])
   })
+
+  it('does not treat an immutable native provenance path as finalized', async () => {
+    const nativePendingArtifact = createArtifactFile({
+      id: 'native-version-1',
+      artifactId: 'native-artifact-1',
+      versionId: 'native-version-1',
+      versionNumber: 1,
+      path: '/Users/example/.open-science/managed/native-version-1/result.txt'
+    })
+    useSessionStore.getState().attachRunArtifacts({
+      sessionId: 'transport-session-1',
+      runId: 'run-native-pending',
+      eventId: 'native-pending-event',
+      artifacts: [nativePendingArtifact]
+    })
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-native-replay', kind: 'stop' }))
+    const messageId = useSessionStore.getState().sessions[0].messages[1].id
+    const finalizedArtifact = {
+      ...nativePendingArtifact,
+      messageId
+    }
+    const finalizeRunArtifacts = vi.fn().mockResolvedValue([finalizedArtifact])
+    const reconcilePendingArtifacts = vi.fn().mockResolvedValue([finalizedArtifact])
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'native-pending-event',
+        kind: 'artifact',
+        runId: 'run-native-pending',
+        artifactClaimId: 'native-pending-claim',
+        artifacts: [nativePendingArtifact]
+      }),
+      {
+        finalizeRunArtifacts,
+        reconcilePendingArtifacts,
+        saveSession: vi.fn().mockResolvedValue(undefined)
+      }
+    )
+
+    expect(reconcilePendingArtifacts).toHaveBeenCalledOnce()
+    expect(finalizeRunArtifacts).not.toHaveBeenCalled()
+  })
 })
 
 describe('loop guard: suppressNextAutoReview', () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3665,14 +3665,14 @@ describe('workspace runtime events', () => {
       ]
     })
     await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-native-replay', kind: 'stop' }))
-    ;(
-      useSessionStore.getState().recordArtifactError as (
-        sessionId: string,
-        error: string,
-        retryable: boolean,
-        eventId: string
-      ) => void
-    )('transport-session-1', 'current claim failed', true, 'native-pending-event')
+    useSessionStore
+      .getState()
+      .recordArtifactError(
+        'transport-session-1',
+        'current claim failed',
+        true,
+        'native-pending-event'
+      )
     const messageId = useSessionStore.getState().sessions[0].messages[1].id
     const finalizedArtifact = {
       ...nativePendingArtifact,
@@ -3724,19 +3724,30 @@ describe('workspace runtime events', () => {
 
     await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-owned-error', kind: 'stop' }))
     await applyWorkspaceRuntimeEvent(artifactEvent, dependencies)
-    ;(
-      useSessionStore.getState().recordArtifactError as (
-        sessionId: string,
-        error: string,
-        retryable: boolean,
-        eventId: string
-      ) => void
-    )('transport-session-1', 'sibling claim failed', true, 'sibling-artifact-event')
+    useSessionStore
+      .getState()
+      .recordArtifactError(
+        'transport-session-1',
+        'current claim failed',
+        true,
+        'replayed-finalized-event'
+      )
+    useSessionStore
+      .getState()
+      .recordArtifactError(
+        'transport-session-1',
+        'sibling claim failed',
+        true,
+        'sibling-artifact-event'
+      )
 
     await applyWorkspaceRuntimeEvent(artifactEvent, dependencies)
 
     expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
     expect(useSessionStore.getState().sessions[0].error).toContain('sibling claim failed')
+    expect(useSessionStore.getState().sessions[0].artifactErrorEventIds).toEqual([
+      'sibling-artifact-event'
+    ])
   })
 
   it('records native artifact reconciliation failures for retry', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3678,8 +3678,15 @@ describe('workspace runtime events', () => {
       ...nativePendingArtifact,
       messageId
     }
+    const operationOrder: string[] = []
     const finalizeRunArtifacts = vi.fn().mockResolvedValue([finalizedArtifact])
-    const reconcilePendingArtifacts = vi.fn().mockResolvedValue([finalizedArtifact])
+    const reconcilePendingArtifacts = vi.fn().mockImplementation(async () => {
+      operationOrder.push('reconcile')
+      return [finalizedArtifact]
+    })
+    const saveSession = vi.fn().mockImplementation(async () => {
+      operationOrder.push('save')
+    })
 
     await applyWorkspaceRuntimeEvent(
       createEvent({
@@ -3692,10 +3699,11 @@ describe('workspace runtime events', () => {
       {
         finalizeRunArtifacts,
         reconcilePendingArtifacts,
-        saveSession: vi.fn().mockResolvedValue(undefined)
+        saveSession
       }
     )
 
+    expect(operationOrder).toEqual(['save', 'reconcile'])
     expect(reconcilePendingArtifacts).toHaveBeenCalledOnce()
     expect(finalizeRunArtifacts).not.toHaveBeenCalled()
     expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
@@ -3740,11 +3748,12 @@ describe('workspace runtime events', () => {
         true,
         'sibling-artifact-event'
       )
+    useSessionStore.getState().recordArtifactError('transport-session-1', 'generic retry failed')
 
     await applyWorkspaceRuntimeEvent(artifactEvent, dependencies)
 
     expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
-    expect(useSessionStore.getState().sessions[0].error).toContain('sibling claim failed')
+    expect(useSessionStore.getState().sessions[0].error).toContain('generic retry failed')
     expect(useSessionStore.getState().sessions[0].artifactErrorEventIds).toEqual([
       'sibling-artifact-event'
     ])

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3551,6 +3551,83 @@ describe('workspace runtime events', () => {
     expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
     expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
   })
+
+  it('finalizes sibling artifact events independently', async () => {
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'run-with-sibling-claims',
+      eventId: 'agent-before-sibling-claims',
+      content: 'Saved both results.'
+    })
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-before-sibling-claims', kind: 'stop' })
+    )
+
+    const messageId = useSessionStore.getState().sessions[0].messages[1].id
+    const firstFinalizedArtifact = createArtifactFile({
+      id: `transport-session-1:${messageId}:first.txt`,
+      sessionId: 'transport-session-1',
+      messageId,
+      runId: undefined,
+      name: 'first.txt',
+      path: `/Users/example/.open-science/artifacts/default-project/transport-session-1/${messageId}/first.txt`
+    })
+    const secondFinalizedArtifact = createArtifactFile({
+      id: `transport-session-1:${messageId}:second.txt`,
+      sessionId: 'transport-session-1',
+      messageId,
+      runId: undefined,
+      name: 'second.txt',
+      path: `/Users/example/.open-science/artifacts/default-project/transport-session-1/${messageId}/second.txt`
+    })
+    const finalizeRunArtifacts = vi
+      .fn()
+      .mockResolvedValueOnce([firstFinalizedArtifact])
+      .mockResolvedValueOnce([firstFinalizedArtifact, secondFinalizedArtifact])
+    const dependencies = {
+      finalizeRunArtifacts,
+      saveSession: vi.fn().mockResolvedValue(undefined)
+    }
+
+    useSessionStore.getState().attachRunArtifacts({
+      sessionId: 'transport-session-1',
+      runId: 'run-with-sibling-claims',
+      eventId: 'first-artifact-event',
+      artifacts: [createArtifactFile({ name: 'first.txt' })]
+    })
+    useSessionStore.getState().attachRunArtifacts({
+      sessionId: 'transport-session-1',
+      runId: 'run-with-sibling-claims',
+      eventId: 'second-artifact-event',
+      artifacts: [createArtifactFile({ name: 'second.txt' })]
+    })
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'first-artifact-event',
+        kind: 'artifact',
+        runId: 'run-with-sibling-claims',
+        artifactClaimId: 'first-claim',
+        artifacts: [createArtifactFile({ name: 'first.txt' })]
+      }),
+      dependencies
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'second-artifact-event',
+        kind: 'artifact',
+        runId: 'run-with-sibling-claims',
+        artifactClaimId: 'second-claim',
+        artifacts: [createArtifactFile({ name: 'second.txt' })]
+      }),
+      dependencies
+    )
+
+    expect(finalizeRunArtifacts).toHaveBeenCalledTimes(2)
+    expect(useSessionStore.getState().sessions[0].messages[1].artifactIds).toEqual([
+      firstFinalizedArtifact.id,
+      secondFinalizedArtifact.id
+    ])
+  })
 })
 
 describe('loop guard: suppressNextAutoReview', () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3789,6 +3789,49 @@ describe('workspace runtime events', () => {
       error: expect.stringContaining('Generated file finalization failed')
     })
   })
+
+  it('rejects incomplete native artifact reconciliation results', async () => {
+    const nativePendingArtifact = createArtifactFile({
+      id: 'native-version-incomplete',
+      artifactId: 'native-artifact-incomplete',
+      versionId: 'native-version-incomplete',
+      versionNumber: 1,
+      path: '/Users/example/.open-science/managed/native-version-incomplete/result.txt'
+    })
+    useSessionStore.getState().attachRunArtifacts({
+      sessionId: 'transport-session-1',
+      runId: 'run-native-incomplete',
+      eventId: 'native-incomplete-event',
+      artifacts: [nativePendingArtifact]
+    })
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-before-native-incomplete', kind: 'stop' })
+    )
+
+    await expect(
+      applyWorkspaceRuntimeEvent(
+        createEvent({
+          id: 'native-incomplete-event',
+          kind: 'artifact',
+          runId: 'run-native-incomplete',
+          artifactClaimId: 'native-incomplete-claim',
+          artifacts: [nativePendingArtifact]
+        }),
+        {
+          reconcilePendingArtifacts: vi.fn().mockResolvedValue([]),
+          finalizeRunArtifacts: vi
+            .fn()
+            .mockRejectedValue(new Error('Artifact run claim not found: native-incomplete-claim')),
+          saveSession: vi.fn().mockResolvedValue(undefined)
+        }
+      )
+    ).rejects.toThrow('Artifact reconciliation did not resolve all native Versions.')
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      artifactErrorEventIds: ['native-incomplete-event']
+    })
+  })
 })
 
 describe('loop guard: suppressNextAutoReview', () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3650,7 +3650,22 @@ describe('workspace runtime events', () => {
       eventId: 'native-pending-event',
       artifacts: [nativePendingArtifact]
     })
+    useSessionStore.getState().attachRunArtifacts({
+      sessionId: 'transport-session-1',
+      runId: 'run-native-pending',
+      eventId: 'unrelated-native-pending-event',
+      artifacts: [
+        createArtifactFile({
+          id: 'unrelated-native-version',
+          artifactId: 'unrelated-native-artifact',
+          versionId: 'unrelated-native-version',
+          name: 'unrelated.txt',
+          path: '/Users/example/.open-science/managed/unrelated-native-version/unrelated.txt'
+        })
+      ]
+    })
     await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-native-replay', kind: 'stop' }))
+    useSessionStore.getState().recordArtifactError('transport-session-1', 'unrelated claim failed')
     const messageId = useSessionStore.getState().sessions[0].messages[1].id
     const finalizedArtifact = {
       ...nativePendingArtifact,
@@ -3676,6 +3691,7 @@ describe('workspace runtime events', () => {
 
     expect(reconcilePendingArtifacts).toHaveBeenCalledOnce()
     expect(finalizeRunArtifacts).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0].error).toContain('unrelated claim failed')
   })
 
   it('records native artifact reconciliation failures for retry', async () => {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3519,6 +3519,38 @@ describe('workspace runtime events', () => {
     expect(session.messages[1].artifactIds).toEqual(['transport-session-1:message-1:result.txt'])
     expect(session.error).toBeUndefined()
   })
+
+  it('does not re-finalize an artifact event that the durable Session already applied', async () => {
+    const finalizedArtifact = createArtifactFile({
+      id: 'transport-session-1:message-1:result.txt',
+      sessionId: 'transport-session-1',
+      messageId: 'message-1',
+      runId: undefined,
+      path: '/Users/example/.open-science/artifacts/default-project/transport-session-1/message-1/result.txt',
+      fileUrl:
+        'file:///Users/example/.open-science/artifacts/default-project/transport-session-1/message-1/result.txt'
+    })
+    const finalizeRunArtifacts = vi
+      .fn()
+      .mockResolvedValueOnce([finalizedArtifact])
+      .mockRejectedValueOnce(new Error('Artifact run claim not found: artifact-claim-expired'))
+    const saveSession = vi.fn().mockResolvedValue(undefined)
+    const artifactEvent = createEvent({
+      id: 'artifact-event-expired-claim',
+      kind: 'artifact',
+      runId: 'run-expired-claim',
+      artifactSessionId: 'artifact-session-1',
+      artifactClaimId: 'artifact-claim-expired',
+      artifacts: [createArtifactFile({ runId: 'run-expired-claim' })]
+    })
+
+    await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-before-finalize', kind: 'stop' }))
+    await applyWorkspaceRuntimeEvent(artifactEvent, { finalizeRunArtifacts, saveSession })
+    await applyWorkspaceRuntimeEvent(artifactEvent, { finalizeRunArtifacts, saveSession })
+
+    expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
+    expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
+  })
 })
 
 describe('loop guard: suppressNextAutoReview', () => {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -352,6 +352,7 @@ const finalizeArtifactEvent = async (
         }
         return true
       }
+      throw new Error('Artifact reconciliation did not resolve all native Versions.')
     } catch (error) {
       useSessionStore
         .getState()

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -302,6 +302,24 @@ const finalizeArtifactEvent = async (
   const session = useSessionStore
     .getState()
     .sessions.find((candidate) => candidate.id === event.sessionId)
+  const persistLatestSession = async (): Promise<void> => {
+    const attachedSession = useSessionStore
+      .getState()
+      .sessions.find((candidate) => candidate.id === event.sessionId)
+    if (!attachedSession) {
+      throw new Error('Artifact finalization Session is no longer available.')
+    }
+    const submittedSession = toPersistedSession(attachedSession)
+    const durableSession = await (dependencies.saveSession ?? saveSessionInRuntimeOrder)(
+      submittedSession
+    )
+    if (durableSession) {
+      useSessionStore.getState().applyDurableSessionProjection({
+        source: attachedSession,
+        session: durableSession
+      })
+    }
+  }
   const ownsArtifactPrompt = (message: { responseToMessageId?: string }): boolean =>
     !event.promptMessageId || message.responseToMessageId === event.promptMessageId
   const appliedMessage = [
@@ -320,6 +338,7 @@ const finalizeArtifactEvent = async (
   const artifactProjectId = session?.projectId ?? event.artifacts[0]?.projectId
   if (appliedMessage && artifactProjectId && artifactVersionIds.length > 0) {
     try {
+      await persistLatestSession()
       const reconcile =
         dependencies.reconcilePendingArtifacts ?? window.api.artifacts.reconcilePendingArtifacts
       const result = await reconcile({
@@ -397,25 +416,6 @@ const finalizeArtifactEvent = async (
   let artifactsFinalized = false
 
   try {
-    const persistLatestSession = async (): Promise<void> => {
-      const attachedSession = useSessionStore
-        .getState()
-        .sessions.find((session) => session.id === event.sessionId)
-      if (!attachedSession) {
-        throw new Error('Artifact finalization Session is no longer available.')
-      }
-      const submittedSession = toPersistedSession(attachedSession)
-      const durableSession = await (dependencies.saveSession ?? saveSessionInRuntimeOrder)(
-        submittedSession
-      )
-      if (durableSession) {
-        useSessionStore.getState().applyDurableSessionProjection({
-          source: attachedSession,
-          session: durableSession
-        })
-      }
-    }
-
     await persistLatestSession()
 
     const finalize = dependencies.finalizeRunArtifacts ?? finalizeRunArtifacts

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -294,6 +294,28 @@ const finalizeArtifactEvent = async (
 ): Promise<boolean> => {
   if (!isFinalizableArtifactEvent(event)) return false
 
+  const session = useSessionStore
+    .getState()
+    .sessions.find((candidate) => candidate.id === event.sessionId)
+  const ownsArtifactPrompt = (message: { responseToMessageId?: string }): boolean =>
+    !event.promptMessageId || message.responseToMessageId === event.promptMessageId
+  const appliedMessage = [
+    ...(session?.messages ?? []),
+    ...(session?.conversationGraph?.messages ?? [])
+  ].find((message) => message.eventIds.includes(event.id) && ownsArtifactPrompt(message))
+  const finalizedArtifactIds = new Set(
+    session?.artifacts
+      ?.filter((artifact) => !artifact.path.split(/[\\/]/).includes('.pending'))
+      .map((artifact) => artifact.id)
+  )
+  const appliedArtifactIds = appliedMessage?.artifactIds ?? []
+  if (
+    appliedArtifactIds.length > 0 &&
+    appliedArtifactIds.every((artifactId) => finalizedArtifactIds.has(artifactId))
+  ) {
+    return true
+  }
+
   const attached = attachArtifactEvent(event, turnUsage)
 
   if (!attached) return true

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -345,7 +345,7 @@ const finalizeArtifactEvent = async (
           ...result.map((artifact) => artifact.id)
         ])
         if (
-          session?.artifactErrorEventId === event.id ||
+          session?.artifactErrorEventIds?.includes(event.id) ||
           sessionReferencesOnly(resolvedArtifactIds)
         ) {
           useSessionStore.getState().clearArtifactError(event.sessionId, event.id)
@@ -380,7 +380,7 @@ const finalizeArtifactEvent = async (
   })
   if (appliedMessage && eventArtifactsAreFinalized) {
     if (
-      session?.artifactErrorEventId === event.id ||
+      session?.artifactErrorEventIds?.includes(event.id) ||
       sessionReferencesOnly(resolvedCompatibilityArtifactIds)
     ) {
       useSessionStore.getState().clearArtifactError(event.sessionId, event.id)

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -13,7 +13,9 @@ import {
   ARTIFACT_FINALIZATION_INVALID_PROOF,
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile,
-  type FinalizeRunArtifactsRequest
+  type FinalizeRunArtifactsRequest,
+  type ReconcilePendingArtifactsRequest,
+  type ReconcilePendingArtifactsResult
 } from '../../../../shared/artifacts'
 import type { ReviewRunNotStartedReason, ReviewRunRequest } from '../../../../shared/reviewer'
 import {
@@ -234,6 +236,9 @@ const isNonActionableCodexDiagnostic = (text: string): boolean => {
 
 type WorkspaceRuntimeEventDependencies = {
   finalizeRunArtifacts?: (request: FinalizeRunArtifactsRequest) => Promise<ArtifactFile[]>
+  reconcilePendingArtifacts?: (
+    request: ReconcilePendingArtifactsRequest
+  ) => Promise<ReconcilePendingArtifactsResult>
   saveSession?: (session: PersistedChatSession) => Promise<PersistedChatSession | void>
 }
 
@@ -304,14 +309,41 @@ const finalizeArtifactEvent = async (
     ...(session?.conversationGraph?.messages ?? [])
   ].find((message) => message.eventIds.includes(event.id) && ownsArtifactPrompt(message))
   const appliedArtifactIds = new Set(appliedMessage?.artifactIds ?? [])
+  const artifactVersionIds = event.artifacts.flatMap((artifact) =>
+    artifact.versionId ? [artifact.versionId] : []
+  )
+  const artifactProjectId = session?.projectId ?? event.artifacts[0]?.projectId
+  if (appliedMessage && artifactProjectId && artifactVersionIds.length > 0) {
+    const reconcile =
+      dependencies.reconcilePendingArtifacts ?? window.api.artifacts.reconcilePendingArtifacts
+    const result = await reconcile({
+      projectId: artifactProjectId,
+      sessionId: event.sessionId,
+      messageId: appliedMessage.id,
+      pendingPaths: event.artifacts
+        .map((artifact) => artifact.path)
+        .filter((path) => path.split(/[\\/]/).includes('.pending')),
+      artifactVersionIds
+    })
+    if (!Array.isArray(result)) {
+      const error = new Error(result.message) as Error & { code: typeof result.code }
+      error.code = result.code
+      throw error
+    }
+    const reconciledVersionIds = new Set(
+      result.flatMap((artifact) => (artifact.versionId ? [artifact.versionId] : []))
+    )
+    if (artifactVersionIds.every((versionId) => reconciledVersionIds.has(versionId))) return true
+  }
   const eventArtifactsAreFinalized = event.artifacts.every((pendingArtifact) =>
     session?.artifacts?.some(
       (artifact) =>
         appliedArtifactIds.has(artifact.id) &&
-        !artifact.path.split(/[\\/]/).includes('.pending') &&
         artifact.name === pendingArtifact.name &&
         artifact.size === pendingArtifact.size &&
-        artifact.mtimeMs === pendingArtifact.mtimeMs
+        artifact.mtimeMs === pendingArtifact.mtimeMs &&
+        !pendingArtifact.versionId &&
+        !artifact.path.split(/[\\/]/).includes('.pending')
     )
   )
   if (appliedMessage && eventArtifactsAreFinalized) {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -309,6 +309,11 @@ const finalizeArtifactEvent = async (
     ...(session?.conversationGraph?.messages ?? [])
   ].find((message) => message.eventIds.includes(event.id) && ownsArtifactPrompt(message))
   const appliedArtifactIds = new Set(appliedMessage?.artifactIds ?? [])
+  const sessionReferencesOnly = (resolvedArtifactIds: ReadonlySet<string>): boolean =>
+    [...(session?.messages ?? []), ...(session?.conversationGraph?.messages ?? [])].every(
+      (message) =>
+        (message.artifactIds ?? []).every((artifactId) => resolvedArtifactIds.has(artifactId))
+    )
   const artifactVersionIds = event.artifacts.flatMap((artifact) =>
     artifact.versionId ? [artifact.versionId] : []
   )
@@ -335,7 +340,13 @@ const finalizeArtifactEvent = async (
         result.flatMap((artifact) => (artifact.versionId ? [artifact.versionId] : []))
       )
       if (artifactVersionIds.every((versionId) => reconciledVersionIds.has(versionId))) {
-        useSessionStore.getState().clearArtifactError(event.sessionId)
+        const resolvedArtifactIds = new Set([
+          ...event.artifacts.map((artifact) => artifact.id),
+          ...result.map((artifact) => artifact.id)
+        ])
+        if (sessionReferencesOnly(resolvedArtifactIds)) {
+          useSessionStore.getState().clearArtifactError(event.sessionId)
+        }
         return true
       }
     } catch (error) {
@@ -349,8 +360,9 @@ const finalizeArtifactEvent = async (
       throw error
     }
   }
-  const eventArtifactsAreFinalized = event.artifacts.every((pendingArtifact) =>
-    session?.artifacts?.some(
+  const resolvedCompatibilityArtifactIds = new Set<string>()
+  const eventArtifactsAreFinalized = event.artifacts.every((pendingArtifact) => {
+    const finalizedArtifact = session?.artifacts?.find(
       (artifact) =>
         appliedArtifactIds.has(artifact.id) &&
         artifact.name === pendingArtifact.name &&
@@ -359,9 +371,13 @@ const finalizeArtifactEvent = async (
         !pendingArtifact.versionId &&
         !artifact.path.split(/[\\/]/).includes('.pending')
     )
-  )
+    if (finalizedArtifact) resolvedCompatibilityArtifactIds.add(finalizedArtifact.id)
+    return Boolean(finalizedArtifact)
+  })
   if (appliedMessage && eventArtifactsAreFinalized) {
-    useSessionStore.getState().clearArtifactError(event.sessionId)
+    if (sessionReferencesOnly(resolvedCompatibilityArtifactIds)) {
+      useSessionStore.getState().clearArtifactError(event.sessionId)
+    }
     return true
   }
 

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -303,16 +303,18 @@ const finalizeArtifactEvent = async (
     ...(session?.messages ?? []),
     ...(session?.conversationGraph?.messages ?? [])
   ].find((message) => message.eventIds.includes(event.id) && ownsArtifactPrompt(message))
-  const finalizedArtifactIds = new Set(
-    session?.artifacts
-      ?.filter((artifact) => !artifact.path.split(/[\\/]/).includes('.pending'))
-      .map((artifact) => artifact.id)
+  const appliedArtifactIds = new Set(appliedMessage?.artifactIds ?? [])
+  const eventArtifactsAreFinalized = event.artifacts.every((pendingArtifact) =>
+    session?.artifacts?.some(
+      (artifact) =>
+        appliedArtifactIds.has(artifact.id) &&
+        !artifact.path.split(/[\\/]/).includes('.pending') &&
+        artifact.name === pendingArtifact.name &&
+        artifact.size === pendingArtifact.size &&
+        artifact.mtimeMs === pendingArtifact.mtimeMs
+    )
   )
-  const appliedArtifactIds = appliedMessage?.artifactIds ?? []
-  if (
-    appliedArtifactIds.length > 0 &&
-    appliedArtifactIds.every((artifactId) => finalizedArtifactIds.has(artifactId))
-  ) {
+  if (appliedMessage && eventArtifactsAreFinalized) {
     return true
   }
 

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -314,28 +314,39 @@ const finalizeArtifactEvent = async (
   )
   const artifactProjectId = session?.projectId ?? event.artifacts[0]?.projectId
   if (appliedMessage && artifactProjectId && artifactVersionIds.length > 0) {
-    const reconcile =
-      dependencies.reconcilePendingArtifacts ?? window.api.artifacts.reconcilePendingArtifacts
-    const result = await reconcile({
-      projectId: artifactProjectId,
-      sessionId: event.sessionId,
-      messageId: appliedMessage.id,
-      pendingPaths: event.artifacts
-        .map((artifact) => artifact.path)
-        .filter((path) => path.split(/[\\/]/).includes('.pending')),
-      artifactVersionIds
-    })
-    if (!Array.isArray(result)) {
-      const error = new Error(result.message) as Error & { code: typeof result.code }
-      error.code = result.code
+    try {
+      const reconcile =
+        dependencies.reconcilePendingArtifacts ?? window.api.artifacts.reconcilePendingArtifacts
+      const result = await reconcile({
+        projectId: artifactProjectId,
+        sessionId: event.sessionId,
+        messageId: appliedMessage.id,
+        pendingPaths: event.artifacts
+          .map((artifact) => artifact.path)
+          .filter((path) => path.split(/[\\/]/).includes('.pending')),
+        artifactVersionIds
+      })
+      if (!Array.isArray(result)) {
+        const error = new Error(result.message) as Error & { code: typeof result.code }
+        error.code = result.code
+        throw error
+      }
+      const reconciledVersionIds = new Set(
+        result.flatMap((artifact) => (artifact.versionId ? [artifact.versionId] : []))
+      )
+      if (artifactVersionIds.every((versionId) => reconciledVersionIds.has(versionId))) {
+        useSessionStore.getState().clearArtifactError(event.sessionId)
+        return true
+      }
+    } catch (error) {
+      useSessionStore
+        .getState()
+        .recordArtifactError(
+          event.sessionId,
+          getErrorText(error),
+          !isArtifactFinalizationProofError(error)
+        )
       throw error
-    }
-    const reconciledVersionIds = new Set(
-      result.flatMap((artifact) => (artifact.versionId ? [artifact.versionId] : []))
-    )
-    if (artifactVersionIds.every((versionId) => reconciledVersionIds.has(versionId))) {
-      useSessionStore.getState().clearArtifactError(event.sessionId)
-      return true
     }
   }
   const eventArtifactsAreFinalized = event.artifacts.every((pendingArtifact) =>

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -344,8 +344,11 @@ const finalizeArtifactEvent = async (
           ...event.artifacts.map((artifact) => artifact.id),
           ...result.map((artifact) => artifact.id)
         ])
-        if (sessionReferencesOnly(resolvedArtifactIds)) {
-          useSessionStore.getState().clearArtifactError(event.sessionId)
+        if (
+          session?.artifactErrorEventId === event.id ||
+          sessionReferencesOnly(resolvedArtifactIds)
+        ) {
+          useSessionStore.getState().clearArtifactError(event.sessionId, event.id)
         }
         return true
       }
@@ -355,7 +358,8 @@ const finalizeArtifactEvent = async (
         .recordArtifactError(
           event.sessionId,
           getErrorText(error),
-          !isArtifactFinalizationProofError(error)
+          !isArtifactFinalizationProofError(error),
+          event.id
         )
       throw error
     }
@@ -375,8 +379,11 @@ const finalizeArtifactEvent = async (
     return Boolean(finalizedArtifact)
   })
   if (appliedMessage && eventArtifactsAreFinalized) {
-    if (sessionReferencesOnly(resolvedCompatibilityArtifactIds)) {
-      useSessionStore.getState().clearArtifactError(event.sessionId)
+    if (
+      session?.artifactErrorEventId === event.id ||
+      sessionReferencesOnly(resolvedCompatibilityArtifactIds)
+    ) {
+      useSessionStore.getState().clearArtifactError(event.sessionId, event.id)
     }
     return true
   }
@@ -430,7 +437,7 @@ const finalizeArtifactEvent = async (
       messageId: attached.messageId,
       artifacts: finalizedArtifacts
     })
-    store.clearArtifactError(event.sessionId)
+    store.clearArtifactError(event.sessionId, event.id)
     openMoleculePreviews(event.sessionId, finalizedArtifacts)
     // Auto-review and every main-process provenance reader load the durable Session, not renderer
     // memory. Persist the checksum-bearing finalized Version descriptors before the stop handler may
@@ -442,7 +449,8 @@ const finalizeArtifactEvent = async (
       store.recordArtifactError(
         event.sessionId,
         getErrorText(error),
-        !isArtifactFinalizationProofError(error)
+        !isArtifactFinalizationProofError(error),
+        event.id
       )
     }
     throw error

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -333,7 +333,10 @@ const finalizeArtifactEvent = async (
     const reconciledVersionIds = new Set(
       result.flatMap((artifact) => (artifact.versionId ? [artifact.versionId] : []))
     )
-    if (artifactVersionIds.every((versionId) => reconciledVersionIds.has(versionId))) return true
+    if (artifactVersionIds.every((versionId) => reconciledVersionIds.has(versionId))) {
+      useSessionStore.getState().clearArtifactError(event.sessionId)
+      return true
+    }
   }
   const eventArtifactsAreFinalized = event.artifacts.every((pendingArtifact) =>
     session?.artifacts?.some(
@@ -347,6 +350,7 @@ const finalizeArtifactEvent = async (
     )
   )
   if (appliedMessage && eventArtifactsAreFinalized) {
+    useSessionStore.getState().clearArtifactError(event.sessionId)
     return true
   }
 

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -68,8 +68,13 @@ export type SessionRunProjectionActions = {
   replaceMessageArtifacts: (input: ReplaceMessageArtifactsInput) => void
   replaceMessageUploads: (input: ReplaceMessageUploadsInput) => void
   replaceMessagePdfContext: (input: ReplaceMessagePdfContextInput) => void
-  recordArtifactError: (sessionId: string, error: string, retryable?: boolean) => void
-  clearArtifactError: (sessionId: string) => void
+  recordArtifactError: (
+    sessionId: string,
+    error: string,
+    retryable?: boolean,
+    eventId?: string
+  ) => void
+  clearArtifactError: (sessionId: string, eventId?: string) => void
   finishRun: (
     sessionId: string,
     turnUsage?: AcpTurnTokenUsage,
@@ -275,20 +280,22 @@ export const createSessionRunProjectionOwner = <
       }))
     },
 
-    recordArtifactError: (sessionId, error, retryable = true) => {
+    recordArtifactError: (sessionId, error, retryable = true, eventId) => {
       const message = error.trim()
       if (!sessionId || !message) return
       setSessionState((state) => ({
         sessions: projectSession(state.sessions, sessionId, (session) =>
-          projectArtifactError(session, message, retryable)
+          projectArtifactError(session, message, retryable, eventId)
         )
       }))
     },
 
-    clearArtifactError: (sessionId) => {
+    clearArtifactError: (sessionId, eventId) => {
       if (!sessionId) return
       setSessionState((state) => ({
-        sessions: projectSession(state.sessions, sessionId, projectArtifactErrorCleared)
+        sessions: projectSession(state.sessions, sessionId, (session) =>
+          projectArtifactErrorCleared(session, eventId)
+        )
       }))
     },
 

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -280,7 +280,7 @@ export const projectArtifactError = (
           eventId
         ])
       ]
-    : undefined
+    : session.artifactErrorEventIds
   return {
     ...session,
     status: 'error',

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -268,22 +268,31 @@ export const projectPermissionCleared = (
 export const projectArtifactError = (
   session: ChatSession,
   error: string,
-  retryable = true
+  retryable = true,
+  eventId?: string
 ): ChatSession => ({
   ...session,
   status: 'error',
   error: `${retryable ? ARTIFACT_ERROR_PREFIX : TERMINAL_ARTIFACT_ERROR_PREFIX}: ${error}`,
   errorReportable: true,
+  artifactErrorEventId: eventId,
   updatedAt: Date.now()
 })
 
-export const projectArtifactErrorCleared = (session: ChatSession): ChatSession => {
+export const projectArtifactErrorCleared = (
+  session: ChatSession,
+  eventId?: string
+): ChatSession => {
   if (!isArtifactFinalizationError(session.error)) return session
+  if (eventId && session.artifactErrorEventId && session.artifactErrorEventId !== eventId) {
+    return session
+  }
   return {
     ...session,
     status: session.activeRun ? 'running' : 'idle',
     error: undefined,
     errorReportable: undefined,
+    artifactErrorEventId: undefined,
     updatedAt: Date.now()
   }
 }

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -270,29 +270,45 @@ export const projectArtifactError = (
   error: string,
   retryable = true,
   eventId?: string
-): ChatSession => ({
-  ...session,
-  status: 'error',
-  error: `${retryable ? ARTIFACT_ERROR_PREFIX : TERMINAL_ARTIFACT_ERROR_PREFIX}: ${error}`,
-  errorReportable: true,
-  artifactErrorEventId: eventId,
-  updatedAt: Date.now()
-})
+): ChatSession => {
+  const artifactErrorEventIds = eventId
+    ? [
+        ...new Set([
+          ...(isArtifactFinalizationError(session.error)
+            ? (session.artifactErrorEventIds ?? [])
+            : []),
+          eventId
+        ])
+      ]
+    : undefined
+  return {
+    ...session,
+    status: 'error',
+    error: `${retryable ? ARTIFACT_ERROR_PREFIX : TERMINAL_ARTIFACT_ERROR_PREFIX}: ${error}`,
+    errorReportable: true,
+    artifactErrorEventIds,
+    updatedAt: Date.now()
+  }
+}
 
 export const projectArtifactErrorCleared = (
   session: ChatSession,
   eventId?: string
 ): ChatSession => {
   if (!isArtifactFinalizationError(session.error)) return session
-  if (eventId && session.artifactErrorEventId && session.artifactErrorEventId !== eventId) {
-    return session
+  if (eventId && session.artifactErrorEventIds?.length) {
+    if (!session.artifactErrorEventIds.includes(eventId)) return session
+    const artifactErrorEventIds = session.artifactErrorEventIds.filter(
+      (candidate) => candidate !== eventId
+    )
+    if (artifactErrorEventIds.length > 0) return { ...session, artifactErrorEventIds }
   }
   return {
     ...session,
     status: session.activeRun ? 'running' : 'idle',
     error: undefined,
     errorReportable: undefined,
-    artifactErrorEventId: undefined,
+    artifactErrorEventIds: undefined,
     updatedAt: Date.now()
   }
 }

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -4308,16 +4308,16 @@ describe('normalizeSessionFile with activities', () => {
     const artifactFailure = normalizeSessionFile({
       ...base,
       error: 'Generated file finalization failed: move failed',
-      artifactErrorEventId: 'artifact-event-1'
+      artifactErrorEventIds: ['artifact-event-1', 'artifact-event-1']
     })
     const unrelatedFailure = normalizeSessionFile({
       ...base,
       error: 'Invalid API key',
-      artifactErrorEventId: 'artifact-event-1'
+      artifactErrorEventIds: ['artifact-event-1']
     })
 
-    expect(artifactFailure?.artifactErrorEventId).toBe('artifact-event-1')
-    expect(unrelatedFailure?.artifactErrorEventId).toBeUndefined()
+    expect(artifactFailure?.artifactErrorEventIds).toEqual(['artifact-event-1'])
+    expect(unrelatedFailure?.artifactErrorEventIds).toBeUndefined()
   })
 
   it('round-trips valid Session details and a bounded generation attempt', () => {

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -4303,6 +4303,23 @@ describe('normalizeSessionFile with activities', () => {
     expect(noError?.errorReportable).toBeUndefined()
   })
 
+  it('persists artifact error event ownership only with an artifact finalization error', () => {
+    const base = { ...createSessionWithActivity(undefined), activities: undefined, status: 'error' }
+    const artifactFailure = normalizeSessionFile({
+      ...base,
+      error: 'Generated file finalization failed: move failed',
+      artifactErrorEventId: 'artifact-event-1'
+    })
+    const unrelatedFailure = normalizeSessionFile({
+      ...base,
+      error: 'Invalid API key',
+      artifactErrorEventId: 'artifact-event-1'
+    })
+
+    expect(artifactFailure?.artifactErrorEventId).toBe('artifact-event-1')
+    expect(unrelatedFailure?.artifactErrorEventId).toBeUndefined()
+  })
+
   it('round-trips valid Session details and a bounded generation attempt', () => {
     const restored = normalizeSessionFile({
       ...createSessionWithActivity(undefined),

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -804,7 +804,7 @@ export type PersistedChatSession = {
   errorReportable?: boolean
   // Identifies the artifact runtime event that owns the current finalization error. Historical
   // Sessions omit it and retain the conservative replay-clearing behavior.
-  artifactErrorEventId?: string
+  artifactErrorEventIds?: string[]
   artifacts?: PersistedArtifact[]
   // Incremented only when finalized file metadata changes; text streaming leaves it untouched.
   filesRevision?: number
@@ -4197,9 +4197,9 @@ const sanitizeSession = (
   if (error) sanitized.error = error
   // Only meaningful alongside an error; persisted only when explicitly false (absent = reportable).
   if (error && session.errorReportable === false) sanitized.errorReportable = false
-  const artifactErrorEventId = asString(session.artifactErrorEventId)
-  if (error?.startsWith('Generated file finalization') && artifactErrorEventId) {
-    sanitized.artifactErrorEventId = artifactErrorEventId
+  const artifactErrorEventIds = [...new Set(asStringArray(session.artifactErrorEventIds))]
+  if (error?.startsWith('Generated file finalization') && artifactErrorEventIds.length > 0) {
+    sanitized.artifactErrorEventIds = artifactErrorEventIds
   }
   if (agentFrameworkId && AGENT_FRAMEWORK_IDS.has(agentFrameworkId)) {
     sanitized.agentFrameworkId = agentFrameworkId

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -802,6 +802,9 @@ export type PersistedChatSession = {
   // unknown ACP-layer failure. Resolved once when the run fails and persisted so the "Report error"
   // gate survives a reload. Absent on older files — treated as reportable (the prior behavior).
   errorReportable?: boolean
+  // Identifies the artifact runtime event that owns the current finalization error. Historical
+  // Sessions omit it and retain the conservative replay-clearing behavior.
+  artifactErrorEventId?: string
   artifacts?: PersistedArtifact[]
   // Incremented only when finalized file metadata changes; text streaming leaves it untouched.
   filesRevision?: number
@@ -4194,6 +4197,10 @@ const sanitizeSession = (
   if (error) sanitized.error = error
   // Only meaningful alongside an error; persisted only when explicitly false (absent = reportable).
   if (error && session.errorReportable === false) sanitized.errorReportable = false
+  const artifactErrorEventId = asString(session.artifactErrorEventId)
+  if (error?.startsWith('Generated file finalization') && artifactErrorEventId) {
+    sanitized.artifactErrorEventId = artifactErrorEventId
+  }
   if (agentFrameworkId && AGENT_FRAMEWORK_IDS.has(agentFrameworkId)) {
     sanitized.agentFrameworkId = agentFrameworkId
   }


### PR DESCRIPTION
## Problem

A generated Artifact can be published successfully and displayed in its Session, then later show `Artifact run claim not found` when the retained artifact runtime event is replayed after the finalized claim's five-minute in-memory TTL. Session projection is idempotent by event id, but the finalization side effect was repeated.

## Proposed change

Treat a replayed artifact event as complete only when its event id is already attached to the same prompt response and every referenced Artifact has a non-pending path. Events whose files remain under `.pending` still call finalization, preserving retry after a real publication failure.

## Scope and non-goals

- No database or persisted-format changes.
- No new fields, states, or enum values.
- No renderer contract or interaction changes beyond removing the false error.
- No persistent Artifact claim registry or TTL change.
- Historical Sessions without the existing artifact event ids retain their prior recovery behavior; no heuristic legacy matching was added.

## Acceptance criteria and validation

- Replaying a fully finalized artifact event does not invoke finalization again or set a Session error.
- Replaying an event after a genuine failed finalization remains retryable.
- `workspace_runtime -> npm run test:module -- workspace_runtime -> 11 files, 433 tests passed`
- `renderer type safety -> npm run typecheck:web -> passed`
- `linted source -> npm run lint -> passed`

All listed checks ran after the last material edit. Full `npm test` was intentionally omitted per the requested module-focused workflow; exact-head PR CI remains authoritative.

## Review focus

Please verify that the guard distinguishes durable finalized paths from `.pending` paths and therefore does not suppress legitimate publication retries.