### PR TITLE
fix(projects): isolate concurrent project deletion

### DIFF
--- a/src/main/archive/coordinator.test.ts
+++ b/src/main/archive/coordinator.test.ts
@@ -412,6 +412,39 @@ describe('ArchiveCoordinator', () => {
     await expect(coordinator.assertProjectAvailable(project.id)).resolves.toBeUndefined()
   })
 
+  it('keeps an unrelated Project available while deletion quiescence is in flight', async () => {
+    const deletionGate = createDeferred<void>()
+    const projects = {
+      get: vi.fn(async (projectId: string) => ({ ...project, id: projectId })),
+      updateArchive: vi.fn()
+    }
+    const sessions = {
+      assertProjectArchivable: vi.fn(),
+      assertSessionAvailable: vi.fn(),
+      updateArchive: vi.fn(),
+      sessionProjectId: vi.fn()
+    }
+    const coordinator = new ArchiveCoordinator(projects, sessions, {
+      isSessionBusy: vi.fn(),
+      isProjectBusy: vi.fn(),
+      liveSessionProjectId: vi.fn()
+    })
+    const quiesce = vi.fn(() => deletionGate.promise)
+
+    const deletion = coordinator.withProjectDeletion(project.id, quiesce)
+    await vi.waitFor(() => expect(quiesce).toHaveBeenCalledOnce())
+
+    const unrelatedOperation = vi.fn().mockResolvedValue('available')
+    const unrelated = coordinator.withProjectAvailable('project-2', unrelatedOperation)
+    await flushMicrotasks()
+    const wasAdmittedDuringDeletion = unrelatedOperation.mock.calls.length === 1
+
+    deletionGate.resolve(undefined)
+    await expect(deletion).resolves.toBeUndefined()
+    await expect(unrelated).resolves.toBe('available')
+    expect(wasAdmittedDuringDeletion).toBe(true)
+  })
+
   it('releases admission after prompt dispatch starts without awaiting prompt completion', async () => {
     const prompt = createDeferred<string>()
     const projects = {
@@ -515,4 +548,10 @@ const createDeferred = <Value>(): {
     resolve = promiseResolve
   })
   return { promise, resolve }
+}
+
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
 }

--- a/src/main/archive/coordinator.ts
+++ b/src/main/archive/coordinator.ts
@@ -33,7 +33,7 @@ type SessionRuntimeActivity = {
 // archive/restore decision and the final runtime admission observe one consistent active state.
 // Prompt execution stays outside it; Task resume holds it only until the Session is durably running.
 class ArchiveCoordinator {
-  private queue: Promise<void> = Promise.resolve()
+  private readonly projectQueues = new Map<string, Promise<void>>()
   private markReadSessions: (sessionIds: string[]) => Promise<void> = async () => undefined
   private readonly deletingProjectIds = new Set<string>()
 
@@ -43,12 +43,19 @@ class ArchiveCoordinator {
     private readonly runtime: SessionRuntimeActivity
   ) {}
 
-  private enqueue<Result>(operation: () => Promise<Result>): Promise<Result> {
-    const result = this.queue.then(operation, operation)
-    this.queue = result.then(
+  private enqueue<Result>(projectId: string, operation: () => Promise<Result>): Promise<Result> {
+    const currentQueue = this.projectQueues.get(projectId) ?? Promise.resolve()
+    const result = currentQueue.then(operation, operation)
+    const nextQueue = result.then(
       () => undefined,
       () => undefined
     )
+    this.projectQueues.set(projectId, nextQueue)
+    void nextQueue.then(() => {
+      if (this.projectQueues.get(projectId) === nextQueue) {
+        this.projectQueues.delete(projectId)
+      }
+    })
     return result
   }
 
@@ -64,7 +71,7 @@ class ArchiveCoordinator {
   }
 
   updateProjectArchive(request: UpdateProjectArchiveRequest): Promise<Project> {
-    return this.enqueue(async () => {
+    return this.enqueue(request.id, async () => {
       this.assertProjectDeletionAvailable(request.id)
       const project = await this.projects.get(request.id)
       if (!project) throw new Error('Project not found.')
@@ -93,7 +100,7 @@ class ArchiveCoordinator {
   }
 
   updateSessionArchive(request: UpdateSessionArchiveRequest): Promise<PersistedChatSession> {
-    return this.enqueue(async () => {
+    return this.enqueue(request.projectId, async () => {
       await this.activeProject(request.projectId)
       const session = await this.sessions.updateArchive(request, () =>
         this.runtime.isSessionBusy(request.projectId, request.sessionId)
@@ -109,7 +116,7 @@ class ArchiveCoordinator {
 
   assertProjectAvailable(projectId: string | undefined): Promise<void> {
     if (!projectId) return Promise.resolve()
-    return this.enqueue(async () => {
+    return this.enqueue(projectId, async () => {
       await this.activeProject(projectId)
     })
   }
@@ -119,7 +126,7 @@ class ArchiveCoordinator {
     operation: () => Promise<Result>
   ): Promise<Result> {
     if (!projectId) return operation()
-    return this.enqueue(async () => {
+    return this.enqueue(projectId, async () => {
       await this.activeProject(projectId)
       return operation()
     })
@@ -129,7 +136,7 @@ class ArchiveCoordinator {
     projectId: string,
     operation: () => Promise<Result>
   ): Promise<Result> {
-    return this.enqueue(async () => {
+    return this.enqueue(projectId, async () => {
       // ProjectDeletionIntent is durable before this boundary. Re-entry is a recovery retry, and a
       // failed teardown must retain the fence until the coordinator completes or explicitly aborts.
       this.deletingProjectIds.add(projectId)
@@ -143,7 +150,7 @@ class ArchiveCoordinator {
   ): Promise<Result> {
     // Parent-message delivery holds this short lifecycle through validation, optional resume, and
     // provider acceptance so Project deletion cannot snapshot ACP ownership in the middle.
-    return this.enqueue(async () => {
+    return this.enqueue(projectId, async () => {
       this.assertProjectDeletionAvailable(projectId)
       return operation()
     })
@@ -158,7 +165,7 @@ class ArchiveCoordinator {
   }
 
   assertSessionAvailable(projectId: string, sessionId: string): Promise<void> {
-    return this.enqueue(() => this.assertSessionAvailableNow(projectId, sessionId))
+    return this.enqueue(projectId, () => this.assertSessionAvailableNow(projectId, sessionId))
   }
 
   withSessionAvailable<Result>(
@@ -166,17 +173,20 @@ class ArchiveCoordinator {
     sessionId: string,
     operation: () => Promise<Result>
   ): Promise<Result> {
-    // ponytail: reuse the global archive queue until measured resume contention justifies
-    // partitioning it by Project.
-    return this.enqueue(async () => {
+    return this.enqueue(projectId, async () => {
       await this.assertSessionAvailableNow(projectId, sessionId)
       return operation()
     })
   }
 
   assertSessionAvailableById(sessionId: string): Promise<void> {
-    return this.enqueue(async () => {
-      await this.assertSessionAvailableByIdNow(sessionId)
+    return this.resolveSessionProjectId(sessionId).then((projectId) => {
+      if (!projectId) {
+        throw new Error('Cannot use a Session whose Project owner is unavailable.')
+      }
+      return this.enqueue(projectId, async () => {
+        await this.assertSessionAvailableByIdNow(sessionId, projectId)
+      })
     })
   }
 
@@ -184,9 +194,14 @@ class ArchiveCoordinator {
     sessionId: string,
     operation: (projectId: string) => Promise<Result>
   ): Promise<Result> {
-    return this.enqueue(async () => {
-      const projectId = await this.assertSessionAvailableByIdNow(sessionId)
-      return operation(projectId)
+    return this.resolveSessionProjectId(sessionId).then((projectId) => {
+      if (!projectId) {
+        throw new Error('Cannot use a Session whose Project owner is unavailable.')
+      }
+      return this.enqueue(projectId, async () => {
+        await this.assertSessionAvailableByIdNow(sessionId, projectId)
+        return operation(projectId)
+      })
     })
   }
 
@@ -194,12 +209,12 @@ class ArchiveCoordinator {
     sessionId: string,
     operation: () => Promise<Result>
   ): Promise<Result> {
-    const admitted = this.enqueue(async () => {
-      const projectId =
-        (await this.sessions.sessionProjectId(sessionId)) ??
-        this.runtime.liveSessionProjectId(sessionId)
-      if (projectId) this.assertProjectDeletionAvailable(projectId)
-      return { result: operation() }
+    const admitted = this.resolveSessionProjectId(sessionId).then((projectId) => {
+      if (!projectId) return { result: operation() }
+      return this.enqueue(projectId, async () => {
+        this.assertProjectDeletionAvailable(projectId)
+        return { result: operation() }
+      })
     })
     return admitted.then(({ result }) => result)
   }
@@ -225,16 +240,16 @@ class ArchiveCoordinator {
     await this.sessions.assertSessionAvailable(ownerProjectId, sessionId)
   }
 
-  private async assertSessionAvailableByIdNow(sessionId: string): Promise<string> {
-    const projectId =
-      (await this.sessions.sessionProjectId(sessionId)) ??
-      this.runtime.liveSessionProjectId(sessionId)
-    if (!projectId) {
-      throw new Error('Cannot use a Session whose Project owner is unavailable.')
-    }
+  private async assertSessionAvailableByIdNow(sessionId: string, projectId: string): Promise<void> {
     await this.activeProject(projectId)
     await this.sessions.assertSessionAvailable(projectId, sessionId)
-    return projectId
+  }
+
+  private async resolveSessionProjectId(sessionId: string): Promise<string | undefined> {
+    return (
+      (await this.sessions.sessionProjectId(sessionId)) ??
+      this.runtime.liveSessionProjectId(sessionId)
+    )
   }
 
   private assertProjectDeletionAvailable(projectId: string): void {

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -837,7 +837,7 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-2')
     expect(projects.delete).toHaveBeenCalledWith('project-2')
     expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-1')
-    expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(3)
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(2)
   })
 
   it('keeps a committed recovery intent when the Project row still exists and replay fails', async () => {
@@ -1096,8 +1096,10 @@ describe('ProjectDeletionCoordinator', () => {
 
     const firstDeletion = coordinator.deleteProject('project-1')
     const secondDeletion = coordinator.deleteProject('project-2')
-    await flushMicrotasks()
-    await flushMicrotasks()
+    await vi.waitFor(() => {
+      expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-1')
+      expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-2')
+    })
 
     let recoveryFinished = false
     const recovery = coordinator.recoverPendingDeletions().then(() => {

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -214,7 +214,8 @@ class ProjectDeletionRecoveryLoop {
 // recovery reports every failure for background retry; foreground Project/Files admission filters
 // those failures by durable Project ownership.
 class ProjectDeletionCoordinator {
-  private operationQueue: Promise<void> = Promise.resolve()
+  private readonly operationQueues = new Map<string, Promise<void>>()
+  private operationGeneration = 0
   private recoveryPromise: Promise<void> | undefined
   private isRecoveryComplete = false
   private recoveryLoop: ProjectDeletionRecoveryLoop | undefined
@@ -247,17 +248,21 @@ class ProjectDeletionCoordinator {
   }
 
   // Enqueues before yielding so two callers in the same event-loop turn cannot publish competing
-  // recovery promises. The queue tail swallows failures only to keep later recovery work runnable.
+  // same-Project operations. Queue tails swallow failures only to keep later work runnable.
   deleteProject(projectId: string): Promise<ProjectDeletionOutcome> {
-    const deletion = this.operationQueue.then(() =>
+    const generation = ++this.operationGeneration
+    this.isRecoveryComplete = false
+    return this.enqueueProjectOperation(projectId, () =>
       withDataRootWrite(async () => {
-        const recoveryComplete = await this.waitForProjectOperationsNow([projectId])
-        this.isRecoveryComplete = false
+        const recoveryComplete = await this.waitForProjectOperationsNow([projectId], projectId)
         try {
           const outcome = await this.runDeletion(projectId)
           // Preserve sticky completion only when scoped admission did not suppress failures owned by
-          // other Projects. Suppressed or newly pending durable intents must remain eligible for retry.
-          this.isRecoveryComplete = outcome.status === 'deleted' && recoveryComplete
+          // other Projects and no newer deletion started during this operation.
+          this.isRecoveryComplete =
+            outcome.status === 'deleted' &&
+            recoveryComplete &&
+            generation === this.operationGeneration
           return outcome
         } catch (error) {
           this.isRecoveryComplete = false
@@ -265,32 +270,31 @@ class ProjectDeletionCoordinator {
         }
       })
     )
-    this.operationQueue = deletion.then(
-      () => undefined,
-      () => undefined
-    )
-    return deletion
   }
 
-  // Every read/recovery gate waits for the full deletion queue that existed when it was called.
-  // Newly requested deletions enqueue synchronously, so later callers cannot bypass active work.
+  // Strict recovery waits for all deletion queues that existed when it was called. Foreground
+  // Project admission uses the scoped method below so unrelated deletions do not block it.
   async recoverPendingDeletions(): Promise<void> {
-    await this.operationQueue
+    await Promise.all(this.operationQueues.values())
     return withDataRootWrite(() => this.recoverPendingDeletionsNow())
   }
 
   // Foreground operations still drive durable recovery, but a failed tail only denies access to the
   // Project(s) that own that intent. Infrastructure failures remain global because intent ownership
-  // could not be established safely. An empty set represents Project list/create operations.
+  // could not be established safely. An empty set checks infrastructure health without waiting for
+  // or replaying Project-owned deletion work.
   async waitForProjectOperations(projectIds: readonly string[]): Promise<void> {
-    await this.operationQueue
-    await withDataRootWrite(() => this.waitForProjectOperationsNow(projectIds))
+    const uniqueProjectIds = [...new Set(projectIds)]
+    await Promise.all(
+      uniqueProjectIds.map((projectId) => this.operationQueues.get(projectId) ?? Promise.resolve())
+    )
+    await withDataRootWrite(() => this.waitForProjectOperationsNow(uniqueProjectIds))
   }
 
   // Restores fail-closed in-memory barriers from local durable authority only. Startup waits for this
   // bounded phase, then remote cleanup is retried by ProjectDeletionRecoveryLoop after the app opens.
   async restorePendingDeletionBarriers(): Promise<void> {
-    await this.operationQueue
+    await Promise.all(this.operationQueues.values())
     return withDataRootWrite(async () => {
       if (!this.lifecycle?.restoreProjectDeletion) return
       const projectIds = new Set(await this.projects.listDeletionIntents())
@@ -309,11 +313,12 @@ class ProjectDeletionCoordinator {
     if (this.recoveryPromise) return this.recoveryPromise
     if (this.isRecoveryComplete) return
 
-    const recovery = this.recoverEveryPendingDeletion()
+    const generation = this.operationGeneration
+    const recovery = this.recoverEveryPendingDeletion().then(() => undefined)
     this.recoveryPromise = recovery
     try {
       await recovery
-      this.isRecoveryComplete = true
+      this.isRecoveryComplete = generation === this.operationGeneration
     } catch (error) {
       this.isRecoveryComplete = false
       throw error
@@ -322,10 +327,13 @@ class ProjectDeletionCoordinator {
     }
   }
 
-  private async waitForProjectOperationsNow(projectIds: readonly string[]): Promise<boolean> {
+  private async waitForProjectOperationsNow(
+    projectIds: readonly string[],
+    currentProjectId?: string
+  ): Promise<boolean> {
+    if (this.isRecoveryComplete) return true
     try {
-      await this.recoverPendingDeletionsNow()
-      return true
+      return await this.recoverEveryPendingDeletion(new Set(projectIds), currentProjectId)
     } catch (error) {
       if (!(error instanceof ProjectDeletionRecoveryError)) throw error
       if (error.affectsAny(new Set(projectIds))) throw error
@@ -333,14 +341,22 @@ class ProjectDeletionCoordinator {
     }
   }
 
-  private async recoverEveryPendingDeletion(): Promise<void> {
-    const { projectIds, retainedProjectIds, failures } = await this.runPendingDeletionRecovery()
-    failures.push(
-      ...(await this.adoptLegacyProjectSessionTombstones(
-        new Set([...projectIds, ...retainedProjectIds])
-      ))
+  private async recoverEveryPendingDeletion(
+    projectIds?: ReadonlySet<string>,
+    currentProjectId?: string
+  ): Promise<boolean> {
+    const pending = await this.runPendingDeletionRecovery(projectIds, currentProjectId)
+    const legacy = await this.adoptLegacyProjectSessionTombstones(
+      new Set([...pending.projectIds, ...pending.retainedProjectIds]),
+      projectIds,
+      currentProjectId
     )
+    const failures = [...pending.failures, ...legacy.failures]
     if (failures.length > 0) throw new ProjectDeletionRecoveryError(failures)
+    return (
+      !projectIds ||
+      [...pending.projectIds, ...legacy.projectIds].every((projectId) => projectIds.has(projectId))
+    )
   }
 
   // Install the non-destructive admission fence before committing deletion intent, then persist
@@ -373,8 +389,11 @@ class ProjectDeletionCoordinator {
     await this.lifecycle?.beforeProjectDelete(projectId)
   }
 
-  // Replays intents serially so crash recovery follows the same ordering as an online deletion.
-  private async runPendingDeletionRecovery(): Promise<{
+  // Replays each intent through its Project queue so online deletion and recovery cannot overlap.
+  private async runPendingDeletionRecovery(
+    selectedProjectIds?: ReadonlySet<string>,
+    currentProjectId?: string
+  ): Promise<{
     projectIds: readonly string[]
     retainedProjectIds: Set<string>
     failures: ProjectDeletionFailure[]
@@ -383,30 +402,30 @@ class ProjectDeletionCoordinator {
     const retainedProjectIds = new Set<string>()
     const failures: ProjectDeletionFailure[] = []
     for (const projectId of projectIds) {
+      if (selectedProjectIds && !selectedProjectIds.has(projectId)) continue
       try {
-        await this.prepareDeletion(projectId)
-        // An absent Project plus an unmarked tombstone identifies a cross-version orphan adoption.
-        // Re-derive its conservative policy from durable state so a crash immediately after intent
-        // creation cannot turn the next retry into authority-creating normal deletion. Any rejection
-        // naturally retains the intent because runtime cleanup may already have removed resources.
-        const requireExistingUploadAuthority =
-          !(await this.projects.get(projectId)) &&
-          (await this.sessions.getProjectSessionDeletionState(projectId)) === 'legacy-committed'
-        const result: ProjectSessionDeletionResult = requireExistingUploadAuthority
-          ? await this.sessions.deleteProjectSessions(projectId, {
-              requireExistingUploadAuthority: true
-            })
-          : await this.sessions.deleteProjectSessions(projectId)
-        if (result.status === 'orphan-retained') {
-          await this.projects.deleteDeletionIntent(projectId)
-          await this.lifecycle?.abortProjectDeletion?.(projectId)
-          retainedProjectIds.add(projectId)
-          continue
-        }
-        const attempt = await this.finishDeletion(projectId)
-        if (attempt.status === 'cleanup-pending') {
-          failures.push({ projectId, error: attempt.error })
-        }
+        await this.runProjectOperation(projectId, currentProjectId, async () => {
+          await this.prepareDeletion(projectId)
+          // An absent Project plus an unmarked tombstone identifies a cross-version orphan adoption.
+          // Re-derive its conservative policy from durable state so a crash immediately after intent
+          // creation cannot turn the next retry into authority-creating normal deletion.
+          const requireExistingUploadAuthority =
+            !(await this.projects.get(projectId)) &&
+            (await this.sessions.getProjectSessionDeletionState(projectId)) === 'legacy-committed'
+          const result: ProjectSessionDeletionResult = requireExistingUploadAuthority
+            ? await this.sessions.deleteProjectSessions(projectId, {
+                requireExistingUploadAuthority: true
+              })
+            : await this.sessions.deleteProjectSessions(projectId)
+          if (result.status === 'orphan-retained') {
+            await this.projects.deleteDeletionIntent(projectId)
+            await this.lifecycle?.abortProjectDeletion?.(projectId)
+            retainedProjectIds.add(projectId)
+            return
+          }
+          const attempt = await this.finishDeletion(projectId)
+          if (attempt.status === 'cleanup-pending') throw attempt.error
+        })
       } catch (error) {
         failures.push({ projectId, error })
       }
@@ -418,32 +437,62 @@ class ProjectDeletionCoordinator {
   // tombstone cleanup. Adopt every surviving unmarked tombstone into the durable intent protocol
   // before its Session migration can write a prepared marker or create new Version authority.
   private async adoptLegacyProjectSessionTombstones(
-    skippedProjectIds: ReadonlySet<string>
-  ): Promise<ProjectDeletionFailure[]> {
+    skippedProjectIds: ReadonlySet<string>,
+    selectedProjectIds?: ReadonlySet<string>,
+    currentProjectId?: string
+  ): Promise<{ projectIds: string[]; failures: ProjectDeletionFailure[] }> {
     const projectIds = await this.sessions.listLegacyProjectSessionTombstones()
     const failures: ProjectDeletionFailure[] = []
     for (const projectId of projectIds) {
       if (skippedProjectIds.has(projectId)) continue
+      if (selectedProjectIds && !selectedProjectIds.has(projectId)) continue
       try {
-        await this.createDeletionIntentWithFence(projectId)
-        await this.lifecycle?.beforeProjectDelete(projectId)
-        const result = await this.sessions.deleteProjectSessions(projectId, {
-          requireExistingUploadAuthority: true
+        await this.runProjectOperation(projectId, currentProjectId, async () => {
+          await this.createDeletionIntentWithFence(projectId)
+          await this.lifecycle?.beforeProjectDelete(projectId)
+          const result = await this.sessions.deleteProjectSessions(projectId, {
+            requireExistingUploadAuthority: true
+          })
+          if (result.status === 'orphan-retained') {
+            await this.projects.deleteDeletionIntent(projectId)
+            await this.lifecycle?.abortProjectDeletion?.(projectId)
+            return
+          }
+          const attempt = await this.finishDeletion(projectId)
+          if (attempt.status === 'cleanup-pending') throw attempt.error
         })
-        if (result.status === 'orphan-retained') {
-          await this.projects.deleteDeletionIntent(projectId)
-          await this.lifecycle?.abortProjectDeletion?.(projectId)
-          continue
-        }
-        const attempt = await this.finishDeletion(projectId)
-        if (attempt.status === 'cleanup-pending') {
-          failures.push({ projectId, error: attempt.error })
-        }
       } catch (error) {
         failures.push({ projectId, error })
       }
     }
-    return failures
+    return { projectIds, failures }
+  }
+
+  private enqueueProjectOperation<Result>(
+    projectId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    const previous = this.operationQueues.get(projectId) ?? Promise.resolve()
+    const result = previous.then(operation, operation)
+    const tail = result.then(
+      () => undefined,
+      () => undefined
+    )
+    this.operationQueues.set(projectId, tail)
+    void tail.then(() => {
+      if (this.operationQueues.get(projectId) === tail) this.operationQueues.delete(projectId)
+    })
+    return result
+  }
+
+  private runProjectOperation<Result>(
+    projectId: string,
+    currentProjectId: string | undefined,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    return currentProjectId === projectId
+      ? operation()
+      : this.enqueueProjectOperation(projectId, operation)
   }
 
   // Authority pruning must succeed before the Project becomes an invisible metadata tombstone. The

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -15,6 +15,7 @@ vi.mock('electron', () => ({
 }))
 
 import { createProjectHandlers, registerPreviewStateIpcHandlers } from './ipc'
+import { ProjectDeletionCoordinator } from './deletion-coordinator'
 
 beforeEach(() => {
   ipcHandlers.clear()
@@ -74,7 +75,7 @@ describe('createProjectHandlers', () => {
     expect(deletionCoordinator.retryDeletionCleanup).toHaveBeenCalledOnce()
   })
 
-  it('recovers durable deletions before listing projects', async () => {
+  it('lists projects without waiting for deletion recovery', async () => {
     const repository = {
       list: vi.fn().mockResolvedValue([]),
       get: vi.fn(),
@@ -91,7 +92,7 @@ describe('createProjectHandlers', () => {
 
     await handlers.list()
 
-    expect(deletionCoordinator.waitForProjectOperations).toHaveBeenCalledWith([])
+    expect(deletionCoordinator.waitForProjectOperations).not.toHaveBeenCalled()
     expect(repository.list).toHaveBeenCalledOnce()
   })
 
@@ -124,12 +125,88 @@ describe('createProjectHandlers', () => {
 
     expect(repository.list).toHaveBeenCalledOnce()
     expect(repository.get).toHaveBeenCalledOnce()
-    expect(deletionCoordinator.waitForProjectOperations).toHaveBeenCalledWith([])
     expect(deletionCoordinator.waitForProjectOperations).toHaveBeenCalledWith(['project-2'])
     expect(deletionCoordinator.waitForProjectOperations).toHaveBeenCalledWith(['project-1'])
   })
 
-  it('recovers durable deletions before every project read or mutation', async () => {
+  it('keeps unrelated Project CRUD available while another deletion is in flight', async () => {
+    const deletionGate = createDeferred<void>()
+    const deletionIntents = new Set<string>()
+    const deletingProject = project
+    const unrelatedProject = { ...project, id: 'project-2', name: 'Other Project' }
+    const repository = {
+      list: vi.fn().mockResolvedValue([unrelatedProject]),
+      get: vi.fn(async (id: string) =>
+        id === deletingProject.id ? deletingProject : unrelatedProject
+      ),
+      create: vi.fn().mockResolvedValue(unrelatedProject),
+      update: vi.fn().mockResolvedValue(unrelatedProject),
+      delete: vi.fn().mockResolvedValue(undefined),
+      createDeletionIntent: vi.fn(async (projectId: string) => {
+        deletionIntents.add(projectId)
+      }),
+      deleteDeletionIntent: vi.fn(async (projectId: string) => {
+        deletionIntents.delete(projectId)
+      }),
+      listDeletionIntents: vi.fn(async () => [...deletionIntents]),
+      listDeletionCleanupProjects: vi.fn().mockResolvedValue([])
+    }
+    const sessions = {
+      deleteProjectSessions: vi.fn(async (projectId: string) => {
+        if (projectId === deletingProject.id) await deletionGate.promise
+        return { status: 'completed' as const }
+      }),
+      getProjectSessionDeletionState: vi.fn().mockResolvedValue('absent' as const),
+      completeProjectSessionDeletion: vi.fn().mockResolvedValue(undefined),
+      listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue([])
+    }
+    const deletionCoordinator = new ProjectDeletionCoordinator(repository, sessions)
+    const updateArchive = vi.fn().mockResolvedValue(unrelatedProject)
+    const handlers = createProjectHandlers(repository, deletionCoordinator, { updateArchive })
+    await deletionCoordinator.recoverPendingDeletions()
+
+    const deletion = handlers.delete(deletingProject.id)
+    await vi.waitFor(() =>
+      expect(sessions.deleteProjectSessions).toHaveBeenCalledWith(deletingProject.id)
+    )
+
+    const operations = [
+      handlers.list(),
+      handlers.get(unrelatedProject.id),
+      handlers.create({ name: 'New Project' }),
+      handlers.update({
+        id: unrelatedProject.id,
+        name: 'Renamed Project',
+        expectedUpdatedAt: unrelatedProject.updatedAt
+      }),
+      handlers.updateArchive({
+        id: unrelatedProject.id,
+        archived: true,
+        expectedArchivedAt: null
+      })
+    ]
+    await flushMicrotasks()
+    const reachedBeforeDeletionFinished = {
+      list: repository.list.mock.calls.length > 0,
+      get: repository.get.mock.calls.some(([id]) => id === unrelatedProject.id),
+      create: repository.create.mock.calls.length > 0,
+      update: repository.update.mock.calls.length > 0,
+      archive: updateArchive.mock.calls.length > 0
+    }
+
+    deletionGate.resolve(undefined)
+    await Promise.all([deletion, ...operations])
+
+    expect(reachedBeforeDeletionFinished).toEqual({
+      list: true,
+      get: true,
+      create: true,
+      update: true,
+      archive: true
+    })
+  })
+
+  it('checks deletion recovery only for operations on existing Projects', async () => {
     const order: string[] = []
     const repository = {
       list: vi.fn(),
@@ -160,7 +237,7 @@ describe('createProjectHandlers', () => {
     await handlers.create({ name: 'Project' })
     await handlers.update({ id: 'project-1', name: 'Renamed', expectedUpdatedAt: 2 })
 
-    expect(order).toEqual(['recover', 'get', 'recover', 'create', 'recover', 'update'])
+    expect(order).toEqual(['recover', 'get', 'create', 'recover', 'update'])
   })
 
   it('forwards the Agent Context field through create and update unchanged', async () => {
@@ -267,4 +344,19 @@ const project = {
   isExample: false,
   createdAt: 1,
   updatedAt: 2
+}
+
+const createDeferred = <Value>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+const flushMicrotasks = async (): Promise<void> => {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve()
 }

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -63,7 +63,6 @@ const createProjectHandlers = (
   }
 ): ProjectHandlers => ({
   list: async () => {
-    await deletionCoordinator.waitForProjectOperations([])
     return repository.list()
   },
   get: async (id) => {
@@ -71,7 +70,6 @@ const createProjectHandlers = (
     return repository.get(id)
   },
   create: async (request) => {
-    await deletionCoordinator.waitForProjectOperations([])
     return repository.create(request)
   },
   update: async (request) => {

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -101,6 +101,20 @@ describe('project repository', () => {
     })
   })
 
+  it('hides projects with a committed deletion intent before soft deletion completes', async () => {
+    const deletingProject = createRow({ id: 'project-deleting', name: 'Deleting' })
+    const activeProject = createRow({ id: 'project-active', name: 'Active' })
+    const { client, projectDeletionIntent } = createMockClient({
+      findMany: () => Promise.resolve([deletingProject, activeProject])
+    })
+    projectDeletionIntent.findMany.mockResolvedValue([{ projectId: 'project-deleting' }])
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+
+    await expect(repository.list()).resolves.toEqual([
+      expect.objectContaining({ id: 'project-active', name: 'Active' })
+    ])
+  })
+
   it('returns null when a project is not found', async () => {
     const { client } = createMockClient({ findUnique: () => Promise.resolve(null) })
     const repository = new ProjectRepository(() => Promise.resolve(client))

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -55,12 +55,16 @@ class ProjectRepository {
   // Lists projects most-recently-updated first for the home screen.
   async list(): Promise<Project[]> {
     const client = await this.getClient()
+    const deletionIntents = await client.projectDeletionIntent.findMany({
+      select: { projectId: true }
+    })
     const rows = await client.project.findMany({
       where: { deletedAt: null },
       orderBy: { updatedAt: 'desc' }
     })
+    const deletingProjectIds = new Set(deletionIntents.map(({ projectId }) => projectId))
 
-    return rows.map(toProject)
+    return rows.filter(({ id }) => !deletingProjectIds.has(id)).map(toProject)
   }
 
   // Returns a single project or null when it no longer exists.


### PR DESCRIPTION
## Problem

Deleting Project A held two process-wide Promise queues through runtime quiescence, Session removal,
soft deletion, and replayable tail cleanup. Project B list/get/create/update/archive admission could
therefore wait for unrelated work. The global list also exposed a Project after its durable deletion
intent was committed but before its metadata row was soft-deleted.

## Change

- Partition Project deletion/recovery queue tails by `projectId` while preserving strict global
  startup/background recovery and same-Project serialization.
- Scope foreground recovery to the Project IDs named by get/update/archive/delete and Project
  Files/Session mutations.
- Let Project list/create proceed without waiting for unrelated deletion work.
- Filter `ProjectRepository.list()` by the existing durable `ProjectDeletionIntent` fence.
- Partition ArchiveCoordinator admission by Project, resolving Session-ID-only entry points to their
  owning Project before enqueueing.

The successful post-soft-delete cleanup tail remains awaited by the initiating deletion request.
Moving every successful tail to the background would change deletion completion semantics and is not
needed once unrelated Projects no longer share either queue; failed tails continue to use the
existing durable recovery loop.

## Regression evidence

Each reported behavior was reproduced at an existing public boundary before its production fix:

- Project IPC + real deletion coordinator: while A's Session deletion was paused, B's
  list/get/create/update/archive repository boundaries were all unreached.
- Project repository list: with a committed intent for A, list returned both A and B instead of only
  B.
- ArchiveCoordinator: while A's deletion quiescence was paused, B's availability callback was
  unreached.

The same tests pass after the fix. The deletion coordinator suite also verifies that two different
Project deletions enter their Session deletion work concurrently while strict recovery still waits
for both.

## Local checks

- `npm test -- src/main/projects/deletion-coordinator.test.ts src/main/projects/ipc.test.ts src/main/projects/repository.test.ts src/main/archive/coordinator.test.ts src/main/session-persistence/ipc.test.ts src/main/session-persistence/deletion-integration.test.ts src/main/project-files/ipc.test.ts` — 135 passed
- `npm run typecheck:node` — passed
- `npm run lint` — passed
- `npm run test:affected:explain -- --base origin/main --head HEAD` — selected full Vitest because
  the archive coordinator test path has no module owner; full local `npm test` intentionally omitted
  per maintainer direction, with exact-head PR Gate authoritative.

## Compatibility and state

- Historical compatibility: unchanged; existing deletion intents and legacy Session tombstones use
  the same recovery paths.
- Persisted data: no new storage or format. List performs an additional read of the existing
  `ProjectDeletionIntent` table.
- Schema/data model: no Prisma schema, column, index, relation, or migration changes.
- States/enums: no new public state or enum value. New state is limited to in-memory per-Project queue
  maps.
- Interaction: unrelated Projects remain usable; the deleting Project disappears from list as soon
  as its durable deletion intent commits. Existing cleanup-pending outcomes/events remain unchanged.
