### PR TITLE
fix(conversation-graph): validate semantic relationships

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -21571,7 +21571,7 @@ describe('ACP runtime session management', () => {
         {
           id: 'agent-frame-1',
           parentFrameId: 'root-frame-1',
-          originMessageId: 'message-parent',
+          originMessageId: 'root-origin',
           originBindingState: 'validated' as const,
           kind: 'compatibility' as const,
           status: 'completed' as const,
@@ -21584,6 +21584,7 @@ describe('ACP runtime session management', () => {
         {
           id: 'root-branch',
           agentFrameId: 'root-frame-1',
+          headMessageId: 'root-origin',
           createdAt,
           updatedAt: createdAt
         },
@@ -21605,6 +21606,17 @@ describe('ACP runtime session management', () => {
         }
       ],
       messages: [
+        {
+          id: 'root-origin',
+          role: 'user' as const,
+          content: 'Delegate the restored task',
+          status: 'complete' as const,
+          eventIds: [],
+          createdAt: createdAt - 1,
+          updatedAt: createdAt - 1,
+          agentFrameId: 'root-frame-1',
+          introducedOnBranchId: 'root-branch'
+        },
         {
           id: 'message-parent',
           role: 'user' as const,
@@ -21663,7 +21675,9 @@ describe('ACP runtime session management', () => {
       title: 'Restored session',
       cwd: '/workspace',
       status: 'idle',
-      messages: conversationGraph.messages.map(projectConversationMessage),
+      messages: conversationGraph.messages
+        .filter((message) => message.agentFrameId === conversationGraph.activeFrameId)
+        .map(projectConversationMessage),
       conversationGraph,
       createdAt,
       updatedAt: createdAt + 2

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -208,7 +208,8 @@ const startFixLoopFakeAgent = (
         // In the real app, the session JSON is updated by the ACP runtime's handleSessionUpdate.
         // In tests, we update the shared session data here.
         const correctionMsgId = `correction-msg-${state.correctionCount}`
-        const auditorMsgId = `auditor-msg-${state.correctionCount}`
+        const auditorMsgId = sessionData.correctionPromptMessageId
+        if (!auditorMsgId) throw new Error('Correction prompt message id was not captured')
         const currentMsgs = sessionData.getSession().messages
         // Add: [Auditor] user message + agent correction response
         const updatedSession: PersistedChatSession = {

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -56,6 +56,16 @@ const createSession = (overrides: Partial<PersistedChatSession> = {}): Persisted
   ...overrides
 })
 
+const createUserMessage = (id: string, createdAt: number): PersistedChatMessage => ({
+  id,
+  role: 'user',
+  content: id,
+  status: 'complete',
+  eventIds: [],
+  createdAt,
+  updatedAt: createdAt
+})
+
 const createIdleSessionWithRunningChild = (originMessageId = 'root-prompt'): PersistedChatSession =>
   createSession({
     conversationGraph: {
@@ -784,6 +794,7 @@ describe('SessionPersistenceCoordinator', () => {
   it('persists blocked Plan feedback as a standard user Message without changing Plan authority', async () => {
     let durable = createSession({
       status: 'waiting-plan-approval',
+      messages: [createUserMessage('interaction-1', 1)],
       runtimeContext: { version: 1, revision: 2, plan: createRuntimePlan() }
     })
     const repository = createSessionRepository({
@@ -807,7 +818,10 @@ describe('SessionPersistenceCoordinator', () => {
     })
 
     expect(beforePersist).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'session-1', messages: [] })
+      expect.objectContaining({
+        id: 'session-1',
+        messages: [expect.objectContaining({ id: 'interaction-1' })]
+      })
     )
     expect(durable.messages).toContainEqual(
       expect.objectContaining({
@@ -828,6 +842,7 @@ describe('SessionPersistenceCoordinator', () => {
   it('atomically persists Plan feedback and its neutral review marker in one Session save', async () => {
     let durable = createSession({
       status: 'waiting-plan-approval',
+      messages: [createUserMessage('interaction-1', 1)],
       runtimeContext: { version: 1, revision: 2, plan: createRuntimePlan() }
     })
     const repository = createSessionRepository({
@@ -883,7 +898,9 @@ describe('SessionPersistenceCoordinator', () => {
     expect(publishRuntimeContextSession).toHaveBeenCalledOnce()
     expect(publishRuntimeContextSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        messages: [expect.objectContaining({ content: 'Split the analysis by cohort.' })],
+        messages: expect.arrayContaining([
+          expect.objectContaining({ content: 'Split the analysis by cohort.' })
+        ]),
         runtimeContext: expect.objectContaining({ revision: 3 })
       }),
       'runtime-context'
@@ -944,7 +961,7 @@ describe('SessionPersistenceCoordinator', () => {
   })
 
   it('publishes the parent Session after every Side chat mutation', async () => {
-    let durable = createSession()
+    let durable = createSession({ messages: [createUserMessage('main-prompt-1', 1)] })
     const repository = createSessionRepository({
       loadSessionWithDiagnostics: vi.fn(async () => ({
         status: 'found' as const,
@@ -1004,6 +1021,7 @@ describe('SessionPersistenceCoordinator', () => {
 
   it('keeps durable relays deliverable after clearing their producer Side chat', async () => {
     let durable = createSession({
+      messages: [createUserMessage('main-prompt-1', 1), createUserMessage('main-prompt-2', 2)],
       runtimeContext: {
         version: 1,
         revision: 5,

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -317,6 +317,9 @@ describe('workspace runtime events', () => {
         causeReviewId: 'review-1'
       }
     })
+    expect(
+      storedSession.messages.find((message) => message.id === 'reviewer-correction-1')
+    ).not.toHaveProperty('responseToMessageId')
     expect(originalPromptMessageId).not.toBe('reviewer-correction-1')
     const correctionResponse = storedSession.messages.find(
       (message) =>

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -722,7 +722,9 @@ const applyWorkspaceRuntimeEvent = async (
       ...(sanitizeMessageAttribution(event.attribution)
         ? { attribution: sanitizeMessageAttribution(event.attribution) }
         : {}),
-      ...(event.promptMessageId ? { responseToMessageId: event.promptMessageId } : {}),
+      ...(event.promptMessageId && event.promptMessageId !== event.messageId
+        ? { responseToMessageId: event.promptMessageId }
+        : {}),
       ...(event.uploads && event.uploads.length > 0 ? { uploads: event.uploads } : {}),
       ...(event.parts && event.parts.length > 0 ? { parts: event.parts } : {})
     })

--- a/src/shared/conversation-graph.test.ts
+++ b/src/shared/conversation-graph.test.ts
@@ -67,6 +67,41 @@ const graphWithActivityGroup = (): ReturnType<typeof synchronizeActiveConversati
     ]
   )
 
+const graphWithChildFrame = (): ReturnType<typeof createLinearConversationGraph> => {
+  const graph = createLinearConversationGraph({
+    sessionId: 'session-1',
+    messages: [message('u1', 'user', 'question', 1), message('a1', 'agent', 'answer', 2)],
+    frameworkId: 'claude-code',
+    createdAt: 1,
+    updatedAt: 2
+  })
+  graph.frames.push({
+    id: 'child-frame',
+    parentFrameId: graph.rootFrameId,
+    originMessageId: 'u1',
+    originBindingState: 'validated',
+    kind: 'delegate',
+    status: 'completed',
+    activeBranchId: 'child-branch',
+    createdAt: 3,
+    completedAt: 4
+  })
+  graph.branches.push({
+    id: 'child-branch',
+    agentFrameId: 'child-frame',
+    headMessageId: 'child-u1',
+    createdAt: 3,
+    updatedAt: 4
+  })
+  graph.messages.push({
+    ...message('child-u1', 'user', 'delegated question', 3),
+    agentFrameId: 'child-frame',
+    introducedOnBranchId: 'child-branch',
+    revisionRootMessageId: 'child-u1'
+  })
+  return graph
+}
+
 describe('conversation graph', () => {
   it('forks an edited user Message without deleting the original downstream path', () => {
     const originalMessages = [
@@ -710,6 +745,140 @@ describe('conversation graph', () => {
     })
 
     expect(() => validateConversationGraph(graph)).toThrow(/Non-root Agent Frame is invalid/)
+  })
+
+  it.each([
+    {
+      relationship: 'validated Frame without an origin Message',
+      mutate: (graph: ReturnType<typeof graphWithChildFrame>) => {
+        delete graph.frames[1].originMessageId
+      }
+    },
+    {
+      relationship: 'validated Frame origin outside its parent Frame',
+      mutate: (graph: ReturnType<typeof graphWithChildFrame>) => {
+        graph.frames[1].originMessageId = 'child-u1'
+      }
+    },
+    {
+      relationship: 'legacy-unavailable Frame carrying an origin Message',
+      mutate: (graph: ReturnType<typeof graphWithChildFrame>) => {
+        graph.frames[1].originBindingState = 'legacy-unavailable'
+      }
+    }
+  ])('rejects a $relationship', ({ mutate }) => {
+    const graph = graphWithChildFrame()
+    mutate(graph)
+
+    expect(() => validateConversationGraph(graph)).toThrow(/Agent Frame origin Message is invalid/)
+  })
+
+  it('rejects an active child Frame whose origin is hidden on its parent current Branch', () => {
+    const graph = graphWithChildFrame()
+    const originalBranchId = graph.branches[0].id
+    graph.activeFrameId = graph.rootFrameId
+    const edited = synchronizeActiveConversationMessages(
+      forkEditedConversationMessage(graph, 'u1', 'branch-edited', 5),
+      [message('u2', 'user', 'revision', 5), message('a2', 'agent', 'new answer', 6)],
+      6
+    )
+    expect(() => validateConversationGraph(edited)).not.toThrow()
+    edited.activeFrameId = 'child-frame'
+
+    expect(edited.frames[0].activeBranchId).not.toBe(originalBranchId)
+    expect(() => validateConversationGraph(edited)).toThrow(
+      /Active Agent Frame origin is not on its parent current Branch/
+    )
+  })
+
+  it('rejects responseToMessageId outside the response Message path', () => {
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [message('u1', 'user', 'question', 1), message('a1', 'agent', 'answer', 2)],
+      frameworkId: 'claude-code',
+      createdAt: 1,
+      updatedAt: 2
+    })
+    const edited = synchronizeActiveConversationMessages(
+      forkEditedConversationMessage(graph, 'u1', 'branch-edited', 3),
+      [
+        message('u2', 'user', 'edited question', 3),
+        { ...message('a2', 'agent', 'edited answer', 4), responseToMessageId: 'u2' }
+      ],
+      4
+    )
+    edited.messages.find(({ id }) => id === 'a2')!.responseToMessageId = 'u1'
+
+    expect(() => validateConversationGraph(edited)).toThrow(/Message response target is invalid/)
+  })
+
+  it('accepts routed user Messages linked to an earlier user or Agent Message on the same path', () => {
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [
+        message('u1', 'user', 'question', 1),
+        { ...message('a1', 'agent', 'choose an option', 2), responseToMessageId: 'u1' },
+        { ...message('u2', 'user', 'option one', 3), responseToMessageId: 'a1' },
+        { ...message('u3', 'user', 'additional context', 4), responseToMessageId: 'u1' }
+      ],
+      frameworkId: 'claude-code',
+      createdAt: 1,
+      updatedAt: 4
+    })
+
+    expect(() => validateConversationGraph(graph)).not.toThrow()
+  })
+
+  it('rejects an Agent response linked to another Agent Message', () => {
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [
+        message('u1', 'user', 'question', 1),
+        { ...message('a1', 'agent', 'first part', 2), responseToMessageId: 'u1' },
+        { ...message('a2', 'agent', 'second part', 3), responseToMessageId: 'a1' }
+      ],
+      frameworkId: 'claude-code',
+      createdAt: 1,
+      updatedAt: 3
+    })
+
+    expect(() => validateConversationGraph(graph)).toThrow(/Message response target is invalid/)
+  })
+
+  it('rejects revisionRootMessageId that does not identify a user Message', () => {
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [message('u1', 'user', 'question', 1), message('a1', 'agent', 'answer', 2)],
+      frameworkId: 'claude-code',
+      createdAt: 1,
+      updatedAt: 2
+    })
+    graph.messages[0].revisionRootMessageId = 'a1'
+
+    expect(() => validateConversationGraph(graph)).toThrow(/Message revision root is invalid/)
+  })
+
+  it('rejects Branch and Message revision links from different chains', () => {
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [
+        message('u1', 'user', 'first question', 1),
+        message('a1', 'agent', 'first answer', 2),
+        message('u2', 'user', 'second question', 3),
+        message('a2', 'agent', 'second answer', 4)
+      ],
+      frameworkId: 'claude-code',
+      createdAt: 1,
+      updatedAt: 4
+    })
+    const edited = synchronizeActiveConversationMessages(
+      forkEditedConversationMessage(graph, 'u2', 'branch-edited', 5),
+      [message('u3', 'user', 'edited second question', 5)],
+      5
+    )
+    edited.branches.find(({ id }) => id === 'branch-edited')!.supersededMessageId = 'u1'
+
+    expect(() => validateConversationGraph(edited)).toThrow(/Message revision chain is invalid/)
   })
 
   it('rejects an Activity fork that is not on the Branch path', () => {

--- a/src/shared/conversation-graph.test.ts
+++ b/src/shared/conversation-graph.test.ts
@@ -858,6 +858,23 @@ describe('conversation graph', () => {
     expect(() => validateConversationGraph(graph)).toThrow(/Message revision root is invalid/)
   })
 
+  it('rejects an unrelated same-Frame revision root for an ordinary user Message', () => {
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [
+        message('u1', 'user', 'first question', 1),
+        message('a1', 'agent', 'first answer', 2),
+        message('u2', 'user', 'second question', 3)
+      ],
+      frameworkId: 'claude-code',
+      createdAt: 1,
+      updatedAt: 3
+    })
+    graph.messages.find(({ id }) => id === 'u2')!.revisionRootMessageId = 'u1'
+
+    expect(() => validateConversationGraph(graph)).toThrow(/Message revision root is invalid/)
+  })
+
   it('rejects Branch and Message revision links from different chains', () => {
     const graph = createLinearConversationGraph({
       sessionId: 'session-1',

--- a/src/shared/conversation-graph.ts
+++ b/src/shared/conversation-graph.ts
@@ -372,6 +372,12 @@ export const validateConversationGraph = (graph: PersistedConversationGraph): vo
       throw new Error('Non-root Agent Frame is invalid.')
     }
     if (!frame.parentFrameId) throw new Error('Agent Frame is detached from root.')
+    if (
+      (frame.originBindingState === 'validated' && !frame.originMessageId) ||
+      (frame.originBindingState === 'legacy-unavailable' && frame.originMessageId)
+    ) {
+      throw new Error('Agent Frame origin Message is invalid.')
+    }
     const parent = frames.get(frame.parentFrameId)
     if (!parent) throw new Error('Agent Frame parent is missing.')
     const children = frameChildren.get(parent.id)
@@ -412,6 +418,7 @@ export const validateConversationGraph = (graph: PersistedConversationGraph): vo
 
   const messageChildren = new Map<string, PersistedMessageNode[]>()
   const messageRoots: PersistedMessageNode[] = []
+  const branchEntryMessages = new Map<string, PersistedMessageNode[]>()
   for (const message of graph.messages) {
     const introducedOnBranch = branches.get(message.introducedOnBranchId)
     if (!introducedOnBranch || introducedOnBranch.agentFrameId !== message.agentFrameId) {
@@ -438,6 +445,12 @@ export const validateConversationGraph = (graph: PersistedConversationGraph): vo
       else messageChildren.set(parent.id, [message])
     } else {
       messageRoots.push(message)
+    }
+    const parent = message.parentMessageId ? messages.get(message.parentMessageId) : undefined
+    if (!parent || parent.introducedOnBranchId !== message.introducedOnBranchId) {
+      const entries = branchEntryMessages.get(message.introducedOnBranchId)
+      if (entries) entries.push(message)
+      else branchEntryMessages.set(message.introducedOnBranchId, [message])
     }
   }
   const messageAncestry = indexTreeAncestry(messageRoots, messageChildren)
@@ -502,6 +515,31 @@ export const validateConversationGraph = (graph: PersistedConversationGraph): vo
         throw new Error('Message Branch Activity fork is not on its parent path.')
       }
     }
+    if (branch.supersededMessageId) {
+      const superseded = messages.get(branch.supersededMessageId)
+      if (
+        !parentBranch ||
+        !parentHead ||
+        !superseded ||
+        superseded.agentFrameId !== branch.agentFrameId ||
+        superseded.parentMessageId !== branch.forkMessageId ||
+        !isTreeAncestor(messageAncestry, superseded.id, parentHead.id)
+      ) {
+        throw new Error('Message revision chain is invalid.')
+      }
+      if (superseded.role === 'user' && branch.headMessageId !== branch.forkMessageId) {
+        const replacement = branchEntryMessages
+          .get(branch.id)
+          ?.find((message) => message.parentMessageId === branch.forkMessageId)
+        if (
+          !replacement ||
+          replacement.role !== 'user' ||
+          replacement.supersedesMessageId !== superseded.id
+        ) {
+          throw new Error('Message revision chain is invalid.')
+        }
+      }
+    }
     let current = head
     while (current && !reachableMessages.has(current.id)) {
       reachableMessages.add(current.id)
@@ -511,6 +549,67 @@ export const validateConversationGraph = (graph: PersistedConversationGraph): vo
   if (reachableMessages.size !== graph.messages.length) {
     const unreachable = graph.messages.find((message) => !reachableMessages.has(message.id))
     throw new Error(`Conversation Message is not reachable from any Branch: ${unreachable?.id}`)
+  }
+
+  for (const frame of graph.frames) {
+    if (frame.id === graph.rootFrameId || frame.originBindingState !== 'validated') continue
+    const origin = frame.originMessageId ? messages.get(frame.originMessageId) : undefined
+    if (!origin || origin.agentFrameId !== frame.parentFrameId) {
+      throw new Error('Agent Frame origin Message is invalid.')
+    }
+  }
+
+  let activeFrame = frames.get(graph.activeFrameId)!
+  while (activeFrame.parentFrameId) {
+    const parent = frames.get(activeFrame.parentFrameId)!
+    const origin = activeFrame.originMessageId
+      ? messages.get(activeFrame.originMessageId)
+      : undefined
+    const parentHead = branchHeads.get(parent.activeBranchId)
+    if (
+      activeFrame.originBindingState !== 'validated' ||
+      !origin ||
+      !parentHead ||
+      !isTreeAncestor(messageAncestry, origin.id, parentHead.id)
+    ) {
+      throw new Error('Active Agent Frame origin is not on its parent current Branch.')
+    }
+    activeFrame = parent
+  }
+
+  for (const message of graph.messages) {
+    if (message.responseToMessageId) {
+      const target = messages.get(message.responseToMessageId)
+      if (
+        !target ||
+        target.id === message.id ||
+        target.agentFrameId !== message.agentFrameId ||
+        !isTreeAncestor(messageAncestry, target.id, message.id) ||
+        (message.role === 'agent' && target.role !== 'user')
+      ) {
+        throw new Error('Message response target is invalid.')
+      }
+    }
+    if (message.revisionRootMessageId) {
+      const root = messages.get(message.revisionRootMessageId)
+      if (!root || root.role !== 'user' || root.agentFrameId !== message.agentFrameId) {
+        throw new Error('Message revision root is invalid.')
+      }
+    }
+    if (message.supersedesMessageId) {
+      const superseded = messages.get(message.supersedesMessageId)
+      const branch = branches.get(message.introducedOnBranchId)
+      if (
+        message.role !== 'user' ||
+        !superseded ||
+        superseded.role !== 'user' ||
+        superseded.agentFrameId !== message.agentFrameId ||
+        branch?.supersededMessageId !== superseded.id ||
+        message.revisionRootMessageId !== (superseded.revisionRootMessageId ?? superseded.id)
+      ) {
+        throw new Error('Message revision chain is invalid.')
+      }
+    }
   }
 
   for (const group of graph.activityGroups) {

--- a/src/shared/conversation-graph.ts
+++ b/src/shared/conversation-graph.ts
@@ -592,7 +592,13 @@ export const validateConversationGraph = (graph: PersistedConversationGraph): vo
     }
     if (message.revisionRootMessageId) {
       const root = messages.get(message.revisionRootMessageId)
-      if (!root || root.role !== 'user' || root.agentFrameId !== message.agentFrameId) {
+      if (
+        message.role !== 'user' ||
+        !root ||
+        root.role !== 'user' ||
+        root.agentFrameId !== message.agentFrameId ||
+        (!message.supersedesMessageId && root.id !== message.id)
+      ) {
         throw new Error('Message revision root is invalid.')
       }
     }

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -395,6 +395,41 @@ describe('conversation graph materialization diagnostics', () => {
     ).toEqual({ status: 'invalid' })
   })
 
+  it('normalizes a historical routed user Message that responds to itself', () => {
+    const messages: PersistedChatMessage[] = [
+      {
+        id: 'routed-message',
+        role: 'user',
+        content: 'Apply the reviewer correction',
+        status: 'complete',
+        eventIds: ['application-event'],
+        responseToMessageId: 'routed-message',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+    const conversationGraph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages,
+      createdAt: 1,
+      updatedAt: 1
+    })
+
+    const decoded = decodeSessionFile({
+      version: SESSION_FILE_VERSION,
+      session: {
+        ...createSessionWithActivity(undefined),
+        messages,
+        conversationGraph
+      }
+    })
+
+    expect(decoded.status).toBe('ok')
+    if (decoded.status !== 'ok') return
+    expect(decoded.session.messages[0].responseToMessageId).toBeUndefined()
+    expect(decoded.session.conversationGraph?.messages[0].responseToMessageId).toBeUndefined()
+  })
+
   it('writes a canonical graph while retaining flat messages as the active projection', () => {
     const session: PersistedChatSession = {
       id: 'session-1',

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -354,6 +354,47 @@ describe('conversation graph materialization diagnostics', () => {
     })
   })
 
+  it('quarantines a persisted graph with a semantically invalid Message response target', () => {
+    const messages: PersistedChatMessage[] = [
+      {
+        id: 'prompt-message',
+        role: 'user',
+        content: 'Persist me',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        id: 'response-message',
+        role: 'agent',
+        content: 'Done',
+        status: 'complete',
+        eventIds: [],
+        responseToMessageId: 'missing-prompt',
+        createdAt: 2,
+        updatedAt: 2
+      }
+    ]
+    const conversationGraph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages,
+      createdAt: 1,
+      updatedAt: 2
+    })
+
+    expect(
+      decodeSessionFile({
+        version: SESSION_FILE_VERSION,
+        session: {
+          ...createSessionWithActivity(undefined),
+          messages,
+          conversationGraph
+        }
+      })
+    ).toEqual({ status: 'invalid' })
+  })
+
   it('writes a canonical graph while retaining flat messages as the active projection', () => {
     const session: PersistedChatSession = {
       id: 'session-1',
@@ -3690,7 +3731,8 @@ describe('normalizeSessionFile with activities', () => {
           {
             ...abandonedResponse,
             agentFrameId: graph.rootFrameId,
-            introducedOnBranchId: abandonedBranchId
+            introducedOnBranchId: abandonedBranchId,
+            parentMessageId: prompt.id
           }
         ]
       },

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -430,6 +430,33 @@ describe('conversation graph materialization diagnostics', () => {
     expect(decoded.session.conversationGraph?.messages[0].responseToMessageId).toBeUndefined()
   })
 
+  it('normalizes the same historical routed user self-link in a flat Session', () => {
+    const decoded = decodeSessionFile({
+      version: SESSION_FILE_VERSION,
+      session: {
+        ...createSessionWithActivity(undefined),
+        messages: [
+          {
+            id: 'routed-message',
+            role: 'user',
+            content: 'Apply the reviewer correction',
+            status: 'complete',
+            eventIds: ['application-event'],
+            responseToMessageId: 'routed-message',
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ]
+      }
+    })
+
+    expect(decoded.status).toBe('ok')
+    if (decoded.status !== 'ok') return
+    expect(decoded.session.messages[0].responseToMessageId).toBeUndefined()
+    expect(decoded.session.conversationGraph?.messages[0].responseToMessageId).toBeUndefined()
+    expect(() => createSessionFile(decoded.session)).not.toThrow()
+  })
+
   it('writes a canonical graph while retaining flat messages as the active projection', () => {
     const session: PersistedChatSession = {
       id: 'session-1',

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -3810,6 +3810,11 @@ const sanitizeConversationGraph = (
         const agentFrameId = asString(candidate.agentFrameId)
         const introducedOnBranchId = asString(candidate.introducedOnBranchId)
         if (!message || !agentFrameId || !introducedOnBranchId) return []
+        // Older application-routed user Messages could persist their own id as the response target.
+        // The edge carries no information, so canonicalize that known legacy shape before validation.
+        if (message.role === 'user' && message.responseToMessageId === message.id) {
+          delete message.responseToMessageId
+        }
         return [
           {
             ...(options.preserveRuntimeState ? message : normalizeMessageAfterRestore(message)),

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -3658,7 +3658,11 @@ const sanitizeMessage = (
   if (streamId) sanitized.streamId = streamId
   if (attribution) sanitized.attribution = attribution
   if (presentation) sanitized.presentation = presentation
-  if (responseToMessageId) sanitized.responseToMessageId = responseToMessageId
+  // Older application-routed user Messages could persist their own id as the response target.
+  // The edge carries no information, so canonicalize that known legacy shape on every read path.
+  if (responseToMessageId && (role !== 'user' || responseToMessageId !== id)) {
+    sanitized.responseToMessageId = responseToMessageId
+  }
   if (artifactIds.length > 0) sanitized.artifactIds = artifactIds
   if (delegatedTask) sanitized.delegatedTask = delegatedTask
   if (delegatedInputVersionIds.length > 0) {
@@ -3810,11 +3814,6 @@ const sanitizeConversationGraph = (
         const agentFrameId = asString(candidate.agentFrameId)
         const introducedOnBranchId = asString(candidate.introducedOnBranchId)
         if (!message || !agentFrameId || !introducedOnBranchId) return []
-        // Older application-routed user Messages could persist their own id as the response target.
-        // The edge carries no information, so canonicalize that known legacy shape before validation.
-        if (message.role === 'user' && message.responseToMessageId === message.id) {
-          delete message.responseToMessageId
-        }
         return [
           {
             ...(options.preserveRuntimeState ? message : normalizeMessageAfterRestore(message)),


### PR DESCRIPTION
## Problem

Schema-v1 Conversation Graph validation covers structural ownership and reachability but accepts contradictory Frame origins, cross-path response targets, and inconsistent user-revision links. Persisted JSON with those relationships can restore the wrong active Frame or misattribute messages, revisions, and delegated provenance.

## Proposed change

- validate `validated` and `legacy-unavailable` origin-state invariants
- require every validated origin to belong to the parent Frame and every active descendant origin to remain visible on the parent current Branch
- validate response targets by Frame and message ancestry while preserving routed user interventions
- omit self-referential response targets when projecting application-owned user prompts
- normalize the same self-reference previously persisted by older application-owned routed user prompts before graph validation
- validate revision roots against their actual user-revision chain and require reciprocal user-revision links
- preserve external imports that use `supersededMessageId` for a replaced Agent Message without forming a user-revision chain
- quarantine semantically corrupt persisted graphs through the existing Session decoder

## Scope and non-goals

- no new persisted fields
- no enum or state additions
- no schema-version or database changes
- no UI or interaction changes for valid data
- no broad migration or inferred repair of corrupt historical provenance
- historical compatibility is narrow: the known legacy user self-link is canonicalized on read; all other contradictory schema-v1 relationships decode as invalid

## Acceptance criteria and validation

The initial regression tests were first run against the unmodified validator and failed stably: 7 new failures with the existing 34 tests still passing. A later Codex Review finding for an unrelated same-Frame revision root was also reproduced as a failing test before its fix. The historical routed-user self-link was reproduced at the Session decoder boundary (`invalid` before the compatibility fix, canonical `ok` afterward).

| Behavior | Final check | Result |
| --- | --- | --- |
| Graph semantics, persisted quarantine, both legacy self-link paths, and new-write projection | `npx vitest run src/shared/conversation-graph.test.ts src/shared/session-persistence.test.ts src/renderer/src/lib/acp/workspace-events.test.ts` | 314 passed |
| Listener-dependent ACP runtime and Reviewer owners | `npx vitest run src/main/acp/runtime.test.ts src/main/reviewer/fix-loop.test.ts` with localhost access | 595 passed |
| Exact-head full and platform coverage | PR Gate: three Ubuntu full-suite shards, module coverage, Linux isolation, Windows core/E2E, macOS build/E2E | passed |
| Changed-file style | Prettier check and focused ESLint | passed |
| Dependency-aware selection | `npm run test:affected:explain -- --base origin/main --head HEAD` | full CI plan because the shared test path has no declared module owner |

The focused 314-test run and exact-head PR CI ran after the final material edit. Per maintainer direction, the complete local `npm test` suite was not run; exact-head PR CI is the final authority.

Both local Node and Web typechecks reached the same unrelated generated-client baseline error: `src/main/projects/repository.ts(39,70)` expects `Project.sessionDefaults`, which is absent from the shared workspace's current Prisma client. The shared client was not regenerated because that would modify another active workspace's dependencies; clean PR CI will validate it.

## Review focus

- narrow compatibility normalization for an application-generated legacy user self-link
- fail-closed handling for every other invalid persisted semantic relationship
- active Frame ancestry visibility after parent Branch changes
- role-aware `responseToMessageId` handling for Agent responses and routed user interventions
- distinction between a generic imported Branch replacement marker and a reciprocal user-revision chain
