### PR TITLE
fix(connectors): release response bodies and enforce call budgets

### DIFF
--- a/src/main/connectors/descriptors/rna.test.ts
+++ b/src/main/connectors/descriptors/rna.test.ts
@@ -366,6 +366,96 @@ describe('rna / rfam', () => {
     })
   })
 
+  it.each([150_000, 295_000])(
+    'search_sequence preserves the default window for a job ready after %ims',
+    async (readyAfterMs) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(0)
+      try {
+        const submissionMs = 20_000
+        const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+          if (init?.method === 'POST') {
+            await new Promise((resolve) => setTimeout(resolve, submissionMs))
+            return Response.json({ jobId: 'job-1', resultURL: 'https://rfam.test/result/1' })
+          }
+          return Response.json(
+            Date.now() >= submissionMs + readyAfterMs
+              ? { hits: {}, searchSequence: 'GGUUCC' }
+              : { status: 'PEND' }
+          )
+        })
+        const result = new ParserEngine({ fetchImpl })
+          .call(tool('search_sequence'), { sequence: 'GGUUCC' }, {})
+          .then(
+            (value) => ({ value, finishedAt: Date.now() }),
+            (error: unknown) => ({ error, finishedAt: Date.now() })
+          )
+        await vi.advanceTimersByTimeAsync(submissionMs + readyAfterMs)
+        expect(await result).toMatchObject({
+          value: { job_id: 'job-1', num_hits: 0, search_sequence: 'GGUUCC' },
+          finishedAt: submissionMs + readyAfterMs
+        })
+        expect(vi.getTimerCount()).toBe(0)
+      } finally {
+        vi.useRealTimers()
+      }
+    }
+  )
+
+  it('search_sequence still stops an unfinished job at its default polling deadline', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) =>
+        Response.json(
+          init?.method === 'POST'
+            ? { jobId: 'job-1', resultURL: 'https://rfam.test/result/1' }
+            : { status: 'PEND' }
+        )
+      )
+      const result = new ParserEngine({ fetchImpl })
+        .call(tool('search_sequence'), { sequence: 'GGUUCC' }, {})
+        .catch((error: unknown) => ({ error, finishedAt: Date.now() }))
+      await vi.advanceTimersByTimeAsync(300_000)
+      expect(await result).toMatchObject({
+        error: { message: expect.stringContaining('Rfam sequence search not finished after 300s') },
+        finishedAt: 300_000
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('search_sequence keeps a hard call deadline for longer custom polling waits', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) =>
+        Response.json(
+          init?.method === 'POST'
+            ? { jobId: 'job-1', resultURL: 'https://rfam.test/result/1' }
+            : { status: 'PEND' }
+        )
+      )
+      const result = new ParserEngine({ fetchImpl })
+        .call(
+          tool('search_sequence'),
+          { sequence: 'GGUUCC', max_wait_s: 1200, poll_interval_s: 30 },
+          {}
+        )
+        .catch((error: unknown) => ({ error, finishedAt: Date.now() }))
+      await vi.advanceTimersByTimeAsync(600_000)
+      expect(await result).toMatchObject({
+        error: { name: 'ConnectorRequestTimeoutError' },
+        finishedAt: 600_000
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('aborts the polling delay without starting another request', async () => {
     vi.useFakeTimers()
     const cancellation = new AbortController()

--- a/src/main/connectors/descriptors/rna.ts
+++ b/src/main/connectors/descriptors/rna.ts
@@ -436,8 +436,10 @@ export const RNA_TOOLS: ToolDescriptor[] = [
   {
     id: 'search_sequence',
     connector: 'rna',
+    // Preserve the default 300s polling window with headroom for submission and network waits.
+    totalTimeoutMs: 600_000,
     description:
-      'Search a single RNA/DNA sequence against all Rfam covariance models (async cmscan): submit to rfam.org and poll until done. Known upstream limitation: the job backend may be down (valid submissions return "SearchUnavailable … come back later"; invalid sequences still get a 400) — the error is surfaced as-is.',
+      'Search a single RNA/DNA sequence against all Rfam covariance models (async cmscan): submit to rfam.org and poll until done. The whole call is capped at 600 seconds, including submission and polling. Known upstream limitation: the job backend may be down (valid submissions return "SearchUnavailable … come back later"; invalid sequences still get a 400) — the error is surfaced as-is.',
     input: {
       type: 'object',
       properties: {

--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -194,7 +194,7 @@ describe('ParserEngine declarative path', () => {
     await expect(engine.call(desc, {}, {})).rejects.toMatchObject({
       name: 'ConnectorRequestTimeoutError',
       message:
-        "Connector request exceeded the 25ms total deadline after 1 attempt for https://x.test/data. This is the Connector's own deadline; increasing an outer execution timeout will not extend it. Do not retry solely with a longer timeout."
+        "Connector call exceeded the 25ms total deadline for c/t. This is the Connector's own deadline; increasing an outer execution timeout will not extend it. Do not retry solely with a longer timeout."
     })
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
@@ -362,18 +362,29 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
-  it('exposes the caller signal to run-style descriptors', async () => {
+  it('propagates caller cancellation through the run-style context signal', async () => {
     const engine = new ParserEngine({ fetchImpl: vi.fn() })
     const cancellation = new AbortController()
+    let observed: AbortSignal | undefined
     const desc: ToolDescriptor = {
       id: 't',
       connector: 'c',
       description: '',
       input: {},
-      run: async (ctx) => ctx.signal
+      run: async (ctx) => {
+        observed = ctx.signal
+        return new Promise((_, reject) => {
+          ctx.signal?.addEventListener('abort', () => reject(ctx.signal?.reason), { once: true })
+        })
+      }
     }
-
-    await expect(engine.call(desc, {}, {}, cancellation.signal)).resolves.toBe(cancellation.signal)
+    const result = engine.call(desc, {}, {}, cancellation.signal)
+    expect(observed).toBeInstanceOf(AbortSignal)
+    expect(observed?.aborted).toBe(false)
+    const reason = new Error('user cancelled')
+    cancellation.abort(reason)
+    await expect(result).rejects.toBe(reason)
+    expect(observed?.reason).toBe(reason)
   })
 
   it('does not retry a client error (4xx other than 429)', async () => {
@@ -445,4 +456,257 @@ describe('ParserEngine declarative path', () => {
     expect(message).not.toContain('SECRET')
     expect(message).toContain('HTTP 401')
   })
+})
+
+describe('ParserEngine request lifecycle regressions', () => {
+  const descriptor: ToolDescriptor = {
+    id: 'lifecycle',
+    connector: 'test',
+    description: '',
+    input: {},
+    url: () => 'https://x.test/data',
+    parse: (raw) => raw,
+    format: 'text'
+  }
+
+  it.each([400, 429, 503])('F02 cancels every unfinished HTTP %i body', async (status) => {
+    const cancellations: ReturnType<typeof vi.fn>[] = []
+    const fetchImpl = vi.fn(async () => {
+      const cancel = vi.fn()
+      cancellations.push(cancel)
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(1024 * 1024))
+          },
+          cancel
+        }),
+        { status }
+      )
+    })
+    const engine = new ParserEngine({ fetchImpl, retryBackoffMs: 0 })
+    await expect(engine.call(descriptor, {}, {})).rejects.toThrow(`HTTP ${status}`)
+    expect(fetchImpl).toHaveBeenCalledTimes(status === 400 ? 1 : 3)
+    for (const cancel of cancellations) expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('F03 includes retry backoff in the call deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 503 }))
+      const engine = new ParserEngine({ fetchImpl, totalTimeoutMs: 30, retryBackoffMs: 40 })
+      const result = engine.call(descriptor, {}, {}).catch((error: unknown) => error)
+      await vi.advanceTimersByTimeAsync(30)
+      expect(await Promise.race([result, Promise.resolve('still pending')])).toMatchObject({
+        name: 'ConnectorRequestTimeoutError',
+        message: expect.stringContaining('30ms total deadline')
+      })
+      expect(fetchImpl).toHaveBeenCalledOnce()
+      await vi.runAllTimersAsync()
+      await result
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('F03 stops waiting for a run descriptor that ignores cancellation', async () => {
+    vi.useFakeTimers()
+    try {
+      const result = new ParserEngine({ totalTimeoutMs: 30 })
+        .call(
+          {
+            ...descriptor,
+            run: async () => new Promise(() => {})
+          },
+          {},
+          {}
+        )
+        .catch((error: unknown) => error)
+      await vi.advanceTimersByTimeAsync(30)
+      expect(await Promise.race([result, Promise.resolve('still pending')])).toMatchObject({
+        name: 'ConnectorRequestTimeoutError'
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('F03 shares the call deadline across sequential fetches', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 20)
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timer)
+              reject(init.signal?.reason)
+            },
+            { once: true }
+          )
+        })
+        return new Response('ok')
+      })
+      const engine = new ParserEngine({ fetchImpl, totalTimeoutMs: 30 })
+      const result = engine
+        .call(
+          {
+            ...descriptor,
+            run: async (ctx) => {
+              await ctx.fetchText('https://x.test/one')
+              return ctx.fetchText('https://x.test/two')
+            }
+          },
+          {},
+          {}
+        )
+        .catch((error: unknown) => error)
+      await vi.advanceTimersByTimeAsync(40)
+      expect(await result).toMatchObject({ name: 'ConnectorRequestTimeoutError' })
+      expect(fetchImpl).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it.each(['60', 'Sat, 05 Sep 2026 00:01:00 GMT'])(
+    'F04 does not retry before Retry-After %s',
+    async (retryAfter) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-09-05T00:00:00Z'))
+      try {
+        const fetchImpl = vi
+          .fn()
+          .mockResolvedValueOnce(
+            new Response(null, { status: 429, headers: { 'Retry-After': retryAfter } })
+          )
+          .mockResolvedValueOnce(new Response('ok'))
+        const result = new ParserEngine({ fetchImpl }).call(descriptor, {}, {})
+        await vi.advanceTimersByTimeAsync(59_999)
+        expect(fetchImpl).toHaveBeenCalledOnce()
+        await vi.advanceTimersByTimeAsync(1)
+        await expect(result).resolves.toBe('ok')
+        expect(fetchImpl).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    }
+  )
+
+  it('F04 returns HTTP status and retry time when the call budget cannot fit Retry-After', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(null, {
+            status: 429,
+            headers: { 'Retry-After': '60' }
+          })
+      )
+      const result = new ParserEngine({ fetchImpl, totalTimeoutMs: 30_000 })
+        .call(descriptor, {}, {})
+        .catch((error: unknown) => error)
+      await vi.runAllTimersAsync()
+      expect(await result).toMatchObject({
+        message: expect.stringMatching(/HTTP 429.*Retry after 60s/)
+      })
+      expect(fetchImpl).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('ParserEngine body cleanup edge cases', () => {
+  const descriptor: ToolDescriptor = {
+    id: 'cleanup',
+    connector: 'test',
+    description: '',
+    input: {},
+    url: () => 'https://x.test/data',
+    parse: (raw) => raw,
+    format: 'text'
+  }
+
+  it.each(['reject', 'pending'])(
+    'F02 preserves HTTP failure when cancellation is %s',
+    async (mode) => {
+      const cancel = vi.fn(() =>
+        mode === 'reject' ? Promise.reject(new Error('cancel failed')) : new Promise<void>(() => {})
+      )
+      const response = new Response(new ReadableStream({ cancel }), { status: 400 })
+      const engine = new ParserEngine({ fetchImpl: vi.fn().mockResolvedValue(response) })
+      await expect(engine.call(descriptor, {}, {})).rejects.toThrow('HTTP 400')
+      expect(cancel).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('F02 cancels the remainder of an oversized successful body', async () => {
+    const cancel = vi.fn()
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(10))
+        },
+        cancel
+      })
+    )
+    const engine = new ParserEngine({
+      fetchImpl: vi.fn().mockResolvedValue(response),
+      maxResponseBytes: 5
+    })
+    await expect(engine.call(descriptor, {}, {})).rejects.toMatchObject({
+      name: 'ConnectorResponseTooLargeError'
+    })
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(response.body?.locked).toBe(false)
+  })
+
+  it('F02 attempts cleanup after a body read fails without hiding the error', async () => {
+    const error = new Error('stream read failed')
+    const response = new Response(
+      new ReadableStream({
+        pull(controller) {
+          controller.error(error)
+        }
+      })
+    )
+    const cancel = vi.spyOn(response.body!, 'cancel')
+    const engine = new ParserEngine({ fetchImpl: vi.fn().mockResolvedValue(response), retries: 0 })
+    await expect(engine.call(descriptor, {}, {})).rejects.toBe(error)
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(response.body?.locked).toBe(false)
+  })
+
+  it.each(['user', 'idle', 'total'])(
+    'F02 cancels a stalled body on %s cancellation',
+    async (mode) => {
+      vi.useFakeTimers()
+      try {
+        const cancel = vi.fn()
+        const response = new Response(new ReadableStream({ cancel }))
+        const caller = new AbortController()
+        const engine = new ParserEngine({
+          fetchImpl: vi.fn().mockResolvedValue(response),
+          timeoutMs: mode === 'idle' ? 10 : 100,
+          totalTimeoutMs: mode === 'total' ? 10 : 100
+        })
+        const result = engine
+          .call(descriptor, {}, {}, caller.signal)
+          .catch((error: unknown) => error)
+        await vi.advanceTimersByTimeAsync(0)
+        if (mode === 'user') caller.abort()
+        await vi.advanceTimersByTimeAsync(10)
+        expect(await Promise.race([result, Promise.resolve('still pending')])).toMatchObject({
+          name: mode === 'user' ? 'AbortError' : 'ConnectorRequestTimeoutError'
+        })
+        expect(cancel).toHaveBeenCalledOnce()
+        expect(response.body?.locked).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    }
+  )
 })

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -40,12 +40,12 @@ function redactUrl(url: string): string {
 class ConnectorRequestTimeoutError extends Error {
   override readonly name = 'ConnectorRequestTimeoutError'
 
-  constructor(url: string, timeoutMs: number, attempts: number, kind: 'idle' | 'total' = 'idle') {
+  constructor(target: string, timeoutMs: number, attempts?: number) {
     super(
       `${
-        kind === 'total'
-          ? `Connector request exceeded the ${timeoutMs}ms total deadline after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} for ${redactUrl(url)}`
-          : `Connector request timed out after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} of ${timeoutMs}ms for ${redactUrl(url)}`
+        attempts === undefined
+          ? `Connector call exceeded the ${timeoutMs}ms total deadline for ${target}`
+          : `Connector request timed out after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} of ${timeoutMs}ms for ${redactUrl(target)}`
       }. This is the Connector's own deadline; increasing an outer execution timeout will not extend it. Do not retry solely with a longer timeout.`
     )
   }
@@ -94,29 +94,61 @@ export class ParserEngine {
     for (const key of descriptor.required ?? []) {
       if (args[key] == null) throw new Error(`missing required arg: ${key}`)
     }
-    const ctx = this.makeContext(
-      credentials,
-      signal,
-      descriptor.totalTimeoutMs ?? this.totalTimeoutMs,
-      descriptor.maxResponseBytes ?? this.maxResponseBytes
+    const totalTimeoutMs = descriptor.totalTimeoutMs ?? this.totalTimeoutMs
+    const deadline = Date.now() + totalTimeoutMs
+    const controller = new AbortController()
+    const callSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal
+    const totalTimer = setTimeout(
+      () =>
+        controller.abort(
+          new ConnectorRequestTimeoutError(
+            `${descriptor.connector}/${descriptor.id}`,
+            totalTimeoutMs
+          )
+        ),
+      totalTimeoutMs
     )
-    if (descriptor.run) {
-      const result = await descriptor.run(ctx, args)
-      signal?.throwIfAborted()
+    let onAbort: () => void = () => {}
+    const aborted = new Promise<never>((_, reject) => {
+      onAbort = () => reject(callSignal.reason)
+      callSignal.addEventListener('abort', onAbort, { once: true })
+    })
+    const execute = async (): Promise<unknown> => {
+      const ctx = this.makeContext(
+        credentials,
+        callSignal,
+        deadline,
+        descriptor.maxResponseBytes ?? this.maxResponseBytes
+      )
+      let result: unknown
+      if (descriptor.run) {
+        result = await descriptor.run(ctx, args)
+      } else {
+        if (!descriptor.url || !descriptor.parse) {
+          throw new Error(`descriptor ${descriptor.id} needs either run() or url()+parse()`)
+        }
+        const url = descriptor.url(args)
+        const raw =
+          descriptor.format === 'text' ? await ctx.fetchText(url) : await ctx.fetchJson(url)
+        result = await descriptor.parse(raw, args)
+      }
+      callSignal.throwIfAborted()
       return result
     }
-    if (!descriptor.url || !descriptor.parse) {
-      throw new Error(`descriptor ${descriptor.id} needs either run() or url()+parse()`)
+    try {
+      return await Promise.race([execute(), aborted])
+    } finally {
+      clearTimeout(totalTimer)
+      callSignal.removeEventListener('abort', onAbort)
+      // Stop sibling requests if a run-style descriptor fails partway through a batch.
+      controller.abort()
     }
-    const url = descriptor.url(args)
-    const raw = descriptor.format === 'text' ? await ctx.fetchText(url) : await ctx.fetchJson(url)
-    return descriptor.parse(raw, args)
   }
 
   private makeContext(
     credentials: ConnectorCredentials,
-    signal: AbortSignal | undefined,
-    totalTimeoutMs: number,
+    signal: AbortSignal,
+    deadline: number,
     maxResponseBytes: number
   ): ToolContext {
     const doFetch = async (
@@ -125,23 +157,21 @@ export class ParserEngine {
       init?: RequestInit
     ): Promise<{ response: Response; bodyText?: string }> => {
       for (let attempt = 0; ; attempt++) {
+        signal.throwIfAborted()
         const controller = new AbortController()
         let idleTimer: ReturnType<typeof setTimeout> | undefined
-        let timedOut: 'idle' | 'total' | undefined
-        const abortForTimeout = (kind: 'idle' | 'total'): void => {
-          timedOut ??= kind
-          controller.abort()
-        }
+        let timedOut = false
         const armTimeout = (): void => {
           if (idleTimer) clearTimeout(idleTimer)
-          idleTimer = setTimeout(() => abortForTimeout('idle'), this.timeoutMs)
+          idleTimer = setTimeout(() => {
+            timedOut = true
+            controller.abort()
+          }, this.timeoutMs)
         }
-        const totalTimer = setTimeout(() => abortForTimeout('total'), totalTimeoutMs)
-        const requestSignal = signal
-          ? AbortSignal.any([controller.signal, signal])
-          : controller.signal
+        const requestSignal = AbortSignal.any([controller.signal, signal])
         let res: Response | undefined
         let bodyText: string | undefined
+        let bodyComplete = false
         let caught = false
         let failure: unknown
         try {
@@ -153,6 +183,12 @@ export class ParserEngine {
           })
           if (res.ok && res.body) {
             const reader = res.body.getReader()
+            // Native fetch observes abort too; explicitly cancel injected/independent streams.
+            const cancelReader = (): void => {
+              void reader.cancel(requestSignal.reason).catch(() => {})
+            }
+            requestSignal.addEventListener('abort', cancelReader, { once: true })
+            if (requestSignal.aborted) cancelReader()
             const decoder = new TextDecoder()
             const chunks: string[] = []
             let responseBytes = 0
@@ -160,7 +196,11 @@ export class ParserEngine {
               armTimeout()
               for (;;) {
                 const chunk = await reader.read()
-                if (chunk.done) break
+                requestSignal.throwIfAborted()
+                if (chunk.done) {
+                  bodyComplete = true
+                  break
+                }
                 if (chunk.value.byteLength === 0) continue
                 responseBytes += chunk.value.byteLength
                 if (responseBytes > maxResponseBytes) {
@@ -174,6 +214,7 @@ export class ParserEngine {
               chunks.push(decoder.decode())
               bodyText = chunks.join('')
             } finally {
+              requestSignal.removeEventListener('abort', cancelReader)
               reader.releaseLock()
             }
           }
@@ -182,18 +223,18 @@ export class ParserEngine {
           failure = err
         } finally {
           if (idleTimer) clearTimeout(idleTimer)
-          if (totalTimer) clearTimeout(totalTimer)
+          // Do not drain unbounded error bodies or wait for a broken cancellation hook.
+          // A cleanup failure must never replace the HTTP/read error.
+          if (res?.body && !bodyComplete) {
+            void res.body.cancel().catch(() => {})
+            controller.abort()
+          }
         }
+        signal.throwIfAborted()
         if (caught) {
-          if (signal?.aborted) throw failure
           if (failure instanceof ConnectorResponseTooLargeError) throw failure
           if (timedOut) {
-            throw new ConnectorRequestTimeoutError(
-              url,
-              timedOut === 'total' ? totalTimeoutMs : this.timeoutMs,
-              attempt + 1,
-              timedOut
-            )
+            throw new ConnectorRequestTimeoutError(url, this.timeoutMs, attempt + 1)
           }
           // Immediate network failures may be transient, so retry them within the bounded budget.
           if (attempt < this.retries) {
@@ -207,15 +248,20 @@ export class ParserEngine {
           signal?.throwIfAborted()
           return { response: res, ...(bodyText !== undefined ? { bodyText } : {}) }
         }
-        // Retry only transient upstream statuses; client errors (4xx except 429) fail fast.
-        if (attempt < this.retries && CONNECTOR_RETRYABLE_STATUS.has(res.status)) {
-          await abortableDelay(
-            connectorRetryDelay(attempt, res.headers?.get?.('retry-after') ?? null, this.backoffMs),
-            signal
-          )
+        // Retry only transient upstream statuses; never shorten the server's requested wait.
+        const retryable = CONNECTOR_RETRYABLE_STATUS.has(res.status)
+        const retryAfter = res.headers?.get?.('retry-after') ?? null
+        const delay = retryable ? connectorRetryDelay(attempt, retryAfter, this.backoffMs) : 0
+        const insufficientBudget = delay >= deadline - Date.now()
+        if (attempt < this.retries && retryable && !(retryAfter && insufficientBudget)) {
+          await abortableDelay(delay, signal)
           continue
         }
-        throw new Error(`HTTP ${res.status} for ${redactUrl(url)}`)
+        const retryHint =
+          retryable && retryAfter
+            ? ` Retry after ${Math.ceil(delay / 1_000)}s.${insufficientBudget ? ' The remaining call budget cannot accommodate this wait.' : ''}`
+            : ''
+        throw new Error(`HTTP ${res.status} for ${redactUrl(url)}.${retryHint}`)
       }
     }
     return {

--- a/src/main/connectors/request-policy.test.ts
+++ b/src/main/connectors/request-policy.test.ts
@@ -19,9 +19,9 @@ describe('Connector request policy', () => {
     expect(boundedExponentialBackoff(4)).toBe(4_000)
   })
 
-  it('honors capped numeric Retry-After before falling back to jittered backoff', () => {
+  it('honors numeric Retry-After before falling back to jittered backoff', () => {
     expect(connectorRetryDelay(0, '2')).toBe(2_000)
-    expect(connectorRetryDelay(0, '30')).toBe(5_000)
+    expect(connectorRetryDelay(0, '30')).toBe(30_000)
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
     expect(connectorRetryDelay(2, null, 200)).toBe(900)
   })

--- a/src/main/connectors/request-policy.ts
+++ b/src/main/connectors/request-policy.ts
@@ -8,9 +8,14 @@ export const connectorRetryDelay = (
   retryAfter: string | null,
   baseMs = 400
 ): number => {
-  const retryAfterSeconds = retryAfter ? Number(retryAfter) : Number.NaN
-  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
-    return Math.min(retryAfterSeconds * 1_000, 5_000)
+  const value = retryAfter?.trim()
+  if (value && /^\d+$/.test(value)) {
+    // Keep even very long waits: the caller checks its remaining budget before scheduling.
+    return Number(value) * 1_000
+  }
+  if (value && /[a-z]/i.test(value)) {
+    const retryAt = Date.parse(value)
+    if (Number.isFinite(retryAt)) return Math.max(0, retryAt - Date.now())
   }
   return boundedExponentialBackoff(attempt, baseMs) + Math.random() * baseMs
 }

--- a/src/main/connectors/types.ts
+++ b/src/main/connectors/types.ts
@@ -36,7 +36,7 @@ export type ToolDescriptor = {
   // Code-only dispatch metadata. It is not part of the generated tool schema or persisted state.
   requiredCredential?: ConnectorCredentialId
   format?: 'json' | 'text'
-  // Per-attempt wall-clock deadline, including response-body streaming. Overrides the engine default.
+  // Whole-call deadline, including retries, waits and all requests in run(). Overrides the engine default.
   totalTimeoutMs?: number
   // Raw response-body budget. Overrides the engine default for tools with unusually small or large payloads.
   maxResponseBytes?: number


### PR DESCRIPTION
HTTP failures in ParserEngine left response bodies unread, each retry reset `totalTimeoutMs`, and `Retry-After: 60` triggered another request after only five seconds. Release unfinished bodies, apply one deadline to the entire tool call, and respect server retry delays within the remaining budget.

- Cancel error bodies before retrying or throwing, and clean up interrupted, oversized, and failed body reads without letting cleanup failures replace the original error or block completion.
- Share the total deadline across retries, backoff, and every request in `run()`, while retaining the independent idle timeout and propagating caller cancellation.
- Accept numeric and HTTP-date `Retry-After` values without the five-second cap. If the remaining budget cannot accommodate the delay, return the HTTP status and suggested wait instead of retrying early.

Compatibility: `totalTimeoutMs` previously documented a per-attempt deadline; it now covers one complete `ParserEngine.call()`. The default 120 seconds is shared by all steps. Rfam sequence search uses the existing descriptor override to allow 600 seconds for submission and polling, preserving its default 300-second polling window; longer custom waits remain bounded by the 600-second whole-call cap. No persisted fields, schema migrations, dependencies, or UI changes are introduced. Arbitrary custom code still needs to cooperate with cancellation to stop its own work.

Validation:
- Added 16 regressions through the existing `ParserEngine.call()` / `fetchImpl` boundary. All fail against the unfixed source for the reported cleanup/deadline/retry behavior and pass after the fix; no new test seam.
- Added four Rfam regressions using the real engine and descriptor with fake timers. They failed twice at the old 120-second deadline before fixing, and now cover delayed submission, late successful results, the default polling timeout, and the hard call cap.
- `npm test -- src/main/connectors`: 58 files passed; 881 tests passed, 39 skipped (rerun with local socket/listener permissions).
- `npm run typecheck:node`, targeted ESLint, Prettier check, and `git diff --check`: passed.
- Full `npm test` was run: 23,374 passed, 627 failed, 226 skipped. Failures include widespread sandbox `listen EPERM` / `spawnSync ps EPERM` and timeout failures; this is not a clean full-suite result. The connector module passes after removing the local-listener restriction.

The body tests demonstrate the missing release path; they do not measure a production connection-pool leak.

