### PR TITLE
feat(providers): add Apodex provider

### DIFF
--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -420,6 +420,8 @@ describe('opencodeFramework.prepareModelConfig', () => {
     ['minimax', 'MiniMax-M3', 'high', { thinking: { type: 'adaptive' } }],
     ['xiaomimimo', 'mimo-v2.5-pro', 'none', { thinking: { type: 'disabled' } }],
     ['xiaomimimo', 'mimo-v2.5-pro', 'high', { thinking: { type: 'enabled' } }],
+    ['apodex', 'apodex-1.1', 'none', {}],
+    ['apodex', 'apodex-1.1', 'high', {}],
     ['deepseek', 'deepseek-v4-pro', 'none', { thinking: { type: 'disabled' } }],
     [
       'deepseek',

--- a/src/main/settings/anthropic-provider-bridge.test.ts
+++ b/src/main/settings/anthropic-provider-bridge.test.ts
@@ -76,26 +76,35 @@ describe('AnthropicProviderBridge', () => {
     const firstBaseUrl = await listen(first.server)
     const secondBaseUrl = await listen(second.server)
     const targets: AnthropicProviderBridgeTarget[] = [
-      { id: 'deepseek/model-a', baseUrl: firstBaseUrl, key: 'key-a', model: 'model-a' },
+      {
+        id: 'deepseek/model-a',
+        baseUrl: firstBaseUrl,
+        key: 'key-a',
+        model: 'model-a',
+        backgroundModel: 'model-a-mini'
+      },
       { id: 'kimi/model-b', baseUrl: secondBaseUrl, key: 'key-b', model: 'model-b' }
     ]
     const bridge = new AnthropicProviderBridge(targets, targets[0].id)
     bridges.push(bridge)
     const connection = await bridge.start()
 
-    const send = (model: string): Promise<Response> =>
+    const send = (model?: unknown): Promise<Response> =>
       fetch(`${connection.baseUrl}/v1/messages?beta=1`, {
         method: 'POST',
         headers: {
           authorization: `Bearer ${connection.token}`,
           'content-type': 'application/json'
         },
-        body: JSON.stringify({ model, messages: [] })
+        body: JSON.stringify({ ...(model === undefined ? {} : { model }), messages: [] })
       })
 
     await expect((await send('untrusted-model')).json()).resolves.toEqual({ model: 'model-a' })
+    await expect((await send('model-a-mini')).json()).resolves.toEqual({ model: 'model-a-mini' })
     expect(bridge.setTarget(targets[1].id)).toBe(true)
     await expect((await send('still-untrusted')).json()).resolves.toEqual({ model: 'model-b' })
+    await expect((await send()).json()).resolves.toEqual({ model: 'model-b' })
+    await expect((await send(42)).json()).resolves.toEqual({ model: 'model-b' })
     await expect(
       (
         await fetch(`${connection.baseUrl}/v1/messages/count_tokens`, {
@@ -114,9 +123,24 @@ describe('AnthropicProviderBridge', () => {
         authorization: 'Bearer key-a',
         body: { model: 'model-a', messages: [] },
         path: '/v1/messages?beta=1'
+      },
+      {
+        authorization: 'Bearer key-a',
+        body: { model: 'model-a-mini', messages: [] },
+        path: '/v1/messages?beta=1'
       }
     ])
     expect(second.requests).toEqual([
+      {
+        authorization: 'Bearer key-b',
+        body: { model: 'model-b', messages: [] },
+        path: '/v1/messages?beta=1'
+      },
+      {
+        authorization: 'Bearer key-b',
+        body: { model: 'model-b', messages: [] },
+        path: '/v1/messages?beta=1'
+      },
       {
         authorization: 'Bearer key-b',
         body: { model: 'model-b', messages: [] },

--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -55,6 +55,7 @@ export type AnthropicProviderBridgeTarget = Readonly<{
   baseUrl: string
   key?: string
   model: string
+  backgroundModel?: string
   useApiKeyHeader?: boolean
 }>
 
@@ -189,7 +190,12 @@ export class AnthropicProviderBridge {
     const parsed = await request.readJsonObject()
 
     const target = this.target
-    const body = JSON.stringify({ ...parsed, model: target.model })
+    const requestedModel = typeof parsed.model === 'string' ? parsed.model : undefined
+    const model =
+      target.backgroundModel !== undefined && requestedModel === target.backgroundModel
+        ? requestedModel
+        : target.model
+    const body = JSON.stringify({ ...parsed, model })
     const headersToForward = requestHeaders(request, target.key, target.useApiKeyHeader)
     const replayKey = providerRequestFingerprint(
       target.id,

--- a/src/main/settings/backend-route-planner.test.ts
+++ b/src/main/settings/backend-route-planner.test.ts
@@ -393,6 +393,47 @@ describe('BackendRoutePlanner provider candidates', () => {
     })
   })
 
+  it('registers the Apodex Mini model for Claude background requests', () => {
+    const provider = makeStoredProvider({
+      type: 'official',
+      vendorId: 'apodex',
+      apiEndpoints: ['anthropic', 'openai'],
+      baseUrl: 'https://api.apodex.ai',
+      model: 'apodex-1.1'
+    })
+    const target = makeTarget(provider, {
+      apiEndpoints: ['anthropic', 'openai'],
+      provider: {
+        type: 'custom',
+        vendorId: 'apodex',
+        apiEndpoints: ['anthropic', 'openai']
+      }
+    })
+
+    const plan = makePlanner().planBackend({
+      settings: { ...makeSettings(provider), agentFrameworkId: 'claude-code' },
+      frameworkId: 'claude-code',
+      target,
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.transport).toEqual({
+      kind: 'claude-anthropic',
+      targets: [
+        {
+          id: JSON.stringify([provider.id, provider.model]),
+          baseUrl: 'https://api.apodex.ai',
+          key: 'plain-provider-key',
+          model: 'apodex-1.1',
+          backgroundModel: 'apodex-1.1-mini',
+          useApiKeyHeader: true
+        }
+      ],
+      initialTargetId: JSON.stringify([provider.id, provider.model])
+    })
+  })
+
   it('filters model catalogs by route and preserves deduplicated effort slots', () => {
     const provider = makeStoredProvider()
     const active = makeTarget(provider, {

--- a/src/main/settings/backend-route-planner.ts
+++ b/src/main/settings/backend-route-planner.ts
@@ -324,6 +324,9 @@ class BackendRoutePlanner {
                 baseUrl,
                 ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
                 model,
+                ...(candidate.provider.vendorId === 'apodex'
+                  ? { backgroundModel: 'apodex-1.1-mini' }
+                  : {}),
                 ...(candidate.provider.vendorId &&
                 usesVendorAnthropicApiKeyHeader(candidate.provider.vendorId)
                   ? { useApiKeyHeader: true }

--- a/src/main/settings/provider-env.test.ts
+++ b/src/main/settings/provider-env.test.ts
@@ -44,6 +44,25 @@ describe('provider-env', () => {
     expect(env.ANTHROPIC_BASE_URL).toBe('https://api.anthropic.com')
   })
 
+  it('configures Claude Code for Apodex prefix caching and background requests', () => {
+    const env = buildProviderEnv(
+      {
+        type: 'custom',
+        vendorId: 'apodex',
+        baseUrl: 'https://api.apodex.ai',
+        model: 'apodex-1.1',
+        key: 'test-token'
+      },
+      options
+    )
+
+    expect(env).toMatchObject({
+      CLAUDE_CODE_ATTRIBUTION_HEADER: '0',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'apodex-1.1-mini',
+      ANTHROPIC_SMALL_FAST_MODEL: 'apodex-1.1-mini'
+    })
+  })
+
   it('injects CLAUDE_CODE_OAUTH_TOKEN for a claude-isolated provider under the app config dir', () => {
     // claude-isolated authenticates a Claude subscription via a long-lived OAuth token (from
     // `claude setup-token`). The token is portable across config dirs, so isolation comes from the

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -89,6 +89,14 @@ const buildProviderEnv = (
 
   if (provider.model) env.ANTHROPIC_MODEL = provider.model
 
+  if (provider.vendorId === 'apodex') {
+    // Apodex requires a stable Claude Code prompt prefix for effective caching and serves only its
+    // own Mini model for Claude's background title/summary requests.
+    env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+    env.ANTHROPIC_DEFAULT_HAIKU_MODEL = 'apodex-1.1-mini'
+    env.ANTHROPIC_SMALL_FAST_MODEL = 'apodex-1.1-mini'
+  }
+
   if (provider.type === 'custom') {
     // The base URL is normalized so a user-supplied trailing `/v1` isn't doubled by the client's own
     // `/v1/messages` suffix (which would 404). Custom gateways authenticate with a bearer token.

--- a/src/main/settings/reasoning-transport.ts
+++ b/src/main/settings/reasoning-transport.ts
@@ -13,8 +13,10 @@ export type ChatReasoningTransport = {
 // Model profiles describe the values the user may select; this resolver describes how an official
 // provider expects that value on its Chat Completions wire. `none` is especially non-portable:
 // GLM accepts it as reasoning_effort, while DeepSeek/MiniMax/MiMo use a thinking switch and
-// OpenRouter uses its normalized reasoning object. Custom providers select one of the same request
-// shapes explicitly; absence remains the backwards-compatible literal reasoning_effort field.
+// OpenRouter uses its normalized reasoning object. Apodex exposes thinking only on Anthropic
+// Messages, so its OpenAI-compatible Chat requests omit reasoning controls. Custom providers select
+// one of the same request shapes explicitly; absence remains the backwards-compatible literal
+// reasoning_effort field.
 export const resolveChatReasoningTransport = (
   vendorId: OfficialVendorId | undefined,
   model: string | undefined,
@@ -22,6 +24,8 @@ export const resolveChatReasoningTransport = (
   customTransport?: CustomReasoningEffortTransport
 ): ChatReasoningTransport => {
   const transport = vendorId ?? customTransport
+
+  if (transport === 'apodex') return {}
 
   if (transport === 'openrouter') {
     // Qwen 3.7 Max exposes a hybrid-thinking toggle but no continuous effort levels in OpenRouter's

--- a/src/main/settings/record-codec.test.ts
+++ b/src/main/settings/record-codec.test.ts
@@ -101,6 +101,7 @@ describe('settings record codec', () => {
   })
 
   it.each([
+    ['apodex', 'Apodex', undefined],
     ['tencent', 'Tencent TokenHub', 'international'],
     ['tencentcodingplan', 'Tencent Coding Plan', undefined],
     ['tencenttokenplan', 'Tencent Token Plan', undefined]

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -535,6 +535,19 @@ describe('Responses-compatible bridge conversion', () => {
       })
     ).toMatchObject({ thinking: { type: 'enabled' } })
 
+    const apodexRequest = responsesToChatRequest(
+      { model: 'catalog', input: 'hi' },
+      'apodex-1.1',
+      undefined,
+      [],
+      {
+        reasoningEffortOverride: 'high',
+        vendorId: 'apodex'
+      }
+    )
+    expect(apodexRequest).not.toHaveProperty('thinking')
+    expect(apodexRequest).not.toHaveProperty('reasoning_effort')
+
     expect(
       responsesToChatRequest({ model: 'catalog', input: 'hi' }, 'qwen/qwen3.7-max', undefined, [], {
         reasoningEffortOverride: 'none',
@@ -2327,6 +2340,50 @@ describe('Responses bridge Skill selector', () => {
     expect(upstreamBody).toMatchObject({ thinking: { type: 'disabled' } })
     expect(upstreamBody).not.toHaveProperty('reasoning_effort')
   })
+
+  it.each([
+    ['Codex', undefined],
+    ['CodeBuddy', { skillSelectorFailureMode: 'throw' as const }]
+  ])(
+    'omits unsupported Apodex Chat reasoning controls for %s Skill routing',
+    async (_framework, options) => {
+      let upstreamBody: Record<string, unknown> = {}
+      const upstreamFetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        upstreamBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return Response.json({
+          choices: [
+            {
+              message: {
+                tool_calls: [
+                  {
+                    function: {
+                      name: 'select_skills',
+                      arguments: JSON.stringify({ skill_names: ['literature-review'] })
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        })
+      })
+      const bridge = new ResponsesBridge(
+        {
+          baseUrl: 'https://api.apodex.ai/v1',
+          model: 'apodex-1.1',
+          vendorId: 'apodex'
+        },
+        upstreamFetch,
+        options
+      )
+
+      await expect(bridge.selectSkills('Prepare a literature review.', catalog)).resolves.toEqual([
+        { name: 'literature-review', path: '/private/review/SKILL.md' }
+      ])
+      expect(upstreamBody).not.toHaveProperty('thinking')
+      expect(upstreamBody).not.toHaveProperty('reasoning_effort')
+    }
+  )
 
   it('retries without tools when forced tool choice produces ordinary content', async () => {
     const requests: Array<Record<string, unknown>> = []

--- a/src/renderer/src/assets/provider-icons/apodex.svg
+++ b/src/renderer/src/assets/provider-icons/apodex.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 510 510" role="img">
+  <title>Apodex</title>
+  <g transform="translate(49.5 232)" fill="none" stroke="#050608" stroke-width="27" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M0 219 229.743 0 411 219"/>
+    <path d="M0 219 112 22l22 27.5"/>
+    <path d="m172.5 98.5 94 120.5"/>
+  </g>
+  <path fill="#437DC4" d="M170 107.311c58.135 1.595 82.992 31.992 84.314 84.689 2.919-52.344 26.981-81.577 84.686-84.318-54.424-.182-85.031-25.827-84.314-84.682-1.543 58.608-31.005 85.294-84.686 84.311Z"/>
+</svg>

--- a/src/renderer/src/pages/settings/provider-form-value.test.ts
+++ b/src/renderer/src/pages/settings/provider-form-value.test.ts
@@ -264,6 +264,7 @@ describe('provider-kind helpers', () => {
     const apiKeys = groupKeys('api')
 
     expect(apiKeys).toContain('official:deepseek')
+    expect(apiKeys).toContain('official:apodex')
     expect(apiKeys).toContain('official:openai')
     expect(apiKeys).toContain('official:tencent')
     expect(apiKeys).toContain('official:tencentcodingplan')

--- a/src/renderer/src/pages/settings/provider-icons.render.test.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.render.test.tsx
@@ -4,6 +4,15 @@ import { describe, expect, it } from 'vitest'
 import { ProviderKindIcon } from './provider-icons'
 
 describe('ProviderKindIcon', () => {
+  it('renders the bundled Apodex provider logo', () => {
+    const html = renderToStaticMarkup(<ProviderKindIcon kindKey="official:apodex" />)
+
+    expect(html).toContain('<img')
+    expect(html).toContain('%3ctitle%3eApodex%3c/title%3e')
+    expect(html).toContain('%23437DC4')
+    expect(html).not.toContain('text-muted-foreground')
+  })
+
   it.each(['official:opencode-go', 'official:opencode'])(
     'reuses the OpenCode logo for %s',
     (kindKey) => {

--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -9,6 +9,7 @@ import TencentCloudColor from '@lobehub/icons/es/TencentCloud/components/Color'
 
 import { cn } from '@/lib/utils'
 import anthropicLogo from '@/assets/provider-icons/anthropic.svg'
+import apodexLogo from '@/assets/provider-icons/apodex.svg'
 import claudeLogo from '@/assets/provider-icons/claude.svg'
 // CodeBuddy is a third-party product mark used only to identify its compatible ACP runtime.
 // Keep it separate from Open Science branding and avoid implying affiliation or endorsement.
@@ -57,6 +58,7 @@ const VENDOR_LOGO: Partial<Record<OfficialVendorId, string>> = {
   openai: openaiLogo,
   anthropic: anthropicLogo,
   xai: grokLogo,
+  apodex: apodexLogo,
   deepseek: deepseekLogo,
   bailian: bailianLogo,
   bailianplan: bailianLogo,

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -37,6 +37,7 @@ describe('provider registry', () => {
     expect(isOfficialVendorId('deepseek')).toBe(true)
     expect(isOfficialVendorId('openai')).toBe(true)
     expect(isOfficialVendorId('xai')).toBe(true)
+    expect(isOfficialVendorId('apodex')).toBe(true)
     expect(isOfficialVendorId('tencent')).toBe(true)
     expect(isOfficialVendorId('tencentcodingplan')).toBe(true)
     expect(isOfficialVendorId('tencenttokenplan')).toBe(true)
@@ -545,6 +546,22 @@ describe('provider registry', () => {
     // hidden and expose only the curated language-model catalog.
     expect(resolveVendorModelsUrl('xai')).toBeUndefined()
     expect(defaultVendorModel('xai')).toBe('grok-4.6')
+  })
+
+  it('routes Apodex core models through Messages and Chat Completions', () => {
+    expect(resolveVendorApiEndpoints('apodex')).toEqual(['anthropic', 'openai'])
+    expect(resolveVendorBaseUrl('apodex')).toBe('https://api.apodex.ai')
+    expect(resolveVendorOpenAiBaseUrl('apodex')).toBe('https://api.apodex.ai/v1')
+    expect(resolveVendorApiKeyUrl('apodex')).toBe('https://platform.apodex.ai/console')
+    expect(resolveVendorModelsUrl('apodex')).toBeUndefined()
+    expect(usesVendorAnthropicApiKeyHeader('apodex')).toBe(true)
+    expect(getOfficialVendor('apodex')?.models).toEqual([
+      { id: 'apodex-1.1', contextWindow: 262_144 },
+      { id: 'apodex-1.1-mini', contextWindow: 262_144 }
+    ])
+    expect(defaultVendorModel('apodex')).toBe('apodex-1.1')
+    expect(isVendorModelMultimodal('apodex', 'apodex-1.1')).toBe(false)
+    expect(isVendorModelResponsesSupported('apodex', 'apodex-1.1')).toBe(false)
   })
 
   it('routes Kimi through both APIs so Codex can bridge it', () => {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -18,6 +18,7 @@ export type OfficialVendorId =
   | 'openai'
   | 'anthropic'
   | 'xai'
+  | 'apodex'
   | 'deepseek'
   | 'bailian'
   | 'bailianplan'
@@ -207,6 +208,23 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     ],
     // Every curated xAI language model accepts text and image input.
     multimodal: { allMultimodal: true }
+  },
+  {
+    id: 'apodex',
+    label: 'Apodex',
+    // Apodex exposes only a thinking on/off switch, not the product's effort ladder.
+    reasoningEffort: 'unsupported',
+    apiEndpoints: ['anthropic', 'openai'],
+    anthropicApiKeyHeader: true,
+    baseUrl: 'https://api.apodex.ai',
+    openaiBaseUrl: 'https://api.apodex.ai/v1',
+    apiKeyUrl: 'https://platform.apodex.ai/console',
+    // Keep this curated: the account catalog can also contain Deep Research SKUs with different
+    // request semantics, while this provider entry is for the two core text models.
+    models: [
+      { id: 'apodex-1.1', contextWindow: 262_144 },
+      { id: 'apodex-1.1-mini', contextWindow: 262_144 }
+    ]
   },
   {
     id: 'deepseek',


### PR DESCRIPTION
## Problem

Apodex core models are not available as a built-in provider, so users must configure an equivalent custom gateway by hand.

## Proposed change

- Register Apodex as an official provider with `apodex-1.1` and `apodex-1.1-mini` (262,144-token, text-only models).
- Route Claude Code through Anthropic Messages and OpenCode/CodeBuddy through OpenAI Chat Completions; let Codex use the existing Responses-to-Chat bridge.
- Omit unsupported `thinking` and `reasoning_effort` controls from Apodex Chat requests; Anthropic Messages retains its native default thinking behavior.
- Send the documented Anthropic API-key header and configure Claude Code attribution/background-model variables required by Apodex.
- Bundle the official Apodex logo for the provider picker.

Sources: [Core Models](https://platform.apodex.ai/docs/models) and [Anthropic Messages](https://platform.apodex.ai/docs/anthropic-messages).

## Scope and non-goals

- Do not advertise native Responses support: the approved integration uses the existing Codex Chat Completions bridge.
- Keep a fixed two-model catalog; do not expose live refresh that could mix in Deep Research SKUs with different semantics.
- No new dependency, database schema, migration, or persisted field.

## Compatibility, state, and persistence

- Historical data: existing settings require no migration.
- New state: `OfficialVendorId` gains the additive `apodex` value.
- Persistence: Apodex reuses the existing official-provider record and encrypted API-key reference.
- Downgrade boundary: an older build that does not recognize `vendorId: "apodex"` will drop that provider record while sanitizing settings.

## Acceptance criteria and validation

Local validation (the complete `npm test` suite is intentionally deferred to PR CI):

- Provider registry, environment, persistence, picker/icon, and framework-route tests: 9 files / 245 tests passed.
- Final Chat transport tests: 3 files / 201 tests passed.
- `npm run test:module -- settings_backend_resolution`: 38 files passed, 1 skipped / 726 tests passed, 4 skipped.
- `npm run test:module -- settings_provider_accounts`: 22 files / 451 tests passed.
- `npm run test:module -- settings_repository`: 20 files / 749 tests passed.
- `npm test -- src/main/agent-framework/codex.test.ts`: 62 tests passed.
- `npm run typecheck:node`: passed.
- `npm run typecheck:web`: passed.
- `npm run lint`: passed.
- Prettier check and `git diff --check`: passed.

Framework/path coverage:

- Claude Code: Anthropic Messages through the existing app-owned provider bridge; Apodex-specific Claude environment covered.
- OpenCode: OpenAI-compatible Chat Completions route covered.
- Codex native Responses: intentionally excluded because this provider does not advertise Responses.
- Codex bridge: existing Responses-to-Chat conversion path covered.
- CodeBuddy: OpenAI-compatible route covered.

Uncovered risks: no live request was made because no Apodex API key was available. The complete `npm test` suite was intentionally not run; `test:affected:explain` falls back to full because `provider-env.ts` is not assigned an owner in the impact manifest. PR CI is the final validation authority.

Independent review found no standards or specification violations.

## Review focus

- Confirm the intentional omission of native Responses/live model refresh.
- Confirm the Chat-control omission, Claude Code vendor-specific environment values, and downgrade boundary.