### PR TITLE
fix(provenance): make message snapshots durable

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -788,6 +788,7 @@
         "owner": [
           "src/main/artifacts/provenance-dependency-read.test.ts",
           "src/main/artifacts/provenance-lifecycle-contract.test.ts",
+          "src/main/artifacts/provenance-message-snapshot-durability.test.ts",
           "src/main/artifacts/provenance-message-snapshot.test.ts",
           "src/main/artifacts/provenance-repository.architecture.test.ts",
           "src/main/artifacts/provenance-repository.test.ts",

--- a/src/main/artifacts/provenance-message-snapshot-durability.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot-durability.test.ts
@@ -116,6 +116,7 @@ describe('Provenance Message snapshot durability', () => {
       'database:staging',
       `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/.staging/messages/snapshot-1.json')}`,
       `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/message-snapshots')}`,
+      `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/.staging/messages')}`,
       'database:ready'
     ])
   })

--- a/src/main/artifacts/provenance-message-snapshot-durability.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot-durability.test.ts
@@ -1,0 +1,122 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createLinearConversationGraph,
+  projectConversationMessage
+} from '../../shared/conversation-graph'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+
+const durabilityEvents = vi.hoisted(() => [] as string[])
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      const handle = await actual.open(...args)
+      return new Proxy(handle, {
+        get(target, property) {
+          if (property === 'sync') {
+            return async () => {
+              durabilityEvents.push(`sync:${String(args[0])}`)
+              return target.sync()
+            }
+          }
+          const value = Reflect.get(target, property, target)
+          return typeof value === 'function' ? value.bind(target) : value
+        }
+      })
+    }
+  }
+})
+
+let storageRoot: string | undefined
+
+afterEach(async () => {
+  durabilityEvents.length = 0
+  if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
+  storageRoot = undefined
+})
+
+describe('Provenance Message snapshot durability', () => {
+  it('flushes the staged file and published directory before marking the snapshot ready', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-message-snapshot-durability-'))
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'agent',
+          content: 'saved artifact',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 1
+    })
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Durability',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: graph.messages.map(projectConversationMessage),
+      conversationGraph: graph,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const version = {
+      originKind: 'agent_generated',
+      rootFrameId: graph.rootFrameId,
+      agentFrameId: graph.activeFrameId,
+      messageBranchId: graph.branches[0]!.id,
+      messageId: 'message-1'
+    }
+    const client = {
+      artifactVersion: {
+        findMany: async () => [version],
+        updateMany: async () => ({ count: 1 })
+      },
+      artifactMessageSnapshot: {
+        findUnique: async () => null,
+        create: async () => {
+          durabilityEvents.push('database:staging')
+        }
+      },
+      $transaction: async (operation: (transaction: unknown) => Promise<unknown>) =>
+        operation({
+          artifactMessageSnapshot: {
+            update: async () => {
+              durabilityEvents.push('database:ready')
+            }
+          },
+          artifactVersion: { updateMany: async () => ({ count: 1 }) }
+        })
+    } as unknown as PrismaClient
+    const { ProvenanceMessageSnapshotRepository } = await import('./provenance-message-snapshot')
+    const snapshots = new ProvenanceMessageSnapshotRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      createId: () => 'snapshot-1',
+      now: () => new Date('2026-09-04T00:00:00.000Z')
+    })
+
+    await snapshots.captureFinalizedMessages(session)
+
+    expect(durabilityEvents).toEqual([
+      'database:staging',
+      `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/.staging/messages/snapshot-1.json')}`,
+      `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/message-snapshots')}`,
+      'database:ready'
+    ])
+  })
+})

--- a/src/main/artifacts/provenance-message-snapshot-durability.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot-durability.test.ts
@@ -117,6 +117,12 @@ describe('Provenance Message snapshot durability', () => {
       `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/.staging/messages/snapshot-1.json')}`,
       `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/message-snapshots')}`,
       `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/.staging/messages')}`,
+      `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance/.staging')}`,
+      `sync:${join(storageRoot, 'artifacts/project-1/session-1/.provenance')}`,
+      `sync:${join(storageRoot, 'artifacts/project-1/session-1')}`,
+      `sync:${join(storageRoot, 'artifacts/project-1')}`,
+      `sync:${join(storageRoot, 'artifacts')}`,
+      `sync:${storageRoot}`,
       'database:ready'
     ])
   })

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -812,6 +812,70 @@ describe('Provenance Message snapshots', () => {
       'artifacts/project-1/session-1/.provenance/.staging/messages'
     )
     expect(syncedDirectories.filter((path) => path === stagingDirectory)).toHaveLength(2)
+    expect(syncedDirectories).toContain(storageRoot)
+  })
+
+  it('does not promote staged bytes replaced after their initial validation', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-provenance-staging-race-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-1', sessionId: 'session-1' }
+    })
+    const id = 'snapshot-raced-1'
+    const storageKey = `artifacts/project-1/session-1/.provenance/message-snapshots/${id}.json`
+    const stagingPath = join(
+      storageRoot,
+      'artifacts/project-1/session-1/.provenance/.staging/messages',
+      `${id}.json`
+    )
+    const payload = {
+      schemaVersion: 3,
+      snapshotId: id,
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      terminalMessageId: 'message-1',
+      createdAt: '2026-07-27T12:00:00.000Z',
+      messages: [{ id: 'message-1', role: 'agent', content: 'original', createdAt: 1 }],
+      activities: [],
+      activityGroups: []
+    }
+    const serialized = `${JSON.stringify(payload, null, 2)}\n`
+    await mkdir(dirname(stagingPath), { recursive: true })
+    await writeFile(stagingPath, serialized, 'utf8')
+    await client.artifactMessageSnapshot.create({
+      data: {
+        id,
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        rootFrameId: 'root-frame-1',
+        agentFrameId: 'agent-frame-1',
+        messageBranchId: 'branch-1',
+        terminalMessageId: 'message-1',
+        state: 'staging',
+        storageKey,
+        checksum: createHash('sha256').update(serialized).digest('hex'),
+        messageCount: 1
+      }
+    })
+    const snapshots = new ProvenanceMessageSnapshotRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      durability: {
+        syncFile: async (path) => {
+          await writeFile(path, 'replaced after validation', 'utf8')
+        },
+        syncDirectory: async () => undefined
+      }
+    })
+
+    await snapshots.reconcileSessionDeletions([])
+
+    await expect(
+      client.artifactMessageSnapshot.findUniqueOrThrow({ where: { id } })
+    ).resolves.toMatchObject({ state: 'staging' })
   })
 
   it('reconciles a large active Session catalog without exceeding SQLite query limits', async () => {

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -759,6 +759,7 @@ describe('Provenance Message snapshots', () => {
     await createStagingSnapshot('snapshot-staging-file-1', false, true)
     await createStagingSnapshot('snapshot-corrupt-1', true)
     let failDurability = true
+    const syncedDirectories: string[] = []
     const snapshots = new ProvenanceMessageSnapshotRepository({
       storageRoot,
       getClient: () => Promise.resolve(client),
@@ -766,7 +767,9 @@ describe('Provenance Message snapshots', () => {
         syncFile: async () => {
           if (failDurability) throw Object.assign(new Error('storage unavailable'), { code: 'EIO' })
         },
-        syncDirectory: async () => undefined
+        syncDirectory: async (path) => {
+          syncedDirectories.push(path)
+        }
       }
     })
 
@@ -804,6 +807,34 @@ describe('Provenance Message snapshots', () => {
         'utf8'
       )
     ).resolves.toContain('snapshot-staging-file-1')
+    const stagingDirectory = join(
+      storageRoot,
+      'artifacts/project-1/session-1/.provenance/.staging/messages'
+    )
+    expect(syncedDirectories.filter((path) => path === stagingDirectory)).toHaveLength(2)
+  })
+
+  it('reconciles a large active Session catalog without exceeding SQLite query limits', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-provenance-session-batches-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const snapshots = new ProvenanceMessageSnapshotRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client)
+    })
+    const sessions: PersistedChatSession[] = Array.from({ length: 20_001 }, (_, index) => ({
+      id: `session-${index}`,
+      projectId: `project-${index}`,
+      title: `Session ${index}`,
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }))
+
+    await expect(snapshots.reconcileSessionDeletions(sessions)).resolves.toBeUndefined()
   })
 
   it('republishes a staging Review scope snapshot before Session deletion reconciliation', async () => {

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -286,6 +286,47 @@ describe('Provenance Message snapshots', () => {
     > & { schemaVersion: number }
     expect(snapshotPayload.schemaVersion).toBe(3)
 
+    await rm(snapshotPath)
+    await snapshots.reconcileSessionDeletions([session])
+    await expect(readFile(snapshotPath, 'utf8')).resolves.toBe(
+      `${JSON.stringify(snapshotPayload, null, 2)}\n`
+    )
+
+    const startupCorruptPayload = structuredClone(snapshotPayload) as typeof snapshotPayload & {
+      messages: Array<Record<string, unknown>>
+    }
+    startupCorruptPayload.messages[0] = {
+      ...startupCorruptPayload.messages[0],
+      content: 'corrupt before startup recovery'
+    }
+    await writeFile(snapshotPath, `${JSON.stringify(startupCorruptPayload, null, 2)}\n`, 'utf8')
+    await snapshots.reconcileSessionDeletions([session])
+    await expect(readFile(snapshotPath, 'utf8')).resolves.toBe(
+      `${JSON.stringify(snapshotPayload, null, 2)}\n`
+    )
+
+    const changedSession = structuredClone(session)
+    const changedMessage = changedSession.conversationGraph?.messages.find(
+      (message) => message.id === 'message-1'
+    )
+    if (!changedMessage || !changedSession.conversationGraph) {
+      throw new Error('Expected the Artifact-owning Message in the changed Session graph.')
+    }
+    changedMessage.content = 'changed after snapshot publication'
+    changedSession.messages = changedSession.conversationGraph.messages.map(
+      projectConversationMessage
+    )
+    await rm(snapshotPath)
+    await snapshots.reconcileSessionDeletions([changedSession])
+    await expect(readFile(snapshotPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      client.artifactMessageSnapshot.findUniqueOrThrow({ where: { id: row.messageSnapshot!.id } })
+    ).resolves.toMatchObject({ state: 'ready', checksum: row.messageSnapshot!.checksum })
+    await snapshots.reconcileSessionDeletions([session])
+    await expect(readFile(snapshotPath, 'utf8')).resolves.toBe(
+      `${JSON.stringify(snapshotPayload, null, 2)}\n`
+    )
+
     // Previously captured v2 snapshots remain readable; they simply have no process timeline.
     const legacyPayload: Record<string, unknown> = { ...snapshotPayload, schemaVersion: 2 }
     delete legacyPayload.activities
@@ -693,19 +734,33 @@ describe('Provenance Message snapshots', () => {
     }
     await createStagingSnapshot('snapshot-valid-1')
     await createStagingSnapshot('snapshot-corrupt-1', true)
+    let failDurability = true
     const snapshots = new ProvenanceMessageSnapshotRepository({
       storageRoot,
-      getClient: () => Promise.resolve(client)
+      getClient: () => Promise.resolve(client),
+      durability: {
+        syncFile: async () => {
+          if (failDurability) throw Object.assign(new Error('storage unavailable'), { code: 'EIO' })
+        },
+        syncDirectory: async () => undefined
+      }
     })
 
     await snapshots.reconcileSessionDeletions([])
 
     await expect(
       client.artifactMessageSnapshot.findUniqueOrThrow({ where: { id: 'snapshot-valid-1' } })
-    ).resolves.toMatchObject({ state: 'ready' })
+    ).resolves.toMatchObject({ state: 'staging' })
     await expect(
       client.artifactMessageSnapshot.findUnique({ where: { id: 'snapshot-corrupt-1' } })
     ).resolves.toBeNull()
+
+    failDurability = false
+    await snapshots.reconcileSessionDeletions([])
+
+    await expect(
+      client.artifactMessageSnapshot.findUniqueOrThrow({ where: { id: 'snapshot-valid-1' } })
+    ).resolves.toMatchObject({ state: 'ready' })
   })
 
   it('republishes a staging Review scope snapshot before Session deletion reconciliation', async () => {

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -701,7 +701,11 @@ describe('Provenance Message snapshots', () => {
     await client.fileOriginSession.create({
       data: { projectId: 'project-1', sessionId: 'session-1' }
     })
-    const createStagingSnapshot = async (id: string, corruptChecksum = false): Promise<void> => {
+    const createStagingSnapshot = async (
+      id: string,
+      corruptChecksum = false,
+      stagingFileOnly = false
+    ): Promise<void> => {
       const storageKey = `artifacts/project-1/session-1/.provenance/message-snapshots/${id}.json`
       const terminalMessageId = `message-${id}`
       const payload = {
@@ -724,7 +728,13 @@ describe('Provenance Message snapshots', () => {
         activityGroups: []
       }
       const serialized = `${JSON.stringify(payload, null, 2)}\n`
-      const path = join(storageRoot!, ...storageKey.split('/'))
+      const path = stagingFileOnly
+        ? join(
+            storageRoot!,
+            'artifacts/project-1/session-1/.provenance/.staging/messages',
+            `${id}.json`
+          )
+        : join(storageRoot!, ...storageKey.split('/'))
       await mkdir(dirname(path), { recursive: true })
       await writeFile(path, serialized, 'utf8')
       await client.artifactMessageSnapshot.create({
@@ -746,6 +756,7 @@ describe('Provenance Message snapshots', () => {
       })
     }
     await createStagingSnapshot('snapshot-valid-1')
+    await createStagingSnapshot('snapshot-staging-file-1', false, true)
     await createStagingSnapshot('snapshot-corrupt-1', true)
     let failDurability = true
     const snapshots = new ProvenanceMessageSnapshotRepository({
@@ -765,6 +776,11 @@ describe('Provenance Message snapshots', () => {
       client.artifactMessageSnapshot.findUniqueOrThrow({ where: { id: 'snapshot-valid-1' } })
     ).resolves.toMatchObject({ state: 'staging' })
     await expect(
+      client.artifactMessageSnapshot.findUniqueOrThrow({
+        where: { id: 'snapshot-staging-file-1' }
+      })
+    ).resolves.toMatchObject({ state: 'staging' })
+    await expect(
       client.artifactMessageSnapshot.findUnique({ where: { id: 'snapshot-corrupt-1' } })
     ).resolves.toBeNull()
 
@@ -774,6 +790,20 @@ describe('Provenance Message snapshots', () => {
     await expect(
       client.artifactMessageSnapshot.findUniqueOrThrow({ where: { id: 'snapshot-valid-1' } })
     ).resolves.toMatchObject({ state: 'ready' })
+    await expect(
+      client.artifactMessageSnapshot.findUniqueOrThrow({
+        where: { id: 'snapshot-staging-file-1' }
+      })
+    ).resolves.toMatchObject({ state: 'ready' })
+    await expect(
+      readFile(
+        join(
+          storageRoot,
+          'artifacts/project-1/session-1/.provenance/message-snapshots/snapshot-staging-file-1.json'
+        ),
+        'utf8'
+      )
+    ).resolves.toContain('snapshot-staging-file-1')
   })
 
   it('republishes a staging Review scope snapshot before Session deletion reconciliation', async () => {

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -327,6 +327,19 @@ describe('Provenance Message snapshots', () => {
       `${JSON.stringify(snapshotPayload, null, 2)}\n`
     )
 
+    // A checksumless legacy row has no immutable witness. Missing bytes must remain unavailable
+    // instead of being reconstructed from mutable Session state.
+    await client.artifactMessageSnapshot.update({
+      where: { id: row.messageSnapshot!.id },
+      data: { checksum: '' }
+    })
+    await rm(snapshotPath)
+    await snapshots.reconcileSessionDeletions([changedSession])
+    await expect(readFile(snapshotPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      client.artifactMessageSnapshot.findUniqueOrThrow({ where: { id: row.messageSnapshot!.id } })
+    ).resolves.toMatchObject({ state: 'ready', checksum: '' })
+
     // Previously captured v2 snapshots remain readable; they simply have no process timeline.
     const legacyPayload: Record<string, unknown> = { ...snapshotPayload, schemaVersion: 2 }
     delete legacyPayload.activities

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -171,6 +171,35 @@ class ProvenanceMessageSnapshotRepository {
     this.durability = options.durability ?? defaultArtifactDurability
   }
 
+  private async syncDirectoryTrees(leaves: string[]): Promise<void> {
+    const root = resolve(this.options.storageRoot)
+    const resolvedLeaves = leaves.map((leaf) => resolve(leaf))
+    const ancestors = new Set<string>()
+    for (const leaf of resolvedLeaves) {
+      const fromRoot = relative(root, leaf)
+      if (fromRoot === '..' || fromRoot.startsWith(`..${sep}`)) {
+        throw new Error('Artifact Message snapshot directory is outside the storage root.')
+      }
+      let current = dirname(leaf)
+      while (current !== root) {
+        ancestors.add(current)
+        current = dirname(current)
+      }
+      ancestors.add(root)
+    }
+    const syncExisting = (path: string): Promise<void> =>
+      this.durability.syncDirectory(path).catch((error: unknown) => {
+        if (!isMissingPathError(error)) throw error
+      })
+    // Publish destination entries before source deletions, then persist newly created ancestors
+    // from deepest to shallowest so every child directory is reachable after a crash.
+    for (const leaf of resolvedLeaves) await syncExisting(leaf)
+    const depth = (path: string): number => relative(root, path).split(sep).filter(Boolean).length
+    for (const directory of [...ancestors].sort((left, right) => depth(right) - depth(left))) {
+      await syncExisting(directory)
+    }
+  }
+
   async validateFinalizedMessageBindings(input: PersistedChatSession): Promise<void> {
     const session = materializeSessionConversationGraph(input)
     if (!session.conversationGraph) {
@@ -578,10 +607,16 @@ class ProvenanceMessageSnapshotRepository {
         } else {
           await this.durability.syncFile(finalPath)
         }
-        await this.durability.syncDirectory(dirname(finalPath))
-        await this.durability.syncDirectory(dirname(stagingPath)).catch((error: unknown) => {
-          if (!isMissingPathError(error)) throw error
-        })
+        await this.syncDirectoryTrees([dirname(finalPath), dirname(stagingPath)])
+        await this.verifyReadySnapshot(
+          { ...snapshot, state: 'ready' },
+          {
+            rootFrameId: snapshot.rootFrameId,
+            agentFrameId: snapshot.agentFrameId,
+            messageBranchId: snapshot.messageBranchId,
+            terminalMessageId: snapshot.terminalMessageId
+          }
+        )
         await client.$transaction(async (transaction) => {
           const promoted = await transaction.artifactMessageSnapshot.updateMany({
             where: { id: snapshot.id, state: 'staging' },
@@ -908,8 +943,13 @@ class ProvenanceMessageSnapshotRepository {
     await writeFile(stagingPath, serialized, 'utf8')
     await this.durability.syncFile(stagingPath)
     await rename(stagingPath, finalPath)
-    await this.durability.syncDirectory(dirname(finalPath))
-    await this.durability.syncDirectory(dirname(stagingPath))
+    await this.syncDirectoryTrees([dirname(finalPath), dirname(stagingPath)])
+    const published = await readFile(finalPath, 'utf8')
+    if (sha256(published) !== checksum) {
+      throw new Error(
+        `Artifact Message snapshot checksum mismatch after publication: ${snapshotId}`
+      )
+    }
     await client.$transaction(async (transaction) => {
       await transaction.artifactMessageSnapshot.update({
         where: { id: snapshotId },

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -19,6 +19,7 @@ import type {
   ProvenanceMessage,
   ProvenanceMessagePart
 } from '../../shared/artifact-provenance'
+import { defaultArtifactDurability, type ArtifactDurability } from './durability'
 import { requireAgentArtifactVersion } from './provenance-version-kind'
 
 type ProvenanceMessageSnapshotOptions = {
@@ -26,6 +27,7 @@ type ProvenanceMessageSnapshotOptions = {
   getClient: () => Promise<PrismaClient>
   createId?: () => string
   now?: () => Date
+  durability?: ArtifactDurability
 }
 
 type SessionDeletionReceipt =
@@ -161,10 +163,12 @@ const projectMessage = (
 class ProvenanceMessageSnapshotRepository {
   private readonly createId: () => string
   private readonly now: () => Date
+  private readonly durability: ArtifactDurability
 
   constructor(private readonly options: ProvenanceMessageSnapshotOptions) {
     this.createId = options.createId ?? randomUUID
     this.now = options.now ?? (() => new Date())
+    this.durability = options.durability ?? defaultArtifactDurability
   }
 
   async validateFinalizedMessageBindings(input: PersistedChatSession): Promise<void> {
@@ -447,6 +451,7 @@ class ProvenanceMessageSnapshotRepository {
   async reconcileSessionDeletions(activeSessions: PersistedChatSession[]): Promise<void> {
     const client = await this.options.getClient()
     await this.recoverStagingMessageSnapshots()
+    await this.repairReadyMessageSnapshots(activeSessions)
     await this.recoverStagingReviewScopeSnapshots()
     const activeKeys = new Set(
       activeSessions.map((session) => `${session.projectId}\0${session.id}`)
@@ -528,6 +533,33 @@ class ProvenanceMessageSnapshotRepository {
             terminalMessageId: snapshot.terminalMessageId
           }
         )
+      } catch {
+        const deleted = await client.artifactMessageSnapshot.deleteMany({
+          where: { id: snapshot.id, state: 'staging' }
+        })
+        if (deleted.count !== 1) continue
+        const stagingPath = join(
+          this.options.storageRoot,
+          'artifacts',
+          snapshot.projectId,
+          snapshot.sessionId,
+          '.provenance',
+          '.staging',
+          'messages',
+          `${snapshot.id}.json`
+        )
+        await Promise.all([
+          rm(resolveStorageKey(this.options.storageRoot, snapshot.storageKey), {
+            force: true
+          }).catch(() => undefined),
+          rm(stagingPath, { force: true }).catch(() => undefined)
+        ])
+        continue
+      }
+      try {
+        const finalPath = resolveStorageKey(this.options.storageRoot, snapshot.storageKey)
+        await this.durability.syncFile(finalPath)
+        await this.durability.syncDirectory(dirname(finalPath))
         await client.$transaction(async (transaction) => {
           const promoted = await transaction.artifactMessageSnapshot.updateMany({
             where: { id: snapshot.id, state: 'staging' },
@@ -551,26 +583,52 @@ class ProvenanceMessageSnapshotRepository {
           })
         })
       } catch {
-        const deleted = await client.artifactMessageSnapshot.deleteMany({
-          where: { id: snapshot.id, state: 'staging' }
+        // A valid staging snapshot remains authoritative until its durability barrier and promotion
+        // can be retried; an I/O or database failure does not prove its bytes are corrupt.
+      }
+    }
+  }
+
+  private async repairReadyMessageSnapshots(activeSessions: PersistedChatSession[]): Promise<void> {
+    if (activeSessions.length === 0) return
+    const sessions = new Map(
+      activeSessions.map((session) => [`${session.projectId}\0${session.id}`, session])
+    )
+    const client = await this.options.getClient()
+    const ready = await client.artifactMessageSnapshot.findMany({
+      where: {
+        state: 'ready',
+        OR: activeSessions.map((session) => ({
+          projectId: session.projectId,
+          sessionId: session.id
+        }))
+      }
+    })
+    for (const snapshot of ready) {
+      try {
+        await this.verifyReadySnapshot(snapshot, {
+          rootFrameId: snapshot.rootFrameId,
+          agentFrameId: snapshot.agentFrameId,
+          messageBranchId: snapshot.messageBranchId,
+          terminalMessageId: snapshot.terminalMessageId
         })
-        if (deleted.count !== 1) continue
-        const stagingPath = join(
-          this.options.storageRoot,
-          'artifacts',
-          snapshot.projectId,
-          snapshot.sessionId,
-          '.provenance',
-          '.staging',
-          'messages',
-          `${snapshot.id}.json`
-        )
-        await Promise.all([
-          rm(resolveStorageKey(this.options.storageRoot, snapshot.storageKey), {
-            force: true
-          }).catch(() => undefined),
-          rm(stagingPath, { force: true }).catch(() => undefined)
-        ])
+      } catch {
+        const session = sessions.get(`${snapshot.projectId}\0${snapshot.sessionId}`)
+        if (!session) continue
+        try {
+          await this.captureScope(
+            session,
+            {
+              rootFrameId: snapshot.rootFrameId,
+              agentFrameId: snapshot.agentFrameId,
+              messageBranchId: snapshot.messageBranchId,
+              messageId: snapshot.terminalMessageId
+            },
+            true
+          )
+        } catch {
+          // Keep the invalid ready row fail-closed and retry while its Session remains recoverable.
+        }
       }
     }
   }
@@ -694,7 +752,8 @@ class ProvenanceMessageSnapshotRepository {
       agentFrameId: string
       messageBranchId: string
       messageId: string | null
-    }
+    },
+    repairReadySnapshot = false
   ): Promise<void> {
     const scope = this.resolveScopePath(session, version)
     if (!scope || !version.messageId || !session.conversationGraph) return
@@ -747,7 +806,7 @@ class ProvenanceMessageSnapshotRepository {
         projectId_sessionId_agentFrameId_messageBranchId_terminalMessageId: unique
       }
     })
-    if (snapshot?.state === 'ready') {
+    if (snapshot?.state === 'ready' && !repairReadySnapshot) {
       await this.verifyReadySnapshot(snapshot, {
         rootFrameId: version.rootFrameId,
         agentFrameId: version.agentFrameId,
@@ -781,6 +840,9 @@ class ProvenanceMessageSnapshotRepository {
     }
     const serialized = `${JSON.stringify(payload, null, 2)}\n`
     const checksum = sha256(serialized)
+    if (repairReadySnapshot && snapshot?.checksum && snapshot.checksum !== checksum) {
+      throw new Error(`Artifact Message snapshot cannot be reconstructed: ${snapshot.id}`)
+    }
     if (!snapshot) {
       await client.artifactMessageSnapshot.create({
         data: {
@@ -810,7 +872,9 @@ class ProvenanceMessageSnapshotRepository {
     await mkdir(dirname(stagingPath), { recursive: true })
     await mkdir(dirname(finalPath), { recursive: true })
     await writeFile(stagingPath, serialized, 'utf8')
+    await this.durability.syncFile(stagingPath)
     await rename(stagingPath, finalPath)
+    await this.durability.syncDirectory(dirname(finalPath))
     await client.$transaction(async (transaction) => {
       await transaction.artifactMessageSnapshot.update({
         where: { id: snapshotId },

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -478,9 +478,17 @@ class ProvenanceMessageSnapshotRepository {
   }
 
   async reconcileSessionDeletions(activeSessions: PersistedChatSession[]): Promise<void> {
-    const client = await this.options.getClient()
+    await this.reconcileMessageSnapshots(activeSessions)
+    await this.reconcileSessionCleanup(activeSessions)
+  }
+
+  async reconcileMessageSnapshots(activeSessions: PersistedChatSession[]): Promise<void> {
     await this.recoverStagingMessageSnapshots()
     await this.repairReadyMessageSnapshots(activeSessions)
+  }
+
+  async reconcileSessionCleanup(activeSessions: PersistedChatSession[]): Promise<void> {
+    const client = await this.options.getClient()
     await this.recoverStagingReviewScopeSnapshots()
     const activeKeys = new Set(
       activeSessions.map((session) => `${session.projectId}\0${session.id}`)

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -521,6 +521,18 @@ class ProvenanceMessageSnapshotRepository {
       where: { state: 'staging' }
     })
     for (const snapshot of staging) {
+      const finalPath = resolveStorageKey(this.options.storageRoot, snapshot.storageKey)
+      const stagingPath = join(
+        this.options.storageRoot,
+        'artifacts',
+        snapshot.projectId,
+        snapshot.sessionId,
+        '.provenance',
+        '.staging',
+        'messages',
+        `${snapshot.id}.json`
+      )
+      let recoverFromStaging = false
       try {
         // Reuse the same immutable-file validation as normal reads. The temporary state override is
         // local to validation; SQLite remains staging until the promotion transaction commits.
@@ -534,31 +546,38 @@ class ProvenanceMessageSnapshotRepository {
           }
         )
       } catch {
-        const deleted = await client.artifactMessageSnapshot.deleteMany({
-          where: { id: snapshot.id, state: 'staging' }
-        })
-        if (deleted.count !== 1) continue
-        const stagingPath = join(
-          this.options.storageRoot,
-          'artifacts',
-          snapshot.projectId,
-          snapshot.sessionId,
-          '.provenance',
-          '.staging',
-          'messages',
-          `${snapshot.id}.json`
-        )
-        await Promise.all([
-          rm(resolveStorageKey(this.options.storageRoot, snapshot.storageKey), {
-            force: true
-          }).catch(() => undefined),
-          rm(stagingPath, { force: true }).catch(() => undefined)
-        ])
-        continue
+        try {
+          await this.verifyReadySnapshot(
+            { ...snapshot, state: 'ready' },
+            {
+              rootFrameId: snapshot.rootFrameId,
+              agentFrameId: snapshot.agentFrameId,
+              messageBranchId: snapshot.messageBranchId,
+              terminalMessageId: snapshot.terminalMessageId
+            },
+            stagingPath
+          )
+          recoverFromStaging = true
+        } catch {
+          const deleted = await client.artifactMessageSnapshot.deleteMany({
+            where: { id: snapshot.id, state: 'staging' }
+          })
+          if (deleted.count !== 1) continue
+          await Promise.all([
+            rm(finalPath, { force: true }).catch(() => undefined),
+            rm(stagingPath, { force: true }).catch(() => undefined)
+          ])
+          continue
+        }
       }
       try {
-        const finalPath = resolveStorageKey(this.options.storageRoot, snapshot.storageKey)
-        await this.durability.syncFile(finalPath)
+        if (recoverFromStaging) {
+          await mkdir(dirname(finalPath), { recursive: true })
+          await this.durability.syncFile(stagingPath)
+          await rename(stagingPath, finalPath)
+        } else {
+          await this.durability.syncFile(finalPath)
+        }
         await this.durability.syncDirectory(dirname(finalPath))
         await client.$transaction(async (transaction) => {
           const promoted = await transaction.artifactMessageSnapshot.updateMany({
@@ -972,15 +991,13 @@ class ProvenanceMessageSnapshotRepository {
       agentFrameId: string
       messageBranchId: string
       terminalMessageId: string
-    }
+    },
+    storagePath = resolveStorageKey(this.options.storageRoot, snapshot.storageKey)
   ): Promise<void> {
     if (snapshot.state !== 'ready') {
       throw new Error(`Artifact Message snapshot is not ready: ${snapshot.id}`)
     }
-    const serialized = await readFile(
-      resolveStorageKey(this.options.storageRoot, snapshot.storageKey),
-      'utf8'
-    ).catch((error: unknown) => {
+    const serialized = await readFile(storagePath, 'utf8').catch((error: unknown) => {
       throw new Error(
         `Artifact Message snapshot is unavailable: ${snapshot.id}: ${error instanceof Error ? error.message : String(error)}`
       )

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -613,6 +613,10 @@ class ProvenanceMessageSnapshotRepository {
           terminalMessageId: snapshot.terminalMessageId
         })
       } catch {
+        // Legacy rows without a checksum have no immutable witness. Valid existing bytes can still
+        // establish one in verifyReadySnapshot, but missing/corrupt bytes must remain fail-closed
+        // rather than being reconstructed from mutable Session state.
+        if (!snapshot.checksum) continue
         const session = sessions.get(`${snapshot.projectId}\0${snapshot.sessionId}`)
         if (!session) continue
         try {

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -42,6 +42,8 @@ type AgentMessageScope = {
   messageId: string | null
 }
 
+const ACTIVE_SESSION_QUERY_BATCH_SIZE = 400
+
 const requireAgentMessageScope = <T extends AgentMessageScope>(
   version: T
 ): T & {
@@ -75,16 +77,14 @@ class FinalizedArtifactBindingConflictError extends Error {
 
 const storageKey = (...segments: string[]): string => segments.join('/')
 const sha256 = (value: string): string => createHash('sha256').update(value).digest('hex')
+const isMissingPathError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'ENOENT'
 const readOptionalText = async (path: string): Promise<string | undefined> =>
   readFile(path, 'utf8').catch((error: unknown) => {
-    if (
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      (error as { code?: unknown }).code === 'ENOENT'
-    ) {
-      return undefined
-    }
+    if (isMissingPathError(error)) return undefined
     throw error
   })
 const resolveStorageKey = (root: string, key: string): string => {
@@ -579,6 +579,9 @@ class ProvenanceMessageSnapshotRepository {
           await this.durability.syncFile(finalPath)
         }
         await this.durability.syncDirectory(dirname(finalPath))
+        await this.durability.syncDirectory(dirname(stagingPath)).catch((error: unknown) => {
+          if (!isMissingPathError(error)) throw error
+        })
         await client.$transaction(async (transaction) => {
           const promoted = await transaction.artifactMessageSnapshot.updateMany({
             where: { id: snapshot.id, state: 'staging' },
@@ -614,15 +617,23 @@ class ProvenanceMessageSnapshotRepository {
       activeSessions.map((session) => [`${session.projectId}\0${session.id}`, session])
     )
     const client = await this.options.getClient()
-    const ready = await client.artifactMessageSnapshot.findMany({
-      where: {
-        state: 'ready',
-        OR: activeSessions.map((session) => ({
-          projectId: session.projectId,
-          sessionId: session.id
+    const ready = []
+    const distinctSessions = [...sessions.values()]
+    for (let index = 0; index < distinctSessions.length; index += ACTIVE_SESSION_QUERY_BATCH_SIZE) {
+      ready.push(
+        ...(await client.artifactMessageSnapshot.findMany({
+          where: {
+            state: 'ready',
+            OR: distinctSessions
+              .slice(index, index + ACTIVE_SESSION_QUERY_BATCH_SIZE)
+              .map((session) => ({
+                projectId: session.projectId,
+                sessionId: session.id
+              }))
+          }
         }))
-      }
-    })
+      )
+    }
     for (const snapshot of ready) {
       try {
         await this.verifyReadySnapshot(snapshot, {
@@ -898,6 +909,7 @@ class ProvenanceMessageSnapshotRepository {
     await this.durability.syncFile(stagingPath)
     await rename(stagingPath, finalPath)
     await this.durability.syncDirectory(dirname(finalPath))
+    await this.durability.syncDirectory(dirname(stagingPath))
     await client.$transaction(async (transaction) => {
       await transaction.artifactMessageSnapshot.update({
         where: { id: snapshotId },

--- a/src/main/artifacts/provenance-repository.architecture.test.ts
+++ b/src/main/artifacts/provenance-repository.architecture.test.ts
@@ -401,6 +401,7 @@ describe('Artifact Provenance repository architecture', () => {
       [
         'src/main/artifacts/provenance-lifecycle-contract.test.ts',
         'src/main/artifacts/provenance-dependency-read.test.ts',
+        'src/main/artifacts/provenance-message-snapshot-durability.test.ts',
         'src/main/artifacts/provenance-message-snapshot.test.ts',
         'src/main/artifacts/provenance-repository.architecture.test.ts',
         'src/main/artifacts/provenance-repository.test.ts',

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -210,6 +210,45 @@ describe('artifact finalization startup recovery', () => {
     })
   })
 
+  it('repairs a missing ready Message snapshot after restoring its Session artifact attachment', async () => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const prepared = await prepareRecovery(compatibility)
+    const originalSession = (await sessions.loadSession(PROJECT_ID, SESSION_ID))!
+    const snapshots = new ProvenanceMessageSnapshotRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client)
+    })
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      snapshots,
+      undefined,
+      prepared.provenance
+    )
+
+    await coordinator.loadAll()
+    const snapshot = await client.artifactMessageSnapshot.findFirstOrThrow({
+      where: { projectId: PROJECT_ID, sessionId: SESSION_ID, state: 'ready' }
+    })
+    await rm(join(storageRoot, ...snapshot.storageKey.split('/')))
+    // Model a crash after the snapshot and Artifact Version commit but before recovered artifact
+    // metadata reached Session JSON.
+    await sessions.saveSession(originalSession)
+
+    const recovered = await coordinator.loadAll()
+
+    expect(recovered.sessions[0].messages[1].artifactIds).toEqual([prepared.version.versionId])
+    await expect(
+      prepared.provenance.getVersionMessages({
+        projectId: PROJECT_ID,
+        appSessionId: SESSION_ID,
+        artifactId: prepared.version.artifactId,
+        versionId: prepared.version.versionId
+      })
+    ).resolves.toMatchObject({ messages: { state: 'available' } })
+  })
+
   it('moves pending compatibility bytes when a bound marker survived without its file move', async () => {
     const compatibility = new ArtifactRepository(storageRoot)
     const { provenance, context, version } = await prepareRecovery(compatibility)

--- a/src/main/session-persistence/coordinator-contract.test.ts
+++ b/src/main/session-persistence/coordinator-contract.test.ts
@@ -516,6 +516,12 @@ describe('SessionPersistenceCoordinator contracts', () => {
       reconcileSessionDeletions: vi.fn(async () => {
         order.push('provenance')
       }),
+      reconcileSessionCleanup: vi.fn(async () => {
+        order.push('provenance:cleanup')
+      }),
+      reconcileMessageSnapshots: vi.fn(async () => {
+        order.push('provenance:snapshots')
+      }),
       prepareSessionDeletion: vi.fn(async (session: PersistedChatSession) => ({
         kind: 'ordinary' as const,
         projectId: session.projectId,
@@ -559,13 +565,14 @@ describe('SessionPersistenceCoordinator contracts', () => {
       'load',
       'unread',
       'permission',
+      'provenance:cleanup',
       'upload:session-1',
       'upload:session-2',
       'artifact-project:project-1',
       'artifact-project:project-2',
       'artifact-session:session-1',
       'artifact-session:session-2',
-      'provenance',
+      'provenance:snapshots',
       'files:reconcile',
       'files:sync:session-1',
       'files:sync:session-2'
@@ -587,5 +594,46 @@ describe('SessionPersistenceCoordinator contracts', () => {
       expect.any(Object),
       expect.objectContaining({ removeOrphanStaging: false })
     )
+  })
+
+  it('runs independent Provenance cleanup before fallible Artifact recovery', async () => {
+    const session = createSession()
+    const { repository } = createRepository([session])
+    const reconcileSessionCleanup = vi.fn(async () => undefined)
+    const reconcileMessageSnapshots = vi.fn(async () => undefined)
+    const provenance = {
+      validateFinalizedMessageBindings: vi.fn(async () => undefined),
+      captureFinalizedMessages: vi.fn(async () => undefined),
+      reconcileSessionDeletions: vi.fn(async () => undefined),
+      reconcileSessionCleanup,
+      reconcileMessageSnapshots,
+      prepareSessionDeletion: vi.fn(async () => ({
+        kind: 'ordinary' as const,
+        projectId: session.projectId,
+        sessionId: session.id
+      })),
+      completeSessionDeletion: vi.fn(async () => undefined),
+      abortSessionDeletion: vi.fn(async () => undefined)
+    }
+    const artifactStorage = {
+      prepareProjectReconciliation: vi.fn(async () => {
+        throw new Error('artifact recovery failed')
+      }),
+      reconcileSession: vi.fn(async () => ({ recoveredMessageArtifacts: [] }))
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      provenance,
+      undefined,
+      artifactStorage
+    )
+
+    await coordinator.loadAll()
+
+    expect(reconcileSessionCleanup).toHaveBeenCalledOnce()
+    expect(reconcileSessionCleanup).toHaveBeenCalledWith([session])
+    expect(reconcileMessageSnapshots).not.toHaveBeenCalled()
   })
 })

--- a/src/main/session-persistence/coordinator-contract.test.ts
+++ b/src/main/session-persistence/coordinator-contract.test.ts
@@ -561,11 +561,11 @@ describe('SessionPersistenceCoordinator contracts', () => {
       'permission',
       'upload:session-1',
       'upload:session-2',
-      'provenance',
       'artifact-project:project-1',
       'artifact-project:project-2',
       'artifact-session:session-1',
       'artifact-session:session-2',
+      'provenance',
       'files:reconcile',
       'files:sync:session-1',
       'files:sync:session-2'

--- a/src/main/session-persistence/reconciliation-owner.ts
+++ b/src/main/session-persistence/reconciliation-owner.ts
@@ -320,7 +320,6 @@ class SessionPersistenceReconciliationOwner {
         }
       }
 
-      await this.provenance?.reconcileSessionDeletions(sessions)
       const projectReconciliations = new Map<string, ArtifactProjectReconciliationSnapshot>()
       if (this.artifactStorage) {
         for (const projectId of new Set(sessions.map((session) => session.projectId))) {
@@ -362,6 +361,10 @@ class SessionPersistenceReconciliationOwner {
           result = { ...result, sessions }
         }
       }
+      // Message snapshot repair needs the authoritative Artifact attachments recovered above;
+      // otherwise a ready snapshot can be compared against incomplete Session JSON and stay
+      // unavailable even after the Session is repaired later in this same startup pass.
+      await this.provenance?.reconcileSessionDeletions(sessions)
       // Restore active owners before scan-order-dependent sync offers canonical rows elsewhere.
       await this.fileIndex.reconcileActiveSessions(sessions)
       for (const session of sessions) {

--- a/src/main/session-persistence/reconciliation-owner.ts
+++ b/src/main/session-persistence/reconciliation-owner.ts
@@ -29,6 +29,8 @@ type SessionReconciliationFileIndex = {
 type SessionReconciliationProvenance = {
   captureFinalizedMessages(session: PersistedChatSession): Promise<void>
   reconcileSessionDeletions(activeSessions: PersistedChatSession[]): Promise<void>
+  reconcileSessionCleanup?(activeSessions: PersistedChatSession[]): Promise<void>
+  reconcileMessageSnapshots?(activeSessions: PersistedChatSession[]): Promise<void>
 }
 
 type SessionPermissionGrantReconciliation = {
@@ -289,6 +291,16 @@ class SessionPersistenceReconciliationOwner {
 
     input.phase('reconcile-derived-state')
     try {
+      const provenance = this.provenance
+      const splitProvenance =
+        provenance?.reconcileSessionCleanup && provenance.reconcileMessageSnapshots
+          ? {
+              reconcileSessionCleanup: provenance.reconcileSessionCleanup.bind(provenance),
+              reconcileMessageSnapshots: provenance.reconcileMessageSnapshots.bind(provenance)
+            }
+          : undefined
+      await splitProvenance?.reconcileSessionCleanup(sessions)
+
       if (this.uploads) {
         for (let index = 0; index < sessions.length; index += 1) {
           const session = sessions[index]
@@ -364,7 +376,8 @@ class SessionPersistenceReconciliationOwner {
       // Message snapshot repair needs the authoritative Artifact attachments recovered above;
       // otherwise a ready snapshot can be compared against incomplete Session JSON and stay
       // unavailable even after the Session is repaired later in this same startup pass.
-      await this.provenance?.reconcileSessionDeletions(sessions)
+      if (splitProvenance) await splitProvenance.reconcileMessageSnapshots(sessions)
+      else await this.provenance?.reconcileSessionDeletions(sessions)
       // Restore active owners before scan-order-dependent sync offers canonical rows elsewhere.
       await this.fileIndex.reconcileActiveSessions(sessions)
       for (const session of sessions) {


### PR DESCRIPTION
## Problem

Message snapshot publication renamed its staging file and marked the database row ready without flushing either the file or the published directory. A power-loss window could therefore leave ready metadata pointing at bytes that never became durable. Startup reconciliation only handled staging rows and could not repair a missing or corrupt ready sidecar.

## Proposed change

- Flush each snapshot staging file, rename it, flush both directory trees through the storage root, revalidate the published bytes, and only then mark the row ready.
- Keep a valid staging row for retry when its durability barrier or database promotion fails, and recover directly from the pre-rename staging file when the final path does not yet exist.
- During startup, validate ready snapshots for Sessions whose persisted graph is still available and reconstruct missing or corrupt sidecars only when the rebuilt bytes match the existing checksum.
- Run ready-snapshot repair after Artifact reconciliation restores authoritative Session attachments.
- Batch ready-snapshot lookup by 400 distinct active Sessions to stay below SQLite expression and parameter limits.

## Compatibility and persistence

- No database schema, field, migration, lifecycle-state, renderer, or interaction changes.
- Historical ready rows with an empty checksum remain readable and receive a checksum when their existing bytes validate structurally.
- Missing or corrupt checksumless snapshots remain unavailable because mutable Session state cannot prove the original history.
- Historical snapshots whose Session JSON has already been deleted remain unreconstructable and fail closed.

## Regression evidence

The tests were first run against the unfixed behavior and failed with the reported symptoms:

- Publication transitioned from staging to ready without file or directory sync.
- Startup left a removed ready sidecar missing with ENOENT.
- A valid staging-only sidecar was deleted instead of recovered.
- Recovery before Artifact reconciliation could not reconstruct attachment-backed snapshots.
- An unbounded 20,001-Session query exceeded SQLite's expression-tree limit.
- Cross-directory rename omitted the staging-directory durability barrier.
- Replacing staging bytes after initial validation could promote incorrect bytes to ready.
- Recursively created ancestor directory entries were not synced.

Final validation after rebasing onto current main:

- `npm run test:module -- artifact_provenance`: 27 files, 1665 tests passed.
- `npm run typecheck:node`: passed.
- `npm run lint`: passed.

The full local `npm run test` suite was intentionally not run; PR CI remains authoritative for the complete portable and platform-specific plans.

## Review focus

- Durability ordering before the ready transaction.
- Fail-closed checksum preservation during startup reconstruction.
- Recovery ordering after Artifact attachment repair.
