### PR TITLE
fix(notebook): resolve the exact requested artifact version

### DIFF
--- a/src/main/notebook/host-artifacts-service.test.ts
+++ b/src/main/notebook/host-artifacts-service.test.ts
@@ -44,22 +44,22 @@ const harness = (
 ): {
   service: HostArtifactsService
   readHostArtifactCatalog: ReturnType<typeof vi.fn>
-  stageLatest: ReturnType<typeof vi.fn>
+  stageVersion: ReturnType<typeof vi.fn>
 } => {
   const readHostArtifactCatalog = vi.fn(async ({ versionId }: { versionId?: string }) =>
     versionId ? items.filter((item) => item.versionId === versionId) : items
   )
-  const stageLatest = vi.fn(async (request: { sourceKind: string }) =>
+  const stageVersion = vi.fn(async (request: { sourceKind: string }) =>
     request.sourceKind === 'artifact-version'
       ? '/managed-inputs/artifact.csv'
       : '/managed-inputs/upload.pdf'
   )
   return {
     service: new HostArtifactsService({ readHostArtifactCatalog } as HostArtifactCatalog, {
-      stageLatest
+      stageVersion
     }),
     readHostArtifactCatalog,
-    stageLatest
+    stageVersion
   }
 }
 
@@ -192,7 +192,7 @@ describe('HostArtifactsService', () => {
     const readHostArtifactCatalog: HostArtifactCatalog['readHostArtifactCatalog'] = async ({
       versionId
     }) => (versionId === historical.versionId ? [historical] : [latest])
-    const service = new HostArtifactsService({ readHostArtifactCatalog }, { stageLatest: vi.fn() })
+    const service = new HostArtifactsService({ readHostArtifactCatalog }, { stageVersion: vi.fn() })
 
     await expect(service.list({ frame_id: 'frame-a' }, context)).resolves.toMatchObject({
       count: 0,
@@ -253,7 +253,7 @@ describe('HostArtifactsService', () => {
     const catalog: HostArtifactCatalog = {
       readHostArtifactCatalog: vi.fn(async () => items)
     }
-    const service = new HostArtifactsService(catalog, { stageLatest: vi.fn() })
+    const service = new HostArtifactsService(catalog, { stageVersion: vi.fn() })
 
     const first = await service.list({ limit: 2 }, context)
     expect(first.artifacts.map((item) => item.id)).toEqual(['C', 'A'])
@@ -303,25 +303,27 @@ describe('HostArtifactsService', () => {
     )
   })
 
-  it('uses a historical Version id only to identify the logical file, then stages latest', async () => {
+  it('stages the exact requested Artifact or Upload Version', async () => {
     const h = harness()
 
     await expect(h.service.resolvePath('artifact-version-1', context)).resolves.toBe(
       '/managed-inputs/artifact.csv'
     )
-    expect(h.stageLatest).toHaveBeenCalledWith({
+    expect(h.stageVersion).toHaveBeenCalledWith({
       projectId: 'project-a',
       targetSessionId: 'calling-session',
       sourceKind: 'artifact-version',
+      inputFileVersionId: 'artifact-version-1',
       expectedSourceFileId: 'artifact-1'
     })
     await expect(h.service.resolvePath('upload-version-1', context)).resolves.toBe(
       '/managed-inputs/upload.pdf'
     )
-    expect(h.stageLatest).toHaveBeenCalledWith({
+    expect(h.stageVersion).toHaveBeenCalledWith({
       projectId: 'project-a',
       targetSessionId: 'calling-session',
       sourceKind: 'upload-version',
+      inputFileVersionId: 'upload-version-1',
       expectedSourceFileId: 'upload-1'
     })
   })
@@ -337,17 +339,17 @@ describe('HostArtifactsService', () => {
         throw new Error('Artifact Version id is ambiguous across generated Artifacts and Uploads.')
       })
     }
-    const ambiguous = new HostArtifactsService(ambiguousCatalog, { stageLatest: vi.fn() })
+    const ambiguous = new HostArtifactsService(ambiguousCatalog, { stageVersion: vi.fn() })
     await expect(ambiguous.resolvePath('collision', context)).rejects.toThrow('ambiguous')
 
     const corrupt = harness()
-    corrupt.stageLatest.mockRejectedValueOnce(new Error('checksum mismatch'))
+    corrupt.stageVersion.mockRejectedValueOnce(new Error('checksum mismatch'))
     await expect(corrupt.service.resolvePath('artifact-version-1', context)).rejects.toThrow(
       'checksum mismatch'
     )
 
     const relative = harness()
-    relative.stageLatest.mockResolvedValueOnce('relative.csv')
+    relative.stageVersion.mockResolvedValueOnce('relative.csv')
     await expect(relative.service.resolvePath('artifact-version-1', context)).rejects.toThrow(
       'relative path'
     )

--- a/src/main/notebook/host-artifacts-service.ts
+++ b/src/main/notebook/host-artifacts-service.ts
@@ -256,7 +256,7 @@ const matchesContentType = (actual: string | undefined, requested: string): bool
 class HostArtifactsService {
   constructor(
     private readonly catalog: HostArtifactCatalog,
-    private readonly inputAuthority: Pick<ImmutableInputAuthority, 'stageLatest'>
+    private readonly inputAuthority: Pick<ImmutableInputAuthority, 'stageVersion'>
   ) {}
 
   async list(options: unknown, context: HostArtifactReadContext): Promise<HostArtifactsResult> {
@@ -348,10 +348,11 @@ class HostArtifactsService {
     if (!item)
       throw new Error(`Artifact Version not found in the current Project: ${versionIdValue}`)
 
-    const path = await this.inputAuthority.stageLatest({
+    const path = await this.inputAuthority.stageVersion({
       projectId: context.projectId,
       targetSessionId: context.sessionId,
       sourceKind: item.source === 'artifact' ? 'artifact-version' : 'upload-version',
+      inputFileVersionId: versionIdValue,
       expectedSourceFileId: item.sourceFileId
     })
     if (!isAbsolute(path)) throw new Error('Notebook input stager returned a relative path.')

--- a/src/main/project-files/host-artifact-catalog.test.ts
+++ b/src/main/project-files/host-artifact-catalog.test.ts
@@ -1,13 +1,15 @@
 import { createHash } from 'node:crypto'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import type { Prisma, PrismaClient } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { ManagedFileVersionService } from '../managed-file-versions/service'
+import { ImmutableInputAuthority } from '../immutable-input-authority'
+import { HostArtifactsService } from '../notebook/host-artifacts-service'
 import { UploadRepository } from '../uploads/repository'
 import { ManagedFileIndexRepository } from './repository'
 
@@ -150,6 +152,71 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
       data: { currentVersionId: versionId }
     })
   }
+
+  it.each(['artifact', 'upload'] as const)(
+    'keeps the listed %s Version content when a newer Version is published before artifactPath',
+    async (source) => {
+      await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
+      const service = new HostArtifactsService(
+        repository,
+        new ImmutableInputAuthority({
+          storageRoot: root,
+          managedFileVersions: new ManagedFileVersionService({
+            storageRoot: root,
+            getClient: () => Promise.resolve(client)
+          })
+        })
+      )
+      const context = { projectId: 'project-a', sessionId: 'reading-session' }
+      const publish = async (versionNumber: number): Promise<void> => {
+        const versionId = `${source}-v${versionNumber}`
+        const content = `value\nv${versionNumber}\n`
+        const contentStorageKey = `${source}s/project-a/session-a/file/${versionId}/content`
+        const path = join(root, ...contentStorageKey.split('/'))
+        await mkdir(dirname(path), { recursive: true })
+        await writeFile(path, content)
+        const metadata = {
+          contentStorageKey,
+          checksum: checksum(content),
+          sizeBytes: BigInt(Buffer.byteLength(content))
+        }
+        if (source === 'artifact') {
+          await createArtifactVersion('project-a', 'session-a', 'file', versionId, versionNumber)
+          await client.artifactVersion.update({ where: { id: versionId }, data: metadata })
+        } else {
+          if (versionNumber === 1) {
+            await createUploadVersion('project-a', 'session-a', 'file', versionId)
+          } else {
+            const first = await client.uploadVersion.findUniqueOrThrow({
+              where: { id: 'upload-v1' }
+            })
+            await client.uploadVersion.create({
+              data: { ...first, ...metadata, id: versionId, versionNumber }
+            })
+          }
+          await client.uploadVersion.update({ where: { id: versionId }, data: metadata })
+          await client.uploadFile.update({
+            where: { id: 'file' },
+            data: { currentVersionId: versionId }
+          })
+        }
+      }
+
+      await publish(1)
+      const listed = await service.list({}, context)
+      const versionId = listed.artifacts[0]!.latestVersionId
+      expect(versionId).toBe(`${source}-v1`)
+      await publish(2)
+      expect((await service.list({}, context)).artifacts[0]!.latestVersionId).toBe(`${source}-v2`)
+
+      const path = await service.resolvePath(versionId, context)
+      await expect(readFile(path, 'utf8')).resolves.toBe('value\nv1\n')
+      expect(await service.resolvePath(versionId, context)).toBe(path)
+      const latestPath = await service.resolvePath(`${source}-v2`, context)
+      expect(latestPath).not.toBe(path)
+      await expect(readFile(latestPath, 'utf8')).resolves.toBe('value\nv2\n')
+    }
+  )
 
   it('resolves default catalog entries from DB heads when ManagedFile projections are stale', async () => {
     await createArtifactVersion('project-a', 'session-a', 'artifact-a', 'artifact-v1', 1)


### PR DESCRIPTION
# fix(notebook): resolve the exact requested artifact version

## Problem

After Notebook lists v1, publishing v2 causes `host.artifactPath(v1)` to return
v2's bytes. This affects both generated Artifacts and Uploads and breaks the
documented immutable Version contract and reproducible input selection.

The existing unit test incorrectly required historical IDs to stage the latest
Version. The new regression exercises the real catalog, SQLite database,
managed Version service, immutable input authority, and staged file contents.
Before the production change, both cases failed twice with the exact symptom:
expected `value\nv1\n`, received `value\nv2\n`.

## Proposed change

Use the existing `stageVersion` operation with the original `inputFileVersionId`,
retaining the current Project, target Session, source kind, and logical file
identity checks. Update the unit contract to require the exact Version ID.

## Scope and non-goals

- No new fields, enums, database migration, persistence format, public API, UI,
  or architecture changes. Existing Session-scoped staging still writes a
  checksum-validated derived copy; it now copies the requested Version.
- Historical Version records need no conversion. Scripts depending on the bug
  will now read their requested historical Version. Previously generated
  incorrect results are not repaired retroactively.
- No latest-by-file-ID API or compatibility mode is introduced.

## Acceptance criteria and validation

All listed checks run after the last material edit. No full local test suite.

| Behavior | Command | Result |
| --- | --- | --- |
| Exact Artifact/Upload bytes, repeat resolution, distinct v2 content, catalog checks, staging and RPC boundary | `npm test -- src/main/notebook/host-artifacts-service.test.ts src/main/project-files/host-artifact-catalog.test.ts src/main/immutable-input-authority.test.ts src/main/notebook/local-rpc-server.artifacts.test.ts` | 28 passed |
| REPL API and Compute consumption of staged paths | `npm test -- src/main/notebook/repl-loop.integration.test.ts src/main/compute/compute-job-workflow-owner.test.ts -t 'host.artifactPath'` | 2 passed; unrelated cases filtered out |
| Main-process composition and types | `npm run typecheck:node` | Passed |
| Source lint | `npm run lint` | Passed |

The selected tests follow the changed service through its storage boundary and
RPC/REPL/Compute consumers. No renderer or framework-specific ACP behavior is
changed. New file assertions use platform-aware path helpers. Local execution
was on Windows; macOS/Linux and the complete suite remain for PR CI.

The shared Prisma Client was regenerated from the current branch schema before
tests; the initial outdated-client and sandbox spawn failures were environment
failures, not regression evidence.

## Review focus

Confirm that version identity survives from `resolvePath` to `stageVersion`, and
that tests assert real file bytes rather than only mocked method calls.
Independent Standards and Spec reviews found no issues and confirmed the final
test mapping.
