### PR TITLE
ci(pr-gate): reduce redundant checks and shard Windows E2E

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -17,6 +17,7 @@ on:
           - classified
           - unit-coverage
           - i18n
+          - windows-e2e
 
 permissions:
   contents: read
@@ -157,6 +158,13 @@ jobs:
               '' \
               '- `workflow_dispatch i18n -> focused dry-run`' \
               >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$DRY_RUN_MODE" == "windows-e2e" ]]; then
+            plan='{"schemaVersion":1,"mode":"selective","roots":["manual:windows-e2e"],"lanes":["policy","e2e_functional_windows","e2e_workspace_windows"],"bundles":["policy","windows_e2e"],"reasonChains":["workflow_dispatch windows-e2e -> focused dry-run"]}'
+            echo "plan=$plan" >> "$GITHUB_OUTPUT"
+            echo 'lanes=["policy","e2e_functional_windows","e2e_workspace_windows"]' >> "$GITHUB_OUTPUT"
+            printf '%s\n' '## PR Gate preflight' '' '- Focused dry-run: Windows E2E shards' >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           if [[ "$TRUSTED_CLASSIFIER_SOURCE" == "base" ]]; then
@@ -343,22 +351,31 @@ jobs:
         id: interface_contracts
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'interface_contracts') }}
         continue-on-error: true
+        env:
+          RUN_DEDICATED_TESTS: ${{ fromJSON(needs.preflight.outputs.plan).mode != 'full' || !contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') }}
         run: |
           npm run check:web-api-map
-          npx vitest run \
-            src/preload/index.test.ts \
-            src/preload/electron-renderer-contract-adapter.test.ts \
-            src/shared/renderer-contract.test.ts \
-            src/shared/renderer-contract-catalog.test.ts \
-            src/shared/renderer-surface-inventory.test.ts \
-            src/shared/renderer-surface-matrix.test.ts \
-            src/shared/web-rpc-contract.test.ts
+          # Full portable shards already execute these tests. Keep the map check in this lane.
+          if [[ "$RUN_DEDICATED_TESTS" == "true" ]]; then
+            npx vitest run \
+              src/preload/index.test.ts \
+              src/preload/electron-renderer-contract-adapter.test.ts \
+              src/shared/renderer-contract.test.ts \
+              src/shared/renderer-contract-catalog.test.ts \
+              src/shared/renderer-surface-inventory.test.ts \
+              src/shared/renderer-surface-matrix.test.ts \
+              src/shared/web-rpc-contract.test.ts
+          fi
       - name: Test CLI and SDK
         id: cli_sdk
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'cli_sdk') }}
         continue-on-error: true
+        env:
+          RUN_DEDICATED_TESTS: ${{ fromJSON(needs.preflight.outputs.plan).mode != 'full' || !contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') }}
         run: |
-          npx vitest run cli packages/open-science
+          if [[ "$RUN_DEDICATED_TESTS" == "true" ]]; then
+            npx vitest run cli packages/open-science
+          fi
           npm run check:cli-package
       - name: Check i18n catalog
         id: i18n
@@ -879,11 +896,15 @@ jobs:
           exit "$failed"
 
   windows_e2e:
-    name: Windows E2E
+    name: Windows E2E (shard ${{ matrix.shard }}/2)
     needs: preflight
     if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'windows_e2e') }}
     runs-on: windows-latest
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -904,14 +925,14 @@ jobs:
         id: e2e_functional_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_windows') }}
         continue-on-error: true
-        # Balance tests inside slow spec files without increasing the two-worker concurrency cap.
-        run: npm run test:e2e:journey -- --workers=2 --fully-parallel --fail-on-flaky-tests
+        # Split individual tests across runners while keeping each runner's two-worker cap.
+        run: npm run test:e2e:journey -- --workers=2 --fully-parallel --shard=${{ matrix.shard }}/2 --fail-on-flaky-tests
       - name: Upload functional failure artifacts
         if: ${{ steps.e2e_functional_windows.outcome == 'failure' }}
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: functional-e2e-windows-failure
+          name: functional-e2e-windows-failure-${{ matrix.shard }}
           path: |
             playwright-report/
             test-results/
@@ -921,13 +942,13 @@ jobs:
         id: e2e_workspace_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_windows') }}
         continue-on-error: true
-        run: npm run test:e2e:workspace -- --workers=2 --fully-parallel --fail-on-flaky-tests
+        run: npm run test:e2e:workspace -- --workers=2 --fully-parallel --shard=${{ matrix.shard }}/2 --fail-on-flaky-tests
       - name: Upload workspace failure artifacts
         if: ${{ steps.e2e_workspace_windows.outcome == 'failure' }}
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: workspace-e2e-windows-failure
+          name: workspace-e2e-windows-failure-${{ matrix.shard }}
           path: |
             playwright-report/
             test-results/
@@ -937,7 +958,7 @@ jobs:
       # The new manifest never emits it, so ordinary PRs do not pay this Windows accessibility cost.
       - name: Run legacy Windows accessibility compatibility
         id: e2e_accessibility_windows
-        if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_accessibility_windows') }}
+        if: ${{ matrix.shard == 1 && steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_accessibility_windows') }}
         continue-on-error: true
         run: npm run test:e2e:accessibility -- --fail-on-flaky-tests
       - name: Upload legacy accessibility failure artifacts

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -768,7 +768,8 @@ jobs:
     needs: preflight
     if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'macos_e2e') }}
     runs-on: macos-14
-    timeout-minutes: 15
+    # Builds and all four E2E groups share this runner; allow the final visual group to finish.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -78,6 +78,9 @@ test('edits and navigates message revisions that persist after relaunch', async 
   let conversation = page.getByRole('region', { name: 'Conversation' })
   await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+  // Reply text can arrive before the Agent turn ends. Wait for Main to observe completion
+  // before editing history and restarting, which otherwise can open a native quit dialog.
+  await expect.poll(() => page.evaluate(() => window.api.storage.detectActive())).toEqual([])
 
   await conversation.getByText(USER_MESSAGE, { exact: true }).hover()
   await conversation.getByRole('button', { name: 'Edit message' }).click()

--- a/scripts/ci/module-impact-shadow.test.ts
+++ b/scripts/ci/module-impact-shadow.test.ts
@@ -33,6 +33,105 @@ function reportFor(
 }
 
 describe('module impact shadow', () => {
+  it.each([
+    [
+      'project defaults recovery',
+      [
+        'src/main/projects/deletion-coordinator.test.ts',
+        'src/main/projects/deletion-coordinator.ts',
+        'src/main/projects/ipc.test.ts',
+        'src/main/projects/project-owned-data.catalog.architecture.test.ts',
+        'src/main/projects/repository.test.ts',
+        'src/main/projects/repository.ts',
+        'src/main/session-persistence/ipc.test.ts'
+      ]
+    ],
+    [
+      'deletion compensation',
+      [
+        'src/main/projects/deletion-coordinator.test.ts',
+        'src/main/projects/deletion-coordinator.ts',
+        'src/main/session-persistence/coordinator.test.ts',
+        'src/main/session-persistence/deletion-owner.ts'
+      ]
+    ]
+  ])('keeps the complete %s diff selective with lifecycle consumers', (_name, paths) => {
+    const report = reportFor(paths.map((path) => ({ path, status: 'modified' })))
+
+    expect(report.resolved.mode).toBe('selective')
+    expect(report.shadow.modules).toContain('project_lifecycle')
+    expect(report.shadow.testFiles).toEqual(
+      expect.arrayContaining([
+        ...paths.filter((path) => path.endsWith('.test.ts')),
+        'src/main/projects/project-runtime-quiescence-owner.test.ts',
+        'src/main/session-persistence/deletion-integration.test.ts',
+        'src/main/data-content-application-commands.test.ts',
+        'src/main/application-command-wiring.test.ts',
+        'src/main/compute/job-deletion-runtime-isolation.test.ts',
+        'src/main/permission-grants/registry.test.ts',
+        'src/renderer/src/stores/project-store.test.ts',
+        'src/renderer/src/pages/home/HomePage.persistence.test.tsx'
+      ])
+    )
+    expect(report.resolved.lanes).toEqual(
+      expect.arrayContaining([
+        'unit_macos',
+        'interface_contracts',
+        'typecheck_node',
+        'typecheck_web',
+        'build',
+        'windows_runtime',
+        'windows_path',
+        'e2e_functional_macos',
+        'e2e_workspace_macos',
+        'e2e_functional_windows',
+        'e2e_workspace_windows'
+      ])
+    )
+    expect(report.resolved.lanes).not.toContain('linux_runtime')
+    expect(report.resolved.lanes).not.toContain('e2e_visual_macos')
+    expect(report.resolved.lanes).not.toContain('e2e_accessibility_macos')
+  })
+
+  it('expands the session deletion interface to its injected project lifecycle caller', () => {
+    const report = reportFor([
+      { path: 'src/main/session-persistence/coordinator.ts', status: 'modified' }
+    ])
+
+    expect(report.resolved.reasonChains).toContain('session_persistence -> project_lifecycle')
+    expect(report.shadow.testFiles).toContain('src/main/projects/deletion-coordinator.test.ts')
+    expect(report.shadow.testFiles).toContain('src/main/session-persistence/ipc.test.ts')
+  })
+
+  it('keeps documentation in its own lane when accompanying an owned code change', () => {
+    const source = { path: 'src/main/projects/deletion-coordinator.ts', status: 'modified' }
+    const codeOnly = reportFor([source])
+    const report = reportFor([source, { path: 'docs/PRD.md', status: 'modified' }])
+
+    expect(report.resolved.mode).toBe('selective')
+    expect(report.shadow.modules).toEqual(codeOnly.shadow.modules)
+    expect(report.shadow.testFiles).toEqual(codeOnly.shadow.testFiles)
+    expect(report.resolved.lanes).toEqual(
+      expect.arrayContaining([...codeOnly.resolved.lanes, 'docs'])
+    )
+    expect(report.resolved.reasonChains).toContain(
+      'docs/PRD.md -> documentation lane -> no module tests'
+    )
+
+    const unknown = reportFor([
+      source,
+      { path: 'README.md', status: 'modified' },
+      { path: 'src/main/projects/new-owner.ts', status: 'added' }
+    ])
+    expect(unknown.resolved.mode).toBe('full')
+    expect(unknown.resolved.reasonChains).toContain(
+      'src/main/projects/new-owner.ts -> unknown module owner -> full'
+    )
+    expect(reportFor([source, { path: 'package.json', status: 'modified' }]).resolved.mode).toBe(
+      'full'
+    )
+  })
+
   it('promotes deterministic module evidence into the resolved plan', () => {
     const report = reportFor([
       { path: 'src/renderer/src/stores/session-store.ts', status: 'modified' }

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -838,7 +838,7 @@
         "src/main/session-persistence/state-owner.ts"
       ],
       "interfacePaths": ["src/main/session-persistence/coordinator.ts"],
-      "consumerModules": [],
+      "consumerModules": ["project_lifecycle"],
       "testFiles": {
         "owner": [
           "src/main/session-persistence/coordinator.architecture.test.ts",
@@ -847,7 +847,8 @@
         ],
         "contract": [
           "src/shared/session-persistence.test.ts",
-          "src/main/session-persistence/coordinator-contract.test.ts"
+          "src/main/session-persistence/coordinator-contract.test.ts",
+          "src/main/session-persistence/ipc.test.ts"
         ],
         "consumer": [
           "src/main/delegation/durable-delegated-work.test.ts",
@@ -916,6 +917,63 @@
       },
       "capabilityOverlays": ["i18n_catalog"],
       "fallbackCapability": "renderer_view"
+    },
+    "project_lifecycle": {
+      "ownerPaths": [
+        "src/main/projects/deletion-coordinator.ts",
+        "src/main/projects/ipc.ts",
+        "src/main/projects/preview-repository.ts",
+        "src/main/projects/project-owned-data.catalog.ts",
+        "src/main/projects/project-runtime-quiescence-owner.ts",
+        "src/main/projects/repository.ts"
+      ],
+      "interfacePaths": [
+        "src/main/projects/deletion-coordinator.ts",
+        "src/main/projects/ipc.ts",
+        "src/main/projects/preview-repository.ts",
+        "src/main/projects/project-runtime-quiescence-owner.ts",
+        "src/main/projects/repository.ts"
+      ],
+      "consumerModules": [],
+      "testFiles": {
+        "owner": [
+          "src/main/projects/deletion-coordinator.test.ts",
+          "src/main/projects/preview-repository.test.ts",
+          "src/main/projects/project-owned-data.catalog.architecture.test.ts",
+          "src/main/projects/project-runtime-quiescence-owner.test.ts",
+          "src/main/projects/repository.test.ts"
+        ],
+        "contract": [
+          "src/main/projects/ipc.test.ts",
+          "src/main/data-content-application-commands.test.ts",
+          "src/main/application-command-composition.test.ts",
+          "src/main/application-command-wiring.test.ts",
+          "src/shared/renderer-contract-catalog.test.ts",
+          "src/shared/renderer-surface-matrix.test.ts",
+          "src/preload/index.test.ts",
+          "src/renderer/web/api-installer.test.ts"
+        ],
+        "consumer": [
+          "src/main/acp/runtime-coordinator.test.ts",
+          "src/main/archive/coordinator.test.ts",
+          "src/main/compute/job-deletion-owner.test.ts",
+          "src/main/compute/job-deletion-runtime-drain.test.ts",
+          "src/main/compute/job-deletion-runtime-isolation.test.ts",
+          "src/main/database/application-database.integration.test.ts",
+          "src/main/local-fs/granted-roots-repository.test.ts",
+          "src/main/permission-grants/registry.test.ts",
+          "src/main/session-persistence/deletion-integration.test.ts",
+          "src/main/session-persistence/ipc.test.ts",
+          "src/main/session-persistence/projection.test.ts",
+          "src/main/side-chat/runtime-owner.test.ts",
+          "src/main/storage/normalize-legacy-paths.test.ts",
+          "src/renderer/src/stores/project-store.test.ts",
+          "src/renderer/src/pages/home/HomePage.persistence.test.tsx",
+          "src/renderer/src/pages/home/HomePage.render.test.tsx"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
     }
   }
 }

--- a/scripts/ci/module-test-impact.mjs
+++ b/scripts/ci/module-test-impact.mjs
@@ -96,6 +96,11 @@ export function createAffectedTestPlan(changes, graph, manifest = defaultManifes
   const seeds = new Set()
   const reasons = []
   for (const change of changes) {
+    const pathPlan = classifyChanges([change])
+    if (pathPlan.lanes.includes('docs') && !pathPlan.bundles.includes('unit')) {
+      reasons.push(`${change.path} -> documentation lane -> no module tests`)
+      continue
+    }
     for (const path of [change.path, change.previousPath].filter(Boolean)) {
       const matchedModules = modulesForPath(manifest, path)
       if (matchedModules.length === 0) return fullPlan(`${path} -> unknown module owner -> full`)

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -181,7 +181,12 @@ describe('module test impact commands', () => {
     )
 
     expect(plan.mode).toBe('selective')
-    expect(plan.modules).toEqual(['artifact_storage', 'artifact_provenance', 'session_persistence'])
+    expect(plan.modules).toEqual([
+      'artifact_storage',
+      'artifact_provenance',
+      'session_persistence',
+      'project_lifecycle'
+    ])
     expect(plan.testFiles).toContain('src/main/reviewer/ipc.test.ts')
     expect(plan.reasonChains).toContain('artifact_storage -> artifact_provenance')
   })
@@ -196,6 +201,7 @@ describe('module test impact commands', () => {
 
       expect([...plan.modules].sort()).toEqual([
         'artifact_provenance',
+        'project_lifecycle',
         'reviewer_orchestrator',
         'session_persistence',
         'workspace_page',
@@ -226,6 +232,7 @@ describe('module test impact commands', () => {
       [
         'artifact_provenance',
         'compute_service',
+        'project_lifecycle',
         'reviewer_orchestrator',
         'session_persistence',
         'settings_backend_resolution',
@@ -241,6 +248,7 @@ describe('module test impact commands', () => {
       [
         'artifact_provenance',
         'compute_service',
+        'project_lifecycle',
         'reviewer_orchestrator',
         'session_persistence',
         'settings_backend_resolution',
@@ -255,6 +263,7 @@ describe('module test impact commands', () => {
       'src/main/settings/provider-accounts.ts',
       [
         'artifact_provenance',
+        'project_lifecycle',
         'reviewer_orchestrator',
         'session_persistence',
         'settings_backend_resolution',
@@ -268,6 +277,7 @@ describe('module test impact commands', () => {
       'src/main/settings/responses-bridge.ts',
       [
         'artifact_provenance',
+        'project_lifecycle',
         'reviewer_orchestrator',
         'session_persistence',
         'settings_backend_resolution',
@@ -280,6 +290,7 @@ describe('module test impact commands', () => {
       'src/main/settings/responses-request-adapter.ts',
       [
         'artifact_provenance',
+        'project_lifecycle',
         'reviewer_orchestrator',
         'session_persistence',
         'settings_backend_resolution',
@@ -292,6 +303,7 @@ describe('module test impact commands', () => {
       'src/main/settings/responses-response-adapter.ts',
       [
         'artifact_provenance',
+        'project_lifecycle',
         'reviewer_orchestrator',
         'session_persistence',
         'settings_backend_resolution',
@@ -304,6 +316,7 @@ describe('module test impact commands', () => {
       'src/main/settings/responses-protocol-types.ts',
       [
         'artifact_provenance',
+        'project_lifecycle',
         'reviewer_orchestrator',
         'session_persistence',
         'settings_backend_resolution',

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -1,4 +1,6 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { load } from 'js-yaml'
@@ -116,7 +118,7 @@ describe('PR Gate workflow', () => {
           required: false,
           default: 'classified',
           type: 'choice',
-          options: ['classified', 'unit-coverage', 'i18n']
+          options: ['classified', 'unit-coverage', 'i18n', 'windows-e2e']
         }
       }
     })
@@ -547,8 +549,8 @@ describe('PR Gate workflow', () => {
     expect(windowsRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)
     expect(windowsRuns).toEqual(
       expect.arrayContaining([
-        'npm run test:e2e:journey -- --workers=2 --fully-parallel --fail-on-flaky-tests',
-        'npm run test:e2e:workspace -- --workers=2 --fully-parallel --fail-on-flaky-tests',
+        'npm run test:e2e:journey -- --workers=2 --fully-parallel --shard=${{ matrix.shard }}/2 --fail-on-flaky-tests',
+        'npm run test:e2e:workspace -- --workers=2 --fully-parallel --shard=${{ matrix.shard }}/2 --fail-on-flaky-tests',
         'npm run test:e2e:accessibility -- --fail-on-flaky-tests'
       ])
     )
@@ -557,6 +559,107 @@ describe('PR Gate workflow', () => {
   it('budgets the complete Windows E2E path beyond dependency and build setup', () => {
     expect(workflow.jobs.windows_e2e['timeout-minutes']).toBe(25)
   })
+
+  it('shards every selected Windows journey without cancelling siblings or colliding artifacts', () => {
+    const job = workflow.jobs.windows_e2e
+    expect(job.strategy).toEqual({ 'fail-fast': false, matrix: { shard: [1, 2] } })
+    expect(job.name).toBe('Windows E2E (shard ${{ matrix.shard }}/2)')
+    for (const lane of ['e2e_functional_windows', 'e2e_workspace_windows']) {
+      const step = job.steps?.find(({ id }) => id === lane)
+      expect(step?.if).toContain(
+        `contains(fromJSON(needs.preflight.outputs.plan).lanes, '${lane}')`
+      )
+      expect(step?.run).toContain('--workers=2 --fully-parallel --shard=${{ matrix.shard }}/2')
+      expect(step?.run).toContain('--fail-on-flaky-tests')
+    }
+    const uploads = job.steps?.filter(({ name }) =>
+      /Upload (functional|workspace)/.test(name ?? '')
+    )
+    expect(uploads).toHaveLength(2)
+    for (const upload of uploads ?? []) {
+      expect(upload.with?.name).toContain('${{ matrix.shard }}')
+    }
+    expect(job.steps?.find(({ id }) => id === 'e2e_accessibility_windows')?.if).toContain(
+      'matrix.shard == 1'
+    )
+    expect(workflow.jobs.gate.needs).toContain('windows_e2e')
+    expect(
+      workflow.jobs.gate.steps?.find(({ name }) => name?.startsWith('Evaluate deterministic gate'))
+        ?.env?.PR_GATE_NEEDS
+    ).toContain('"windows_e2e":{"result":"${{ needs.windows_e2e.result }}"}')
+  })
+
+  it.skipIf(process.platform === 'win32').each(['true', 'false'])(
+    'retains unique static checks when dedicated tests are %s',
+    (runDedicatedTests) => {
+      const directory = mkdtempSync(join(tmpdir(), 'pr-gate-static-'))
+      try {
+        for (const command of ['npm', 'npx']) {
+          writeFileSync(
+            join(directory, command),
+            `#!/bin/sh\nprintf '%s\\n' '${command}'" $*" >> "$COMMAND_LOG"\n`,
+            { mode: 0o755 }
+          )
+        }
+        for (const id of ['interface_contracts', 'cli_sdk']) {
+          const step = workflow.jobs.static.steps?.find((step) => step.id === id)
+          expect(step?.env?.RUN_DEDICATED_TESTS).toBe(
+            "${{ fromJSON(needs.preflight.outputs.plan).mode != 'full' || !contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') }}"
+          )
+          const log = join(directory, id)
+          const run = spawnSync('bash', ['-e', '-c', step!.run!], {
+            env: {
+              ...process.env,
+              PATH: `${directory}:${process.env.PATH}`,
+              COMMAND_LOG: log,
+              RUN_DEDICATED_TESTS: runDedicatedTests
+            },
+            encoding: 'utf8'
+          })
+          expect(run.status, run.stderr).toBe(0)
+          const commands = readFileSync(log, 'utf8')
+          expect(commands).toContain(
+            id === 'interface_contracts' ? 'npm run check:web-api-map' : 'npm run check:cli-package'
+          )
+          expect(commands.includes('npx vitest run')).toBe(runDedicatedTests === 'true')
+        }
+      } finally {
+        rmSync(directory, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'executes the focused Windows plan through the real preflight script',
+    () => {
+      const directory = mkdtempSync(join(tmpdir(), 'pr-gate-windows-'))
+      try {
+        const output = join(directory, 'output')
+        const classify = workflow.jobs.preflight.steps?.find(({ id }) => id === 'classify')
+        const run = spawnSync('bash', ['-e', '-c', classify!.run!], {
+          env: {
+            ...process.env,
+            EVENT_NAME: 'workflow_dispatch',
+            DRY_RUN_MODE: 'windows-e2e',
+            GITHUB_OUTPUT: output,
+            GITHUB_STEP_SUMMARY: join(directory, 'summary')
+          },
+          encoding: 'utf8'
+        })
+        expect(run.status, run.stderr).toBe(0)
+        const planLine = readFileSync(output, 'utf8')
+          .split('\n')
+          .find((line) => line.startsWith('plan='))!
+        expect(JSON.parse(planLine.slice(5))).toMatchObject({
+          mode: 'selective',
+          bundles: ['policy', 'windows_e2e'],
+          lanes: ['policy', 'e2e_functional_windows', 'e2e_workspace_windows']
+        })
+      } finally {
+        rmSync(directory, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('rebuilds the Windows sandbox host before the native lifecycle smoke', () => {
     const steps = workflow.jobs.windows_core.steps ?? []

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -560,6 +560,10 @@ describe('PR Gate workflow', () => {
     expect(workflow.jobs.windows_e2e['timeout-minutes']).toBe(25)
   })
 
+  it('budgets the combined macOS builds and all four E2E groups', () => {
+    expect(workflow.jobs.macos_e2e['timeout-minutes']).toBe(20)
+  })
+
   it('shards every selected Windows journey without cancelling siblings or colliding artifacts', () => {
     const job = workflow.jobs.windows_e2e
     expect(job.strategy).toEqual({ 'fail-fast': false, matrix: { shard: [1, 2] } })

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3156,7 +3156,7 @@ describe('notebook runtime service', () => {
           workspaceCwd: root
         })
       }
-      const executions = Array.from({ length: 7 }, (_, index) =>
+      const executions = Array.from({ length: 6 }, (_, index) =>
         service.executeShell({
           sessionId: `session-${index + 1}`,
           workspaceCwd: root,
@@ -3164,36 +3164,41 @@ describe('notebook runtime service', () => {
         })
       )
 
-      await vi.waitFor(async () => {
-        const queuedState = await service.state({
-          sessionId: 'session-7',
-          workspaceCwd: root
-        })
-        expect(queuedState.runs).toHaveLength(1)
-      })
-      const queuedState = await service.state({
-        sessionId: 'session-7',
-        workspaceCwd: root
-      })
-      const queuedRun = queuedState.runs.at(-1)
-      if (queuedRun?.status !== 'queued') {
-        await vi.waitFor(() => expect(entered).toHaveLength(7))
-        for (const release of releases.values()) release()
-        await Promise.allSettled(executions)
-      }
-      expect(queuedRun).toMatchObject({ script: 'command-7', status: 'queued' })
-
       try {
-        await vi.waitFor(() => expect(entered).toHaveLength(6))
+        // Fill the slots before submitting the queued call; filesystem scheduling must not
+        // decide which Session gets the seventh admission under coverage on a busy runner.
+        await vi.waitFor(() => expect(entered).toHaveLength(6), { timeout: 10_000 })
+        executions.push(
+          service.executeShell({
+            sessionId: 'session-7',
+            workspaceCwd: root,
+            command: 'command-7'
+          })
+        )
+        await vi.waitFor(
+          async () => {
+            const state = await service.state({ sessionId: 'session-7', workspaceCwd: root })
+            expect(state.runs).toHaveLength(1)
+            expect(state.runs[0]).toMatchObject({ script: 'command-7', status: 'queued' })
+          },
+          { timeout: 10_000 }
+        )
         expect(entered).toHaveLength(6)
         expect(entered).not.toContain('command-7')
 
         releases.get('command-1')?.()
-        await vi.waitFor(() => expect(entered).toContain('command-7'))
+        await vi.waitFor(() => expect(entered).toContain('command-7'), { timeout: 10_000 })
         for (const release of releases.values()) release()
 
         await expect(Promise.all(executions)).resolves.toHaveLength(7)
       } finally {
+        // Drain calls that have not reached the process stub yet as well as those already
+        // running, even when a readiness assertion fails before the normal release path.
+        execute.mockImplementation(async ({ command }) => ({
+          stdout: command,
+          stderr: '',
+          exitCode: 0
+        }))
         for (const release of releases.values()) release()
         await Promise.allSettled(executions)
       }

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -1096,7 +1096,7 @@ describe('Session persistence coordinator architecture', () => {
     expect(sessionPersistence.interfacePaths).toEqual([
       'src/main/session-persistence/coordinator.ts'
     ])
-    expect(sessionPersistence.consumerModules).toEqual([])
+    expect(sessionPersistence.consumerModules).toEqual(['project_lifecycle'])
     expect(sessionPersistence.testFiles.owner).toEqual([
       'src/main/session-persistence/coordinator.architecture.test.ts',
       'src/main/session-persistence/coordinator.test.ts',
@@ -1104,7 +1104,8 @@ describe('Session persistence coordinator architecture', () => {
     ])
     expect(sessionPersistence.testFiles.contract).toEqual([
       'src/shared/session-persistence.test.ts',
-      'src/main/session-persistence/coordinator-contract.test.ts'
+      'src/main/session-persistence/coordinator-contract.test.ts',
+      'src/main/session-persistence/ipc.test.ts'
     ])
     expect(sessionPersistence.testFiles.consumer).toEqual([
       'src/main/delegation/durable-delegated-work.test.ts',


### PR DESCRIPTION
## Problem

Recent project-deletion fixes fall back to the complete PR Gate because the module manifest has no
project lifecycle owner. Mixed documentation/code changes can also fall back merely because a
Markdown file has no runtime Module. Full plans repeat interface/CLI unit tests in Static, while the
Windows E2E job takes 15:20–15:53 in three sampled successful runs.

## Change

- Add `project_lifecycle` (22 Modules total), its owner/contract/consumer tests, and the
  `session_persistence -> project_lifecycle` consumer relationship. Replaying #2170 and #2165 now
  selects 37 and 62 test files respectively, retaining Windows/native/path and both desktop journey lanes.
- Keep accompanying documentation in its existing docs lane without requiring a runtime Module.
  Unknown source owners and global inputs still fail closed to a full plan.
- In full plans with portable shards, execute interface/CLI Vitest tests once. Static keeps the API-map
  and CLI package checks; selective plans keep their dedicated unit checks. The i18n guard stays separate.
- Run Windows journeys across two Playwright shards, retaining two workers per runner, selected-lane
  checks, flaky-test failures, and failure artifacts. Add a focused `windows-e2e` manual dry-run using
  the real jobs. This follows the native sharding approach used by
  [AFFiNE](https://github.com/toeverything/AFFiNE/blob/canary/.github/workflows/build-test.yml) and
  documented by [Playwright](https://playwright.dev/docs/test-sharding).

- Wait for Main to report no active work before the message-revision E2E edits history and restarts,
  instead of treating reply text as proof that the Agent turn ended. Give the combined macOS job
  20 minutes: its previous 15-minute cap interrupted visual checks after all earlier groups passed.
- Make the existing Notebook shell-admission test fill six slots before submitting the seventh,
  and always drain pending executions before fixture cleanup. Use bounded readiness polling for
  filesystem-backed queue records under coverage.

## Scope and non-goals

No application behavior, data format, migration, or persistence change. No new application state or
enum. CI adds the `project_lifecycle` identifier, `windows-e2e` manual choice, and shard indices 1/2.
Existing diagnostic artifacts retain their location and retention; Windows names include the shard.
Existing trusted-base plan and legacy Windows accessibility compatibility remain supported, with
legacy accessibility running once. No checks move to advisory Nightly, no threshold is lowered, and
no gate protection is weakened. Shared database client changes remain full fallback.

Two Windows runners repeat setup/build, adding roughly four runner-minutes; reduced gate latency
depends on runner availability and the other selected jobs. Timings below distinguish measurements
from projections. This PR itself deliberately selects the full gate because it changes global CI inputs.

## Acceptance criteria and validation

Local validation (targeted suites overlap; counts are not additive):

| Behavior | Command/check | Result |
| --- | --- | --- |
| Classification, documentation routing, sharding, mandatory static checks, gate failures | `npm test -- scripts/ci src/main/session-persistence/coordinator.architecture.test.ts scripts/electron-app-fixture.test.ts` | 307 tests passed |
| Project ownership, deletion recovery, IPC/command wiring, compute/permission cleanup, renderer consumers | `npm run test:module -- project_lifecycle` | 684 tests passed, 29 files |
| Session persistence contracts and project admission | `npm run test:module -- session_persistence` | 540 tests passed, 10 files |
| Main, sandbox, and renderer types | `npm run typecheck` | Passed |
| Linted scripts/tests | `npm run lint` | Passed |
| Touched-file format and diff whitespace | Prettier check; `git diff --check` | Passed |
| Duplicate-test coverage | Portable Vitest file discovery | All 7 interface and 8 CLI/SDK files present among 1,393 files |
| Windows shard completeness | Playwright JSON discovery with both real journey commands | Functional 21 = 11 + 10; workspace 24 = 12 + 12; disjoint and complete |
| Final plan | `npm run test:affected -- --base HEAD^ --head HEAD --explain` | Full fallback for CI inputs, as intended |

Per maintainer instruction, the full local npm test suite was not run. Native Windows execution and
the full suite belong to the focused dry-run and exact-head PR CI. macOS discovery does not prove
Windows-specific tests pass. Independent automated review of `c151a646` returned **mergeable**, with no actionable findings.
The exact-head PR Gate passed; CI Integrity retains its deliberate workflow-edit protection below.

Focused Windows dry-run: https://github.com/aipoch/open-science/actions/runs/33936593513 (both shards and gate passed at `9255b07a`).

Follow-up at `5ed3a6e9`: 307 CI/fixture tests passed; Electron E2E build and three consecutive local
message-revision journeys passed (25.8 seconds). [PR Gate 33938899200](https://github.com/aipoch/open-science/actions/runs/33938899200)
passed both Windows shards (9m33s / 12m01s), all macOS checks including visual (10m33s), Static,
Linux isolation, Windows core and portable shards 1/2. Portable shard 3 exposed an existing
Notebook shell-admission readiness timeout and leaked fixture operations; aggregate coverage
correctly failed on that result.

Follow-up at `c151a64`: all 256 tests in `src/main/notebook/runtime-service.test.ts` passed, as did
the admission test with portable-CI coverage flags, Node/sandbox typechecks, lint, formatting and
whitespace checks. [Exact-head PR Gate 33939883794](https://github.com/aipoch/open-science/actions/runs/33939883794)
**passed** all three portable shards, aggregate coverage, Static, Linux isolation, Windows core,
both Windows E2E shards (10m00s / 11m37s), and the complete macOS job (11m55s).
The slower Windows shard took 11m37s versus 15m20s–15m53s for the sampled baseline single job;
this is one measured run, not a guaranteed latency improvement. Independent automated review
confirmed no actionable findings on this exact head.

Cache inspection confirmed both platforms already restore the shared `setup-node` npm cache keyed
by OS, architecture and lockfile; the Windows cache used here is stored under `refs/heads/main`. No duplicate cache layer or cross-platform node_modules reuse is added.
Baseline: [run 33933912031](https://github.com/aipoch/open-science/actions/runs/33933912031),
[run 33933543002](https://github.com/aipoch/open-science/actions/runs/33933543002),
[run 33932347250](https://github.com/aipoch/open-science/actions/runs/33932347250).

## Review focus

Check injected lifecycle/IPC consumer coverage, docs-only ownership exemption, full-versus-selective
test execution, shard completeness, and aggregate failure handling. The two replayed changes retain
Windows risk and functional/workspace E2E while excluding unrelated Linux isolation and visual/a11y
lanes. Unanalysed owners retain full fallback.

**Maintainer merge boundary:** CI Integrity intentionally reports `protected-gate-control-plane` for
the `pr-gate.yml` edit. Local inspection confirmed this is its only violation. After functional CI and
review pass, merging requires a separate explicit maintainer ruleset-bypass decision; the guard is
unchanged. No bypass has been performed.
