### PR TITLE
fix(cli): keep the authoritative Run result when the event stream times out

### DIFF
--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -1244,8 +1244,18 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
         ? client.events({ signal: abortController.signal })
         : undefined
     await eventStream?.ready
+    // The event stream only renders progress; waitForRun remains authoritative for the final Run
+    // state, so a mid-run stream failure must not fail an otherwise-successful command.
     const eventTask = eventStream
-      ? streamRunEvents(eventStream, runRef, options, deps, abortController.signal)
+      ? streamRunEvents(eventStream, runRef, options, deps, abortController.signal).catch(
+          (error) => {
+            if (abortController.signal.aborted) return
+            const message = error instanceof Error ? error.message : String(error)
+            deps.warn(
+              `Run event stream stopped: ${message} Final Run state will still be read from Open Science.`
+            )
+          }
+        )
       : undefined
     let result
     try {

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1241,6 +1241,158 @@ describe('task CLI', () => {
     expect(client.cancelRun).not.toHaveBeenCalled()
   })
 
+  it('keeps the authoritative Run result when the event stream times out mid-run', async () => {
+    const streamFailure = Object.assign(
+      new Error('Open Science event stream timed out after 30000 milliseconds.'),
+      { code: 'timeout' }
+    )
+    const events = (): {
+      ready: Promise<void>
+      [Symbol.asyncIterator](): {
+        next(): Promise<IteratorResult<never>>
+      }
+    } => ({
+      ready: Promise.resolve(),
+      [Symbol.asyncIterator]() {
+        return {
+          next: () =>
+            new Promise<IteratorResult<never>>((_, reject) => {
+              setTimeout(() => reject(streamFailure), 5)
+            })
+        }
+      }
+    })
+    const client = {
+      listProjects,
+      events,
+      startRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        status: 'running'
+      }),
+      waitForRun: vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(
+              () =>
+                resolve({
+                  id: 'run-1',
+                  sessionId: 'session-1',
+                  status: 'completed',
+                  output: 'Done',
+                  artifacts: []
+                }),
+              15
+            )
+          })
+      )
+    }
+    const log = vi.fn()
+    const warn = vi.fn()
+    const setExitCode = vi.fn()
+
+    await runTaskCommand(
+      {
+        command: 'run',
+        options: {
+          project: 'project-1',
+          prompt: 'Research this.',
+          wait: true,
+          json: false,
+          jsonl: false
+        }
+      },
+      {
+        connect: vi.fn().mockResolvedValue(client),
+        stdinIsTTY: true,
+        log,
+        warn,
+        setExitCode
+      }
+    )
+
+    expect(client.waitForRun).toHaveBeenCalledWith('run-1')
+    expect(warn).toHaveBeenCalledWith(
+      'Run event stream stopped: Open Science event stream timed out after 30000 milliseconds. Final Run state will still be read from Open Science.'
+    )
+    expect(log).toHaveBeenCalledWith('Done')
+    expect(setExitCode).not.toHaveBeenCalled()
+  })
+
+  it('keeps the authoritative Run failure when the event stream times out mid-run', async () => {
+    const streamFailure = Object.assign(
+      new Error('Open Science event stream timed out after 30000 milliseconds.'),
+      { code: 'timeout' }
+    )
+    const events = (): {
+      ready: Promise<void>
+      [Symbol.asyncIterator](): {
+        next(): Promise<IteratorResult<never>>
+      }
+    } => ({
+      ready: Promise.resolve(),
+      [Symbol.asyncIterator]() {
+        return {
+          next: () =>
+            new Promise<IteratorResult<never>>((_, reject) => {
+              setTimeout(() => reject(streamFailure), 5)
+            })
+        }
+      }
+    })
+    const client = {
+      listProjects,
+      events,
+      startRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        status: 'running'
+      }),
+      waitForRun: vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(
+              () =>
+                resolve({
+                  id: 'run-1',
+                  sessionId: 'session-1',
+                  status: 'failed',
+                  error: 'Provider failed',
+                  artifacts: []
+                }),
+              15
+            )
+          })
+      )
+    }
+    const log = vi.fn()
+    const warn = vi.fn()
+    const setExitCode = vi.fn()
+
+    await runTaskCommand(
+      {
+        command: 'run',
+        options: {
+          project: 'project-1',
+          prompt: 'Research this.',
+          wait: true,
+          json: false,
+          jsonl: false
+        }
+      },
+      {
+        connect: vi.fn().mockResolvedValue(client),
+        stdinIsTTY: true,
+        log,
+        warn,
+        setExitCode
+      }
+    )
+
+    expect(log).toHaveBeenCalledWith('Run failed: Provider failed')
+    expect(setExitCode).toHaveBeenCalledWith(1)
+  })
+
   it('explicitly cancels the server run after a wait timeout and preserves the timeout error', async () => {
     const timeout = Object.assign(new Error('Timed out waiting for run run-1.'), {
       code: 'timeout'

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1319,7 +1319,7 @@ describe('task CLI', () => {
     expect(setExitCode).not.toHaveBeenCalled()
   })
 
-  it('keeps the authoritative Run failure when the event stream times out mid-run', async () => {
+  it('keeps the authoritative Run failure in JSONL when the event stream times out', async () => {
     const streamFailure = Object.assign(
       new Error('Open Science event stream timed out after 30000 milliseconds.'),
       { code: 'timeout' }
@@ -1377,7 +1377,7 @@ describe('task CLI', () => {
           prompt: 'Research this.',
           wait: true,
           json: false,
-          jsonl: false
+          jsonl: true
         }
       },
       {
@@ -1389,7 +1389,14 @@ describe('task CLI', () => {
       }
     )
 
-    expect(log).toHaveBeenCalledWith('Run failed: Provider failed')
+    expect(warn).toHaveBeenCalledWith(
+      'Run event stream stopped: Open Science event stream timed out after 30000 milliseconds. Final Run state will still be read from Open Science.'
+    )
+    expect(JSON.parse(log.mock.calls[0][0])).toMatchObject({
+      id: 'run-1',
+      status: 'failed',
+      error: 'Provider failed'
+    })
     expect(setExitCode).toHaveBeenCalledWith(1)
   })
 


### PR DESCRIPTION
## Problem

`run --wait` opens the auxiliary progress-event stream beside `waitForRun()` and awaits the monitoring task in the `finally` block (`packages/open-science/cli.mjs`). When the event stream fails mid-run — most commonly its 30-second idle timeout (`Open Science event stream timed out after 30000 milliseconds.`, code `timeout`) — the already-rejected task is awaited after `waitForRun()` has resolved, so the stream error replaces the authoritative Run result: the CLI exits `1` even though the server-side Run completed, and a genuinely failed Run reports the stream error instead of its real failure. This is #2134, observed with automation parents that suspend draining the CLI's stdout pipe: the stalled loop stops processing WebSocket frames, and the armed idle timer fires once the loop resumes.

The stream is an auxiliary observation channel (progress rendering, JSONL lines); `waitForRun()` polls the Task HTTP API and is authoritative for the terminal Run status — the same contract the `stream.resync-required` handling already documents ("final Run state still comes from the Task HTTP API"). A stream failure is therefore not a run failure.

## Proposed change

Demote a non-aborted event-stream failure of the CLI monitoring task to a one-line stderr warning:

```text
Run event stream stopped: <reason> Final Run state will still be read from Open Science.
```

The command keeps waiting on `waitForRun()` and reports its authoritative result and exit code. The `.catch` handler is attached directly to the monitoring task, which also removes the floating rejected promise (and its `unhandledRejection` window) that the old code produced between stream failure and teardown. A failure racing with teardown (the abort signal already fired) is dropped silently so the original run-path error propagates unchanged.

## Scope and non-goals

- CLI error propagation only (`run --wait` human and `--jsonl` paths). `--json` never opens the stream and is unaffected.
- No SDK transport change: the idle-timeout watchdog still fails the iterator (no auto-reconnect), and `events.ready` failures still fail the command because they happen before the Run is started. Automatic idle-timeout reconnect/resync would be follow-up hardening on top of this semantic fix.
- The documented SDK progress-loop example in `packages/open-science/README.md` has the same latent await shape; left untouched as an SDK docs change rather than CLI behavior.

## Acceptance criteria and validation

Regression tests in `packages/open-science/cli.test.ts`, written first and confirmed failing on `main` with exactly the issue's error before the fix:

- Event stream times out mid-run, `waitForRun()` returns `completed` → command succeeds, prints the run output, exit code `0`, one stderr warning (timeout no longer wins).
- Event stream times out mid-run, `waitForRun()` returns `failed` → command prints `Run failed: <real error>`, exit code `1` (real failure no longer masked by the stream error).
- Event stream healthy, `waitForRun()` rejects with its own timeout → the wait timeout still propagates and aborts the stream (pre-existing test, unchanged and still green).

Final evidence mapping (commands run after the last material edit):

| Behavior                                        | Command                                       | Result |
| ----------------------------------------------- | --------------------------------------------- | ------ |
| CLI run branch decoupling + regression tests   | `npm run test:cli` (complete `packages/open-science` suite, 93 tests) | pass   |
| Changed source lint                             | `npm run lint`                                | pass   |

Impact-set rationale: the changed module is the `packages/open-science` CLI package and its complete test set is `test:cli`; `cli.test.ts` appears in `scripts/ci/module-impact.json` only as a consumer of unchanged settings/review fixtures, so no other module's owner tests apply. No typecheck applies (`packages/` is outside `tsconfig.node.json` and the web tsconfig). Exact-head PR Gate remains authoritative for the complete portable and platform suites.

Uncovered risks: the production pipe-backpressure trigger is not reproduced end-to-end here; the deterministic tests inject the same failure the real SDK emits after the idle window, which exercises the exact code path under fix.

## Review focus

- The single behavioral decision: a non-aborted event-stream failure must not fail the command while `waitForRun()` stays authoritative — including the stderr warning as the right surface for both human and `--jsonl` output.
- The abort-race guard (drop failures once the signal fired) that keeps `--timeout-ms` and `--cancel-on-timeout` semantics unchanged.

Fixes #2134
