### PR TITLE
fix(performance): give Windows runtime soak a realistic timeout

### DIFF
--- a/.github/workflows/runtime-resource-soak.yml
+++ b/.github/workflows/runtime-resource-soak.yml
@@ -56,7 +56,7 @@ jobs:
     needs: plan
     if: needs.plan.outputs.should_test == 'true'
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: 70
     env:
       CI: 'true'
       PROFILE_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'soak' }}

--- a/e2e/runtime-performance.spec.ts
+++ b/e2e/runtime-performance.spec.ts
@@ -1,4 +1,8 @@
 import { expect, test as playwrightTest } from '@playwright/test'
+import {
+  RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS,
+  runtimePerformanceTestTimeoutMs
+} from '../scripts/performance/runtime-profile-timeout'
 import { createProject, openProjectSession, sendPrompt } from './certification/helpers'
 import { test } from './fixtures/electron-app'
 
@@ -27,7 +31,7 @@ const stressCycles = positiveIntegerEnvironment('OPEN_SCIENCE_PERF_STRESS_CYCLES
 test('records isolated startup, ACP, Notebook, and recovery resource trends', async ({
   app
 }, testInfo) => {
-  playwrightTest.setTimeout(180_000 + stressCycles * 15_000)
+  playwrightTest.setTimeout(runtimePerformanceTestTimeoutMs(stressCycles))
   await app.completeOnboarding()
   await app.configureFakeAgent()
   await app.beginResourceProfile({
@@ -50,16 +54,21 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
     await app.sampleResourceProfileNow()
 
     await app.markResourceProfilePhase('acp-turn')
-    await sendPrompt(page, ACP_PROMPT, ACP_REPLY, 60_000)
+    await sendPrompt(page, ACP_PROMPT, ACP_REPLY, RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS)
     await app.sampleResourceProfileNow()
 
     for (let cycle = 0; cycle < stressCycles; cycle += 1) {
       await app.markResourceProfilePhase('session-stress')
-      await sendPrompt(page, `${STRESS_PROMPT} Cycle ${cycle + 1}.`, STRESS_REPLY, 60_000)
+      await sendPrompt(
+        page,
+        `${STRESS_PROMPT} Cycle ${cycle + 1}.`,
+        STRESS_REPLY,
+        RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS
+      )
       await app.sampleResourceProfileNow()
 
       await app.markResourceProfilePhase('notebook-tool')
-      await sendPrompt(page, NOTEBOOK_PROMPT, NOTEBOOK_REPLY, 60_000)
+      await sendPrompt(page, NOTEBOOK_PROMPT, NOTEBOOK_REPLY, RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS)
       await app.sampleResourceProfileNow()
     }
 
@@ -67,12 +76,20 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
     await page.waitForTimeout(phaseDurationMs)
     await openProjectSession(page, PROFILE_PROJECT_NAME, ACP_PROMPT)
     await expect(page.getByText(STRESS_REPLY, { exact: false }).last()).toBeVisible({
-      timeout: 60_000
+      timeout: RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS
     })
     await app.sampleResourceProfileNow()
   } finally {
-    result = await app.finishResourceProfile()
+    result = await app.finishResourceProfile().catch((error: unknown) => {
+      // Fixture teardown may abort the profiler first when Playwright times the test out.
+      if (error instanceof Error && error.message === 'Runtime resource profiling is not active.') {
+        return undefined
+      }
+      throw error
+    })
   }
+
+  if (!result) throw new Error('Runtime resource profile was not recorded.')
 
   await testInfo.attach('runtime-resource-summary', {
     path: result.summaryMarkdownPath,

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -118,7 +118,7 @@ describe('release and scheduled workflow topology', () => {
       needs: 'plan',
       if: "needs.plan.outputs.should_test == 'true'",
       'runs-on': 'windows-latest',
-      'timeout-minutes': 40
+      'timeout-minutes': 70
     })
     expect(profile.run).toContain("'--stress-cycles=1'")
     expect(profile.run).toContain("'--stress-cycles=6'")

--- a/scripts/performance/run-runtime-profile.mjs
+++ b/scripts/performance/run-runtime-profile.mjs
@@ -114,6 +114,9 @@ await run(
     'e2e/runtime-performance.spec.ts',
     '--workers=1',
     `--repeat-each=${options.repeat}`,
+    // Independent samples already come from --repeat-each. CI retries would replay a 10+ minute
+    // soak after a timeout and exceed the workflow budget without extra evidence.
+    '--retries=0',
     '--reporter=list'
   ],
   environment

--- a/scripts/performance/run-runtime-profile.test.ts
+++ b/scripts/performance/run-runtime-profile.test.ts
@@ -77,6 +77,7 @@ process.exit(0)
           'e2e/runtime-performance.spec.ts',
           '--workers=1',
           '--repeat-each=1',
+          '--retries=0',
           '--reporter=list'
         ]
       ])

--- a/scripts/performance/runtime-profile-timeout.test.ts
+++ b/scripts/performance/runtime-profile-timeout.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS,
+  runtimePerformanceTestTimeoutMs
+} from './runtime-profile-timeout'
+
+describe('runtime performance timeout budget', () => {
+  it('gives smoke and soak journeys enough time for later slower stress cycles', () => {
+    // Smoke: 4 min base + 1.5 min for one Session/Notebook cycle.
+    expect(runtimePerformanceTestTimeoutMs(1)).toBe(330_000)
+    // Soak: six accumulating streamed turns on Windows CI need ~13 minutes, not 4.5.
+    expect(runtimePerformanceTestTimeoutMs(6)).toBe(780_000)
+    expect(RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS).toBe(120_000)
+  })
+
+  it('rejects a non-positive cycle count', () => {
+    expect(() => runtimePerformanceTestTimeoutMs(0)).toThrow(/positive integer/)
+    expect(() => runtimePerformanceTestTimeoutMs(1.5)).toThrow(/positive integer/)
+  })
+})

--- a/scripts/performance/runtime-profile-timeout.ts
+++ b/scripts/performance/runtime-profile-timeout.ts
@@ -1,0 +1,17 @@
+// Startup, two Electron restarts, idle/recovery waits, and ACP setup on Windows CI.
+const RUNTIME_PERFORMANCE_BASE_TIMEOUT_MS = 240_000
+// Later soak cycles render every prior 90-chunk stress payload in one Session; 15s/cycle is not enough.
+const RUNTIME_PERFORMANCE_PER_STRESS_CYCLE_TIMEOUT_MS = 90_000
+const RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS = 120_000
+
+const runtimePerformanceTestTimeoutMs = (stressCycles: number): number => {
+  if (!Number.isSafeInteger(stressCycles) || stressCycles < 1) {
+    throw new Error('stressCycles must be a positive integer.')
+  }
+  return (
+    RUNTIME_PERFORMANCE_BASE_TIMEOUT_MS +
+    stressCycles * RUNTIME_PERFORMANCE_PER_STRESS_CYCLE_TIMEOUT_MS
+  )
+}
+
+export { RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS, runtimePerformanceTestTimeoutMs }

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -101,6 +101,8 @@ describe('startup quit ownership handoff', () => {
             createConfirmClose: () => async () => 'quit',
             prepareForQuit: async () => {},
             abortQuitPreparation: () => {},
+            holdSettingsInstallAdmission: () => () => undefined,
+            getActiveSettingsInstallId: () => undefined,
             flushSessionPersistence: async () => {},
             shutdownBackends: () => runtime.dispose()
           })

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -958,6 +958,8 @@ describe('production delegated-work composition', () => {
             shutdownBackends,
             prepareForQuit,
             abortQuitPreparation,
+            holdSettingsInstallAdmission: () => () => undefined,
+            getActiveSettingsInstallId: () => undefined,
             flushSessionPersistence,
             isMigrationInProgress: () => false,
             quit,


### PR DESCRIPTION
## Problem

Scheduled `Runtime Resource Soak` on Windows has failed every day since 1 Sep. The Playwright journey hits `Test timeout of 270000ms exceeded` on all three `--repeat-each` samples, then CI retries each sample once. The follow-on `Runtime resource profiling is not active` error is teardown noise: fixture `dispose()` aborts the profiler before `finally` can finish it.

The 270s budget is `180s + 6 × 15s`. Each soak stress turn streams 90 chunks of 2048 `x` characters into one Session, so later cycles get slower as the transcript grows. 15s/cycle is not enough on hosted Windows runners. One 4 Sep attempt also missed `Runtime resource stress journey complete.` within the 60s `sendPrompt` wait.

Manual `smoke` (1 cycle) still passes. Soak never records recovery evidence, so the process-count and storage invariants are not actually being checked.

## Proposed change

- Raise the per-test budget to `240s + cycles × 90s` (soak = 13 min) and wait 120s for prompt/recovery text.
- Pass `--retries=0` to Playwright. `--repeat-each` already collects independent samples; CI retries doubled a timed-out soak without extra evidence.
- Extend the workflow job from 40 min to 70 min so three 13-minute samples plus install/build fit.
- If fixture teardown already aborted the profiler, do not mask the original timeout with `profiling is not active`.

## Scope and non-goals

- Test harness and soak workflow budget only.
- Does not change fake-agent stress payload, soak cycle count, or resource invariants.
- Does not change ACP, Session persistence format, or compute-job cancellation.

## Compatibility and persistence

- **Historical data compatibility:** none. No persisted format, migration, or on-disk layout change.
- **New state / enum values:** none.
- **Data persistence:** none. Soak still writes profile artifacts under `test-results/` as before.

## Acceptance criteria and validation

- Soak Playwright timeout is 780s for 6 cycles, not 270s.
- Profile launcher invokes Playwright with `--retries=0`.
- Soak job `timeout-minutes` is 70.
- Missing profiler after teardown fails with `Runtime resource profile was not recorded` instead of the harness-internal abort message.

## Review focus

- Whether 90s/cycle plus 120s prompt waits are enough for later accumulating stress turns without making the job unbounded.
- Whether skipping Playwright retries is acceptable given `--repeat-each=3`.

## Test Impact Set

Ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Soak vs smoke timeout budget | `npx vitest run scripts/performance/runtime-profile-timeout.test.ts` | pass |
| Launcher passes `--retries=0` | `npx vitest run scripts/performance/run-runtime-profile.test.ts` | pass |
| Workflow job timeout pin | `npx vitest run scripts/ci/release-workflows.test.ts` | pass |
| Lint of changed files | `npx eslint` on the touched TS/MJS files | pass |

Not run locally: full `npm test`, Electron E2E, and the Windows soak job. PR Gate is authoritative for the portable suite. Soak is schedule-only; after merge the next daily soak (or a manual `soak` dispatch on this branch) is the end-to-end check.

## Uncovered risks

- `ComputeJobCancellationReaper` still logs Prisma interactive-transaction timeouts (`5s` limit, ~28s elapsed) under soak load. That is a real SQLite contention signal, but it was not the test failure. Left for a follow-up.
- If later stress cycles still cannot surface `Runtime resource stress journey complete.` within 120s (renderer virtualization or hydration of a ~1MB Session), soak will fail on `sendPrompt` rather than the old 270s budget. That would be a product/UI issue, not a budget issue.