### PR TITLE
fix(notebook): probe Windows R through Rscript

### DIFF
--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -14,6 +14,25 @@ import {
 import { DEFAULT_PY_ENV, DEFAULT_R_ENV, envPrefix, rBin, rScriptBin } from './runtime-paths'
 
 describe('defaultDiscoveryDeps Windows conda R probes', () => {
+  it('probes an R environment version through Rscript instead of launching R.exe', async () => {
+    const interpreter = 'C:\\Program Files\\R\\R-4.6.0\\bin\\x64\\R.exe'
+    const exec = vi.fn(async (): Promise<{ stdout: string; stderr: string }> => ({
+      stdout: '',
+      stderr: 'R scripting front-end version 4.6.0 (2026-04-24)'
+    }))
+    const deps = defaultDiscoveryDeps('C:\\Users\\HM\\OpenScience\\runtime', undefined, {
+      platform: 'win32',
+      exec
+    })
+
+    await expect(deps.probeVersion(interpreter, 'r')).resolves.toBe('4.6.0')
+    expect(exec).toHaveBeenCalledWith(
+      'C:\\Program Files\\R\\R-4.6.0\\bin\\x64\\Rscript.exe',
+      ['--version'],
+      expect.objectContaining({ windowsHide: true })
+    )
+  })
+
   it('uses the injected environment and subprocess port for interpreter probes', async () => {
     const env = { PATH: 'injected-path', DISCOVERY_SENTINEL: 'injected' }
     const exec = vi.fn(
@@ -69,7 +88,7 @@ describe('defaultDiscoveryDeps Windows conda R probes', () => {
     await expect(deps.probeVersion(interpreter, 'r')).resolves.toBe('4.4.3')
     await expect(deps.rRunnable(interpreter)).resolves.toBe(true)
     expect(exec.mock.calls.map(([file]) => file)).toEqual([
-      interpreter,
+      `${prefix}\\Lib\\R\\bin\\Rscript.exe`,
       `${prefix}\\Lib\\R\\bin\\Rscript.exe`
     ])
   })

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -537,13 +537,12 @@ export const defaultDiscoveryDeps = (
           const output = `${stdout}\n${stderr}`
           return isPython3Version(output) ? output.trim().replace(/^Python\s+/i, '') : undefined
         }
-        // No shell: execFile runs the interpreter directly, so a path with spaces/metacharacters is
-        // handled safely (shell:true would break "C:\Program Files\…" and allow injection).
-        const { stdout, stderr } = await exec(
-          interpreterPath,
-          ['--version'],
-          probeOptions(interpreterPath)
-        )
+        // Probe through Rscript rather than R.exe. On Windows R.exe may create its own visible
+        // frontend even when the child process has windowsHide set; Rscript is the headless CLI we
+        // already use for readiness checks and kernel launches. No shell means paths with spaces or
+        // metacharacters are passed safely.
+        const rscript = rscriptFor(interpreterPath)
+        const { stdout, stderr } = await exec(rscript, ['--version'], probeOptions(rscript))
         return parseRVersion(`${stdout}\n${stderr}`)
       } catch {
         return undefined


### PR DESCRIPTION
## Problem

On Windows, R environment discovery probes a discovered `R.exe` directly with `--version`. The R frontend can surface a visible version window even though the child process uses `windowsHide`, and repeated discovery refreshes can therefore interrupt the user with repeated R version windows.

A regression test was added first and failed on the unfixed implementation with the expected causal mismatch: it expected `Rscript.exe --version`, but discovery invoked `R.exe --version`.

## Proposed change

- Derive the discovered environment's sibling `Rscript.exe` for the version probe.
- Keep `R.exe` unchanged as the environment identity and binding path.
- Retain the existing timeout, hidden-process, environment activation, and version parsing behavior.

## Scope and non-goals

- No database or persisted-format changes.
- No historical-data compatibility work.
- No new fields, enum values, runtime states, or interaction model.
- No change to environment discovery frequency or caching.
- No broad process/window suppression mechanism.

## Acceptance criteria and validation

The checks below ran after the last material implementation edit:

- Windows R version probe avoids `R.exe` -> `npm test -- src/main/notebook/environment-discovery.test.ts` -> 22/22 passed
- Main-process type contracts remain valid -> `npm run typecheck:node` -> passed
- Source and tests meet repository lint rules -> `npm run lint` -> passed
- Patch formatting -> `git diff --check` -> passed

The complete local `npm test` suite was intentionally not run. PR Gate classifies the currently unmapped notebook discovery test as a full-plan change, so CI remains authoritative for the complete portable suite.

## Review focus

Please verify that retaining `R.exe` as the environment identity while using sibling `Rscript.exe` only for the version probe preserves existing binding semantics.

Uncovered local risk: this machine does not have the reported CRAN R 4.6.0 installation, so the real window was not visually re-observed. The regression test covers the subprocess boundary responsible for launching that frontend.