### PR TITLE
fix(error-notice): center and enlarge the brand mark

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -934,8 +934,8 @@ colors communicate a successful or failed probe/migration result.
 
 ## Error notices
 
-Use the shared `ErrorNotice` for error summaries. Center the decorative flask mark (`size-14`) above
-the summary with a 24px gap to distinguish it from the smaller status icon. Use one bounded column
+Use the shared `ErrorNotice` for error summaries. Center the decorative flask mark (`size-18`) above
+the summary with a 32px gap to distinguish it from the smaller status icon. Use one bounded column
 (`max-w-md`, `min-w-0`), and left-align headings, descriptions, codes, and help.
 Pair the status icon with the first text line. Long error text and identifiers must wrap inside the
 column. Group primary and secondary actions at the trailing edge with `flex-wrap` and a consistent

--- a/docs/design.md
+++ b/docs/design.md
@@ -934,8 +934,9 @@ colors communicate a successful or failed probe/migration result.
 
 ## Error notices
 
-Use the shared `ErrorNotice` for error summaries. Keep the decorative flask mark compact (`size-10`),
-use one bounded column (`max-w-md`, `min-w-0`), and left-align headings, descriptions, codes, and help.
+Use the shared `ErrorNotice` for error summaries. Center the decorative flask mark (`size-14`) above
+the summary with a 24px gap to distinguish it from the smaller status icon. Use one bounded column
+(`max-w-md`, `min-w-0`), and left-align headings, descriptions, codes, and help.
 Pair the status icon with the first text line. Long error text and identifiers must wrap inside the
 column. Group primary and secondary actions at the trailing edge with `flex-wrap` and a consistent
 small gap; wrap whole controls instead of splitting their labels. Preserve semantic status tones,

--- a/src/renderer/src/components/error-notice.tsx
+++ b/src/renderer/src/components/error-notice.tsx
@@ -74,7 +74,7 @@ const ErrorNotice = ({
 }: ErrorNoticeProps): React.JSX.Element => {
   return (
     <section className="flex w-full min-w-0 max-w-md flex-col gap-4 text-left">
-      <FlaskLogo className="size-10 self-center text-text-300" />
+      <FlaskLogo className="mb-2 size-14 self-center text-text-300" />
 
       {title !== undefined || description !== undefined ? (
         <div className="flex min-w-0 items-start gap-3">

--- a/src/renderer/src/components/error-notice.tsx
+++ b/src/renderer/src/components/error-notice.tsx
@@ -74,7 +74,7 @@ const ErrorNotice = ({
 }: ErrorNoticeProps): React.JSX.Element => {
   return (
     <section className="flex w-full min-w-0 max-w-md flex-col gap-4 text-left">
-      <FlaskLogo className="mb-2 size-14 self-center text-text-300" />
+      <FlaskLogo className="mb-4 size-18 self-center text-text-300" />
 
       {title !== undefined || description !== undefined ? (
         <div className="flex min-w-0 items-start gap-3">

--- a/src/renderer/src/components/error-notice.tsx
+++ b/src/renderer/src/components/error-notice.tsx
@@ -74,7 +74,7 @@ const ErrorNotice = ({
 }: ErrorNoticeProps): React.JSX.Element => {
   return (
     <section className="flex w-full min-w-0 max-w-md flex-col gap-4 text-left">
-      <FlaskLogo className="size-10 text-text-300" />
+      <FlaskLogo className="size-10 self-center text-text-300" />
 
       {title !== undefined || description !== undefined ? (
         <div className="flex min-w-0 items-start gap-3">


### PR DESCRIPTION
## Problem

Error notices place the brand mark against the left edge above the error summary. In source previews this makes the logo appear detached from the centered notice.

## Proposed change

Center the decorative logo above the error details in shared ErrorNotice, enlarge it from 40px to 72px, and increase separation from 16px to 32px. Preserve colors, content layout, and actions. Update the existing design specification.

## Scope and non-goals

Three Tailwind presentation classes. All ErrorNotice consumers inherit it. No fields, enums, persistence, migration, interface, architecture, or interaction changes. Does not alter source loading or HTTP error handling.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Real shared component and application CSS: logo center offset changes from -204px to 0; centered above details at 320/375/414/768px in light and dark themes, without horizontal overflow.
- ErrorNotice, database-startup-gate, PreviewPanel: 59 tests passed.
- npm run typecheck:web passed.
- npm run lint: passed.
- Independent standards/spec reviews: no findings.
- Browser visual checks used a component fixture. Full source-preview/Electron workflow was not rerun for this alignment-only change. Full portable/platform checks remain PR CI authority; no full local npm test run.

## Review focus

Centered brand mark above readable error details, including narrow panels.
