### PR TITLE
feat(providers): add latest OpenAI and Anthropic models

### DIFF
--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -460,6 +460,63 @@ describe('codexFramework', () => {
     ])
   })
 
+  it('keeps the native catalog when an unbundled official model is only a sibling option', () => {
+    const framework = createCodexFramework()
+    const activeProvider = {
+      type: 'official' as const,
+      vendorId: 'openai' as const,
+      apiEndpoints: ['responses' as const],
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-5.4',
+      key: 'sk-plaintext-secret'
+    }
+    const config = framework.prepareModelConfig(activeProvider, {
+      storageRoot: '/data',
+      executablePath: '/runtime/codex-acp',
+      nativeVersion: CODEX_VERSION,
+      providerModelCatalog: [
+        { provider: activeProvider },
+        { provider: { ...activeProvider, model: 'gpt-6-astra', contextWindow: 1_050_000 } }
+      ]
+    })
+
+    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).not.toHaveProperty('model_catalog_json')
+  })
+
+  it('adds local metadata when the active official model is not bundled by Codex', () => {
+    const framework = createCodexFramework()
+    const config = framework.prepareModelConfig(
+      {
+        type: 'official',
+        vendorId: 'openai',
+        apiEndpoints: ['responses'],
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-6-astra',
+        contextWindow: 1_050_000,
+        key: 'sk-plaintext-secret'
+      },
+      {
+        storageRoot: '/data',
+        executablePath: '/runtime/codex-acp',
+        nativeVersion: CODEX_VERSION,
+        reasoningEffort: 'max',
+        reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max']
+      }
+    )
+
+    const codexConfig = JSON.parse(config.env?.CODEX_CONFIG ?? '')
+    const modelCatalogFile = config.configFiles?.find(
+      (file) => file.path === codexConfig.model_catalog_json
+    )
+    expect(JSON.parse(modelCatalogFile?.content ?? '').models).toEqual([
+      expect.objectContaining({
+        slug: 'gpt-6-astra',
+        context_window: 1_050_000,
+        default_reasoning_level: 'max'
+      })
+    ])
+  })
+
   it('keeps bundled metadata for a custom Responses provider on the official OpenAI API host', () => {
     const framework = createCodexFramework()
     const config = framework.prepareModelConfig(

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -293,6 +293,7 @@ const buildCodexNativeModelCatalog = (
   provider: CodexNativeModelCatalogInput,
   catalog: readonly AgentModelCatalogEntry[] = []
 ): Record<string, unknown> | undefined => {
+  const activeModel = provider.model?.trim()
   const candidates = new Map<string, CodexNativeModelCatalogInput>()
   for (const entry of catalog) {
     const model = entry.provider.model?.trim()
@@ -304,14 +305,23 @@ const buildCodexNativeModelCatalog = (
       reasoningEfforts: entry.reasoningEfforts
     })
   }
-  if (provider.model) {
-    const catalogEntry = candidates.get(provider.model)
-    candidates.set(provider.model, {
+  if (activeModel) {
+    const catalogEntry = candidates.get(activeModel)
+    candidates.set(activeModel, {
       ...catalogEntry,
       ...provider,
+      model: activeModel,
       reasoningEffort: provider.reasoningEffort ?? catalogEntry?.reasoningEffort,
       reasoningEfforts: provider.reasoningEfforts ?? catalogEntry?.reasoningEfforts
     })
+  }
+
+  // model_catalog_json replaces Codex's native catalog rather than extending it. Keep the native
+  // catalog intact when the active official model already has trusted bundled metadata; an
+  // unbundled sibling in the provider catalog should not replace the active model's metadata.
+  const activeCatalogEntry = activeModel ? candidates.get(activeModel) : undefined
+  if (activeCatalogEntry && buildCodexNativeModelCatalogEntry(activeCatalogEntry) === undefined) {
+    return undefined
   }
 
   const models = [...candidates.values()]

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -726,6 +726,7 @@ describe('SettingsService: providers', () => {
         apiEndpoints: ['responses'],
         models: [
           'gpt-5.6-sol',
+          'gpt-6-astra',
           'gpt-5.6-terra',
           'gpt-5.6-luna',
           'gpt-5.5',
@@ -5262,19 +5263,19 @@ describe('SettingsService: reasoning effort', () => {
   it('uses the OpenAI and Anthropic registries for subscription models', async () => {
     const service = createService()
     const codex = (await service.upsertProvider({ type: 'codex-isolated' })).providers[0]
-    await service.setActiveProvider(codex.id, 'gpt-5.6-sol')
+    await service.setActiveProvider(codex.id, 'gpt-6-astra')
 
-    expect(await service.resolveActiveReasoningEffort('max')).toBe('ultra')
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('max')
 
     const claude = (
       await service.upsertProvider({
         type: 'claude-shared',
-        model: 'claude-haiku-4-5-20251001'
+        model: 'claude-fable-5-1'
       })
     ).providers.find((provider) => provider.type === 'claude-shared')!
-    await service.setActiveProvider(claude.id, 'claude-haiku-4-5-20251001')
+    await service.setActiveProvider(claude.id, 'claude-fable-5-1')
 
-    expect(await service.resolveActiveReasoningEffort('max')).toBe('default')
+    expect(await service.resolveActiveReasoningEffort('max')).toBe('max')
   })
 
   it('does not guess an effort profile for an unpinned Codex subscription model', async () => {

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -275,11 +275,20 @@ describe('provider registry', () => {
 
   it('exposes the first catalog entry as the default model', () => {
     expect(defaultVendorModel('openai')).toBe('gpt-5.6-sol')
+    expect(defaultVendorModel('anthropic')).toBe('claude-opus-5')
     expect(defaultVendorModel('xai')).toBe('grok-4.6')
     expect(defaultVendorModel('zhipu')).toBe('glm-5.3')
   })
 
   it('resolves model-specific static reasoning effort profiles without network discovery', () => {
+    expect(resolveVendorModelReasoningEffort('openai', 'gpt-6-astra')).toEqual({
+      supported: true,
+      slots: ['low', 'medium', 'high', 'xhigh', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('anthropic', 'claude-fable-5-1')).toEqual({
+      supported: true,
+      slots: ['low', 'medium', 'high', 'xhigh', 'max']
+    })
     expect(resolveVendorModelReasoningEffort('openai', 'gpt-5.5')).toEqual({
       supported: true,
       slots: ['none', 'low', 'medium', 'high', 'xhigh']
@@ -951,8 +960,10 @@ describe('provider registry', () => {
     })
 
     it('resolves shipped models with vendor-published per-model limits', () => {
+      expect(resolveModelContextWindow('anthropic', 'claude-fable-5-1')).toBe(1_000_000)
       expect(resolveModelContextWindow('anthropic', 'claude-opus-4-8')).toBe(1_000_000)
       expect(resolveModelContextWindow('anthropic', 'claude-haiku-4-5-20251001')).toBe(200_000)
+      expect(resolveModelContextWindow('openai', 'gpt-6-astra')).toBe(1_050_000)
       expect(resolveModelContextWindow('openai', 'gpt-5.6-sol')).toBe(1_050_000)
       expect(resolveModelContextWindow('openai', 'gpt-5.4-mini')).toBe(400_000)
       expect(resolveModelContextWindow('xai', 'grok-4.5')).toBe(500_000)

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -139,6 +139,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         contextWindow: 1_050_000,
         reasoningEffort: 'low-medium-high-xhigh-ultra'
       },
+      { id: 'gpt-6-astra', contextWindow: 1_050_000, reasoningEffort: 'standard-5' },
       {
         id: 'gpt-5.6-terra',
         contextWindow: 1_050_000,
@@ -167,6 +168,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     // Models with a 1M-context variant list both the standard id and the `[1m]` one.
     models: [
       { id: 'claude-opus-5', contextWindow: 1_000_000 },
+      { id: 'claude-fable-5-1', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8[1m]', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-5', contextWindow: 1_000_000 },


### PR DESCRIPTION
## Problem

The bundled first-party model catalogs lag the latest OpenAI and Anthropic releases, so GPT-6 Astra and Claude Fable 5.1 cannot be selected with their published context and reasoning metadata.

Official references:
- OpenAI GPT-6 Astra: https://developers.openai.com/api/docs/models/gpt-6-astra
- Codex model availability: https://learn.chatgpt.com/docs/models
- Anthropic Claude Fable 5.1: https://platform.claude.com/docs/en/models/fable-5-1/overview
- Claude Code model configuration: https://code.claude.com/docs/en/model-config

## Proposed change

- Add `gpt-6-astra` after the existing OpenAI default with a 1,050,000-token context window and low/medium/high/xhigh/max reasoning levels.
- Add `claude-fable-5-1` after the existing Anthropic default with a 1,000,000-token context window and low/medium/high/xhigh/max reasoning levels.
- Preserve the native Codex model catalog when the active model already has trusted bundled metadata; generate app-owned metadata when Astra is the active model and the managed Codex build does not bundle it.
- Cover catalog ordering, explicit model selection, context limits, effort mapping, and native catalog selection.

## Scope and non-goals

Included:
- First-party OpenAI, Codex subscription, Anthropic, and Claude subscription model exposure.
- Codex native catalog handling needed to expose a newly published model safely.
- Registry, Codex framework, and settings-service regression tests.

Excluded:
- No change to the existing defaults: OpenAI remains `gpt-5.6-sol`, and Anthropic remains `claude-opus-5`.
- No migration or overwrite of an existing `activeModel` or provider model selection.
- No change to the Claude CLI-owned default when a Claude subscription has no pinned model.
- No provider type, enum, state, persistence schema, or i18n change.
- No OpenCode Zen, OpenRouter, or xAI catalog updates without provider-specific publication evidence.

## Acceptance criteria and validation

- GPT-6 Astra and Claude Fable 5.1 are selectable from the relevant official and subscription catalogs.
- Existing catalog defaults and existing model IDs remain unchanged.
- A selected Astra model receives conservative local Codex metadata when required.
- Selecting a trusted bundled Codex model does not replace the native model catalog merely because Astra is another candidate.

Validation:
- Codex framework module: 64 passed.
- Provider registry module: 67 passed.
- Settings service module: 274 passed.
- Provider form/onboarding call chain: 3 files, 92 passed.
- Full TypeScript typecheck passed.
- Targeted Prettier and ESLint checks passed.
- `git diff --check` passed.

The repository impact classifier requests the complete Vitest suite because `src/shared/provider-registry.ts` has no registered module owner. Per task scope, the local full suite was not run; PR CI is the final authority.

## Review focus

Please verify the exact model IDs, published context limits and reasoning profiles, preservation of the current catalog defaults, and the active-model guard around `model_catalog_json`.
