### PR TITLE
fix(deletion): preserve compensation failures

### DIFF
--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -190,6 +190,32 @@ describe('ProjectDeletionCoordinator', () => {
     await expect(deletion).rejects.toThrow('intent unavailable')
   })
 
+  it('preserves intent creation and deletion-fence rollback failures', async () => {
+    const intentError = new Error('intent unavailable')
+    const rollbackError = new Error('deletion fence unavailable')
+    const projects = createProjects()
+    projects.createDeletionIntent = vi.fn().mockRejectedValue(intentError)
+    const abortProjectDeletion = vi.fn().mockRejectedValue(rollbackError)
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      createSessions(),
+      undefined,
+      undefined,
+      undefined,
+      {
+        beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        restoreProjectDeletion: vi.fn().mockResolvedValue(undefined),
+        abortProjectDeletion
+      }
+    )
+
+    const failure = await coordinator.deleteProject('project-1').catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([intentError, rollbackError])
+    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
+  })
+
   it('retains the durable intent and deletion barrier when runtime quiescence fails', async () => {
     const projects = createProjects()
     const abortProjectDeletion = vi.fn()

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -379,7 +379,14 @@ class ProjectDeletionCoordinator {
       await this.lifecycle?.restoreProjectDeletion?.(projectId)
       await this.projects.createDeletionIntent(projectId)
     } catch (error) {
-      await this.lifecycle?.abortProjectDeletion?.(projectId)
+      try {
+        await this.lifecycle?.abortProjectDeletion?.(projectId)
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          `Project deletion setup and fence rollback failed: ${projectId}`
+        )
+      }
       throw error
     }
   }

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -3773,6 +3773,56 @@ describe('SessionPersistenceCoordinator', () => {
     })
   })
 
+  it('preserves the deletion failure and every failed compensation', async () => {
+    const session = createSession()
+    const deletionError = new Error('disk locked')
+    const indexRollbackError = new Error('database unavailable')
+    const computeRollbackError = new Error('compute cleanup unavailable')
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn().mockResolvedValue({ status: 'found', session }),
+      deleteSession: vi.fn().mockRejectedValue(deletionError)
+    })
+    const fileIndex = createFileIndex({
+      restoreSession: vi.fn().mockRejectedValue(indexRollbackError)
+    })
+    const computeJobs = {
+      prepareSessionJobDeletion: vi.fn(async () => undefined),
+      commitSessionJobDeletion: vi.fn(async () => undefined),
+      prepareProjectJobDeletion: vi.fn(async () => undefined),
+      commitProjectJobDeletion: vi.fn(async () => undefined),
+      abortSessionJobDeletion: vi.fn().mockRejectedValue(computeRollbackError)
+    }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      createTestLogger(),
+      computeJobs
+    )
+
+    const failure = await coordinator
+      .deleteSession('project-1', 'session-1')
+      .catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([
+      deletionError,
+      indexRollbackError,
+      computeRollbackError
+    ])
+    expect(fileIndex.restoreSession).toHaveBeenCalledWith(
+      'project-1',
+      'session-1',
+      'delete-session-operation'
+    )
+    expect(computeJobs.abortSessionJobDeletion).toHaveBeenCalledWith('project-1', 'session-1')
+    expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledWith('project-1')
+  })
+
   it('does not widen an already scoped file reconciliation failure during hydration', async () => {
     const session = createSession()
     const result = { sessions: [session], manifest: { version: 1 as const } }

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -498,8 +498,7 @@ class SessionPersistenceDeletionOwner {
       let recoveryPhase: string | undefined
       try {
         if (!jsonDeleted) {
-          let recoveryError: unknown
-          let recoveryFailed = false
+          const recoveryErrors: unknown[] = []
           try {
             if (receipt.kind === 'retained') {
               recoveryPhase = 'abort-provenance'
@@ -510,16 +509,14 @@ class SessionPersistenceDeletionOwner {
               await this.fileIndex.restoreSession(projectId, sessionId, token)
             }
           } catch (restoreError) {
-            recoveryError = restoreError
-            recoveryFailed = true
+            recoveryErrors.push(restoreError)
           }
           if (computeJobsPrepared) {
             try {
               await this.computeJobs?.abortSessionJobDeletion?.(projectId, sessionId)
             } catch (computeRestoreError) {
               recoveryPhase = 'abort-compute-cleanup'
-              recoveryError = computeRestoreError
-              recoveryFailed = true
+              recoveryErrors.push(computeRestoreError)
             }
           }
           if (managedWorkspaceRetained && session) {
@@ -527,11 +524,19 @@ class SessionPersistenceDeletionOwner {
               recoveryPhase = 'restore-managed-workspace'
               await this.workspaceOwnership?.restoreActive(session)
             } catch (workspaceRestoreError) {
-              recoveryError = workspaceRestoreError
-              recoveryFailed = true
+              recoveryErrors.push(workspaceRestoreError)
             }
           }
-          if (recoveryFailed) throw recoveryError
+          if (recoveryErrors.length > 0) {
+            throw new AggregateError(
+              [error, ...recoveryErrors],
+              `Session deletion rollback failed: ${recoveryErrors
+                .map((recoveryError) =>
+                  recoveryError instanceof Error ? recoveryError.message : String(recoveryError)
+                )
+                .join('; ')}`
+            )
+          }
         } else {
           this.fileIndex.markReconciliationIncomplete(projectId)
         }


### PR DESCRIPTION
## Summary

- preserve the original Project deletion setup failure when fence rollback also fails
- collect the original Session deletion failure and every failed compensation in `AggregateError`
- add public-boundary regression coverage for both double-failure paths

## Verification

- `npx vitest run src/main/projects/deletion-coordinator.test.ts src/main/session-persistence/coordinator.test.ts --reporter=dot` (204 passed)
- `npx eslint src/main/projects/deletion-coordinator.ts src/main/projects/deletion-coordinator.test.ts src/main/session-persistence/deletion-owner.ts src/main/session-persistence/coordinator.test.ts`
- `npm run typecheck:node`