### PR TITLE
fix(startup): bound startup shell wait

### DIFF
--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -414,6 +414,8 @@ describe('waitForStartupShell', () => {
     destroy: ReturnType<typeof vi.fn>
     emitWindow: (event: string) => void
     emitWebContents: (event: string, ...args: unknown[]) => void
+    windowListenerCount: (event: string) => number
+    webContentsListenerCount: (event: string) => number
     window: Pick<BrowserWindow, 'destroy' | 'once' | 'removeListener' | 'webContents'>
   } => {
     const windowEvents = new EventEmitter()
@@ -423,6 +425,8 @@ describe('waitForStartupShell', () => {
       destroy,
       emitWindow: (event) => windowEvents.emit(event),
       emitWebContents: (event, ...args) => webContentsEvents.emit(event, ...args),
+      windowListenerCount: (event) => windowEvents.listenerCount(event),
+      webContentsListenerCount: (event) => webContentsEvents.listenerCount(event),
       window: Object.assign(windowEvents, {
         destroy,
         webContents: webContentsEvents
@@ -474,5 +478,39 @@ describe('waitForStartupShell', () => {
 
     await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce())
     expect(source.destroy).not.toHaveBeenCalled()
+  })
+
+  it('discards a silent startup window after a bounded wait', async () => {
+    vi.useFakeTimers()
+    try {
+      const source = makeWindow()
+      const settled = vi.fn()
+      const diagnostics = { phase: vi.fn() }
+      void waitForStartupShell(source.window, { diagnostics }).then(settled)
+
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      expect(settled).toHaveBeenCalledOnce()
+      expect(source.destroy).toHaveBeenCalledOnce()
+      expect(diagnostics.phase).toHaveBeenCalledOnce()
+      expect(diagnostics.phase).toHaveBeenCalledWith('startup-shell-timeout', {
+        timeoutMs: 15_000
+      })
+      expect(source.windowListenerCount('ready-to-show')).toBe(0)
+      expect(source.windowListenerCount('closed')).toBe(0)
+      expect(source.webContentsListenerCount('did-fail-load')).toBe(0)
+      expect(source.webContentsListenerCount('render-process-gone')).toBe(0)
+
+      source.emitWindow('ready-to-show')
+      source.emitWindow('closed')
+      source.emitWebContents('did-fail-load', {}, -105, 'NAME_NOT_RESOLVED', 'file://index', true)
+      source.emitWebContents('render-process-gone', {}, { reason: 'crashed', exitCode: 1 })
+      await Promise.resolve()
+
+      expect(settled).toHaveBeenCalledOnce()
+      expect(source.destroy).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -27,6 +27,7 @@ type SystemShutdownRelay = {
 }
 
 const STARTUP_SYSTEM_SHUTDOWN_TIMEOUT_MS = 5_000
+const STARTUP_SHELL_TIMEOUT_MS = 15_000
 
 type StartupWindowSurface = {
   focus: () => void
@@ -189,12 +190,17 @@ export const prepareVisibleStartupRuntime = async <Shell, Modules, Runtime>(
 // and lifecycle must keep initializing even when Chromium cannot produce the first frame. Main-frame
 // load failure discards the unusable window; windows.ts owns renderer-process crash recovery.
 export const waitForStartupShell = (
-  window: Pick<BrowserWindow, 'destroy' | 'once' | 'removeListener' | 'webContents'>
+  window: Pick<BrowserWindow, 'destroy' | 'once' | 'removeListener' | 'webContents'>,
+  options: {
+    diagnostics?: Pick<DiagnosticOperation, 'phase'>
+    timeoutMs?: number
+  } = {}
 ): Promise<void> =>
   new Promise((resolve) => {
     let settled = false
 
     const cleanup = (): void => {
+      clearTimeout(timeout)
       window.removeListener('ready-to-show', settle)
       window.removeListener('closed', settle)
       window.webContents.removeListener('did-fail-load', onDidFailLoad)
@@ -224,6 +230,12 @@ export const waitForStartupShell = (
     window.once('closed', settle)
     window.webContents.on('did-fail-load', onDidFailLoad)
     window.webContents.once('render-process-gone', settle)
+    const timeoutMs = options.timeoutMs ?? STARTUP_SHELL_TIMEOUT_MS
+    const timeout = setTimeout(() => {
+      options.diagnostics?.phase('startup-shell-timeout', { timeoutMs })
+      window.destroy()
+      settle()
+    }, timeoutMs)
   })
 
 // Runs the ordered startup sequence: gate on the single-instance lock (quitting a secondary launch

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -403,7 +403,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // 5 MB backend chunk immediately after BrowserWindow construction can otherwise delay
       // ready-to-show even though the window no longer depends on that chunk.
       const startupShellRendered = startupWindow
-        ? waitForStartupShell(startupWindow)
+        ? waitForStartupShell(startupWindow, { diagnostics: startupDiagnostics })
         : Promise.resolve()
       if (startupWindow) {
         if (!forwardSecondInstanceDuringStartup) {


### PR DESCRIPTION
## Summary

- bound the startup shell first-paint barrier to 15 seconds
- record a startup-shell-timeout diagnostic, discard the unusable hidden window, and continue runtime composition
- add a fake-timer regression covering listener cleanup and single settlement

## Reproduction

Before the fix, advancing fake timers by 15 seconds with no Chromium window or renderer terminal event left waitForStartupShell unresolved. The regression test failed because the settlement callback had been called zero times.

## Impact

No persistent fields, schema, data model, user interaction, or architectural owner changes. The only added field is timeoutMs on the transient startup diagnostic event. Existing lifecycle behavior recreates the destroyed initial window after composition.

## Validation

- npx vitest run src/main/app-startup.test.ts src/main/index-startup-order.test.ts src/main/app-lifecycle.test.ts: 96 passed
- npm run typecheck:node: passed
- ESLint and Prettier checks for changed files: passed
- full local suite outside the sandbox: 23,710 passed, 226 skipped, 4 unrelated failures (remote-access temp cleanup, notebook concurrency timeout, and two R graphics capture assertions)