### PR TITLE
fix(ui): clarify action feedback and enforce accessibility checks

### DIFF
--- a/e2e/accessibility-reporter.ts
+++ b/e2e/accessibility-reporter.ts
@@ -12,11 +12,14 @@ import { dirname, resolve } from 'node:path'
 const ACCESSIBILITY_SCAN_ATTACHMENT = 'accessibility-scan'
 const ACCESSIBILITY_UI_FINDING_ATTACHMENT = 'accessibility-ui-finding'
 const ACCESSIBILITY_UI_READY_ATTACHMENT = 'accessibility-ui-ready'
-const ACCESSIBILITY_ADVISORY = process.env.ACCESSIBILITY_ADVISORY === '1'
+const ACCESSIBILITY_COLLECT_ALL = process.env.ACCESSIBILITY_COLLECT_ALL === '1'
 const DEFAULT_RESULT_PATH = 'test-results/accessibility/accessibility-summary.json'
 const ACCESSIBILITY_SURFACES = [
   'Onboarding',
   'Home',
+  'Home (narrow)',
+  'Onboarding step focus',
+  'Go-to locations (open)',
   'New project dialog',
   'Workspace',
   'Settings',
@@ -112,13 +115,13 @@ const formatAccessibilitySummary = (
     `Result: **${heading}**`,
     '',
     `- axe scans completed: ${scans.length}`,
-    `- advisory findings: ${result.findings}`
+    `- blocking findings: ${result.findings}`
   ]
 
   if (result.status === 'infra-failure') {
     lines.push('', 'The real UI scan did not complete. Treat this as test infrastructure failure.')
   } else if (result.status === 'advisory') {
-    lines.push('', 'Findings are advisory and do not block this pull request.')
+    lines.push('', 'Findings block this pull request.')
     if (scans.some(({ violations }) => violations.length > 0)) {
       lines.push('', '### axe findings', '')
     }
@@ -202,7 +205,7 @@ class AccessibilityReporter implements Reporter {
           formatAccessibilitySummary(result, scans, uiFindings)
         )
       }
-      if (result.status === 'infra-failure') return { status: 'failed' }
+      if (result.status !== 'passed') return { status: 'failed' }
       return undefined
     } catch (error) {
       console.error('Failed to publish accessibility scan evidence.', error)
@@ -213,7 +216,7 @@ class AccessibilityReporter implements Reporter {
 
 export default AccessibilityReporter
 export {
-  ACCESSIBILITY_ADVISORY,
+  ACCESSIBILITY_COLLECT_ALL,
   ACCESSIBILITY_SCAN_ATTACHMENT,
   ACCESSIBILITY_SURFACES,
   ACCESSIBILITY_UI_FINDING_ATTACHMENT,

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path'
 import type { Locator, Page } from 'playwright'
 import { createProject, sendPrompt } from './certification/helpers'
 import {
-  ACCESSIBILITY_ADVISORY,
+  ACCESSIBILITY_COLLECT_ALL,
   ACCESSIBILITY_SCAN_ATTACHMENT,
   ACCESSIBILITY_UI_FINDING_ATTACHMENT,
   ACCESSIBILITY_UI_READY_ATTACHMENT,
@@ -54,7 +54,7 @@ const scanAccessibility = async (page: Page, surface: AccessibilitySurface): Pro
     body: JSON.stringify({ surface, violations: blocking } satisfies AccessibilityScan),
     contentType: 'application/json'
   })
-  if (!ACCESSIBILITY_ADVISORY) {
+  if (!ACCESSIBILITY_COLLECT_ALL) {
     expect(blocking, `${surface} has blocking axe violations`).toEqual([])
   }
 }
@@ -75,7 +75,7 @@ const expectKeyboardOutcome = async (
     await assertion()
     return true
   } catch (error) {
-    if (!ACCESSIBILITY_ADVISORY) throw error
+    if (!ACCESSIBILITY_COLLECT_ALL) throw error
     await page.evaluate(() => document.readyState)
     await recordAccessibilityFinding(
       surface,
@@ -130,7 +130,7 @@ const focusWithTab = async (page: Page, target: Locator, maxTabs = 80): Promise<
     if (await target.evaluate((element) => document.activeElement === element)) return true
     await page.keyboard.press('Tab')
   }
-  if (ACCESSIBILITY_ADVISORY) {
+  if (ACCESSIBILITY_COLLECT_ALL) {
     await recordAccessibilityFinding(
       'Keyboard focus order',
       `Keyboard focus did not reach ${await target.getAttribute('aria-label')}`
@@ -149,10 +149,22 @@ test('reports accessibility violations in startup and home surfaces', async ({ a
     app.page.getByRole('heading', { name: 'Set up your research workspace.' })
   ).toBeVisible()
   await scanAccessibility(app.page, 'Onboarding')
+  const continueButton = app.page.getByRole('button', { name: 'Continue', exact: true })
+  await expect(continueButton).toBeEnabled()
+  await continueButton.focus()
+  await continueButton.press('Enter')
+  const locationStep = app.page.getByRole('region', { name: 'Choose data location' })
+  await expect(locationStep).toBeVisible()
+  await expectKeyboardOutcome(app.page, 'Onboarding step focus', async () => {
+    await expect(locationStep.getByRole('heading', { level: 2 })).toBeFocused()
+  })
+  await scanAccessibility(app.page, 'Onboarding step focus')
 
   const page = await app.completeOnboarding()
   await expect(page.getByRole('region', { name: 'Projects' })).toBeVisible()
   await scanAccessibility(page, 'Home')
+  await setViewport(page, 390, 844)
+  await scanAccessibility(page, 'Home (narrow)')
 })
 
 test('reports accessibility violations in core dialog and workspace surfaces', async ({ app }) => {
@@ -267,6 +279,7 @@ test('reports accessibility violations across representative state combinations'
     .getByRole('tab', { name: 'Files' })
     .press('Delete')
 
+  await app.configureFileBrowserFixture()
   await page.getByRole('button', { name: 'Settings', exact: true }).click()
   const settings = page.getByRole('dialog', { name: 'Settings' })
   await settings
@@ -276,6 +289,19 @@ test('reports accessibility violations across representative state combinations'
   await expect(settings.getByRole('heading', { name: 'SSH hosts' })).toBeVisible()
   await setViewport(page, 767)
   await scanAccessibility(page, 'Compute settings (narrow, dark)')
+  await settings.getByRole('button', { name: 'Browse files on Accessibility fixture' }).click()
+  const goTo = page.getByRole('button', { name: 'Go to', exact: true })
+  await goTo.press('Enter')
+  const locations = page.getByRole('menu', { name: 'Go to', exact: true })
+  await expect(locations).toBeVisible()
+  await waitForFiniteAnimations(page)
+  await scanAccessibility(page, 'Go-to locations (open)')
+  await page.keyboard.press('Escape')
+  await expectKeyboardOutcome(page, 'Go-to Escape focus return', async () => {
+    await expect(locations).toBeHidden()
+    await expect(goTo).toBeFocused()
+  })
+  await page.keyboard.press('Escape')
   await settings.getByRole('button', { name: 'Close settings' }).click()
   await expect(settings).toBeHidden()
 
@@ -372,7 +398,7 @@ test('supports the core project journey with keyboard input only', async ({ app 
   const settingsFocusRestored = await settingsTrigger.evaluate(
     (element) => document.activeElement === element
   )
-  if (ACCESSIBILITY_ADVISORY && !settingsFocusRestored) {
+  if (ACCESSIBILITY_COLLECT_ALL && !settingsFocusRestored) {
     await recordAccessibilityFinding(
       'Keyboard focus restoration',
       'Closing settings did not restore focus to the settings trigger.'
@@ -426,7 +452,7 @@ for (const theme of ['Light', 'Dark'] as const) {
         contentType: 'application/json'
       })
       violations.push(...blockingViolations(result))
-      if (!ACCESSIBILITY_ADVISORY) expect.soft(result.violations, label).toEqual([])
+      if (!ACCESSIBILITY_COLLECT_ALL) expect.soft(result.violations, label).toEqual([])
       expect.soft(result.incomplete, `${label} must be measurable`).toEqual([])
     }
 

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -296,6 +296,18 @@ test('reports accessibility violations across representative state combinations'
   await expect(locations).toBeVisible()
   await waitForFiniteAnimations(page)
   await scanAccessibility(page, 'Go-to locations (open)')
+  const fileBrowser = page.getByRole('dialog', { name: 'Remote file browser' })
+  const removeBookmark = locations.getByRole('menuitem', {
+    name: 'Remove bookmark /scratch/fixture/pinned',
+    exact: true
+  })
+  await removeBookmark.click({ timeout: 5_000 })
+  await expect(fileBrowser).toBeVisible()
+  await goTo.press('Enter')
+  await expect(removeBookmark).toHaveCount(0)
+  await locations.getByRole('menuitem', { name: 'Home /home/fixture', exact: true }).click()
+  await expect(fileBrowser).toBeVisible()
+  await goTo.press('Enter')
   await page.keyboard.press('Escape')
   await expectKeyboardOutcome(page, 'Go-to Escape focus return', async () => {
     await expect(locations).toBeHidden()

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -156,7 +156,9 @@ test('reports accessibility violations in startup and home surfaces', async ({ a
   const locationStep = app.page.getByRole('region', { name: 'Choose data location' })
   await expect(locationStep).toBeVisible()
   await expectKeyboardOutcome(app.page, 'Onboarding step focus', async () => {
-    await expect(locationStep.getByRole('heading', { level: 2 })).toBeFocused()
+    await expect(
+      app.page.getByRole('heading', { name: 'Where should Open Science store your data?' })
+    ).toBeFocused()
   })
   await scanAccessibility(app.page, 'Onboarding step focus')
 
@@ -303,10 +305,14 @@ test('reports accessibility violations across representative state combinations'
   })
   await removeBookmark.click({ timeout: 5_000 })
   await expect(fileBrowser).toBeVisible()
+  await expect(locations).toBeHidden()
+  await expect(goTo).toBeFocused()
   await goTo.press('Enter')
   await expect(removeBookmark).toHaveCount(0)
   await locations.getByRole('menuitem', { name: 'Home /home/fixture', exact: true }).click()
   await expect(fileBrowser).toBeVisible()
+  await expect(locations).toBeHidden()
+  await expect(goTo).toBeFocused()
   await goTo.press('Enter')
   await page.keyboard.press('Escape')
   await expectKeyboardOutcome(page, 'Go-to Escape focus return', async () => {

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -121,6 +121,7 @@ type ElectronApp = {
     message: string
   } | null>
   completeOnboarding: () => Promise<Page>
+  configureFileBrowserFixture: () => Promise<void>
   configureFakeAgent: () => Promise<Page>
   createTestDirectory: (name: string) => Promise<string>
   enableFakeRemoteIt: () => Promise<Page>
@@ -495,6 +496,35 @@ class ElectronAppHarness implements ElectronApp {
     this.resourceProfiler = undefined
     profiler.detach()
     return profiler.finish()
+  }
+
+  // Keep real renderer/preload navigation while replacing the external SSH directory read.
+  // This isolated Electron process is disposed after the test, including its IPC handler.
+  async configureFileBrowserFixture(): Promise<void> {
+    await this.runningApplication.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler('compute:list-dir')
+      ipcMain.handle('compute:list-dir', () => ({
+        entries: [],
+        truncated: false,
+        roots: { home: '/home/fixture', scratch: '/scratch/fixture' },
+        resolvedPath: '/home/fixture'
+      }))
+    })
+    await this.page.evaluate(async () => {
+      const bridge = window as unknown as {
+        api: {
+          compute: {
+            create: (request: { sshAlias: string; displayName: string }) => Promise<unknown>
+            bookmarksSet: (providerId: string, paths: string[]) => Promise<unknown>
+          }
+        }
+      }
+      await bridge.api.compute.create({
+        sshAlias: 'a11y-fixture',
+        displayName: 'Accessibility fixture'
+      })
+      await bridge.api.compute.bookmarksSet('ssh:a11y-fixture', ['/scratch/fixture/pinned'])
+    })
   }
 
   async completeOnboarding(): Promise<Page> {

--- a/scripts/ci/accessibility-reporter.test.ts
+++ b/scripts/ci/accessibility-reporter.test.ts
@@ -141,7 +141,7 @@ describe('accessibility run classification', () => {
     })
   })
 
-  it('writes an advisory report without failing the Playwright run', async () => {
+  it('fails the Playwright run when complete evidence contains keyboard findings', async () => {
     const root = mkdtempSync(join(tmpdir(), 'accessibility-reporter-'))
     const previousResultPath = process.env.ACCESSIBILITY_RESULT_PATH
 
@@ -177,7 +177,9 @@ describe('accessibility run classification', () => {
         } as never
       )
 
-      await expect(reporter.onEnd({ status: 'passed' } as never)).resolves.toBeUndefined()
+      await expect(reporter.onEnd({ status: 'passed' } as never)).resolves.toEqual({
+        status: 'failed'
+      })
       expect(JSON.parse(readFileSync(resultPath, 'utf8'))).toMatchObject({
         status: 'advisory',
         axeRunCount: ACCESSIBILITY_SURFACES.length,
@@ -194,7 +196,7 @@ describe('accessibility run classification', () => {
 
 it('accepts complete evidence from the expanded responsive and contrast matrix', () => {
   const surfaces = [
-    ...ACCESSIBILITY_SURFACES.slice(0, 12),
+    ...ACCESSIBILITY_SURFACES.slice(0, 15),
     'Home (375px, light)',
     'Home (375px, dark)',
     'Home (767px, light)',

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -612,7 +612,7 @@ describe('PR Gate workflow', () => {
     })
   })
 
-  it('enables advisory accessibility signaling only in the macOS PR lane', () => {
+  it('runs complete accessibility collection in the macOS PR lane', () => {
     const macosStep = workflow.jobs.macos_e2e.steps?.find(
       ({ id }) => id === 'e2e_accessibility_macos'
     )

--- a/scripts/ci/run-accessibility-e2e.mjs
+++ b/scripts/ci/run-accessibility-e2e.mjs
@@ -10,6 +10,9 @@ const EXPECTED_TESTS = 11
 export const EXPECTED_ACCESSIBILITY_SURFACES = [
   'Onboarding',
   'Home',
+  'Home (narrow)',
+  'Onboarding step focus',
+  'Go-to locations (open)',
   'New project dialog',
   'Workspace',
   'Settings',
@@ -89,7 +92,8 @@ export function runAccessibilityE2e(environment = process.env) {
     {
       env: {
         ...environment,
-        ACCESSIBILITY_ADVISORY: '1',
+        // Collect every surface before the reporter fails the run for findings.
+        ACCESSIBILITY_COLLECT_ALL: '1',
         ACCESSIBILITY_RESULT_PATH: resultPath
       },
       stdio: 'inherit'
@@ -98,10 +102,10 @@ export function runAccessibilityE2e(environment = process.env) {
 
   if (run.error) throw run.error
   const result = readAccessibilityResult(resultPath)
-  if (run.status !== 0 && result.status !== 'infra-failure') {
-    throw new Error('Playwright failed after publishing a non-infrastructure accessibility result.')
+  if (run.status !== 0 && result.status === 'passed') {
+    throw new Error('Playwright failed after publishing a passing accessibility result.')
   }
-  return result.status === 'infra-failure' ? 1 : 0
+  return result.status === 'passed' && run.status === 0 ? 0 : 1
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/ci/run-accessibility-e2e.test.ts
+++ b/scripts/ci/run-accessibility-e2e.test.ts
@@ -1,13 +1,17 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   EXPECTED_ACCESSIBILITY_SURFACES,
   publishInfrastructureFailure,
-  readAccessibilityResult
+  readAccessibilityResult,
+  runAccessibilityE2e
 } from './run-accessibility-e2e.mjs'
+
+vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }))
 
 type CompleteResult = {
   schemaVersion: number
@@ -30,21 +34,64 @@ const completeResult = (status: 'passed' | 'advisory'): CompleteResult => ({
 })
 
 describe('accessibility E2E result contract', () => {
+  it.each([
+    ['passed', 0, 0],
+    ['advisory', 0, 1],
+    ['advisory', 1, 1],
+    ['infra-failure', 1, 1]
+  ] as const)(
+    'returns %s findings with process status %s as exit %s',
+    (status, processStatus, expected) => {
+      const root = mkdtempSync(join(tmpdir(), 'accessibility-exit-'))
+      const resultPath = join(root, 'summary.json')
+      vi.mocked(spawnSync).mockImplementation((_command, _args, options) => {
+        expect(options?.env?.ACCESSIBILITY_COLLECT_ALL).toBe('1')
+        expect(options?.env?.ACCESSIBILITY_ADVISORY).toBeUndefined()
+        writeFileSync(resultPath, JSON.stringify({ ...completeResult('passed'), status }))
+        return { status: processStatus } as ReturnType<typeof spawnSync>
+      })
+      try {
+        expect(runAccessibilityE2e({ ACCESSIBILITY_RESULT_PATH: resultPath })).toBe(expected)
+        expect(JSON.parse(readFileSync(resultPath, 'utf8')).status).toBe(status)
+      } finally {
+        vi.mocked(spawnSync).mockReset()
+        rmSync(root, { force: true, recursive: true })
+      }
+    }
+  )
+
   it.each(['passed', 'advisory'] as const)('accepts a versioned %s result', (status) => {
     const root = mkdtempSync(join(tmpdir(), 'accessibility-result-'))
     const path = join(root, 'summary.json')
 
     try {
       writeFileSync(path, JSON.stringify(completeResult(status)))
-      expect(readAccessibilityResult(path)).toMatchObject({ status, axeRunCount: 18 })
+      expect(readAccessibilityResult(path)).toMatchObject({
+        status,
+        axeRunCount: EXPECTED_ACCESSIBILITY_SURFACES.length
+      })
     } finally {
       rmSync(root, { force: true, recursive: true })
     }
   })
 
   it.each([
-    { name: 'stale schema', result: { schemaVersion: 0, status: 'passed', axeRunCount: 12 } },
-    { name: 'unknown status', result: { schemaVersion: 1, status: 'unknown', axeRunCount: 12 } },
+    {
+      name: 'stale schema',
+      result: {
+        schemaVersion: 0,
+        status: 'passed',
+        axeRunCount: EXPECTED_ACCESSIBILITY_SURFACES.length
+      }
+    },
+    {
+      name: 'unknown status',
+      result: {
+        schemaVersion: 1,
+        status: 'unknown',
+        axeRunCount: EXPECTED_ACCESSIBILITY_SURFACES.length
+      }
+    },
     { name: 'missing axe count', result: { schemaVersion: 1, status: 'passed' } },
     { name: 'zero axe evidence', result: { ...completeResult('passed'), axeRunCount: 0 } },
     { name: 'missing surface evidence', result: { ...completeResult('passed'), scans: [] } },
@@ -91,7 +138,7 @@ it('accepts complete evidence from the expanded responsive and contrast matrix',
   const root = mkdtempSync(join(tmpdir(), 'accessibility-expanded-'))
   const path = join(root, 'summary.json')
   const surfaces = [
-    ...EXPECTED_ACCESSIBILITY_SURFACES.slice(0, 12),
+    ...EXPECTED_ACCESSIBILITY_SURFACES.slice(0, 15),
     'Home (375px, light)',
     'Home (375px, dark)',
     'Home (767px, light)',
@@ -114,7 +161,7 @@ it('accepts complete evidence from the expanded responsive and contrast matrix',
     expect(readAccessibilityResult(path)).toMatchObject({
       status: 'passed',
       plannedTests: 11,
-      axeRunCount: 18
+      axeRunCount: 21
     })
   } finally {
     rmSync(root, { force: true, recursive: true })

--- a/src/renderer/src/components/DataRootWarning.tsx
+++ b/src/renderer/src/components/DataRootWarning.tsx
@@ -16,7 +16,7 @@ const DataRootWarning = (): React.JSX.Element => {
       className="flex items-start gap-2 rounded-lg border border-session-waiting/40 bg-session-waiting/10 px-3 py-2 text-xs text-session-waiting"
     >
       <TriangleAlert className="mt-px size-3.5 shrink-0" aria-hidden="true" />
-      <span>
+      <span className="text-text-000">
         {t(
           "{{appName}} manages this folder. Don't move, rename, or delete files inside it — doing so can break your projects and history.",
           { appName: APP.name }

--- a/src/renderer/src/components/JobDetailModal.render.test.tsx
+++ b/src/renderer/src/components/JobDetailModal.render.test.tsx
@@ -215,6 +215,9 @@ describe('JobDetailModal — detail view', () => {
     await act(async () => retry?.click())
 
     expect(container.textContent).toContain('Unable to cancel remote job.')
+    expect(container.querySelector('[role="alert"]')?.textContent).not.toContain(
+      'cancel unavailable'
+    )
     expect(jobsCancel).toHaveBeenCalledTimes(2)
   })
 

--- a/src/renderer/src/hooks/useProjectFormDialog.test.tsx
+++ b/src/renderer/src/hooks/useProjectFormDialog.test.tsx
@@ -165,7 +165,8 @@ describe('useProjectFormDialog', () => {
     await act(async () => submitForm(hook.current()))
 
     expect(hook.current().dialogProps.open).toBe(true)
-    expect(hook.current().dialogProps.error).toBe('database is locked')
+    expect(hook.current().dialogProps.error).toBe('Could not save project. Please try again.')
+    expect(hook.current().dialogProps.errorDetail).toBe('database is locked')
     expect(hook.current().dialogProps.isSubmitting).toBe(false)
     expect(openProject).not.toHaveBeenCalled()
     hook.unmount()
@@ -245,7 +246,7 @@ describe('useProjectFormDialog', () => {
     await act(async () => submitForm(hook.current()))
 
     expect(hook.current().dialogProps.open).toBe(true)
-    expect(hook.current().dialogProps.error).toBe('Could not save project.')
+    expect(hook.current().dialogProps.error).toBe('Could not save project. Please try again.')
     expect(hook.current().dialogProps.isSubmitting).toBe(false)
     expect(openProject).not.toHaveBeenCalled()
     hook.unmount()
@@ -259,7 +260,7 @@ describe('useProjectFormDialog', () => {
     await act(async () => submitForm(hook.current()))
 
     expect(hook.current().dialogProps.open).toBe(true)
-    expect(hook.current().dialogProps.error).toBe('Could not save project.')
+    expect(hook.current().dialogProps.error).toBe('Could not save project. Please try again.')
     expect(hook.current().dialogProps.isSubmitting).toBe(false)
     expect(openProject).not.toHaveBeenCalled()
     hook.unmount()

--- a/src/renderer/src/hooks/useProjectFormDialog.ts
+++ b/src/renderer/src/hooks/useProjectFormDialog.ts
@@ -19,6 +19,7 @@ type ProjectFormDialogProps = {
   agentContextDraft: string
   isSubmitting: boolean
   error: string | undefined
+  errorDetail?: string
   onNameChange: (value: string) => void
   onDescriptionChange: (value: string) => void
   onAgentContextChange: (value: string) => void
@@ -46,6 +47,7 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
   const [descriptionDraft, setDescriptionDraft] = useState('')
   const [agentContextDraft, setAgentContextDraft] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorDetail, setErrorDetail] = useState<string>()
   const [formError, setFormError] = useState<string | undefined>(undefined)
 
   const openCreateDialog = useCallback((): void => {
@@ -57,6 +59,7 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
     setDescriptionDraft('')
     setAgentContextDraft('')
     setFormError(undefined)
+    setErrorDetail(undefined)
   }, [isSubmitting])
 
   const openEditDialog = useCallback(
@@ -73,6 +76,7 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
       setDescriptionDraft(project.description)
       setAgentContextDraft(project.agentContext ?? '')
       setFormError(undefined)
+      setErrorDetail(undefined)
     },
     [isSubmitting]
   )
@@ -98,6 +102,7 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
 
     setIsSubmitting(true)
     setFormError(undefined)
+    setErrorDetail(undefined)
 
     const request = isCreate
       ? createProject({ name, description, agentContext })
@@ -114,7 +119,7 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
         // The store resolves undefined when the IPC layer returns no project row; surface that
         // instead of silently swallowing the save.
         if (!project) {
-          setFormError(t('Could not save project.'))
+          setFormError(t('Could not save project. Please try again.'))
           return
         }
 
@@ -123,12 +128,11 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
         if (isCreate) openProject(project.id, 'user')
       })
       .catch((error: unknown) => {
+        setErrorDetail(error instanceof Error ? error.message : String(error))
         setFormError(
           error instanceof Error && error.message === 'Project changed elsewhere.'
             ? t('Project changed elsewhere. Reopen Project Settings and try again.')
-            : error instanceof Error
-              ? error.message
-              : t('Could not save project.')
+            : t('Could not save project. Please try again.')
         )
       })
       .finally(() => {
@@ -147,12 +151,19 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
       description: isEdit
         ? t("Update this project's name, description, and agent context.")
         : t('Group related sessions under a project. You can rename it later.'),
-      submitLabel: isEdit ? t('Save') : t('Create project'),
+      submitLabel: isSubmitting
+        ? isEdit
+          ? t('Saving…')
+          : t('Creating…')
+        : isEdit
+          ? t('Save')
+          : t('Create project'),
       nameDraft,
       descriptionDraft,
       agentContextDraft,
       isSubmitting,
       error: formError,
+      errorDetail,
       onNameChange: setNameDraft,
       onDescriptionChange: setDescriptionDraft,
       onAgentContextChange: setAgentContextDraft,

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -219,7 +219,8 @@ describe('HomePage persistence recovery', () => {
       (button) => button.textContent?.trim() === 'Archive'
     )
     expect(archive?.disabled).toBe(true)
-    expect(archive?.title).toBe('Update Open Science before archiving this project.')
+    expect(archive?.title).toBe('')
+    expect(container.textContent).toContain('Update Open Science before archiving this project.')
   })
 
   it('maps a raced incomplete-catalog archive rejection to index repair guidance', async () => {

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -613,7 +613,7 @@ describe('HomePage activity overview', () => {
     expect(document.body.textContent).not.toContain('Save changes')
   })
 
-  it('disables Project archive while any current delegated Attempt is running', async () => {
+  it('explains unavailable archive in menu content without relying on native title', async () => {
     useProjectStore.setState({
       ...createInitialProjectState(),
       projects: [project],
@@ -644,8 +644,11 @@ describe('HomePage activity overview', () => {
 
     const archiveItem = Array.from(
       document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
-    ).find((item) => item.textContent?.trim() === 'Archive')
+    ).find((item) => item.textContent?.trim().startsWith('Archive'))
     expect(archiveItem?.getAttribute('aria-disabled')).toBe('true')
+    expect(document.body.querySelector('[role="menu"]')?.textContent).toContain(
+      'Finish or stop active sessions before archiving this project.'
+    )
   })
 
   it('pins and unpins a Project from the first menu action', async () => {

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -702,6 +702,7 @@ const HomePage = ({
               variant="outline"
               size="sm"
               className="h-8 gap-1 rounded-md px-3 text-xs"
+              aria-label={t('New project')}
               onClick={openCreateDialog}
               aria-label={t('New project')}
             >
@@ -1017,7 +1018,11 @@ const HomePage = ({
                             disabled={
                               !canArchiveProject(project) || archivingProjectIds.has(project.id)
                             }
-                            title={archiveUnavailableReason(project)}
+                            aria-describedby={
+                              archiveUnavailableReason(project)
+                                ? `archive-reason-${project.id}`
+                                : undefined
+                            }
                             onSelect={() => archiveProject(project)}
                           >
                             <Archive className="size-4" strokeWidth={2} aria-hidden="true" />
@@ -1026,20 +1031,34 @@ const HomePage = ({
                               ? t('Archiving…')
                               : t('Archive', { context: 'verb' })}
                           </DropdownMenuItem>
+                          {archiveUnavailableReason(project) ? (
+                            <p
+                              id={`archive-reason-${project.id}`}
+                              className="max-w-64 px-2 pb-2 text-xs text-muted-foreground"
+                            >
+                              {archiveUnavailableReason(project)}
+                            </p>
+                          ) : null}
                           <DropdownMenuSeparator />
                           <DropdownMenuItem
                             className="gap-2 text-danger-000 data-[highlighted]:bg-danger-900 data-[highlighted]:text-danger-000"
                             disabled={!canDeleteProjects}
-                            title={
-                              canDeleteProjects
-                                ? undefined
-                                : t('Retry project recovery before deleting projects.')
+                            aria-describedby={
+                              !canDeleteProjects ? `delete-reason-${project.id}` : undefined
                             }
                             onSelect={() => openDeleteDialog(project)}
                           >
                             <Trash2 className="size-4" strokeWidth={2} aria-hidden="true" />
                             {t('Delete')}
                           </DropdownMenuItem>
+                          {!canDeleteProjects ? (
+                            <p
+                              id={`delete-reason-${project.id}`}
+                              className="max-w-64 px-2 pb-2 text-xs text-muted-foreground"
+                            >
+                              {t('Retry project recovery before deleting projects.')}
+                            </p>
+                          ) : null}
                         </DropdownMenuContent>
                       </DropdownMenu>
                     </div>

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -702,7 +702,6 @@ const HomePage = ({
               variant="outline"
               size="sm"
               className="h-8 gap-1 rounded-md px-3 text-xs"
-              aria-label={t('New project')}
               onClick={openCreateDialog}
               aria-label={t('New project')}
             >

--- a/src/renderer/src/pages/home/ProjectFormDialog.behavior.test.tsx
+++ b/src/renderer/src/pages/home/ProjectFormDialog.behavior.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Project } from '../../../../shared/projects'
+import { useProjectFormDialog } from '@/hooks/useProjectFormDialog'
+import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
+import { ProjectFormDialog } from './ProjectFormDialog'
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Research',
+  description: '',
+  isExample: false,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const Harness = (): React.JSX.Element => {
+  const form = useProjectFormDialog()
+  return (
+    <>
+      <button onClick={form.openCreateDialog}>Create fixture</button>
+      <button onClick={() => form.openEditDialog(project)}>Edit fixture</button>
+      <ProjectFormDialog {...form.dialogProps} />
+    </>
+  )
+}
+
+beforeEach(() => useProjectStore.setState(createInitialProjectState()))
+afterEach(cleanup)
+
+describe('project form public submission behavior', () => {
+  it.each(['create', 'edit'] as const)(
+    'exposes pending %s and disables unavailable exits',
+    async (mode) => {
+      let reject!: (error: Error) => void
+      const request = vi.fn(
+        () =>
+          new Promise<Project>((_resolve, rejectPromise) => {
+            reject = rejectPromise
+          })
+      )
+      Object.defineProperty(window, 'api', {
+        configurable: true,
+        value: { projects: { create: request, update: request } }
+      })
+      render(<Harness />)
+      fireEvent.click(screen.getByText(mode === 'create' ? 'Create fixture' : 'Edit fixture'))
+      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Research' } })
+      const submit = screen.getByRole('button', {
+        name: mode === 'create' ? 'Create project' : 'Save'
+      }) as HTMLButtonElement
+      fireEvent.click(submit)
+      expect(request).toHaveBeenCalledOnce()
+      try {
+        expect
+          .soft((screen.getByRole('button', { name: 'Close' }) as HTMLButtonElement).disabled)
+          .toBe(true)
+        expect
+          .soft((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled)
+          .toBe(true)
+        expect.soft(submit.closest('form')?.getAttribute('aria-busy')).toBe('true')
+        expect.soft(submit.textContent).toBe(mode === 'create' ? 'Creating…' : 'Saving…')
+        expect.soft(submit.querySelector('svg')).not.toBeNull()
+      } finally {
+        await act(async () => reject(new Error('database is locked')))
+      }
+      expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(
+        false
+      )
+      expect(screen.getByLabelText('Name').getAttribute('value')).toBe('Research')
+    }
+  )
+
+  it('keeps a failed create actionable and puts raw errors in collapsed diagnostics', async () => {
+    const raw = "Error invoking remote method 'projects:create': SQLITE_BUSY: database is locked"
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { projects: { create: vi.fn().mockRejectedValue(new Error(raw)) } }
+    })
+    render(<Harness />)
+    fireEvent.click(screen.getByText('Create fixture'))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Research' } })
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Create project' })))
+    const alert = screen.getByRole('alert')
+    expect.soft(alert.textContent).toMatch(/Could not.*project.*try again/i)
+    expect.soft(alert.textContent).not.toContain('SQLITE_BUSY')
+    const detail = screen.getByText(raw).closest('details')
+    expect.soft(detail).not.toBeNull()
+    expect.soft(detail?.open).toBe(false)
+    expect(
+      (screen.getByRole('button', { name: 'Create project' }) as HTMLButtonElement).disabled
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/pages/home/ProjectFormDialog.tsx
+++ b/src/renderer/src/pages/home/ProjectFormDialog.tsx
@@ -1,7 +1,8 @@
-import { X } from 'lucide-react'
+import { LoaderCircle, X } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 import { useTranslation } from 'react-i18next'
 
+import { DiagnosticDetails } from '@/components/diagnostic-details'
 import { Button } from '@/components/ui/button'
 import {
   dialogBodyClassName,
@@ -34,6 +35,7 @@ type ProjectFormDialogProps = {
   agentContextDraft: string
   isSubmitting: boolean
   error: string | undefined
+  errorDetail?: string
   onNameChange: (value: string) => void
   onDescriptionChange: (value: string) => void
   onAgentContextChange: (value: string) => void
@@ -53,6 +55,7 @@ const ProjectFormDialog = ({
   agentContextDraft,
   isSubmitting,
   error,
+  errorDetail,
   onNameChange,
   onDescriptionChange,
   onAgentContextChange,
@@ -79,7 +82,7 @@ const ProjectFormDialog = ({
           onInteractOutside={(event) => event.preventDefault()}
           className={dialogPanelClassName('w-[min(460px,calc(100vw-2rem))] p-0')}
         >
-          <form onSubmit={onConfirm}>
+          <form onSubmit={onConfirm} aria-busy={isSubmitting}>
             <div className={dialogHeaderClassName}>
               <div className="min-w-0">
                 <Dialog.Title className={dialogTitleClassName}>{dialogTitle}</Dialog.Title>
@@ -92,6 +95,7 @@ const ProjectFormDialog = ({
                 aria-label={t('Close')}
                 className={dialogCloseButtonClassName}
                 onClick={onCancel}
+                disabled={isSubmitting}
               >
                 <X className="size-4" aria-hidden="true" />
               </Button>
@@ -160,16 +164,28 @@ const ProjectFormDialog = ({
                 {error}
               </p>
             ) : null}
+            {errorDetail ? (
+              <div className="px-5 pb-4">
+                <DiagnosticDetails detail={errorDetail} />
+              </div>
+            ) : null}
             <div className={dialogFooterClassName}>
               <Button
                 type="button"
                 variant="ghost"
                 className={dialogCancelButtonClassName}
                 onClick={onCancel}
+                disabled={isSubmitting}
               >
                 {t('Cancel')}
               </Button>
               <Button type="submit" disabled={nameDraft.trim().length === 0 || isSubmitting}>
+                {isSubmitting ? (
+                  <LoaderCircle
+                    className="size-4 animate-spin motion-reduce:animate-none"
+                    aria-hidden="true"
+                  />
+                ) : null}
                 {dialogSubmitLabel}
               </Button>
             </div>

--- a/src/renderer/src/pages/onboarding/LocationStep.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.tsx
@@ -213,7 +213,7 @@ const LocationStep = ({
           ) : null}
 
           <div className="rounded-xl border border-border-200 p-4">
-            <span className="text-xs font-medium text-text-100">{t('Location')}</span>
+            <span className="text-xs font-medium text-text-000">{t('Location')}</span>
             <div className="mt-1 flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
               <p
                 aria-label={t('Data location path')}

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -64,6 +64,18 @@ describe('OnboardingWizard flow', () => {
     expect(layout?.className).toContain('md:grid-cols-[240px_minmax(0,1fr)]')
   })
 
+  it('moves focus into the new step after Continue', async () => {
+    readyClaudeState()
+    await renderWizard()
+    const continueButton = findButton(/^continue$/i)
+    continueButton?.focus()
+    expect(document.activeElement).toBe(continueButton)
+    await clickButton(/^continue$/i)
+    const location = currentSection('Choose data location')
+    expect(location).not.toBeNull()
+    expect(location?.contains(document.activeElement)).toBe(true)
+  })
+
   it('walks all five steps forward in order, tracking progress', async () => {
     readyClaudeState()
 

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -64,18 +64,6 @@ describe('OnboardingWizard flow', () => {
     expect(layout?.className).toContain('md:grid-cols-[240px_minmax(0,1fr)]')
   })
 
-  it('moves focus into the new step after Continue', async () => {
-    readyClaudeState()
-    await renderWizard()
-    const continueButton = findButton(/^continue$/i)
-    continueButton?.focus()
-    expect(document.activeElement).toBe(continueButton)
-    await clickButton(/^continue$/i)
-    const location = currentSection('Choose data location')
-    expect(location).not.toBeNull()
-    expect(location?.contains(document.activeElement)).toBe(true)
-  })
-
   it('walks all five steps forward in order, tracking progress', async () => {
     readyClaudeState()
 

--- a/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { fireEvent, getByRole, waitFor } from '@testing-library/react'
+import { fireEvent, screen, getByRole, waitFor } from '@testing-library/react'
 import axe from 'axe-core'
+import { openRadixMenu, clickRadixMenuItem } from './test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComputeHost } from '../../../../shared/compute'
@@ -534,14 +535,29 @@ describe('FileBrowserModal', () => {
     const goToButton = document.querySelector('[aria-haspopup=menu]') as
       HTMLButtonElement | undefined
     await act(async () => {
-      fireEvent.keyDown(goToButton!, { key: 'Enter' })
+      openRadixMenu(goToButton)
     })
 
     expect(document.body.textContent).toContain('/scratch/b/pinned')
     expect(document.body.textContent).not.toContain('/scratch/a/pinned')
   })
 
-  it('shows an inline error when bookmarks fail to load', async () => {
+  it('exposes valid accessibility semantics while Go-to locations are open', async () => {
+    await act(async () => {
+      root.render(<FileBrowserModal open onClose={vi.fn()} initialProviderId="ssh:biowulf" />)
+    })
+    const trigger = screen.getByRole('button', { name: 'Go to' })
+    await act(async () => openRadixMenu(trigger))
+    expect(screen.getByText('Pin current folder')).toBeDefined()
+    const result = await axe.run(document.body, {
+      runOnly: { type: 'rule', values: ['aria-required-attr', 'aria-required-children'] }
+    })
+    expect(
+      result.violations.map(({ id, nodes }) => ({ id, targets: nodes.map(({ target }) => target) }))
+    ).toEqual([])
+  })
+
+  it('keeps bookmark diagnostics collapsed after load fails', async () => {
     setComputeApi({
       listDir: vi.fn().mockResolvedValue(mockListing),
       bookmarksGet: vi.fn().mockRejectedValue(new Error('Bookmark service unavailable')),
@@ -556,7 +572,11 @@ describe('FileBrowserModal', () => {
     })
 
     expect(document.body.textContent).toContain("Couldn't load bookmarks.")
-    expect(document.body.textContent).toContain('Bookmark service unavailable')
+    const details = Array.from(document.querySelectorAll('details')).find((element) =>
+      element.textContent?.includes('Bookmark service unavailable')
+    )
+    expect(details).toBeDefined()
+    expect(details?.open).toBe(false)
   })
 
   it('restores bookmarks and shows an inline error when saving fails', async () => {
@@ -575,13 +595,13 @@ describe('FileBrowserModal', () => {
     const goToButton = document.querySelector('[aria-haspopup=menu]') as
       HTMLButtonElement | undefined
     await act(async () => {
-      fireEvent.keyDown(goToButton!, { key: 'Enter' })
+      openRadixMenu(goToButton)
     })
-    const pinButton = Array.from(document.querySelectorAll('[role=menuitem]')).find((element) =>
-      element.textContent?.includes('Pin current folder')
+    const pinButton = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+      (element) => element.textContent?.includes('Pin current folder')
     ) as HTMLButtonElement | undefined
     await act(async () => {
-      pinButton?.click()
+      clickRadixMenuItem(pinButton)
       await Promise.resolve()
     })
 
@@ -606,13 +626,15 @@ describe('FileBrowserModal', () => {
     const goToButton = document.querySelector('[aria-haspopup=menu]') as
       HTMLButtonElement | undefined
     await act(async () => {
-      fireEvent.keyDown(goToButton!, { key: 'Enter' })
+      openRadixMenu(goToButton)
     })
-    const removeButton = Array.from(document.querySelectorAll('[role=menuitem]')).find(
+    const removeButton = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find(
       (element) => element.getAttribute('aria-label') === 'Remove bookmark /scratch/user/pinned'
     ) as HTMLButtonElement | undefined
     await act(async () => {
-      removeButton?.click()
+      clickRadixMenuItem(removeButton)
       await Promise.resolve()
     })
 

--- a/src/renderer/src/pages/settings/FileBrowserModal.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.tsx
@@ -34,6 +34,7 @@ import { formatDisplayDateTime } from '@/lib/locale-format'
 import type { DirListing, RemoteDirEntry } from '../../../../shared/remote-fs'
 import type { ComputeAuthenticationErrorCode } from '../../../../shared/compute'
 import { resolveRemotePath, validateRemotePath } from '../../../../shared/remote-fs'
+import { DiagnosticDetails } from '@/components/diagnostic-details'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -857,7 +858,10 @@ export function FileBrowserModal({
                 >
                   <div className={'flex-1'}>
                     <p className={'font-semibold'}>{bookmarksState.summary}</p>
-                    <p className={'mt-0.5 text-muted-foreground'}>{bookmarksState.detail}</p>
+                    <p className="mt-0.5 text-muted-foreground">
+                      {t('Close the file browser and open it again to retry.')}
+                    </p>
+                    <DiagnosticDetails detail={bookmarksState.detail} />
                   </div>
                 </div>
               )}

--- a/src/renderer/src/pages/settings/file-browser-i18n.render.test.tsx
+++ b/src/renderer/src/pages/settings/file-browser-i18n.render.test.tsx
@@ -2,8 +2,8 @@
 // Locale coverage for FileBrowserModal: chrome, listing columns, error banner, detail panel and
 // the download success banner must all follow the active language — including text that was
 // produced by an earlier event and is only rendered later (see the language-switch cases).
+import { openRadixMenu } from './test-utils'
 import { act } from 'react'
-import { fireEvent } from '@testing-library/react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -96,7 +96,7 @@ const selectFile = async (name: string): Promise<void> => {
 const openGoTo = async (): Promise<void> => {
   const trigger = document.body.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]')
   await act(async () => {
-    fireEvent.keyDown(trigger!, { key: 'Enter' })
+    openRadixMenu(trigger)
   })
 }
 

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -217,7 +217,7 @@ const ComposerModelPicker = ({
                   <>
                     {/* The model name alone ellipsizes under the trigger's max width; the effort
                         suffix is the newer signal and stays fully visible. */}
-                    <span className="truncate font-medium text-text-100">
+                    <span className="truncate font-medium text-text-000">
                       {optionLabel(displayCurrent)}
                     </span>
                     {effortSuffixLabel ? (

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -63,6 +63,7 @@ import {
 } from '../../../../shared/annotations'
 
 import { FileDropOverlay } from '@/components/FileDropOverlay'
+import { DiagnosticDetails } from '@/components/diagnostic-details'
 import { ErrorNotice } from '@/components/error-notice'
 import { RemoteJobBadge } from '@/components/RemoteJobBadge'
 import { Button } from '@/components/ui/button'
@@ -436,6 +437,7 @@ const ConversationPanel = ({
       attachments,
       transfers: attachmentTransfers,
       error: composerError,
+      errorDetail: composerErrorDetail,
       historyStatus,
       isHistoryBrowsing,
       isUploading: isUploadingAttachments,
@@ -1108,6 +1110,9 @@ const ConversationPanel = ({
                   >
                     <ErrorNotice icon={AlertTriangle} tone="red" title={composerError} />
                   </div>
+                ) : null}
+                {composerError && composerErrorDetail ? (
+                  <DiagnosticDetails detail={composerErrorDetail} />
                 ) : null}
                 {/* Interrupted sessions get a neutral banner with a Resume action instead of the
                     red error box, so the user can re-attach and continue the interrupted turn. */}

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -590,7 +590,7 @@ const ManagedVersionNavigation = ({
       >
         <ChevronLeft aria-hidden="true" />
       </Button>
-      <span className="min-w-8 text-center text-xs font-medium text-text-100">
+      <span className="min-w-8 text-center text-xs font-medium text-text-000">
         v{inspect.selectedVersion?.versionNumber ?? inspect.versions[selectedIndex]?.versionNumber}
       </span>
       <Button

--- a/src/renderer/src/pages/workspace/WorkspaceToolActivityRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolActivityRow.tsx
@@ -29,7 +29,9 @@ const WorkspaceToolActivityRow = ({
       <span className="mt-0.5 inline-flex shrink-0 items-center md:mt-0">
         <WorkspaceActivityIcon activity={activity} phase={phase} />
       </span>
-      <span className="min-w-0 flex-1 truncate text-left">
+      <span
+        className={`min-w-0 flex-1 truncate text-left ${phase === 'declined' ? 'text-text-000' : ''}`}
+      >
         {formatActivityTitle(activity, phase, t)}
       </span>
     </div>

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -569,8 +569,12 @@ describe('workspace composer controller', () => {
 
     expect(hook.result.current.view.attachments).toEqual([])
     expect(hook.result.current.view.transfers).toEqual([
-      expect.objectContaining({ status: 'error', error: 'claim failed' })
+      expect.objectContaining({
+        status: 'error',
+        error: 'Could not attach the file. Check available storage and try again.'
+      })
     ])
+    expect(hook.result.current.view.errorDetail).toBe('claim failed')
     expect(uploadApi.abortTransfer).toHaveBeenCalledWith({ transferId: expect.any(String) })
   })
 
@@ -1190,7 +1194,7 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.transfers[0]).toMatchObject({
       name: 'paper.pdf',
       status: 'error',
-      error: 'disk full'
+      error: 'Could not attach the file. Check available storage and try again.'
     })
 
     act(() => expect(hook.result.current.actions.undo()).toBe(true))
@@ -1200,7 +1204,7 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.transfers[0]).toMatchObject({
       name: 'paper.pdf',
       status: 'error',
-      error: 'disk full'
+      error: 'Could not attach the file. Check available storage and try again.'
     })
     expect(stageLocalFile).toHaveBeenCalledOnce()
   })
@@ -1618,7 +1622,7 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.caretRequest).toBeUndefined()
   })
 
-  it('restores the original text inline when staging a converted paste fails', async () => {
+  it('shows an actionable summary after attachment staging fails', async () => {
     const hook = renderController(uploads(vi.fn().mockRejectedValue(new Error('disk full'))))
     mounted.push(hook)
     const node: ComposerPastedTextNode = {
@@ -1633,7 +1637,8 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.transfers).toEqual([])
     expect(hook.result.current.view.doc).toEqual(textDoc('before payload after'))
     expect(hook.result.current.view.attachments).toEqual([])
-    expect(hook.result.current.view.error).toBe('disk full')
+    expect(hook.result.current.view.error).not.toBe('disk full')
+    expect(hook.result.current.view.error).toMatch(/try again|storage|space/i)
     act(() => expect(hook.result.current.actions.undo()).toBe(true))
     expect(hook.result.current.view.doc).toEqual(emptyDoc)
   })

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -120,6 +120,7 @@ type WorkspaceComposerController = {
     attachments: UploadedAttachment[]
     transfers: ComposerUploadTransfer[]
     error: string | null
+    errorDetail?: string
     historyStatus: string
     isHistoryBrowsing: boolean
     isUploading: boolean
@@ -277,7 +278,7 @@ const useWorkspaceComposerController = ({
     automaticReadingEnabledRef,
     setActiveAutomaticReadingEnabled
   })
-  const { attachments, transfers, error, isUploading } = uploadController.view
+  const { attachments, transfers, error, errorDetail, isUploading } = uploadController.view
   const {
     changeDoc,
     stageFiles,
@@ -1097,6 +1098,7 @@ const useWorkspaceComposerController = ({
       attachments,
       transfers,
       error,
+      errorDetail,
       historyStatus,
       isHistoryBrowsing: historyBrowsingKey === currentDraftKey,
       isUploading,

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { VISION_MODEL_NOT_CONFIGURED_MESSAGE } from '../../../../shared/run-error-classification'
@@ -79,6 +80,7 @@ type WorkspaceComposerUploadController = {
     attachments: UploadedAttachment[]
     transfers: ComposerUploadTransfer[]
     error: string | null
+    errorDetail?: string
     isUploading: boolean
   }
   actions: {
@@ -159,7 +161,13 @@ export const useWorkspaceComposerUploadController = ({
 }: WorkspaceComposerUploadControllerInput): WorkspaceComposerUploadController => {
   const [attachments, setAttachments] = useState<UploadedAttachment[]>([])
   const [transfers, setTransfers] = useState<ComposerUploadTransfer[]>([])
-  const [error, setError] = useState<string | null>(null)
+  const { t } = useTranslation()
+  const [error, setErrorText] = useState<string | null>(null)
+  const [errorDetail, setErrorDetail] = useState<string>()
+  const setError = useCallback((message: string | null): void => {
+    setErrorText(message)
+    setErrorDetail(undefined)
+  }, [])
   const attachmentsRef = useRef(attachments)
   const transfersRef = useRef<ComposerUploadTransfer[]>([])
   const controllersRef = useRef<Record<string, AbortController>>({})
@@ -242,7 +250,7 @@ export const useWorkspaceComposerUploadController = ({
         (deleteError) => setError(asText(deleteError))
       )
     },
-    [uploads]
+    [uploads, setError]
   )
   const currentSnapshot = useCallback(
     (caret?: ComposerCaretPosition): ComposerHistorySnapshot => {
@@ -620,7 +628,7 @@ export const useWorkspaceComposerUploadController = ({
             if (controller.signal.aborted) {
               updateTransfer({ remove: true })
             } else {
-              const message = asText(uploadError)
+              const message = t('Could not attach the file. Check available storage and try again.')
               if (transfer.pastedTextId) {
                 updateTransfer({ remove: true })
                 reconcileFailedPastedTextUndo(draftKey, transfer.pastedTextId, transfer.transferId)
@@ -629,7 +637,10 @@ export const useWorkspaceComposerUploadController = ({
                 updateTransfer({ status: 'error', error: message })
               }
               delete transferFilesRef.current[transfer.transferId]
-              if (activeDraftKeyRef.current === draftKey) setError(message)
+              if (activeDraftKeyRef.current === draftKey) {
+                setError(message)
+                setErrorDetail(asText(uploadError))
+              }
             }
           } finally {
             delete controllersRef.current[transfer.transferId]
@@ -644,7 +655,9 @@ export const useWorkspaceComposerUploadController = ({
       restorePastedTextInline,
       reconcileFailedPastedTextUndo,
       updateDraftTransfers,
-      uploads
+      uploads,
+      setError,
+      t
     ]
   )
 
@@ -695,7 +708,8 @@ export const useWorkspaceComposerUploadController = ({
       supportsImageInput,
       transfers.length,
       captureUndo,
-      updateActiveTransfers
+      updateActiveTransfers,
+      setError
     ]
   )
 
@@ -721,7 +735,7 @@ export const useWorkspaceComposerUploadController = ({
         .deleteUpload({ path: attachment.path })
         .catch((deleteError) => setError(asText(deleteError)))
     },
-    [updateActiveAttachments, updateActiveTransfers, uploads]
+    [updateActiveAttachments, updateActiveTransfers, uploads, setError]
   )
 
   const reconcileRemovedPastedTextUploads = useCallback(
@@ -817,7 +831,8 @@ export const useWorkspaceComposerUploadController = ({
       setActiveDoc,
       transfers.length,
       captureUndo,
-      updateActiveTransfers
+      updateActiveTransfers,
+      setError
     ]
   )
 
@@ -1197,7 +1212,8 @@ export const useWorkspaceComposerUploadController = ({
       markChanged,
       removePastedText,
       updateActiveAttachments,
-      uploads
+      uploads,
+      setError
     ]
   )
 
@@ -1269,7 +1285,8 @@ export const useWorkspaceComposerUploadController = ({
       draftsRef,
       setActiveAttachments,
       setActiveTransfers,
-      uploads
+      uploads,
+      setError
     ]
   )
 
@@ -1278,6 +1295,7 @@ export const useWorkspaceComposerUploadController = ({
       attachments,
       transfers,
       error,
+      errorDetail,
       isUploading: transfers.some(unfinishedComposerUpload)
     },
     actions: {

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -796,7 +796,6 @@
     "Could not reveal the log file.": "Die Protokolldatei konnte nicht angezeigt werden.",
     "Could not save contribution template. Try again.": "Beitragsvorlage konnte nicht gespeichert werden. Versuchen Sie es erneut.",
     "Could not save Vision model. Refresh the model catalog and try again.": "Vision-Modell konnte nicht gespeichert werden. Aktualisieren Sie den Modellkatalog und versuchen Sie es erneut.",
-    "Could not save project.": "Projekt konnte nicht gespeichert werden.",
     "Project changed elsewhere. Reopen Project Settings and try again.": "Projekt wurde an anderer Stelle geändert. Öffnen Sie die Projekteinstellungen erneut und versuchen Sie es erneut.",
     "Could not save provider.": "Der Anbieter konnte nicht gespeichert werden.",
     "Could not save the Claude token.": "Das Claude-Token konnte nicht gespeichert werden.",
@@ -4206,6 +4205,9 @@
     "unsupported": "nicht unterstützt",
     "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "Kein Modell von {{provider}} wird über die Codex Chat Completions-Brücke unterstützt.",
     "CSV parsing encountered a problem. The preview may be incomplete.": "Beim Lesen der CSV-Daten ist ein Problem aufgetreten. Die Vorschau ist möglicherweise unvollständig.",
-    "{{percent}}% of {{size}}": "{{percent}} % von {{size}}"
+    "{{percent}}% of {{size}}": "{{percent}} % von {{size}}",
+    "Could not save project. Please try again.": "Das Projekt konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
+    "Could not attach the file. Check available storage and try again.": "Die Datei konnte nicht angehängt werden. Prüfen Sie den verfügbaren Speicherplatz und versuchen Sie es erneut.",
+    "Close the file browser and open it again to retry.": "Schließen Sie den Dateibrowser und öffnen Sie ihn erneut, um es noch einmal zu versuchen."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -852,7 +852,6 @@
     "Could not reveal the log file.": "No se pudo mostrar el archivo de registro.",
     "Could not save contribution template. Try again.": "No se pudo guardar la plantilla de contribución. Inténtelo de nuevo.",
     "Could not save Vision model. Refresh the model catalog and try again.": "No se pudo guardar el modelo de visión. Actualice el catálogo de modelos y vuelva a intentarlo.",
-    "Could not save project.": "No se pudo guardar el proyecto.",
     "Project changed elsewhere. Reopen Project Settings and try again.": "El proyecto se modificó en otro lugar. Vuelva a abrir Configuración del proyecto e inténtelo de nuevo.",
     "Could not save provider.": "No se pudo guardar el proveedor.",
     "Could not save the Claude token.": "No se pudo guardar el token Claude.",
@@ -4361,6 +4360,9 @@
     "unsupported": "no compatible",
     "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "Ningún modelo de {{provider}} es compatible con el puente de Chat Completions de Codex.",
     "CSV parsing encountered a problem. The preview may be incomplete.": "Se ha producido un problema al analizar el CSV. La vista previa puede estar incompleta.",
-    "{{percent}}% of {{size}}": "{{percent}} % de {{size}}"
+    "{{percent}}% of {{size}}": "{{percent}} % de {{size}}",
+    "Could not save project. Please try again.": "No se pudo guardar el proyecto. Vuelva a intentarlo.",
+    "Could not attach the file. Check available storage and try again.": "No se pudo adjuntar el archivo. Compruebe el espacio de almacenamiento disponible y vuelva a intentarlo.",
+    "Close the file browser and open it again to retry.": "Cierre el explorador de archivos y vuelva a abrirlo para intentarlo de nuevo."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -852,7 +852,6 @@
     "Could not reveal the log file.": "Impossible de révéler le fichier journal.",
     "Could not save contribution template. Try again.": "Impossible d'enregistrer le modèle de contribution. Essayer à nouveau.",
     "Could not save Vision model. Refresh the model catalog and try again.": "Impossible d'enregistrer le modèle Vision. Actualisez le catalogue de modèles et réessayez.",
-    "Could not save project.": "Impossible d'enregistrer le projet.",
     "Project changed elsewhere. Reopen Project Settings and try again.": "Projet modifié ailleurs. Rouvrez les paramètres du projet et réessayez.",
     "Could not save provider.": "Impossible d'enregistrer le fournisseur.",
     "Could not save the Claude token.": "Impossible d'enregistrer le jeton Claude.",
@@ -4361,6 +4360,9 @@
     "unsupported": "non pris en charge",
     "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "Aucun modèle de {{provider}} n’est pris en charge via la passerelle Chat Completions de Codex.",
     "CSV parsing encountered a problem. The preview may be incomplete.": "Un problème est survenu lors de l’analyse du CSV. L’aperçu peut être incomplet.",
-    "{{percent}}% of {{size}}": "{{percent}} % de {{size}}"
+    "{{percent}}% of {{size}}": "{{percent}} % de {{size}}",
+    "Could not save project. Please try again.": "Impossible d’enregistrer le projet. Veuillez réessayer.",
+    "Could not attach the file. Check available storage and try again.": "Impossible de joindre le fichier. Vérifiez l’espace de stockage disponible et réessayez.",
+    "Close the file browser and open it again to retry.": "Fermez le navigateur de fichiers et rouvrez-le pour réessayer."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -805,7 +805,6 @@
     "Could not reveal the log file.": "ログファイルをフォルダーに表示できませんでした。",
     "Could not save contribution template. Try again.": "投稿テンプレートを保存できませんでした。もう一度やり直してください。",
     "Could not save Vision model. Refresh the model catalog and try again.": "ビジョンモデルを保存できませんでした。モデルカタログを更新して、再試行してください。",
-    "Could not save project.": "プロジェクトを保存できませんでした。",
     "Project changed elsewhere. Reopen Project Settings and try again.": "プロジェクトが別の場所に変更されました。プロジェクト設定を再度開き、再試行してください。",
     "Could not save provider.": "プロバイダーを保存できませんでした。",
     "Could not save the Claude token.": "Claude トークンを保存できませんでした。",
@@ -4051,6 +4050,9 @@
     "unsupported": "非対応",
     "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "{{provider}} のモデルは、いずれも Codex Chat Completions ブリッジではサポートされていません。",
     "CSV parsing encountered a problem. The preview may be incomplete.": "CSV の解析中に問題が発生しました。プレビューが不完全な可能性があります。",
-    "{{percent}}% of {{size}}": "{{size}} の {{percent}}%"
+    "{{percent}}% of {{size}}": "{{size}} の {{percent}}%",
+    "Could not save project. Please try again.": "プロジェクトを保存できませんでした。もう一度お試しください。",
+    "Could not attach the file. Check available storage and try again.": "ファイルを添付できませんでした。ストレージの空き容量を確認して、もう一度お試しください。",
+    "Close the file browser and open it again to retry.": "ファイルブラウザーを閉じて再度開き、もう一度お試しください。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -824,7 +824,6 @@
     "Could not reveal the log file.": "로그 파일을 표시할 수 없습니다.",
     "Could not save contribution template. Try again.": "참여 템플릿을 저장할 수 없습니다. 다시 시도해 보세요.",
     "Could not save Vision model. Refresh the model catalog and try again.": "Vision 모델을 저장할 수 없습니다. 모델 카탈로그를 새로 고치고 다시 시도하세요.",
-    "Could not save project.": "프로젝트를 저장할 수 없습니다.",
     "Project changed elsewhere. Reopen Project Settings and try again.": "프로젝트가 다른 곳에서 변경되었습니다. 프로젝트 설정을 다시 열고 다시 시도하세요.",
     "Could not save provider.": "모델 제공업체를 저장할 수 없습니다.",
     "Could not save the Claude token.": "Claude 토큰을 저장할 수 없습니다.",
@@ -4049,6 +4048,9 @@
     "unsupported": "지원되지 않음",
     "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "{{provider}}의 모델은 모두 Codex Chat Completions 브리지에서 지원되지 않습니다.",
     "CSV parsing encountered a problem. The preview may be incomplete.": "CSV를 분석하는 중 문제가 발생했습니다. 미리보기가 불완전할 수 있습니다.",
-    "{{percent}}% of {{size}}": "{{size}} 중 {{percent}}%"
+    "{{percent}}% of {{size}}": "{{size}} 중 {{percent}}%",
+    "Could not save project. Please try again.": "프로젝트를 저장하지 못했습니다. 다시 시도해 주세요.",
+    "Could not attach the file. Check available storage and try again.": "파일을 첨부하지 못했습니다. 저장 공간을 확인한 후 다시 시도해 주세요.",
+    "Close the file browser and open it again to retry.": "파일 브라우저를 닫았다가 다시 열어 재시도해 주세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -847,7 +847,6 @@
     "Could not reveal the log file.": "Не удалось показать файл журнала.",
     "Could not save contribution template. Try again.": "Не удалось сохранить шаблон для публикации. Попробуйте снова.",
     "Could not save Vision model. Refresh the model catalog and try again.": "Не удалось сохранить модель Vision. Обновите каталог моделей и попробуйте снова.",
-    "Could not save project.": "Не удалось сохранить проект.",
     "Project changed elsewhere. Reopen Project Settings and try again.": "Проект был изменён в другом месте. Снова откройте настройки проекта и повторите попытку.",
     "Could not save provider.": "Не удалось сохранить поставщика.",
     "Could not save the Claude token.": "Не удалось сохранить токен Claude.",
@@ -4491,6 +4490,9 @@
     "unsupported": "не поддерживается",
     "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "Ни одна модель {{provider}} не поддерживается через мост Codex Chat Completions.",
     "CSV parsing encountered a problem. The preview may be incomplete.": "При разборе CSV возникла проблема. Предпросмотр может быть неполным.",
-    "{{percent}}% of {{size}}": "{{percent}}% из {{size}}"
+    "{{percent}}% of {{size}}": "{{percent}}% из {{size}}",
+    "Could not save project. Please try again.": "Не удалось сохранить проект. Повторите попытку.",
+    "Could not attach the file. Check available storage and try again.": "Не удалось прикрепить файл. Проверьте свободное место и повторите попытку.",
+    "Close the file browser and open it again to retry.": "Закройте файловый браузер и откройте его снова, чтобы повторить попытку."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -891,7 +891,6 @@
     "Could not reveal the log file.": "无法在文件夹中显示日志文件。",
     "Could not save contribution template. Try again.": "无法保存贡献模板，请重试。",
     "Could not save Vision model. Refresh the model catalog and try again.": "无法保存视觉模型。请刷新模型目录后重试。",
-    "Could not save project.": "无法保存项目。",
     "Project changed elsewhere. Reopen Project Settings and try again.": "项目已在其他位置更改。请重新打开项目设置后再试。",
     "Could not save provider.": "无法保存模型服务商。",
     "Could not save the Claude token.": "无法保存 Claude 令牌。",
@@ -4051,6 +4050,9 @@
     "unsupported": "不支持",
     "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "{{provider}} 的所有模型均不支持通过 Codex Chat Completions 桥接使用。",
     "CSV parsing encountered a problem. The preview may be incomplete.": "CSV 解析出现问题，预览可能不完整。",
-    "{{percent}}% of {{size}}": "{{size}} 的 {{percent}}%"
+    "{{percent}}% of {{size}}": "{{size}} 的 {{percent}}%",
+    "Could not save project. Please try again.": "无法保存项目。请重试。",
+    "Could not attach the file. Check available storage and try again.": "无法添加附件。请检查可用存储空间后重试。",
+    "Close the file browser and open it again to retry.": "请关闭文件浏览器后重新打开以重试。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -890,7 +890,6 @@
     "Could not reveal the log file.": "無法在資料夾中顯示記錄檔。",
     "Could not save contribution template. Try again.": "無法儲存貢獻範本，請重試。",
     "Could not save Vision model. Refresh the model catalog and try again.": "無法儲存視覺模型。請重新整理模型目錄後再試一次。",
-    "Could not save project.": "無法儲存專案。",
     "Project changed elsewhere. Reopen Project Settings and try again.": "專案已在其他位置變更。請重新開啟專案設定後再試。",
     "Could not save provider.": "無法儲存模型服務商。",
     "Could not save the Claude token.": "無法儲存 Claude 權杖。",
@@ -4051,6 +4050,9 @@
     "unsupported": "不支援",
     "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "{{provider}} 的所有模型均不支援透過 Codex Chat Completions 橋接使用。",
     "CSV parsing encountered a problem. The preview may be incomplete.": "CSV 剖析發生問題，預覽可能不完整。",
-    "{{percent}}% of {{size}}": "{{size}} 的 {{percent}}%"
+    "{{percent}}% of {{size}}": "{{size}} 的 {{percent}}%",
+    "Could not save project. Please try again.": "無法儲存專案。請重試。",
+    "Could not attach the file. Check available storage and try again.": "無法附加檔案。請檢查可用儲存空間後重試。",
+    "Close the file browser and open it again to retry.": "請關閉檔案瀏覽器後重新開啟以重試。"
   }
 }


### PR DESCRIPTION
## Problem

Slow project create/update requests leave Close and Cancel looking actionable, while errors from project saves, attachment staging and bookmark loading expose implementation text. Disabled project actions hide their explanations in native titles. The accessibility signal still exits successfully with serious axe findings. Main now includes overlapping contrast, menu and keyboard-locator fixes; this PR preserves those changes and makes the complete scan blocking.

## Proposed change

- Reuse the existing submitting state for disabled exits, `aria-busy`, a spinner and Creating…/Saving… labels. Preserve drafts and the existing in-flight dismissal guard.
- Show archive/delete restrictions beside their disabled menu actions and associate the text with `aria-describedby`.
- Use translated recovery copy for the reproduced error paths and keep raw exceptions in the existing collapsed `DiagnosticDetails`. Preserve existing project-conflict handling and file-browser error classifications.
- Correct the remaining observed contrast failures and retain main’s named Home action, onboarding heading focus, and shared Radix Go-to menu above the file-browser overlay.
- Collect all accessibility evidence, then fail on findings or incomplete evidence. Extend main’s scan contract from 18 to 21 surfaces, including narrow Home, open Go-to and onboarding step focus; retain its scoped Conversation locator and responsive/theme matrix.

## Scope and non-goals

No dependencies, process architecture, domain states/enums, persisted fields, data-model relationships, storage paths or migrations change. Optional `errorDetail` fields are transient presentation state only. No user-data compatibility work is needed. The existing CI report status `advisory` remains serialized for findings, but findings now fail the process; no new report status is added.

`continue-on-error` already feeds a final selected-check enforcement step, so the workflow itself needs no change. Job cancellation already has a translated retry surface and receives a regression assertion only. Skill operations and the Workspace memory toggle are outside this bounded first error-copy batch because they were not behaviorally reproduced.

## Acceptance criteria and validation

Before production edits, nine focused regressions failed repeatedly at the reported public behavior boundaries; the existing job-cancellation control passed. The original complete Electron signal returned exit 0 with 12 scans, serious contrast findings and a keyboard-locator finding. Narrow Home additionally reproduced a critical missing button name twice. The new onboarding-step scan reproduced two additional contrast nodes twice before their correction.

Final local behavior-to-check mapping (each check ran after the last material edit affecting that behavior):

| Behavior / consumer reason | Check | Result |
| --- | --- | --- |
| Shared project dialog used by Home and Workspace; disabled menu reasons | `npx vitest run src/renderer/src/pages/home/ProjectFormDialog.behavior.test.tsx src/renderer/src/hooks/useProjectFormDialog.test.tsx src/renderer/src/pages/home/HomePage.render.test.tsx src/renderer/src/pages/home/HomePage.persistence.test.tsx src/renderer/src/pages/home/home-dialogs.render.test.tsx` | Passed; the full Home selection has 58 tests |
| Upload/paste failures, draft/history preservation, Workspace consumers | `npm run test:module -- workspace_page` | 30 files, 752 tests passed |
| Composer diagnostic consumer and contrast surfaces | Targeted `ConversationPanel.interaction`, `ComposerModelPicker.render`, `PreviewFileSurface`, `EmptyConversationBanner.render`, and `workspace-tool-activity-style` suites | Passed |
| Go-to semantics/bookmark recovery; onboarding focus; shared storage warning consumers | Targeted `FileBrowserModal.render`, `file-browser-i18n.render`, `OnboardingWizard.render`, `LocationStep.render`, `StoragePanel.render`, and `components-i18n.render` suites | Passed |
| Gate exit status, evidence completeness, existing workflow enforcement | `npx vitest run scripts/ci/accessibility-reporter.test.ts scripts/ci/run-accessibility-e2e.test.ts scripts/ci/pr-gate-workflow.test.ts` | Passed |
| All eight translated locales | `npx vitest run src/renderer/src/i18n/resources.test.ts` | Passed |
| Renderer and Electron/test-fixture interfaces | `npm run typecheck:web`; `npm run typecheck:node` | Passed |
| Source/config consistency | `npm run lint`; changed-file Prettier check; `git diff --check` | Passed |
| Real Electron accessibility and full keyboard journey | `npm run build:e2e`; `npm run test:e2e:accessibility:signal` | Passed after rebase: 11 tests, 21 scans, zero axe/keyboard findings, exit 0 |

Rebased onto `d284a2dedfedd091079fdb998cf213fb79e4a3f5` (`main`). Conflict resolution keeps main’s heading-focus implementation and all responsive/theme scans, combines all eight locale additions, and drops the now-redundant formatting-only commit and step-container focus test. After rebase, 10 focused suites passed (948 tests), workflow/Home/onboarding follow-up passed (94 tests), both process typechecks, lint and changed-file formatting passed. The pointer journey now explicitly awaits menu dismissal and trigger focus return before reopening; both isolated repeats passed without a production interaction change. The complete 11-test/21-surface signal passed afterward.

Review follow-up: real Playwright mouse clicks reproduced overlay interception twice. Raising only the Go-to portal to `z-[80]` made two repeated runs pass, including actual bookmark removal, directory navigation, preservation of the outer dialog, and Escape focus return. The separate speculation that a nested Radix portal needs an outside-interaction guard did not reproduce after correcting stacking; no extra dismissal interception was added. The full matrix includes these pointer assertions.

CI also identified one stale Home recovery assertion requiring the old native title and one indentation issue. Both were corrected with focused local checks before the final push; neither correction changes runtime behavior.

The strengthened runner was also exercised against a real complete 15-surface scan containing one remaining contrast defect: all five test flows completed, but the process correctly returned exit 1. That defect was then corrected and the matrix rerun.

Per maintainer instruction, no complete local `npm test` was run. The curated module is supplemented with direct interface/consumer tests above. `npm run test:affected:explain -- --base origin/main --head HEAD` selects the full fallback because the runner/reporter are global gate inputs and E2E files are unknown to selective routing. Per the explicit maintainer instruction, exact-head PR CI owns that full portable and selected platform plan. Local Electron coverage is macOS; this does not claim a full screen-reader or touch-device audit. One local run completed all 15 scans with zero findings but failed the renderer error gate on `reviewer:get-for-session` reporting no registered handler. Two isolated keyboard-journey repeats then passed without code changes; this intermittent IPC failure is recorded rather than suppressed. Build warnings about existing mixed static/dynamic imports remain unchanged.

## Review focus

Confirm disabled reasons remain readable without invoking the action, diagnostics stay collapsed and drafts survive failures, Go-to Escape restores focus, and complete scans with any serious/critical or keyboard finding cannot pass the macOS gate. Check the owner/consumer validation mapping against the final diff before treating the PR as verified.
