### PR TITLE
fix(notebook): clarify Windows network protection setup

### DIFF
--- a/packages/notebook-network-sandbox/src/index.test.ts
+++ b/packages/notebook-network-sandbox/src/index.test.ts
@@ -246,7 +246,7 @@ describe('NotebookNetworkSandbox', () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     const sandbox = new NotebookNetworkSandbox(options())
-    vi.spyOn(sandbox, 'status').mockResolvedValue({
+    const initialStatus = vi.spyOn(sandbox, 'status').mockResolvedValueOnce({
       kind: 'setupRequired',
       platform: 'win32',
       reasons: ['Notebook AppContainer profile is not installed']
@@ -255,6 +255,17 @@ describe('NotebookNetworkSandbox', () => {
     try {
       await expect(sandbox.initialize()).resolves.toBeUndefined()
       expect(backend.initialize).toHaveBeenCalledOnce()
+      initialStatus.mockRestore()
+      backend.refreshWindowsProtection.mockResolvedValue({
+        warnings: [],
+        errors: ['Notebook AppContainer profile is not installed']
+      })
+
+      await expect(sandbox.status()).resolves.toEqual({
+        kind: 'setupRequired',
+        platform: 'win32',
+        reasons: ['Notebook AppContainer profile is not installed']
+      })
     } finally {
       await sandbox.dispose()
       if (platform) Object.defineProperty(process, 'platform', platform)

--- a/src/renderer/src/pages/settings/NotebookNetworkProtectionBanner.render.test.tsx
+++ b/src/renderer/src/pages/settings/NotebookNetworkProtectionBanner.render.test.tsx
@@ -51,11 +51,35 @@ describe('NotebookNetworkProtectionBanner', () => {
     expect(onOpen).toHaveBeenCalledOnce()
   })
 
-  it('does not claim protection is active when setup is required', async () => {
+  it('keeps Windows standard execution available without claiming protection or requiring setup to run', async () => {
+    const onOpen = vi.fn()
     window.api.settings.getNotebookNetworkStatus = vi.fn().mockResolvedValue({
       kind: 'setupRequired',
       platform: 'win32',
       reasons: ['windowsProfileMissing']
+    })
+    await act(async () => root.render(<NotebookNetworkProtectionBanner onOpen={onOpen} />))
+    await flush()
+
+    expect(container.textContent).toContain('Notebook network protection is not set up.')
+    expect(container.textContent).toContain(
+      'Notebook continues using standard execution. No protected mode is active.'
+    )
+    expect(container.textContent).not.toContain('before notebooks can run')
+    expect(container.textContent).not.toContain('Network protection on')
+
+    const button = container.querySelector<HTMLButtonElement>('button')
+    expect(button?.textContent).toBe('Network settings')
+    expect(button?.disabled).toBe(false)
+    await act(async () => button?.click())
+    expect(onOpen).toHaveBeenCalledOnce()
+  })
+
+  it('requires setup before Linux notebooks can run when bubblewrap is missing', async () => {
+    window.api.settings.getNotebookNetworkStatus = vi.fn().mockResolvedValue({
+      kind: 'setupRequired',
+      platform: 'linux',
+      reasons: ['linuxBubblewrapMissing']
     })
     await act(async () => root.render(<NotebookNetworkProtectionBanner onOpen={() => undefined} />))
     await flush()
@@ -63,8 +87,8 @@ describe('NotebookNetworkProtectionBanner', () => {
     expect(container.textContent).toContain(
       'Notebook network protection needs setup before notebooks can run.'
     )
-    expect(container.textContent).toContain('Notebook continues using standard execution.')
-    expect(container.textContent).not.toContain('protection is active')
+    expect(container.textContent).not.toContain('Notebook continues using standard execution.')
+    expect(container.textContent).not.toContain('Network protection on')
   })
 
   it('uses a generic, actionable message when the status check fails', async () => {

--- a/src/renderer/src/pages/settings/NotebookNetworkProtectionBanner.tsx
+++ b/src/renderer/src/pages/settings/NotebookNetworkProtectionBanner.tsx
@@ -98,12 +98,13 @@ const NotebookNetworkProtectionBanner = ({
       case 'setupRequired':
         return {
           Icon: ShieldAlert,
-          title: t('Notebook network protection needs setup before notebooks can run.'),
+          title:
+            status.platform === 'win32'
+              ? t('Notebook network protection is not set up.')
+              : t('Notebook network protection needs setup before notebooks can run.'),
           description:
             status.platform === 'win32'
-              ? t(
-                  'Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.'
-                )
+              ? t('Notebook continues using standard execution. No protected mode is active.')
               : t('Open Network settings to review the required setup.'),
           tone: 'warning'
         }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -126,6 +126,7 @@
     "Protected using Windows sandboxing. New Notebook sessions are protected.": "Durch die Windows-Sandbox geschützt. Neue Notebook-Sitzungen sind geschützt.",
     "Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.": "Python, R, REPL, Bash und Paketdownloads in Notebooks werden sicher über die von Ihnen zugelassenen Domains geleitet. Bis zur Einrichtung werden Notebooks weiterhin im Standardmodus ausgeführt.",
     "Notebook continues using standard execution. No protected mode is active.": "Notebooks werden weiterhin im Standardmodus ausgeführt. Es ist kein geschützter Modus aktiv.",
+    "Notebook network protection is not set up.": "Der Notebook-Netzwerkschutz ist nicht eingerichtet.",
     "Notebook network protection needs setup before notebooks can run.": "Der Notebook-Netzwerkschutz muss eingerichtet werden, bevor Notebooks ausgeführt werden können.",
     "Notebook network protection is not supported on this platform.": "Der Notebook-Netzwerkschutz wird auf dieser Plattform nicht unterstützt.",
     "Setting up…": "Wird eingerichtet…",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -128,6 +128,7 @@
     "Protected using Windows sandboxing. New Notebook sessions are protected.": "Protegido mediante el sandbox de Windows. Las nuevas sesiones de Notebook estarán protegidas.",
     "Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.": "Dirija de forma segura Python, R, REPL, Bash y las descargas de paquetes de Notebook a través de los dominios que haya aprobado. Hasta que lo configure, Notebook seguirá utilizando la ejecución estándar.",
     "Notebook continues using standard execution. No protected mode is active.": "Notebook seguirá utilizando la ejecución estándar. No hay ningún modo protegido activo.",
+    "Notebook network protection is not set up.": "La protección de red de Notebook no está configurada.",
     "Notebook network protection needs setup before notebooks can run.": "Debe configurar la protección de red de Notebook antes de ejecutar notebooks.",
     "Notebook network protection is not supported on this platform.": "Esta plataforma no admite la protección de red de Notebook.",
     "Setting up…": "Configurando…",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -128,6 +128,7 @@
     "Protected using Windows sandboxing. New Notebook sessions are protected.": "Protection assurée par le bac à sable Windows. Les nouvelles sessions Notebook sont protégées.",
     "Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.": "Acheminez de manière sécurisée Python, R, REPL, Bash et les téléchargements de paquets du Notebook via les domaines que vous avez approuvés. Tant que la configuration n’est pas terminée, le Notebook continue d’utiliser l’exécution standard.",
     "Notebook continues using standard execution. No protected mode is active.": "Le Notebook continue d’utiliser l’exécution standard. Aucun mode protégé n’est actif.",
+    "Notebook network protection is not set up.": "La protection réseau de Notebook n’est pas configurée.",
     "Notebook network protection needs setup before notebooks can run.": "La protection réseau du Notebook doit être configurée avant l’exécution des notebooks.",
     "Notebook network protection is not supported on this platform.": "La protection réseau du Notebook n’est pas prise en charge sur cette plateforme.",
     "Setting up…": "Configuration…",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -124,6 +124,7 @@
     "Protected using Windows sandboxing. New Notebook sessions are protected.": "Windows サンドボックスで保護されています。新しい Notebook セッションが保護されます。",
     "Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.": "Notebook の Python、R、REPL、Bash、パッケージのダウンロードを、承認したドメイン経由で安全にルーティングします。セットアップするまで、Notebook は標準実行を継続します。",
     "Notebook continues using standard execution. No protected mode is active.": "Notebook は標準実行を継続します。保護モードは有効ではありません。",
+    "Notebook network protection is not set up.": "Notebook のネットワーク保護は設定されていません。",
     "Notebook network protection needs setup before notebooks can run.": "Notebook を実行する前にネットワーク保護のセットアップが必要です。",
     "Notebook network protection is not supported on this platform.": "このプラットフォームでは Notebook のネットワーク保護はサポートされていません。",
     "Setting up…": "セットアップ中…",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -124,6 +124,7 @@
     "Protected using Windows sandboxing. New Notebook sessions are protected.": "Windows 샌드박스로 보호됩니다. 새 Notebook 세션이 보호됩니다.",
     "Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.": "Notebook Python, R, REPL, Bash 및 패키지 다운로드를 승인한 도메인을 통해 안전하게 라우팅합니다. 설정하기 전까지 Notebook은 표준 실행을 계속 사용합니다.",
     "Notebook continues using standard execution. No protected mode is active.": "Notebook은 표준 실행을 계속 사용합니다. 보호 모드는 활성화되어 있지 않습니다.",
+    "Notebook network protection is not set up.": "Notebook 네트워크 보호가 설정되지 않았습니다.",
     "Notebook network protection needs setup before notebooks can run.": "Notebook을 실행하기 전에 네트워크 보호 설정이 필요합니다.",
     "Notebook network protection is not supported on this platform.": "이 플랫폼에서는 Notebook 네트워크 보호가 지원되지 않습니다.",
     "Setting up…": "설정 중…",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -130,6 +130,7 @@
     "Protected using Windows sandboxing. New Notebook sessions are protected.": "Защита обеспечивается песочницей Windows. Новые сеансы Notebook будут защищены.",
     "Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.": "Безопасно направляйте Python, R, REPL, Bash и загрузки пакетов Notebook через разрешённые домены. До завершения настройки Notebook продолжит использовать стандартное выполнение.",
     "Notebook continues using standard execution. No protected mode is active.": "Notebook продолжит использовать стандартное выполнение. Защищённый режим не активен.",
+    "Notebook network protection is not set up.": "Сетевая защита Notebook не настроена.",
     "Notebook network protection needs setup before notebooks can run.": "Перед запуском Notebook необходимо настроить сетевую защиту.",
     "Notebook network protection is not supported on this platform.": "Сетевая защита Notebook не поддерживается на этой платформе.",
     "Setting up…": "Настройка…",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -124,6 +124,7 @@
     "Protected using Windows sandboxing. New Notebook sessions are protected.": "已通过 Windows 沙箱保护。新的 Notebook 会话将受到保护。",
     "Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.": "通过您批准的域名安全地路由 Notebook Python、R、REPL、Bash 和软件包下载。在完成设置前，Notebook 将继续使用标准执行模式。",
     "Notebook continues using standard execution. No protected mode is active.": "Notebook 将继续使用标准执行模式。当前未启用保护模式。",
+    "Notebook network protection is not set up.": "Notebook 网络保护尚未设置。",
     "Notebook network protection needs setup before notebooks can run.": "运行 Notebook 前需要先设置 Notebook 网络保护。",
     "Notebook network protection is not supported on this platform.": "此平台不支持 Notebook 网络保护。",
     "Setting up…": "正在设置…",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -124,6 +124,7 @@
     "Protected using Windows sandboxing. New Notebook sessions are protected.": "已透過 Windows 沙箱保護。新的 Notebook 工作階段將受到保護。",
     "Securely route Notebook Python, R, REPL, Bash, and package downloads through your approved domains. Until set up, Notebook continues using standard execution.": "透過您核准的網域安全地路由 Notebook Python、R、REPL、Bash 和套件下載。在完成設定前，Notebook 將繼續使用標準執行模式。",
     "Notebook continues using standard execution. No protected mode is active.": "Notebook 將繼續使用標準執行模式。目前未啟用保護模式。",
+    "Notebook network protection is not set up.": "Notebook 網路保護尚未設定。",
     "Notebook network protection needs setup before notebooks can run.": "執行 Notebook 前必須先設定 Notebook 網路保護。",
     "Notebook network protection is not supported on this platform.": "此平台不支援 Notebook 網路保護。",
     "Setting up…": "正在設定…",


### PR DESCRIPTION
## Problem

F10: On Windows without Notebook network protection set up, the Runtimes banner says setup is required before notebooks can run while its description and runtime allow standard execution. This makes execution availability and protection status contradictory.

## Proposed change

Show “Notebook network protection is not set up.” and “Notebook continues using standard execution. No protected mode is active.” on Windows. Keep the existing Network settings navigation and Linux setup prerequisite. Add the title to all eight renderer locales and reuse the existing translated description.

## Scope and non-goals

- Presentation and regression tests only; no sandbox execution or enforcement changes.
- No new fields, enum states, architecture, IPC/data model, persistence, historical compatibility path, or migration.
- Keep installation in the existing Network settings flow.

## Acceptance criteria and validation

Before changing production code, the component regression failed twice on the rendered phrase `before notebooks can run`, while the same DOM confirmed standard execution continued. The baseline suites had 22 passing tests; after adding regression coverage, exactly one of 23 tests failed. After the fix, all 23 passed.

Final local checks ran after the last material edit. A subsequent formatting-only line-wrap correction also passed the banner suite, lint, and formatting checks:

| Behavior | Command | Result |
| --- | --- | --- |
| Windows/Linux banner, navigation, Settings consumers, eight-locale guards, owner status projection | `npm test -- src/renderer/src/pages/settings/NotebookNetworkProtectionBanner.render.test.tsx src/renderer/src/pages/settings/NotebookNetworkDomainsForm.render.test.tsx src/renderer/src/pages/settings/NetworkPanel.render.test.tsx src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx src/renderer/src/pages/settings/network-panel-i18n.render.test.tsx src/renderer/src/i18n/resources.test.ts src/main/notebook/network-sandbox-owner.test.ts` | 889 passed |
| Successful Windows standard-mode initialization still reports setupRequired; standard launch selection; sandbox module contracts | `npm run test:module -- notebook_network_sandbox` | 89 passed, 3 conditional skips; run outside the restricted agent sandbox because local sockets were blocked there |
| Main, renderer, and sandbox type contracts | `npm run typecheck` | Passed |
| Repository lint | `npm run lint` | Passed |
| Formatting of all 11 changed files | `node node_modules/prettier/bin/prettier.cjs --check <changed files>` | Passed |

Impact review: CodeGraph identified RuntimesPanel and the preview as banner consumers and traced the Settings status facade to the sandbox status projection. Tests exercise the existing Settings API boundary; no production test seam was introduced. The capability classifier selects renderer, i18n, sandbox and downstream platform/UI lanes. The module-only affected planner falls back to full because the banner has no declared module owner; per maintainer instruction, local validation uses the explicit owner/consumer checks above and leaves the complete suite and cross-platform UI checks to PR Gate.

Uncovered locally: Windows desktop/network-enforcement execution and Windows/Linux CI lanes. Windows behavior here is exercised through existing portable mocks, not claimed as Windows hardware validation. No global local test suite was run.

The initial macOS workspace lane reported a flaky bottom-follow E2E (20px excursion against a 2px limit; its retry passed). On the unchanged PR head, `npm run build:e2e` and `npm run test:e2e -- e2e/message-tool-layout-stability.spec.ts -g "keeps bottom-follow" --repeat-each=5 --retries=0` passed all five local runs. A single targeted macOS CI rerun then passed all 24 workspace tests without retries, plus 19 functional journeys, 5 accessibility tests, and 3 visual tests, retaining `--fail-on-flaky-tests`. No code, assertion threshold, or retry-policy change was needed. [Successful macOS rerun](https://github.com/aipoch/open-science/actions/runs/33936318740/job/101236456651).

The repository's independent Codex review on `6cda9feeb9b2c8eb95cf85ae5185b43c4ea7b3fd` reports **mergeable, no actionable findings**.

## Review focus

Confirm that the title states protection status while the description states execution availability, Linux remains blocked pending required setup, and successful initialization is not treated as proof of protection. Independent review of the final evidence mapping is requested through the repository's normal PR review workflow.

