### PR TITLE
fix(sessions): respect newer metadata during lazy hydration

### DIFF
--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -956,6 +956,8 @@ describe('production delegated-work composition', () => {
               window as unknown as ReturnType<AppLifecycleDeps['createMainWindow']>,
             createTray: () => undefined,
             shutdownBackends,
+            holdSettingsInstallAdmission: () => () => undefined,
+            getActiveSettingsInstallId: () => undefined,
             prepareForQuit,
             abortQuitPreparation,
             flushSessionPersistence,

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { SessionPersistenceStateOwner } from '../../../../main/session-persistence/state-owner'
 import { ARTIFACT_FINALIZATION_INVALID_PROOF } from '../../../../shared/artifacts'
 import {
   activateConversationBranch,
@@ -975,6 +976,75 @@ describe('renderer session persistence bridge', () => {
     expect(useSessionStore.getState().sessions).toHaveLength(1)
     expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
     expect(observedSelections).toEqual([undefined])
+  })
+
+  it('keeps a newer durable pin through lazy hydration and an unrelated title save', async () => {
+    const authority = createPersistedSession({
+      title: 'Remote title',
+      pinned: true,
+      archivedAt: 3,
+      revision: 2,
+      createdAt: 1,
+      updatedAt: 3
+    })
+    const write = vi.fn(async (candidate: PersistedChatSession, expectedRevision?: number) => ({
+      ...candidate,
+      revision: (expectedRevision ?? 0) + 1
+    }))
+    const main = new SessionPersistenceStateOwner({
+      repository: {
+        loadSessionWithDiagnostics: async () => ({ status: 'found', session: authority }),
+        saveSession: write
+      },
+      fileIndex: { syncSession: async () => [] },
+      assertMutable: () => undefined,
+      notifyFilesChanged: () => undefined,
+      notifyRuntimeContextSessionUpdated: () => undefined,
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    })
+    const saveSession = vi.fn<SessionPersistenceApi['saveSession']>((session, options) =>
+      main.saveSession(session, options)
+    )
+    useSessionStore.getState().hydrateSessionSummaries(
+      [
+        {
+          number: 1,
+          id: authority.id,
+          projectId: authority.projectId,
+          title: 'Old summary title',
+          status: 'idle',
+          presentedStatus: 'idle',
+          pinned: false,
+          revision: 1,
+          activeMessageCount: 0,
+          artifactCount: 0,
+          filesRevision: 0,
+          createdAt: authority.createdAt,
+          updatedAt: 2,
+          needsStartupRecovery: false
+        }
+      ],
+      undefined
+    )
+    const save = createStoreSaver(createApi({ saveSession }), useSessionStore.getState())
+
+    // This is the full-snapshot boundary used by another window's Session update event.
+    useSessionStore.getState().upsertPersistedSession(authority)
+    await save(useSessionStore.getState())
+    expect(saveSession).not.toHaveBeenCalled()
+    useSessionStore.getState().renameSession(authority.id, 'Local title edit')
+    await save(useSessionStore.getState())
+
+    expect(saveSession).toHaveBeenCalledOnce()
+    expect(saveSession.mock.calls[0][0].revision).toBe(2)
+    expect(write).toHaveBeenCalledOnce()
+    expect(write.mock.calls[0][1]).toBe(2)
+    const durable = await saveSession.mock.results[0].value
+    expect(durable.archivedAt).toBe(3)
+    expect(durable.title).toBe('Local title edit')
+    expect(durable.pinned, 'An unrelated title save must not undo the newer durable pin.').toBe(
+      true
+    )
   })
 
   it('does not echo an externally hydrated session back to persistence', async () => {

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -529,12 +529,13 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
       const existing = state.sessions.find((candidate) => candidate.id === session.id)
       if (existing?.contentLoaded === false) {
         const loaded = hydrateSession(session)
+        const incomingIsNewer = sessionRevision(session) > sessionRevision(existing)
         const hydrated: ChatSession = {
           ...loaded,
           number: existing.number ?? loaded.number,
-          title: existing.title,
-          pinned: existing.pinned,
-          archivedAt: existing.archivedAt,
+          title: !incomingIsNewer || existing.unsavedTitle ? existing.title : loaded.title,
+          pinned: incomingIsNewer ? loaded.pinned : existing.pinned,
+          archivedAt: incomingIsNewer ? loaded.archivedAt : existing.archivedAt,
           revision: Math.max(existing.revision ?? 0, loaded.revision ?? 0),
           filesRevision: Math.max(existing.filesRevision ?? 0, loaded.filesRevision ?? 0),
           updatedAt: Math.max(existing.updatedAt, loaded.updatedAt),

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1393,6 +1393,72 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].activePlanProjection).toBe(projection)
   })
 
+  it.each(['none', 'title', 'pin'] as const)(
+    'adopts newer durable metadata when a summary has only %s locally edited',
+    (editedField) => {
+      useSessionStore.getState().hydrateSessionSummaries(
+        [
+          {
+            number: 1,
+            id: 'session-1',
+            projectId: 'project-1',
+            title: 'Old summary title',
+            status: 'idle',
+            presentedStatus: 'idle',
+            pinned: false,
+            revision: 1,
+            activeMessageCount: 1,
+            artifactCount: 0,
+            filesRevision: 0,
+            createdAt: 1,
+            updatedAt: 2,
+            needsStartupRecovery: false
+          }
+        ],
+        undefined
+      )
+      expect(useSessionStore.getState().sessions[0].unsavedTitle).toBeUndefined()
+      if (editedField === 'title')
+        useSessionStore.getState().renameSession('session-1', 'Local title')
+      if (editedField === 'pin') useSessionStore.getState().togglePinned('session-1')
+
+      useSessionStore.getState().upsertPersistedSession({
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'New durable title',
+        cwd: '/workspace',
+        status: 'idle',
+        pinned: editedField !== 'pin',
+        archivedAt: 3,
+        revision: 2,
+        messages: [
+          {
+            id: 'message-1',
+            role: 'user',
+            content: 'New durable body',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        createdAt: 1,
+        updatedAt: 3
+      })
+
+      const current = useSessionStore.getState().sessions[0]
+      expect(current.contentLoaded).not.toBe(false)
+      expect(current.revision).toBe(2)
+      expect(current.messages[0].content).toBe('New durable body')
+      expect(current).toMatchObject({
+        title: editedField === 'title' ? 'Local title' : 'New durable title',
+        pinned: editedField !== 'pin',
+        archivedAt: 3
+      })
+      expect(current.unsavedTitle).toBe(editedField === 'title' ? true : undefined)
+    }
+  )
+
   it('preserves pending summary metadata edits when lazy hydration finishes', () => {
     useSessionStore.getState().hydrateSessionSummaries(
       [


### PR DESCRIPTION
## Problem

An unopened Session starts from a revision-1 summary. When another client supplies a revision-2 full snapshot, lazy hydration previously kept the summary title, pin and archive while accepting the newer body/revision. A later unrelated title save could therefore submit the old pin with the current revision; Main correctly accepted that revision and passed the stale pin to its repository.

## Proposed change

Compare durable revisions in the existing lazy-hydration branch. A newer snapshot supplies title, pin and archive; only an explicitly pending local title (`unsavedTitle`) overrides it. Same/older lazy responses retain the existing metadata protection. This follows the confirmed title-only conflict policy: a pending local pin does not defeat a newer durable value.

## Scope and non-goals

- No new fields, transient markers, enum values, services, dependencies, IPC methods, UI flows, or durable schema/model changes.
- Persistence continues through the existing renderer saver and Main owner. This prevents stale pin submission; Main archive/runtime/details protections remain unchanged. Dedicated Session-details events are a separate projection path.
- No historical-data migration/backfill or compatibility adapter is needed. Already overwritten historical pin values cannot be reconstructed by this fix.
- A separate test-only commit supplies two now-required Settings lifecycle dependencies in the existing delegated-work fixture. Main had merged the Settings lifecycle change after that fixture was added. The unchanged baseline failed Node typechecking and seven cancelled-quit cases (`getActiveSettingsInstallId is not a function`); no lifecycle production behavior changes.

## Acceptance criteria and validation

Before changing production code, the public store/saver regressions repeatedly failed in the reported way: three failures (untouched metadata, title-only metadata, stale pin at the Main write port) and one passing existing same-revision control. After the fix, the focused matrix passes all five cases, including the approved newer-revision pin conflict policy.

Final Test Impact Set (run after the final material edit):

| Behavior / boundary | Project-owned check | Result |
| --- | --- | --- |
| Lazy revision/metadata merge; same-revision edits; loaded title acknowledgements | `session-store.test.ts`, `session-store.architecture.test.ts`, `session_renderer` module contracts | PASS |
| Serialization, external-update no-echo, title-only saves, current-revision pin write | renderer `session-persistence.test.ts` and `.render.test.tsx`, real `SessionPersistenceStateOwner` through recording repository ports | PASS |
| Lifecycle events, archive undo, runtime/workspace/files/compute consumers | `useLifecycleSync.test.tsx`, `archive-undo-store.test.ts`, all declared tests of `workspace_runtime`, `workspace_page`, `project_files_view`, `compute_service` | PASS |
| Durable revision and Main field ownership | Main `coordinator.test.ts`, `coordinator-contract.test.ts`, `revision-conflict.test.ts` | PASS |
| Baseline lifecycle fixture repair | full `production-composition.test.ts` and `app-lifecycle.test.ts` | PASS |
| Process typing and style | `npm run typecheck:node`, `npm run typecheck:web`, `npm run lint`, changed-file Prettier check, `git diff --check` | PASS |

The test command is `npm test -- <deduplicated module testFiles plus explicit files above> --maxWorkers=2`; module lists come from `createModuleTestPlan` in `scripts/ci/module-test-impact.mjs`. Final result: **106 files passed / 1 skipped; 3,231 tests passed / 6 skipped**. Both typechecks, repository lint, formatting and diff checks passed.

The final automatic affected plan falls back to full at the existing production-composition test, which has no manifest owner; the original P01-only plan also fell back at the unowned renderer saver test. Per the maintainer request, no full local `npm test` was run and the manifest was not changed to narrow CI. Full PR CI remains authoritative. Socket-based consumer tests require localhost/Unix-socket permissions; sandbox EPERM failures were rerun with those permissions.

Independent Standards and Spec reviews found no actionable findings and confirmed the final impact mapping, including the two-line fixture repair. The new persistence regression is an in-memory composition test through real serialization/Main revision validation, not a real SQLite or two-window E2E run. No provider protocol, path handling, layout, or persisted format changes justify additional live-provider, visual, migration or generated-API checks; configured full/platform PR CI is still required.

## Review focus

Check that old summary metadata cannot acquire a newer durable revision, pending title protection stays field-specific, and unrelated saves retain the incoming pin. Confirm that the test-only fixture repair remains separate from the production fix.
