### PR TITLE
fix(startup): guard quits until runtime lifecycle handoff

### DIFF
--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -3,6 +3,11 @@ import { EventEmitter } from 'node:events'
 import type { BrowserWindow } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 
+import { installAppLifecycle } from './app-lifecycle'
+import { composeApplicationRuntime } from './application-runtime'
+import { installDatabaseStartupQuitGuard } from './database/database-startup-ipc'
+import { createDatabaseStartupOwner } from './database/database-startup-owner'
+
 import {
   createSecondInstanceRelay,
   createStartupWindowCloseOptions,
@@ -24,6 +29,110 @@ const deferred = <T>(): {
     resolve
   }
 }
+
+describe('startup quit ownership handoff', () => {
+  it.each(['after verification', 'after first module', 'during last module'])(
+    'cleans every started owner when ordinary quit is requested %s',
+    async (checkpoint) => {
+      const reached = deferred<void>()
+      const resume = deferred<void>()
+      const pauseAt = async (stage: string): Promise<void> => {
+        if (stage !== checkpoint) return
+        reached.resolve()
+        await resume.promise
+      }
+      const owner = createDatabaseStartupOwner({
+        verifyDatabase: async () => {},
+        reportBlocked: vi.fn()
+      })
+      const app = Object.assign(new EventEmitter(), {
+        exit: vi.fn(),
+        quit: () => {
+          const event = {
+            defaultPrevented: false,
+            preventDefault: () => {
+              event.defaultPrevented = true
+            }
+          }
+          app.emit('before-quit', event)
+          if (!event.defaultPrevented) app.exit(0)
+          return event
+        }
+      })
+      const guard = installDatabaseStartupQuitGuard({ app: app as never, owner })
+      const disposers = [vi.fn(), vi.fn()]
+      const starts = [vi.fn(), vi.fn()]
+      const startup = orchestrateAppStartup({
+        acquireSingleInstanceLock: () => true,
+        quit: app.quit,
+        prepare: async () => {
+          await owner.start()
+          await pauseAt('after verification')
+          return composeApplicationRuntime(async (modules) => {
+            await modules.add({}, () => ({
+              capability: {},
+              start: starts[0],
+              dispose: disposers[0]
+            }))
+            await pauseAt('after first module')
+            await modules.add({}, () => ({
+              capability: {},
+              start: async () => {
+                starts[1]()
+                await pauseAt('during last module')
+              },
+              dispose: disposers[1]
+            }))
+            return {}
+          })
+        },
+        installMigrationQuitGuard: () => {},
+        installAppLifecycle: (runtime) => {
+          const lifecycle = installAppLifecycle({
+            app: app as never,
+            quit: app.quit,
+            createMainWindow: vi.fn(),
+            createInitialWindow: false,
+            createTray: () => undefined,
+            countWindows: () => 0,
+            isMigrationInProgress: () => false,
+            detectActiveSessions: () => [],
+            hasActiveReviewerWork: () => false,
+            createConfirmClose: () => async () => 'quit',
+            prepareForQuit: async () => {},
+            abortQuitPreparation: () => {},
+            flushSessionPersistence: async () => {},
+            shutdownBackends: () => runtime.dispose()
+          })
+          return { onSecondInstance: () => {}, onSystemShutdown: lifecycle.onSystemShutdown }
+        },
+        markReady: () => {
+          owner.complete()
+          guard.release()
+        }
+      })
+
+      try {
+        await reached.promise
+        expect(owner.getState()).toEqual({ phase: 'starting' })
+        expect.soft(app.quit().defaultPrevented).toBe(true)
+        expect.soft(app.exit).not.toHaveBeenCalled()
+        resume.resolve()
+        await startup
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        for (let index = 0; index < starts.length; index += 1) {
+          expect(starts[index]).toHaveBeenCalledOnce()
+          expect.soft(disposers[index]).toHaveBeenCalledOnce()
+        }
+        expect(app.exit).toHaveBeenCalledOnce()
+      } finally {
+        resume.resolve()
+        guard.dispose()
+        app.removeAllListeners()
+      }
+    }
+  )
+})
 
 describe('createSecondInstanceRelay', () => {
   it('records a signal that arrives before bind and drains it on bind, with its argv', () => {

--- a/src/main/database/database-startup-ipc.test.ts
+++ b/src/main/database/database-startup-ipc.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DATABASE_STARTUP_CHANNELS, type DatabaseStartupState } from '../../shared/database-startup'
 import { installDatabaseStartupQuitGuard, registerDatabaseStartupIpc } from './database-startup-ipc'
 import { createDatabaseStartupOwner, type DatabaseStartupOwner } from './database-startup-owner'
+import { DatabaseMigrationError } from './migration-service'
 
 describe('database startup Electron bridge', () => {
   it('serves the current state and broadcasts owner changes', async () => {
@@ -133,6 +136,116 @@ describe('database startup Electron bridge', () => {
 
     expect(quit).toHaveBeenCalledOnce()
     guard.dispose()
+  })
+})
+
+describe('startup quit handoff deadline', () => {
+  let guard: ReturnType<typeof installDatabaseStartupQuitGuard> | undefined
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    guard?.dispose()
+    vi.useRealTimers()
+  })
+
+  const setup = (
+    verifyDatabase: Parameters<
+      typeof createDatabaseStartupOwner
+    >[0]['verifyDatabase'] = async () => {}
+  ): {
+    owner: DatabaseStartupOwner
+    app: { quit: ReturnType<typeof vi.fn>; exit: ReturnType<typeof vi.fn> }
+    guard: ReturnType<typeof installDatabaseStartupQuitGuard>
+    requestQuit: () => ReturnType<typeof vi.fn>
+  } => {
+    const owner = createDatabaseStartupOwner({ verifyDatabase, reportBlocked: vi.fn() })
+    const app = Object.assign(new EventEmitter(), { quit: vi.fn(), exit: vi.fn() })
+    guard = installDatabaseStartupQuitGuard({ app: app as never, owner })
+    const requestQuit = (): ReturnType<typeof vi.fn> => {
+      const preventDefault = vi.fn()
+      app.emit('before-quit', { preventDefault })
+      return preventDefault
+    }
+    return { owner, app, guard, requestQuit }
+  }
+
+  it('bounds a stalled handoff without extending the deadline for repeated quits', async () => {
+    const { owner, app, guard, requestQuit } = setup()
+    await owner.start()
+    expect(requestQuit()).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(2_500)
+    expect(requestQuit()).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(2_499)
+    expect(app.exit).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(app.exit).toHaveBeenCalledExactlyOnceWith(0)
+    guard.release()
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(app.quit).not.toHaveBeenCalled()
+    expect(app.exit).toHaveBeenCalledOnce()
+  })
+
+  it.each(['starting', 'ready'] as const)(
+    'replays one quit and cancels the deadline when ownership is released from %s',
+    async (phase) => {
+      const { owner, app, guard, requestQuit } = setup()
+      await owner.start()
+      if (phase === 'ready') owner.complete()
+      expect(requestQuit()).toHaveBeenCalledOnce()
+      expect(requestQuit()).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(1)
+      expect(app.quit).not.toHaveBeenCalled()
+      guard.release()
+      guard.release()
+      expect(app.quit).toHaveBeenCalledOnce()
+      expect(requestQuit()).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(app.exit).not.toHaveBeenCalled()
+    }
+  )
+
+  it('starts the handoff deadline only after an active migration settles', async () => {
+    let finish!: () => void
+    const { owner, app, requestQuit } = setup(
+      (progress) =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+          progress({ phase: 'migrating', migrationId: '0001' })
+        })
+    )
+    const attempt = owner.start()
+    expect(requestQuit()).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(app.exit).not.toHaveBeenCalled()
+    finish()
+    await attempt
+    await vi.advanceTimersByTimeAsync(4_999)
+    expect(app.exit).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(app.exit).toHaveBeenCalledExactlyOnceWith(0)
+  })
+
+  it.each([false, true])(
+    'cancels pending work on disposal (attempt settled: %s)',
+    async (settled) => {
+      const { owner, app, guard, requestQuit } = setup()
+      await owner.start()
+      requestQuit()
+      if (settled) await vi.advanceTimersByTimeAsync(1)
+      guard.dispose()
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(app.quit).not.toHaveBeenCalled()
+      expect(app.exit).not.toHaveBeenCalled()
+    }
+  )
+
+  it('allows a first quit in blocked startup without a handoff deadline', async () => {
+    const { owner, app, requestQuit } = setup(async () => {
+      throw new DatabaseMigrationError('database_open_failed', 'Database is locked.', true)
+    })
+    expect((await owner.start()).phase).toBe('blocked')
+    expect(requestQuit()).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(app.exit).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/database/database-startup-ipc.ts
+++ b/src/main/database/database-startup-ipc.ts
@@ -42,7 +42,7 @@ const registerDatabaseStartupIpc = (deps: DatabaseStartupIpcDeps): (() => void) 
 }
 
 type DatabaseStartupQuitGuardDeps = {
-  app: Pick<App, 'on' | 'removeListener'> & { quit: () => void }
+  app: Pick<App, 'on' | 'removeListener' | 'exit'> & { quit: () => void }
   owner: Pick<DatabaseStartupOwner, 'getState' | 'isMigrating' | 'whenAttemptSettled'>
 }
 
@@ -58,16 +58,32 @@ const installDatabaseStartupQuitGuard = (
   let pendingQuit = false
   let quitIssued = false
   let released = false
+  let disposed = false
+  let quitTimeout: ReturnType<typeof setTimeout> | undefined
+  const clearQuitTimeout = (): void => {
+    if (quitTimeout) clearTimeout(quitTimeout)
+    quitTimeout = undefined
+  }
   const maybeQuit = (): void => {
-    if (!pendingQuit || !attemptSettled || quitIssued) return
+    if (!pendingQuit || !attemptSettled || quitIssued || disposed) return
     // A blocked startup never installs the application lifecycle. A verified startup hands the quit
     // request to that lifecycle so every runtime owner created during composition is torn down normally.
-    if (!released && deps.owner.getState().phase !== 'blocked') return
+    if (!released && deps.owner.getState().phase !== 'blocked') {
+      // Bound only the post-verification handoff. Never interrupt a database migration for an
+      // ordinary quit; a stalled runtime cannot provide its cooperative disposer before completion.
+      quitTimeout ??= setTimeout(() => {
+        quitIssued = true
+        deps.app.exit(0)
+      }, 5_000)
+      return
+    }
     quitIssued = true
+    clearQuitTimeout()
     deps.app.quit()
   }
   const onBeforeQuit = (event: Electron.Event): void => {
-    if (!deps.owner.isMigrating()) return
+    const phase = deps.owner.getState().phase
+    if (!deps.owner.isMigrating() && phase !== 'starting' && phase !== 'ready') return
     event.preventDefault()
     if (pendingQuit) return
     pendingQuit = true
@@ -78,13 +94,16 @@ const installDatabaseStartupQuitGuard = (
   }
   deps.app.on('before-quit', onBeforeQuit)
   const dispose = (): void => {
+    disposed = true
+    clearQuitTimeout()
     deps.app.removeListener('before-quit', onBeforeQuit)
   }
   return {
     dispose,
     release: () => {
       released = true
-      dispose()
+      clearQuitTimeout()
+      deps.app.removeListener('before-quit', onBeforeQuit)
       maybeQuit()
     }
   }


### PR DESCRIPTION
## Problem

A first ordinary quit after database verification enters `starting` bypasses the migration-only startup guard. The full application lifecycle is installed only after runtime composition, so the request can exit without running cleanup for modules already started.

## Proposed change

Retain quit ownership through `starting` and the brief `ready` interval before guard release. Coalesce pending requests and replay once through the installed lifecycle. If post-verification handoff stalls for 5 seconds after a quit request, exit directly; this explicitly accepted emergency fallback cannot guarantee cleanup of stalled modules or their child processes. Release/disposal cancels the timer, and disposal prevents late settlement callbacks from issuing quit.

Keep ordinary quits during active migration waiting for settlement and allow blocked startup to quit. Existing bounded system-shutdown behavior is unchanged.

## Scope and non-goals

- Reuse the existing guard, runtime builder, and full lifecycle; no new owner, dependency or production test seam.
- No business fields, persistence, historical migration, schema, model, startup phase or error-code changes. Only process-local timer/disposal state and the existing Electron `app.exit` capability are added to the guard.
- No composition cancellation/rollback redesign or changes to ACP framework protocols. Normal shutdown continues through the same shared disposer for all providers.

## Acceptance criteria and validation

All checks below ran on the final material implementation.

- Ordinary quit after verification, after the first module starts, and during the last module startup -> real owner + guard + startup orchestrator + runtime builder + full lifecycle in `app-startup.test.ts` -> all three cases repeatedly failed before the fix (quit not prevented, cleanup calls zero) and pass after it, with each started owner disposed once.
- Handoff deadline, repeated requests, migration settlement, blocked exit, release/disposal cancellation -> `database-startup-ipc.test.ts` -> pass. Expanded tests against original production code: 7 failed, 28 passed; failures identify missing handoff/deadline behavior.
- Final Test Impact Set: `npx vitest run src/main/app-startup.test.ts src/main/database/database-startup-ipc.test.ts src/main/database/database-startup-owner.test.ts src/main/application-runtime.test.ts src/main/app-lifecycle.test.ts src/main/system-lifecycle-adapters.test.ts` -> 6 files, 139 tests passed. Covers lifecycle ownership, representative consumers, cleanup and existing native/signal adapter contracts.
- `npm run typecheck:node` (including sandbox typecheck) -> passed.
- `npm run lint` -> passed.
- Independent standards/spec reviews -> no actionable findings; impact mapping accepted.

Tests use synthetic modules and simulated Electron events through existing boundaries. They do not demonstrate real child-process termination, native OS shutdown, or database integrity. Renderer/provider-specific tests are excluded because their contracts and implementation are unchanged. No full local portable suite ran per maintainer request; exact-head PR CI remains the full portable/platform validation authority.

## Review focus

Ownership lasts until explicit release. The deadline applies after verification, never to an ongoing migration for an ordinary quit, and cannot survive successful handoff or disposal.
