### PR TITLE
fix(notebook): confine installer caches to managed runtime storage

### DIFF
--- a/src/main/notebook/micromamba.test.ts
+++ b/src/main/notebook/micromamba.test.ts
@@ -319,13 +319,13 @@ describe('micromambaSpawnEnv', () => {
     expect(env.MAMBA_ROOT_PREFIX).toBeUndefined()
   })
 
-  it('leaves inherited non-Windows environment behavior unchanged apart from CA injection', () => {
+  it.each(['darwin', 'linux'] as const)('pins the managed package cache on %s', (platform) => {
     const env = micromambaSpawnEnv('/runtime', '/ca.pem', {
-      platform: 'darwin',
+      platform,
       env: { CONDA_PKGS_DIRS: '/existing', MAMBA_ROOT_PREFIX: '/existing-root' }
     })
 
-    expect(env.CONDA_PKGS_DIRS).toBe('/existing')
+    expect(env.CONDA_PKGS_DIRS).toBe('/runtime/pkgs')
     expect(env.MAMBA_ROOT_PREFIX).toBe('/existing-root')
     expect(env.CONDA_SSL_VERIFY).toBe('/ca.pem')
   })

--- a/src/main/notebook/micromamba.ts
+++ b/src/main/notebook/micromamba.ts
@@ -154,14 +154,18 @@ export const micromambaSpawnEnv = (
 ): NodeJS.ProcessEnv => {
   const platform = deps.platform ?? process.platform
   const inherited = deps.env ?? process.env
-  if (platform !== 'win32') return { ...inherited, ...caBundleEnv(caBundle) }
+  const selected = deps.selectCache
+    ? deps.selectCache(root, maxCacheRelativePath)
+    : selectMicromambaCache(root, maxCacheRelativePath, deps)
+  // Pin every platform to the cache covered by our locks and filesystem grant. Otherwise libmamba
+  // also probes its user-home cache, which is deliberately inaccessible inside the Notebook sandbox.
+  if (platform !== 'win32') {
+    return { ...inherited, ...caBundleEnv(caBundle), CONDA_PKGS_DIRS: selected.path }
+  }
 
   const cleaned = Object.fromEntries(
     Object.entries(inherited).filter(([key]) => !/^(CONDA|MAMBA)_/i.test(key))
   )
-  const selected = deps.selectCache
-    ? deps.selectCache(root, maxCacheRelativePath)
-    : selectMicromambaCache(root, maxCacheRelativePath, deps)
   return {
     ...cleaned,
     ...caBundleEnv(caBundle),

--- a/src/main/notebook/package-cache-sandbox.integration.test.ts
+++ b/src/main/notebook/package-cache-sandbox.integration.test.ts
@@ -1,0 +1,107 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { expect, it } from 'vitest'
+
+import { installPackages } from './package-manager'
+import { sandboxedPackageSpawn } from './package-process-sandbox'
+
+// Use an already staged binary; this check never downloads tools or packages.
+const micromamba = resolve(
+  process.env.OPEN_SCIENCE_TEST_MICROMAMBA ?? `resources/bin/mac/${process.arch}/micromamba`
+)
+
+it.skipIf(process.platform !== 'darwin' || !existsSync(micromamba))(
+  'plans a pandas install while the user package cache remains denied by Seatbelt',
+  async () => {
+    const storageRoot = realpathSync(mkdtempSync(join(tmpdir(), 'os-package-cache-sandbox-')))
+    const runtimeRoot = join(storageRoot, 'runtime')
+    const home = join(storageRoot, 'home')
+    const userCache = join(home, '.mamba', 'pkgs')
+    const shard = join(userCache, 'cache', 'shards', 'private.msgpack.zst')
+    const profile = join(storageRoot, 'sandbox.sb')
+    const request = { language: 'python' as const, packages: ['pandas'] }
+    try {
+      mkdirSync(join(userCache, 'cache', 'shards'), { recursive: true })
+      writeFileSync(shard, 'private cache')
+      mkdirSync(join(runtimeRoot, 'envs', 'default-python', 'conda-meta'), { recursive: true })
+      writeFileSync(join(runtimeRoot, 'envs', 'default-python', 'conda-meta', 'history'), '')
+      // An offline solver-only package: no archive is downloaded or installed.
+      for (const subdir of ['noarch', process.arch === 'arm64' ? 'osx-arm64' : 'osx-64']) {
+        const channel = join(storageRoot, 'channel', subdir)
+        mkdirSync(channel, { recursive: true })
+        writeFileSync(
+          join(channel, 'repodata.json'),
+          JSON.stringify({
+            info: { subdir },
+            packages:
+              subdir === 'noarch'
+                ? {
+                    'pandas-1.0-0.tar.bz2': {
+                      name: 'pandas',
+                      version: '1.0',
+                      build: '0',
+                      build_number: 0,
+                      depends: [],
+                      subdir,
+                      noarch: 'generic',
+                      size: 1,
+                      sha256: '0'.repeat(64)
+                    }
+                  }
+                : {},
+            'packages.conda': {},
+            repodata_version: 1
+          })
+        )
+      }
+      writeFileSync(
+        profile,
+        `(version 1)\n(allow default)\n(deny file-read* file-write* (subpath ${JSON.stringify(userCache)}))\n`
+      )
+      const checkDenied = (): void => {
+        const denied = spawnSync('/usr/bin/sandbox-exec', ['-f', profile, '/bin/cat', shard], {
+          encoding: 'utf8'
+        })
+        expect(denied.stderr).toContain('Operation not permitted')
+        expect(denied.status).toBe(1)
+      }
+      checkDenied()
+      const spawn = sandboxedPackageSpawn({
+        request,
+        runtimeRoot,
+        storageRoot,
+        processSandbox: {
+          wrap: async (invocation) => ({
+            executable: '/usr/bin/sandbox-exec',
+            args: ['-f', profile, invocation.executable, ...invocation.args],
+            env: invocation.env,
+            annotateStderr: (stderr) => stderr,
+            cleanup: () => {}
+          })
+        }
+      })
+      const result = await installPackages(request, {
+        storageRoot,
+        micromamba,
+        condaChannel: pathToFileURL(join(storageRoot, 'channel')).href,
+        micromambaEnv: { env: { PATH: '/usr/bin:/bin', HOME: home } },
+        spawn: (command, args, ...rest) =>
+          spawn(
+            command,
+            args.includes('install') ? [...args, '--offline', '--dry-run'] : args,
+            ...rest
+          )
+      })
+      expect(result.ok, result.log).toBe(true)
+      expect(result.method).toBe('conda')
+      expect(result.fallbackUsed).toBe(false)
+      checkDenied()
+    } finally {
+      rmSync(storageRoot, { recursive: true, force: true })
+    }
+  }
+)

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -1008,6 +1008,15 @@ describe('installPackages', () => {
     })
   })
 
+  it('passes the workload cache to conda and its nested pip subprocesses', async () => {
+    const { spawn, calls } = scriptedSpawn([ok])
+    await installPackages({ language: 'python', packages: ['pandas'] }, { spawn, ...base })
+    const cacheRoot = join(runtimeRoot(base.storageRoot), 'cache', 'notebook')
+
+    expect(calls[0][2]?.PIP_CACHE_DIR).toBe(join(cacheRoot, 'pip'))
+    expect(calls[0][2]?.OPEN_SCIENCE_NOTEBOOK_CACHE_DIR).toBe(cacheRoot)
+  })
+
   it('does not set CA vars when no bundle is configured', async () => {
     const { spawn, calls } = scriptedSpawn([ok])
     await installPackages({ language: 'python', packages: ['numpy'] }, { spawn, ...base })

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -1236,12 +1236,15 @@ export async function installPackages(
     const cache = deps.micromambaEnv?.selectCache
       ? deps.micromambaEnv.selectCache(root, DEFAULT_MAX_CACHE_RELATIVE_PATH)
       : selectMicromambaCache(root, DEFAULT_MAX_CACHE_RELATIVE_PATH, deps.micromambaEnv)
-    const env = micromambaSpawnEnv(
-      root,
-      deps.caBundle,
-      { ...deps.micromambaEnv, selectCache: () => cache },
-      DEFAULT_MAX_CACHE_RELATIVE_PATH
-    )
+    const env = {
+      ...micromambaSpawnEnv(
+        root,
+        deps.caBundle,
+        { ...deps.micromambaEnv, selectCache: () => cache },
+        DEFAULT_MAX_CACHE_RELATIVE_PATH
+      ),
+      ...notebookWorkloadCacheEnv(root)
+    }
     condaContext = { cache, env }
     return condaContext
   }


### PR DESCRIPTION
# fix(notebook): confine installer caches to managed runtime storage

## Problem

A managed pandas install can fail when libmamba probes a user-home package cache that the Notebook sandbox deliberately denies. On macOS/Linux, the micromamba child environment did not pin the selected application cache. The conda branch also omitted the workload-cache environment already supplied to ordinary pip/R workers, allowing nested pip calls to emit user-cache permission warnings.

## Proposed change

Set CONDA_PKGS_DIRS to the existing selected application cache on every platform, and supply the existing workload-cache environment to conda workers. Keep the filesystem policy and installer fallback classification unchanged. Windows continues using its existing owned short-cache selector.

## Scope and non-goals

No new schema, API/result field, state, UI interaction, ownership marker, or persistent format. Reuse runtime/pkgs and runtime/cache/notebook. Existing user caches are neither migrated nor deleted; requests that previously used a user cache may redownload packages. Existing environments and Notebook data need no migration.

## Acceptance criteria and validation

A real macOS Seatbelt regression calls installPackages through the package sandbox adapter with staged micromamba and an offline local-channel pandas solver fixture. It failed twice before the fix with a libmamba filesystem permission error and passes after the fix, while explicit user-cache reads remain denied. The current binary fails at ~/.mamba/pkgs path canonicalization rather than the report's .cache/conda shard stat; this verifies the same cache-boundary failure class, not that exact binary/path. No package is downloaded or installed by the fixture.

Checks run after the final material edit:

- Cache selection -> micromamba.test.ts and micromamba-cache.test.ts -> passed.
- Installer env, preflight, install/remove and fallback -> package-manager.test.ts -> passed.
- Sandbox projection/lifecycle and real macOS solver -> package-process-sandbox.test.ts and package-cache-sandbox.integration.test.ts -> passed.
- Shared helper consumers -> provisioner.startup.test.ts, provisioner-runtime.test.ts and package-listing.test.ts -> passed.
- Operation/results, logging, workload ownership -> package-operations.test.ts, runtime-service-logging.integration.test.ts and notebook-workload-cache.test.ts -> passed.
- These 11 files were run together via `npm test -- <explicit paths>`: 246 tests passed. The native sandbox fixture used OPEN_SCIENCE_TEST_MICROMAMBA pointing to the existing staged binary.
- Node/sandbox typecheck: passed. Repository lint: passed.
- Changed-file Prettier check and git diff --check: passed.

The existing affected-plan classifier reports unknown Module ownership for micromamba.ts and selects full fallback. Per the maintainer's explicit request, local testing used the caller-derived focused set; no complete local suite was run. CI remains authoritative. Native Linux/Windows isolation and a full online pandas installation were not exercised locally. The macOS regression skips without a staged binary; a skipped run is not native coverage.

## Review focus

Confirm all micromamba consumers use the existing cache selected by their current owner, that conda subprocesses retain workload-cache variables, and that no private user-cache grant is added. Independent review and final PR checks remain outstanding.
