### PR TITLE
fix(i18n): translate visible renderer copy missed by guards

### DIFF
--- a/src/renderer/src/i18n/resources.test.ts
+++ b/src/renderer/src/i18n/resources.test.ts
@@ -4892,9 +4892,10 @@ const isProse = (text: string): boolean => {
   if (!/[A-Za-z]{2}/.test(text)) return false
   // Units and bare measurements: 12px, 1.5 s.
   if (/^\d+(?:\.\d+)?\s*[a-z%]*$/.test(text)) return false
-  // A single lowercase token is an identifier or a fragment, not a sentence. Multi-word copy and
-  // anything that starts capitalised, numeric or quoted is fair game.
-  if (!/^[A-Z0-9“"']/.test(text) && !text.includes(' ')) return false
+  // Plain lowercase words can be UI copy (for example, unsupported). Exempt only explicit
+  // technical labels and identifier syntax, rather than every lowercase word.
+  if (text === 'abc') return false // Spreadsheet text-column type marker.
+  if (!/^[A-Z0-9“"']/.test(text) && !text.includes(' ') && !/^[a-z]+$/.test(text)) return false
   return true
 }
 
@@ -5006,6 +5007,17 @@ const bareJsxExpressionValues = (source: string): BareCopy[] => {
     ts.ScriptKind.TSX
   )
   const found: BareCopy[] = []
+  // Reuse TypeScript's lexical binding so shadowed parameters and same-named local variables
+  // cannot borrow each other's copy. This program reads only the current source, not its imports.
+  const options: ts.CompilerOptions = { noLib: true, noResolve: true }
+  const program = ts.createProgram([sourceFile.fileName], options, {
+    ...ts.createCompilerHost(options),
+    getSourceFile: (name) => (name === sourceFile.fileName ? sourceFile : undefined),
+    fileExists: (name) => name === sourceFile.fileName,
+    readFile: () => undefined
+  })
+  const checker = program.getTypeChecker()
+  const visited = new Set<ts.Expression>()
 
   const record = (node: ts.Node, text: string): void => {
     const normalized = text.replace(/\s+/g, ' ').trim()
@@ -5017,6 +5029,21 @@ const bareJsxExpressionValues = (source: string): BareCopy[] => {
   }
 
   const inspect = (expression: ts.Expression): void => {
+    if (visited.has(expression)) return
+    visited.add(expression)
+    if (ts.isIdentifier(expression)) {
+      const declaration = checker.getSymbolAtLocation(expression)?.valueDeclaration
+      if (
+        declaration &&
+        ts.isVariableDeclaration(declaration) &&
+        ts.isIdentifier(declaration.name) &&
+        declaration.initializer &&
+        ts.isVariableDeclarationList(declaration.parent) &&
+        (declaration.parent.flags & ts.NodeFlags.Const) !== 0
+      )
+        inspect(declaration.initializer)
+      return
+    }
     if (
       ts.isParenthesizedExpression(expression) ||
       ts.isAsExpression(expression) ||
@@ -5080,6 +5107,10 @@ const NOT_TRANSLATABLE = new Set([
   'Discord',
   'GitHub',
   'SKILL.md',
+  'claude setup-token',
+  'argocd',
+  'API_TOKEN=',
+  'Authorization: X-Api-Key:',
   'openid profile',
   'Python',
   'Enter',
@@ -5112,7 +5143,10 @@ const CODE_LOOKALIKE = /^(?:default|case|return|break|const|let|await)\b/
 const KNOWN_BARE = new Set<string>()
 
 describe('bare copy', () => {
-  const components = SCAN_ROOTS.flatMap(sourceFiles).filter((path) => path.endsWith('.tsx'))
+  // Design-state fixtures are development-only; production renderer components remain scanned.
+  const components = SCAN_ROOTS.flatMap(sourceFiles).filter(
+    (path) => path.endsWith('.tsx') && !path.endsWith('.preview.tsx')
+  )
 
   const offenders = components.flatMap((path) => {
     const source = readFileSync(path, 'utf8')
@@ -5156,6 +5190,39 @@ describe('bare copy', () => {
 // over-eager match reports copy that is already handled. These pin the shapes that actually caused
 // trouble while the migration ran.
 describe('bare copy detection', () => {
+  it('finds lowercase user-facing words instead of treating every word as an identifier', () => {
+    expect(bareJsxAstText('<span>unsupported</span>')).toEqual([{ text: 'unsupported', line: 1 }])
+    expect(bareJsxExpressionValues("<span>{ready ? 'available' : 'unavailable'}</span>")).toEqual([
+      { text: 'available', line: 1 },
+      { text: 'unavailable', line: 1 }
+    ])
+  })
+
+  it('follows local const templates and conditional reasons into visible JSX', () => {
+    expect(
+      bareJsxExpressionValues(
+        'const label = `${rows} rows · ${columns} columns`; const reason = ready ? undefined : `No model from ${name} is supported.`; const view = <><span>{label}</span><button aria-label={reason} /></>'
+      )
+    ).toEqual([
+      { text: 'rows · columns', line: 1 },
+      { text: 'No model from is supported.', line: 1 }
+    ])
+  })
+
+  it('respects local binding scope and accepts translated templates and technical content', () => {
+    expect(
+      bareJsxExpressionValues(
+        "const label = 'Not rendered'; function View({ label }: Props) { return <span>{label}</span> }; const other = () => { const label = t('{{rows}} rows', { rows }); return <span>{label}</span> }"
+      )
+    ).toEqual([])
+    expect(bareJsxAstText('<span>abc</span><code>ssh-agent</code><span>12px</span>')).toEqual([])
+    expect(
+      bareJsxExpressionValues(
+        "const command = 'claude setup-token'; const view = <code>{command}</code>"
+      ).filter(({ text }) => !NOT_TRANSLATABLE.has(text))
+    ).toEqual([])
+  })
+
   it('finds text in an element', () => {
     expect(bareJsxText('<span>Needs repair</span>')).toEqual([{ text: 'Needs repair', line: 1 }])
   })

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -1542,8 +1542,8 @@ const ArtifactProvenancePanel = ({
                   </dd>
                   <dt className="text-text-300">{t('Source')}</dt>
                   <dd className="text-text-100">
-                    {asString(environment.runtime_source) ?? 'unknown'} ·{' '}
-                    {asString(environment.kernel_kind) ?? 'unknown'}
+                    {asString(environment.runtime_source) ?? t('unknown')} ·{' '}
+                    {asString(environment.kernel_kind) ?? t('unknown')}
                   </dd>
                   <dt className="text-text-300">{t('Capture')}</dt>
                   <dd className="text-text-100">
@@ -1586,7 +1586,7 @@ const ArtifactProvenancePanel = ({
                             {asString(pkg.version) ?? '—'}
                           </td>
                           <td className="px-3 py-2 text-text-300">
-                            {asString(pkg.loaded_state) ?? 'unknown'}
+                            {asString(pkg.loaded_state) ?? t('unknown')}
                           </td>
                         </tr>
                       ))}
@@ -1702,7 +1702,7 @@ const ArtifactProvenancePanel = ({
                                         : '—'}
                                   </td>
                                   <td className="whitespace-normal break-words px-2 py-2 align-top text-text-300">
-                                    {asString(operation.result) ?? 'unknown'}
+                                    {asString(operation.result) ?? t('unknown')}
                                   </td>
                                 </tr>
                                 {hasPackageChanges ? (

--- a/src/renderer/src/pages/workspace/ComposerContextUsage.tsx
+++ b/src/renderer/src/pages/workspace/ComposerContextUsage.tsx
@@ -301,7 +301,8 @@ const ComposerContextUsage = ({
           ) : (
             <div className="whitespace-nowrap text-muted-foreground tabular-nums">
               {hasKnownSize ? `${formatTokens(used)} / ${formatTokens(size)}` : formatTokens(used)}{' '}
-              tokens{percent !== undefined ? ` (${percent}%)` : ''}
+              {t('tokens')}
+              {percent !== undefined ? ` (${percent}%)` : ''}
             </div>
           )}
           {showCompactAction ? (

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -20,6 +20,7 @@ import {
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { incompatibilityReason } from './composer-model-picker-utils'
+import * as providerRegistry from '../../../../shared/provider-registry'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -74,6 +75,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   vi.restoreAllMocks()
+  void i18next.changeLanguage('en')
 })
 
 const provider = (overrides: Partial<ProviderView>): ProviderView => ({
@@ -189,6 +191,66 @@ const modelRowTrigger = (): HTMLElement | undefined =>
   subTriggers().find((el) => el.getAttribute('data-testid') === 'model-row')
 
 describe('ComposerModelPicker', () => {
+  it('localizes the unsupported badge in a mixed model catalog', async () => {
+    await i18next.changeLanguage('zh-Hans')
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: [
+        {
+          id: 'opencode',
+          displayName: 'OpenCode',
+          supportedApiTypes: ['anthropic', 'openai'],
+          supportsSkills: true
+        }
+      ],
+      providers: [
+        provider({
+          id: 'mixed',
+          type: 'official',
+          vendorId: 'opencode',
+          apiEndpoints: ['openai'],
+          models: ['kimi-k2.7-code', 'gpt-5.6-sol']
+        })
+      ],
+      activeProviderId: 'mixed',
+      activeModel: 'kimi-k2.7-code'
+    })
+    render()
+    await openMenu(container.querySelector('button')!)
+    await openSubmenu(modelRowTrigger()!)
+    const row = menuItems().find((item) =>
+      item.getAttribute('aria-label')?.includes('gpt-5.6-sol')
+    )!
+    expect(row.textContent).toContain('不支持')
+    expect(row.textContent).not.toContain('unsupported')
+    expect(row.getAttribute('aria-disabled')).toBe('true')
+    act(() => row.click())
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('localizes the provider reason when every model is bridge-unsupported', async () => {
+    // The bundled catalog currently has no bridge exclusions. Control its existing policy boundary
+    // to exercise the picker branch without changing production state or the catalog model.
+    vi.spyOn(providerRegistry, 'isModelBridgeSupported').mockReturnValue(false)
+    await i18next.changeLanguage('zh-Hans')
+    useSettingsStore.setState({
+      ...codexFramework,
+      providers: [
+        provider({ id: 'gateway', name: 'Gateway', apiEndpoints: ['openai'], models: ['model-a'] })
+      ]
+    })
+    render()
+    await openMenu(container.querySelector('button')!)
+    await openSubmenu(modelRowTrigger()!)
+    const row = menuItems().find((item) => item.getAttribute('aria-disabled') === 'true')!
+    expect(row.getAttribute('aria-label')).toBe(
+      'Gateway 的所有模型均不支持通过 Codex Chat Completions 桥接使用。'
+    )
+    expect(row.title).toBe(row.getAttribute('aria-label'))
+    act(() => row.click())
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it('renders nothing when there is a single selectable option', () => {
     useSettingsStore.setState({
       providers: [provider({ id: 'p1', models: ['only'], reasoningEffortPreset: 'unsupported' })]

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -84,8 +84,6 @@ const ComposerModelPicker = ({
   includeAllClaudeSubscriptions = false,
   onChange
 }: ComposerModelPickerProps): React.JSX.Element | null => {
-  // Only the shared incompatibility copy is translated here; the rest of this picker's strings belong
-  // to the workspace surface and are converted with it.
   const { t } = useTranslation()
   const { t: tCommon } = useTranslation()
   const providers = useSettingsStore((state) => state.providers)
@@ -366,7 +364,10 @@ const ComposerModelPicker = ({
               const reason = compatible
                 ? undefined
                 : endpointCompatible && agentFrameworkId === 'codex'
-                  ? `No model from ${group.provider.name} is supported over the Codex Chat Completions bridge.`
+                  ? t(
+                      'No model from {{provider}} is supported over the Codex Chat Completions bridge.',
+                      { provider: group.provider.name }
+                    )
                   : incompatibilityReason(
                       {
                         apiEndpoints: group.provider.apiEndpoints,
@@ -412,7 +413,7 @@ const ComposerModelPicker = ({
                                   <span className="min-w-0 flex-1 truncate">
                                     {optionLabel(option)}
                                   </span>
-                                  <span className="text-xs">unsupported</span>
+                                  <span className="text-xs">{t('unsupported')}</span>
                                 </DropdownMenuItem>
                               </TooltipTrigger>
                               <TooltipContent side="right" className="max-w-72 leading-5">

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1821,7 +1821,10 @@ const ConversationPanel = ({
                                   ? t('Cancelling…')
                                   : transfer.status === 'error'
                                     ? transfer.error || t('Upload failed')
-                                    : `${percent}% of ${formatAttachmentSize(transfer.totalBytes)}`
+                                    : t('{{percent}}% of {{size}}', {
+                                        percent,
+                                        size: formatAttachmentSize(transfer.totalBytes)
+                                      })
                             const pastedText = transfer.pastedTextId
                               ? pastedTextById.get(transfer.pastedTextId)
                               : undefined

--- a/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.tsx
+++ b/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.tsx
@@ -200,7 +200,10 @@ const DownloadSessionArtifactsDialog = ({
               </div>
               {status === 'ready' ? (
                 <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-                  {selectedArtifacts.length} of {artifacts.length} selected
+                  {t('{{selected}} of {{total}} selected', {
+                    selected: selectedArtifacts.length,
+                    total: artifacts.length
+                  })}
                 </span>
               ) : null}
             </div>

--- a/src/renderer/src/pages/workspace/SessionReviewerPanel.tsx
+++ b/src/renderer/src/pages/workspace/SessionReviewerPanel.tsx
@@ -204,7 +204,7 @@ const ReviewerLogRow = ({ entry }: { entry: ReviewerLogEntry }): React.JSX.Eleme
             aria-hidden
           />
         </span>
-        <span className="font-semibold text-text-300">{entry.toolName || 'tool'}</span>
+        <span className="font-semibold text-text-300">{entry.toolName || t('Tool')}</span>
         {summary ? (
           <code className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-text-400">
             {summary}

--- a/src/renderer/src/pages/workspace/WorkspaceWebSearchActivityRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceWebSearchActivityRow.tsx
@@ -27,6 +27,7 @@ const formatResultCountLabel = (
 const renderSearchDetailsBody = (
   activity: ToolActivity,
   details: WebSearchDetails,
+  t: ReturnType<typeof useTranslation>['t'],
   annotationPort?: AnnotationPort
 ): React.JSX.Element => {
   const annotate = (children: React.ReactNode, sectionId: string): React.JSX.Element =>
@@ -53,7 +54,7 @@ const renderSearchDetailsBody = (
   return (
     <>
       <div className="grid grid-cols-[auto_1fr] items-start gap-x-4 gap-y-1.5">
-        <span className="pt-px text-text-100">query</span>
+        <span className="pt-px text-text-100">{t('query')}</span>
         {annotate(
           <span className="whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-text-000">
             {details.query}
@@ -125,7 +126,7 @@ const WorkspaceWebSearchActivityRow = ({
       panelTestId="tool-search-details"
       onToggle={onToggleSearch}
     >
-      {renderSearchDetailsBody(activity, details, annotationPort)}
+      {renderSearchDetailsBody(activity, details, t, annotationPort)}
     </WorkspaceToolActivityRowButton>
   )
 }

--- a/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { i18next } from '@/i18n'
+import { createManagedPreviewTestTransport } from '../managed-preview-test-support'
+import { CsvPreviewRenderer } from './CsvPreview'
+
+const item = {
+  id: 'csv-file',
+  type: 'file' as const,
+  title: 'data.csv',
+  name: 'data.csv',
+  path: 'artifact://data.csv',
+  format: 'csv' as const,
+  source: 'artifact' as const,
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  managedFileId: 'csv-file'
+}
+const read = vi.fn()
+
+beforeEach(async () => {
+  await i18next.changeLanguage('zh-Hans')
+  read.mockReset()
+  const transport = createManagedPreviewTestTransport({ read })
+  vi.stubGlobal('api', {
+    previewResources: { acquire: transport.acquire, release: transport.release }
+  })
+  vi.stubGlobal('fetch', transport.fetch)
+})
+afterEach(async () => {
+  cleanup()
+  vi.unstubAllGlobals()
+  await i18next.changeLanguage('en')
+})
+
+const mockCsv = (content: string, truncated = false): void => {
+  read.mockResolvedValue({ content, encoding: 'utf8', size: content.length, truncated })
+}
+
+describe('CSV preview localization', () => {
+  it.each([false, true])('localizes row and column counts (truncated: %s)', async (truncated) => {
+    mockCsv('sample,value\nA,1\nB,2', truncated)
+    render(<CsvPreviewRenderer item={item} />)
+    const table = await screen.findByRole('table')
+    expect(table.textContent).toContain('sample')
+    expect(screen.getByText(truncated ? '2+ 行 · 2 列' : '2 行 · 2 列')).toBeTruthy()
+    expect(document.body.textContent).not.toMatch(/rows|columns/)
+    expect(document.body.textContent).not.toContain('CSV 解析出现问题')
+  })
+
+  it('uses stable translated warning copy for malformed CSV while retaining parsed data', async () => {
+    // Real Papa Parse input: the quoted field has no closing quote.
+    mockCsv('sample,value\nA,"unterminated')
+    render(<CsvPreviewRenderer item={item} />)
+    const table = await screen.findByRole('table')
+    expect(table.textContent).toContain('unterminated')
+    expect(document.body.textContent).not.toContain('Quoted field unterminated')
+    expect(screen.getByText(/CSV 解析出现问题，预览可能不完整。/)).toBeTruthy()
+  })
+})

--- a/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx
@@ -46,9 +46,15 @@ export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JS
   const dataRows = rows.slice(1, VISIBLE_ROWS + 1)
   const visibleHeaders = headers.slice(0, VISIBLE_COLUMNS)
   const hiddenColumnCount = Math.max(headers.length - visibleHeaders.length, 0)
-  const rowCountLabel = `${Math.max(rows.length - 1, 0)}${state.preview.truncated ? '+' : ''} rows · ${
-    headers.length
-  } columns`
+  const rowCountLabel = state.preview.truncated
+    ? t('{{rows}}+ rows · {{columns}} columns', {
+        rows: Math.max(rows.length - 1, 0),
+        columns: headers.length
+      })
+    : t('{{rows}} rows · {{columns}} columns', {
+        rows: Math.max(rows.length - 1, 0),
+        columns: headers.length
+      })
 
   return (
     <div className="flex size-full flex-col overflow-hidden bg-bg-10">
@@ -60,7 +66,12 @@ export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JS
             columns: visibleHeaders.length
           })}
         </span>
-        {errors[0] ? <span className="text-danger-000"> · {errors[0]}</span> : null}
+        {errors[0] ? (
+          <span className="text-danger-000">
+            {' '}
+            · {t('CSV parsing encountered a problem. The preview may be incomplete.')}
+          </span>
+        ) : null}
       </div>
       <div className="min-h-0 flex-1 overflow-auto">
         <table className="min-w-full border-separate border-spacing-0 text-left text-[12px]">

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4201,6 +4201,10 @@
     "Managed runtime pack unavailable": "Verwaltetes Laufzeitpaket ist nicht verfügbar",
     "Environment setup progress": "Fortschritt der Umgebungseinrichtung",
     "Download progress": "Downloadfortschritt",
-    "Notebook environment ready": "Notebook-Umgebung ist bereit"
+    "Notebook environment ready": "Notebook-Umgebung ist bereit",
+    "unsupported": "nicht unterstützt",
+    "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "Kein Modell von {{provider}} wird über die Codex Chat Completions-Brücke unterstützt.",
+    "CSV parsing encountered a problem. The preview may be incomplete.": "Beim Lesen der CSV-Daten ist ein Problem aufgetreten. Die Vorschau ist möglicherweise unvollständig.",
+    "{{percent}}% of {{size}}": "{{percent}} % von {{size}}"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4356,6 +4356,10 @@
     "Managed runtime pack unavailable": "El paquete del entorno de ejecución administrado no está disponible",
     "Environment setup progress": "Progreso de la configuración del entorno",
     "Download progress": "Progreso de la descarga",
-    "Notebook environment ready": "El entorno de Notebook está listo"
+    "Notebook environment ready": "El entorno de Notebook está listo",
+    "unsupported": "no compatible",
+    "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "Ningún modelo de {{provider}} es compatible con el puente de Chat Completions de Codex.",
+    "CSV parsing encountered a problem. The preview may be incomplete.": "Se ha producido un problema al analizar el CSV. La vista previa puede estar incompleta.",
+    "{{percent}}% of {{size}}": "{{percent}} % de {{size}}"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4356,6 +4356,10 @@
     "Managed runtime pack unavailable": "Le paquet d’environnement d’exécution géré est indisponible",
     "Environment setup progress": "Progression de la configuration de l’environnement",
     "Download progress": "Progression du téléchargement",
-    "Notebook environment ready": "L’environnement Notebook est prêt"
+    "Notebook environment ready": "L’environnement Notebook est prêt",
+    "unsupported": "non pris en charge",
+    "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "Aucun modèle de {{provider}} n’est pris en charge via la passerelle Chat Completions de Codex.",
+    "CSV parsing encountered a problem. The preview may be incomplete.": "Un problème est survenu lors de l’analyse du CSV. L’aperçu peut être incomplet.",
+    "{{percent}}% of {{size}}": "{{percent}} % de {{size}}"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4046,6 +4046,10 @@
     "Managed runtime pack unavailable": "管理対象ランタイムパックを利用できません",
     "Environment setup progress": "環境セットアップの進行状況",
     "Download progress": "ダウンロードの進行状況",
-    "Notebook environment ready": "Notebook 環境の準備ができました"
+    "Notebook environment ready": "Notebook 環境の準備ができました",
+    "unsupported": "非対応",
+    "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "{{provider}} のモデルは、いずれも Codex Chat Completions ブリッジではサポートされていません。",
+    "CSV parsing encountered a problem. The preview may be incomplete.": "CSV の解析中に問題が発生しました。プレビューが不完全な可能性があります。",
+    "{{percent}}% of {{size}}": "{{size}} の {{percent}}%"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4044,6 +4044,10 @@
     "Managed runtime pack unavailable": "관리되는 런타임 팩을 사용할 수 없습니다",
     "Environment setup progress": "환경 설정 진행률",
     "Download progress": "다운로드 진행률",
-    "Notebook environment ready": "Notebook 환경 준비 완료"
+    "Notebook environment ready": "Notebook 환경 준비 완료",
+    "unsupported": "지원되지 않음",
+    "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "{{provider}}의 모델은 모두 Codex Chat Completions 브리지에서 지원되지 않습니다.",
+    "CSV parsing encountered a problem. The preview may be incomplete.": "CSV를 분석하는 중 문제가 발생했습니다. 미리보기가 불완전할 수 있습니다.",
+    "{{percent}}% of {{size}}": "{{size}} 중 {{percent}}%"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4486,6 +4486,10 @@
     "Managed runtime pack unavailable": "Пакет управляемой среды выполнения недоступен",
     "Environment setup progress": "Ход настройки среды",
     "Download progress": "Ход загрузки",
-    "Notebook environment ready": "Среда Notebook готова"
+    "Notebook environment ready": "Среда Notebook готова",
+    "unsupported": "не поддерживается",
+    "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "Ни одна модель {{provider}} не поддерживается через мост Codex Chat Completions.",
+    "CSV parsing encountered a problem. The preview may be incomplete.": "При разборе CSV возникла проблема. Предпросмотр может быть неполным.",
+    "{{percent}}% of {{size}}": "{{percent}}% из {{size}}"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4046,6 +4046,10 @@
     "Managed runtime pack unavailable": "托管运行时包不可用",
     "Environment setup progress": "环境设置进度",
     "Download progress": "下载进度",
-    "Notebook environment ready": "Notebook 环境已就绪"
+    "Notebook environment ready": "Notebook 环境已就绪",
+    "unsupported": "不支持",
+    "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "{{provider}} 的所有模型均不支持通过 Codex Chat Completions 桥接使用。",
+    "CSV parsing encountered a problem. The preview may be incomplete.": "CSV 解析出现问题，预览可能不完整。",
+    "{{percent}}% of {{size}}": "{{size}} 的 {{percent}}%"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4046,6 +4046,10 @@
     "Managed runtime pack unavailable": "托管執行環境包無法使用",
     "Environment setup progress": "環境設定進度",
     "Download progress": "下載進度",
-    "Notebook environment ready": "Notebook 環境已就緒"
+    "Notebook environment ready": "Notebook 環境已就緒",
+    "unsupported": "不支援",
+    "No model from {{provider}} is supported over the Codex Chat Completions bridge.": "{{provider}} 的所有模型均不支援透過 Codex Chat Completions 橋接使用。",
+    "CSV parsing encountered a problem. The preview may be incomplete.": "CSV 剖析發生問題，預覽可能不完整。",
+    "{{percent}}% of {{size}}": "{{size}} 的 {{percent}}%"
   }
 }


### PR DESCRIPTION
## Problem

F09: non-English users see `unsupported` in mixed model menus, English CSV totals, and raw Papa Parse warnings. The provider-wide Codex bridge reason also interpolates an English sentence. The original 805 i18n checks pass despite these gaps.

## Proposed change

Translate these strings through the existing renderer namespace and eight catalogs. Reuse existing complete/truncated CSV count keys; show stable translated parser-warning copy while retaining the parsed table. Extend the existing guard to recognize ordinary lowercase words and follow same-file const bindings using TypeScript's lexical binder. Retain explicit technical-copy exceptions and exclude development-only `.preview.tsx` fixtures.

The stricter guard also exposed fallback `unknown`/`tool`, `tokens`, search `query`, upload progress, and artifact-selection counters. Translate those existing UI entry points as part of bringing the guard to green.

## Scope and non-goals

No new application fields, enum values, persistence, stored formats, historical-data compatibility, migrations, dependencies, public component props, model eligibility, parser behavior or interaction changes. Raw parser wording is replaced by a general warning; this does not introduce a parser error taxonomy. The scanner covers local const bindings, not arbitrary cross-file/runtime data flow.

## Acceptance criteria and validation

Before production fixes, two runs produced the same seven failures: two menu DOM tests, three real-parser CSV DOM tests and two scanner regressions. The existing 805 i18n checks remained green. The provider-wide bridge test uses the existing compatibility-policy function because the bundled model registry currently contains no bridge exclusions; this is latent-branch coverage, not a claim that today's default catalog naturally triggers it. No production test seam was added.

After the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Catalogs in all eight languages and scanner regressions | resources.test.ts | Passed |
| Model-menu labels, accessibility and non-selection | ComposerModelPicker.render.test.tsx | Passed |
| Complete/truncated CSV totals and malformed-input warning | previews/renderers/CsvPreview.test.tsx | Passed |
| Managed preview and consumers | usePreviewFileContent.test.tsx, preview-registry.test.tsx, PreviewFileContent.test.tsx, artifact-preview.test.tsx | Passed |
| Unchanged model policy | configured-model-catalog.test.ts | Passed |
| Additional copy consumers | ArtifactProvenancePanel.render.test.tsx, ComposerContextUsage.render.test.tsx, ConversationPanel.interaction.test.tsx, DownloadSessionArtifactsDialog.interaction.test.tsx, SessionReviewerPanel.render.test.tsx, SessionReviewerPanel.log.render.test.tsx, WorkspaceActivityGroup.annotations.test.tsx | Passed |
| Renderer types | npm run typecheck:web | Passed |
| Repository lint | npm run lint | Passed |
| Whitespace errors | git diff --check | Passed |

The 15 listed suites ran together through `npm test -- <explicit paths> --maxWorkers=2`: **1137 tests passed**. The maintainer requested focused local checks; the full suite was not run locally. DOM regressions use zh-Hans and catalog guards cover all eight locales. No native/path/persistence or main/preload/ACP behavior changed, so local native/platform suites were not selected. Real Electron layout and visual fit in every language remain untested locally. PR CI and independent review remain pending.

## Review focus

Confirm stable warning copy is appropriate, technical exceptions remain narrow, and all additional changes are copy-only. Verify the evidence mapping covers the final diff; required PR CI remains authoritative.
