### PR TITLE
fix(files): isolate integrity failures and paginate version history

### DIFF
--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, realpath, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { ProvenanceIntegrityError } from '../../shared/provenance-read-result'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -117,6 +118,30 @@ const createPreviewLease = (
 })
 
 describe('artifact IPC handlers', () => {
+  it.each([
+    { error: new Error('database busy'), kind: 'load-failed' },
+    { error: new ProvenanceIntegrityError('evidence checksum mismatch'), kind: 'integrity-failed' }
+  ])('preserves $kind across the registered provenance IPC endpoint', async ({ error, kind }) => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-provenance-ipc-error-'))
+    const provenance = new ArtifactProvenanceRepository({ storageRoot, getClient: vi.fn() })
+    vi.spyOn(provenance, 'getVersionCore').mockRejectedValueOnce(error)
+    const handlers = createArtifactHandlers(
+      new ArtifactRepository(storageRoot),
+      new ArtifactRunRegistry(),
+      { provenance }
+    )
+    registerArtifactIpcHandlers(undefined, undefined, undefined, undefined, handlers)
+    const result = await ipcHandlers.get('artifacts:get-version-provenance')!(undefined, {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1'
+    })
+    expect(JSON.parse(JSON.stringify(result))).toEqual({
+      failure: { kind, message: error.message }
+    })
+  })
+
   const createFinalizedArtifact = (overrides: Partial<ArtifactFile> = {}): ArtifactFile => ({
     id: 'session-1:message-1:result.txt',
     projectId: 'default-project',

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -1,3 +1,7 @@
+import {
+  captureProvenanceRead,
+  type ProvenanceReadResult
+} from '../../shared/provenance-read-result'
 import { shell } from 'electron'
 import { basename, dirname } from 'node:path'
 
@@ -57,19 +61,21 @@ type ArtifactHandlers = {
   reconcilePendingArtifacts: (request: ReconcilePendingArtifactsRequest) => Promise<ArtifactFile[]>
   openFile: (request: OpenArtifactFileRequest) => Promise<void>
   readPreview: (request: ReadArtifactPreviewRequest) => Promise<ArtifactPreviewResult>
-  getLineage: (request: GetArtifactLineageRequest) => Promise<ArtifactLineageProvenance | undefined>
+  getLineage: (
+    request: GetArtifactLineageRequest
+  ) => Promise<ProvenanceReadResult<ArtifactLineageProvenance | undefined>>
   getVersionProvenance: (
     request: GetArtifactVersionProvenanceRequest
-  ) => Promise<ArtifactVersionProvenance>
+  ) => Promise<ProvenanceReadResult<ArtifactVersionProvenance>>
   getVersionExecution: (
     request: GetArtifactVersionProvenanceRequest
-  ) => Promise<ArtifactVersionExecutionProvenance>
+  ) => Promise<ProvenanceReadResult<ArtifactVersionExecutionProvenance>>
   getVersionMessages: (
     request: GetArtifactVersionProvenanceRequest
-  ) => Promise<ArtifactVersionMessagesProvenance>
+  ) => Promise<ProvenanceReadResult<ArtifactVersionMessagesProvenance>>
   getVersionReview: (
     request: GetArtifactVersionProvenanceRequest
-  ) => Promise<ArtifactVersionReviewProvenance>
+  ) => Promise<ProvenanceReadResult<ArtifactVersionReviewProvenance>>
   getCodeReconstruction: (
     request: GetArtifactCodeReconstructionRequest
   ) => Promise<ArtifactCodeReconstructionState>
@@ -273,26 +279,31 @@ const createArtifactHandlers = (
       }
       throw new Error('Managed Artifact preview requires a logical identity.')
     },
-    getLineage: (request) => {
-      if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
-      return dependencies.provenance.getLineage(request)
-    },
-    getVersionProvenance: (request) => {
-      if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
-      return dependencies.provenance.getVersionCore(request)
-    },
-    getVersionExecution: (request) => {
-      if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
-      return dependencies.provenance.getVersionExecution(request)
-    },
-    getVersionMessages: (request) => {
-      if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
-      return dependencies.provenance.getVersionMessages(request)
-    },
-    getVersionReview: (request) => {
-      if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
-      return dependencies.provenance.getVersionReview(request)
-    },
+    getLineage: (request) =>
+      captureProvenanceRead(async () => {
+        if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
+        return dependencies.provenance.getLineage(request)
+      }),
+    getVersionProvenance: (request) =>
+      captureProvenanceRead(async () => {
+        if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
+        return dependencies.provenance.getVersionCore(request)
+      }),
+    getVersionExecution: (request) =>
+      captureProvenanceRead(async () => {
+        if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
+        return dependencies.provenance.getVersionExecution(request)
+      }),
+    getVersionMessages: (request) =>
+      captureProvenanceRead(async () => {
+        if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
+        return dependencies.provenance.getVersionMessages(request)
+      }),
+    getVersionReview: (request) =>
+      captureProvenanceRead(async () => {
+        if (!dependencies.provenance) throw new Error('Artifact Provenance is not configured.')
+        return dependencies.provenance.getVersionReview(request)
+      }),
     getCodeReconstruction: (request) => {
       if (!dependencies.codeReconstruction) {
         throw new Error('Artifact code reconstruction is not configured.')

--- a/src/main/artifacts/provenance-core-evidence.ts
+++ b/src/main/artifacts/provenance-core-evidence.ts
@@ -1,3 +1,4 @@
+import { ProvenanceIntegrityError } from '../../shared/provenance-read-result'
 import type { Prisma } from '@prisma/client'
 
 import type { ArtifactVersionEvidence } from '../../shared/artifact-provenance'
@@ -119,7 +120,9 @@ const validateArtifactCoreEvidence = (
     !environmentValid ||
     !inputsValid
   ) {
-    throw new Error(`Artifact Version core evidence metadata mismatch: ${version.id}`)
+    throw new ProvenanceIntegrityError(
+      `Artifact Version core evidence metadata mismatch: ${version.id}`
+    )
   }
 }
 

--- a/src/main/artifacts/provenance-execution-evidence.ts
+++ b/src/main/artifacts/provenance-execution-evidence.ts
@@ -1,3 +1,4 @@
+import { ProvenanceIntegrityError } from '../../shared/provenance-read-result'
 import type {
   ArtifactVersionEnvironmentEvidence,
   ArtifactVersionEvidence,
@@ -582,7 +583,7 @@ const validateArtifactExecutionSnapshot = (
     terminalRun?.runId !== expected.producerRunId ||
     terminalRun.runIndex !== expected.producerRunIndex
   ) {
-    throw new Error('Artifact Version execution snapshot metadata mismatch.')
+    throw new ProvenanceIntegrityError('Artifact Version execution snapshot metadata mismatch.')
   }
 }
 

--- a/src/main/artifacts/provenance-lifecycle-contract.test.ts
+++ b/src/main/artifacts/provenance-lifecycle-contract.test.ts
@@ -1,7 +1,8 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile, writeFile, unlink } from 'node:fs/promises'
 import { basename, join, sep } from 'node:path'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { captureProvenanceRead } from '../../shared/provenance-read-result'
 
 import type {
   ArtifactVersionEvidence,
@@ -200,6 +201,62 @@ describe('artifact provenance durable lifecycle contract', () => {
     }
   )
 
+  it.each(['database', 'backfill-race', 'checksum', 'missing'] as const)(
+    'preserves the actionable message snapshot failure for %s',
+    async (failure) => {
+      const value = await fixture()
+      const session = durableSession(value.storageRoot)
+      const repository = new ArtifactProvenanceRepository({
+        ...value.repositoryOptions,
+        loadSession: async () => session
+      })
+      await value.stagePng('first bytes')
+      const version = await repository.createVersion(versionRequest(session))
+      await repository.finalizeRun(finalizationRequest(version.versionId, session))
+      const snapshots = new ProvenanceMessageSnapshotRepository({
+        storageRoot: value.storageRoot,
+        getClient: async () => value.client
+      })
+      await snapshots.captureFinalizedMessages(session)
+      const row = await value.client.artifactVersion.findUniqueOrThrow({
+        where: { id: version.versionId },
+        include: { messageSnapshot: true }
+      })
+      const snapshot = row.messageSnapshot!
+      const path = join(value.storageRoot, ...snapshot.storageKey.split('/'))
+      if (failure === 'checksum') await writeFile(path, '{"corrupt":true}')
+      else if (failure === 'missing') await unlink(path)
+      else {
+        await value.client.artifactMessageSnapshot.update({
+          where: { id: snapshot.id },
+          data: { checksum: '' }
+        })
+        const update = vi.spyOn(value.client.artifactMessageSnapshot, 'updateMany')
+        if (failure === 'database')
+          update.mockRejectedValueOnce(new Error('database temporarily unavailable'))
+        else update.mockResolvedValueOnce({ count: 0 })
+      }
+      const request = {
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactId: version.artifactId,
+        versionId: version.versionId
+      }
+      expect(
+        await captureProvenanceRead(() => repository.getVersionMessages(request))
+      ).toMatchObject({
+        failure: {
+          kind: failure === 'checksum' || failure === 'missing' ? 'integrity-failed' : 'load-failed'
+        }
+      })
+      if (failure === 'database' || failure === 'backfill-race') {
+        await expect(repository.getVersionMessages(request)).resolves.toMatchObject({
+          messages: { state: 'available' }
+        })
+      }
+    }
+  )
+
   it('segments exact-Version projections and isolates reconstruction cache entries', async () => {
     const value = await fixture()
     const session = durableSession(value.storageRoot)
@@ -285,9 +342,9 @@ describe('artifact provenance durable lifecycle contract', () => {
     })
 
     await writeFile(snapshotPath, '{"corrupt":true}\n', 'utf8')
-    await expect(repository.getVersionMessages(firstIdentity)).resolves.toEqual({
-      messages: { state: 'unavailable', reason: 'message-snapshot-corrupt' }
-    })
+    await expect(repository.getVersionMessages(firstIdentity)).rejects.toThrow(
+      'Message snapshot checksum mismatch.'
+    )
 
     const coreRow = await value.client.artifactVersion.findUniqueOrThrow({
       where: { id: first.versionId }

--- a/src/main/artifacts/provenance-read-model.ts
+++ b/src/main/artifacts/provenance-read-model.ts
@@ -420,8 +420,7 @@ class ArtifactProvenanceReadModel {
             where: { id: version.messageSnapshot.id, state: 'ready', checksum: '' },
             data: { checksum: snapshotChecksum }
           })
-          if (updated.count !== 1)
-            throw new ProvenanceIntegrityError('Message snapshot checksum backfill raced.')
+          if (updated.count !== 1) throw new Error('Message snapshot checksum backfill raced.')
         }
         const rawActivities = snapshot.schemaVersion === 3 ? snapshot.activities : []
         const rawActivityGroups = snapshot.schemaVersion === 3 ? snapshot.activityGroups : []
@@ -451,12 +450,15 @@ class ArtifactProvenanceReadModel {
         })
         messages = { state: 'available', items, activities, activityGroups }
       } catch (error) {
+        if (!(error instanceof UnsupportedMessageSnapshotVersionError)) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            throw new ProvenanceIntegrityError('Message snapshot file is missing.')
+          }
+          throw error
+        }
         messages = {
           state: 'unavailable',
-          reason:
-            error instanceof UnsupportedMessageSnapshotVersionError
-              ? 'message-snapshot-unsupported'
-              : 'message-snapshot-corrupt'
+          reason: 'message-snapshot-unsupported'
         }
       }
     }

--- a/src/main/artifacts/provenance-read-model.ts
+++ b/src/main/artifacts/provenance-read-model.ts
@@ -1,7 +1,13 @@
+import {
+  parseVersionHistoryCursor,
+  versionHistoryPage,
+  VERSION_HISTORY_PAGE_SIZE
+} from '../../shared/version-history'
+import { ProvenanceIntegrityError } from '../../shared/provenance-read-result'
 import { readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
-import type { PrismaClient } from '@prisma/client'
+import type { Prisma, PrismaClient } from '@prisma/client'
 
 import type {
   ArtifactExecutionSnapshot,
@@ -129,7 +135,9 @@ const validateArtifactExecutionInputs = (
     snapshot.inputFiles.length !== evidence.inputs.length ||
     snapshot.inputFiles.length !== rows.length
   ) {
-    throw new Error('Artifact Version execution snapshot input metadata mismatch.')
+    throw new ProvenanceIntegrityError(
+      'Artifact Version execution snapshot input metadata mismatch.'
+    )
   }
 }
 
@@ -183,32 +191,24 @@ class ArtifactProvenanceReadModel {
     try {
       artifactId = assertSafeSegment(request.artifactId, 'artifact id')
     } catch {
-      // Legacy managed-file ids can contain Session/message/filename segments. They never identify a
-      // native lineage, so absence is the compatible result rather than an IPC-visible validation error.
       return undefined
     }
+    const before = parseVersionHistoryCursor(request.cursor)
     const client = await this.options.getClient()
-    // Prisma derives the included relation payload from this exact query shape.
-    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    const findLineage = () =>
+    const visible = {
+      artifactId,
+      artifact: { is: { projectId, sessionId: appSessionId } },
+      OR: [
+        { originKind: 'agent_generated', state: { in: ['pending', 'finalized'] } },
+        { originKind: { in: ['user_edit', 'legacy'] }, state: 'finalized' }
+      ]
+    } satisfies Prisma.ArtifactVersionWhereInput
+    const findLineage = (): Promise<Prisma.ArtifactLineageGetPayload<{
+      include: { originSession: true }
+    }> | null> =>
       client.artifactLineage.findFirst({
         where: { id: artifactId, projectId, sessionId: appSessionId },
-        include: {
-          originSession: true,
-          versions: {
-            where: {
-              OR: [
-                {
-                  originKind: 'agent_generated',
-                  state: { in: ['pending', 'finalized'] }
-                },
-                { originKind: 'user_edit', state: 'finalized' },
-                { originKind: 'legacy', state: 'finalized' }
-              ]
-            },
-            orderBy: [{ versionNumber: 'asc' as const }, { id: 'asc' as const }]
-          }
-        }
+        include: { originSession: true }
       })
     let lineage = await findLineage()
     if (!lineage) {
@@ -216,7 +216,38 @@ class ArtifactProvenanceReadModel {
       lineage = await findLineage()
     }
     if (!lineage) return undefined
-
+    const [records, head, exact] = await Promise.all([
+      client.artifactVersion.findMany({
+        where: { ...visible, ...(before === undefined ? {} : { versionNumber: { lt: before } }) },
+        orderBy: { versionNumber: 'desc' },
+        take: VERSION_HISTORY_PAGE_SIZE + 1
+      }),
+      client.artifactVersion.findFirst({ where: visible, orderBy: { versionNumber: 'desc' } }),
+      request.versionId
+        ? client.artifactVersion.findFirst({ where: { ...visible, id: request.versionId } })
+        : undefined
+    ])
+    const selected = request.versionId ? exact : head
+    const basedOn = selected?.basedOnVersionId
+      ? await client.artifactVersion.findFirst({
+          where: { ...visible, id: selected.basedOnVersionId }
+        })
+      : undefined
+    const project = (version: NonNullable<typeof head>): Promise<ArtifactVersionDescriptor> =>
+      this.options.projectVersionDescriptor(version, projectId, appSessionId)
+    const [previous, next] = selected
+      ? await Promise.all([
+          client.artifactVersion.findFirst({
+            where: { ...visible, versionNumber: { lt: selected.versionNumber } },
+            orderBy: { versionNumber: 'desc' }
+          }),
+          client.artifactVersion.findFirst({
+            where: { ...visible, versionNumber: { gt: selected.versionNumber } },
+            orderBy: { versionNumber: 'asc' }
+          })
+        ])
+      : [undefined, undefined]
+    const page = versionHistoryPage(records)
     return {
       artifactId: lineage.id,
       filename: lineage.filename,
@@ -226,11 +257,13 @@ class ArtifactProvenanceReadModel {
         title: lineage.originSession.titleSnapshot ?? undefined,
         deletedAt: lineage.originSession.deletedAt?.toISOString()
       },
-      versions: await Promise.all(
-        lineage.versions.map((version) =>
-          this.options.projectVersionDescriptor(version, projectId, lineage.sessionId)
-        )
-      )
+      versions: await Promise.all(page.versions.map(project)),
+      nextCursor: page.nextCursor,
+      previousVersion: previous ? await project(previous) : undefined,
+      nextVersion: next ? await project(next) : undefined,
+      selectedVersion: selected ? await project(selected) : undefined,
+      headVersion: head ? await project(head) : undefined,
+      basedOnVersion: basedOn ? await project(basedOn) : undefined
     }
   }
 
@@ -349,14 +382,14 @@ class ArtifactProvenanceReadModel {
           version.messageSnapshot.checksum &&
           version.messageSnapshot.checksum !== snapshotChecksum
         ) {
-          throw new Error('Message snapshot checksum mismatch.')
+          throw new ProvenanceIntegrityError('Message snapshot checksum mismatch.')
         }
         const decodedSnapshot = decodeArtifactMessageSnapshot(serializedSnapshot)
         if (decodedSnapshot.status === 'unsupported') {
           throw new UnsupportedMessageSnapshotVersionError()
         }
         if (decodedSnapshot.status === 'corrupt') {
-          throw new Error('Message snapshot schema is invalid.')
+          throw new ProvenanceIntegrityError('Message snapshot schema is invalid.')
         }
         const snapshot = decodedSnapshot.value
         const hasValidPath = snapshot.messages.every(
@@ -374,20 +407,21 @@ class ArtifactProvenanceReadModel {
           snapshot.messages.at(-1)?.id !== version.messageId ||
           !hasValidPath
         ) {
-          throw new Error('Message snapshot metadata mismatch.')
+          throw new ProvenanceIntegrityError('Message snapshot metadata mismatch.')
         }
         if (
           snapshot.schemaVersion === 3 &&
           (!Array.isArray(snapshot.activities) || !Array.isArray(snapshot.activityGroups))
         ) {
-          throw new Error('Message snapshot activity metadata mismatch.')
+          throw new ProvenanceIntegrityError('Message snapshot activity metadata mismatch.')
         }
         if (!version.messageSnapshot.checksum) {
           const updated = await client.artifactMessageSnapshot.updateMany({
             where: { id: version.messageSnapshot.id, state: 'ready', checksum: '' },
             data: { checksum: snapshotChecksum }
           })
-          if (updated.count !== 1) throw new Error('Message snapshot checksum backfill raced.')
+          if (updated.count !== 1)
+            throw new ProvenanceIntegrityError('Message snapshot checksum backfill raced.')
         }
         const rawActivities = snapshot.schemaVersion === 3 ? snapshot.activities : []
         const rawActivityGroups = snapshot.schemaVersion === 3 ? snapshot.activityGroups : []
@@ -407,7 +441,7 @@ class ArtifactProvenanceReadModel {
             group.activityIds.some((activityId) => !activityIds.has(activityId))
           )
         ) {
-          throw new Error('Message snapshot activity metadata mismatch.')
+          throw new ProvenanceIntegrityError('Message snapshot activity metadata mismatch.')
         }
         const items = snapshot.messages.map((message) => {
           const attribution = sanitizeMessageAttribution(message.attribution)
@@ -449,14 +483,14 @@ class ArtifactProvenanceReadModel {
           if (snapshot?.state === 'ready') {
             try {
               if (sha256(snapshot.snapshotJson) !== snapshot.checksum) {
-                throw new Error('Review scope snapshot checksum mismatch.')
+                throw new ProvenanceIntegrityError('Review scope snapshot checksum mismatch.')
               }
               const decodedSnapshot = decodeReviewScopeSnapshot(snapshot.snapshotJson)
               if (
                 decodedSnapshot.status === 'unsupported' ||
                 decodedSnapshot.status === 'corrupt'
               ) {
-                throw new Error('Review scope snapshot schema is invalid.')
+                throw new ProvenanceIntegrityError('Review scope snapshot schema is invalid.')
               }
               scopeSnapshot = {
                 state: 'available',
@@ -634,11 +668,12 @@ class ArtifactProvenanceReadModel {
     checksum: string,
     corruptMessage: string
   ): Promise<string> {
-    if (sha256(canonical) !== checksum) throw new Error(corruptMessage)
+    if (sha256(canonical) !== checksum) throw new ProvenanceIntegrityError(corruptMessage)
     const bytes = await readOptionalFile(path)
     if (!bytes) return canonical
     const value = bytes.toString('utf8')
-    if (value !== canonical || sha256(bytes) !== checksum) throw new Error(corruptMessage)
+    if (value !== canonical || sha256(bytes) !== checksum)
+      throw new ProvenanceIntegrityError(corruptMessage)
     return value
   }
 

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -58,6 +58,71 @@ afterEach(async () => {
 })
 
 describe('artifact provenance repository', () => {
+  it('pages lineage history while resolving an old selected Version independently', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-lineage-history-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-1', sessionId: 'session-1' }
+    })
+    await client.artifactLineage.create({
+      data: {
+        id: 'history-file',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        filename: 'notes.md',
+        normalizedFilename: 'notes.md'
+      }
+    })
+    await client.artifactVersion.createMany({
+      data: Array.from({ length: 102 }, (_, index) => ({
+        id: `history-v${index + 1}`,
+        artifactId: 'history-file',
+        versionNumber: index + 1,
+        filename: 'notes.md',
+        originKind: 'legacy',
+        state: 'finalized',
+        contentStorageKey: `artifacts/project-1/session-1/history-file/v${index + 1}/content`,
+        sizeBytes: 0n,
+        checksum: 'a'.repeat(64)
+      }))
+    })
+    await client.artifactLineage.update({
+      where: { id: 'history-file' },
+      data: { currentVersionId: 'history-v102' }
+    })
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client)
+    })
+    const request = {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactId: 'history-file',
+      versionId: 'history-v1'
+    }
+    const first = await repository.getLineage(request)
+    expect(first?.versions).toHaveLength(50)
+    expect(first?.selectedVersion?.versionId).toBe('history-v1')
+    expect(first?.headVersion?.versionId).toBe('history-v102')
+    const second = await repository.getLineage({ ...request, cursor: first!.nextCursor })
+    const last = await repository.getLineage({ ...request, cursor: second!.nextCursor })
+    expect(second?.versions).toHaveLength(50)
+    expect(last?.versions.map((version) => version.versionNumber)).toEqual([1, 2])
+    expect(last?.nextCursor).toBeUndefined()
+    expect(
+      new Set(
+        [...first!.versions, ...second!.versions, ...last!.versions].map(
+          (version) => version.versionId
+        )
+      ).size
+    ).toBe(102)
+    await expect(
+      repository.getLineage({ ...request, projectId: 'other-project' })
+    ).resolves.toBeUndefined()
+  })
+
   it('projects finalized user edits in lineage without inventing Agent provenance', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-user-edit-lineage-'))
     const client = createProjectDbClient(storageRoot)

--- a/src/main/managed-file-versions/service.integration.test.ts
+++ b/src/main/managed-file-versions/service.integration.test.ts
@@ -149,6 +149,98 @@ describe('ManagedFileVersionService (SQLite + filesystem)', () => {
   }
 
   it.each(['artifact', 'upload'] as const)(
+    'bounds the initial %s history response for a frequently edited file',
+    async (source) => {
+      const fixture = await createFixture(source)
+      const totalVersions = 202
+      const numbers = Array.from({ length: totalVersions - 2 }, (_, index) => index + 3)
+      const latestId = `${source}-v${totalVersions}`
+      const key = (number: number): string =>
+        `${source}s/project-1/session-1/${fixture.fileId}/versions/${source}-v${number}/content`
+      if (source === 'artifact') {
+        const template = await client.artifactVersion.findUniqueOrThrow({
+          where: { id: fixture.versionIds[1] }
+        })
+        await client.artifactVersion.createMany({
+          data: numbers.map((versionNumber) => ({
+            ...template,
+            id: `${source}-v${versionNumber}`,
+            versionNumber,
+            basedOnVersionId: `${source}-v${versionNumber - 1}`,
+            contentStorageKey: key(versionNumber)
+          }))
+        })
+        await client.artifactLineage.update({
+          where: { id: fixture.fileId },
+          data: { currentVersionId: latestId }
+        })
+      } else {
+        const template = await client.uploadVersion.findUniqueOrThrow({
+          where: { id: fixture.versionIds[1] }
+        })
+        await client.uploadVersion.createMany({
+          data: numbers.map((versionNumber) => ({
+            ...template,
+            id: `${source}-v${versionNumber}`,
+            versionNumber,
+            basedOnVersionId: `${source}-v${versionNumber - 1}`,
+            contentStorageKey: key(versionNumber)
+          }))
+        })
+        await client.uploadFile.update({
+          where: { id: fixture.fileId },
+          data: { currentVersionId: latestId }
+        })
+      }
+      // Only the selected head is read; older immutable content is not needed to list metadata.
+      const latestPath = join(storageRoot, ...key(totalVersions).split('/'))
+      await mkdir(dirname(latestPath), { recursive: true })
+      await writeFile(latestPath, 'second\n')
+      const service = new ManagedFileVersionService({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+      const result = await service.inspect({
+        source,
+        projectId: 'project-1',
+        fileId: fixture.fileId
+      })
+      expect(result.selectedVersionId).toBe(latestId)
+      expect(result.text).toBe('second\n')
+      expect(result.versions.some((version) => version.id === latestId)).toBe(true)
+      expect(result.versions).toHaveLength(50)
+      const versionIds = result.versions.map((version) => version.id)
+      let cursor = result.nextCursor
+      while (cursor) {
+        const page = await service.inspect({
+          source,
+          projectId: 'project-1',
+          fileId: fixture.fileId,
+          versionId: fixture.versionIds[0],
+          cursor
+        })
+        expect(page.versions.length).toBeLessThanOrEqual(50)
+        expect(page.selectedVersion?.id).toBe(fixture.versionIds[0])
+        expect(page.headVersion?.id).toBe(latestId)
+        expect(page.nextVersion?.id).toBe(fixture.versionIds[1])
+        expect(page.previousVersion).toBeUndefined()
+        versionIds.push(...page.versions.map((version) => version.id))
+        cursor = page.nextCursor
+      }
+      expect(versionIds).toHaveLength(totalVersions)
+      expect(new Set(versionIds).size).toBe(totalVersions)
+      await expect(
+        service.inspect({
+          source,
+          projectId: 'project-1',
+          fileId: fixture.fileId,
+          cursor: 'invalid'
+        })
+      ).rejects.toMatchObject({ code: 'INVALID_REQUEST' })
+    }
+  )
+
+  it.each(['artifact', 'upload'] as const)(
     'resolves the %s DB head by default and an explicit owned historical version exactly',
     async (source) => {
       const fixture = await createFixture(source)

--- a/src/main/managed-file-versions/service.ts
+++ b/src/main/managed-file-versions/service.ts
@@ -1,4 +1,9 @@
 import { randomUUID } from 'node:crypto'
+import {
+  parseVersionHistoryCursor,
+  versionHistoryPage,
+  VERSION_HISTORY_PAGE_SIZE
+} from '../../shared/version-history'
 
 import type { Prisma, PrismaClient } from '@prisma/client'
 
@@ -463,7 +468,24 @@ class ManagedFileVersionService {
     request: ManagedFileVersionInspectRequest
   ): Promise<ManagedFileVersionInspectResult> {
     const resolved = await this.resolveRecord(request)
-    const versions = await this.listVersions(resolved.logicalFile)
+    let before: number | undefined
+    try {
+      before = parseVersionHistoryCursor(request.cursor)
+    } catch {
+      operationError('INVALID_REQUEST', 'Invalid version history cursor.')
+    }
+    const page = versionHistoryPage(await this.listVersions(resolved.logicalFile, before))
+    const head =
+      resolved.version.id === resolved.logicalFile.currentVersionId
+        ? resolved
+        : await this.resolveRecord({
+            ...request,
+            versionId: resolved.logicalFile.currentVersionId!
+          })
+    const [previous, next] = await Promise.all([
+      this.listVersions(resolved.logicalFile, resolved.version.versionNumber, undefined, 1),
+      this.listVersions(resolved.logicalFile, undefined, resolved.version.versionNumber, 1)
+    ])
     const writeUnavailableReason = await this.writeUnavailableReason(resolved.logicalFile)
     const eligibility = await this.readTextEligibility(resolved)
 
@@ -475,9 +497,22 @@ class ManagedFileVersionService {
       displayName: resolved.logicalFile.displayName,
       headVersionId: resolved.logicalFile.currentVersionId!,
       selectedVersionId: resolved.version.id,
-      versions: versions.map((version) =>
+      versions: page.versions.map((version) =>
         toDescriptor(request.source, resolved.logicalFile.displayName, version)
       ),
+      nextCursor: page.nextCursor,
+      previousVersion: previous[0]
+        ? toDescriptor(request.source, resolved.logicalFile.displayName, previous[0])
+        : undefined,
+      nextVersion: next[0]
+        ? toDescriptor(request.source, resolved.logicalFile.displayName, next[0])
+        : undefined,
+      selectedVersion: toDescriptor(
+        request.source,
+        resolved.logicalFile.displayName,
+        resolved.version
+      ),
+      headVersion: toDescriptor(request.source, resolved.logicalFile.displayName, head.version),
       canEdit: eligibility.editable && writeUnavailableReason === undefined,
       canDiff: eligibility.editable && resolved.version.basedOnVersionId !== null,
       ...(eligibility.editable ? { text: eligibility.text, textFormat: eligibility.format } : {}),
@@ -1160,16 +1195,27 @@ class ManagedFileVersionService {
       : null
   }
 
-  private async listVersions(logicalFile: ManagedLogicalFile): Promise<ManagedFileVersionRecord[]> {
+  private async listVersions(
+    logicalFile: ManagedLogicalFile,
+    before?: number,
+    after?: number,
+    take = VERSION_HISTORY_PAGE_SIZE + 1
+  ): Promise<ManagedFileVersionRecord[]> {
     const client = await this.options.getClient()
     if (logicalFile.source === 'artifact') {
       const versions = await client.artifactVersion.findMany({
         where: {
           artifactId: logicalFile.id,
+          ...(before === undefined
+            ? after === undefined
+              ? {}
+              : { versionNumber: { gt: after } }
+            : { versionNumber: { lt: before } }),
           state: 'finalized',
           OR: [{ originKind: { not: 'agent_generated' } }, { managedVisibleAt: { not: null } }]
         },
-        orderBy: { versionNumber: 'asc' }
+        orderBy: { versionNumber: after === undefined ? 'desc' : 'asc' },
+        take
       })
       return versions.map((version) => ({
         ...version,
@@ -1179,8 +1225,17 @@ class ManagedFileVersionService {
       }))
     }
     const versions = await client.uploadVersion.findMany({
-      where: { uploadFileId: logicalFile.id, state: 'ready' },
-      orderBy: { versionNumber: 'asc' }
+      where: {
+        uploadFileId: logicalFile.id,
+        state: 'ready',
+        ...(before === undefined
+          ? after === undefined
+            ? {}
+            : { versionNumber: { gt: after } }
+          : { versionNumber: { lt: before } })
+      },
+      orderBy: { versionNumber: after === undefined ? 'desc' : 'asc' },
+      take
     })
     return versions.map((version) => ({
       ...version,

--- a/src/main/project-files/mutation-owner.ts
+++ b/src/main/project-files/mutation-owner.ts
@@ -29,10 +29,21 @@ const RETRYABLE_COLLISION_REVISION = -1
 type ManagedFileSoftDeleteToken = string
 type ManagedFileSyncOptions = { force?: boolean }
 
+// Callers must not widen failures already recorded against known projects into a global outage.
+class ProjectFilesReconciliationError extends AggregateError {
+  constructor(
+    errors: unknown[],
+    readonly projectIds: readonly string[]
+  ) {
+    super(errors, 'Project file reconciliation failed.')
+  }
+}
+
 // Owns every Project Files projection mutation and its completeness state. The public repository
 // delegates here while retaining the stable caller interface and the query orchestration for FI2.
 class ProjectFilesMutationOwner {
   private readonly incompleteSessions = new Map<string, string>()
+  private readonly incompleteProjects = new Set<string>()
   private isReconciliationIncomplete = false
 
   constructor(
@@ -346,6 +357,9 @@ class ProjectFilesMutationOwner {
     sessions: PersistedChatSession[],
     projectId?: string
   ): Promise<void> {
+    let scopedFailure = false
+    const failures: unknown[] = []
+    const failedProjects = new Set<string>()
     try {
       const client = await this.getClient()
       const activeKeys = new Set(
@@ -367,43 +381,70 @@ class ProjectFilesMutationOwner {
       )
 
       for (const indexed of indexedSessions) {
-        const key = sessionKey(indexed.projectId, indexed.sessionId)
-        const isActive = activeKeys.has(key) || retainedKeys.has(key)
+        try {
+          const key = sessionKey(indexed.projectId, indexed.sessionId)
+          const isActive = activeKeys.has(key) || retainedKeys.has(key)
 
-        if (isActive && indexed.deletedAt !== null) {
-          await client.$transaction([
-            client.managedFile.updateMany({
-              where: {
-                projectId: indexed.projectId,
-                sessionId: indexed.sessionId,
-                deletedAt: { not: null }
-              },
-              data: { deletedAt: null, deleteOperationId: null }
-            }),
-            client.managedFileSessionSync.updateMany({
-              where: {
-                projectId: indexed.projectId,
-                sessionId: indexed.sessionId,
-                deletedAt: { not: null }
-              },
-              data: { deletedAt: null, deleteOperationId: null }
-            })
-          ])
-        } else if (!isActive && indexed.deletedAt === null) {
-          await this.softDeleteSession(indexed.projectId, indexed.sessionId)
+          if (isActive && indexed.deletedAt !== null) {
+            await client.$transaction([
+              client.managedFile.updateMany({
+                where: {
+                  projectId: indexed.projectId,
+                  sessionId: indexed.sessionId,
+                  deletedAt: { not: null }
+                },
+                data: { deletedAt: null, deleteOperationId: null }
+              }),
+              client.managedFileSessionSync.updateMany({
+                where: {
+                  projectId: indexed.projectId,
+                  sessionId: indexed.sessionId,
+                  deletedAt: { not: null }
+                },
+                data: { deletedAt: null, deleteOperationId: null }
+              })
+            ])
+          } else if (!isActive && indexed.deletedAt === null) {
+            await this.softDeleteSession(indexed.projectId, indexed.sessionId)
+          }
+        } catch (error) {
+          failures.push(error)
+          failedProjects.add(indexed.projectId)
         }
       }
       for (const origin of retainedOrigins) {
-        await this.rebuildRetainedOriginProjection(client, origin.projectId, origin.sessionId)
+        try {
+          await this.rebuildRetainedOriginProjection(client, origin.projectId, origin.sessionId)
+        } catch (error) {
+          failures.push(error)
+          failedProjects.add(origin.projectId)
+        }
       }
       for (const key of this.incompleteSessions.keys()) {
-        if ((!projectId || key.startsWith(`${projectId}:`)) && !activeKeys.has(key)) {
+        if (
+          (!projectId || key.startsWith(`${projectId}:`)) &&
+          !activeKeys.has(key) &&
+          ![...failedProjects].some((id) => key.startsWith(`${id}:`))
+        ) {
           this.incompleteSessions.delete(key)
         }
       }
-      if (!projectId) this.isReconciliationIncomplete = false
+      for (const id of [...this.incompleteProjects]) {
+        if ((!projectId || projectId === id) && !failedProjects.has(id))
+          this.incompleteProjects.delete(id)
+      }
+      for (const id of failedProjects) this.incompleteProjects.add(id)
+      if (failures.length) {
+        scopedFailure = true
+        throw new ProjectFilesReconciliationError(failures, [...failedProjects])
+      }
+      if (projectId) this.incompleteProjects.delete(projectId)
+      else {
+        this.incompleteProjects.clear()
+        this.isReconciliationIncomplete = false
+      }
     } catch (error) {
-      this.isReconciliationIncomplete = true
+      if (!scopedFailure) this.markReconciliationIncomplete(projectId)
       throw error
     }
   }
@@ -522,17 +563,19 @@ class ProjectFilesMutationOwner {
     })
   }
 
-  markReconciliationIncomplete(): void {
-    this.isReconciliationIncomplete = true
+  markReconciliationIncomplete(projectId?: string): void {
+    if (projectId) this.incompleteProjects.add(projectId)
+    else this.isReconciliationIncomplete = true
   }
 
   isIndexComplete(projectId: string): boolean {
     return (
       !this.isReconciliationIncomplete &&
+      !this.incompleteProjects.has(projectId) &&
       ![...this.incompleteSessions.keys()].some((key) => key.startsWith(`${projectId}:`))
     )
   }
 }
 
-export { ProjectFilesMutationOwner }
+export { ProjectFilesMutationOwner, ProjectFilesReconciliationError }
 export type { ManagedFileSoftDeleteToken, ManagedFileSyncOptions }

--- a/src/main/project-files/repository.architecture.test.ts
+++ b/src/main/project-files/repository.architecture.test.ts
@@ -105,6 +105,7 @@ describe('Project Files repository architecture', () => {
       [
         'value:createManagedFileIndexRepository',
         'value:ManagedFileIndexRepository',
+        'value:ProjectFilesReconciliationError',
         'type:LegacyArtifactVersionAdopter',
         'type:LegacyUploadVersionUpgrader',
         'type:ManagedFileSoftDeleteToken',

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -3152,6 +3152,69 @@ describe('ManagedFileIndexRepository', () => {
     })
   })
 
+  it.each(['unrelated project', 'recovered project'] as const)(
+    'keeps the %s complete after a Project-scoped reconciliation failure',
+    async (scenario) => {
+      const getClient = vi.fn().mockResolvedValue(client)
+      const recoveringRepository = new ManagedFileIndexRepository(
+        getClient,
+        storageRoot,
+        new ManagedFileVersionService({ storageRoot, getClient: () => Promise.resolve(client) }),
+        uploadRepository
+      )
+      await recoveringRepository.reconcileActiveSessions([])
+      getClient.mockRejectedValueOnce(new Error('database busy'))
+
+      await expect(recoveringRepository.reconcileProjectSessions(PROJECT_ID, [])).rejects.toThrow(
+        'database busy'
+      )
+      await expect(recoveringRepository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+        isIndexComplete: false
+      })
+      if (scenario === 'recovered project') {
+        await recoveringRepository.reconcileProjectSessions(PROJECT_ID, [])
+      }
+      await expect(
+        recoveringRepository.getOverview(
+          scenario === 'unrelated project' ? 'project-b' : PROJECT_ID
+        )
+      ).resolves.toMatchObject({ isIndexComplete: true })
+    }
+  )
+
+  it('keeps a known retained-origin failure scoped during a global reconciliation', async () => {
+    await client.fileOriginSession.create({
+      data: {
+        projectId: PROJECT_ID,
+        sessionId: SESSION_ID,
+        state: 'deleted',
+        deletedAt: new Date()
+      }
+    })
+    vi.spyOn(client.artifactLineage, 'findMany').mockRejectedValueOnce(
+      new Error('retained projection busy')
+    )
+    await expect(repository.reconcileActiveSessions([])).rejects.toThrow()
+    await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      isIndexComplete: false
+    })
+    await expect(repository.getOverview('project-b')).resolves.toMatchObject({
+      isIndexComplete: true
+    })
+  })
+
+  it('does not clear global uncertainty when only one Project is reconciled', async () => {
+    repository.markReconciliationIncomplete()
+    await repository.reconcileProjectSessions(PROJECT_ID, [])
+    await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      isIndexComplete: false
+    })
+    await repository.reconcileActiveSessions([])
+    await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      isIndexComplete: true
+    })
+  })
+
   it('reports an incomplete index until failed startup reconciliation succeeds', async () => {
     const artifactPath = join(
       storageRoot,

--- a/src/main/project-files/repository.ts
+++ b/src/main/project-files/repository.ts
@@ -85,8 +85,8 @@ class ManagedFileIndexRepository {
     return this.mutationOwner.reconcileProjectSessions(projectId, sessions)
   }
 
-  markReconciliationIncomplete(): void {
-    this.mutationOwner.markReconciliationIncomplete()
+  markReconciliationIncomplete(projectId?: string): void {
+    this.mutationOwner.markReconciliationIncomplete(projectId)
   }
 
   async getOverview(
@@ -135,6 +135,7 @@ const createManagedFileIndexRepository = (
   )
 
 export { createManagedFileIndexRepository, ManagedFileIndexRepository }
+export { ProjectFilesReconciliationError } from './mutation-owner'
 export type {
   ManagedFileSoftDeleteToken,
   ProjectFilesClient,

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -1,3 +1,4 @@
+import { ProjectFilesReconciliationError } from '../project-files/repository'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -3752,6 +3753,22 @@ describe('SessionPersistenceCoordinator', () => {
     await expect(coordinator.saveSession(session)).resolves.toMatchObject({
       id: 'session-1'
     })
+  })
+
+  it('does not widen an already scoped file reconciliation failure during hydration', async () => {
+    const session = createSession()
+    const result = { sessions: [session], manifest: { version: 1 as const } }
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+    })
+    const fileIndex = createFileIndex({
+      reconcileActiveSessions: vi
+        .fn()
+        .mockRejectedValue(new ProjectFilesReconciliationError([new Error('busy')], ['project-1']))
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+    await coordinator.loadAll()
+    expect(fileIndex.markReconciliationIncomplete).not.toHaveBeenCalled()
   })
 
   it('hydrates sessions after indexing and reconciles only a complete scan', async () => {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,3 +1,4 @@
+import { ProjectFilesReconciliationError } from '../project-files/repository'
 import type { ProjectFileSource, ProjectFilesChangedEvent } from '../../shared/project-files'
 import type { ReconcilePendingArtifactsRequest } from '../../shared/artifacts'
 import {
@@ -143,7 +144,7 @@ type SessionFileIndex = {
   softDeleteProject(projectId: string): Promise<ManagedFileSoftDeleteToken>
   reconcileProjectSessions(projectId: string, sessions: PersistedChatSession[]): Promise<void>
   reconcileActiveSessions(sessions: PersistedChatSession[]): Promise<void>
-  markReconciliationIncomplete(): void
+  markReconciliationIncomplete(projectId?: string): void
 }
 
 type SessionProvenancePersistence = {
@@ -430,6 +431,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
           } catch (error) {
             recoveryFailure ??= error
             recoveryFailureCount += 1
+            this.fileIndex.markReconciliationIncomplete(sessions[index].projectId)
             const sessionRecovery = startDiagnosticOperation(this.log, {
               operation: 'delegation-recovery',
               fields: { mode: 'startup' }
@@ -440,7 +442,6 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         }
         if (recoveryFailureCount > 0) {
           this.stateOwner.replaceMetadata(sessions, false)
-          this.fileIndex.markReconciliationIncomplete()
           result = {
             ...result,
             sessions,
@@ -501,7 +502,9 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
 
       if (reconciliation.status === 'degraded') {
         this.stateOwner.markMetadataIncomplete()
-        this.fileIndex.markReconciliationIncomplete()
+        if (!(reconciliation.failure instanceof ProjectFilesReconciliationError)) {
+          this.fileIndex.markReconciliationIncomplete()
+        }
         operation.fail(reconciliation.failure, {
           status: 'degraded',
           hydrationAvailable: true,
@@ -935,7 +938,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
           }
         } catch {
           // Unknown durable state is treated as committed: retain the in-memory tombstone and intent.
-          this.fileIndex.markReconciliationIncomplete()
+          this.fileIndex.markReconciliationIncomplete(projectId)
         }
         throw error
       }

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -1,3 +1,4 @@
+import { ProjectFilesReconciliationError } from '../project-files/repository'
 import type { ProjectFilesChangedEvent, ProjectFileSource } from '../../shared/project-files'
 import {
   hasAnswerableDelegatedQuestion,
@@ -72,7 +73,7 @@ type SessionDeletionFileIndex = {
   softDeleteProject(projectId: string): Promise<ManagedFileSoftDeleteToken>
   reconcileProjectSessions(projectId: string, sessions: PersistedChatSession[]): Promise<void>
   reconcileActiveSessions(sessions: PersistedChatSession[]): Promise<void>
-  markReconciliationIncomplete(): void
+  markReconciliationIncomplete(projectId?: string): void
 }
 
 type SessionDeletionProvenance = {
@@ -323,7 +324,7 @@ class SessionPersistenceDeletionOwner {
                 'Cannot adopt a legacy Project tombstone with incomplete Session authority.'
               )
             }
-            this.fileIndex.markReconciliationIncomplete()
+            this.fileIndex.markReconciliationIncomplete(projectId)
           }
           for (const session of scan.sessions) {
             let cleanup: { hasUnsafeResidual: boolean }
@@ -341,14 +342,14 @@ class SessionPersistenceDeletionOwner {
                 error instanceof OrphanLegacyUploadAuthorityMissingError
               ) {
                 await this.computeJobs?.commitProjectJobDeletion(projectId)
-                this.fileIndex.markReconciliationIncomplete()
+                this.fileIndex.markReconciliationIncomplete(projectId)
                 await this.fileIndex.softDeleteProject(projectId)
                 await this.notifySessionsDeleted(deletedSessionIds)
                 return { status: 'orphan-retained', reason: 'missing-upload-authority' }
               }
               throw error
             }
-            if (cleanup.hasUnsafeResidual) this.fileIndex.markReconciliationIncomplete()
+            if (cleanup.hasUnsafeResidual) this.fileIndex.markReconciliationIncomplete(projectId)
           }
         }
         const retainedWorkspaceSessions: PersistedChatSession[] = []
@@ -532,10 +533,10 @@ class SessionPersistenceDeletionOwner {
           }
           if (recoveryFailed) throw recoveryError
         } else {
-          this.fileIndex.markReconciliationIncomplete()
+          this.fileIndex.markReconciliationIncomplete(projectId)
         }
       } catch (restoreError) {
-        this.fileIndex.markReconciliationIncomplete()
+        this.fileIndex.markReconciliationIncomplete(projectId)
         operation.fail(restoreError, { failurePhase, recoveryPhase })
         throw restoreError
       }
@@ -572,9 +573,10 @@ class SessionPersistenceDeletionOwner {
         this.stateOwner.markMetadataIncomplete()
         this.fileIndex.markReconciliationIncomplete()
       }
-    } catch {
+    } catch (error) {
       this.stateOwner.markMetadataIncomplete()
-      this.fileIndex.markReconciliationIncomplete()
+      if (!(error instanceof ProjectFilesReconciliationError))
+        this.fileIndex.markReconciliationIncomplete()
     }
 
     for (const change of survivorChanges) {
@@ -615,7 +617,7 @@ class SessionPersistenceDeletionOwner {
       this.stateOwner.invalidateBindingTopology(projectId, sessionId)
     } catch {
       this.stateOwner.markMetadataIncomplete()
-      this.fileIndex.markReconciliationIncomplete()
+      this.fileIndex.markReconciliationIncomplete(projectId)
       return false
     }
 

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -510,9 +510,9 @@ export const GlobalSearchDialog = ({
           setActionError(t('Could not resolve file version.'))
           return
         }
-        const head = result.value.versions.find(
-          (version) => version.id === result.value.headVersionId
-        )
+        const head =
+          result.value.headVersion ??
+          result.value.versions.find((version) => version.id === result.value.headVersionId)
         if (!head) {
           setActionError(t('The current file version is unavailable.'))
           return

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -470,6 +470,169 @@ afterEach(() => {
 })
 
 describe('ArtifactProvenancePanel', () => {
+  it('retries an earlier history page without reloading core evidence or changing selection', async () => {
+    act(() => root.unmount())
+    container.replaceChildren()
+    root = createRoot(container)
+    const latest = {
+      ...descriptor,
+      id: 'version-102',
+      versionId: 'version-102',
+      versionNumber: 102
+    }
+    const initial = {
+      artifactId: 'artifact-1',
+      filename: 'sin.png',
+      originSession: { sessionId: 'session-1', state: 'active' as const },
+      versions: Array.from({ length: 50 }, (_, i) => ({
+        ...descriptor,
+        id: `version-${i + 53}`,
+        versionId: `version-${i + 53}`,
+        versionNumber: i + 53
+      })),
+      selectedVersion: descriptor,
+      headVersion: latest,
+      nextVersion: secondDescriptor,
+      nextCursor: '53'
+    }
+    const getLineage = vi.mocked(window.api.artifacts.getLineage)
+    getLineage
+      .mockReset()
+      .mockResolvedValueOnce(initial)
+      .mockRejectedValueOnce(new Error('history temporarily unavailable'))
+      .mockResolvedValueOnce({
+        ...initial,
+        versions: [descriptor, secondDescriptor],
+        nextCursor: undefined
+      })
+    getVersionProvenance.mockClear()
+    await act(async () =>
+      root.render(<ArtifactProvenancePanel item={item} projectId="project-1" onClose={vi.fn()} />)
+    )
+    await flush()
+    await clickTab('Load earlier versions')
+    await flush()
+    expect(container.textContent).toContain('history temporarily unavailable')
+    await clickTab('Retry loading earlier versions')
+    await flush()
+    expect(getLineage).toHaveBeenLastCalledWith({
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1',
+      cursor: '53'
+    })
+    expect(getVersionProvenance).toHaveBeenCalledTimes(1)
+    expect(container.textContent).not.toContain('history temporarily unavailable')
+    expect(container.textContent).toContain('v1')
+    expect(
+      container
+        .querySelector('button[aria-label="Next Artifact version"]')
+        ?.hasAttribute('disabled')
+    ).toBe(false)
+  })
+
+  it.each(['missing', 'checksum-mismatch'] as const)(
+    'offers diagnostics for %s content while retaining captured provenance',
+    async (reason) => {
+      act(() => root.unmount())
+      container.replaceChildren()
+      root = createRoot(container)
+      getVersionProvenance.mockResolvedValue({
+        ...provenance(),
+        contentStatus: { state: 'unavailable', reason }
+      })
+      await act(async () =>
+        root.render(<ArtifactProvenancePanel item={item} projectId="project-1" onClose={vi.fn()} />)
+      )
+      await flush()
+      expect(container.textContent).toContain(
+        `Artifact content is ${reason}; captured provenance remains available.`
+      )
+      const diagnostics = [...container.querySelectorAll('button')].find(
+        (button) => button.textContent?.trim() === 'View diagnostics'
+      )
+      expect(
+        diagnostics,
+        'known content integrity failures must offer a diagnostic entry'
+      ).toBeDefined()
+      await act(async () => diagnostics!.click())
+      const diagnosticText = container.querySelector('pre')!.textContent!
+      expect(JSON.parse(diagnosticText)).toMatchObject({
+        projectId: 'project-1',
+        artifactId: 'artifact-1',
+        versionId: 'version-1',
+        section: 'content',
+        kind: 'integrity-failed',
+        message: reason
+      })
+      const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+      try {
+        await clickTab('Copy diagnostics')
+        await flush()
+        expect(writeText).toHaveBeenCalledWith(diagnosticText)
+        expect(container.textContent).toContain('Copied')
+      } finally {
+        if (clipboardDescriptor) Object.defineProperty(navigator, 'clipboard', clipboardDescriptor)
+        else Reflect.deleteProperty(navigator, 'clipboard')
+      }
+    }
+  )
+
+  it.each(['lineage', 'provenance'] as const)(
+    'retries a transient %s load failure without closing the panel',
+    async (stage) => {
+      act(() => root.unmount())
+      container.replaceChildren()
+      root = createRoot(container)
+      const load =
+        stage === 'lineage' ? vi.mocked(window.api.artifacts.getLineage) : getVersionProvenance
+      load.mockClear()
+      load.mockRejectedValueOnce(new Error('database busy'))
+      await act(async () =>
+        root.render(<ArtifactProvenancePanel item={item} projectId="project-1" onClose={vi.fn()} />)
+      )
+      await flush()
+      expect(container.textContent).toContain('database busy')
+      const retry = [...container.querySelectorAll('button')].find(
+        (button) => button.textContent?.trim() === 'Retry'
+      )
+      expect(retry, 'a transient load error must offer Retry in the open panel').toBeDefined()
+      await act(async () => retry!.click())
+      await flush()
+      expect(load).toHaveBeenCalledTimes(2)
+      expect(container.textContent).not.toContain('database busy')
+    }
+  )
+
+  it.each(['Execution Log', 'Messages', 'Review'] as const)(
+    'retries a transient deferred %s failure without changing versions',
+    async (tab) => {
+      const load =
+        tab === 'Execution Log'
+          ? getVersionExecution
+          : tab === 'Messages'
+            ? getVersionMessages
+            : getVersionReview
+      load.mockRejectedValueOnce(new Error('IPC temporarily unavailable'))
+      await clickTab(tab)
+      await flush()
+      expect(load).toHaveBeenCalledTimes(1)
+      expect(container.textContent).toContain('IPC temporarily unavailable')
+      const retry = [...container.querySelectorAll('button')].find(
+        (button) => button.textContent?.trim() === 'Retry'
+      )
+      expect(retry, 'a failed deferred section must offer Retry').toBeDefined()
+      await act(async () => retry!.click())
+      await flush()
+      expect(load).toHaveBeenCalledTimes(2)
+      expect(getVersionProvenance).toHaveBeenCalledTimes(1)
+      expect(container.textContent).not.toContain('IPC temporarily unavailable')
+    }
+  )
+
   it('shows user-edit lineage without requesting Agent provenance', async () => {
     act(() => root.unmount())
     container.replaceChildren()

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -470,6 +470,39 @@ afterEach(() => {
 })
 
 describe('ArtifactProvenancePanel', () => {
+  it('navigates to the previous Artifact version outside the loaded history page', async () => {
+    act(() => root.unmount())
+    container.replaceChildren()
+    root = createRoot(container)
+    vi.mocked(window.api.artifacts.getLineage).mockResolvedValue({
+      artifactId: 'artifact-1',
+      filename: 'sin.png',
+      originSession: { sessionId: 'session-1', state: 'active' },
+      versions: [],
+      selectedVersion: secondDescriptor,
+      previousVersion: descriptor,
+      headVersion: secondDescriptor
+    })
+    await act(async () =>
+      root.render(
+        <ArtifactProvenancePanel
+          item={{ ...item, selectedVersionId: 'version-2' }}
+          projectId="project-1"
+          onClose={vi.fn()}
+        />
+      )
+    )
+    await flush()
+    const previous = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Previous Artifact version"]'
+    )
+    expect(previous?.disabled).toBe(false)
+    await act(async () => previous?.click())
+    await flush()
+    expect(getVersionProvenance).toHaveBeenLastCalledWith(
+      expect.objectContaining({ versionId: 'version-1' })
+    )
+  })
   it('retries an earlier history page without reloading core evidence or changing selection', async () => {
     act(() => root.unmount())
     container.replaceChildren()

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -1,3 +1,11 @@
+import { useVersionHistoryPages } from './use-version-history-pages'
+import { VersionHistoryLoadButton } from './VersionHistoryLoadButton'
+import {
+  provenanceReadFailure,
+  unwrapProvenanceRead,
+  type ProvenanceReadFailure
+} from '../../../../shared/provenance-read-result'
+import { ProvenanceLoadNotice } from './ProvenanceLoadNotice'
 import { ChevronLeft, ChevronRight, Circle, Download, LoaderCircle, X } from 'lucide-react'
 import type { TFunction } from 'i18next'
 import { Fragment, useEffect, useMemo, useState } from 'react'
@@ -60,7 +68,8 @@ type DeferredSection =
   | Pick<ArtifactVersionProvenance, 'messages'>
   | Pick<ArtifactVersionProvenance, 'review'>
 type DeferredSectionResult =
-  { state: 'loaded'; section: DeferredSection } | { state: 'error'; message: string }
+  | { state: 'loaded'; section: DeferredSection }
+  | { state: 'error'; message: string; kind: ProvenanceReadFailure['kind'] }
 
 type CodeReconstructionPanelState =
   | { status: 'loading' }
@@ -504,21 +513,25 @@ const ArtifactProvenancePanel = ({
   const formatDate = useDateTimeFormat()
   const tabScrollFadeRef = useHorizontalScrollFade<HTMLDivElement>()
   const lineageKey = `${projectId}:${item.sessionId}:${item.artifactId ?? ''}`
-  const lineageRequestKey = `${lineageKey}:${item.selectedVersionId ?? ''}`
-  const [lineageResult, setLineageResult] = useState<{
-    key: string
-    value?: ArtifactLineageProvenance
-    unavailable?: boolean
-    error?: string
-  }>()
   const [selectedVersion, setSelectedVersion] = useState<{
     artifactId: string
     versionId: string
   }>()
+  const requestedVersionId =
+    selectedVersion && selectedVersion.artifactId === item.artifactId
+      ? selectedVersion.versionId
+      : item.selectedVersionId
+  const lineageRequestKey = `${lineageKey}:${requestedVersionId ?? ''}`
+  const [lineageResult, setLineageResult] = useState<{
+    key: string
+    value?: ArtifactLineageProvenance
+    unavailable?: boolean
+    error?: ProvenanceReadFailure
+  }>()
   const [provenanceResult, setProvenanceResult] = useState<{
     key: string
     value?: ArtifactVersionProvenance
-    error?: string
+    error?: ProvenanceReadFailure
   }>()
   const [activeTab, setActiveTab] = useState<ProvenanceTab>('code')
   const [deferredSectionResults, setDeferredSectionResults] = useState<
@@ -528,6 +541,8 @@ const ArtifactProvenancePanel = ({
     Record<string, CodeReconstructionPanelState>
   >({})
   const [reviewRevision, setReviewRevision] = useState(0)
+  const [lineageRetry, setLineageRetry] = useState(0)
+  const [coreRetry, setCoreRetry] = useState(0)
   const [showAllPackagesKey, setShowAllPackagesKey] = useState<string>()
   const [exportingNotebook, setExportingNotebook] = useState(false)
   const [notebookExportFailure, setNotebookExportFailure] = useState<{
@@ -538,13 +553,36 @@ const ArtifactProvenancePanel = ({
     key: string
     message: string
   }>()
-  const lineage = lineageResult?.key === lineageRequestKey ? lineageResult.value : undefined
+  const initialLineage = lineageResult?.key === lineageRequestKey ? lineageResult.value : undefined
+  const historyLineage = lineageResult?.key.startsWith(lineageKey + ':')
+    ? lineageResult.value
+    : undefined
+  const history = useVersionHistoryPages({
+    historyKey:
+      lineageKey +
+      ':' +
+      (historyLineage?.headVersion?.versionId ?? historyLineage?.versions.at(-1)?.versionId ?? ''),
+    initial: historyLineage,
+    loadPage: async (cursor) => {
+      const value = unwrapProvenanceRead(
+        await window.api.artifacts.getLineage({
+          projectId,
+          appSessionId: item.sessionId,
+          artifactId: item.artifactId!,
+          versionId: item.selectedVersionId,
+          cursor
+        })
+      )
+      if (!value) throw new Error('Artifact history is unavailable.')
+      return value
+    }
+  })
+  const lineage = useMemo(
+    () => (initialLineage ? { ...initialLineage, versions: history.versions } : undefined),
+    [initialLineage, history.versions]
+  )
   const lineageUnavailable =
     lineageResult?.key === lineageRequestKey && lineageResult.unavailable === true
-  const requestedVersionId =
-    selectedVersion && selectedVersion.artifactId === item.artifactId
-      ? selectedVersion.versionId
-      : item.selectedVersionId
   const selectedVersionDescriptor = lineage
     ? resolveArtifactVersionDescriptor(lineage, requestedVersionId)
     : undefined
@@ -552,9 +590,11 @@ const ArtifactProvenancePanel = ({
   const isUserEdit = selectedVersionDescriptor?.originKind === 'user_edit'
   const isLegacyVersion = selectedVersionDescriptor?.originKind === 'legacy'
   const basedOnVersionId = selectedVersionDescriptor?.basedOnVersionId ?? undefined
-  const basedOnVersionNumber = lineage?.versions.find(
-    (version) => version.versionId === basedOnVersionId
-  )?.versionNumber
+  const basedOnVersionNumber =
+    lineage?.versions.find((version) => version.versionId === basedOnVersionId)?.versionNumber ??
+    (lineage?.basedOnVersion?.versionId === basedOnVersionId
+      ? lineage?.basedOnVersion?.versionNumber
+      : undefined)
   const selectedVersionUnavailable = Boolean(lineage && requestedVersionId && !selectedVersionId)
   const provenanceKey = `${lineageKey}:${selectedVersionId ?? ''}`
   const coreProvenance =
@@ -566,7 +606,12 @@ const ArtifactProvenancePanel = ({
     codeActionFailure?.key === provenanceKey ? codeActionFailure.message : undefined
   const codeReconstructionResult = codeReconstructionResults[provenanceKey]
   const error =
-    (selectedVersionUnavailable ? t('The selected Artifact version is unavailable.') : undefined) ??
+    (selectedVersionUnavailable
+      ? {
+          kind: 'load-failed' as const,
+          message: t('The selected Artifact version is unavailable.')
+        }
+      : undefined) ??
     (lineageResult?.key === lineageRequestKey ? lineageResult.error : undefined) ??
     (provenanceResult?.key === provenanceKey ? provenanceResult.error : undefined)
 
@@ -582,7 +627,13 @@ const ArtifactProvenancePanel = ({
     let active = true
     if (!item.artifactId) return
     void window.api.artifacts
-      .getLineage({ projectId, appSessionId: item.sessionId, artifactId: item.artifactId })
+      .getLineage({
+        projectId,
+        appSessionId: item.sessionId,
+        artifactId: item.artifactId,
+        ...(requestedVersionId ? { versionId: requestedVersionId } : {})
+      })
+      .then(unwrapProvenanceRead)
       .then((value) => {
         if (!active) return
         setLineageResult({ key: lineageRequestKey, value, unavailable: value === undefined })
@@ -591,33 +642,7 @@ const ArtifactProvenancePanel = ({
         if (active) {
           setLineageResult({
             key: lineageRequestKey,
-            error: failure instanceof Error ? failure.message : String(failure)
-          })
-        }
-      })
-    return () => {
-      active = false
-    }
-  }, [item.artifactId, item.sessionId, lineageRequestKey, projectId])
-
-  useEffect(() => {
-    let active = true
-    if (!item.artifactId || !selectedVersionId || !lineage || isUserEdit || isLegacyVersion) return
-    void window.api.artifacts
-      .getVersionProvenance({
-        projectId,
-        appSessionId: item.sessionId,
-        artifactId: item.artifactId,
-        versionId: selectedVersionId
-      })
-      .then((value) => {
-        if (active) setProvenanceResult({ key: provenanceKey, value })
-      })
-      .catch((failure: unknown) => {
-        if (active) {
-          setProvenanceResult({
-            key: provenanceKey,
-            error: failure instanceof Error ? failure.message : String(failure)
+            error: provenanceReadFailure(failure)
           })
         }
       })
@@ -625,11 +650,47 @@ const ArtifactProvenancePanel = ({
       active = false
     }
   }, [
+    item.artifactId,
+    item.sessionId,
+    lineageRequestKey,
+    projectId,
+    lineageRetry,
+    requestedVersionId
+  ])
+
+  useEffect(() => {
+    let active = true
+    if (!item.artifactId || !selectedVersionId || !initialLineage || isUserEdit || isLegacyVersion)
+      return
+    void window.api.artifacts
+      .getVersionProvenance({
+        projectId,
+        appSessionId: item.sessionId,
+        artifactId: item.artifactId,
+        versionId: selectedVersionId
+      })
+      .then(unwrapProvenanceRead)
+      .then((value) => {
+        if (active) setProvenanceResult({ key: provenanceKey, value })
+      })
+      .catch((failure: unknown) => {
+        if (active) {
+          setProvenanceResult({
+            key: provenanceKey,
+            error: provenanceReadFailure(failure)
+          })
+        }
+      })
+    return () => {
+      active = false
+    }
+  }, [
+    coreRetry,
     isUserEdit,
     isLegacyVersion,
     item.artifactId,
     item.sessionId,
-    lineage,
+    initialLineage,
     projectId,
     provenanceKey,
     selectedVersionId
@@ -733,6 +794,7 @@ const ArtifactProvenancePanel = ({
     if (!load) return
     const sectionKey = `${provenanceKey}:${activeTab}:${activeTab === 'review' ? reviewReloadKey : 0}`
     void load
+      .then((value) => unwrapProvenanceRead<DeferredSection>(value))
       .then((section) => {
         if (!active) return
         setDeferredSectionResults((current) => ({
@@ -746,7 +808,7 @@ const ArtifactProvenancePanel = ({
           ...current,
           [sectionKey]: {
             state: 'error',
-            message: failure instanceof Error ? failure.message : String(failure)
+            ...provenanceReadFailure(failure)
           }
         }))
       })
@@ -764,6 +826,29 @@ const ArtifactProvenancePanel = ({
     reviewReloadKey,
     selectedVersionId
   ])
+
+  const diagnosticsFor = (failure: ProvenanceReadFailure, section: string): string =>
+    JSON.stringify(
+      {
+        projectId,
+        sessionId: item.sessionId,
+        artifactId: item.artifactId,
+        versionId: selectedVersionId,
+        section,
+        ...failure
+      },
+      null,
+      2
+    )
+  const retryCore = (): void => {
+    if (lineageResult?.error) {
+      setLineageResult(undefined)
+      setLineageRetry((value) => value + 1)
+    } else {
+      setProvenanceResult(undefined)
+      setCoreRetry((value) => value + 1)
+    }
+  }
 
   const selectedIndex =
     lineage?.versions.findIndex((version) => version.versionId === selectedVersionId) ?? -1
@@ -869,7 +954,7 @@ const ArtifactProvenancePanel = ({
 
   const selectVersion = (versionId: string): void => {
     if (!item.artifactId) return
-    const version = lineage?.versions.find((candidate) => candidate.versionId === versionId)
+    const version = lineage ? resolveArtifactVersionDescriptor(lineage, versionId) : undefined
     if (!version) return
 
     const nextItem = createPreviewFileItemForArtifactVersion({ item, version, projectId })
@@ -886,7 +971,7 @@ const ArtifactProvenancePanel = ({
     setNotebookExportFailure(undefined)
     try {
       const baseName = item.name.replace(/\.[^.]+$/u, '') || 'artifact'
-      const versionNumber = lineage?.versions[selectedIndex]?.versionNumber ?? 1
+      const versionNumber = selectedVersionDescriptor?.versionNumber ?? 1
       for (const kernel of executionKernels) {
         const notebook = buildExecutionNotebook(rawExecutionRuns, kernel, {
           artifactId: item.artifactId,
@@ -930,7 +1015,7 @@ const ArtifactProvenancePanel = ({
         bytes.byteOffset + bytes.byteLength
       ) as ArrayBuffer
       const baseName = item.name.replace(/\.[^.]+$/u, '') || 'artifact'
-      const versionNumber = lineage?.versions[selectedIndex]?.versionNumber ?? 1
+      const versionNumber = selectedVersionDescriptor?.versionNumber ?? 1
       const format = scriptDownloadFormats[language]
       await window.api.saveBlobFile({
         suggestedName: `${baseName}-v${versionNumber}.${format.extension}`,
@@ -1021,25 +1106,33 @@ const ArtifactProvenancePanel = ({
           aria-label={t('Previous Artifact version')}
           disabled={selectedIndex <= 0}
           onClick={() => {
-            const versionId = lineage?.versions[selectedIndex - 1]?.versionId
+            const versionId = (
+              selectedIndex > 0 ? lineage?.versions[selectedIndex - 1] : lineage?.previousVersion
+            )?.versionId
             if (versionId) selectVersion(versionId)
           }}
         >
           <ChevronLeft aria-hidden="true" />
         </Button>
         <span className="text-xs font-medium text-text-100">
-          {selectedIndex >= 0
-            ? `v${lineage?.versions[selectedIndex]?.versionNumber}`
-            : t('Version')}
+          {selectedVersionDescriptor ? `v${selectedVersionDescriptor.versionNumber}` : t('Version')}
         </span>
         <Button
           type="button"
           variant="ghost"
           size="icon-xs"
           aria-label={t('Next Artifact version')}
-          disabled={!lineage || selectedIndex < 0 || selectedIndex >= lineage.versions.length - 1}
+          disabled={
+            !lineage ||
+            ((selectedIndex < 0 || selectedIndex >= lineage.versions.length - 1) &&
+              !lineage.nextVersion)
+          }
           onClick={() => {
-            const versionId = lineage?.versions[selectedIndex + 1]?.versionId
+            const versionId = (
+              selectedIndex >= 0
+                ? (lineage?.versions[selectedIndex + 1] ?? lineage?.nextVersion)
+                : lineage?.nextVersion
+            )?.versionId
             if (versionId) selectVersion(versionId)
           }}
         >
@@ -1069,6 +1162,7 @@ const ArtifactProvenancePanel = ({
         </Button>
       </div>
 
+      <VersionHistoryLoadButton history={history} />
       {!isUserEdit && !isLegacyVersion ? (
         <div
           ref={tabScrollFadeRef}
@@ -1091,7 +1185,18 @@ const ArtifactProvenancePanel = ({
       ) : null}
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {error ? <p className="p-5 text-sm text-danger-000">{error}</p> : null}
+        {error ? (
+          <ProvenanceLoadNotice
+            key={provenanceKey + ':core'}
+            failure={error}
+            diagnostics={diagnosticsFor(error, lineageResult?.error ? 'lineage' : 'core')}
+            onRetry={
+              selectedVersionUnavailable || error.kind === 'integrity-failed'
+                ? undefined
+                : retryCore
+            }
+          />
+        ) : null}
         {!error && lineageUnavailable ? (
           <p className="p-5 text-sm text-text-300">
             {t('Provenance is not available for this legacy file.')}
@@ -1138,16 +1243,39 @@ const ArtifactProvenancePanel = ({
           </div>
         ) : null}
         {provenance && deferredSectionResult?.state === 'error' ? (
-          <p className="p-5 text-sm text-danger-000">{deferredSectionResult.message}</p>
+          <ProvenanceLoadNotice
+            key={deferredSectionKey}
+            failure={deferredSectionResult}
+            diagnostics={diagnosticsFor(deferredSectionResult, activeTab)}
+            onRetry={
+              deferredSectionResult.kind === 'integrity-failed'
+                ? undefined
+                : () =>
+                    setDeferredSectionResults((current) => {
+                      const next = { ...current }
+                      if (deferredSectionKey) delete next[deferredSectionKey]
+                      return next
+                    })
+            }
+          />
         ) : null}
         {provenance && activeTab === 'code' ? (
           <section>
             {provenance.contentStatus.state === 'unavailable' ? (
-              <p className="border-b border-warning-100/50 bg-warning-100/10 px-4 py-2 text-xs text-warning-900">
-                {t('Artifact content is {{reason}}; captured provenance remains available.', {
-                  reason: provenance.contentStatus.reason
-                })}
-              </p>
+              <ProvenanceLoadNotice
+                key={provenanceKey + ':content'}
+                failure={{
+                  kind: 'integrity-failed',
+                  message: t(
+                    'Artifact content is {{reason}}; captured provenance remains available.',
+                    { reason: provenance.contentStatus.reason }
+                  )
+                }}
+                diagnostics={diagnosticsFor(
+                  { kind: 'integrity-failed', message: provenance.contentStatus.reason },
+                  'content'
+                )}
+              />
             ) : null}
             <div className={tabActionBarClassName}>
               {generatedCode ? (

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -1104,7 +1104,7 @@ const ArtifactProvenancePanel = ({
           variant="ghost"
           size="icon-xs"
           aria-label={t('Previous Artifact version')}
-          disabled={selectedIndex <= 0}
+          disabled={selectedIndex <= 0 && !lineage?.previousVersion}
           onClick={() => {
             const versionId = (
               selectedIndex > 0 ? lineage?.versions[selectedIndex - 1] : lineage?.previousVersion

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -342,6 +342,34 @@ describe('PreviewFileSurface managed text versions', () => {
       .mockResolvedValue({ ok: true, value: managedInspect })
   })
 
+  it.each(['plot.png', 'report.pdf', 'README.md'])(
+    'offers older history for %s only alongside a version navigator',
+    async (name) => {
+      const isText = name.endsWith('.md')
+      window.api.managedFileVersions.inspect = vi.fn().mockResolvedValue({
+        ok: true,
+        value: {
+          ...managedInspect,
+          displayName: name,
+          nextCursor: '1',
+          text: isText ? managedInspect.text : undefined,
+          canEdit: isText,
+          canDiff: isText
+        }
+      })
+      await act(async () =>
+        root.render(<PreviewFileSurface item={{ ...managedUploadItem, name }} onClose={vi.fn()} />)
+      )
+      expect(
+        container.querySelector('[data-testid="managed-preview-version-navigation"]') !== null
+      ).toBe(isText)
+      const loader = [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Load earlier versions'
+      )
+      expect(loader !== undefined).toBe(isText)
+    }
+  )
+
   it('keeps the selected download target while inspection is pending and after failure', async () => {
     type Result = Awaited<ReturnType<typeof window.api.managedFileVersions.inspect>>
     let rejectInspect!: (error: Error) => void

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -342,6 +342,68 @@ describe('PreviewFileSurface managed text versions', () => {
       .mockResolvedValue({ ok: true, value: managedInspect })
   })
 
+  it('keeps the selected download target while inspection is pending and after failure', async () => {
+    type Result = Awaited<ReturnType<typeof window.api.managedFileVersions.inspect>>
+    let rejectInspect!: (error: Error) => void
+    window.api.managedFileVersions.inspect = vi.fn((request) =>
+      request.versionId === 'upload-v1'
+        ? new Promise<Result>((_resolve, reject) => {
+            rejectInspect = reject
+          })
+        : Promise.resolve({
+            ok: true as const,
+            value: {
+              ...managedInspect,
+              selectedVersion: managedInspect.versions[1],
+              headVersion: managedInspect.versions[1]
+            }
+          })
+    )
+    await act(async () =>
+      root.render(<PreviewFileSurface item={managedUploadItem} onClose={vi.fn()} />)
+    )
+    await click(container.querySelector('[aria-label="Previous file version"]'))
+    const expectSelectedDownload = (): void => {
+      expect(downloadButtonSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          versionId: 'upload-v1',
+          versionNumber: 1,
+          latestVersionId: 'upload-v2'
+        })
+      )
+      expect(
+        container.querySelector('[data-testid="managed-preview-version-navigation"]')?.textContent
+      ).toContain('v1')
+    }
+    expectSelectedDownload()
+    await act(async () => rejectInspect(new Error('inspection temporarily unavailable')))
+    expectSelectedDownload()
+  })
+
+  it('navigates to the previous managed version outside the loaded history page', async () => {
+    window.api.managedFileVersions.inspect = vi.fn().mockResolvedValue({
+      ok: true,
+      value: {
+        ...managedInspect,
+        versions: [],
+        selectedVersion: managedInspect.versions[1],
+        headVersion: managedInspect.versions[1],
+        previousVersion: managedInspect.versions[0]
+      }
+    })
+    await act(async () =>
+      root.render(<PreviewFileSurface item={managedUploadItem} onClose={vi.fn()} />)
+    )
+    const previous = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Previous file version"]'
+    )
+    expect(previous?.disabled).toBe(false)
+    await click(previous)
+    expect(window.api.managedFileVersions.inspect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ versionId: 'upload-v1' })
+    )
+  })
+
   it('stays read-only when the Web runtime omits the managed-file namespace', async () => {
     Object.defineProperty(window, 'api', {
       configurable: true,

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -1,3 +1,6 @@
+import { useVersionHistoryPages } from './use-version-history-pages'
+import { VersionHistoryLoadButton } from './VersionHistoryLoadButton'
+import { unwrapProvenanceRead } from '../../../../shared/provenance-read-result'
 import {
   BookOpen,
   Check,
@@ -21,6 +24,7 @@ import {
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState
 } from 'react'
@@ -507,7 +511,8 @@ const ArtifactVersionNavigation = ({
   const selectedIndex = lineage.versions.findIndex(
     (version) => version.versionId === selectedVersionId
   )
-  if (selectedIndex < 0) return null
+  const selected = resolveArtifactVersionDescriptor(lineage, selectedVersionId)
+  if (!selected) return null
 
   return (
     <div
@@ -519,25 +524,32 @@ const ArtifactVersionNavigation = ({
         variant="ghost"
         size="icon-xs"
         aria-label={t('Previous Artifact version')}
-        disabled={selectedIndex <= 0}
+        disabled={selectedIndex <= 0 && !lineage.previousVersion}
         onClick={() => {
-          const versionId = lineage.versions[selectedIndex - 1]?.versionId
+          const versionId = (
+            selectedIndex > 0 ? lineage.versions[selectedIndex - 1] : lineage.previousVersion
+          )?.versionId
           if (versionId) onSelect(versionId)
         }}
       >
         <ChevronLeft aria-hidden="true" />
       </Button>
-      <span className="text-xs font-medium text-text-100">
-        v{lineage.versions[selectedIndex]?.versionNumber}
-      </span>
+      <span className="text-xs font-medium text-text-100">v{selected.versionNumber}</span>
       <Button
         type="button"
         variant="ghost"
         size="icon-xs"
         aria-label={t('Next Artifact version')}
-        disabled={selectedIndex >= lineage.versions.length - 1}
+        disabled={
+          (selectedIndex < 0 || selectedIndex >= lineage.versions.length - 1) &&
+          !lineage.nextVersion
+        }
         onClick={() => {
-          const versionId = lineage.versions[selectedIndex + 1]?.versionId
+          const versionId = (
+            selectedIndex >= 0
+              ? (lineage.versions[selectedIndex + 1] ?? lineage.nextVersion)
+              : lineage.nextVersion
+          )?.versionId
           if (versionId) onSelect(versionId)
         }}
       >
@@ -570,23 +582,32 @@ const ManagedVersionNavigation = ({
         aria-label={t('Previous file version')}
         disabled={selectedIndex <= 0}
         onClick={() => {
-          const id = inspect.versions[selectedIndex - 1]?.id
+          const id = (
+            selectedIndex > 0 ? inspect.versions[selectedIndex - 1] : inspect.previousVersion
+          )?.id
           if (id) onSelect(id)
         }}
       >
         <ChevronLeft aria-hidden="true" />
       </Button>
       <span className="min-w-8 text-center text-xs font-medium text-text-100">
-        v{inspect.versions[selectedIndex]?.versionNumber}
+        v{inspect.selectedVersion?.versionNumber ?? inspect.versions[selectedIndex]?.versionNumber}
       </span>
       <Button
         type="button"
         variant="ghost"
         size="icon-xs"
         aria-label={t('Next file version')}
-        disabled={selectedIndex >= inspect.versions.length - 1}
+        disabled={
+          (selectedIndex < 0 || selectedIndex >= inspect.versions.length - 1) &&
+          !inspect.nextVersion
+        }
         onClick={() => {
-          const id = inspect.versions[selectedIndex + 1]?.id
+          const id = (
+            selectedIndex >= 0
+              ? (inspect.versions[selectedIndex + 1] ?? inspect.nextVersion)
+              : inspect.nextVersion
+          )?.id
           if (id) onSelect(id)
         }}
       >
@@ -711,15 +732,46 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
     // Selection and origin lifecycle changes can update a stable tab without changing its Artifact
     // identity. Keep the response keyed to the full request so stale lineage is never consumed.
     const lineageRequestKey = `${lineageKey}:${sessionFilesRevision}:${previewItem.selectedVersionId ?? ''}:${previewItem.originSession?.state ?? ''}`
-    const lineage =
+    const initialLineage =
       lineageLoadState?.key === lineageRequestKey && lineageLoadState.phase === 'loaded'
         ? lineageLoadState.value
         : undefined
+    const historyLineage =
+      lineageLoadState?.key.startsWith(lineageKey + ':') && lineageLoadState.phase === 'loaded'
+        ? lineageLoadState.value
+        : undefined
+    const lineageHistory = useVersionHistoryPages({
+      historyKey:
+        lineageKey +
+        ':' +
+        (historyLineage?.headVersion?.versionId ??
+          historyLineage?.versions.at(-1)?.versionId ??
+          ''),
+      initial: historyLineage,
+      loadPage: async (cursor) => {
+        const value = unwrapProvenanceRead(
+          await window.api.artifacts.getLineage({
+            projectId: projectId!,
+            appSessionId: previewItem.sessionId,
+            artifactId: previewItem.artifactId!,
+            versionId: previewItem.selectedVersionId,
+            cursor
+          })
+        )
+        if (!value) throw new Error('Artifact history is unavailable.')
+        return value
+      }
+    })
+    const lineage = useMemo(
+      () => (initialLineage ? { ...initialLineage, versions: lineageHistory.versions } : undefined),
+      [initialLineage, lineageHistory.versions]
+    )
     const lineageFailed =
       lineageLoadState?.key === lineageRequestKey && lineageLoadState.phase === 'error'
-    const exactSelectedVersion = lineage?.versions.find(
-      (version) => version.versionId === previewItem.selectedVersionId
-    )
+    const exactSelectedVersion =
+      lineage && previewItem.selectedVersionId
+        ? resolveArtifactVersionDescriptor(lineage, previewItem.selectedVersionId)
+        : undefined
     const newestLoadedVersion = lineage?.versions.at(-1)
     const selectionIsNewerThanLoadedLineage =
       typeof previewItem.versionNumber === 'number' &&
@@ -914,10 +966,16 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
         .getLineage({
           projectId,
           appSessionId: previewItem.sessionId,
-          artifactId: previewItem.artifactId
+          artifactId: previewItem.artifactId,
+          ...(previewItem.selectedVersionId ? { versionId: previewItem.selectedVersionId } : {})
         })
         .then((value) => {
-          if (active) setLineageLoadState({ key: lineageRequestKey, phase: 'loaded', value })
+          if (active)
+            setLineageLoadState({
+              key: lineageRequestKey,
+              phase: 'loaded',
+              value: unwrapProvenanceRead(value)
+            })
         })
         .catch(() => {
           if (active) setLineageLoadState({ key: lineageRequestKey, phase: 'error' })
@@ -932,6 +990,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
       lineageRetryToken,
       previewItem.artifactId,
       previewItem.sessionId,
+      previewItem.selectedVersionId,
       previewItem.source,
       projectId
     ])
@@ -1018,7 +1077,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
 
     const selectPreviewVersion = (versionId: string): void => {
       if (!lineage || !projectId) return
-      const version = lineage.versions.find((candidate) => candidate.versionId === versionId)
+      const version = resolveArtifactVersionDescriptor(lineage, versionId)
       if (!version) return
 
       applyVersionItem(
@@ -1062,9 +1121,13 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
 
     const selectManagedVersion = (versionId: string): void => {
       if (!managedNavigationInspect || !projectId) return
-      const version = managedNavigationInspect.versions.find(
-        (candidate) => candidate.id === versionId
-      )
+      const version = [
+        managedNavigationInspect.selectedVersion,
+        managedNavigationInspect.headVersion,
+        managedNavigationInspect.previousVersion,
+        managedNavigationInspect.nextVersion,
+        ...managedNavigationInspect.versions
+      ].find((candidate) => candidate?.id === versionId)
       if (!version) return
       const nextItem = createPreviewFileItemForManagedVersion({
         item: previewItem,
@@ -1398,6 +1461,11 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                   lineage={lineage}
                   selectedVersionId={selectedVersionId}
                   onSelect={selectPreviewVersion}
+                />
+              ) : null}
+              {!showProvenance ? (
+                <VersionHistoryLoadButton
+                  history={managedIdentity ? managedWorkflow.history : lineageHistory}
                 />
               ) : null}
               <div

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -580,7 +580,7 @@ const ManagedVersionNavigation = ({
         variant="ghost"
         size="icon-xs"
         aria-label={t('Previous file version')}
-        disabled={selectedIndex <= 0}
+        disabled={selectedIndex <= 0 && !inspect.previousVersion}
         onClick={() => {
           const id = (
             selectedIndex > 0 ? inspect.versions[selectedIndex - 1] : inspect.previousVersion

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -1449,24 +1449,25 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                   </Button>
                 </div>
               ) : !showProvenance && managedNavigationInspect?.text !== undefined ? (
-                <ManagedVersionNavigation
-                  inspect={managedNavigationInspect}
-                  onSelect={selectManagedVersion}
-                />
+                <>
+                  <ManagedVersionNavigation
+                    inspect={managedNavigationInspect}
+                    onSelect={selectManagedVersion}
+                  />
+                  <VersionHistoryLoadButton history={managedWorkflow.history} />
+                </>
               ) : !showProvenance &&
                 !managedIdentity &&
                 lineage &&
                 hasManagedTextEditExtension(resolvedPreviewItem.name) ? (
-                <ArtifactVersionNavigation
-                  lineage={lineage}
-                  selectedVersionId={selectedVersionId}
-                  onSelect={selectPreviewVersion}
-                />
-              ) : null}
-              {!showProvenance ? (
-                <VersionHistoryLoadButton
-                  history={managedIdentity ? managedWorkflow.history : lineageHistory}
-                />
+                <>
+                  <ArtifactVersionNavigation
+                    lineage={lineage}
+                    selectedVersionId={selectedVersionId}
+                    onSelect={selectPreviewVersion}
+                  />
+                  <VersionHistoryLoadButton history={lineageHistory} />
+                </>
               ) : null}
               <div
                 data-testid="preview-file-content-region"

--- a/src/renderer/src/pages/workspace/ProvenanceLoadNotice.tsx
+++ b/src/renderer/src/pages/workspace/ProvenanceLoadNotice.tsx
@@ -1,0 +1,63 @@
+import { TriangleAlert } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { ErrorNotice } from '@/components/error-notice'
+import { Button } from '@/components/ui/button'
+import type { ProvenanceReadFailure } from '../../../../shared/provenance-read-result'
+
+export const ProvenanceLoadNotice = ({
+  failure,
+  diagnostics,
+  onRetry
+}: {
+  failure: ProvenanceReadFailure
+  diagnostics: string
+  onRetry?: () => void
+}): React.JSX.Element => {
+  const { t } = useTranslation()
+  const [showDiagnostics, setShowDiagnostics] = useState(false)
+  const [copyFailed, setCopyFailed] = useState(false)
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="flex flex-col items-center gap-3 p-5" role="alert">
+      <ErrorNotice
+        icon={TriangleAlert}
+        tone={failure.kind === 'integrity-failed' ? 'red' : 'amber'}
+        title={
+          failure.kind === 'integrity-failed'
+            ? t('Provenance integrity error')
+            : t('Provenance could not be loaded')
+        }
+        description={failure.message}
+        primaryButton={onRetry ? { label: t('Retry'), onClick: onRetry } : undefined}
+        secondaryButton={{ label: t('View diagnostics'), onClick: () => setShowDiagnostics(true) }}
+      />
+      {showDiagnostics ? (
+        <div className="w-full min-w-0 space-y-2">
+          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-3 text-xs">
+            {diagnostics}
+          </pre>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setCopyFailed(false)
+              void Promise.resolve()
+                .then(() => navigator.clipboard.writeText(diagnostics))
+                .then(() => setCopied(true))
+                .catch(() => setCopyFailed(true))
+            }}
+          >
+            {copied ? t('Copied') : t('Copy diagnostics')}
+          </Button>
+          {copyFailed ? (
+            <p className="text-sm text-danger-000">
+              {t('Could not copy diagnostics. Select and copy the text above.')}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/pages/workspace/VersionHistoryLoadButton.tsx
+++ b/src/renderer/src/pages/workspace/VersionHistoryLoadButton.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+
+export const VersionHistoryLoadButton = ({
+  history
+}: {
+  history: { nextCursor?: string; loading: boolean; error?: string; loadEarlier: () => void }
+}): React.JSX.Element | null => {
+  const { t } = useTranslation()
+  if (!history.nextCursor) return null
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-2 py-1">
+      <Button variant="ghost" size="xs" disabled={history.loading} onClick={history.loadEarlier}>
+        {history.loading
+          ? t('Loading earlier versions…')
+          : history.error
+            ? t('Retry loading earlier versions')
+            : t('Load earlier versions')}
+      </Button>
+      {history.error ? (
+        <span role="alert" className="text-xs text-danger-000">
+          {history.error}
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -168,9 +168,9 @@ export const ArtifactMentionPopup = ({
           setSelectionError(t('Could not resolve file version.'))
           return
         }
-        const head = result.value.versions.find(
-          (version) => version.id === result.value.headVersionId
-        )
+        const head =
+          result.value.headVersion ??
+          result.value.versions.find((version) => version.id === result.value.headVersionId)
         if (!head) {
           setSelectionError(t('The current file version is unavailable.'))
           return

--- a/src/renderer/src/pages/workspace/preview-file-item.ts
+++ b/src/renderer/src/pages/workspace/preview-file-item.ts
@@ -263,8 +263,15 @@ export const resolveArtifactVersionDescriptor = (
   selectedVersionId: string | undefined
 ): ArtifactVersionDescriptor | undefined =>
   selectedVersionId === undefined
-    ? lineage.versions.at(-1)
-    : lineage.versions.find((version) => version.versionId === selectedVersionId)
+    ? (lineage.headVersion ?? lineage.versions.at(-1))
+    : [
+        lineage.selectedVersion,
+        lineage.headVersion,
+        lineage.basedOnVersion,
+        lineage.previousVersion,
+        lineage.nextVersion,
+        ...lineage.versions
+      ].find((version) => version?.versionId === selectedVersionId)
 
 // Converts a sent user upload into the same preview shape used by message attachment clicks.
 export const createPreviewFileItemFromUpload = (

--- a/src/renderer/src/pages/workspace/use-version-history-pages.ts
+++ b/src/renderer/src/pages/workspace/use-version-history-pages.ts
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+type HistoryPage<Version> = { versions: Version[]; nextCursor?: string }
+
+// Pages survive selection changes within one file/head, but never cross an identity or head change.
+export const useVersionHistoryPages = <Version extends { id: string; versionNumber: number }>({
+  historyKey,
+  initial,
+  loadPage
+}: {
+  historyKey: string
+  initial?: HistoryPage<Version>
+  loadPage: (cursor: string) => Promise<HistoryPage<Version>>
+}): {
+  versions: Version[]
+  nextCursor?: string
+  loading: boolean
+  error?: string
+  loadEarlier: () => void
+} => {
+  const [state, setState] = useState<{
+    key: string
+    pages: HistoryPage<Version>[]
+    loading: boolean
+    error?: string
+  }>()
+  const request = useRef<object | undefined>(undefined)
+  useEffect(() => {
+    request.current = undefined
+    return () => {
+      request.current = undefined
+    }
+  }, [historyKey])
+  const current = state?.key === historyKey ? state : undefined
+  const pages = current?.pages ?? []
+  const nextCursor = pages.length ? pages.at(-1)!.nextCursor : initial?.nextCursor
+  const versions = useMemo(
+    () =>
+      [
+        ...new Map(
+          [
+            ...(current?.pages ?? []).flatMap((page) => page.versions),
+            ...(initial?.versions ?? [])
+          ].map((version) => [version.id, version])
+        ).values()
+      ].sort((left, right) => left.versionNumber - right.versionNumber),
+    [current?.pages, initial?.versions]
+  )
+  return {
+    versions,
+    nextCursor,
+    loading: current?.loading ?? false,
+    error: current?.error,
+    loadEarlier: () => {
+      if (!nextCursor || request.current) return
+      const token = {}
+      request.current = token
+      setState({ key: historyKey, pages, loading: true })
+      void loadPage(nextCursor)
+        .then((page) => {
+          if (request.current !== token) return
+          setState({ key: historyKey, pages: [...pages, page], loading: false })
+        })
+        .catch((error: unknown) => {
+          if (request.current !== token) return
+          setState({
+            key: historyKey,
+            pages,
+            loading: false,
+            error: error instanceof Error ? error.message : String(error)
+          })
+        })
+        .finally(() => {
+          if (request.current === token) request.current = undefined
+        })
+    }
+  }
+}

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
@@ -1,3 +1,4 @@
+import { useVersionHistoryPages } from './use-version-history-pages'
 import type { TFunction } from 'i18next'
 import {
   useCallback,
@@ -31,11 +32,14 @@ type ManagedVersionWorkflow = {
   startDiff: () => void
   stopDiff: () => void
   resetForVersionSelection: (preserveDiffMode: boolean) => void
+  history: ReturnType<typeof useVersionHistoryPages>
   refreshInspect: () => void
 }
 
 const isSourceTextVersion = (inspect: ManagedFileVersionInspectResult): boolean => {
-  const selected = inspect.versions.find((version) => version.id === inspect.selectedVersionId)
+  const selected =
+    inspect.selectedVersion ??
+    inspect.versions.find((version) => version.id === inspect.selectedVersionId)
   return selected !== undefined && !selected.basedOnVersionId && inspect.text !== undefined
 }
 
@@ -83,7 +87,7 @@ const useManagedVersionWorkflow = ({
     storedInspect.value.fileId === identity.fileId
       ? storedInspect.value
       : undefined
-  const navigationInspect =
+  const initialNavigationInspect =
     inspect ??
     (previousInspect &&
     (!item.selectedVersionId ||
@@ -92,13 +96,32 @@ const useManagedVersionWorkflow = ({
         ? { ...previousInspect, selectedVersionId: item.selectedVersionId }
         : previousInspect
       : undefined)
+  const history = useVersionHistoryPages({
+    historyKey:
+      source + ':' + projectId + ':' + identity?.fileId + ':' + previousInspect?.headVersionId,
+    initial: initialNavigationInspect ?? previousInspect,
+    loadPage: async (cursor) => {
+      const result = await window.api.managedFileVersions.inspect({
+        ...identity!,
+        versionId: initialNavigationInspect?.selectedVersionId,
+        cursor
+      })
+      if (!result.ok) throw new Error(result.error.message)
+      return result.value
+    }
+  })
+  const navigationInspect = initialNavigationInspect
+    ? { ...initialNavigationInspect, versions: history.versions }
+    : undefined
   const controlsInspect = inspect ?? (mode === 'diff' ? navigationInspect : undefined)
-  const selectedDownloadVersion = navigationInspect?.versions.find(
-    (version) => version.id === navigationInspect.selectedVersionId
-  )
-  const latestDownloadVersion = navigationInspect?.versions.find(
-    (version) => version.id === navigationInspect.headVersionId
-  )
+  const selectedDownloadVersion =
+    navigationInspect?.selectedVersion ??
+    navigationInspect?.versions.find(
+      (version) => version.id === navigationInspect.selectedVersionId
+    )
+  const latestDownloadVersion =
+    navigationInspect?.headVersion ??
+    navigationInspect?.versions.find((version) => version.id === navigationInspect.headVersionId)
 
   const resetDiff = useCallback(
     (nextMode: SetStateAction<ManagedVersionMode>): void => {
@@ -183,6 +206,7 @@ const useManagedVersionWorkflow = ({
     stopDiff: () => resetDiff('view'),
     resetForVersionSelection: (preserveDiffMode: boolean) =>
       resetDiff(preserveDiffMode && mode === 'diff' ? 'diff' : 'view'),
+    history,
     refreshInspect: () => setRefresh((value) => value + 1)
   }
 }

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
@@ -87,29 +87,43 @@ const useManagedVersionWorkflow = ({
     storedInspect.value.fileId === identity.fileId
       ? storedInspect.value
       : undefined
-  const initialNavigationInspect =
-    inspect ??
-    (previousInspect &&
-    (!item.selectedVersionId ||
-      previousInspect.versions.some((version) => version.id === item.selectedVersionId))
-      ? item.selectedVersionId
-        ? { ...previousInspect, selectedVersionId: item.selectedVersionId }
-        : previousInspect
-      : undefined)
   const history = useVersionHistoryPages({
     historyKey:
       source + ':' + projectId + ':' + identity?.fileId + ':' + previousInspect?.headVersionId,
-    initial: initialNavigationInspect ?? previousInspect,
+    initial: inspect ?? previousInspect,
     loadPage: async (cursor) => {
       const result = await window.api.managedFileVersions.inspect({
         ...identity!,
-        versionId: initialNavigationInspect?.selectedVersionId,
+        versionId: item.selectedVersionId ?? previousInspect?.selectedVersionId,
         cursor
       })
       if (!result.ok) throw new Error(result.error.message)
       return result.value
     }
   })
+  const pendingSelectedVersion = previousInspect
+    ? [
+        previousInspect.selectedVersion,
+        previousInspect.headVersion,
+        previousInspect.previousVersion,
+        previousInspect.nextVersion,
+        ...history.versions
+      ].find((version) => version?.id === item.selectedVersionId)
+    : undefined
+  const initialNavigationInspect =
+    inspect ??
+    (previousInspect &&
+    (!item.selectedVersionId || item.selectedVersionId === previousInspect.selectedVersionId)
+      ? previousInspect
+      : previousInspect && pendingSelectedVersion
+        ? {
+            ...previousInspect,
+            selectedVersionId: pendingSelectedVersion.id,
+            selectedVersion: pendingSelectedVersion,
+            previousVersion: undefined,
+            nextVersion: undefined
+          }
+        : undefined)
   const navigationInspect = initialNavigationInspect
     ? { ...initialNavigationInspect, versions: history.versions }
     : undefined

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -140,6 +140,8 @@ export type GetArtifactLineageRequest = {
   projectId: string
   appSessionId: string
   artifactId: string
+  versionId?: string
+  cursor?: string
 }
 
 export type GetArtifactVersionProvenanceRequest = GetArtifactLineageRequest & {
@@ -197,6 +199,12 @@ export type ArtifactLineageProvenance = {
     deletedAt?: string
   }
   versions: ArtifactVersionDescriptor[]
+  nextCursor?: string
+  selectedVersion?: ArtifactVersionDescriptor
+  headVersion?: ArtifactVersionDescriptor
+  basedOnVersion?: ArtifactVersionDescriptor
+  previousVersion?: ArtifactVersionDescriptor
+  nextVersion?: ArtifactVersionDescriptor
 }
 
 type ArtifactEnvironmentUnavailableReason = Extract<

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4169,6 +4169,14 @@
     "Auto (recommended)": "Automatisch (empfohlen)",
     "HTTPS": "HTTPS",
     "WebSocket": "WebSocket",
-    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Im automatischen Modus wird WebSocket verwendet, wenn verfügbar, und andernfalls auf HTTPS zurückgegriffen. Verwenden Sie HTTPS für bessere Kompatibilität oder WebSocket für geringere Latenz."
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Im automatischen Modus wird WebSocket verwendet, wenn verfügbar, und andernfalls auf HTTPS zurückgegriffen. Verwenden Sie HTTPS für bessere Kompatibilität oder WebSocket für geringere Latenz.",
+    "Provenance integrity error": "Integritätsfehler der Herkunftsdaten",
+    "Provenance could not be loaded": "Herkunftsdaten konnten nicht geladen werden",
+    "View diagnostics": "Diagnose anzeigen",
+    "Copy diagnostics": "Diagnose kopieren",
+    "Could not copy diagnostics. Select and copy the text above.": "Diagnose konnte nicht kopiert werden. Wählen Sie den Text oben aus und kopieren Sie ihn.",
+    "Loading earlier versions…": "Frühere Versionen werden geladen…",
+    "Retry loading earlier versions": "Frühere Versionen erneut laden",
+    "Load earlier versions": "Frühere Versionen laden"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4324,6 +4324,14 @@
     "Auto (recommended)": "Automático (recomendado)",
     "HTTPS": "HTTPS",
     "WebSocket": "WebSocket",
-    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "El modo automático usa WebSocket cuando está disponible y recurre a HTTPS. Use HTTPS para mayor compatibilidad o WebSocket para reducir la latencia."
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "El modo automático usa WebSocket cuando está disponible y recurre a HTTPS. Use HTTPS para mayor compatibilidad o WebSocket para reducir la latencia.",
+    "Provenance integrity error": "Error de integridad de la procedencia",
+    "Provenance could not be loaded": "No se pudo cargar la procedencia",
+    "View diagnostics": "Ver diagnóstico",
+    "Copy diagnostics": "Copiar diagnóstico",
+    "Could not copy diagnostics. Select and copy the text above.": "No se pudo copiar el diagnóstico. Seleccione y copie el texto anterior.",
+    "Loading earlier versions…": "Cargando versiones anteriores…",
+    "Retry loading earlier versions": "Reintentar cargar versiones anteriores",
+    "Load earlier versions": "Cargar versiones anteriores"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4324,6 +4324,14 @@
     "Auto (recommended)": "Automatique (recommandé)",
     "HTTPS": "HTTPS",
     "WebSocket": "WebSocket",
-    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Le mode automatique utilise WebSocket lorsqu’il est disponible et se replie sur HTTPS. Utilisez HTTPS pour la compatibilité ou WebSocket pour réduire la latence."
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Le mode automatique utilise WebSocket lorsqu’il est disponible et se replie sur HTTPS. Utilisez HTTPS pour la compatibilité ou WebSocket pour réduire la latence.",
+    "Provenance integrity error": "Erreur d’intégrité de la provenance",
+    "Provenance could not be loaded": "Impossible de charger la provenance",
+    "View diagnostics": "Afficher le diagnostic",
+    "Copy diagnostics": "Copier le diagnostic",
+    "Could not copy diagnostics. Select and copy the text above.": "Impossible de copier le diagnostic. Sélectionnez et copiez le texte ci-dessus.",
+    "Loading earlier versions…": "Chargement des versions antérieures…",
+    "Retry loading earlier versions": "Réessayer de charger les versions antérieures",
+    "Load earlier versions": "Charger les versions antérieures"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4014,6 +4014,14 @@
     "Auto (recommended)": "自動（推奨）",
     "HTTPS": "HTTPS",
     "WebSocket": "WebSocket",
-    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自動では、利用可能な場合は WebSocket を使用し、HTTPS にフォールバックします。互換性を重視する場合は HTTPS、低遅延を重視する場合は WebSocket を使用してください。"
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自動では、利用可能な場合は WebSocket を使用し、HTTPS にフォールバックします。互換性を重視する場合は HTTPS、低遅延を重視する場合は WebSocket を使用してください。",
+    "Provenance integrity error": "来歴の整合性エラー",
+    "Provenance could not be loaded": "来歴を読み込めませんでした",
+    "View diagnostics": "診断情報を表示",
+    "Copy diagnostics": "診断情報をコピー",
+    "Could not copy diagnostics. Select and copy the text above.": "診断情報をコピーできませんでした。上のテキストを選択してコピーしてください。",
+    "Loading earlier versions…": "以前のバージョンを読み込み中…",
+    "Retry loading earlier versions": "以前のバージョンの読み込みを再試行",
+    "Load earlier versions": "以前のバージョンを読み込む"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4012,6 +4012,14 @@
     "Auto (recommended)": "자동(권장)",
     "HTTPS": "HTTPS",
     "WebSocket": "WebSocket",
-    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "자동 모드는 사용 가능한 경우 WebSocket을 사용하고 HTTPS로 대체합니다. 호환성이 중요하면 HTTPS를, 지연 시간을 줄이려면 WebSocket을 사용하세요."
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "자동 모드는 사용 가능한 경우 WebSocket을 사용하고 HTTPS로 대체합니다. 호환성이 중요하면 HTTPS를, 지연 시간을 줄이려면 WebSocket을 사용하세요.",
+    "Provenance integrity error": "출처 무결성 오류",
+    "Provenance could not be loaded": "출처를 불러오지 못했습니다",
+    "View diagnostics": "진단 정보 보기",
+    "Copy diagnostics": "진단 정보 복사",
+    "Could not copy diagnostics. Select and copy the text above.": "진단 정보를 복사하지 못했습니다. 위의 텍스트를 선택하여 복사하세요.",
+    "Loading earlier versions…": "이전 버전 불러오는 중…",
+    "Retry loading earlier versions": "이전 버전 불러오기 재시도",
+    "Load earlier versions": "이전 버전 불러오기"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4454,6 +4454,14 @@
     "Auto (recommended)": "Автоматически (рекомендуется)",
     "HTTPS": "HTTPS",
     "WebSocket": "WebSocket",
-    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Автоматический режим использует WebSocket, когда он доступен, и переключается на HTTPS. Используйте HTTPS для совместимости или WebSocket для снижения задержки."
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "Автоматический режим использует WebSocket, когда он доступен, и переключается на HTTPS. Используйте HTTPS для совместимости или WebSocket для снижения задержки.",
+    "Provenance integrity error": "Ошибка целостности данных о происхождении",
+    "Provenance could not be loaded": "Не удалось загрузить данные о происхождении",
+    "View diagnostics": "Показать диагностику",
+    "Copy diagnostics": "Копировать диагностику",
+    "Could not copy diagnostics. Select and copy the text above.": "Не удалось скопировать диагностику. Выделите и скопируйте текст выше.",
+    "Loading earlier versions…": "Загрузка предыдущих версий…",
+    "Retry loading earlier versions": "Повторить загрузку предыдущих версий",
+    "Load earlier versions": "Загрузить предыдущие версии"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4014,6 +4014,14 @@
     "Auto (recommended)": "自动（推荐）",
     "HTTPS": "HTTPS",
     "WebSocket": "WebSocket",
-    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自动模式会在可用时使用 WebSocket，并在不可用时回退到 HTTPS。使用 HTTPS 可提高兼容性，使用 WebSocket 可降低延迟。"
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自动模式会在可用时使用 WebSocket，并在不可用时回退到 HTTPS。使用 HTTPS 可提高兼容性，使用 WebSocket 可降低延迟。",
+    "Provenance integrity error": "来源完整性错误",
+    "Provenance could not be loaded": "无法加载来源信息",
+    "View diagnostics": "查看诊断信息",
+    "Copy diagnostics": "复制诊断信息",
+    "Could not copy diagnostics. Select and copy the text above.": "无法复制诊断信息。请选择并复制上方文本。",
+    "Loading earlier versions…": "正在加载更早的版本…",
+    "Retry loading earlier versions": "重试加载更早的版本",
+    "Load earlier versions": "加载更早的版本"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4014,6 +4014,14 @@
     "Auto (recommended)": "自動（建議）",
     "HTTPS": "HTTPS",
     "WebSocket": "WebSocket",
-    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自動模式會在可用時使用 WebSocket，並在不可用時回退到 HTTPS。使用 HTTPS 可提高相容性，使用 WebSocket 可降低延遲。"
+    "Auto uses WebSocket when available and falls back to HTTPS. Use HTTPS for compatibility or WebSocket for lower latency.": "自動模式會在可用時使用 WebSocket，並在不可用時回退到 HTTPS。使用 HTTPS 可提高相容性，使用 WebSocket 可降低延遲。",
+    "Provenance integrity error": "來源完整性錯誤",
+    "Provenance could not be loaded": "無法載入來源資訊",
+    "View diagnostics": "檢視診斷資訊",
+    "Copy diagnostics": "複製診斷資訊",
+    "Could not copy diagnostics. Select and copy the text above.": "無法複製診斷資訊。請選取並複製上方文字。",
+    "Loading earlier versions…": "正在載入更早的版本…",
+    "Retry loading earlier versions": "重試載入更早的版本",
+    "Load earlier versions": "載入更早的版本"
   }
 }

--- a/src/shared/managed-file-versions.ts
+++ b/src/shared/managed-file-versions.ts
@@ -68,6 +68,11 @@ type ManagedFileVersionInspectResult = {
   headVersionId: string
   selectedVersionId: string
   versions: ManagedFileVersionDescriptor[]
+  nextCursor?: string
+  selectedVersion?: ManagedFileVersionDescriptor
+  headVersion?: ManagedFileVersionDescriptor
+  previousVersion?: ManagedFileVersionDescriptor
+  nextVersion?: ManagedFileVersionDescriptor
   canEdit: boolean
   canDiff: boolean
   unavailableReason?: ManagedTextEditUnavailableReason | 'PROJECT_NOT_WRITABLE' | 'FILE_DELETED'
@@ -106,7 +111,10 @@ type ManagedFileVersionErrorShape = {
 type ManagedFileVersionIpcResult<Value> =
   { ok: true; value: Value } | { ok: false; error: ManagedFileVersionErrorShape }
 
-type ManagedFileVersionInspectRequest = ManagedFileIdentity & { versionId?: string }
+type ManagedFileVersionInspectRequest = ManagedFileIdentity & {
+  versionId?: string
+  cursor?: string
+}
 type ManagedFileVersionDiffRequest = ManagedFileIdentity & { versionId: string; requestId: string }
 type ManagedFileVersionCancelDiffRequest = { requestId: string }
 

--- a/src/shared/provenance-read-result.ts
+++ b/src/shared/provenance-read-result.ts
@@ -1,0 +1,43 @@
+export type ProvenanceReadFailure = {
+  kind: 'load-failed' | 'integrity-failed'
+  message: string
+}
+
+export type ProvenanceReadResult<Value> = Value | { failure: ProvenanceReadFailure }
+
+export class ProvenanceIntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ProvenanceIntegrityError'
+  }
+}
+
+// Return domain failures as plain data so both Electron and Web retain their classification.
+export const captureProvenanceRead = async <Value>(
+  read: () => Promise<Value>
+): Promise<ProvenanceReadResult<Value>> => {
+  try {
+    return await read()
+  } catch (error) {
+    return {
+      failure: {
+        kind: error instanceof ProvenanceIntegrityError ? 'integrity-failed' : 'load-failed',
+        message: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+}
+
+export const unwrapProvenanceRead = <Value>(result: ProvenanceReadResult<Value>): Value => {
+  if (result && typeof result === 'object' && 'failure' in result) {
+    const failure = result.failure as ProvenanceReadFailure
+    if (failure.kind === 'integrity-failed') throw new ProvenanceIntegrityError(failure.message)
+    throw new Error(failure.message)
+  }
+  return result as Value
+}
+
+export const provenanceReadFailure = (error: unknown): ProvenanceReadFailure => ({
+  kind: error instanceof ProvenanceIntegrityError ? 'integrity-failed' : 'load-failed',
+  message: error instanceof Error ? error.message : String(error)
+})

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -1,3 +1,4 @@
+import type { ProvenanceReadResult } from './provenance-read-result'
 import type {
   AcpCancelPromptRequest,
   AcpAgentRuntimeUpdate,
@@ -797,19 +798,29 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     (request: GetArtifactCodeReconstructionRequest) => Promise<ArtifactCodeReconstructionState>
   >()('artifacts', ['artifacts:get-code-reconstruction']),
   'artifacts.getLineage': callable<
-    (request: GetArtifactLineageRequest) => Promise<ArtifactLineageProvenance | undefined>
+    (
+      request: GetArtifactLineageRequest
+    ) => Promise<ProvenanceReadResult<ArtifactLineageProvenance | undefined>>
   >()('artifacts', ['artifacts:get-lineage']),
   'artifacts.getVersionExecution': callable<
-    (request: GetArtifactVersionProvenanceRequest) => Promise<ArtifactVersionExecutionProvenance>
+    (
+      request: GetArtifactVersionProvenanceRequest
+    ) => Promise<ProvenanceReadResult<ArtifactVersionExecutionProvenance>>
   >()('artifacts', ['artifacts:get-version-execution']),
   'artifacts.getVersionMessages': callable<
-    (request: GetArtifactVersionProvenanceRequest) => Promise<ArtifactVersionMessagesProvenance>
+    (
+      request: GetArtifactVersionProvenanceRequest
+    ) => Promise<ProvenanceReadResult<ArtifactVersionMessagesProvenance>>
   >()('artifacts', ['artifacts:get-version-messages']),
   'artifacts.getVersionProvenance': callable<
-    (request: GetArtifactVersionProvenanceRequest) => Promise<ArtifactVersionProvenance>
+    (
+      request: GetArtifactVersionProvenanceRequest
+    ) => Promise<ProvenanceReadResult<ArtifactVersionProvenance>>
   >()('artifacts', ['artifacts:get-version-provenance']),
   'artifacts.getVersionReview': callable<
-    (request: GetArtifactVersionProvenanceRequest) => Promise<ArtifactVersionReviewProvenance>
+    (
+      request: GetArtifactVersionProvenanceRequest
+    ) => Promise<ProvenanceReadResult<ArtifactVersionReviewProvenance>>
   >()('artifacts', ['artifacts:get-version-review']),
   'artifacts.openFile': callable<(request: OpenArtifactFileRequest) => Promise<void>>()(
     'artifacts',

--- a/src/shared/version-history.ts
+++ b/src/shared/version-history.ts
@@ -1,0 +1,23 @@
+export const VERSION_HISTORY_PAGE_SIZE = 50
+
+// The cursor is an exclusive version-number boundary. Ownership is always supplied separately
+// and applied by the database query; a cursor can never select a different logical file.
+export const parseVersionHistoryCursor = (cursor?: string): number | undefined => {
+  if (cursor === undefined) return undefined
+  if (!/^[1-9]\d*$/.test(cursor) || !Number.isSafeInteger(Number(cursor))) {
+    throw new Error('Invalid version history cursor.')
+  }
+  return Number(cursor)
+}
+
+export const versionHistoryPage = <Version extends { versionNumber: number }>(
+  newestFirst: Version[]
+): { versions: Version[]; nextCursor?: string } => {
+  const versions = newestFirst.slice(0, VERSION_HISTORY_PAGE_SIZE).reverse()
+  return {
+    versions,
+    ...(newestFirst.length > VERSION_HISTORY_PAGE_SIZE
+      ? { nextCursor: String(versions[0].versionNumber) }
+      : {})
+  }
+}


### PR DESCRIPTION
## Problem

A reconciliation failure in one project marks unrelated projects incomplete. Provenance request failures provide no recovery action, and message snapshot failures can be swallowed as unavailable. Both managed-file inspection and Artifact lineage fetch every version, so repeated editing grows database reads and IPC payloads without a bound.

## Proposed change

- Track known reconciliation failures by project; retain global degradation only when the affected scope is unknown. Preserve that scope through startup recovery and deletion callers.
- Provide manual Retry for failed provenance requests, retaining successful sections. Use the existing ErrorNotice for integrity failures and expose local, copyable diagnostics. Preserve unsupported-version explanations.
- Return the latest 50 versions and an exclusive older-page cursor. Resolve selected/head/adjacent/based-on descriptors independently, preserving exact historical references and download targets. Add Load earlier versions with retry and deduplication.

## Scope and non-goals

- Historical data: existing rows, saved version identities, legacy unavailable explanations, and existing metadata fallback remain readable. No migration or new compatibility adapter; bundled main/preload/renderer contracts change together.
- New transient classifications: `load-failed` and `integrity-failed`. Project failure sets, cursors, descriptors, retries and diagnostics are runtime state.
- Persistence: no schema, table, index, file format, retention rule or persisted cursor changes. Existing legacy checksum backfill remains; a lost backfill race stays retryable.
- No background retry, automatic repair, history archival, or diagnostics upload.

## Acceptance criteria and validation

Regression-first evidence: the original 11 behavioral regressions failed consistently on the unmodified implementation, with existing controls passing. Seven additional review regressions failed twice on `0232c885c` before their fixes, then passed: pending/failed-selection downloads, off-page navigation in both surfaces, and four database/snapshot failure cases. The GitHub review follow-up adds PNG/PDF regressions that failed twice before the loader was colocated with navigation; a Markdown positive control passed. Tests use existing public repository, registered IPC, and rendered component boundaries; no production test seam was added.

Final local impact mapping (after the last material edit):

| Behavior / boundary | Project-owned checks | Result |
| --- | --- | --- |
| Project isolation and recovery | project-files repository, architecture and IPC; session coordinator, deletion integration and Artifact finalization recovery | passed |
| Bounded history and historical identity | managed-file service integration and IPC; provenance repository | passed |
| Provenance failure propagation and snapshot compatibility | provenance lifecycle, message snapshot, dependency read, architecture, IPC; preload | passed |
| Navigation, retry, diagnostics and download consumers | ArtifactProvenancePanel, PreviewFileSurface, FilePreviewDialog.versioning, GlobalSearchDialog, ArtifactMentionPopup | passed |
| Eight-locale UI contract | i18n resources guard | passed |
| Affected processes and source quality | `npm run typecheck:web`, `npm run typecheck:node`, `npm run lint` | passed |

Final result: 21 test files passed; 1578 tests passed and 1 skipped, across two explicit commands. All test rows use `npm test -- <listed explicit test paths> --maxWorkers=2`; the complete local suite was not run, as requested. Independent Standards and Spec reviews confirmed the final coverage mapping and found no remaining findings after corrections. IPC/preload and search/mention/preview consumers are included because response contracts changed; session recovery/deletion consumers are included because failure scope propagation changed. No platform-specific filesystem mutation or schema change was introduced. PR CI remains authoritative for cross-platform and complete portable coverage.

Uncovered local check: isolated headless Web startup succeeded, but the in-app browser rejected localhost with `ERR_BLOCKED_BY_CLIENT`, preventing visual inspection. Rendered component interactions and translated-copy guards cover behavior, not visual appearance.

## Review focus

Project-scoped versus unknown global failures; exact selected/head identity while loading pages or waiting for inspection; retryable versus integrity failures without swallowing message errors; preservation of existing visibility and ownership filters.


