### PR TITLE
fix(workspace): improve divider hover and resize interactions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -787,6 +787,10 @@ colors communicate a successful or failed probe/migration result.
 - Activity stream: `ScrollArea className="min-w-0 flex-1"`.
 - Composer: fixed to the bottom of the activity stream and constrained to `max-w-4xl`, with the composer text track aligned to the message content.
 - Right viewer area: `border-l border-border/20`.
+- Desktop side-panel dividers reveal a centered, full-height 2px `text-200` line on hover,
+  keyboard focus, and drag. Mouse resize targets extend 10px to either side of the divider;
+  collapsed dividers stay hidden and disabled. Keep the one-pixel layout footprint.
+  Arrow-key resizing must work on first opening and after collapsing and reopening either panel.
 - Right card: `m-2 rounded-lg bg-card shadow-sm`.
 - An open Notebook Variables view shares the Preview with the Notebook and manual kernel terminal
   when the Notebook surface is at least `55rem` wide, using a fixed 40% right column. Below that

--- a/e2e/workspace-files.spec.ts
+++ b/e2e/workspace-files.spec.ts
@@ -1,3 +1,4 @@
+import { realpath, writeFile } from 'node:fs/promises'
 import { expect } from '@playwright/test'
 import type { Locator, Page } from 'playwright'
 import { test } from './fixtures/electron-app'
@@ -294,4 +295,124 @@ test('loads managed image previews from Project files', async ({ app }) => {
   await expect
     .poll(() => image.evaluate((element) => (element as HTMLImageElement).naturalWidth))
     .toBeGreaterThan(0)
+})
+
+test.describe('Workspace dividers', () => {
+  test.beforeEach(async ({ app }) => {
+    const page = await app.completeOnboarding()
+    await createProject(page)
+    const directory = await realpath(await app.createTestDirectory('resize-preview'))
+    await writeFile(`${directory}/resize.txt`, 'Resize preview content')
+    await page.getByRole('button', { name: 'Files', exact: true }).click()
+    await page.getByRole('button', { name: 'Filter project files' }).click()
+    await page
+      .getByRole('menu', { name: 'Filter project files' })
+      .getByRole('menuitemradio')
+      .last()
+      .click()
+    const browser = page.getByLabel('Local file browser')
+    await browser.getByLabel('Directory path').fill(directory)
+    await browser.getByLabel('Directory path').press('Enter')
+    await browser
+      .getByRole('list', { name: 'Directory contents' })
+      .getByRole('button')
+      .filter({ hasText: 'resize.txt' })
+      .click()
+    await expect(page.getByRole('tab').filter({ hasText: 'resize.txt' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+  })
+
+  for (const side of ['left', 'right'] as const) {
+    test(`${side} workspace divider responds to arrow keys after reopening`, async ({ app }) => {
+      const page = app.page
+      await page.emulateMedia({ reducedMotion: 'reduce' })
+      const handle = page.getByRole('separator', { name: `Resize ${side} panel` })
+      const panelName = side === 'left' ? 'sidebar' : 'preview'
+      const direction = side === 'left' ? 1 : -1
+      for (const reopen of [false, true]) {
+        if (reopen) {
+          await page.getByRole('button', { name: `Collapse ${panelName} panel` }).click()
+          await expect(handle).toHaveCount(0)
+          await page.getByRole('button', { name: `Expand ${panelName} panel` }).click()
+        }
+        await expect(handle).toBeVisible()
+        const box = (await handle.boundingBox())!
+        await handle.focus()
+        await page.keyboard.press(side === 'left' ? 'ArrowRight' : 'ArrowLeft')
+        await expect
+          .poll(async () => direction * ((await handle.boundingBox())!.x - box.x), {
+            timeout: 3000
+          })
+          .toBeGreaterThan(0)
+      }
+    })
+
+    test(`${side} workspace divider shows a full-height line on hover`, async ({
+      app
+    }, testInfo) => {
+      const page = app.page
+      const handle = page.getByRole('separator', { name: `Resize ${side} panel` })
+      await expect(handle).toBeVisible()
+      const box = (await handle.boundingBox())!
+      // Hover away from the old central tick: the divider itself should be discoverable.
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 4)
+      await page.screenshot({ path: testInfo.outputPath(`${side}-hover.png`) })
+      await expect
+        .poll(() =>
+          handle.evaluate((el) => {
+            const line = getComputedStyle(el, '::before')
+            return {
+              visible: Number(line.opacity) >= 0.9,
+              fullHeight: parseFloat(line.height) >= el.getBoundingClientRect().height * 0.9
+            }
+          })
+        )
+        .toEqual({ visible: true, fullHeight: true })
+
+      await page.mouse.move(box.x + 40, box.y + box.height / 4)
+      await expect
+        .poll(() => handle.evaluate((el) => getComputedStyle(el, '::before').opacity))
+        .toBe('0')
+      await handle.focus()
+      // Enter through the keyboard: programmatic focus after a mouse click is not focus-visible.
+      await page.keyboard.press('Tab')
+      await page.keyboard.press('Shift+Tab')
+      await expect(handle).toBeFocused()
+      await expect
+        .poll(() => handle.evaluate((el) => Number(getComputedStyle(el, '::before').opacity)))
+        .toBeGreaterThanOrEqual(0.9)
+    })
+
+    test(`${side} workspace divider can be dragged from either side of its edge`, async ({
+      app
+    }) => {
+      const page = app.page
+      const handle = page.getByRole('separator', { name: `Resize ${side} panel` })
+      await expect(handle).toBeVisible()
+      const direction = side === 'left' ? 1 : -1
+      for (const offset of [-8, 8]) {
+        const box = (await handle.boundingBox())!
+        const x = box.x + box.width / 2 + offset
+        const y = box.y + box.height / 4
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        await page.mouse.move(x + direction * 40, y, { steps: 5 })
+        await page.mouse.up()
+        await expect
+          .poll(async () => direction * ((await handle.boundingBox())!.x - box.x))
+          .toBeGreaterThan(30)
+      }
+      await page
+        .getByRole('button', {
+          name: side === 'left' ? 'Collapse sidebar panel' : 'Collapse preview panel'
+        })
+        .click()
+      await expect(handle).toHaveCount(0)
+      await expect(
+        page.getByRole('separator', { name: `Resize ${side} panel`, includeHidden: true })
+      ).toHaveAttribute('data-separator', 'disabled')
+    })
+  }
 })

--- a/src/renderer/src/components/ui/resizable.tsx
+++ b/src/renderer/src/components/ui/resizable.tsx
@@ -34,6 +34,9 @@ function ResizableHandle({
 }): React.JSX.Element {
   return (
     <Separator
+      // The library caches keyboard panel associations at registration, excluding disabled edges.
+      // Re-register when enabled so an initially collapsed panel supports keyboard resizing.
+      key={props.disabled ? 'disabled' : 'enabled'}
       data-slot="resizable-handle"
       className={cn(
         // Wide after-hit area makes CSS :hover match the draggable edge; default tick is thin and centered.

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -541,7 +541,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     }
   })
 
-  // Right preview edge keeps the always-on divider from main; left stays tick-on-hover only.
+  // Right preview edge keeps its resting border; pointer geometry is covered in Electron E2E.
   it('keeps the always-on border divider on the right preview resize handle', async () => {
     await renderPage()
 
@@ -550,14 +550,8 @@ describe('WorkspacePage preview panel resize sync', () => {
 
     expect(rightHandle?.className).toContain('bg-border')
     expect(rightHandle?.className).toContain('shadow-[1px_0_3px_rgba(30,28,24,0.08)]')
-    expect(rightHandle?.className).toContain('before:w-1')
-    expect(rightHandle?.className).toContain('before:right-full')
     expect(leftHandle?.className).not.toContain('bg-border')
     expect(leftHandle?.className).not.toContain('shadow-[1px_0_3px_rgba(30,28,24,0.08)]')
-    expect(leftHandle?.className).not.toContain('before:w-1')
-    expect(leftHandle?.className).toContain('before:right-full')
-    expect(leftHandle?.className).toContain('before:mr-[3px]')
-    expect(leftHandle?.className).toContain('before:left-auto')
   })
 
   it('animates the sidebar to zero and restores its last open size', async () => {

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -25,6 +25,9 @@ const SIDEBAR_TOGGLE_RIGHT_INSET = 38
 const PREVIEW_PANEL_DEFAULT_SIZE = 40
 const PREVIEW_PANEL_DEFAULT_SIZE_CSS = `${PREVIEW_PANEL_DEFAULT_SIZE}%`
 const PREVIEW_PANEL_MIN_OPEN_SIZE = 30
+// Match the visible divider and its hit area to the resize library's hover/drag region.
+const WORKSPACE_RESIZE_HANDLE_CLASS_NAME =
+  'z-20 after:w-5 before:top-0 before:h-full before:translate-y-0 before:bg-text-200 hover:before:opacity-100 focus-visible:before:opacity-100 data-[separator=hover]:before:opacity-100 data-[separator=active]:before:opacity-100 transition-opacity duration-200 ease-out'
 const OPEN_DIALOG_SELECTOR =
   '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
 
@@ -574,6 +577,7 @@ const WorkspacePanelLayout = ({
         ) : null}
         <ResizablePanelGroup
           orientation="horizontal"
+          resizeTargetMinimumSize={{ coarse: 20, fine: 20 }}
           aria-hidden={isMobile && mobileSidebar.isOpen ? true : undefined}
           inert={isMobile && mobileSidebar.isOpen ? true : undefined}
           className={isMobile ? 'min-w-0 flex-1' : '-mr-[10px] min-w-0 flex-1'}
@@ -602,8 +606,8 @@ const WorkspacePanelLayout = ({
                 aria-label={t('Resize left panel')}
                 disabled={sidebar.state === 'collapsed'}
                 aria-hidden={sidebar.state === 'collapsed'}
-                className={`before:left-auto before:right-full before:mr-[3px] before:translate-x-0 transition-opacity duration-200 ease-out ${
-                  sidebar.state === 'collapsed' ? 'opacity-0' : 'opacity-100'
+                className={`${WORKSPACE_RESIZE_HANDLE_CLASS_NAME} ${
+                  sidebar.state === 'collapsed' ? 'pointer-events-none opacity-0' : 'opacity-100'
                 }`}
               />
             </>
@@ -622,8 +626,8 @@ const WorkspacePanelLayout = ({
                 aria-label={t('Resize right panel')}
                 disabled={preview.state === 'collapsed'}
                 aria-hidden={preview.state === 'collapsed'}
-                className={`bg-border shadow-[1px_0_3px_rgba(30,28,24,0.08)] before:left-auto before:right-full before:mr-0.5 before:w-1 before:translate-x-0 transition-opacity duration-200 ease-out ${
-                  preview.state === 'collapsed' ? 'opacity-0' : 'opacity-100'
+                className={`${WORKSPACE_RESIZE_HANDLE_CLASS_NAME} bg-border shadow-[1px_0_3px_rgba(30,28,24,0.08)] ${
+                  preview.state === 'collapsed' ? 'pointer-events-none opacity-0' : 'opacity-100'
                 }`}
               />
 


### PR DESCRIPTION
## Problem

Workspace dividers are difficult to discover and grab: hovering the left edge shows only a faint 32px tick, parts of the right edge have no indicator despite being draggable, and dragging 8px away from either edge does not resize the panel. The initially disabled right divider also throws `Matching panels not found` on arrow-key resizing after its first opening.

## Proposed change

- Show a centered, full-height 2px divider on hover, keyboard focus, and drag. Match its transparent 20px mouse target to the resize library while retaining the 1px layout footprint.
- Re-register the shared separator when its enabled state changes so the library rebuilds keyboard-to-panel associations. Keep collapsed dividers hidden and noninteractive.
- Add real Electron mouse/keyboard regressions to the existing Workspace CI suite and update the design contract.

## Compatibility and state

- Historical data compatibility: none required; no migration or persisted-format change.
- New states/enums: none. Existing enabled/disabled and open/collapsed states are reused.
- Persistence: none. No data fields, storage, schema, IPC, or dependencies are added.

## Acceptance criteria and validation

- Before fixing: four mouse regressions failed twice each (8 failures), with a short/invisible indicator or zero drag movement. The right keyboard regression also failed twice with zero movement and `Matching panels not found`; the left control passed. Tests use public accessible controls and real Electron input without a new production test seam.
- Workspace owner and contracts → `npm run test:module -- workspace_page` → 30 files / 755 tests passed.
- Shared adapter and Preview/Notebook consumers → targeted `npm test --` for `resizable.test.tsx`, `NotebookPreview.gate.render.test.tsx`, `NotebookPreview.follow-scroll.test.tsx`, and `PreviewPanel.test.tsx` → 4 files / 104 tests passed.
- Pointer/keyboard behavior, first opening/reopening, focus, and disabled state → `npm run build:e2e` then `npm run test:e2e -- e2e/workspace-files.spec.ts -g "Workspace dividers" --repeat-each=2` → build passed and all 12 runs passed.
- Renderer types → `npm run typecheck:web` → passed.
- Code style → `npm run lint` and Prettier checks → passed without warnings.

All listed local checks run against the final material edits in the isolated worktree. The before/after evidence and final test selection were reviewed against both shared-component consumers; PR checks remain the independent CI authority.

The impact set includes the shared separator's Notebook and Preview consumers because its registration lifecycle changes. Main-process, data-migration, and framework lanes are not changed by this implementation. Local Electron checks run on macOS; PR CI is authoritative for cross-platform/full verification. The dependency-aware explain command selects full CI because the E2E spec is classified as unknown. Per maintainer instruction, local execution uses the explicit module/consumer impact set above and defers the full suite to PR CI.

## Review focus

Confirm the target and visible line remain centered, collapsed edges do not intercept input, and arrow-key resize works on the first opening and after reopening without changing panel sizes or content identity merely on an ordinary rerender.
