### PR TITLE
fix(preview): retry text reads during artifact publication

### DIFF
--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -329,6 +329,39 @@ describe('PreviewFileContent', () => {
     )
   })
 
+  it('waits for an Artifact Version to publish before rendering Markdown', async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.mocked(window.api.previewResources.acquire).mockRejectedValueOnce(
+      new Error(
+        "Error invoking remote method 'preview-resources:acquire': ManagedFileVersionError: Managed file has no published version."
+      )
+    )
+    vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
+      content: '# Published report',
+      encoding: 'utf8',
+      size: 18,
+      truncated: false
+    })
+
+    try {
+      await renderFile(createFileItem({ format: 'markdown', name: 'report.md' }))
+
+      expect(window.api.previewResources.acquire).toHaveBeenCalledOnce()
+      await act(async () => vi.advanceTimersByTimeAsync(200))
+
+      expect(container.textContent).toContain('Published report')
+      expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(2)
+      expect(consoleError).not.toHaveBeenCalledWith(
+        'Failed to read file preview',
+        expect.anything()
+      )
+    } finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it('enables annotations for HTML Source but not HTML Render', async () => {
     vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
       content: '<main>selectable source</main>',

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
@@ -4,10 +4,12 @@ import type { ArtifactPreviewResult } from '../../../../../shared/artifacts'
 import type { PreviewFileSource } from '@/stores/preview-workbench-store'
 
 import { createManagedPreviewRequest } from './preview-file-reader'
-import { isUnavailableFileError } from './preview-errors'
+import { isManagedFilePublicationPendingError, isUnavailableFileError } from './preview-errors'
 
 export const PREVIEW_TEXT_MAX_BYTES = 1024 * 1024
 const MAX_PREVIEW_BYTES = 10 * 1024 * 1024
+const PUBLICATION_RETRY_DELAY_MS = 200
+const PUBLICATION_RETRY_LIMIT = 4
 
 type PreviewPagination = {
   pageNumber: number
@@ -64,7 +66,20 @@ const readManagedPreviewPage = async (
     signal: AbortSignal
   }
 ): Promise<ArtifactPreviewResult> => {
-  const resource = await window.api.previewResources.acquire(createManagedPreviewRequest(request))
+  const previewRequest = createManagedPreviewRequest(request)
+  let resource
+  for (let attempt = 0; ; attempt += 1) {
+    if (request.signal.aborted) throw request.signal.reason
+    try {
+      resource = await window.api.previewResources.acquire(previewRequest)
+      break
+    } catch (error) {
+      if (attempt === PUBLICATION_RETRY_LIMIT || !isManagedFilePublicationPendingError(error)) {
+        throw error
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, PUBLICATION_RETRY_DELAY_MS))
+    }
+  }
 
   try {
     if (request.signal.aborted) throw request.signal.reason


### PR DESCRIPTION
## Problem

A generated Artifact can become previewable after its staging path is published but before the database transaction assigns its first finalized `currentVersionId`. During that short window, Markdown and other text previews call `preview-resources:acquire`, receive `VERSION_NOT_FOUND` (`Managed file has no published version.`), and enter a terminal preview error instead of recovering when publication completes.

Without this change, opening a text-based generated Artifact in that window shows an unavailable preview and emits rejected IPC/read errors. The user must retry manually or reopen the preview after publication.

## Proposed change

- Retry managed text-preview acquisition up to four times with the existing 200 ms publication-race cadence used by generated image previews.
- Retry only the recognized `Managed file has no published version` condition; all other failures remain immediate.
- Add a Markdown rendering regression test at the existing `PreviewFileContent` behavior boundary. The test reproduces the exact Electron IPC error, fails on the unmodified implementation, and verifies that the published content appears after retry.

## Scope and non-goals

- No schema, database field, migration, persisted state, enum, renderer contract, architecture, or interaction change.
- No renderer access to unpublished staging bytes; the managed Version authority remains unchanged.
- No repair of permanently orphaned historical records whose `currentVersionId` never becomes available. Bounded retries still end in the existing error for those records.
- No new dependency or test seam.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

- Artifact publication race -> Markdown preview recovers -> `npm test -- src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx -t 'waits for an Artifact Version to publish before rendering Markdown'` -> passed; the same test was run twice before the fix and failed with `Preview unavailable / Markdown couldn't be read for preview`.
- Shared text-preview consumers -> selected CodeGraph impact set -> `npm test -- src/renderer/src/pages/workspace/FilePreviewDialog.escape.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx src/renderer/src/pages/workspace/previews/preview-registry.test.tsx src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.test.tsx src/renderer/src/pages/workspace/previews/renderers/PlanJsonPreview.test.tsx src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx` -> 8 files, 214 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint` -> passed.
- Impact explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> conservative full plan because the new regression test is not declared in the module manifest. Per maintainer direction, the complete local `npm test` suite was not run; PR CI is the final authority.

Platform scope: the changed retry policy is renderer-only and uses the existing surface-neutral `previewResources` API. Electron supplies the reported error shape; local and remote Web use the same hook and remain covered by the shared renderer tests. No path or OS-specific logic changed.

## Review focus

- Confirm the retry remains limited to the publication-pending error and is bounded to 800 ms total delay.
- Confirm the regression test exercises rendered Markdown through the existing public preview boundary rather than a new seam.
- Confirm permanently missing Versions still fall through to the existing error after retries.

Uncovered risk: a permanent orphan record now takes up to about 800 ms longer to show the same error. PR CI and reviewer confirmation remain the final verification authority.
