### PR TITLE
fix(notebook): settle kernel activity after run write failures

### DIFF
--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -309,9 +309,10 @@ class NotebookExecutionOwner {
     )
     const { environment, processKey } = admission.route
     const { binding, resolvedInterpreter } = admission
+    const kernelStatusBefore = session.kernelStatus(processKey)
     const kernelWasTerminated =
       session.isKernelTerminated(processKey) ||
-      session.kernelStatus(processKey) === 'terminated' ||
+      kernelStatusBefore === 'terminated' ||
       session.hasDurableKernelTermination(processKey)
     const kernelEpoch = session.kernelEpoch(
       processKey,
@@ -475,16 +476,33 @@ class NotebookExecutionOwner {
         }),
       settleLive: (result) => {
         session.completeCellRun(cell.id, result.status, result.cwdAfter ?? cwdBefore)
+        // Live activity ends even if either Run write fails. Only settle this process epoch's
+        // running state; lifecycle transitions (termination, restart, error) own their own status.
+        if (
+          kernelMarkedRunning &&
+          session.currentKernelEpochId(processKey) === kernelEpochId &&
+          session.kernelStatus(processKey) === 'running' &&
+          !session.isKernelTerminated(processKey) &&
+          (executedOnLiveKernel || !reachedExecutor)
+        ) {
+          if (!reachedExecutor && kernelWasTerminated) {
+            session.markKernelTerminated(processKey)
+            session.setKernelStatus(processKey, 'terminated')
+          } else if (!reachedExecutor && kernelStatusBefore === 'error') {
+            session.setKernelStatus(processKey, 'error')
+          } else {
+            this.options.setKernelStatus(session, 'idle', processKey)
+          }
+        }
       }
     })
     if (
-      !session.isKernelTerminated(processKey) &&
-      (executedOnLiveKernel || (kernelMarkedRunning && !reachedExecutor))
+      kernelWasTerminated &&
+      session.currentKernelEpochId(processKey) === kernelEpochId &&
+      session.kernelStatus(processKey) === 'idle' &&
+      !session.isKernelTerminated(processKey)
     ) {
-      this.options.setKernelStatus(session, 'idle', processKey)
-      if (kernelWasTerminated) {
-        await this.options.persistRecoveredKernelIdle(session, processKey)
-      }
+      await this.options.persistRecoveredKernelIdle(session, processKey)
     }
     const dependencyProjection = await this.options
       .projectDependencies(session, run, resolvedInterpreter)
@@ -595,15 +613,20 @@ class NotebookExecutionOwner {
       cwd: session.cwd,
       platform: this.options.platform
     })
+    const replStatusBefore = session.kernelStatus('repl')
     const replWasTerminated =
       !blockedMutation &&
-      (session.kernelStatus('repl') === 'terminated' || session.hasDurableKernelTermination('repl'))
+      (replStatusBefore === 'terminated' || session.hasDurableKernelTermination('repl'))
+    const replEpochId = blockedMutation
+      ? undefined
+      : session.kernelEpochId('repl', replWasTerminated)
     if (!blockedMutation) {
       session.clearKernelTerminated('repl')
       this.setReplStatus(session, 'running')
     }
 
     let executedOnLiveKernel = !blockedMutation
+    let reachedExecutor = false
     const { result } = await this.options.runTerminalization.run({
       session,
       runningRun,
@@ -637,6 +660,7 @@ class NotebookExecutionOwner {
                     ?.filter((input) => input.sourceKind === 'artifact-version')
                     .map((input) => input.sourceFileId) ?? []
               })
+              reachedExecutor = true
               return session
                 .execute({
                   runId,
@@ -664,16 +688,34 @@ class NotebookExecutionOwner {
         ).catch((error: unknown) => {
           executedOnLiveKernel = false
           return errorToExecutionResult(error, session.cwd)
-        })
+        }),
+      settleLive: () => {
+        if (
+          executedOnLiveKernel &&
+          session.currentKernelEpochId('repl') === replEpochId &&
+          session.kernelStatus('repl') === 'running' &&
+          !session.isKernelTerminated('repl')
+        ) {
+          if (!reachedExecutor && replWasTerminated) {
+            session.markKernelTerminated('repl')
+            session.setKernelStatus('repl', 'terminated')
+          } else if (!reachedExecutor && replStatusBefore === 'error') {
+            session.setKernelStatus('repl', 'error')
+          } else {
+            this.setReplStatus(session, 'idle')
+          }
+        }
+      }
     })
 
-    if (executedOnLiveKernel && !session.isKernelTerminated('repl')) {
-      this.setReplStatus(session, 'idle')
-      // A terminated status is durable; clear it once, while ordinary running/idle transitions stay
-      // in memory and do not rewrite the whole run.json document.
-      if (replWasTerminated) {
-        await this.options.persistRecoveredKernelIdle(session, 'repl')
-      }
+    // Clear durable termination only after the recovered Run commits; ordinary activity is volatile.
+    if (
+      replWasTerminated &&
+      session.currentKernelEpochId('repl') === replEpochId &&
+      session.kernelStatus('repl') === 'idle' &&
+      !session.isKernelTerminated('repl')
+    ) {
+      await this.options.persistRecoveredKernelIdle(session, 'repl')
     }
 
     return {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1611,6 +1611,148 @@ describe('notebook runtime service', () => {
     ])
   })
 
+  it.each(
+    (['python', 'r', 'repl'] as const).flatMap((kind) =>
+      (['appendRun', 'updateRun'] as const).map((write) => ({ kind, write }))
+    )
+  )('settles $kind kernel activity after a transient $write failure', async ({ kind, write }) => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const failure = new Error('injected run write failure')
+    const writeSpy = vi.spyOn(repository, write).mockRejectedValueOnce(failure)
+    const { service } = lifecycleCallbackHarness(root, { repository })
+    const request = { sessionId: 'session-1', workspaceCwd: root, code: '1' }
+
+    await expect(
+      kind === 'repl'
+        ? service.executeControl(request)
+        : service.execute({ ...request, language: kind })
+    ).rejects.toBe(failure)
+    expect(writeSpy).toHaveBeenCalledTimes(1)
+
+    // Reading state retries only the terminal record; live ownership must already be settled.
+    const state = await service.state(request)
+    expect(state.runs.map((run) => run.status)).toEqual(write === 'updateRun' ? ['completed'] : [])
+    expect(state.activeRunId).toBeUndefined()
+    expect(state.cells.every((cell) => cell.status !== 'running')).toBe(true)
+    if (kind === 'python') expect.soft(state.kernelStatus).toBe('idle')
+    const processKey =
+      kind === 'repl' ? 'repl' : `${kind}:${kind === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV}`
+    expect(state.environments).toContainEqual(
+      expect.objectContaining({ processKey, status: 'idle' })
+    )
+    expect(
+      (
+        await new NotebookRunRepository(root).findExisting('default-project', 'session-1')
+      )?.runs.map((run) => run.status)
+    ).toEqual(write === 'updateRun' ? ['completed'] : [])
+    await service.dispose()
+  })
+
+  it.each(['python', 'r', 'repl'] as const)(
+    'preserves a later %s termination when retrying a terminal Run write',
+    async (kind) => {
+      const root = await createStorageRoot()
+      const repository = new NotebookRunRepository(root)
+      const failure = new Error('injected terminal write failure')
+      vi.spyOn(repository, 'updateRun').mockRejectedValueOnce(failure)
+      const { service, lifecycles } = lifecycleCallbackHarness(root, { repository })
+      const request = { sessionId: 'session-1', workspaceCwd: root, code: '1' }
+      await expect(
+        kind === 'repl'
+          ? service.executeControl(request)
+          : service.execute({ ...request, language: kind })
+      ).rejects.toBe(failure)
+
+      const environment = kind === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+      await lifecycles[0].onTerminated(kind, environment)
+      const state = await service.state(request)
+      expect(state.runs).toEqual([expect.objectContaining({ status: 'completed' })])
+      expect(state.activeRunId).toBeUndefined()
+      if (kind === 'python') expect(state.kernelStatus).toBe('terminated')
+      expect(state.environments).toContainEqual(
+        expect.objectContaining({
+          processKey: kind === 'repl' ? 'repl' : `${kind}:${environment}`,
+          status: 'terminated'
+        })
+      )
+      expect(
+        (await new NotebookRunRepository(root).findExisting('default-project', 'session-1'))?.kernel
+          .terminatedKernelInstances
+      ).toContainEqual(kind === 'repl' ? { kind } : { kind, environment })
+      await service.dispose()
+    }
+  )
+
+  it.each(['terminated', 'idle-shutdown', 'error'] as const)(
+    'preserves a concurrent %s transition when the terminal Run write fails',
+    async (transition) => {
+      const root = await createStorageRoot()
+      const repository = new NotebookRunRepository(root)
+      const failure = new Error('injected terminal write failure')
+      const restartFailure = new Error('injected restart failure')
+      const { service, lifecycles } = lifecycleCallbackHarness(root, {
+        repository,
+        shutdown:
+          transition === 'error'
+            ? vi.fn().mockRejectedValueOnce(restartFailure).mockResolvedValue({ reaped: true })
+            : undefined
+      })
+      const request = { sessionId: 'session-1', workspaceCwd: root, code: '1' }
+      vi.spyOn(repository, 'updateRun').mockImplementationOnce(async () => {
+        if (transition === 'error') {
+          await expect(service.restart(request)).rejects.toBe(restartFailure)
+        } else if (transition === 'idle-shutdown') {
+          await lifecycles[0].onIdleShutdown('python', DEFAULT_PY_ENV)
+        } else {
+          await lifecycles[0].onTerminated('python', DEFAULT_PY_ENV)
+        }
+        throw failure
+      })
+
+      await expect(service.execute(request)).rejects.toBe(failure)
+      const state = await service.state(request)
+      const status = transition === 'error' ? 'error' : 'terminated'
+      expect(state.runs).toEqual([expect.objectContaining({ status: 'completed' })])
+      expect(state.activeRunId).toBeUndefined()
+      expect(state.kernelStatus).toBe(status)
+      expect(state.environments).toContainEqual(
+        expect.objectContaining({ processKey: `python:${DEFAULT_PY_ENV}`, status })
+      )
+      await service.dispose()
+    }
+  )
+
+  it.each(['python', 'r', 'repl'] as const)(
+    'preserves an existing %s termination when the initial Run write prevents dispatch',
+    async (kind) => {
+      const root = await createStorageRoot()
+      const repository = new NotebookRunRepository(root)
+      const { service, lifecycles } = lifecycleCallbackHarness(root, { repository })
+      const request = { sessionId: 'session-1', workspaceCwd: root, code: '1' }
+      const execute = (): Promise<unknown> =>
+        kind === 'repl'
+          ? service.executeControl(request)
+          : service.execute({ ...request, language: kind })
+      await execute()
+      const environment = kind === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+      await lifecycles[0].onTerminated(kind, environment)
+      const failure = new Error('injected initial write failure')
+      vi.spyOn(repository, 'appendRun').mockRejectedValueOnce(failure)
+
+      await expect(execute()).rejects.toBe(failure)
+      const state = await service.state(request)
+      expect(state.activeRunId).toBeUndefined()
+      expect(state.environments).toContainEqual(
+        expect.objectContaining({
+          processKey: kind === 'repl' ? 'repl' : `${kind}:${environment}`,
+          status: 'terminated'
+        })
+      )
+      await service.dispose()
+    }
+  )
+
   it('does not invoke the executor when the initial running record cannot be persisted', async () => {
     const root = await createStorageRoot()
     const repository = new NotebookRunRepository(root)


### PR DESCRIPTION
## Problem

A transient initial or terminal Run write failure leaves Python, R, or REPL activity at `running`.
After a state read repairs a completed terminal Run, the active Run is gone but the Notebook still
appears busy and disables the selected kernel's terminal.

## Proposed change

Settle volatile Kernel activity in the existing terminalization cleanup callback, before its change
notification. Restrict cleanup to the execution's process epoch and running state. Preserve genuine
termination, restart/error transitions, and pre-existing termination/error when dispatch never starts.
Terminal retries continue to repair only Run records, so they cannot replay stale Kernel transitions.

## Scope and non-goals

Two files: the execution owner and runtime-service regression tests. No public API, renderer logic,
architecture, state enum, schema, persisted field, or historical migration changes. REPL uses the
existing volatile epoch map. Ordinary running/idle transitions remain in memory; the existing durable
termination-clear path remains tied to successful execution persistence. No new durable retry journal.

## Acceptance criteria and validation

The first six regressions failed twice on unmodified production code with `running` instead of `idle`,
while completed Run recovery and active-Run cleanup succeeded. Fifteen focused cases now cover both
write boundaries across Python/R/REPL, late termination, concurrent termination/idle shutdown/restart
error, and pre-dispatch termination preservation.

The final local evidence is listed below. Independent review and exact-head PR CI remain required.

## Review focus

Cleanup must remain scoped to the current process epoch; terminal retry must never replay activity
changes. Verify Run, active Cell/Run, environment, and coarse default-Python status together. Existing
termination receipts and lifecycle-owned error/restarting status must survive cleanup.

## Final local evidence (commit `94d9c6d5`)

All checks below used the final material source/test contents. The temporary baseline comparison
restored the execution owner byte-for-byte afterward. No full local Vitest suite was run.

| Behavior | Project-owned command | Result |
| --- | --- | --- |
| Both write boundaries and lifecycle preservation | `npm test -- src/main/notebook/runtime-service.test.ts -t 'settles .* kernel activity\|preserves (a (later\|concurrent)\|an existing)'` | 15 passed |
| Runtime owner, terminalization, epochs, state projection, owner boundaries, renderer terminal gate | `npm test -- src/main/notebook/runtime-service.test.ts src/main/notebook/run-terminalization.test.ts src/main/notebook/session-aggregate.test.ts src/main/notebook/session-read-model.test.ts src/main/notebook/runtime-service.architecture.test.ts src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx --maxWorkers=1` | 358 passed; one existing Shell queue case hit the 15-second timeout |
| Remaining Shell queue case | `npm test -- src/main/notebook/runtime-service.test.ts -t 'queues overlapping shell calls in the same Session until the active command finishes' --maxWorkers=1` | Passed on both baseline production code and fixed production code in isolated reruns |
| Main and sandbox type contracts | `npm run typecheck:node` | Passed |
| Linted source | `npm run lint` | Passed |
| Patch integrity | `git diff --check` | Passed; final tracked worktree clean |

The wider first run under heavy concurrent machine load had eight concurrency/timing failures and
cleanup-after-timeout ENOENT errors. The final single-worker run reduced this to the one Shell timeout
above; both isolated baseline and fixed reruns passed. This does not prove CI timing stability, so the
initial failures are retained as a limitation rather than described as a clean first-pass run.

`test:affected:explain` reported `unknown module owner -> full` for the execution owner. The Notebook
module is not registered in the module selection manifest. Per the user's explicit no-full-suite
instruction, use the manually traced owner/consumer set above; do not modify CI ownership metadata
for this fix. Public interfaces, paths, subprocess implementation, and platform adapters are unchanged.
Cross-platform/full portable CI and independent review remain required before merge.
