### PR TITLE
fix(session-store): preserve streamed chunks across clock rollback

### DIFF
--- a/src/renderer/src/stores/session-store-run-output-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-output-helpers.ts
@@ -206,7 +206,9 @@ export const projectAgentMessageChunks = (
     return { session, results: inputs.map(() => undefined), shouldCommit: false }
   }
   const replayedGraphMessages = new Map<string, ChatMessage[]>()
+  const graphMessagesById = new Map<string, ChatMessage>()
   for (const message of session.conversationGraph?.messages ?? []) {
+    graphMessagesById.set(message.id, message)
     if (message.role !== 'agent') continue
     for (const eventId of message.eventIds) {
       if (!incomingEventIds.has(eventId)) continue
@@ -286,7 +288,11 @@ export const projectAgentMessageChunks = (
     }
 
     const hasVisibleOutput = content.trim().length > 0 || Boolean(sanitizedImage)
-    const now = Date.now()
+    const now = Math.max(
+      Date.now(),
+      (existing?.message.updatedAt ?? -1) + 1,
+      (graphMessagesById.get(messageId)?.updatedAt ?? -1) + 1
+    )
     const mergeContent = (current = ''): string => {
       const text = `${current}${content}`
       return session.agentFrameworkId === 'claude-code'

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2408,7 +2408,7 @@ describe('session store', () => {
     ).toEqual([command])
   })
 
-  it('accepts a newer durable root Branch head before saving the next streamed chunk', () => {
+  it('persists the next streamed chunk when the durable graph timestamp is ahead of the wall clock', () => {
     const prompt = {
       id: 'root-prompt',
       role: 'user' as const,
@@ -2444,8 +2444,14 @@ describe('session store', () => {
     })
 
     const durable = toPersistedSession(useSessionStore.getState().sessions[0])
-    durable.updatedAt += 10
+    const futureUpdatedAt = Date.now() + 60_000
+    const responseMessageId = durable.messages.at(-1)!.id
+    durable.messages.at(-1)!.updatedAt = futureUpdatedAt
+    durable.conversationGraph!.messages.find(({ id }) => id === responseMessageId)!.updatedAt =
+      futureUpdatedAt
+    durable.updatedAt = futureUpdatedAt
     useSessionStore.getState().upsertPersistedSession(durable)
+    vi.setSystemTime(futureUpdatedAt - 120_000)
     useSessionStore.getState().appendAgentMessageChunk({
       sessionId: base.id,
       streamId: 'root-stream',
@@ -2455,7 +2461,14 @@ describe('session store', () => {
     })
 
     const current = useSessionStore.getState().sessions[0]
-    expect(() => toPersistedSession(current)).not.toThrow()
+    expect(current.messages.at(-1)?.content).toBe('Delegation complete')
+    const persisted = toPersistedSession(current)
+    useSessionStore.getState().hydrateSessions([persisted])
+
+    expect(persisted.messages.at(-1)?.content).toBe('Delegation complete')
+    expect(useSessionStore.getState().sessions[0].messages.at(-1)?.content).toBe(
+      'Delegation complete'
+    )
     expect(
       current.conversationGraph?.branches.find(
         ({ id }) => id === current.conversationGraph?.frames[0].activeBranchId


### PR DESCRIPTION
## Problem

Conversation graph synchronization accepts mutable flat-message payload only when its `updatedAt` is strictly newer than the graph node. Streamed chunks previously used raw `Date.now()`, so a clock rollback or a pre-existing future timestamp could leave the flat message newer in memory but older by timestamp. Persistence then rematerialized the flat projection from the stale graph and dropped the latest chunk.

## Proposed change

- Index graph messages during the existing graph scan.
- Assign each streamed update an `updatedAt` that is at least one greater than the current flat and graph message timestamps, while continuing to use wall-clock time when it is already ahead.
- Extend the existing public store-to-persistence regression test to simulate a future durable timestamp, move the clock backward, append a chunk, serialize, and hydrate it again.

## Scope and non-goals

- Keep the conversation graph stale/equal projection guard unchanged.
- Do not add a logical revision/provider sequence in this focused fix.
- No architecture or interaction changes.
- No new fields, enum values, dependencies, or migrations.

## Persistence and compatibility

This changes persistence behavior by preventing a newly streamed payload from being replaced by an older graph payload before save. The persisted schema and data model are unchanged. Historical sessions, including sessions with future timestamps, require no migration; their next streamed update advances the existing timestamp monotonically.

## Acceptance criteria and validation

The listed checks ran after the last material edit.

- Clock rollback/future graph timestamp -> targeted regression test -> failed before the fix with expected `Delegation complete`, received `De`; passes after the fix.
- Session renderer owner, persistence contract, and representative consumer behavior -> `npm run test:module -- session_renderer` -> 5 files, 606 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting -> `npx prettier --check src/renderer/src/stores/session-store-run-output-helpers.ts src/renderer/src/stores/session-store.test.ts` -> passed.

A full local `npm test` was intentionally not run; PR CI is the complete validation authority.

## Review focus

Please verify that the reducer-owned monotonic timestamp is scoped to updates of the same streamed message and that the existing graph conflict semantics remain intact.