### PR TITLE
fix(accessibility): restore contrast and keyboard navigation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -119,7 +119,7 @@ The light theme uses a warm off-white page background, white cards, and a deep-g
   --bg-400: hsl(45 10% 88%);
   --border-ink-channel: 60 2% 12%;
   --text-000: hsl(0 0% 7%);
-  --text-100: hsl(43 3% 47%);
+  --text-100: var(--muted-foreground);
   --text-300: hsl(43 3% 57%);
   --rail-card-bg: 0 0% 100%;
   --danger-000: hsl(0 45% 38%);

--- a/e2e/accessibility-reporter.ts
+++ b/e2e/accessibility-reporter.ts
@@ -26,7 +26,13 @@ const ACCESSIBILITY_SURFACES = [
   'Long conversation (dark)',
   'Artifact provenance',
   'Compute settings (narrow, dark)',
-  'Conversation recovery warning'
+  'Conversation recovery warning',
+  'Home (375px, light)',
+  'Home (375px, dark)',
+  'Home (767px, light)',
+  'Home (767px, dark)',
+  'Reported text (light)',
+  'Reported text (dark)'
 ] as const
 
 type AccessibilitySurface = (typeof ACCESSIBILITY_SURFACES)[number]

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -320,7 +320,9 @@ test('supports the core project journey with keyboard input only', async ({ app 
   if (
     !(await expectKeyboardOutcome(page, 'Send a message with Enter', async () => {
       await expect(
-        page.getByText('Summarize the deterministic fixture.', { exact: true })
+        page
+          .getByLabel('Conversation', { exact: true })
+          .getByText('Summarize the deterministic fixture.', { exact: true })
       ).toBeVisible()
     }))
   )
@@ -376,3 +378,72 @@ test('supports the core project journey with keyboard input only', async ({ app 
   }
   await expect(settingsTrigger).toBeFocused()
 })
+
+for (const width of [375, 767]) {
+  for (const theme of ['Light', 'Dark'] as const) {
+    test(`home has named project actions at ${width}px in ${theme}`, async ({ app }) => {
+      const page = await app.completeOnboarding()
+      await setTheme(page, theme)
+      await setViewport(page, width)
+      await waitForFiniteAnimations(page)
+      await scanAccessibility(page, 'Home')
+      const action = page.getByRole('button', { name: 'New project', exact: true }).first()
+      await expect(action).toBeVisible()
+      await action.click()
+      await expect(page.getByRole('dialog', { name: 'New project' })).toBeVisible()
+    })
+  }
+}
+
+for (const theme of ['Light', 'Dark'] as const) {
+  test(`reported text keeps sufficient contrast in ${theme}`, async ({ app }) => {
+    await app.completeOnboarding()
+    const page = await app.configureFakeAgent()
+    await setTheme(page, theme)
+    await createProject(page, `Contrast regression ${theme}`)
+    await page.evaluate(await readFile(AXE_PATH, 'utf8'))
+
+    const checkContrast = async (target: Locator, label: string): Promise<void> => {
+      await expect(target).toBeVisible()
+      await waitForFiniteAnimations(page)
+      const result = await target.evaluate(async (element) => {
+        const axe = (
+          globalThis as unknown as {
+            axe: { run: (context: Element, options: unknown) => Promise<AxeResults> }
+          }
+        ).axe
+        return axe.run(element, { runOnly: { type: 'rule', values: ['color-contrast'] } })
+      })
+      await test.info().attach(label, {
+        body: JSON.stringify({ violations: result.violations, incomplete: result.incomplete }),
+        contentType: 'application/json'
+      })
+      expect.soft(result.violations, label).toEqual([])
+      expect.soft(result.incomplete, `${label} must be measurable`).toEqual([])
+    }
+
+    for (const width of [1280, 767]) {
+      await setViewport(page, width)
+      await checkContrast(
+        page.getByText('Discover, share, and collaborate on research that matters', {
+          exact: true
+        }),
+        `Empty conversation ${width}px`
+      )
+      await checkContrast(
+        page
+          .getByRole('button', { name: 'Select model', exact: true })
+          .getByText('e2e-model', { exact: true }),
+        `Model ${width}px`
+      )
+    }
+    await page.getByRole('textbox', { name: 'Ask anything' }).fill('Request fixture permission.')
+    await page.getByRole('button', { name: 'Send message' }).click()
+    await page.getByRole('button', { name: 'Deny', exact: true }).click()
+    await expect(page.getByText('Fixture permission denied.', { exact: true })).toBeVisible()
+    await checkContrast(
+      page.getByText('Declined by you: tool', { exact: true }),
+      'Declined tool 767px'
+    )
+  })
+}

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -26,6 +26,16 @@ test.beforeEach(async ({ app }) => {
   void app
 })
 
+const blockingViolations = (results: AxeResults): AccessibilityScan['violations'] =>
+  results.violations
+    .filter((violation) => violation.impact === 'critical' || violation.impact === 'serious')
+    .map<AccessibilityScan['violations'][number]>(({ id, impact, help, nodes }) => ({
+      id,
+      impact: impact ?? null,
+      help,
+      nodes: nodes.map(({ html, target }) => ({ html, target }))
+    }))
+
 const scanAccessibility = async (page: Page, surface: AccessibilitySurface): Promise<void> => {
   const axeSource = await readFile(AXE_PATH, 'utf8')
   await page.evaluate(axeSource)
@@ -38,14 +48,7 @@ const scanAccessibility = async (page: Page, surface: AccessibilitySurface): Pro
 
     return axe.run(document, { runOnly: { type: 'tag', values: tags } })
   }, WCAG_TAGS)) as AxeResults
-  const blocking = results.violations
-    .filter((violation) => violation.impact === 'critical' || violation.impact === 'serious')
-    .map<AccessibilityScan['violations'][number]>(({ id, impact, help, nodes }) => ({
-      id,
-      impact: impact ?? null,
-      help,
-      nodes: nodes.map(({ html, target }) => ({ html, target }))
-    }))
+  const blocking = blockingViolations(results)
 
   await test.info().attach(ACCESSIBILITY_SCAN_ATTACHMENT, {
     body: JSON.stringify({ surface, violations: blocking } satisfies AccessibilityScan),
@@ -379,18 +382,21 @@ test('supports the core project journey with keyboard input only', async ({ app 
   await expect(settingsTrigger).toBeFocused()
 })
 
-for (const width of [375, 767]) {
+for (const width of [375, 767] as const) {
   for (const theme of ['Light', 'Dark'] as const) {
     test(`home has named project actions at ${width}px in ${theme}`, async ({ app }) => {
       const page = await app.completeOnboarding()
       await setTheme(page, theme)
       await setViewport(page, width)
       await waitForFiniteAnimations(page)
-      await scanAccessibility(page, 'Home')
-      const action = page.getByRole('button', { name: 'New project', exact: true }).first()
-      await expect(action).toBeVisible()
-      await action.click()
-      await expect(page.getByRole('dialog', { name: 'New project' })).toBeVisible()
+      const surface = `Home (${width}px, ${theme === 'Light' ? 'light' : 'dark'})` as const
+      await scanAccessibility(page, surface)
+      await expectKeyboardOutcome(page, surface, async () => {
+        const action = page.getByRole('button', { name: 'New project', exact: true }).first()
+        await expect(action).toBeVisible()
+        await action.click()
+        await expect(page.getByRole('dialog', { name: 'New project' })).toBeVisible()
+      })
     })
   }
 }
@@ -402,6 +408,7 @@ for (const theme of ['Light', 'Dark'] as const) {
     await setTheme(page, theme)
     await createProject(page, `Contrast regression ${theme}`)
     await page.evaluate(await readFile(AXE_PATH, 'utf8'))
+    const violations: AccessibilityScan['violations'] = []
 
     const checkContrast = async (target: Locator, label: string): Promise<void> => {
       await expect(target).toBeVisible()
@@ -418,7 +425,8 @@ for (const theme of ['Light', 'Dark'] as const) {
         body: JSON.stringify({ violations: result.violations, incomplete: result.incomplete }),
         contentType: 'application/json'
       })
-      expect.soft(result.violations, label).toEqual([])
+      violations.push(...blockingViolations(result))
+      if (!ACCESSIBILITY_ADVISORY) expect.soft(result.violations, label).toEqual([])
       expect.soft(result.incomplete, `${label} must be measurable`).toEqual([])
     }
 
@@ -445,5 +453,12 @@ for (const theme of ['Light', 'Dark'] as const) {
       page.getByText('Declined by you: tool', { exact: true }),
       'Declined tool 767px'
     )
+    await test.info().attach(ACCESSIBILITY_SCAN_ATTACHMENT, {
+      body: JSON.stringify({
+        surface: theme === 'Light' ? 'Reported text (light)' : 'Reported text (dark)',
+        violations
+      } satisfies AccessibilityScan),
+      contentType: 'application/json'
+    })
   })
 }

--- a/e2e/preview-context-menu.spec.ts
+++ b/e2e/preview-context-menu.spec.ts
@@ -50,7 +50,7 @@ const openLocalBrowserAt = async (page: Page, directory: string): Promise<void> 
     .click()
   const browser = page.getByLabel('Local file browser')
   await expect(browser).toBeVisible()
-  const contents = browser.getByRole('listbox', { name: 'Directory contents' })
+  const contents = browser.getByRole('list', { name: 'Directory contents' })
   await expect(contents).toBeVisible()
   const address = browser.getByLabel('Directory path')
   await address.fill(canonicalDirectory)
@@ -61,7 +61,7 @@ const openLocalBrowserAt = async (page: Page, directory: string): Promise<void> 
 
 const openLocalFile = async (page: Page, name: string): Promise<void> => {
   await page
-    .getByRole('listbox', { name: 'Directory contents' })
+    .getByRole('list', { name: 'Directory contents' })
     .getByRole('button')
     .filter({ hasText: name })
     .click()

--- a/scripts/ci/accessibility-reporter.test.ts
+++ b/scripts/ci/accessibility-reporter.test.ts
@@ -31,9 +31,9 @@ describe('accessibility run classification', () => {
     expect(
       classifyAccessibilityRun({
         runStatus: 'passed',
-        plannedTests: 5,
-        completedTests: 5,
-        readyTests: 5,
+        plannedTests: 11,
+        completedTests: 11,
+        readyTests: 11,
         scans: completeScans(),
         uiFindings: []
       })
@@ -43,9 +43,9 @@ describe('accessibility run classification', () => {
   it('keeps a complete scan with blocking findings advisory', () => {
     const result = classifyAccessibilityRun({
       runStatus: 'passed',
-      plannedTests: 5,
-      completedTests: 5,
-      readyTests: 5,
+      plannedTests: 11,
+      completedTests: 11,
+      readyTests: 11,
       scans: completeScans().map((item) =>
         item.surface === 'Settings' ? scan('Settings', 2) : item
       ),
@@ -61,8 +61,8 @@ describe('accessibility run classification', () => {
       name: 'Electron launch failed before axe ran',
       input: {
         runStatus: 'failed' as const,
-        plannedTests: 5,
-        completedTests: 5,
+        plannedTests: 11,
+        completedTests: 11,
         readyTests: 0,
         scans: [],
         uiFindings: []
@@ -72,9 +72,9 @@ describe('accessibility run classification', () => {
       name: 'a test ended without any axe evidence',
       input: {
         runStatus: 'passed' as const,
-        plannedTests: 5,
-        completedTests: 5,
-        readyTests: 5,
+        plannedTests: 11,
+        completedTests: 11,
+        readyTests: 11,
         scans: completeScans().slice(1),
         uiFindings: []
       }
@@ -90,9 +90,9 @@ describe('accessibility run classification', () => {
     expect(
       classifyAccessibilityRun({
         runStatus: 'passed',
-        plannedTests: 5,
-        completedTests: 5,
-        readyTests: 5,
+        plannedTests: 11,
+        completedTests: 11,
+        readyTests: 11,
         scans: completeScans(),
         uiFindings: [{ surface: 'Keyboard-only project journey', message: 'Focus was lost' }]
       })
@@ -103,9 +103,9 @@ describe('accessibility run classification', () => {
     expect(
       classifyAccessibilityRun({
         runStatus: 'failed',
-        plannedTests: 5,
-        completedTests: 5,
-        readyTests: 5,
+        plannedTests: 11,
+        completedTests: 11,
+        readyTests: 11,
         scans: completeScans(),
         uiFindings: []
       })
@@ -190,4 +190,26 @@ describe('accessibility run classification', () => {
       rmSync(root, { force: true, recursive: true })
     }
   })
+})
+
+it('accepts complete evidence from the expanded responsive and contrast matrix', () => {
+  const surfaces = [
+    ...ACCESSIBILITY_SURFACES.slice(0, 12),
+    'Home (375px, light)',
+    'Home (375px, dark)',
+    'Home (767px, light)',
+    'Home (767px, dark)',
+    'Reported text (light)',
+    'Reported text (dark)'
+  ]
+  expect(
+    classifyAccessibilityRun({
+      runStatus: 'passed',
+      plannedTests: 11,
+      completedTests: 11,
+      readyTests: 11,
+      scans: surfaces.map((surface) => ({ surface, violations: [] })) as AccessibilityScan[],
+      uiFindings: []
+    })
+  ).toEqual({ status: 'passed', findings: 0 })
 })

--- a/scripts/ci/run-accessibility-e2e.mjs
+++ b/scripts/ci/run-accessibility-e2e.mjs
@@ -6,7 +6,7 @@ import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 const DEFAULT_RESULT_PATH = 'test-results/accessibility/accessibility-summary.json'
-const EXPECTED_TESTS = 5
+const EXPECTED_TESTS = 11
 export const EXPECTED_ACCESSIBILITY_SURFACES = [
   'Onboarding',
   'Home',
@@ -19,7 +19,13 @@ export const EXPECTED_ACCESSIBILITY_SURFACES = [
   'Long conversation (dark)',
   'Artifact provenance',
   'Compute settings (narrow, dark)',
-  'Conversation recovery warning'
+  'Conversation recovery warning',
+  'Home (375px, light)',
+  'Home (375px, dark)',
+  'Home (767px, light)',
+  'Home (767px, dark)',
+  'Reported text (light)',
+  'Reported text (dark)'
 ]
 
 export function readAccessibilityResult(path) {

--- a/scripts/ci/run-accessibility-e2e.test.ts
+++ b/scripts/ci/run-accessibility-e2e.test.ts
@@ -22,9 +22,9 @@ type CompleteResult = {
 const completeResult = (status: 'passed' | 'advisory'): CompleteResult => ({
   schemaVersion: 1,
   status,
-  plannedTests: 5,
-  completedTests: 5,
-  readyTests: 5,
+  plannedTests: 11,
+  completedTests: 11,
+  readyTests: 11,
   axeRunCount: EXPECTED_ACCESSIBILITY_SURFACES.length,
   scans: EXPECTED_ACCESSIBILITY_SURFACES.map((surface) => ({ surface }))
 })
@@ -36,7 +36,7 @@ describe('accessibility E2E result contract', () => {
 
     try {
       writeFileSync(path, JSON.stringify(completeResult(status)))
-      expect(readAccessibilityResult(path)).toMatchObject({ status, axeRunCount: 12 })
+      expect(readAccessibilityResult(path)).toMatchObject({ status, axeRunCount: 18 })
     } finally {
       rmSync(root, { force: true, recursive: true })
     }
@@ -57,7 +57,7 @@ describe('accessibility E2E result contract', () => {
         )
       }
     },
-    { name: 'incomplete ready evidence', result: { ...completeResult('passed'), readyTests: 4 } }
+    { name: 'incomplete ready evidence', result: { ...completeResult('passed'), readyTests: 10 } }
   ])('rejects $name', ({ result }) => {
     const root = mkdtempSync(join(tmpdir(), 'accessibility-result-'))
     const path = join(root, 'nested', 'summary.json')
@@ -85,4 +85,38 @@ describe('accessibility E2E result contract', () => {
       rmSync(root, { force: true, recursive: true })
     }
   })
+})
+
+it('accepts complete evidence from the expanded responsive and contrast matrix', () => {
+  const root = mkdtempSync(join(tmpdir(), 'accessibility-expanded-'))
+  const path = join(root, 'summary.json')
+  const surfaces = [
+    ...EXPECTED_ACCESSIBILITY_SURFACES.slice(0, 12),
+    'Home (375px, light)',
+    'Home (375px, dark)',
+    'Home (767px, light)',
+    'Home (767px, dark)',
+    'Reported text (light)',
+    'Reported text (dark)'
+  ]
+  try {
+    writeFileSync(
+      path,
+      JSON.stringify({
+        ...completeResult('passed'),
+        plannedTests: 11,
+        completedTests: 11,
+        readyTests: 11,
+        axeRunCount: surfaces.length,
+        scans: surfaces.map((surface) => ({ surface }))
+      })
+    )
+    expect(readAccessibilityResult(path)).toMatchObject({
+      status: 'passed',
+      plannedTests: 11,
+      axeRunCount: 18
+    })
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
 })

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -277,7 +277,7 @@
   --bg-400: hsl(45 10% 88%);
   --border-ink-channel: 60 2% 12%;
   --text-000: hsl(0 0% 7%);
-  --text-100: hsl(43 3% 47%);
+  --text-100: var(--muted-foreground);
   --text-200: hsl(43 3% 52%);
   --text-300: hsl(43 3% 57%);
   --rail-card-bg: 0 0% 100%;

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -703,6 +703,7 @@ const HomePage = ({
               size="sm"
               className="h-8 gap-1 rounded-md px-3 text-xs"
               onClick={openCreateDialog}
+              aria-label={t('New project')}
             >
               <Plus className="size-3.5" strokeWidth={2} aria-hidden="true" />
               <span className="hidden sm:inline">{t('New project')}</span>

--- a/src/renderer/src/pages/onboarding/AgentStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/AgentStep.render.test.tsx
@@ -99,7 +99,7 @@ describe('AgentStep', () => {
     expect(container.textContent).not.toContain('Automatic detection')
     expect(container.textContent).not.toContain('Manual setup')
     const panel = container.querySelector('section[aria-label="Set up the agent runtime"]')
-    expect(panel?.querySelector('h3')?.textContent).toBe('Set up the agent runtime')
+    expect(panel?.querySelector('h2')?.textContent).toBe('Set up the agent runtime')
     expect(panel?.textContent).toContain(
       'Pick the agent Open Science drives, then install it. Only this agent needs to be installed to continue.'
     )

--- a/src/renderer/src/pages/onboarding/EnvironmentStep.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentStep.tsx
@@ -7,8 +7,7 @@ import {
   CardContent,
   CardDescription,
   CardFooter,
-  CardHeader,
-  CardTitle
+  CardHeader
 } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
@@ -39,7 +38,9 @@ const EnvironmentStep = ({ onContinue }: EnvironmentStepProps): React.JSX.Elemen
   return (
     <>
       <CardHeader className="gap-1 rounded-t-lg px-6 py-5">
-        <CardTitle className="text-[15px] font-semibold">{t('Prepare environment')}</CardTitle>
+        <h2 tabIndex={-1} className="text-[15px] font-semibold">
+          {t('Prepare environment')}
+        </h2>
         {/* Re-check lives on the title row (the setup card's own intro row is hidden via hideIntro),
             so the step header and the checklist read as one surface. */}
         <CardAction>

--- a/src/renderer/src/pages/onboarding/LocationStep.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.tsx
@@ -4,13 +4,7 @@ import { useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
-import {
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle
-} from '@/components/ui/card'
+import { CardContent, CardDescription, CardFooter, CardHeader } from '@/components/ui/card'
 import {
   dialogBodyClassName,
   dialogCloseButtonClassName,
@@ -170,9 +164,9 @@ const LocationStep = ({
   return (
     <>
       <CardHeader className="gap-1 rounded-t-lg px-4 py-5 sm:px-6">
-        <CardTitle className="text-[15px] font-semibold">
+        <h2 tabIndex={-1} className="text-[15px] font-semibold">
           {t('Where should Open Science store your data?')}
-        </CardTitle>
+        </h2>
         <CardDescription className="text-xs leading-5">
           {t(
             'Large files (artifacts, notebooks, environments) go here. Your settings and history always stay in the default location. You can change this later in Settings.'

--- a/src/renderer/src/pages/onboarding/NotebookStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/NotebookStep.render.test.tsx
@@ -86,7 +86,7 @@ describe('NotebookStep', () => {
     await renderStep()
 
     const panel = container.querySelector('section[aria-label="Notebook runtime (optional)"]')
-    expect(panel?.querySelector('h3')?.textContent).toBe('Notebook runtime (optional)')
+    expect(panel?.querySelector('h2')?.textContent).toBe('Notebook runtime (optional)')
     expect(panel?.textContent).toContain(
       'Notebooks run in an app-managed Python environment by default. You can change any of this later in Settings → Runtimes.'
     )

--- a/src/renderer/src/pages/onboarding/NotebookStep.tsx
+++ b/src/renderer/src/pages/onboarding/NotebookStep.tsx
@@ -47,6 +47,7 @@ const NotebookStep = ({ onBack }: NotebookStepProps): React.JSX.Element => {
         {/* Reuse the complete Settings surface so discovery, interpreter controls, language logos,
             managed setup, progress, recovery, and cancellation stay identical in both places. */}
         <RuntimesPanel
+          headingAs="h2"
           title={t('Notebook runtime (optional)')}
           description={t(
             'Notebooks run in an app-managed Python environment by default. You can change any of this later in Settings → Runtimes.'

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -735,3 +735,48 @@ describe('OnboardingWizard flow', () => {
     expect(window.api.storage.getInfo).not.toHaveBeenCalled()
   })
 })
+
+it('regression: step changes move focus to the new heading', async () => {
+  readyClaudeState()
+  await renderWizard()
+  act(() => {
+    findButton(/^continue$/i)!.focus()
+  })
+  await clickButton(/^continue$/i)
+  expect(currentSection('Choose data location')).not.toBeNull()
+  expect(document.activeElement?.textContent).toBe('Where should Open Science store your data?')
+  expect(document.activeElement?.tagName).toBe('H2')
+  act(() => {
+    findButton(/^back$/i)!.focus()
+  })
+  await clickButton(/^back$/i)
+  expect(document.activeElement?.textContent).toBe('Prepare environment')
+  expect(document.activeElement?.tagName).toBe('H2')
+})
+
+it('regression: every setup step exposes and focuses its own level-two heading', async () => {
+  readyClaudeState()
+  await renderWizard()
+  const expectHeading = (title: string): void => {
+    expect(document.activeElement?.tagName).toBe('H2')
+    expect(document.activeElement?.textContent).toBe(title)
+  }
+  await clickButton(/^continue$/i)
+  expectHeading('Where should Open Science store your data?')
+  await clickButton(/^continue$/i)
+  expectHeading('Set up the agent runtime')
+  await clickButton(/^continue$/i)
+  expectHeading('Connect a model')
+  await fillRequiredProviderFields(container)
+  await clickButton(/test & continue/i)
+  expectHeading('Notebook runtime (optional)')
+  for (const title of [
+    'Connect a model',
+    'Set up the agent runtime',
+    'Where should Open Science store your data?',
+    'Prepare environment'
+  ]) {
+    await clickButton(/^back$/i)
+    expectHeading(title)
+  }
+})

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -183,6 +183,19 @@ const OnboardingWizard = ({
   const envInit = useNotebookEnvStore((s) => s.init)
 
   const [step, setStep] = useState<WizardStep>('environment')
+  const stepCard = useRef<HTMLDivElement>(null)
+  const previousStep = useRef(step)
+  useEffect(() => {
+    if (previousStep.current === step) return
+    previousStep.current = step
+    // Settings-backed steps already own an h2. Keep focus scoped to the wizard and only move it
+    // when the step changes, never when async checks or form inputs update.
+    const heading = stepCard.current?.querySelector('h2')
+    if (heading) {
+      heading.tabIndex = -1
+      heading.focus()
+    }
+  }, [step])
   // The provider draft lives here (not in ProviderStep) so going Back and returning keeps it.
   const [formValue, setFormValue] = useState<ProviderFormValue>(() =>
     createEmptyProviderFormValue()
@@ -353,7 +366,10 @@ const OnboardingWizard = ({
           </section>
 
           {/* One stable work surface keeps the setup steps aligned as their content changes. */}
-          <Card className="min-h-[420px] gap-0 rounded-lg bg-bg-000 py-0 shadow-card ring-1 ring-border-200">
+          <Card
+            ref={stepCard}
+            className="min-h-[420px] gap-0 rounded-lg bg-bg-000 py-0 shadow-card ring-1 ring-border-200"
+          >
             {/* Each step owns its validation gate and advances only through its callback. The shell
                 owns cross-step drafts so Back/Continue never discards provider or location input. */}
             {step === 'environment' ? (

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -2,13 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
-import {
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle
-} from '@/components/ui/card'
+import { CardContent, CardDescription, CardFooter, CardHeader } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import type {
   UpsertProviderRequest,
@@ -395,7 +389,9 @@ const ProviderStep = ({
   return (
     <>
       <CardHeader className="gap-1 rounded-t-lg px-6 py-5">
-        <CardTitle className="text-[15px] font-semibold">{t('Connect a model')}</CardTitle>
+        <h2 tabIndex={-1} className="text-[15px] font-semibold">
+          {t('Connect a model')}
+        </h2>
         <CardDescription className="text-xs leading-5">
           {t('Choose the provider Open Science should use for new research sessions.')}
         </CardDescription>

--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -645,6 +645,7 @@ const AgentPanel = ({
           the active runtime can't be uninstalled (switch to the other one first). */}
       <SettingsSection
         title={title}
+        headingAs={isOnboarding ? 'h2' : 'h3'}
         aria-label={title}
         description={description}
         actionClassName="ml-auto"

--- a/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, getByRole, waitFor } from '@testing-library/react'
+import axe from 'axe-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComputeHost } from '../../../../shared/compute'
@@ -260,7 +261,7 @@ describe('FileBrowserModal', () => {
     })
 
     // Click on readme.txt to select it
-    const fileButton = Array.from(document.querySelectorAll('[role="option"]')).find((el) =>
+    const fileButton = Array.from(document.querySelectorAll('button')).find((el) =>
       el.textContent?.includes('readme.txt')
     ) as HTMLElement | undefined
     await act(async () => {
@@ -299,7 +300,7 @@ describe('FileBrowserModal', () => {
     })
 
     // Select readme.txt
-    const fileButton = Array.from(document.querySelectorAll('[role="option"]')).find((el) =>
+    const fileButton = Array.from(document.querySelectorAll('button')).find((el) =>
       el.textContent?.includes('readme.txt')
     ) as HTMLElement | undefined
     await act(async () => {
@@ -359,8 +360,8 @@ describe('FileBrowserModal', () => {
       await Promise.resolve()
     })
 
-    const hostBButton = Array.from(document.querySelectorAll('button')).find(
-      (element) => element.textContent?.trim() === 'host-b'
+    const hostBButton = Array.from(document.querySelectorAll('button')).find((element) =>
+      element.textContent?.startsWith('host-b')
     ) as HTMLButtonElement | undefined
     expect(hostBButton?.disabled).toBe(false)
 
@@ -419,8 +420,8 @@ describe('FileBrowserModal', () => {
       )
     })
 
-    const hostBButton = Array.from(document.querySelectorAll('button')).find(
-      (element) => element.textContent?.trim() === 'host-b'
+    const hostBButton = Array.from(document.querySelectorAll('button')).find((element) =>
+      element.textContent?.startsWith('host-b')
     ) as HTMLButtonElement | undefined
     await act(async () => {
       hostBButton?.click()
@@ -450,7 +451,7 @@ describe('FileBrowserModal', () => {
     expect(document.body.textContent).toContain('from-host-b.txt')
     expect(document.body.textContent).not.toContain('from-host-a.txt')
 
-    const fileButton = Array.from(document.querySelectorAll('[role=option]')).find((element) =>
+    const fileButton = Array.from(document.querySelectorAll('button')).find((element) =>
       element.textContent?.includes('from-host-b.txt')
     ) as HTMLButtonElement | undefined
     await act(async () => {
@@ -513,8 +514,8 @@ describe('FileBrowserModal', () => {
       )
       await Promise.resolve()
     })
-    const hostBButton = Array.from(document.querySelectorAll('button')).find(
-      (element) => element.textContent?.trim() === 'host-b'
+    const hostBButton = Array.from(document.querySelectorAll('button')).find((element) =>
+      element.textContent?.startsWith('host-b')
     ) as HTMLButtonElement | undefined
     await act(async () => {
       hostBButton?.click()
@@ -530,10 +531,10 @@ describe('FileBrowserModal', () => {
       await hostABookmarks.promise
     })
 
-    const goToButton = document.querySelector('[aria-haspopup=listbox]') as
+    const goToButton = document.querySelector('[aria-haspopup=menu]') as
       HTMLButtonElement | undefined
     await act(async () => {
-      goToButton?.click()
+      fireEvent.keyDown(goToButton!, { key: 'Enter' })
     })
 
     expect(document.body.textContent).toContain('/scratch/b/pinned')
@@ -571,12 +572,12 @@ describe('FileBrowserModal', () => {
       )
       await Promise.resolve()
     })
-    const goToButton = document.querySelector('[aria-haspopup=listbox]') as
+    const goToButton = document.querySelector('[aria-haspopup=menu]') as
       HTMLButtonElement | undefined
     await act(async () => {
-      goToButton?.click()
+      fireEvent.keyDown(goToButton!, { key: 'Enter' })
     })
-    const pinButton = Array.from(document.querySelectorAll('button')).find((element) =>
+    const pinButton = Array.from(document.querySelectorAll('[role=menuitem]')).find((element) =>
       element.textContent?.includes('Pin current folder')
     ) as HTMLButtonElement | undefined
     await act(async () => {
@@ -602,12 +603,12 @@ describe('FileBrowserModal', () => {
       )
       await Promise.resolve()
     })
-    const goToButton = document.querySelector('[aria-haspopup=listbox]') as
+    const goToButton = document.querySelector('[aria-haspopup=menu]') as
       HTMLButtonElement | undefined
     await act(async () => {
-      goToButton?.click()
+      fireEvent.keyDown(goToButton!, { key: 'Enter' })
     })
-    const removeButton = Array.from(document.querySelectorAll('button')).find(
+    const removeButton = Array.from(document.querySelectorAll('[role=menuitem]')).find(
       (element) => element.getAttribute('aria-label') === 'Remove bookmark /scratch/user/pinned'
     ) as HTMLButtonElement | undefined
     await act(async () => {
@@ -638,7 +639,7 @@ describe('FileBrowserModal', () => {
     })
 
     // Select readme.txt
-    const fileButton = Array.from(document.querySelectorAll('[role="option"]')).find((el) =>
+    const fileButton = Array.from(document.querySelectorAll('button')).find((el) =>
       el.textContent?.includes('readme.txt')
     ) as HTMLElement | undefined
     await act(async () => {
@@ -672,7 +673,7 @@ describe('FileBrowserModal', () => {
       await Promise.resolve()
     })
 
-    const fileButton = Array.from(document.querySelectorAll('[role="option"]')).find((element) =>
+    const fileButton = Array.from(document.querySelectorAll('button')).find((element) =>
       element.textContent?.includes('readme.txt')
     ) as HTMLElement | undefined
     expect(fileButton).toBeDefined()
@@ -682,4 +683,117 @@ describe('FileBrowserModal', () => {
 
     expect(document.body.textContent).not.toContain('Add to project')
   })
+})
+
+describe('FileBrowserModal accessibility regressions', () => {
+  const renderBrowser = async (onClose = vi.fn()): Promise<void> => {
+    await act(async () => {
+      root.render(<FileBrowserModal open onClose={onClose} initialProviderId="ssh:biowulf" />)
+    })
+  }
+
+  const openGoTo = async (): Promise<HTMLElement> => {
+    const trigger = getByRole(document.body, 'button', { name: 'Go to' })
+    await act(async () => {
+      trigger.focus()
+      fireEvent.keyDown(trigger, { key: 'Enter' })
+      // Native buttons synthesize click for Enter in a browser; jsdom does not.
+      if (trigger.getAttribute('aria-expanded') !== 'true') trigger.click()
+    })
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    return trigger
+  }
+
+  it('regression: Escape dismisses Go to before the file browser', async () => {
+    const onClose = vi.fn()
+    await renderBrowser(onClose)
+    const trigger = await openGoTo()
+    await act(async () => {
+      fireEvent.keyDown(document.activeElement ?? document, { key: 'Escape' })
+    })
+    expect(onClose).not.toHaveBeenCalled()
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
+  })
+
+  it('regression: Go to supports keyboard focus and ArrowDown navigation', async () => {
+    await renderBrowser()
+    await openGoTo()
+    expect(document.activeElement?.textContent).toContain('Scratch')
+    await act(async () => {
+      fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' })
+    })
+    await waitFor(() => expect(document.activeElement?.textContent).toContain('Home'))
+  })
+
+  it('regression: Go to and directory children match their ARIA container roles', async () => {
+    await renderBrowser()
+    await openGoTo()
+    const result = await axe.run(document.body, {
+      runOnly: {
+        type: 'rule',
+        values: ['aria-required-children', 'aria-required-parent', 'nested-interactive']
+      }
+    })
+    expect(
+      result.violations.map(({ id, nodes }) => ({ id, html: nodes.map((node) => node.html) }))
+    ).toEqual([])
+  })
+
+  it('regression: host buttons expose the current selection', async () => {
+    await renderBrowser()
+    expect(
+      getByRole(document.body, 'button', { name: /biowulf/ }).getAttribute('aria-pressed')
+    ).toBe('true')
+  })
+
+  it.each([
+    { probeResult: connectedHost().probeResult, status: 'Probe succeeded' },
+    { probeResult: { ...connectedHost().probeResult!, ok: false }, status: 'Probe failed' },
+    { probeResult: undefined, status: 'Not probed yet' }
+  ])(
+    'regression: host buttons expose probe status as text ($status)',
+    async ({ probeResult, status }) => {
+      useComputeStore.setState({ hosts: [connectedHost({ probeResult })] })
+      await renderBrowser()
+      const host = getByRole(document.body, 'button', { name: new RegExp(`biowulf.*${status}`) })
+      expect(host.getAttribute('aria-pressed')).toBe('true')
+    }
+  )
+})
+
+it('regression: a remote directory can be opened using native button activation', async () => {
+  await act(async () => {
+    root.render(<FileBrowserModal open onClose={vi.fn()} initialProviderId="ssh:biowulf" />)
+  })
+  const entry = Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find((button) =>
+    button.textContent?.startsWith('data')
+  )!
+  expect(entry).toBeDefined()
+  await act(async () => {
+    entry.focus()
+    // Enter on a native button produces a click, not a double-click.
+    entry.click()
+  })
+  expect(window.api.compute.listDir).toHaveBeenLastCalledWith('ssh:biowulf', '/scratch/user/data')
+})
+
+it('regression: clicking outside Go to dismisses only its popup', async () => {
+  const onClose = vi.fn()
+  await act(async () => {
+    root.render(<FileBrowserModal open onClose={onClose} initialProviderId="ssh:biowulf" />)
+  })
+  const trigger = getByRole(document.body, 'button', { name: 'Go to' })
+  await act(async () => {
+    fireEvent.pointerDown(trigger, { pointerType: 'mouse', button: 0, ctrlKey: false })
+    fireEvent.click(trigger)
+  })
+  expect(trigger.getAttribute('aria-expanded')).toBe('true')
+  const address = getByRole(document.body, 'textbox', { name: 'Current directory path' })
+  await act(async () => {
+    fireEvent.pointerDown(address, { pointerType: 'mouse', button: 0 })
+    fireEvent.click(address)
+  })
+  expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  expect(onClose).not.toHaveBeenCalled()
 })

--- a/src/renderer/src/pages/settings/FileBrowserModal.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.tsx
@@ -1,6 +1,6 @@
 // Remote file browser modal (compute-file-preview, issue 02 + issue 03).
 // Opened from the ComputePanel host card folder-icon button (and later from the Files panel Remote
-// dropdown, issue 05). Presents a listbox-style directory listing with navigation, a detail panel for
+// dropdown, issue 05). Presents a directory listing with navigation, a detail panel for
 // selected files, and a Go-to dropdown with Scratch / Home / Pin / bookmarks.
 //
 // Design decisions (from design.md):
@@ -35,6 +35,14 @@ import type { DirListing, RemoteDirEntry } from '../../../../shared/remote-fs'
 import type { ComputeAuthenticationErrorCode } from '../../../../shared/compute'
 import { resolveRemotePath, validateRemotePath } from '../../../../shared/remote-fs'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { dialogOverlayClassName, dialogPanelClassName } from '@/components/ui/dialog-chrome'
 import { cn } from '@/lib/utils'
 import { useComputeStore } from '@/stores/compute-store'
@@ -577,7 +585,7 @@ export function FileBrowserModal({
     void navigate(resolved)
   }
 
-  const handleEntryDoubleClick = (entry: RemoteDirEntry): void => {
+  const handleOpenDirectory = (entry: RemoteDirEntry): void => {
     if (!entry.isDirectory) return
     const listing = browserState.kind === 'ok' ? browserState.listing : null
     const next = `${(listing?.resolvedPath ?? cwd).replace(/\/$/, '')}/${entry.name}`
@@ -678,9 +686,10 @@ export function FileBrowserModal({
                 key={h.providerId}
                 type="button"
                 onClick={() => handleHostSelect(h.providerId)}
+                aria-pressed={h.providerId === host?.providerId}
                 className={cn(
                   'flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors',
-                  h.providerId === activeProviderId
+                  h.providerId === host?.providerId
                     ? 'bg-primary text-primary-foreground'
                     : 'bg-muted text-muted-foreground hover:bg-muted/80'
                 )}
@@ -693,6 +702,13 @@ export function FileBrowserModal({
                   aria-hidden="true"
                 />
                 {h.displayName}
+                <span className="sr-only">
+                  {h.probeResult
+                    ? h.probeResult.ok
+                      ? t('Probe succeeded')
+                      : t('Probe failed')
+                    : t('Not probed yet')}
+                </span>
               </button>
             ))}
             <div className="flex-1" />
@@ -734,95 +750,70 @@ export function FileBrowserModal({
             </Button>
 
             {/* Go-to dropdown */}
-            <div className="relative">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="gap-1 text-xs"
-                onClick={() => setGotoOpen(!gotoOpen)}
-                aria-haspopup="listbox"
-                aria-expanded={gotoOpen}
+            <DropdownMenu open={gotoOpen} onOpenChange={setGotoOpen} modal={false}>
+              <DropdownMenuTrigger asChild>
+                <Button type="button" variant="ghost" size="sm" className="gap-1 text-xs">
+                  <MapPin className="size-3.5" aria-hidden="true" />
+                  {t('Go to')}
+                  <ChevronDown className="size-3.5 opacity-60" aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                className="z-[80] min-w-[200px]"
+                aria-label={t('Go-to locations')}
               >
-                <MapPin className="size-3.5" />
-                {t('Go to')}
-                <ChevronDown className="size-3.5 opacity-60" />
-              </Button>
-              {gotoOpen && (
-                <div
-                  className="absolute left-0 top-full z-10 mt-1 min-w-[200px] rounded-lg border border-border bg-popover p-1 shadow-md"
-                  role="listbox"
-                  aria-label={t('Go-to locations')}
-                >
-                  {goToItems.map((item) => (
-                    <button
-                      key={item.path}
-                      type="button"
-                      role="option"
-                      className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent"
-                      onClick={() => {
-                        setGotoOpen(false)
-                        void navigate(item.path)
-                      }}
-                    >
-                      {item.icon}
-                      <span className="flex-1">{item.label}</span>
-                      <span className="truncate max-w-[100px] text-muted-foreground font-mono">
-                        {item.path}
-                      </span>
-                    </button>
-                  ))}
-                  {goToItems.length > 0 && <div className="my-1 border-t border-border" />}
-                  {bookmarksState.kind === 'loading' && (
-                    <p className={'px-2 py-1.5 text-xs text-muted-foreground'}>
-                      {t('Loading bookmarks...')}
-                    </p>
-                  )}
-                  {/* Pin current folder */}
-                  <button
-                    disabled={bookmarksState.kind === 'loading'}
-                    type="button"
-                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent"
-                    onClick={() => void handlePinCurrent()}
+                {goToItems.map((item) => (
+                  <DropdownMenuItem
+                    key={item.path}
+                    className="gap-2 text-xs"
+                    onSelect={() => void navigate(item.path)}
                   >
-                    <MapPin className="size-3.5 text-muted-foreground" />
-                    <span>{t('Pin current folder')}</span>
-                  </button>
-                  {/* Bookmarks */}
-                  {bookmarks.length > 0 && (
-                    <>
-                      <div className="my-1 border-t border-border" />
-                      <p className="px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                        {t('Bookmarks')}
-                      </p>
-                      {bookmarks.map((bm) => (
-                        <div key={bm} className="flex items-center gap-1">
-                          <button
-                            type="button"
-                            className="flex flex-1 items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent"
-                            onClick={() => {
-                              setGotoOpen(false)
-                              void navigate(bm)
-                            }}
-                          >
-                            <Bookmark className="size-3.5 text-muted-foreground" />
-                            <span className="truncate max-w-[140px] font-mono">{bm}</span>
-                          </button>
-                          <button
-                            type="button"
-                            aria-label={t('Remove bookmark {{path}}', { path: bm })}
-                            className="mr-1 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-destructive"
-                            onClick={() => void handleRemoveBookmark(bm)}
-                          >
-                            <X className="size-3" />
-                          </button>
-                        </div>
-                      ))}
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
+                    {item.icon}
+                    <span className="flex-1">{item.label}</span>
+                    <span className="truncate max-w-[100px] text-muted-foreground font-mono">
+                      {item.path}
+                    </span>
+                  </DropdownMenuItem>
+                ))}
+                {goToItems.length > 0 && <DropdownMenuSeparator />}
+                {bookmarksState.kind === 'loading' && (
+                  <DropdownMenuLabel>{t('Loading bookmarks...')}</DropdownMenuLabel>
+                )}
+                <DropdownMenuItem
+                  disabled={bookmarksState.kind === 'loading'}
+                  className="gap-2 text-xs"
+                  onSelect={() => void handlePinCurrent()}
+                >
+                  <MapPin className="size-3.5 text-muted-foreground" aria-hidden="true" />
+                  {t('Pin current folder')}
+                </DropdownMenuItem>
+                {bookmarks.length > 0 && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>{t('Bookmarks')}</DropdownMenuLabel>
+                    {bookmarks.map((bm) => (
+                      <div key={bm} className="flex items-center gap-1">
+                        <DropdownMenuItem
+                          className="min-w-0 flex-1 gap-2 text-xs"
+                          onSelect={() => void navigate(bm)}
+                        >
+                          <Bookmark className="size-3.5 text-muted-foreground" aria-hidden="true" />
+                          <span className="truncate max-w-[140px] font-mono">{bm}</span>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          aria-label={t('Remove bookmark {{path}}', { path: bm })}
+                          className="shrink-0 text-muted-foreground"
+                          onSelect={() => void handleRemoveBookmark(bm)}
+                        >
+                          <X className="size-3" aria-hidden="true" />
+                        </DropdownMenuItem>
+                      </div>
+                    ))}
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             {/* Address bar */}
             <form onSubmit={handleAddressSubmit} className="flex flex-1 items-center">
@@ -936,7 +927,7 @@ export function FileBrowserModal({
 
               {/* Entry list */}
               {browserState.kind === 'ok' && (
-                <div role="listbox" aria-label={t('Directory contents')}>
+                <div>
                   {/* Header row */}
                   <div className="grid grid-cols-[1fr_80px_80px] border-b border-border bg-muted/30 px-3 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
                     <span>{t('Name')}</span>
@@ -948,45 +939,55 @@ export function FileBrowserModal({
                       {t('Empty directory')}
                     </p>
                   )}
-                  {listing?.entries.map((entry) => (
-                    <button
-                      key={entry.name}
-                      type="button"
-                      role="option"
-                      aria-selected={selected?.entry.name === entry.name}
-                      className={cn(
-                        'grid w-full grid-cols-[1fr_80px_80px] items-center px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent',
-                        selected?.entry.name === entry.name ? 'bg-accent/80' : ''
-                      )}
-                      onClick={() => {
-                        if (browserState.kind !== 'ok') return
-                        setSelected({
-                          entry,
-                          providerId: browserState.providerId,
-                          resolvedDir: browserState.listing.resolvedPath
-                        })
-                      }}
-                      onDoubleClick={() => handleEntryDoubleClick(entry)}
-                    >
-                      <span className="flex items-center gap-1.5 truncate">
-                        {entry.isDirectory ? (
-                          <Folder className="size-3.5 shrink-0 text-sky-500" aria-hidden="true" />
-                        ) : (
-                          <File
-                            className="size-3.5 shrink-0 text-muted-foreground"
-                            aria-hidden="true"
-                          />
-                        )}
-                        <span className="truncate">{entry.name}</span>
-                      </span>
-                      <span className="text-right text-muted-foreground">
-                        {entry.isDirectory ? '—' : formatSize(entry.size)}
-                      </span>
-                      <span className="text-right text-muted-foreground">
-                        {relativeTime(entry.mtimeMs, t)}
-                      </span>
-                    </button>
-                  ))}
+                  <ul aria-label={t('Directory contents')}>
+                    {listing?.entries.map((entry) => (
+                      <li key={entry.name}>
+                        <button
+                          type="button"
+                          aria-pressed={
+                            entry.isDirectory ? undefined : selected?.entry.name === entry.name
+                          }
+                          className={cn(
+                            'grid w-full grid-cols-[1fr_80px_80px] items-center px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent',
+                            selected?.entry.name === entry.name ? 'bg-accent/80' : ''
+                          )}
+                          onClick={() => {
+                            if (browserState.kind !== 'ok') return
+                            if (entry.isDirectory) {
+                              handleOpenDirectory(entry)
+                              return
+                            }
+                            setSelected({
+                              entry,
+                              providerId: browserState.providerId,
+                              resolvedDir: browserState.listing.resolvedPath
+                            })
+                          }}
+                        >
+                          <span className="flex items-center gap-1.5 truncate">
+                            {entry.isDirectory ? (
+                              <Folder
+                                className="size-3.5 shrink-0 text-sky-500"
+                                aria-hidden="true"
+                              />
+                            ) : (
+                              <File
+                                className="size-3.5 shrink-0 text-muted-foreground"
+                                aria-hidden="true"
+                              />
+                            )}
+                            <span className="truncate">{entry.name}</span>
+                          </span>
+                          <span className="text-right text-muted-foreground">
+                            {entry.isDirectory ? '—' : formatSize(entry.size)}
+                          </span>
+                          <span className="text-right text-muted-foreground">
+                            {relativeTime(entry.mtimeMs, t)}
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
                   {listing?.truncated && (
                     <p className="border-t border-border px-3 py-2 text-center text-xs text-muted-foreground">
                       {t('Showing first 5,000 entries. Navigate into a subdirectory to see more.')}

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -80,6 +80,7 @@ type ManagedOperationView = {
 }
 
 type RuntimesPanelProps = {
+  headingAs?: 'h2' | 'h3'
   title: string
   description: React.ReactNode
   onOpenNetworkProtection?: () => void
@@ -87,6 +88,7 @@ type RuntimesPanelProps = {
 
 const RuntimesPanel = ({
   title,
+  headingAs,
   description,
   onOpenNetworkProtection
 }: RuntimesPanelProps): React.JSX.Element => {
@@ -593,6 +595,7 @@ const RuntimesPanel = ({
     <div className="p-5" data-testid="runtimes-panel">
       <SettingsSection
         title={title}
+        headingAs={headingAs}
         description={description}
         aria-label={title}
         contentClassName="space-y-5"

--- a/src/renderer/src/pages/settings/SettingsLayout.tsx
+++ b/src/renderer/src/pages/settings/SettingsLayout.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils'
 type SettingsSectionProps = ComponentProps<'section'> & {
   title: string
   titleId?: string
+  headingAs?: 'h2' | 'h3'
   // Optional decorative glyph rendered just before the title (e.g. a language logo).
   icon?: ReactNode
   description?: ReactNode
@@ -24,6 +25,7 @@ type SettingsSectionProps = ComponentProps<'section'> & {
 const SettingsSection = ({
   title,
   titleId,
+  headingAs: Heading = 'h3',
   icon,
   description,
   action,
@@ -44,7 +46,7 @@ const SettingsSection = ({
       className={cn('flex flex-wrap items-start justify-between gap-3 sm:gap-4', headerClassName)}
     >
       <div className="min-w-0 flex-1">
-        <h3
+        <Heading
           id={titleId}
           className="flex min-w-0 items-center gap-2 break-words text-base font-semibold text-foreground"
         >
@@ -57,7 +59,7 @@ const SettingsSection = ({
             </span>
           ) : null}
           {title}
-        </h3>
+        </Heading>
         {description ? (
           <p className="mt-0.5 max-w-2xl break-words text-[13px] leading-5 text-muted-foreground">
             {description}

--- a/src/renderer/src/pages/settings/file-browser-i18n.render.test.tsx
+++ b/src/renderer/src/pages/settings/file-browser-i18n.render.test.tsx
@@ -3,6 +3,7 @@
 // the download success banner must all follow the active language — including text that was
 // produced by an earlier event and is only rendered later (see the language-switch cases).
 import { act } from 'react'
+import { fireEvent } from '@testing-library/react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -83,8 +84,8 @@ const renderModal = async (): Promise<void> => {
 }
 
 const selectFile = async (name: string): Promise<void> => {
-  const entry = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
-    (el) => el.textContent?.includes(name)
+  const entry = Array.from(document.body.querySelectorAll<HTMLElement>('button')).find((el) =>
+    el.textContent?.includes(name)
   )
   await act(async () => {
     entry?.click()
@@ -93,9 +94,9 @@ const selectFile = async (name: string): Promise<void> => {
 
 // Go-to locations, pin-current and the bookmark list only mount while the dropdown is open.
 const openGoTo = async (): Promise<void> => {
-  const trigger = document.body.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')
+  const trigger = document.body.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]')
   await act(async () => {
-    trigger?.click()
+    fireEvent.keyDown(trigger!, { key: 'Enter' })
   })
 }
 

--- a/src/renderer/src/pages/workspace/EmptyConversationBanner.render.test.tsx
+++ b/src/renderer/src/pages/workspace/EmptyConversationBanner.render.test.tsx
@@ -10,11 +10,11 @@ describe('EmptyConversationBanner', () => {
     expect(html).toContain('data-testid="empty-conversation-banner"')
     expect(html).toContain('What will you research in Open Science?')
     expect(html).toContain('Discover, share, and collaborate on research that matters')
-    // The dotted flask is decorative; only the heading carries meaning.
+    // The dotted flask is decorative; the heading and description carry meaning.
     expect(html).toContain('aria-hidden="true"')
     expect(html).toContain('<h2')
     expect(html).toContain('class="size-28 text-text-300 opacity-40 md:size-32 dark:opacity-80"')
     expect(html).toContain('class="text-balance text-lg font-normal text-text-000 md:text-xl"')
-    expect(html).toContain('class="text-xs text-text-300"')
+    expect(html).toContain('class="text-xs text-text-100"')
   })
 })

--- a/src/renderer/src/pages/workspace/EmptyConversationBanner.tsx
+++ b/src/renderer/src/pages/workspace/EmptyConversationBanner.tsx
@@ -20,7 +20,7 @@ const EmptyConversationBanner = (): React.JSX.Element => {
         <h2 className="text-balance text-lg font-normal text-text-000 md:text-xl">
           {t('What will you research in Open Science?')}
         </h2>
-        <p className="text-xs text-text-300">
+        <p className="text-xs text-text-100">
           {t('Discover, share, and collaborate on research that matters')}
         </p>
       </div>

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.test.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act } from 'react'
+import axe from 'axe-core'
 import { createRoot, type Root } from 'react-dom/client'
 import type { PropsWithChildren } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -379,4 +380,22 @@ describe('LocalFileBrowser Go to menu', () => {
     expect(follows(pinnedLabel, bookmarkItem)).toBe(true)
     expect(follows(bookmarkItem, pinAction)).toBe(true)
   })
+})
+
+it('regression: local directory children match their ARIA container role', async () => {
+  listDir.mockImplementation(async (path: string): Promise<LocalDirListing> => ({
+    entries: [{ name: 'data', isDirectory: true, size: 0, mtimeMs: 1704067200000 }],
+    truncated: false,
+    resolvedPath: path
+  }))
+  await act(async () => {
+    root.render(<LocalFileBrowser />)
+  })
+  await flush()
+  const result = await axe.run(container, {
+    runOnly: { type: 'rule', values: ['aria-required-children', 'aria-required-parent'] }
+  })
+  expect(
+    result.violations.map(({ id, nodes }) => ({ id, html: nodes.map((node) => node.html) }))
+  ).toEqual([])
 })

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
@@ -321,7 +321,7 @@ const LocalListing = ({
           {t('Empty folder')}
         </div>
       ) : (
-        <ul role="listbox" aria-label={t('Directory contents')}>
+        <ul aria-label={t('Directory contents')}>
           {state.entries.map((entry) => (
             <li key={entry.name} className="border-b border-border-300/40 last:border-b-0">
               <button

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -1707,6 +1707,7 @@
     "Previous preview page": "Vorherige Vorschauseite",
     "Previous question": "Vorherige Frage",
     "Probe": "Prüfen",
+    "Probe succeeded": "Prüfung erfolgreich",
     "Probe failed": "Prüfung fehlgeschlagen",
     "Probe failed unexpectedly.": "Die Prüfung ist unerwartet fehlgeschlagen.",
     "Probing…": "Host wird geprüft…",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1816,6 +1816,7 @@
     "Previous preview page": "Página de vista previa anterior",
     "Previous question": "Pregunta anterior",
     "Probe": "Comprobar",
+    "Probe succeeded": "Sondeo correcto",
     "Probe failed": "Error en la comprobación",
     "Probe failed unexpectedly.": "La comprobación falló inesperadamente.",
     "Probing…": "Comprobando…",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1816,6 +1816,7 @@
     "Previous preview page": "Page d'aperçu précédente",
     "Previous question": "Question précédente",
     "Probe": "Sonde",
+    "Probe succeeded": "Vérification réussie",
     "Probe failed": "La sonde a échoué",
     "Probe failed unexpectedly.": "La sonde a échoué de manière inattendue.",
     "Probing…": "Sonder…",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1751,6 +1751,7 @@
     "Previous preview page": "前のプレビューページ",
     "Previous question": "前の質問",
     "Probe": "プローブ",
+    "Probe succeeded": "接続テスト成功",
     "Probe failed": "プローブに失敗しました",
     "Probe failed unexpectedly.": "プローブが予期せず失敗しました。",
     "Probing…": "プローブ中…",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1762,6 +1762,7 @@
     "Previous preview page": "이전 미리보기 페이지",
     "Previous question": "이전 질문",
     "Probe": "점검",
+    "Probe succeeded": "연결 테스트 성공",
     "Probe failed": "점검 실패",
     "Probe failed unexpectedly.": "점검이 예기치 않게 실패했습니다.",
     "Probing…": "점검 중…",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1817,6 +1817,7 @@
     "Previous preview page": "Предыдущая страница предпросмотра",
     "Previous question": "Предыдущий вопрос",
     "Probe": "Проба",
+    "Probe succeeded": "Проверка успешна",
     "Probe failed": "Проба не удалась",
     "Probe failed unexpectedly.": "Проба не удалась.",
     "Probing…": "Проба...",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1837,6 +1837,7 @@
     "Previous preview page": "上一预览页",
     "Previous question": "上一个问题",
     "Probe": "探测",
+    "Probe succeeded": "探测成功",
     "Probe failed": "探测失败",
     "Probe failed unexpectedly.": "探测意外失败。",
     "Probing…": "正在探测…",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1834,6 +1834,7 @@
     "Previous preview page": "上一預覽頁",
     "Previous question": "上一個問題",
     "Probe": "探測",
+    "Probe succeeded": "探測成功",
     "Probe failed": "探測失敗",
     "Probe failed unexpectedly.": "探測意外失敗。",
     "Probing…": "正在探測…",


### PR DESCRIPTION
## Problem

Real Electron + axe reproduced insufficient light-theme contrast in empty-conversation guidance (3.01:1), declined tool text (4.05:1), and the model name (4.34:1; also affected desktop width). The 375px home page exposed an unnamed New project button. File-browser roles promised keyboard behavior they did not implement, host selection/probe status depended on color, and onboarding transitions lost focus.

## Proposed change

- Reuse the existing muted foreground token for light-theme secondary workspace text and promote the empty-conversation description to that tier. Name the responsive New project button using existing translated copy.
- Replace remote Go to with the existing Radix dropdown components, including keyboard navigation, outside dismissal and Escape/focus return. Render directory contents as lists with buttons. Remote directories now open on single click or Enter; files open Details.
- Expose current-host selection and the existing probe result, with translated success text in all eight locales.
- Focus a real level-two step heading after onboarding transitions. Shared Settings sections retain their existing heading level unless onboarding explicitly requests h2.
- Extend the CI evidence contract to all 11 tests and 18 distinct scan surfaces, including responsive home and measured contrast results. Preserve strict local assertions, advisory CI findings and blocking scan-completeness checks.
- Update consumers' role/heading expectations and scope the existing keyboard-journey message assertion to Conversation so session/header duplicates cannot make it ambiguous.

## Scope and non-goals

No new dependencies, domain fields/enums, IPC contracts, data-model relationships, persistence formats, or historical migrations. Existing bookmark writes retain their owner/API. No additional empty-state project-creation flow.

## Acceptance criteria and validation

The final 12 component regressions were run against unchanged baseline production source and all failed for the reported behaviors; restoring the fix made all 12 pass. The original Electron theme/width matrix also failed consistently over two repetitions before the fix. Two additional reporting-contract regressions failed before synchronization; the CI entrypoint independently reproduced exit 1 despite 11 passing UI tests, then returned exit 0 after synchronization.

| Behavior / consumers | Check | Result |
| --- | --- | --- |
| Home, all onboarding steps, shared Settings headings, compute/browser/bookmark races, project files, model picker/activity styles, theme, i18n | Explicit Vitest impact set below | 22 files / 1,220 tests pass |
| Final browser test API correction | `npx vitest run src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx` | 26 pass |
| Core accessibility and local preview consumer | `npm run build:e2e`, then `npx playwright test e2e/accessibility.spec.ts e2e/preview-context-menu.spec.ts` | Build and 12 Electron tests pass |
| Repeated light/dark contrast and 375px/767px home actions | `npx playwright test e2e/accessibility.spec.ts -g 'reported text\|home has named' --repeat-each=2` | 12/12 pass across both repetitions |
| CI scan reporting contract | `npx vitest run scripts/ci/accessibility-reporter.test.ts scripts/ci/run-accessibility-e2e.test.ts scripts/ci/pr-gate-workflow.test.ts`; `npm run test:e2e:accessibility:signal` | 47 tests pass; 11 Electron tests / 18 scan surfaces / 0 findings, exit 0 |
| Strict accessibility entrypoint after reporting update | `npm run test:e2e:accessibility` | 11 Electron tests pass |
| Renderer interfaces and source hygiene | `npm run typecheck`; `npm run lint`; Prettier on changed files; `git diff --check` | All pass |

Explicit impact-set command:

```sh
npx vitest run \
  src/renderer/src/pages/home/HomePage.render.test.tsx \
  src/renderer/src/pages/home/HomePage.persistence.test.tsx \
  src/renderer/src/pages/onboarding \
  src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx \
  src/renderer/src/pages/settings/file-browser-i18n.render.test.tsx \
  src/renderer/src/pages/settings/ComputePanel.render.test.tsx \
  src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx \
  src/renderer/src/pages/workspace/ProjectFilesView.test.tsx \
  src/renderer/src/pages/workspace/LocalFileBrowser.test.tsx \
  src/renderer/src/pages/workspace/EmptyConversationBanner.render.test.tsx \
  src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx \
  src/renderer/src/pages/workspace/workspace-tool-activity-style.test.ts \
  src/renderer/src/components/JobDetailModal.render.test.tsx \
  src/renderer/src/assets/diff-colors.test.ts \
  src/renderer/src/stores/theme-store.test.ts \
  src/renderer/src/i18n/resources.test.ts
```

Consumer coverage follows FileBrowserModal's ComputePanel/ProjectFilesView/JobDetailModal entry points and the AgentPanel/RuntimesPanel headings reused by onboarding. Shared text-token changes are checked on home, conversation, permission, settings, provenance and preview surfaces in Electron. No main/preload behavior changed, so no local backend or migration suite was added. The complete portable and platform suites remain PR CI's responsibility, as requested by the maintainer.

Behavior checks ran after the final product-code edit; the affected browser suite was rerun after the final test API typing correction. After the reporting-only follow-up, its 47 contract/workflow tests, both Electron accessibility entrypoints, full process typechecks and lint were rerun. Product source was unchanged in that follow-up. Local Electron evidence is macOS; DOM/axe assertions do not replace manual screen-reader speech checks or Windows/Linux CI.

## Review focus

Light-theme secondary-token consumers, keyboard/focus behavior across the nested menu and dialog, single-activation remote directory navigation, and preserving Settings heading defaults.
