### PR TITLE
fix(notebook): snapshot queued cell execution inputs

### DIFF
--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -141,7 +141,6 @@ test('edits and navigates message revisions that persist after relaunch', async 
   await conversation.getByRole('button', { name: 'Edit message' }).click()
   await conversation.getByRole('textbox', { name: 'Edit message' }).fill(EDITED_USER_MESSAGE)
   await conversation.getByRole('button', { name: 'Send', exact: true }).click()
-  await expect.poll(() => page.evaluate(() => window.api.storage.detectActive())).toEqual([])
 
   const revision = conversation.getByLabel('Message revision', { exact: true })
   const previousRevision = conversation.getByRole('button', {
@@ -149,22 +148,27 @@ test('edits and navigates message revisions that persist after relaunch', async 
   })
   const nextRevision = conversation.getByRole('button', { name: 'Next message revision' })
   await expect(conversation.getByText(EDITED_USER_MESSAGE, { exact: true })).toBeVisible()
-  await expect(revision).toHaveText('2/2')
+  await expect(revision).toHaveText(['2/2'])
   await expect(previousRevision).toBeEnabled()
   await expect(nextRevision).toBeDisabled()
 
+  // The edit starts another Agent turn. Let it finish before switching branches or restarting,
+  // otherwise application.close() can wait indefinitely on the native active-session quit dialog.
+  await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+  await expect.poll(() => page.evaluate(() => window.api.storage.detectActive())).toEqual([])
+
   await previousRevision.click()
   await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
-  await expect(revision).toHaveText('1/2')
+  await expect(revision).toHaveText(['1/2'])
   await expect(previousRevision).toBeDisabled()
   await expect(nextRevision).toBeEnabled()
 
   await nextRevision.click()
   await expect(conversation.getByText(EDITED_USER_MESSAGE, { exact: true })).toBeVisible()
-  await expect(revision).toHaveText('2/2')
+  await expect(revision).toHaveText(['2/2'])
   await previousRevision.click()
   await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
-  await expect(revision).toHaveText('1/2')
+  await expect(revision).toHaveText(['1/2'])
 
   page = await app.restart()
   await page
@@ -174,7 +178,7 @@ test('edits and navigates message revisions that persist after relaunch', async 
   conversation = page.getByRole('region', { name: 'Conversation' })
   await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
-  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveText('1/2')
+  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveText(['1/2'])
   await expect(
     conversation.getByRole('button', { name: 'Previous message revision' })
   ).toBeDisabled()
@@ -182,8 +186,7 @@ test('edits and navigates message revisions that persist after relaunch', async 
 
   await conversation.getByRole('button', { name: 'Next message revision' }).click()
   await expect(conversation.getByText(EDITED_USER_MESSAGE, { exact: true })).toBeVisible()
-  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveCount(1)
-  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveText('2/2')
+  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveText(['2/2'])
 })
 
 test('keeps Memory reversible while the replacement session awaits history replay', async ({

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -959,8 +959,6 @@ describe('production delegated-work composition', () => {
             prepareForQuit,
             holdSettingsInstallAdmission: () => () => undefined,
             abortQuitPreparation,
-            holdSettingsInstallAdmission: () => () => undefined,
-            getActiveSettingsInstallId: () => undefined,
             flushSessionPersistence,
             isMigrationInProgress: () => false,
             quit,

--- a/src/main/notebook/cell-execution-input.test.ts
+++ b/src/main/notebook/cell-execution-input.test.ts
@@ -1,0 +1,142 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { NotebookRunRepository } from './repository'
+import {
+  NotebookRuntimeService,
+  type NotebookExecutionRequest,
+  type NotebookExecutionResult
+} from './runtime-service'
+import { NotebookSessionAggregate } from './session-aggregate'
+
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+let root: string
+afterEach(async () => {
+  vi.restoreAllMocks()
+  if (root) await rm(root, { recursive: true, force: true })
+})
+
+describe('cell execution input', () => {
+  it.each(['queue', 'persistence', 'environment preparation', 'executor'] as const)(
+    'protects submitted code while blocked at %s',
+    async (blockedAt) => {
+      root = await mkdtemp(join(tmpdir(), 'notebook-cell-input-'))
+      const request = { sessionId: 'session-1', workspaceCwd: root }
+      const repository = new NotebookRunRepository(root)
+      const entered = deferred()
+      const release = deferred()
+      const hold = async (): Promise<void> => {
+        entered.resolve()
+        await release.promise
+      }
+      const executions: NotebookExecutionRequest[] = []
+      if (blockedAt === 'persistence') {
+        const appendRun = repository.appendRun.bind(repository)
+        vi.spyOn(repository, 'appendRun').mockImplementation(async (...args) => {
+          await hold()
+          return appendRun(...args)
+        })
+      }
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectId: 'default-project',
+        repository,
+        environmentStateTracker: {
+          prepareRun: vi.fn(async () => {
+            if (blockedAt === 'environment preparation') await hold()
+            return { fingerprint: 'stable', inventoryRefreshed: false, warnings: [] }
+          }),
+          captureCompletedRun: vi.fn().mockRejectedValue(new Error('capture unavailable')),
+          inspectPackages: vi.fn(),
+          markPackageMutationDirty: vi.fn(),
+          refreshAfterPackageMutation: vi.fn()
+        },
+        executorFactory: () => ({
+          execute: async (input): Promise<NotebookExecutionResult> => {
+            executions.push(input)
+            if (blockedAt === 'executor' || (blockedAt === 'queue' && executions.length === 1)) {
+              await hold()
+            }
+            return {
+              status: 'completed',
+              stdout: '',
+              stderr: '',
+              traceback: '',
+              cwdAfter: input.cwd,
+              outputs: []
+            }
+          },
+          shutdown: async () => ({ reaped: true })
+        })
+      })
+      const begin = await service.beginCodeCell(request)
+      const cellRequest = { ...request, cellId: begin.cellId }
+      const originalCode = 'print("original complete code")'
+      await service.appendCodeCell({ ...cellRequest, writeId: begin.writeId, delta: originalCode })
+      await service.finishCodeCell({ ...cellRequest, writeId: begin.writeId })
+
+      const first =
+        blockedAt === 'queue' ? service.execute({ ...request, code: 'print("A")' }) : undefined
+      if (first) await entered.promise
+      // Queued cells have no public queued status. Observe the existing queue entry without
+      // replacing its behavior; all writes, runs, and result assertions use the runtime API.
+      const enqueue = vi.spyOn(NotebookSessionAggregate.prototype, 'enqueueExecution')
+      const submitted = { ...cellRequest, timeoutMs: 1234 }
+      const running = service.runCell(submitted)
+      let rewriteError: unknown
+      try {
+        if (first) {
+          await vi.waitFor(() => expect(enqueue).toHaveBeenCalledOnce())
+          const cancellation = new AbortController()
+          const duplicate = service.runCell(cellRequest, cancellation.signal)
+          await vi.waitFor(() => expect(enqueue).toHaveBeenCalledTimes(2))
+          cancellation.abort()
+          await expect(duplicate).rejects.toBe(cancellation.signal.reason)
+          // Cancelling one submission must not release the other submission's write restriction.
+        } else await entered.promise
+        try {
+          const rewrite = await service.beginCodeCell(cellRequest)
+          await service.appendCodeCell({
+            ...cellRequest,
+            writeId: rewrite.writeId,
+            delta: 'print("partial new code'
+          })
+          // Deliberately do not finish this stream before execution resumes.
+        } catch (error) {
+          rewriteError = error
+        }
+        submitted.timeoutMs = 9999
+      } finally {
+        release.resolve()
+      }
+      const [run] = await Promise.all([running, first])
+      const dispatched = executions.at(-1)!
+      expect.soft(dispatched.code).toBe(originalCode)
+      expect.soft(dispatched.language).toBe('python')
+      expect.soft(run.script).toBe(dispatched.code)
+      expect.soft(dispatched.timeoutMs).toBe(1234)
+      const state = await service.state(request)
+      expect.soft(state.activeWrite).toBeUndefined()
+      expect.soft(state.cells.find((cell) => cell.id === begin.cellId)).toMatchObject({
+        code: originalCode,
+        status: 'completed'
+      })
+      expect(rewriteError).toEqual(
+        expect.objectContaining({ message: expect.stringMatching(/queued or running/) })
+      )
+      // The restriction lasts only for this execution; the same cell becomes editable again.
+      const rewrite = await service.beginCodeCell(cellRequest)
+      await service.finishCodeCell({ ...cellRequest, writeId: rewrite.writeId })
+    }
+  )
+})

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -279,16 +279,26 @@ class NotebookExecutionOwner {
     signal?: AbortSignal,
     helperModuleIds?: readonly string[]
   ): Promise<{ run: NotebookRunRecord; dependencyProjection: NotebookDependencyProjection }> {
-    const cell = session.cellView(request.cellId)
-    if (session.isCellReceiving(cell.id)) {
-      throw new Error(`Notebook cell is still receiving code: ${cell.id}`)
-    }
-    const route = this.options.dataExecutionAdmission.route(session, cell.language)
-    return session.enqueueExecution(
-      route.processKey,
-      () => this.executeDataCellExclusive(session, cell, request, signal, helperModuleIds),
-      signal
-    )
+    // Snapshot caller-owned inputs before the first queue/preparation/persistence wait.
+    // The host-owned input lease stays live so resolver access reaches the completed run.
+    const { registeredInputFiles, ...submittedRequest } = request
+    const executionRequest = { ...structuredClone(submittedRequest), registeredInputFiles }
+    const executionHelperIds = helperModuleIds?.slice()
+    return session.withCellExecution(executionRequest.cellId, (cell) => {
+      const route = this.options.dataExecutionAdmission.route(session, cell.language)
+      return session.enqueueExecution(
+        route.processKey,
+        () =>
+          this.executeDataCellExclusive(
+            session,
+            cell,
+            executionRequest,
+            signal,
+            executionHelperIds
+          ),
+        signal
+      )
+    })
   }
   private async executeDataCellExclusive(
     session: NotebookSessionAggregate,

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -229,6 +229,7 @@ export class NotebookSessionAggregate<
   private cwdValue: string
   private readonly cells = new Map<string, NotebookCell>()
   private writeCancellationCleanup: (() => void) | undefined
+  private readonly cellExecutions = new Map<string, number>()
   private activeWriteValue: NotebookWriteLock | undefined
   private readonly activeRunIds = new Set<string>()
   private activeRunIdValue: string | undefined
@@ -308,6 +309,9 @@ export class NotebookSessionAggregate<
     cancellation?: { signal: AbortSignal; onAbort: () => void }
   ): Readonly<NotebookCell> {
     cancellation?.signal.throwIfAborted()
+    if (this.cellExecutions.has(input.cellId)) {
+      throw new Error(`Notebook cell is queued or running: ${input.cellId}`)
+    }
     if (this.activeWriteValue) {
       throw new Error(`Notebook cell is already receiving code: ${this.activeWriteValue.cellId}`)
     }
@@ -371,7 +375,27 @@ export class NotebookSessionAggregate<
   }
 
   cellView(cellId: string): Readonly<NotebookCell> {
-    return this.requireCell(cellId)
+    return cloneCell(this.requireCell(cellId))
+  }
+
+  // Hold editing from admission through queueing and settlement. Count submissions so repeated
+  // runs of the same cell retain the write restriction until the last one settles or is cancelled.
+  async withCellExecution<T>(
+    cellId: string,
+    execute: (cell: Readonly<NotebookCell>) => Promise<T>
+  ): Promise<T> {
+    const cell = this.cellView(cellId)
+    if (this.isCellReceiving(cellId)) {
+      throw new Error(`Notebook cell is still receiving code: ${cellId}`)
+    }
+    this.cellExecutions.set(cellId, (this.cellExecutions.get(cellId) ?? 0) + 1)
+    try {
+      return await execute(cell)
+    } finally {
+      const remaining = this.cellExecutions.get(cellId)! - 1
+      if (remaining === 0) this.cellExecutions.delete(cellId)
+      else this.cellExecutions.set(cellId, remaining)
+    }
   }
 
   isCellReceiving(cellId: string): boolean {


### PR DESCRIPTION
## Problem

N01: a completed cell queued behind a busy kernel can be rewritten before dispatch. The queue retains the mutable cell, so it can execute an unfinished replacement stream. Rewriting during persistence or environment preparation can also make `run.script` differ from the dispatched source; completion can overwrite a receiving cell's status.

## Proposed change

- Snapshot cell code/language, caller-owned request parameters, and helper IDs before asynchronous waits. Preserve the host-owned input lease's live access evidence so completed runs still record `resolver-accessed` inputs.
- Reject writes to a cell while it has queued or executing submissions. Release the restriction in `finally`; count submissions so cancelling one queued run cannot unlock another.
- Add gated runtime API regressions for queueing, persistence, environment preparation, and active execution, including duplicate-run cancellation and editing after completion. The existing queue method is observed without replacing its behavior; no production test seam is added.

## Scope and non-goals

Five files: the Notebook fix and regressions, plus two CI test repairs. No database migration, persistent Cell/Run fields, renderer layout, public transport contract, or kernel protocol changes. The new per-cell count is transient session state. Other cells remain writable.

## Acceptance criteria and validation

Rebased onto `main` at `8865d540`. Conflict resolution preserves both write-stream cancellation cleanup from main and the execution snapshot/write restriction from this PR. Duplicate lifecycle fixture properties already present in main are removed.

- **Original reproduction:** the four gated Notebook regressions failed on unmodified production code at `682c1038`, exposing partial replacement code, script/source mismatch, and active-write/status inconsistency; they pass with the fix.
- **Notebook ownership, write cancellation, runtime/RPC consumers, and lifecycle:** after conflict resolution, 508 tests passed across `cell-execution-input.test.ts`, `session-aggregate.test.ts`, `runtime-service.test.ts`, `runtime-service.architecture.test.ts`, `input-registry.test.ts`, `local-rpc-server.test.ts`, `production-composition.test.ts`, and `app-lifecycle.test.ts` using `npm test -- <paths> --maxWorkers=1`.
- **Final fixture cleanup:** after removing the duplicate properties, all 62 tests in `production-composition.test.ts` passed again. No production code changed after the 508-test run.
- **Types and lint:** `npm run typecheck:node` (including sandbox) and `npm run lint` passed after the final edit.
- **Electron E2E:** `npm run build:e2e` passed. The revision/relaunch test was run three times with no retries; two passed and one failed at the final revision assertion because both `1/2` and `2/2` remained visible for 20 seconds after relaunch and switching. This remains unresolved; the E2E result is not green. The earlier three-pass result was before this rebase.

The affected production boundary is the Notebook main-process owner and its runtime/RPC consumers. The lifecycle and E2E edits are test-only. Full portable and Windows platform confirmation remain owned by exact-head CI; no renderer production, packaging, or kernel protocol changes are included. Independent review and exact-head CI remain required.

## Review focus

Keep immutable execution parameters distinct from live input-access evidence, and retain the write restriction until every submission for the cell has settled.
