### PR TITLE
docs(readme): refresh Open Science README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
-# Open Science - The open-source AI research workbench with scientific AI agents
+<h1 align="center">Open Science</h1>
 
-[![Download](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 #1 BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![Platforms macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![License](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](LICENSE)
-[![Website](https://img.shields.io/badge/Website-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  Open-source, local-first, model-agnostic AI research workbench for reproducible science.
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Download" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Version" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="#1 BiomniBench-DA Public 50" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Platforms macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="LICENSE">
+    <img alt="License Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="Website aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -1,13 +1,35 @@
-# Open Science – Die quelloffene KI-Forschungsumgebung mit wissenschaftlichen KI-Agenten
+<h1 align="center">Open Science</h1>
 
-[![Download](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 Platz 1 bei BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![Plattformen macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![Lizenz](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)
-[![Website](https://img.shields.io/badge/Website-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  Quelloffene, lokal betriebene und modellunabhängige KI-Forschungsumgebung für reproduzierbare Wissenschaft.
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Herunterladen" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Version" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="Platz 1 bei BiomniBench-DA Public 50" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Plattformen macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="../../LICENSE">
+    <img alt="Lizenz Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="Website aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="../../README.md"><img alt="README auf Englisch" src="https://img.shields.io/badge/English-d9d9d9"></a>

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -1,13 +1,35 @@
-# Open Science - Entorno abierto de investigación con agentes científicos de IA
+<h1 align="center">Open Science</h1>
 
-[![Descargar](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![Versión](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 N.º 1 en BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![Plataformas macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![Licencia](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)
-[![Sitio web](https://img.shields.io/badge/Website-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  Entorno de investigación con IA de código abierto, centrado en la ejecución local e independiente del modelo, para una ciencia reproducible.
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Descargar" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Versión" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="N.º 1 en BiomniBench-DA Public 50" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Plataformas macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="../../LICENSE">
+    <img alt="Licencia Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="Sitio web aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="../../README.md"><img alt="README en inglés" src="https://img.shields.io/badge/English-d9d9d9"></a>

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -1,13 +1,35 @@
-# Open Science - Le banc de travail de recherche IA open source avec des agents IA scientifiques
+<h1 align="center">Open Science</h1>
 
-[![Télécharger](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![Version](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 N° 1 sur BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![Plateformes macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![Licence](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)
-[![Site web](https://img.shields.io/badge/Website-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  Environnement de recherche en IA open source, local et indépendant des modèles, pour une science reproductible.
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Télécharger" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Version" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="N° 1 sur BiomniBench-DA Public 50" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Plateformes macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="../../LICENSE">
+    <img alt="Licence Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="Site web aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="../../README.md"><img alt="English README" src="https://img.shields.io/badge/English-d9d9d9"></a>

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,13 +1,35 @@
-# Open Science - 科学 AI エージェントを備えたオープンソースの AI 研究ワークベンチ
+<h1 align="center">Open Science</h1>
 
-[![ダウンロード](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![バージョン](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 BiomniBench-DA Public 50で第1位](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![対応プラットフォーム macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![ライセンス](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)
-[![ウェブサイト](https://img.shields.io/badge/Website-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  再現可能な科学のための、オープンソース、ローカルファースト、モデル非依存の AI 研究ワークベンチ。
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="ダウンロード" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="バージョン" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="BiomniBench-DA Public 50 で第1位" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="対応プラットフォーム macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="../../LICENSE">
+    <img alt="Apache 2.0 ライセンス" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="ウェブサイト aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="../../README.md"><img alt="English README" src="https://img.shields.io/badge/English-d9d9d9"></a>

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -1,13 +1,35 @@
-# Open Science - 과학 AI 에이전트를 갖춘 오픈 소스 AI 연구 워크벤치
+<h1 align="center">Open Science</h1>
 
-[![다운로드](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![버전](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 BiomniBench-DA Public 50 1위](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![지원 플랫폼 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![라이선스](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)
-[![웹사이트](https://img.shields.io/badge/Website-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  재현 가능한 과학을 위한 오픈 소스·로컬 우선·모델 독립형 AI 연구 워크벤치입니다.
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="다운로드" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="버전" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="BiomniBench-DA Public 50 1위" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="지원 플랫폼 macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="../../LICENSE">
+    <img alt="Apache 2.0 라이선스" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="웹사이트 aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="../../README.md"><img alt="English README" src="https://img.shields.io/badge/English-d9d9d9"></a>

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -1,13 +1,35 @@
-# Open Science — открытая рабочая среда для исследований с научными ИИ-агентами
+<h1 align="center">Open Science</h1>
 
-[![Скачать](https://img.shields.io/badge/Скачать-последний%20выпуск-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![Версия](https://img.shields.io/github/v/release/aipoch/open-science?label=Версия&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 № 1 в BiomniBench-DA Public 50](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![Платформы macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![Лицензия](https://img.shields.io/badge/Лицензия-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)
-[![Сайт](https://img.shields.io/badge/Сайт-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-присоединиться%20к%20сообществу-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  Открытая, локальная и независимая от моделей среда ИИ-исследований для воспроизводимой науки.
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Скачать" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Версия" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="№ 1 в BiomniBench-DA Public 50" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="Платформы macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="../../LICENSE">
+    <img alt="Лицензия Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="Сайт aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="../../README.md"><img alt="README на английском" src="https://img.shields.io/badge/English-d9d9d9"></a>

--- a/docs/zh-Hans/README.md
+++ b/docs/zh-Hans/README.md
@@ -1,13 +1,35 @@
-# Open Science - 搭载科学 AI 智能体的开源 AI 研究工作台
+<h1 align="center">Open Science</h1>
 
-[![下载](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![版本](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 BiomniBench-DA Public 50 第一名](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![支持平台 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![许可证](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)
-[![网站](https://img.shields.io/badge/Website-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  面向可复现科学研究的开源、本地优先、模型无关 AI 研究工作台。
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="下载" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="版本" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="BiomniBench-DA Public 50 第一名" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="支持平台 macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="../../LICENSE">
+    <img alt="Apache 2.0 许可证" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="网站 aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="../../README.md"><img alt="English README" src="https://img.shields.io/badge/English-d9d9d9"></a>

--- a/docs/zh-Hant/README.md
+++ b/docs/zh-Hant/README.md
@@ -1,13 +1,35 @@
-# Open Science - 搭載科學 AI 智能體的開源 AI 研究工作台
+<h1 align="center">Open Science</h1>
 
-[![下載](https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=for-the-badge&logo=github)](https://github.com/aipoch/open-science/releases/latest)
-[![版本](https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=for-the-badge&color=4dabf7)](https://github.com/aipoch/open-science/releases/latest)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-4dabf7?style=for-the-badge)](https://doi.org/10.5281/zenodo.22252246)
-[![🏆 BiomniBench-DA Public 50 第一名](https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-F9B000?style=for-the-badge)](https://huggingface.co/datasets/phylobio/BiomniBench-DA)
-[![支援平台 macOS Windows Linux](https://img.shields.io/badge/Platforms-macOS%20%7C%20Windows%20%7C%20Linux-4dabf7?style=for-the-badge)](https://github.com/aipoch/open-science/releases/latest)
-[![授權條款](https://img.shields.io/badge/License-Apache--2.0-4dabf7?style=for-the-badge)](../../LICENSE)
-[![網站](https://img.shields.io/badge/Website-aipoch.com-2f9e44?style=for-the-badge)](https://aipoch.com/open-science)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zxQAYjReRv)
+<p align="center">
+  面向可重現科學研究的開源、本機優先、模型無關 AI 研究工作台。
+</p>
+
+<p align="center">
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="下載" src="https://img.shields.io/badge/Download-Latest%20Release-2f9e44?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="版本" src="https://img.shields.io/github/v/release/aipoch/open-science?label=Version&style=flat&color=4dabf7">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.22252246">
+    <img alt="DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22252246-0b7285?style=flat">
+  </a>
+  <a href="https://huggingface.co/datasets/phylobio/BiomniBench-DA">
+    <img alt="BiomniBench-DA Public 50 第一名" src="https://img.shields.io/badge/%F0%9F%8F%86%20%231-BiomniBench--DA%20Public%2050-f59f00?style=flat">
+  </a>
+  <a href="https://github.com/aipoch/open-science/releases/latest">
+    <img alt="支援平台 macOS Windows Linux" src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-4263eb?style=flat">
+  </a>
+  <a href="../../LICENSE">
+    <img alt="Apache 2.0 授權條款" src="https://img.shields.io/badge/license-Apache--2.0-7950f2?style=flat">
+  </a>
+  <a href="https://aipoch.com/open-science">
+    <img alt="網站 aipoch.com" src="https://img.shields.io/badge/website-aipoch.com-e8590c?style=flat">
+  </a>
+  <a href="https://discord.gg/zxQAYjReRv">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20Community-5865F2?style=flat&logo=discord&logoColor=white">
+  </a>
+</p>
 
 <p align="center">
   <a href="../../README.md"><img alt="English README" src="https://img.shields.io/badge/English-d9d9d9"></a>


### PR DESCRIPTION
## Problem

The refreshed header was applied only to the English README, leaving the eight localized READMEs with the previous heading and badge layout.

## Proposed change

- Center the Open Science heading and product tagline in every README.
- Use the same compact, color-separated badge layout across all nine languages.
- Localize each translated README tagline and badge alternative text.
- Preserve the existing language selector and destination links.

## Scope and non-goals

This is documentation-only. It does not change application behavior, persisted data, schemas, enums, or historical-data compatibility.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Header and badge consistency across all nine READMEs -> targeted shell assertions -> passed.
- Markdown formatting -> targeted Prettier check for all nine READMEs -> passed.
- Commit and PR policy -> node scripts/ci/check-pr-policy.mjs -> passed.
- Diff whitespace validation -> git diff origin/main...HEAD --check -> passed.

Full npm tests were not run because the change is documentation-only. PR CI remains authoritative. No uncovered runtime, platform, persistence, or compatibility risks were identified.

## Review focus

Please review the localized taglines and the visual consistency of the header and badge row.