### PR TITLE
fix(database): preserve retries and enforce persisted contracts

### DIFF
--- a/prisma/sqlite-check-constraints.json
+++ b/prisma/sqlite-check-constraints.json
@@ -43,7 +43,7 @@
     {
       "tableName": "SessionModelCallUsage",
       "name": "SessionModelCallUsage_nonnegative_check",
-      "expression": "\"inputTokens\" >= 0 AND \"cacheTokens\" >= 0 AND \"outputTokens\" >= 0 AND ((\"cachedReadTokens\" IS NULL AND \"cachedWriteTokens\" IS NULL) OR (\"cachedReadTokens\" >= 0 AND \"cachedWriteTokens\" >= 0)) AND (\"contextUsedTokens\" IS NULL OR \"contextUsedTokens\" >= 0) AND (\"contextWindowSize\" IS NULL OR \"contextWindowSize\" > 0)"
+      "expression": "\"inputTokens\" >= 0 AND \"cacheTokens\" >= 0 AND \"outputTokens\" >= 0 AND ((\"cachedReadTokens\" IS NULL AND \"cachedWriteTokens\" IS NULL) OR (\"cachedReadTokens\" IS NOT NULL AND \"cachedWriteTokens\" IS NOT NULL AND \"cachedReadTokens\" >= 0 AND \"cachedWriteTokens\" >= 0)) AND (\"contextUsedTokens\" IS NULL OR \"contextUsedTokens\" >= 0) AND (\"contextWindowSize\" IS NULL OR \"contextWindowSize\" > 0)"
     },
     {
       "tableName": "SessionAuxiliaryTurnUsage",
@@ -58,7 +58,7 @@
     {
       "tableName": "SessionAuxiliaryTurnUsage",
       "name": "SessionAuxiliaryTurnUsage_nonnegative_check",
-      "expression": "\"completedAtMs\" >= 0 AND \"inputTokens\" >= 0 AND \"cacheTokens\" >= 0 AND \"outputTokens\" >= 0 AND ((\"cachedReadTokens\" IS NULL AND \"cachedWriteTokens\" IS NULL) OR (\"cachedReadTokens\" >= 0 AND \"cachedWriteTokens\" >= 0)) AND (\"modelCallCount\" IS NULL OR \"modelCallCount\" > 0)"
+      "expression": "\"completedAtMs\" >= 0 AND \"inputTokens\" >= 0 AND \"cacheTokens\" >= 0 AND \"outputTokens\" >= 0 AND ((\"cachedReadTokens\" IS NULL AND \"cachedWriteTokens\" IS NULL) OR (\"cachedReadTokens\" IS NOT NULL AND \"cachedWriteTokens\" IS NOT NULL AND \"cachedReadTokens\" >= 0 AND \"cachedWriteTokens\" >= 0)) AND (\"modelCallCount\" IS NULL OR \"modelCallCount\" > 0)"
     },
     {
       "tableName": "SessionRun",
@@ -588,7 +588,7 @@
     {
       "tableName": "ComputeJobOperation",
       "name": "ComputeJobOperation_lifecycle_check",
-      "expression": "(\"phase\" = 'active' AND \"outcome\" IS NULL AND \"settledAt\" IS NULL) OR (\"phase\" = 'settled' AND \"outcome\" IN ('fulfilled', 'superseded') AND \"settledAt\" IS NOT NULL)"
+      "expression": "(\"phase\" = 'active' AND \"outcome\" IS NULL AND \"settledAt\" IS NULL) OR (\"phase\" = 'settled' AND \"outcome\" IS NOT NULL AND \"outcome\" IN ('fulfilled', 'superseded') AND \"settledAt\" IS NOT NULL)"
     },
     {
       "tableName": "ComputeJobOperation",
@@ -618,7 +618,7 @@
     {
       "tableName": "MemoryCategory",
       "name": "MemoryCategory_shape_check",
-      "expression": "((\"systemKey\" = 'about-you' AND \"name\" IS NULL AND \"nameKey\" IS NULL AND \"guidance\" = '' AND \"autoRecall\" = true) OR (\"systemKey\" IS NULL AND \"name\" IS NOT NULL AND \"nameKey\" IS NOT NULL))"
+      "expression": "((\"systemKey\" IS NOT NULL AND \"systemKey\" = 'about-you' AND \"name\" IS NULL AND \"nameKey\" IS NULL AND \"guidance\" = '' AND \"autoRecall\" = true) OR (\"systemKey\" IS NULL AND \"name\" IS NOT NULL AND \"nameKey\" IS NOT NULL))"
     },
     {
       "tableName": "MemoryCategory",
@@ -674,6 +674,31 @@
       "tableName": "MemoryEntry",
       "name": "MemoryEntry_revision_check",
       "expression": "\"revision\" >= 1"
+    },
+    {
+      "tableName": "UploadVersion",
+      "name": "UploadVersion_numeric_bounds_check",
+      "expression": "\"sizeBytes\" >= 0 AND \"versionNumber\" >= 1"
+    },
+    {
+      "tableName": "ArtifactVersion",
+      "name": "ArtifactVersion_numeric_bounds_check",
+      "expression": "\"sizeBytes\" >= 0 AND \"versionNumber\" >= 1"
+    },
+    {
+      "tableName": "ArtifactVersionInput",
+      "name": "ArtifactVersionInput_numeric_bounds_check",
+      "expression": "\"sizeBytes\" >= 0 AND (\"sourceVersionNumber\" IS NULL OR \"sourceVersionNumber\" >= 1)"
+    },
+    {
+      "tableName": "ManagedFile",
+      "name": "ManagedFile_numeric_bounds_check",
+      "expression": "\"sizeBytes\" >= 0"
+    },
+    {
+      "tableName": "ManagedFileVersionWriteOperation",
+      "name": "ManagedFileVersionWriteOperation_numeric_bounds_check",
+      "expression": "\"sizeBytes\" >= 0"
     }
   ],
   "indexes": [

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -112,6 +112,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0027_project_session_defaults',
     checksum: 'af7f3740a6032de71789e25567ee6605f961ee0dea3b89df2b47f9a589e738c7'
+  },
+  {
+    id: '0028_database_numeric_and_null_constraints',
+    checksum: '7ee2e3ec746080d5e1bedcddaea5ded1b080d8bcbc8ec59ed4139ff8c5e5de4a'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -72,7 +72,7 @@ const rebuildComputeJobWithoutAnalysisConstraints = async (
 
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
-    expect(MIGRATION_MANIFEST.slice(-5).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
+    expect(MIGRATION_MANIFEST.slice(-6).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: '0023_compute_job_operation',
         checksum: 'c625e336996c7dd1eba64da8ccd306104ccd68cf219e60ee2c3889749f86b079'
@@ -92,6 +92,10 @@ describe('packaged database migration ledger smoke', () => {
       {
         id: '0027_project_session_defaults',
         checksum: 'af7f3740a6032de71789e25567ee6605f961ee0dea3b89df2b47f9a589e738c7'
+      },
+      {
+        id: '0028_database_numeric_and_null_constraints',
+        checksum: '7ee2e3ec746080d5e1bedcddaea5ded1b080d8bcbc8ec59ed4139ff8c5e5de4a'
       }
     ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
@@ -129,7 +133,7 @@ describe('packaged database migration ledger smoke', () => {
       }
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints')`
       )
 
       await migrateApplicationDatabase(client)
@@ -165,7 +169,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await rebuildComputeJobWithoutAnalysisConstraints(client, false)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints')`
       )
       await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
         "id", "providerId", "shape", "sessionId", "projectId", "status", "intent",
@@ -199,7 +203,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await client.$executeRawUnsafe('DROP INDEX "MemoryEntry_global_contentKey_key"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints')`
       )
       await client.memoryEntry.createMany({
         data: [
@@ -297,7 +301,7 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints')`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
 
@@ -374,7 +378,8 @@ describe('packaged database migration ledger smoke', () => {
            '0024_compute_job_file_evidence',
            '0025_managed_file_version_foundation',
            '0026_compute_job_remote_cleanup',
-           '0027_project_session_defaults'
+           '0027_project_session_defaults',
+           '0028_database_numeric_and_null_constraints'
          )`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -17,7 +17,7 @@ const COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID = '0021_compute_job_analysis_con
 const MEMORY_GLOBAL_CONTENT_UNIQUE_MIGRATION_ID = '0022_memory_global_content_unique'
 const COMPUTE_JOB_OPERATION_MIGRATION_ID = '0023_compute_job_operation'
 const COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID = '0024_compute_job_file_evidence'
-const CURRENT_MIGRATION_ID = '0027_project_session_defaults'
+const CURRENT_MIGRATION_ID = '0028_database_numeric_and_null_constraints'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -307,7 +307,7 @@ describe('agent memory project scope migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "fileEvidence"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "producerRunId"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
       SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
@@ -318,6 +318,7 @@ describe('agent memory project scope migration', () => {
       COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID,
       '0025_managed_file_version_foundation',
       '0026_compute_job_remote_cleanup',
+      '0027_project_session_defaults',
       CURRENT_MIGRATION_ID
     )
 
@@ -333,6 +334,7 @@ describe('agent memory project scope migration', () => {
         COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID,
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults',
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -214,7 +214,8 @@ describe('application database (integration)', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
 
@@ -1262,7 +1263,8 @@ describe('application database (integration)', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
 

--- a/src/main/database/compute-job-operation-migration.test.ts
+++ b/src/main/database/compute-job-operation-migration.test.ts
@@ -24,7 +24,7 @@ describe('Compute Job operation migration', () => {
     await migrateApplicationDatabase(client)
     await client.$executeRawUnsafe(`DROP TABLE "ComputeJobOperation"`)
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints')`
     )
     const [{ sql: computeJobSqlBefore }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
       `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
@@ -40,7 +40,7 @@ describe('Compute Job operation migration', () => {
       client.$queryRawUnsafe<Array<{ id: string }>>(
         `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1`
       )
-    ).resolves.toEqual([{ id: '0027_project_session_defaults' }])
+    ).resolves.toEqual([{ id: '0028_database_numeric_and_null_constraints' }])
   })
 
   it('adds a constrained operation sidecar without rebuilding historical ComputeJob rows', async () => {

--- a/src/main/database/compute-job-remote-cleanup-migration.test.ts
+++ b/src/main/database/compute-job-remote-cleanup-migration.test.ts
@@ -67,9 +67,13 @@ describe('Compute Job remote cleanup migration', () => {
     )`)
 
     await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toMatchObject({
-      applied: ['0026_compute_job_remote_cleanup', '0027_project_session_defaults'],
+      applied: [
+        '0026_compute_job_remote_cleanup',
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
+      ],
       from: '0025_managed_file_version_foundation',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ remoteCleanupDisposition: string }>>(

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -74,10 +74,11 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ],
       from: '0015_session_model_call_usage',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -166,10 +166,11 @@ describe('database JSON constraints migration', () => {
           '0024_compute_job_file_evidence',
           '0025_managed_file_version_foundation',
           '0026_compute_job_remote_cleanup',
-          '0027_project_session_defaults'
+          '0027_project_session_defaults',
+          '0028_database_numeric_and_null_constraints'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0027_project_session_defaults'
+        to: '0028_database_numeric_and_null_constraints'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
       await expect(

--- a/src/main/database/database-null-and-version-bounds.test.ts
+++ b/src/main/database/database-null-and-version-bounds.test.ts
@@ -1,0 +1,436 @@
+import { access, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import {
+  MIGRATION_MANIFEST,
+  migrateApplicationDatabase,
+  type MigrationManifestEntry
+} from './migration-service'
+import { applySqliteMigrationOperations } from './sqlite-schema-migrations'
+import { visionEvidenceMigration } from './migrations/0009-vision-evidence'
+
+type Row = Record<string, string | number | null>
+const now = Date.now()
+const rows: Record<string, Row> = {
+  MemoryCategory: {
+    id: 'category',
+    systemKey: null,
+    name: 'Research',
+    nameKey: 'research',
+    guidance: '',
+    autoRecall: 1,
+    updatedAt: now
+  },
+  ComputeJobOperation: {
+    id: 'operation',
+    jobId: 'job',
+    kind: 'cancel',
+    phase: 'settled',
+    outcome: 'fulfilled',
+    settledAt: now,
+    updatedAt: now
+  },
+  SessionAuxiliaryTurnUsage: {
+    sessionId: 'session',
+    eventId: 'event',
+    source: 'reviewer',
+    frameworkId: 'codex-response',
+    completedAtMs: 0,
+    inputTokens: 0,
+    cacheTokens: 0,
+    outputTokens: 0,
+    cachedReadTokens: 5,
+    cachedWriteTokens: 5
+  },
+  SessionModelCallUsage: {
+    sessionId: 'session',
+    messageId: 'message',
+    callId: 'call',
+    callIndex: 0,
+    inputTokens: 0,
+    cacheTokens: 0,
+    outputTokens: 0,
+    cachedReadTokens: 5,
+    cachedWriteTokens: 5
+  },
+  UploadVersion: {
+    id: 'version',
+    uploadFileId: 'upload',
+    versionNumber: 1,
+    state: 'ready',
+    contentStorageKey: 'uploads/data',
+    filename: 'data',
+    originalFilename: 'data',
+    sizeBytes: 0,
+    checksum: 'a'.repeat(64),
+    updatedAt: now
+  },
+  ArtifactVersion: {
+    id: 'version',
+    artifactId: 'artifact',
+    versionNumber: 1,
+    state: 'finalized',
+    originKind: 'legacy',
+    contentStorageKey: 'artifacts/data',
+    filename: 'data',
+    sizeBytes: 0,
+    checksum: 'a'.repeat(64),
+    updatedAt: now
+  },
+  ManagedFile: {
+    source: 'upload',
+    sourceFileId: 'upload',
+    projectId: 'project',
+    sessionId: 'session',
+    displayName: 'data',
+    storageKey: 'uploads/data',
+    sizeBytes: 0,
+    sortAtMs: 0,
+    updatedAt: now
+  },
+  ManagedFileVersionWriteOperation: {
+    operationId: 'write',
+    source: 'upload',
+    projectId: 'project',
+    sourceFileId: 'upload',
+    basedOnVersionId: 'version',
+    expectedHeadVersionId: 'version',
+    state: 'staging',
+    storageTag: 'tag',
+    storedFilename: 'data',
+    contentStorageKey: 'uploads/write',
+    checksum: 'a'.repeat(64),
+    sizeBytes: 0,
+    textFormatJson: '{}',
+    updatedAt: now
+  }
+}
+rows.ArtifactVersionInput = {
+  id: 'input',
+  artifactVersionId: 'version',
+  ordinal: 0,
+  inputFileVersionId: 'version',
+  sourceKind: 'upload-version',
+  sourceFileId: 'upload',
+  sourceUploadVersionId: 'version',
+  sourceVersionNumber: 1,
+  sourceProjectId: 'project',
+  sourceSessionId: 'session',
+  filename: 'data',
+  sizeBytes: 0,
+  checksum: 'a'.repeat(64),
+  storageKey: 'uploads/data',
+  strongestAssociation: 'captured-version'
+}
+const nullCases: Array<[string, Row]> = [
+  ['MemoryCategory', { name: null, nameKey: null }],
+  ['ComputeJobOperation', { outcome: null }],
+  ['SessionAuxiliaryTurnUsage', { cachedReadTokens: null }],
+  ['SessionAuxiliaryTurnUsage', { cachedWriteTokens: null }],
+  ['SessionModelCallUsage', { cachedReadTokens: null }],
+  ['SessionModelCallUsage', { cachedWriteTokens: null }]
+]
+const numericCases: Array<[string, Row]> = [
+  ['UploadVersion', { versionNumber: -1 }],
+  ['UploadVersion', { versionNumber: 0 }],
+  ['UploadVersion', { sizeBytes: -3 }],
+  ['ArtifactVersion', { versionNumber: -1 }],
+  ['ArtifactVersion', { versionNumber: 0 }],
+  ['ArtifactVersion', { sizeBytes: -3 }],
+  ['ArtifactVersionInput', { sizeBytes: -3 }],
+  ['ArtifactVersionInput', { sourceVersionNumber: -1 }],
+  ['ArtifactVersionInput', { sourceVersionNumber: 0 }],
+  ['ManagedFile', { sizeBytes: -3 }],
+  ['ManagedFileVersionWriteOperation', { sizeBytes: -3 }]
+]
+
+describe('D02/D04 persisted database boundaries', () => {
+  let client: PrismaClient
+  let root: string
+  // Identifiers and rows are trusted test fixtures, never external input.
+  const insert = (table: string, row: Row): Promise<number> =>
+    client.$executeRawUnsafe(
+      `INSERT INTO "${table}" (${Object.keys(row)
+        .map((key) => `"${key}"`)
+        .join(',')}) VALUES (${Object.keys(row)
+        .map(() => '?')
+        .join(',')})`,
+      ...Object.values(row)
+    )
+  const prepare = async (table: string): Promise<void> => {
+    if (table === 'ArtifactVersionInput') {
+      await insert('UploadVersion', rows.UploadVersion!)
+      await insert('ArtifactVersion', rows.ArtifactVersion!)
+    }
+  }
+  const seedParents = async (): Promise<void> => {
+    await insert('Project', { id: 'project', name: 'Project', updatedAt: now })
+    await insert('Session', {
+      id: 'session',
+      number: 1,
+      projectId: 'project',
+      title: 'Session',
+      status: 'idle',
+      presentedStatus: 'idle',
+      createdAtMs: 0,
+      updatedAtMs: 0
+    })
+    await insert('SessionTurnUsage', {
+      sessionId: 'session',
+      messageId: 'message',
+      completedAtMs: 0,
+      inputTokens: 0,
+      cacheTokens: 0,
+      outputTokens: 0,
+      isRootFrame: 1
+    })
+    await insert('ComputeJob', {
+      id: 'job',
+      providerId: 'ssh:host',
+      shape: 'direct_ssh',
+      sessionId: 'session',
+      projectId: 'project',
+      status: 'success',
+      intent: 'test',
+      command: 'true',
+      commandHash: 'hash'
+    })
+    await insert('FileOriginSession', {
+      projectId: 'project',
+      sessionId: 'session',
+      updatedAt: now
+    })
+    await insert('UploadFile', {
+      id: 'upload',
+      projectId: 'project',
+      sessionId: 'session',
+      filename: 'data',
+      originalFilename: 'data',
+      updatedAt: now
+    })
+    await insert('ArtifactLineage', {
+      id: 'artifact',
+      projectId: 'project',
+      sessionId: 'session',
+      filename: 'data',
+      normalizedFilename: 'data',
+      updatedAt: now
+    })
+  }
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'open-science-persisted-boundaries-'))
+    client = createProjectDbClient(root)
+  })
+
+  afterEach(async () => {
+    await client?.$disconnect()
+    if (root) await rm(root, { recursive: true, force: true })
+  })
+
+  describe('current schema', () => {
+    beforeEach(async () => {
+      await migrateApplicationDatabase(client)
+      await seedParents()
+    })
+    describe.each(['INSERT', 'UPDATE'] as const)('%s', (operation) => {
+      it.each([...nullCases, ...numericCases])('rejects %s %j', async (table, patch) => {
+        await prepare(table)
+        const row = rows[table]!
+        if (operation === 'INSERT') {
+          await expect(insert(table, { ...row, ...patch })).rejects.toThrow(
+            /CHECK constraint failed/i
+          )
+        } else {
+          await insert(table, row)
+          await expect(
+            client.$executeRawUnsafe(
+              `UPDATE "${table}" SET ${Object.keys(patch)
+                .map((key) => `"${key}" = ?`)
+                .join(',')} WHERE "${Object.keys(row)[0]}" = ?`,
+              ...Object.values(patch),
+              Object.values(row)[0]
+            )
+          ).rejects.toThrow(/CHECK constraint failed/i)
+        }
+      })
+    })
+
+    it.each([...nullCases, ...numericCases])(
+      'blocks startup with invalid persisted %s %j',
+      async (table, patch) => {
+        await prepare(table)
+        // Emulate corruption/old accepted data without weakening the schema being verified.
+        await client.$executeRawUnsafe('PRAGMA ignore_check_constraints = ON')
+        try {
+          await insert(table, { ...rows[table]!, ...patch })
+        } finally {
+          await client.$executeRawUnsafe('PRAGMA ignore_check_constraints = OFF')
+        }
+        await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+          code: 'database_validation_failed',
+          retryable: false
+        })
+      }
+    )
+
+    it('accepts valid rows, including empty files and nullable cache pairs, on reopen', async () => {
+      for (const [table, row] of Object.entries(rows)) {
+        await insert(
+          table,
+          table.startsWith('Session')
+            ? { ...row, cachedReadTokens: null, cachedWriteTokens: null }
+            : row
+        )
+      }
+      await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
+    })
+
+    it.each([
+      ['MemoryCategory', { name: null }],
+      ['MemoryCategory', { nameKey: null }],
+      ['MemoryCategory', { systemKey: 'unknown' }],
+      ['ComputeJobOperation', { outcome: 'unknown' }],
+      ['ComputeJobOperation', { settledAt: null }]
+    ] as Array<[string, Row]>)('rejects other invalid shapes in %s %j', async (table, patch) => {
+      await expect(insert(table, { ...rows[table]!, ...patch })).rejects.toThrow(
+        /CHECK constraint failed/i
+      )
+    })
+  })
+
+  describe('released 0027 schema', () => {
+    const migrationId = '0028_database_numeric_and_null_constraints'
+    beforeEach(async () => {
+      // Build history exclusively from released immutable entries, not today's generated DDL.
+      const released: readonly MigrationManifestEntry[] = MIGRATION_MANIFEST.slice(
+        0,
+        MIGRATION_MANIFEST.findIndex(({ id }) => id === migrationId)
+      )
+      expect(released.at(-1)?.id).toBe('0027_project_session_defaults')
+      await client.$executeRawUnsafe('PRAGMA foreign_keys = OFF')
+      for (const migration of released) {
+        for (const statement of migration.statements) await client.$executeRawUnsafe(statement)
+        await applySqliteMigrationOperations(client, migration.operations ?? [])
+        // Match the released owner's repair after 0025 renames UploadVersion.
+        if (migration.id === '0025_managed_file_version_foundation') {
+          await applySqliteMigrationOperations(client, visionEvidenceMigration.operations)
+        }
+      }
+      await client.$executeRawUnsafe(`CREATE TABLE "_open_science_migrations" (
+        "id" TEXT NOT NULL PRIMARY KEY, "checksum" TEXT NOT NULL,
+        "appliedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "_open_science_migrations_checksum_check" CHECK (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
+      )`)
+      for (const migration of released)
+        await client.$executeRawUnsafe(
+          `INSERT INTO "_open_science_migrations" ("id", "checksum") VALUES (?, ?)`,
+          migration.id,
+          migration.checksum
+        )
+      await client.$executeRawUnsafe('PRAGMA foreign_keys = ON')
+      await seedParents()
+    })
+
+    const readRows = (table: string): Promise<unknown[]> =>
+      client.$queryRawUnsafe(`SELECT * FROM "${table}" ORDER BY 1`)
+
+    it('upgrades valid legacy rows while retaining foreign keys, triggers, and allocator history', async () => {
+      for (const [table, row] of Object.entries(rows)) await insert(table, row)
+      await insert('MemoryEntry', {
+        id: 'memory',
+        categoryId: 'category',
+        content: 'preserved research',
+        contentKey: 'preserved research',
+        origin: 'user',
+        updatedAt: now
+      })
+      await client.$executeRawUnsafe(`UPDATE "UploadFile" SET "currentVersionId" = 'version'`)
+      await client.$executeRawUnsafe(`UPDATE "ArtifactLineage" SET "currentVersionId" = 'version'`)
+      await client.$executeRawUnsafe(
+        `UPDATE "ArtifactVersionInput" SET "sourceVersionNumber" = NULL`
+      )
+      await client.$executeRawUnsafe(
+        `UPDATE "SessionAuxiliaryTurnUsage" SET "cachedReadTokens" = NULL, "cachedWriteTokens" = NULL`
+      )
+      await client.$executeRawUnsafe(
+        `UPDATE sqlite_sequence SET seq = 43 WHERE name = 'ManagedFile'`
+      )
+      await client.$executeRawUnsafe(`DELETE FROM "ManagedFile"`)
+      const tables = [...Object.keys(rows), 'MemoryEntry', 'UploadFile', 'ArtifactLineage']
+      const before = await Promise.all(tables.map(readRows))
+      const ledger = await readRows('_open_science_migrations')
+      await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+        applied: [migrationId],
+        to: migrationId
+      })
+      expect(await Promise.all(tables.map(readRows))).toEqual(before)
+      expect((await readRows('_open_science_migrations')).slice(0, -1)).toEqual(ledger)
+      await expect(client.$queryRawUnsafe('PRAGMA foreign_key_check')).resolves.toEqual([])
+      await expect(
+        client.$executeRawUnsafe(
+          `DELETE FROM "MemoryCategory" WHERE "id" = 'memory-category-about-you'`
+        )
+      ).rejects.toThrow('About you category cannot be deleted')
+      await expect(
+        client.$queryRawUnsafe(
+          `SELECT "rowid" FROM "MemoryEntryFts" WHERE "MemoryEntryFts" MATCH 'preserved'`
+        )
+      ).resolves.toHaveLength(1)
+      await insert('ManagedFile', rows.ManagedFile!)
+      await expect(client.$queryRawUnsafe(`SELECT seq FROM "ManagedFile"`)).resolves.toEqual([
+        { seq: 44 }
+      ])
+      await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
+    })
+
+    it('rejects unknown historical columns without losing their data', async () => {
+      await client.$executeRawUnsafe(
+        `ALTER TABLE "MemoryCategory" ADD COLUMN "unrecognized" TEXT DEFAULT 'preserve'`
+      )
+      await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+        code: 'database_validation_failed',
+        retryable: false
+      })
+      await expect(
+        client.$queryRawUnsafe(`SELECT "unrecognized" FROM "MemoryCategory"`)
+      ).resolves.toEqual([{ unrecognized: 'preserve' }])
+    })
+
+    it.each([...nullCases, ...numericCases])(
+      'rolls back an upgrade containing invalid %s %j without deleting data',
+      async (table, patch) => {
+        await prepare(table)
+        await insert(table, { ...rows[table]!, ...patch })
+        const before = await readRows(table)
+        const ledger = await readRows('_open_science_migrations')
+        const schema = await client.$queryRawUnsafe(
+          `SELECT type, name, tbl_name, sql FROM sqlite_schema ORDER BY type, name`
+        )
+        await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+          code: 'database_validation_failed',
+          retryable: false,
+          migrationId,
+          cause: expect.objectContaining({ data: { kind: 'check-constraint-violation', table } })
+        })
+        await expect(
+          access(join(root, `open-science.db.before-${migrationId}.backup`))
+        ).resolves.toBeUndefined()
+        expect(await readRows(table)).toEqual(before)
+        expect(await readRows('_open_science_migrations')).toEqual(ledger)
+        expect(
+          await client.$queryRawUnsafe(
+            `SELECT type, name, tbl_name, sql FROM sqlite_schema ORDER BY type, name`
+          )
+        ).toEqual(schema)
+        await expect(client.$queryRawUnsafe('PRAGMA foreign_keys')).resolves.toEqual([
+          { foreign_keys: 1n }
+        ])
+      }
+    )
+  })
+})

--- a/src/main/database/database-startup-ipc.test.ts
+++ b/src/main/database/database-startup-ipc.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { DATABASE_STARTUP_CHANNELS, type DatabaseStartupState } from '../../shared/database-startup'
 import { installDatabaseStartupQuitGuard, registerDatabaseStartupIpc } from './database-startup-ipc'
-import type { DatabaseStartupOwner } from './database-startup-owner'
+import { createDatabaseStartupOwner, type DatabaseStartupOwner } from './database-startup-owner'
 
 describe('database startup Electron bridge', () => {
   it('serves the current state and broadcasts owner changes', async () => {
@@ -133,5 +133,43 @@ describe('database startup Electron bridge', () => {
 
     expect(quit).toHaveBeenCalledOnce()
     guard.dispose()
+  })
+})
+
+describe('D03 window delivery failure isolation', () => {
+  it('delivers to surviving windows when another webContents.send throws', async () => {
+    const owner = createDatabaseStartupOwner({
+      verifyDatabase: async () => {},
+      reportBlocked: vi.fn()
+    })
+    const destroyedSend = vi.fn()
+    const healthySend = vi.fn()
+    const dispose = registerDatabaseStartupIpc({
+      ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+      owner,
+      quit: vi.fn(),
+      getWindows: () =>
+        [
+          { isDestroyed: () => true, webContents: { send: destroyedSend } },
+          {
+            isDestroyed: () => false,
+            webContents: {
+              send: (_channel: string, state: DatabaseStartupState) => {
+                if (state.phase === 'starting') throw new Error('Object has been destroyed')
+              }
+            }
+          },
+          { isDestroyed: () => false, webContents: { send: healthySend } }
+        ] as never
+    })
+    try {
+      expect.soft(await owner.start()).toEqual({ phase: 'starting' })
+      expect
+        .soft(healthySend)
+        .toHaveBeenCalledWith(DATABASE_STARTUP_CHANNELS.stateChanged, { phase: 'starting' })
+      expect(destroyedSend).not.toHaveBeenCalled()
+    } finally {
+      dispose()
+    }
   })
 })

--- a/src/main/database/database-startup-ipc.ts
+++ b/src/main/database/database-startup-ipc.ts
@@ -1,7 +1,10 @@
 import type { App, BrowserWindow, IpcMain } from 'electron'
 
 import { DATABASE_STARTUP_CHANNELS } from '../../shared/database-startup'
+import { createLogger, errorLogFields } from '../logger'
 import type { DatabaseStartupOwner } from './database-startup-owner'
+
+const log = createLogger('database-startup-ipc')
 
 type DatabaseStartupIpcDeps = {
   ipcMain: Pick<IpcMain, 'handle' | 'removeHandler'>
@@ -17,8 +20,16 @@ const registerDatabaseStartupIpc = (deps: DatabaseStartupIpcDeps): (() => void) 
 
   const unsubscribe = deps.owner.subscribe((state) => {
     for (const window of deps.getWindows()) {
-      if (!window.isDestroyed())
-        window.webContents.send(DATABASE_STARTUP_CHANNELS.stateChanged, state)
+      try {
+        if (!window.isDestroyed())
+          window.webContents.send(DATABASE_STARTUP_CHANNELS.stateChanged, state)
+      } catch (error) {
+        try {
+          log.warn('database startup window notification failed', errorLogFields(error))
+        } catch {
+          // Continue delivering to the remaining windows even if logging fails.
+        }
+      }
     }
   })
 

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -119,7 +119,8 @@ describe('database startup logging', () => {
               '0024_compute_job_file_evidence',
               '0025_managed_file_version_foundation',
               '0026_compute_job_remote_cleanup',
-              '0027_project_session_defaults'
+              '0027_project_session_defaults',
+              '0028_database_numeric_and_null_constraints'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/database-startup-owner.test.ts
+++ b/src/main/database/database-startup-owner.test.ts
@@ -188,3 +188,46 @@ describe('database startup owner', () => {
     expect(blocked.phase === 'blocked' && blocked.error.diagnostics).toBeFalsy()
   })
 })
+
+describe('D03 subscriber failure isolation', () => {
+  it('keeps verification, published state, and retry consistent when starting delivery throws', async () => {
+    const verifyDatabase = vi.fn(async () => {})
+    const reportBlocked = vi.fn()
+    const owner = createDatabaseStartupOwner({ verifyDatabase, reportBlocked })
+    const unsubscribe = owner.subscribe((state) => {
+      if (state.phase === 'starting') throw new Error('injected notification failure')
+    })
+    const healthyListener = vi.fn()
+    owner.subscribe(healthyListener)
+
+    expect.soft(await owner.start()).toEqual({ phase: 'starting' })
+    await owner.whenVerified()
+    expect.soft(healthyListener).toHaveBeenCalledWith({ phase: 'starting' })
+    expect.soft(reportBlocked).not.toHaveBeenCalled()
+    unsubscribe()
+    expect.soft(await owner.retry()).toEqual({ phase: 'starting' })
+    expect(verifyDatabase).toHaveBeenCalledOnce()
+    owner.complete()
+    expect(owner.getState()).toEqual({ phase: 'ready' })
+  })
+  it('can retry a database failure even if blocked notifications throw', async () => {
+    const failure = new DatabaseMigrationError('database_open_failed', 'locked', true)
+    const verifyDatabase = vi.fn().mockRejectedValueOnce(failure).mockResolvedValue(undefined)
+    const owner = createDatabaseStartupOwner({ verifyDatabase, reportBlocked: vi.fn() })
+    owner.subscribe(() => {
+      throw new Error('notification unavailable')
+    })
+    const healthy = vi.fn()
+    owner.subscribe(healthy)
+    await expect(owner.start()).resolves.toMatchObject({
+      phase: 'blocked',
+      error: { retryable: true }
+    })
+    expect(healthy).toHaveBeenCalledWith(expect.objectContaining({ phase: 'blocked' }))
+    await expect(owner.retry()).resolves.toEqual({ phase: 'starting' })
+    await owner.whenVerified()
+    owner.complete()
+    expect(healthy).toHaveBeenCalledWith({ phase: 'ready' })
+    expect(verifyDatabase).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/database/database-startup-owner.ts
+++ b/src/main/database/database-startup-owner.ts
@@ -1,5 +1,8 @@
 import type { DatabaseStartupState, StartupEnvironment } from '../../shared/database-startup'
+import { createLogger, errorLogFields } from '../logger'
 import { DatabaseMigrationError, type SchemaMigrationProgress } from './migration-service'
+
+const log = createLogger('database-startup-owner')
 
 type DatabaseStartupOwnerDeps = {
   reportBlocked: (error: DatabaseMigrationError) => void
@@ -35,7 +38,17 @@ const createDatabaseStartupOwner = (deps: DatabaseStartupOwnerDeps): DatabaseSta
 
   const publish = (next: DatabaseStartupState): void => {
     state = next
-    for (const listener of listeners) listener(state)
+    for (const listener of listeners) {
+      try {
+        listener(next)
+      } catch (error) {
+        try {
+          log.warn('database startup notification failed', errorLogFields(error))
+        } catch {
+          // Notification and diagnostic failures cannot change database readiness.
+        }
+      }
+    }
   }
 
   const runAttempt = (): Promise<DatabaseStartupState> => {

--- a/src/main/database/database-storage-failures.test.ts
+++ b/src/main/database/database-storage-failures.test.ts
@@ -1,0 +1,221 @@
+import { chmod, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import { createDatabaseStartupOwner } from './database-startup-owner'
+import { migrationSqlExecutor } from './migration-sql-executor'
+import {
+  checksumMigrationPayload,
+  MIGRATION_MANIFEST,
+  migrateApplicationDatabase,
+  migrateApplicationDatabaseWithManifest,
+  type MigrationManifestEntry
+} from './migration-service'
+
+const storageErrors = [
+  'SQLITE_BUSY: database is locked',
+  'SQLITE_LOCKED: database table is locked',
+  'database table is locked',
+  'SQLITE_IOERR: disk I/O error',
+  'SQLITE_FULL: database or disk is full',
+  'SQLITE_READONLY: attempt to write a readonly database',
+  'EACCES: permission denied',
+  'EPERM: operation not permitted'
+]
+
+// A real transactional migration whose verification only succeeds after its UPDATE.
+const id = '9999_storage_failure_probe'
+const statements = [`UPDATE "Project" SET "name" = 'after' WHERE "id" = 'probe'`] as const
+const verifiers = [
+  {
+    kind: 'table-value-equals',
+    version: 1,
+    table: 'Project',
+    keyColumn: 'id',
+    keyValue: 'probe',
+    valueColumn: 'name',
+    expectedValue: 'after'
+  }
+] as const
+const probeMigration: MigrationManifestEntry = {
+  id,
+  statements,
+  verifiers,
+  checksum: checksumMigrationPayload(id, statements, verifiers),
+  backupOnApply: 'none',
+  backupRetention: 'retain'
+}
+
+describe('D01 storage failures through the migration entry point', () => {
+  let client: PrismaClient
+  let root: string
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'open-science-storage-failure-'))
+    client = createProjectDbClient(root)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'probe', name: 'before' } })
+  })
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await client?.$disconnect()
+    if (root) await rm(root, { recursive: true, force: true })
+  })
+
+  describe.each([
+    'open',
+    'migration',
+    'validation',
+    'pre-migration validation',
+    'post-migration validation'
+  ] as const)('%s', (phase) => {
+    it.each(storageErrors)('can retry after removing %s', async (message) => {
+      const failure = new Error(message)
+      let injected = 0
+      let enabled = true
+      let migrationApplied = false
+      const query = migrationSqlExecutor.query
+      const execute = migrationSqlExecutor.execute
+      if (phase === 'open') {
+        const raw = client.$queryRaw.bind(client)
+        vi.spyOn(client, '$queryRaw').mockImplementation((...args) => {
+          if (enabled) {
+            injected++
+            throw failure
+          }
+          return raw(...args)
+        })
+      }
+      vi.spyOn(migrationSqlExecutor, 'execute').mockImplementation(async (db, sql, ...values) => {
+        if (sql === statements[0]) {
+          if (enabled && phase === 'migration') {
+            injected++
+            throw failure
+          }
+          const result = await execute(db, sql, ...values)
+          migrationApplied = true
+          return result
+        }
+        return execute(db, sql, ...values)
+      })
+      vi.spyOn(migrationSqlExecutor, 'query').mockImplementation(async (db, sql, ...values) => {
+        if (
+          enabled &&
+          ((phase === 'validation' && sql === 'PRAGMA foreign_key_check') ||
+            (phase === 'pre-migration validation' &&
+              !migrationApplied &&
+              sql.includes('FROM "Project"')) ||
+            (phase === 'post-migration validation' &&
+              migrationApplied &&
+              sql.includes('FROM "Project"')))
+        ) {
+          injected++
+          throw failure
+        }
+        return query(db, sql, ...values)
+      })
+      const manifest =
+        phase === 'migration' ||
+        phase === 'pre-migration validation' ||
+        phase === 'post-migration validation'
+          ? [...MIGRATION_MANIFEST, probeMigration]
+          : MIGRATION_MANIFEST
+      const owner = createDatabaseStartupOwner({
+        reportBlocked: vi.fn(),
+        verifyDatabase: async () => {
+          await migrateApplicationDatabaseWithManifest(client, manifest)
+        }
+      })
+      const blocked = await owner.start()
+      expect(injected).toBeGreaterThan(0)
+      expect.soft(blocked).toMatchObject({ phase: 'blocked', error: { retryable: true } })
+      if (blocked.phase === 'blocked') {
+        expect.soft(blocked.error.code).not.toBe('database_validation_failed')
+        expect.soft(blocked.error.code).not.toBe('database_runtime_unavailable')
+      }
+      enabled = false
+      await expect(owner.retry()).resolves.toEqual({ phase: 'starting' })
+    })
+  })
+
+  it('does not classify an initialization permission error as a missing engine', async () => {
+    const failure = Object.assign(new Error('EACCES: permission denied opening database'), {
+      name: 'PrismaClientInitializationError'
+    })
+    vi.spyOn(client, '$queryRaw').mockRejectedValueOnce(failure)
+    await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+      code: 'database_open_failed',
+      retryable: true,
+      cause: failure
+    })
+  })
+  it('retries validation after a real SQLite exclusive lock is released', async () => {
+    const blocker = createProjectDbClient(root)
+    const query = migrationSqlExecutor.query
+    let locked = false
+    let enabled = true
+    await client.$queryRawUnsafe('PRAGMA busy_timeout = 1')
+    vi.spyOn(migrationSqlExecutor, 'query').mockImplementation(async (db, sql, ...values) => {
+      if (enabled && !locked && sql === 'PRAGMA integrity_check') {
+        await blocker.$executeRawUnsafe('BEGIN EXCLUSIVE')
+        locked = true
+      }
+      return query(db, sql, ...values)
+    })
+    const reportBlocked = vi.fn()
+    const owner = createDatabaseStartupOwner({
+      reportBlocked,
+      verifyDatabase: async () => {
+        await migrateApplicationDatabase(client)
+      }
+    })
+    try {
+      const result = await owner.start()
+      expect(locked).toBe(true)
+      expect(result).toMatchObject({
+        phase: 'blocked',
+        error: { code: 'database_open_failed', retryable: true }
+      })
+      expect(reportBlocked.mock.calls[0][0].cause.message).toMatch(/database is locked/i)
+      await blocker.$executeRawUnsafe('ROLLBACK')
+      locked = false
+      enabled = false
+      await expect(owner.retry()).resolves.toEqual({ phase: 'starting' })
+    } finally {
+      if (locked) await blocker.$executeRawUnsafe('ROLLBACK')
+      await blocker.$disconnect()
+    }
+  })
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'retries after actual database file permissions are restored',
+    async () => {
+      const path = join(root, 'open-science.db')
+      await client.$disconnect()
+      await chmod(path, 0o000)
+      const reportBlocked = vi.fn()
+      const owner = createDatabaseStartupOwner({
+        reportBlocked,
+        verifyDatabase: async () => {
+          await migrateApplicationDatabase(client)
+        }
+      })
+      try {
+        expect.soft(await owner.start()).toMatchObject({
+          phase: 'blocked',
+          error: { code: 'database_open_failed', retryable: true }
+        })
+        expect(reportBlocked).toHaveBeenCalledOnce()
+        expect(reportBlocked.mock.calls[0][0].cause.message).toMatch(
+          /unable to open (?:the )?database file/i
+        )
+        await chmod(path, 0o600)
+        await expect(owner.retry()).resolves.toEqual({ phase: 'starting' })
+      } finally {
+        await chmod(path, 0o600)
+      }
+    }
+  )
+})

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -97,7 +97,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     PRIMARY KEY ("sessionId", "callId"),
     CONSTRAINT "SessionModelCallUsage_sessionId_messageId_fkey" FOREIGN KEY ("sessionId", "messageId") REFERENCES "SessionTurnUsage" ("sessionId", "messageId") ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT "SessionModelCallUsage_identity_check" CHECK (length(trim("messageId")) > 0 AND length(trim("callId")) > 0 AND "callIndex" >= 0 AND ("sourceInvocationId" IS NULL OR length(trim("sourceInvocationId")) > 0) AND ("frameworkId" IS NULL OR length(trim("frameworkId")) > 0) AND ("backendId" IS NULL OR length(trim("backendId")) > 0) AND ("model" IS NULL OR length(trim("model")) > 0)),
-    CONSTRAINT "SessionModelCallUsage_nonnegative_check" CHECK ("inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("contextUsedTokens" IS NULL OR "contextUsedTokens" >= 0) AND ("contextWindowSize" IS NULL OR "contextWindowSize" > 0))
+    CONSTRAINT "SessionModelCallUsage_nonnegative_check" CHECK ("inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" IS NOT NULL AND "cachedWriteTokens" IS NOT NULL AND "cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("contextUsedTokens" IS NULL OR "contextUsedTokens" >= 0) AND ("contextWindowSize" IS NULL OR "contextWindowSize" > 0))
 );`,
   `CREATE TABLE IF NOT EXISTS "SessionAuxiliaryTurnUsage" (
     "sessionId" TEXT NOT NULL,
@@ -117,7 +117,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     PRIMARY KEY ("sessionId", "eventId"),
     CONSTRAINT "SessionAuxiliaryTurnUsage_identity_check" CHECK (length(trim("sessionId")) > 0 AND length(trim("eventId")) > 0 AND length(trim("frameworkId")) > 0 AND ("model" IS NULL OR length(trim("model")) > 0)),
     CONSTRAINT "SessionAuxiliaryTurnUsage_source_check" CHECK ("source" IN ('reviewer', 'side-chat', 'vision', 'session-details', 'host-llm', 'artifact-code-reconstruction', 'context-compaction')),
-    CONSTRAINT "SessionAuxiliaryTurnUsage_nonnegative_check" CHECK ("completedAtMs" >= 0 AND "inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("modelCallCount" IS NULL OR "modelCallCount" > 0))
+    CONSTRAINT "SessionAuxiliaryTurnUsage_nonnegative_check" CHECK ("completedAtMs" >= 0 AND "inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" IS NOT NULL AND "cachedWriteTokens" IS NOT NULL AND "cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("modelCallCount" IS NULL OR "modelCallCount" > 0))
 );`,
   `CREATE TABLE IF NOT EXISTS "SessionRun" (
     "sessionId" TEXT NOT NULL,
@@ -263,7 +263,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "updatedAt" DATETIME NOT NULL,
     "deletedAt" DATETIME,
     "deleteOperationId" TEXT,
-    CONSTRAINT "ManagedFile_source_check" CHECK ("source" IN ('artifact', 'upload'))
+    CONSTRAINT "ManagedFile_source_check" CHECK ("source" IN ('artifact', 'upload')),
+    CONSTRAINT "ManagedFile_numeric_bounds_check" CHECK ("sizeBytes" >= 0)
 );`,
   `CREATE TABLE IF NOT EXISTS "ManagedFileSessionSync" (
     "projectId" TEXT NOT NULL,
@@ -341,7 +342,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "UploadVersion_uploadFileId_basedOnVersionId_fkey" FOREIGN KEY ("uploadFileId", "basedOnVersionId") REFERENCES "UploadVersion" ("uploadFileId", "id") ON DELETE RESTRICT ON UPDATE CASCADE,
     CONSTRAINT "UploadVersion_state_check" CHECK ("state" IN ('staging', 'ready')),
     CONSTRAINT "UploadVersion_originKind_check" CHECK ("originKind" IN ('user_upload', 'user_edit', 'legacy')),
-    CONSTRAINT "UploadVersion_userEdit_check" CHECK (("originKind" <> 'user_edit' OR ("state" = 'ready' AND "basedOnVersionId" IS NOT NULL AND "storageTag" IS NOT NULL AND "storedFilename" IS NOT NULL)))
+    CONSTRAINT "UploadVersion_userEdit_check" CHECK (("originKind" <> 'user_edit' OR ("state" = 'ready' AND "basedOnVersionId" IS NOT NULL AND "storageTag" IS NOT NULL AND "storedFilename" IS NOT NULL))),
+    CONSTRAINT "UploadVersion_numeric_bounds_check" CHECK ("sizeBytes" >= 0 AND "versionNumber" >= 1)
 );`,
   `CREATE TABLE IF NOT EXISTS "VisionEvidence" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -433,7 +435,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ArtifactVersion_provenance_check" CHECK ((("originKind" = 'agent_generated' AND "artifactRunId" IS NOT NULL AND "rootFrameId" IS NOT NULL AND "agentFrameId" IS NOT NULL AND "messageBranchId" IS NOT NULL AND "runtimeSegmentId" IS NOT NULL AND "promptMessageId" IS NOT NULL AND "evidenceStorageKey" IS NOT NULL AND "evidenceJson" IS NOT NULL AND "evidenceChecksum" IS NOT NULL AND "evidenceSchemaVersion" IS NOT NULL) OR ("originKind" = 'user_edit' AND "state" = 'finalized' AND "basedOnVersionId" IS NOT NULL AND "storageTag" IS NOT NULL AND "storedFilename" IS NOT NULL AND "artifactRunId" IS NULL AND "writeRequestChecksum" IS NULL AND "rootFrameId" IS NULL AND "agentFrameId" IS NULL AND "messageBranchId" IS NULL AND "runtimeSegmentId" IS NULL AND "promptMessageId" IS NULL AND "notebookSessionId" IS NULL AND "producerRunId" IS NULL AND "producerRunIndex" IS NULL AND "messageId" IS NULL AND "messageSnapshotId" IS NULL AND "evidenceStorageKey" IS NULL AND "evidenceJson" IS NULL AND "evidenceChecksum" IS NULL AND "evidenceSchemaVersion" IS NULL AND "executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR "originKind" = 'legacy')),
     CONSTRAINT "ArtifactVersion_evidenceJson_check" CHECK ("evidenceJson" IS NULL OR (json_valid("evidenceJson") AND json_type("evidenceJson") = 'object')),
     CONSTRAINT "ArtifactVersion_executionSnapshotJson_check" CHECK ("executionSnapshotJson" IS NULL OR (json_valid("executionSnapshotJson") AND json_type("executionSnapshotJson") = 'object')),
-    CONSTRAINT "ArtifactVersion_executionSnapshotBundle_check" CHECK ((("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL)))
+    CONSTRAINT "ArtifactVersion_executionSnapshotBundle_check" CHECK ((("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL))),
+    CONSTRAINT "ArtifactVersion_numeric_bounds_check" CHECK ("sizeBytes" >= 0 AND "versionNumber" >= 1)
 );`,
   `CREATE TABLE IF NOT EXISTS "ManagedFileVersionWriteOperation" (
     "operationId" TEXT NOT NULL PRIMARY KEY,
@@ -454,7 +457,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL,
     CONSTRAINT "ManagedFileVersionWriteOperation_source_check" CHECK ("source" IN ('artifact', 'upload')),
-    CONSTRAINT "ManagedFileVersionWriteOperation_state_check" CHECK ("state" IN ('staging', 'file_ready', 'published', 'conflict', 'failed'))
+    CONSTRAINT "ManagedFileVersionWriteOperation_state_check" CHECK ("state" IN ('staging', 'file_ready', 'published', 'conflict', 'failed')),
+    CONSTRAINT "ManagedFileVersionWriteOperation_numeric_bounds_check" CHECK ("sizeBytes" >= 0)
 );`,
   `CREATE TABLE IF NOT EXISTS "ArtifactVersionInput" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -481,7 +485,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ArtifactVersionInput_sourceProjectId_sourceSessionId_fkey" FOREIGN KEY ("sourceProjectId", "sourceSessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
     CONSTRAINT "ArtifactVersionInput_sourceKind_check" CHECK ("sourceKind" IN ('artifact-version', 'upload-version')),
     CONSTRAINT "ArtifactVersionInput_sourceIdentity_check" CHECK ((("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR ("sourceKind" = 'upload-version' AND "sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL AND "inputFileVersionId" = "sourceUploadVersionId"))),
-    CONSTRAINT "ArtifactVersionInput_strongestAssociation_check" CHECK ("strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version'))
+    CONSTRAINT "ArtifactVersionInput_strongestAssociation_check" CHECK ("strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version')),
+    CONSTRAINT "ArtifactVersionInput_numeric_bounds_check" CHECK ("sizeBytes" >= 0 AND ("sourceVersionNumber" IS NULL OR "sourceVersionNumber" >= 1))
 );`,
   `CREATE TABLE IF NOT EXISTS "ReviewFindingDisposition" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -596,7 +601,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ComputeJobOperation_revision_check" CHECK ("revision" >= 1),
     CONSTRAINT "ComputeJobOperation_attemptCount_check" CHECK ("attemptCount" >= 0),
     CONSTRAINT "ComputeJobOperation_phase_check" CHECK ("phase" IN ('active', 'settled')),
-    CONSTRAINT "ComputeJobOperation_lifecycle_check" CHECK (("phase" = 'active' AND "outcome" IS NULL AND "settledAt" IS NULL) OR ("phase" = 'settled' AND "outcome" IN ('fulfilled', 'superseded') AND "settledAt" IS NOT NULL)),
+    CONSTRAINT "ComputeJobOperation_lifecycle_check" CHECK (("phase" = 'active' AND "outcome" IS NULL AND "settledAt" IS NULL) OR ("phase" = 'settled' AND "outcome" IS NOT NULL AND "outcome" IN ('fulfilled', 'superseded') AND "settledAt" IS NOT NULL)),
     CONSTRAINT "ComputeJobOperation_claim_check" CHECK (("claimToken" IS NULL AND "claimExpiresAt" IS NULL) OR ("phase" = 'active' AND "claimToken" IS NOT NULL AND "claimExpiresAt" IS NOT NULL)),
     CONSTRAINT "ComputeJobOperation_settled_implementation_check" CHECK ("phase" = 'active' OR ("eligibleAt" IS NULL AND "claimToken" IS NULL AND "claimExpiresAt" IS NULL))
 );`,
@@ -703,7 +708,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "revision" INTEGER NOT NULL DEFAULT 1,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL,
-    CONSTRAINT "MemoryCategory_shape_check" CHECK ((("systemKey" = 'about-you' AND "name" IS NULL AND "nameKey" IS NULL AND "guidance" = '' AND "autoRecall" = true) OR ("systemKey" IS NULL AND "name" IS NOT NULL AND "nameKey" IS NOT NULL))),
+    CONSTRAINT "MemoryCategory_shape_check" CHECK ((("systemKey" IS NOT NULL AND "systemKey" = 'about-you' AND "name" IS NULL AND "nameKey" IS NULL AND "guidance" = '' AND "autoRecall" = true) OR ("systemKey" IS NULL AND "name" IS NOT NULL AND "nameKey" IS NOT NULL))),
     CONSTRAINT "MemoryCategory_name_check" CHECK ("name" IS NULL OR length(trim("name")) BETWEEN 1 AND 64),
     CONSTRAINT "MemoryCategory_nameKey_check" CHECK ("nameKey" IS NULL OR length("nameKey") BETWEEN 1 AND 64),
     CONSTRAINT "MemoryCategory_guidance_check" CHECK (length("guidance") <= 1000),

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -23,7 +23,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0027_test_suffix'
+  const id = '9997_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -294,7 +294,7 @@ describe('application database migrations', () => {
   it.each([
     {
       name: 'missing Prisma engine',
-      error: Object.assign(new Error('runtime failed'), {
+      error: Object.assign(new Error('Could not load libquery_engine: ENOENT'), {
         name: 'PrismaClientInitializationError',
         code: 'ENOENT'
       }),
@@ -403,10 +403,11 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ],
       from: null,
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -419,8 +420,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0027_project_session_defaults',
-      to: '0027_project_session_defaults'
+      from: '0028_database_numeric_and_null_constraints',
+      to: '0028_database_numeric_and_null_constraints'
     })
   })
 
@@ -488,7 +489,7 @@ describe('application database migrations', () => {
       'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
     )
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints')`
     )
     await removeComputeAnalysisSchema(client, true)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
@@ -514,7 +515,8 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
     await expect(
@@ -595,7 +597,8 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -640,7 +643,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -664,7 +667,7 @@ describe('application database migrations', () => {
     await removeComputeAnalysisSchema(client, true)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"')
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`)
+      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints')`)
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: [
@@ -689,10 +692,11 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -770,10 +774,11 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(
       client.$queryRaw<
@@ -896,7 +901,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0027_project_session_defaults'
+      migrationId: '0028_database_numeric_and_null_constraints'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -912,9 +917,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0027_test_suffix'],
-      from: '0027_project_session_defaults',
-      to: '0027_test_suffix'
+      applied: ['9997_test_suffix'],
+      from: '0028_database_numeric_and_null_constraints',
+      to: '9997_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -948,7 +953,8 @@ describe('application database migrations', () => {
       { id: '0025_managed_file_version_foundation' },
       { id: '0026_compute_job_remote_cleanup' },
       { id: '0027_project_session_defaults' },
-      { id: '0027_test_suffix' }
+      { id: '0028_database_numeric_and_null_constraints' },
+      { id: '9997_test_suffix' }
     ])
   })
 
@@ -1027,10 +1033,11 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     expect(backupEvents).toEqual([
       {
@@ -1072,7 +1079,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0027_test_suffix'
+      migrationId: '9997_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -1111,7 +1118,8 @@ describe('application database migrations', () => {
       { id: '0024_compute_job_file_evidence' },
       { id: '0025_managed_file_version_foundation' },
       { id: '0026_compute_job_remote_cleanup' },
-      { id: '0027_project_session_defaults' }
+      { id: '0027_project_session_defaults' },
+      { id: '0028_database_numeric_and_null_constraints' }
     ])
   })
 
@@ -1179,7 +1187,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0027_test_suffix'
+      migrationId: '9997_test_suffix'
     })
   })
 
@@ -1232,9 +1240,10 @@ describe('application database migrations', () => {
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
         '0027_project_session_defaults',
-        '0027_test_suffix'
+        '0028_database_numeric_and_null_constraints',
+        '9997_test_suffix'
       ],
-      to: '0027_test_suffix'
+      to: '9997_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -1490,7 +1499,8 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
     await expect(
@@ -1614,7 +1624,8 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1690,7 +1701,8 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
     await expect(
@@ -1769,7 +1781,8 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -1882,7 +1895,8 @@ describe('application database migrations', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ]
     })
     await expect(
@@ -2015,7 +2029,7 @@ describe('application database migrations', () => {
     client = createProjectDbClient(storageRoot)
     await migrateApplicationDatabase(client)
 
-    const firstId = '0028_test_batch_start'
+    const firstId = '9998_test_batch_start'
     const firstStatements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
     const firstVerifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
     const first = {
@@ -2026,7 +2040,7 @@ describe('application database migrations', () => {
       backupOnApply: 'required' as const,
       backupRetention: 'retain' as const
     }
-    const secondId = '0029_test_batch_failure'
+    const secondId = '9999_test_batch_failure'
     const secondStatements = [
       `CREATE TABLE "MigrationSuffixProbe" ("id" TEXT NOT NULL PRIMARY KEY)`
     ] as const
@@ -2184,7 +2198,8 @@ describe('application database migrations', () => {
       failure = error
     }
     expect(failure).toMatchObject({
-      code: 'database_migration_failed',
+      code: 'database_validation_failed',
+      retryable: false,
       migrationId: '0001_runtime_schema_baseline'
     })
     expect((failure as Error).cause).toMatchObject({
@@ -2225,7 +2240,8 @@ describe('application database migrations', () => {
       failure = error
     }
     expect(failure).toMatchObject({
-      code: 'database_migration_failed',
+      code: 'database_validation_failed',
+      retryable: false,
       migrationId: '0001_runtime_schema_baseline'
     })
     expect((failure as Error).cause).toMatchObject({
@@ -2276,7 +2292,8 @@ describe('application database migrations', () => {
       failure = error
     }
     expect(failure).toMatchObject({
-      code: 'database_migration_failed',
+      code: 'database_validation_failed',
+      retryable: false,
       migrationId: '0001_runtime_schema_baseline'
     })
     expect((failure as Error).cause).toMatchObject({
@@ -2402,8 +2419,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0026_compute_job_remote_cleanup.backup',
       'open-science.db.before-0027_project_session_defaults.backup',
+      'open-science.db.before-0028_database_numeric_and_null_constraints.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)
@@ -2619,7 +2636,8 @@ describe('application database migrations', () => {
     )`)
 
     await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
-      code: 'database_migration_failed'
+      code: 'database_validation_failed',
+      retryable: false
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -2740,7 +2758,7 @@ describe('application database migrations', () => {
     client = createProjectDbClient(storageRoot)
     await migrateApplicationDatabase(client)
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-        WHERE "id" IN ('0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults')`)
+        WHERE "id" IN ('0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering', '0013_session_projection', '0014_review_query_indexes', '0015_session_model_call_usage', '0016_compute_job_sensitive_data_encryption', '0017_agent_memory_project_scope', '0018_session_auxiliary_turn_usage', '0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints')`)
     await client.$executeRawUnsafe('DROP TABLE "VisionEvidence"')
     await removeComputePasswordAuthSchema(client)
     await removeComputeAnalysisSchema(client, true)
@@ -2754,7 +2772,7 @@ describe('application database migrations', () => {
         MIGRATION_MANIFEST.findIndex(({ id }) => id === '0009_vision_evidence')
       ).map(({ id }) => id),
       from: '0008_database_json_constraints',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -2813,10 +2831,11 @@ describe('application database migrations', () => {
       applied: [
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(
       client.$queryRaw<Array<{ uploadVersionId: string }>>`

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -52,6 +52,7 @@ import {
 } from './migrations/0025-managed-file-version-foundation'
 import { computeJobRemoteCleanupMigration } from './migrations/0026-compute-job-remote-cleanup'
 import { projectSessionDefaultsMigration } from './migrations/0027-project-session-defaults'
+import { numericAndNullConstraintsMigration } from './migrations/0028-database-numeric-and-null-constraints'
 import {
   applySqliteMigrationOperations,
   type SqliteMigrationOperation
@@ -354,6 +355,12 @@ const PROJECT_SESSION_DEFAULTS_CHECKSUM = checksumMigrationPayload(
   projectSessionDefaultsMigration.verifiers,
   projectSessionDefaultsMigration.operations
 )
+const NUMERIC_AND_NULL_CONSTRAINTS_CHECKSUM = checksumMigrationPayload(
+  numericAndNullConstraintsMigration.id,
+  numericAndNullConstraintsMigration.statements,
+  numericAndNullConstraintsMigration.verifiers,
+  numericAndNullConstraintsMigration.operations
+)
 const COMPUTE_JOB_SENSITIVE_DATA_ENCRYPTION_CHECKSUM = checksumMigrationPayload(
   computeJobSensitiveDataEncryptionMigration.id,
   computeJobSensitiveDataEncryptionMigration.statements,
@@ -449,6 +456,12 @@ const COMPUTE_JOB_OPERATION_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints
         Object.fromEntries(constraints.map(({ name, expression }) => [name, expression]))
       ])
   )
+const NUMERIC_AND_NULL_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints = Object.fromEntries(
+  numericAndNullConstraintsMigration.verifiers[0].tables.map(({ table, constraints }) => [
+    table,
+    Object.fromEntries(constraints.map(({ name, expression }) => [name, expression]))
+  ])
+)
 const mergeAllowedSuffixChecks = (
   ...contracts: readonly AllowedSuffixCheckConstraints[]
 ): AllowedSuffixCheckConstraints => {
@@ -623,6 +636,13 @@ const MIGRATION_MANIFEST = [
     checksum: PROJECT_SESSION_DEFAULTS_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
+  },
+  {
+    ...numericAndNullConstraintsMigration,
+    checksum: NUMERIC_AND_NULL_CONSTRAINTS_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain',
+    foreignKeysDuringApply: 'disabled'
   }
 ] as const satisfies readonly MigrationManifestEntry[]
 // schema-locality: begin frozen-0001-repairs
@@ -873,10 +893,16 @@ const runMigrationVerifiers = async (
           const tableSql = rows[0]?.sql
           if (
             !tableSql ||
-            table.constraints.some(
-              ({ name, expression }) =>
-                !tableSql.includes(`CONSTRAINT "${name}" CHECK (${expression})`)
-            )
+            table.constraints.some(({ name, expression }) => {
+              const upgradedExpression = allowedSuffixChecks[table.table]?.[name]
+              return (
+                !tableSql.includes(`CONSTRAINT "${name}" CHECK (${expression})`) &&
+                !(
+                  upgradedExpression &&
+                  tableSql.includes(`CONSTRAINT "${name}" CHECK (${upgradedExpression})`)
+                )
+              )
+            })
           ) {
             throw new Error(
               `Migration verification found missing CHECK constraints in ${table.table}.`
@@ -969,8 +995,18 @@ const verifyCurrentApplicationSchema = async (client: PrismaClient): Promise<voi
     tableNames: MEMORY_AUXILIARY_TABLE_NAMES,
     triggerNames: memoryTriggerNames
   })
-  await runMigrationVerifiers(client, agentMemoryProjectScopeMigration.verifiers)
-  await runMigrationVerifiers(client, sessionAuxiliaryTurnUsageMigration.verifiers)
+  // The generated schema enforces the latest checks; frozen auxiliary verifiers also accept
+  // the exact stronger expressions from the immutable suffix.
+  await runMigrationVerifiers(
+    client,
+    agentMemoryProjectScopeMigration.verifiers,
+    NUMERIC_AND_NULL_ALLOWED_SUFFIX_CHECKS
+  )
+  await runMigrationVerifiers(
+    client,
+    sessionAuxiliaryTurnUsageMigration.verifiers,
+    NUMERIC_AND_NULL_ALLOWED_SUFFIX_CHECKS
+  )
   await runMigrationVerifiers(client, sessionUsageAttributionMigration.verifiers)
   await runMigrationVerifiers(client, computeJobAnalysisStateMigration.verifiers)
   await runMigrationVerifiers(client, computeJobAnalysisConstraintsMigration.verifiers)
@@ -1316,31 +1352,25 @@ const classifyDatabaseFailure = (
   if (error instanceof DatabaseMigrationError) return error
 
   let engineCode = ''
-  let engineName = ''
   try {
     if ((typeof error === 'object' && error !== null) || typeof error === 'function') {
       const code = Reflect.get(error, 'code')
-      const name = Reflect.get(error, 'name')
       if (typeof code === 'string') engineCode = code
-      if (typeof name === 'string') engineName = name
     }
   } catch {
     // Classification remains fail-closed when a hostile error object cannot be inspected.
   }
-  const detail = `${error instanceof Error ? error.message : String(error)} ${engineCode} ${engineName}`
+  const detail = `${error instanceof Error ? error.message : String(error)} ${engineCode}`
   const transient =
-    /SQLITE_(?:BUSY|LOCKED|IOERR|FULL|READONLY)|database is locked|database or disk is full|attempt to write a readonly database|disk I\/O|EACCES|EPERM|permission denied/i.test(
+    /SQLITE_(?:BUSY|LOCKED|IOERR|FULL|READONLY|CANTOPEN)|database(?: table| schema)? is locked|unable to open (?:the )?database file|database or disk is full|attempt to write a readonly database|disk I\/O|EACCES|EPERM|permission denied/i.test(
       detail
     )
   const runtimeUnavailable =
-    /query engine|libquery_engine|PrismaClientInitializationError|dynamic librar|shared object|dlopen/i.test(
-      detail
-    )
+    /query engine|libquery_engine|dynamic librar|shared object|dlopen/i.test(detail)
   const validationFailure =
-    phase === 'validation' ||
-    (error instanceof DatabaseValidationError &&
-      error.data.kind === 'check-constraint-violation') ||
-    /classification blocked|unsupported value|unknown columns?|row-count mismatch|foreign-key violation|baseline verification/i.test(
+    (phase === 'validation' && !transient) ||
+    error instanceof DatabaseValidationError ||
+    /CHECK constraint failed|FOREIGN KEY constraint failed|classification blocked|unsupported value|unknown columns?|row-count mismatch|foreign-key violation|baseline verification/i.test(
       detail
     )
 
@@ -1362,7 +1392,7 @@ const classifyDatabaseFailure = (
       { cause: error }
     )
   }
-  if (phase === 'open') {
+  if (phase !== 'migration') {
     return new DatabaseMigrationError(
       'database_open_failed',
       'Open Science could not open its database.',
@@ -1508,15 +1538,26 @@ const applyManifestMigration = async (
     ? await adaptMigrationOperationsForCurrentSchema(client, migration.operations ?? [])
     : { operations: migration.operations ?? [], currentTableNames: [] }
   const currentTableNames = new Set(adapted.currentTableNames)
+  // An unledgered current schema can already carry 0028's stronger CHECKs. Accept that exact
+  // immutable suffix while verifying older steps, so their ALTERs are not replayed over it.
+  const allowedCheckUpgrades =
+    migration.id < numericAndNullConstraintsMigration.id
+      ? NUMERIC_AND_NULL_ALLOWED_SUFFIX_CHECKS
+      : {}
   const verifyMigrationTarget = async (targetClient: PrismaClient): Promise<void> => {
     if (!canVerifyAsCurrentSchema) {
-      await runMigrationVerifiers(targetClient, migration.verifiers)
+      await runMigrationVerifiers(targetClient, migration.verifiers, allowedCheckUpgrades)
       return
     }
     await verifyCurrentRuntimeSchemaTables(targetClient, adapted.currentTableNames)
-    await runMigrationVerifiers(targetClient, migration.verifiers, {}, currentTableNames)
+    await runMigrationVerifiers(
+      targetClient,
+      migration.verifiers,
+      allowedCheckUpgrades,
+      currentTableNames
+    )
     if (migration.id === projectPreviewStateOwnerFkMigration.id) {
-      await runMigrationVerifiers(targetClient, migration.verifiers)
+      await runMigrationVerifiers(targetClient, migration.verifiers, allowedCheckUpgrades)
     }
   }
   const disableForeignKeys =
@@ -1536,8 +1577,11 @@ const applyManifestMigration = async (
       try {
         await verifyMigrationTarget(transactionClient)
         contractAlreadySatisfied = true
-      } catch {
-        // The migration statements below own bringing this schema suffix into compliance.
+      } catch (error) {
+        const failure = classifyDatabaseFailure(error, 'validation', migration.id)
+        // Only a contract mismatch calls for schema changes. A failed read must not cause
+        // non-idempotent ALTER statements to be replayed over an already compatible schema.
+        if (failure.code !== 'database_validation_failed') throw failure
       }
       if (
         contractAlreadySatisfied &&
@@ -1572,13 +1616,7 @@ const applyManifestMigration = async (
       try {
         await verifyMigrationTarget(transactionClient)
       } catch (error) {
-        throw new DatabaseMigrationError(
-          'database_validation_failed',
-          'The existing database does not satisfy the required schema contract.',
-          false,
-          migration.id,
-          { cause: error }
-        )
+        throw classifyDatabaseFailure(error, 'validation', migration.id)
       }
       await insertLedgerRow(transactionClient, migration)
     })

--- a/src/main/database/migrations/0028-database-numeric-and-null-constraints.ts
+++ b/src/main/database/migrations/0028-database-numeric-and-null-constraints.ts
@@ -1,0 +1,597 @@
+/* Immutable 0028 migration snapshot. Do not regenerate after release. */
+import { MEMORY_AUXILIARY_SCHEMA_OBJECTS } from './0017-agent-memory-project-scope'
+
+// Copy into replacement tables before dropping originals. Unlike renaming the old tables,
+// this preserves every inbound foreign-key target while enforcement is disabled by the owner.
+const tables = [
+  {
+    tableName: 'SessionModelCallUsage',
+    ddl: `CREATE TABLE IF NOT EXISTS "SessionModelCallUsage" (
+    "sessionId" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "callId" TEXT NOT NULL,
+    "callIndex" INTEGER NOT NULL,
+    "sourceInvocationId" TEXT,
+    "frameworkId" TEXT,
+    "providerId" TEXT,
+    "backendId" TEXT,
+    "model" TEXT,
+    "inputTokens" BIGINT NOT NULL,
+    "cacheTokens" BIGINT NOT NULL,
+    "cachedReadTokens" BIGINT,
+    "cachedWriteTokens" BIGINT,
+    "outputTokens" BIGINT NOT NULL,
+    "contextUsedTokens" BIGINT,
+    "contextWindowSize" BIGINT,
+
+    PRIMARY KEY ("sessionId", "callId"),
+    CONSTRAINT "SessionModelCallUsage_sessionId_messageId_fkey" FOREIGN KEY ("sessionId", "messageId") REFERENCES "SessionTurnUsage" ("sessionId", "messageId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SessionModelCallUsage_identity_check" CHECK (length(trim("messageId")) > 0 AND length(trim("callId")) > 0 AND "callIndex" >= 0 AND ("sourceInvocationId" IS NULL OR length(trim("sourceInvocationId")) > 0) AND ("frameworkId" IS NULL OR length(trim("frameworkId")) > 0) AND ("backendId" IS NULL OR length(trim("backendId")) > 0) AND ("model" IS NULL OR length(trim("model")) > 0)),
+    CONSTRAINT "SessionModelCallUsage_nonnegative_check" CHECK ("inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" IS NOT NULL AND "cachedWriteTokens" IS NOT NULL AND "cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("contextUsedTokens" IS NULL OR "contextUsedTokens" >= 0) AND ("contextWindowSize" IS NULL OR "contextWindowSize" > 0))
+);`,
+    columns: [
+      'sessionId',
+      'messageId',
+      'callId',
+      'callIndex',
+      'sourceInvocationId',
+      'frameworkId',
+      'providerId',
+      'backendId',
+      'model',
+      'inputTokens',
+      'cacheTokens',
+      'cachedReadTokens',
+      'cachedWriteTokens',
+      'outputTokens',
+      'contextUsedTokens',
+      'contextWindowSize'
+    ]
+  },
+  {
+    tableName: 'SessionAuxiliaryTurnUsage',
+    ddl: `CREATE TABLE IF NOT EXISTS "SessionAuxiliaryTurnUsage" (
+    "sessionId" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "frameworkId" TEXT NOT NULL,
+    "providerId" TEXT,
+    "model" TEXT,
+    "completedAtMs" BIGINT NOT NULL,
+    "inputTokens" BIGINT NOT NULL,
+    "cacheTokens" BIGINT NOT NULL,
+    "cachedReadTokens" BIGINT,
+    "cachedWriteTokens" BIGINT,
+    "outputTokens" BIGINT NOT NULL,
+    "modelCallCount" INTEGER,
+
+    PRIMARY KEY ("sessionId", "eventId"),
+    CONSTRAINT "SessionAuxiliaryTurnUsage_identity_check" CHECK (length(trim("sessionId")) > 0 AND length(trim("eventId")) > 0 AND length(trim("frameworkId")) > 0 AND ("model" IS NULL OR length(trim("model")) > 0)),
+    CONSTRAINT "SessionAuxiliaryTurnUsage_source_check" CHECK ("source" IN ('reviewer', 'side-chat', 'vision', 'session-details', 'host-llm', 'artifact-code-reconstruction', 'context-compaction')),
+    CONSTRAINT "SessionAuxiliaryTurnUsage_nonnegative_check" CHECK ("completedAtMs" >= 0 AND "inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" IS NOT NULL AND "cachedWriteTokens" IS NOT NULL AND "cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("modelCallCount" IS NULL OR "modelCallCount" > 0))
+);`,
+    columns: [
+      'sessionId',
+      'eventId',
+      'source',
+      'frameworkId',
+      'providerId',
+      'model',
+      'completedAtMs',
+      'inputTokens',
+      'cacheTokens',
+      'cachedReadTokens',
+      'cachedWriteTokens',
+      'outputTokens',
+      'modelCallCount'
+    ]
+  },
+  {
+    tableName: 'ManagedFile',
+    ddl: `CREATE TABLE IF NOT EXISTS "ManagedFile" (
+    "seq" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "source" TEXT NOT NULL,
+    "sourceFileId" TEXT NOT NULL,
+    "sourceVersionId" TEXT,
+    "checksum" TEXT,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "messageId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "mimeType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "mtimeMs" BIGINT,
+    "sortAtMs" BIGINT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "deletedAt" DATETIME,
+    "deleteOperationId" TEXT,
+    CONSTRAINT "ManagedFile_source_check" CHECK ("source" IN ('artifact', 'upload')),
+    CONSTRAINT "ManagedFile_numeric_bounds_check" CHECK ("sizeBytes" >= 0)
+);`,
+    columns: [
+      'seq',
+      'source',
+      'sourceFileId',
+      'sourceVersionId',
+      'checksum',
+      'projectId',
+      'sessionId',
+      'messageId',
+      'displayName',
+      'storageKey',
+      'mimeType',
+      'sizeBytes',
+      'mtimeMs',
+      'sortAtMs',
+      'createdAt',
+      'updatedAt',
+      'deletedAt',
+      'deleteOperationId'
+    ]
+  },
+  {
+    tableName: 'UploadVersion',
+    ddl: `CREATE TABLE IF NOT EXISTS "UploadVersion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "uploadFileId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "originKind" TEXT NOT NULL DEFAULT 'user_upload',
+    "basedOnVersionId" TEXT,
+    "storageTag" TEXT,
+    "storedFilename" TEXT,
+    "writeOperationId" TEXT,
+    "contentStorageKey" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "createdAt" DATETIME,
+    "registeredAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UploadVersion_uploadFileId_fkey" FOREIGN KEY ("uploadFileId") REFERENCES "UploadFile" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "UploadVersion_uploadFileId_basedOnVersionId_fkey" FOREIGN KEY ("uploadFileId", "basedOnVersionId") REFERENCES "UploadVersion" ("uploadFileId", "id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "UploadVersion_state_check" CHECK ("state" IN ('staging', 'ready')),
+    CONSTRAINT "UploadVersion_originKind_check" CHECK ("originKind" IN ('user_upload', 'user_edit', 'legacy')),
+    CONSTRAINT "UploadVersion_userEdit_check" CHECK (("originKind" <> 'user_edit' OR ("state" = 'ready' AND "basedOnVersionId" IS NOT NULL AND "storageTag" IS NOT NULL AND "storedFilename" IS NOT NULL))),
+    CONSTRAINT "UploadVersion_numeric_bounds_check" CHECK ("sizeBytes" >= 0 AND "versionNumber" >= 1)
+);`,
+    columns: [
+      'id',
+      'uploadFileId',
+      'versionNumber',
+      'state',
+      'originKind',
+      'basedOnVersionId',
+      'storageTag',
+      'storedFilename',
+      'writeOperationId',
+      'contentStorageKey',
+      'filename',
+      'originalFilename',
+      'contentType',
+      'sizeBytes',
+      'checksum',
+      'createdAt',
+      'registeredAt',
+      'updatedAt'
+    ]
+  },
+  {
+    tableName: 'ArtifactVersion',
+    ddl: `CREATE TABLE IF NOT EXISTS "ArtifactVersion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "artifactId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "filename" TEXT NOT NULL,
+    "originKind" TEXT NOT NULL DEFAULT 'agent_generated',
+    "basedOnVersionId" TEXT,
+    "storageTag" TEXT,
+    "storedFilename" TEXT,
+    "artifactRunId" TEXT,
+    "writeOperationId" TEXT,
+    "writeRequestChecksum" TEXT,
+    "rootFrameId" TEXT,
+    "agentFrameId" TEXT,
+    "messageBranchId" TEXT,
+    "runtimeSegmentId" TEXT,
+    "promptMessageId" TEXT,
+    "notebookSessionId" TEXT,
+    "producerRunId" TEXT,
+    "producerRunIndex" INTEGER,
+    "messageId" TEXT,
+    "messageSnapshotId" TEXT,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "managedVisibleAt" DATETIME,
+    "contentStorageKey" TEXT NOT NULL,
+    "evidenceStorageKey" TEXT,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "evidenceJson" TEXT,
+    "evidenceChecksum" TEXT,
+    "evidenceSchemaVersion" INTEGER,
+    "executionSnapshotJson" TEXT,
+    "executionSnapshotChecksum" TEXT,
+    "executionSnapshotStorageKey" TEXT,
+    "executionSnapshotSchemaVersion" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ArtifactVersion_artifactId_fkey" FOREIGN KEY ("artifactId") REFERENCES "ArtifactLineage" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersion_artifactId_basedOnVersionId_fkey" FOREIGN KEY ("artifactId", "basedOnVersionId") REFERENCES "ArtifactVersion" ("artifactId", "id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersion_messageSnapshotId_fkey" FOREIGN KEY ("messageSnapshotId") REFERENCES "ArtifactMessageSnapshot" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersion_state_check" CHECK ("state" IN ('staging', 'pending', 'finalized')),
+    CONSTRAINT "ArtifactVersion_filename_check" CHECK (length("filename") > 0),
+    CONSTRAINT "ArtifactVersion_originKind_check" CHECK ("originKind" IN ('agent_generated', 'user_edit', 'legacy')),
+    CONSTRAINT "ArtifactVersion_provenance_check" CHECK ((("originKind" = 'agent_generated' AND "artifactRunId" IS NOT NULL AND "rootFrameId" IS NOT NULL AND "agentFrameId" IS NOT NULL AND "messageBranchId" IS NOT NULL AND "runtimeSegmentId" IS NOT NULL AND "promptMessageId" IS NOT NULL AND "evidenceStorageKey" IS NOT NULL AND "evidenceJson" IS NOT NULL AND "evidenceChecksum" IS NOT NULL AND "evidenceSchemaVersion" IS NOT NULL) OR ("originKind" = 'user_edit' AND "state" = 'finalized' AND "basedOnVersionId" IS NOT NULL AND "storageTag" IS NOT NULL AND "storedFilename" IS NOT NULL AND "artifactRunId" IS NULL AND "writeRequestChecksum" IS NULL AND "rootFrameId" IS NULL AND "agentFrameId" IS NULL AND "messageBranchId" IS NULL AND "runtimeSegmentId" IS NULL AND "promptMessageId" IS NULL AND "notebookSessionId" IS NULL AND "producerRunId" IS NULL AND "producerRunIndex" IS NULL AND "messageId" IS NULL AND "messageSnapshotId" IS NULL AND "evidenceStorageKey" IS NULL AND "evidenceJson" IS NULL AND "evidenceChecksum" IS NULL AND "evidenceSchemaVersion" IS NULL AND "executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR "originKind" = 'legacy')),
+    CONSTRAINT "ArtifactVersion_evidenceJson_check" CHECK ("evidenceJson" IS NULL OR (json_valid("evidenceJson") AND json_type("evidenceJson") = 'object')),
+    CONSTRAINT "ArtifactVersion_executionSnapshotJson_check" CHECK ("executionSnapshotJson" IS NULL OR (json_valid("executionSnapshotJson") AND json_type("executionSnapshotJson") = 'object')),
+    CONSTRAINT "ArtifactVersion_executionSnapshotBundle_check" CHECK ((("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL))),
+    CONSTRAINT "ArtifactVersion_numeric_bounds_check" CHECK ("sizeBytes" >= 0 AND "versionNumber" >= 1)
+);`,
+    columns: [
+      'id',
+      'artifactId',
+      'versionNumber',
+      'filename',
+      'originKind',
+      'basedOnVersionId',
+      'storageTag',
+      'storedFilename',
+      'artifactRunId',
+      'writeOperationId',
+      'writeRequestChecksum',
+      'rootFrameId',
+      'agentFrameId',
+      'messageBranchId',
+      'runtimeSegmentId',
+      'promptMessageId',
+      'notebookSessionId',
+      'producerRunId',
+      'producerRunIndex',
+      'messageId',
+      'messageSnapshotId',
+      'state',
+      'managedVisibleAt',
+      'contentStorageKey',
+      'evidenceStorageKey',
+      'contentType',
+      'sizeBytes',
+      'checksum',
+      'evidenceJson',
+      'evidenceChecksum',
+      'evidenceSchemaVersion',
+      'executionSnapshotJson',
+      'executionSnapshotChecksum',
+      'executionSnapshotStorageKey',
+      'executionSnapshotSchemaVersion',
+      'createdAt',
+      'updatedAt'
+    ]
+  },
+  {
+    tableName: 'ManagedFileVersionWriteOperation',
+    ddl: `CREATE TABLE IF NOT EXISTS "ManagedFileVersionWriteOperation" (
+    "operationId" TEXT NOT NULL PRIMARY KEY,
+    "source" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "sourceFileId" TEXT NOT NULL,
+    "basedOnVersionId" TEXT NOT NULL,
+    "expectedHeadVersionId" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "storageTag" TEXT NOT NULL,
+    "storedFilename" TEXT NOT NULL,
+    "contentStorageKey" TEXT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "sizeBytes" BIGINT NOT NULL,
+    "textFormatJson" TEXT NOT NULL,
+    "resultVersionId" TEXT,
+    "errorCode" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ManagedFileVersionWriteOperation_source_check" CHECK ("source" IN ('artifact', 'upload')),
+    CONSTRAINT "ManagedFileVersionWriteOperation_state_check" CHECK ("state" IN ('staging', 'file_ready', 'published', 'conflict', 'failed')),
+    CONSTRAINT "ManagedFileVersionWriteOperation_numeric_bounds_check" CHECK ("sizeBytes" >= 0)
+);`,
+    columns: [
+      'operationId',
+      'source',
+      'projectId',
+      'sourceFileId',
+      'basedOnVersionId',
+      'expectedHeadVersionId',
+      'state',
+      'storageTag',
+      'storedFilename',
+      'contentStorageKey',
+      'checksum',
+      'sizeBytes',
+      'textFormatJson',
+      'resultVersionId',
+      'errorCode',
+      'createdAt',
+      'updatedAt'
+    ]
+  },
+  {
+    tableName: 'ArtifactVersionInput',
+    ddl: `CREATE TABLE IF NOT EXISTS "ArtifactVersionInput" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "artifactVersionId" TEXT NOT NULL,
+    "ordinal" INTEGER NOT NULL,
+    "inputFileVersionId" TEXT NOT NULL,
+    "sourceKind" TEXT NOT NULL,
+    "sourceFileId" TEXT NOT NULL,
+    "sourceArtifactVersionId" TEXT,
+    "sourceUploadVersionId" TEXT,
+    "sourceVersionNumber" INTEGER,
+    "sourceCreatedAt" DATETIME,
+    "sourceProjectId" TEXT NOT NULL,
+    "sourceSessionId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "strongestAssociation" TEXT NOT NULL,
+    CONSTRAINT "ArtifactVersionInput_artifactVersionId_fkey" FOREIGN KEY ("artifactVersionId") REFERENCES "ArtifactVersion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceArtifactVersionId_fkey" FOREIGN KEY ("sourceArtifactVersionId") REFERENCES "ArtifactVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceUploadVersionId_fkey" FOREIGN KEY ("sourceUploadVersionId") REFERENCES "UploadVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceProjectId_sourceSessionId_fkey" FOREIGN KEY ("sourceProjectId", "sourceSessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceKind_check" CHECK ("sourceKind" IN ('artifact-version', 'upload-version')),
+    CONSTRAINT "ArtifactVersionInput_sourceIdentity_check" CHECK ((("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR ("sourceKind" = 'upload-version' AND "sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL AND "inputFileVersionId" = "sourceUploadVersionId"))),
+    CONSTRAINT "ArtifactVersionInput_strongestAssociation_check" CHECK ("strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version')),
+    CONSTRAINT "ArtifactVersionInput_numeric_bounds_check" CHECK ("sizeBytes" >= 0 AND ("sourceVersionNumber" IS NULL OR "sourceVersionNumber" >= 1))
+);`,
+    columns: [
+      'id',
+      'artifactVersionId',
+      'ordinal',
+      'inputFileVersionId',
+      'sourceKind',
+      'sourceFileId',
+      'sourceArtifactVersionId',
+      'sourceUploadVersionId',
+      'sourceVersionNumber',
+      'sourceCreatedAt',
+      'sourceProjectId',
+      'sourceSessionId',
+      'filename',
+      'contentType',
+      'sizeBytes',
+      'checksum',
+      'storageKey',
+      'strongestAssociation'
+    ]
+  },
+  {
+    tableName: 'ComputeJobOperation',
+    ddl: `CREATE TABLE IF NOT EXISTS "ComputeJobOperation" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "jobId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "phase" TEXT NOT NULL DEFAULT 'active',
+    "outcome" TEXT,
+    "revision" INTEGER NOT NULL DEFAULT 1,
+    "attemptCount" INTEGER NOT NULL DEFAULT 0,
+    "eligibleAt" DATETIME,
+    "claimToken" TEXT,
+    "claimExpiresAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "settledAt" DATETIME,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ComputeJobOperation_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "ComputeJob" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ComputeJobOperation_kind_check" CHECK ("kind" = 'cancel'),
+    CONSTRAINT "ComputeJobOperation_revision_check" CHECK ("revision" >= 1),
+    CONSTRAINT "ComputeJobOperation_attemptCount_check" CHECK ("attemptCount" >= 0),
+    CONSTRAINT "ComputeJobOperation_phase_check" CHECK ("phase" IN ('active', 'settled')),
+    CONSTRAINT "ComputeJobOperation_lifecycle_check" CHECK (("phase" = 'active' AND "outcome" IS NULL AND "settledAt" IS NULL) OR ("phase" = 'settled' AND "outcome" IS NOT NULL AND "outcome" IN ('fulfilled', 'superseded') AND "settledAt" IS NOT NULL)),
+    CONSTRAINT "ComputeJobOperation_claim_check" CHECK (("claimToken" IS NULL AND "claimExpiresAt" IS NULL) OR ("phase" = 'active' AND "claimToken" IS NOT NULL AND "claimExpiresAt" IS NOT NULL)),
+    CONSTRAINT "ComputeJobOperation_settled_implementation_check" CHECK ("phase" = 'active' OR ("eligibleAt" IS NULL AND "claimToken" IS NULL AND "claimExpiresAt" IS NULL))
+);`,
+    columns: [
+      'id',
+      'jobId',
+      'kind',
+      'phase',
+      'outcome',
+      'revision',
+      'attemptCount',
+      'eligibleAt',
+      'claimToken',
+      'claimExpiresAt',
+      'createdAt',
+      'settledAt',
+      'updatedAt'
+    ]
+  },
+  {
+    tableName: 'MemoryCategory',
+    ddl: `CREATE TABLE IF NOT EXISTS "MemoryCategory" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "systemKey" TEXT,
+    "name" TEXT,
+    "nameKey" TEXT,
+    "guidance" TEXT NOT NULL DEFAULT '',
+    "autoRecall" BOOLEAN NOT NULL DEFAULT false,
+    "revision" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "MemoryCategory_shape_check" CHECK ((("systemKey" IS NOT NULL AND "systemKey" = 'about-you' AND "name" IS NULL AND "nameKey" IS NULL AND "guidance" = '' AND "autoRecall" = true) OR ("systemKey" IS NULL AND "name" IS NOT NULL AND "nameKey" IS NOT NULL))),
+    CONSTRAINT "MemoryCategory_name_check" CHECK ("name" IS NULL OR length(trim("name")) BETWEEN 1 AND 64),
+    CONSTRAINT "MemoryCategory_nameKey_check" CHECK ("nameKey" IS NULL OR length("nameKey") BETWEEN 1 AND 64),
+    CONSTRAINT "MemoryCategory_guidance_check" CHECK (length("guidance") <= 1000),
+    CONSTRAINT "MemoryCategory_autoRecall_check" CHECK ("autoRecall" IN (false, true)),
+    CONSTRAINT "MemoryCategory_revision_check" CHECK ("revision" >= 1)
+);`,
+    columns: [
+      'id',
+      'systemKey',
+      'name',
+      'nameKey',
+      'guidance',
+      'autoRecall',
+      'revision',
+      'createdAt',
+      'updatedAt'
+    ]
+  }
+] as const
+
+const indexes = [
+  `CREATE UNIQUE INDEX IF NOT EXISTS "SessionModelCallUsage_sessionId_messageId_callIndex_key" ON "SessionModelCallUsage"("sessionId", "messageId", "callIndex");`,
+  `CREATE INDEX IF NOT EXISTS "SessionAuxiliaryTurnUsage_completedAtMs_idx" ON "SessionAuxiliaryTurnUsage"("completedAtMs");`,
+  `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "deletedAt", "sortAtMs", "seq");`,
+  `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "source", "deletedAt", "sortAtMs", "seq");`,
+  `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_sessionId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "sessionId", "source", "deletedAt", "sortAtMs", "seq");`,
+  `CREATE INDEX IF NOT EXISTS "ManagedFile_sessionId_deletedAt_idx" ON "ManagedFile"("sessionId", "deletedAt");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_sourceFileId_key" ON "ManagedFile"("projectId", "source", "sourceFileId");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_storageKey_key" ON "ManagedFile"("projectId", "source", "storageKey");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "UploadVersion_writeOperationId_key" ON "UploadVersion"("writeOperationId");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "UploadVersion_contentStorageKey_key" ON "UploadVersion"("contentStorageKey");`,
+  `CREATE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_state_registeredAt_idx" ON "UploadVersion"("uploadFileId", "state", "registeredAt");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_versionNumber_key" ON "UploadVersion"("uploadFileId", "versionNumber");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_id_key" ON "UploadVersion"("uploadFileId", "id");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_writeOperationId_key" ON "ArtifactVersion"("writeOperationId");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_contentStorageKey_key" ON "ArtifactVersion"("contentStorageKey");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_createdAt_idx" ON "ArtifactVersion"("artifactId", "createdAt");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactRunId_state_idx" ON "ArtifactVersion"("artifactRunId", "state");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersion_rootFrameId_agentFrameId_messageBranchId_promptMessageId_idx" ON "ArtifactVersion"("rootFrameId", "agentFrameId", "messageBranchId", "promptMessageId");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageId_idx" ON "ArtifactVersion"("messageId");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageSnapshotId_idx" ON "ArtifactVersion"("messageSnapshotId");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_versionNumber_key" ON "ArtifactVersion"("artifactId", "versionNumber");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_id_key" ON "ArtifactVersion"("artifactId", "id");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFileVersionWriteOperation_contentStorageKey_key" ON "ManagedFileVersionWriteOperation"("contentStorageKey");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFileVersionWriteOperation_resultVersionId_key" ON "ManagedFileVersionWriteOperation"("resultVersionId");`,
+  `CREATE INDEX IF NOT EXISTS "ManagedFileVersionWriteOperation_source_sourceFileId_state_idx" ON "ManagedFileVersionWriteOperation"("source", "sourceFileId", "state");`,
+  `CREATE INDEX IF NOT EXISTS "ManagedFileVersionWriteOperation_projectId_state_createdAt_idx" ON "ManagedFileVersionWriteOperation"("projectId", "state", "createdAt");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceKind_inputFileVersionId_idx" ON "ArtifactVersionInput"("sourceKind", "inputFileVersionId");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceArtifactVersionId_idx" ON "ArtifactVersionInput"("sourceArtifactVersionId");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceUploadVersionId_idx" ON "ArtifactVersionInput"("sourceUploadVersionId");`,
+  `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceProjectId_sourceSessionId_idx" ON "ArtifactVersionInput"("sourceProjectId", "sourceSessionId");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_sourceKind_inputFileVersionId_key" ON "ArtifactVersionInput"("artifactVersionId", "sourceKind", "inputFileVersionId");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_ordinal_key" ON "ArtifactVersionInput"("artifactVersionId", "ordinal");`,
+  `CREATE INDEX IF NOT EXISTS "ComputeJobOperation_kind_phase_eligibleAt_createdAt_idx" ON "ComputeJobOperation"("kind", "phase", "eligibleAt", "createdAt");`,
+  `CREATE INDEX IF NOT EXISTS "ComputeJobOperation_kind_phase_claimExpiresAt_idx" ON "ComputeJobOperation"("kind", "phase", "claimExpiresAt");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "ComputeJobOperation_jobId_kind_key" ON "ComputeJobOperation"("jobId", "kind");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "MemoryCategory_systemKey_key" ON "MemoryCategory"("systemKey");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "MemoryCategory_nameKey_key" ON "MemoryCategory"("nameKey");`
+] as const
+
+const numericAndNullConstraintsMigration = {
+  id: '0028_database_numeric_and_null_constraints',
+  statements: [] as const,
+  operations: [
+    {
+      kind: 'rebuild-table-set',
+      version: 2,
+      tables: tables.map(({ tableName, ddl, columns }) => ({
+        tableName,
+        canonicalTableDdl: ddl,
+        columns
+      })),
+      dropOrder: tables.map(({ tableName }) => tableName),
+      indexes,
+      triggers: MEMORY_AUXILIARY_SCHEMA_OBJECTS.filter(
+        ({ type, name }) => type === 'trigger' && name.startsWith('MemoryCategory_')
+      ).map(({ sql }) => sql)
+    }
+  ] as const,
+  verifiers: [
+    {
+      kind: 'check-constraints-exist',
+      version: 1,
+      tables: [
+        {
+          table: 'MemoryCategory',
+          constraints: [
+            {
+              name: 'MemoryCategory_shape_check',
+              expression:
+                '(("systemKey" IS NOT NULL AND "systemKey" = \'about-you\' AND "name" IS NULL AND "nameKey" IS NULL AND "guidance" = \'\' AND "autoRecall" = true) OR ("systemKey" IS NULL AND "name" IS NOT NULL AND "nameKey" IS NOT NULL))'
+            }
+          ]
+        },
+        {
+          table: 'ComputeJobOperation',
+          constraints: [
+            {
+              name: 'ComputeJobOperation_lifecycle_check',
+              expression:
+                '("phase" = \'active\' AND "outcome" IS NULL AND "settledAt" IS NULL) OR ("phase" = \'settled\' AND "outcome" IS NOT NULL AND "outcome" IN (\'fulfilled\', \'superseded\') AND "settledAt" IS NOT NULL)'
+            }
+          ]
+        },
+        {
+          table: 'SessionAuxiliaryTurnUsage',
+          constraints: [
+            {
+              name: 'SessionAuxiliaryTurnUsage_nonnegative_check',
+              expression:
+                '"completedAtMs" >= 0 AND "inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" IS NOT NULL AND "cachedWriteTokens" IS NOT NULL AND "cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("modelCallCount" IS NULL OR "modelCallCount" > 0)'
+            }
+          ]
+        },
+        {
+          table: 'SessionModelCallUsage',
+          constraints: [
+            {
+              name: 'SessionModelCallUsage_nonnegative_check',
+              expression:
+                '"inputTokens" >= 0 AND "cacheTokens" >= 0 AND "outputTokens" >= 0 AND (("cachedReadTokens" IS NULL AND "cachedWriteTokens" IS NULL) OR ("cachedReadTokens" IS NOT NULL AND "cachedWriteTokens" IS NOT NULL AND "cachedReadTokens" >= 0 AND "cachedWriteTokens" >= 0)) AND ("contextUsedTokens" IS NULL OR "contextUsedTokens" >= 0) AND ("contextWindowSize" IS NULL OR "contextWindowSize" > 0)'
+            }
+          ]
+        },
+        {
+          table: 'UploadVersion',
+          constraints: [
+            {
+              name: 'UploadVersion_numeric_bounds_check',
+              expression: '"sizeBytes" >= 0 AND "versionNumber" >= 1'
+            }
+          ]
+        },
+        {
+          table: 'ArtifactVersion',
+          constraints: [
+            {
+              name: 'ArtifactVersion_numeric_bounds_check',
+              expression: '"sizeBytes" >= 0 AND "versionNumber" >= 1'
+            }
+          ]
+        },
+        {
+          table: 'ArtifactVersionInput',
+          constraints: [
+            {
+              name: 'ArtifactVersionInput_numeric_bounds_check',
+              expression:
+                '"sizeBytes" >= 0 AND ("sourceVersionNumber" IS NULL OR "sourceVersionNumber" >= 1)'
+            }
+          ]
+        },
+        {
+          table: 'ManagedFile',
+          constraints: [
+            { name: 'ManagedFile_numeric_bounds_check', expression: '"sizeBytes" >= 0' }
+          ]
+        },
+        {
+          table: 'ManagedFileVersionWriteOperation',
+          constraints: [
+            {
+              name: 'ManagedFileVersionWriteOperation_numeric_bounds_check',
+              expression: '"sizeBytes" >= 0'
+            }
+          ]
+        }
+      ]
+    },
+    { kind: 'foreign-key-integrity', version: 1 }
+  ] as const
+}
+
+export { numericAndNullConstraintsMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -86,10 +86,11 @@ describe('notification attention metadata migration', () => {
         '0024_compute_job_file_evidence',
         '0025_managed_file_version_foundation',
         '0026_compute_job_remote_cleanup',
-        '0027_project_session_defaults'
+        '0027_project_session_defaults',
+        '0028_database_numeric_and_null_constraints'
       ],
       from: '0006_database_domain_constraints',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)

--- a/src/main/database/project-session-defaults-migration.test.ts
+++ b/src/main/database/project-session-defaults-migration.test.ts
@@ -63,9 +63,9 @@ describe('Project Session defaults migration', () => {
     )
 
     await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toMatchObject({
-      applied: ['0027_project_session_defaults'],
+      applied: ['0027_project_session_defaults', '0028_database_numeric_and_null_constraints'],
       from: '0026_compute_job_remote_cleanup',
-      to: '0027_project_session_defaults'
+      to: '0028_database_numeric_and_null_constraints'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ sessionDefaults: string }>>(

--- a/src/main/database/sqlite-schema-migrations.ts
+++ b/src/main/database/sqlite-schema-migrations.ts
@@ -31,10 +31,11 @@ type SqliteMigrationTable = {
 
 type SqliteRebuildTableSetOperation = {
   kind: 'rebuild-table-set'
-  version: 1
+  version: 1 | 2
   tables: readonly SqliteMigrationTable[]
   dropOrder: readonly string[]
   indexes: readonly string[]
+  triggers?: readonly string[]
 }
 
 type SqliteMigrationOperation = SqliteRebuildTableSetOperation
@@ -216,20 +217,32 @@ const applyRebuildTableSet = async (
     })
   }
 
+  // Version 1 is frozen for released migrations. Version 2 copies into replacement tables
+  // first, preserving inbound references without rebuilding unrelated child tables.
+  const replacementFirst = operation.version === 2
   for (const table of prepared) {
     await migrationSqlExecutor.execute(
       client,
-      `ALTER TABLE ${quoteIdentifier(table.tableName)} RENAME TO ${quoteIdentifier(table.backupTableName)}`
+      replacementFirst
+        ? table.targetDdl.replace(
+            `CREATE TABLE IF NOT EXISTS ${quoteIdentifier(table.tableName)}`,
+            `CREATE TABLE ${quoteIdentifier(table.backupTableName)}`
+          )
+        : `ALTER TABLE ${quoteIdentifier(table.tableName)} RENAME TO ${quoteIdentifier(table.backupTableName)}`
     )
   }
-  for (const table of prepared) await migrationSqlExecutor.execute(client, table.targetDdl)
+  if (!replacementFirst) {
+    for (const table of prepared) await migrationSqlExecutor.execute(client, table.targetDdl)
+  }
 
   for (const table of prepared) {
     const quotedColumns = table.copyColumns.map(quoteIdentifier).join(', ')
+    const sourceName = replacementFirst ? table.tableName : table.backupTableName
+    const targetName = replacementFirst ? table.backupTableName : table.tableName
     try {
       await migrationSqlExecutor.execute(
         client,
-        `INSERT INTO ${quoteIdentifier(table.tableName)} (${quotedColumns}) SELECT ${quotedColumns} FROM ${quoteIdentifier(table.backupTableName)}`
+        `INSERT INTO ${quoteIdentifier(targetName)} (${quotedColumns}) SELECT ${quotedColumns} FROM ${quoteIdentifier(sourceName)}`
       )
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error)
@@ -242,7 +255,7 @@ const applyRebuildTableSet = async (
         }
       )
     }
-    const targetRowCount = await countRows(client, table.tableName)
+    const targetRowCount = await countRows(client, targetName)
     if (targetRowCount !== table.sourceRowCount) {
       throw new DatabaseValidationError(
         `SQLite schema migration found a row-count mismatch for ${table.tableName}.`,
@@ -261,14 +274,23 @@ const applyRebuildTableSet = async (
     const table = preparedByName.get(tableName)!
     await migrationSqlExecutor.execute(
       client,
-      `DROP TABLE ${quoteIdentifier(table.backupTableName)}`
+      `DROP TABLE ${quoteIdentifier(replacementFirst ? table.tableName : table.backupTableName)}`
     )
+  }
+  if (replacementFirst) {
+    for (const table of prepared)
+      await migrationSqlExecutor.execute(
+        client,
+        `ALTER TABLE ${quoteIdentifier(table.backupTableName)} RENAME TO ${quoteIdentifier(table.tableName)}`
+      )
   }
   for (const table of prepared) {
     if (table.autoincrementSequence === undefined) continue
     await restoreAutoincrementSequence(client, table.tableName, table.autoincrementSequence)
   }
   for (const index of operation.indexes) await migrationSqlExecutor.execute(client, index)
+  for (const trigger of operation.triggers ?? [])
+    await migrationSqlExecutor.execute(client, trigger)
 
   const violations = await migrationSqlExecutor.query<SqliteForeignKeyViolationRow[]>(
     client,

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -568,19 +568,32 @@ describe('artifact finalization startup recovery', () => {
         if (failDirectorySync) throw new Error('compatibility storage is read-only')
       }
     })
-    const { provenance, version } = await prepareRecovery(compatibility)
     const visibleBytes = Buffer.from('previous visible artifact')
-    const visibleVersionId = 'artifact-visible-v0'
+    const visibleVersionId = 'artifact-visible-v1'
     const visibleStorageKey =
-      'artifacts/project-1/session-1/.provenance/artifact-visible/versions/artifact-visible-v0/content'
+      'artifacts/project-1/session-1/.provenance/artifact-visible/versions/artifact-visible-v1/content'
     const visiblePath = join(storageRoot, ...visibleStorageKey.split('/'))
     await mkdir(dirname(visiblePath), { recursive: true })
     await writeFile(visiblePath, visibleBytes)
+    // Seed the visible Version before the real writer allocates the pending Version.
+    const artifactId = 'existing-artifact'
+    await client.fileOriginSession.create({
+      data: { projectId: PROJECT_ID, sessionId: SESSION_ID }
+    })
+    await client.artifactLineage.create({
+      data: {
+        id: artifactId,
+        projectId: PROJECT_ID,
+        sessionId: SESSION_ID,
+        filename: 'result.png',
+        normalizedFilename: 'result.png'
+      }
+    })
     await client.artifactVersion.create({
       data: {
         id: visibleVersionId,
-        artifactId: version.artifactId,
-        versionNumber: 0,
+        artifactId,
+        versionNumber: 1,
         filename: 'result.png',
         originKind: 'legacy',
         state: 'finalized',
@@ -590,9 +603,11 @@ describe('artifact finalization startup recovery', () => {
       }
     })
     await client.artifactLineage.update({
-      where: { id: version.artifactId },
+      where: { id: artifactId },
       data: { currentVersionId: visibleVersionId }
     })
+    const { provenance, version } = await prepareRecovery(compatibility)
+    expect(version.versionNumber).toBe(2)
     await client.managedFile.create({
       data: {
         source: 'artifact',

--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -313,4 +313,28 @@ describe('DatabaseStartupGate', () => {
     expect(issueLink.getAttribute('aria-disabled')).toBe('true')
     expect(issueLink.getAttribute('href')).toBeNull()
   })
+  it('shows storage recovery guidance for a retryable validation-query failure', () => {
+    render(
+      <DatabaseStartupGate>
+        <div>Business application</div>
+      </DatabaseStartupGate>
+    )
+    act(() =>
+      publish({
+        phase: 'blocked',
+        error: {
+          code: 'database_open_failed',
+          message: 'Open Science could not open its database.',
+          retryable: true
+        }
+      })
+    )
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+    expect(
+      screen.getByText(
+        'Quit other copies of Open Science, check free disk space and folder permissions, then retry.'
+      )
+    ).toBeTruthy()
+    expect(screen.queryByText(/Part of the stored data doesn't match/)).toBeNull()
+  })
 })

--- a/src/shared/uploads.test.ts
+++ b/src/shared/uploads.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createUploadVersionReference,
   formatUploadSizeLimit,
+  uploadApplicationCommandContracts,
   parseUploadVersionReference
 } from './uploads'
 
@@ -38,4 +39,34 @@ describe('upload Version references', () => {
       versionId: 'version-legacy'
     })
   })
+})
+
+describe('upload version numeric bounds', () => {
+  const attachment = {
+    id: 'upload',
+    sessionId: 'session',
+    name: 'empty.txt',
+    originalName: 'empty.txt',
+    path: 'uploads/empty.txt',
+    size: 0
+  }
+  it.each([-1, 0, 1.5])('rejects version number %s at finalization', (versionNumber) => {
+    expect(() =>
+      uploadApplicationCommandContracts.finalizeSession.args.parse([
+        { sessionId: 'session', attachments: [{ ...attachment, versionNumber }] }
+      ])
+    ).toThrow()
+  })
+  it.each([undefined, 1])(
+    'preserves empty and legacy attachments with version %s',
+    (versionNumber) => {
+      const request = {
+        sessionId: 'session',
+        attachments: [{ ...attachment, ...(versionNumber === undefined ? {} : { versionNumber }) }]
+      }
+      expect(uploadApplicationCommandContracts.finalizeSession.args.parse([request])).toEqual([
+        request
+      ])
+    }
+  )
 })

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -113,7 +113,7 @@ const uploadedAttachmentSchema = z
   .object({
     id: z.string(),
     versionId: z.string().optional(),
-    versionNumber: z.number().finite().optional(),
+    versionNumber: z.number().int().positive().optional(),
     sessionId: z.string(),
     name: z.string(),
     originalName: z.string(),


### PR DESCRIPTION
## Problem

Four reported database defects let the same storage failure become nonretryable during validation, permit invalid NULL/value combinations and negative file metadata, and let a failing startup subscriber change database readiness. The original public-boundary regression suite ran twice against unchanged production code: both runs produced 30 passing controls and the same 68 expected failures across 98 cases.

## Proposed change

- **D01:** classify recoverable storage failures consistently in open, migration, preflight, post-migration and final validation. Require engine-load evidence instead of treating every Prisma initialization error as a missing runtime. Reuse the existing retry button and storage guidance.
- **D02:** make the four nullable CHECK contracts reject partial cache pairs, settled operations without outcomes and invalid memory categories.
- **D03:** isolate each startup listener and each window delivery, logging notification failures without changing readiness or preventing later notifications.
- **D04:** enforce positive version numbers and nonnegative file sizes in version, input, managed-file and write-intent tables; align the uploaded-attachment command DTO.

## Scope and non-goals

Persistence changes are in immutable migration **0028**, with generated target CHECKs. Released migrations/checksums remain unchanged. Nine tables are rebuilt transactionally with a required retained backup; legal historical values, row identities, heads, FKs, indexes, memory triggers and autoincrement are preserved. Invalid historical rows or unknown columns block with a diagnostic and roll back schema/data/ledger; no data is guessed or deleted. Existing newer-database protection applies to downgrades.

There are no new business fields, states, relationships, screens or translated strings. The internal table-rebuild descriptor gains version 2 to copy before dropping originals and preserve inbound FKs; released version-1 execution stays frozen. Omitted legacy attachment versions, nullable input versions and empty files remain legal. Existing Session JSON readers are unchanged. Checksum-format policy and partial isolation of corrupt memory records are deferred.

## Acceptance criteria and validation

All listed final checks ran after the last material source edit. No complete local `npm test` was run, as requested; PR CI remains the complete/platform authority.

| Behavior | Project-owned command / selection | Result |
| --- | --- | --- |
| Storage classification/retry, INSERT/UPDATE/startup rejection, historical upgrade/rollback, startup owner/IPC, Gate guidance, DTO and ledger/schema generation | `npx vitest run src/main/database scripts/database-migration-ledger-smoke.test.ts scripts/generate-database-schema.test.ts src/shared/uploads.test.ts src/renderer/src/components/database-startup-gate.test.tsx` | 314 passed |
| Persistent consumers and recovery | Curated `test:module` plans for `artifact_storage`, `upload_repository`, `project_files_repository`, `artifact_provenance`, `session_persistence`, `compute_service`; run their 96 deduplicated test files plus `src/main/memory` and `src/main/managed-file-versions` | 3612 passed, 6 existing skips |
| Main, sandbox and renderer types | `npm run typecheck` | Passed |
| Source/config lint | `npm run lint` | Passed |
| Generated SQLite target | `npm run db:schema:check` | Passed |
| Diff whitespace | `git diff --check` | Passed |

The consumer set comes from repository-owned `createModuleTestPlan` reason chains: database contract changes affect file metadata writers/readers, session finalization, usage persistence, compute operation outcomes and memory snapshots. The final `test:affected:explain -- --base origin/main --head HEAD` plan is also inspected; CI owns any full fallback for database paths outside the current module manifest.

Additional red-before-green tests cover raw SQLite table-lock wording, actual POSIX permission denial, and preflight failure swallowing. A real second SQLite connection holds an exclusive lock; releasing it allows retry. Restoring file permissions also allows retry. Seventeen invalid historical-value cases preserve all original data and ledger on failure. CHECK, foreign-key, ledger and newer-version failures remain blocking.

## Review focus

Review classifier precedence, readiness/delivery separation, and 0028's replacement-first rebuild with exact stronger-suffix verification. Test evidence is local self-review; independent review should confirm the final impact mapping.

Platform limits: chmod reproduction is skipped on Windows and root; Windows ACL behavior is left to platform coverage. Actual Electron window-destruction races were not reproduced; the real IPC adapter is exercised with destroyed-window and throwing `webContents.send` stubs. No renderer interaction or copy changed, so no UI E2E lane was added locally.
