### PR TITLE
fix(preview): invalidate managed version checks on file updates

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -413,17 +413,9 @@ test('supports the core project journey with keyboard input only', async ({ app 
     }))
   )
     return
-  const settingsFocusRestored = await settingsTrigger.evaluate(
-    (element) => document.activeElement === element
-  )
-  if (ACCESSIBILITY_COLLECT_ALL && !settingsFocusRestored) {
-    await recordAccessibilityFinding(
-      'Keyboard focus restoration',
-      'Closing settings did not restore focus to the settings trigger.'
-    )
-    return
-  }
-  await expect(settingsTrigger).toBeFocused()
+  await expectKeyboardOutcome(page, 'Keyboard focus restoration', async () => {
+    await expect(settingsTrigger).toBeFocused()
+  })
 })
 
 for (const width of [375, 767] as const) {

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx
@@ -153,6 +153,96 @@ describe.each(['upload', 'artifact'] as const)('%s real preview resource freshne
     }
   )
 
+  it('annotates the displayed image version after a head-only refresh', async () => {
+    const item: PreviewFileItem = {
+      id: 'image-file',
+      type: 'file',
+      source,
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      managedFileId: 'file-1',
+      artifactId: source === 'artifact' ? 'file-1' : undefined,
+      path: `${source === 'upload' ? 'upload-version' : 'artifact-version'}:project-1/session-1/file-1/v2`,
+      title: 'figure.png',
+      name: 'figure.png',
+      mimeType: 'image/png',
+      format: 'image'
+    }
+    // The content format/name belong to the image in this scenario.
+    const originalInspect = window.api.managedFileVersions.inspect
+    window.api.managedFileVersions.inspect = vi.fn(async (request) => {
+      const result = await originalInspect(request)
+      return result.ok
+        ? {
+            ok: true as const,
+            value: {
+              ...result.value,
+              displayName: 'figure.png',
+              versions: result.value.versions.map((version) => ({
+                ...version,
+                displayName: 'figure.png',
+                contentType: 'image/png'
+              })),
+              text: undefined,
+              canEdit: false,
+              canDiff: false
+            }
+          }
+        : result
+    })
+    const onAddAnnotation = vi.fn()
+    await act(async () =>
+      root.render(
+        <PreviewFileSurface item={item} onClose={vi.fn()} onAddAnnotation={onAddAnnotation} />
+      )
+    )
+    head = 3
+    await act(async () => notify({ projectId: 'project-1', sources: [source], kind: 'upsert' }))
+    const surface = container.querySelector<HTMLElement>('[data-image-annotation-surface]')!
+    const image = container.querySelector<HTMLImageElement>('img')!
+    Object.defineProperties(image, {
+      naturalWidth: { value: 800, configurable: true },
+      naturalHeight: { value: 400, configurable: true }
+    })
+    surface.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 400, height: 400, right: 400, bottom: 400 }) as DOMRect
+    Object.defineProperties(surface, {
+      clientWidth: { value: 400, configurable: true },
+      clientHeight: { value: 400, configurable: true }
+    })
+    await act(async () => image.dispatchEvent(new Event('load', { bubbles: true })))
+    await act(async () => {
+      image.dispatchEvent(
+        new MouseEvent('pointerdown', { bubbles: true, clientX: 200, clientY: 200, button: 0 })
+      )
+      image.dispatchEvent(
+        new MouseEvent('pointerup', { bubbles: true, clientX: 200, clientY: 200, button: 0 })
+      )
+    })
+    const note = document.querySelector<HTMLTextAreaElement>('[aria-label="Annotation note"]')
+    expect(note).not.toBeNull()
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set?.call(
+        note,
+        'Current image evidence'
+      )
+      note!.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () =>
+      Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Annotate')
+        ?.click()
+    )
+    expect(onAddAnnotation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: expect.objectContaining({
+          versionId: 'v3',
+          path: `${source === 'upload' ? 'upload-version' : 'artifact-version'}:project-1/session-1/file-1/v3`
+        })
+      })
+    )
+  })
+
   it('keeps historical content and its lease while updating the head', async () => {
     const item: PreviewFileItem = {
       id: 'file-1',

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore,
+  type PreviewFileItem
+} from '@/stores/preview-workbench-store'
+import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import type { ManagedFileVersionInspectResult } from '../../../../shared/managed-file-versions'
+import type { ProjectFilesChangedEvent } from '../../../../shared/project-files'
+import { PreviewFileSurface } from './PreviewFileSurface'
+
+let root: Root
+let container: HTMLDivElement
+let notify: (event: ProjectFilesChangedEvent) => void
+let head: number
+const acquire = vi.fn<Window['api']['previewResources']['acquire']>()
+const release = vi.fn<Window['api']['previewResources']['release']>()
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  useSessionStore.setState(createInitialSessionState())
+  head = 2
+  let nextBlob = 0
+  vi.stubGlobal(
+    'URL',
+    class extends URL {
+      static createObjectURL(): string {
+        return `blob:preview-${++nextBlob}`
+      }
+      static revokeObjectURL(): void {
+        // Test URLs hold no browser-owned bytes.
+      }
+    }
+  )
+  acquire.mockReset().mockImplementation(async (request) => {
+    const version =
+      'versionId' in request && request.versionId ? Number(request.versionId.slice(1)) : head
+    return {
+      id: `resource-v${version}`,
+      url: `open-science-preview://v${version}/report`,
+      size: 7,
+      mimeType: 'text/plain',
+      version: 1
+    }
+  })
+  release.mockReset().mockResolvedValue(undefined)
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const version = String(input).includes('://v2/') ? 2 : 3
+      return new Response(`body v${version}`)
+    })
+  )
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      previewResources: { acquire, release },
+      projectFiles: {
+        onChanged: vi.fn((listener: typeof notify) => {
+          notify = listener
+          return vi.fn()
+        })
+      },
+      artifacts: { getLineage: vi.fn().mockResolvedValue(undefined) },
+      managedFileVersions: {
+        inspect: vi.fn(async (request: { source: 'upload' | 'artifact'; versionId?: string }) => {
+          const versions = [1, 2, 3].map((version) => ({
+            id: `v${version}`,
+            source: request.source,
+            fileId: 'file-1',
+            versionNumber: version,
+            displayName: 'report.txt',
+            originKind: 'user_edit' as const,
+            basedOnVersionId: version === 1 ? null : `v${version - 1}`,
+            contentType: 'text/plain',
+            sizeBytes: 7,
+            checksum: String(version),
+            createdAt: '2026-09-05T00:00:00Z'
+          }))
+          const value: ManagedFileVersionInspectResult = {
+            source: request.source,
+            projectId: 'project-1',
+            fileId: 'file-1',
+            sessionId: 'session-1',
+            displayName: 'report.txt',
+            headVersionId: `v${head}`,
+            selectedVersionId: request.versionId ?? `v${head}`,
+            versions,
+            canEdit: true,
+            canDiff: true,
+            text: `body v${head}`
+          }
+          return { ok: true, value }
+        })
+      }
+    }
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.unstubAllGlobals()
+})
+
+describe.each(['upload', 'artifact'] as const)('%s real preview resource freshness', (source) => {
+  it.each(['text', 'html', 'image'] as const)(
+    'refreshes default %s content after a head-only notification',
+    async (format) => {
+      const item: PreviewFileItem = {
+        id: 'file-1',
+        type: 'file',
+        source,
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        managedFileId: 'file-1',
+        path: 'report',
+        title: 'report.txt',
+        name: 'report.txt',
+        format
+      }
+      usePreviewWorkbenchStore.getState().activateProject('project-1')
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(item)
+      await act(async () =>
+        root.render(<PreviewFileSurface item={item} onClose={vi.fn()} workbenchConnected />)
+      )
+      if (format === 'text') expect(container.textContent).toContain('body v2')
+      else if (format === 'html') expect(container.querySelector('iframe')?.src).toContain('://v2/')
+      else expect(container.querySelector('img')?.src).toContain('blob:preview-')
+      const previousImageUrl = container.querySelector('img')?.src
+      acquire.mockClear()
+      release.mockClear()
+      head = 3
+      await act(async () => notify({ projectId: 'project-1', sources: [source], kind: 'upsert' }))
+      expect.soft(acquire).toHaveBeenLastCalledWith(expect.objectContaining({ versionId: 'v3' }))
+      expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject(item)
+      expect(
+        (usePreviewWorkbenchStore.getState().items[0] as PreviewFileItem).selectedVersionId
+      ).toBeUndefined()
+      if (format !== 'image')
+        expect.soft(release).toHaveBeenCalledWith({ resourceId: 'resource-v2' })
+      if (format === 'text') expect(container.textContent).toContain('body v3')
+      else if (format === 'html') expect(container.querySelector('iframe')?.src).toContain('://v3/')
+      else expect(container.querySelector('img')?.src).not.toBe(previousImageUrl)
+    }
+  )
+
+  it('keeps historical content and its lease while updating the head', async () => {
+    const item: PreviewFileItem = {
+      id: 'file-1',
+      type: 'file',
+      source,
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      managedFileId: 'file-1',
+      path: 'report',
+      title: 'report.txt',
+      name: 'report.txt',
+      format: 'text',
+      selectedVersionId: 'v2'
+    }
+    await act(async () => root.render(<PreviewFileSurface item={item} onClose={vi.fn()} />))
+    expect(container.textContent).toContain('body v2')
+    acquire.mockClear()
+    release.mockClear()
+    head = 3
+    await act(async () => notify({ projectId: 'project-1', sources: [source], kind: 'upsert' }))
+    expect(container.textContent).toContain('body v2')
+    expect(acquire).not.toHaveBeenCalled()
+    expect(release).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -538,6 +538,156 @@ describe('PreviewFileSurface managed text versions', () => {
       if (change === 'baseline') expect(save.mock.calls[1][0].basedOnVersionId).toBe('upload-v1')
     }
   )
+  it('uses the refreshed head for editing and downloads after same-file metadata changes', async () => {
+    const latestVersion = { ...managedInspect.versions[1], id: 'upload-v3', versionNumber: 3 }
+    const currentItem = { ...managedUploadItem, selectedVersionId: undefined }
+    await act(async () => root.render(<PreviewFileSurface item={currentItem} onClose={vi.fn()} />))
+    window.api.managedFileVersions.inspect = vi.fn().mockResolvedValue({
+      ok: true,
+      value: {
+        ...managedInspect,
+        headVersionId: 'upload-v3',
+        selectedVersionId: 'upload-v3',
+        versions: [...managedInspect.versions, latestVersion],
+        text: '# New head\n'
+      }
+    })
+    await act(async () =>
+      root.render(
+        <PreviewFileSurface
+          item={{ ...currentItem, size: 100, mtimeMs: 3, versionNumber: 3 }}
+          onClose={vi.fn()}
+        />
+      )
+    )
+    expect(downloadButtonSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        versionId: 'upload-v3',
+        latestVersionId: 'upload-v3'
+      })
+    )
+    await click(container.querySelector('[aria-label="Edit README.md"]'))
+    expect(container.querySelector<HTMLTextAreaElement>('textarea')?.value).toBe('# New head\n')
+  })
+
+  it('refreshes the head from parent metadata while keeping a locally selected historical version', async () => {
+    let head = 'upload-v2'
+    window.api.managedFileVersions.inspect = vi.fn<typeof window.api.managedFileVersions.inspect>(
+      async (request) => ({
+        ok: true,
+        value: {
+          ...managedInspect,
+          headVersionId: head,
+          headVersion: {
+            ...managedInspect.versions[1],
+            id: head,
+            versionNumber: head === 'upload-v2' ? 2 : 3
+          },
+          selectedVersionId: request.versionId ?? head
+        }
+      })
+    )
+    const currentItem = { ...managedUploadItem, selectedVersionId: undefined }
+    await act(async () => root.render(<PreviewFileSurface item={currentItem} onClose={vi.fn()} />))
+    await click(container.querySelector('[aria-label="Previous file version"]'))
+    expect(window.api.managedFileVersions.inspect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ versionId: 'upload-v1' })
+    )
+    head = 'upload-v3'
+    await act(async () =>
+      root.render(
+        <PreviewFileSurface
+          item={{ ...currentItem, mtimeMs: 3, versionNumber: 3 }}
+          onClose={vi.fn()}
+        />
+      )
+    )
+    expect(downloadButtonSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        versionId: 'upload-v1',
+        latestVersionId: 'upload-v3'
+      })
+    )
+  })
+
+  it('preserves a draft and its original version baseline when the default file path advances', async () => {
+    const currentItem = { ...managedUploadItem, selectedVersionId: undefined }
+    await act(async () => root.render(<PreviewFileSurface item={currentItem} onClose={vi.fn()} />))
+    await click(container.querySelector('[aria-label="Edit README.md"]'))
+    await changeTextarea(container.querySelector<HTMLTextAreaElement>('textarea')!, '# Draft\n')
+    window.api.managedFileVersions.inspect = vi.fn().mockResolvedValue({
+      ok: true,
+      value: {
+        ...managedInspect,
+        headVersionId: 'upload-v3',
+        selectedVersionId: 'upload-v3',
+        text: '# New head\n'
+      }
+    })
+    window.api.managedFileVersions.saveTextEdit = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { kind: 'conflict', actualHead: managedInspect.versions[1] }
+    })
+    await act(async () =>
+      root.render(
+        <PreviewFileSurface
+          item={{
+            ...currentItem,
+            path: 'upload-version:project-1/session-1/upload-v3',
+            versionNumber: 3
+          }}
+          onClose={vi.fn()}
+        />
+      )
+    )
+    expect(container.querySelector<HTMLTextAreaElement>('textarea')?.value).toBe('# Draft\n')
+    await click(container.querySelector('[aria-label="Save changes"]'))
+    expect(window.api.managedFileVersions.saveTextEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        basedOnVersionId: 'upload-v2',
+        expectedHeadVersionId: 'upload-v2',
+        content: '# Draft\n'
+      })
+    )
+  })
+
+  it('retains draft controls but disables saving during external reinspection and after deletion', async () => {
+    let notify!: Parameters<typeof window.api.projectFiles.onChanged>[0]
+    window.api.projectFiles = {
+      ...window.api.projectFiles,
+      onChanged: vi.fn((listener) => {
+        notify = listener
+        return vi.fn()
+      })
+    }
+    await act(async () =>
+      root.render(<PreviewFileSurface item={managedUploadItem} onClose={vi.fn()} />)
+    )
+    await click(container.querySelector('[aria-label="Edit README.md"]'))
+    await changeTextarea(container.querySelector<HTMLTextAreaElement>('textarea')!, '# Draft\n')
+    type Result = Awaited<ReturnType<typeof window.api.managedFileVersions.inspect>>
+    let resolveInspect!: (value: Result) => void
+    window.api.managedFileVersions.inspect = vi.fn(
+      () =>
+        new Promise<Result>((resolve) => {
+          resolveInspect = resolve
+        })
+    )
+    await act(async () => notify?.({ projectId: 'project-1', sources: ['upload'], kind: 'delete' }))
+    const saveButton = (): HTMLButtonElement | null =>
+      container.querySelector<HTMLButtonElement>('[aria-label="Save changes"]')
+    expect(saveButton()?.disabled).toBe(true)
+    expect(container.querySelector<HTMLTextAreaElement>('textarea')?.value).toBe('# Draft\n')
+    await act(async () =>
+      resolveInspect({
+        ok: true,
+        value: { ...managedInspect, canEdit: false, unavailableReason: 'FILE_DELETED' }
+      })
+    )
+    expect(saveButton()?.disabled).toBe(true)
+    await click(saveButton())
+    expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
+  })
 
   it.each(['plot.png', 'report.pdf', 'README.md'])(
     'offers older history for %s only alongside a version navigator',

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -538,6 +538,64 @@ describe('PreviewFileSurface managed text versions', () => {
       if (change === 'baseline') expect(save.mock.calls[1][0].basedOnVersionId).toBe('upload-v1')
     }
   )
+  it.each(['upload', 'artifact'] as const)(
+    'links the confirmed %s PDF version after a head-only refresh',
+    async (source) => {
+      selectPdfContextSession()
+      const { linkPdfContext } = installPdfContextApi()
+      let notify!: Parameters<typeof window.api.projectFiles.onChanged>[0]
+      window.api.projectFiles = {
+        ...window.api.projectFiles,
+        onChanged: vi.fn((listener) => {
+          notify = listener
+          return vi.fn()
+        })
+      }
+      let head = 'upload-v2'
+      window.api.managedFileVersions.inspect = vi.fn(async () => ({
+        ok: true as const,
+        value: {
+          ...managedInspect,
+          source,
+          headVersionId: head,
+          selectedVersionId: head,
+          versions: managedInspect.versions.map((version, index) => ({
+            ...version,
+            source,
+            id: index === 1 ? head : version.id,
+            versionNumber: index === 1 && head === 'upload-v3' ? 3 : version.versionNumber,
+            displayName: 'paper.pdf'
+          }))
+        }
+      }))
+      const pdfItem: PreviewFileItem = {
+        ...managedUploadItem,
+        source,
+        format: 'pdf',
+        name: 'paper.pdf',
+        title: 'paper.pdf',
+        selectedVersionId: undefined,
+        artifactId: source === 'artifact' ? 'upload-file-1' : undefined,
+        path: `${source === 'upload' ? 'upload-version' : 'artifact-version'}:project-1/session-1/upload-file-1/upload-v2`
+      }
+      await act(async () => root.render(<PreviewFileSurface item={pdfItem} onClose={vi.fn()} />))
+      head = 'upload-v3'
+      await act(async () => notify({ projectId: 'project-1', sources: [source], kind: 'upsert' }))
+      await clickHeaderAction('Read with agent')
+      expect(linkPdfContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sources: [
+            {
+              sourceKind: `${source}-version`,
+              sourceFileId: 'upload-file-1',
+              sourceVersionId: 'upload-v3'
+            }
+          ]
+        })
+      )
+    }
+  )
+
   it('uses the refreshed head for editing and downloads after same-file metadata changes', async () => {
     const latestVersion = { ...managedInspect.versions[1], id: 'upload-v3', versionNumber: 3 }
     const currentItem = { ...managedUploadItem, selectedVersionId: undefined }
@@ -931,7 +989,7 @@ describe('PreviewFileSurface managed text versions', () => {
       expect.objectContaining({
         annotationVersionId: 'artifact-v2',
         item: expect.objectContaining({
-          path: '/stale/managed-file-projection.md',
+          path: 'artifact-version:project-1/session-1/artifact-1/artifact-v2',
           selectedVersionId: 'artifact-v2'
         })
       })

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -651,43 +651,61 @@ describe('PreviewFileSurface managed text versions', () => {
     )
   })
 
-  it('retains draft controls but disables saving during external reinspection and after deletion', async () => {
-    let notify!: Parameters<typeof window.api.projectFiles.onChanged>[0]
-    window.api.projectFiles = {
-      ...window.api.projectFiles,
-      onChanged: vi.fn((listener) => {
-        notify = listener
-        return vi.fn()
-      })
-    }
-    await act(async () =>
-      root.render(<PreviewFileSurface item={managedUploadItem} onClose={vi.fn()} />)
-    )
-    await click(container.querySelector('[aria-label="Edit README.md"]'))
-    await changeTextarea(container.querySelector<HTMLTextAreaElement>('textarea')!, '# Draft\n')
-    type Result = Awaited<ReturnType<typeof window.api.managedFileVersions.inspect>>
-    let resolveInspect!: (value: Result) => void
-    window.api.managedFileVersions.inspect = vi.fn(
-      () =>
-        new Promise<Result>((resolve) => {
-          resolveInspect = resolve
+  it.each([true, false])(
+    'retains draft controls during reinspection and after deletion (text available: %s)',
+    async (hasText) => {
+      let notify!: Parameters<typeof window.api.projectFiles.onChanged>[0]
+      window.api.projectFiles = {
+        ...window.api.projectFiles,
+        onChanged: vi.fn((listener) => {
+          notify = listener
+          return vi.fn()
         })
-    )
-    await act(async () => notify?.({ projectId: 'project-1', sources: ['upload'], kind: 'delete' }))
-    const saveButton = (): HTMLButtonElement | null =>
-      container.querySelector<HTMLButtonElement>('[aria-label="Save changes"]')
-    expect(saveButton()?.disabled).toBe(true)
-    expect(container.querySelector<HTMLTextAreaElement>('textarea')?.value).toBe('# Draft\n')
-    await act(async () =>
-      resolveInspect({
-        ok: true,
-        value: { ...managedInspect, canEdit: false, unavailableReason: 'FILE_DELETED' }
-      })
-    )
-    expect(saveButton()?.disabled).toBe(true)
-    await click(saveButton())
-    expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
-  })
+      }
+      await act(async () =>
+        root.render(<PreviewFileSurface item={managedUploadItem} onClose={vi.fn()} />)
+      )
+      await click(container.querySelector('[aria-label="Edit README.md"]'))
+      await changeTextarea(container.querySelector<HTMLTextAreaElement>('textarea')!, '# Draft\n')
+      type Result = Awaited<ReturnType<typeof window.api.managedFileVersions.inspect>>
+      let resolveInspect!: (value: Result) => void
+      window.api.managedFileVersions.inspect = vi.fn(
+        () =>
+          new Promise<Result>((resolve) => {
+            resolveInspect = resolve
+          })
+      )
+      await act(async () =>
+        notify?.({ projectId: 'project-1', sources: ['upload'], kind: 'delete' })
+      )
+      const saveButton = (): HTMLButtonElement | null =>
+        container.querySelector<HTMLButtonElement>('[aria-label="Save changes"]')
+      expect(saveButton()?.disabled).toBe(true)
+      expect(container.querySelector<HTMLTextAreaElement>('textarea')?.value).toBe('# Draft\n')
+      await act(async () =>
+        resolveInspect({
+          ok: true,
+          value: {
+            ...managedInspect,
+            canEdit: false,
+            canDiff: false,
+            text: hasText ? managedInspect.text : undefined,
+            unavailableReason: 'FILE_DELETED'
+          }
+        })
+      )
+      expect(saveButton()?.disabled).toBe(true)
+      await click(saveButton())
+      expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
+      const cancel = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Cancel'
+      )
+      await click(cancel ?? null)
+      expect(
+        document.body.querySelector('[data-testid="discard-preview-changes-confirmation"]')
+      ).not.toBeNull()
+    }
+  )
 
   it.each(['plot.png', 'report.pdf', 'README.md'])(
     'offers older history for %s only alongside a version navigator',
@@ -914,7 +932,7 @@ describe('PreviewFileSurface managed text versions', () => {
         annotationVersionId: 'artifact-v2',
         item: expect.objectContaining({
           path: '/stale/managed-file-projection.md',
-          selectedVersionId: undefined
+          selectedVersionId: 'artifact-v2'
         })
       })
     )

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -715,6 +715,13 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
       navigationInspect: managedNavigationInspect,
       controlsInspect: managedControlsInspect
     } = managedWorkflow
+    // Remount resource-owning renderers when the confirmed selection advances. Historical
+    // selections keep their lease, and pending inspections retain the last confirmed content.
+    const previewContentKey = JSON.stringify([
+      contentKey,
+      previewItem.selectedVersionId ?? managedNavigationInspect?.selectedVersionId,
+      reloadToken
+    ])
     // Managed files accept annotations only after inspection confirms the logical DB head.
     const annotationVersionPending = managedIdentity !== undefined && managedInspect === undefined
     const annotationBlockedByHistoricalVersion =
@@ -800,6 +807,12 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
             projectId
           })
         : previewItem
+    // Bind byte reads and shared renderer caches to the confirmed immutable selection without
+    // pinning the workbench tab, which must keep following future head notifications.
+    const contentItem =
+      managedNavigationInspect && !previewItem.selectedVersionId
+        ? { ...resolvedPreviewItem, selectedVersionId: managedNavigationInspect.selectedVersionId }
+        : resolvedPreviewItem
     const { action: pdfContextAction, readingContextBindingId } = usePdfContextAction(
       resolvedPreviewItem,
       onPdfContextError,
@@ -1365,96 +1378,92 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                 downloadVersionContext={managedWorkflow.downloadVersionContext}
                 managedControlsOnly={mode === 'edit'}
                 managedControls={
-                  managedWorkflow.showTextTools && managedControlsInspect ? (
-                    mode === 'edit' ? (
-                      <div className="flex h-7 shrink-0 items-center gap-1">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="text-text-000 hover:text-text-000"
-                          onClick={() => {
-                            requestLeave(() => {
-                              invalidateSave()
-                              setMode('view')
-                              setDraft('')
-                              setEditBaseline(undefined)
-                            })
-                          }}
-                        >
-                          {t('Cancel')}
-                        </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          aria-label={t('Save changes')}
-                          disabled={!isDirty || saving || !managedInspect?.canEdit}
-                          onClick={() => void saveEdit()}
-                        >
-                          {t('Save')}
-                        </Button>
-                      </div>
-                    ) : (
-                      <>
-                        {managedInspect?.canEdit ? (
-                          <TooltipProvider delayDuration={200}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon-xs"
-                                  className={previewHeaderActionClassName}
-                                  aria-label={t('Edit {{name}}', {
-                                    name: resolvedPreviewItem.name
-                                  })}
-                                  onClick={beginEdit}
-                                >
-                                  <Pencil aria-hidden="true" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent className={tooltipClassName}>
-                                {t('Edit content')}
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ) : null}
+                  mode === 'edit' ? (
+                    <div className="flex h-7 shrink-0 items-center gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-text-000 hover:text-text-000"
+                        onClick={() => {
+                          requestLeave(() => {
+                            invalidateSave()
+                            setMode('view')
+                            setDraft('')
+                            setEditBaseline(undefined)
+                          })
+                        }}
+                      >
+                        {t('Cancel')}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        aria-label={t('Save changes')}
+                        disabled={!isDirty || saving || !managedInspect?.canEdit}
+                        onClick={() => void saveEdit()}
+                      >
+                        {t('Save')}
+                      </Button>
+                    </div>
+                  ) : managedWorkflow.showTextTools && managedControlsInspect ? (
+                    <>
+                      {managedInspect?.canEdit ? (
                         <TooltipProvider delayDuration={200}>
                           <Tooltip>
                             <TooltipTrigger asChild>
                               <Button
                                 type="button"
-                                variant={mode === 'diff' ? 'default' : 'ghost'}
+                                variant="ghost"
                                 size="icon-xs"
-                                className={
-                                  mode === 'diff' ? undefined : previewHeaderActionClassName
-                                }
-                                aria-label={
-                                  mode === 'diff'
-                                    ? t('Stop comparing {{name}}', {
-                                        name: resolvedPreviewItem.name
-                                      })
-                                    : t('Compare {{name}} with its source version', {
-                                        name: resolvedPreviewItem.name
-                                      })
-                                }
-                                disabled={mode !== 'diff' && !managedControlsInspect.canDiff}
-                                onClick={toggleDiff}
+                                className={previewHeaderActionClassName}
+                                aria-label={t('Edit {{name}}', {
+                                  name: resolvedPreviewItem.name
+                                })}
+                                onClick={beginEdit}
                               >
-                                <FileDiff aria-hidden="true" />
+                                <Pencil aria-hidden="true" />
                               </Button>
                             </TooltipTrigger>
                             <TooltipContent className={tooltipClassName}>
-                              {mode === 'diff'
-                                ? t('Stop comparing {{name}}', { name: resolvedPreviewItem.name })
-                                : managedControlsInspect.canDiff
-                                  ? t('Compare with source version')
-                                  : t('No source version to compare')}
+                              {t('Edit content')}
                             </TooltipContent>
                           </Tooltip>
                         </TooltipProvider>
-                      </>
-                    )
+                      ) : null}
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant={mode === 'diff' ? 'default' : 'ghost'}
+                              size="icon-xs"
+                              className={mode === 'diff' ? undefined : previewHeaderActionClassName}
+                              aria-label={
+                                mode === 'diff'
+                                  ? t('Stop comparing {{name}}', {
+                                      name: resolvedPreviewItem.name
+                                    })
+                                  : t('Compare {{name}} with its source version', {
+                                      name: resolvedPreviewItem.name
+                                    })
+                              }
+                              disabled={mode !== 'diff' && !managedControlsInspect.canDiff}
+                              onClick={toggleDiff}
+                            >
+                              <FileDiff aria-hidden="true" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent className={tooltipClassName}>
+                            {mode === 'diff'
+                              ? t('Stop comparing {{name}}', { name: resolvedPreviewItem.name })
+                              : managedControlsInspect.canDiff
+                                ? t('Compare with source version')
+                                : t('No source version to compare')}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </>
                   ) : undefined
                 }
               />
@@ -1579,8 +1588,8 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                     managedWorkflow.isSelectedSourceText ? (
                       renderContent ? (
                         <PreviewFileContent
-                          key={`${contentKey ?? ''}:${previewItem.selectedVersionId ?? ''}:${reloadToken}`}
-                          item={resolvedPreviewItem}
+                          key={previewContentKey}
+                          item={contentItem}
                           downloadVersionContext={managedWorkflow.downloadVersionContext}
                           annotationVersionId={annotationVersionId}
                           annotationBlockedByHistoricalVersion={
@@ -1613,8 +1622,8 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                     )
                   ) : renderContent ? (
                     <PreviewFileContent
-                      key={`${contentKey ?? ''}:${previewItem.selectedVersionId ?? ''}:${reloadToken}`}
-                      item={resolvedPreviewItem}
+                      key={previewContentKey}
+                      item={contentItem}
                       downloadVersionContext={managedWorkflow.downloadVersionContext}
                       annotationVersionId={annotationVersionId}
                       annotationBlockedByHistoricalVersion={annotationBlockedByHistoricalVersion}

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -670,6 +670,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
     const [editBaseline, setEditBaseline] = useState<{
       text: string
       expectedHeadVersionId: string
+      basedOnVersionId: string
     }>()
     const [saving, setSaving] = useState(false)
     const [editError, setEditError] = useState<string>()
@@ -695,12 +696,14 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
         : undefined
     )
     const sourceItem = storedItem?.type === 'file' ? storedItem : item
-    const itemIdentityKey = `${sourceItem.projectId ?? ''}:${sourceItem.source ?? 'artifact'}:${sourceItem.id}:${sourceItem.managedFileId ?? ''}:${sourceItem.artifactId ?? ''}:${sourceItem.selectedVersionId ?? ''}:${sourceItem.path}`
+    // Managed paths advance with the head; only logical file/selection changes discard a draft.
+    const itemIdentityKey = `${sourceItem.projectId ?? ''}:${sourceItem.source ?? 'artifact'}:${sourceItem.id}:${sourceItem.managedFileId ?? ''}:${sourceItem.artifactId ?? ''}:${sourceItem.selectedVersionId ?? ''}:${sourceItem.managedFileId ? '' : sourceItem.path}`
     const previewItem = versionOverride?.key === itemIdentityKey ? versionOverride.item : sourceItem
     const projectId = previewItem.projectId ?? activeProjectId
     const previewIdentityKey = `${previewItem.projectId ?? ''}:${previewItem.source ?? 'artifact'}:${previewItem.id}:${previewItem.managedFileId ?? ''}:${previewItem.artifactId ?? ''}:${previewItem.selectedVersionId ?? ''}:${previewItem.path}`
     const managedWorkflow = useManagedVersionWorkflow({
       item: previewItem,
+      sourceItem,
       projectId,
       mode,
       setMode,
@@ -1011,7 +1014,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
           applyVersionItem(nextItem, true, onApplied)
         })
       }
-      const nextIdentityKey = `${nextItem.projectId ?? ''}:${nextItem.source ?? 'artifact'}:${nextItem.id}:${nextItem.managedFileId ?? ''}:${nextItem.artifactId ?? ''}:${nextItem.selectedVersionId ?? ''}:${nextItem.path}`
+      const nextIdentityKey = `${nextItem.projectId ?? ''}:${nextItem.source ?? 'artifact'}:${nextItem.id}:${nextItem.managedFileId ?? ''}:${nextItem.artifactId ?? ''}:${nextItem.selectedVersionId ?? ''}:${nextItem.managedFileId ? '' : nextItem.path}`
       if (workbenchConnected) {
         acceptedIdentityTransitionRef.current = nextIdentityKey
         if (!usePreviewWorkbenchStore.getState().upsertItem(nextItem, true)) {
@@ -1150,7 +1153,8 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
       setDraft(managedInspect.text)
       setEditBaseline({
         text: managedInspect.text,
-        expectedHeadVersionId: managedInspect.headVersionId
+        expectedHeadVersionId: managedInspect.headVersionId,
+        basedOnVersionId: managedInspect.selectedVersionId
       })
       setEditError(undefined)
       setConflictHead(undefined)
@@ -1160,7 +1164,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
     const saveEdit = async (): Promise<void> => {
       if (
         !managedIdentity ||
-        !managedInspect ||
+        !managedInspect?.canEdit ||
         !editBaseline ||
         draft === editBaseline.text ||
         saving
@@ -1179,13 +1183,13 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
           previous.source !== managedIdentity.source ||
           previous.projectId !== managedIdentity.projectId ||
           previous.fileId !== managedIdentity.fileId ||
-          previous.basedOnVersionId !== managedInspect.selectedVersionId ||
+          previous.basedOnVersionId !== editBaseline.basedOnVersionId ||
           previous.expectedHeadVersionId !== editBaseline.expectedHeadVersionId ||
           previous.content !== draft
         ) {
           pendingSaveRef.current = {
             ...managedIdentity,
-            basedOnVersionId: managedInspect.selectedVersionId,
+            basedOnVersionId: editBaseline.basedOnVersionId,
             expectedHeadVersionId: editBaseline.expectedHeadVersionId,
             content: draft,
             operationId: crypto.randomUUID()
@@ -1384,7 +1388,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                           type="button"
                           size="sm"
                           aria-label={t('Save changes')}
-                          disabled={!isDirty || saving}
+                          disabled={!isDirty || saving || !managedInspect?.canEdit}
                           onClick={() => void saveEdit()}
                         >
                           {t('Save')}

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -809,12 +809,22 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
         : previewItem
     // Bind byte reads and shared renderer caches to the confirmed immutable selection without
     // pinning the workbench tab, which must keep following future head notifications.
+    const contentVersion =
+      managedNavigationInspect?.selectedVersion ??
+      managedNavigationInspect?.versions.find(
+        (version) => version.id === managedNavigationInspect.selectedVersionId
+      )
     const contentItem =
-      managedNavigationInspect && !previewItem.selectedVersionId
-        ? { ...resolvedPreviewItem, selectedVersionId: managedNavigationInspect.selectedVersionId }
+      managedNavigationInspect && contentVersion && !previewItem.selectedVersionId
+        ? createPreviewFileItemForManagedVersion({
+            item: resolvedPreviewItem,
+            version: contentVersion,
+            projectId: managedNavigationInspect.projectId,
+            sessionId: managedNavigationInspect.sessionId
+          })
         : resolvedPreviewItem
     const { action: pdfContextAction, readingContextBindingId } = usePdfContextAction(
-      resolvedPreviewItem,
+      contentItem,
       onPdfContextError,
       { link: onLinkReadingContext, unlink: onUnlinkReadingContext }
     )

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
@@ -10,6 +10,7 @@ import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 import type { ProjectFilesChangedEvent } from '../../../../shared/project-files'
 import type {
   ManagedFileSource,
+  ManagedFileVersionDiffResult,
   ManagedFileVersionInspectResult,
   ManagedFileVersionIpcResult
 } from '../../../../shared/managed-file-versions'
@@ -420,5 +421,124 @@ it.each(['error', 'reject'] as const)(
     expect(workflow.inspect).toBeUndefined()
     // The pending refresh must retain Stop comparing; an obsolete failure must not leave diff mode.
     expect(workflow.controlsInspect?.headVersionId).toBe('v2')
+  }
+)
+
+it.each(['notification', 'metadata'] as const)(
+  'withholds the old diff until the refreshed head comparison completes after a %s',
+  async (trigger) => {
+    const oldDiff: ManagedFileVersionDiffResult = {
+      baseVersionId: 'v1',
+      selectedVersionId: 'v2',
+      lines: []
+    }
+    const newDiff: ManagedFileVersionDiffResult = {
+      baseVersionId: 'v2',
+      selectedVersionId: 'v3',
+      lines: []
+    }
+    let resolveInspect!: (value: InspectResult) => void
+    let resolveDiff!: (value: ManagedFileVersionIpcResult<ManagedFileVersionDiffResult>) => void
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot('upload', 2) })
+    inspect.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveInspect = resolve
+      })
+    )
+    window.api.managedFileVersions.diffText = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, value: oldDiff })
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveDiff = resolve
+        })
+      )
+    window.api.managedFileVersions.cancelDiff = vi
+      .fn()
+      .mockResolvedValue({ ok: true, value: { cancelled: true } })
+    const item = itemFor('upload')
+    await render(item)
+    await act(async () => workflow.startDiff())
+    expect(workflow.diffResult).toEqual(oldDiff)
+
+    if (trigger === 'notification') await changed('upload')
+    else await render({ ...item, mtimeMs: 3, versionNumber: 3 })
+    expect.soft(workflow.diffResult).toBeUndefined()
+    expect(workflow.navigationInspect?.headVersionId).toBe('v2')
+    await act(async () => resolveInspect({ ok: true, value: snapshot('upload', 3) }))
+    expect.soft(workflow.diffResult).toBeUndefined()
+    expect(workflow.inspect?.headVersionId).toBe('v3')
+    await act(async () => resolveDiff({ ok: true, value: newDiff }))
+    expect(workflow.diffResult).toEqual(newDiff)
+  }
+)
+
+it('withholds an old diff error while rechecking and comparing the current version', async () => {
+  inspect.mockResolvedValue({ ok: true, value: snapshot('upload', 2) })
+  window.api.managedFileVersions.diffText = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('old comparison failed'))
+    .mockReturnValue(new Promise(() => undefined))
+  window.api.managedFileVersions.cancelDiff = vi
+    .fn()
+    .mockResolvedValue({ ok: true, value: { cancelled: true } })
+  await render(itemFor('upload'))
+  await act(async () => workflow.startDiff())
+  expect(workflow.diffError).toBeDefined()
+  await changed('upload')
+  expect(workflow.diffError).toBeUndefined()
+})
+
+it.each(['success', 'error', 'reject'] as const)(
+  'ignores an obsolete diff %s arriving with a file notification before React commits',
+  async (outcome) => {
+    inspect.mockResolvedValue({ ok: true, value: snapshot('upload', 2) })
+    let resolveOld!: (value: ManagedFileVersionIpcResult<ManagedFileVersionDiffResult>) => void
+    let rejectOld!: (error: Error) => void
+    let resolveLatest!: (value: ManagedFileVersionIpcResult<ManagedFileVersionDiffResult>) => void
+    window.api.managedFileVersions.diffText = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise((resolve, reject) => {
+          resolveOld = resolve
+          rejectOld = reject
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveLatest = resolve
+        })
+      )
+    window.api.managedFileVersions.cancelDiff = vi
+      .fn()
+      .mockResolvedValue({ ok: true, value: { cancelled: true } })
+    await render(itemFor('upload'))
+    await act(async () => workflow.startDiff())
+    const oldRequest = vi.mocked(window.api.managedFileVersions.diffText).mock.calls[0][0]
+    const result: ManagedFileVersionDiffResult = {
+      baseVersionId: 'v1',
+      selectedVersionId: 'v2',
+      lines: []
+    }
+    await act(async () => {
+      for (const listener of changedListeners) {
+        listener({ projectId: 'project-1', sources: ['upload'], kind: 'upsert' })
+      }
+      if (outcome === 'success') resolveOld({ ok: true, value: result })
+      else if (outcome === 'error')
+        resolveOld({
+          ok: false,
+          error: { code: 'STORAGE_UNAVAILABLE', message: 'obsolete failure' }
+        })
+      else rejectOld(new Error('obsolete failure'))
+      await Promise.resolve()
+    })
+    expect(workflow.diffResult).toBeUndefined()
+    expect(workflow.diffError).toBeUndefined()
+    expect(window.api.managedFileVersions.cancelDiff).toHaveBeenCalledWith({
+      requestId: oldRequest.requestId
+    })
+    await act(async () => resolveLatest({ ok: true, value: result }))
+    expect(workflow.diffResult).toEqual(result)
   }
 )

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
@@ -1,0 +1,388 @@
+// @vitest-environment jsdom
+import { act, useLayoutEffect, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18next } from '@/i18n'
+import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
+import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+import type { ProjectFilesChangedEvent } from '../../../../shared/project-files'
+import type {
+  ManagedFileSource,
+  ManagedFileVersionInspectResult,
+  ManagedFileVersionIpcResult
+} from '../../../../shared/managed-file-versions'
+import { useManagedVersionWorkflow, type ManagedVersionMode } from './useManagedVersionWorkflow'
+
+type InspectResult = ManagedFileVersionIpcResult<ManagedFileVersionInspectResult>
+let root: Root
+let container: HTMLDivElement
+let workflow: ReturnType<typeof useManagedVersionWorkflow>
+let changedListeners: Set<(event: ProjectFilesChangedEvent) => void>
+const inspect = vi.fn<(request: unknown) => Promise<InspectResult>>()
+
+function Harness({ item }: { item: PreviewFileItem }): null {
+  const [mode, setMode] = useState<ManagedVersionMode>('view')
+  const current = useManagedVersionWorkflow({
+    item,
+    projectId: item.projectId,
+    mode,
+    setMode,
+    t: i18next.t
+  })
+  useLayoutEffect(() => {
+    workflow = current
+  })
+  return null
+}
+
+const render = async (item: PreviewFileItem): Promise<void> => {
+  await act(async () => root.render(<Harness item={item} />))
+}
+
+const itemFor = (source: ManagedFileSource): PreviewFileItem => ({
+  id: `${source}:file-1`,
+  type: 'file',
+  source,
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  managedFileId: 'file-1',
+  title: 'report.md',
+  name: 'report.md',
+  format: 'markdown',
+  path: 'versions/v1/report.md',
+  size: 10,
+  mtimeMs: 1,
+  versionNumber: 1
+})
+
+function snapshot(
+  source: ManagedFileSource,
+  head: number,
+  selected = head
+): ManagedFileVersionInspectResult {
+  const versions = Array.from({ length: head }, (_, index) => ({
+    id: `v${index + 1}`,
+    source,
+    fileId: 'file-1',
+    versionNumber: index + 1,
+    displayName: 'report.md',
+    originKind: 'user_edit' as const,
+    basedOnVersionId: index === 0 ? null : `v${index}`,
+    contentType: 'text/markdown',
+    sizeBytes: 10 + index,
+    checksum: `checksum-${index}`,
+    createdAt: '2026-09-05T00:00:00.000Z'
+  }))
+  return {
+    source,
+    projectId: 'project-1',
+    fileId: 'file-1',
+    sessionId: 'session-1',
+    displayName: 'report.md',
+    headVersionId: `v${head}`,
+    selectedVersionId: `v${selected}`,
+    versions,
+    selectedVersion: versions[selected - 1],
+    headVersion: versions[head - 1],
+    canEdit: true,
+    canDiff: selected > 1,
+    text: `text v${selected}`
+  }
+}
+
+const changed = async (
+  source: ManagedFileSource,
+  kind: 'upsert' | 'delete' = 'upsert'
+): Promise<void> => {
+  await act(async () => {
+    for (const listener of changedListeners) {
+      listener({ projectId: 'project-1', sessionId: 'session-1', sources: [source], kind })
+    }
+  })
+}
+
+beforeEach(() => {
+  inspect.mockReset()
+  useProjectStore.setState(createInitialProjectState())
+  useSessionStore.setState(createInitialSessionState())
+  changedListeners = new Set()
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  vi.stubGlobal('api', undefined)
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      managedFileVersions: { inspect },
+      projectFiles: {
+        onChanged: (listener: (event: ProjectFilesChangedEvent) => void) => {
+          changedListeners.add(listener)
+          return () => changedListeners.delete(listener)
+        }
+      }
+    }
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.unstubAllGlobals()
+})
+
+describe.each(['upload', 'artifact'] as const)('%s version inspection freshness', (source) => {
+  it('refreshes the head, editable text and download context when the same file metadata changes', async () => {
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot(source, 1) })
+    inspect.mockResolvedValue({ ok: true, value: snapshot(source, 2) })
+    const item = itemFor(source)
+    await render(item)
+    expect(workflow.inspect?.headVersionId).toBe('v1')
+    await render({ ...item, path: 'versions/v2/report.md', size: 11, mtimeMs: 2, versionNumber: 2 })
+
+    expect.soft(inspect).toHaveBeenCalledTimes(2)
+    expect.soft(workflow.inspect?.headVersionId).toBe('v2')
+    expect.soft(workflow.controlsInspect?.text).toBe('text v2')
+    expect.soft(workflow.downloadVersionContext?.latestVersionId).toBe('v2')
+  })
+
+  it('refreshes on a file notification while preserving an explicitly selected historical version', async () => {
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot(source, 1) })
+    inspect.mockResolvedValue({ ok: true, value: snapshot(source, 2, 1) })
+    await render({ ...itemFor(source), selectedVersionId: 'v1' })
+    await changed(source)
+
+    expect.soft(workflow.inspect?.headVersionId).toBe('v2')
+    expect.soft(workflow.inspect?.selectedVersionId).toBe('v1')
+    expect.soft(workflow.downloadVersionContext?.latestVersionId).toBe('v2')
+    expect.soft(inspect).toHaveBeenLastCalledWith(expect.objectContaining({ versionId: 'v1' }))
+  })
+
+  it('withdraws stale write capability when the source is deleted', async () => {
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot(source, 1) })
+    inspect.mockResolvedValue({
+      ok: true,
+      value: { ...snapshot(source, 1), canEdit: false, unavailableReason: 'FILE_DELETED' }
+    })
+    await render(itemFor(source))
+    expect(workflow.controlsInspect?.canEdit).toBe(true)
+    await changed(source, 'delete')
+
+    expect(workflow.controlsInspect?.canEdit).not.toBe(true)
+  })
+
+  it('keeps confirmed navigation but withholds stale editable text while metadata reinspection is pending', async () => {
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot(source, 1) })
+    inspect.mockReturnValue(new Promise(() => undefined))
+    const item = itemFor(source)
+    await render(item)
+    await render({ ...item, mtimeMs: 2 })
+
+    expect(workflow.navigationInspect?.headVersionId).toBe('v1')
+    expect(workflow.inspect).toBeUndefined()
+    expect(workflow.controlsInspect).toBeUndefined()
+  })
+
+  it('does not accept an old in-flight inspection after a newer file notification', async () => {
+    let resolveOld!: (result: InspectResult) => void
+    inspect.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveOld = resolve
+      })
+    )
+    inspect.mockResolvedValue({ ok: true, value: snapshot(source, 2) })
+    await render(itemFor(source))
+    await changed(source)
+    await act(async () => resolveOld({ ok: true, value: snapshot(source, 1) }))
+
+    expect(workflow.inspect?.headVersionId).toBe('v2')
+  })
+
+  it('refreshes write capability when origin lifecycle metadata changes', async () => {
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot(source, 1) })
+    inspect.mockResolvedValue({
+      ok: true,
+      value: { ...snapshot(source, 1), canEdit: false, unavailableReason: 'FILE_DELETED' }
+    })
+    const item = itemFor(source)
+    await render({ ...item, originSession: { state: 'active' } })
+    await render({ ...item, originSession: { state: 'deleted' } })
+
+    expect(workflow.controlsInspect?.canEdit).not.toBe(true)
+  })
+
+  it('refreshes write capability when the project is archived with the hook still mounted', async () => {
+    const project = {
+      id: 'project-1',
+      name: 'Research',
+      description: '',
+      isExample: false,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    useProjectStore.getState().upsertProject(project)
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot(source, 1) })
+    inspect.mockResolvedValue({
+      ok: true,
+      value: { ...snapshot(source, 1), canEdit: false, unavailableReason: 'PROJECT_NOT_WRITABLE' }
+    })
+    await render(itemFor(source))
+    await act(async () => {
+      useProjectStore.getState().upsertProject({ ...project, archivedAt: 2, updatedAt: 2 })
+    })
+
+    expect(workflow.controlsInspect?.canEdit).not.toBe(true)
+  })
+
+  it('already rejects an old response after explicit refresh (control)', async () => {
+    let resolveOld!: (result: InspectResult) => void
+    inspect.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveOld = resolve
+      })
+    )
+    inspect.mockResolvedValue({ ok: true, value: snapshot(source, 2) })
+    await render(itemFor(source))
+    await act(async () => workflow.refreshInspect())
+    await act(async () => resolveOld({ ok: true, value: snapshot(source, 1) }))
+
+    expect(workflow.inspect?.headVersionId).toBe('v2')
+  })
+})
+
+it('refreshes managed artifact inspection when the owning session filesRevision increases', async () => {
+  const session = {
+    id: 'session-1',
+    projectId: 'project-1',
+    title: 'Research',
+    cwd: '.',
+    status: 'idle' as const,
+    messages: [],
+    filesRevision: 1,
+    createdAt: 1,
+    updatedAt: 1
+  }
+  useSessionStore.setState({ sessions: [session] })
+  inspect.mockResolvedValueOnce({ ok: true, value: snapshot('artifact', 1) })
+  inspect.mockResolvedValue({ ok: true, value: snapshot('artifact', 2) })
+  await render(itemFor('artifact'))
+  await act(async () => {
+    useSessionStore.setState({ sessions: [{ ...session, filesRevision: 2, updatedAt: 2 }] })
+  })
+
+  expect(workflow.inspect?.headVersionId).toBe('v2')
+})
+
+it.each([{ path: 'versions/v2/report.md' }, { size: 11 }, { mtimeMs: 2 }, { versionNumber: 2 }])(
+  'invalidates when only metadata %j changes',
+  async (metadata) => {
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot('upload', 1) })
+    inspect.mockResolvedValue({ ok: true, value: snapshot('upload', 2) })
+    const item = itemFor('upload')
+    await render(item)
+    await render({ ...item, ...metadata })
+    expect(workflow.inspect?.headVersionId).toBe('v2')
+  }
+)
+
+it('filters unrelated changes, handles project resets, and cleans up when the managed identity leaves', async () => {
+  inspect.mockResolvedValue({ ok: true, value: snapshot('artifact', 1) })
+  const item = itemFor('artifact')
+  await render(item)
+  expect(changedListeners.size).toBe(1)
+  await act(async () => {
+    for (const listener of changedListeners) {
+      listener({ projectId: 'other', sources: ['artifact'], kind: 'reset' })
+      listener({ projectId: 'project-1', sources: ['upload'], kind: 'upsert' })
+      listener({
+        projectId: 'project-1',
+        sessionId: 'other',
+        sources: ['artifact'],
+        kind: 'upsert'
+      })
+    }
+  })
+  await render({ ...item })
+  expect(inspect).toHaveBeenCalledTimes(1)
+  await act(async () => {
+    for (const listener of changedListeners) {
+      listener({ projectId: 'project-1', sessionId: 'other', sources: [], kind: 'reset' })
+    }
+  })
+  expect(inspect).toHaveBeenCalledTimes(2)
+  await render({ ...item, managedFileId: undefined })
+  expect(changedListeners.size).toBe(0)
+  expect(workflow.inspect).toBeUndefined()
+})
+
+it('keeps inspection unconfirmed when a notification and an old response arrive before React commits', async () => {
+  let resolveOld!: (value: InspectResult) => void
+  let resolveLatest!: (value: InspectResult) => void
+  inspect.mockReturnValueOnce(
+    new Promise((resolve) => {
+      resolveOld = resolve
+    })
+  )
+  inspect.mockReturnValueOnce(
+    new Promise((resolve) => {
+      resolveLatest = resolve
+    })
+  )
+  await render(itemFor('upload'))
+  await act(async () => {
+    for (const listener of changedListeners) {
+      listener({ projectId: 'project-1', sources: ['upload'], kind: 'upsert' })
+    }
+    resolveOld({ ok: true, value: snapshot('upload', 1) })
+    await Promise.resolve()
+  })
+  expect(workflow.inspect).toBeUndefined()
+  await act(async () => resolveLatest({ ok: true, value: snapshot('upload', 2) }))
+  expect(workflow.inspect?.headVersionId).toBe('v2')
+})
+
+it('accepts only the last inspection when multiple file notifications race', async () => {
+  inspect.mockResolvedValueOnce({ ok: true, value: snapshot('upload', 1) })
+  let resolveSecond!: (value: InspectResult) => void
+  let resolveThird!: (value: InspectResult) => void
+  inspect.mockReturnValueOnce(
+    new Promise((resolve) => {
+      resolveSecond = resolve
+    })
+  )
+  inspect.mockReturnValueOnce(
+    new Promise((resolve) => {
+      resolveThird = resolve
+    })
+  )
+  await render(itemFor('upload'))
+  await changed('upload')
+  await changed('upload')
+  await act(async () => resolveThird({ ok: true, value: snapshot('upload', 3) }))
+  await act(async () => resolveSecond({ ok: true, value: snapshot('upload', 2) }))
+  expect(workflow.inspect?.headVersionId).toBe('v3')
+})
+
+it.each(['error', 'reject'] as const)(
+  'withholds edit authority after a refresh %s even without optional metadata',
+  async (failure) => {
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot('upload', 1) })
+    await render({
+      ...itemFor('upload'),
+      size: undefined,
+      mtimeMs: undefined,
+      versionNumber: undefined
+    })
+    if (failure === 'error') {
+      inspect.mockResolvedValue({ ok: false, error: { code: 'FILE_DELETED', message: 'deleted' } })
+    } else {
+      inspect.mockRejectedValue(new Error('unavailable'))
+    }
+    await changed('upload')
+    expect(workflow.inspect).toBeUndefined()
+    expect(workflow.controlsInspect).toBeUndefined()
+    expect(workflow.navigationInspect?.selectedVersionId).toBe('v1')
+  }
+)

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
@@ -386,3 +386,39 @@ it.each(['error', 'reject'] as const)(
     expect(workflow.navigationInspect?.selectedVersionId).toBe('v1')
   }
 )
+
+it.each(['error', 'reject'] as const)(
+  'ignores an obsolete inspection %s arriving with a notification before React commits',
+  async (failure) => {
+    window.api.managedFileVersions.diffText = vi.fn().mockReturnValue(new Promise(() => undefined))
+    window.api.managedFileVersions.cancelDiff = vi
+      .fn()
+      .mockResolvedValue({ ok: true, value: { cancelled: true } })
+    inspect.mockResolvedValueOnce({ ok: true, value: snapshot('upload', 2) })
+    let resolveOld!: (value: InspectResult) => void
+    let rejectOld!: (error: Error) => void
+    inspect.mockReturnValueOnce(
+      new Promise((resolve, reject) => {
+        resolveOld = resolve
+        rejectOld = reject
+      })
+    )
+    inspect.mockReturnValue(new Promise(() => undefined))
+    await render(itemFor('upload'))
+    await act(async () => workflow.startDiff())
+    await act(async () => workflow.refreshInspect())
+    expect(workflow.controlsInspect?.headVersionId).toBe('v2')
+    await act(async () => {
+      for (const listener of changedListeners) {
+        listener({ projectId: 'project-1', sources: ['upload'], kind: 'upsert' })
+      }
+      if (failure === 'error')
+        resolveOld({ ok: false, error: { code: 'STORAGE_UNAVAILABLE', message: 'obsolete error' } })
+      else rejectOld(new Error('obsolete error'))
+      await Promise.resolve()
+    })
+    expect(workflow.inspect).toBeUndefined()
+    // The pending refresh must retain Stop comparing; an obsolete failure must not leave diff mode.
+    expect(workflow.controlsInspect?.headVersionId).toBe('v2')
+  }
+)

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
@@ -78,6 +78,7 @@ const useManagedVersionWorkflow = ({
     setRefresh(refreshGeneration.current)
   }, [])
   const [diff, setDiff] = useState<{
+    key?: string
     result?: ManagedFileVersionDiffResult
     error?: string
   }>({})
@@ -263,28 +264,29 @@ const useManagedVersionWorkflow = ({
   }, [identity, item.selectedVersionId, requestKey, refresh, resetDiff])
 
   useEffect(() => {
-    if (mode !== 'diff' || !identity || !inspect?.canDiff) return
+    if (mode !== 'diff' || !identity || !requestKey || !inspect?.canDiff) return
     const requestId = crypto.randomUUID()
     activeDiffRequestId.current = requestId
     void window.api.managedFileVersions
       .diffText({ ...identity, versionId: inspect.selectedVersionId, requestId })
       .then((result) => {
-        if (activeDiffRequestId.current !== requestId) return
+        if (activeDiffRequestId.current !== requestId || refresh !== refreshGeneration.current)
+          return
         activeDiffRequestId.current = undefined
-        if (result.ok) setDiff({ result: result.value })
+        if (result.ok) setDiff({ key: requestKey, result: result.value })
         else if (result.error.code !== 'DIFF_CANCELLED')
-          setDiff({ error: t('Diff could not be loaded.') })
+          setDiff({ key: requestKey, error: t('Diff could not be loaded.') })
       })
       .catch(() => {
-        if (activeDiffRequestId.current === requestId)
-          setDiff({ error: t('Diff could not be loaded.') })
+        if (activeDiffRequestId.current === requestId && refresh === refreshGeneration.current)
+          setDiff({ key: requestKey, error: t('Diff could not be loaded.') })
       })
     return () => {
       if (activeDiffRequestId.current !== requestId) return
       activeDiffRequestId.current = undefined
       void window.api.managedFileVersions.cancelDiff({ requestId })
     }
-  }, [identity, inspect?.canDiff, inspect?.selectedVersionId, mode, t])
+  }, [identity, inspect?.canDiff, inspect?.selectedVersionId, mode, requestKey, refresh, t])
 
   return {
     identity,
@@ -293,8 +295,9 @@ const useManagedVersionWorkflow = ({
     inspectError,
     navigationInspect,
     controlsInspect,
-    diffResult: diff.result,
-    diffError: diff.error,
+    // Navigation may survive a refresh; comparison content belongs to one confirmed inspection.
+    diffResult: inspect && diff.key === requestKey ? diff.result : undefined,
+    diffError: inspect && diff.key === requestKey ? diff.error : undefined,
     showTextTools: controlsInspect?.text !== undefined,
     isSelectedSourceText: inspect !== undefined && isSourceTextVersion(inspect),
     downloadVersionContext:

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
@@ -11,6 +11,8 @@ import {
 } from 'react'
 
 import { errorDetail } from '@/lib/error-detail'
+import { useProjectStore } from '@/stores/project-store'
+import { useSessionStore } from '@/stores/session-store'
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 import type {
   ManagedFileIdentity,
@@ -48,12 +50,14 @@ const isSourceTextVersion = (inspect: ManagedFileVersionInspectResult): boolean 
 
 const useManagedVersionWorkflow = ({
   item,
+  sourceItem = item,
   projectId,
   mode,
   setMode,
   t
 }: {
   item: PreviewFileItem
+  sourceItem?: PreviewFileItem
   projectId: string | undefined
   mode: ManagedVersionMode
   setMode: Dispatch<SetStateAction<ManagedVersionMode>>
@@ -80,8 +84,38 @@ const useManagedVersionWorkflow = ({
         : undefined,
     [item.managedFileId, projectId, source]
   )
+  // Select primitive snapshots so unrelated messages/project edits do not invalidate inspection.
+  const sessionRevision = useSessionStore((state) => {
+    const session = state.sessions.find((candidate) => candidate.id === item.sessionId)
+    return JSON.stringify([session?.id, session?.filesRevision, session?.archivedAt])
+  })
+  const projectLifecycle = useProjectStore((state) => {
+    const project = state.projects.find((candidate) => candidate.id === projectId)
+    return JSON.stringify([
+      project?.id,
+      project?.archivedAt,
+      projectId ? state.projectDeletionRequests.has(projectId) : false
+    ])
+  })
+  // A local historical selection must still observe its parent file metadata advancing.
   const requestKey = identity
-    ? `${source}:${projectId}:${identity.fileId}:${item.selectedVersionId ?? ''}:${refresh}`
+    ? JSON.stringify([
+        source,
+        projectId,
+        identity.fileId,
+        item.selectedVersionId,
+        item.sessionId,
+        sourceItem.path,
+        sourceItem.name,
+        sourceItem.size,
+        sourceItem.mtimeMs,
+        sourceItem.versionNumber,
+        sourceItem.originSession?.state,
+        sourceItem.originSession?.deletedAt,
+        sessionRevision,
+        projectLifecycle,
+        refresh
+      ])
     : undefined
   const inspect =
     storedInspect && storedInspect.key === requestKey ? storedInspect.value : undefined
@@ -141,7 +175,10 @@ const useManagedVersionWorkflow = ({
   const navigationInspect = initialNavigationInspect
     ? { ...initialNavigationInspect, versions: history.versions }
     : undefined
-  const controlsInspect = inspect ?? (mode === 'diff' ? navigationInspect : undefined)
+  // Keep Cancel/Stop comparing available during refresh, without granting stale write authority.
+  const controlsInspect =
+    inspect ??
+    (mode !== 'view' && navigationInspect ? { ...navigationInspect, canEdit: false } : undefined)
   const selectedDownloadVersion =
     navigationInspect?.selectedVersion ??
     navigationInspect?.versions.find(
@@ -161,6 +198,20 @@ const useManagedVersionWorkflow = ({
     },
     [setMode]
   )
+
+  useEffect(() => {
+    if (!identity) return
+    return window.api.projectFiles?.onChanged?.((event) => {
+      if (event.projectId !== identity.projectId) return
+      if (
+        event.kind !== 'reset' &&
+        (!event.sources.includes(identity.source) ||
+          (event.sessionId !== undefined && event.sessionId !== item.sessionId))
+      )
+        return
+      setRefresh((value) => value + 1)
+    })
+  }, [identity, item.sessionId])
 
   useEffect(() => {
     let active = true

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
@@ -71,6 +71,12 @@ const useManagedVersionWorkflow = ({
     error: { code?: string; message?: string }
   }>()
   const [refresh, setRefresh] = useState(0)
+  const refreshGeneration = useRef(0)
+  const refreshInspect = useCallback(() => {
+    // Notifications invalidate responses synchronously, before React commits the next effect.
+    refreshGeneration.current += 1
+    setRefresh(refreshGeneration.current)
+  }, [])
   const [diff, setDiff] = useState<{
     result?: ManagedFileVersionDiffResult
     error?: string
@@ -209,9 +215,9 @@ const useManagedVersionWorkflow = ({
           (event.sessionId !== undefined && event.sessionId !== item.sessionId))
       )
         return
-      setRefresh((value) => value + 1)
+      refreshInspect()
     })
-  }, [identity, item.sessionId])
+  }, [identity, item.sessionId, refreshInspect])
 
   useEffect(() => {
     let active = true
@@ -225,7 +231,7 @@ const useManagedVersionWorkflow = ({
         ...(item.selectedVersionId ? { versionId: item.selectedVersionId } : {})
       })
       .then((result) => {
-        if (!active) return
+        if (!active || refresh !== refreshGeneration.current) return
         if (!result.ok) {
           setInspectFailure({ key: requestKey, error: result.error })
           return leaveDiffMode()
@@ -236,7 +242,7 @@ const useManagedVersionWorkflow = ({
         else if (!result.value.canDiff) setDiff({})
       })
       .catch((error: unknown) => {
-        if (!active) return
+        if (!active || refresh !== refreshGeneration.current) return
         setInspectFailure({
           key: requestKey,
           error: {
@@ -254,7 +260,7 @@ const useManagedVersionWorkflow = ({
     return () => {
       active = false
     }
-  }, [identity, item.selectedVersionId, requestKey, resetDiff])
+  }, [identity, item.selectedVersionId, requestKey, refresh, resetDiff])
 
   useEffect(() => {
     if (mode !== 'diff' || !identity || !inspect?.canDiff) return
@@ -307,7 +313,7 @@ const useManagedVersionWorkflow = ({
       resetDiff(preserveDiffMode && mode === 'diff' ? 'diff' : 'view')
     },
     history,
-    refreshInspect: () => setRefresh((value) => value + 1)
+    refreshInspect
   }
 }
 

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -6158,6 +6158,7 @@ describe('session store public contract', () => {
       'src/renderer/src/pages/workspace/use-pdf-context-action.ts',
       'src/renderer/src/pages/workspace/use-side-chat-controller.ts',
       'src/renderer/src/pages/workspace/use-workspace-branch-switch-guard.ts',
+      'src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts',
       'src/renderer/src/pages/workspace/visible-project-sessions.ts',
       'src/renderer/src/pages/workspace/workspace-agent-control-availability.ts',
       'src/renderer/src/pages/workspace/workspace-compute-host-access-controller.ts',


### PR DESCRIPTION
## Problem

F03 (P2): an open managed preview keeps its first inspection when the same logical file changes. Updated metadata, session filesRevision, file notifications, deletion and project archival do not refresh the head, editable text or latest-download context. Backend head checks prevent direct overwrite, but the preview still offers an obsolete edit baseline. Refreshing inspection alone also leaves old preview leases and shared image caches active; losing text availability during editing can hide Cancel.

## Proposed change

- Invalidate inspection using existing file metadata, session revisions, project/source lifecycle and scoped `project-files:changed` notifications; reuse effect cleanup and a component-local refresh generation to reject responses immediately when a notification arrives.
- Preserve explicitly selected historical versions while refreshing the head. Parent metadata still invalidates inspection after a local historical selection.
- Keep confirmed navigation and draft controls while refreshing, but withhold write authority until inspection succeeds. Disable saving after deletion/archival.
- Preserve drafts when a managed path advances and retain their original source version and expected-head baseline.
- Bind diff results and errors to the current inspection key, cancel obsolete comparisons, and reject responses that race with a file notification. Keep confirmed navigation while the existing comparison loading state is shown.
- Bind rendered content to the confirmed immutable selection and remount its resource lifecycle when that selection advances. Reuse the existing managed-version item converter so its locator, metadata and version ID agree, and pass that same item to PDF context actions. This refreshes text, HTML and shared image caches while the workbench tab remains unpinned and PDF/image evidence refers to the displayed version.
- Keep Cancel available throughout edit mode, including successful refreshes that return no text; Save stays disabled without fresh write capability.
- Register the new hook consumer in the public session-store facade contract.

## Scope and non-goals

Renderer-only production changes. No database/schema/serialization changes, migrations, new enum values, IPC channels, global cache, polling, or automatic draft rebasing. Existing optional metadata remains optional; no historical-data migration or compatibility layer is needed. `basedOnVersionId` is retained only in the existing component-local edit baseline; the hook also accepts the existing parent item for invalidation.

## Acceptance criteria and validation

Reproduction mounted the real React hook with the real history hook and lifecycle stores, stubbing only the existing API transport. On unchanged production code, the original 17 hook cases ran twice: **15 failures and 2 passing explicit-refresh controls**. Failures matched the report: inspect called once instead of twice, v1/text v1 instead of v2, and stale canEdit. Two additional race cases failed before synchronous invalidation was added: an obsolete error/rejection arriving with a notification could exit diff mode before React committed. Three component cases also failed before the production fix; another exposed historical-selection metadata invalidation before the follow-up fix.

The independent review also identified stale comparison output after inspection refresh. Three new hook cases (notification, metadata and old error) failed on the pre-fix code in two consecutive runs; three additional obsolete diff success/error/rejection race cases also failed before the follow-up fix. All six pass after the fix. The CI consumer-contract failure was reproduced locally before updating its explicit public-consumer list.

The final review regressions mount the real PreviewFileSurface, content renderers and resource hooks, stubbing only transport and browser Blob URLs. Against the rebased pre-fix Surface, two consecutive runs produced **7 failures and 3 passing controls**: text/HTML/image previews stayed on v2 after the head became v3, and an edit with unavailable text lost its controls. Historical content/leases and the text-available control remained valid. All pass after the fix; the checks also require exact-version resource acquisition and an unchanged, unpinned workbench item.

Four additional public behavior regressions cover PDF reading-context links and real image annotation creation for both upload and artifact sources after a head-only notification. On unchanged production code, they failed in two consecutive runs: upload evidence kept v2, artifact PDF linking was unavailable, and artifact image annotation creation was rejected. All four pass with matching v3 immutable locators.

At maintainer request, the branch was rebased onto main `1cccf098`. Conflicts with #2201 were resolved by preserving its inspect diagnostics and pending-save operation identity together with this PR's synchronous invalidation and original draft baseline. Both success and failure responses retain the generation guard; save retries compare and send the draft's original `basedOnVersionId`. Both sets of regression tests remain present. Main #2211 supplies the lifecycle fixture repair; this PR adds no lifecycle file change.

The maintainer approved the additional change to `e2e/accessibility.spec.ts`. CI and a prior complete local accessibility scan reported premature Settings focus-restoration failure, while normal retrying focus assertions passed twice. The unfixed complete rerun subsequently passed, confirming the timing-dependent nature of the diagnostic. Collection mode now uses the existing keyboard-outcome helper and retrying `toBeFocused()` assertion, with the same timeout and failure condition. Settings production behavior is unchanged.

Final checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Hook freshness, historical selection, lifecycle, notification filtering/cleanup, failed refreshes, interleaved responses; preview draft/edit/download consumers; panel, item conversion, file index, IPC notifications, real text/HTML/image content and lease behavior, public session-store consumer contracts, PDF reading-context actions, real image annotation creation and lifecycle fixture/quit contracts; upstream save replay and accessibility reporter/runner contracts | Focused command below | 808 passed |
| Project Files owners, preview contract, file index, workspace and tool-preview consumers | `npm run test:module -- project_files_view` | 281 passed (overlaps focused set) |
| Main-process and sandbox types, including the CI-failing fixture | `npm run typecheck:node` | Passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Patch whitespace | `git diff --check` | Passed |
| Electron build | `npm run build:e2e` | Passed |
| Accessibility quality signal, including deferred Settings focus restoration | `npm run test:e2e:accessibility:signal` | 11 tests, 21 scans, zero findings |
| Real Electron file previews: upload edits, version/diff navigation, images and PDF reading context | `npm run test:e2e -- e2e/workspace-files.spec.ts` | 10 passed on macOS |

```sh
npm test -- \
  src/main/delegation/production-composition.test.ts \
  src/main/app-lifecycle.test.ts \
  src/main/managed-file-versions/service.integration.test.ts \
  src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx \
  src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx \
  src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx \
  src/renderer/src/pages/workspace/PreviewPanel.test.tsx \
  src/renderer/src/pages/workspace/preview-file-item.test.ts \
  src/renderer/src/pages/workspace/use-project-files-index.test.tsx \
  src/main/managed-file-versions/ipc.test.ts \
  src/renderer/src/stores/session-store.test.ts \
  src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx \
  src/renderer/src/pages/workspace/previews/useManagedPreviewResource.test.tsx \
  src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx \
  src/renderer/src/pages/workspace/previews/preview-file-reader.test.ts \
  src/renderer/src/pages/workspace/previews/renderers/ImagePreview.test.tsx \
  src/renderer/src/pages/workspace/annotations/image-annotation-source.test.ts \
  src/renderer/src/pages/workspace/annotations/ImagePointAnnotationSurface.test.tsx \
  scripts/ci/accessibility-reporter.test.ts \
  scripts/ci/run-accessibility-e2e.test.ts --maxWorkers=4
```

The affected-test explain command selects the full fallback because PreviewFileSurface is not a declared module owner. Per maintainer instruction, local validation uses the explicit module/consumer set above; PR CI is authoritative for the full plan. There are no disk-path operations, persisted-format changes, native IPC changes or Agent-framework-specific changes, so no local migration or cross-platform packaging lane was added. The prior macOS message-revision E2E failure passed in the subsequent CI run. The new PR CI run remains authoritative for the rebased head. Lifecycle composition tests and Electron E2E run outside the agent sandbox for local RPC listeners and Electron launch. The previous CI also reported macOS workspace-file resource-loading flakes and a Windows message-layout assertion; the affected macOS workspace-file suite passes locally, while the new CI remains authoritative for platform results.

## Review focus

Check consistent immutable locators for content, PDF context and image annotations without pinning the tab, retained Cancel after text becomes unavailable, diff result/error freshness, notification scope/cleanup, preservation of the original draft baseline, and parent metadata updates while a historical selection is pinned. The automated cases exercise the public renderer/event boundary; they do not claim a live second-window or Agent end-to-end run. The archival case deliberately keeps the preview mounted; normal global lifecycle navigation may already close it. AI review for the conflict-resolved head `5c969528` completed as **mergeable / no actionable findings** ([review](https://github.com/aipoch/open-science/pull/2198#issuecomment-5552074089)). Static checks pass on this head. Other CI lanes are still running; there are currently no failed checks. The PR remains unmerged.
