### PR TITLE
docs(readme): add AIPOCH to localized headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   Open-source, local-first, model-agnostic AI research workbench for reproducible science.

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   Quelloffene, lokal betriebene und modellunabhängige KI-Forschungsumgebung für reproduzierbare Wissenschaft.

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   Entorno de investigación con IA de código abierto, centrado en la ejecución local e independiente del modelo, para una ciencia reproducible.

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   Environnement de recherche en IA open source, local et indépendant des modèles, pour une science reproductible.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   再現可能な科学のための、オープンソース、ローカルファースト、モデル非依存の AI 研究ワークベンチ。

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   재현 가능한 과학을 위한 오픈 소스·로컬 우선·모델 독립형 AI 연구 워크벤치입니다.

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   Открытая, локальная и независимая от моделей среда ИИ-исследований для воспроизводимой науки.

--- a/docs/zh-Hans/README.md
+++ b/docs/zh-Hans/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   面向可复现科学研究的开源、本地优先、模型无关 AI 研究工作台。

--- a/docs/zh-Hant/README.md
+++ b/docs/zh-Hant/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Science</h1>
+<h1 align="center">AIPOCH Open Science</h1>
 
 <p align="center">
   面向可重現科學研究的開源、本機優先、模型無關 AI 研究工作台。


### PR DESCRIPTION
## Problem

The localized README header layout is already synchronized across all indexed languages, but every header still uses "Open Science" instead of the requested "AIPOCH Open Science" brand title.

## Proposed change

Update the centered H1 in the root README and all eight indexed localized READMEs to "AIPOCH Open Science".

Updated files:

- README.md
- docs/zh-Hans/README.md
- docs/zh-Hant/README.md
- docs/ja/README.md
- docs/ko/README.md
- docs/fr/README.md
- docs/ru/README.md
- docs/de/README.md
- docs/es/README.md

## Scope and non-goals

This is a title-only documentation change. It does not change localized descriptions, badge labels, language links, release content, application code, or runtime behavior.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Multilingual completeness -> root language-index discovery and base-to-head changed-file gate -> passed for all 9 indexed READMEs.
- Header consistency -> exact H1 and header-structure validation -> passed for all 9 READMEs.
- Formatting -> npx --yes prettier@3.7.4 --check on all 9 READMEs -> passed.
- Navigation integrity -> local TOC-anchor and relative-link target validation -> passed.
- Diff hygiene -> git diff --check -> passed.
- Repository policy -> node scripts/ci/check-pr-policy.mjs using the proposed PR title and base/head commits -> passed.

No source tests, typechecks, platform lanes, or consumer tests were included because this change only replaces the first-line documentation title and does not alter interfaces or runtime behavior.

## Review focus

Please verify that the AIPOCH brand prefix is appropriate and consistently applied to the centered title in every indexed language version.

## Uncovered risks

Independent reviewer confirmation and GitHub CI are still pending. No runtime risks are expected from this documentation-only change.