### PR TITLE
feat(notebook): extract managed environment lock export primitive

### DIFF
--- a/src/main/notebook/env-ipc.test.ts
+++ b/src/main/notebook/env-ipc.test.ts
@@ -39,6 +39,7 @@ const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisi
   upgradeIfNeeded: vi.fn().mockResolvedValue(undefined),
   repair: vi.fn().mockResolvedValue(undefined),
   restoreRelocatedEnvs: vi.fn().mockResolvedValue(undefined),
+  restoreEnvironmentFromLock: vi.fn().mockResolvedValue(undefined),
   cancel: vi.fn(),
   ...over
 })

--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -43,6 +43,7 @@ const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisi
     await options?.onVerified?.()
   }),
   restoreRelocatedEnvs: vi.fn().mockResolvedValue(undefined),
+  restoreEnvironmentFromLock: vi.fn().mockResolvedValue(undefined),
   cancel: vi.fn(),
   ...over
 })

--- a/src/main/notebook/environment-lock.restore.integration.test.ts
+++ b/src/main/notebook/environment-lock.restore.integration.test.ts
@@ -1,0 +1,134 @@
+// Local integration test for issue #924's portable restore acceptance: an exported @EXPLICIT lock
+// must rebuild an equivalent managed environment WITHOUT the original prefix and WITHOUT a
+// pre-populated package cache (downloads re-fetch every tarball).
+//
+// Run with a real micromamba on PATH (or OPEN_SCIENCE_TEST_MICROMAMBA):
+//   OPEN_SCIENCE_TEST_MICROMAMBA=$(pwd)/.tmp-micromamba/micromamba \
+//     npx vitest run src/main/notebook/environment-lock.restore.integration.test.ts
+//
+// It is env-gated like the kernel suites (RUN_KERNEL/OPEN_SCIENCE_TEST_PY_ENV) so `npm test`
+// never touches the network. Setup, mirroring .github/workflows/runtime-certification.yml:
+//   node scripts/fetch-micromamba.mjs linux-64 .tmp-micromamba/micromamba
+//   .tmp-micromamba/micromamba create -y -p .tmp-int-env -c conda-forge python=3.12
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { exportEnvironmentLock } from './environment-lock'
+import { DefaultRuntimeProvisioner, type ProvisionerDeps } from './provisioner'
+import { DEFAULT_PY_ENV, envPrefix, pkgsCache, pythonBin, runtimeRoot } from './runtime-paths'
+import { captureMicromamba, verifyExecutable } from './provisioner-runtime'
+
+const mm = process.env.OPEN_SCIENCE_TEST_MICROMAMBA
+const gate = mm && existsSync(mm) ? describe : describe.skip
+
+const runMm = (args: string[], opts: { cwd?: string } = {}): string => {
+  const result = spawnSync(mm!, args, {
+    encoding: 'utf8',
+    cwd: opts.cwd,
+    env: { ...process.env, CONDA_PKGS_DIRS: undefined }
+  })
+  if (result.status !== 0) {
+    throw new Error(`micromamba ${args.join(' ')} failed: ${result.stderr?.slice(0, 400)}`)
+  }
+  return result.stdout
+}
+
+const integrationDeps = (root: string): ProvisionerDeps => ({
+  root,
+  mm: mm!,
+  channel: 'conda-forge',
+  fetchBundle: async () => undefined,
+  verify: async (bin, prefix) => verifyExecutable(bin, { prefix }),
+  runArgv: async (argv) => {
+    const result = spawnSync(argv[0]!, argv.slice(1), { encoding: 'utf8' })
+    if (result.status !== 0) {
+      throw new Error(
+        `micromamba failed (${result.status}; ${argv.join(' ')}):\n${result.stderr?.slice(0, 400)}`
+      )
+    }
+  },
+  downloadPackage: async (url, dest, signal) => {
+    // Direct URL fetch via the bundled Node fetch; the production wiring uses the shared
+    // resilient downloader (system proxy aware). Integration-wise both fetch the same bytes.
+    const response = await fetch(url, { signal })
+    if (!response.ok) throw new Error(`package request failed (${response.status}): ${url}`)
+    const bytes = Buffer.from(await response.arrayBuffer())
+    // Stage via rename so a killed download never leaves a torn tarball in staging.
+    const temp = `${dest}.part`
+    writeFileSync(temp, bytes)
+    renameSync(temp, dest)
+  },
+  now: () => 't-now'
+})
+
+gate('environment lock portable restore (integration)', () => {
+  it(
+    'restores an exported lock into an empty-cache root as an equivalent env',
+    { timeout: 600_000 },
+    async () => {
+      const work = mkdtempSync(join(tmpdir(), 'envlock-restore-'))
+      try {
+        // Phase 1: create a minimal managed env (python + one small noarch package) in a SOURCE root.
+        // --root-prefix binds the source root's own pkgs cache so the test never touches the host's
+        // global micromamba cache (the target phase below is fully independent regardless).
+        const sourceRoot = runtimeRoot(join(work, 'source-data'))
+        const sourceEnvName = DEFAULT_PY_ENV
+        runMm(
+          [
+            'create',
+            '-y',
+            '--no-rc',
+            '--root-prefix',
+            sourceRoot,
+            '-p',
+            envPrefix(sourceRoot, sourceEnvName),
+            '-c',
+            'conda-forge',
+            'python=3.12',
+            'six'
+          ],
+          { cwd: work }
+        )
+        const lock = await exportEnvironmentLock(
+          { name: sourceEnvName, prefix: envPrefix(sourceRoot, sourceEnvName) },
+          {
+            mm: mm!,
+            capture: (argv) => captureMicromamba(argv)
+          }
+        )
+        expect(lock.startsWith('@EXPLICIT\n')).toBe(true)
+        expect((lock.match(/^https?:\/\//gm) ?? []).length).toBeGreaterThan(0)
+
+        // Phase 2: a pristine TARGET root — no prefix, no cache. The lock is all we carry over.
+        const targetData = join(work, 'target-data')
+        const targetRoot = runtimeRoot(targetData)
+        const deps = integrationDeps(targetRoot)
+        const provisioner = new DefaultRuntimeProvisioner(deps)
+        await provisioner.restoreEnvironmentFromLock(sourceEnvName, lock)
+
+        const prefix = envPrefix(targetRoot, sourceEnvName)
+        expect(existsSync(pythonBin(prefix))).toBe(true)
+        // The restored env lists the SAME pinned packages (URL equality = version+build+md5).
+        const restoredLock = await exportEnvironmentLock(
+          { name: sourceEnvName, prefix },
+          { mm: mm!, capture: (argv) => captureMicromamba(argv) }
+        )
+        expect(restoredLock).toBe(lock)
+        // Verify the interpreter actually runs from the restored prefix.
+        const probe = spawnSync(pythonBin(prefix), ['-c', 'import six; print("ok")'], {
+          encoding: 'utf8'
+        })
+        expect(probe.status).toBe(0)
+        expect(probe.stdout.trim()).toBe('ok')
+        // And the downloads seeded the target's durable cache (portable restore evidence).
+        expect(existsSync(pkgsCache(targetRoot))).toBe(true)
+      } finally {
+        rmSync(work, { recursive: true, force: true })
+      }
+    }
+  )
+})

--- a/src/main/notebook/environment-lock.test.ts
+++ b/src/main/notebook/environment-lock.test.ts
@@ -1,11 +1,19 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { DiscoveredInterpreter } from '../../shared/notebook-runtime'
-import { exportEnvironmentLock, managedEnvironmentRef } from './environment-lock'
+import {
+  downloadExplicitLockPackages,
+  exportEnvironmentLock,
+  managedEnvironmentRef,
+  parseExplicitLock
+} from './environment-lock'
+import { isSafePackageBasename } from './pack-content'
+import { md5File } from './provisioner-runtime'
 import {
   DEFAULT_ENV_VERSION,
   DEFAULT_PY_ENV,
@@ -172,5 +180,194 @@ describe('managedEnvironmentRef', () => {
       EXPLICIT_LOCK
     )
     expect(capture.mock.calls[0]?.[0]).toContain(shortPrefix)
+  })
+})
+
+const md5Of = (content: string): string => {
+  const hash = createHash('md5')
+  hash.update(content)
+  return hash.digest('hex')
+}
+
+const lockLine = (subdir: string, file: string, md5: string): string =>
+  `https://conda.anaconda.org/conda-forge/${subdir}/${file}#${md5}`
+
+describe('parseExplicitLock', () => {
+  const MD5 = md5Of('pkg')
+  const lock = (lines: string[]): string => `@EXPLICIT\n${lines.join('\n')}\n`
+
+  it('parses a valid lock into pinned entries and ignores comments', () => {
+    const entries = parseExplicitLock(
+      lock([
+        '# platform: linux-64',
+        lockLine('linux-64', 'python-3.12.conda', MD5),
+        lockLine('noarch', 'numpy-2.1.conda', MD5)
+      ]),
+      { platform: 'linux', arch: 'x64' }
+    )
+    expect(entries).toEqual([
+      {
+        url: `https://conda.anaconda.org/conda-forge/linux-64/python-3.12.conda`,
+        file: 'python-3.12.conda',
+        md5: MD5
+      },
+      {
+        url: `https://conda.anaconda.org/conda-forge/noarch/numpy-2.1.conda`,
+        file: 'numpy-2.1.conda',
+        md5: MD5
+      }
+    ])
+  })
+
+  it('rejects a lock that is missing the @EXPLICIT marker', () => {
+    expect(() =>
+      parseExplicitLock(lock([lockLine('linux-64', 'a.conda', MD5)]).replace('@EXPLICIT\n', ''), {
+        platform: 'linux',
+        arch: 'x64'
+      })
+    ).toThrow('not a valid @EXPLICIT')
+  })
+
+  it('rejects a lock with no package URLs', () => {
+    expect(() => parseExplicitLock('@EXPLICIT\n', { platform: 'linux', arch: 'x64' })).toThrow(
+      'no package URLs'
+    )
+  })
+
+  it('rejects malformed md5 and malformed URLs', () => {
+    expect(() =>
+      parseExplicitLock(lock([lockLine('linux-64', 'a.conda', 'zz')]), {
+        platform: 'linux',
+        arch: 'x64'
+      })
+    ).toThrow('malformed package entry')
+    expect(() =>
+      parseExplicitLock(lock([`https://conda.anaconda.org#${MD5}`]), {
+        platform: 'linux',
+        arch: 'x64'
+      })
+    ).toThrow('malformed package entry')
+  })
+
+  it('rejects sha256-digest locks with a clear unsupported error', () => {
+    const sha = 'a'.repeat(64)
+    expect(() =>
+      parseExplicitLock(lock([lockLine('linux-64', 'a.conda', sha)]), {
+        platform: 'linux',
+        arch: 'x64'
+      })
+    ).toThrow('sha256')
+  })
+
+  it('rejects a lock exported for a different platform', () => {
+    expect(() =>
+      parseExplicitLock(lock([lockLine('osx-arm64', 'python-3.12.conda', MD5)]), {
+        platform: 'linux',
+        arch: 'x64'
+      })
+    ).toThrow('osx-arm64')
+  })
+
+  it('rejects duplicate package files', () => {
+    expect(() =>
+      parseExplicitLock(
+        lock([lockLine('linux-64', 'a.conda', MD5), lockLine('linux-64', 'a.conda', MD5)]),
+        { platform: 'linux', arch: 'x64' }
+      )
+    ).toThrow('duplicate')
+  })
+
+  it('rejects an unsupported non-URL body line instead of dropping it', () => {
+    expect(() =>
+      parseExplicitLock(lock(['python=3.12, numpy']), { platform: 'linux', arch: 'x64' })
+    ).toThrow('unsupported line')
+  })
+
+  it('rejects a backslash traversal basename before it reaches any download destination', () => {
+    // `url.split('/')` leaves `..\..\.env-ready` intact as the "basename"; on Windows join() would
+    // resolve it OUTSIDE the staging dir — the shared basename validator must reject it first.
+    expect(() =>
+      parseExplicitLock(`@EXPLICIT\nhttps://example.com/linux-64/..\\..\\.env-ready#${MD5}\n`, {
+        platform: 'linux',
+        arch: 'x64'
+      })
+    ).toThrow('malformed package entry')
+  })
+
+  it('validates package basenames with Windows semantics regardless of the host', () => {
+    // Every unsafe form must reject, on any host OS: traversal (both separators), dot segments,
+    // Windows drive paths, and non-conda extensions.
+    for (const file of [
+      '..\\..\\foo.conda',
+      '../foo.conda',
+      '.\\foo.conda',
+      'C:\\foo.conda',
+      'foo/bar.conda',
+      '.',
+      '..',
+      '.env-ready',
+      'foo.txt'
+    ]) {
+      expect(isSafePackageBasename(file)).toBe(false)
+    }
+    expect(isSafePackageBasename('python-3.12.conda')).toBe(true)
+    expect(isSafePackageBasename('old-base.tar.bz2')).toBe(true)
+  })
+})
+
+describe('downloadExplicitLockPackages', () => {
+  const MD5 = md5Of('tarball bytes')
+
+  it('downloads every entry and verifies each md5', async () => {
+    const dir = await makeRuntimeRoot()
+    const entries = parseExplicitLock(
+      `@EXPLICIT\n${lockLine('linux-64', 'python-3.12.conda', MD5)}\n`,
+      { platform: 'linux', arch: 'x64' }
+    )
+    const download = vi.fn().mockImplementation(async (_url, dest) => {
+      await writeFile(dest, 'tarball bytes', 'utf8')
+    })
+    const seen: Array<[number, number]> = []
+    await downloadExplicitLockPackages(entries, dir, {
+      download,
+      md5: (path) => md5File(path),
+      onProgress: (completed, total) => seen.push([completed, total])
+    })
+    expect(download).toHaveBeenCalledOnce()
+    expect(seen).toEqual([[1, 1]])
+    expect((await md5File(join(dir, 'python-3.12.conda'))).toLowerCase()).toBe(MD5)
+  })
+
+  it('rejects a download whose md5 does not match the lock', async () => {
+    const dir = await makeRuntimeRoot()
+    const entries = parseExplicitLock(
+      `@EXPLICIT\n${lockLine('linux-64', 'python-3.12.conda', MD5)}\n`,
+      { platform: 'linux', arch: 'x64' }
+    )
+    const download = vi.fn().mockImplementation(async (_url, dest) => {
+      await writeFile(dest, 'CORRUPTED', 'utf8')
+    })
+    await expect(
+      downloadExplicitLockPackages(entries, dir, { download, md5: (path) => md5File(path) })
+    ).rejects.toThrow('md5 verification')
+  })
+
+  it('propagates an aborted download signal', async () => {
+    const dir = await makeRuntimeRoot()
+    const entries = parseExplicitLock(
+      `@EXPLICIT\n${lockLine('linux-64', 'python-3.12.conda', MD5)}\n`,
+      { platform: 'linux', arch: 'x64' }
+    )
+    const controller = new AbortController()
+    controller.abort(new Error('cancelled'))
+    const download = vi.fn().mockRejectedValue(controller.signal.reason)
+    await expect(
+      downloadExplicitLockPackages(entries, dir, {
+        download,
+        md5: (path) => md5File(path),
+        signal: controller.signal
+      })
+    ).rejects.toThrow('cancelled')
+    expect(download).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/notebook/environment-lock.test.ts
+++ b/src/main/notebook/environment-lock.test.ts
@@ -1,0 +1,176 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { DiscoveredInterpreter } from '../../shared/notebook-runtime'
+import { exportEnvironmentLock, managedEnvironmentRef } from './environment-lock'
+import {
+  DEFAULT_ENV_VERSION,
+  DEFAULT_PY_ENV,
+  DEFAULT_R_ENV,
+  envPrefix,
+  writeReadyMarker
+} from './runtime-paths'
+
+const roots: string[] = []
+const makeRuntimeRoot = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'envlock-'))
+  roots.push(root)
+  return root
+}
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const interpreter = (overrides: Partial<DiscoveredInterpreter>): DiscoveredInterpreter => ({
+  language: 'python',
+  provenance: 'app-managed',
+  envId: '/runtime/envs/default-python/bin/python',
+  interpreterPath: '/runtime/envs/default-python/bin/python',
+  label: 'Default Python',
+  runnable: true,
+  ...overrides
+})
+
+// Realistic `micromamba list --explicit --md5` stdout: comment/header lines, padded URL lines,
+// and a non-URL title line that must all be stripped.
+const EXPLICIT_STDOUT = [
+  '# platform: linux-64',
+  '@EXPLICIT',
+  '  https://conda.anaconda.org/conda-forge/noarch/python-3.12.conda#abc123  ',
+  'https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.conda#def456',
+  'a non-URL title line'
+].join('\n')
+
+const EXPLICIT_LOCK =
+  [
+    '@EXPLICIT',
+    'https://conda.anaconda.org/conda-forge/noarch/python-3.12.conda#abc123',
+    'https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.conda#def456'
+  ].join('\n') + '\n'
+
+describe('exportEnvironmentLock', () => {
+  it('normalizes valid explicit output into a validated @EXPLICIT lock', async () => {
+    const capture = vi.fn().mockResolvedValue(EXPLICIT_STDOUT)
+    const lock = await exportEnvironmentLock(
+      { name: 'default-python', prefix: '/runtime/envs/default-python' },
+      { mm: '/mm', capture }
+    )
+    expect(lock).toBe(EXPLICIT_LOCK)
+    expect(capture).toHaveBeenCalledWith([
+      '/mm',
+      '--no-rc',
+      'list',
+      '--prefix',
+      '/runtime/envs/default-python',
+      '--explicit',
+      '--md5'
+    ])
+  })
+
+  it('rejects an env whose exported lock has no package URLs', async () => {
+    const capture = vi.fn().mockResolvedValue('# nothing installed\n@EXPLICIT\n')
+    await expect(
+      exportEnvironmentLock(
+        { name: 'default-r', prefix: '/runtime/envs/default-r' },
+        { mm: '/mm', capture }
+      )
+    ).rejects.toThrow('Could not export default-r: the exported lock contains no package URLs.')
+  })
+
+  it('propagates micromamba capture failures unchanged', async () => {
+    const failure = new Error('micromamba failed (/mm list --prefix): no such environment')
+    const capture = vi.fn().mockRejectedValue(failure)
+    await expect(
+      exportEnvironmentLock(
+        { name: 'half-made', prefix: '/runtime/envs/half-made' },
+        { mm: '/mm', capture }
+      )
+    ).rejects.toBe(failure)
+  })
+})
+
+describe('managedEnvironmentRef', () => {
+  it('resolves and exports a managed Python env from a discovered interpreter', async () => {
+    const runtime = await makeRuntimeRoot()
+    const prefix = envPrefix(runtime, DEFAULT_PY_ENV)
+    const ref = managedEnvironmentRef(interpreter({ condaEnv: DEFAULT_PY_ENV }), runtime)
+    expect(ref).toEqual({ name: DEFAULT_PY_ENV, prefix })
+    if (!ref) throw new Error('expected a managed ref')
+
+    const capture = vi.fn().mockResolvedValue(EXPLICIT_STDOUT)
+    await expect(exportEnvironmentLock(ref, { mm: '/mm', capture })).resolves.toBe(EXPLICIT_LOCK)
+    expect(capture.mock.calls[0]?.[0]).toContain(prefix)
+  })
+
+  it('resolves and exports a managed R env from a discovered interpreter', async () => {
+    const runtime = await makeRuntimeRoot()
+    const prefix = envPrefix(runtime, DEFAULT_R_ENV)
+    const ref = managedEnvironmentRef(
+      interpreter({
+        language: 'r',
+        provenance: 'app-managed',
+        condaEnv: DEFAULT_R_ENV,
+        interpreterPath: '/runtime/envs/default-r/bin/R'
+      }),
+      runtime
+    )
+    expect(ref).toEqual({ name: DEFAULT_R_ENV, prefix })
+    if (!ref) throw new Error('expected a managed ref')
+
+    const capture = vi.fn().mockResolvedValue(EXPLICIT_STDOUT)
+    await expect(exportEnvironmentLock(ref, { mm: '/mm', capture })).resolves.toBe(EXPLICIT_LOCK)
+    expect(capture.mock.calls[0]?.[0]).toContain(prefix)
+  })
+
+  it('returns undefined rather than guessing when a managed interpreter has no conda env name', () => {
+    expect(managedEnvironmentRef(interpreter({ condaEnv: undefined }), '/runtime')).toBeUndefined()
+  })
+
+  it('treats agent-created envs as managed', () => {
+    const runtime = '/runtime'
+    const ref = managedEnvironmentRef(
+      interpreter({ provenance: 'agent-created', condaEnv: 'my-analysis' }),
+      runtime
+    )
+    expect(ref).toEqual({ name: 'my-analysis', prefix: envPrefix(runtime, 'my-analysis') })
+  })
+
+  it('returns undefined for user-own interpreters, even inside a foreign conda env', () => {
+    const ref = managedEnvironmentRef(
+      interpreter({
+        provenance: 'user-own',
+        condaEnv: 'my-conda-env',
+        interpreterPath: '/home/u/miniconda3/envs/my-conda-env/bin/python'
+      }),
+      '/runtime'
+    )
+    expect(ref).toBeUndefined()
+  })
+
+  it('resolves the Windows short default prefix when the ready marker commits it', async () => {
+    const runtime = await makeRuntimeRoot()
+    const shortPrefix = join(runtime, 'envs', '.p')
+    await mkdir(shortPrefix, { recursive: true })
+    writeReadyMarker(runtime, DEFAULT_ENV_VERSION, 'ready', '.p')
+
+    const ref = managedEnvironmentRef(
+      interpreter({
+        condaEnv: DEFAULT_PY_ENV,
+        interpreterPath: join(shortPrefix, 'python.exe')
+      }),
+      runtime,
+      'win32'
+    )
+    expect(ref).toEqual({ name: DEFAULT_PY_ENV, prefix: shortPrefix })
+    if (!ref) throw new Error('expected a managed ref')
+
+    const capture = vi.fn().mockResolvedValue(EXPLICIT_STDOUT)
+    await expect(exportEnvironmentLock(ref, { mm: 'C:\\mm.exe', capture })).resolves.toBe(
+      EXPLICIT_LOCK
+    )
+    expect(capture.mock.calls[0]?.[0]).toContain(shortPrefix)
+  })
+})

--- a/src/main/notebook/environment-lock.ts
+++ b/src/main/notebook/environment-lock.ts
@@ -1,6 +1,9 @@
+import { join } from 'node:path'
+
 import type { DiscoveredInterpreter } from '../../shared/notebook-runtime'
+import { isSafePackageBasename } from './pack-content'
 import { explicitLockArgv, normalizeExplicitLock } from './micromamba'
-import { envPrefix } from './runtime-paths'
+import { envPrefix, runtimeSubdir } from './runtime-paths'
 
 // One app-managed conda environment the main process resolved from its own trusted state
 // (discovery or relocation). `prefix` is always derived from the runtime root — never accepted
@@ -45,4 +48,104 @@ export const exportEnvironmentLock = async (
     throw new Error(`Could not export ${env.name}: the exported lock contains no package URLs.`)
   }
   return lock
+}
+
+// One pinned package of an @EXPLICIT lock: the URL, its cache basename, and its md5 digest.
+export type ExplicitLockEntry = {
+  url: string
+  file: string
+  md5: string
+}
+
+export type ParseExplicitLockOpts = {
+  platform?: NodeJS.Platform
+  arch?: string
+}
+
+// Parses + validates an @EXPLICIT lock BEFORE any restore mutation. Unlike the export direction,
+// this is EXTERNAL input: every rule rejects rather than silently dropping — a dropped package
+// line would silently restore a different env. Mirrors lockPackages' file/md5 rules so the seed
+// layer (validateAndSeedPackIntoCache) and micromamba see exactly the entries validated here.
+// ponytail: md5-only — a sha256-digest lock rejects with a clear error; supporting it needs the
+// seed layer's md5File gate widened too. Upgrade there if sha256 locks ever matter.
+export const parseExplicitLock = (
+  lock: string,
+  opts: ParseExplicitLockOpts = {}
+): ExplicitLockEntry[] => {
+  const lines = lock.split('\n').map((line) => line.trim())
+  const first = lines.find((line) => line !== '')
+  if (first !== '@EXPLICIT') {
+    throw new Error('The lock is not a valid @EXPLICIT environment lock.')
+  }
+  const subdir = runtimeSubdir(opts.platform ?? process.platform, opts.arch ?? process.arch)
+  const entries: ExplicitLockEntry[] = []
+  const seen = new Set<string>()
+  for (const line of lines) {
+    if (line === '' || line === '@EXPLICIT' || line.startsWith('#')) continue
+    if (!/^https?:\/\//.test(line)) {
+      throw new Error(`The lock contains an unsupported line: ${line.slice(0, 120)}`)
+    }
+    const hashIndex = line.indexOf('#')
+    const url = hashIndex >= 0 ? line.slice(0, hashIndex) : ''
+    const md5 = hashIndex >= 0 ? line.slice(hashIndex + 1) : ''
+    if (/^[0-9a-f]{64}$/i.test(md5)) {
+      throw new Error(
+        'The lock pins sha256 digests, which restore does not support yet. ' +
+          'Export the environment with micromamba md5 locks instead.'
+      )
+    }
+    const segments = url.split('/').filter(Boolean)
+    // A valid package URL is scheme/host/path/basename at minimum, and the basename must be a
+    // plain conda archive (isSafePackageBasename): it becomes the download destination under the
+    // staging dir, so a `\` or dot-segment must reject here — not travel through join() on Windows.
+    const file = segments.at(-1) ?? ''
+    if (segments.length < 3 || !isSafePackageBasename(file) || !/^[0-9a-f]{32}$/i.test(md5)) {
+      throw new Error(`The lock contains a malformed package entry: ${line.slice(0, 120)}`)
+    }
+    // The conda URL segment before the basename is the platform subdir; anything but noarch or
+    // this host's subdir means the lock was exported for another platform — reject it up front
+    // instead of letting the offline create extract foreign binaries (or fail halfway).
+    const packageSubdir = segments.at(-2) ?? ''
+    if (packageSubdir !== 'noarch' && packageSubdir !== subdir) {
+      throw new Error(
+        `The lock was exported for platform "${packageSubdir}" and cannot be restored on "${subdir}".`
+      )
+    }
+    if (seen.has(file)) {
+      throw new Error(`The lock contains duplicate entries for ${file}.`)
+    }
+    seen.add(file)
+    entries.push({ url, file, md5 })
+  }
+  if (entries.length === 0) {
+    throw new Error('The lock contains no package URLs.')
+  }
+  return entries
+}
+
+export type DownloadExplicitLockDeps = {
+  // Downloads one package URL to a local path. Production wires the shared resilient downloader;
+  // tests inject a fake.
+  download: (url: string, dest: string, signal?: AbortSignal) => Promise<void>
+  md5: (path: string) => Promise<string>
+  signal?: AbortSignal
+  onProgress?: (completed: number, total: number) => void
+}
+
+// Downloads every lock entry into `dir` and verifies each md5. The md5 gate is what makes a
+// restored env byte-identical to the exported one — a mismatched download rejects the whole
+// restore before anything is seeded into the shared cache or any prefix is touched.
+export const downloadExplicitLockPackages = async (
+  entries: readonly ExplicitLockEntry[],
+  dir: string,
+  deps: DownloadExplicitLockDeps
+): Promise<void> => {
+  for (const [index, entry] of entries.entries()) {
+    const dest = join(dir, entry.file)
+    await deps.download(entry.url, dest, deps.signal)
+    if ((await deps.md5(dest)).toLowerCase() !== entry.md5.toLowerCase()) {
+      throw new Error(`Downloaded package failed md5 verification: ${entry.file}`)
+    }
+    deps.onProgress?.(index + 1, entries.length)
+  }
 }

--- a/src/main/notebook/environment-lock.ts
+++ b/src/main/notebook/environment-lock.ts
@@ -1,0 +1,48 @@
+import type { DiscoveredInterpreter } from '../../shared/notebook-runtime'
+import { explicitLockArgv, normalizeExplicitLock } from './micromamba'
+import { envPrefix } from './runtime-paths'
+
+// One app-managed conda environment the main process resolved from its own trusted state
+// (discovery or relocation). `prefix` is always derived from the runtime root — never accepted
+// from the renderer.
+export type ManagedEnvironment = {
+  name: string
+  prefix: string
+}
+
+// Resolves a discovered interpreter to the managed env it lives in, or undefined when the user
+// owns it or its conda env name is missing — never guess a default env for an interpreter we
+// cannot place. 'app-managed' and 'agent-created' envs both sit under the app runtime root and
+// are exported through the bundled micromamba; user-own interpreters (including a foreign conda
+// install) stay out of scope — their packages are managed manually.
+export const managedEnvironmentRef = (
+  interpreter: DiscoveredInterpreter,
+  runtimeRoot: string,
+  platform: NodeJS.Platform = process.platform
+): ManagedEnvironment | undefined => {
+  if (interpreter.provenance === 'user-own' || !interpreter.condaEnv) return undefined
+  const name = interpreter.condaEnv
+  return { name, prefix: envPrefix(runtimeRoot, name, platform) }
+}
+
+export type ExportEnvironmentLockDeps = {
+  // Resolved micromamba binary.
+  mm: string
+  // Runs a micromamba argv and returns stdout (for `list --explicit --md5`).
+  capture: (argv: string[]) => Promise<string>
+}
+
+// Exports one managed environment prefix as a validated @EXPLICIT lock: capture, normalize,
+// then require at least one package URL to survive — an empty lock is a failure, never a
+// success. The @EXPLICIT marker itself is normalizeExplicitLock's contract, not re-checked here.
+export const exportEnvironmentLock = async (
+  env: ManagedEnvironment,
+  deps: ExportEnvironmentLockDeps
+): Promise<string> => {
+  const raw = await deps.capture(explicitLockArgv(deps.mm, env.prefix))
+  const lock = normalizeExplicitLock(raw)
+  if (!/^https?:\/\//m.test(lock)) {
+    throw new Error(`Could not export ${env.name}: the exported lock contains no package URLs.`)
+  }
+  return lock
+}

--- a/src/main/notebook/environment-operation-foundation.test.ts
+++ b/src/main/notebook/environment-operation-foundation.test.ts
@@ -26,6 +26,7 @@ const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisi
   upgradeIfNeeded: vi.fn().mockResolvedValue(undefined),
   repair: vi.fn().mockResolvedValue(undefined),
   restoreRelocatedEnvs: vi.fn().mockResolvedValue(undefined),
+  restoreEnvironmentFromLock: vi.fn().mockResolvedValue(undefined),
   cancel: vi.fn(),
   ...over
 })

--- a/src/main/notebook/environment-operation-foundation.ts
+++ b/src/main/notebook/environment-operation-foundation.ts
@@ -182,6 +182,8 @@ const serializeProvisioner = (provisioner: RuntimeProvisioner): RuntimeProvision
       serializeLanguage(language, () => provisioner.repair(language, onProgress, options)),
     restoreRelocatedEnvs: (onProgress) =>
       serialize(() => provisioner.restoreRelocatedEnvs(onProgress)),
+    restoreEnvironmentFromLock: (name, lockText, opts) =>
+      serialize(() => provisioner.restoreEnvironmentFromLock(name, lockText, opts)),
     // Cancellation must interrupt immediately rather than wait behind the operation it is aborting.
     // A language-specific idle cancel remains a no-op so it cannot arm an unrelated future operation.
     cancel: (language) => {

--- a/src/main/notebook/micromamba.ts
+++ b/src/main/notebook/micromamba.ts
@@ -233,6 +233,18 @@ export const listArgv = (mm: string, root: string, prefix: string): string[] => 
   '--json'
 ]
 
+// micromamba list --prefix <prefix> --explicit --md5
+// Raw explicit package URLs (+MD5) for one env; normalizeExplicitLock turns them into a lock.
+export const explicitLockArgv = (mm: string, prefix: string): string[] => [
+  mm,
+  '--no-rc',
+  'list',
+  '--prefix',
+  prefix,
+  '--explicit',
+  '--md5'
+]
+
 // Normalizes raw `micromamba list --explicit --md5` output into a valid @EXPLICIT lock. The raw
 // output lacks the @EXPLICIT header and includes comment/title lines; feeding it to
 // `create --file --offline` as-is silently degrades to an online solve and errors (spec §2.5). We

--- a/src/main/notebook/pack-content.ts
+++ b/src/main/notebook/pack-content.ts
@@ -1,5 +1,5 @@
 import { copyFile, mkdir, readFile, readdir, stat } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, posix, win32 } from 'node:path'
 
 import { pkgsCache } from './runtime-paths'
 import { md5File } from './provisioner-runtime'
@@ -7,6 +7,20 @@ import { micromambaCacheLockKey, type MicromambaCache } from './micromamba-cache
 import { withExclusiveCacheLock } from './pkgs-cache-lock'
 
 export type LockPackage = { file: string; md5: string }
+
+// A lock line's URL basename doubles as the cached tarball's filename AND the local download
+// destination, so it must be a plain conda archive basename — never a path. A `\` survives a naive
+// `url.split('/')` and lets `join(staging, '..\\..\\x')` escape the staging dir on Windows (and a
+// URL-legal dot-segment like `.`/`..` is equally unsafe), so validate with BOTH path modules'
+// basename semantics (pure functions — host-independent) plus the conda archive extension.
+// Shared by every lock parser so the download, seed, and micromamba sides cannot drift.
+export const isSafePackageBasename = (file: string): boolean =>
+  file !== '.' &&
+  file !== '..' &&
+  /^[^/\\]+$/.test(file) &&
+  posix.basename(file) === file &&
+  win32.basename(file) === file &&
+  /\.(conda|tar\.bz2)$/i.test(file)
 
 // Parses the @EXPLICIT entries and rejects malformed lines before any file is copied into the shared
 // micromamba cache. Package URLs are expected to end in a basename and a 32-char md5 digest.
@@ -23,7 +37,7 @@ export const lockPackages = (lockText: string): LockPackage[] => {
 
   if (packages.length === 0) throw new Error('runtime pack lock contains no package entries')
   for (const pkg of packages) {
-    if (!pkg.file || pkg.file.includes('/') || !/^[0-9a-f]{32}$/i.test(pkg.md5)) {
+    if (!isSafePackageBasename(pkg.file) || !/^[0-9a-f]{32}$/i.test(pkg.md5)) {
       throw new Error(`runtime pack lock contains a malformed package entry: ${pkg.file}`)
     }
   }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
@@ -16,10 +16,12 @@ import {
   logicalEnvNameFromDirectory,
   pkgsCache,
   pythonBin,
+  pythonReady,
   rBin,
   readRReadyMarker,
   readReadyMarker,
   readyMarkerPath,
+  runtimeSubdir,
   writeRReadyMarker,
   writeReadyMarker
 } from './runtime-paths'
@@ -32,7 +34,8 @@ import {
   DefaultRuntimeProvisioner,
   type FetchedBundle,
   type ProvisionProgress,
-  type ProvisionerDeps
+  type ProvisionerDeps,
+  type RuntimeProvisioner
 } from './provisioner'
 import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
@@ -2969,5 +2972,350 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     expect(restored).toEqual([DEFAULT_PY_ENV])
     expect(existsSync(join(dir, `${DEFAULT_PY_ENV}.lock`))).toBe(false)
     expect(existsSync(join(dir, 'my-analysis.lock'))).toBe(true)
+  })
+})
+
+describe('DefaultRuntimeProvisioner.restoreEnvironmentFromLock', () => {
+  const PKG_CONTENT = 'restore tarball'
+  const PKG_MD5 = createHash('md5').update(PKG_CONTENT).digest('hex')
+  const PKG = 'python-3.12.conda'
+  // Host-independent subdir: the provisioner parses the lock against the HOST platform, so a
+  // hardcoded linux-64 URL would fail the foreign-platform gate on macOS/Windows runners.
+  const SUBDIR = runtimeSubdir()
+  const LOCK = `@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/${SUBDIR}/${PKG}#${PKG_MD5}\n`
+
+  // makeDeps variant that fakes downloads (writes the pinned content) and materializes the
+  // interpreter on create, like the existing runArgv double.
+  const makeRestoreDeps = (
+    root: string,
+    overrides: Partial<ProvisionerDeps> & {
+      downloadPackage?: (url: string, dest: string, signal?: AbortSignal) => Promise<void>
+    } = {}
+  ): ProvisionerDeps => {
+    const { downloadPackage, ...rest } = overrides
+    const deps = makeDeps(root, rest)
+    return {
+      ...deps,
+      downloadPackage:
+        downloadPackage ??
+        (async (url, dest) => {
+          writeFileSync(dest, PKG_CONTENT)
+          expect(url).toBe(`https://conda.anaconda.org/conda-forge/${SUBDIR}/${PKG}`)
+        })
+    }
+  }
+
+  it('creates a managed env from a lock: downloads, seeds the cache, then creates offline', async () => {
+    const root = makeRoot()
+    const argvs: string[][] = []
+    const deps = makeRestoreDeps(root, {
+      runArgv: async (argv) => {
+        argvs.push(argv)
+        const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        const bin = prefix === envPrefix(root, DEFAULT_PY_ENV) ? pythonBin(prefix) : rBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+    const progress: ProvisionProgress[] = []
+    await new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(DEFAULT_PY_ENV, LOCK, {
+      onProgress: (p) => progress.push(p)
+    })
+
+    expect(argvs).toEqual([
+      [
+        '/mm',
+        '--no-rc',
+        'create',
+        '-p',
+        envPrefix(root, DEFAULT_PY_ENV),
+        '--file',
+        expect.any(String),
+        '--offline',
+        '-y',
+        '--root-prefix',
+        root
+      ]
+    ])
+    // The staged lock file was passed to create and the cache was seeded from the download.
+    expect(argvs[0]![6]).toMatch(/\.incoming-.*default-python\.lock$/)
+    expect(existsSync(join(pkgsCache(root), PKG))).toBe(true)
+    // .incoming staging is cleaned and the interpreter + ready marker exist.
+    expect(existsSync(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))).toBe(true)
+    expect(readReadyMarker(root)?.defaultEnvVersion).toBe(DEFAULT_ENV_VERSION)
+    expect(readdirSync(join(root, 'packs')).filter((f) => f.startsWith('.incoming-'))).toEqual([])
+    expect(progress.at(-1)?.phase).toBe('done')
+  })
+
+  it('replaces a broken existing prefix and stamps the marker only after verify succeeds', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, 'my-analysis')
+    mkdirSync(join(prefix, 'conda-meta'), { recursive: true }) // half-built leftover
+    let markerDuringRun = false
+    const deps = makeRestoreDeps(root, {
+      runArgv: async (argv) => {
+        const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        markerDuringRun = existsSync(readyMarkerPath(root))
+        const bin = pythonBin(p)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+    await new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock('my-analysis', LOCK)
+    expect(markerDuringRun).toBe(false) // never looks ready mid-restore
+    expect(existsSync(pythonBin(prefix))).toBe(true)
+    expect(existsSync(join(prefix, 'conda-meta'))).toBe(false) // leftover cleared by create
+  })
+
+  it('rejects an invalid lock before any download or mutation', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    mkdirSync(join(prefix, 'conda-meta'), { recursive: true })
+    const downloadPackage = vi.fn()
+    const runArgv = vi.fn()
+    const deps = makeRestoreDeps(root, { downloadPackage, runArgv })
+    await expect(
+      new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(
+        DEFAULT_PY_ENV,
+        `@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/${SUBDIR}/a.conda#nothex\n`
+      )
+    ).rejects.toThrow('malformed package entry')
+    expect(downloadPackage).not.toHaveBeenCalled()
+    expect(runArgv).not.toHaveBeenCalled()
+    expect(existsSync(join(prefix, 'conda-meta'))).toBe(true) // existing prefix untouched
+  })
+
+  it('rejects an unknown or unsafe target env name', async () => {
+    const root = makeRoot()
+    const runArgv = vi.fn()
+    const deps = makeRestoreDeps(root, { runArgv })
+    const provisioner = new DefaultRuntimeProvisioner(deps)
+    await expect(provisioner.restoreEnvironmentFromLock('../escape', LOCK)).rejects.toThrow(
+      'Invalid environment name'
+    )
+    await expect(provisioner.restoreEnvironmentFromLock('python', LOCK)).rejects.toThrow(
+      'reserved environment name'
+    )
+    expect(runArgv).not.toHaveBeenCalled()
+  })
+
+  it('rejects when no downloader is wired', async () => {
+    const root = makeRoot()
+    const deps = makeDeps(root)
+    await expect(
+      new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(DEFAULT_PY_ENV, LOCK)
+    ).rejects.toThrow('downloadPackage unwired')
+  })
+
+  it('aborts before deleting the existing env when a download fails md5 verification', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'original')
+    const deps = makeRestoreDeps(root, {
+      downloadPackage: async (_url, dest) => {
+        writeFileSync(dest, 'CORRUPTED')
+      }
+    })
+    await expect(
+      new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(DEFAULT_PY_ENV, LOCK)
+    ).rejects.toThrow('md5 verification')
+    expect(existsSync(bin)).toBe(true) // existing env untouched — download fails closed
+    expect(existsSync(join(pkgsCache(root), PKG))).toBe(false) // nothing seeded
+  })
+
+  it('fails cleanly on a create failure and leaves no ready marker', async () => {
+    const root = makeRoot()
+    const deps = makeRestoreDeps(root, {
+      runArgv: vi.fn().mockRejectedValue(new Error('micromamba failed (1; create)'))
+    })
+    await expect(
+      new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(DEFAULT_PY_ENV, LOCK)
+    ).rejects.toThrow('micromamba failed')
+    expect(existsSync(readyMarkerPath(root))).toBe(false)
+    expect(existsSync(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))).toBe(false)
+    // Staging is cleaned; the seeded cache file remains (verified bytes, reusable on retry).
+    expect(readdirSync(join(root, 'packs'))).toEqual([])
+  })
+
+  it('aborts the in-flight download on cancellation', async () => {
+    const root = makeRoot()
+    const controller = new AbortController()
+    const runArgv = vi.fn()
+    const deps = makeRestoreDeps(root, {
+      runArgv,
+      downloadPackage: vi.fn().mockRejectedValue(new Error('Runtime setup cancelled.'))
+    })
+    await expect(
+      new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(DEFAULT_PY_ENV, LOCK, {
+        signal: controller.signal
+      })
+    ).rejects.toThrow('Runtime setup cancelled.')
+    expect(runArgv).not.toHaveBeenCalled() // never reached the destructive phase
+    expect(existsSync(readyMarkerPath(root))).toBe(false)
+  })
+
+  it('crash-journals the download staging so recovery removes the orphan', async () => {
+    const root = makeRoot()
+    const deps = makeRestoreDeps(root, {
+      downloadPackage: async (_url, dest) => {
+        // Simulate the hard-quit window: the download journal record exists while staging is live.
+        const packsEntries = readdirSync(join(root, 'packs'))
+        if (packsEntries.some((e) => e.startsWith('.incoming-'))) {
+          const pending = await RuntimeOperationJournal.forPath(
+            operationJournalPath(root)
+          ).pending()
+          expect(pending.find((r) => r.kind === 'download' && r.phase === 'restore')).toMatchObject(
+            { targetPath: expect.stringContaining('.incoming-') }
+          )
+        }
+        writeFileSync(dest, PKG_CONTENT)
+      }
+    })
+    await new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock('my-analysis', LOCK)
+    // The journal entry is completed and the staging removed on the normal path.
+    expect(await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).toEqual([])
+    expect(readdirSync(join(root, 'packs'))).toEqual([])
+  })
+
+  it('runs journaled through the materialize/restore kind (prefix-write supervision)', async () => {
+    const root = makeRoot()
+    let recordDuringCreate: RuntimeOperationRecord | undefined
+    const deps = makeRestoreDeps(root, {
+      runArgv: async (argv) => {
+        // While the prefix write runs, the journal must hold a materialize record for the target.
+        recordDuringCreate = (
+          await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()
+        ).find((r) => r.kind === 'materialize' && r.phase === 'restore')
+        const prefix = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        const bin = pythonBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+    await new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock('my-analysis', LOCK)
+    expect(recordDuringCreate).toMatchObject({
+      kind: 'materialize',
+      runtimeId: 'my-analysis',
+      targetPath: envPrefix(root, 'my-analysis')
+    })
+    // Completed afterwards — no retained operations.
+    expect(await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).toEqual([])
+  })
+
+  it('re-checks the recovery block after acquiring the prefix lock (TOCTOU)', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const runArgv = vi.fn()
+    // The pre-check passes (nothing blocked yet); while the restore WAITS for the prefix lock, a
+    // concurrent failed install marks the prefix blocked. The authoritative re-check inside the
+    // lock must reject — rmSync/create may never race a possibly-live orphan writer.
+    const blocked = new Set<string>()
+    let markBlockedOnNextLock = true
+    const deps = makeRestoreDeps(root, {
+      runArgv,
+      isPrefixBlocked: (candidate) => blocked.has(candidate),
+      withPrefixLock: async (envName, fn) => {
+        if (markBlockedOnNextLock) {
+          markBlockedOnNextLock = false
+          expect(envName).toBe(DEFAULT_PY_ENV)
+          blocked.add(prefix)
+        }
+        return fn()
+      }
+    })
+    await expect(
+      new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(DEFAULT_PY_ENV, LOCK)
+    ).rejects.toThrow('RUNTIME_RECOVERY_BLOCKED')
+    expect(runArgv).not.toHaveBeenCalled()
+    // Nothing was staged or downloaded either.
+    expect(existsSync(join(root, 'packs'))).toBe(false)
+  })
+
+  it('clears the old ready marker at the destructive boundary so a failed replace never looks ready', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    // A previously READY default: valid interpreter + committed marker.
+    const bin = pythonBin(prefix)
+    mkdirSync(join(bin, '..'), { recursive: true })
+    writeFileSync(bin, 'original')
+    writeReadyMarker(root, DEFAULT_ENV_VERSION, 't-old')
+    expect(pythonReady(root, DEFAULT_ENV_VERSION)).toBe(true)
+    // A create that links the interpreter (a mid-create crash window) and then fails.
+    const deps = makeRestoreDeps(root, {
+      runArgv: async (argv) => {
+        const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        mkdirSync(join(pythonBin(p), '..'), { recursive: true })
+        writeFileSync(pythonBin(p), 'linked-then-broken')
+        throw new Error('micromamba failed (1; create)')
+      }
+    })
+    await expect(
+      new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(DEFAULT_PY_ENV, LOCK)
+    ).rejects.toThrow('micromamba failed')
+    // The OLD marker must not vouch for the new partial prefix: pythonReady reads marker + bin
+    // presence only, so the marker has to be gone for the failure to be visible.
+    expect(existsSync(readyMarkerPath(root))).toBe(false)
+    expect(pythonReady(root, DEFAULT_ENV_VERSION)).toBe(false)
+  })
+
+  it('rejects restoring a default env with the wrong language interpreter', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    // The create materializes ONLY an R interpreter — e.g. an r-base lock restored as
+    // default-python. Forcing the DEFAULT_PY_ENV interpreter check must fail the restore loudly
+    // instead of "succeeding" with an env whose ready marker pythonReady() would then contradict.
+    const deps = makeRestoreDeps(root, {
+      runArgv: async (argv) => {
+        const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
+        mkdirSync(join(rBin(p), '..'), { recursive: true })
+        writeFileSync(rBin(p), 'x')
+      }
+    })
+    await expect(
+      new DefaultRuntimeProvisioner(deps).restoreEnvironmentFromLock(DEFAULT_PY_ENV, LOCK)
+    ).rejects.toThrow('missing its expected interpreter')
+    expect(existsSync(readyMarkerPath(root))).toBe(false)
+    expect(existsSync(pythonBin(prefix))).toBe(false)
+  })
+
+  it('serializes against a concurrent provision through serializeProvisioner', async () => {
+    const root = makeRoot()
+    const order: string[] = []
+    let releaseProvision: (() => void) | undefined
+    const deps = makeRestoreDeps(root)
+    const raw = new DefaultRuntimeProvisioner(deps)
+    const wrapped: RuntimeProvisioner = {
+      status: () => raw.status(),
+      provisionPython: (onProgress) => {
+        order.push('provision:start')
+        return new Promise<void>((resolve) => {
+          releaseProvision = resolve
+        }).then(() => {
+          order.push('provision:end')
+          return raw.provisionPython(onProgress).catch(() => undefined)
+        })
+      },
+      provisionR: raw.provisionR.bind(raw),
+      upgradeIfNeeded: raw.upgradeIfNeeded.bind(raw),
+      repair: raw.repair.bind(raw),
+      restoreRelocatedEnvs: raw.restoreRelocatedEnvs.bind(raw),
+      restoreEnvironmentFromLock: (name: string, lock: string): Promise<void> => {
+        order.push('restore:start')
+        return raw.restoreEnvironmentFromLock(name, lock).then(() => {
+          order.push('restore:end')
+        })
+      },
+      cancel: raw.cancel.bind(raw)
+    }
+    const provisioner = serializeProvisioner(wrapped)
+    const provision = provisioner.provisionPython(() => {})
+    // The restore must wait behind the in-flight provision; then run to completion.
+    await vi.waitFor(() => expect(order).toContain('provision:start'))
+    releaseProvision?.()
+    await provision
+    await provisioner.restoreEnvironmentFromLock('my-analysis', LOCK)
+    expect(order.indexOf('restore:start')).toBeGreaterThan(order.indexOf('provision:end'))
   })
 })

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1,8 +1,20 @@
-import { type Dirent, existsSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs'
+import {
+  type Dirent,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { basename, dirname, join } from 'node:path'
 
 import type { NotebookLanguage } from '../../shared/notebook'
+import { resilientDownload } from '../net/resilient-download'
+import { netFetchStandard } from '../skills/net-fetch'
 import {
   bootTokenProvesReboot,
   listOperationChildren,
@@ -70,16 +82,19 @@ import type { NotebookProcessSandbox } from './process-sandbox'
 import {
   isChildUnconfirmedError,
   captureMicromamba,
+  md5File,
   micromambaDiagnosticText,
   runMicromamba,
   verifyExecutable
 } from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
+import { downloadExplicitLockPackages, parseExplicitLock } from './environment-lock'
 import {
   DEFAULT_ENV_VERSION,
   resolveRuntimeCdnBase,
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
+  assertSafeEnvName,
   envPrefix,
   legacyDefaultEnvPrefix,
   logicalEnvNameFromDirectory,
@@ -203,6 +218,11 @@ export type ProvisionerDeps = {
   retainWorkingCache?: MicromambaWorkingCacheRetainer
   // Captures the new environment's explicit lock before a named environment is exposed to a kernel.
   captureExplicitLock?: (prefix: string) => Promise<string>
+  // Downloads one pinned package URL to a local path for a lock restore (see
+  // restoreEnvironmentFromLock). Production wires the shared resilient downloader (system/VPN
+  // proxy aware, resumable); tests inject a fake. md5 verification is NOT done here — the
+  // restore verifies every download against the lock before anything is seeded or deleted.
+  downloadPackage?: (url: string, dest: string, signal?: AbortSignal) => Promise<void>
   // Verifies `<bin> --version`; rejects otherwise.
   verify: (bin: string, prefix: string) => Promise<void>
   // Clock injection for the ready-marker timestamp.
@@ -337,6 +357,16 @@ export interface RuntimeProvisioner {
   // Rebuilds envs captured by a data-root relocation (see runtime-relocation.ts) offline from their
   // @EXPLICIT locks + the copied pkgs cache. No-op when no relocation bundle is present.
   restoreRelocatedEnvs(onProgress: (p: ProvisionProgress) => void): Promise<void>
+  // Restores ONE managed env from a validated @EXPLICIT lock (the reverse of exportEnvironmentLock,
+  // issue #924): downloads each pinned URL into journaled staging (md5-verified), seeds the shared
+  // pkgs cache, then rebuilds the prefix offline through the same journaled create as the
+  // relocation restore. Create and replace are one sequence — an existing prefix is cleared inside
+  // the journal. Only managed env names are addressable; user-own interpreters are out of scope.
+  restoreEnvironmentFromLock(
+    name: string,
+    lockText: string,
+    opts?: { signal?: AbortSignal; onProgress?: (p: ProvisionProgress) => void }
+  ): Promise<void>
 }
 
 export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
@@ -1258,6 +1288,208 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     }
   }
 
+  // Restores ONE managed env from a validated @EXPLICIT lock (user-facing counterpart to
+  // exportEnvironmentLock, issue #924). Every pinned package URL is downloaded into a journaled
+  // .incoming-* staging dir and md5-verified BEFORE the prefix is touched, then seeded into the
+  // shared pkgs cache and rebuilt OFFLINE through the same journaled create the relocation restore
+  // uses (kind 'materialize', phase 'restore'), so crash recovery, child-PID supervision, and the
+  // corrupt-cache lock behave identically. Create and replace are one sequence: an existing prefix
+  // is cleared INSIDE the journal (never before begin() succeeds), and a download/verify failure
+  // leaves it untouched — with an empty package cache the downloads alone rebuild it, which is what
+  // makes the restore fully portable. A failed restore never looks ready: the ready marker is
+  // stamped only after the recreated interpreter verifies (defaults; named envs are bin-present by
+  // definition, D7). Readiness/discovery re-evaluate on the next status()/listEnvironments() pull.
+  // Cancellation: opts.signal aborts the in-flight download and create; an aborted create leaves
+  // the same partial prefix a cancelled provision does — cleared by the next restore or by
+  // startup recovery. Live kernels are NOT torn down here; an in-session caller must drain them
+  // through the explicit-repair path first (the only sanctioned teardown).
+  async restoreEnvironmentFromLock(
+    name: string,
+    lockText: string,
+    opts?: { signal?: AbortSignal; onProgress?: (p: ProvisionProgress) => void }
+  ): Promise<void> {
+    // The two default envs are the reserved managed names; anything else must be a safe env name.
+    // assertSafeEnvName also rejects the bare 'python'/'r' aliases — restore never guesses a
+    // target from an ambiguous name.
+    if (name !== DEFAULT_PY_ENV && name !== DEFAULT_R_ENV) assertSafeEnvName(name)
+    const prefix = envPrefix(this.deps.root, name, this.platform)
+    if (
+      this.platform === 'win32' &&
+      prefix.length + DEFAULT_MAX_ENV_RELATIVE_PATH > WINDOWS_MAX_USABLE_PATH
+    ) {
+      throw new Error(
+        `Environment "${name}" exceeds the conservative Windows environment path budget; ` +
+          'choose a shorter name or data-root path.'
+      )
+    }
+    // Validate the lock BEFORE any mutation (staging included): a malformed, checksum-broken, or
+    // foreign-platform lock must not download a byte or delete the existing env.
+    const entries = parseExplicitLock(lockText, { platform: this.platform, arch: process.arch })
+    const downloadPackage = this.deps.downloadPackage
+    if (!downloadPackage) {
+      throw new Error(
+        'Environment restore requires a package downloader (downloadPackage unwired).'
+      )
+    }
+    this.assertPrefixWritable(prefix)
+    const onProgress = opts?.onProgress ?? (() => undefined)
+    await this.withEnvPrefixLock(name, async () => {
+      // Authoritative re-check AFTER the lock: a package install or repair can fail with an
+      // unconfirmed child and mark this prefix blocked while the restore WAITED for the lock —
+      // the early check above is only a fast path, never the destructive-boundary check.
+      this.assertPrefixWritable(prefix)
+      onProgress({
+        phase: 'restore',
+        event: { code: 'restoring-environment', environment: name },
+        progress: 0.05
+      })
+      // Stage under <root>/packs (same volume as the cache seed/copy targets). The 'download'
+      // journal record mirrors createFetchBundleAdapter's lifecycle: it is only cleared in the
+      // finally, so a killed process leaves a record whose targetPath startup recovery removes.
+      const packsRoot = join(this.deps.root, 'packs')
+      mkdirSync(packsRoot, { recursive: true })
+      const staging = mkdtempSync(join(packsRoot, '.incoming-'))
+      const lockPath = join(staging, `${name}.lock`)
+      writeFileSync(lockPath, lockText, 'utf8')
+      const journal = RuntimeOperationJournal.forPath(operationJournalPath(this.deps.root))
+      const operationId = randomUUID()
+      await journal
+        .begin({
+          operationId,
+          kind: 'download',
+          runtimeId: name,
+          phase: 'restore',
+          startedAt: Date.now(),
+          targetPath: staging
+        })
+        .catch(() => undefined)
+      try {
+        onProgress({
+          phase: 'restore',
+          event: { code: 'preparing-packages', environment: name },
+          progress: 0.1
+        })
+        await downloadExplicitLockPackages(entries, staging, {
+          download: (url, dest, signal) => downloadPackage(url, dest, signal),
+          md5: (path) => md5File(path),
+          signal: opts?.signal,
+          onProgress: (completed, total) =>
+            onProgress({
+              phase: 'restore',
+              event: { code: 'verifying-packages', completed, total },
+              progress: 0.1 + (0.4 * completed) / total
+            })
+        })
+        onProgress({
+          phase: 'restore',
+          event: { code: 'preparing-packages', environment: name },
+          progress: 0.55
+        })
+        // Re-parses the staged lock + re-verifies every md5 (second, independent gate), then seeds
+        // the working/durable cache idempotently — a cache hit only skips the copy, not the check.
+        await validateAndSeedPackIntoCache(staging, lockPath, this.cache)
+        onProgress({
+          phase: 'restore',
+          event: { code: 'environment-create', environment: name },
+          progress: 0.6
+        })
+        await this.withJournaledPrefixWrite(
+          'materialize',
+          name,
+          prefix,
+          'restore',
+          async (onBeforeSpawn, onChild) => {
+            const cache = this.cache
+            await this.runWithMaxPathRecovery(
+              () =>
+                withSharedCacheLocks(this.cacheLockKeys(cache), () => {
+                  // Clear the default's ready marker BEFORE the destructive replace. pythonReady()
+                  // reads marker + interpreter presence only — it never re-verifies — so leaving
+                  // the OLD marker in place would let a hard crash mid-create (interpreter already
+                  // linked, later packages missing) surface as a "ready" but broken default. From
+                  // this point on only a fresh verify can re-stamp readiness; a crash instead falls
+                  // back to the normal re-provision/recovery path.
+                  if (name === DEFAULT_PY_ENV)
+                    rmSync(readyMarkerPath(this.deps.root), { force: true })
+                  else if (name === DEFAULT_R_ENV)
+                    rmSync(rReadyMarkerPath(this.deps.root), { force: true })
+                  // Clear any prior content so the offline recreate starts clean (a wedge like
+                  // conda-meta-without-interpreter would make `create -p` fail). INSIDE the
+                  // journal: a fail-closed begin() can never leave the prefix deleted.
+                  rmSync(prefix, { recursive: true, force: true })
+                  return this.deps.runArgv(
+                    createFromLockArgv(this.deps.mm, this.deps.root, prefix, lockPath),
+                    opts?.signal,
+                    onChild,
+                    onBeforeSpawn,
+                    cache,
+                    DEFAULT_MAX_CACHE_RELATIVE_PATH
+                  )
+                }),
+              undefined,
+              cache
+            )
+            return this.deps.retainWorkingCache
+              ? [
+                  {
+                    workingRoot: cache.path,
+                    authorizations: archiveAuthorizationsFromExplicitLock(lockText)
+                  }
+                ]
+              : []
+          }
+        )
+        // Reserved defaults must verify THEIR OWN interpreter — a default-python restored from an
+        // R-only lock must fail loudly, not "succeed" with an R env that pythonReady() then reads
+        // as not-ready. Named envs infer by presence (a named env may be either language).
+        const bin =
+          name === DEFAULT_PY_ENV
+            ? pythonBin(prefix, this.platform)
+            : name === DEFAULT_R_ENV
+              ? rBin(prefix, this.platform)
+              : existsSync(pythonBin(prefix, this.platform))
+                ? pythonBin(prefix, this.platform)
+                : rBin(prefix, this.platform)
+        if (!existsSync(bin)) {
+          throw new Error(
+            `Restored ${name} is missing its expected interpreter at ${bin}; ` +
+              (name === DEFAULT_PY_ENV || name === DEFAULT_R_ENV
+                ? 'the lock does not match the environment it was restored into.'
+                : 'the create did not produce a runnable interpreter.')
+          )
+        }
+        await this.deps.verify(bin, prefix)
+        // Stamp the default marker only after the rebuilt interpreter verifies, so a failed
+        // restore never looks ready.
+        const now = (this.deps.now ?? defaultNow)()
+        if (name === DEFAULT_PY_ENV)
+          writeReadyMarker(
+            this.deps.root,
+            DEFAULT_ENV_VERSION,
+            now,
+            this.markerPrefixDirectory(name)
+          )
+        else if (name === DEFAULT_R_ENV)
+          writeRReadyMarker(
+            this.deps.root,
+            DEFAULT_ENV_VERSION,
+            now,
+            this.markerPrefixDirectory(name)
+          )
+        onProgress({
+          phase: 'done',
+          event: { code: 'environment-ready', environment: name },
+          progress: 1
+        })
+      } finally {
+        rmSync(staging, { recursive: true, force: true })
+        // Staging is gone (committed or cleaned) — clear the journal entry so only a killed
+        // process leaves it for startup recovery.
+        await journal.complete(operationId).catch(() => undefined)
+      }
+    })
+  }
+
   // Named-env create (design D2). Reuses the same online-create path as `materialize` (no bundle
   // fetch — named envs are always solved live) but does NOT stamp/require the .env-ready marker: a
   // named env is "ready" iff its interpreter bin exists (D7). Packages = base floor + user packages,
@@ -1860,6 +2092,8 @@ export type ProductionProvisionerDeps = {
   verify?: ProvisionerDeps['verify']
   retainWorkingCache?: ProvisionerDeps['retainWorkingCache']
   captureExplicitLock?: ProvisionerDeps['captureExplicitLock']
+  // Narrow seam for the lock-restore downloader's network contract test.
+  downloadPackage?: ProvisionerDeps['downloadPackage']
 }
 
 // Wires the real micromamba binary, CDN fetch, subprocess runner and interpreter verification into a
@@ -1911,6 +2145,18 @@ export const createProductionProvisioner = (
       await runner.resolve()
       return fetchBundle(...args)
     },
+    // Lock-restore package downloads share the pack fetcher's resilience: system/VPN proxy via
+    // Electron net, Range resume, retry, and a stall timeout. md5 verification happens per file
+    // in downloadExplicitLockPackages (locks pin md5, not sha256).
+    downloadPackage:
+      deps.downloadPackage ??
+      (async (url, dest, signal) => {
+        await resilientDownload(url, dest, {
+          stallTimeoutMs: 60_000,
+          signal,
+          deps: { fetchImpl: netFetchStandard }
+        })
+      }),
     runArgv: async (
       argv,
       signal,

--- a/src/main/notebook/runtime-relocation.ts
+++ b/src/main/notebook/runtime-relocation.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { normalizeExplicitLock } from './micromamba'
+import { exportEnvironmentLock } from './environment-lock'
 import {
   envPrefix,
   logicalEnvNameFromDirectory,
@@ -65,6 +65,7 @@ export const exportRuntimeLocks = async (
   entries.sort((a, b) => Number(b.canonical) - Number(a.canonical))
   const seen = new Set<string>()
 
+  const lockDeps = { mm: deps.mm, capture: deps.capture }
   const locks: Array<{ name: string; contents: string }> = []
   for (const { name, prefix } of entries) {
     if (seen.has(name)) continue
@@ -72,20 +73,8 @@ export const exportRuntimeLocks = async (
     // Skip mid-creation leftovers with no interpreter — nothing to reconstruct.
     if (!existsSync(pythonBin(prefix, deps.platform)) && !existsSync(rBin(prefix, deps.platform)))
       continue
-    const raw = await deps.capture([
-      deps.mm,
-      '--no-rc',
-      'list',
-      '--prefix',
-      prefix,
-      '--explicit',
-      '--md5'
-    ])
-    const lock = normalizeExplicitLock(raw)
-    if (!/^https?:\/\//m.test(lock)) {
-      throw new Error(`Could not preserve ${name}: the exported lock contains no package URLs.`)
-    }
-    locks.push({ name, contents: lock })
+    const contents = await exportEnvironmentLock({ name, prefix }, lockDeps)
+    locks.push({ name, contents })
   }
   if (locks.length === 0) return []
 


### PR DESCRIPTION
## Summary

Backend for #924 — managed-environment `@EXPLICIT` lock export and restore. Two commits, no IPC / renderer / provenance changes.

### Commit 1 — lock export primitive

- `environment-lock.ts`: `exportEnvironmentLock(env, deps)` (capture `list --explicit --md5` → `normalizeExplicitLock()` → require ≥1 package URL) and `managedEnvironmentRef()` (resolve a `DiscoveredInterpreter` to a trusted `{name, prefix}`; `user-own` / no-condaEnv → `undefined`, never a guessed default).
- `runtime-relocation.ts` now calls the shared primitive (one implementation, not two).

### Commit 2 — lock restore backend

- `parseExplicitLock(lock, {platform, arch})` — validates external input before any mutation: `@EXPLICIT` marker, md5-pinned URLs (sha256 locks rejected with a clear error), malformed entries, foreign-platform locks, duplicates. Unrecognized body lines are rejected, never silently dropped (a dropped package would silently restore a *different* env).
- `DefaultRuntimeProvisioner.restoreEnvironmentFromLock(name, lockText, {signal, onProgress})` — create and replace are one sequence:
  1. download every pinned URL into journaled `.incoming-*` staging (production: the shared resilient downloader — system/VPN proxy, Range resume, stall timeout),
  2. md5-verify each download,
  3. seed the shared pkgs cache via the existing `validateAndSeedPackIntoCache`,
  4. clear + rebuild the prefix **offline** via `createFromLockArgv` through the same `withJournaledPrefixWrite('materialize', phase 'restore')` machinery the relocation restore uses.

Properties:
- **Fully portable**: downloads verify before the prefix is cleared, and an empty package cache is fine — the downloads alone rebuild the env.
- **Crash-consistent with provisioning**: same journal kind/phase (startup recovery's `verifyOrRebuildEnv` arm), child-PID supervision, fail-closed `begin()`, download-journal staging cleanup, Windows MAX_PATH recovery, archive publication evidence.
- **Serialized** with all other mutations via `serializeProvisioner` + the per-env prefix lock + the shared pkgs-cache lock.
- **Cancellable** via `AbortSignal` (aborts download and create; a partial prefix is cleaned by the next restore or startup recovery).
- **Never looks ready on failure**: the ready marker is stamped only after the rebuilt interpreter verifies.
- Unsafe/unknown target names rejected (`assertSafeEnvName` + reserved defaults); user-own interpreters and external R out of scope; live kernels must be drained through the explicit-repair path by an in-session caller (the only sanctioned teardown).
- No renderer-supplied prefix; main process only.

## Test plan

Layer 1 (unit, Electron-free, no network):
- `environment-lock.test.ts` (20): parser accepts/throws per rule; downloader verifies md5, rejects corrupted files, propagates abort.
- `provisioner.test.ts` restore suite (11): exact create argv + staged lock path; broken-prefix replace with marker-only-after-verify; invalid lock rejected before download/mutation; unsafe/reserved names; unwired downloader; download-md5 failure leaves the existing env untouched; create failure leaves no marker and cleans staging; cancellation; download journal + materialize journal records observed mid-run and completed after; serialization behind an in-flight provision.
- All prior suites stay green (relocation, migration, ipc, lifecycle, foundation): 213 tests across 7 files.
- `tsc --noEmit -p tsconfig.node.json`, eslint, prettier clean.

Layer 2 (integration, env-gated behind `OPEN_SCIENCE_TEST_MICROMAMBA`, real micromamba 2.8.1 + network — never in `npm test`):
- `environment-lock.restore.integration.test.ts`: create minimal env (python=3.12 + six) → export lock → restore into a **pristine root** (no prefix, no cache) → re-export is **byte-identical to the input lock** → `import six` runs from the restored prefix. This is the portable-restore acceptance criterion.

Part of #924
