### PR TITLE
fix(markdown): keep source icons within fullscreen tables

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -887,6 +887,9 @@ if (process.argv.includes('--version')) {
         } else if (prompt.includes(CITATION_PREVIEW_PROMPT)) {
           reply =
             'The fixture evidence supports this claim ([Torre et al. 2026](https://citation.example/paper "Fixture study")), with an independent replication ([Chen et al. 2026](https://citation.example/replication "Replication study")).'
+        } else if (prompt.includes('Expand a table with source links.')) {
+          reply =
+            '| PMID | Journal |\n| --- | --- |\n| [42668673](https://citation.example/paper) | Bioact Mater |\n| [42537459](https://unadmitted.example/paper) | Biomaterials |'
         } else if (
           await submitReviewerPass(sessionRoutes.get(context.params.sessionId)?.mcpServers ?? [])
         ) {

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -14,6 +14,61 @@ const CONTEXT_COMPACTION_PROMPT = 'Preview context compaction.'
 const CITATION_PREVIEW_PROMPT = 'Preview a cited source.'
 const AXE_PATH = resolve(process.cwd(), 'node_modules/axe-core/axe.min.js')
 
+test('keeps source icons inside table cells after expanding a message table', async ({ app }) => {
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await allowCitationPreviewDomain(page)
+  await page.route('https://citation.example/favicon.ico', (route) =>
+    route.fulfill({
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16" fill="teal"/></svg>'
+    })
+  )
+  await createProject(page)
+  await page
+    .getByRole('textbox', { name: 'Ask anything' })
+    .fill('Expand a table with source links.')
+  await page.getByRole('button', { name: 'Send message' }).click()
+
+  const table = page.getByRole('region', { name: 'Conversation' }).locator('table')
+  await expect(table).toBeVisible()
+  await expect(table.locator('[data-session-link-favicon]')).toHaveCount(2)
+  await expect(table.locator('[data-session-link-favicon][data-state="local"]')).toHaveCount(1)
+  await table.hover()
+  await page.getByTitle('View fullscreen', { exact: true }).click()
+
+  const fullscreen = page.locator('[data-streamdown="table-fullscreen"]')
+  await expect(fullscreen).toBeVisible()
+  await expect(fullscreen.locator('[data-session-link-favicon]')).toHaveCount(2)
+  // Exercise the actual portal and stylesheet: jsdom cannot detect an icon covering the dialog.
+  await expect
+    .poll(() =>
+      fullscreen.locator('[data-session-link-favicon]').evaluateAll((icons) =>
+        icons.every((icon) => {
+          const cell = icon.closest('td')!.getBoundingClientRect()
+          return [...icon.querySelectorAll('svg, img')].every((image) => {
+            const bounds = image.getBoundingClientRect()
+            return (
+              bounds.width > 0 &&
+              bounds.width <= 20 &&
+              bounds.height > 0 &&
+              bounds.height <= 20 &&
+              bounds.left >= cell.left &&
+              bounds.right <= cell.right &&
+              bounds.top >= cell.top &&
+              bounds.bottom <= cell.bottom
+            )
+          })
+        })
+      )
+    )
+    .toBe(true)
+  await fullscreen.getByTitle('Download table', { exact: true }).click()
+  await expect(fullscreen.getByRole('button', { name: 'CSV', exact: true })).toBeVisible()
+  await fullscreen.getByTitle('Exit fullscreen', { exact: true }).click()
+  await expect(fullscreen).toHaveCount(0)
+})
+
 const persistedMemoryState = async (
   page: Page
 ): Promise<{

--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -192,9 +192,10 @@
   }
 
   /* --- Streamdown dropdown panels & items --- */
+  /* Match menu divs, not the absolutely positioned SVG/img inside source-link icon spans. */
   :is(
     .agent-markdown-root [data-streamdown='mermaid-block-actions'] .relative > .absolute,
-    [data-streamdown='table-fullscreen'] .relative > .absolute
+    [data-streamdown='table-fullscreen'] div.relative > div.absolute
   ) {
     @apply fixed! m-0! overflow-hidden rounded-md border border-sd-border bg-sd-surface! shadow-sd-menu-lg break-normal;
     top: var(--sd-menu-top, 0) !important;
@@ -207,7 +208,7 @@
     @apply z-markdown-menu min-w-[7.5rem] w-max shadow-sd-menu;
   }
 
-  [data-streamdown='table-fullscreen'] .relative > .absolute {
+  [data-streamdown='table-fullscreen'] div.relative > div.absolute {
     @apply z-markdown-menu! min-w-32! w-max! max-w-[calc(100vw-1rem)]! transform-none!;
   }
 
@@ -222,7 +223,7 @@
 
   :is(
     .agent-markdown-root [data-streamdown='table-wrapper'] .relative > .absolute button,
-    [data-streamdown='table-fullscreen'] .relative > .absolute button,
+    [data-streamdown='table-fullscreen'] div.relative > div.absolute button,
     .agent-markdown-root [data-streamdown='mermaid-block-actions'] .relative > .absolute button,
     body
       > div.fixed.inset-0.z-50.flex.items-center.justify-center[role='button']:not(


### PR DESCRIPTION
## Problem

Expanding a message table containing source links makes the local globe and favicon images inherit fullscreen dropdown geometry. The icons can grow from 14px to over 1000px and obscure the table. The broad `.relative > .absolute` dropdown selectors also match the positioned SVG/image children of each source-link icon span.

## Proposed change

Restrict the three fullscreen dropdown selectors to `div.relative > div.absolute`, matching the existing menu DOM and excluding link icons. Add one regression through the existing conversation fixture, table toolbar, and real fullscreen portal; verify local-globe and favicon geometry, cell containment, the download format menu, and fullscreen exit.

## Scope and non-goals

CSS correction only; no new dependencies or production test seams. No data fields, enum values, persistence, historical-data migration/compatibility, architecture, data-model, or interaction-flow changes. Existing menu geometry and actions are preserved.

## Acceptance criteria and validation

All final green checks below ran after the last material edit. The explicitly labeled original-code regression records the pre-fix baseline.

| Behavior / concern | Command or verification | Result |
| --- | --- | --- |
| Regression reliability on original code | `npx playwright test e2e/workspace-conversation.spec.ts -g 'keeps source icons inside table cells' --repeat-each=2` before CSS fix | Failed twice specifically on icon bounds/cell containment; screenshot matched the report |
| Corrected icon geometry, download menu, fullscreen exit | Same E2E command against final build | 2 passed |
| Markdown owner and Session Message consumers | `npx vitest run src/renderer/src/components/streamdown src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx src/renderer/src/pages/workspace/SessionMessageMarkdown.integration.test.tsx` | 15 files, 119 tests passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Production composition and CSS compilation | `npm run build:e2e` | Passed |
| Lint | `npm run lint` | Passed |
| Theme behavior | Actual Web component in Chromium, light and dark, with installed Streamdown adapters | Icons remain 14px; dropdown and exit checked |

CodeGraph confirmed the shared `AgentMarkdown` / `SessionMessageLink` consumer path and the existing DOM menu adapter. CSS portal relationships are exercised by E2E. Independent Standards and Spec reviews reported no findings and confirmed this impact set.

No Node/ACP protocol, persistence, migration, or platform-path production code changed. macOS Electron and Web Chromium were verified locally; Windows and the complete suite remain PR CI authority. Per maintainer instruction, no full local `npm test` was run. `npm run test:affected:explain -- --base c112e286 --head HEAD` selects the full CI fallback because the E2E files lack a declared module owner; the impact manifest was not changed.

## Review focus

Confirm that only menu divs receive fixed dropdown styles and the real-browser regression continues to exercise both SVG and image icons.
