### PR TITLE
perf(managed-files): cache immutable verification

### DIFF
--- a/src/main/managed-file-versions/service.integration.test.ts
+++ b/src/main/managed-file-versions/service.integration.test.ts
@@ -2845,12 +2845,18 @@ describe('ManagedFileVersionService (SQLite + filesystem)', () => {
       where: { id: fixture.versionIds[1] },
       data: { contentType: 'video/mp4' }
     })
+    const versionFileOperator = new NodeVersionFileOperator({ storageRoot })
+    const openImmutable = vi.spyOn(versionFileOperator, 'openImmutable')
     const service = new ManagedFileVersionService({
       storageRoot,
-      getClient: () => Promise.resolve(client)
+      getClient: () => Promise.resolve(client),
+      versionFileOperator
     })
 
     await expect(service.auditActiveVersionIntegrity()).resolves.toEqual([])
+    expect(openImmutable).toHaveBeenCalledWith(expect.any(String), expect.any(Object), {
+      forceVerify: true
+    })
   })
 
   describe('openUnpublishedVersion', () => {

--- a/src/main/managed-file-versions/service.ts
+++ b/src/main/managed-file-versions/service.ts
@@ -23,6 +23,7 @@ import { ManagedFileVersionError } from './error'
 import {
   NodeVersionFileOperator,
   VersionFileOperatorError,
+  type OpenImmutableOptions,
   type PlannedFile,
   type ReadLease,
   type VersionFileOperator,
@@ -430,10 +431,14 @@ class ManagedFileVersionService {
       }
     }
 
-    const lease = await this.versionFileOperator.openImmutable(activeVersion.contentStorageKey, {
-      sizeBytes: bytes.byteLength,
-      checksum
-    })
+    const lease = await this.versionFileOperator.openImmutable(
+      activeVersion.contentStorageKey,
+      {
+        sizeBytes: bytes.byteLength,
+        checksum
+      },
+      { forceVerify: true }
+    )
     await lease.close()
     const published = await client.$transaction(async (tx) => {
       const logicalFile = await this.loadLogicalFile(tx, {
@@ -1190,7 +1195,8 @@ class ManagedFileVersionService {
   }
 
   private async openVersionLease(
-    resolved: ResolvedManagedFileVersion
+    resolved: ResolvedManagedFileVersion,
+    options?: OpenImmutableOptions
   ): Promise<ManagedFileReadLease> {
     let operatorLease: ReadLease
     try {
@@ -1199,7 +1205,8 @@ class ManagedFileVersionService {
         {
           sizeBytes: Number(resolved.version.sizeBytes),
           checksum: resolved.version.checksum
-        }
+        },
+        options
       )
     } catch (error) {
       throw translateVersionFileError(
@@ -1267,7 +1274,7 @@ class ManagedFileVersionService {
   }
 
   private async verifyResolvedVersion(resolved: ResolvedManagedFileVersion): Promise<void> {
-    const lease = await this.openVersionLease(resolved)
+    const lease = await this.openVersionLease(resolved, { forceVerify: true })
     await lease.close()
   }
 
@@ -1583,7 +1590,8 @@ class ManagedFileVersionService {
     try {
       const lease = await this.versionFileOperator.openImmutable(
         operation.contentStorageKey,
-        expectedIntegrity
+        expectedIntegrity,
+        { forceVerify: true }
       )
       await lease.close()
     } catch (error) {

--- a/src/main/managed-file-versions/version-file-operator.test.ts
+++ b/src/main/managed-file-versions/version-file-operator.test.ts
@@ -601,16 +601,21 @@ describe('NodeVersionFileOperator', () => {
     await firstLease.close()
     const secondOperator = new module.NodeVersionFileOperator(options)
     const secondLease = await secondOperator.openImmutable(stored.storageRef, stored)
-    await secondLease.close()
 
     expect(verifiedBytesRead).toBe(content.byteLength)
 
     await writeFile(immutablePath, Buffer.alloc(content.byteLength, 8))
     await utimes(immutablePath, fixedTime, fixedTime)
+    await expect(secondLease.readRange(0, content.byteLength)).rejects.toMatchObject({
+      code: 'INTEGRITY_FAILED'
+    })
+    await secondLease.close()
+    expect(verifiedBytesRead).toBe(content.byteLength * 3)
+
     await expect(secondOperator.openImmutable(stored.storageRef, stored)).rejects.toMatchObject({
       code: 'INTEGRITY_FAILED'
     })
-    expect(verifiedBytesRead).toBe(content.byteLength * 2)
+    expect(verifiedBytesRead).toBe(content.byteLength * 4)
   })
 
   it('removes a verified immutable file idempotently', async () => {

--- a/src/main/managed-file-versions/version-file-operator.test.ts
+++ b/src/main/managed-file-versions/version-file-operator.test.ts
@@ -593,6 +593,8 @@ describe('NodeVersionFileOperator', () => {
     immutablePath = join(cleanupRoot, ...plannedFile.storageRef.split('/'))
     const content = Buffer.alloc(256 * 1024, 7)
     const stored = await operator.publishImmutable({ ...planInput, plannedFile, content })
+    const fixedTime = new Date('2000-01-01T00:00:00.000Z')
+    await utimes(immutablePath, fixedTime, fixedTime)
     verifiedBytesRead = 0
 
     const firstLease = await operator.openImmutable(stored.storageRef, stored)
@@ -604,7 +606,7 @@ describe('NodeVersionFileOperator', () => {
     expect(verifiedBytesRead).toBe(content.byteLength)
 
     await writeFile(immutablePath, Buffer.alloc(content.byteLength, 8))
-    await utimes(immutablePath, new Date(0), new Date(0))
+    await utimes(immutablePath, fixedTime, fixedTime)
     await expect(secondOperator.openImmutable(stored.storageRef, stored)).rejects.toMatchObject({
       code: 'INTEGRITY_FAILED'
     })

--- a/src/main/managed-file-versions/version-file-operator.test.ts
+++ b/src/main/managed-file-versions/version-file-operator.test.ts
@@ -604,18 +604,24 @@ describe('NodeVersionFileOperator', () => {
 
     expect(verifiedBytesRead).toBe(content.byteLength)
 
+    const auditLease = await secondOperator.openImmutable(stored.storageRef, stored, {
+      forceVerify: true
+    })
+    await auditLease.close()
+    expect(verifiedBytesRead).toBe(content.byteLength * 2)
+
     await writeFile(immutablePath, Buffer.alloc(content.byteLength, 8))
     await utimes(immutablePath, fixedTime, fixedTime)
     await expect(secondLease.readRange(0, content.byteLength)).rejects.toMatchObject({
       code: 'INTEGRITY_FAILED'
     })
     await secondLease.close()
-    expect(verifiedBytesRead).toBe(content.byteLength * 3)
+    expect(verifiedBytesRead).toBe(content.byteLength * 4)
 
     await expect(secondOperator.openImmutable(stored.storageRef, stored)).rejects.toMatchObject({
       code: 'INTEGRITY_FAILED'
     })
-    expect(verifiedBytesRead).toBe(content.byteLength * 4)
+    expect(verifiedBytesRead).toBe(content.byteLength * 5)
   })
 
   it('removes a verified immutable file idempotently', async () => {

--- a/src/main/managed-file-versions/version-file-operator.test.ts
+++ b/src/main/managed-file-versions/version-file-operator.test.ts
@@ -10,6 +10,7 @@ import {
   rm,
   rmdir,
   symlink,
+  utimes,
   writeFile
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -542,6 +543,72 @@ describe('NodeVersionFileOperator', () => {
       code: 'INTEGRITY_FAILED'
     })
     await invalidRangeLease.close()
+  })
+
+  it('does not hash the same unchanged immutable file again on a later open', async () => {
+    const module = await import('./version-file-operator')
+    cleanupRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-'))
+    let verifiedBytesRead = 0
+    let immutablePath = ''
+    const options: ConstructorParameters<typeof module.NodeVersionFileOperator>[0] = {
+      storageRoot: cleanupRoot,
+      fileSystem: {
+        open: async (...args) => {
+          const handle = await openFile(...args)
+          if (String(args[0]) !== immutablePath) return handle
+          return new Proxy(handle, {
+            get(target, property) {
+              if (property === 'read') {
+                return async (
+                  buffer: Uint8Array,
+                  offset: number,
+                  length: number,
+                  position: number
+                ) => {
+                  const result = await target.read(buffer, offset, length, position)
+                  verifiedBytesRead += result.bytesRead
+                  return result
+                }
+              }
+              const value = Reflect.get(target, property, target)
+              return typeof value === 'function' ? value.bind(target) : value
+            }
+          })
+        }
+      }
+    }
+    const operator = new module.NodeVersionFileOperator(options)
+    const planInput = {
+      operationId: 'operation-repeated-read',
+      scope: {
+        source: 'artifact' as const,
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        logicalFileId: 'artifact-1'
+      },
+      logicalFilename: 'large.bin',
+      candidateIndex: 0
+    }
+    const plannedFile = operator.planImmutable(planInput)
+    immutablePath = join(cleanupRoot, ...plannedFile.storageRef.split('/'))
+    const content = Buffer.alloc(256 * 1024, 7)
+    const stored = await operator.publishImmutable({ ...planInput, plannedFile, content })
+    verifiedBytesRead = 0
+
+    const firstLease = await operator.openImmutable(stored.storageRef, stored)
+    await firstLease.close()
+    const secondOperator = new module.NodeVersionFileOperator(options)
+    const secondLease = await secondOperator.openImmutable(stored.storageRef, stored)
+    await secondLease.close()
+
+    expect(verifiedBytesRead).toBe(content.byteLength)
+
+    await writeFile(immutablePath, Buffer.alloc(content.byteLength, 8))
+    await utimes(immutablePath, new Date(0), new Date(0))
+    await expect(secondOperator.openImmutable(stored.storageRef, stored)).rejects.toMatchObject({
+      code: 'INTEGRITY_FAILED'
+    })
+    expect(verifiedBytesRead).toBe(content.byteLength * 2)
   })
 
   it('removes a verified immutable file idempotently', async () => {

--- a/src/main/managed-file-versions/version-file-operator.ts
+++ b/src/main/managed-file-versions/version-file-operator.ts
@@ -111,6 +111,9 @@ const snapshotMatches = (expected: LeaseSnapshot, actual: BigIntStats): boolean 
   expected.size === actual.size &&
   expected.mtimeNs === actual.mtimeNs
 
+const verificationSnapshotMatches = (expected: LeaseSnapshot, actual: BigIntStats): boolean =>
+  snapshotMatches(expected, actual) && expected.ctimeNs === actual.ctimeNs
+
 const normalizeStorageError = (
   error: unknown,
   fallbackCode: VersionFileOperatorErrorCode,
@@ -515,11 +518,26 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
         mtimeNs: before.mtimeNs,
         ctimeNs: before.ctimeNs
       }
-      const verificationKey = immutableVerificationKey(expectedIntegrity, snapshot)
-      if (!verifiedImmutableFiles.has(verificationKey)) {
+      let verificationKey = immutableVerificationKey(expectedIntegrity, snapshot)
+      let cached = verifiedImmutableFiles.has(verificationKey)
+      if (cached) {
+        const after = await handle.stat({ bigint: true })
+        if (!snapshotMatches(snapshot, after)) {
+          throw new Error('Immutable version changed during cached integrity verification.')
+        }
+        if (snapshot.ctimeNs !== after.ctimeNs) {
+          snapshot.ctimeNs = after.ctimeNs
+          verificationKey = immutableVerificationKey(expectedIntegrity, snapshot)
+          cached = false
+        }
+      }
+      if (!cached) {
         const checksum = await checksumHandle(handle, expectedIntegrity.sizeBytes)
         const after = await handle.stat({ bigint: true })
-        if (checksum !== expectedIntegrity.checksum || !snapshotMatches(snapshot, after)) {
+        if (
+          checksum !== expectedIntegrity.checksum ||
+          !verificationSnapshotMatches(snapshot, after)
+        ) {
           throw new Error('Immutable version changed during integrity verification.')
         }
         rememberVerifiedImmutableFile(verificationKey)
@@ -544,6 +562,26 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
               'INTEGRITY_FAILED',
               'Immutable version changed during trusted consumption.'
             )
+          }
+          if (snapshot.ctimeNs !== current.ctimeNs) {
+            const checksum = await checksumHandle(leaseHandle, expectedIntegrity.sizeBytes)
+            const after = await leaseHandle.stat({ bigint: true })
+            const revalidationSnapshot: LeaseSnapshot = {
+              ...snapshot,
+              ctimeNs: current.ctimeNs
+            }
+            if (
+              checksum !== expectedIntegrity.checksum ||
+              !verificationSnapshotMatches(revalidationSnapshot, after)
+            ) {
+              throw new VersionFileOperatorError(
+                'INTEGRITY_FAILED',
+                'Immutable version changed during trusted consumption.'
+              )
+            }
+            verifiedImmutableFiles.delete(immutableVerificationKey(expectedIntegrity, snapshot))
+            snapshot.ctimeNs = after.ctimeNs
+            rememberVerifiedImmutableFile(immutableVerificationKey(expectedIntegrity, snapshot))
           }
         } catch (error) {
           throw normalizeStorageError(

--- a/src/main/managed-file-versions/version-file-operator.ts
+++ b/src/main/managed-file-versions/version-file-operator.ts
@@ -97,7 +97,7 @@ class VersionFileOperatorError extends Error {
   }
 }
 
-type LeaseSnapshot = Pick<BigIntStats, 'dev' | 'ino' | 'size' | 'mtimeNs'>
+type LeaseSnapshot = Pick<BigIntStats, 'dev' | 'ino' | 'size' | 'mtimeNs' | 'ctimeNs'>
 
 type StorageParentSnapshot = Pick<BigIntStats, 'dev' | 'ino'> & {
   path: string
@@ -199,7 +199,14 @@ const immutableOperationTails = new Map<string, Promise<void>>()
 const verifiedImmutableFiles = new Set<string>()
 
 const immutableVerificationKey = (integrity: Integrity, snapshot: LeaseSnapshot): string =>
-  [integrity.checksum, snapshot.dev, snapshot.ino, snapshot.size, snapshot.mtimeNs].join('\0')
+  [
+    integrity.checksum,
+    snapshot.dev,
+    snapshot.ino,
+    snapshot.size,
+    snapshot.mtimeNs,
+    snapshot.ctimeNs
+  ].join('\0')
 
 const rememberVerifiedImmutableFile = (key: string): void => {
   verifiedImmutableFiles.add(key)
@@ -505,7 +512,8 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
         dev: before.dev,
         ino: before.ino,
         size: before.size,
-        mtimeNs: before.mtimeNs
+        mtimeNs: before.mtimeNs,
+        ctimeNs: before.ctimeNs
       }
       const verificationKey = immutableVerificationKey(expectedIntegrity, snapshot)
       if (!verifiedImmutableFiles.has(verificationKey)) {

--- a/src/main/managed-file-versions/version-file-operator.ts
+++ b/src/main/managed-file-versions/version-file-operator.ts
@@ -194,7 +194,19 @@ type VersionFileSystem = {
 const SAFE_SCOPE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u
 const VERSION_FILE_CANDIDATE_LIMIT = 16
 const VERSION_TOKEN_SPACE = 36n ** 8n
+const VERIFIED_IMMUTABLE_FILE_LIMIT = 1024
 const immutableOperationTails = new Map<string, Promise<void>>()
+const verifiedImmutableFiles = new Set<string>()
+
+const immutableVerificationKey = (integrity: Integrity, snapshot: LeaseSnapshot): string =>
+  [integrity.checksum, snapshot.dev, snapshot.ino, snapshot.size, snapshot.mtimeNs].join('\0')
+
+const rememberVerifiedImmutableFile = (key: string): void => {
+  verifiedImmutableFiles.add(key)
+  if (verifiedImmutableFiles.size <= VERIFIED_IMMUTABLE_FILE_LIMIT) return
+  const oldest = verifiedImmutableFiles.values().next().value
+  if (oldest !== undefined) verifiedImmutableFiles.delete(oldest)
+}
 
 const serializeImmutableOperation = async <T>(
   key: string,
@@ -495,19 +507,14 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
         size: before.size,
         mtimeNs: before.mtimeNs
       }
-      const hash = createHash('sha256')
-      let position = 0
-      while (position < expectedIntegrity.sizeBytes) {
-        const buffer = Buffer.allocUnsafe(
-          Math.min(64 * 1024, expectedIntegrity.sizeBytes - position)
-        )
-        await readExact(handle, buffer, position)
-        hash.update(buffer)
-        position += buffer.byteLength
-      }
-      const after = await handle.stat({ bigint: true })
-      if (hash.digest('hex') !== expectedIntegrity.checksum || !snapshotMatches(snapshot, after)) {
-        throw new Error('Immutable version changed during integrity verification.')
+      const verificationKey = immutableVerificationKey(expectedIntegrity, snapshot)
+      if (!verifiedImmutableFiles.has(verificationKey)) {
+        const checksum = await checksumHandle(handle, expectedIntegrity.sizeBytes)
+        const after = await handle.stat({ bigint: true })
+        if (checksum !== expectedIntegrity.checksum || !snapshotMatches(snapshot, after)) {
+          throw new Error('Immutable version changed during integrity verification.')
+        }
+        rememberVerifiedImmutableFile(verificationKey)
       }
 
       const leaseHandle = handle

--- a/src/main/managed-file-versions/version-file-operator.ts
+++ b/src/main/managed-file-versions/version-file-operator.ts
@@ -52,6 +52,10 @@ type StoredFile = Integrity & {
   versionToken?: string
 }
 
+type OpenImmutableOptions = {
+  forceVerify?: boolean
+}
+
 type PublishImmutableInput = PlanImmutableInput & {
   plannedFile: PlannedFile
   content: Uint8Array
@@ -148,7 +152,11 @@ const normalizeStorageError = (
 interface VersionFileOperator {
   planImmutable(input: PlanImmutableInput): PlannedFile
   publishImmutable(input: PublishImmutableInput): Promise<StoredFile>
-  openImmutable(storageRef: string, expectedIntegrity: Integrity): Promise<ReadLease>
+  openImmutable(
+    storageRef: string,
+    expectedIntegrity: Integrity,
+    options?: OpenImmutableOptions
+  ): Promise<ReadLease>
   removeImmutable(storageRef: string, expectedIntegrity: Integrity): Promise<void>
 }
 
@@ -477,7 +485,11 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
     }
   }
 
-  async openImmutable(storageRef: string, expectedIntegrity: Integrity): Promise<ReadLease> {
+  async openImmutable(
+    storageRef: string,
+    expectedIntegrity: Integrity,
+    options?: OpenImmutableOptions
+  ): Promise<ReadLease> {
     const localPath = this.resolveStorageRef(storageRef)
     if (
       !Number.isSafeInteger(expectedIntegrity.sizeBytes) ||
@@ -519,7 +531,7 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
         ctimeNs: before.ctimeNs
       }
       let verificationKey = immutableVerificationKey(expectedIntegrity, snapshot)
-      let cached = verifiedImmutableFiles.has(verificationKey)
+      let cached = !options?.forceVerify && verifiedImmutableFiles.has(verificationKey)
       if (cached) {
         const after = await handle.stat({ bigint: true })
         if (!snapshotMatches(snapshot, after)) {
@@ -1558,6 +1570,7 @@ export {
   type NodeVersionFileOperatorOptions,
   type Integrity,
   type InspectRecoveryInput,
+  type OpenImmutableOptions,
   type PlanImmutableInput,
   type PlannedFile,
   type PublishImmutableInput,


### PR DESCRIPTION
## Problem

`openImmutable()` recalculates SHA-256 over the entire managed immutable file on every lease acquisition. Reopening an unchanged large artifact, provenance inspection, and preview admission can therefore repeat up to the full file size in reads even when the caller only needs an initial range.

The regression test reproduced this on the unmodified implementation: opening one unchanged 256 KiB file twice read 524,288 bytes for integrity verification instead of 262,144 bytes.

## Proposed change

- Cache successful immutable-file verification in process memory by `checksum + dev + inode + size + mtimeNs + ctimeNs`.
- Bound the cache to 1,024 entries with FIFO eviction.
- Continue full SHA-256 verification on the first open and whenever the filesystem fingerprint changes.
- Recheck a cache hit before returning the lease; if `ctimeNs` changes during later consumption, fully rehash the held handle before accepting the read.
- Preserve pinned-inode semantics by allowing a `ctimeNs` change caused by path replacement only after that held handle passes full revalidation.
- Add an internal, non-persisted `forceVerify` open option and use it for active-version audits, publication verification, and recovery/replay verification.

## Scope and non-goals

- Only issue 5 (repeated immutable-file hashing) is addressed. Provenance message snapshot growth is explicitly out of scope.
- No database or persisted-format changes.
- No persisted data fields, schema versions, migrations, enum values, or persisted state. The only new option is the in-memory `forceVerify` method argument.
- No renderer interaction or public API changes.
- No historical-data compatibility work is required; the cache is process-local and starts empty after restart.
- Export/copy, deletion, and cross-session copy paths retain their full checksum verification.
- Concurrent cold opens are not coalesced; they may each perform the initial verification.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Repeated-open behavior, restored-mtime invalidation, and in-flight rewrite rejection -> `npm test -- src/main/managed-file-versions/version-file-operator.test.ts` -> 49 passed.
- Managed-file service integration -> `npm test -- src/main/managed-file-versions/service.integration.test.ts` -> 78 passed.
- Direct preview consumers -> `npm test -- src/main/managed-preview-resources.test.ts src/main/managed-preview-ipc.test.ts` -> 64 passed.
- Electron main type safety -> `npm run typecheck:node` -> passed.
- Repository lint -> `npm run lint` -> passed.

The full local test suite was intentionally not run; the scoped module and direct-consumer checks above cover the changed behavior, and PR Gate will classify and run the final exact-head CI plan.

## Review focus

- Whether the immutable storage boundary and non-user-settable `ctimeNs` are strong enough to trust the filesystem fingerprint after one successful full verification.
- Cache-hit TOCTOU handling and full held-handle revalidation after a `ctimeNs` change.
- Cache invalidation and bounded eviction behavior.
- Preservation of full verification for critical copy/export and deletion operations.

Uncovered risk: the optimization depends on the existing app-managed immutable-storage boundary and the host filesystem reporting content/metadata changes through `ctimeNs`. An actor with privileges sufficient to rewrite raw filesystem metadata remains outside that boundary.
