### PR TITLE
fix(message-scroll): prevent completion-row height flash

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -747,7 +747,7 @@ if (process.argv.includes('--version')) {
           // Mirrors a real agent turn: intent text, a slow tool call, then follow-up text.
           const intentMessageId = `e2e-message-${nextMessageId++}`
           // A long intent text, chunked quickly so live pacing trails far behind arrival.
-          for (let chunk = 0; chunk < 20; chunk += 1) {
+          for (let chunk = 0; chunk < 30; chunk += 1) {
             await context.client.notify(acp.methods.client.session.update, {
               sessionId: context.params.sessionId,
               update: {
@@ -755,7 +755,7 @@ if (process.argv.includes('--version')) {
                 messageId: intentMessageId,
                 content: {
                   type: 'text',
-                  text: `Intent paragraph ${chunk}: I will now run the slow tool for you. `
+                  text: `Intent paragraph ${chunk}: I will now run the slow tool for you.\n\n`
                 }
               }
             })

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -9,6 +9,7 @@ const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
 const TOOL_STATUS_LAYOUT_SHIFT_PROMPT = 'Run the status-bearing layout stability journey.'
 const BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT =
   'Run the buffered text tool layout stability journey.'
+const TOOL_ORDER_PROMPT = 'Run the ordered slow tool journey.'
 const AGENT_STDERR_SUMMARY = 'Agent process stderr: 1 chunk, 22 bytes; raw output omitted.'
 
 // Windows CI stalls the first fake-agent turn when the window is shown from launch. Keep it hidden
@@ -188,6 +189,88 @@ test('keeps a running tool stationary while one line of buffered Markdown finish
       firstTop: tops[0],
       minimumTop: Math.min(...tops),
       maximumTop: Math.max(...tops),
+      finalTop: tops.at(-1)
+    })
+  ).toBeLessThanOrEqual(2)
+})
+
+test('keeps bottom-follow from overshooting when a paced tool turn completes', async ({ app }) => {
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+
+  await page.getByRole('button', { name: 'New project' }).click()
+  const dialog = page.getByRole('dialog', { name: 'New project' })
+  await dialog.getByLabel('Name').fill(PROJECT_NAME)
+  await dialog.getByRole('button', { name: 'Create project' }).click()
+  await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
+
+  const conversation = page.getByRole('region', { name: 'Conversation' })
+  const textbox = page.getByRole('textbox', { name: 'Ask anything' })
+
+  await textbox.fill(USER_MESSAGE)
+  await page.getByRole('button', { name: 'Send message' }).click()
+  await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+  await expect(page.getByTestId('session-persistence-alert')).toHaveCount(0)
+  await revealWindowForLayoutSampling(app, page)
+
+  await textbox.fill(TOOL_ORDER_PROMPT)
+  await page.getByRole('button', { name: 'Send message' }).click()
+
+  const toolGroup = conversation.locator('[data-message-id="activity-group-e2e-order-tool"]')
+  await expect(toolGroup).toBeVisible()
+  await expect(conversation.getByText('Interacting with tools', { exact: true })).toBeVisible()
+  const scrollToEndButton = page.getByRole('button', { name: 'Scroll to end' })
+  await expect(scrollToEndButton).toBeVisible()
+  await scrollToEndButton.click()
+  await expect.poll(() => conversation.evaluate((element) => element.scrollTop)).toBeGreaterThan(0)
+  await expect
+    .poll(() =>
+      conversation.evaluate(
+        (element) => element.scrollHeight - element.clientHeight - element.scrollTop
+      )
+    )
+    .toBeLessThanOrEqual(2)
+
+  const tops = await toolGroup.evaluate(
+    (element) =>
+      new Promise<number[]>((resolve) => {
+        const observations: number[] = []
+        const startedAt = performance.now()
+        let completedAt: number | undefined
+
+        const sample = (): void => {
+          observations.push(element.getBoundingClientRect().top)
+
+          const now = performance.now()
+          if (!element.querySelector('[data-testid="tool-chip"][role="status"]')) {
+            completedAt ??= now
+          }
+          if (
+            (completedAt !== undefined && now - completedAt >= 1_000) ||
+            now - startedAt >= 5_000
+          ) {
+            resolve(observations)
+            return
+          }
+          requestAnimationFrame(sample)
+        }
+
+        requestAnimationFrame(sample)
+      })
+  )
+
+  await expect(
+    conversation.getByText('The slow tool has finished running.', { exact: true })
+  ).toBeVisible()
+
+  const minimumTop = Math.min(...tops)
+  const endpointTop = Math.min(tops[0], tops.at(-1) ?? tops[0])
+  const upwardOvershoot = endpointTop - minimumTop
+  expect(
+    upwardOvershoot,
+    JSON.stringify({
+      firstTop: tops[0],
+      minimumTop,
       finalTop: tops.at(-1)
     })
   ).toBeLessThanOrEqual(2)

--- a/e2e/message-tool-order.spec.ts
+++ b/e2e/message-tool-order.spec.ts
@@ -31,7 +31,7 @@ test('shows tool cards and indicators while the intent text is still pacing', as
 
   // The intent text is still mid-presentation (long text, live pacing).
   const transcriptText = (await conversation.textContent()) ?? ''
-  expect(transcriptText).not.toContain('Intent paragraph 19')
+  expect(transcriptText).not.toContain('Intent paragraph 29')
 
   // The tool indicator is visible while the tool runs.
   await expect(conversation.getByText('Interacting with tools')).toBeVisible()

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1516,7 +1516,11 @@ const WorkspaceMessageScrollerImpl = ({
 
                   return presentingMessageIds.has(item.message.id) ? null : (
                     <Fragment key={item.id}>
-                      <MessageScrollerItem messageId={item.id} className="min-w-0">
+                      <MessageScrollerItem
+                        messageId={item.id}
+                        className="min-w-0"
+                        disableContainment
+                      >
                         <div className="px-4 pb-1 md:px-6">
                           <div className="mx-auto w-full max-w-[56rem]">
                             <WorkspaceAssistantTurnCompletion


### PR DESCRIPTION
## Problem

When a paced agent response is following the bottom of an overflowing conversation, completing a tool turn can move the visible tool row upward and then snap it back. The completion row mounts with `content-visibility: auto` and temporarily contributes the shared 10rem intrinsic placeholder before Chromium resolves its real height.

The minimized Electron reproduction records the tool row moving `620px -> 520px -> 640px` on the unfixed build: a 100px transient upward overshoot matching the reported flash.

## Proposed change

- Disable content-visibility containment for the compact assistant turn-completion row, using the existing `MessageScrollerItem` escape hatch already used by other live/dynamic rows.
- Extend the existing paced tool fixture until the transcript genuinely overflows.
- Add a CI-wired Electron regression that explicitly enters bottom-follow, samples the public tool row every animation frame through completion, and rejects transient upward overshoot while allowing normal monotonic streaming growth.

## Scope and non-goals

- No new fields, persisted data, migrations, state/enum values, or historical-data compatibility work.
- No architecture, data-model, or interaction-flow change; only the erroneous visual jump is removed.
- No new scroll state machine or measurement seam. The fix is one existing presentation flag on a small row.

## Acceptance criteria and validation

Final evidence mapping (all passing checks ran against the final behavior-changing state):

- Reported bottom-follow overshoot -> `npx playwright test e2e/message-tool-layout-stability.spec.ts -g "keeps bottom-follow from overshooting" --repeat-each=3` -> 3/3 passed.
- Same regression on the unfixed build -> identical command with `--repeat-each=2` -> 2/2 failed for the expected 100px upward overshoot.
- Adjacent tool/Markdown layout behavior -> `npx playwright test e2e/message-tool-layout-stability.spec.ts` -> 4/4 passed.
- Existing paced tool ordering behavior -> `npx playwright test e2e/message-tool-order.spec.ts` -> 1/1 passed.
- Scroller owner and direct renderer consumers -> targeted Vitest run for `message-scroller`, all `WorkspaceMessageScroller` suites, and `workspace-components` -> 170/170 passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.
- E2E production bundle -> `npm run build:e2e` -> passed (existing build warnings only).

`npm run test:affected:explain -- --base origin/main --head HEAD` conservatively selects the full suite because the changed `e2e/` paths are not classified in the module manifest. Per maintainer direction, the full local `npm test` was not run; exact-head PR Gate is authoritative for the full portable and platform lanes.

The changed component interface is unchanged. `ConversationPanel` is covered by the Electron journey; `SubagentReleaseSurfaces` reuses the same scroller component without a distinct code path. The remaining risk is platform-specific Chromium scroll/content-visibility behavior, which the CI-wired Electron test is intended to exercise on the PR lanes.

## Review focus

- Confirm that permanently opting the small completion row out of content visibility is the appropriate tradeoff versus adding dynamic scroll/measurement state.
- Confirm that the regression permits expected monotonic streaming movement and catches only the up-then-back overshoot.
