### PR TITLE
fix(artifacts): recover finalization in multi-message turns

### DIFF
--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -56,12 +56,13 @@ type ArtifactProvenanceFinalizationRecoveryOptions = {
   >
 }
 
-// Resolves the one agent message produced by the prepared prompt turn. It deliberately considers
+// Resolves the agent message owning the prepared prompt turn's output. It deliberately considers
 // only messages before the next user prompt on the declared Branch and Runtime Segment; choosing a
 // latest message (or accepting multiple candidates) could attach a crashed run to a later turn.
 const inferDurableFinalizationMessageId = (
   session: PersistedChatSession,
-  context: PreparedArtifactFinalizationContext
+  context: PreparedArtifactFinalizationContext,
+  versionIds: readonly string[]
 ): string | undefined => {
   const graph = materializeSessionConversationGraph(session).conversationGraph!
   if (graph.rootFrameId !== context.rootFrameId) return undefined
@@ -89,10 +90,28 @@ const inferDurableFinalizationMessageId = (
         message.introducedOnBranchId === context.messageBranchId &&
         message.runtimeSegmentId === context.runtimeSegmentId
     )
-  if (candidates.length !== 1) return undefined
+  let message = candidates.length === 1 ? candidates[0] : undefined
+  if (candidates.length > 1) {
+    // A turn may contain commentary before its result. Use durable attachments to distinguish the
+    // owner, but reject even a partial competing claim anywhere in the Session graph/projection.
+    const claimedMessageIds = new Set(
+      [...session.messages, ...(session.conversationGraph?.messages ?? [])]
+        .filter((candidate) => candidate.artifactIds?.some((id) => versionIds.includes(id)))
+        .map((candidate) => candidate.id)
+    )
+    if (claimedMessageIds.size !== 1) return undefined
+    message = candidates.find((candidate) => claimedMessageIds.has(candidate.id))
+    if (
+      !message ||
+      !versionIds.every((id) => isArtifactLinkedToDurableMessage(session, message!.id, id))
+    ) {
+      return undefined
+    }
+  }
+  if (!message) return undefined
 
-  validateDurableMessageOwnership(session, { ...context, messageId: candidates[0].id })
-  return candidates[0].id
+  validateDurableMessageOwnership(session, { ...context, messageId: message.id })
+  return message.id
 }
 
 // Require Session metadata and every persisted owner projection to carry ArtifactFile.id.
@@ -249,7 +268,12 @@ class ArtifactProvenanceFinalizationRecovery {
       let proof: { messageId: string } | undefined
       try {
         const messageId =
-          marker.messageId ?? inferDurableFinalizationMessageId(durableSession, markerContext)
+          marker.messageId ??
+          inferDurableFinalizationMessageId(
+            durableSession,
+            markerContext,
+            runVersions.map((version) => version.id)
+          )
         if (messageId) {
           validateDurableMessageOwnership(durableSession, {
             ...markerContext,

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -7,17 +7,25 @@ import type { PrismaClient } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', () => ({
-  app: { getPath: () => '/home/user', isPackaged: true }
+  app: { getPath: () => '/home/user', isPackaged: true },
+  ipcMain: { handle: vi.fn() },
+  shell: { openPath: vi.fn() }
 }))
 
 import { createLinearConversationGraph } from '../../shared/conversation-graph'
-import { ARTIFACT_FINALIZATION_INVALID_PROOF } from '../../shared/artifacts'
+import {
+  ARTIFACT_FINALIZATION_INVALID_PROOF,
+  type ReconcilePendingArtifactsRequest
+} from '../../shared/artifacts'
 import type { PersistedChatSession } from '../../shared/session-persistence'
-import { createPngInlineSource } from '../artifacts/artifact-test-fixtures'
+import { createPngBytes, createPngInlineSource } from '../artifacts/artifact-test-fixtures'
 import { ProvenanceMessageSnapshotRepository } from '../artifacts/provenance-message-snapshot'
 import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
 import { requireAgentArtifactVersion } from '../artifacts/provenance-version-kind'
 import { ArtifactRepository } from '../artifacts/repository'
+import { createArtifactHandlers } from '../artifacts/ipc'
+import { ArtifactRunRegistry } from '../artifacts/run-registry'
+import { ManagedPreviewResources } from '../managed-preview-resources'
 import { ManagedFileVersionService } from '../managed-file-versions/service'
 import { ManagedFileIndexRepository } from '../project-files/repository'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
@@ -96,6 +104,361 @@ describe('artifact finalization startup recovery', () => {
     expect(durableSession?.artifacts).toBeUndefined()
 
     await expect(coordinator.retryArtifactFinalization(request)).resolves.toEqual(recovery)
+  })
+
+  const prepareAttachedRecovery = async (
+    outputCount = 1,
+    earlierMessage = true
+  ): Promise<
+    Awaited<ReturnType<typeof prepareRecovery>> & {
+      compatibility: ArtifactRepository
+      session: PersistedChatSession
+      coordinator: SessionPersistenceCoordinator
+      handlers: ReturnType<typeof createArtifactHandlers>
+      resources: ManagedPreviewResources
+      request: ReconcilePendingArtifactsRequest
+    }
+  > => {
+    const compatibility = new ArtifactRepository(storageRoot)
+    const fixture = await prepareRecovery(compatibility, outputCount)
+    const { versions, provenance } = fixture
+    await client.project.create({ data: { id: PROJECT_ID, name: 'Recovery project' } })
+    const session = (await sessions.loadSession(PROJECT_ID, SESSION_ID))!
+    session.messages[1].artifactIds = versions.map((version) => version.versionId)
+    session.artifacts = versions.map((version) => ({
+      id: version.versionId,
+      artifactId: version.artifactId,
+      versionId: version.versionId,
+      versionNumber: version.versionNumber,
+      kind: 'managed-file',
+      path: version.path,
+      fileUrl: version.fileUrl,
+      name: version.name,
+      mimeType: version.mimeType,
+      size: version.size,
+      mtimeMs: version.mtimeMs,
+      sha256: version.checksum
+    }))
+    if (earlierMessage) {
+      session.messages.splice(1, 0, {
+        id: 'assistant-preface',
+        role: 'agent',
+        status: 'complete',
+        content: 'I will generate the result.',
+        eventIds: [],
+        createdAt: 2,
+        updatedAt: 2
+      })
+    }
+    session.conversationGraph = createLinearConversationGraph({
+      sessionId: SESSION_ID,
+      messages: session.messages.map(
+        ({ id, role, content, status, eventIds, createdAt, updatedAt, artifactIds }) => ({
+          id,
+          role,
+          content,
+          status,
+          eventIds,
+          createdAt,
+          updatedAt,
+          artifactIds
+        })
+      ),
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 2
+    })
+    await sessions.saveSession(session)
+    const coordinator = new SessionPersistenceCoordinator(
+      sessions,
+      files,
+      undefined,
+      undefined,
+      undefined,
+      provenance
+    )
+    const managedVersions = new ManagedFileVersionService({
+      storageRoot,
+      getClient: () => Promise.resolve(client)
+    })
+    const handlers = createArtifactHandlers(compatibility, new ArtifactRunRegistry(), {
+      openLatestManagedFile: (request) =>
+        managedVersions.openLatest({
+          projectId: request.projectId!,
+          source: 'artifact',
+          fileId: request.fileId!
+        }),
+      openManagedFileVersion: (request) =>
+        managedVersions.openVersion(
+          {
+            projectId: request.projectId!,
+            source: 'artifact',
+            fileId: request.fileId!
+          },
+          request.versionId
+        )
+    })
+    const resources = new ManagedPreviewResources({
+      resolvePath: async () => {
+        throw new Error('Public previews must use managed Versions.')
+      },
+      openLatestManagedFile: (source, request) =>
+        managedVersions.openLatest({ ...request, source }),
+      openManagedFileVersion: (source, request) =>
+        managedVersions.openVersion({ ...request, source }, request.versionId)
+    })
+    const request = {
+      projectId: PROJECT_ID,
+      sessionId: SESSION_ID,
+      messageId: 'message-1',
+      pendingPaths: [],
+      artifactVersionIds: versions.map((version) => version.versionId)
+    }
+    return { ...fixture, compatibility, session, coordinator, handlers, resources, request }
+  }
+
+  it.each([
+    { earlierMessage: false, outputCount: 1, restart: false },
+    { earlierMessage: true, outputCount: 1, restart: false },
+    { earlierMessage: true, outputCount: 2, restart: true }
+  ])(
+    'publishes durably attached pending Versions: %j',
+    async ({ earlierMessage, outputCount, restart }) => {
+      const { versions, coordinator, handlers, resources, request } = await prepareAttachedRecovery(
+        outputCount,
+        earlierMessage
+      )
+      const first = versions[0]
+      const identity = {
+        projectId: PROJECT_ID,
+        source: 'artifact' as const,
+        fileId: first.artifactId
+      }
+      const unavailable = {
+        code: 'VERSION_NOT_FOUND',
+        message: 'Managed file has no published version.'
+      }
+      await expect(handlers.readPreview({ path: first.path, ...identity })).rejects.toMatchObject(
+        unavailable
+      )
+      await expect(resources.acquire(1, identity)).rejects.toMatchObject(unavailable)
+      if (restart) {
+        await coordinator.loadAll()
+        await expect(
+          handlers.readPreview({ path: first.path, ...identity, encoding: 'base64' })
+        ).resolves.toMatchObject({ content: createPngBytes('recovered bytes').toString('base64') })
+      }
+      const recovered = await coordinator.retryArtifactFinalization(request)
+      expect(recovered?.artifacts.map((artifact) => artifact.versionId).sort()).toEqual(
+        versions.map((version) => version.versionId).sort()
+      )
+      await expect(coordinator.retryArtifactFinalization(request)).resolves.toEqual(recovered)
+      for (const version of versions) {
+        await expect(
+          client.artifactLineage.findUniqueOrThrow({ where: { id: version.artifactId } })
+        ).resolves.toMatchObject({ currentVersionId: version.versionId })
+        await expect(
+          client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+        ).resolves.toMatchObject({
+          state: 'finalized',
+          messageId: 'message-1',
+          managedVisibleAt: expect.any(Date)
+        })
+        const expected = createPngBytes('recovered bytes')
+        for (const versionId of [undefined, version.versionId]) {
+          await expect(
+            handlers.readPreview({
+              path: version.path,
+              projectId: PROJECT_ID,
+              fileId: version.artifactId,
+              versionId,
+              encoding: 'base64'
+            })
+          ).resolves.toMatchObject({ content: expected.toString('base64'), truncated: false })
+          const resource = await resources.acquire(1, {
+            projectId: PROJECT_ID,
+            source: 'artifact',
+            fileId: version.artifactId,
+            versionId
+          })
+          try {
+            const range = await resources.readRange(1, {
+              resourceId: resource.id,
+              begin: 0,
+              end: expected.length
+            })
+            expect(Buffer.from(range.data)).toEqual(expected)
+          } finally {
+            resources.release(1, { resourceId: resource.id })
+          }
+        }
+      }
+    }
+  )
+
+  it.each([
+    'missing-metadata',
+    'partial-run',
+    'competing-owner',
+    'missing-projection',
+    'later-turn'
+  ] as const)('keeps ambiguous recovery unpublished with %s', async (scenario) => {
+    const { session, versions, provenance, compatibility } = await prepareAttachedRecovery(2)
+    const graph = session.conversationGraph!
+    const owner = graph.messages.find((message) => message.id === 'message-1')!
+    if (scenario === 'missing-metadata') session.artifacts = []
+    if (scenario === 'partial-run') {
+      owner.artifactIds = [versions[0].versionId]
+      session.messages.at(-1)!.artifactIds = owner.artifactIds
+    }
+    if (scenario === 'competing-owner') graph.messages[1].artifactIds = [versions[0].versionId]
+    if (scenario === 'missing-projection') session.messages.at(-1)!.artifactIds = []
+    if (scenario === 'later-turn') {
+      graph.messages.push(
+        {
+          ...owner,
+          id: 'next-prompt',
+          role: 'user',
+          status: 'complete',
+          artifactIds: undefined,
+          revisionRootMessageId: 'next-prompt',
+          parentMessageId: owner.id
+        },
+        {
+          ...owner,
+          id: 'later-owner',
+          revisionRootMessageId: 'later-owner',
+          parentMessageId: 'next-prompt'
+        }
+      )
+      graph.branches[0].headMessageId = 'later-owner'
+      owner.artifactIds = []
+      session.messages.at(-1)!.artifactIds = []
+    }
+    const result = await provenance.reconcileSession(PROJECT_ID, SESSION_ID, session)
+    expect(result.unresolvedNativeFinalizationRunIds).toContain(RUN_ID)
+    for (const version of versions) {
+      await expect(
+        client.artifactLineage.findUniqueOrThrow({ where: { id: version.artifactId } })
+      ).resolves.toMatchObject({ currentVersionId: null })
+    }
+    for (const version of versions) {
+      await expect(
+        client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+      ).resolves.toMatchObject({ state: 'pending', messageId: null, managedVisibleAt: null })
+    }
+    const pending = await compatibility.listPendingRunFiles({
+      projectId: PROJECT_ID,
+      sessionId: STORAGE_SESSION_ID,
+      runId: RUN_ID
+    })
+    expect(pending).toHaveLength(2)
+    for (const file of pending)
+      expect(await readFile(file.path)).toEqual(createPngBytes('recovered bytes'))
+  })
+
+  it('uses the attached owner even when another assistant message follows it', async () => {
+    const { session, coordinator, request, versions } = await prepareAttachedRecovery()
+    const ownerId = 'assistant-preface'
+    for (const message of [...session.messages, ...session.conversationGraph!.messages]) {
+      message.artifactIds = message.id === ownerId ? [versions[0].versionId] : undefined
+    }
+    await sessions.saveSession(session)
+    await expect(
+      coordinator.retryArtifactFinalization({ ...request, messageId: ownerId })
+    ).resolves.toMatchObject({
+      artifacts: [expect.objectContaining({ versionId: versions[0].versionId })]
+    })
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: versions[0].versionId } })
+    ).resolves.toMatchObject({ messageId: ownerId, state: 'finalized' })
+  })
+
+  it.each([false, true])(
+    'recovers an inactive Branch unless another Branch claims its Version: %s',
+    async (competingClaim) => {
+      const { session, versions, provenance } = await prepareAttachedRecovery()
+      const graph = session.conversationGraph!
+      const activeBranchId = 'other-branch'
+      const activeMessage = {
+        id: 'other-message',
+        role: 'user' as const,
+        content: 'other branch',
+        status: 'complete' as const,
+        eventIds: [],
+        createdAt: 3,
+        updatedAt: 3,
+        artifactIds: competingClaim ? [versions[0].versionId] : undefined
+      }
+      graph.frames[0].activeBranchId = activeBranchId
+      graph.branches.push({
+        id: activeBranchId,
+        agentFrameId: graph.rootFrameId,
+        headMessageId: activeMessage.id,
+        createdAt: 3,
+        updatedAt: 3
+      })
+      graph.messages.push({
+        ...activeMessage,
+        agentFrameId: graph.rootFrameId,
+        introducedOnBranchId: activeBranchId,
+        revisionRootMessageId: activeMessage.id,
+        runtimeSegmentId: graph.runtimeSegments[0].id
+      })
+      session.messages = [activeMessage]
+      await sessions.saveSession(session)
+      const durable = (await sessions.loadSession(PROJECT_ID, SESSION_ID))!
+      const result = await provenance.reconcileSession(PROJECT_ID, SESSION_ID, durable)
+      expect(result.unresolvedNativeFinalizationRunIds).toEqual(competingClaim ? [RUN_ID] : [])
+      await expect(
+        client.artifactVersion.findUniqueOrThrow({ where: { id: versions[0].versionId } })
+      ).resolves.toMatchObject(
+        competingClaim
+          ? { state: 'pending', messageId: null, managedVisibleAt: null }
+          : { state: 'finalized', messageId: 'message-1', managedVisibleAt: expect.any(Date) }
+      )
+    }
+  )
+
+  it('retains exact marker Version-set validation after resolving the durable owner', async () => {
+    const { coordinator, request, versions } = await prepareAttachedRecovery(2)
+    const markerPath = join(
+      storageRoot,
+      'artifacts',
+      PROJECT_ID,
+      STORAGE_SESSION_ID,
+      '.runs',
+      `${RUN_ID}.json`
+    )
+    const marker = JSON.parse(await readFile(markerPath, 'utf8'))
+    await writeFile(
+      markerPath,
+      JSON.stringify({ ...marker, artifactVersionIds: [versions[0].versionId] })
+    )
+    await expect(coordinator.retryArtifactFinalization(request)).rejects.toMatchObject({
+      code: ARTIFACT_FINALIZATION_INVALID_PROOF
+    })
+    for (const version of versions) {
+      await expect(
+        client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+      ).resolves.toMatchObject({ state: 'pending', messageId: null, managedVisibleAt: null })
+    }
+  })
+
+  it('retries the multi-message run after its durable attachment arrives', async () => {
+    const { session, versions, coordinator, request } = await prepareAttachedRecovery()
+    const linked = structuredClone(session)
+    session.artifacts = []
+    for (const message of [...session.messages, ...session.conversationGraph!.messages])
+      message.artifactIds = []
+    await sessions.saveSession(session)
+    await expect(coordinator.retryArtifactFinalization(request)).rejects.toThrow(
+      'Native Artifact finalization remains unresolved.'
+    )
+    await sessions.saveSession(linked)
+    await expect(coordinator.retryArtifactFinalization(request)).resolves.toMatchObject({
+      artifacts: [expect.objectContaining({ versionId: versions[0].versionId })]
+    })
   })
 
   it('replays an explicitly requested finalized Version that is already linked', async () => {
@@ -995,8 +1358,10 @@ describe('artifact finalization startup recovery', () => {
   }
 
   const prepareRecovery = async (
-    compatibility: ArtifactRepository
+    compatibility: ArtifactRepository,
+    outputCount = 1
   ): Promise<{
+    versions: Awaited<ReturnType<ArtifactProvenanceRepository['createVersion']>>[]
     provenance: ArtifactProvenanceRepository
     version: Awaited<ReturnType<ArtifactProvenanceRepository['createVersion']>>
     context: {
@@ -1045,29 +1410,36 @@ describe('artifact finalization startup recovery', () => {
       runtimeSegmentId: conversationGraph.runtimeSegments[0].id,
       promptMessageId: prompt.id
     }
-    await compatibility.writePendingFile({
-      projectId: PROJECT_ID,
-      sessionId: STORAGE_SESSION_ID,
-      runId: RUN_ID,
-      filename: 'result.png',
-      source: createPngInlineSource('recovered bytes')
-    })
-    const version = await provenance.createVersion({
-      projectId: PROJECT_ID,
-      appSessionId: SESSION_ID,
-      artifactStorageSessionId: STORAGE_SESSION_ID,
-      artifactRunId: RUN_ID,
-      writeOperationId: 'write-1',
-      writeRequestChecksum: 'a'.repeat(64),
-      ...context,
-      filename: 'result.png'
-    })
+    const versions: Awaited<ReturnType<ArtifactProvenanceRepository['createVersion']>>[] = []
+    for (let index = 0; index < outputCount; index += 1) {
+      const filename = index === 0 ? 'result.png' : `result-${index}.png`
+      await compatibility.writePendingFile({
+        projectId: PROJECT_ID,
+        sessionId: STORAGE_SESSION_ID,
+        runId: RUN_ID,
+        filename,
+        source: createPngInlineSource('recovered bytes')
+      })
+      versions.push(
+        await provenance.createVersion({
+          projectId: PROJECT_ID,
+          appSessionId: SESSION_ID,
+          artifactStorageSessionId: STORAGE_SESSION_ID,
+          artifactRunId: RUN_ID,
+          writeOperationId: `write-${index + 1}`,
+          writeRequestChecksum: 'a'.repeat(64),
+          ...context,
+          filename
+        })
+      )
+    }
+    const version = versions[0]
     await compatibility.prepareRunFinalization({
       projectId: PROJECT_ID,
       sourceSessionId: STORAGE_SESSION_ID,
       sessionId: SESSION_ID,
       runId: RUN_ID,
-      artifactVersionIds: [version.versionId],
+      artifactVersionIds: versions.map((version) => version.versionId),
       provenanceContext: context
     })
     const session: PersistedChatSession = {
@@ -1083,6 +1455,6 @@ describe('artifact finalization startup recovery', () => {
       updatedAt: 2
     }
     await sessions.saveSession(session)
-    return { provenance, version, context }
+    return { provenance, version, versions, context }
   }
 })


### PR DESCRIPTION
## Problem

An Artifact run can emit an assistant preface followed by its result. If finalization is retried with an unbound prepared marker, recovery requires exactly one assistant message and cannot resolve that turn even when the durable Session already attaches every output to one message. Versions remain pending and both preview consumers fail with `VERSION_NOT_FOUND`.

The same minimized failure reproduces on main and the PR2–PR9 integration branch.

## Proposed change

For multi-message turns, resolve the owner from durable attachments only when every run Version belongs to one eligible same-turn message, Session artifact metadata and all present message projections agree, and no other message claims any run Version. Keep existing single-message inference, explicit marker ownership, exact Version-set validation, and finalization → compatibility publication → managed visibility ordering.

## Scope and non-goals

Two files: the recovery owner and SQLite/filesystem regression coverage. No preview bypass, timeout changes, UI changes, new APIs, new enum values, or schema migrations.

Historical recovery is intentional and maintainer-approved: existing pending runs with sufficient durable proof can recover through ordinary retry/startup. Insufficient or conflicting proof remains blocked. Persistence uses existing Version ownership/state, marker/publication, current-version and visibility fields; no new persisted format or authority is introduced.

## Acceptance criteria and validation

Checks below ran after the final behavior change; the final helper return-type annotation also passed Node typecheck, lint and formatting.

| Behavior/check | Command / scope | Result |
| --- | --- | --- |
| Recovery owner, Session/IPC contracts, shared framework consumers, public previews | Repository module-plan runner: union of `artifact_provenance` + `session_persistence` + four supplemental suites below; `--maxWorkers=1 --no-file-parallelism` | 38 files, 2,208 passed; one unrelated oversized Codex REPL test timed out under load |
| Timed-out ACP case | `npm test -- src/main/acp/runtime.test.ts -t "routes an oversized Codex MCP 'REPL execution' through permission controls without publishing it" --maxWorkers=1 --no-file-parallelism` | Passed separately on baseline main (5.21 s test) and fixed branch (6.11 s test) |
| Original incident on PR2–PR9 integration | Full final recovery integration suite + private preserved-incident replay in an isolated integration checkout | 32 passed; both public preview consumers return the preserved bytes |
| Node and sandbox types | `npm run typecheck:node` | Passed |
| Web types | `npm run typecheck:web` | Passed |
| Lint / formatting | `npm run lint`; Prettier check on both changed files | Passed |

Supplemental suites: `src/main/managed-file-versions/service.integration.test.ts`, `src/main/managed-file-preview.test.ts`, `src/main/managed-preview-resources.test.ts`, `src/renderer/src/lib/session-persistence/session-persistence.test.ts`.

The earlier parallel run encountered CPU/memory pressure, expired fixture transactions and sandbox-denied RPC sockets. The final module run used one worker with local socket access. No test assertions/timeouts were changed. No full local suite was run, as requested; required PR CI remains final authority. Live model regeneration was not repeated: integration acceptance replays the original persisted incident through real recovery and both preview consumers, using disposable fixtures and leaving original data untouched.

The test impact set combines the repository-owned `artifact_provenance` and `session_persistence` module plans, deduplicates their tests, and adds managed Version/preview and renderer persistence consumer suites. Run with one worker and no file parallelism on the loaded development machine.

The changed owner is shared by `claude-code`, `opencode`, `codex-response`, and `codex-bridge`; deterministic single/multiple-message graph fixtures cover the affected behavior. Framework wire methods, launchers, model selection, permissions, subscriptions and transports are unchanged, so no new adapter-specific matrix is introduced. Local execution is macOS; required Windows-sensitive CI remains authoritative. The broader affected-plan lifecycle expansion is conservative because the changed integration test is registered to several modules; no lifecycle, deletion, project repository, or public interface changes are introduced.

Final exact-head CI for `5ed88619ceb387de1cf4d5279479281072478cd7`: **all selected checks passed**, including PR Gate, module tests and coverage, static checks, macOS build/E2E, Windows core, both Windows E2E shards, CI Integrity, PR policy and CodeQL. [PR Gate run](https://github.com/aipoch/open-science/actions/runs/33943477713). The full portable, Linux Notebook isolation and legacy coverage lanes were intentionally unselected/skipped. Automated Codex review returned **mergeable — no actionable findings**. Squash merge awaits explicit maintainer approval.

## Review focus

Keep ownership proof fail-closed for partial, conflicting, cross-turn and cross-Branch claims. Review startup recovery before any explicit retry, an earlier assistant owner, an inactive Branch, exact marker-set mismatch, repeated recovery, and both preview consumers before/after publication. Independent read-only review of the final production diff and impact mapping found no actionable issues.
