### PR TITLE
fix(notebook): scope references and verify runtime binding commits

### DIFF
--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -957,7 +957,6 @@ describe('production delegated-work composition', () => {
             createTray: () => undefined,
             shutdownBackends,
             prepareForQuit,
-            holdSettingsInstallAdmission: () => () => undefined,
             abortQuitPreparation,
             holdSettingsInstallAdmission: () => () => undefined,
             getActiveSettingsInstallId: () => undefined,
@@ -967,7 +966,6 @@ describe('production delegated-work composition', () => {
             countWindows: () => 1,
             detectActiveSessions: () => [],
             hasActiveReviewerWork: () => false,
-            getActiveSettingsInstallId: () => undefined,
             createConfirmClose: () => confirmClose
           })
           quit()

--- a/src/main/notebook/environment-operations.ts
+++ b/src/main/notebook/environment-operations.ts
@@ -1,7 +1,7 @@
 import type { NotebookKernelMetadata, NotebookLanguage } from '../../shared/notebook'
 import type { ProvisionProgress } from '../../shared/notebook-env'
 import type { NotebookSessionRuntimeBinding } from './session-aggregate'
-import type { NotebookLaneIdentity } from './lane-identity'
+import { notebookLaneKey, type NotebookLaneIdentity } from './lane-identity'
 import { EnvironmentLeaseManager, type EnvironmentLeaseMode } from './environment-lease-manager'
 import type { NotebookRecoveryCoordinator } from './recovery-coordinator'
 import { errorLogFields } from '../logger'
@@ -237,18 +237,14 @@ export class NotebookEnvironmentOperations {
     runtimeId: string,
     options: { force?: boolean } = {}
   ): Promise<void> {
-    const targetSessions = Array.from(this.options.sessions()).filter((session) => {
-      const binding = session.runtimeBinding(language)
-      return binding?.runtimeId === runtimeId && binding.status !== 'unavailable'
-    })
+    // A pending selection can enter or leave this runtime. Match after the lane's earlier binding
+    // writes settle, rather than omitting a not-yet-published selection from revocation.
+    const targetSessions = Array.from(this.options.sessions())
     await this.options.bindings.runWrites(
-      targetSessions.map((session) => session.sessionId),
+      targetSessions.map((session) => notebookLaneKey(session.lane)),
       async () => {
         for (const session of targetSessions) {
-          const current = Array.from(this.options.sessions()).find(
-            (candidate) => candidate.sessionId === session.sessionId
-          )
-          if (current !== session) continue
+          if (!Array.from(this.options.sessions()).includes(session)) continue
           const revocation = await this.options.bindings.revoke(
             session,
             language,

--- a/src/main/notebook/local-rpc-notebook-adapter.test.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.test.ts
@@ -168,14 +168,18 @@ describe('notebook local RPC adapter', () => {
     expect(runtimeRequest).not.toHaveProperty('kernelSkillIds')
   })
 
-  it.each(['bindRuntime', 'switchRuntime'] as const)(
-    'forwards the service-owned failure receipt for %s without deriving a target',
-    async (method) => {
+  it.each(
+    (['bindRuntime', 'switchRuntime'] as const).flatMap((method) =>
+      [false, true].map((bindingChanged) => ({ method, bindingChanged }))
+    )
+  )(
+    'forwards the $method failure receipt with bindingChanged=$bindingChanged',
+    async ({ method, bindingChanged }) => {
       const capability = createCapability()
       const failure = {
         ok: false,
-        bindingChanged: false,
-        error: '"analysis" is not an enabled python runtime.',
+        bindingChanged,
+        error: 'Binding persistence failed. The previous kernel has stopped.',
         target: { language: 'python', selection: 'unresolved' }
       }
       vi.mocked(capability[method]).mockResolvedValueOnce(failure)

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1632,12 +1632,28 @@ describe('notebook control tool results', () => {
     expect(JSON.stringify(listedEnvironments)).not.toContain('internalPath')
   })
 
-  it('keeps failed bind/switch receipts explicit about the unchanged effective target', () => {
-    expect(
-      compactRuntimeBindingResult({
+  it.each([false, true])(
+    'keeps failed bind/switch receipts explicit when bindingChanged=%s',
+    (bindingChanged) => {
+      expect(
+        compactRuntimeBindingResult({
+          ok: false,
+          bindingChanged,
+          error: 'Binding persistence failed. The previous kernel has stopped.',
+          target: {
+            language: 'python',
+            selection: 'explicit-binding',
+            runtimeSource: 'managed',
+            environmentName: 'current-env',
+            runtimeId: '/runtime/envs/current-env/bin/python',
+            label: 'conda: current-env',
+            prefix: '/runtime/envs/current-env'
+          }
+        })
+      ).toEqual({
         ok: false,
-        bindingChanged: false,
-        error: '"analysis" is not an enabled python runtime.',
+        bindingChanged,
+        error: 'Binding persistence failed. The previous kernel has stopped.',
         target: {
           language: 'python',
           selection: 'explicit-binding',
@@ -1648,21 +1664,8 @@ describe('notebook control tool results', () => {
           prefix: '/runtime/envs/current-env'
         }
       })
-    ).toEqual({
-      ok: false,
-      bindingChanged: false,
-      error: '"analysis" is not an enabled python runtime.',
-      target: {
-        language: 'python',
-        selection: 'explicit-binding',
-        runtimeSource: 'managed',
-        environmentName: 'current-env',
-        runtimeId: '/runtime/envs/current-env/bin/python',
-        label: 'conda: current-env',
-        prefix: '/runtime/envs/current-env'
-      }
-    })
-  })
+    }
+  )
 })
 
 describe('manage_environments tool', () => {

--- a/src/main/notebook/repository.ts
+++ b/src/main/notebook/repository.ts
@@ -674,9 +674,13 @@ class NotebookRunRepository {
 
   // Reads an existing history document without creating one, returning null when none exists yet.
   // Used to detect notebooks that predate the current app launch so the UI can rehydrate entries.
-  async findExisting(projectId: string, sessionId: string): Promise<NotebookRunDocument | null> {
+  async findExisting(
+    projectId: string,
+    sessionId: string,
+    lane?: NotebookLaneIdentity
+  ): Promise<NotebookRunDocument | null> {
     try {
-      return await this.loadExisting(projectId, sessionId)
+      return await this.loadExisting(projectId, sessionId, lane)
     } catch (error) {
       if (isMissingFileError(error)) {
         return null

--- a/src/main/notebook/runtime-binding.ts
+++ b/src/main/notebook/runtime-binding.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util'
 import type { NotebookLanguage } from '../../shared/notebook'
 import {
   isEnvEnabled,
@@ -44,7 +45,7 @@ type RuntimeBindingSession = Pick<
   readonly lane: NotebookSessionAggregate['lane']
 }
 
-type RuntimeBindingRepository = Pick<NotebookRunRepository, 'setRuntimeBindings'>
+type RuntimeBindingRepository = Pick<NotebookRunRepository, 'setRuntimeBindings' | 'findExisting'>
 
 type NotebookRuntimeBindingOwnerOptions = {
   dataRoot: string
@@ -77,6 +78,10 @@ const defaultEnvironment = (
 
 /** Owns Notebook runtime discovery, selection, binding transitions, and durable wire snapshots. */
 export class NotebookRuntimeBindingOwner {
+  private readonly changes = new WeakMap<
+    RuntimeBindingSession,
+    Promise<RuntimeBindingOperationResult>
+  >()
   private activeWrites = 0
   private readonly activeWritesBySession = new Map<string, number>()
   private globalWriteGate: AdmissionGate | undefined
@@ -225,25 +230,7 @@ export class NotebookRuntimeBindingOwner {
     runtimeId: string,
     beforeBind?: (binding: NotebookSessionRuntimeBinding) => Promise<void>
   ): Promise<RuntimeBindingOperationResult> {
-    try {
-      const binding = await this.resolveEnabledRuntime(language, runtimeId)
-      const existing = session.runtimeBinding(language)
-      if (existing && existing.runtimeId !== binding.runtimeId) {
-        throw new Error(
-          `A ${language} runtime is already bound for this session. Use ` +
-            'notebook_switch_runtime to change it (it tears down the current kernel first).'
-        )
-      }
-      if (!existing) await beforeBind?.(binding)
-      session.setRuntimeBinding(language, binding)
-      await this.persist(session)
-      return {
-        bound: this.toWireBinding(binding),
-        bindings: this.snapshot(session)
-      }
-    } catch (error) {
-      return this.failureResult(session, language, error)
-    }
+    return this.change(session, language, runtimeId, false, beforeBind)
   }
 
   async switch(
@@ -252,28 +239,103 @@ export class NotebookRuntimeBindingOwner {
     runtimeId: string,
     beforeReplace: () => Promise<void>
   ): Promise<RuntimeBindingOperationResult> {
+    return this.change(session, language, runtimeId, true, beforeReplace)
+  }
+
+  private change(
+    session: RuntimeBindingSession,
+    language: NotebookLanguage,
+    runtimeId: string,
+    replace: boolean,
+    beforeChange?: (binding: NotebookSessionRuntimeBinding) => Promise<void>
+  ): Promise<RuntimeBindingOperationResult> {
+    // Both languages share one durable snapshot. Build each candidate only after the previous
+    // change has settled, so a concurrent selection cannot erase the other language's binding.
+    const previous = this.changes.get(session) ?? Promise.resolve()
+    const operation = previous
+      .catch(() => undefined)
+      .then(async () => {
+        let binding: NotebookSessionRuntimeBinding
+        try {
+          binding = await this.resolveEnabledRuntime(language, runtimeId)
+          const existing = session.runtimeBinding(language)
+          if (!replace && existing && existing.runtimeId !== binding.runtimeId) {
+            throw new Error(
+              `A ${language} runtime is already bound for this session. Use ` +
+                'notebook_switch_runtime to change it (it tears down the current kernel first).'
+            )
+          }
+          if (replace || !existing) await beforeChange?.(binding)
+        } catch (error) {
+          return this.failureResult(session, language, error)
+        }
+        // Keep reconciliation failures outside the validation catch: an unreadable commit must not
+        // be turned into a fabricated bindingChanged:false receipt.
+        return this.commitBinding(session, binding)
+      })
+    this.changes.set(session, operation)
+    return operation.finally(() => {
+      if (this.changes.get(session) === operation) this.changes.delete(session)
+    })
+  }
+
+  private async commitBinding(
+    session: RuntimeBindingSession,
+    binding: NotebookSessionRuntimeBinding
+  ): Promise<RuntimeBindingOperationResult> {
+    const language = binding.language
+    const previous = this.snapshot(session)
+    const candidate = this.toWireBinding(binding)
     try {
-      const binding = await this.resolveEnabledRuntime(language, runtimeId)
-      await beforeReplace()
-      session.setRuntimeBinding(language, binding)
-      await this.persist(session)
-      return {
-        bound: this.toWireBinding(binding),
-        bindings: this.snapshot(session)
-      }
+      await this.options.repository.setRuntimeBindings(
+        session.projectId,
+        session.sessionId,
+        { ...previous, [language]: candidate },
+        session.lane
+      )
     } catch (error) {
-      return this.failureResult(session, language, error)
+      // A rename may have succeeded before directory sync or cache refresh failed. Read the exact
+      // lane back before deciding whether the old or the candidate binding is authoritative.
+      try {
+        const document = await this.options.repository.findExisting(
+          session.projectId,
+          session.sessionId,
+          session.lane
+        )
+        if (!document) throw new Error('Notebook document is missing.')
+        const wire = document.runtimeBindings?.[language]
+        const stored = wire ? this.toWireBinding(wire) : undefined
+        if (isDeepStrictEqual(stored, candidate)) {
+          session.setRuntimeBinding(language, binding)
+        } else if (!isDeepStrictEqual(stored, previous[language])) {
+          throw new Error('Stored runtime binding differs from both attempted bindings.')
+        }
+      } catch (readError) {
+        throw new Error(
+          `Could not confirm stored runtime binding after ${String(error)}: ${String(readError)}`,
+          { cause: error }
+        )
+      }
+      return this.failureResult(
+        session,
+        language,
+        error,
+        !isDeepStrictEqual(previous[language], this.snapshot(session)[language])
+      )
     }
+    session.setRuntimeBinding(language, binding)
+    return { bound: candidate, bindings: this.snapshot(session) }
   }
 
   private async failureResult(
     session: RuntimeBindingSession,
     language: NotebookLanguage,
-    error: unknown
+    error: unknown,
+    bindingChanged = false
   ): Promise<RuntimeBindingOperationResult> {
     return {
       ok: false,
-      bindingChanged: false,
+      bindingChanged,
       error: error instanceof Error ? error.message : String(error),
       bindings: this.snapshot(session),
       target: await this.effectiveTarget(session, language)

--- a/src/main/notebook/runtime-binding.ts
+++ b/src/main/notebook/runtime-binding.ts
@@ -78,10 +78,7 @@ const defaultEnvironment = (
 
 /** Owns Notebook runtime discovery, selection, binding transitions, and durable wire snapshots. */
 export class NotebookRuntimeBindingOwner {
-  private readonly changes = new WeakMap<
-    RuntimeBindingSession,
-    Promise<RuntimeBindingOperationResult>
-  >()
+  private readonly pendingWrites = new Map<string, AdmissionGate>()
   private activeWrites = 0
   private readonly activeWritesBySession = new Map<string, number>()
   private globalWriteGate: AdmissionGate | undefined
@@ -111,17 +108,29 @@ export class NotebookRuntimeBindingOwner {
     }
     this.acquireWrites(sessionIds)
 
+    // Reserve every affected lane together. Revocation, repair and explicit selections all mutate
+    // the same binding snapshot; their read/modify/write sequences must share this queue.
+    const predecessors = sessionIds.flatMap((id) => {
+      const pending = this.pendingWrites.get(id)
+      return pending ? [pending.promise] : []
+    })
+    const gate = admissionGate()
+    for (const id of sessionIds) this.pendingWrites.set(id, gate)
+
     let result: Promise<T>
     try {
       // Start the operation synchronously with admission. In particular, ensureSession() must enter
       // the registry before a same-tick global teardown can close registry creation admission.
-      result = operation()
+      result = predecessors.length > 0 ? Promise.all(predecessors).then(operation) : operation()
     } catch (error) {
-      for (const sessionId of sessionIds) this.releaseWrite(sessionId)
-      return Promise.reject(error)
+      result = Promise.reject(error)
     }
     return result.finally(() => {
-      for (const sessionId of sessionIds) this.releaseWrite(sessionId)
+      for (const sessionId of sessionIds) {
+        if (this.pendingWrites.get(sessionId) === gate) this.pendingWrites.delete(sessionId)
+        this.releaseWrite(sessionId)
+      }
+      gate.release()
     })
   }
 
@@ -242,41 +251,30 @@ export class NotebookRuntimeBindingOwner {
     return this.change(session, language, runtimeId, true, beforeReplace)
   }
 
-  private change(
+  private async change(
     session: RuntimeBindingSession,
     language: NotebookLanguage,
     runtimeId: string,
     replace: boolean,
     beforeChange?: (binding: NotebookSessionRuntimeBinding) => Promise<void>
   ): Promise<RuntimeBindingOperationResult> {
-    // Both languages share one durable snapshot. Build each candidate only after the previous
-    // change has settled, so a concurrent selection cannot erase the other language's binding.
-    const previous = this.changes.get(session) ?? Promise.resolve()
-    const operation = previous
-      .catch(() => undefined)
-      .then(async () => {
-        let binding: NotebookSessionRuntimeBinding
-        try {
-          binding = await this.resolveEnabledRuntime(language, runtimeId)
-          const existing = session.runtimeBinding(language)
-          if (!replace && existing && existing.runtimeId !== binding.runtimeId) {
-            throw new Error(
-              `A ${language} runtime is already bound for this session. Use ` +
-                'notebook_switch_runtime to change it (it tears down the current kernel first).'
-            )
-          }
-          if (replace || !existing) await beforeChange?.(binding)
-        } catch (error) {
-          return this.failureResult(session, language, error)
-        }
-        // Keep reconciliation failures outside the validation catch: an unreadable commit must not
-        // be turned into a fabricated bindingChanged:false receipt.
-        return this.commitBinding(session, binding)
-      })
-    this.changes.set(session, operation)
-    return operation.finally(() => {
-      if (this.changes.get(session) === operation) this.changes.delete(session)
-    })
+    let binding: NotebookSessionRuntimeBinding
+    try {
+      binding = await this.resolveEnabledRuntime(language, runtimeId)
+      const existing = session.runtimeBinding(language)
+      if (!replace && existing && existing.runtimeId !== binding.runtimeId) {
+        throw new Error(
+          `A ${language} runtime is already bound for this session. Use ` +
+            'notebook_switch_runtime to change it (it tears down the current kernel first).'
+        )
+      }
+      if (replace || !existing) await beforeChange?.(binding)
+    } catch (error) {
+      return this.failureResult(session, language, error)
+    }
+    // Keep reconciliation failures outside the validation catch: an unreadable commit must not
+    // be turned into a fabricated bindingChanged:false receipt.
+    return this.commitBinding(session, binding)
   }
 
   private async commitBinding(

--- a/src/main/notebook/runtime-repair.ts
+++ b/src/main/notebook/runtime-repair.ts
@@ -2,6 +2,7 @@ import type { NotebookLanguage } from '../../shared/notebook'
 import type { NotebookEnvironmentOperations } from './environment-operations'
 import type { NotebookPackageAdmittedTarget } from './package-admission'
 import type { NotebookRuntimeBindingOwner } from './runtime-binding'
+import { notebookLaneKey } from './lane-identity'
 import {
   addRepairRequired,
   clearRepairRequired,
@@ -68,7 +69,7 @@ class NotebookRuntimeRepairOwner {
     const environmentName = defaultEnvironment(language)
     const target = { language, environmentName, binding } satisfies RuntimeRepairScope
     const affectedLanguages = ['python', 'r'] as const
-    const sessions = this.matchingSessions(target, true)
+    const sessions = Array.from(this.options.sessions())
     const repairKeys = new Set(this.options.policy.registryKeys(language, environmentName, binding))
     for (const session of sessions) {
       for (const [boundLanguage, boundBinding] of session.runtimeBindingEntries()) {
@@ -92,7 +93,7 @@ class NotebookRuntimeRepairOwner {
     }
 
     await this.options.bindings.runWrites(
-      sessions.map((session) => session.sessionId),
+      sessions.map((session) => notebookLaneKey(session.lane)),
       async () => {
         const changed = new Set<RepairSession>()
         for (const session of sessions) {
@@ -132,9 +133,9 @@ class NotebookRuntimeRepairOwner {
     const languages: readonly NotebookLanguage[] = managed
       ? ['python', 'r']
       : [repairTarget.language]
-    const sessions = this.matchingSessions(repairTarget, managed)
+    const sessions = Array.from(this.options.sessions())
     await this.options.bindings.runWrites(
-      sessions.map((session) => session.sessionId),
+      sessions.map((session) => notebookLaneKey(session.lane)),
       async () => {
         const changed = new Set<RepairSession>()
         if (managed) {
@@ -228,14 +229,13 @@ class NotebookRuntimeRepairOwner {
       }
     }
 
-    const sessions = this.matchingSessions(target, false).filter((session) =>
-      Boolean(session.runtimeBinding(language))
-    )
+    const sessions = Array.from(this.options.sessions())
     await this.options.bindings.runWrites(
-      sessions.map((session) => session.sessionId),
+      sessions.map((session) => notebookLaneKey(session.lane)),
       async () => {
         for (const session of sessions) {
           if (!this.options.isCurrentSession(session)) continue
+          if (!this.matches(session, language, target, false)) continue
           const previous = session.runtimeBinding(language)
           if (!previous) continue
           session.setRuntimeBinding(language, replacement)
@@ -322,27 +322,10 @@ class NotebookRuntimeRepairOwner {
     )
   }
 
-  private matchingSessions(target: RuntimeRepairScope, crossLanguage: boolean): RepairSession[] {
-    const languages: readonly NotebookLanguage[] = crossLanguage
-      ? ['python', 'r']
-      : [target.language]
-    return Array.from(this.options.sessions()).filter((session) =>
-      languages.some((language) => this.matches(session, language, target, crossLanguage))
-    )
-  }
-
   private async restoreBindings(target: RuntimeRepairScope, crossLanguage: boolean): Promise<void> {
-    const sessions = this.matchingSessions(target, crossLanguage).filter((session) =>
-      session
-        .runtimeBindingEntries()
-        .some(
-          ([language, binding]) =>
-            binding.reason === 'repair-required' &&
-            this.matches(session, language, target, crossLanguage)
-        )
-    )
+    const sessions = Array.from(this.options.sessions())
     await this.options.bindings.runWrites(
-      sessions.map((session) => session.sessionId),
+      sessions.map((session) => notebookLaneKey(session.lane)),
       async () => {
         const changedSessions: RepairSession[] = []
         for (const session of sessions) {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4041,6 +4041,82 @@ describe('notebook runtime service', () => {
     expect(reference).toBeNull()
   })
 
+  describe('N05 project-scoped session references', () => {
+    const states = ['live', 'persisted', 'absent'] as const
+
+    it.each(states.flatMap((p) => states.map((q) => ({ p, q }))))(
+      'keeps a shared session ID scoped to its project (P=$p, Q=$q)',
+      async ({ p, q }) => {
+        const root = await createStorageRoot()
+        const makeService = (): NotebookRuntimeService =>
+          new NotebookRuntimeService({
+            configRoot: root,
+            dataRoot: root,
+            projectId: 'project-p',
+            repository: new NotebookRunRepository(root)
+          })
+        const projects = [
+          { projectId: 'project-p', state: p },
+          { projectId: 'project-q', state: q }
+        ]
+        const writer = makeService()
+        const service = makeService()
+        try {
+          for (const { projectId, state } of projects) {
+            if (state === 'absent') continue
+            const workspaceCwd = join(root, projectId)
+            await mkdir(workspaceCwd)
+            await writer.state({ projectId, sessionId: 'shared-session', workspaceCwd })
+          }
+          await writer.shutdownAll()
+          for (const { projectId, state } of projects) {
+            if (state !== 'live') continue
+            await service.state({
+              projectId,
+              sessionId: 'shared-session',
+              workspaceCwd: join(root, projectId)
+            })
+          }
+
+          // Include the omitted project ID: it must still resolve to the configured default.
+          for (const requestedProjectId of [undefined, 'project-p', 'project-q']) {
+            const projectId = requestedProjectId ?? 'project-p'
+            const state = projectId === 'project-p' ? p : q
+            const reference = await service.getSessionReference({
+              projectId: requestedProjectId,
+              sessionId: 'shared-session',
+              workspaceCwd: join(root, projectId)
+            })
+            const notebookSessionRoot = join(root, 'notebooks', projectId, 'shared-session')
+            expect.soft(reference).toEqual(
+              state === 'absent'
+                ? null
+                : {
+                    projectId,
+                    sessionId: 'shared-session',
+                    workspaceCwd: expect.any(String),
+                    notebookSessionRoot,
+                    dataRoot: join(notebookSessionRoot, 'data'),
+                    runtimeRoot: getRuntimeRoot(root),
+                    runJsonPath: join(notebookSessionRoot, 'run.json')
+                  }
+            )
+            if (reference && state !== 'absent') {
+              // Live references expose the execution cwd; persisted references expose workspaceCwd.
+              // Both must belong to the requested project, regardless of the selected read source.
+              expect
+                .soft([join(root, projectId), join(notebookSessionRoot, 'data')])
+                .toContain(reference.workspaceCwd)
+            }
+          }
+        } finally {
+          await writer.dispose()
+          await service.dispose()
+        }
+      }
+    )
+  })
+
   it('rebuilds a session reference from persisted run.json without a live runtime session', async () => {
     const root = await createStorageRoot()
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -8638,6 +8638,99 @@ describe('v4 runtime bindings & agent tools', () => {
     }
   )
 
+  it.each(
+    (['bindRuntime', 'switchRuntime'] as const).flatMap((operation) =>
+      [false, true].flatMap((writeFails) =>
+        [false, true].map((childLane) => ({ operation, writeFails, childLane }))
+      )
+    )
+  )(
+    'N06 waits for $operation before dispatch (write fails: $writeFails, child lane: $childLane)',
+    async ({ operation, writeFails, childLane }) => {
+      const root = await createStorageRoot()
+      const repository = new NotebookRunRepository(root)
+      const executions: NotebookExecutionRequest[] = []
+      const terminations: string[] = []
+      const service = bindingService(root, {
+        repository,
+        executions,
+        terminations,
+        enablement: {
+          enabled: { [userPyA.envId]: true, [userPyB.envId]: true },
+          installAuthorized: {}
+        }
+      })
+      const request = {
+        projectId: 'project-q',
+        sessionId: 'same-session',
+        workspaceCwd: root,
+        ...(childLane
+          ? {
+              provenanceContext: {
+                rootFrameId: 'root-frame-same-session',
+                agentFrameId: 'child',
+                messageBranchId: 'branch',
+                runtimeSegmentId: 'segment',
+                promptMessageId: 'message'
+              }
+            }
+          : {})
+      }
+      const started = createDeferred<void>()
+      const gate = createDeferred<void>()
+      let changing: Promise<unknown> | undefined
+      let executing: Promise<unknown> | undefined
+      try {
+        if (operation === 'switchRuntime') {
+          await service.bindRuntime({ ...request, language: 'python', runtimeId: userPyA.envId })
+        }
+        const cell = await service.execute({ ...request, code: '1' })
+        executions.length = 0
+        const persist = repository.setRuntimeBindings.bind(repository)
+        vi.spyOn(repository, 'setRuntimeBindings').mockImplementationOnce(async (...args) => {
+          started.resolve()
+          await gate.promise
+          if (writeFails) throw new Error('binding commit failed')
+          return persist(...args)
+        })
+        changing = service[operation]({
+          ...request,
+          language: 'python',
+          runtimeId: userPyB.envId
+        })
+        await started.promise
+        expect(terminations).toEqual(['python:default-python'])
+        executing = service.runCell({ ...request, cellId: cell.cellId })
+        // Another project's identical session ID remains executable while this lane is held.
+        await expect(
+          service.execute({
+            projectId: 'other-project',
+            sessionId: request.sessionId,
+            workspaceCwd: root,
+            code: '2'
+          })
+        ).resolves.toHaveProperty('status', 'completed')
+        expect.soft(executions.filter((run) => run.projectId === request.projectId)).toEqual([])
+        gate.resolve()
+        await changing
+        await expect(executing).resolves.toHaveProperty('status', 'completed')
+        const dispatched = executions.filter((run) => run.projectId === request.projectId)
+        expect(dispatched).toHaveLength(1)
+        expect(dispatched[0].resolvedInterpreter?.command).toBe(
+          writeFails
+            ? operation === 'switchRuntime'
+              ? userPyA.interpreterPath
+              : undefined
+            : userPyB.interpreterPath
+        )
+      } finally {
+        gate.resolve()
+        await Promise.allSettled([changing, executing])
+        await service.dispose()
+      }
+    }
+  )
+
   it('reconciles a failed binding write against its project and child lane, not the root binding', async () => {
     const root = await createStorageRoot()
     const repository = new NotebookRunRepository(root)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -19,7 +19,7 @@ import {
 import { effectiveMirrorAsync, resetAutoMirrorCache } from './mirror-probe'
 import { getNotebookInputRoot } from './input-staging'
 import { getNotebookDataRoot, NotebookRunRepository, getRuntimeRoot } from './repository'
-import { createRootNotebookLane } from './lane-identity'
+import { createFrameNotebookLane, createRootNotebookLane } from './lane-identity'
 import {
   RuntimeOperationJournal,
   operationJournalPath,
@@ -8428,6 +8428,7 @@ describe('v4 runtime bindings & agent tools', () => {
       enablement?: RuntimeEnablement
       executions?: NotebookExecutionRequest[]
       terminations?: string[]
+      notebookChanges?: string[]
       terminate?: (kind: 'python' | 'r' | 'repl', env: string) => Promise<void>
       platform?: NodeJS.Platform
       repository?: NotebookRunRepository
@@ -8466,6 +8467,9 @@ describe('v4 runtime bindings & agent tools', () => {
       },
       platform: options.platform,
       environmentManager: options.environmentManager,
+      callbacks: {
+        onNotebookChanged: (reference) => options.notebookChanges?.push(reference.sessionId)
+      },
       installPackagesImpl: options.installPackagesImpl,
       // A fake installer must have a fake inventory refresh too. Mixing the fake installer with a
       // scan of the host's real /usr/bin/python3 makes these tests depend on runner packages.
@@ -8499,6 +8503,233 @@ describe('v4 runtime bindings & agent tools', () => {
       })
     })
   }
+
+  it.each(
+    [
+      { operation: 'bindRuntime', running: false },
+      { operation: 'bindRuntime', running: true },
+      { operation: 'switchRuntime', running: true }
+    ].flatMap((scenario) =>
+      (['before-write', 'after-write', 'unreadable'] as const).map((failurePhase) => ({
+        ...scenario,
+        operation: scenario.operation as 'bindRuntime' | 'switchRuntime',
+        failurePhase
+      }))
+    )
+  )(
+    'N06 reports $failurePhase failure in $operation (running kernel: $running)',
+    async ({ operation, running, failurePhase }) => {
+      const root = await createStorageRoot()
+      const repository = new NotebookRunRepository(root)
+      const executions: NotebookExecutionRequest[] = []
+      const terminations: string[] = []
+      const notebookChanges: string[] = []
+      const enablement = {
+        enabled: { [userPyA.envId]: true, [userPyB.envId]: true },
+        installAuthorized: {}
+      }
+      const service = bindingService(root, {
+        repository,
+        enablement,
+        executions,
+        terminations,
+        notebookChanges
+      })
+      const request = { projectId: 'default-project', sessionId: 's', workspaceCwd: root }
+      const runJsonPath = join(root, 'notebooks', request.projectId, request.sessionId, 'run.json')
+      const diskBindings = async (): Promise<unknown> =>
+        JSON.parse(await readFile(runJsonPath, 'utf8')).runtimeBindings
+      let restarted: NotebookRuntimeService | undefined
+      try {
+        if (operation === 'switchRuntime') {
+          await expect(
+            service.bindRuntime({ ...request, language: 'python', runtimeId: userPyA.envId })
+          ).resolves.toHaveProperty('bound.runtimeId', userPyA.envId)
+        }
+        if (running) {
+          await expect(service.execute({ ...request, code: '1' })).resolves.toHaveProperty(
+            'status',
+            'completed'
+          )
+        }
+        const before = (await service.state(request)).runtimeBindings
+        const beforeDisk = await diskBindings()
+        const failure = new Error('N06 injected runtime binding write failure')
+        const persistBindings = repository.setRuntimeBindings.bind(repository)
+        const write = vi
+          .spyOn(repository, 'setRuntimeBindings')
+          .mockImplementation(async (...args) => {
+            if (failurePhase === 'after-write') await persistBindings(...args)
+            if (failurePhase === 'unreadable') {
+              vi.spyOn(repository, 'findExisting').mockRejectedValueOnce(
+                new Error('N06 readback failed')
+              )
+            }
+            throw failure
+          })
+        notebookChanges.length = 0
+
+        const operationResult = service[operation]({
+          ...request,
+          language: 'python',
+          runtimeId: userPyB.envId
+        })
+        if (failurePhase === 'unreadable') {
+          await expect(operationResult).rejects.toThrow(/confirm.*stored.*binding/i)
+          return
+        }
+        const result = await operationResult
+        const published = failurePhase === 'after-write'
+
+        expect(write).toHaveBeenCalledTimes(1)
+        expect.soft(result).not.toHaveProperty('bound')
+        expect.soft(result).toMatchObject({
+          ok: false,
+          bindingChanged: published,
+          error: expect.stringContaining(failure.message),
+          target: {
+            selection:
+              published || operation === 'switchRuntime' ? 'explicit-binding' : 'implicit-default',
+            runtimeId: published
+              ? userPyB.envId
+              : operation === 'switchRuntime'
+                ? userPyA.envId
+                : managedPy.envId
+          }
+        })
+        const expected = published
+          ? { python: expect.objectContaining({ runtimeId: userPyB.envId }), r: undefined }
+          : before
+        expect.soft(result.bindings).toEqual(expected)
+        expect.soft((await service.state(request)).runtimeBindings).toEqual(expected)
+        if (published) {
+          expect.soft(await diskBindings()).toMatchObject({ python: { runtimeId: userPyB.envId } })
+        } else {
+          expect.soft(await diskBindings()).toEqual(beforeDisk)
+        }
+        if (running) {
+          expect.soft(result).toHaveProperty('error', expect.stringMatching(/kernel.*stopped/i))
+          expect.soft(notebookChanges).toContain(request.sessionId)
+        }
+        // This is a new repository and owner, not the live service's in-memory projection.
+        restarted = bindingService(root, { enablement, executions })
+        expect.soft((await restarted.state(request)).runtimeBindings).toEqual(expected)
+        await expect(restarted.execute({ ...request, code: '2' })).resolves.toHaveProperty(
+          'status',
+          'completed'
+        )
+        expect
+          .soft(executions.at(-1)?.resolvedInterpreter?.command)
+          .toBe(
+            published
+              ? userPyB.interpreterPath
+              : operation === 'switchRuntime'
+                ? userPyA.interpreterPath
+                : undefined
+          )
+        expect.soft(executions.at(-1)?.environment).toBe(DEFAULT_PY_ENV)
+        // Record the existing teardown boundary separately from the binding commit contract.
+        expect.soft(terminations).toEqual(running ? ['python:default-python'] : [])
+        write.mockRestore()
+      } finally {
+        await restarted?.dispose()
+        await service.dispose()
+      }
+    }
+  )
+
+  it('reconciles a failed binding write against its project and child lane, not the root binding', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const service = bindingService(root, {
+      repository,
+      enablement: {
+        enabled: { [userPyA.envId]: true, [userPyB.envId]: true },
+        installAuthorized: {}
+      }
+    })
+    const request = { projectId: 'project-q', sessionId: 's', workspaceCwd: root }
+    const child = {
+      ...request,
+      provenanceContext: {
+        rootFrameId: 'root-frame-s',
+        agentFrameId: 'child',
+        messageBranchId: 'branch',
+        runtimeSegmentId: 'segment',
+        promptMessageId: 'message'
+      }
+    }
+    try {
+      await service.bindRuntime({ ...request, language: 'python', runtimeId: userPyB.envId })
+      await service.bindRuntime({ ...child, language: 'python', runtimeId: userPyA.envId })
+      vi.spyOn(repository, 'setRuntimeBindings').mockRejectedValueOnce(
+        new Error('child write failed')
+      )
+      await expect(
+        service.switchRuntime({ ...child, language: 'python', runtimeId: userPyB.envId })
+      ).resolves.toMatchObject({
+        ok: false,
+        bindingChanged: false,
+        target: { runtimeId: userPyA.envId }
+      })
+      expect((await service.state(child)).runtimeBindings.python?.runtimeId).toBe(userPyA.envId)
+      const fresh = new NotebookRunRepository(root)
+      expect((await fresh.findExisting('project-q', 's'))?.runtimeBindings?.python?.runtimeId).toBe(
+        userPyB.envId
+      )
+      expect(
+        (
+          await fresh.findExisting(
+            'project-q',
+            's',
+            createFrameNotebookLane('project-q', 's', 'child')
+          )
+        )?.runtimeBindings?.python?.runtimeId
+      ).toBe(userPyA.envId)
+    } finally {
+      await service.dispose()
+    }
+  })
+
+  it('publishes bindings after commit and preserves both languages during concurrent selections', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const service = bindingService(root, {
+      repository,
+      discovered: [userPyA, userR],
+      enablement: { enabled: { [userPyA.envId]: true, [userR.envId]: true }, installAuthorized: {} }
+    })
+    const request = { projectId: 'default-project', sessionId: 's', workspaceCwd: root }
+    const started = createDeferred<void>()
+    const gate = createDeferred<void>()
+    const persist = repository.setRuntimeBindings.bind(repository)
+    vi.spyOn(repository, 'setRuntimeBindings').mockImplementationOnce(async (...args) => {
+      started.resolve()
+      await gate.promise
+      return persist(...args)
+    })
+    const python = service.bindRuntime({ ...request, language: 'python', runtimeId: userPyA.envId })
+    const r = service.bindRuntime({ ...request, language: 'r', runtimeId: userR.envId })
+    try {
+      await started.promise
+      expect
+        .soft((await service.listRuntimes(request)).bindings)
+        .toEqual({ python: undefined, r: undefined })
+      gate.resolve()
+      const results = await Promise.all([python, r])
+      expect(results.every((result) => 'bound' in result)).toBe(true)
+      const expected = { python: { runtimeId: userPyA.envId }, r: { runtimeId: userR.envId } }
+      expect((await service.state(request)).runtimeBindings).toMatchObject(expected)
+      expect(
+        (await new NotebookRunRepository(root).findExisting(request.projectId, request.sessionId))
+          ?.runtimeBindings
+      ).toMatchObject(expected)
+    } finally {
+      gate.resolve()
+      await Promise.allSettled([python, r])
+      await service.dispose()
+    }
+  })
 
   it('prepares a healthy managed Python reinstall by closing explicit and implicit kernels', async () => {
     const root = await createStorageRoot()

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -8731,6 +8731,103 @@ describe('v4 runtime bindings & agent tools', () => {
     }
   })
 
+  it.each(
+    (['revoke-old', 'revoke-new', 'prepare-repair', 'complete-repair'] as const).flatMap(
+      (mutation) => [false, true].map((childLane) => ({ mutation, childLane }))
+    )
+  )(
+    'N06 serializes $mutation with a published switch (child lane: $childLane)',
+    async ({ mutation, childLane }) => {
+      const root = await createStorageRoot()
+      const repository = new NotebookRunRepository(root)
+      const enablement = {
+        enabled: { [managedPy.envId]: true, [userPyB.envId]: true },
+        installAuthorized: {}
+      }
+      const service = bindingService(root, { repository, enablement })
+      const request = {
+        projectId: 'project-q',
+        sessionId: 'same-session',
+        workspaceCwd: root,
+        ...(childLane
+          ? {
+              provenanceContext: {
+                rootFrameId: 'root-frame-same-session',
+                agentFrameId: 'child',
+                messageBranchId: 'branch',
+                runtimeSegmentId: 'segment',
+                promptMessageId: 'message'
+              }
+            }
+          : {})
+      }
+      const published = createDeferred<void>()
+      const gate = createDeferred<void>()
+      let switching: Promise<unknown> | undefined
+      let mutating: Promise<unknown> | undefined
+      let restarted: NotebookRuntimeService | undefined
+      try {
+        await service.bindRuntime({ ...request, language: 'python', runtimeId: managedPy.envId })
+        const persist = repository.setRuntimeBindings.bind(repository)
+        vi.spyOn(repository, 'setRuntimeBindings').mockImplementationOnce(async (...args) => {
+          const document = await persist(...args)
+          published.resolve()
+          await gate.promise
+          return document
+        })
+        switching = service.switchRuntime({
+          ...request,
+          language: 'python',
+          runtimeId: userPyB.envId
+        })
+        await published.promise
+        if (mutation.startsWith('revoke')) {
+          const runtimeId = mutation === 'revoke-old' ? managedPy.envId : userPyB.envId
+          enablement.enabled[runtimeId] = false
+          mutating = service.revokeRuntime('python', runtimeId)
+        } else if (mutation === 'prepare-repair') {
+          mutating = service.prepareRuntimeRepair('python', {
+            kind: 'runtime',
+            runtimeId: managedPy.envId
+          })
+        } else {
+          mutating = service.completeRuntimeRepair('python')
+        }
+        // Let the competing public operation enter while publication is held. No wall-clock race.
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        gate.resolve()
+        await expect(switching).resolves.toHaveProperty('bound.runtimeId', userPyB.envId)
+        await mutating
+        const expected = {
+          runtimeId: userPyB.envId,
+          status: mutation === 'revoke-new' ? 'unavailable' : 'active'
+        }
+        expect.soft((await service.state(request)).runtimeBindings.python).toMatchObject(expected)
+        const lane = childLane
+          ? createFrameNotebookLane(request.projectId, request.sessionId, 'child')
+          : createRootNotebookLane(request.projectId, request.sessionId, 'root-frame-same-session')
+        expect
+          .soft(
+            (
+              await new NotebookRunRepository(root).findExisting(
+                request.projectId,
+                request.sessionId,
+                lane
+              )
+            )?.runtimeBindings?.python
+          )
+          .toMatchObject(expected)
+        restarted = bindingService(root, { enablement })
+        expect.soft((await restarted.state(request)).runtimeBindings.python).toMatchObject(expected)
+      } finally {
+        gate.resolve()
+        await Promise.allSettled([switching, mutating])
+        await restarted?.dispose()
+        await service.dispose()
+      }
+    }
+  )
+
   it('prepares a healthy managed Python reinstall by closing explicit and implicit kernels', async () => {
     const root = await createStorageRoot()
     const terminations: string[] = []

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -452,7 +452,8 @@ class NotebookRuntimeService {
       defaultProjectId,
       repository: this.repository,
       dependencyAnalyzer: this.dependencyAnalyzer,
-      findSession: (sessionId) => this.sessions.get(this.sessionLifecycle.rootLane(sessionId)),
+      findSession: (projectId, sessionId) =>
+        this.sessions.get(this.sessionLifecycle.rootLane(sessionId, projectId)),
       runtimeBindings: (session) => this.runtimeBindingOwner.snapshot(session),
       runtimeEnvironment: (session, language) => this.resolveRunEnv(session, language),
       isRestartRecommended: (processKey) =>

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -734,55 +734,62 @@ class NotebookRuntimeService {
   async bindRuntime(
     request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string }
   ): Promise<RuntimeBindingOperationResult> {
-    return this.sessionLifecycle.runProjectOperation(request, () =>
-      this.runtimeBindingOwner.runWrite(
-        notebookLaneKey(this.sessionLifecycle.laneForRequest(request)),
-        async () => {
-          const session = await this.sessionLifecycle.ensure(request)
-          return this.runtimeBindingOwner.bind(
-            session,
-            request.language,
-            request.runtimeId,
-            async (binding) => {
-              if (binding.source !== 'external') return
-              const oldEnv = this.resolveRunEnv(session, request.language)
-              const processKey = dataProcessKey(request.language, oldEnv)
-              if (session.kernelStatus(processKey) === undefined) return
-              const kind = request.language === 'r' ? 'r' : 'python'
-              await session.terminateExecutor(kind, oldEnv)
-              await this.tearDownLanguageBinding(session, request.language, oldEnv)
-            }
-          )
-        }
-      )
-    )
+    return this.changeRuntimeBinding(request, 'bind')
   }
 
-  // notebook_switch_runtime: an EXPLICIT switch — tear down the old kernel + clear that language's
-  // state, then rebind. Refuses a disabled/unknown runtime (same MAIN-process gate as bind).
+  // An explicit switch stops the previous kernel before committing the new runtime selection.
   async switchRuntime(
     request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string }
+  ): Promise<RuntimeBindingOperationResult> {
+    return this.changeRuntimeBinding(request, 'switch')
+  }
+
+  private async changeRuntimeBinding(
+    request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string },
+    operation: 'bind' | 'switch'
   ): Promise<RuntimeBindingOperationResult> {
     return this.sessionLifecycle.runProjectOperation(request, () =>
       this.runtimeBindingOwner.runWrite(
         notebookLaneKey(this.sessionLifecycle.laneForRequest(request)),
         async () => {
           const session = await this.sessionLifecycle.ensure(request)
-          const result = await this.runtimeBindingOwner.switch(
-            session,
-            request.language,
-            request.runtimeId,
-            async () => {
-              // PHYSICALLY tear down the CURRENT runtime's kernel for this language BEFORE rebinding, so the
-              // new runtime starts fresh and two same-language interpreters never coexist.
-              const oldEnv = this.resolveRunEnv(session, request.language)
-              const kind = request.language === 'r' ? 'r' : 'python'
-              await session.terminateExecutor(kind, oldEnv)
-              await this.tearDownLanguageBinding(session, request.language, oldEnv)
-            }
-          )
-          if ('bound' in result) this.sessionLifecycle.notifyChanged(session)
-          return result
+          let kernelStopped = false
+          let bindingChanged = false
+          const stoppedDiagnostic =
+            ' The previous kernel has stopped; its variables are gone. The next execution starts a fresh kernel.'
+          const stopKernel = async (): Promise<void> => {
+            const oldEnv = this.resolveRunEnv(session, request.language)
+            const status = session.kernelStatus(dataProcessKey(request.language, oldEnv))
+            const kind = request.language === 'r' ? 'r' : 'python'
+            await session.terminateExecutor(kind, oldEnv)
+            kernelStopped = status !== undefined && status !== 'terminated'
+            await this.tearDownLanguageBinding(session, request.language, oldEnv)
+          }
+          try {
+            const result = await this.runtimeBindingOwner[operation](
+              session,
+              request.language,
+              request.runtimeId,
+              async (binding?: NotebookSessionRuntimeBinding) => {
+                if (operation === 'bind') {
+                  if (binding?.source !== 'external') return
+                  const env = this.resolveRunEnv(session, request.language)
+                  if (session.kernelStatus(dataProcessKey(request.language, env)) === undefined)
+                    return
+                }
+                await stopKernel()
+              }
+            )
+            bindingChanged = 'bound' in result || result.bindingChanged
+            return kernelStopped && 'error' in result
+              ? { ...result, error: result.error + stoppedDiagnostic }
+              : result
+          } catch (error) {
+            if (!kernelStopped) throw error
+            throw new Error(String(error) + stoppedDiagnostic, { cause: error })
+          } finally {
+            if (kernelStopped || bindingChanged) this.sessionLifecycle.notifyChanged(session)
+          }
         }
       )
     )
@@ -1059,6 +1066,9 @@ class NotebookRuntimeService {
       if (request.historyBefore && !isNotebookRunCursor(request.historyBefore))
         throw new Error('Notebook state history cursor is invalid.')
       const session = await this.sessionLifecycle.ensure(request)
+      // Project durable history only after the lane's binding commit settles, including reads
+      // that arrived just before shutdown closed session creation admission.
+      await this.runtimeBindingOwner.waitForWrites(notebookLaneKey(session.lane))
       await this.runTerminalization.reconcilePending(session)
       return this.sessionReadModel.state(
         session,

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -947,6 +947,9 @@ class NotebookRuntimeService {
   ): Promise<NotebookRunSummary> {
     return this.sessionLifecycle.runProjectOperation(request, async (deletionSignal) => {
       const session = await this.sessionLifecycle.ensure(request)
+      // Select the execution route only after an admitted binding transition has committed or
+      // reconciled its failure; the old interpreter must not restart during stop/persist.
+      await this.runtimeBindingOwner.waitForWrites(notebookLaneKey(session.lane))
       const { run, dependencyProjection } = await this.executionOwner.executeDataCell(
         session,
         request,

--- a/src/main/notebook/session-read-model.test.ts
+++ b/src/main/notebook/session-read-model.test.ts
@@ -463,6 +463,24 @@ describe('NotebookSessionReadModel', () => {
     ).resolves.toBeNull()
   })
 
+  it.each([
+    { projectId: 'another-project', sessionId: 'session-1' },
+    { projectId: 'default-project', sessionId: 'another-session' }
+  ])(
+    'N05 rejects a live reference with mismatched identity $projectId/$sessionId',
+    async (identity) => {
+      const storageRoot = await createRoot()
+      const session = { ...makeSession(storageRoot), ...identity }
+      await expect(
+        makeReadModel(storageRoot, session).getSessionReference({
+          projectId: 'default-project',
+          sessionId: 'session-1',
+          workspaceCwd: storageRoot
+        })
+      ).resolves.toBeNull()
+    }
+  )
+
   it('exposes the one Session Notebook when only a child Frame has produced Runs', async () => {
     const storageRoot = await createRoot()
     const repository = new NotebookRunRepository(storageRoot)

--- a/src/main/notebook/session-read-model.ts
+++ b/src/main/notebook/session-read-model.ts
@@ -98,7 +98,7 @@ type NotebookSessionReadModelOptions<Session extends NotebookSessionReadSource> 
   defaultProjectId: string
   repository: NotebookRunRepository
   dependencyAnalyzer: Pick<NotebookDependencyAnalyzer, 'project'>
-  findSession: (sessionId: string) => Session | undefined
+  findSession: (projectId: string, sessionId: string) => Session | undefined
   runtimeBindings: (session: Session) => NotebookRuntimeBindings
   runtimeEnvironment?: (session: Session, language: NotebookLanguage) => string
   isRestartRecommended: (processKey: string) => boolean
@@ -110,7 +110,7 @@ class NotebookSessionReadModel<Session extends NotebookSessionReadSource> {
 
   // A handoff peek must never create a Session or read disk: absent/non-actionable live state is absent.
   peekHandoffContext(sessionId: string): NotebookHandoffContext | undefined {
-    const session = this.options.findSession(sessionId)
+    const session = this.options.findSession(this.options.defaultProjectId, sessionId)
     if (!session) return undefined
 
     const snapshot = session.snapshot()
@@ -249,8 +249,10 @@ class NotebookSessionReadModel<Session extends NotebookSessionReadSource> {
     request: NotebookSessionRequest
   ): Promise<NotebookSessionReference | null> {
     const projectId = resolveProjectId(request, this.options.defaultProjectId)
-    const live = this.options.findSession(request.sessionId)
-    if (live) return this.toSessionReference(live)
+    const live = this.options.findSession(projectId, request.sessionId)
+    if (live?.projectId === projectId && live.sessionId === request.sessionId) {
+      return this.toSessionReference(live)
+    }
 
     const document = await this.options.repository.findAnyExisting(projectId, request.sessionId)
     if (!document) return null

--- a/src/shared/notebook-runtime.ts
+++ b/src/shared/notebook-runtime.ts
@@ -127,7 +127,8 @@ export type RuntimeBindingOperationResult =
     }
   | {
       ok: false
-      bindingChanged: false
+      // A failed durability confirmation may follow a published binding. Report the actual change.
+      bindingChanged: boolean
       error: string
       bindings: NotebookRuntimeBindings
       target: RuntimeTargetReceipt


### PR DESCRIPTION
## Problem

N05: querying project Q with a session ID active in the default project P returned P's Notebook reference, even when Q had no stored Notebook.

N06: explicit runtime bind/switch returned `bound` after `setRuntimeBindings` rejected. Live selection diverged from run.json and from the target restored after relaunch.

## Proposed change

- Route live reference lookup by project and session, then verify the returned identity. Preserve root/frame-history reference behavior.
- Persist candidate bindings before publishing them in memory. Serialize explicit selections, revocation and repair through the existing lane admission boundary. Recheck each current binding after preceding writes settle so neither another language nor a stale lifecycle operation can overwrite the committed snapshot.
- On a write error, read the exact project/session/lane: retain the previous binding if uncommitted, report the actual new binding if already published, and reject explicitly if storage cannot be confirmed.
- Report an already-stopped kernel through the existing error diagnostic and change event. State projections wait for admitted binding writes so shutdown/reload cannot return a premature snapshot.
- Remove duplicate lifecycle callbacks introduced in a main-branch test fixture, which caused the CI merge to fail TypeScript with TS1117.
- New data-cell executions wait for their lane's admitted binding writes before selecting the route, so an execution arriving during stop/persist uses the committed or reconciled binding. Other projects and lanes remain independent.

## Scope and non-goals

No stored fields, database migrations, new enums, or UI controls. Existing run.json bindings and historical root/frame layouts remain readable. The existing failure flag `bindingChanged` can now be `true` when publication occurred before a durability error. A lost historical selection that was never saved cannot be reconstructed. Stopped kernel variables are not restored.

No unauthorized file-read claim is made for N05. Reload/revocation/repair best-effort persistence policy is unchanged.

## Acceptance criteria and validation

Reproduced through the public Notebook runtime service, with real temporary storage and existing repository/executor injection. No production test seam was introduced. Before production changes, two runs selected 20 tests: 6 controls passed and the same 14 regressions failed for identity leakage, false binding success, or missing failure signaling. After the fixes all 20 passed. Additional coverage checks exact child-lane readback, publication ordering and concurrent Python/R selection.

Independent review identified revocation racing a pending switch. Eight additional public-service tests cover revoking the old/new runtime and preparing/completing repair, on both root and child lanes. Both runs on the pre-correction code failed all eight cases because live, stored or reloaded bindings were wrong. All eight pass with the shared lane queue and post-wait target checks.

Another eight public-service cases reproduce execution arriving during binding persistence: bind/switch, commit success/failure, root/child lane. Before the execution barrier, all eight failed in two runs by dispatching early, with successful commits also executing on the wrong interpreter. All eight pass after the barrier; they also verify that another project's identical session ID remains executable.

Final Test Impact Set (all listed checks ran after the final rebase and duplicate-fixture correction):

| Behavior / boundary | Command | Result |
| --- | --- | --- |
| Runtime regressions, execution admission, binding lifecycle, repair, registry and owner boundaries | `npm test -- src/main/notebook/runtime-service.test.ts src/main/notebook/environment-operations.test.ts src/main/notebook/runtime-repair.test.ts src/main/notebook/runtime-repair-policy.test.ts src/main/notebook/session-registry.test.ts src/main/notebook/runtime-service.architecture.test.ts --maxWorkers=2` | 365 passed |
| Package/repair consumers, reference projection, durable storage, lane identity and command/IPC adapters | `npm test -- src/main/notebook/package-mutation.test.ts src/main/notebook/package-operations.test.ts src/main/notebook/environment-management.test.ts src/main/notebook/session-read-model.test.ts src/main/notebook/repository.test.ts src/main/notebook/repository-cache-consistency.test.ts src/main/notebook/repository-kernel-metadata.test.ts src/main/notebook/lane-identity.test.ts src/main/notebook/notebook-workflows.test.ts src/main/notebook/runtime-workflows.test.ts src/main/notebook/ipc.test.ts src/main/notebook/local-rpc-notebook-adapter.test.ts --maxWorkers=2` | 148 passed |
| Delegated lane and live RPC/MCP forwarding | `npm test -- src/main/notebook/delegated-lane-capability.test.ts src/main/notebook/local-rpc-server.mcpcall.test.ts src/main/notebook/local-rpc-server.frames.test.ts src/main/notebook/mcp-server.test.ts --maxWorkers=2` | 142 passed |
| Previously failing startup/delegation lifecycle CI fixtures and their owner | `npm test -- src/main/app-startup.test.ts src/main/app-lifecycle.test.ts src/main/delegation/production-composition.test.ts --maxWorkers=2` | 163 passed; duplicate lifecycle fixture callbacks removed |
| Shared durable JSON primitive updated by latest main | `npm test -- src/main/storage/durable-json-file.test.ts --maxWorkers=2` | 17 passed |
| Main process and sandbox types | `npm run typecheck:node` | Passed |
| Shared result type consumed by renderer | `npm run typecheck:web` | Passed after rebase |
| Linted source | `npm run lint` | Passed |
| Changed-file formatting and patch whitespace | `npx prettier --check <changed files>`; `git diff --check` | Passed |

All 835 tests above passed in one explicitly filtered run after rebasing onto main 8865d540 and removing two duplicate fixture properties. Before the correction, `npm run typecheck:node` reproduced the exact two TS1117 diagnostics from PR Gate; after correction it passed. The existing typecheck guards this fixture syntax, with its lifecycle behavior covered by the listed tests. The four fix commits are patch-equivalent before and after rebase (git range-diff). The runtime/RPC groups ran outside the agent sandbox to allow their required localhost listeners and child processes. Full portable/platform suites are left to PR CI as requested by the maintainer. New path expectations use node:path. These tests inject repository failures before or after the real write; they do not simulate a physical power loss or certify OS fsync behavior.

Known unresolved case: if a binding write publishes and then errors, and exact-lane readback is also unavailable, the call rejects but a later execution can still use the prior in-memory binding. This was independently reproduced in two local tests. A transient per-lane execution/mutation barrier is awaiting maintainer design feedback; those failing tests and the proposed behavior are not part of this submitted diff. Do not treat a green CI run as resolution of this case.

## Review focus

Confirm that the final impact map covers the existing read-model, lifecycle, repository and RPC/MCP consumers; that error readback uses the exact lane; and that `bindingChanged: false` is never used to claim restoration of a stopped kernel or an unconfirmed disk state. CodeGraph informed caller/owner mapping, with worktree source inspection and adapter/storage tests covering dynamic contracts. Automated independent review and final-head PR CI remain the merge authority.
