### PR TITLE
fix(memory): prevent stale snapshots and incorrect category selection

### DIFF
--- a/src/renderer/src/stores/memory-store.test.ts
+++ b/src/renderer/src/stores/memory-store.test.ts
@@ -60,6 +60,155 @@ describe('memory store', () => {
     expect(useMemoryStore.getState()).toMatchObject({ revision: 2, enabled: true })
   })
 
+  it('finishes loading without replacing a newer snapshot with an older revision', async () => {
+    setMemoryApi({
+      snapshot: vi.fn().mockResolvedValueOnce(snapshot(3)).mockResolvedValueOnce(snapshot(2))
+    })
+
+    await useMemoryStore.getState().load()
+    await useMemoryStore.getState().load()
+
+    expect(useMemoryStore.getState()).toMatchObject({ ...snapshot(3), status: 'ready' })
+  })
+
+  it('keeps a newer load snapshot when an older mutation response arrives last', async () => {
+    let resolveMutation!: (value: MemorySnapshot) => void
+    const pendingMutation = new Promise<MemorySnapshot>((resolve) => {
+      resolveMutation = resolve
+    })
+    setMemoryApi({
+      snapshot: vi.fn().mockResolvedValueOnce(snapshot(1)).mockResolvedValueOnce(snapshot(3)),
+      setEnabled: vi.fn(() => pendingMutation)
+    })
+    await useMemoryStore.getState().load()
+
+    const mutation = useMemoryStore.getState().setEnabled(true)
+    await useMemoryStore.getState().load()
+    expect(useMemoryStore.getState()).toMatchObject({ revision: 3, enabled: false })
+    resolveMutation({ ...snapshot(2), enabled: true })
+    await mutation
+
+    expect(useMemoryStore.getState()).toMatchObject({
+      revision: 3,
+      enabled: false,
+      status: 'ready'
+    })
+  })
+
+  it('allows a pending newer load to finish after a stale mutation response', async () => {
+    let resolveMutation!: (value: MemorySnapshot) => void
+    let resolveLoad!: (value: MemorySnapshot) => void
+    const pendingMutation = new Promise<MemorySnapshot>((resolve) => {
+      resolveMutation = resolve
+    })
+    const pendingLoad = new Promise<MemorySnapshot>((resolve) => {
+      resolveLoad = resolve
+    })
+    setMemoryApi({
+      snapshot: vi.fn().mockResolvedValueOnce(snapshot(3)).mockReturnValueOnce(pendingLoad),
+      setEnabled: vi.fn(() => pendingMutation)
+    })
+    const mutation = useMemoryStore.getState().setEnabled(true)
+    await useMemoryStore.getState().load()
+    const load = useMemoryStore.getState().load()
+
+    resolveMutation({ ...snapshot(2), enabled: true })
+    await mutation
+    resolveLoad(snapshot(4))
+    await load
+
+    expect(useMemoryStore.getState()).toMatchObject({
+      revision: 4,
+      enabled: false,
+      status: 'ready'
+    })
+  })
+
+  it.each([
+    ['Mine', 'Mine'],
+    ['　Ｍｉｎｅ \t Notes　', 'Mine Notes']
+  ])(
+    'returns and selects %s when another window also created a category',
+    async (name, storedName) => {
+      let resolveCreate!: (value: MemorySnapshot) => void
+      const pendingCreate = new Promise<MemorySnapshot>((resolve) => {
+        resolveCreate = resolve
+      })
+      setMemoryApi({
+        snapshot: vi.fn().mockResolvedValue(snapshot(1)),
+        createCategory: vi.fn(() => pendingCreate)
+      })
+      await useMemoryStore.getState().load()
+
+      const creation = useMemoryStore.getState().createCategory({
+        name,
+        guidance: '',
+        autoRecall: false
+      })
+      resolveCreate({
+        ...snapshot(3),
+        categories: [
+          ...snapshot().categories,
+          ...[
+            { id: 'other', name: 'Other' },
+            { id: 'mine', name: storedName }
+          ].map((category, index) => ({
+            ...category,
+            guidance: '',
+            autoRecall: false,
+            revision: 1,
+            createdAt: index + 2,
+            updatedAt: index + 2,
+            entries: []
+          }))
+        ]
+      })
+
+      expect.soft(await creation).toBe('mine')
+      expect(useMemoryStore.getState().selectedCategoryId).toBe('mine')
+    }
+  )
+
+  it('does not select a created category already removed by a newer snapshot', async () => {
+    let resolveCreate!: (value: MemorySnapshot) => void
+    const pendingCreate = new Promise<MemorySnapshot>((resolve) => {
+      resolveCreate = resolve
+    })
+    setMemoryApi({
+      snapshot: vi.fn().mockResolvedValueOnce(snapshot(1)).mockResolvedValueOnce(snapshot(3)),
+      createCategory: vi.fn(() => pendingCreate)
+    })
+    await useMemoryStore.getState().load()
+    const creation = useMemoryStore.getState().createCategory({
+      name: 'Mine',
+      guidance: '',
+      autoRecall: false
+    })
+    await useMemoryStore.getState().load()
+    resolveCreate({
+      ...snapshot(2),
+      categories: [
+        ...snapshot().categories,
+        {
+          id: 'mine',
+          name: 'Mine',
+          guidance: '',
+          autoRecall: false,
+          revision: 1,
+          createdAt: 2,
+          updatedAt: 2,
+          entries: []
+        }
+      ]
+    })
+
+    expect(await creation).toBe('mine')
+    expect(useMemoryStore.getState()).toMatchObject({
+      ...snapshot(3),
+      selectedCategoryId: 'memory-category-about-you'
+    })
+  })
+
   it('reloads only when another renderer announces a newer revision', async () => {
     let listener: ((event: { revision: number }) => void) | undefined
     const read = vi.fn().mockResolvedValue(snapshot(3))

--- a/src/renderer/src/stores/memory-store.ts
+++ b/src/renderer/src/stores/memory-store.ts
@@ -45,6 +45,10 @@ export const createInitialMemoryState = (): MemorySnapshot & {
 
 let loadSequence = 0
 
+// Match the repository's unique category name key.
+const categoryNameKey = (name: string): string =>
+  name.normalize('NFKC').trim().replace(/\s+/gu, ' ').toLowerCase()
+
 const stateFromSnapshot = (
   snapshot: MemorySnapshot,
   selectedCategoryId?: string,
@@ -70,11 +74,18 @@ const stateFromSnapshot = (
 }
 
 export const useMemoryStore = create<MemoryStore>((set, get) => {
+  const applySnapshot = (snapshot: MemorySnapshot): boolean => {
+    const state = get()
+    if (snapshot.revision < state.revision) return false
+    // Only an accepted snapshot can supersede pending loads.
+    loadSequence += 1
+    set(stateFromSnapshot(snapshot, state.selectedCategoryId, state.selectedProjectId))
+    return true
+  }
+
   const applyMutation = async (operation: () => Promise<MemorySnapshot>): Promise<void> => {
     try {
-      const snapshot = await operation()
-      loadSequence += 1
-      set(stateFromSnapshot(snapshot, get().selectedCategoryId, get().selectedProjectId))
+      applySnapshot(await operation())
     } catch (error) {
       set({ error: error instanceof Error ? error.message : 'memory' })
       throw error
@@ -96,11 +107,7 @@ export const useMemoryStore = create<MemoryStore>((set, get) => {
       try {
         const snapshot = await window.api.memory.snapshot()
         if (sequence !== loadSequence) return
-        if (snapshot.revision < get().revision) {
-          set({ status: 'ready' })
-          return
-        }
-        set(stateFromSnapshot(snapshot, get().selectedCategoryId, get().selectedProjectId))
+        if (!applySnapshot(snapshot)) set({ status: 'ready' })
       } catch {
         if (sequence !== loadSequence) return
         set({ status: 'error', error: 'load' })
@@ -108,15 +115,20 @@ export const useMemoryStore = create<MemoryStore>((set, get) => {
     },
     setEnabled: (enabled) => applyMutation(() => window.api.memory.setEnabled({ enabled })),
     createCategory: async (request) => {
-      const before = new Set(get().categories.map(({ id }) => id))
+      const requestedNameKey = categoryNameKey(request.name)
       let createdId = ''
       await applyMutation(async () => {
         const snapshot = await window.api.memory.createCategory(request)
-        createdId = snapshot.categories.find(({ id }) => !before.has(id))?.id ?? ''
+        createdId =
+          snapshot.categories.find(
+            (category) => 'name' in category && categoryNameKey(category.name) === requestedNameKey
+          )?.id ?? ''
         return snapshot
       })
       if (!createdId) throw new Error('Created memory category is missing.')
-      set({ selectedCategoryId: createdId, selectedProjectId: undefined })
+      if (get().categories.some(({ id }) => id === createdId)) {
+        set({ selectedCategoryId: createdId, selectedProjectId: undefined })
+      }
       return createdId
     },
     updateCategory: (request) => applyMutation(() => window.api.memory.updateCategory(request)),


### PR DESCRIPTION
## Problem

F03: an older memory mutation response can overwrite a newer loaded snapshot (revision 3 becomes 2), leaving the UI stale and subsequent edits using outdated revisions. A stale mutation also invalidates pending loads.

F04: creating Mine while an unseen Other category exists returns and selects Other because the store guesses identity from the first unfamiliar ID in the response.

## Proposed change

- Route load and mutation snapshots through the same revision acceptance guard. Only accepted snapshots supersede pending loads.
- Identify the created category in its own response using the repository's existing unique-name normalization (NFKC, trim, whitespace collapse, lowercase).
- Keep the current selection if a newer snapshot has already removed the created category.

## Scope and non-goals

Only the memory store and its tests change. No new state enum, API field, dependency, database column, persisted format, migration, or historical-data compatibility handling. Existing UI steps and public store signatures remain intact. Category identification relies on the existing unique name key and serialized service mutation/snapshot contract; keep the renderer normalization aligned if that contract changes.

## Acceptance criteria and validation

Deterministic regression tests use the existing public store and mocked API boundary, without production test seams or timing sleeps. Before production edits, both original reproductions failed twice for the reported reasons. Expanded coverage on unfixed code also failed for stale-mutation load invalidation and stale creation selection. After the fix, all regression cases pass; existing old-load coverage remains green.

Final local Test Impact Set (all checks run after the last material edit):

| Behavior | Command | Result |
| --- | --- | --- |
| Snapshot ordering, category identity, pending loads, selection, Settings consumers, unchanged snapshot/service contracts | `npm test -- src/renderer/src/stores/memory-store.test.ts src/renderer/src/pages/settings/MemoryPanel.render.test.tsx src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/shared/memory.test.ts src/main/memory/service.test.ts` | 5 files, 180 tests passed |
| Workspace consumer of the global memory gate | `npm test -- src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx` | 33 tests passed |
| Renderer consumers and types | `npm run typecheck:web` | Passed |
| Source lint | `npm run lint` | Passed |
| Patch whitespace | `git diff --check` | Passed |

`npm run test:affected:explain -- --base origin/main --head HEAD` reports a full fallback because
`memory-store.test.ts` has no registered module owner. The focused mapping above is based on the
actual final diff and its direct consumers; the full plan is left to PR CI at the maintainer's request.
The root CodeGraph index belongs to another worktree, so it was used for initial structural context,
with final changed source and consumer paths verified in this worktree directly.

MemoryPanel, SettingsPage, and WorkspacePage are the direct production consumers. No main/preload/shared implementation or transport contract changes, so no additional adapter or Node typecheck lane is needed locally. No path, native runtime, or persistence logic changes require a new platform or migration test. Live multi-window/network timing was not exercised; the response interleavings are reproduced deterministically at the store boundary. The maintainer requested focused local tests and full PR CI rather than a local complete Vitest run. Required exact-head CI and independent automated review remain authoritative.

## Review focus

- Older snapshots must not overwrite newer contents or invalidate a newer pending load.
- Category identity must come from the operation response, independently of stale renderer IDs.
- A delayed create response must not select a category absent from the current snapshot.
