### PR TITLE
fix(uploads): return the published standalone attachment

### DIFF
--- a/src/main/uploads/command-owner.test.ts
+++ b/src/main/uploads/command-owner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -15,7 +15,8 @@ import {
   waitForDataRootWriters
 } from '../storage/migration-state'
 import { createUploadCommandOwner } from './command-owner'
-import type { UploadRepository } from './repository'
+import { UploadRepository } from './repository'
+import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 
 type TestCaller = Readonly<{
   context: ReturnType<typeof createElectronCallerContext>
@@ -396,9 +397,18 @@ describe('upload command owner', () => {
       path: '/managed/.pending/notes.txt',
       size: 17
     }
+    const published = {
+      ...attachment,
+      sessionId: 'standalone-uploads',
+      path: join(root, 'versions', 'version-1', 'content'),
+      versionId: 'version-1',
+      versionNumber: 1,
+      checksum: 'published-checksum',
+      createdAt: '2026-09-05T00:00:00.000Z'
+    }
     const repository = {
       stageLocalFile: vi.fn(async () => attachment),
-      finalizePendingSessionUploads: vi.fn(async () => [attachment])
+      finalizePendingSessionUploads: vi.fn(async () => [published])
     } as unknown as UploadRepository
     const owner = createUploadCommandOwner(repository)
     const leases = new ApplicationCallerLeaseRegistry()
@@ -415,7 +425,7 @@ describe('upload command owner', () => {
           }
         ] as const)
       )
-    ).resolves.toEqual(attachment)
+    ).resolves.toEqual(published)
     expect(repository.stageLocalFile).toHaveBeenCalledWith(
       expect.objectContaining({ sourcePath, size: 17 }),
       expect.any(Function)
@@ -428,6 +438,77 @@ describe('upload command owner', () => {
 
     beginMigration()
     await waitForDataRootWriters()
+  })
+
+  it('returns readable durable content and version identity after standalone publication', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upload-owner-'))
+    temporaryRoots.push(root)
+    const sourcePath = join(root, 'notes.txt')
+    await writeFile(sourcePath, 'standalone upload')
+    const client = createProjectDbClient(root)
+    try {
+      await migrateApplicationDatabase(client)
+      const repository = new UploadRepository(root, { getClient: async () => client })
+      const owner = createUploadCommandOwner(repository)
+      const caller = createCaller(new ApplicationCallerLeaseRegistry(), 16)
+      const attachment = await owner.stageLocalPath(
+        invocationFor(caller, [
+          { transferId: 'durable-transfer', sourcePath, name: 'notes.txt', projectId: 'project-1' }
+        ] as const)
+      )
+      const file = await client.uploadFile.findUniqueOrThrow({
+        where: { id: attachment.id },
+        include: { currentVersion: true }
+      })
+      const version = file.currentVersion!
+      const durablePath = join(root, ...version.contentStorageKey.split('/'))
+      expect(file.sessionId).toBe('standalone-uploads')
+      expect(version.state).toBe('ready')
+      await expect(readFile(durablePath, 'utf8')).resolves.toBe('standalone upload')
+      expect.soft(attachment).toMatchObject({
+        sessionId: file.sessionId,
+        path: durablePath,
+        versionId: version.id,
+        versionNumber: version.versionNumber,
+        checksum: version.checksum,
+        createdAt: version.createdAt?.toISOString()
+      })
+      await expect(stat(attachment.path)).resolves.toMatchObject({ size: 17 })
+    } finally {
+      await client.$disconnect()
+    }
+  })
+
+  it.each([0, 2])('rejects standalone publication returning %i attachments', async (count) => {
+    const root = await mkdtemp(join(tmpdir(), 'upload-owner-'))
+    temporaryRoots.push(root)
+    const sourcePath = join(root, 'notes.txt')
+    await writeFile(sourcePath, 'standalone upload')
+    const attachment = {
+      id: 'standalone-attachment',
+      sessionId: '.pending',
+      name: 'notes.txt',
+      originalName: 'notes.txt',
+      path: join(root, '.pending', 'notes.txt'),
+      size: 17
+    }
+    const repository = {
+      stageLocalFile: vi.fn(async () => attachment),
+      finalizePendingSessionUploads: vi.fn(async () =>
+        Array.from({ length: count }, () => attachment)
+      ),
+      deleteUpload: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const caller = createCaller(new ApplicationCallerLeaseRegistry(), 17)
+
+    await expect(
+      owner.stageLocalPath(
+        invocationFor(caller, [
+          { transferId: 'invalid-count-transfer', sourcePath, name: 'notes.txt' }
+        ] as const)
+      )
+    ).rejects.toThrow(`Expected exactly one published standalone upload, received ${count}.`)
   })
 
   it('deletes the standalone copy when its durable publication fails', async () => {

--- a/src/main/uploads/command-owner.ts
+++ b/src/main/uploads/command-owner.ts
@@ -287,18 +287,23 @@ const createUploadCommandOwner = (
       )
       const projectId = request.projectId ?? DEFAULT_UPLOAD_PROJECT_ID
       try {
-        await withDataRootWrite(() =>
+        const published = await withDataRootWrite(() =>
           repository.finalizePendingSessionUploads(
             STANDALONE_UPLOAD_SESSION_ID,
             [attachment],
             projectId
           )
         )
+        if (published.length !== 1) {
+          throw new Error(
+            `Expected exactly one published standalone upload, received ${published.length}.`
+          )
+        }
+        return published[0]
       } catch (error) {
         await repository.deleteUpload({ path: attachment.path }).catch(() => undefined)
         throw error
       }
-      return attachment
     },
     beginTransfer: async ({ callerLease, args: [request] }) => {
       const owner = registerCaller(callerLease)


### PR DESCRIPTION
## Problem

F02 (P2): saving a local file as an artifact completes publication but `stageLocalPath` returns the earlier pending attachment. Its path has already been renamed away and the response lacks the published version identity. Consumers using the response to preview or attach the file fail even though durable storage succeeded.

## Proposed change

Return the sole attachment from `finalizePendingSessionUploads`; reject zero or multiple results with an explicit error. Keep existing failure cleanup. Distinguish pending and published objects in the unit fixture, and cover real filesystem/SQLite publication through the existing command-owner boundary without a new test seam.

## Scope and non-goals

Only the upload command owner and its tests change. No new fields, enum states, schema/model changes, migration, historical compatibility handling, architecture or UI changes. Existing file publication and database/index writes remain unchanged. This does not repair previously retained stale responses or add rollback of already-published versions when an invariant fails.

## Acceptance criteria and validation

Before the production fix, the real database/file regression failed twice with the reported behavior: database version ready, durable content readable, returned session `.pending`, missing version fields, and `ENOENT` for the returned path. The distinct-object fixture and 0/2-result cases also failed before the fix and pass afterward.

Final evidence (checks cover the final material edit):

| Behavior | Command | Result |
| --- | --- | --- |
| Upload owner, published identity/readable path, cardinality, IPC and repository/reference/persistence consumers | `npm run test:module -- upload_repository` | 10 files, 179 passed; includes all 20 command-owner tests |
| Application-command and preload adapters, preview actions and Save as artifact consumers | `npm test -- src/main/data-content-application-commands.test.ts src/preload/index.test.ts src/renderer/src/pages/workspace/preview-tab-actions.test.ts src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx` | 4 files, 268 passed |
| Main runtime and sandbox types | `npm run typecheck:node` | Passed |
| Lint | `npm run lint` | Passed; focused ESLint also passed after the final test edit |
| Changed-file formatting | `prettier --check src/main/uploads/command-owner.ts src/main/uploads/command-owner.test.ts` | Passed |

Impact follows the shared owner through both IPC and application-command adapters to existing renderer consumers. No renderer implementation/shared type changed, so no additional renderer build or UI E2E was run locally. Path assertions use platform-aware joins; Windows/Linux execution and the full suite remain for PR CI. No full local suite was run, as requested by the maintainer.

The existing impact manifest does not declare `command-owner.ts` as an owner path, although its test is registered under `upload_repository`. Consequently `npm run test:affected:explain -- --base HEAD^ --head HEAD` requests full fallback. The focused selection above was derived from the inspected boundaries; this PR does not expand scope to modify the manifest. Exact-head CI and independent review remain required.

## Review focus

Ensure the success response is the published attachment and the exactly-one invariant reports an error without returning a stale pending object. Existing publication, caller lifecycle, event ordering and failure cleanup should remain intact.
