### PR TITLE
fix(preview): pin managed resources across pagination

### DIFF
--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -807,7 +807,7 @@ describe('PreviewFileContent', () => {
     })
 
     expect(fetch).toHaveBeenLastCalledWith(
-      'open-science-preview://resource-2/file-1',
+      'open-science-preview://resource-1/file-1',
       expect.objectContaining({ headers: { Range: expect.stringMatching(/^bytes=5-/u) } })
     )
     expect(container.textContent).toContain('second page')

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act } from 'react'
+import { act, StrictMode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -35,6 +35,7 @@ describe('usePreviewFileContent', () => {
   let root: Root
 
   beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
     container = document.createElement('div')
     document.body.appendChild(container)
     window.api = {
@@ -73,6 +74,113 @@ describe('usePreviewFileContent', () => {
     vi.unstubAllGlobals()
   })
 
+  it.each([
+    ['artifact', '11112222', undefined],
+    ['upload', '11112222', undefined],
+    ['artifact', '11', undefined],
+    ['upload', '11', undefined],
+    ['artifact', '11112222', 'old'],
+    ['upload', '11112222', 'old']
+  ] as const)(
+    'keeps %s pages on one version when the new head is %s (selection: %s)',
+    async (source, newHead, selectedVersionId) => {
+      const versions: Record<string, string> = { old: 'AAAABBBB', new: newHead }
+      let head = 'old'
+      let nextId = 0
+      const resources = new Map<string, string>()
+      vi.mocked(window.api.previewResources.acquire).mockImplementation(async (request) => {
+        if (request.source !== 'artifact' && request.source !== 'upload') {
+          throw new Error('Expected a managed version request.')
+        }
+        // A capability pins the version resolved at acquisition, until release.
+        const content = versions[request.versionId ?? head]
+        const id = String(++nextId)
+        const url = `https://preview.test/${id}`
+        resources.set(url, content)
+        return { id, url, size: content.length, mimeType: 'text/plain', version: nextId }
+      })
+      vi.mocked(window.api.previewResources.release).mockImplementation(async ({ resourceId }) => {
+        resources.delete(`https://preview.test/${resourceId}`)
+      })
+      vi.mocked(fetch).mockImplementation(async (input, init) => {
+        const content = resources.get(String(input))
+        if (content === undefined) throw new Error('Preview resource has been released.')
+        const range = new Headers(init?.headers).get('range')?.match(/^bytes=(\d+)-(\d+)$/u)
+        if (!range) throw new Error('Expected a byte range.')
+        const begin = Number(range[1])
+        const end = Math.min(Number(range[2]) + 1, content.length)
+        return new Response(content.slice(begin, end), {
+          status: 206,
+          headers: { 'Content-Range': `bytes ${begin}-${end - 1}/${content.length}` }
+        })
+      })
+
+      const PaginatedProbe = ({ fileId = 'file-1' }: { fileId?: string }): React.JSX.Element => {
+        const state = usePreviewFileContent({
+          projectId: 'project-1',
+          managedFileId: fileId,
+          selectedVersionId,
+          source,
+          path: '/managed/file.txt',
+          maxBytes: 4
+        })
+        return state.status === 'ready' ? (
+          <>
+            <button type="button" aria-label="Next page" onClick={state.pagination.nextPage}>
+              {state.preview.content}
+            </button>
+            <button
+              type="button"
+              aria-label="Previous page"
+              onClick={state.pagination.previousPage}
+            />
+          </>
+        ) : (
+          <div>{state.status === 'error' ? String(state.error) : state.status}</div>
+        )
+      }
+
+      root = createRoot(container)
+      await act(async () => root.render(<PaginatedProbe />))
+      expect(container.textContent).toBe('AAAA')
+
+      // Publish between completed page reads, before any refresh notification.
+      head = 'new'
+      await act(async () => container.querySelector('button')?.click())
+      expect(container.textContent).toBe('BBBB')
+      expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(1)
+      expect(window.api.previewResources.release).not.toHaveBeenCalled()
+
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[aria-label="Previous page"]')?.click()
+      )
+      expect(container.textContent).toBe('AAAA')
+      await act(async () => container.querySelector('button')?.click())
+      expect(container.textContent).toBe('BBBB')
+
+      // Identity switches start at zero, including returning to a previously paged file.
+      await act(async () => root.render(<PaginatedProbe fileId="file-2" />))
+      expect(container.textContent).toBe(selectedVersionId ? 'AAAA' : newHead.slice(0, 4))
+      await act(async () => root.render(<PaginatedProbe />))
+      expect(container.textContent).toBe(selectedVersionId ? 'AAAA' : newHead.slice(0, 4))
+      expect(resources.size).toBe(1)
+
+      head = 'old'
+      await act(async () => root.render(<PaginatedProbe fileId="file-3" />))
+      await act(async () => container.querySelector('button')?.click())
+      expect(container.textContent).toBe('BBBB')
+      head = 'new'
+      // Refresh/retry uses the existing renderer-remount boundary.
+      await act(async () => root.render(<PaginatedProbe key="refresh" fileId="file-3" />))
+      expect(container.textContent).toBe(selectedVersionId ? 'AAAA' : newHead.slice(0, 4))
+      expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(5)
+      expect(window.api.previewResources.release).toHaveBeenCalledTimes(4)
+      await act(async () => root.render(null))
+      expect(resources.size).toBe(0)
+      expect(window.api.previewResources.release).toHaveBeenCalledTimes(5)
+    }
+  )
+
   it('keeps project and session scope when acquiring a version-backed upload', async () => {
     root = createRoot(container)
     await act(async () => root.render(<Probe />))
@@ -89,11 +197,87 @@ describe('usePreviewFileContent', () => {
       headers: { Range: 'bytes=0-14' },
       signal: expect.any(AbortSignal)
     })
+    expect(container.textContent).toBe('group,count\nA,2')
+    expect(window.api.previewResources.release).not.toHaveBeenCalled()
+    await act(async () => root.render(null))
     expect(window.api.previewResources.release).toHaveBeenCalledWith({
       resourceId: 'resource:upload-file-1'
     })
-    expect(container.textContent).toBe('group,count\nA,2')
   })
+
+  it.each(['unmount', 'switch', 'strict-mode'] as const)(
+    'releases an acquisition completed after %s without reading it',
+    async (action) => {
+      const stale = {
+        id: 'stale',
+        url: 'https://preview.test/stale',
+        size: 8,
+        mimeType: 'text/plain',
+        version: 1
+      }
+      let finishAcquire!: (resource: typeof stale) => void
+      vi.mocked(window.api.previewResources.acquire).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishAcquire = resolve
+          })
+      )
+      root = createRoot(container)
+      await act(async () =>
+        root.render(
+          action === 'strict-mode' ? (
+            <StrictMode>
+              <Probe />
+            </StrictMode>
+          ) : (
+            <Probe />
+          )
+        )
+      )
+      if (action !== 'strict-mode') {
+        await act(async () =>
+          root.render(action === 'unmount' ? null : <SwitchingProbe fileId="second" />)
+        )
+      }
+      await act(async () => finishAcquire(stale))
+
+      expect(window.api.previewResources.release).toHaveBeenCalledWith({ resourceId: 'stale' })
+      expect(vi.mocked(fetch).mock.calls.some(([url]) => url === stale.url)).toBe(false)
+      expect(
+        vi
+          .mocked(window.api.previewResources.release)
+          .mock.calls.filter(([request]) => request.resourceId === 'stale')
+      ).toHaveLength(1)
+    }
+  )
+
+  it.each(['local', 'notebook-input'] as const)(
+    'continues releasing %s resources after each read',
+    async (source) => {
+      const PathProbe = (): React.JSX.Element => {
+        const state = usePreviewFileContent({
+          source,
+          path: '/input.txt',
+          projectId: 'project-1',
+          sessionId: 'session-1'
+        })
+        return <div>{state.status}</div>
+      }
+      vi.mocked(window.api.previewResources.acquire).mockResolvedValue({
+        id: 'path',
+        url: 'https://preview.test/path',
+        size: 15,
+        mimeType: 'text/plain',
+        version: 1
+      })
+      root = createRoot(container)
+      await act(async () => root.render(<PathProbe />))
+      expect(container.textContent).toBe('ready')
+      expect(window.api.previewResources.release).toHaveBeenCalledExactlyOnceWith({
+        resourceId: 'path'
+      })
+    }
+  )
 
   it('does not leave concurrent direct preview reads when switching files', async () => {
     let activeDirectReads = 0
@@ -125,6 +309,22 @@ describe('usePreviewFileContent', () => {
     expect(window.api.previewResources.release).toHaveBeenCalledWith({
       resourceId: 'resource:first'
     })
+  })
+
+  it('does not expose old page offsets when returning while another file is still loading', async () => {
+    root = createRoot(container)
+    await act(async () => root.render(<SwitchingProbe fileId="first" />))
+    expect(container.textContent).toBe('ready')
+    vi.mocked(fetch).mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true })
+        })
+    )
+    await act(async () => root.render(<SwitchingProbe fileId="second" />))
+    expect(container.textContent).toBe('loading')
+    await act(async () => root.render(<SwitchingProbe fileId="first" />))
+    expect(container.textContent).toBe('loading')
   })
 
   it('requests the next UTF-8 page from the previous byte boundary', async () => {

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { ArtifactPreviewResult } from '../../../../../shared/artifacts'
+import type { ManagedPreviewResource } from '../../../../../shared/preview-resources'
 import type { PreviewFileSource } from '@/stores/preview-workbench-store'
 
 import { createManagedPreviewRequest } from './preview-file-reader'
@@ -40,6 +41,8 @@ type UsePreviewFileContentRequest = {
   encoding?: 'utf8' | 'base64'
 }
 
+type PreviewResourceOwner = { resource?: ManagedPreviewResource }
+
 const encodeBase64 = (bytes: Uint8Array): string => {
   let binary = ''
   for (let offset = 0; offset < bytes.length; offset += 32 * 1024) {
@@ -64,11 +67,12 @@ const readManagedPreviewPage = async (
     encoding: 'utf8' | 'base64'
     offset: number
     signal: AbortSignal
-  }
+  },
+  owner?: PreviewResourceOwner
 ): Promise<ArtifactPreviewResult> => {
   const previewRequest = createManagedPreviewRequest(request)
-  let resource
-  for (let attempt = 0; ; attempt += 1) {
+  let resource = owner?.resource
+  for (let attempt = 0; !resource; attempt += 1) {
     if (request.signal.aborted) throw request.signal.reason
     try {
       resource = await window.api.previewResources.acquire(previewRequest)
@@ -83,6 +87,7 @@ const readManagedPreviewPage = async (
 
   try {
     if (request.signal.aborted) throw request.signal.reason
+    if (owner) owner.resource = resource
 
     const requestedBytes = Number.isFinite(request.maxBytes)
       ? Math.floor(request.maxBytes)
@@ -138,8 +143,16 @@ const readManagedPreviewPage = async (
       offset: request.offset,
       ...(size > nextOffset ? { nextOffset } : {})
     }
+  } catch (error) {
+    // A failed sequence cannot navigate further; retry starts from a fresh resource.
+    // Aborting an obsolete page must not revoke the resource used by its successor.
+    if (!request.signal.aborted && owner?.resource === resource) owner.resource = undefined
+    throw error
   } finally {
-    await window.api.previewResources.release({ resourceId: resource.id }).catch(() => undefined)
+    // Path reads and acquisitions that completed after cancellation still release per page.
+    if (owner?.resource !== resource) {
+      await window.api.previewResources.release({ resourceId: resource.id }).catch(() => undefined)
+    }
   }
 }
 
@@ -174,6 +187,7 @@ export const usePreviewFileContent = ({
   )
   const activePageState =
     pageState.fileKey === fileKey ? pageState : { fileKey, offsets: [0], index: 0 }
+  if (pageState.fileKey !== fileKey) setPageState(activePageState)
   const offset = activePageState.offsets[activePageState.index] ?? 0
   const requestKey = `${fileKey}:${offset}`
   const [state, setState] = useState<PreviewFileContentInternalState>({
@@ -181,22 +195,40 @@ export const usePreviewFileContent = ({
     requestKey
   })
 
+  const resourceOwnerRef = useRef<PreviewResourceOwner>({})
+  useEffect(() => {
+    const owner: PreviewResourceOwner = {}
+    resourceOwnerRef.current = owner
+    return () => {
+      // The capability pins one immutable version across forward and backward page reads.
+      // Identity changes and refresh/remount boundaries start a new pagination sequence.
+      if (owner.resource) {
+        void window.api.previewResources
+          .release({ resourceId: owner.resource.id })
+          .catch(() => undefined)
+      }
+    }
+  }, [fileKey])
+
   useEffect(() => {
     let canceled = false
     const abortController = new AbortController()
 
-    void readManagedPreviewPage({
-      projectId,
-      sessionId,
-      source,
-      path,
-      ...(managedFileId ? { managedFileId } : {}),
-      ...(selectedVersionId ? { selectedVersionId } : {}),
-      maxBytes,
-      encoding,
-      offset,
-      signal: abortController.signal
-    })
+    void readManagedPreviewPage(
+      {
+        projectId,
+        sessionId,
+        source,
+        path,
+        ...(managedFileId ? { managedFileId } : {}),
+        ...(selectedVersionId ? { selectedVersionId } : {}),
+        maxBytes,
+        encoding,
+        offset,
+        signal: abortController.signal
+      },
+      source === 'artifact' || source === 'upload' ? resourceOwnerRef.current : undefined
+    )
       .then((preview) => {
         if (!canceled) setState({ status: 'ready', preview, requestKey })
       })
@@ -225,7 +257,11 @@ export const usePreviewFileContent = ({
     source
   ])
 
-  if (state.requestKey !== requestKey) return { status: 'loading' }
+  if (state.requestKey !== requestKey) {
+    // Remember pending identities too, so returning to a file cannot revive its old page.
+    setState({ status: 'loading', requestKey })
+    return { status: 'loading' }
+  }
 
   if (state.status !== 'ready') return state
 


### PR DESCRIPTION
## Problem

F04: default managed previews acquire the latest head for every page. If `AAAABBBB` becomes `11112222` between four-byte reads, the viewer shows `AAAA` followed by `2222`. A shorter replacement can instead fail with `Invalid managed file preview offset.`. An update notification cannot eliminate this between-pages race.

Before changing production code, a real React hook test reproduced both outcomes for artifact and upload sources through the existing acquire/fetch/release boundary. Two consecutive runs failed all four new content assertions and passed the three existing tests. No production test seam was added.

## Proposed change

Retain the existing managed capability and its immutable-version lease throughout a pagination sequence, including backward navigation. Release on file changes, refresh/remount, unmount, or read failure; release late canceled acquisitions without reading them. Keep local and Notebook input resources on their existing per-page lifecycle.

Reset offsets and remember pending request identities when switching files, preventing an A → loading B → A transition from exposing an old page while a new resource loads. This additional boundary was also reproduced with a failing hook test before its fix.

## Scope and non-goals

Three files: the shared preview content hook and its hook/consumer tests. The public hook, IPC contract, main-process implementation, controls, and translation catalogs remain unchanged. Existing refresh/retry boundaries resolve the current head and restart at page one; notification delivery (F03) is outside this change.

No new persisted fields, domain-model changes, status enum values, migrations, or historical-data compatibility requirements. The only added state is transient resource ownership. The cost is retaining one existing capability/file handle during an active managed pagination sequence; only the active page contents remain in memory.

## Acceptance criteria and validation

Final Test Impact Set, run after the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Head advances or shrinks; backward navigation; selected versions; refresh; file switches; late cancellation/Strict Mode; path-read release | `usePreviewFileContent.test.tsx` | 15 passed |
| Request identity adapter and real preview consumers, bounded ranges, retry and unavailable-file handling | `preview-file-reader.test.ts`, `PreviewFileContent.test.tsx`, `PreviewFallback.test.tsx`, renderer tests for CSV, Plan JSON, and molecules | Passed |
| Existing trusted lease, capability release and protocol/IPC contract | `managed-preview-resources.test.ts`, `managed-preview-protocol.test.ts`, `managed-preview-ipc.test.ts` | Passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Lint and formatting | `npm run lint`; Prettier check on the three changed files; `git diff --check` | Passed |

Exact combined test command (10 files, **170 passed**):

```sh
npm test -- src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx src/renderer/src/pages/workspace/previews/preview-file-reader.test.ts src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx src/renderer/src/pages/workspace/previews/PreviewFallback.test.tsx src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx src/renderer/src/pages/workspace/previews/renderers/PlanJsonPreview.test.tsx src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.test.tsx src/main/managed-preview-resources.test.ts src/main/managed-preview-protocol.test.ts src/main/managed-preview-ipc.test.ts --maxWorkers=2
```

Impact review traced the shared hook's renderer consumers and the existing main-process lease boundary. No new external dependency on the private resource owner was introduced. No platform path handling, persistence, or native implementation changed; desktop/platform E2E and the complete portable suite are left to CI as requested by the maintainer. The automatic module explain plan falls back to full because these preview files have no curated module owner; it was not presented as selective proof.

A broader preview-directory run exposed an unrelated existing failure in `PreviewTextAnnotationSurface.test.tsx` (`keeps the trigger after preview code highlighting retargets the selected code`, no highlighted tokens before the wait timeout). An isolated, unmodified worktree at base `e7f1dda317618898540f893c4d21fe2f9e291138` reproduced the same assertion failure. It does not import the changed hook. This PR does not modify or suppress that test. CI remains the final authority.

## Review focus

Resource ownership across cancellation and remount boundaries, and the invariant that every visible page and byte offset in one sequence belongs to the same acquired managed version.
