### PR TITLE
refactor(storage): clarify config and data root routing

### DIFF
--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -41,7 +41,7 @@ import {
   buildSpecialistIdentityPrefix
 } from '../specialist/identity'
 import type { SpecialistService } from '../specialist/service'
-import { resolveConfigRoot, resolveDataRoot, resolveStorageRoot } from '../storage-root'
+import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
 import type { UploadRepository } from '../uploads/repository'
 import type {
   SessionCatalog,
@@ -213,7 +213,7 @@ const createAcpRuntime = ({
   const defaultCwd = homedir()
   const runtimeCoordinatorRef: { current?: AcpRuntimeCoordinator } = {}
   // One lazily-shared repository for Agent Context lookups; getProjectDbClient caches the client.
-  const projectRepository = new ProjectRepository(() => getProjectDbClient(resolveStorageRoot()))
+  const projectRepository = new ProjectRepository(() => getProjectDbClient(resolveConfigRoot()))
   const eventBroadcast = createAcpRuntimeEventBroadcastCoalescer({
     publish: (events) => broadcastToRenderers('acp:event', events)
   })

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -39,7 +39,7 @@ import type { PermissionGrantRegistry } from '../permission-grants/registry'
 // ---------------------------------------------------------------------------
 // electron mock — captures ipcMain.handle registrations and stubs BrowserWindow
 // so the broadcaster path never tries to walk real renderer windows. Also
-// stubs `app` so resolveStorageRoot() resolves against a controllable home
+// stubs `app` so resolveConfigRoot() resolves against a controllable home
 // directory (OPEN_SCIENCE_STORAGE_ROOT is preferred when set).
 // ---------------------------------------------------------------------------
 

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -31,7 +31,7 @@ import { computeProviderId } from '../../shared/compute'
 import type { DirListing, DownloadDest, LocalFile } from '../../shared/remote-fs'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { createLogger, errorLogFields } from '../logger'
-import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
+import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
 import { createSettingsComputeGrantPort } from '../settings/compute-grant-port'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import type { TaskNotificationService } from '../notifications/task-notifications'
@@ -608,13 +608,13 @@ const createComputeHandlers = (
 // is passed as a provider (not a resolved promise) so a failed first initialization can be retried on
 // the next request instead of being cached for the app's lifetime.
 const createDefaultComputeHostRepository = (): ComputeHostRepository =>
-  new ComputeHostRepository(() => getProjectDbClient(resolveStorageRoot()))
+  new ComputeHostRepository(() => getProjectDbClient(resolveConfigRoot()))
 
 const createDefaultComputeJobRepository = (): ComputeJobRepository =>
-  new ComputeJobRepository(() => getProjectDbClient(resolveStorageRoot()))
+  new ComputeJobRepository(() => getProjectDbClient(resolveConfigRoot()))
 
 const createDefaultComputeJobOperationRepository = (): ComputeJobOperationRepository =>
-  new ComputeJobOperationRepository(() => getProjectDbClient(resolveStorageRoot()))
+  new ComputeJobOperationRepository(() => getProjectDbClient(resolveConfigRoot()))
 
 // Broadcasts a job summary to all renderer windows. Called by the JobPoller onJobUpdated hook
 // and by the job dispatcher on status transitions (Phase 3d, design.md §9).
@@ -692,14 +692,14 @@ const createComputeIpcModule = (
   sessionLimitPersistence?: SessionConcurrencyLimitPersistence
 ): ComputeIpcModule => {
   const operationRepository = createDefaultComputeJobOperationRepository()
-  const storageRoot = resolveStorageRoot()
+  const configRoot = resolveConfigRoot()
   const dataRoot = resolveDataRoot()
   const sessionCacheOwner = new SessionCacheOwner(dataRoot)
   void repository
     .cleanupOrphanCredentials?.()
     .catch((error) => log.warn('orphan Compute Credential cleanup failed', errorLogFields(error)))
   const effectiveLegacyComputeGrants =
-    legacyComputeGrants ?? createSettingsComputeGrantPort(storageRoot)
+    legacyComputeGrants ?? createSettingsComputeGrantPort(configRoot)
 
   // Broadcast dispatcher status transitions to the renderer, same hook shape as the JobPoller uses.
   const onJobUpdated = createJobUpdatedBroadcaster(repository, dataRoot, jobRepository)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -309,7 +309,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { installDatabaseStartupQuitGuard, registerDatabaseStartupIpc },
         { buildStartupDiagnostics },
         { getProjectDbClient },
-        { resolveStorageRoot },
+        { resolveConfigRoot },
         { SettingsDocumentStore },
         { SettingsRepository }
       ] = await Promise.all([
@@ -337,7 +337,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // Create the settings document owner before any native surface. The startup locale repository
       // and the later application Settings repository share this store, so every settings.json
       // mutation uses one serialization queue and one atomic-write implementation.
-      const settingsStore = new SettingsDocumentStore(resolveStorageRoot())
+      const settingsStore = new SettingsDocumentStore(resolveConfigRoot())
       const startupSettingsRepository = new SettingsRepository(settingsStore)
       const startupSettings = await startupSettingsRepository.getSettings()
       const localeOwner = new LocalePreferenceOwner(
@@ -363,7 +363,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         reportBlocked: databaseStartupLogging.reportBlocked,
         buildDiagnostics: (error) =>
           buildStartupDiagnostics(error, {
-            configRoot: resolveStorageRoot(),
+            configRoot: resolveConfigRoot(),
             dataRoot: startupSettings.dataRoot
           }),
         environment: {
@@ -375,7 +375,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         },
         verifyDatabase: async (onProgress) => {
           await getProjectDbClient(
-            resolveStorageRoot(),
+            resolveConfigRoot(),
             databaseStartupLogging.migrationOptions(onProgress)
           )
         }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -376,7 +376,6 @@ import {
   initDataRoot,
   resolveConfigRoot,
   resolveDataRoot,
-  resolveStorageRoot,
   samePath
 } from './storage-root'
 import { createUpdateCommandOwner, registerUpdateIpcHandlers } from './update/ipc'
@@ -512,12 +511,12 @@ const createApplicationModules = async (
   const permissionApprovalPresence = new PermissionApprovalPresence()
   const webSessionPersistenceFlush = createWebSessionPersistenceFlush(applicationEvents)
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
-  const specialistPackageSkillAdapter = new UserSkillSpecialistPackageAdapter(resolveStorageRoot())
+  const specialistPackageSkillAdapter = new UserSkillSpecialistPackageAdapter(resolveConfigRoot())
   const specialistPackageRecovery = {
     current: undefined as (<T>(operation: () => Promise<T>) => Promise<T>) | undefined
   }
   const settingsRepository = new SettingsRepository(
-    settingsStore ?? resolveStorageRoot(),
+    settingsStore ?? resolveConfigRoot(),
     (operation) => specialistPackageSkillAdapter.runMutationExclusive(operation)
   )
   const networkProxyRuntime = new NetworkProxyRuntime({
@@ -692,7 +691,7 @@ const createApplicationModules = async (
   }
   const notificationInbox = createNotificationInboxController({
     headless,
-    repository: new NotificationInboxDbRepository(() => getProjectDbClient(resolveStorageRoot())),
+    repository: new NotificationInboxDbRepository(() => getProjectDbClient(resolveConfigRoot())),
     onChanged: (event) => applicationEvents.publish('notifications:changed', event),
     onError: (error) =>
       createLogger('notifications').warn('message center operation failed', errorLogFields(error))
@@ -720,7 +719,7 @@ const createApplicationModules = async (
   }
   const managedFileVersionService = new ManagedFileVersionService({
     storageRoot: resolveDataRoot(),
-    getClient: () => getProjectDbClient(resolveStorageRoot())
+    getClient: () => getProjectDbClient(resolveConfigRoot())
   })
   // Session reads and permission scope validation both need a late-bound view of ACP ownership:
   // startup runs before the runtime exists, while later reads must preserve live prompt state.
@@ -764,7 +763,7 @@ const createApplicationModules = async (
   )
   const auxiliaryUsageLog = createLogger('session-usage:auxiliary')
   const auxiliaryUsageRecorder = new SessionAuxiliaryTurnUsageRecorder(() =>
-    getProjectDbClient(resolveStorageRoot())
+    getProjectDbClient(resolveConfigRoot())
   )
   const recordAuxiliaryUsage = async (record: SessionAuxiliaryTurnUsageRecord): Promise<void> => {
     try {
@@ -813,7 +812,7 @@ const createApplicationModules = async (
   })
   const artifactProvenanceRepository = new ArtifactProvenanceRepository({
     storageRoot: resolveDataRoot(),
-    getClient: () => getProjectDbClient(resolveStorageRoot()),
+    getClient: () => getProjectDbClient(resolveConfigRoot()),
     inputAuthority: immutableInputAuthority,
     managedFileVersions: managedFileVersionService,
     compatibilityRepository: artifactRepository,
@@ -821,7 +820,7 @@ const createApplicationModules = async (
   })
   const provenanceMessageSnapshots = new ProvenanceMessageSnapshotRepository({
     storageRoot: resolveDataRoot(),
-    getClient: () => getProjectDbClient(resolveStorageRoot())
+    getClient: () => getProjectDbClient(resolveConfigRoot())
   })
   const artifactRunRegistry = new ArtifactRunRegistry()
   // The upload repository above is shared so staging recovery, Session upgrade, prompt finalization,
@@ -832,7 +831,7 @@ const createApplicationModules = async (
   // settings service is passed as the legacy store so a pre-existing settings.json
   // grantedLocalRoots field is imported into the DB once on first use.
   const grantedRootsRepository = new GrantedLocalRootsRepository(
-    () => getProjectDbClient(resolveStorageRoot()),
+    () => getProjectDbClient(resolveConfigRoot()),
     settingsService
   )
   grantedRootsRepositoryRef.current = grantedRootsRepository
@@ -881,7 +880,7 @@ const createApplicationModules = async (
 
   // Construct one storage/index/deletion graph for every related IPC surface. Sharing these instances
   // is essential: separate coordinators would have independent queues and recovery gates.
-  const configRoot = resolveStorageRoot()
+  const configRoot = resolveConfigRoot()
   const permissionGrantRegistry = await createPermissionGrantRegistry({
     getClient: () => getProjectDbClient(configRoot),
     isScopeLive: (scope) =>
@@ -1426,7 +1425,7 @@ const createApplicationModules = async (
 
   // Builtins are validated once at startup from read-only repository resources. Package imports use
   // the same repository while keeping their dynamic Connector/custom-Skill catalog separate.
-  const specialistRepository = new SpecialistRepository(resolveStorageRoot())
+  const specialistRepository = new SpecialistRepository(resolveConfigRoot())
   const appVersion = app.getVersion()
   const specialistSkills = await settingsService.listSpecialistSkillCatalog({ bundledOnly: true })
   composition.phase('specialist-catalog')
@@ -1452,7 +1451,7 @@ const createApplicationModules = async (
     builtinRegistry,
     (operation) => specialistPackageRecovery.current?.(operation) ?? operation()
   )
-  const marketplaceRepository = new MarketplaceRepository(resolveStorageRoot())
+  const marketplaceRepository = new MarketplaceRepository(resolveConfigRoot())
   const marketplaceOperationCoordinator = new MarketplaceOperationCoordinator()
   await specialistService.ensureBuiltinCatalogReady()
   composition.phase('builtin-specialists')
@@ -1484,7 +1483,7 @@ const createApplicationModules = async (
     }
   }
   const specialistPackageService = new SpecialistPackageService({
-    storageDir: resolveStorageRoot(),
+    storageDir: resolveConfigRoot(),
     repository: specialistRepository,
     catalog: async () => {
       const appVersion = app.getVersion()
@@ -1665,7 +1664,7 @@ const createApplicationModules = async (
   // Startup registers the complete production adapter below before any IPC surface becomes callable.
   const completionGateRuntimeRegistry = new CompletionGateRuntimeRegistry()
   const completionHandoffLifecycle = new CompletionHandoffLifecycle(
-    new FileCompletionHandoffRepository(join(resolveStorageRoot(), 'specialist-handoffs')),
+    new FileCompletionHandoffRepository(join(resolveConfigRoot(), 'specialist-handoffs')),
     completionGateRuntimeRegistry,
     Date.now,
     (event) => broadcastToRenderers(SPECIALIST_IPC.HANDOFF_LIFECYCLE_CHANGED, event),
@@ -1767,7 +1766,7 @@ const createApplicationModules = async (
   const connectorApplication = await modules.add(
     {
       settings: settingsService,
-      skillsDir: connectorSkillSourceDir(resolveStorageRoot()),
+      skillsDir: connectorSkillSourceDir(resolveConfigRoot()),
       openExternal: (url) => shell.openExternal(url),
       notifyStatusChanged: () =>
         broadcastToRenderers('settings:connector-runtime-changed', undefined),

--- a/src/main/notebook/micromamba.ts
+++ b/src/main/notebook/micromamba.ts
@@ -34,7 +34,7 @@ const isFile = (path: string): boolean => {
 // packaged resource (process.resourcesPath) → <storageRoot>/runtime/micromamba/bin → PATH. The
 // storage-root fallback reuses the production session dir name
 // (PROD_SESSION_DIR_NAME, i.e. ~/.open-science) since this module stays electron-free and cannot
-// see the dev/prod choice made by resolveStorageRoot; dev builds rely on the env override or PATH.
+// see the dev/prod choice made by resolveConfigRoot; dev builds rely on the env override or PATH.
 export type MicromambaLocation = {
   kind: 'override' | 'bundled' | 'runtime' | 'path'
   path: string

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -18,7 +18,7 @@ import type { ProjectDeletionCoordinator } from './deletion-coordinator'
 import { PreviewStateRepository } from './preview-repository'
 import { getProjectDbClient } from './prisma-client'
 import { ProjectRepository } from './repository'
-import { resolveStorageRoot } from '../storage-root'
+import { resolveConfigRoot } from '../storage-root'
 
 type ProjectHandlers = {
   list: () => Promise<Project[]>
@@ -35,10 +35,10 @@ type ProjectHandlers = {
 // passed as a provider (not a resolved promise) so a failed first initialization can be retried on the
 // next request instead of being cached for the app's lifetime.
 const createDefaultProjectRepository = (): ProjectRepository =>
-  new ProjectRepository(() => getProjectDbClient(resolveStorageRoot()))
+  new ProjectRepository(() => getProjectDbClient(resolveConfigRoot()))
 
 const createDefaultPreviewStateRepository = (): PreviewStateRepository =>
-  new PreviewStateRepository(() => getProjectDbClient(resolveStorageRoot()))
+  new PreviewStateRepository(() => getProjectDbClient(resolveConfigRoot()))
 
 type ProjectDeleteHandler = Pick<
   ProjectDeletionCoordinator,

--- a/src/main/projects/prisma-client.ts
+++ b/src/main/projects/prisma-client.ts
@@ -13,14 +13,14 @@ const PROJECT_DB_FILE = 'open-science.db'
 // SQLite PRAGMAs used by migrations are connection-scoped. Keeping a single connection also avoids
 // unnecessary SQLITE_BUSY contention for the local application database.
 const PROJECT_DB_CONNECTION_LIMIT = 1
-const projectDatabasePath = (storageRoot: string): string =>
-  join(storageRoot, PROJECT_DB_FILE).replace(/\\/g, '/')
+const projectDatabasePath = (configRoot: string): string =>
+  join(configRoot, PROJECT_DB_FILE).replace(/\\/g, '/')
 
-// Builds a client bound to the SQLite file under the given storage root. Not a singleton, so tests can
+// Builds a client bound to the SQLite file under the given config root. Not a singleton, so tests can
 // point separate clients at temp directories. Backslashes are normalized so the file: URL is valid on
 // Windows (Prisma's SQLite connector expects forward slashes).
-const createProjectDbClient = (storageRoot: string): PrismaClient => {
-  const dbPath = projectDatabasePath(storageRoot)
+const createProjectDbClient = (configRoot: string): PrismaClient => {
+  const dbPath = projectDatabasePath(configRoot)
 
   return new PrismaClient({
     datasources: {
@@ -33,7 +33,7 @@ let clientPromise: Promise<PrismaClient> | undefined
 
 // Production singleton: ensures the storage directory exists and resolves only after schema verification.
 const getProjectDbClient = (
-  storageRoot: string,
+  configRoot: string,
   migrationOptions: SchemaMigrationOptions = {}
 ): Promise<PrismaClient> => {
   if (!clientPromise) {
@@ -41,11 +41,11 @@ const getProjectDbClient = (
       let client: PrismaClient | undefined
 
       try {
-        await mkdir(storageRoot, { recursive: true })
-        client = createProjectDbClient(storageRoot)
+        await mkdir(configRoot, { recursive: true })
+        client = createProjectDbClient(configRoot)
         await migrateApplicationDatabase(client, {
           ...migrationOptions,
-          databasePath: projectDatabasePath(storageRoot)
+          databasePath: projectDatabasePath(configRoot)
         })
       } catch (error) {
         await client?.$disconnect().catch(() => undefined)

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -28,7 +28,7 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('../storage-root', () => ({
-  resolveStorageRoot: () => CONFIG_ROOT,
+  resolveConfigRoot: () => CONFIG_ROOT,
   resolveDataRoot: () => DATA_ROOT
 }))
 
@@ -57,7 +57,7 @@ vi.mock('./repository', () => ({
 
 // Spies on getProjectDbClient so the injected-config-root test can assert that
 // registerReviewerIpcHandlers really passes options.storageRoot into the prisma-client getter that
-// the ReviewRepository's lazy thunk captures. A regression that re-introduces resolveStorageRoot()
+// the ReviewRepository's lazy thunk captures. A regression that bypasses resolveConfigRoot()
 // here would otherwise slip past unnoticed.
 const getProjectDbClient = vi.fn()
 vi.mock('../projects/prisma-client', () => ({
@@ -373,7 +373,7 @@ describe('reviewer IPC handlers', () => {
 
     const passed = runReview.mock.calls[0][0] as { artifactStorageRoot: string }
     expect(passed.artifactStorageRoot).toBe(INJECTED_DATA_ROOT)
-    // ReviewRepository is constructed against the injected config root, not the resolveStorageRoot()
+    // ReviewRepository is constructed against the injected config root, not the resolveConfigRoot()
     // default. The repository captures a thunk `() => getProjectDbClient(storageRoot)`; invoke it
     // and assert the captured storageRoot surfaces through the getProjectDbClient spy.
     expect(reviewRepositoryThunks).toHaveLength(1)

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -20,7 +20,7 @@ import { flagStaleReviews } from './stale-reviews'
 import { ReviewRepository } from './repository'
 import type { ReviewerAcpRuntime } from './acp-runtime'
 import type { SessionAuxiliaryTurnUsageRecord } from '../session-persistence/auxiliary-turn-usage'
-import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
+import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { SessionRepository } from '../session-persistence/repository'
 import { broadcastToRenderers } from '../renderer-broadcast'
@@ -167,7 +167,7 @@ const createInFlightReviewStart = (): InFlightReviewStart => {
 // Owns reviewer arbitration and fix-loop cancellation independently from any command transport.
 // The triggerReview alias preserves the existing direct-call result returned by IPC registration.
 const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerCommandOwner => {
-  const storageRoot = options.storageRoot ?? resolveStorageRoot()
+  const storageRoot = options.storageRoot ?? resolveConfigRoot()
   const dataRoot = options.dataRoot ?? resolveDataRoot()
   const artifactProvenanceRepository = options.artifactProvenanceRepository
   const reviewRepository = createDefaultReviewRepository(storageRoot, dataRoot)

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -21,7 +21,7 @@ import type {
 } from '../../shared/session-persistence'
 import { broadcastLifecycleEvent, getLifecycleClientId } from '../lifecycle-broadcast'
 import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
-import { resolveStorageRoot } from '../storage-root'
+import { resolveConfigRoot } from '../storage-root'
 import { SessionRepository } from './repository'
 import { SessionProjectionRepository } from './projection'
 import { ReviewRepository } from '../reviewer/repository'
@@ -261,13 +261,13 @@ const createDefaultSessionRepository = (
   hasLiveRuntimeSession: (projectId: string, sessionId: string) => boolean = () => false
 ): SessionRepository =>
   new SessionRepository(
-    resolveStorageRoot(),
+    resolveConfigRoot(),
     { hasActiveRuntimePrompt, hasLiveRuntimeSession },
-    new SessionProjectionRepository(() => getProjectDbClient(resolveStorageRoot()))
+    new SessionProjectionRepository(() => getProjectDbClient(resolveConfigRoot()))
   )
 
 const createDefaultReviewRepository = (): ReviewRepository =>
-  new ReviewRepository(() => getProjectDbClient(resolveStorageRoot()))
+  new ReviewRepository(() => getProjectDbClient(resolveConfigRoot()))
 
 // Registers renderer-callable persistence commands without coupling them to ACP runtime IPC.
 const registerSessionPersistenceIpcHandlers = (

--- a/src/main/session-persistence/paths.ts
+++ b/src/main/session-persistence/paths.ts
@@ -5,7 +5,7 @@ export const PROD_SESSION_DIR_NAME = '.open-science'
 export const DEV_SESSION_DIR_NAME = '.open-science-project'
 
 // Builds the app-owned session directory in the user's home folder. Kept pure (no electron) so it
-// stays unit-testable; the dev/prod choice is applied by the main-only resolveStorageRoot helper.
+// stays unit-testable; the dev/prod choice is applied by the main-only resolveConfigRoot helper.
 export const getSessionPersistenceDir = (
   homePath: string,
   dirName: string = PROD_SESSION_DIR_NAME

--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -155,7 +155,7 @@ describe('AgentRuntimeManager', () => {
 
     return new AgentRuntimeManager({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       userClaudeDir: join(storageRoot, 'user-claude'),
       skills,
       connectors,

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -120,8 +120,8 @@ const CODEX_INSTALL_TARGET: InstallTarget = {
   scriptUnix: ''
 }
 
-const isManagedCodexPath = (adapterPath: string, storageRoot: string): boolean =>
-  adapterPath === managedCodexAdapterEntry(storageRoot)
+const isManagedCodexPath = (adapterPath: string, configRoot: string): boolean =>
+  adapterPath === managedCodexAdapterEntry(configRoot)
 
 export type ExecuteClaudeProbe = (
   executablePath: string,
@@ -285,7 +285,7 @@ const codexVersionsFromProbe = (
 
 export type AgentRuntimeManagerOptions = {
   repository: SettingsRepository
-  storageRoot: string
+  configRoot: string
   userClaudeDir: string
   skills: SkillCatalogModule
   connectors: ConnectorSettingsModule
@@ -316,7 +316,7 @@ export type AgentRuntimeManagerOptions = {
 // reconnect decisions remain outside this module.
 export class AgentRuntimeManager {
   private readonly repository: SettingsRepository
-  private readonly storageRoot: string
+  private readonly configRoot: string
   private readonly userClaudeDir: string
   private readonly skills: SkillCatalogModule
   private readonly connectors: ConnectorSettingsModule
@@ -346,7 +346,7 @@ export class AgentRuntimeManager {
 
   constructor(options: AgentRuntimeManagerOptions) {
     this.repository = options.repository
-    this.storageRoot = options.storageRoot
+    this.configRoot = options.configRoot
     this.userClaudeDir = options.userClaudeDir
     this.skills = options.skills
     this.connectors = options.connectors
@@ -355,25 +355,25 @@ export class AgentRuntimeManager {
     const baseDetectDeps = options.detectDeps ?? createDefaultDetectDeps()
     this.detectDeps = {
       ...baseDetectDeps,
-      extraDirs: [...(baseDetectDeps.extraDirs ?? []), managedClaudeDir(this.storageRoot)]
+      extraDirs: [...(baseDetectDeps.extraDirs ?? []), managedClaudeDir(this.configRoot)]
     }
 
     const baseOpencodeDetectDeps = options.opencodeDetectDeps ?? createOpencodeDetectDeps()
     this.opencodeDetectDeps = {
       ...baseOpencodeDetectDeps,
-      extraDirs: [...(baseOpencodeDetectDeps.extraDirs ?? []), managedOpencodeDir(this.storageRoot)]
+      extraDirs: [...(baseOpencodeDetectDeps.extraDirs ?? []), managedOpencodeDir(this.configRoot)]
     }
     const baseCodeBuddyDetectDeps = options.codebuddyDetectDeps ?? createOpencodeDetectDeps()
     this.codebuddyDetectDeps = {
       ...baseCodeBuddyDetectDeps,
       extraDirs: [
         ...(baseCodeBuddyDetectDeps.extraDirs ?? []),
-        managedCodeBuddyDir(this.storageRoot)
+        managedCodeBuddyDir(this.configRoot)
       ]
     }
 
-    const managedAdapterPath = managedCodexAdapterEntry(this.storageRoot)
-    const managedNativePath = managedCodexBinary(this.storageRoot)
+    const managedAdapterPath = managedCodexAdapterEntry(this.configRoot)
+    const managedNativePath = managedCodexBinary(this.configRoot)
     this.codexDetectDeps = options.codexDetectDeps ?? {
       env: baseOpencodeDetectDeps.env,
       homePath: baseOpencodeDetectDeps.homePath,
@@ -482,7 +482,7 @@ export class AgentRuntimeManager {
     )
 
     return runEnvironmentCheck({
-      storageRoot: this.storageRoot,
+      storageRoot: this.configRoot,
       agentFrameworkId,
       frameworks: [
         {
@@ -577,7 +577,7 @@ export class AgentRuntimeManager {
         const outcome = await this.installManagedClaudeImpl({
           installId,
           onEvent,
-          dataRoot: this.storageRoot,
+          dataRoot: this.configRoot,
           registries,
           verifyBinary: this.detectDeps.getVersion
         })
@@ -617,7 +617,7 @@ export class AgentRuntimeManager {
         const outcome = await this.installManagedOpencodeImpl({
           installId,
           onEvent,
-          dataRoot: this.storageRoot
+          dataRoot: this.configRoot
         })
         if (outcome.result.ok && outcome.resolvedPath) {
           await this.repository.setOpencodeInfo(outcome.resolvedPath, outcome.version)
@@ -645,7 +645,7 @@ export class AgentRuntimeManager {
       const outcome = await this.installManagedCodeBuddyImpl({
         installId,
         onEvent,
-        dataRoot: this.storageRoot
+        dataRoot: this.configRoot
       })
       if (outcome.result.ok && outcome.resolvedPath) {
         await this.repository.setCodeBuddyInfo(outcome.resolvedPath, outcome.version)
@@ -665,7 +665,7 @@ export class AgentRuntimeManager {
         const settings = await this.repository.getSettings()
         const configuredCodexPath = settings.codex?.nativePath
         const managedCodexPath =
-          this.codexDetectDeps.managedCodexPath ?? managedCodexBinary(this.storageRoot)
+          this.codexDetectDeps.managedCodexPath ?? managedCodexBinary(this.configRoot)
         const externalCodexPath =
           configuredCodexPath && configuredCodexPath !== managedCodexPath
             ? configuredCodexPath
@@ -677,7 +677,7 @@ export class AgentRuntimeManager {
         const outcome = await this.installManagedCodexImpl({
           installId,
           onEvent,
-          dataRoot: this.storageRoot,
+          dataRoot: this.configRoot,
           ...(existingCodexPath ? { existingCodexPath } : {})
         })
         if (
@@ -729,11 +729,11 @@ export class AgentRuntimeManager {
     const resolvedPath = settings.claude?.resolvedPath
     const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'claude-code'
 
-    if (!resolvedPath || !isManagedClaudePath(resolvedPath, this.storageRoot)) {
+    if (!resolvedPath || !isManagedClaudePath(resolvedPath, this.configRoot)) {
       return { activeBackendAffected: false }
     }
 
-    await uninstallManagedClaude(this.storageRoot)
+    await uninstallManagedClaude(this.configRoot)
     await this.detectClaude()
     await this.autoSwitchAwayFrom('claude-code')
     return { activeBackendAffected: wasActive }
@@ -744,11 +744,11 @@ export class AgentRuntimeManager {
     const resolvedPath = settings.opencodePath
     const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'opencode'
 
-    if (!resolvedPath || !isManagedOpencodePath(resolvedPath, this.storageRoot)) {
+    if (!resolvedPath || !isManagedOpencodePath(resolvedPath, this.configRoot)) {
       return { activeBackendAffected: false }
     }
 
-    await uninstallManagedOpencode(this.storageRoot)
+    await uninstallManagedOpencode(this.configRoot)
     await this.detectOpencode()
     await this.autoSwitchAwayFrom('opencode')
     return { activeBackendAffected: wasActive }
@@ -759,11 +759,11 @@ export class AgentRuntimeManager {
     const resolvedPath = settings.codebuddyPath
     const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'codebuddy'
 
-    if (!resolvedPath || !isManagedCodeBuddyPath(resolvedPath, this.storageRoot)) {
+    if (!resolvedPath || !isManagedCodeBuddyPath(resolvedPath, this.configRoot)) {
       return { activeBackendAffected: false }
     }
 
-    await uninstallManagedCodeBuddy(this.storageRoot)
+    await uninstallManagedCodeBuddy(this.configRoot)
     await this.detectCodeBuddy()
     await this.autoSwitchAwayFrom('codebuddy')
     return { activeBackendAffected: wasActive }
@@ -774,11 +774,11 @@ export class AgentRuntimeManager {
     const resolvedPath = settings.codex?.resolvedPath
     const wasActive = (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID) === 'codex'
 
-    if (!resolvedPath || !isManagedCodexPath(resolvedPath, this.storageRoot)) {
+    if (!resolvedPath || !isManagedCodexPath(resolvedPath, this.configRoot)) {
       return { activeBackendAffected: false }
     }
 
-    await uninstallManagedCodex(this.storageRoot)
+    await uninstallManagedCodex(this.configRoot)
     await this.repository.clearCodexInfo()
     await this.detectCodex()
     await this.autoSwitchAwayFrom('codex')
@@ -786,10 +786,10 @@ export class AgentRuntimeManager {
   }
 
   isManagedRuntimePath(frameworkId: AgentFrameworkId, path: string): boolean {
-    if (frameworkId === 'claude-code') return isManagedClaudePath(path, this.storageRoot)
-    if (frameworkId === 'opencode') return isManagedOpencodePath(path, this.storageRoot)
-    if (frameworkId === 'codebuddy') return isManagedCodeBuddyPath(path, this.storageRoot)
-    return isManagedCodexPath(path, this.storageRoot)
+    if (frameworkId === 'claude-code') return isManagedClaudePath(path, this.configRoot)
+    if (frameworkId === 'opencode') return isManagedOpencodePath(path, this.configRoot)
+    if (frameworkId === 'codebuddy') return isManagedCodeBuddyPath(path, this.configRoot)
+    return isManagedCodexPath(path, this.configRoot)
   }
 
   async isNpmAvailable(): Promise<boolean> {
@@ -835,7 +835,7 @@ export class AgentRuntimeManager {
     )
     await syncConnectorSkillDocs(join(configRoot, 'skills'), bundledConnectorIds)
     const customSkillSync = await syncMaterializedCustomServerSkillDocs(
-      connectorSkillSourceDir(this.storageRoot),
+      connectorSkillSourceDir(this.configRoot),
       join(configRoot, 'skills'),
       this.connectors.materializedCustomSkillNames()
     )
@@ -859,7 +859,7 @@ export class AgentRuntimeManager {
     includeSkillAndConnectorContext = true
   ): Promise<ClaudeRuntimeAssets> {
     return provisionClaudeRuntime({
-      storageRoot: this.storageRoot,
+      storageRoot: this.configRoot,
       provisionPrivateProfile: (privateProfileDir) =>
         provisionAppClaudePrivateProfile(privateProfileDir, modelConfig),
       materializeProjection: async (projectionRoot) => {
@@ -923,7 +923,7 @@ export class AgentRuntimeManager {
       throw new Error('Codex native executable not found. Re-detect or install Codex in settings.')
     }
     const adapterPath =
-      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.storageRoot)
+      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.configRoot)
     if (!(await this.pathExists(adapterPath))) {
       throw new Error('Open Science Codex ACP adapter not found. Install Codex in settings.')
     }
@@ -964,7 +964,7 @@ export class AgentRuntimeManager {
 
     const runtimeConfig = await this.provisionClaudeRuntimeConfig(settings)
     const envOverrides = buildProviderEnv(provider, {
-      storageRoot: this.storageRoot,
+      storageRoot: this.configRoot,
       claudeExecutablePath: executablePath,
       userClaudeConfigDir: this.userClaudeDir
     })
@@ -1214,7 +1214,7 @@ export class AgentRuntimeManager {
   ): Promise<ConfiguredCodexRuntimeProbe> {
     if (!codex?.resolvedPath) return {}
     const controlledAdapterPath =
-      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.storageRoot)
+      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.configRoot)
     if (codex.resolvedPath !== controlledAdapterPath) return {}
 
     const [adapterOutput, nativeOutput] = await Promise.all([
@@ -1327,7 +1327,7 @@ export class AgentRuntimeManager {
     const codexNativePath =
       codexRuntime.codexComponents?.nativeCliPath ?? settings.codex?.nativePath
     const controlledAdapterPath =
-      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.storageRoot)
+      this.codexDetectDeps.managedAdapterPath ?? managedCodexAdapterEntry(this.configRoot)
     this.storeReusableRuntimeProbe('preflightRuntimeProbe', {
       fingerprint: runtimeProbeFingerprint({
         claudePath,

--- a/src/main/settings/device-credentials.ts
+++ b/src/main/settings/device-credentials.ts
@@ -200,8 +200,8 @@ export class DeviceCredentialStore {
   private readonly filePath: string
   private operation = Promise.resolve()
 
-  constructor(storageRoot: string) {
-    this.filePath = join(storageRoot, 'credentials.json')
+  constructor(configRoot: string) {
+    this.filePath = join(configRoot, 'credentials.json')
   }
 
   async list(): Promise<StoredDeviceCredential[]> {

--- a/src/main/settings/network-proxy-settings.test.ts
+++ b/src/main/settings/network-proxy-settings.test.ts
@@ -68,7 +68,7 @@ describe('Network proxy settings persistence', () => {
   it('projects old documents as System and applies saved changes only after persistence', async () => {
     const repository = new SettingsRepository(dir)
     const applyNetworkProxy = vi.fn().mockResolvedValue(undefined)
-    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+    const service = new SettingsService({ repository, configRoot: dir, applyNetworkProxy })
 
     await expect(service.getSettingsView()).resolves.toMatchObject({
       networkProxy: { mode: 'system' }
@@ -82,7 +82,7 @@ describe('Network proxy settings persistence', () => {
   it('does not persist a proxy setting that the runtime rejected', async () => {
     const repository = new SettingsRepository(dir)
     const applyNetworkProxy = vi.fn().mockRejectedValueOnce(new Error('proxy session unavailable'))
-    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+    const service = new SettingsService({ repository, configRoot: dir, applyNetworkProxy })
 
     await expect(service.setNetworkProxy({ mode: 'direct' })).rejects.toThrow(
       'proxy session unavailable'
@@ -103,7 +103,7 @@ describe('Network proxy settings persistence', () => {
       runtimeProxy = settings
       if (settings.mode === 'direct') throw new Error('notebook proxy refresh failed')
     })
-    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+    const service = new SettingsService({ repository, configRoot: dir, applyNetworkProxy })
 
     await expect(service.setNetworkProxy({ mode: 'direct' })).rejects.toThrow(
       'notebook proxy refresh failed'
@@ -128,7 +128,7 @@ describe('Network proxy settings persistence', () => {
       .fn()
       .mockRejectedValueOnce(applyError)
       .mockRejectedValueOnce(runtimeRollbackError)
-    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+    const service = new SettingsService({ repository, configRoot: dir, applyNetworkProxy })
 
     const result = service.setNetworkProxy({ mode: 'direct' })
 
@@ -157,7 +157,7 @@ describe('Network proxy settings persistence', () => {
       if (settings.mode === 'direct') await firstApply
       runtimeMode = settings.mode
     })
-    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+    const service = new SettingsService({ repository, configRoot: dir, applyNetworkProxy })
 
     const firstSave = service.setNetworkProxy({ mode: 'direct' })
     await vi.waitFor(() => expect(applyNetworkProxy).toHaveBeenCalledWith({ mode: 'direct' }))

--- a/src/main/settings/service.connectors.test.ts
+++ b/src/main/settings/service.connectors.test.ts
@@ -24,7 +24,7 @@ describe('SettingsService connector facade', () => {
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), 'osci-svc-connectors-facade-'))
     repository = new SettingsRepository(dir)
-    service = new SettingsService({ repository, storageRoot: dir })
+    service = new SettingsService({ repository, configRoot: dir })
     return async () => {
       await rm(dir, { recursive: true, force: true })
     }

--- a/src/main/settings/service.providers.test.ts
+++ b/src/main/settings/service.providers.test.ts
@@ -23,7 +23,7 @@ describe('SettingsService provider facade', () => {
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), 'osci-service-providers-facade-'))
     repository = new SettingsRepository(dir)
-    service = new SettingsService({ repository, storageRoot: dir })
+    service = new SettingsService({ repository, configRoot: dir })
     return async () => {
       await rm(dir, { recursive: true, force: true })
     }
@@ -62,7 +62,7 @@ describe('SettingsService provider facade', () => {
     const now = vi.spyOn(Date, 'now').mockReturnValue(123)
     const facade = new SettingsService({
       repository,
-      storageRoot: dir,
+      configRoot: dir,
       installManagedClaudeImpl: async ({ installId }) => ({
         result: { installId, ok: false, error: 'expected test failure' }
       })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -204,7 +204,7 @@ const createService = (
   new SettingsService({
     repository,
     log: options.log ?? silentLog,
-    storageRoot,
+    configRoot: storageRoot,
     // Point at a non-existent user Claude dir so tests never read the real ~/.claude. The same
     // path is now used by claude-isolated skill-scanning; claude-default is gone.
     userClaudeDir: options.userClaudeDir ?? join(storageRoot, 'no-user-claude'),
@@ -3905,7 +3905,7 @@ describe('SettingsService: skills', () => {
   const createSkillService = async (): Promise<InstanceType<typeof SettingsService>> =>
     new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       skillRegistry: new SkillRegistry(await seedBundle())
     })
 
@@ -4224,7 +4224,7 @@ describe('SettingsService: skills', () => {
     )
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       userClaudeDir,
       skillRegistry: new SkillRegistry(skillBundle)
     })
@@ -4307,7 +4307,7 @@ describe('SettingsService: skills', () => {
     await chmod(adapterPath, 0o755)
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       skillRegistry: new SkillRegistry(await seedBundle()),
       codexDetectDeps: {
         env: { PATH: dirname(adapterPath) },
@@ -4415,7 +4415,7 @@ describe('SettingsService: skills', () => {
     )
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       skillRegistry: new SkillRegistry(await seedBundle())
     })
     const empty = await repository.getSettings()
@@ -4448,7 +4448,7 @@ describe('SettingsService: skills', () => {
     await chmod(adapterPath, 0o755)
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       skillRegistry: new SkillRegistry(await seedBundle()),
       codexDetectDeps: {
         env: {},
@@ -4535,7 +4535,7 @@ describe('SettingsService: skills', () => {
   it('uses the frontmatter name when nudging an imported skill', async () => {
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       skillRegistry: new SkillRegistry(await seedBundle()),
       userSkills: {
         list: () =>
@@ -4564,7 +4564,7 @@ describe('SettingsService: skills', () => {
     const importFromGitHub = vi.fn().mockResolvedValue({ status: 'imported', id: 'imported-x' })
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       skillRegistry: new SkillRegistry(await seedBundle()),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       userSkills: { importFromGitHub, list: () => Promise.resolve([]) } as any
@@ -4585,7 +4585,7 @@ describe('SettingsService: skills', () => {
     const scanRepo = vi.fn().mockResolvedValue([])
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       userSkills: { scanRepo } as any
     })
@@ -4616,7 +4616,7 @@ describe('SettingsService: skills', () => {
     vi.stubGlobal('fetch', fetch)
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       userSkills: { scanRepo } as any
     })
@@ -4645,7 +4645,7 @@ describe('SettingsService: skills', () => {
     })
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       userSkills: { previewGitHubSkill } as any
     })
@@ -4864,7 +4864,7 @@ describe('checkEnvironment', () => {
     await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       detectDeps: {
         env: {},
         homePath: '/home',
@@ -4889,7 +4889,7 @@ describe('checkEnvironment', () => {
     await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       detectDeps: {
         env: { PATH: '/other-bin' },
         homePath: '/home',
@@ -4916,7 +4916,7 @@ describe('checkEnvironment', () => {
     await repository.setClaudeInfo({ resolvedPath: stale, version: '2.1.0' })
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       detectDeps: {
         env: { PATH: '/found-bin' },
         homePath: '/home',
@@ -6300,7 +6300,7 @@ describe('SettingsService: listAgentHomeSkills framework routing', () => {
       .mockRejectedValue(new Error(`EACCES: ${join(hostSkillPath, 'SKILL.md')}`))
     const service = new SettingsService({
       repository,
-      storageRoot,
+      configRoot: storageRoot,
       userClaudeDir,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       userSkills: { previewAgentHomeSkill } as any

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -89,7 +89,7 @@ import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement } from '../../shared/notebook-runtime'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
-import { resolveStorageRoot } from '../storage-root'
+import { resolveConfigRoot } from '../storage-root'
 import {
   DEFAULT_AGENT_FRAMEWORK_ID,
   type AgentModelChangeTarget,
@@ -156,7 +156,7 @@ export type UninstallResult = {
 
 export type SettingsServiceOptions = {
   repository?: SettingsRepository
-  storageRoot?: string
+  configRoot?: string
   // Packaged main entry reused as the isolated stdio Skill runtime MCP child.
   skillRuntimeMcpEntryPath?: string
   log?: Logger
@@ -209,7 +209,7 @@ export type SettingsServiceOptions = {
   getNotebookNetworkStatus?: () => Promise<NotebookNetworkStatus>
   installNotebookNetwork?: () => Promise<{ cancelled: boolean }>
   removeNotebookNetwork?: () => Promise<{ cancelled: boolean }>
-  // Encrypted-token controller for claude-isolated; default-constructed against this.storageRoot
+  // Encrypted-token controller for claude-isolated; default-constructed against this.configRoot
   // when omitted. Storage is delegated to the host's SettingsRepository + encrypt/tryDecryptKey
   // pipeline, mirroring how CodexAuthController delegates to openCodexAuthSession.
   claudeIsolatedAuth?: ClaudeIsolatedAuthControllerPort
@@ -231,7 +231,7 @@ class SettingsService {
   private readonly runtimeManager: AgentRuntimeManager
   private readonly backendResolver: AgentBackendResolver
   private readonly scenarioModels: ScenarioModelOwner
-  private readonly storageRoot: string
+  private readonly configRoot: string
   private readonly networkProxy: NetworkProxySettingsOwner
   private readonly notebookNetwork: NotebookNetworkSettingsOwner
   private readonly packageMirror: PackageMirrorSettingsOwner
@@ -248,8 +248,8 @@ class SettingsService {
   private deviceCredentialDisconnector?: (credentialId: string) => Promise<void>
   private skillDeletionGuard?: (skillId: string) => Promise<void>
   constructor(options: SettingsServiceOptions = {}) {
-    this.storageRoot = options.storageRoot ?? resolveStorageRoot()
-    this.repository = options.repository ?? new SettingsRepository(this.storageRoot)
+    this.configRoot = options.configRoot ?? resolveConfigRoot()
+    this.repository = options.repository ?? new SettingsRepository(this.configRoot)
     this.networkProxy = new NetworkProxySettingsOwner({
       repository: this.repository,
       apply: options.applyNetworkProxy ?? (async () => undefined)
@@ -283,13 +283,13 @@ class SettingsService {
     this.connectors = new ConnectorSettingsModule(
       this.repository,
       options.openAlexFetch,
-      new DeviceCredentialStore(this.storageRoot)
+      new DeviceCredentialStore(this.configRoot)
     )
     this.userClaudeDir = options.userClaudeDir ?? getUserClaudeConfigDir()
     const userCodexDir = options.userCodexDir ?? join(homedir(), '.codex')
     this.skills = new SkillCatalogModule({
       repository: this.repository,
-      storageRoot: this.storageRoot,
+      storageRoot: this.configRoot,
       userClaudeDir: this.userClaudeDir,
       userCodexDir,
       userAgentsDir: options.userAgentsDir ?? join(homedir(), '.agents'),
@@ -301,7 +301,7 @@ class SettingsService {
     const allocateSettingsIdSequence = createSettingsIdSequence()
     this.runtimeManager = new AgentRuntimeManager({
       repository: this.repository,
-      storageRoot: this.storageRoot,
+      configRoot: this.configRoot,
       userClaudeDir: this.userClaudeDir,
       skills: this.skills,
       connectors: this.connectors,
@@ -319,7 +319,7 @@ class SettingsService {
     })
     this.providers = new ProviderAccountsModule({
       repository: this.repository,
-      storageRoot: this.storageRoot,
+      storageRoot: this.configRoot,
       userClaudeDir: this.userClaudeDir,
       userCodexDir,
       allocateSettingsIdSequence,
@@ -337,7 +337,7 @@ class SettingsService {
       providers: this.providers,
       runtime: this.runtimeManager,
       connectors: this.connectors,
-      storageRoot: this.storageRoot,
+      storageRoot: this.configRoot,
       userClaudeDir: this.userClaudeDir,
       skillRuntimeMcpEntryPath: options.skillRuntimeMcpEntryPath ?? process.argv[1] ?? '',
       getXaiOAuthAccessToken: (forceRefresh) => this.providers.getXaiOAuthAccessToken(forceRefresh)
@@ -777,7 +777,7 @@ class SettingsService {
     }
 
     if (!(await this.connectors.provisionedConnectorSkillNames()).includes(name)) return null
-    const filePath = join(connectorSkillSourceDir(this.storageRoot), name, 'SKILL.md')
+    const filePath = join(connectorSkillSourceDir(this.configRoot), name, 'SKILL.md')
     const metadata = await stat(filePath).catch(() => undefined)
     // The body is renderer-bound preview text; cap it at the shared preview budget before reading.
     if (!metadata?.isFile() || metadata.size > SKILL_IMPORT_LIMITS.maxPreviewContentBytes) {
@@ -1397,7 +1397,7 @@ class SettingsService {
   }
 }
 
-// Production service rooted at the shared storage root with real detection dependencies.
+// Production service rooted at the fixed config root with real detection dependencies.
 const createDefaultSettingsService = (): SettingsService => new SettingsService()
 
 export { SettingsService, createDefaultSettingsService }

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -754,7 +754,7 @@ describe('Settings backend ownership architecture', () => {
     const mainIpc = readSource(resolve(projectRoot, 'src/main/ipc.ts'))
     const mainIndex = readSource(resolve(projectRoot, 'src/main/index.ts'))
     expect(mainIndex).toContain(
-      'const settingsStore = new SettingsDocumentStore(resolveStorageRoot())'
+      'const settingsStore = new SettingsDocumentStore(resolveConfigRoot())'
     )
     expect(mainIndex).toContain(
       'const startupSettingsRepository = new SettingsRepository(settingsStore)'
@@ -762,7 +762,7 @@ describe('Settings backend ownership architecture', () => {
     expect(mainIndex).toMatch(
       /registerIpcHandlers\(\{\s+mainEntryPath,\s+settingsStore,\s+translate,/u
     )
-    expect(mainIpc).toContain('settingsStore ?? resolveStorageRoot()')
+    expect(mainIpc).toContain('settingsStore ?? resolveConfigRoot()')
     expect(mainIpc).toContain('await settingsService.migrateAgentHomeSkillIdentities()')
     expect(mainIpc.indexOf('specialistPackageRecovery.current =')).toBeLessThan(
       mainIpc.indexOf('await settingsService.migrateAgentHomeSkillIdentities()')

--- a/src/main/storage-root-routing.architecture.test.ts
+++ b/src/main/storage-root-routing.architecture.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
+
+import {
+  createSourceFile,
+  forEachChild,
+  isIdentifier,
+  ScriptKind,
+  ScriptTarget,
+  type Node
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+import { listProductionSources } from '../../test/architecture-source-index'
+
+const projectRoot = resolve(__dirname, '../..')
+const source = (path: string): string => readFileSync(resolve(projectRoot, path), 'utf8')
+
+const referencesIdentifier = (path: string, name: string): boolean => {
+  const file = createSourceFile(
+    path,
+    readFileSync(path, 'utf8'),
+    ScriptTarget.Latest,
+    true,
+    path.endsWith('.tsx') ? ScriptKind.TSX : ScriptKind.TS
+  )
+  let found = false
+  const visit = (node: Node): void => {
+    if (isIdentifier(node) && node.text === name) found = true
+    if (!found) forEachChild(node, visit)
+  }
+  visit(file)
+  return found
+}
+
+describe('storage root routing architecture', () => {
+  it('uses configRoot as the canonical fixed-root resolver name', () => {
+    const rootSource = source('src/main/storage-root.ts')
+
+    expect(rootSource).toContain('const resolveConfigRoot = (): string =>')
+    expect(rootSource).toContain('const resolveStorageRoot = resolveConfigRoot')
+
+    const legacyConsumers = listProductionSources(projectRoot)
+      .filter((path) => path !== resolve(projectRoot, 'src/main/storage-root.ts'))
+      .filter((path) => referencesIdentifier(path, 'resolveStorageRoot'))
+      .map((path) => relative(projectRoot, path).replaceAll('\\', '/'))
+
+    expect(legacyConsumers).toEqual([])
+  })
+
+  it('names configuration-owned public seams configRoot', () => {
+    const database = source('src/main/projects/prisma-client.ts')
+    expect(database).toContain('const projectDatabasePath = (configRoot: string)')
+    expect(database).toContain('const createProjectDbClient = (configRoot: string)')
+    expect(database).toMatch(/const getProjectDbClient = \(\s+configRoot: string,/)
+
+    const settings = source('src/main/settings/service.ts')
+    expect(settings).toContain('  configRoot?: string')
+    expect(settings).toContain('private readonly configRoot: string')
+    expect(settings).toContain('new DeviceCredentialStore(this.configRoot)')
+    expect(settings).toContain('configRoot: this.configRoot')
+
+    expect(source('src/main/settings/device-credentials.ts')).toContain(
+      'constructor(configRoot: string)'
+    )
+
+    const runtime = source('src/main/settings/agent-runtime-manager.ts')
+    expect(runtime).toContain('  configRoot: string')
+    expect(runtime).toContain('private readonly configRoot: string')
+  })
+
+  it('routes Upload, Notebook, and Workspace through dataRoot', () => {
+    const uploads = source('src/main/uploads/ipc.ts')
+    expect(uploads).toContain('new UploadRepository(resolveDataRoot(), {')
+    expect(uploads).toContain('getProjectDbClient(resolveConfigRoot())')
+    expect(source('src/main/uploads/repository.ts')).toContain(
+      'constructor(dataRoot: string, options: UploadRepositoryOptions = {})'
+    )
+
+    const notebookComposition = source('src/main/ipc.ts')
+    expect(notebookComposition).toMatch(
+      /configRoot: resolveConfigRoot\(\),\s+dataRoot: resolveDataRoot\(\)/
+    )
+
+    expect(source('src/main/acp/managed-session-workspace.ts')).toContain(
+      'resolveRoot: resolveDataRoot'
+    )
+  })
+})

--- a/src/main/storage-root.test.ts
+++ b/src/main/storage-root.test.ts
@@ -342,7 +342,7 @@ describe('resolveDataRoot / initDataRoot', () => {
   })
 })
 
-describe('resolveStorageRoot', () => {
+describe('resolveConfigRoot', () => {
   beforeEach(() => {
     appMock.isPackaged = false
     appMock.getPath.mockClear()
@@ -354,13 +354,13 @@ describe('resolveStorageRoot', () => {
   })
 
   it('uses the normal development directory by default', () => {
-    expect(resolveStorageRoot()).toBe(join('/Users/tester', '.open-science-project'))
+    expect(resolveConfigRoot()).toBe(join('/Users/tester', '.open-science-project'))
   })
 
   it('uses an absolute development preview override without changing HOME', () => {
     vi.stubEnv('OPEN_SCIENCE_STORAGE_ROOT', '/tmp/open-science-preview/storage')
 
-    expect(resolveStorageRoot()).toBe(normalize('/tmp/open-science-preview/storage'))
+    expect(resolveConfigRoot()).toBe(normalize('/tmp/open-science-preview/storage'))
     expect(appMock.getPath).not.toHaveBeenCalled()
   })
 
@@ -368,14 +368,14 @@ describe('resolveStorageRoot', () => {
     appMock.isPackaged = true
     vi.stubEnv('OPEN_SCIENCE_E2E_STORAGE_ROOT', '/tmp/open-science-certification/storage')
 
-    expect(resolveStorageRoot()).toBe(normalize('/tmp/open-science-certification/storage'))
+    expect(resolveConfigRoot()).toBe(normalize('/tmp/open-science-certification/storage'))
     expect(appMock.getPath).not.toHaveBeenCalled()
   })
 
   it('rejects an ambiguous relative E2E root', () => {
     vi.stubEnv('OPEN_SCIENCE_E2E_STORAGE_ROOT', 'certification/storage')
 
-    expect(() => resolveStorageRoot()).toThrow(
+    expect(() => resolveConfigRoot()).toThrow(
       'OPEN_SCIENCE_E2E_STORAGE_ROOT must be an absolute path'
     )
   })
@@ -383,13 +383,17 @@ describe('resolveStorageRoot', () => {
   it('rejects an ambiguous relative preview override', () => {
     vi.stubEnv('OPEN_SCIENCE_STORAGE_ROOT', 'preview/storage')
 
-    expect(() => resolveStorageRoot()).toThrow('must be an absolute path')
+    expect(() => resolveConfigRoot()).toThrow('must be an absolute path')
   })
 
   it('ignores the preview override in packaged builds', () => {
     appMock.isPackaged = true
     vi.stubEnv('OPEN_SCIENCE_STORAGE_ROOT', '/tmp/ignored')
 
-    expect(resolveStorageRoot()).toBe(join('/Users/tester', '.open-science'))
+    expect(resolveConfigRoot()).toBe(join('/Users/tester', '.open-science'))
+  })
+
+  it('keeps resolveStorageRoot as a compatibility alias', () => {
+    expect(resolveStorageRoot()).toBe(resolveConfigRoot())
   })
 })

--- a/src/main/storage-root.ts
+++ b/src/main/storage-root.ts
@@ -23,7 +23,7 @@ const resolveE2eStorageRoot = (): string | undefined => {
 // A development-only absolute override supports truly isolated onboarding previews without changing
 // HOME — changing HOME breaks the macOS default-keychain lookup and can trigger a dangerous "restore
 // default keychain" dialog. Packaged certification uses its own explicit, disposable E2E root.
-const resolveStorageRoot = (): string => {
+const resolveConfigRoot = (): string => {
   const e2eRoot = resolveE2eStorageRoot()
   if (e2eRoot) return e2eRoot
 
@@ -43,8 +43,8 @@ const resolveStorageRoot = (): string => {
   )
 }
 
-// Alias for call-site clarity now that a second (data) root exists.
-const resolveConfigRoot = resolveStorageRoot
+// Legacy alias retained for source compatibility. New production call sites use resolveConfigRoot.
+const resolveStorageRoot = resolveConfigRoot
 
 // Visible, no-space data folder name. NO space: runtime/ holds conda/venv whose tools break on
 // spaced paths. dev gets a suffix so it never shares data with a packaged build.

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -16,14 +16,14 @@ import type {
 } from '../../shared/uploads'
 import { DEFAULT_UPLOAD_PROJECT_ID, STANDALONE_UPLOAD_SESSION_ID } from '../../shared/uploads'
 import { getProjectDbClient } from '../projects/prisma-client'
-import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
+import { resolveConfigRoot, resolveDataRoot } from '../storage-root'
 import type { UploadCommandOwner } from './command-owner'
 import { UploadRepository } from './repository'
 
 // Uploads are data-class: they follow the configurable data root (defaults to the config root).
 const createDefaultUploadRepository = (): UploadRepository =>
   new UploadRepository(resolveDataRoot(), {
-    getClient: () => getProjectDbClient(resolveStorageRoot())
+    getClient: () => getProjectDbClient(resolveConfigRoot())
   })
 
 // Registers the small upload IPC surface used by the renderer composer and preview panel.

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -45,21 +45,21 @@ class UploadRepository {
   private readonly stagedPublicationOwner: StagedPublicationOwner
   private readonly legacyRecoveryOwner: LegacyRecoveryOwner
 
-  constructor(storageRoot: string, options: UploadRepositoryOptions = {}) {
-    this.transferOwner = new ActiveTransferOwner(storageRoot, options)
-    this.managedUploadResolver = new ManagedUploadResolver(storageRoot, options)
-    const cleanupOwner = new VerifiedLegacyCleanupOwner(storageRoot, options, {
+  constructor(dataRoot: string, options: UploadRepositoryOptions = {}) {
+    this.transferOwner = new ActiveTransferOwner(dataRoot, options)
+    this.managedUploadResolver = new ManagedUploadResolver(dataRoot, options)
+    const cleanupOwner = new VerifiedLegacyCleanupOwner(dataRoot, options, {
       resolveManagedUploadPath: (...args) =>
         this.managedUploadResolver.resolveManagedUploadPath(...args)
     })
-    this.stagedPublicationOwner = new StagedPublicationOwner(storageRoot, options, {
+    this.stagedPublicationOwner = new StagedPublicationOwner(dataRoot, options, {
       resolver: this.managedUploadResolver,
       completeStagingUpload: (...args) => this.legacyRecoveryOwner.completeStagingUpload(...args),
       hasOrphanLegacyCandidate: (...args) =>
         this.legacyRecoveryOwner.hasOrphanLegacyCandidate(...args),
       removeVerifiedLegacyCopy: (input) => this.legacyRecoveryOwner.removeVerifiedLegacyCopy(input)
     })
-    this.legacyRecoveryOwner = new LegacyRecoveryOwner(storageRoot, options, {
+    this.legacyRecoveryOwner = new LegacyRecoveryOwner(dataRoot, options, {
       resolveManagedUploadPath: (request) =>
         this.managedUploadResolver.resolveManagedUploadPath(request),
       finalizeSessionUploads: (...args) =>


### PR DESCRIPTION
## Problem

`resolveStorageRoot()` computes the fixed configuration root, while `resolveConfigRoot()` was only
an alias. The same `storageRoot` name also meant the configuration root at Settings boundaries and
the relocatable data root at the Upload repository boundary.

No current runtime misroute was observed: Uploads already receive `resolveDataRoot()` and SQLite
receives the fixed root. The defect is architectural. Both roots are strings, and legacy installs
may intentionally resolve both to the same directory, so a future root swap stays type-correct and
can be hidden by ordinary behavior tests.

## Proposed change

- make `resolveConfigRoot()` the canonical fixed-root implementation and retain
  `resolveStorageRoot` as a compatibility alias;
- migrate production resolver consumers to the semantic config-root name;
- name the database, Settings, device credential, and Agent Runtime boundaries `configRoot`;
- name the Upload repository facade argument `dataRoot` while leaving feature-local internals alone;
- add a root-routing architecture test covering Database, Credentials, Agent Runtime, Upload,
  Notebook, and Workspace ownership.

## Scope and non-goals

- No filesystem relocation or migration.
- No database schema, Settings document, IPC payload, or persisted path changes.
- No UI or interaction changes.
- No new state or enum values.
- No mechanical repository-wide rename of every feature-local `storageRoot` variable.
- No branded path types or new dependency-injection framework.

## Historical compatibility

Existing config/data locations and the legacy same-root fallback are unchanged. The exported
`resolveStorageRoot` alias remains available for source compatibility, but the architecture test
prevents production modules from using it as a new dependency.

## Persistence impact

None. This change does not add or alter persisted fields, schemas, migrations, files, or directory
layout. It only changes internal identifiers and compile-time composition names.

## Acceptance criteria and validation

The regression test was added before production changes and run against the unmodified behavior:

- `npm test -- src/main/storage-root-routing.architecture.test.ts` -> expected failure, 3/3 tests
  failed for the canonical resolver, configuration-owned seams, and Upload database routing.

Checks below ran after the last material edit:

- root routing and affected consumers -> targeted Vitest command covering 15 test files -> 348/348
  passed;
- Settings facade and Agent Runtime behavior -> `npm test -- src/main/settings/service.test.ts` ->
  274/274 passed (run outside the filesystem sandbox because the suite binds a loopback port);
- main-process contracts -> `npm run typecheck:node` -> passed;
- source/style checks -> `npm run lint` -> passed;
- whitespace validation -> `git diff --check` -> passed.

The full portable and cross-platform suites were intentionally not run locally. PR Gate remains the
authority for complete and platform-specific coverage.

## Review focus

- Confirm the compatibility alias does not retain new production consumers.
- Confirm the architecture test guards semantic boundaries without forcing a broad internal rename.
- Confirm every changed call site preserves its pre-change root value and therefore changes no
  persisted location.
