### PR TITLE
fix(uploads): enforce durable publication lifecycle barriers

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -721,6 +721,7 @@
           "src/main/uploads/active-transfer-owner.test.ts",
           "src/main/uploads/repository.test.ts",
           "src/main/uploads/repository.characterization.test.ts",
+          "src/main/uploads/publication-lifecycle.integration.test.ts",
           "src/main/uploads/repository.architecture.test.ts"
         ],
         "contract": ["src/main/uploads/ipc.test.ts", "src/main/uploads/command-owner.test.ts"],

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -726,6 +726,8 @@
         ],
         "contract": ["src/main/uploads/ipc.test.ts", "src/main/uploads/command-owner.test.ts"],
         "consumer": [
+          "src/main/acp/runtime.test.ts",
+          "src/main/session-persistence/coordinator.test.ts",
           "src/main/session-persistence/deletion-integration.test.ts",
           "src/main/acp/file-reference-resolver.test.ts",
           "src/main/acp/prompt-content-owner.test.ts",

--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -336,6 +336,7 @@ describe('managed file reference resolver', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const uploads = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const [pending] = await stageUploadFixtures(uploads, {
       files: [
@@ -398,6 +399,7 @@ describe('managed file reference resolver', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
     const uploads = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const [pending] = await stageUploadFixtures(uploads, {
       files: [

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -10048,6 +10048,7 @@ describe('ACP runtime session management', () => {
     const client = createProjectDbClient(root)
     temporaryDisconnections.push(() => client.$disconnect())
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     await client.fileOriginSession.create({
       data: { projectId: 'project-1', sessionId: 'current-session' }
     })

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -103,8 +103,6 @@ describe('startup quit ownership handoff', () => {
             createConfirmClose: () => async () => 'quit',
             prepareForQuit: async () => {},
             abortQuitPreparation: () => {},
-            holdSettingsInstallAdmission: () => () => undefined,
-            getActiveSettingsInstallId: () => undefined,
             flushSessionPersistence: async () => {},
             shutdownBackends: () => runtime.dispose()
           })

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -962,8 +962,6 @@ describe('production delegated-work composition', () => {
             getActiveSettingsInstallId: () => undefined,
             flushSessionPersistence,
             isMigrationInProgress: () => false,
-            holdSettingsInstallAdmission: () => () => undefined,
-            getActiveSettingsInstallId: () => undefined,
             quit,
             countWindows: () => 1,
             detectActiveSessions: () => [],

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -4785,6 +4785,7 @@ describe('SessionPersistenceCoordinator', () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-upload-startup-partial-'))
     const client = createProjectDbClient(root)
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const content = Buffer.from('sample,value\na,1\n')
     const retainedPath = join(root, 'uploads', 'default-project', 'session-1', 'retained.csv')
     const missingPath = join(root, 'uploads', 'default-project', 'session-1', 'missing.csv')

--- a/src/main/session-persistence/deletion-integration.test.ts
+++ b/src/main/session-persistence/deletion-integration.test.ts
@@ -10,6 +10,7 @@ vi.mock('electron', () => ({
   app: { getPath: () => '/home/user', isPackaged: true }
 }))
 
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
 import {
   SessionDeletionCommittedError,
   type PersistedChatSession
@@ -22,6 +23,7 @@ import { ProjectDeletionCoordinator } from '../projects/deletion-coordinator'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { ProjectRepository } from '../projects/repository'
 import { UploadRepository } from '../uploads/repository'
+import { stageUploadFixtures } from '../uploads/repository.test-utils'
 import { SessionPersistenceCoordinator } from './coordinator'
 import { SessionRepository } from './repository'
 import { SessionProjectionRepository } from './projection'
@@ -560,6 +562,69 @@ describe('managed-file deletion integration', () => {
     })
     await expect(readdir(projectDir)).rejects.toMatchObject({ code: 'ENOENT' })
   })
+
+  it.each(['Project', 'Session'])(
+    'deletes a legacy %s with a persisted pending upload without publishing the draft',
+    async (scope) => {
+      const [pending] = await stageUploadFixtures(uploads, {
+        files: [
+          {
+            name: 'draft.txt',
+            content: Buffer.from('unpublished draft').toString('base64')
+          }
+        ]
+      })
+      const session = createSession(uploadPath, artifactPath)
+      session.messages[0].uploads = [pending]
+      session.conversationGraph = createLinearConversationGraph({
+        sessionId: session.id,
+        messages: session.messages,
+        createdAt: session.createdAt,
+        updatedAt: session.updatedAt
+      })
+      // Current Session saves reject pending references; reproduce a retained legacy JSON record.
+      await writeFile(
+        join(storageRoot, 'sessions', PROJECT_ID, `${SESSION_ID}.json`),
+        JSON.stringify({ version: 2, session }),
+        'utf8'
+      )
+      const projectDeletion = new ProjectDeletionCoordinator(
+        new ProjectRepository(async () => client),
+        coordinator,
+        undefined,
+        new ArtifactProvenanceRepository({ storageRoot, getClient: async () => client })
+      )
+
+      if (scope === 'Project') {
+        const save = vi
+          .spyOn(sessions, 'saveSession')
+          .mockRejectedValueOnce(new Error('session file unavailable'))
+        await expect(projectDeletion.deleteProject(PROJECT_ID)).rejects.toThrow(
+          'session file unavailable'
+        )
+        save.mockRestore()
+        await expect(readFile(pending.path, 'utf8')).resolves.toBe('unpublished draft')
+        expect(
+          await readFile(join(storageRoot, 'sessions', PROJECT_ID, `${SESSION_ID}.json`), 'utf8')
+        ).toContain(pending.id)
+        expect(await client.uploadVersion.count({ where: { uploadFileId: pending.id } })).toBe(0)
+        await expect(projectDeletion.deleteProject(PROJECT_ID)).resolves.toEqual({
+          status: 'deleted'
+        })
+      } else {
+        await coordinator.deleteSession(PROJECT_ID, SESSION_ID)
+      }
+
+      expect(await client.uploadVersion.count({ where: { uploadFileId: pending.id } })).toBe(0)
+      expect(await client.projectDeletionIntent.count()).toBe(0)
+      await expect(sessions.loadAll()).resolves.toMatchObject({ sessions: [] })
+      await expect(readFile(pending.path, 'utf8')).resolves.toBe('unpublished draft')
+      await new UploadRepository(storageRoot, {
+        getClient: async () => client
+      }).recoverStagingUploads()
+      await expect(readFile(pending.path)).rejects.toMatchObject({ code: 'ENOENT' })
+    }
+  )
 
   it('soft-deletes project rows but retains upload and artifact bytes after project deletion', async () => {
     const legacyPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -8,11 +8,13 @@ import {
   SessionDeletionCommittedError,
   type LoadAllSessionsResult,
   type PersistedChatSession,
+  type PersistedChatMessage,
   type PersistedSessionStatus,
   type SessionLoadFailure,
   type SessionLoadWarning,
   type UpdateSessionArchiveRequest
 } from '../../shared/session-persistence'
+import { PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
 import type { SessionDeletionReceipt } from '../artifacts/provenance-message-snapshot'
 import { ArchiveAvailabilityError } from '../archive/availability-error'
 import type { ManagedFileSoftDeleteToken } from '../project-files/repository'
@@ -26,6 +28,33 @@ import type { ProjectSessionDeletionState } from './repository'
 import { saveSessionWithRevision } from './save-session'
 import type { SessionPersistenceStateOwner } from './state-owner'
 import { hasLegacySessionUpload } from './legacy-upload'
+
+// Old JSON may still reference process-local drafts. Drop only those references during deletion;
+// the existing startup transfer owner cleans their bytes after the process ends.
+const withoutPendingUploadReferences = (session: PersistedChatSession): PersistedChatSession => {
+  const strip = <Message extends PersistedChatMessage>(message: Message): Message => ({
+    ...message,
+    ...(message.uploads
+      ? {
+          uploads: message.uploads.filter(
+            (upload) => upload.versionId || upload.sessionId !== PENDING_UPLOAD_SESSION_ID
+          )
+        }
+      : {})
+  })
+  return {
+    ...session,
+    messages: session.messages.map(strip),
+    ...(session.conversationGraph
+      ? {
+          conversationGraph: {
+            ...session.conversationGraph,
+            messages: session.conversationGraph.messages.map(strip)
+          }
+        }
+      : {})
+  }
+}
 
 type ProjectSessionDeletionResult =
   { status: 'completed' } | { status: 'orphan-retained'; reason: 'missing-upload-authority' }
@@ -246,9 +275,10 @@ class SessionPersistenceDeletionOwner {
       return this.uploads.upgradeLegacySessionUploads(session, { mode: 'terminal-delete' })
     }
 
-    const upgradedSession = await this.uploads.upgradeLegacySessionUploads(session, {
-      mode: 'live-save'
-    })
+    const upgradedSession = await this.uploads.upgradeLegacySessionUploads(
+      withoutPendingUploadReferences(session),
+      { mode: 'live-save' }
+    )
     const persisted = await saveSessionWithRevision(this.repository, upgradedSession)
     return this.uploads.upgradeLegacySessionUploads(persisted, {
       mode: 'terminal-delete'
@@ -266,9 +296,12 @@ class SessionPersistenceDeletionOwner {
 
     let terminalSession = session
     if (hasLegacySessionUpload(session)) {
-      terminalSession = await this.uploads.upgradeLegacySessionUploads(session, {
-        mode: requireExistingUploadAuthority ? 'orphan-recovery' : 'live-save'
-      })
+      terminalSession = await this.uploads.upgradeLegacySessionUploads(
+        withoutPendingUploadReferences(session),
+        {
+          mode: requireExistingUploadAuthority ? 'orphan-recovery' : 'live-save'
+        }
+      )
       await saveUpgradedSession(terminalSession)
     }
 

--- a/src/main/skills/conversation-import.test.ts
+++ b/src/main/skills/conversation-import.test.ts
@@ -362,6 +362,7 @@ describe('ConversationSkillImporter', () => {
     const client = createProjectDbClient(root)
     disconnects.push(() => client.$disconnect())
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const uploads = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const skills = new UserSkillRepository(root)
     const [staged] = await stageUploadFixtures(uploads, {

--- a/src/main/uploads/command-owner.test.ts
+++ b/src/main/uploads/command-owner.test.ts
@@ -545,6 +545,49 @@ describe('upload command owner', () => {
     expect(repository.deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
   })
 
+  it('schedules standalone publication after copying and cleans the draft if deletion wins', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upload-owner-'))
+    temporaryRoots.push(root)
+    const sourcePath = join(root, 'notes.txt')
+    await writeFile(sourcePath, 'standalone')
+    const attachment = {
+      id: 'draft',
+      sessionId: '.pending',
+      name: 'notes.txt',
+      originalName: 'notes.txt',
+      path: sourcePath,
+      size: 10
+    }
+    const order: string[] = []
+    const repository = {
+      stageLocalFile: vi.fn(async () => {
+        order.push('copy')
+        return attachment
+      }),
+      finalizePendingSessionUploads: vi.fn(async () => [attachment]),
+      deleteUpload: vi.fn(async () => {
+        order.push('cleanup')
+      })
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository, {
+      withSessionMutation: async (projectId, sessionId) => {
+        order.push('schedule')
+        expect([projectId, sessionId]).toEqual(['project-1', 'standalone-uploads'])
+        throw new Error('Project deletion won')
+      }
+    })
+    const caller = createCaller(new ApplicationCallerLeaseRegistry(), 17)
+    await expect(
+      owner.stageLocalPath(
+        invocationFor(caller, [
+          { transferId: 'scheduled-copy', sourcePath, name: 'notes.txt', projectId: 'project-1' }
+        ])
+      )
+    ).rejects.toThrow('Project deletion won')
+    expect(order).toEqual(['copy', 'schedule', 'cleanup'])
+    expect(repository.finalizePendingSessionUploads).not.toHaveBeenCalled()
+  })
+
   it('finalizes session uploads inside the injected session mutation', async () => {
     const repository = {
       finalizePendingSessionUploads: vi.fn(async () => [])

--- a/src/main/uploads/command-owner.test.ts
+++ b/src/main/uploads/command-owner.test.ts
@@ -448,6 +448,7 @@ describe('upload command owner', () => {
     const client = createProjectDbClient(root)
     try {
       await migrateApplicationDatabase(client)
+      await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
       const repository = new UploadRepository(root, { getClient: async () => client })
       const owner = createUploadCommandOwner(repository)
       const caller = createCaller(new ApplicationCallerLeaseRegistry(), 16)

--- a/src/main/uploads/command-owner.ts
+++ b/src/main/uploads/command-owner.ts
@@ -287,13 +287,17 @@ const createUploadCommandOwner = (
       )
       const projectId = request.projectId ?? DEFAULT_UPLOAD_PROJECT_ID
       try {
-        const published = await withDataRootWrite(() =>
-          repository.finalizePendingSessionUploads(
-            STANDALONE_UPLOAD_SESSION_ID,
-            [attachment],
-            projectId
-          )
-        )
+        const published = await withDataRootWrite(() => {
+          const finalize = (): Promise<UploadedAttachment[]> =>
+            repository.finalizePendingSessionUploads(
+              STANDALONE_UPLOAD_SESSION_ID,
+              [attachment],
+              projectId
+            )
+          return options.withSessionMutation
+            ? options.withSessionMutation(projectId, STANDALONE_UPLOAD_SESSION_ID, finalize)
+            : finalize()
+        })
         if (published.length !== 1) {
           throw new Error(
             `Expected exactly one published standalone upload, received ${published.length}.`

--- a/src/main/uploads/legacy-recovery-owner.ts
+++ b/src/main/uploads/legacy-recovery-owner.ts
@@ -109,7 +109,35 @@ class LegacyRecoveryOwner {
         const persisted = toPersistedUploadedAttachment(
           toRuntimeUploadedAttachment(upload, session.projectId)
         )
-        if (isLiveSave) return persisted
+        if (isLiveSave) {
+          if (this.options.getClient) {
+            const client = await this.options.getClient()
+            const headless = await client.uploadVersion.findFirst({
+              where: {
+                id: upload.versionId,
+                uploadFileId: upload.id,
+                versionNumber: 1,
+                state: 'ready',
+                uploadFile: {
+                  projectId: session.projectId,
+                  sessionId: upload.sessionId,
+                  currentVersionId: null
+                }
+              }
+            })
+            // Archived legacy adoption preserves ready evidence without publishing a head. Retry
+            // that publication after restore, using the same transactional lifecycle checks.
+            if (headless)
+              await this.completeStagingUpload(
+                session.projectId,
+                upload.sessionId,
+                toRuntimeUploadedAttachment(upload, session.projectId),
+                headless,
+                { preserveSource: true }
+              )
+          }
+          return persisted
+        }
         const reconciliationKey = `${upload.id}:${upload.versionId}`
         let reconciliation = reconciliations.get(reconciliationKey)
         if (!reconciliation) {
@@ -461,8 +489,7 @@ class LegacyRecoveryOwner {
         if (current.state === 'ready') return current
         if (!(
           options.legacySessionUpload &&
-          ((current.originKind === 'legacy' && lifecycle.projectExists) ||
-            file.currentVersionId === current.id)
+          (lifecycle.projectExists || file.currentVersionId === current.id)
         )) {
           throw new Error('Upload publication is blocked by the Project or origin lifecycle.')
         }

--- a/src/main/uploads/legacy-recovery-owner.ts
+++ b/src/main/uploads/legacy-recovery-owner.ts
@@ -16,6 +16,7 @@ import {
 import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
 import {
   OrphanLegacyUploadAuthorityMissingError,
+  readUploadPublicationLifecycle,
   runUploadTransaction,
   type PublicationOptions,
   type UploadVersionRecord
@@ -167,7 +168,7 @@ class LegacyRecoveryOwner {
           isProjectFilesSync ? upload.sessionId : session.id,
           [toRuntimeUploadedAttachment(upload, session.projectId)],
           session.projectId,
-          { preserveLegacySource: isLiveSave, requireExistingAuthority }
+          { preserveLegacySource: isLiveSave, requireExistingAuthority, legacySessionUpload: true }
         )
         if (!finalized) return undefined
         if (isTerminalDelete) {
@@ -357,7 +358,7 @@ class LegacyRecoveryOwner {
     sessionId: string,
     attachment: UploadedAttachment,
     version: UploadVersionRecord,
-    options: { preserveSource?: boolean } = {}
+    options: { preserveSource?: boolean; legacySessionUpload?: boolean } = {}
   ): Promise<UploadedAttachment> {
     const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
     assertPathInsideRoot(
@@ -443,14 +444,34 @@ class LegacyRecoveryOwner {
     await rm(`${finalPath}${LIVE_COPY_TEMP_SUFFIX}`, { force: true })
     const client = await this.options.getClient!()
     const ready = await runUploadTransaction(client, async (tx) => {
-      const updated =
-        version.state === 'ready'
-          ? version
-          : await tx.uploadVersion.update({ where: { id: version.id }, data: { state: 'ready' } })
+      const current = await tx.uploadVersion.findUniqueOrThrow({ where: { id: version.id } })
       const file = await tx.uploadFile.findUniqueOrThrow({
         where: { id: version.uploadFileId },
         include: { currentVersion: true }
       })
+      const lifecycle = await readUploadPublicationLifecycle(
+        tx,
+        projectId,
+        sessionId,
+        version.uploadFileId
+      )
+      // Reusing immutable evidence grants no permission to advance a head or revive Files. Legacy
+      // path adoption is explicit; startup recovery cannot reinterpret a pending upload as history.
+      if (!lifecycle.writable) {
+        if (current.state === 'ready') return current
+        if (!(
+          options.legacySessionUpload &&
+          ((current.originKind === 'legacy' && lifecycle.projectExists) ||
+            file.currentVersionId === current.id)
+        )) {
+          throw new Error('Upload publication is blocked by the Project or origin lifecycle.')
+        }
+      }
+      const updated =
+        current.state === 'ready'
+          ? current
+          : await tx.uploadVersion.update({ where: { id: version.id }, data: { state: 'ready' } })
+      if (!lifecycle.writable) return updated
       const shouldAdvanceHead =
         !file.currentVersion || file.currentVersion.versionNumber < updated.versionNumber
       if (shouldAdvanceHead) {
@@ -492,9 +513,7 @@ class LegacyRecoveryOwner {
           mimeType: head.contentType,
           sizeBytes: head.sizeBytes,
           mtimeMs: BigInt(timestamp.getTime()),
-          sortAtMs: BigInt(timestamp.getTime()),
-          deletedAt: null,
-          deleteOperationId: null
+          sortAtMs: BigInt(timestamp.getTime())
         }
       })
       return updated

--- a/src/main/uploads/publication-lifecycle.integration.test.ts
+++ b/src/main/uploads/publication-lifecycle.integration.test.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient } from '@prisma/client'
+import { createHash } from 'node:crypto'
 import type { ReadStream } from 'node:fs'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -326,4 +327,95 @@ describe('upload publication lifecycle (SQLite + filesystem)', () => {
       deleteOperationId: 'delete-during-publication'
     })
   })
+
+  it('publishes recovered legacy evidence after its project is unarchived', async () => {
+    const oldRepository = new UploadRepository(root)
+    const [legacy] = await oldRepository.finalizePendingSessionUploads(
+      sessionId,
+      await stage(oldRepository),
+      projectId
+    )
+    await block('archived project')
+    const repository = new UploadRepository(root, { getClient: async () => client })
+    const upgraded = await repository.upgradeLegacySessionUploads(sessionWithUpload(legacy), {
+      mode: 'live-save'
+    })
+    await repository.upgradeLegacySessionUploads(upgraded, { mode: 'live-save' })
+    expect(await client.managedFile.count()).toBe(0)
+    expect((await client.uploadFile.findFirstOrThrow()).currentVersionId).toBeNull()
+    await client.project.update({ where: { id: projectId }, data: { archivedAt: null } })
+
+    await repository.upgradeLegacySessionUploads(upgraded, { mode: 'live-save' })
+
+    const versionId = upgraded.messages[0].uploads![0].versionId
+    expect
+      .soft(await client.uploadFile.findFirstOrThrow())
+      .toMatchObject({ currentVersionId: versionId })
+    expect.soft(await client.managedFile.count({ where: { deletedAt: null } })).toBe(1)
+  })
+
+  it.each(['archived project', 'project deletion intent'])(
+    'recovers a pre-existing legacy staging row behind a %s barrier',
+    async (barrier) => {
+      const oldRepository = new UploadRepository(root)
+      const [legacy] = await oldRepository.finalizePendingSessionUploads(
+        sessionId,
+        await stage(oldRepository),
+        projectId
+      )
+      await client.fileOriginSession.create({ data: { projectId, sessionId } })
+      await client.uploadFile.create({
+        data: {
+          id: legacy.id,
+          projectId,
+          sessionId,
+          filename: legacy.name,
+          originalFilename: legacy.originalName,
+          versions: {
+            create: {
+              id: 'interrupted-legacy-version',
+              versionNumber: 1,
+              state: 'staging',
+              contentStorageKey: `uploads/${projectId}/${sessionId}/${legacy.id}/versions/interrupted-legacy-version/content`,
+              filename: legacy.name,
+              originalFilename: legacy.originalName,
+              sizeBytes: BigInt(Buffer.byteLength(content)),
+              checksum: createHash('sha256').update(content).digest('hex')
+            }
+          }
+        }
+      })
+      expect((await client.uploadVersion.findFirstOrThrow()).originKind).toBe('user_upload')
+      await block(barrier)
+      const repository = new UploadRepository(root, { getClient: async () => client })
+
+      const wrongPath = join(root, 'uploads', 'default-project', sessionId, 'unrelated.txt')
+      await writeFile(wrongPath, content)
+      await expect(
+        repository.upgradeLegacySessionUploads(sessionWithUpload({ ...legacy, path: wrongPath }), {
+          mode: 'live-save'
+        })
+      ).rejects.toThrow(/lifecycle/)
+      expect(await client.uploadVersion.count({ where: { state: 'ready' } })).toBe(0)
+
+      await expect(
+        repository.upgradeLegacySessionUploads(
+          sessionWithUpload({ ...legacy, checksum: '0'.repeat(64) }),
+          { mode: 'live-save' }
+        )
+      ).rejects.toThrow(/lifecycle/)
+      expect(await client.uploadVersion.count({ where: { state: 'ready' } })).toBe(0)
+
+      await expect(
+        repository.upgradeLegacySessionUploads(sessionWithUpload(legacy), {
+          mode: 'live-save'
+        })
+      ).resolves.toMatchObject({
+        messages: [{ uploads: [{ versionId: 'interrupted-legacy-version' }] }]
+      })
+
+      expect(await client.uploadVersion.count()).toBe(1)
+      expect(await client.managedFile.count()).toBe(0)
+    }
+  )
 })

--- a/src/main/uploads/publication-lifecycle.integration.test.ts
+++ b/src/main/uploads/publication-lifecycle.integration.test.ts
@@ -1,0 +1,329 @@
+import type { PrismaClient } from '@prisma/client'
+import type { ReadStream } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { STANDALONE_UPLOAD_SESSION_ID, type UploadedAttachment } from '../../shared/uploads'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createElectronCallerContext } from '../caller-context'
+import { ApplicationCallerLeaseRegistry } from '../caller-lifecycle'
+import { ManagedFileVersionService } from '../managed-file-versions/service'
+import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+import { createUploadCommandOwner } from './command-owner'
+import { UploadRepository } from './repository'
+import { stageUploadFixtures } from './repository.test-utils'
+
+describe('upload publication lifecycle (SQLite + filesystem)', () => {
+  let root: string
+  let client: PrismaClient
+  const projectId = 'project-1'
+  const sessionId = 'session-1'
+  const content = 'lifecycle evidence\n'
+  const deletedAt = new Date('2026-09-05T00:00:00Z')
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'open-science-upload-lifecycle-'))
+    client = createProjectDbClient(root)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: projectId, name: 'Publication target' } })
+  })
+
+  afterEach(async () => {
+    await client.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  const stage = (repository: UploadRepository): Promise<UploadedAttachment[]> =>
+    stageUploadFixtures(repository, {
+      files: [
+        {
+          name: 'evidence.txt',
+          mimeType: 'text/plain',
+          content: Buffer.from(content).toString('base64')
+        }
+      ]
+    })
+
+  const block = async (barrier: string): Promise<void> => {
+    if (barrier === 'missing project') {
+      await client.project.delete({ where: { id: projectId } })
+    } else if (barrier === 'archived project') {
+      await client.project.update({ where: { id: projectId }, data: { archivedAt: deletedAt } })
+    } else if (barrier === 'project deletion intent') {
+      await client.projectDeletionIntent.create({ data: { projectId } })
+    } else {
+      await client.fileOriginSession.upsert({
+        where: { projectId_sessionId: { projectId, sessionId } },
+        create: { projectId, sessionId, state: 'deleted', deletedAt },
+        update: { state: 'deleted', deletedAt }
+      })
+    }
+  }
+
+  const sessionWithUpload = (upload: UploadedAttachment): PersistedChatSession => ({
+    id: sessionId,
+    projectId,
+    title: 'Legacy session',
+    cwd: root,
+    status: 'idle',
+    messages: [
+      {
+        id: 'message-1',
+        role: 'user',
+        content: 'Evidence',
+        status: 'complete',
+        eventIds: [],
+        uploads: [upload],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ],
+    createdAt: 1,
+    updatedAt: 1
+  })
+
+  it('publishes an active project and origin through the public repository', async () => {
+    const repository = new UploadRepository(root, { getClient: async () => client })
+    const [published] = await repository.finalizePendingSessionUploads(
+      sessionId,
+      await stage(repository),
+      projectId
+    )
+    await expect(readFile(published.path, 'utf8')).resolves.toBe(content)
+    const service = new ManagedFileVersionService({
+      storageRoot: root,
+      getClient: async () => client
+    })
+    await expect(
+      service.inspect({ source: 'upload', projectId, fileId: published.id })
+    ).resolves.toMatchObject({ canEdit: true })
+  })
+
+  it.each(['missing project', 'archived project', 'project deletion intent', 'deleted origin'])(
+    'rejects a new upload behind a persisted %s barrier',
+    async (barrier) => {
+      const repository = new UploadRepository(root, { getClient: async () => client })
+      const attachments = await stage(repository)
+      await block(barrier)
+
+      const [result] = await Promise.allSettled([
+        repository.finalizePendingSessionUploads(sessionId, attachments, projectId)
+      ])
+      // If the regression returns, verify its reported consequence rather than accepting an
+      // unrelated I/O or fixture failure as reproduction evidence.
+      if (result.status === 'fulfilled') {
+        await expect(readFile(result.value[0].path, 'utf8')).resolves.toBe(content)
+        const service = new ManagedFileVersionService({
+          storageRoot: root,
+          getClient: async () => client
+        })
+        const inspection = service.inspect({
+          source: 'upload',
+          projectId,
+          fileId: attachments[0].id
+        })
+        if (barrier === 'missing project' || barrier === 'project deletion intent') {
+          await expect(inspection).rejects.toMatchObject({
+            code: barrier === 'missing project' ? 'FILE_NOT_FOUND' : 'FILE_DELETED'
+          })
+        } else {
+          await expect(inspection).resolves.toMatchObject({
+            canEdit: false,
+            unavailableReason:
+              barrier === 'deleted origin' ? 'FILE_DELETED' : 'PROJECT_NOT_WRITABLE'
+          })
+        }
+      }
+      expect
+        .soft(result.status, 'publication must reject the persisted lifecycle barrier')
+        .toBe('rejected')
+      expect.soft(await client.uploadVersion.count({ where: { state: 'ready' } })).toBe(0)
+      expect.soft(await client.managedFile.count({ where: { deletedAt: null } })).toBe(0)
+    }
+  )
+
+  it.each(['missing project', 'archived project', 'project deletion intent', 'deleted origin'])(
+    'does not advance ready/head when %s appears after registration',
+    async (barrier) => {
+      let blocked = false
+      const repository = new UploadRepository(root, {
+        // Existing dependency boundary: act only after a real staging transaction has committed,
+        // before completion obtains its client. No transaction or filesystem operation is mocked.
+        getClient: async () => {
+          if (!blocked && (await client.uploadVersion.count({ where: { state: 'staging' } }))) {
+            blocked = true
+            await block(barrier)
+          }
+          return client
+        }
+      })
+      const [result] = await Promise.allSettled([
+        repository.finalizePendingSessionUploads(sessionId, await stage(repository), projectId)
+      ])
+      expect(blocked).toBe(true)
+      expect.soft(result.status).toBe('rejected')
+      expect.soft(await client.uploadVersion.count({ where: { state: 'ready' } })).toBe(0)
+      expect
+        .soft(await client.uploadFile.count({ where: { currentVersionId: { not: null } } }))
+        .toBe(0)
+      expect.soft(await client.managedFile.count({ where: { deletedAt: null } })).toBe(0)
+
+      // Restart with an ordinary client supplier: recovery must respect the same durable barrier.
+      const restarted = new UploadRepository(root, { getClient: async () => client })
+      await restarted.recoverStagingUploads().catch(() => undefined)
+      expect.soft(await client.uploadVersion.count({ where: { state: 'ready' } })).toBe(0)
+      expect.soft(await client.managedFile.count({ where: { deletedAt: null } })).toBe(0)
+    }
+  )
+
+  it('rejects standalone save when its project is deleted while the local stream is copying', async () => {
+    const sourcePath = join(root, 'local.txt')
+    await writeFile(sourcePath, content)
+    let deletedDuringCopy = false
+    const repository = new UploadRepository(root, {
+      getClient: async () => client,
+      createLocalReadStream: () =>
+        Readable.from(
+          (async function* () {
+            yield Buffer.from(content.slice(0, 1))
+            await client.project.delete({ where: { id: projectId } })
+            deletedDuringCopy = true
+            yield Buffer.from(content.slice(1))
+          })()
+        ) as ReadStream
+    })
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const callerContext = createElectronCallerContext(1)
+    const owned = leases.acquire(callerContext)
+    try {
+      const [result] = await Promise.allSettled([
+        owner.stageLocalPath({
+          callerContext,
+          callerLease: owned.lease,
+          args: [{ transferId: 'standalone-copy', projectId, sourcePath, name: 'local.txt' }]
+        })
+      ])
+      expect(deletedDuringCopy).toBe(true)
+      expect.soft(result.status).toBe('rejected')
+      expect.soft(await client.uploadVersion.count({ where: { state: 'ready' } })).toBe(0)
+      expect
+        .soft(
+          await client.managedFile.count({
+            where: { sessionId: STANDALONE_UPLOAD_SESSION_ID, deletedAt: null }
+          })
+        )
+        .toBe(0)
+      await expect(readFile(sourcePath, 'utf8')).resolves.toBe(content)
+    } finally {
+      owner.releaseCaller(owned.lease)
+    }
+  })
+
+  it('does not resurrect a deleted Files projection when retrying an existing immutable upload', async () => {
+    const repository = new UploadRepository(root, { getClient: async () => client })
+    const [published] = await repository.finalizePendingSessionUploads(
+      sessionId,
+      await stage(repository),
+      projectId
+    )
+    await block('deleted origin')
+    await client.managedFile.updateMany({ data: { deletedAt, deleteOperationId: 'delete-1' } })
+
+    await repository
+      .finalizePendingSessionUploads(sessionId, [published], projectId)
+      .catch(() => undefined)
+
+    await expect(client.managedFile.findFirstOrThrow()).resolves.toMatchObject({
+      deletedAt,
+      deleteOperationId: 'delete-1'
+    })
+    expect(await client.uploadVersion.count({ where: { state: 'ready' } })).toBe(1)
+    await expect(readFile(published.path, 'utf8')).resolves.toBe(content)
+  })
+
+  it.each(['archived project', 'project deletion intent', 'deleted origin'])(
+    'preserves legacy session evidence behind a %s barrier without publishing Files',
+    async (barrier) => {
+      const oldRepository = new UploadRepository(root)
+      const [legacy] = await oldRepository.finalizePendingSessionUploads(
+        sessionId,
+        await stage(oldRepository),
+        projectId
+      )
+      await block(barrier)
+      const repository = new UploadRepository(root, { getClient: async () => client })
+      const upgraded = await repository.upgradeLegacySessionUploads(sessionWithUpload(legacy), {
+        mode: 'live-save'
+      })
+      const reference = upgraded.messages[0].uploads![0]
+      const version = await client.uploadVersion.findUniqueOrThrow({
+        where: { id: reference.versionId }
+      })
+      expect.soft(version).toMatchObject({ state: 'ready', originKind: 'legacy' })
+      expect
+        .soft(await client.uploadFile.findFirstOrThrow())
+        .toMatchObject({ currentVersionId: null })
+      expect.soft(await client.managedFile.count()).toBe(0)
+      await expect(
+        readFile(join(root, ...version.contentStorageKey.split('/')), 'utf8')
+      ).resolves.toBe(content)
+      await expect(readFile(legacy.path, 'utf8')).resolves.toBe(content)
+      const retry = await repository.upgradeLegacySessionUploads(sessionWithUpload(legacy), {
+        mode: 'live-save'
+      })
+      expect(retry.messages[0].uploads![0].versionId).toBe(reference.versionId)
+      expect(await client.managedFile.count()).toBe(0)
+    }
+  )
+
+  it('does not grant pending uploads historical authority through legacy upgrade', async () => {
+    const repository = new UploadRepository(root, { getClient: async () => client })
+    const [pending] = await stage(repository)
+    await block('deleted origin')
+    await expect(
+      repository.upgradeLegacySessionUploads(sessionWithUpload(pending), { mode: 'live-save' })
+    ).rejects.toThrow(/lifecycle/)
+    expect(await client.uploadVersion.count()).toBe(0)
+  })
+
+  it('preserves a Files tombstone committed between staging and completion', async () => {
+    let tombstoned = false
+    const repository = new UploadRepository(root, {
+      getClient: async () => {
+        const version = await client.uploadVersion.findFirst({ where: { state: 'staging' } })
+        if (!tombstoned && version) {
+          tombstoned = true
+          await client.managedFile.create({
+            data: {
+              projectId,
+              sessionId,
+              source: 'upload',
+              sourceFileId: version.uploadFileId,
+              sourceVersionId: version.id,
+              displayName: version.filename,
+              storageKey: version.contentStorageKey,
+              sizeBytes: version.sizeBytes,
+              sortAtMs: 1n,
+              deletedAt,
+              deleteOperationId: 'delete-during-publication'
+            }
+          })
+        }
+        return client
+      }
+    })
+    await expect(
+      repository.finalizePendingSessionUploads(sessionId, await stage(repository), projectId)
+    ).rejects.toThrow(/lifecycle/)
+    expect(tombstoned).toBe(true)
+    expect(await client.uploadVersion.count({ where: { state: 'ready' } })).toBe(0)
+    await expect(client.managedFile.findFirstOrThrow()).resolves.toMatchObject({
+      deletedAt,
+      deleteOperationId: 'delete-during-publication'
+    })
+  })
+})

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -242,6 +242,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, {
       getClient: () => Promise.resolve(client)
     })
@@ -441,6 +442,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, {
       getClient: () => Promise.resolve(client)
     })
@@ -511,6 +513,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, {
       getClient: () => Promise.resolve(client)
     })
@@ -548,6 +551,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const [pending] = await stageUploadFixtures(repository, {
       files: [
@@ -626,6 +630,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const content = Buffer.from('already renamed')
     const versionId = 'upload-version-post-rename'
@@ -731,6 +736,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const content = Buffer.from('copied before crash')
     const checksum = createHash('sha256').update(content).digest('hex')
@@ -792,6 +798,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'legacy.csv')
     await mkdir(dirname(legacyPath), { recursive: true })
@@ -866,6 +873,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const content = 'sample,value\na,1\n'
     const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'legacy.csv')
@@ -927,6 +935,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const content = 'sample,value\na,1\n'
     const legacyPath = join(root, 'uploads', 'default-project', 'session-1', 'legacy.csv')
@@ -1016,6 +1025,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const uploadId = 'conflicting-orphan-upload'
     const absentPath = join(root, 'uploads', 'default-project', 'session-1', 'absent.csv')
@@ -1066,6 +1076,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const uploadId = 'conflicting-existing-upload'
     const versionId = 'conflicting-existing-version'
@@ -1160,6 +1171,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const content = Buffer.from('sample,value\na,1\n')
     const checksum = createHash('sha256').update(content).digest('hex')
@@ -1434,6 +1446,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
     const content = Buffer.from('sample,value\na,1\n')
     const checksum = '5fe3f7b7e3492c63599954312dcb1e1d78488782753b6d3068c8d03292c7c1f6'
@@ -1776,6 +1789,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     await client.fileOriginSession.create({
       data: { projectId: 'other-project', sessionId: 'session-1' }
     })
@@ -1825,6 +1839,7 @@ describe('upload repository', () => {
     const client = createProjectDbClient(root)
     disconnect = () => client.$disconnect()
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
     await client.managedFile.create({
       data: {
         source: 'upload',

--- a/src/main/uploads/staged-publication-owner.ts
+++ b/src/main/uploads/staged-publication-owner.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import { createReadStream } from 'node:fs'
 import { mkdir, realpath, stat } from 'node:fs/promises'
 import { createHash, randomUUID } from 'node:crypto'
@@ -228,6 +229,17 @@ class StagedPublicationOwner {
       if (attachment.versionId && attachment.versionId !== existingVersion.id) {
         throw new Error('Upload Version identity conflicts with the existing immutable Version.')
       }
+      // Older legacy migrations used originKind=user_upload. A trusted path-only Session
+      // reference must still match this v1's exact legacy locator and immutable metadata.
+      const legacySessionUpload =
+        options.legacySessionUpload === true &&
+        attachment.sessionId === sessionId &&
+        !attachment.versionId &&
+        resolve(attachment.path) ===
+          resolve(getSessionUploadDir(this.storageRoot, sessionId), existingVersion.filename) &&
+        attachment.name === existingVersion.filename &&
+        attachment.size === Number(existingVersion.sizeBytes) &&
+        (!attachment.checksum || attachment.checksum === existingVersion.checksum)
       const published = await this.dependencies.completeStagingUpload(
         projectId,
         sessionId,
@@ -235,8 +247,7 @@ class StagedPublicationOwner {
         existingVersion,
         {
           preserveSource: options.preserveLegacySource === true,
-          legacySessionUpload:
-            options.legacySessionUpload === true && attachment.sessionId === sessionId
+          legacySessionUpload
         }
       )
       if (

--- a/src/main/uploads/staged-publication-owner.ts
+++ b/src/main/uploads/staged-publication-owner.ts
@@ -26,6 +26,7 @@ type StagedPublicationOptions = {
 type PublicationOptions = {
   preserveLegacySource?: boolean
   requireExistingAuthority?: boolean
+  legacySessionUpload?: boolean
 }
 
 type UploadVersionRecord = {
@@ -33,6 +34,7 @@ type UploadVersionRecord = {
   uploadFileId: string
   versionNumber: number
   state: string
+  originKind: string
   contentStorageKey: string
   filename: string
   originalFilename: string
@@ -58,6 +60,43 @@ const runUploadTransaction = <Result>(
   operation: (transaction: Prisma.TransactionClient) => Promise<Result>
 ): Promise<Result> => client.$transaction(operation, UPLOAD_TRANSACTION_OPTIONS)
 
+// Publication authority is durable and must be read in the transaction that changes it. The
+// command scheduler orders local callers, but cannot substitute for these deletion barriers.
+const readUploadPublicationLifecycle = async (
+  tx: Prisma.TransactionClient,
+  projectId: string,
+  sessionId: string,
+  uploadFileId: string
+): Promise<{ projectExists: boolean; writable: boolean }> => {
+  const [project, deleting, origin, sync, projection] = await Promise.all([
+    tx.project.findUnique({ where: { id: projectId } }),
+    tx.projectDeletionIntent.findUnique({ where: { projectId } }),
+    tx.fileOriginSession.findUnique({ where: { projectId_sessionId: { projectId, sessionId } } }),
+    tx.managedFileSessionSync.findUnique({
+      where: { projectId_sessionId: { projectId, sessionId } }
+    }),
+    tx.managedFile.findUnique({
+      where: {
+        projectId_source_sourceFileId: { projectId, source: 'upload', sourceFileId: uploadFileId }
+      }
+    })
+  ])
+  return {
+    projectExists: project !== null,
+    writable:
+      !!project &&
+      !project.archivedAt &&
+      !project.deletedAt &&
+      !deleting &&
+      (!origin ||
+        (origin.state === 'active' && !origin.deletedAt && !origin.deletionOperationId)) &&
+      !sync?.deletedAt &&
+      !sync?.deleteOperationId &&
+      !projection?.deletedAt &&
+      !projection?.deleteOperationId
+  }
+}
+
 type StagedPublicationDependencies = {
   resolver: ManagedUploadResolver
   completeStagingUpload: (
@@ -65,7 +104,7 @@ type StagedPublicationDependencies = {
     sessionId: string,
     attachment: UploadedAttachment,
     version: UploadVersionRecord,
-    options?: { preserveSource?: boolean }
+    options?: { preserveSource?: boolean; legacySessionUpload?: boolean }
   ) => Promise<UploadedAttachment>
   hasOrphanLegacyCandidate: (
     projectId: string,
@@ -194,7 +233,11 @@ class StagedPublicationOwner {
         sessionId,
         attachment,
         existingVersion,
-        { preserveSource: options.preserveLegacySource === true }
+        {
+          preserveSource: options.preserveLegacySource === true,
+          legacySessionUpload:
+            options.legacySessionUpload === true && attachment.sessionId === sessionId
+        }
       )
       if (
         !options.preserveLegacySource &&
@@ -278,6 +321,12 @@ class StagedPublicationOwner {
         create: { projectId, sessionId },
         update: {}
       })
+      const lifecycle = await readUploadPublicationLifecycle(tx, projectId, sessionId, uploadFileId)
+      const legacySessionUpload =
+        options.legacySessionUpload === true && attachment.sessionId === sessionId
+      if (!lifecycle.writable && !(legacySessionUpload && lifecycle.projectExists)) {
+        throw new Error('Upload publication is blocked by the Project or origin lifecycle.')
+      }
       await tx.uploadFile.create({
         data: {
           id: uploadFileId,
@@ -293,6 +342,7 @@ class StagedPublicationOwner {
           uploadFileId,
           versionNumber: 1,
           state: 'staging',
+          originKind: legacySessionUpload ? 'legacy' : 'user_upload',
           contentStorageKey,
           filename: attachment.name,
           originalFilename: attachment.originalName,
@@ -305,10 +355,17 @@ class StagedPublicationOwner {
     })
 
     return this.dependencies.completeStagingUpload(projectId, sessionId, attachment, registered, {
-      preserveSource: options.preserveLegacySource === true
+      preserveSource: options.preserveLegacySource === true,
+      legacySessionUpload:
+        options.legacySessionUpload === true && attachment.sessionId === sessionId
     })
   }
 }
 
-export { OrphanLegacyUploadAuthorityMissingError, runUploadTransaction, StagedPublicationOwner }
+export {
+  OrphanLegacyUploadAuthorityMissingError,
+  readUploadPublicationLifecycle,
+  runUploadTransaction,
+  StagedPublicationOwner
+}
 export type { PublicationOptions, UploadVersionRecord }


### PR DESCRIPTION
## Problem

F01: uploads can publish into missing, archived or deleting Projects and deleted origins, including deletion during copying or after staging registration. The call reports success while immutable bytes are inaccessible or uneditable. Retrying an existing upload can also clear Files tombstones.

## Proposed change

- Check Project, ProjectDeletionIntent, origin state and Files/session deletion markers inside both registration and ready/head transactions. Re-read the durable version before completion and preserve tombstones.
- Schedule standalone finalization through the existing Project-scoped session mutation hook.
- Keep bounded historical recovery separate from new uploads. Old session paths may establish immutable evidence behind a barrier without publishing head/Files. Pre-existing staging rows with the old `user_upload` default require matching legacy locator and v1 identity; pending and ordinary startup recovery cannot acquire this exception.
- Retry ready v1 evidence without a head after an archive barrier clears, through the same completion transaction.
- During requested Session/Project deletion, remove unversioned pending references from both flat and graph messages before legacy upgrade. Preserve draft bytes through preparation failure; the existing startup transfer owner removes them after restart.

## Scope and non-goals

- No new table, field, enum/state, foreign key, migration or disk format. No new UI or public repository method.
- Historical compatibility: retain existing immutable evidence and bounded legacy adoption, including interrupted old staging rows. Never clear deletion barriers during recovery. Legacy pending references are discarded only during deletion; current Session saves already reject those references.
- Persistence changes use existing Session JSON, version state/head and Files projection fields. No cascading Project deletion or automatic sweep of previously invalid ready rows. Blocked new staging remains subject to existing recovery/cleanup ownership.
- Preserve main's standalone published-attachment return fix while adding the scheduler. Remove duplicate settings-install dependency keys from two existing lifecycle test fixtures on the rebased main.
- Correct valid-publication test fixtures to create their Project, and include real ACP/session consumers in the upload module test set.

## Acceptance criteria and validation

Real migrated SQLite and temporary disk reproduce the original issue through public repository/command boundaries. Two runs on unmodified production code each had one active-project control pass and ten identical regression failures (prohibited ready/head/Files publication or erased tombstones). Independent review's three recovery cases were also reproduced twice before their fixes: four identical failures per run. All corresponding cases now pass. No production test seam was introduced.

Checks below ran after the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Publication barriers, archive restore, legacy staging authority, deletion of historical pending references, graph messages, failed preparation and restart cleanup | Explicit lifecycle and deletion integration files via `npm test -- <paths>` | 47 passed in the final plan |
| Upload, Session persistence, Project lifecycle, Files owners/contracts/consumers | Deduplicated union of `createModuleTestPlan` for `upload_repository`, `session_persistence`, `project_lifecycle`, `project_files_repository`, run through `executeModuleTestPlan` with `--maxWorkers 2` | 2390 passed in 60 files |
| Version-service inspection, operation scheduler, module planner/manifest/classifier | Five explicit contract/guard files included in that final plan | Included above |
| Rebased main: startup/delegation fixture keys, Session deletion commit boundary and retained workspace ownership | Explicit startup/delegation, Session deletion owner and managed-workspace integration files in the final plan | Included above |
| Main-process types and lint | `npm run typecheck:node`; `npm run lint` | Passed |
| Formatting | Prettier on changed files; `git diff --check` | Passed |

The final deduplicated plan contains 60 test files. Extra checks beyond the four module plans are version-service inspection, operation scheduling, the three module manifest/planner/classifier guards, startup and delegated-work production composition, Session deletion owner, and managed-workspace ownership integration. The branch was rebased linearly onto main `e598d33a`; its Session deletion commit-boundary handling remains intact. CodeGraph caller analysis and architecture checks cover the stable facades; the lifecycle helper is used only by sibling upload owners. ACP execution paths are covered by the runtime consumer suite; no ACP protocol or subscription behavior changes.

No full local suite was run, per maintainer instruction. The manifest diff changes test membership only. Path checks use platform helpers; Windows, macOS and Linux CI remain authoritative for platform behavior. Latest-head PR Gate and independent review must complete before merge.

## Review focus

Check both transaction boundaries, historical path authority versus pending uploads, archive restoration of headless evidence, preservation of all deletion markers, and pending-reference handling across both message representations. Draft bytes intentionally remain until the existing startup cleanup rather than being destroyed before deletion preparation commits.
