### PR TITLE
refactor(session-persistence): expose narrow capability views

### DIFF
--- a/src/main/acp/durable-continuation-context-owner.ts
+++ b/src/main/acp/durable-continuation-context-owner.ts
@@ -18,14 +18,11 @@ import {
   sanitizeSessionReferences,
   type PersistedChatSession
 } from '../../shared/session-persistence'
-import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type { SessionCatalog, SessionMutation } from '../session-persistence/coordinator'
 import { validateElicitationAnswers } from './elicitation-owner'
 
-type DurableContinuationSessions = Pick<
-  SessionPersistenceCoordinator,
-  'loadSessionForContinuation'
-> &
-  Partial<Pick<SessionPersistenceCoordinator, 'appendUserMessageToInteraction'>>
+type DurableContinuationSessions = Pick<SessionCatalog, 'loadSessionForContinuation'> &
+  Partial<SessionMutation>
 
 type DurableContinuationPreparation = Readonly<{
   provenanceContext: NonNullable<AcpPromptRequest['provenanceContext']>

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -5,17 +5,16 @@ import {
   type SessionPermissionRuntimeContext,
   type SessionRuntimeContext
 } from '../../shared/session-persistence'
-import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type {
+  SessionCatalog,
+  SessionMutation,
+  SessionRuntimeContextCommands
+} from '../session-persistence/coordinator'
 import type { DurablePermissionWaitCandidate } from './permission-broker'
 
-type PermissionWaitSessions = Pick<
-  SessionPersistenceCoordinator,
-  | 'readSessionRuntimeContext'
-  | 'patchSessionRuntimeContext'
-  | 'containsMessageOnActiveBranch'
-  | 'loadSessionForContinuation'
-> &
-  Partial<Pick<SessionPersistenceCoordinator, 'sessionProjectId'>>
+type PermissionWaitSessions = SessionRuntimeContextCommands &
+  Pick<SessionCatalog, 'containsMessageOnActiveBranch' | 'loadSessionForContinuation'> &
+  Partial<Pick<SessionCatalog, 'sessionProjectId'> & SessionMutation>
 
 type RestoredPermissionDecision = Readonly<{
   permission: SessionPermissionRuntimeContext

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -43,7 +43,11 @@ import {
 import type { SpecialistService } from '../specialist/service'
 import { resolveConfigRoot, resolveDataRoot, resolveStorageRoot } from '../storage-root'
 import type { UploadRepository } from '../uploads/repository'
-import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type {
+  SessionCatalog,
+  SessionMutation,
+  SessionRuntimeContextCommands
+} from '../session-persistence/coordinator'
 import type { LiteratureDocumentReader } from '../literature/document-reader'
 import type { NotebookRpcConnection } from '../notebook/mcp-server'
 import type { ResolvedAgentBackend } from '../agent-framework'
@@ -145,15 +149,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
   beforeSessionDelete?: (sessionId: string) => Promise<void>
   afterSessionDelete?: (sessionId: string, retained: boolean) => void
   specialistService?: SpecialistService
-  sessionPersistenceCoordinator?: Pick<
-    SessionPersistenceCoordinator,
-    | 'readSessionRuntimeContext'
-    | 'patchSessionRuntimeContext'
-    | 'appendUserMessageToInteraction'
-    | 'containsMessageOnActiveBranch'
-    | 'loadSessionForContinuation'
-    | 'sessionProjectId'
-  >
+  sessionPersistenceCoordinator?: SessionRuntimeContextCommands & SessionMutation & SessionCatalog
   literatureReader?: Pick<LiteratureDocumentReader, 'readCurrent'>
   delegatedWork?: RootDelegatedWorkControl
   fixedBackend?: ResolvedAgentBackend

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -146,7 +146,11 @@ import {
 import type { PlanResponseResult, PlanServiceDependencies } from '../session-plan/plan-service'
 import { SessionPlanContinuationOwner } from './session-plan-continuation-owner'
 import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
-import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type {
+  SessionCatalog,
+  SessionMutation,
+  SessionRuntimeContextCommands
+} from '../session-persistence/coordinator'
 import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
 import type { AcpRuntimePublicationOwner } from './runtime-publication-owner'
 import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
@@ -221,16 +225,9 @@ type AcpRuntimeOptions = {
   skills?: AcpTurnSkillHooks
   plan?: AcpRuntimePlanOptions
   permissionWait?: {
-    sessions: Pick<
-      SessionPersistenceCoordinator,
-      | 'readSessionRuntimeContext'
-      | 'patchSessionRuntimeContext'
-      | 'containsMessageOnActiveBranch'
-      | 'loadSessionForContinuation'
-    > &
-      Partial<
-        Pick<SessionPersistenceCoordinator, 'appendUserMessageToInteraction' | 'sessionProjectId'>
-      >
+    sessions: SessionRuntimeContextCommands &
+      Pick<SessionCatalog, 'containsMessageOnActiveBranch' | 'loadSessionForContinuation'> &
+      Partial<Pick<SessionCatalog, 'sessionProjectId'> & SessionMutation>
     onSessionUpdated?: import('./permission-wait-owner').PublishPermissionWaitSession
     onContinuationSessionUpdated?: import('./permission-wait-owner').PublishPermissionWaitSession
   }
@@ -395,14 +392,9 @@ type AcpRuntimePlanOptions = {
     projectId: string
   }) => Promise<NotebookRpcConnection>
   registerSessionAlias?: (aliasSessionId: string, sessionId: string) => void
-  sessions: Pick<
-    SessionPersistenceCoordinator,
-    | 'readSessionRuntimeContext'
-    | 'patchSessionRuntimeContext'
-    | 'appendUserMessageToInteraction'
-    | 'containsMessageOnActiveBranch'
-    | 'loadSessionForContinuation'
-  >
+  sessions: SessionRuntimeContextCommands &
+    SessionMutation &
+    Pick<SessionCatalog, 'containsMessageOnActiveBranch' | 'loadSessionForContinuation'>
   onApprovalRequested?: PlanServiceDependencies['onApprovalRequested']
   onApprovalSettled?: PlanServiceDependencies['onApprovalSettled']
 }

--- a/src/main/acp/session-plan-continuation-owner.ts
+++ b/src/main/acp/session-plan-continuation-owner.ts
@@ -1,10 +1,7 @@
 import type { SessionPlanContinuation } from '../../shared/session-persistence'
-import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type { SessionRuntimeContextCommands } from '../session-persistence/coordinator'
 
-type SessionPlanContinuationSessions = Pick<
-  SessionPersistenceCoordinator,
-  'readSessionRuntimeContext' | 'patchSessionRuntimeContext'
->
+type SessionPlanContinuationSessions = SessionRuntimeContextCommands
 
 const isRevisionConflict = (error: unknown): boolean =>
   typeof error === 'object' &&

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -242,7 +242,8 @@ import {
 } from './permission-grants/reconciliation'
 import {
   SessionPersistenceCoordinator,
-  type ComputeJobDeletionParticipant
+  type ComputeJobDeletionParticipant,
+  type SessionDeletion
 } from './session-persistence/coordinator'
 import { withSessionCacheDeletion } from './compute/session-cache-owner'
 import { createMainPromptSideChatRelay } from './side-chat/main-prompt-relay'
@@ -452,7 +453,7 @@ export type ApplicationRuntimeInterfaces = {
   taskAgent: TaskAgentPort
   taskControls: TaskControlPorts
   computePreferences: Pick<SessionEnabledComputeHostsOwner, 'withReservation' | 'set'>
-  sessionDeletionCapability: Pick<SessionPersistenceCoordinator, 'setSessionDeletionHandlers'>
+  sessionDeletionCapability: Pick<SessionDeletion, 'setSessionDeletionHandlers'>
   archiveCapability: Pick<ArchiveCoordinator, 'isSessionAvailableById' | 'setMarkReadSessions'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
   hasActiveReviewerWork: () => boolean

--- a/src/main/literature/document-reader.ts
+++ b/src/main/literature/document-reader.ts
@@ -9,7 +9,7 @@ import type {
 import type { NotebookRunInputFile } from '../../shared/notebook'
 import type { ImmutableInputAuthority } from '../immutable-input-authority'
 import { createLogger, errorLogFields } from '../logger'
-import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type { SessionCatalog } from '../session-persistence/coordinator'
 import { extractPdfText } from '../uploads/attachment-media'
 import { LiteratureFullTextIndex, type LiteratureIndexChunk } from './full-text-index'
 import type { LiteratureReadDocumentRequest } from './mcp-server'
@@ -34,7 +34,7 @@ type LiteratureDocumentReaderOptions = Readonly<{
     // Test-only compatibility for fixtures that predate immutable read leases.
     resolveContent?: (input: NotebookRunInputFile) => Promise<string>
   }
-  sessions: Pick<SessionPersistenceCoordinator, 'loadSessionForContinuation'>
+  sessions: Pick<SessionCatalog, 'loadSessionForContinuation'>
 }>
 
 type ReadCurrentLiteratureRequest = Readonly<{

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -369,6 +369,36 @@ const constructionSites = (className: string): string[] => {
   return sites.sort()
 }
 
+const concreteCoordinatorConsumerFiles = (): string[] =>
+  findTypeScriptFiles(resolve(projectRoot, 'src/main'))
+    .filter((path) => !path.endsWith('/session-persistence/coordinator.ts'))
+    .filter((path) => path !== resolve(projectRoot, 'src/main/ipc.ts'))
+    .filter((path) => {
+      const sourceFile = createSourceFile(
+        path,
+        readFileSync(path, 'utf8'),
+        ScriptTarget.Latest,
+        true,
+        ScriptKind.TS
+      )
+      return sourceFile.statements.filter(isImportDeclaration).some((statement) => {
+        if (!isStringLiteralLike(statement.moduleSpecifier)) return false
+        const importedPath = resolve(path, '..', statement.moduleSpecifier.text)
+        if (importedPath !== resolve(__dirname, 'coordinator')) return false
+        const bindings = statement.importClause?.namedBindings
+        return (
+          bindings !== undefined &&
+          isNamedImports(bindings) &&
+          bindings.elements.some(
+            (element) =>
+              (element.propertyName ?? element.name).text === 'SessionPersistenceCoordinator'
+          )
+        )
+      })
+    })
+    .map((path) => relative(projectRoot, path).split(sep).join('/'))
+    .sort()
+
 type ModuleImpactManifest = {
   modules: Record<
     string,
@@ -506,16 +536,25 @@ describe('Session persistence coordinator architecture', () => {
     expect(exportedNames(facadeFile, 'type')).toEqual(
       [
         'ComputeJobDeletionParticipant',
+        'DelegatedWorkRecordCommands',
         'PatchSessionRuntimeContextCommand',
         'ProjectSessionDeletionResult',
+        'SessionCatalog',
+        'SessionDeletion',
         'SessionDeletionHandlers',
         'SessionFileIndex',
         'SessionMetadata',
         'SessionMetadataSnapshot',
+        'SessionMutation',
         'SessionMutationRepository',
-        'SessionProvenancePersistence'
+        'SessionProvenancePersistence',
+        'SessionRuntimeContextCommands'
       ].sort()
     )
+  })
+
+  it('keeps production consumers on named capability views', () => {
+    expect(concreteCoordinatorConsumerFiles()).toEqual([])
   })
 
   it('composes each owner once and keeps mutable state with its sole owner', () => {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1083,15 +1083,43 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
 }
 const sessionKey = (projectId: string, sessionId: string): string => `${projectId}:${sessionId}`
 
+type SessionCatalog = Pick<
+  SessionPersistenceCoordinator,
+  'containsMessageOnActiveBranch' | 'loadSessionForContinuation' | 'sessionProjectId'
+>
+type SessionMutation = Pick<SessionPersistenceCoordinator, 'appendUserMessageToInteraction'>
+type SessionRuntimeContextCommands = Pick<
+  SessionPersistenceCoordinator,
+  'readSessionRuntimeContext' | 'patchSessionRuntimeContext'
+>
+type SessionDeletion = Pick<
+  SessionPersistenceCoordinator,
+  | 'assertProjectArchivable'
+  | 'assertSessionAvailable'
+  | 'completeProjectSessionDeletion'
+  | 'deleteProjectSessions'
+  | 'deleteSession'
+  | 'getProjectSessionDeletionState'
+  | 'listLegacyProjectSessionTombstones'
+  | 'markCommittedProjectSessionsPrepared'
+  | 'setSessionDeletionHandlers'
+  | 'updateArchive'
+>
+
 export { SessionPersistenceCoordinator, SessionRuntimeContextRevisionConflictError }
 export type {
   ComputeJobDeletionParticipant,
+  DelegatedWorkRecordCommands,
   PatchSessionRuntimeContextCommand,
   ProjectSessionDeletionResult,
+  SessionCatalog,
+  SessionDeletion,
   SessionDeletionHandlers,
   SessionFileIndex,
   SessionMetadata,
   SessionMetadataSnapshot,
+  SessionMutation,
   SessionMutationRepository,
-  SessionProvenancePersistence
+  SessionProvenancePersistence,
+  SessionRuntimeContextCommands
 }

--- a/src/main/session-persistence/pdf-context-owner.ts
+++ b/src/main/session-persistence/pdf-context-owner.ts
@@ -15,7 +15,7 @@ import type { NotebookRunInputFile } from '../../shared/notebook'
 import type { ImmutableInputAuthority } from '../immutable-input-authority'
 import { createLogger, errorLogFields } from '../logger'
 import { inspectPdfPageCount, MAX_AUTO_EXTRACT_PDF_BYTES } from '../uploads/attachment-media'
-import type { SessionPersistenceCoordinator } from './coordinator'
+import type { SessionRuntimeContextCommands } from './coordinator'
 
 const log = createLogger('literature-reading-context')
 
@@ -28,10 +28,7 @@ type SessionPdfContextOwnerOptions = Readonly<{
   pendingUploads?: Readonly<{
     resolveContent: (request: { projectId: string; path: string }) => Promise<string>
   }>
-  sessions: Pick<
-    SessionPersistenceCoordinator,
-    'readSessionRuntimeContext' | 'patchSessionRuntimeContext'
-  >
+  sessions: SessionRuntimeContextCommands
 }>
 
 type SessionPdfContextLinkResult = Readonly<{

--- a/src/main/session-plan/production-plan-service.ts
+++ b/src/main/session-plan/production-plan-service.ts
@@ -1,6 +1,9 @@
 import type { ArtifactTurnOwner } from '../acp/artifact-turn-owner'
 import type { ManagedFileVersionService } from '../managed-file-versions/service'
-import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type {
+  SessionMutation,
+  SessionRuntimeContextCommands
+} from '../session-persistence/coordinator'
 import { SessionRuntimeContextRevisionConflictError } from '../session-persistence/coordinator'
 import { PlanService, type PlanServiceDependencies } from './plan-service'
 import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
@@ -9,10 +12,7 @@ type ProductionPlanServiceDependencies = Readonly<{
   interactions?: SessionPlanInteractionOwner
   artifactTurns: Pick<ArtifactTurnOwner, 'handleForExecution' | 'write'>
   managedFileVersions: Pick<ManagedFileVersionService, 'openUnpublishedVersion'>
-  sessions: Pick<
-    SessionPersistenceCoordinator,
-    'readSessionRuntimeContext' | 'patchSessionRuntimeContext' | 'appendUserMessageToInteraction'
-  >
+  sessions: SessionRuntimeContextCommands & SessionMutation
   onApprovalRequested?: PlanServiceDependencies['onApprovalRequested']
   onApprovalSettled?: PlanServiceDependencies['onApprovalSettled']
 }>


### PR DESCRIPTION
## Problem

SessionPersistenceCoordinator owns about sixty methods across catalog, mutation, runtime-context, delegated-work, deletion, repair, and manifest workflows. Production consumers outside the composition root derived local Picks directly from the concrete class, so they remained coupled to its unrestricted method namespace.

## Proposed change

- Export named Session catalog, mutation, runtime-context, and deletion capability views.
- Re-export the existing delegated-work command contract instead of introducing a duplicate abstraction.
- Move eight production consumers from concrete-class Picks to the named views.
- Add an AST architecture regression that permits the concrete class only at the src/main/ipc.ts construction root.

The coordinator remains the sole owner of its scheduler, global/project/session ordering, owner composition, and deletion fences.

## Scope and non-goals

This is a compile-time interface refactor only. It does not move methods, create runtime wrappers, split owners, or change object identity and call ordering.

There are no new data fields, enum or status values, data-model changes, UI changes, persistence-format changes, migrations, or historical-compatibility requirements.

## Acceptance criteria and validation

The regression test was first run against the unmodified implementation and failed with the eight concrete-class consumer files named in the assertion. After the final material edit:

- production dependency seam -> npx vitest run src/main/session-persistence/coordinator.architecture.test.ts -> 9 tests passed
- Session persistence owner, contract, and representative consumers -> npm run test:module -- session_persistence -> 9 files and 509 tests passed
- affected Main-process types -> npm run typecheck:node -> passed
- linted source and test changes -> npm run lint -> passed
- final impact selection -> npm run test:affected:explain -- --base origin/main --head HEAD -> full fallback because an ACP consumer path has no module owner

The complete local npm test suite was intentionally not run per maintainer instruction. PR CI is the authority for the fallback suite and platform lanes.

## Review focus

Please verify that each named capability remains no wider than the methods required by its consumers, and that no scheduler, fence, persistence behavior, or runtime object wiring changed.