### PR TITLE
fix(error-notice): align summaries and diagnostic actions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -932,6 +932,21 @@ colors communicate a successful or failed probe/migration result.
 - Creating a custom OAuth Connector saves its configuration first, then immediately starts browser authorization in a cancellable dialog. Cancelling or failing authorization keeps the saved Connector disabled so the user can retry from the same dialog or finish later. Existing Connector rows reuse this dialog for sign-in rather than presenting a separate inline waiting state.
 - When a runtime refresh shows that a previously authenticated OAuth Connector has lost its tokens, the app raises one transient global notice with a shortcut back to Settings. The Connector row remains the persistent source of truth and continues to show that sign-in is required. This notice is session-local UI state: it adds no persisted status field, migration, or shared enum value.
 
+## Error notices
+
+Use the shared `ErrorNotice` for error summaries. Keep the decorative flask mark compact (`size-10`),
+use one bounded column (`max-w-md`, `min-w-0`), and left-align headings, descriptions, codes, and help.
+Pair the status icon with the first text line. Long error text and identifiers must wrap inside the
+column. Group primary and secondary actions at the trailing edge with `flex-wrap` and a consistent
+small gap; wrap whole controls instead of splitting their labels. Preserve semantic status tones,
+disabled/loading behavior, and immediately visible keyboard focus.
+
+Provenance diagnostics share the summary's width below a divider. A disclosure button exposes its
+expanded state and controls the diagnostic region; the copy action belongs in that region's header
+and appears only while expanded. Keep diagnostics selectable, keyboard-scrollable, and bounded in
+height. Report copy success inline and copy failures next to the diagnostic text. The error summary's
+alert region excludes the diagnostic payload so opening it does not announce the entire JSON blob.
+
 ## Clickable Area Guidelines
 
 | Area              | Clickable part                                       | shadcn pattern                                                                           |

--- a/src/renderer/src/components/error-notice.test.tsx
+++ b/src/renderer/src/components/error-notice.test.tsx
@@ -79,6 +79,7 @@ describe('ErrorNotice', () => {
     const retry = screen.getByRole('button', { name: /Retrying/ })
     expect(retry).toHaveProperty('disabled', true)
     expect(container.querySelector('.animate-spin')).not.toBeNull()
+    expect(retry.getAttribute('aria-busy')).toBe('true')
     retry.click()
     expect(onRetry).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/error-notice.tsx
+++ b/src/renderer/src/components/error-notice.tsx
@@ -46,9 +46,16 @@ const NoticeButton = ({
   button: ErrorNoticeButton
   variant?: 'secondary'
 }): React.JSX.Element => (
-  <Button variant={variant} onClick={button.onClick} disabled={button.disabled || button.loading}>
+  <Button
+    type="button"
+    className="focus-visible:transition-none"
+    variant={variant}
+    onClick={button.onClick}
+    disabled={button.disabled || button.loading}
+    aria-busy={button.loading || undefined}
+  >
     {button.loading ? (
-      <LoaderCircle className="size-4 animate-spin motion-reduce:animate-none" />
+      <LoaderCircle className="size-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
     ) : null}
     {button.label}
   </Button>
@@ -66,54 +73,54 @@ const ErrorNotice = ({
   primaryButton
 }: ErrorNoticeProps): React.JSX.Element => {
   return (
-    <section className="flex w-full max-w-md flex-col items-center gap-5">
-      <FlaskLogo className="mb-1 h-auto w-1/3 text-text-300" />
+    <section className="flex w-full min-w-0 max-w-md flex-col gap-4 text-left">
+      <FlaskLogo className="size-10 text-text-300" />
 
       {title !== undefined || description !== undefined ? (
-        <div className="flex w-full items-start gap-4">
+        <div className="flex min-w-0 items-start gap-3">
           {Icon ? (
             <div
-              className={`flex size-11 shrink-0 items-center justify-center rounded-full ${TONE_CLASSES[tone ?? 'amber']}`}
+              className={`flex size-9 shrink-0 items-center justify-center rounded-full ${TONE_CLASSES[tone ?? 'amber']}`}
             >
-              <Icon className="size-5" strokeWidth={1.8} />
+              <Icon className="size-4" strokeWidth={1.8} aria-hidden="true" />
             </div>
           ) : null}
-          <div className="flex flex-col gap-1.5 pt-0.5">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
             {title !== undefined ? (
-              <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+              <h1 className="text-base leading-6 font-semibold text-foreground [overflow-wrap:anywhere]">
+                {title}
+              </h1>
             ) : null}
             {description !== undefined ? (
-              <p className="text-sm leading-6 text-muted-foreground">{description}</p>
+              <p className="text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]">
+                {description}
+              </p>
             ) : null}
           </div>
         </div>
       ) : null}
 
       {errorCode !== undefined ? (
-        <p className="w-full rounded-lg bg-muted px-3.5 py-2.5 text-center font-mono text-xs text-muted-foreground">
+        <p className="w-full rounded-lg bg-muted px-3 py-2.5 font-mono text-xs text-muted-foreground [overflow-wrap:anywhere]">
           {errorCode}
         </p>
       ) : null}
 
       {help ? (
-        <div className="flex w-full flex-col gap-3.5 rounded-2xl bg-muted p-5">
+        <div className="flex w-full min-w-0 flex-col gap-4 rounded-lg bg-muted p-4 [overflow-wrap:anywhere]">
           <div className="flex flex-col gap-1">
-            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
-              {help.whyLabel}
-            </p>
+            <p className="text-xs font-medium text-muted-foreground">{help.whyLabel}</p>
             <p className="text-[13px] leading-6 text-foreground/90">{help.why}</p>
           </div>
           <div className="flex flex-col gap-1">
-            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
-              {help.howLabel}
-            </p>
+            <p className="text-xs font-medium text-muted-foreground">{help.howLabel}</p>
             <p className="text-[13px] leading-6 text-foreground/90">{help.how}</p>
           </div>
         </div>
       ) : null}
 
       {secondaryButton !== undefined || primaryButton !== undefined ? (
-        <div className="flex items-center gap-3">
+        <div className="flex w-full flex-wrap items-center justify-end gap-2">
           {secondaryButton ? <NoticeButton button={secondaryButton} variant="secondary" /> : null}
           {primaryButton ? <NoticeButton button={primaryButton} /> : null}
         </div>
@@ -125,10 +132,10 @@ const ErrorNotice = ({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground"
+                className="inline-flex max-w-full items-center gap-1.5 self-end rounded-sm text-xs text-muted-foreground underline decoration-dotted underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
                 onClick={issueLink.onClick}
               >
-                <CircleQuestionMark className="size-3.5" />
+                <CircleQuestionMark className="size-3.5 shrink-0" aria-hidden="true" />
                 {issueLink.label}
               </button>
             </TooltipTrigger>

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -589,7 +589,13 @@ describe('ArtifactProvenancePanel', () => {
         diagnostics,
         'known content integrity failures must offer a diagnostic entry'
       ).toBeDefined()
+      expect(diagnostics!.getAttribute('aria-expanded')).toBe('false')
       await act(async () => diagnostics!.click())
+      expect(diagnostics!.getAttribute('aria-expanded')).toBe('true')
+      const diagnosticsRegion = document.getElementById(
+        diagnostics!.getAttribute('aria-controls')!
+      )!
+      expect(diagnosticsRegion.hidden).toBe(false)
       const diagnosticText = container.querySelector('pre')!.textContent!
       expect(JSON.parse(diagnosticText)).toMatchObject({
         projectId: 'project-1',
@@ -607,6 +613,27 @@ describe('ArtifactProvenancePanel', () => {
         await flush()
         expect(writeText).toHaveBeenCalledWith(diagnosticText)
         expect(container.textContent).toContain('Copied')
+
+        writeText.mockRejectedValueOnce(new Error('clipboard unavailable'))
+        await clickTab('Copied')
+        await flush()
+        expect(container.textContent).not.toContain('Copied')
+        expect(container.textContent).toContain(
+          'Could not copy diagnostics. Select and copy the text above.'
+        )
+        expect(container.querySelector('pre')!.textContent).toBe(diagnosticText)
+
+        await clickTab('Copy diagnostics')
+        await flush()
+        expect(container.textContent).toContain('Copied')
+        expect(container.textContent).not.toContain('Could not copy diagnostics.')
+
+        await clickTab('Hide diagnostics')
+        expect(diagnosticsRegion.hidden).toBe(true)
+        expect(diagnostics!.getAttribute('aria-expanded')).toBe('false')
+        await clickTab('View diagnostics')
+        expect(diagnosticsRegion.hidden).toBe(false)
+        expect(container.querySelector('pre')!.textContent).toBe(diagnosticText)
       } finally {
         if (clipboardDescriptor) Object.defineProperty(navigator, 'clipboard', clipboardDescriptor)
         else Reflect.deleteProperty(navigator, 'clipboard')

--- a/src/renderer/src/pages/workspace/ProvenanceLoadNotice.tsx
+++ b/src/renderer/src/pages/workspace/ProvenanceLoadNotice.tsx
@@ -1,5 +1,5 @@
-import { TriangleAlert } from 'lucide-react'
-import { useState } from 'react'
+import { Check, ChevronDown, Copy, TriangleAlert } from 'lucide-react'
+import { useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ErrorNotice } from '@/components/error-notice'
@@ -16,48 +16,75 @@ export const ProvenanceLoadNotice = ({
   onRetry?: () => void
 }): React.JSX.Element => {
   const { t } = useTranslation()
+  const diagnosticsId = useId()
   const [showDiagnostics, setShowDiagnostics] = useState(false)
   const [copyFailed, setCopyFailed] = useState(false)
   const [copied, setCopied] = useState(false)
   return (
-    <div className="flex flex-col items-center gap-3 p-5" role="alert">
-      <ErrorNotice
-        icon={TriangleAlert}
-        tone={failure.kind === 'integrity-failed' ? 'red' : 'amber'}
-        title={
-          failure.kind === 'integrity-failed'
-            ? t('Provenance integrity error')
-            : t('Provenance could not be loaded')
-        }
-        description={failure.message}
-        primaryButton={onRetry ? { label: t('Retry'), onClick: onRetry } : undefined}
-        secondaryButton={{ label: t('View diagnostics'), onClick: () => setShowDiagnostics(true) }}
-      />
-      {showDiagnostics ? (
-        <div className="w-full min-w-0 space-y-2">
-          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-muted p-3 text-xs">
+    <div className="mx-auto flex w-full min-w-0 max-w-md flex-col gap-5 p-5">
+      <div role="alert">
+        <ErrorNotice
+          icon={TriangleAlert}
+          tone={failure.kind === 'integrity-failed' ? 'red' : 'amber'}
+          title={
+            failure.kind === 'integrity-failed'
+              ? t('Provenance integrity error')
+              : t('Provenance could not be loaded')
+          }
+          description={failure.message}
+          primaryButton={onRetry ? { label: t('Retry'), onClick: onRetry } : undefined}
+        />
+      </div>
+      <div className="min-w-0 border-t border-border pt-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="focus-visible:transition-none"
+            aria-expanded={showDiagnostics}
+            aria-controls={diagnosticsId}
+            onClick={() => setShowDiagnostics((shown) => !shown)}
+          >
+            <ChevronDown
+              className={showDiagnostics ? 'size-3.5' : 'size-3.5 -rotate-90'}
+              aria-hidden="true"
+            />
+            {showDiagnostics ? t('Hide diagnostics') : t('View diagnostics')}
+          </Button>
+          {showDiagnostics ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="ml-auto focus-visible:transition-none"
+              onClick={() => {
+                setCopyFailed(false)
+                setCopied(false)
+                void Promise.resolve()
+                  .then(() => navigator.clipboard.writeText(diagnostics))
+                  .then(() => setCopied(true))
+                  .catch(() => setCopyFailed(true))
+              }}
+            >
+              {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+              <span aria-live="polite">{copied ? t('Copied') : t('Copy diagnostics')}</span>
+            </Button>
+          ) : null}
+        </div>
+        <div id={diagnosticsId} hidden={!showDiagnostics} className="mt-3 min-w-0 space-y-2">
+          <pre
+            tabIndex={0}
+            aria-label={t('View diagnostics')}
+            className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded-lg border border-border bg-muted p-3 text-xs leading-5 text-muted-foreground select-text focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
             {diagnostics}
           </pre>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setCopyFailed(false)
-              void Promise.resolve()
-                .then(() => navigator.clipboard.writeText(diagnostics))
-                .then(() => setCopied(true))
-                .catch(() => setCopyFailed(true))
-            }}
-          >
-            {copied ? t('Copied') : t('Copy diagnostics')}
-          </Button>
           {copyFailed ? (
-            <p className="text-sm text-danger-000">
+            <p className="text-sm text-danger-000" role="alert">
               {t('Could not copy diagnostics. Select and copy the text above.')}
             </p>
           ) : null}
         </div>
-      ) : null}
+      </div>
     </div>
   )
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4175,6 +4175,7 @@
     "Provenance integrity error": "Integritätsfehler der Herkunftsdaten",
     "Provenance could not be loaded": "Herkunftsdaten konnten nicht geladen werden",
     "View diagnostics": "Diagnose anzeigen",
+    "Hide diagnostics": "Diagnosedaten ausblenden",
     "Copy diagnostics": "Diagnose kopieren",
     "Could not copy diagnostics. Select and copy the text above.": "Diagnose konnte nicht kopiert werden. Wählen Sie den Text oben aus und kopieren Sie ihn.",
     "Loading earlier versions…": "Frühere Versionen werden geladen…",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4330,6 +4330,7 @@
     "Provenance integrity error": "Error de integridad de la procedencia",
     "Provenance could not be loaded": "No se pudo cargar la procedencia",
     "View diagnostics": "Ver diagnóstico",
+    "Hide diagnostics": "Ocultar diagnóstico",
     "Copy diagnostics": "Copiar diagnóstico",
     "Could not copy diagnostics. Select and copy the text above.": "No se pudo copiar el diagnóstico. Seleccione y copie el texto anterior.",
     "Loading earlier versions…": "Cargando versiones anteriores…",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4330,6 +4330,7 @@
     "Provenance integrity error": "Erreur d’intégrité de la provenance",
     "Provenance could not be loaded": "Impossible de charger la provenance",
     "View diagnostics": "Afficher le diagnostic",
+    "Hide diagnostics": "Masquer le diagnostic",
     "Copy diagnostics": "Copier le diagnostic",
     "Could not copy diagnostics. Select and copy the text above.": "Impossible de copier le diagnostic. Sélectionnez et copiez le texte ci-dessus.",
     "Loading earlier versions…": "Chargement des versions antérieures…",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4020,6 +4020,7 @@
     "Provenance integrity error": "来歴の整合性エラー",
     "Provenance could not be loaded": "来歴を読み込めませんでした",
     "View diagnostics": "診断情報を表示",
+    "Hide diagnostics": "診断情報を非表示",
     "Copy diagnostics": "診断情報をコピー",
     "Could not copy diagnostics. Select and copy the text above.": "診断情報をコピーできませんでした。上のテキストを選択してコピーしてください。",
     "Loading earlier versions…": "以前のバージョンを読み込み中…",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4018,6 +4018,7 @@
     "Provenance integrity error": "출처 무결성 오류",
     "Provenance could not be loaded": "출처를 불러오지 못했습니다",
     "View diagnostics": "진단 정보 보기",
+    "Hide diagnostics": "진단 정보 숨기기",
     "Copy diagnostics": "진단 정보 복사",
     "Could not copy diagnostics. Select and copy the text above.": "진단 정보를 복사하지 못했습니다. 위의 텍스트를 선택하여 복사하세요.",
     "Loading earlier versions…": "이전 버전 불러오는 중…",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4460,6 +4460,7 @@
     "Provenance integrity error": "Ошибка целостности данных о происхождении",
     "Provenance could not be loaded": "Не удалось загрузить данные о происхождении",
     "View diagnostics": "Показать диагностику",
+    "Hide diagnostics": "Скрыть диагностику",
     "Copy diagnostics": "Копировать диагностику",
     "Could not copy diagnostics. Select and copy the text above.": "Не удалось скопировать диагностику. Выделите и скопируйте текст выше.",
     "Loading earlier versions…": "Загрузка предыдущих версий…",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4020,6 +4020,7 @@
     "Provenance integrity error": "来源完整性错误",
     "Provenance could not be loaded": "无法加载来源信息",
     "View diagnostics": "查看诊断信息",
+    "Hide diagnostics": "收起诊断信息",
     "Copy diagnostics": "复制诊断信息",
     "Could not copy diagnostics. Select and copy the text above.": "无法复制诊断信息。请选择并复制上方文本。",
     "Loading earlier versions…": "正在加载更早的版本…",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4020,6 +4020,7 @@
     "Provenance integrity error": "來源完整性錯誤",
     "Provenance could not be loaded": "無法載入來源資訊",
     "View diagnostics": "檢視診斷資訊",
+    "Hide diagnostics": "收合診斷資訊",
     "Copy diagnostics": "複製診斷資訊",
     "Could not copy diagnostics. Select and copy the text above.": "無法複製診斷資訊。請選取並複製上方文字。",
     "Loading earlier versions…": "正在載入更早的版本…",


### PR DESCRIPTION
## Problem

Provenance failures combined a large centered brand mark and centered actions with a full-width diagnostics block and a detached copy button. The competing widths and alignment made the error pane difficult to scan.

## Proposed change

- Give shared error notices a compact brand mark, a bounded left-aligned summary, wrapping long text, and a trailing group of actions.
- Keep Provenance diagnostics at the same width below a divider; group the disclosure and copy action in its header, support collapse, and announce clipboard feedback without announcing the JSON payload.
- Reuse existing tokens, controls, failure classifications and callbacks; translate the new collapse label in all eight catalogs.

## Scope and non-goals

Renderer presentation only. The shared treatment also applies to startup, job, preview, editor and application error consumers. No public component prop changes, backend retry changes, historical-data compatibility work, new business enum/state values, persistence, migrations, IPC, platform paths or dependencies. Existing local disclosure and clipboard state is reused.

## Acceptance criteria and validation

Final Test Impact Set (after the last production edit):

| Behavior | Command / evidence | Result |
| --- | --- | --- |
| Shared optional sections, callbacks and loading | `npx vitest run src/renderer/src/components/error-notice.test.tsx` | Passed |
| Provenance retry, disclosure, exact diagnostics, copy success/failure/recovery | `npx vitest run src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx` | Passed |
| Representative consumers | `npx vitest run src/renderer/src/components/database-startup-gate.test.tsx src/renderer/src/components/JobDetailModal.render.test.tsx src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx` | Passed |
| All translated catalogs | `npx vitest run src/renderer/src/i18n/resources.test.ts` | Passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Formatting | Prettier check on changed TSX, locale JSON and design documentation; `git diff --check` | Passed |
| Layout and accessibility | Actual production components and stylesheet through a localhost Vite fixture in Ego Browser | 36 width/locale combinations without overflow; light/dark WCAG 2 A/AA and 2.1 AA axe scans: zero violations; disclosure, clipboard success/failure and keyboard focus checked |

The six Vitest suites ran together: **885 tests passed**. Browser widths were 320/375/414/768 CSS px across English and all eight translations, including long unbroken messages. Light/dark and narrow screenshots are delivered in the task.

The dependency-aware classifier reports `error-notice.test.tsx -> unknown module owner -> full`. The maintainer explicitly requested focused local tests and full verification in PR CI; no local full `npm test` run is claimed. No CI/classifier/ownership configuration was changed. Require the final PR CI plan to pass.

No main/preload or local OS-specific suites were added because the diff changes no backend, IPC, filesystem, path or persisted behavior. Shared consumers beyond the representative render suites retain their props/callback contracts and are structurally reviewed/typechecked; their full live screens were not individually replayed. Browser evidence uses actual components with fixture diagnostics, not a live database or Electron reproduction.

## Review focus

Shared error layout in other consumers, long translated control labels, disclosure accessibility and clipboard feedback. Independent Standards and Spec reviews completed with no open findings; a focus-style consistency finding was corrected before the final local checks.
