### PR TITLE
fix(settings): restore live proxy state after apply failure

### DIFF
--- a/src/main/settings/network-proxy-settings-owner.ts
+++ b/src/main/settings/network-proxy-settings-owner.ts
@@ -34,11 +34,20 @@ class NetworkProxySettingsOwner {
     try {
       await this.options.apply(networkProxy)
     } catch (error) {
+      const rollbackErrors: unknown[] = []
       try {
         await this.options.repository.setNetworkProxy(previous)
       } catch (rollbackError) {
+        rollbackErrors.push(rollbackError)
+      }
+      try {
+        await this.options.apply(previous)
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError)
+      }
+      if (rollbackErrors.length > 0) {
         throw new AggregateError(
-          [error, rollbackError],
+          [error, ...rollbackErrors],
           'Could not apply or restore the proxy configuration.'
         )
       }

--- a/src/main/settings/network-proxy-settings.test.ts
+++ b/src/main/settings/network-proxy-settings.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { NetworkProxySettings } from '../../shared/network-proxy'
 import { createEmptySettings } from './types'
 
 vi.mock('electron', () => ({
@@ -80,7 +81,7 @@ describe('Network proxy settings persistence', () => {
 
   it('does not persist a proxy setting that the runtime rejected', async () => {
     const repository = new SettingsRepository(dir)
-    const applyNetworkProxy = vi.fn().mockRejectedValue(new Error('proxy session unavailable'))
+    const applyNetworkProxy = vi.fn().mockRejectedValueOnce(new Error('proxy session unavailable'))
     const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
 
     await expect(service.setNetworkProxy({ mode: 'direct' })).rejects.toThrow(
@@ -88,6 +89,54 @@ describe('Network proxy settings persistence', () => {
     )
 
     expect((await repository.getSettings()).networkProxy).toBeUndefined()
+  })
+
+  it('restores persistence and live proxy state after a partial runtime apply failure', async () => {
+    const previous = {
+      mode: 'manual' as const,
+      server: 'http://old-proxy.example:8080'
+    }
+    const repository = new SettingsRepository(dir)
+    await repository.setNetworkProxy(previous)
+    let runtimeProxy: NetworkProxySettings = previous
+    const applyNetworkProxy = vi.fn(async (settings: NetworkProxySettings) => {
+      runtimeProxy = settings
+      if (settings.mode === 'direct') throw new Error('notebook proxy refresh failed')
+    })
+    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+
+    await expect(service.setNetworkProxy({ mode: 'direct' })).rejects.toThrow(
+      'notebook proxy refresh failed'
+    )
+
+    expect((await repository.getSettings()).networkProxy).toEqual(previous)
+    expect(runtimeProxy).toEqual(previous)
+    expect(applyNetworkProxy).toHaveBeenNthCalledWith(1, { mode: 'direct' })
+    expect(applyNetworkProxy).toHaveBeenNthCalledWith(2, previous)
+  })
+
+  it('preserves the apply error while reporting persistence and runtime rollback failures', async () => {
+    const repository = new SettingsRepository(dir)
+    const originalSetNetworkProxy = repository.setNetworkProxy.bind(repository)
+    const persistenceRollbackError = new Error('persistence rollback failed')
+    vi.spyOn(repository, 'setNetworkProxy')
+      .mockImplementationOnce(originalSetNetworkProxy)
+      .mockRejectedValueOnce(persistenceRollbackError)
+    const applyError = new Error('notebook proxy refresh failed')
+    const runtimeRollbackError = new Error('runtime rollback failed')
+    const applyNetworkProxy = vi
+      .fn()
+      .mockRejectedValueOnce(applyError)
+      .mockRejectedValueOnce(runtimeRollbackError)
+    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+
+    const result = service.setNetworkProxy({ mode: 'direct' })
+
+    await expect(result).rejects.toMatchObject({
+      message: 'Could not apply or restore the proxy configuration.',
+      errors: [applyError, persistenceRollbackError, runtimeRollbackError]
+    })
+    expect(applyNetworkProxy).toHaveBeenNthCalledWith(2, { mode: 'system' })
   })
 
   it('keeps persisted and runtime proxy order aligned across concurrent saves', async () => {


### PR DESCRIPTION
## Problem

Proxy saves persist the new value before applying it to the live process. Production application updates the Electron Session and proxy environment before refreshing the Notebook network sandbox. If that refresh fails after the first side effect succeeds, the owner restores only storage, leaving live networking partially switched and inconsistent with both the UI error and the persisted setting.

## Proposed change

- Reapply the previous proxy after restoring the previous persisted value.
- Attempt persistence and live rollback independently so one rollback failure does not suppress the other.
- Preserve the original apply error as the first `AggregateError` entry and append every rollback failure.
- Add service-boundary regression tests that reproduce partial live mutation and combined rollback failures.

## Scope and non-goals

No settings fields, persisted format, migrations, enum states, renderer interaction, IPC contract, or public API changes. Existing agents, Notebook kernels, and installers are not restarted.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Partial runtime application failure restores disk and live state -> `npm test -- src/main/settings/network-proxy-settings.test.ts` -> 8/8 passed.
- Settings owner, contracts, and representative consumers remain valid -> `npm run test:module -- settings_service_facade` -> 30 files, 940/940 passed.
- Main-process and Notebook sandbox types remain valid -> `npm run typecheck:node` -> passed.
- Source and tests satisfy lint rules -> `npm run lint -- src/main/settings/network-proxy-settings-owner.ts src/main/settings/network-proxy-settings.test.ts` -> passed.

The first module run was blocked by the restricted local sandbox (`listen EPERM` on `127.0.0.1`); the identical command passed outside that sandbox. Per request, the complete local `npm test` suite was not run; exact-head PR CI remains the final cross-platform authority.

## Review focus

Please verify the compensation order and that `AggregateError.errors` retains the original apply failure first, followed by persistence and live rollback failures.