### PR TITLE
fix(delegation): retain settlement wakes after cancelled quit

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1083,6 +1083,7 @@ describe('AcpRuntimeCoordinator', () => {
       wakeMessages: vi.fn(async () => undefined),
       stopSession: vi.fn(async () => undefined),
       stopAll: vi.fn(async () => undefined),
+      shutdown: vi.fn(async () => undefined),
       deleteSession: vi.fn(async () => undefined),
       deleteProject: vi.fn(async () => undefined)
     }
@@ -1159,6 +1160,43 @@ describe('AcpRuntimeCoordinator', () => {
     expect(delegated.stopAll).toHaveBeenCalledOnce()
   })
 
+  it.each([
+    ['prepareForQuit', 'stopAll'],
+    ['disconnect', 'stopAll'],
+    ['shutdownForUpdateGate', 'stopAll'],
+    ['shutdownForQuit', 'shutdown'],
+    ['shutdown', 'shutdown']
+  ] as const)('uses delegated %s lifecycle with %s', async (operation, cleanup) => {
+    const delegated = {
+      pendingPermissions: () => [],
+      subscribe: () => () => undefined,
+      respondToPermission: async () => false,
+      setPermissionProfile: async () => undefined,
+      stopSession: async () => undefined,
+      stopAll: vi.fn(async () => undefined),
+      shutdown: vi.fn(async () => undefined),
+      deleteSession: async () => undefined,
+      deleteProject: async () => undefined
+    }
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({ frameworkId: 'codex', sessionIds: ['session-1'], callbacks }).runtime,
+      {},
+      '',
+      undefined,
+      undefined,
+      undefined,
+      {},
+      undefined,
+      delegated
+    )
+
+    await coordinator[operation]()
+
+    expect(delegated[cleanup]).toHaveBeenCalledOnce()
+    expect(delegated[cleanup === 'stopAll' ? 'shutdown' : 'stopAll']).not.toHaveBeenCalled()
+  })
+
   it('fences only the active Conversation Turn and exposes a separate Subagent Stop scope', async () => {
     const prompt = createDeferred<unknown>()
     let rejectChildCancellation!: (error: Error) => void
@@ -1177,6 +1215,7 @@ describe('AcpRuntimeCoordinator', () => {
       stopActiveBranch,
       stopSession: vi.fn(async () => undefined),
       stopAll: vi.fn(async () => undefined),
+      shutdown: vi.fn(async () => undefined),
       deleteSession: vi.fn(async () => undefined),
       deleteProject: vi.fn(async () => undefined)
     }
@@ -1641,6 +1680,7 @@ describe('AcpRuntimeCoordinator', () => {
       setPermissionProfile: async () => undefined,
       stopSession: async () => undefined,
       stopAll: async () => undefined,
+      shutdown: async () => undefined,
       deleteSession: async () => undefined,
       deleteProject: async () => undefined,
       rootTurnStarted,
@@ -1723,6 +1763,7 @@ describe('AcpRuntimeCoordinator', () => {
         setPermissionProfile: async () => undefined,
         stopSession: async () => undefined,
         stopAll: async () => undefined,
+        shutdown: async () => undefined,
         deleteSession: async () => undefined,
         deleteProject: async () => undefined,
         rootTurnStarted,
@@ -3894,6 +3935,7 @@ describe('AcpRuntimeCoordinator', () => {
       setPermissionProfile: async () => undefined,
       stopSession: async () => undefined,
       stopAll: async () => undefined,
+      shutdown: async () => undefined,
       deleteSession: vi.fn(() => delegatedDeletion.promise),
       deleteProject: async () => undefined
     }

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -450,7 +450,7 @@ class AcpRuntimeCoordinator {
   shutdown(): void {
     this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
-    void this.delegatedWork?.stopAll().catch(() => undefined)
+    void this.delegatedWork?.shutdown().catch(() => undefined)
     for (const runtime of this.runtimes) runtime.shutdown()
     this.clearRuntimeOwnership()
     this.onDisconnected?.()
@@ -460,7 +460,10 @@ class AcpRuntimeCoordinator {
     this.providerShutdownStartedForQuit = true
     this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
-    return this.shutdownAll((runtime) => runtime.shutdownForQuit())
+    return this.shutdownAll(
+      (runtime) => runtime.shutdownForQuit(),
+      () => this.delegatedWork?.shutdown()
+    )
   }
 
   // Gives active agents a bounded chance to return their terminal stop response before process-tree
@@ -529,7 +532,10 @@ class AcpRuntimeCoordinator {
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
     this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
-    return this.shutdownAll((runtime) => runtime.shutdownForUpdateGate())
+    return this.shutdownAll(
+      (runtime) => runtime.shutdownForUpdateGate(),
+      () => this.delegatedWork?.stopAll()
+    )
   }
 
   async createSession(request: AcpCreateSessionRequest = {}): Promise<AcpCreateSessionResponse> {
@@ -1974,11 +1980,12 @@ class AcpRuntimeCoordinator {
   }
 
   private async shutdownAll(
-    shutdown: (runtime: AcpRuntime) => Promise<{ reaped: boolean }>
+    shutdown: (runtime: AcpRuntime) => Promise<{ reaped: boolean }>,
+    stopDelegatedWork: () => Promise<void> | undefined
   ): Promise<{ reaped: boolean }> {
     const runtimes = Array.from(this.runtimes)
     const [delegatedOutcome, ...outcomes] = await Promise.allSettled([
-      this.delegatedWork?.stopAll() ?? Promise.resolve(),
+      stopDelegatedWork() ?? Promise.resolve(),
       ...runtimes.map(shutdown)
     ])
     const failure =

--- a/src/main/delegation/delegation-settlement-wake-owner.test.ts
+++ b/src/main/delegation/delegation-settlement-wake-owner.test.ts
@@ -626,33 +626,51 @@ describe('DelegationSettlementWakeOwner', () => {
     vi.useRealTimers()
   })
 
-  it('clears a pending settlement timer on shutdown', async () => {
-    vi.useFakeTimers()
-    let current = snapshot([])
-    const dispatch = vi.fn(acceptDispatch)
-    const owner = new DelegationSettlementWakeOwner({
-      readSnapshot: async () => current,
-      dispatch
-    })
-    await endRootTurn(
-      owner,
-      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
-      () => {
-        current = snapshot([child('alpha', 'running')])
-      }
-    )
-    current = snapshot([child('alpha', 'completed')])
-    await owner.onRecordsChanged('session-1')
+  it.each(['shutdown', 'invalidateAll'] as const)(
+    'clears a pending settlement timer on %s',
+    async (cleanup) => {
+      vi.useFakeTimers()
+      let current = snapshot([])
+      const dispatch = vi.fn(acceptDispatch)
+      const owner = new DelegationSettlementWakeOwner({
+        readSnapshot: async () => current,
+        dispatch
+      })
+      await endRootTurn(
+        owner,
+        { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+        () => {
+          current = snapshot([child('alpha', 'running')])
+        }
+      )
+      current = snapshot([child('alpha', 'completed')])
+      await owner.onRecordsChanged('session-1')
 
-    owner.shutdown()
-    await vi.advanceTimersByTimeAsync(200)
+      owner[cleanup]()
+      owner[cleanup]()
+      await vi.advanceTimersByTimeAsync(200)
 
-    expect(dispatch).not.toHaveBeenCalled()
-    expect(vi.getTimerCount()).toBe(0)
-    vi.useRealTimers()
-  })
+      expect(dispatch).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(0)
+      const nextLease = await owner.onRootTurnStarted({
+        sessionId: 'session-1',
+        originatingPromptId: 'root-prompt'
+      })
+      if (cleanup === 'shutdown') expect(nextLease).toBeUndefined()
+      else expect(nextLease).toEqual(expect.any(String))
+      owner.shutdown()
+      owner.invalidateAll()
+      await expect(
+        owner.onRootTurnStarted({
+          sessionId: 'session-1',
+          originatingPromptId: 'root-prompt'
+        })
+      ).resolves.toBeUndefined()
+      vi.useRealTimers()
+    }
+  )
 
-  it.each(['session', 'project', 'shutdown', 'branch'] as const)(
+  it.each(['session', 'project', 'shutdown', 'branch', 'all'] as const)(
     'rejects a prior root-turn lease whose terminal callback arrives after %s invalidation',
     async (scope) => {
       vi.useFakeTimers()
@@ -670,6 +688,7 @@ describe('DelegationSettlementWakeOwner', () => {
       if (scope === 'session') owner.invalidateSession('session-1')
       else if (scope === 'project') await owner.invalidateProject('project-1')
       else if (scope === 'shutdown') owner.shutdown()
+      else if (scope === 'all') owner.invalidateAll()
       else await owner.invalidateBranch('session-1', 'root-prompt')
 
       if (scope === 'shutdown') {
@@ -697,58 +716,127 @@ describe('DelegationSettlementWakeOwner', () => {
     }
   )
 
-  it('does not let a rejected stale turn-start snapshot delete a replacement Session state', async () => {
+  it.each(['session', 'all'] as const)(
+    'does not let a rejected stale turn-start snapshot delete a replacement Session state after %s invalidation',
+    async (scope) => {
+      vi.useFakeTimers()
+      let rejectOldSnapshot!: (error: Error) => void
+      const oldSnapshot = new Promise<DelegationSettlementSnapshot | undefined>(
+        (_resolve, reject) => {
+          rejectOldSnapshot = reject
+        }
+      )
+      let reads = 0
+      let current = snapshot([], { activeRootPromptIds: ['new-prompt'] })
+      const dispatch = vi.fn(acceptDispatch)
+      const owner = new DelegationSettlementWakeOwner({
+        readSnapshot: async () => {
+          reads += 1
+          return reads === 1 ? oldSnapshot : current
+        },
+        dispatch,
+        createPromptId: () => 'new-wake'
+      })
+
+      const oldStart = owner.onRootTurnStarted({
+        sessionId: 'session-1',
+        originatingPromptId: 'old-prompt'
+      })
+      if (scope === 'session') owner.invalidateSession('session-1')
+      else owner.invalidateAll()
+      const newLease = await owner.onRootTurnStarted({
+        sessionId: 'session-1',
+        originatingPromptId: 'new-prompt'
+      })
+      current = snapshot([child('new-child', 'running', { originatingPromptId: 'new-prompt' })], {
+        activeRootPromptIds: ['new-prompt']
+      })
+      await owner.onRootTurnEnded({
+        sessionId: 'session-1',
+        originatingPromptId: 'new-prompt',
+        clean: true,
+        leaseId: newLease
+      })
+
+      rejectOldSnapshot(new Error('stale snapshot failed'))
+      await expect(oldStart).rejects.toThrow('stale snapshot failed')
+      current = snapshot([child('new-child', 'completed', { originatingPromptId: 'new-prompt' })], {
+        activeRootPromptIds: ['new-prompt']
+      })
+      await owner.onRecordsChanged('session-1')
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(dispatch).toHaveBeenCalledOnce()
+      expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+        originatingPromptId: 'new-prompt',
+        promptId: 'new-wake'
+      })
+      vi.useRealTimers()
+    }
+  )
+
+  it('ignores an old dispatch failure and terminal callback after reusable cleanup', async () => {
     vi.useFakeTimers()
-    let rejectOldSnapshot!: (error: Error) => void
-    const oldSnapshot = new Promise<DelegationSettlementSnapshot | undefined>(
-      (_resolve, reject) => {
-        rejectOldSnapshot = reject
-      }
+    let current = snapshot([])
+    let rejectOldDispatch!: (reason: Error) => void
+    const oldDispatch = new Promise<void>((_resolve, reject) => {
+      rejectOldDispatch = reject
+    })
+    let prompt = 0
+    const dispatch = vi.fn((request: DelegationSettlementDispatch) =>
+      request.promptId === 'wake-1' ? oldDispatch : Promise.resolve()
     )
-    let reads = 0
-    let current = snapshot([], { activeRootPromptIds: ['new-prompt'] })
-    const dispatch = vi.fn(acceptDispatch)
     const owner = new DelegationSettlementWakeOwner({
-      readSnapshot: async () => {
-        reads += 1
-        return reads === 1 ? oldSnapshot : current
-      },
+      readSnapshot: async () => current,
       dispatch,
-      createPromptId: () => 'new-wake'
+      createPromptId: () => `wake-${++prompt}`
     })
-
-    const oldStart = owner.onRootTurnStarted({
-      sessionId: 'session-1',
-      originatingPromptId: 'old-prompt'
+    const turn = { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true }
+    await endRootTurn(owner, turn, () => {
+      current = snapshot([child('old', 'running')])
     })
-    owner.invalidateSession('session-1')
-    const newLease = await owner.onRootTurnStarted({
-      sessionId: 'session-1',
-      originatingPromptId: 'new-prompt'
-    })
-    current = snapshot([child('new-child', 'running', { originatingPromptId: 'new-prompt' })], {
-      activeRootPromptIds: ['new-prompt']
-    })
-    await owner.onRootTurnEnded({
-      sessionId: 'session-1',
-      originatingPromptId: 'new-prompt',
-      clean: true,
-      leaseId: newLease
-    })
-
-    rejectOldSnapshot(new Error('stale snapshot failed'))
-    await expect(oldStart).rejects.toThrow('stale snapshot failed')
-    current = snapshot([child('new-child', 'completed', { originatingPromptId: 'new-prompt' })], {
-      activeRootPromptIds: ['new-prompt']
-    })
+    current = snapshot([child('old', 'completed')])
     await owner.onRecordsChanged('session-1')
     await vi.advanceTimersByTimeAsync(100)
-
     expect(dispatch).toHaveBeenCalledOnce()
-    expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
-      originatingPromptId: 'new-prompt',
-      promptId: 'new-wake'
+
+    owner.invalidateAll()
+    await endRootTurn(owner, turn, () => {
+      current = snapshot([
+        child('old', 'completed'),
+        child('new', 'running'),
+        child('later', 'running')
+      ])
     })
+    current = snapshot([
+      child('old', 'completed'),
+      child('new', 'completed'),
+      child('later', 'running')
+    ])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch.mock.calls[1][0].text).toContain('attempt-new')
+    expect(dispatch.mock.calls[1][0].text).not.toContain('attempt-old')
+
+    current = snapshot([
+      child('old', 'completed'),
+      child('new', 'completed'),
+      child('later', 'completed')
+    ])
+    await owner.onRecordsChanged('session-1')
+    rejectOldDispatch(new Error('late old failure'))
+    await owner.onWakePromptEnded('session-1', 'wake-1')
+    await vi.advanceTimersByTimeAsync(500)
+    // The new flight is still held; the old callbacks cannot release it or retry its old batch.
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    await owner.onWakePromptEnded('session-1', 'wake-2')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledTimes(3)
+    expect(dispatch.mock.calls[2][0].text).toContain('attempt-later')
+    expect(dispatch.mock.calls[2][0].text).not.toContain('attempt-old')
+    expect(dispatch.mock.calls[2][0].text).not.toContain('attempt-new')
+    owner.shutdown()
     vi.useRealTimers()
   })
 

--- a/src/main/delegation/delegation-settlement-wake-owner.ts
+++ b/src/main/delegation/delegation-settlement-wake-owner.ts
@@ -348,10 +348,14 @@ class DelegationSettlementWakeOwner {
     })
   }
 
-  shutdown(): void {
-    this.stopped = true
+  invalidateAll(): void {
     for (const state of this.sessions.values()) if (state.timer) clearTimeout(state.timer)
     this.sessions.clear()
+  }
+
+  shutdown(): void {
+    this.stopped = true
+    this.invalidateAll()
   }
 
   private enqueueExisting(

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -1,9 +1,12 @@
+import { EventEmitter } from 'node:events'
 import { access, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { installAppLifecycle, type AppLifecycleDeps } from '../app-lifecycle'
+import { clearApplicationShutdownTrigger } from '../application-shutdown-trigger'
 import {
   activateConversationBranch,
   createLinearConversationGraph,
@@ -810,6 +813,209 @@ describe('production delegated-work composition', () => {
     vi.useRealTimers()
   })
 
+  it.each([
+    ['codex', 'no-quit'],
+    ['codex', 'conflict'],
+    ['codex', 'renderer-failed'],
+    ['codex', 'timeout'],
+    ['codex', 'conflict-without-work'],
+    ['claude-code', 'conflict'],
+    ['opencode', 'conflict'],
+    ['codebuddy', 'conflict']
+  ] as const)(
+    'continues new delegated work exactly once after a cancelled quit: %s / %s',
+    async (frameworkId, finalSave) => {
+      vi.useFakeTimers()
+      clearApplicationShutdownTrigger()
+      root = await mkdtemp(join(tmpdir(), 'delegated-quit-abort-'))
+      const nextPromptId = 'root-message-after-quit'
+      const harness = await createCompositionHarness(
+        root,
+        frameworkId,
+        createDeterministicDelegateExecution(),
+        undefined,
+        { settlementContinuations: { dispatch: (request) => dispatch(request) } },
+        [{ rootMessageId: nextPromptId, toolInvocationId: 'delegate-after-quit', createdAt: 3 }]
+      )
+      const durable = harness.durable()
+      durable.conversationGraph!.messages.find(({ id }) => id === nextPromptId)!.runtimeSegmentId =
+        durable.conversationGraph!.runtimeSegments[0].id
+      harness.replaceDurable(durable)
+      const snapshot: AcpStateSnapshot = {
+        status: 'connected',
+        cwd: '/workspace',
+        sessionId: harness.session.id,
+        sessionIds: [harness.session.id],
+        events: [],
+        pendingPermissions: [],
+        permissionProfiles: {},
+        permissionGrants: {},
+        contextUsageBySession: {},
+        promptInFlight: false,
+        promptInFlightSessionIds: []
+      }
+      let callbacks!: AcpRuntimeCallbacks
+      let turn = 0
+      const receipts: Array<{ frameId: string; attemptId: string }> = []
+      const finish = async (
+        request: AcpPromptRequest,
+        promptAttemptId: string | undefined,
+        delegate: boolean
+      ): Promise<{ stopReason: 'end_turn' }> => {
+        const token = `turn-${++turn}`
+        callbacks.onPromptStarted?.(request.sessionId, token, promptAttemptId)
+        callbacks.onProviderPromptAccepted?.(request.sessionId, promptAttemptId)
+        try {
+          if (delegate) {
+            const receipt = await harness.composition.host.delegate(
+              {
+                ...harness.caller,
+                originMessageId: request.provenanceContext!.promptMessageId,
+                toolInvocationId: `delegate-${token}`
+              },
+              { task: 'Check the result', name: token },
+              { wait: false }
+            )
+            receipts.push(receipt.children[0])
+          }
+          return { stopReason: 'end_turn' }
+        } finally {
+          callbacks.onPromptEnded?.(request.sessionId, token)
+        }
+      }
+      const sendAppContinuation = vi.fn((request: AcpPromptRequest, attempt?: string) =>
+        finish(request, attempt, false)
+      )
+      const runtime = {
+        getState: () => snapshot,
+        getSnapshot: () => snapshot,
+        getActivePromptSessions: () => [],
+        getQuitBlockingPromptSessions: () => [],
+        sendPrompt: (request: AcpPromptRequest, attempt?: string) => finish(request, attempt, true),
+        sendAppContinuation,
+        shutdown: () => undefined
+      } as unknown as AcpRuntime
+      const coordinator = new AcpRuntimeCoordinator(
+        (runtimeCallbacks) => {
+          callbacks = runtimeCallbacks
+          return runtime
+        },
+        {},
+        '',
+        undefined,
+        undefined,
+        undefined,
+        {},
+        undefined,
+        harness.composition.root
+      )
+      const dispatch = createDelegationSettlementContinuationDispatch({
+        sendAppContinuationObserved: (request, accepted) =>
+          coordinator.sendAppContinuationObserved(request, accepted),
+        onPromptEnded: (sessionId, promptId) =>
+          harness.composition.root.settlementPromptEnded?.(sessionId, promptId)
+      })
+      const prompt = (promptMessageId: string): Promise<unknown> =>
+        coordinator.sendPrompt({
+          sessionId: harness.session.id,
+          text: 'Delegate a background check',
+          provenanceContext: { promptMessageId }
+        })
+      try {
+        if (finalSave !== 'no-quit') {
+          if (finalSave !== 'conflict-without-work') {
+            await prompt(harness.caller.originMessageId)
+            await expect.poll(() => harness.execution.controls()).toHaveLength(1)
+            harness.execution.control(receipts[0].attemptId).accept()
+          }
+          const app = Object.assign(new EventEmitter(), { exit: vi.fn() })
+          const window = Object.assign(new EventEmitter(), {
+            isDestroyed: () => false,
+            isMinimized: () => false,
+            isVisible: () => true,
+            show: vi.fn(),
+            restore: vi.fn(),
+            focus: vi.fn()
+          })
+          const flushSessionPersistence = vi
+            .fn()
+            .mockResolvedValueOnce('completed')
+            .mockResolvedValueOnce(finalSave === 'conflict-without-work' ? 'conflict' : finalSave)
+          const prepareForQuit = vi.fn(() => coordinator.prepareForQuit())
+          const abortQuitPreparation = vi.fn(() => coordinator.abortQuitPreparation())
+          const shutdownBackends = vi.fn(async () => undefined)
+          const confirmClose = vi.fn(async (variant: string) =>
+            variant === 'persistence-failed' ? ('cancel' as const) : ('quit' as const)
+          )
+          const quit = (): void => {
+            app.emit('before-quit', { preventDefault: vi.fn() })
+          }
+          installAppLifecycle({
+            app: app as unknown as AppLifecycleDeps['app'],
+            createMainWindow: () =>
+              window as unknown as ReturnType<AppLifecycleDeps['createMainWindow']>,
+            createTray: () => undefined,
+            shutdownBackends,
+            prepareForQuit,
+            abortQuitPreparation,
+            flushSessionPersistence,
+            isMigrationInProgress: () => false,
+            quit,
+            countWindows: () => 1,
+            detectActiveSessions: () => [],
+            hasActiveReviewerWork: () => false,
+            createConfirmClose: () => confirmClose
+          })
+          quit()
+          await expect.poll(() => window.focus).toHaveBeenCalledOnce()
+          expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
+          expect(prepareForQuit).toHaveBeenCalledOnce()
+          expect(abortQuitPreparation).toHaveBeenCalledOnce()
+          expect(shutdownBackends).not.toHaveBeenCalled()
+          expect(app.exit).not.toHaveBeenCalled()
+          if (finalSave === 'timeout')
+            expect(confirmClose).toHaveBeenCalledWith('persistence-failed', [])
+          if (receipts[0]) {
+            await expect(harness.composition.host.children(harness.caller)).resolves.toMatchObject([
+              { attemptId: receipts[0].attemptId, status: 'cancelled' }
+            ])
+            // A late completion from the cancelled execution must not resurrect its notification.
+            harness.execution.control(receipts[0].attemptId).complete('late old result')
+          }
+          await vi.advanceTimersByTimeAsync(200)
+          expect(sendAppContinuation).not.toHaveBeenCalled()
+        }
+        await prompt(nextPromptId)
+        await expect.poll(() => harness.execution.controls()).toHaveLength(receipts.length)
+        const child = receipts.at(-1)!
+        harness.execution.control(child.attemptId).accept()
+        harness.execution.control(child.attemptId).complete('new result')
+        await expect
+          .poll(
+            async () =>
+              (await harness.composition.host.children(harness.caller)).find(
+                ({ attemptId }) => attemptId === child.attemptId
+              )?.status
+          )
+          .toBe('completed')
+        await vi.advanceTimersByTimeAsync(100)
+        expect(
+          sendAppContinuation,
+          'After staying in the app, a new completed child must automatically resume its root turn.'
+        ).toHaveBeenCalledOnce()
+        expect(sendAppContinuation.mock.calls[0][0].text).toContain(child.attemptId)
+        expect(sendAppContinuation.mock.calls[0][0].provenanceContext?.promptMessageId).toBe(
+          nextPromptId
+        )
+        await vi.advanceTimersByTimeAsync(500)
+        expect(sendAppContinuation).toHaveBeenCalledOnce()
+      } finally {
+        await harness.composition.root.shutdown()
+        clearApplicationShutdownTrigger()
+      }
+    }
+  )
+
   it('runs same-turn collect and staggered settlement wakes through ACP admission and terminal callbacks', async () => {
     vi.useFakeTimers()
     root = await mkdtemp(join(tmpdir(), 'delegated-production-acp-settlement-chain-'))
@@ -1040,7 +1246,7 @@ describe('production delegated-work composition', () => {
     ])
   })
 
-  it.each(['branch', 'project', 'shutdown'] as const)(
+  it.each(['branch', 'project', 'stopAll', 'shutdown'] as const)(
     'cancels a pending settlement wake on %s invalidation',
     async (scope) => {
       vi.useFakeTimers()
@@ -1086,12 +1292,21 @@ describe('production delegated-work composition', () => {
       } else if (scope === 'project') {
         await harness.composition.root.deleteProject(harness.session.projectId)
       } else {
-        await harness.composition.root.stopAll()
+        await harness.composition.root[scope]()
       }
       await vi.advanceTimersByTimeAsync(200)
 
       expect(dispatch).not.toHaveBeenCalled()
       expect(vi.getTimerCount()).toBe(0)
+      if (scope === 'stopAll' || scope === 'shutdown') {
+        const nextLease = await harness.composition.root.rootTurnStarted?.({
+          sessionId: harness.session.id,
+          originatingPromptId: harness.caller.originMessageId
+        })
+        if (scope === 'shutdown') expect(nextLease).toBeUndefined()
+        else expect(nextLease).toEqual(expect.any(String))
+        await harness.composition.root.shutdown()
+      }
       vi.useRealTimers()
     }
   )

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -123,7 +123,9 @@ type RootDelegatedWorkControl = Readonly<{
     }>
   ): Promise<void>
   settlementPromptEnded?(sessionId: string, promptId: string): Promise<void>
+  // Cancel current work and notifications while retaining the ability to observe future turns.
   stopAll(): Promise<void>
+  shutdown(): Promise<void>
   deleteSession(sessionId: string): Promise<void>
   deleteProject(projectId: string): Promise<void>
 }>
@@ -456,6 +458,11 @@ const createProductionDelegatedWorkComposition = (
     }
   })
 
+  const stopScopedWork = async (): Promise<void> => {
+    const scoped = await Promise.all([...works.values()])
+    await Promise.all(scoped.map(({ key, work }) => work.stopSession(key)))
+  }
+
   const root: RootDelegatedWorkControl = Object.freeze({
     pendingPermissions: () =>
       Object.freeze(
@@ -581,9 +588,12 @@ const createProductionDelegatedWorkComposition = (
       await settlementWake?.onWakePromptEnded(sessionId, promptId)
     },
     async stopAll() {
+      settlementWake?.invalidateAll()
+      await stopScopedWork()
+    },
+    async shutdown() {
       settlementWake?.shutdown()
-      const scoped = await Promise.all([...works.values()])
-      await Promise.all(scoped.map(({ key, work }) => work.stopSession(key)))
+      await stopScopedWork()
     },
     async deleteSession(sessionId) {
       settlementWake?.invalidateSession(sessionId)


### PR DESCRIPTION
## Problem

S01: cancelling an ordinary quit after the final Session save fails leaves delegated settlement notifications permanently disabled. New root prompts can delegate children and those children complete, but the application never sends their automatic continuation. Quit preparation called `stopAll()`, which irreversibly shut down the shared notification owner, even when no scoped work existed.

## Proposed change

Separate reusable cleanup from terminal disposal behind the existing delegated-work facade:

| Lifecycle | Delegated cleanup |
| --- | --- |
| Quit preparation, disconnect, recoverable update gate | `stopAll()` invalidates current watches/leases/timers and cancels current work; future turns remain observable |
| Final quit or synchronous application shutdown | `shutdown()` permanently closes notifications and stops work |

Reuse existing session-state, lease, and prompt identities to reject old callbacks. Cancelled attempts remain cancelled. No owner replacement or additional state machine is needed.

## Scope and non-goals

- Small internal lifecycle split across three production files; no new service, dependency, UI, or IPC API.
- **Historical compatibility:** no migration, backfill, or revival of old cancelled attempts.
- **New state/enums/data fields:** none; reuse existing state and terminal flag.
- **Persistence/data model:** no stored-format/schema/write-path changes. Existing cancellation still records its terminal state through the existing persistence path.
- Restores automatic settlement continuation; does not claim the delegated execution engine was broken.

## Acceptance criteria and validation

Before changing production code, the composed regression repeatedly failed on the original main implementation: final-save conflict, renderer failure, timeout followed by staying, and conflict with no existing delegated work all completed the new child but observed **0 continuations instead of 1**. The no-quit control passed.

After the fix, all eight composition scenarios pass, including representative conflict cases for Claude Code, OpenCode, and CodeBuddy. The regression composes the real app lifecycle, coordinator, production delegation owner, and continuation dispatch; only Electron/window, renderer flush, storage, and provider execution boundaries are deterministic fixtures. Old cancelled work produces no late notification; new work resumes exactly once.

All checks below ran after the last material edit. The final targeted run passed **11 files / 446 tests**, using `npm test -- <files below> --maxWorkers=1 --no-file-parallelism`:

| Behavior → framework/path | Test files → result |
| --- | --- |
| Quit rollback → Codex; representative Claude Code/OpenCode/CodeBuddy | `src/main/delegation/production-composition.test.ts` → passed |
| Timers, repeated cleanup, stale leases/snapshots/dispatch callbacks, irreversible shutdown → shared owner | `src/main/delegation/delegation-settlement-wake-owner.test.ts` → passed |
| Admission, continuation and reusable/terminal routing → shared ACP facade | `src/main/acp/runtime-coordinator.test.ts`, `src/main/delegation/settlement-continuation-dispatch.test.ts` → passed |
| Adapter selection and cancellation → four supported frameworks | `src/main/delegation/production-frameworks.test.ts`, `src/main/delegation/acp-execution.test.ts` → passed |
| Native Responses / Chat Completions bridge launch configuration → Codex | `src/main/agent-framework/codex.test.ts` → passed |
| Quit/flush/abort/final teardown and update-gate consumers → application lifecycle | `src/main/app-lifecycle.test.ts`, `src/main/lifecycle-shutdown.test.ts`, `src/main/application-runtime.test.ts`, `src/main/acp/connection-close-workflow.test.ts` → passed |

`npm run typecheck:node`, `npm run lint`, changed-file Prettier, and `git diff --check` also passed. Independent Standards and Spec reviews found no actionable issues and confirmed the final impact mapping.

The affected-test planner requests full coverage because the coordinator is not registered in its module manifest. Per maintainer instruction, the local run uses the explicit mapped modules above; full verification remains with PR CI. No wire format, model-specific logic, platform path, renderer or persisted schema changes warrant a local Cartesian matrix. These tests establish deterministic composition and launcher configuration compatibility, not live-model or real Electron E2E behavior. Configured platform/full-suite CI remains required.

## Review focus

Confirm that every reusable teardown preserves future notification capability, final teardown remains irreversible, and stale work cannot interfere with replacement leases or dispatches.
