### PR TITLE
fix(windows-installer): preflight locked update targets

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -232,6 +232,7 @@ FunctionEnd
   # Page callbacks do not run in silent mode. There is no later user choice in that mode, so the
   # installMode selected by initMultiUser is already final and machine protection can run now.
   ${if} ${Silent}
+    Call ensureExistingUninstallerIsWritable
     !insertmacro protectMachineDataRootForSelectedMode
   ${endif}
 !macroend
@@ -240,8 +241,9 @@ FunctionEnd
 # The normal path restores each directory immediately after its matching old-uninstaller pass.
 !macro customHeader
   # NSIS extracts the new uninstaller after the application package. Probe the same write access
-  # its File command will request before extracting anything, so a stale locked uninstaller cannot
-  # turn a silent install into a false success or leave an interactive install offering the unsafe
+  # its File command will request before uninstalling the old app, and again before extraction.
+  # Checking only after uninstalling can reject the update with the old executable already gone.
+  # A stale locked uninstaller must not turn a silent install into a false success or offer the unsafe
   # Ignore choice. OPEN_EXISTING keeps this check non-destructive; Retry lets the user release a
   # transient lock, while silent installs take the Cancel path and return a failure code.
   Function ensureExistingUninstallerIsWritable
@@ -261,6 +263,8 @@ FunctionEnd
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(uninstallFailed)$\r$\n$INSTDIR\${UNINSTALL_FILENAME}" IDRETRY ensureExistingUninstallerIsWritable_retry
 
     ensureExistingUninstallerIsWritable_cancel:
+      # customInit may already have moved nested user data outside the old installation.
+      !insertmacro restoreAllNestedDataRoots
       SetErrorLevel 2
       Quit
 
@@ -272,6 +276,7 @@ FunctionEnd
     !ifdef openScienceOriginalInstFilesPre
       Call ${openScienceOriginalInstFilesPre}
     !endif
+    Call ensureExistingUninstallerIsWritable
     !insertmacro protectMachineDataRootForSelectedMode
   FunctionEnd
 

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -1063,23 +1063,25 @@ const launchUninstallerLockHolder = async (
   env,
   spawnProcess = spawn,
   waitForReady = waitFor,
-  terminate = terminateProcessTree
+  terminate = terminateProcessTree,
+  shareMode = 'None'
 ) => {
   const uninstaller = await findUninstaller(installDirectory)
-  const ready = join(env.TEMP, 'installer-smoke-lock-holder.ready')
+  const ready = join(env.TEMP, `installer-smoke-lock-holder-${randomUUID()}.ready`)
   const child = spawnProcess(
     'powershell.exe',
     [
       '-NoProfile',
       '-NonInteractive',
       '-Command',
-      "$stream = [System.IO.File]::Open($env:OPEN_SCIENCE_LOCK_PATH, 'Open', 'Read', 'None'); [System.IO.File]::WriteAllText($env:OPEN_SCIENCE_LOCK_READY, 'ready'); [System.Threading.Thread]::Sleep([System.Threading.Timeout]::Infinite)"
+      "$stream = [System.IO.File]::Open($env:OPEN_SCIENCE_LOCK_PATH, 'Open', 'Read', $env:OPEN_SCIENCE_LOCK_SHARE); [System.IO.File]::WriteAllText($env:OPEN_SCIENCE_LOCK_READY, 'ready'); [System.Threading.Thread]::Sleep([System.Threading.Timeout]::Infinite)"
     ],
     {
       env: {
         ...env,
         OPEN_SCIENCE_LOCK_PATH: uninstaller,
-        OPEN_SCIENCE_LOCK_READY: ready
+        OPEN_SCIENCE_LOCK_READY: ready,
+        OPEN_SCIENCE_LOCK_SHARE: shareMode
       },
       windowsHide: true
     }
@@ -1087,7 +1089,7 @@ const launchUninstallerLockHolder = async (
   const exit = observeChildExit(child)
   try {
     await Promise.race([
-      waitForReady('the old uninstaller to be exclusively locked', async () =>
+      waitForReady('the old uninstaller to be write-locked', async () =>
         (await pathExists(ready)) ? true : undefined
       ),
       exit.then((code) => {
@@ -1099,6 +1101,46 @@ const launchUninstallerLockHolder = async (
     throw error
   }
   return { child, uninstaller }
+}
+
+// Exercise a registered, working installation rather than an orphaned uninstaller. Read sharing
+// lets the old uninstaller be copied and launched, but blocks replacing its original file. A check
+// performed only after uninstalling is too late: it leaves the app executable missing on failure.
+const drillLockedUpgrade = async ({
+  installer,
+  installDirectory,
+  env,
+  executableName = APP_EXECUTABLE
+}) => {
+  const executable = join(installDirectory, executableName)
+  const original = createHash('sha256')
+    .update(await readFile(executable))
+    .digest('hex')
+  const lock = await launchUninstallerLockHolder(
+    installDirectory,
+    env,
+    spawn,
+    waitFor,
+    terminateProcessTree,
+    'Read'
+  )
+  try {
+    const result = await runProcess(installer, ['/S', '--updated', `/D=${installDirectory}`], {
+      allowNonZero: true,
+      env,
+      timeoutMs: 30_000
+    })
+    if (result.code === 0) throw new Error('Update accepted a write-locked uninstaller target.')
+    if (lock.child.exitCode !== null) throw new Error('Update terminated the external lock holder.')
+    const remaining = await readFile(executable).catch((cause) => {
+      throw new Error('Rejected update removed the previously launchable application.', { cause })
+    })
+    if (createHash('sha256').update(remaining).digest('hex') !== original) {
+      throw new Error('Rejected update replaced the previous application.')
+    }
+  } finally {
+    await terminateProcessTree(lock.child)
+  }
 }
 
 const drillOrphanedUninstallerLock = async ({ installer, installDirectory, env }) => {
@@ -1354,6 +1396,9 @@ const main = async () => {
           await launchAndExpectDatabaseBlocked({ installDirectory, env })
         }
         if (configRoot) await upgradeProfileGuard.verifyCycle(cycle.phase, configRoot)
+        if (cycle.phase === 'previous') {
+          await drillLockedUpgrade({ installer: currentInstaller, installDirectory, env })
+        }
       }
     )
     const smokeIsolatedDatabase = async (storageRoot, expectLegacyProject) => {
@@ -1420,6 +1465,7 @@ export {
   buildSmokePlan,
   cleanupSmokeRoot,
   createUpgradeProfileGuard,
+  drillLockedUpgrade,
   drillOrphanedUninstallerLock,
   executeSmokePlan,
   fetchWithTimeout,


### PR DESCRIPTION
## Problem

A Windows update can remove the working application before rejecting a write-locked uninstaller. A read-sharing lock allows the old uninstaller to be copied and run, but prevents replacing its original file. The post-uninstall check then exits with code 2, leaving the installation without its application executable.

This matches a report of a missing installation followed by manual reinstall. The reporter's exact lock owner and update target remain unconfirmed; the native reproduction retained the old uninstaller rather than a literally empty directory.

## Proposed change

Run the existing uninstaller writeability check before removing the old app, in silent mode and after the interactive target-directory preflight. Restore already-preserved nested data when that check cancels. Retain the post-uninstall check.

Extend the existing Windows installer smoke flow with a read-sharing lock on a registered installation's uninstaller. Require rejection without changing the previous executable, then let the existing upgrade cycle verify a successful retry. Use unique lock-ready files to avoid stale readiness between drills.

## Scope and non-goals

- No new application states, data fields, schema, registry fields, persistence formats, or rollback service.
- No historical data migration; existing nested `OpenScience` data preservation remains supported and was exercised.
- Existing interactive Retry/Cancel behavior and silent failure behavior remain; checking happens earlier. No new UI copy or controls.
- This protects against an already-locked target, not arbitrary power loss, disk exhaustion, or a lock acquired after preflight.

## Acceptance criteria and validation

Checks below ran after the last material logic edit. No full portable test suite was run locally.

| Behavior | Check | Result |
| --- | --- | --- |
| Lock must not remove a working installation | New `drillLockedUpgrade` against real NSIS fixtures using versioned 0.24.0/0.25.1 hooks | Unfixed: reproducible exit 2 and missing EXE; project regression fails with ENOENT. Fixed: original EXE unchanged and launchable |
| Retry after releasing the lock | Same isolated native update sequence | New fixture EXE launches successfully |
| Early rejection preserves nested data | Native fixture with existing `OpenScience` data sentinel | Sentinel restored; old app launches; subsequent update succeeds |
| Installer harness, update handoff, packaging configuration | `npm test -- scripts/windows-installer-smoke.test.ts scripts/windows-updater-certification.test.ts scripts/electron-builder-config.test.ts src/main/update/electron-updater-strategy.test.ts` | 4 files, 102 tests passed |
| Lint and formatting | `npm run lint`; uncached ESLint on changed script; Prettier check; `git diff --check` | Passed; uncached changed-script check clean |

The native regression uses the actual NSIS lifecycle and committed regression helper, isolated product identity and tiny launchable executables. External managed-resource cleanup scripts were harmless fixture replacements. D: installation/C: temporary-directory behavior was exercised. User logs and local diagnostic artifacts are not included.

The new drill runs in `node scripts/windows-installer-smoke.mjs --installer-dir <new-artifacts> --previous-installer-dir <old-artifacts>`. Full released Electron packages and the interactive wizard were not executed locally. No main/renderer TypeScript interface changed; native Windows CI and independent review remain the broader validation boundary.

## Review focus

Confirm that both pre-uninstall entry points run after the install target is known, early cancellation restores any already-preserved data, and the new smoke drill preserves a registered prior installation without terminating the external lock holder.
