### PR TITLE
fix(projects): tolerate corrupt session defaults

### DIFF
--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -13,15 +13,6 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-const project = {
-  id: 'project-1',
-  name: 'Project',
-  description: 'Description',
-  isExample: false,
-  createdAt: 1,
-  updatedAt: 2
-}
-
 describe('ProjectDeletionCoordinator', () => {
   it('rejects deletion recovery while a data-root migration is pending', async () => {
     const projects = createProjects()
@@ -219,7 +210,7 @@ describe('ProjectDeletionCoordinator', () => {
     let projectExists = true
     let intentExists = false
     const projects = createProjects()
-    projects.get = vi.fn(async () => (projectExists ? project : null))
+    projects.exists = vi.fn(async () => projectExists)
     projects.delete = vi.fn(async () => {
       projectExists = false
       return undefined
@@ -292,7 +283,7 @@ describe('ProjectDeletionCoordinator', () => {
     let projectExists = true
     let intentExists = false
     const projects = createProjects()
-    projects.get = vi.fn(async () => (projectExists ? project : null))
+    projects.exists = vi.fn(async () => projectExists)
     projects.delete = vi.fn(async () => {
       projectExists = false
       return undefined
@@ -625,7 +616,7 @@ describe('ProjectDeletionCoordinator', () => {
   it('adopts an orphaned legacy tombstone into an intent before preparing its Session authority', async () => {
     const order: string[] = []
     const projects = createProjects()
-    projects.get = vi.fn().mockResolvedValue(null)
+    projects.exists = vi.fn().mockResolvedValue(false)
     projects.createDeletionIntent = vi.fn(async () => {
       order.push('intent-created')
     })
@@ -662,7 +653,7 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('retains an adopted legacy intent when retained index deletion fails', async () => {
     const projects = createProjects()
-    projects.get = vi.fn().mockResolvedValue(null)
+    projects.exists = vi.fn().mockResolvedValue(false)
     const sessions = createSessions({
       listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue(['project-old']),
       deleteProjectSessions: vi.fn().mockRejectedValue(new Error('index temporarily unavailable'))
@@ -680,7 +671,7 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('continues adopting unrelated legacy tombstones after one cleanup fails', async () => {
     const projects = createProjects()
-    projects.get = vi.fn().mockResolvedValue(null)
+    projects.exists = vi.fn().mockResolvedValue(false)
     const sessions = createSessions({
       listLegacyProjectSessionTombstones: vi
         .fn()
@@ -704,7 +695,7 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('drops the temporary intent and continues when an adopted orphan must be retained', async () => {
     const projects = createProjects()
-    projects.get = vi.fn().mockResolvedValue(null)
+    projects.exists = vi.fn().mockResolvedValue(false)
     const sessions = createSessions({
       listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue(['project-old']),
       deleteProjectSessions: vi.fn().mockResolvedValue({
@@ -723,7 +714,7 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('re-derives orphan authority policy when replaying an adopted intent after restart', async () => {
     const projects = createProjects()
-    projects.get = vi.fn().mockResolvedValue(null)
+    projects.exists = vi.fn().mockResolvedValue(false)
     projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-old'])
     const sessions = createSessions({
       getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed')
@@ -739,7 +730,7 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('releases a replayed orphan-retained intent without adopting it twice in one recovery', async () => {
     const projects = createProjects()
-    projects.get = vi.fn().mockResolvedValue(null)
+    projects.exists = vi.fn().mockResolvedValue(false)
     projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-old'])
     const sessions = createSessions({
       getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed'),
@@ -902,7 +893,7 @@ describe('ProjectDeletionCoordinator', () => {
     let projectExists = true
     let intentExists = false
     const projects = createProjects()
-    projects.get = vi.fn(async () => (projectExists ? project : null))
+    projects.exists = vi.fn(async () => projectExists)
     projects.delete = vi.fn(async () => {
       projectExists = false
       return undefined
@@ -960,7 +951,7 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('publishes Project deletion when background recovery reaches the terminal state', async () => {
     const projects = createProjects()
-    projects.get = vi.fn().mockResolvedValue(null)
+    projects.exists = vi.fn().mockResolvedValue(false)
     projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
     const events = { publish: vi.fn() }
     const coordinator = new ProjectDeletionCoordinator(
@@ -1116,7 +1107,7 @@ describe('ProjectDeletionCoordinator', () => {
 })
 
 const createProjects = (): ProjectDeletionRepository => ({
-  get: vi.fn().mockResolvedValue(project),
+  exists: vi.fn().mockResolvedValue(true),
   delete: vi.fn().mockResolvedValue(undefined),
   createDeletionIntent: vi.fn().mockResolvedValue(undefined),
   deleteDeletionIntent: vi.fn().mockResolvedValue(undefined),

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -1,5 +1,5 @@
 import { isCurrentInFlight } from '../../shared/in-flight-promise'
-import type { Project, ProjectDeletionCleanup, ProjectDeletionOutcome } from '../../shared/projects'
+import type { ProjectDeletionCleanup, ProjectDeletionOutcome } from '../../shared/projects'
 import type { ProjectSessionDeletionResult } from '../session-persistence/coordinator'
 import type { ProjectSessionDeletionState } from '../session-persistence/repository'
 import { withDataRootWrite } from '../storage/migration-state'
@@ -7,7 +7,7 @@ import type { ApplicationEventPublisher } from '../application-events'
 import type { ProjectDeletionResult } from './repository'
 
 type ProjectDeletionRepository = {
-  get(id: string): Promise<Project | null>
+  exists(id: string): Promise<boolean>
   delete(id: string): Promise<ProjectDeletionResult | undefined>
   createDeletionIntent(projectId: string): Promise<void>
   deleteDeletionIntent(projectId: string): Promise<void>
@@ -364,8 +364,7 @@ class ProjectDeletionCoordinator {
   // remains fail-closed: the Project may still be visible, but recovery retains the fence and replays
   // quiescence before continuing durable deletion.
   private async runDeletion(projectId: string): Promise<ProjectDeletionOutcome> {
-    const project = await this.projects.get(projectId)
-    if (!project) return { status: 'deleted' }
+    if (!(await this.projects.exists(projectId))) return { status: 'deleted' }
 
     await this.createDeletionIntentWithFence(projectId)
     await this.lifecycle?.beforeProjectDelete(projectId)
@@ -410,7 +409,7 @@ class ProjectDeletionCoordinator {
           // Re-derive its conservative policy from durable state so a crash immediately after intent
           // creation cannot turn the next retry into authority-creating normal deletion.
           const requireExistingUploadAuthority =
-            !(await this.projects.get(projectId)) &&
+            !(await this.projects.exists(projectId)) &&
             (await this.sessions.getProjectSessionDeletionState(projectId)) === 'legacy-committed'
           const result: ProjectSessionDeletionResult = requireExistingUploadAuthority
             ? await this.sessions.deleteProjectSessions(projectId, {
@@ -502,7 +501,7 @@ class ProjectDeletionCoordinator {
     // Prune is transactional and idempotent. Run it before the soft delete so a Registry/database
     // failure retains the visible Project plus its durable intent for an explicit or startup retry.
     await this.permissionGrants?.prune({ kind: 'project', projectId })
-    const projectExists = Boolean(await this.projects.get(projectId))
+    const projectExists = await this.projects.exists(projectId)
     const projectDeletion = projectExists ? await this.projects.delete(projectId) : undefined
     if (projectDeletion) {
       this.events?.publish('memory:changed', { revision: projectDeletion.memoryRevision })

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -139,6 +139,7 @@ describe('createProjectHandlers', () => {
       get: vi.fn(async (id: string) =>
         id === deletingProject.id ? deletingProject : unrelatedProject
       ),
+      exists: vi.fn().mockResolvedValue(true),
       create: vi.fn().mockResolvedValue(unrelatedProject),
       update: vi.fn().mockResolvedValue(unrelatedProject),
       delete: vi.fn().mockResolvedValue(undefined),

--- a/src/main/projects/project-owned-data.catalog.architecture.test.ts
+++ b/src/main/projects/project-owned-data.catalog.architecture.test.ts
@@ -408,7 +408,7 @@ describe('Project-owned data catalog architecture', () => {
       ),
       [
         'this.permissionGrants?.prune',
-        'this.projects.get',
+        'this.projects.exists',
         'this.projects.delete',
         'this.permissionGrants?.finalizeOwnerDeletion',
         'this.reviews?.deleteReviewsForProject',

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -128,7 +128,10 @@ describe('project repository', () => {
     const projects = await repository.list()
 
     expect(projects.map(({ id }) => id)).toEqual(['corrupt-project', 'healthy-project'])
-    expect(projects[0]?.sessionDefaults).toEqual({})
+    expect(projects[0]?.sessionDefaults).toEqual({
+      permissionProfile: 'ask',
+      delegationPolicy: 'deny'
+    })
   })
 
   it('returns null when a project is not found', async () => {
@@ -147,17 +150,43 @@ describe('project repository', () => {
     await expect(repository.get('project-1')).resolves.toBeNull()
   })
 
-  it('keeps project metadata readable when stored Session defaults fail validation', async () => {
+  it('preserves valid safety defaults when another stored default fails validation', async () => {
     const { client } = createMockClient({
       findUnique: () =>
-        Promise.resolve(createRow({ sessionDefaults: '{"memoryEnabled":"not-a-boolean"}' }))
+        Promise.resolve(
+          createRow({
+            sessionDefaults:
+              '{"permissionProfile":"ask","delegationPolicy":"deny","memoryEnabled":"not-a-boolean"}'
+          })
+        )
     })
     const repository = new ProjectRepository(() => Promise.resolve(client))
 
     await expect(repository.get('project-1')).resolves.toMatchObject({
       id: 'project-1',
       name: 'Research',
-      sessionDefaults: {}
+      sessionDefaults: { permissionProfile: 'ask', delegationPolicy: 'deny' }
+    })
+  })
+
+  it('uses conservative values when stored safety defaults fail validation', async () => {
+    const { client } = createMockClient({
+      findUnique: () =>
+        Promise.resolve(
+          createRow({
+            sessionDefaults:
+              '{"permissionProfile":"unrestricted","delegationPolicy":"sometimes","memoryEnabled":false}'
+          })
+        )
+    })
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+
+    await expect(repository.get('project-1')).resolves.toMatchObject({
+      sessionDefaults: {
+        permissionProfile: 'ask',
+        delegationPolicy: 'deny',
+        memoryEnabled: false
+      }
     })
   })
 

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -115,6 +115,22 @@ describe('project repository', () => {
     ])
   })
 
+  it('keeps every project available when one row has malformed Session defaults', async () => {
+    const { client } = createMockClient({
+      findMany: () =>
+        Promise.resolve([
+          createRow({ id: 'corrupt-project', sessionDefaults: '{not-json' }),
+          createRow({ id: 'healthy-project', sessionDefaults: '{}' })
+        ])
+    })
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+
+    const projects = await repository.list()
+
+    expect(projects.map(({ id }) => id)).toEqual(['corrupt-project', 'healthy-project'])
+    expect(projects[0]?.sessionDefaults).toEqual({})
+  })
+
   it('returns null when a project is not found', async () => {
     const { client } = createMockClient({ findUnique: () => Promise.resolve(null) })
     const repository = new ProjectRepository(() => Promise.resolve(client))
@@ -129,6 +145,33 @@ describe('project repository', () => {
     const repository = new ProjectRepository(() => Promise.resolve(client))
 
     await expect(repository.get('project-1')).resolves.toBeNull()
+  })
+
+  it('keeps project metadata readable when stored Session defaults fail validation', async () => {
+    const { client } = createMockClient({
+      findUnique: () =>
+        Promise.resolve(createRow({ sessionDefaults: '{"memoryEnabled":"not-a-boolean"}' }))
+    })
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+
+    await expect(repository.get('project-1')).resolves.toMatchObject({
+      id: 'project-1',
+      name: 'Research',
+      sessionDefaults: {}
+    })
+  })
+
+  it('checks active existence without hydrating optional Project configuration', async () => {
+    const { client, project } = createMockClient({
+      findUnique: () => Promise.resolve({ deletedAt: null })
+    })
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+
+    await expect(repository.exists('project-1')).resolves.toBe(true)
+    expect(project.findUnique).toHaveBeenCalledWith({
+      where: { id: 'project-1' },
+      select: { deletedAt: true }
+    })
   })
 
   it('trims the name and defaults the description on create', async () => {
@@ -197,6 +240,29 @@ describe('project repository', () => {
     ).rejects.toThrow('Project changed elsewhere.')
 
     expect(project.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns an ordinary update after the write commits despite malformed Session defaults', async () => {
+    const updated = createRow({
+      name: 'Renamed',
+      sessionDefaults: '{not-json',
+      updatedAt: new Date(1710000000200)
+    })
+    const { client, project } = createMockClient({
+      findUnique: () => Promise.resolve(updated),
+      updateMany: () => Promise.resolve({ count: 1 })
+    })
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+
+    await expect(
+      repository.update({
+        id: 'project-1',
+        name: 'Renamed',
+        expectedUpdatedAt: 1710000000100
+      })
+    ).resolves.toMatchObject({ name: 'Renamed', sessionDefaults: {} })
+
+    expect(project.updateMany).toHaveBeenCalledOnce()
   })
 
   it('does not roll back concurrent activity time while changing pin placement', async () => {

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -29,6 +29,15 @@ type ProjectClient = Pick<
 
 type ProjectDeletionResult = Readonly<{ memoryRevision: number }>
 
+const decodeProjectSessionDefaults = (value: string | null): Project['sessionDefaults'] => {
+  try {
+    const decoded = projectSessionDefaultsSchema.safeParse(JSON.parse(value ?? '{}'))
+    return decoded.success ? decoded.data : {}
+  } catch {
+    return {}
+  }
+}
+
 // Normalizes Prisma rows into the epoch-ms shape shared with the renderer.
 const toProject = (row: PrismaProject): Project => ({
   id: row.id,
@@ -36,7 +45,7 @@ const toProject = (row: PrismaProject): Project => ({
   description: row.description,
   // An empty Agent Context is omitted on the wire, matching the optional shared schema field.
   ...(row.agentContext ? { agentContext: row.agentContext } : {}),
-  sessionDefaults: projectSessionDefaultsSchema.parse(JSON.parse(row.sessionDefaults ?? '{}')),
+  sessionDefaults: decodeProjectSessionDefaults(row.sessionDefaults),
   isExample: row.isExample,
   ...(row.pinned ? { pinned: true } : {}),
   ...(row.archivedAt ? { archivedAt: row.archivedAt.getTime() } : {}),
@@ -73,6 +82,15 @@ class ProjectRepository {
     const row = await client.project.findUnique({ where: { id } })
 
     return row && row.deletedAt === null ? toProject(row) : null
+  }
+
+  async exists(id: string): Promise<boolean> {
+    const client = await this.getClient()
+    const row = await client.project.findUnique({
+      where: { id },
+      select: { deletedAt: true }
+    })
+    return row?.deletedAt === null
   }
 
   // Creates a project; rejects blank names before touching the database.

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -31,10 +31,34 @@ type ProjectDeletionResult = Readonly<{ memoryRevision: number }>
 
 const decodeProjectSessionDefaults = (value: string | null): Project['sessionDefaults'] => {
   try {
-    const decoded = projectSessionDefaultsSchema.safeParse(JSON.parse(value ?? '{}'))
-    return decoded.success ? decoded.data : {}
+    const decoded: unknown = JSON.parse(value ?? '{}')
+    if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) {
+      return { permissionProfile: 'ask', delegationPolicy: 'deny' }
+    }
+    const source = decoded as Record<string, unknown>
+    const defaults = Object.fromEntries(
+      Object.entries(projectSessionDefaultsSchema.shape).flatMap(([key, schema]) => {
+        const field = schema.safeParse(source[key])
+        return field.success && field.data !== undefined ? [[key, field.data]] : []
+      })
+    )
+    if (
+      source.permissionProfile !== undefined &&
+      !projectSessionDefaultsSchema.shape.permissionProfile.safeParse(source.permissionProfile)
+        .success
+    ) {
+      defaults.permissionProfile = 'ask'
+    }
+    if (
+      source.delegationPolicy !== undefined &&
+      !projectSessionDefaultsSchema.shape.delegationPolicy.safeParse(source.delegationPolicy)
+        .success
+    ) {
+      defaults.delegationPolicy = 'deny'
+    }
+    return projectSessionDefaultsSchema.parse(defaults)
   } catch {
-    return {}
+    return { permissionProfile: 'ask', delegationPolicy: 'deny' }
   }
 }
 

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -84,7 +84,7 @@ const createMockReviewRepository = (): ReviewRepository =>
 describe('session persistence IPC handlers', () => {
   it('saves a Session for Project B while Project A cleanup remains failed', async () => {
     const projects: ProjectDeletionRepository = {
-      get: vi.fn().mockResolvedValue(null),
+      exists: vi.fn().mockResolvedValue(false),
       delete: vi.fn().mockResolvedValue(undefined),
       createDeletionIntent: vi.fn().mockResolvedValue(undefined),
       deleteDeletionIntent: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Problem

`Project.sessionDefaults` is stored as unconstrained TEXT, while Project hydration used throwing JSON and Zod parsers. One malformed or schema-invalid value therefore broke the entire Project list, blocked the normal deletion path at its existence check, and made an already-committed metadata update appear to fail while reading its return value.

## Proposed change

- Decode persisted Project Session defaults field by field at the repository boundary, preserving valid fields and using conservative `ask` / `deny` fallbacks for invalid safety policy.
- Give the deletion coordinator a minimal active-Project existence query so destructive recovery does not hydrate unrelated optional configuration.
- Preserve the per-Project deletion isolation introduced by #2172 while using the minimal existence query inside online and recovery deletion paths.
- Cover malformed JSON, schema-invalid JSON, list isolation, post-write responses, and the narrow existence query with regression tests.

## Scope and non-goals

- No Prisma schema, database column, migration, or persisted JSON format change.
- No new Project status enum or renderer interaction.
- Invalid stored TEXT is preserved by ordinary Project updates; read projections fail closed without rewriting it, and an explicit future Session-defaults update can replace it with canonical JSON.
- Versioned Session-default envelopes and a user-facing repair workflow are intentionally left for a separately designed compatibility change.

## Acceptance criteria and validation

All commands below ran after rebasing onto the current `origin/main` and resolving its Project deletion changes.

- Project list/get/update tolerate invalid Session defaults; valid sibling fields survive; malformed or invalid safety policy fails closed; deletion checks remain configuration-independent; concurrent Project deletion behavior remains intact -> `npm test -- src/main/projects/deletion-coordinator.test.ts src/main/projects/ipc.test.ts src/main/projects/repository.test.ts src/main/projects/project-owned-data.catalog.architecture.test.ts src/main/archive/coordinator.test.ts src/main/session-persistence/ipc.test.ts src/main/session-persistence/deletion-integration.test.ts src/main/project-files/ipc.test.ts src/main/data-content-application-commands.test.ts src/shared/projects.test.ts` -> 10 files, 207 tests passed.
- Prisma-backed Project CRUD remains compatible with the new selected-field query -> `npm test -- src/main/database/application-database.integration.test.ts -t 'ensures the schema (no seed) and round-trips CRUD'` -> 1 passed, 21 skipped.
- Main-process and sandbox types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.

The complete portable and platform suites are intentionally left to required PR CI. This change does not alter renderer contracts, persisted schemas, paths, platform APIs, or ACP behavior, so no renderer, migration, platform, or framework-specific local lane was added.

## Review focus

- Whether field-wise recovery plus conservative `permissionProfile: 'ask'` and `delegationPolicy: 'deny'` fallbacks is the correct fail-closed boundary for corrupt optional defaults.
- Whether every deletion existence check is now independent from full Project hydration without weakening deletion intent recovery or per-Project concurrency.
