### PR TITLE
fix(renderer): correct CSV counts and Unicode title search

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -687,6 +687,10 @@ colors communicate a successful or failed probe/migration result.
 - Viewer toolbar buttons: `Button variant="ghost" size="icon"`, `size-7 rounded-md`.
 - Image / document preview area: `flex-1 min-h-0 overflow-auto bg-card`.
 - Empty preview panel shell and scroll body use `bg-bg-10`.
+- CSV/TSV previews use the first record as column headers and explicitly disclose that convention,
+  including for files without headers. Byte-limited reads and parser row limits independently make
+  the total unknown; show only the previewed row/column range in that case. Show an exact total only
+  when neither limit truncated the content. Keep parsing and rendering bounded.
 - File library search: `Input` or `CommandInput`, with focus using `ring-ring`.
 - File library view switch: `ToggleGroup type="single"`; inactive hover uses `bg-muted`, and the selected item uses `bg-bg-400 text-text-000`. Keep these states neutral rather than using `accent`.
 - File row: `h-9 rounded-md px-2 hover:bg-bg-200`; keep the text color unchanged on hover.
@@ -751,6 +755,11 @@ colors communicate a successful or failed probe/migration result.
   quiet monospaced tabular text. Do not render a redundant Session type badge. A pure numeric query
   matches positive Session-number prefixes and ranks an exact number first; nonnumeric queries remain
   title-only so global search does not expand into message-body or metadata search.
+- Session title search compares NFKC-normalized, lowercase text while preserving the original title
+  for display. Compatibility forms (including full-width input) and composed/decomposed accents
+  match; accents remain significant, and `ß` is not expanded to `ss`. Full-width numeric queries
+  follow the same Session-number lookup as ASCII digits. This policy applies to the local Session
+  title catalog, not the separate Artifact filename search.
 - List row: `h-10 rounded-lg px-3 hover:bg-accent hover:text-accent-foreground`.
 - Inline more actions: default `opacity-0`, then `opacity-100` on hover or focus-visible.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -757,7 +757,8 @@ colors communicate a successful or failed probe/migration result.
   title-only so global search does not expand into message-body or metadata search.
 - Session title search compares NFKC-normalized, lowercase text while preserving the original title
   for display. Compatibility forms (including full-width input) and composed/decomposed accents
-  match; accents remain significant, and `ß` is not expanded to `ss`. Full-width numeric queries
+  match; accents remain significant, so substring matches must include any trailing combining marks
+  (including the dot produced by lowercasing `İ`). `ß` is not expanded to `ss`. Full-width numeric queries
   follow the same Session-number lookup as ASCII digits. This policy applies to the local Session
   title catalog, not the separate Artifact filename search.
 - List row: `h-10 rounded-lg px-3 hover:bg-accent hover:text-accent-foreground`.

--- a/src/renderer/src/components/global-search/global-search-catalog.test.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.test.ts
@@ -19,6 +19,62 @@ const sessions = (count: number, projectId = 'project-a'): SearchableSession[] =
   }))
 
 describe('global search catalog', () => {
+  it.each([
+    ['Übersicht', 'übersicht'],
+    ['ÉTUDE', 'étude'],
+    ['ТЕСТ', 'тест'],
+    ['Analysis', 'ＡＮＡＬＹＳＩＳ'],
+    ['Étude', 'E\u0301tude'],
+    ['ＡＮＡＬＹＳＩＳ', 'analysis'],
+    ['E\u0301tude', 'étude'],
+    ['ﬀ analysis', 'ff'],
+    ['Ⓓ analysis', 'd']
+  ])('finds title %s using query %s', (title, query) => {
+    const result = searchSessionTitles({
+      sessions: [{ ...sessions(1)[0], title }],
+      projectNames: new Map([['project-a', 'Alpha']]),
+      primaryProjectId: 'project-a',
+      query,
+      visiblePrimaryCount: 8
+    })
+
+    expect(result.primary.map((session) => session.id)).toEqual(['session-0'])
+    expect(result.primaryTotalCount).toBe(1)
+    expect(result.primary[0].title).toBe(title)
+  })
+
+  it.each([
+    ['Étude', 'etude'],
+    ['Übersicht', 'ubersicht'],
+    ['Straße', 'strasse']
+  ])('keeps title %s distinct from query %s', (title, query) => {
+    const result = searchSessionTitles({
+      sessions: [{ ...sessions(1)[0], title }],
+      projectNames: new Map([['project-a', 'Alpha']]),
+      primaryProjectId: 'project-a',
+      query,
+      visiblePrimaryCount: 8
+    })
+
+    expect(result.primary).toEqual([])
+  })
+
+  it('uses the existing number lookup for full-width digits', () => {
+    const result = searchSessionTitles({
+      sessions: [
+        { ...sessions(1)[0], id: 'prefix', number: 123, updatedAt: 2_000 },
+        { ...sessions(1)[0], id: 'exact', number: 12 },
+        { ...sessions(1)[0], id: 'title-only', title: '12', number: 7 }
+      ],
+      projectNames: new Map([['project-a', 'Alpha']]),
+      primaryProjectId: 'project-a',
+      query: '１２',
+      visiblePrimaryCount: 8
+    })
+
+    expect(result.primary.map((session) => session.id)).toEqual(['exact', 'prefix'])
+  })
+
   it('matches Session titles, partitions other projects, and reveals primary results in batches of eight', () => {
     const result = searchSessionTitles({
       sessions: [

--- a/src/renderer/src/components/global-search/global-search-catalog.test.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.test.ts
@@ -28,7 +28,12 @@ describe('global search catalog', () => {
     ['ＡＮＡＬＹＳＩＳ', 'analysis'],
     ['E\u0301tude', 'étude'],
     ['ﬀ analysis', 'ff'],
-    ['Ⓓ analysis', 'd']
+    ['Ⓓ analysis', 'd'],
+    ['İstanbul', 'İ'],
+    ['İstanbul', 'i\u0307'],
+    ['İstanbul in summer', 'i'],
+    ['Literal [.*+?^${}()|\\] query', '[.*+?^${}()|\\]'],
+    ['İstanbul', '']
   ])('finds title %s using query %s', (title, query) => {
     const result = searchSessionTitles({
       sessions: [{ ...sessions(1)[0], title }],
@@ -46,7 +51,11 @@ describe('global search catalog', () => {
   it.each([
     ['Étude', 'etude'],
     ['Übersicht', 'ubersicht'],
-    ['Straße', 'strasse']
+    ['Straße', 'strasse'],
+    ['İstanbul', 'i'],
+    ['i\u0307stanbul', 'i'],
+    ['i\u0307\u0301stanbul', 'i\u0307'],
+    ['No wildcard match', '.*']
   ])('keeps title %s distinct from query %s', (title, query) => {
     const result = searchSessionTitles({
       sessions: [{ ...sessions(1)[0], title }],

--- a/src/renderer/src/components/global-search/global-search-catalog.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.ts
@@ -25,8 +25,8 @@ export type SessionSearchGroups = {
   other: SessionSearchResult[]
 }
 
-const foldAsciiCase = (value: string): string =>
-  value.replace(/[A-Z]/g, (character) => character.toLowerCase())
+// Normalize only comparison text: compatibility forms match, but accents remain significant.
+const normalizeSearchText = (value: string): string => value.normalize('NFKC').toLowerCase()
 
 const compareByRecency = (left: SearchableSession, right: SearchableSession): number =>
   right.updatedAt - left.updatedAt || right.id.localeCompare(left.id)
@@ -59,7 +59,7 @@ export const searchSessionTitles = ({
   query: string
   visiblePrimaryCount: number
 }): SessionSearchGroups => {
-  const foldedQuery = foldAsciiCase(query.trim())
+  const foldedQuery = normalizeSearchText(query).trim()
   const numericQuery = /^\d+$/.test(foldedQuery) ? foldedQuery : undefined
   const matches = sessions
     .filter(
@@ -68,7 +68,7 @@ export const searchSessionTitles = ({
         projectNames.has(session.projectId) &&
         (numericQuery
           ? String(validSessionNumber(session.number) ?? '').startsWith(numericQuery)
-          : foldAsciiCase(session.title).includes(foldedQuery))
+          : normalizeSearchText(session.title).includes(foldedQuery))
     )
     .sort((left, right) => {
       if (numericQuery) {

--- a/src/renderer/src/components/global-search/global-search-catalog.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.ts
@@ -61,6 +61,11 @@ export const searchSessionTitles = ({
 }): SessionSearchGroups => {
   const foldedQuery = normalizeSearchText(query).trim()
   const numericQuery = /^\d+$/.test(foldedQuery) ? foldedQuery : undefined
+  // A literal substring must include trailing marks (e.g. the dot added when İ lowercases).
+  const titlePattern = new RegExp(
+    `${foldedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?!\\p{M})`,
+    'u'
+  )
   const matches = sessions
     .filter(
       (session) =>
@@ -68,7 +73,7 @@ export const searchSessionTitles = ({
         projectNames.has(session.projectId) &&
         (numericQuery
           ? String(validSessionNumber(session.number) ?? '').startsWith(numericQuery)
-          : normalizeSearchText(session.title).includes(foldedQuery))
+          : titlePattern.test(normalizeSearchText(session.title)))
     )
     .sort((left, right) => {
       if (numericQuery) {

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -753,7 +753,8 @@ describe('PreviewFileContent', () => {
 
     await renderFile(createFileItem({ format: 'csv', name: 'measurements.tsv' }))
 
-    expect(container.textContent).toContain('100+ rows · 26 columns')
+    expect(container.textContent).not.toContain('100+ rows · 26 columns')
+    expect(container.textContent).not.toContain('100 rows · 26 columns')
     expect(container.textContent).toContain('Showing 100 rows · 24 columns')
     expect(container.textContent).toContain('2 more columns hidden in this preview')
     expect(container.textContent).toContain('r1c1')

--- a/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx
@@ -1,59 +1,148 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from '@testing-library/react'
+import { parse } from 'papaparse'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { i18next } from '@/i18n'
+
 import { createManagedPreviewTestTransport } from '../managed-preview-test-support'
+import { PREVIEW_TEXT_MAX_BYTES } from '../usePreviewFileContent'
 import { CsvPreviewRenderer } from './CsvPreview'
 
-const item = {
-  id: 'csv-file',
-  type: 'file' as const,
-  title: 'data.csv',
-  name: 'data.csv',
-  path: 'artifact://data.csv',
-  format: 'csv' as const,
-  source: 'artifact' as const,
-  projectId: 'project-1',
-  sessionId: 'session-1',
-  managedFileId: 'csv-file'
-}
-const read = vi.fn()
-
-beforeEach(async () => {
-  await i18next.changeLanguage('zh-Hans')
-  read.mockReset()
-  const transport = createManagedPreviewTestTransport({ read })
-  vi.stubGlobal('api', {
-    previewResources: { acquire: transport.acquire, release: transport.release }
-  })
-  vi.stubGlobal('fetch', transport.fetch)
-})
 afterEach(async () => {
   cleanup()
   vi.unstubAllGlobals()
   await i18next.changeLanguage('en')
 })
 
-const mockCsv = (content: string, truncated = false): void => {
-  read.mockResolvedValue({ content, encoding: 'utf8', size: content.length, truncated })
+const renderCsv = (
+  content: string,
+  extension = 'csv',
+  truncated = false
+): ReturnType<typeof render> => {
+  const transport = createManagedPreviewTestTransport({
+    read: async () => ({ content, encoding: 'utf8', size: content.length, truncated })
+  })
+  vi.stubGlobal('api', { previewResources: transport })
+  vi.stubGlobal('fetch', transport.fetch)
+
+  return render(
+    <CsvPreviewRenderer
+      item={{
+        id: 'file-data',
+        type: 'file',
+        title: `data.${extension}`,
+        name: `data.${extension}`,
+        path: `artifact://data.${extension}`,
+        format: 'csv',
+        source: 'artifact',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        managedFileId: 'file-data',
+        selectedVersionId: 'version-1'
+      }}
+    />
+  )
 }
 
+describe('CSV preview row count', () => {
+  it.each([
+    ['csv', ','],
+    ['tsv', '\t']
+  ])(
+    'does not report the first 100 rows as the complete %s file count',
+    async (extension, delimiter) => {
+      const content = [
+        `a${delimiter}b`,
+        ...Array.from({ length: 1_000 }, (_, index) => `${index}${delimiter}x`)
+      ].join('\n')
+      const size = new TextEncoder().encode(content).byteLength
+      expect(size).toBe(5_893)
+      expect(size).toBeLessThan(PREVIEW_TEXT_MAX_BYTES)
+      expect(parse(content, { delimiter, skipEmptyLines: true }).data).toHaveLength(1_001)
+      expect(parse(content, { delimiter, skipEmptyLines: true, preview: 101 }).meta.truncated).toBe(
+        true
+      )
+
+      const { container } = renderCsv(content, extension)
+
+      await screen.findByRole('table')
+      expect(container.querySelectorAll('tbody tr')).toHaveLength(100)
+      expect(screen.getByText('Showing 100 rows · 2 columns')).toBeTruthy()
+      expect(screen.queryByText('100 rows · 2 columns', { exact: true })).toBeNull()
+    }
+  )
+
+  it.each([0, 1, 100])(
+    'reports an exact count for a complete file with %i data rows',
+    async (count) => {
+      renderCsv(['a,b', ...Array.from({ length: count }, (_, i) => `${i},x`)].join('\n'))
+      await screen.findByRole('table')
+      expect(screen.getByText(`${count} rows · 2 columns`, { exact: true })).toBeTruthy()
+    }
+  )
+
+  it('omits the total when bytes are truncated before the parser row limit', async () => {
+    renderCsv('a,b\n1,x\n2,y', 'csv', true)
+    await screen.findByRole('table')
+    expect(screen.getByText('Showing 2 rows · 2 columns')).toBeTruthy()
+    expect(screen.queryByText('2 rows · 2 columns', { exact: true })).toBeNull()
+    expect(screen.queryByText('2+ rows · 2 columns', { exact: true })).toBeNull()
+  })
+
+  it('discloses the first-row header convention for headerless data', async () => {
+    const { container } = renderCsv('1,2\n3,4')
+    await screen.findByRole('table')
+    expect(screen.getByRole('columnheader', { name: '1' })).toBeTruthy()
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(1)
+    expect(screen.getByText('First row is used as column headers')).toBeTruthy()
+  })
+
+  it('counts CSV records rather than physical lines and ignores empty lines', async () => {
+    renderCsv('a,b\n"first\nsecond",x\n\nthird,y\n')
+    await screen.findByRole('table')
+    expect(screen.getByText('2 rows · 2 columns', { exact: true })).toBeTruthy()
+  })
+
+  it('handles empty files without claiming a header exists', async () => {
+    renderCsv('')
+    await screen.findByRole('table')
+    expect(screen.getByText('0 rows · 0 columns', { exact: true })).toBeTruthy()
+    expect(screen.queryByText('First row is used as column headers')).toBeNull()
+  })
+
+  it('uses fallback labels for blank headers and leaves missing cells empty', async () => {
+    const { container } = renderCsv(',b\n1')
+    await screen.findByRole('table')
+    expect(screen.getByRole('columnheader', { name: 'Column 1' })).toBeTruthy()
+    expect(container.querySelector('tbody tr')?.lastElementChild?.textContent).toBe('')
+  })
+})
+
 describe('CSV preview localization', () => {
+  beforeEach(async () => {
+    await i18next.changeLanguage('zh-Hans')
+  })
+
   it.each([false, true])('localizes row and column counts (truncated: %s)', async (truncated) => {
-    mockCsv('sample,value\nA,1\nB,2', truncated)
-    render(<CsvPreviewRenderer item={item} />)
+    renderCsv('sample,value\nA,1\nB,2', 'csv', truncated)
     const table = await screen.findByRole('table')
     expect(table.textContent).toContain('sample')
-    expect(screen.getByText(truncated ? '2+ 行 · 2 列' : '2 行 · 2 列')).toBeTruthy()
+    if (truncated) {
+      expect(screen.queryByText('2 行 · 2 列', { exact: true })).toBeNull()
+      expect(screen.queryByText('2+ 行 · 2 列', { exact: true })).toBeNull()
+    } else {
+      expect(screen.getByText('2 行 · 2 列', { exact: true })).toBeTruthy()
+    }
+    expect(screen.getByText('显示 2 行 · 2 列')).toBeTruthy()
     expect(document.body.textContent).not.toMatch(/rows|columns/)
     expect(document.body.textContent).not.toContain('CSV 解析出现问题')
   })
 
   it('uses stable translated warning copy for malformed CSV while retaining parsed data', async () => {
     // Real Papa Parse input: the quoted field has no closing quote.
-    mockCsv('sample,value\nA,"unterminated')
-    render(<CsvPreviewRenderer item={item} />)
+    renderCsv('sample,value\nA,"unterminated')
     const table = await screen.findByRole('table')
     expect(table.textContent).toContain('unterminated')
     expect(document.body.textContent).not.toContain('Quoted field unterminated')

--- a/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx
@@ -12,7 +12,7 @@ const VISIBLE_COLUMNS = 24
 const parseCsvRows = (
   content: string,
   extension: string
-): { rows: string[][]; errors: string[] } => {
+): { rows: string[][]; errors: string[]; rowTruncated: boolean } => {
   const parsed = parse<string[]>(content, {
     delimiter: extension === 'tsv' ? '\t' : '',
     skipEmptyLines: true,
@@ -21,7 +21,8 @@ const parseCsvRows = (
 
   return {
     rows: parsed.data.filter((row): row is string[] => Array.isArray(row)),
-    errors: parsed.errors.map((error) => error.message)
+    errors: parsed.errors.map((error) => error.message),
+    rowTruncated: parsed.meta.truncated
   }
 }
 
@@ -41,25 +42,28 @@ export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JS
     )
   }
 
-  const { rows, errors } = parseCsvRows(state.preview.content, getFileExtension(item.name))
+  const { rows, errors, rowTruncated } = parseCsvRows(
+    state.preview.content,
+    getFileExtension(item.name)
+  )
+  // CSV does not reliably identify headers. Preserve the first-row convention and disclose it.
   const headers = rows[0] ?? []
   const dataRows = rows.slice(1, VISIBLE_ROWS + 1)
   const visibleHeaders = headers.slice(0, VISIBLE_COLUMNS)
   const hiddenColumnCount = Math.max(headers.length - visibleHeaders.length, 0)
-  const rowCountLabel = state.preview.truncated
-    ? t('{{rows}}+ rows · {{columns}} columns', {
-        rows: Math.max(rows.length - 1, 0),
-        columns: headers.length
-      })
-    : t('{{rows}} rows · {{columns}} columns', {
-        rows: Math.max(rows.length - 1, 0),
-        columns: headers.length
-      })
+  const totalKnown = !state.preview.truncated && !rowTruncated
 
   return (
     <div className="flex size-full flex-col overflow-hidden bg-bg-10">
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border-300 bg-bg-000 px-3 py-2 text-[12px] text-text-300">
-        <span>{rowCountLabel}</span>
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-border-300 bg-bg-000 px-3 py-2 text-[12px] text-text-300">
+        {totalKnown ? (
+          <span>
+            {t('{{rows}} rows · {{columns}} columns', {
+              rows: dataRows.length,
+              columns: headers.length
+            })}
+          </span>
+        ) : null}
         <span className="shrink-0">
           {t('Showing {{rows}} rows · {{columns}} columns', {
             rows: dataRows.length,
@@ -116,12 +120,17 @@ export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JS
           </tbody>
         </table>
       </div>
-      {hiddenColumnCount > 0 ? (
+      {headers.length > 0 ? (
         <div className="shrink-0 border-t border-border-300 bg-bg-000 px-3 py-2 text-[12px] text-text-300">
-          {t('{{count}} more columns hidden in this preview', {
-            count: hiddenColumnCount,
-            defaultValue_one: '{{count}} more column hidden in this preview'
-          })}
+          <div>{t('First row is used as column headers')}</div>
+          {hiddenColumnCount > 0 ? (
+            <div>
+              {t('{{count}} more columns hidden in this preview', {
+                count: hiddenColumnCount,
+                defaultValue_one: '{{count}} more column hidden in this preview'
+              })}
+            </div>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -100,6 +100,7 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "First row is used as column headers": "Die erste Zeile wird als Spaltenüberschrift verwendet",
     "Notebook network access": "Notebook-Netzwerkzugriff",
     "Control which internet domains Notebook Python, R, REPL, and Bash can reach.": "Legen Sie fest, auf welche Internetdomains Python, R, REPL und Bash in Notebooks zugreifen können.",
     "Open Science domains": "Domains von Open Science",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -101,6 +101,7 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "First row is used as column headers": "La primera fila se usa como encabezados de columna",
     "Notebook network access": "Acceso de red de Notebook",
     "Control which internet domains Notebook Python, R, REPL, and Bash can reach.": "Controle a qué dominios de Internet pueden acceder los entornos Python, R, REPL y Bash de Notebook.",
     "Open Science domains": "Dominios de Open Science",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -101,6 +101,7 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "First row is used as column headers": "La première ligne sert d’en-têtes de colonnes",
     "Notebook network access": "Accès réseau du Notebook",
     "Control which internet domains Notebook Python, R, REPL, and Bash can reach.": "Contrôlez les domaines Internet accessibles par les environnements Python, R, REPL et Bash de Notebook.",
     "Open Science domains": "Domaines Open Science",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "First row is used as column headers": "先頭行を列見出しとして使用します",
     "Notebook network access": "Notebook のネットワークアクセス",
     "Control which internet domains Notebook Python, R, REPL, and Bash can reach.": "Notebook の Python、R、REPL、Bash がアクセスできるインターネットドメインを制御します。",
     "Open Science domains": "Open Science ドメイン",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "First row is used as column headers": "첫 번째 행을 열 머리글로 사용합니다",
     "Notebook network access": "Notebook 네트워크 액세스",
     "Control which internet domains Notebook Python, R, REPL, and Bash can reach.": "Notebook의 Python, R, REPL 및 Bash가 액세스할 수 있는 인터넷 도메인을 제어합니다.",
     "Open Science domains": "Open Science 도메인",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "First row is used as column headers": "Первая строка используется для заголовков столбцов",
     "Notebook network access": "Сетевой доступ Notebook",
     "Control which internet domains Notebook Python, R, REPL, and Bash can reach.": "Управляйте интернет-доменами, доступными средам Python, R, REPL и Bash в Notebook.",
     "Open Science domains": "Домены Open Science",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "First row is used as column headers": "首行用作列标题",
     "Notebook network access": "Notebook 网络访问",
     "Control which internet domains Notebook Python, R, REPL, and Bash can reach.": "控制 Notebook Python、R、REPL 和 Bash 可以访问哪些互联网域名。",
     "Open Science domains": "Open Science 域名",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "First row is used as column headers": "首列用作欄標題",
     "Notebook network access": "Notebook 網路存取",
     "Control which internet domains Notebook Python, R, REPL, and Bash can reach.": "控制 Notebook Python、R、REPL 與 Bash 可存取哪些網際網路網域。",
     "Open Science domains": "Open Science 網域",


### PR DESCRIPTION
## Problem

F07: A complete 5,893-byte CSV/TSV with 1,000 data records displays `100 rows` as the file total because the renderer discards Papa Parse's row-limit truncation flag.

F08: Session title search folds only ASCII case, so `Übersicht`/`übersicht`, `ÉTUDE`/`étude`, and `ТЕСТ`/`тест` do not match. Full-width input and canonically equivalent accent encodings also miss.

## Proposed change

- Retain parser row truncation separately from byte-read truncation. If either limit applies, show only the preview range; otherwise show the exact record count. Keep the 100-row/24-column display limits.
- Explicitly disclose the existing first-record-as-column-headers convention in all eight translated locales. Headerless files keep that convention; no heuristic or new control is introduced.
- Normalize comparison strings with NFKC and locale-independent lowercase. Preserve displayed titles and accent distinctions, including combining marks produced by lowercasing dotted I. Literal substring matches cannot end before a combining mark; do not expand `ß` to `ss`. Full-width digits use the existing Session-number lookup. Document these rules in the renderer owner document.

## Scope and non-goals

Renderer-only behavior plus localized copy. The only added field is a private, transient parser-result boolean. No public interface, architecture, persisted data, schema, migration, historical-data compatibility layer, state enum, dependency, or Artifact filename-search change.

NFKC intentionally also equates compatible ligatures and enclosed letters. Papa Parse may conservatively report truncation at exactly 100 data records with a trailing newline; the preview then omits the total. Full-file scanning and automatic header detection are outside scope.

## Acceptance criteria and validation

Reproduction preceded production edits on base `10f37790`. Two consecutive focused runs failed identically: both CSV/TSV component cases rendered the misleading exact `100 rows` label, and five Unicode search cases returned an empty result. Five existing catalog cases passed. CSV tests use the real content hook and Papa Parse through the existing managed-resource test transport; search tests use the existing public catalog function. No production test seam was added.

The independent review identified a dotted-I boundary case. Before the follow-up fix, two public catalog cases (`İstanbul` and its decomposed spelling queried with `i`) failed by returning a result; 18 existing cases passed. The fix also covers complete mark sequences, later valid occurrences, literal regex punctuation, and empty queries.

Rebased onto `d284a2de` at the maintainer’s request. Resolved CSV renderer and test conflicts by retaining main’s translated parser warning and localization checks alongside this PR’s bounded-count regressions.

All checks below ran after the conflict resolution and last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| CSV/TSV row/byte limits, complete records, first-row convention, blank/multiline records; preview read and registry consumers; Unicode matching, numeric lookup, search dialog consumers; locale guards | `npx vitest run src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx src/renderer/src/pages/workspace/previews/preview-registry.test.tsx src/renderer/src/components/global-search/ src/renderer/src/i18n/resources.test.ts --coverage --coverage.include=src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx --coverage.include=src/renderer/src/components/global-search/global-search-catalog.ts` | 8 files, 935 tests passed |
| Changed renderer coverage | Same final test command above | Combined lines 98.21%, branches 98.41%, functions 100%; CSV lines 95.65%, branches 96.15%, functions 100%; repository thresholds passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Lint | `npm run lint` | Passed |
| Whitespace | `git diff --check` | Passed |

Impact evidence: CsvPreviewRenderer is mounted by the preview registry; searchSessionTitles is consumed by GlobalSearchDialog. Their existing consumer suites are included, together with the real preview-read hook and the i18n guard. No main/preload contracts or platform paths changed, so local node/native/platform suites were excluded. The automated impact-plan explanation falls back to the full suite because `docs/design.md` has no module owner. Per maintainer instruction, the local run remains explicitly targeted; exact-head PR CI owns the full fallback and cross-platform verification.

Uncovered locally: manual Electron/Web visual inspection and OS-specific CI lanes. Independent PR review and exact-head CI remain required before considering the change fully verified.

## Review focus

Confirm that unknown totals never appear as exact counts, the disclosed header convention matches the retained behavior, and Unicode normalization does not strip accents or mutate displayed/persisted titles.
