### PR TITLE
fix(notebook): honor reused cell languages and preserve run inputs

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -386,36 +386,51 @@ test('supports the core project journey with keyboard input only', async ({ app 
     return
 
   const settingsTrigger = page.getByRole('button', { name: 'Settings', exact: true })
-  if (!(await focusWithTab(page, settingsTrigger))) return
-  await page.keyboard.press('Enter')
-  const settings = page.getByRole('dialog', { name: 'Settings' })
-  if (
-    !(await expectKeyboardOutcome(page, 'Open settings with Enter', async () => {
-      await expect(settings).toBeVisible()
-    }))
-  )
-    return
-  const compute = settings
-    .getByRole('navigation', { name: 'Settings' })
-    .getByRole('button', { name: 'Compute', exact: true })
-  if (!(await focusWithTab(page, compute))) return
-  await page.keyboard.press('Enter')
-  if (
-    !(await expectKeyboardOutcome(page, 'Open Compute settings with Enter', async () => {
-      await expect(settings.getByRole('heading', { name: 'SSH hosts' })).toBeVisible()
-    }))
-  )
-    return
-  await page.keyboard.press('Escape')
-  if (
-    !(await expectKeyboardOutcome(page, 'Close settings with Escape', async () => {
-      await expect(settings).toBeHidden()
-    }))
-  )
-    return
-  await expectKeyboardOutcome(page, 'Keyboard focus restoration', async () => {
-    await expect(settingsTrigger).toBeFocused()
-  })
+  for (const delayedFocus of [false, true]) {
+    if (!(await focusWithTab(page, settingsTrigger))) return
+    if (delayedFocus) {
+      // Focus-scope cleanup can restore focus on a later task after the dialog is hidden.
+      await settingsTrigger.evaluate((element) => {
+        const focus = element.focus.bind(element)
+        element.focus = (options) => {
+          element.focus = focus
+          window.setTimeout(() => focus(options), 1_000)
+        }
+      })
+    }
+    await page.keyboard.press('Enter')
+    const settings = page.getByRole('dialog', { name: 'Settings' })
+    if (
+      !(await expectKeyboardOutcome(page, 'Open settings with Enter', async () => {
+        await expect(settings).toBeVisible()
+      }))
+    )
+      return
+    const compute = settings
+      .getByRole('navigation', { name: 'Settings' })
+      .getByRole('button', { name: 'Compute', exact: true })
+    if (!(await focusWithTab(page, compute))) return
+    await page.keyboard.press('Enter')
+    if (
+      !(await expectKeyboardOutcome(page, 'Open Compute settings with Enter', async () => {
+        await expect(settings.getByRole('heading', { name: 'SSH hosts' })).toBeVisible()
+      }))
+    )
+      return
+    await page.keyboard.press('Escape')
+    if (
+      !(await expectKeyboardOutcome(page, 'Close settings with Escape', async () => {
+        await expect(settings).toBeHidden()
+      }))
+    )
+      return
+    if (
+      !(await expectKeyboardOutcome(page, 'Keyboard focus restoration', async () => {
+        await expect(settingsTrigger).toBeFocused()
+      }))
+    )
+      return
+  }
 })
 
 for (const width of [375, 767] as const) {

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -69,6 +69,7 @@ type ElectronCleanupTarget = {
 type ElectronCleanupOptions = {
   forcedTimeoutMs: number
   gracefulTimeoutMs: number
+  requireGraceful?: boolean
 }
 
 const settlesWithin = async (promise: Promise<void>, timeoutMs: number): Promise<boolean> =>
@@ -88,7 +89,7 @@ const settlesWithin = async (promise: Promise<void>, timeoutMs: number): Promise
 
 const closeElectronApplicationForCleanup = async (
   target: ElectronCleanupTarget,
-  { gracefulTimeoutMs, forcedTimeoutMs }: ElectronCleanupOptions
+  { gracefulTimeoutMs, forcedTimeoutMs, requireGraceful = false }: ElectronCleanupOptions
 ): Promise<void> => {
   const forceCloseWithinBudget = async (): Promise<void> => {
     if (await settlesWithin(target.forceClose(), forcedTimeoutMs)) return
@@ -107,6 +108,9 @@ const closeElectronApplicationForCleanup = async (
 
   await forceCloseWithinBudget()
   if (closeError !== undefined) throw closeError
+  if (requireGraceful) {
+    throw new Error(`Electron E2E graceful close did not finish within ${gracefulTimeoutMs}ms.`)
+  }
 }
 
 type ElectronApp = {
@@ -906,16 +910,10 @@ class ElectronAppHarness implements ElectronApp {
   }
 
   private async close(): Promise<void> {
-    if (!this.application) return
-
-    const application = this.application
-    this.resourceProfiler?.detach(application)
-    this.application = undefined
-    this.currentPage = undefined
-    await application.close()
+    await this.closeForCleanup(true)
   }
 
-  private async closeForCleanup(): Promise<void> {
+  private async closeForCleanup(requireGraceful = false): Promise<void> {
     if (!this.application) return
 
     const application = this.application
@@ -931,7 +929,7 @@ class ElectronAppHarness implements ElectronApp {
             throw new Error('Electron E2E forced close did not reap the process tree.')
         }
       },
-      { gracefulTimeoutMs: 10_000, forcedTimeoutMs: 10_000 }
+      { gracefulTimeoutMs: 10_000, forcedTimeoutMs: 10_000, requireGraceful }
     )
   }
 }

--- a/scripts/electron-app-fixture.test.ts
+++ b/scripts/electron-app-fixture.test.ts
@@ -66,6 +66,20 @@ describe('Electron E2E cleanup', () => {
     expect(forceClose).toHaveBeenCalledOnce()
   })
 
+  it('reaps a blocked restart without treating forced termination as a successful save', async () => {
+    vi.useFakeTimers()
+    const forceClose = vi.fn(async () => undefined)
+    const closing = closeElectronApplicationForCleanup(
+      { close: () => new Promise<void>(() => undefined), forceClose },
+      { gracefulTimeoutMs: 100, forcedTimeoutMs: 100, requireGraceful: true }
+    )
+    await Promise.all([
+      expect(closing).rejects.toThrow('graceful close did not finish within 100ms'),
+      vi.advanceTimersByTimeAsync(100)
+    ])
+    expect(forceClose).toHaveBeenCalledOnce()
+  })
+
   it('awaits forced reaping before propagating a graceful close error', async () => {
     const reaping = deferred()
     const forceClose = vi.fn(() => reaping.promise)

--- a/src/main/compute/job-deletion-runtime-drain.test.ts
+++ b/src/main/compute/job-deletion-runtime-drain.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   createDeletionRuntimeHarness,
@@ -22,16 +22,11 @@ describe('Compute Job deletion runtime drain boundary', () => {
       await (isPlanning ? harness.cleanupPlanningStarted : harness.cleanupStarted)
       if (!isPlanning) expect(harness.authorityCommitted()).toBe(true)
 
-      harness.runScheduledPoll()
-      await vi.waitFor(
-        async () => {
-          await expect(harness.survivorStatus()).resolves.toMatchObject({
-            status: 'success',
-            exit_code: 0
-          })
-        },
-        { timeout: 500, interval: 10 }
-      )
+      await harness.runScheduledPoll()
+      await expect(harness.survivorStatus()).resolves.toMatchObject({
+        status: 'success',
+        exit_code: 0
+      })
 
       if (isPlanning) harness.releaseCleanupPlanning()
       else harness.releaseRemoteCleanup()

--- a/src/main/compute/job-deletion-runtime-isolation.test-support.ts
+++ b/src/main/compute/job-deletion-runtime-isolation.test-support.ts
@@ -146,7 +146,7 @@ const createDeletionRuntimeHarness = async (
   deleteOwner(): Promise<unknown>
   releaseCleanupPlanning(): void
   releaseRemoteCleanup(): void
-  runScheduledPoll(): void
+  runScheduledPoll(): Promise<void>
   survivorStatus(): Promise<JobStatusResult>
   deletedStatus(): Promise<JobStatusResult>
   dispose(): Promise<void>
@@ -207,6 +207,7 @@ const createDeletionRuntimeHarness = async (
 
   let scheduledTick: (() => void) | undefined
   const initialTick = deferred()
+  const survivorUpdated = deferred()
   const pollerRepository = Object.create(jobRepository) as ComputeJobRepository
   pollerRepository.findNonTerminal = async () => {
     const jobs = await jobRepository.findNonTerminal()
@@ -217,6 +218,9 @@ const createDeletionRuntimeHarness = async (
     connectionBroker,
     hostRepository,
     jobRepository: pollerRepository,
+    onJobUpdated: (job) => {
+      if (job.job_id === 'survivor-job') survivorUpdated.resolve()
+    },
     makeNonce: () => NONCE,
     setInterval: (callback) => {
       scheduledTick = callback
@@ -296,9 +300,10 @@ const createDeletionRuntimeHarness = async (
     deleteOwner: () => deletionCase.deleteOwner(coordinator),
     releaseCleanupPlanning: releaseCleanupPlanning.resolve,
     releaseRemoteCleanup: releaseRemoteCleanup.resolve,
-    runScheduledPoll: () => {
+    runScheduledPoll: async () => {
       if (!scheduledTick) throw new Error('Job poller did not install its scheduled tick.')
       scheduledTick()
+      await survivorUpdated.promise
     },
     survivorStatus: () =>
       readStatus('survivor-job', deletionCase.survivorProjectId, 'survivor-session'),
@@ -308,7 +313,7 @@ const createDeletionRuntimeHarness = async (
       releaseCleanupPlanning.resolve()
       releaseRemoteCleanup.resolve()
       unbindRuntime()
-      poller.stop()
+      await poller.stop()
       await client.$disconnect()
       await rm(storageRoot, { recursive: true, force: true })
     }

--- a/src/main/compute/job-deletion-runtime-isolation.test.ts
+++ b/src/main/compute/job-deletion-runtime-isolation.test.ts
@@ -1,15 +1,30 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { ComputeJobRepository } from './job-repository'
+
 import {
   createDeletionRuntimeHarness,
   deletionCases
 } from './job-deletion-runtime-isolation.test-support'
 
 describe('Compute Job deletion runtime isolation', () => {
-  it.each(deletionCases)(
-    'keeps another Session polling when $name remote cleanup fails after authority commits',
+  it.each([
+    ...deletionCases.map((deletionCase) => ({ ...deletionCase, pollDelayMs: 0 })),
+    { ...deletionCases[0], pollDelayMs: 750 }
+  ])(
+    'keeps another Session polling when $name remote cleanup fails after authority commits (poll delay: $pollDelayMs ms)',
     async (deletionCase) => {
       const harness = await createDeletionRuntimeHarness(deletionCase)
+      const findNonTerminal = ComputeJobRepository.prototype.findNonTerminal
+      const delayedPoll = deletionCase.pollDelayMs
+        ? vi
+            .spyOn(ComputeJobRepository.prototype, 'findNonTerminal')
+            .mockImplementationOnce(async function (this: ComputeJobRepository) {
+              const jobs = await findNonTerminal.call(this)
+              await new Promise((resolve) => setTimeout(resolve, deletionCase.pollDelayMs))
+              return jobs
+            })
+        : undefined
       try {
         await expect(harness.deleteOwner()).rejects.toThrow(
           'The Compute Host could not be reached.'
@@ -17,17 +32,13 @@ describe('Compute Job deletion runtime isolation', () => {
         expect(harness.authorityCommitted()).toBe(true)
         await expect(harness.deletedStatus()).resolves.toMatchObject({ status: 'success' })
 
-        harness.runScheduledPoll()
-        await vi.waitFor(
-          async () => {
-            await expect(harness.survivorStatus()).resolves.toMatchObject({
-              status: 'success',
-              exit_code: 0
-            })
-          },
-          { timeout: 500, interval: 10 }
-        )
+        await harness.runScheduledPoll()
+        await expect(harness.survivorStatus()).resolves.toMatchObject({
+          status: 'success',
+          exit_code: 0
+        })
       } finally {
+        delayedPoll?.mockRestore()
         await harness.dispose()
       }
     }

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4476,10 +4476,13 @@ describe('notebook runtime service', () => {
     ['python', 'r', false],
     ['r', 'python', false],
     ['python', 'r', true],
-    ['r', 'python', true]
+    ['r', 'python', true],
+    ['r', undefined, false],
+    ['r', undefined, true]
   ] as const)(
-    'reuses a cell from %s to %s with consistent execution and history (queued=%s)',
-    async (oldLanguage, newLanguage, queued) => {
+    'reuses a cell from %s with requested language %s and consistent execution and history (queued=%s)',
+    async (oldLanguage, requestedLanguage, queued) => {
+      const newLanguage = requestedLanguage ?? oldLanguage
       const root = await createStorageRoot()
       const blockerStarted = createDeferred<void>()
       const releaseBlocker = createDeferred<void>()
@@ -4535,7 +4538,7 @@ describe('notebook runtime service', () => {
           await vi.waitFor(() => expect(enqueue).toHaveBeenCalledTimes(1))
           enqueue.mockRestore()
           await expect(
-            service.beginCodeCell({ ...request, language: newLanguage })
+            service.beginCodeCell({ ...request, language: requestedLanguage })
           ).rejects.toThrow('Notebook cell is queued or running: cell-b')
           const rejected = await service.state(request)
           expect(rejected.cells.find((cell) => cell.id === request.cellId)).toMatchObject({
@@ -4546,7 +4549,7 @@ describe('notebook runtime service', () => {
           await Promise.all(pending)
         }
 
-        const begin = await service.beginCodeCell({ ...request, language: newLanguage })
+        const begin = await service.beginCodeCell({ ...request, language: requestedLanguage })
         const receiving = await service.state(request)
         await service.appendCodeCell({
           ...request,

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -10,7 +10,7 @@ import type {
   NotebookExecutionResult,
   NotebookExecutorLifecycleCallbacks
 } from './runtime-service'
-import type { NotebookSessionExecutor } from './session-aggregate'
+import { NotebookSessionAggregate, type NotebookSessionExecutor } from './session-aggregate'
 import {
   NotebookRuntimeService,
   resolveDefaultExecutorOptions,
@@ -4471,6 +4471,129 @@ describe('notebook runtime service', () => {
       runCount: 1
     })
   })
+
+  it.each([
+    ['python', 'r', false],
+    ['r', 'python', false],
+    ['python', 'r', true],
+    ['r', 'python', true]
+  ] as const)(
+    'reuses a cell from %s to %s with consistent execution and history (queued=%s)',
+    async (oldLanguage, newLanguage, queued) => {
+      const root = await createStorageRoot()
+      const blockerStarted = createDeferred<void>()
+      const releaseBlocker = createDeferred<void>()
+      const execute = vi.fn(
+        async (request: NotebookExecutionRequest): Promise<NotebookExecutionResult> => {
+          if (request.code === '# blocker') {
+            blockerStarted.resolve()
+            await releaseBlocker.promise
+          }
+          return {
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }
+        }
+      )
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository: new NotebookRunRepository(root),
+        executorFactory: () => ({ execute, shutdown: async () => ({ reaped: true }) })
+      })
+      const request = { sessionId: 'session-1', workspaceCwd: root, cellId: 'cell-b' }
+      const code = { python: 'x = 42', r: 'x <- 42' }
+      const writeCell = async (language: NotebookLanguage): Promise<void> => {
+        const begin = await service.beginCodeCell({ ...request, language })
+        await service.appendCodeCell({ ...request, writeId: begin.writeId, delta: code[language] })
+        await service.finishCodeCell({ ...request, writeId: begin.writeId })
+      }
+      await writeCell(oldLanguage)
+
+      const pending: Array<Promise<unknown>> = []
+      let enqueue: ReturnType<typeof vi.spyOn> | undefined
+      try {
+        if (queued) {
+          pending.push(
+            service.execute({
+              ...request,
+              cellId: 'blocker',
+              language: oldLanguage,
+              code: '# blocker'
+            })
+          )
+          await blockerStarted.promise
+          // Data runs have no public queued-state projection. Observe the existing queue entry
+          // without replacing its behavior so rewriting happens strictly after admission.
+          enqueue = vi.spyOn(NotebookSessionAggregate.prototype, 'enqueueExecution')
+          pending.push(service.runCell(request))
+          await vi.waitFor(() => expect(enqueue).toHaveBeenCalledTimes(1))
+          enqueue.mockRestore()
+          await expect(
+            service.beginCodeCell({ ...request, language: newLanguage })
+          ).rejects.toThrow('Notebook cell is queued or running: cell-b')
+          const rejected = await service.state(request)
+          expect(rejected.cells.find((cell) => cell.id === request.cellId)).toMatchObject({
+            language: oldLanguage,
+            code: code[oldLanguage]
+          })
+          releaseBlocker.resolve()
+          await Promise.all(pending)
+        }
+
+        const begin = await service.beginCodeCell({ ...request, language: newLanguage })
+        const receiving = await service.state(request)
+        await service.appendCodeCell({
+          ...request,
+          writeId: begin.writeId,
+          delta: code[newLanguage]
+        })
+        await service.finishCodeCell({ ...request, writeId: begin.writeId })
+        const written = await service.state(request)
+
+        const result = await service.runCell(request)
+        const state = await service.state(request)
+
+        expect.soft(execute.mock.calls.at(-1)?.[0]).toMatchObject({
+          language: newLanguage,
+          code: code[newLanguage]
+        })
+        expect.soft(receiving.cells.find((cell) => cell.id === request.cellId)).toMatchObject({
+          language: newLanguage,
+          code: '',
+          status: 'receiving-code'
+        })
+        expect.soft(written.cells.find((cell) => cell.id === request.cellId)).toMatchObject({
+          language: newLanguage,
+          code: code[newLanguage]
+        })
+        expect.soft(result.status).toBe('completed')
+        expect.soft(state.runs.find((run) => run.runId === result.runId)).toMatchObject({
+          kernelKind: newLanguage,
+          script: code[newLanguage]
+        })
+        if (queued) {
+          expect.soft(execute.mock.calls[1][0]).toMatchObject({
+            language: oldLanguage,
+            code: code[oldLanguage]
+          })
+          expect.soft(state.runs.filter((run) => run.cellId === request.cellId)).toMatchObject([
+            { kernelKind: oldLanguage, script: code[oldLanguage] },
+            { kernelKind: newLanguage, script: code[newLanguage] }
+          ])
+        }
+      } finally {
+        enqueue?.mockRestore()
+        releaseBlocker.resolve()
+        await Promise.allSettled(pending)
+      }
+    }
+  )
 
   it('serializes overlapping runs on the shared interpreter instead of failing the second', async () => {
     const root = await createStorageRoot()

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -864,7 +864,7 @@ class NotebookRuntimeService {
       const cell = session.beginCellWrite(
         {
           cellId,
-          language: request.language ?? 'python',
+          language: request.language,
           writeId,
           source,
           startedAt: Date.now()

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -323,6 +323,7 @@ export class NotebookSessionAggregate<
       code: '',
       status: 'receiving-code'
     }
+    cell.language = input.language
     cell.status = 'receiving-code'
     cell.code = ''
     cell.writeId = input.writeId

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -198,7 +198,7 @@ export type NotebookSessionSnapshot = Readonly<{
 
 type BeginCellWrite = {
   cellId: string
-  language: NotebookLanguage
+  language?: NotebookLanguage
   writeId: string
   source: NotebookRunSource
   startedAt: number
@@ -319,11 +319,11 @@ export class NotebookSessionAggregate<
     const existing = this.cells.get(input.cellId)
     const cell: NotebookCell = existing ?? {
       id: input.cellId,
-      language: input.language,
+      language: input.language ?? 'python',
       code: '',
       status: 'receiving-code'
     }
-    cell.language = input.language
+    cell.language = input.language ?? cell.language
     cell.status = 'receiving-code'
     cell.code = ''
     cell.writeId = input.writeId


### PR DESCRIPTION
## Problem

Reusing a completed Python cell ID with `language: r` replaces its code but silently retains Python. The executor receives `{ language: "python", code: "x <- 42" }`, and the Run records the wrong `kernelKind`. R → Python has the same defect (N03).

## Change

An idle cell adopts an explicitly supplied language on each new write. If language is omitted, an existing cell keeps its language; only a new cell defaults to Python. Cell state, executor requests, and Run history agree.

The branch is rebased onto `main` at `b5077745`. N01 execution snapshots, busy-cell protection, and write cancellation are upstream. The N03 production change adds no persisted fields, schema migrations, dependencies, or renderer changes.

The approved CI follow-up also updates Compute and Electron tests/fixtures: await the existing survivor-job update notification instead of imposing a 500 ms polling deadline; preserve upstream's retrying focus assertion and exercise a delayed focus return; route restart shutdown through bounded cleanup while requiring a graceful close for persistence assertions. Forced cleanup reaps a blocked process and reports failure rather than claiming a successful save.

## Validation

The explicit-language regressions failed before the original fix, and the omitted-language cases reproduced the subsequent review finding before its fix. Tests cover Python → R, R → Python, omitted language on an existing R cell, queued-cell write rejection, executor inputs, returned state, and Run history.

The regressions use public runtime write/run/state boundaries and the existing injected executor. A queue spy observes admission without replacing behavior; no production test seam was added. Real Python/R interpreter processes are not exercised by these regressions.

Post-rebase validation: **534 tests passed across 11 files**, covering Notebook runtime, aggregate, queued inputs, architecture, workflows, IPC/RPC, application commands, delegation composition and app startup. Full Node/sandbox/Web typechecks and the changed files’ ESLint and Prettier checks passed.

## Review focus

Confirm that explicitly supplied language is honored, omission preserves an existing cell’s language, and the upstream busy-cell restriction prevents changes to already-submitted execution inputs or historical Runs.


Latest validation after rebase: 341 tests across six affected files; full Node/sandbox/Web typechecks; ESLint, Prettier and diff checks; Electron build; the full accessibility gate (11 tests, 21 axe scans, zero findings); and two consecutive message-revision restart E2E runs. The slow-poll and blocked-restart regressions failed before their fixes. Before the upstream focus fix, the delayed-focus case reproduced the exact CI finding in a complete 11-test/21-scan run; it now passes. Windows bottom-follow overshoot was not reproduced in three unchanged local runs; both Windows E2E shards passed in CI.


Final CI: [PR Gate run 33969429407](https://github.com/aipoch/open-science/actions/runs/33969429407) passed for `1b378a79`, including Static checks, all Ubuntu shards, coverage, Linux Notebook isolation, Windows core/E2E, macOS, and CodeQL. The first macOS attempt had an unrelated file-preview resource-error flake; its single rerun passed all 31 workspace tests with no flaky outcomes. Its root cause remains unconfirmed, and no error suppression was added.
