### PR TITLE
fix(session-persistence): reject cyclic identity reservations

### DIFF
--- a/src/main/session-persistence/coordinator-contract.test.ts
+++ b/src/main/session-persistence/coordinator-contract.test.ts
@@ -1,6 +1,9 @@
+import { setImmediate } from 'node:timers/promises'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
+import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
+import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
 import type {
   PersistedChatSession,
   SessionPlanRuntimeContext
@@ -115,6 +118,129 @@ const createFileIndex = (overrides: Partial<SessionFileIndex> = {}): SessionFile
 })
 
 describe('SessionPersistenceCoordinator contracts', () => {
+  it.each(
+    (['read', 'write', 'delete'] as const).flatMap((operation) =>
+      [false, true].map((withGlobalBarrier) => ({ operation, withGlobalBarrier }))
+    )
+  )(
+    'rejects Project deletion without stalling a $operation queued during scanning (global barrier: $withGlobalBarrier)',
+    async ({ operation, withGlobalBarrier }) => {
+      const scanStarted = createDeferred()
+      const scanGate = createDeferred()
+      const session = createSession()
+      const { repository, sessions } = createRepository([session])
+      vi.mocked(repository.loadProjectWithDiagnostics).mockImplementationOnce(async () => {
+        scanStarted.resolve()
+        await scanGate.promise
+        return { sessions: [session], isComplete: true }
+      })
+      const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+      const deletion = coordinator.deleteProjectSessions(session.projectId)
+      await scanStarted.promise
+      const successor =
+        operation === 'read'
+          ? coordinator.readSessionRuntimeContext(session.projectId, session.id)
+          : operation === 'write'
+            ? coordinator.saveSession(session)
+            : coordinator.deleteSession(session.projectId, session.id)
+      // Observe the successor without leaving a rejection unhandled during the checkpoint.
+      const successorResult = Promise.allSettled([successor])
+      const independent = coordinator.saveSession(
+        createSession({ id: 'session-2', projectId: 'project-2' })
+      )
+      const snapshot = withGlobalBarrier ? coordinator.sessionMetadataSnapshot() : undefined
+      const later = coordinator.runSessionMutation('project-2', 'session-2', async () => 'later')
+      let allSettled = false
+      void Promise.allSettled([deletion, successor, independent, snapshot, later]).then(() => {
+        allSettled = true
+      })
+
+      await setImmediate()
+      expect(
+        vi.mocked(repository.saveSession).mock.calls.some(([saved]) => saved.id === 'session-2')
+      ).toBe(true)
+      expect(repository.deleteProjectSessions).not.toHaveBeenCalled()
+      scanGate.resolve()
+      // All fixture I/O is Promise-based. One event-loop turn drains runnable work; a dependency
+      // cycle leaves these operations unsettled. Fail on that behavior, not a test timeout.
+      await setImmediate()
+      expect(allSettled).toBe(true)
+      expect(repository.deleteProjectSessions).not.toHaveBeenCalled()
+      await expect(deletion).rejects.toThrow(
+        'Session identity reservation conflicted with a later operation. Retry the operation.'
+      )
+      const [result] = await successorResult
+      expect(result.status).toBe('fulfilled')
+      if (operation === 'read') {
+        expect(result).toMatchObject({ value: { version: 1 } })
+      } else if (operation === 'write') {
+        expect(result).toMatchObject({ value: { id: session.id } })
+      } else {
+        expect(result).toEqual({ status: 'fulfilled', value: undefined })
+      }
+      await expect(independent).resolves.toMatchObject({ id: 'session-2' })
+      if (snapshot)
+        await expect(snapshot).resolves.toMatchObject({
+          sessions: expect.arrayContaining([
+            { id: 'session-2', projectId: 'project-2', title: 'Session' }
+          ])
+        })
+      await expect(later).resolves.toBe('later')
+      expect(sessions.has(session.id)).toBe(operation !== 'delete')
+      expect(sessions.has('session-2')).toBe(true)
+      const retry = coordinator.deleteProjectSessions(session.projectId)
+      let retrySettled = false
+      void Promise.allSettled([retry]).then(() => {
+        retrySettled = true
+      })
+      await setImmediate()
+      expect(retrySettled).toBe(true)
+      await expect(retry).resolves.toEqual({ status: 'completed' })
+      expect(sessions.has(session.id)).toBe(false)
+    }
+  )
+
+  it('finishes deletion cleanup while another Project changes Compute Host access', async () => {
+    const scanStarted = createDeferred()
+    const scanGate = createDeferred()
+    const session = createSession()
+    const other = createSession({ id: 'session-2', projectId: 'project-2' })
+    const { repository } = createRepository([session, other])
+    vi.mocked(repository.loadProjectWithDiagnostics).mockImplementationOnce(async () => {
+      scanStarted.resolve()
+      await scanGate.promise
+      return { sessions: [session], isComplete: true }
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+    const hosts = new SessionEnabledComputeHostsOwner({
+      registry: new EnabledComputeHostsRegistry(),
+      hostExists: async () => true,
+      listHostIds: async () => [],
+      sessionAuthority: coordinator,
+      withDataRootWrite: (operation) => operation()
+    })
+    coordinator.setSessionDeletionHandlers({
+      commit: (sessionIds) => hosts.clear(sessionIds),
+      reconcile: async () => undefined
+    })
+    await coordinator.loadAll()
+    const deletion = coordinator.deleteProjectSessions(session.projectId)
+    await scanStarted.promise
+    const update = hosts.setHostEnabled(other.id, 'ssh:host', false)
+    await setImmediate()
+    let allSettled = false
+    const completion = Promise.allSettled([deletion, update])
+    void completion.then(() => {
+      allSettled = true
+    })
+    scanGate.resolve()
+    await setImmediate()
+    expect(repository.deleteProjectSessions).toHaveBeenCalledWith(session.projectId)
+    expect(allSettled).toBe(true)
+    expect((await completion).every((result) => result.status === 'fulfilled')).toBe(true)
+  })
+
   it('keeps scoped lanes failure-tolerant and snapshots behind a global barrier', async () => {
     const gate = createDeferred()
     const order: string[] = []

--- a/src/main/session-persistence/operation-scheduler.test.ts
+++ b/src/main/session-persistence/operation-scheduler.test.ts
@@ -1,3 +1,4 @@
+import { setImmediate } from 'node:timers/promises'
 import { describe, expect, it } from 'vitest'
 
 import { SessionPersistenceOperationScheduler } from './operation-scheduler'
@@ -19,6 +20,79 @@ const flushMicrotasks = async (): Promise<void> => {
 }
 
 describe('SessionPersistenceOperationScheduler', () => {
+  it.each([false, true])(
+    'rejects identity expansion behind a successor without bypassing earlier owners (transitive: %s)',
+    async (transitive) => {
+      const scheduler = new SessionPersistenceOperationScheduler()
+      const identityGate = createDeferred()
+      const extendGate = createDeferred()
+      const order: string[] = []
+      const identity = scheduler.runSessionIdentity('session-1', async () => {
+        order.push('identity:start')
+        await identityGate.promise
+        order.push('identity:end')
+      })
+      const project = scheduler.runProject('project-1', async (scope) => {
+        await extendGate.promise
+        return scope.runSessionIdentities(['unclaimed-session', 'session-1'], async () => {
+          order.push('nested')
+        })
+      })
+      const successor = scheduler.runSession('project-1', 'session-1', async () => {
+        order.push('successor')
+      })
+      const indirect = transitive
+        ? scheduler.runSession('project-2', 'session-1', async () => {
+            order.push('indirect')
+          })
+        : undefined
+      const global = scheduler.runGlobal(async () => {
+        order.push('global')
+      })
+      const later = scheduler.runProject('project-3', async () => {
+        order.push('later')
+      })
+      let projectSettled = false
+      const projectResult = Promise.allSettled([project]).then((results) => {
+        projectSettled = true
+        return results
+      })
+      extendGate.resolve()
+      await setImmediate()
+      expect(projectSettled).toBe(true)
+      expect(await projectResult).toEqual([
+        {
+          status: 'rejected',
+          reason: new Error(
+            'Session identity reservation conflicted with a later operation. Retry the operation.'
+          )
+        }
+      ])
+      expect(order).toEqual(['identity:start'])
+
+      let allSettled = false
+      const completion = Promise.allSettled([identity, successor, indirect, global, later])
+      void completion.then(() => {
+        allSettled = true
+      })
+      identityGate.resolve()
+      await setImmediate()
+      expect(allSettled).toBe(true)
+      expect((await completion).every((result) => result.status === 'fulfilled')).toBe(true)
+      expect(order).toEqual([
+        'identity:start',
+        'identity:end',
+        'successor',
+        ...(transitive ? ['indirect'] : []),
+        'global',
+        'later'
+      ])
+      await expect(
+        scheduler.runSessionIdentity('unclaimed-session', async () => 'available')
+      ).resolves.toBe('available')
+    }
+  )
+
   it('allows independent Projects to progress concurrently', async () => {
     const scheduler = new SessionPersistenceOperationScheduler()
     const projectOneGate = createDeferred()

--- a/src/main/session-persistence/operation-scheduler.ts
+++ b/src/main/session-persistence/operation-scheduler.ts
@@ -22,7 +22,11 @@ class SessionPersistenceOperationScope {
 class SessionPersistenceOperationScheduler {
   private globalTail: Promise<void> = Promise.resolve()
   private generation = 0
-  private readonly scopeTails = new Map<string, Map<number, Promise<void>>>()
+  private sequence = 0
+  private readonly scopeTails = new Map<
+    string,
+    Map<number, { sequence: number; tail: Promise<void> }>
+  >()
 
   runProject<Result>(projectId: string, operation: ScopedOperation<Result>): Promise<Result> {
     return this.runScoped([projectScope(projectId)], operation)
@@ -79,7 +83,9 @@ class SessionPersistenceOperationScheduler {
   runGlobal<Result>(operation: Operation<Result>): Promise<Result> {
     const predecessors = new Set([
       this.globalTail,
-      ...[...this.scopeTails.values()].flatMap((tails) => [...tails.values()])
+      ...[...this.scopeTails.values()].flatMap((tails) =>
+        [...tails.values()].map(({ tail }) => tail)
+      )
     ])
     const run = Promise.all(predecessors).then(operation)
     this.globalTail = settledTail(run)
@@ -92,11 +98,12 @@ class SessionPersistenceOperationScheduler {
     operation: ScopedOperation<Result>
   ): Promise<Result> {
     const generation = this.generation
+    const sequence = ++this.sequence
     const uniqueScopes = [...new Set(scopes)]
     const predecessors = new Set([
       this.globalTail,
       ...uniqueScopes.flatMap((scope) => {
-        const tail = this.scopeTails.get(scope)?.get(generation)
+        const tail = this.scopeTails.get(scope)?.get(generation)?.tail
         return tail ? [tail] : []
       })
     ])
@@ -105,11 +112,16 @@ class SessionPersistenceOperationScheduler {
       const additionalSessionIds = sessionIds.filter(
         (sessionId) => !heldScopes.has(sessionScope(sessionId))
       )
-      return this.runNestedSessionIdentities(generation, additionalSessionIds, nestedOperation)
+      return this.runNestedSessionIdentities(
+        generation,
+        sequence,
+        additionalSessionIds,
+        nestedOperation
+      )
     })
     const run = Promise.all(predecessors).then(() => operation(operationScope))
     const tail = settledTail(run)
-    this.recordScopeTail(uniqueScopes, generation, tail)
+    this.recordScopeTail(uniqueScopes, generation, sequence, tail)
     return run
   }
 
@@ -117,36 +129,47 @@ class SessionPersistenceOperationScheduler {
   // a later global barrier cannot become both its predecessor and its dependent.
   private runNestedSessionIdentities<Result>(
     generation: number,
+    sequence: number,
     sessionIds: readonly string[],
     operation: Operation<Result>
   ): Promise<Result> {
     const uniqueScopes = [...new Set(sessionIds.map(sessionScope))]
-    const predecessors = new Set(
-      uniqueScopes.flatMap((scope) => {
-        const tail = this.scopeTails.get(scope)?.get(generation)
-        return tail ? [tail] : []
-      })
-    )
+    const reservations = uniqueScopes.flatMap((scope) => {
+      const reservation = this.scopeTails.get(scope)?.get(generation)
+      return reservation ? [reservation] : []
+    })
+    // A later reservation may depend on this operation, directly or through another scope.
+    // Fail before recording any identity rather than forming a cycle or bypassing its predecessors.
+    // ponytail: conservatively reject later reservations; track dependencies only if retries become costly.
+    if (reservations.some((reservation) => reservation.sequence > sequence)) {
+      return Promise.reject(
+        new Error(
+          'Session identity reservation conflicted with a later operation. Retry the operation.'
+        )
+      )
+    }
+    const predecessors = new Set(reservations.map(({ tail }) => tail))
     const run = Promise.all(predecessors).then(operation)
     const tail = settledTail(run)
-    this.recordScopeTail(uniqueScopes, generation, tail)
+    this.recordScopeTail(uniqueScopes, generation, sequence, tail)
     return run
   }
 
   private recordScopeTail(
     scopes: readonly string[],
     generation: number,
+    sequence: number,
     tail: Promise<void>
   ): void {
     for (const scope of scopes) {
-      const tails = this.scopeTails.get(scope) ?? new Map<number, Promise<void>>()
-      tails.set(generation, tail)
+      const tails = this.scopeTails.get(scope) ?? new Map()
+      tails.set(generation, { sequence, tail })
       this.scopeTails.set(scope, tails)
     }
     void tail.then(() => {
       for (const scope of scopes) {
         const tails = this.scopeTails.get(scope)
-        if (tails?.get(generation) !== tail) continue
+        if (tails?.get(generation)?.tail !== tail) continue
         tails.delete(generation)
         if (tails.size === 0) this.scopeTails.delete(scope)
       }


### PR DESCRIPTION
## Problem

L01: while Project deletion scans Session authority, a later read, write, or single-Session deletion can reserve the same Project and Session tails. Expanding deletion's identity scope then waits on its own successor, leaving both requests and subsequent global barriers pending indefinitely.

## Proposed change

Stamp scoped admissions and their queue tails with an in-memory sequence. Reject nested identity expansion before recording any tail if an identity has a later reservation in the same barrier generation. Earlier predecessors retain their ordering, and existing failure handling releases the Project queue so callers can retry deletion.

This is deliberately conservative: even an independent later reservation can require a retry. It avoids a general dependency graph while preserving cross-Project concurrency and the existing deletion notification/Compute Host queue ordering.

## Scope and non-goals

- Adds only private, in-memory admission/tail sequence metadata. No enum, persisted field, schema, migration, historical compatibility path, or IPC payload change.
- Conflicting deletion reports an error before the nested deletion body starts; pending reads/writes/deletions and global barriers finish, and an uncontended retry succeeds.
- Existing deletion authority, rollback, transcript branches, framework protocols, and UI navigation remain unchanged. No automatic retry or timeout is introduced.

## Acceptance criteria and validation

Eight regression cases were run against the original scheduler: all failed because operations remained unsettled after draining fixture Promise work, without using test timeouts. The same final tests pass with this change. A ninth real Coordinator + Compute Host owner case guards cross-Project cleanup progress.

Final local Test Impact Set (run after the last material edit):

| Behavior | Command | Result |
| --- | --- | --- |
| Direct/transitive successor conflicts, predecessor ordering, Project read/write/delete, later global barrier, independent Project progress, retry, Compute Host cleanup | `npm test -- src/main/session-persistence/operation-scheduler.test.ts src/main/session-persistence/coordinator-contract.test.ts` | 30 passed |
| Persistence owner, contracts, representative delegation and deletion consumers | `npm run test:module -- session_persistence` | 567 passed |
| Project lifecycle, compute deletion, IPC, renderer/preload consumers | `npm run test:module -- project_lifecycle` | 685 passed |
| Repository scheduler consumer, queue ordering, projection diagnostics | `npm test -- src/main/session-persistence/repository.test.ts src/main/session-persistence/repository-queue.test.ts src/main/session-persistence/projection-diagnostics.test.ts` | 90 passed |
| Main-process types | `npm run typecheck:node` | passed |
| Lint, formatting, whitespace | `npm run lint`; Prettier check on the three changed files; `git diff --check` | passed |

CodeGraph identifies Coordinator and Repository as scheduler consumers; the worktree index belongs to the root checkout, so imports, explicit tests, and module manifests supplement its relationship map. `npm run test:affected:explain -- --base c112e286 --head HEAD` selects the full plan because the scheduler test is not assigned a module owner. Per the maintainer's explicit instruction, local validation remains module-based; PR CI retains authority for complete and platform checks. No renderer source changed, so no separate web typecheck or browser/Electron UI run was added. Live remote runtime is not exercised locally. Independent PR review is pending.

## Review focus

Ensure rejection happens before any partial identity reservation or destructive deletion, earlier identity owners are never bypassed, original barrier generations remain intact, and existing rollback releases pending work for an uncontended retry.
