### PR TITLE
fix(project-state): clarify cleanup and home scope

### DIFF
--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -154,10 +154,10 @@ const createDependencies = (): HostApplicationCommandDependencies => ({
       kind: 'move' as const,
       dataRoot: '/target/OpenScience'
     })),
-    migrate: vi.fn(async () => ({ ok: true as const })),
+    migrate: vi.fn(async () => ({ ok: true as const, cleanupPending: false })),
     setDataRootAndRelaunch: vi.fn(async () => ({ ok: true as const })),
     cancelMigrate: vi.fn(() => undefined),
-    commitAndRelaunch: vi.fn(async () => ({ ok: true as const })),
+    commitAndRelaunch: vi.fn(async () => ({ ok: true as const, cleanupPending: false })),
     discardMigratedCopy: vi.fn(async () => ({ ok: true as const })),
     dismissLegacyMovePrompt: vi.fn(async () => undefined)
   },

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -490,7 +490,7 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
       } else {
         handoffPending = true
       }
-      return result
+      return result.ok ? { ...result, cleanupPending: false } : result
     } catch (err) {
       // runDataRootMigration never rejects; guard the IPC boundary anyway so a renderer call
       // never sees a raw thrown error. Nothing was committed, so lift the write-gate.

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -187,8 +187,14 @@ describe('storage IPC handlers', () => {
     const owner = createStorageCommandOwner(deps)
     registerStorageIpcHandlers(deps, owner)
 
-    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
-    await expect(owner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({ ok: true })
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: false
+    })
+    await expect(owner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: false
+    })
 
     expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target, {
       previousDataRoot: dataRoot
@@ -213,9 +219,15 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({ cleanupRuntimeCache, cleanupJournal })
     const owner = createStorageCommandOwner(deps)
 
-    await expect(owner.migrate({ parent: targetParent })).resolves.toEqual({ ok: true })
+    await expect(owner.migrate({ parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: false
+    })
     cleanupRuntimeCache.mockClear()
-    await expect(owner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({ ok: true })
+    await expect(owner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: true
+    })
 
     expect(cleanupRuntimeCache).not.toHaveBeenCalled()
     await expect(cleanupJournal.hasPending()).resolves.toBe(true)
@@ -270,7 +282,8 @@ describe('storage IPC handlers', () => {
       target
     })
     await expect(restartedOwner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({
-      ok: true
+      ok: true,
+      cleanupPending: false
     })
 
     expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target, {
@@ -808,7 +821,8 @@ describe('storage IPC handlers', () => {
     registerStorageIpcHandlers(deps)
 
     await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({
-      ok: true
+      ok: true,
+      cleanupPending: false
     })
     expect(deps.runtime.disconnect).toHaveBeenCalledTimes(1)
     // Phase 1 is copy-only: the pointer is not flipped and the app does not restart until the user
@@ -828,7 +842,10 @@ describe('storage IPC handlers', () => {
     })
     registerStorageIpcHandlers(deps)
 
-    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: false
+    })
 
     expect(prepareDataRootHandoff).toHaveBeenCalledWith({ surface: 'electron-renderer' }, true)
   })
@@ -1069,7 +1086,10 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({ micromambaRunner: runner, exportRuntimeLocks: exportLocks })
     registerStorageIpcHandlers(deps)
 
-    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: false
+    })
 
     expect(runner.resolve).toHaveBeenCalledOnce()
     expect(exportLocks).toHaveBeenCalledWith(dataRoot, target, {
@@ -1084,12 +1104,16 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({ logger })
     registerStorageIpcHandlers(deps)
 
-    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: false
+    })
     const markerToken = (await readMigrationMarker(target))?.token
     expect(markerToken).toBeTruthy()
 
     await expect(invoke('storage:commit-and-relaunch', { parent: targetParent })).resolves.toEqual({
-      ok: true
+      ok: true,
+      cleanupPending: false
     })
 
     const completed = diagnosticRecords(logger).filter((record) => record.outcome === 'completed')
@@ -1308,7 +1332,7 @@ describe('storage IPC handlers', () => {
     expect(guardApp.quit).not.toHaveBeenCalled()
     finishPointerWrite?.()
 
-    await expect(commit).resolves.toEqual({ ok: true })
+    await expect(commit).resolves.toEqual({ ok: true, cleanupPending: false })
     await vi.waitFor(() => expect(guardApp.quit).toHaveBeenCalledOnce())
     expect(deps.relaunch).toHaveBeenCalledOnce()
     expect(isMigrationPending()).toBe(true)
@@ -1356,7 +1380,8 @@ describe('storage IPC handlers', () => {
     vi.mocked(deps.runtime.shutdownForQuit).mockClear()
 
     await expect(invoke('storage:commit-and-relaunch', { parent: targetParent })).resolves.toEqual({
-      ok: true
+      ok: true,
+      cleanupPending: false
     })
 
     expect(deps.runtime.shutdownForQuit).not.toHaveBeenCalled()
@@ -1436,7 +1461,8 @@ describe('storage IPC handlers', () => {
     await invoke('storage:migrate', { parent: targetParent })
 
     await expect(invoke('storage:commit-and-relaunch', { parent: targetParent })).resolves.toEqual({
-      ok: true
+      ok: true,
+      cleanupPending: false
     })
     expect(previousRoots).toEqual([dataRoot])
     expect(persisted).toEqual([target])
@@ -1529,7 +1555,10 @@ describe('storage IPC handlers', () => {
     registerStorageIpcHandlers(fakeDeps())
 
     expect(isMigrationPending()).toBe(false)
-    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: false
+    })
     // The copy succeeded but nothing is committed yet, so the gate stays up.
     expect(isMigrationPending()).toBe(true)
   })
@@ -1538,7 +1567,10 @@ describe('storage IPC handlers', () => {
     initDataRoot(dataRoot)
     registerStorageIpcHandlers(fakeDeps())
 
-    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({ ok: true })
+    await expect(invoke('storage:migrate', { parent: targetParent })).resolves.toEqual({
+      ok: true,
+      cleanupPending: false
+    })
     const secondOutcome = await invoke('storage:migrate', { parent: currentParent })
 
     expect(secondOutcome).toEqual({
@@ -1576,7 +1608,8 @@ describe('storage IPC handlers', () => {
 
     try {
       await expect(invoke('storage:migrate', { parent: alternateParent })).resolves.toEqual({
-        ok: true
+        ok: true,
+        cleanupPending: false
       })
       expect(runDataRootMigration).toHaveBeenCalledOnce()
       await expect(cleanupJournal.hasPending()).resolves.toBe(true)
@@ -1702,7 +1735,7 @@ describe('storage IPC handlers', () => {
     })
 
     releaseDisconnect?.()
-    await expect(first).resolves.toEqual({ ok: true })
+    await expect(first).resolves.toEqual({ ok: true, cleanupPending: false })
   })
 
   it('rejects a pointer-only switch while a migration copy is in flight', async () => {

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -1441,7 +1441,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, cleanupPending: false })
     expect(setDataRoot).toHaveBeenCalledWith(target)
     await expect(cleanupJournal.hasPending()).resolves.toBe(false)
     await expect(readMigrationMarker(target)).resolves.toBeNull()
@@ -1485,7 +1485,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, cleanupPending: false })
     expect(setDataRoot).toHaveBeenCalledWith(target)
     await expect(readFile(join(target, RUNTIME_REPAIR_REGISTRY_FILE), 'utf8')).resolves.toBe(
       contents
@@ -1535,7 +1535,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(commitResult).toEqual({ ok: true })
+    expect(commitResult).toEqual({ ok: true, cleanupPending: false })
     const copiedFile = await stat(join(target, 'artifacts', 'observations.csv'))
     expect(Math.trunc(copiedFile.atimeMs / 1000)).toBe(Math.trunc(originalAtime.getTime() / 1000))
     expect(Math.trunc(copiedFile.mtimeMs / 1000)).toBe(Math.trunc(originalMtime.getTime() / 1000))
@@ -1589,7 +1589,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(commitResult).toEqual({ ok: true })
+    expect(commitResult).toEqual({ ok: true, cleanupPending: false })
     await expect(
       readFile(join(target, 'artifacts', 'absolute-link', 'result.txt'), 'utf8')
     ).resolves.toBe('preserved content')
@@ -1684,7 +1684,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, cleanupPending: false })
     const terminalRecords = diagnosticRecords(logger).filter(
       (record) => record.outcome === 'completed'
     )
@@ -1742,7 +1742,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, cleanupPending: false })
     // setDataRoot MUST precede delete: once the pointer is committed, an interrupted delete only
     // orphans the old root; the reverse order could strand data.
     expect(order).toEqual(['setDataRoot', 'deleteSources'])
@@ -1946,12 +1946,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(result).toEqual(
-      expect.objectContaining({
-        ok: true,
-        cleanupWarning: expect.any(String)
-      })
-    )
+    expect(result).toEqual({ ok: true, cleanupPending: true })
     expect(await readMigrationMarker(target)).toMatchObject({
       status: 'verified',
       source: currentDataRoot,
@@ -1988,9 +1983,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(result).toEqual(
-      expect.objectContaining({ ok: true, cleanupWarning: expect.any(String) })
-    )
+    expect(result).toEqual({ ok: true, cleanupPending: true })
     expect(cleanupRuntimeCache).toHaveBeenCalledWith(currentDataRoot)
     await expect(cleanupJournal.hasPending()).resolves.toBe(true)
     await expect(readMigrationMarker(target)).resolves.toMatchObject({ token: 'tok-test' })
@@ -2042,7 +2035,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, cleanupPending: true })
     expect(deleteSources).not.toHaveBeenCalled()
     await expect(cleanupJournal.hasPending()).resolves.toBe(true)
     await expect(readMigrationMarker(target)).resolves.toMatchObject({ token: 'tok-test' })
@@ -2070,7 +2063,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
           emptyParent
         )
 
-        expect(result).toEqual({ ok: true })
+        expect(result).toEqual({ ok: true, cleanupPending: true })
         expect(diagnosticRecords(logger)).toContainEqual(
           expect.objectContaining({
             operation: 'data-root-commit',
@@ -2105,9 +2098,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
       emptyParent
     )
 
-    expect(result).toEqual(
-      expect.objectContaining({ ok: true, cleanupWarning: expect.any(String) })
-    )
+    expect(result).toEqual({ ok: true, cleanupPending: true })
     expect(deps.setDataRoot).toHaveBeenCalledOnce()
     expect(diagnosticRecords(logger)).toContainEqual(
       expect.objectContaining({

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -1117,13 +1117,7 @@ export const commitDataRootSwitch = async (
     cleanupDegraded: cleanupDegraded || cleanupDeferred,
     cleanupFailureCount
   })
-  return cleanupFailureCount > 0
-    ? {
-        ok: true,
-        cleanupWarning:
-          'Your data is using the new location, but some files remain in the old one. Open Science will try to remove them again the next time it starts.'
-      }
-    : { ok: true }
+  return { ok: true, cleanupPending: cleanupDegraded || cleanupDeferred }
 }
 
 // Throws away an uncommitted staged copy at `<parent>/OpenScience` (the user chose "Keep current

--- a/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
@@ -27,9 +27,9 @@ const installApi = (overrides: Partial<MockStorageApi> = {}): MockStorageApi => 
     inspectDataRoot: vi.fn().mockResolvedValue({ kind: 'move', dataRoot: '/home/u/OpenScience' }),
     dismissLegacyMovePrompt: vi.fn().mockResolvedValue(undefined),
     detectActive: vi.fn().mockResolvedValue([]),
-    migrate: vi.fn().mockResolvedValue({ ok: true }),
+    migrate: vi.fn().mockResolvedValue({ ok: true, cleanupPending: false }),
     cancelMigrate: vi.fn().mockResolvedValue(undefined),
-    commitAndRelaunch: vi.fn().mockResolvedValue({ ok: true }),
+    commitAndRelaunch: vi.fn().mockResolvedValue({ ok: true, cleanupPending: false }),
     discardMigratedCopy: vi.fn().mockResolvedValue({ ok: true }),
     onProgress: vi.fn(() => () => {}),
     ...overrides

--- a/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
@@ -653,4 +653,33 @@ describe('FileBrowserModal', () => {
     ) as HTMLButtonElement | undefined
     expect(addButton?.disabled).toBe(true)
   })
+
+  it('does not offer the last workspace Project after returning home', async () => {
+    useProjectStore.setState({
+      projects: [{ id: 'proj-1', name: 'My Project', createdAt: 1, updatedAt: 1 }],
+      isLoaded: true,
+      loadError: undefined
+    } as Parameters<typeof useProjectStore.setState>[0])
+    useNavigationStore.setState({ view: 'workspace', activeProjectId: 'proj-1' })
+    useNavigationStore.getState().goHome('user')
+
+    await act(async () => {
+      root.render(
+        <FileBrowserModal open={true} onClose={vi.fn()} initialProviderId="ssh:biowulf" />
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const fileButton = Array.from(document.querySelectorAll('[role="option"]')).find((element) =>
+      element.textContent?.includes('readme.txt')
+    ) as HTMLElement | undefined
+    expect(fileButton).toBeDefined()
+    await act(async () => {
+      fileButton?.click()
+    })
+
+    expect(document.body.textContent).not.toContain('Add to project')
+  })
 })

--- a/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
@@ -21,9 +21,9 @@ type MockStorageApi = {
 const installApi = (overrides: Partial<MockStorageApi> = {}): MockStorageApi => {
   const api: MockStorageApi = {
     detectActive: vi.fn().mockResolvedValue([]),
-    migrate: vi.fn().mockResolvedValue({ ok: true }),
+    migrate: vi.fn().mockResolvedValue({ ok: true, cleanupPending: false }),
     cancelMigrate: vi.fn().mockResolvedValue(undefined),
-    commitAndRelaunch: vi.fn().mockResolvedValue({ ok: true }),
+    commitAndRelaunch: vi.fn().mockResolvedValue({ ok: true, cleanupPending: false }),
     discardMigratedCopy: vi.fn().mockResolvedValue({ ok: true }),
     onProgress: vi.fn(() => () => {}),
     ...overrides
@@ -172,7 +172,7 @@ describe('StorageMigrationModal', () => {
     expect(document.body.textContent).toMatch(/cleaning up/i)
 
     await act(async () => {
-      resolveMigrate?.({ ok: true })
+      resolveMigrate?.({ ok: true, cleanupPending: false })
       await Promise.resolve()
     })
 
@@ -191,7 +191,7 @@ describe('StorageMigrationModal', () => {
   it('Keep current location discards the copy and closes without committing', async () => {
     const onClose = vi.fn()
     const api = installApi({
-      migrate: vi.fn().mockResolvedValue({ ok: true })
+      migrate: vi.fn().mockResolvedValue({ ok: true, cleanupPending: false })
     })
 
     await act(async () => {

--- a/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
@@ -133,9 +133,9 @@ beforeEach(() => {
         .mockResolvedValue({ kind: 'move', dataRoot: '/mnt/data/OpenScience' }),
       setDataRootAndRelaunch: vi.fn().mockResolvedValue({ ok: true }),
       detectActive: vi.fn().mockResolvedValue([]),
-      migrate: vi.fn().mockResolvedValue({ ok: true }),
+      migrate: vi.fn().mockResolvedValue({ ok: true, cleanupPending: false }),
       cancelMigrate: vi.fn().mockResolvedValue(undefined),
-      commitAndRelaunch: vi.fn().mockResolvedValue({ ok: true }),
+      commitAndRelaunch: vi.fn().mockResolvedValue({ ok: true, cleanupPending: false }),
       discardMigratedCopy: vi.fn().mockResolvedValue({ ok: true }),
       onProgress: vi.fn(() => () => {})
     }

--- a/src/renderer/src/stores/navigation-store.test.ts
+++ b/src/renderer/src/stores/navigation-store.test.ts
@@ -361,10 +361,15 @@ describe('navigation store', () => {
   })
 
   it('returns to the home screen without losing session state', () => {
+    useSessionStore
+      .getState()
+      .hydrateSessions([createSession({})], { version: SESSION_MANIFEST_VERSION })
     useNavigationStore.getState().openSession('project-a', 'session-1', 'user')
     useNavigationStore.getState().goHome('user')
 
     expect(useNavigationStore.getState().view).toBe('home')
+    expect(useNavigationStore.getState().activeProjectId).toBeUndefined()
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-1')
   })
 
   it('routes a New Project request home as a one-shot intent', () => {

--- a/src/renderer/src/stores/navigation-store.ts
+++ b/src/renderer/src/stores/navigation-store.ts
@@ -87,14 +87,13 @@ const navigationState = (
   NavigationStore,
   'view' | 'activeProjectId' | 'userNavigationRevision' | 'explicitNavigationRevision'
 > => ({
-  activeProjectId: state.activeProjectId,
+  view: next.view,
+  activeProjectId:
+    next.view === 'home' ? undefined : (next.activeProjectId ?? state.activeProjectId),
   userNavigationRevision:
     origin === 'user' ? state.userNavigationRevision + 1 : state.userNavigationRevision,
   explicitNavigationRevision:
-    origin === 'automatic'
-      ? state.explicitNavigationRevision
-      : state.explicitNavigationRevision + 1,
-  ...next
+    origin === 'automatic' ? state.explicitNavigationRevision : state.explicitNavigationRevision + 1
 })
 
 // Picks the most recently updated non-pending session in a project so opening a project lands on its

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -83,7 +83,7 @@ export type MigrationProgress = {
 }
 export type MigrationResult = { ok: true } | { ok: false; error: string; cancelled?: boolean }
 export type MigrationOutcome =
-  | { ok: true; cleanupWarning?: string }
+  | { ok: true; cleanupPending: boolean }
   | { ok: false; error: string; cancelled?: boolean }
   | { ok: false; error: string; switchoverFailed: true }
 


### PR DESCRIPTION
## Problem

- A committed data-root migration could defer old-root cleanup behind an earlier durable cleanup intent while returning an indistinguishable `{ ok: true }` result.
- Returning Home retained `activeProjectId`, so consumers that inferred Project scope from that field alone could expose workspace-only actions for the last Project.

Both behaviors were reproduced through existing public boundaries before implementation. The new regression assertions failed twice on the original code for the reported reasons: the migration result lacked `cleanupPending`, and File Browser still rendered `Add to project` after `goHome()`.

## Proposed change

- Make successful `MigrationOutcome` values carry `cleanupPending: boolean`. Commit derives it from the existing durable cleanup state; copy-only migration returns `false`.
- Make the shared navigation transition clear `activeProjectId` whenever the destination view is Home.
- Preserve selected Session and preview state so returning to the workspace continues to use the existing owners.

## Scope and non-goals

- No database or persisted-data schema changes.
- No historical-data migration or compatibility path is required; the boolean projects existing cleanup-journal state across the same-version command boundary.
- No new enum values.
- No discriminated-union navigation rewrite and no `lastWorkspaceProjectId`; this is the smallest invariant fix for the observed behavior.
- The unrelated staged-copy discard `cleanupWarning` contract remains unchanged.

## Acceptance criteria and validation

All listed checks ran against the final material diff.

- Deferred cleanup is observable and normal cleanup reports false -> `npx vitest run src/main/storage/migration-service.test.ts src/main/storage/ipc.test.ts src/main/host-application-commands.test.ts src/shared/storage.test.ts ...` -> passed as part of 9 files / 339 tests.
- Home clears current Project scope while retaining Session state; File Browser no longer offers the last workspace Project -> the same focused Vitest run -> passed as part of 9 files / 339 tests.
- Node/main and sandbox contracts -> `npm run typecheck:node` -> passed.
- Renderer contracts -> `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint -- --no-cache` -> passed with no warnings.
- Final diff whitespace -> `git diff --check origin/main...HEAD` -> passed.

`npm run test:affected -- --base origin/main --head HEAD --explain` conservatively selected the full fallback because `src/main/storage/command-owner.ts` is not mapped to a Module in `module-impact.json`. Per the requested workflow, the complete local `npm test` was not run; exact-head PR Gate CI is authoritative for the remaining portable and platform coverage.

## Review focus

- Whether `cleanupPending` accurately follows every post-commit degraded/deferred cleanup path without changing cleanup ownership.
- Whether clearing Project scope centrally on every Home transition preserves the intended Session/preview retention behavior.
