### PR TITLE
fix(skills): validate recovered packages before deleting backups

### DIFF
--- a/src/main/skills/skill-package-transaction-owner.ts
+++ b/src/main/skills/skill-package-transaction-owner.ts
@@ -221,11 +221,31 @@ export class SkillPackageTransactionOwner {
 
     for (const [directoryName, backups] of backupsByDirectoryName) {
       const live = join(dir, directoryName)
-      const liveExists = await stat(live).then(
+      let liveExists = await stat(live).then(
         () => true,
         () => false
       )
       backups.sort((left, right) => right.generation.localeCompare(left.generation))
+      if (liveExists) {
+        // A live directory with a backup may have crashed before final validation. Revalidate
+        // before deleting any recovery copy, including when only cleanup failed last time.
+        const generation = backups[0].generation
+        try {
+          await this.validatePromoted?.({
+            source,
+            directoryName,
+            staging: join(dir, `.${directoryName}.import-${generation}`),
+            generation
+          })
+        } catch (error) {
+          log.warn('interrupted Skill package update failed validation; restoring backup', {
+            directoryName,
+            error
+          })
+          await rm(live, { recursive: true, force: true })
+          liveExists = false
+        }
+      }
       for (let index = 0; index < backups.length; index += 1) {
         const path = join(dir, backups[index].entry)
         if (index === 0 && !liveExists) {

--- a/src/main/skills/user-skill-repository.atomic.test.ts
+++ b/src/main/skills/user-skill-repository.atomic.test.ts
@@ -2,15 +2,15 @@ import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Wrap the real fs/promises but make `rename` a spy we can fail on demand. Every other call (mkdir,
-// writeFile, stat, rm) stays real so the test exercises the actual staging/backup dance on disk.
+// Wrap real filesystem operations with spies for deterministic swap and cleanup failures.
 vi.mock('node:fs/promises', async (importActual) => {
   const actual = await importActual<typeof import('node:fs/promises')>()
   return {
     ...actual,
-    rename: vi.fn((...args: Parameters<typeof actual.rename>) => actual.rename(...args))
+    rename: vi.fn((...args: Parameters<typeof actual.rename>) => actual.rename(...args)),
+    rm: vi.fn((...args: Parameters<typeof actual.rm>) => actual.rm(...args))
   }
 })
 
@@ -23,9 +23,12 @@ const SKILL_URL = 'https://github.com/acme/skills/tree/main/pack/foo'
 // The unmocked rename, captured once; each test resets the spy to pass through to it so a prior test's
 // failure injection can't leak into the next test's setup.
 let realRename: typeof import('node:fs/promises').rename
+let realRm: typeof import('node:fs/promises').rm
 beforeEach(async () => {
   realRename = (await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')).rename
+  realRm = (await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')).rm
   vi.mocked(fsp.rename).mockImplementation((from, to) => realRename(from, to))
+  vi.mocked(fsp.rm).mockImplementation((path, options) => realRm(path, options))
 })
 
 const fetchSkill =
@@ -154,6 +157,107 @@ describe('writeImported swap atomicity', () => {
     // Staging was discarded; nothing partial remains.
     vi.mocked(fsp.rename).mockImplementation((from, to) => realRename(from, to))
     expect(await repo.list()).toEqual([])
+  })
+})
+
+describe.each(['imported', 'personal'] as const)('%s replacement recovery validation', (source) => {
+  let root: string
+  let sourceDir: string
+  let live: string
+  let backup: string
+  let staging: string
+  const oldDocument = '---\nname: foo\n---\nold body'
+  const newDocument = '---\nname: foo\n---\nnew body'
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'atomic-recovery-validation-'))
+    sourceDir = join(root, 'skills', source)
+    live = join(sourceDir, 'foo')
+    backup = join(sourceDir, '.foo.backup-crash')
+    staging = join(sourceDir, '.foo.import-crash')
+    await mkdir(live, { recursive: true })
+    await writeFile(join(live, 'SKILL.md'), oldDocument)
+    if (source === 'imported') {
+      await writeFile(join(live, '.source.json'), JSON.stringify({ url: SKILL_URL }))
+    }
+    await mkdir(staging)
+    await writeFile(join(staging, 'SKILL.md'), newDocument)
+  })
+
+  afterEach(async () => {
+    await realRm(root, { recursive: true, force: true })
+  })
+
+  it.each(['first rename', 'second rename'])(
+    'restores the previous package after a crash following the %s',
+    async (boundary) => {
+      await realRename(live, backup)
+      if (boundary === 'second rename') await realRename(staging, live)
+      const validate = vi.fn<NonNullable<ConstructorParameters<typeof UserSkillRepository>[2]>>(
+        async (list) => {
+          const skills = await list()
+          const document = await readFile(join(skills[0].sourceDir, 'SKILL.md'), 'utf8')
+          if (document.includes('new body')) throw new Error('new helper rejected')
+        }
+      )
+      const restarted = new UserSkillRepository(root, undefined, validate)
+
+      // Public reads execute the real runRecovered path and repository validator binding.
+      expect.soft(await restarted.body(`${source}-foo`)).toBe('old body')
+      expect.soft(validate).toHaveBeenCalledTimes(boundary === 'second rename' ? 1 : 0)
+      expect.soft(await readFile(join(live, 'SKILL.md'), 'utf8')).toBe(oldDocument)
+      expect(await fsp.readdir(sourceDir)).toEqual(['foo'])
+    }
+  )
+
+  it('rolls back when promotion validation fails', async () => {
+    const validate = vi.fn(async () => {
+      throw new Error('new helper rejected')
+    })
+    const repo = new UserSkillRepository(root, undefined, validate)
+
+    if (source === 'imported') {
+      await expect(repo.importFromGitHub(SKILL_URL, fetchSkill(newDocument))).rejects.toThrow(
+        'new helper rejected'
+      )
+    } else {
+      await expect(
+        repo.updatePersonal('personal-foo', { name: 'foo', description: '', body: 'new body' })
+      ).rejects.toThrow('new helper rejected')
+    }
+
+    expect(validate).toHaveBeenCalledTimes(1)
+    expect(await readFile(join(live, 'SKILL.md'), 'utf8')).toBe(oldDocument)
+    expect(await fsp.readdir(sourceDir)).toEqual(['foo'])
+  })
+
+  it('revalidates a successful promotion before retrying failed backup cleanup', async () => {
+    const validate = vi.fn(async () => {})
+    const repo = new UserSkillRepository(root, undefined, validate)
+    vi.mocked(fsp.rm).mockImplementation(async (path, options) => {
+      if (String(path).includes('.backup-')) throw new Error('backup cleanup failed')
+      return realRm(path, options)
+    })
+    if (source === 'imported') {
+      await repo.importFromGitHub(SKILL_URL, fetchSkill(newDocument))
+    } else {
+      await repo.updatePersonal('personal-foo', { name: 'foo', description: '', body: 'new body' })
+    }
+    expect(validate).toHaveBeenCalledTimes(1)
+    const entries = await fsp.readdir(sourceDir)
+    const leftover = entries.find((entry) => entry.includes('.backup-'))!
+    expect(await readFile(join(sourceDir, leftover, 'SKILL.md'), 'utf8')).toBe(oldDocument)
+
+    validate.mockClear()
+    const restarted = new UserSkillRepository(root, undefined, validate)
+    expect(await restarted.body(`${source}-foo`)).toBe('new body')
+    expect.soft(validate).toHaveBeenCalledTimes(1)
+    expect(await fsp.readdir(sourceDir)).toContain(leftover)
+
+    vi.mocked(fsp.rm).mockImplementation((path, options) => realRm(path, options))
+    expect(await restarted.body(`${source}-foo`)).toBe('new body')
+    expect.soft(validate).toHaveBeenCalledTimes(2)
+    expect(await fsp.readdir(sourceDir)).toEqual(['foo'])
   })
 })
 


### PR DESCRIPTION
## Problem

If replacement crashes after staging is renamed to live but before final validation finishes, recovery sees both the new live package and the old backup. It previously deleted the backup without running the promotion validator, retaining a potentially invalid package and losing the previous usable copy.

The regression reproduced this through `UserSkillRepository.body()` and the real recovery/validator binding in temporary directories. On unchanged production code, two consecutive runs observed zero validator calls, the new body retained, and the backup deleted.

## Proposed change

Revalidate a live package before removing any leftover backups. If validation rejects it, restore the previous package through the existing recovery path. A successful validation followed by cleanup failure leaves the backup available for the next recovery attempt.

## Scope and non-goals

Only the shared Skill transaction owner and its existing atomicity suite change. No new persisted fields, migration, dependencies, UI changes, or production test seams. Existing backup layouts remain compatible.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- `npm test -- src/main/skills/user-skill-repository.atomic.test.ts`: 14 passed. Covers imported and personal packages after the first rename, after the second rename, on validation rejection, and on cleanup failure after successful validation. Before the fix, 4 tests failed and 10 passed; after it, all 14 passed.
- `npm run test:module -- user_skills_repository`: 19 files / 835 tests passed, covering the owner, repository contracts, and declared consumers.
- `npm test -- src/main/settings/skill-catalog.registered-helpers.test.ts`: 4 passed, covering the final helper-validation integration.
- `npm run typecheck:node`: passed.
- `npm run lint`: passed without warnings in the isolated worktree.
- Prettier checks for both changed files and `git diff --check`: passed.

RPC/helper tests were rerun outside the outer execution sandbox after its restrictions caused `EPERM` failures. Crash boundaries use real temporary filesystem states rather than terminating the application; Windows and power-loss durability were not exercised locally.

## Review focus

Backup cleanup must follow validation, and failed rollback must leave the recovery copy available. Since there is no durable commit marker, a leftover backup triggers revalidation even if validation succeeded before the crash; a later rejection conservatively restores the old version.
