### PR TITLE
fix(notebook): correct environment repair and package outcomes

### DIFF
--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -40,6 +40,7 @@ const fakeProvisioner = (over: Partial<RuntimeProvisioner> = {}): RuntimeProvisi
   provisionR: vi.fn().mockResolvedValue(undefined),
   upgradeIfNeeded: vi.fn().mockResolvedValue(undefined),
   repair: vi.fn().mockImplementation(async (_language, _onProgress, options) => {
+    await options?.onStarting?.()
     await options?.onVerified?.()
   }),
   restoreRelocatedEnvs: vi.fn().mockResolvedValue(undefined),
@@ -159,6 +160,7 @@ describe('createNotebookEnvironmentLifecycle', () => {
     // UI repair is the user's Reset: it force-clears the quarantine (force: true).
     expect(provisioner.repair).toHaveBeenCalledWith('r', expect.any(Function), {
       force: true,
+      onStarting: expect.any(Function),
       onVerified: expect.any(Function)
     })
   })
@@ -169,7 +171,8 @@ describe('createNotebookEnvironmentLifecycle', () => {
       order.push('prepare')
     })
     const provisioner = fakeProvisioner({
-      repair: vi.fn(async () => {
+      repair: vi.fn(async (_language, _progress, options) => {
+        await options?.onStarting?.()
         order.push('repair')
       })
     })
@@ -198,14 +201,16 @@ describe('createNotebookEnvironmentLifecycle', () => {
 
   it('does not enter destructive repair when runtime coordination fails', async () => {
     const provisioner = fakeProvisioner()
+    const onRepairCompleted = vi.fn()
     const lifecycle = createLifecycle(provisioner, {
+      onRepairCompleted,
       onRepairStarting: async () => {
         throw new Error('binding persist denied')
       }
     })
 
     await expect(lifecycle.repair('r', 'default-r')).rejects.toThrow('binding persist denied')
-    expect(provisioner.repair).not.toHaveBeenCalled()
+    expect(onRepairCompleted).not.toHaveBeenCalled()
   })
 
   it('publishes a successful verified repair back to the runtime service', async () => {
@@ -417,6 +422,7 @@ describe('createNotebookEnvironmentLifecycle', () => {
     await lifecycle.repair('python', 'default-python')
     expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function), {
       force: true,
+      onStarting: expect.any(Function),
       onVerified: expect.any(Function)
     })
 

--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -160,7 +160,7 @@ describe('createNotebookEnvironmentLifecycle', () => {
     // UI repair is the user's Reset: it force-clears the quarantine (force: true).
     expect(provisioner.repair).toHaveBeenCalledWith('r', expect.any(Function), {
       force: true,
-      onStarting: expect.any(Function),
+      onStarting: undefined,
       onVerified: expect.any(Function)
     })
   })
@@ -422,7 +422,7 @@ describe('createNotebookEnvironmentLifecycle', () => {
     await lifecycle.repair('python', 'default-python')
     expect(provisioner.repair).toHaveBeenCalledWith('python', expect.any(Function), {
       force: true,
-      onStarting: expect.any(Function),
+      onStarting: undefined,
       onVerified: expect.any(Function)
     })
 

--- a/src/main/notebook/environment-lifecycle-workflows.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.ts
@@ -148,11 +148,13 @@ const createNotebookEnvironmentLifecycle = (
           if (deps.waitForRecovery) await deps.waitForRecovery()
           await provisioner.repair(parsedLanguage, report, {
             force: true,
-            onStarting: () =>
-              deps.onRepairStarting?.(
-                parsedLanguage,
-                explicitRuntimeRepairTarget(parsedLanguage, runtimeIdentity)
-              ),
+            onStarting: deps.onRepairStarting
+              ? () =>
+                  deps.onRepairStarting?.(
+                    parsedLanguage,
+                    explicitRuntimeRepairTarget(parsedLanguage, runtimeIdentity)
+                  )
+              : undefined,
             onVerified: () => deps.onRepairCompleted?.(parsedLanguage)
           })
         }),

--- a/src/main/notebook/environment-lifecycle-workflows.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.ts
@@ -146,14 +146,13 @@ const createNotebookEnvironmentLifecycle = (
       (report) =>
         withDataRootWrite(async () => {
           if (deps.waitForRecovery) await deps.waitForRecovery()
-          if (deps.onRepairStarting) {
-            await deps.onRepairStarting(
-              parsedLanguage,
-              explicitRuntimeRepairTarget(parsedLanguage, runtimeIdentity)
-            )
-          }
           await provisioner.repair(parsedLanguage, report, {
             force: true,
+            onStarting: () =>
+              deps.onRepairStarting?.(
+                parsedLanguage,
+                explicitRuntimeRepairTarget(parsedLanguage, runtimeIdentity)
+              ),
             onVerified: () => deps.onRepairCompleted?.(parsedLanguage)
           })
         }),

--- a/src/main/notebook/environment-management.test.ts
+++ b/src/main/notebook/environment-management.test.ts
@@ -80,6 +80,44 @@ const harness = (
 }
 
 describe('NotebookEnvironmentManagementOwner', () => {
+  it.each(['default-python-analysis', 'default-r-analysis', 'default-python', 'default-r'])(
+    'E07 rejects reserved create name %s before any environment side effect',
+    async (name) => {
+      const { owner, options, manager: configured } = harness()
+      await expect(owner.manage({ action: 'create', name, language: 'python' })).rejects.toThrow(
+        /reserved|app-managed/
+      )
+      expect(options.ensureRecovered).not.toHaveBeenCalled()
+      expect(configured?.createNamedEnvironment).not.toHaveBeenCalled()
+    }
+  )
+
+  it('E07 permits creation and removal of an ordinary user environment', async () => {
+    const { owner, manager: configured } = harness()
+    await expect(
+      owner.manage({ action: 'create', name: 'analysis', language: 'python' })
+    ).resolves.toHaveProperty('created.name', 'analysis')
+    await owner.manage({ action: 'remove', name: 'analysis' })
+    expect(configured?.removeEnvironment).toHaveBeenCalledWith('analysis')
+  })
+
+  it.each(['default-python-analysis', 'default-r-analysis'])(
+    'E07 preserves an existing conflicting environment %s without proven ownership',
+    async (name) => {
+      const configured = manager()
+      vi.mocked(configured.listEnvironments).mockReturnValue([
+        { name, language: 'python', ready: true, isDefault: false }
+      ])
+      const { owner } = harness({ manager: configured })
+      await expect(owner.manage({ action: 'list' })).resolves.toHaveProperty(
+        'environments.0.name',
+        name
+      )
+      await expect(owner.manage({ action: 'remove', name })).rejects.toThrow(/app-managed|reserved/)
+      expect(configured.removeEnvironment).not.toHaveBeenCalled()
+    }
+  )
+
   it('keeps manager configuration inside the owner', async () => {
     const configuredHarness = harness()
     const owner = new NotebookEnvironmentManagementOwner({
@@ -218,7 +256,7 @@ describe('NotebookEnvironmentManagementOwner', () => {
     })
 
     await expect(owner.manage({ action: 'remove', name: 'default-python-3.13' })).rejects.toThrow(
-      /app-managed and cannot be removed/
+      /reserved environment name/
     )
     await expect(owner.manage({ action: 'remove', name: 'analysis' })).rejects.toThrow(
       /in use by a running kernel/

--- a/src/main/notebook/environment-management.ts
+++ b/src/main/notebook/environment-management.ts
@@ -5,7 +5,7 @@ import type {
   ManageEnvironmentsResult
 } from '../../shared/notebook-env'
 import type { NotebookEnvironmentOperations } from './environment-operations'
-import { assertSafeEnvName, DEFAULT_PY_ENV, DEFAULT_R_ENV, envPrefix } from './runtime-paths'
+import { assertSafeEnvName, envPrefix } from './runtime-paths'
 import type { NotebookRuntimeRepairOwner } from './runtime-repair'
 import type { NotebookSessionRuntimeBinding } from './session-aggregate'
 import { managedRuntimeIdentity } from './runtime-target'
@@ -37,12 +37,6 @@ type NotebookEnvironmentManagementOptions = {
   runtimeRepair: Pick<NotebookRuntimeRepairOwner, 'completeRemovedManagedEnvironment'>
   isAgentEnvironmentCreationEnabled: () => Promise<boolean>
 }
-
-const isAppManagedEnvironment = (name: string): boolean =>
-  name === DEFAULT_PY_ENV ||
-  name === DEFAULT_R_ENV ||
-  name.startsWith(`${DEFAULT_PY_ENV}-`) ||
-  name.startsWith(`${DEFAULT_R_ENV}-`)
 
 /** Owns named-environment validation, lifecycle ordering, and live-use protection. */
 class NotebookEnvironmentManagementOwner {
@@ -102,12 +96,6 @@ class NotebookEnvironmentManagementOwner {
         return { environments: manager.listEnvironments() }
       case 'remove': {
         const name = assertSafeEnvName(request.name)
-        if (isAppManagedEnvironment(name)) {
-          throw new Error(
-            `Environment "${name}" is app-managed and cannot be removed. Only environments you ` +
-              'created with manage_environments(action:"create") can be removed.'
-          )
-        }
         if (this.isLive(name)) {
           throw new Error(
             `Environment "${name}" is in use by a running kernel — restart the notebook or ` +

--- a/src/main/notebook/environment-operations.test.ts
+++ b/src/main/notebook/environment-operations.test.ts
@@ -6,7 +6,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { NotebookSessionRuntimeBinding } from './session-aggregate'
 import { NotebookEnvironmentOperations } from './environment-operations'
-import { createRootNotebookLane, type NotebookLaneIdentity } from './lane-identity'
+import {
+  createFrameNotebookLane,
+  createRootNotebookLane,
+  notebookLaneKey,
+  notebookLaneScope,
+  type NotebookLaneIdentity
+} from './lane-identity'
+import { NotebookSessionRegistry, type NotebookSessionRegistryMember } from './session-registry'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
 
 let storageRoot: string | undefined
@@ -39,7 +46,8 @@ type TestSession = {
 }
 
 const createOwner = async (
-  sessions: TestSession[] = []
+  sessions: TestSession[] | (() => Iterable<TestSession>) = [],
+  beforeWrites: (keys: string[]) => Promise<void> | void = () => undefined
 ): Promise<{
   owner: NotebookEnvironmentOperations
   notifyChanged: ReturnType<typeof vi.fn>
@@ -49,8 +57,10 @@ const createOwner = async (
   const notifyChanged = vi.fn()
   const clearKernelTermination = vi.fn(async () => undefined)
   const bindings = {
-    runWrites: async <T>(_sessionIds: Iterable<string>, operation: () => Promise<T>): Promise<T> =>
-      operation(),
+    runWrites: async <T>(keys: Iterable<string>, operation: () => Promise<T>): Promise<T> => {
+      await beforeWrites([...keys])
+      return operation()
+    },
     revoke: async <Context>(
       session: TestSession,
       language: NotebookLanguage,
@@ -73,7 +83,7 @@ const createOwner = async (
   const owner = new NotebookEnvironmentOperations({
     recovery,
     bindings,
-    sessions: () => sessions,
+    sessions: typeof sessions === 'function' ? sessions : () => sessions,
     clearKernelTermination,
     notifyChanged,
     now: () => 123
@@ -82,6 +92,77 @@ const createOwner = async (
 }
 
 describe('NotebookEnvironmentOperations', () => {
+  it.each([false, true])('E04 revokes all current lane owners (force: %s)', async (force) => {
+    const makeSession = (
+      lane: NotebookLaneIdentity
+    ): TestSession & NotebookSessionRegistryMember => ({
+      ...notebookLaneScope(lane),
+      lane,
+      bindings: {
+        python: {
+          language: 'python' as const,
+          runtimeId: '/env/python',
+          source: 'external' as const,
+          provenance: 'user-own' as const,
+          interpreterPath: '/env/python',
+          label: 'Python',
+          status: 'active' as const
+        }
+      } as TestSession['bindings'],
+      statuses: new Map<string, 'running'>([['python:default-python', 'running']]),
+      runtimeBinding(language: NotebookLanguage) {
+        return this.bindings[language]
+      },
+      setRuntimeBinding(language: NotebookLanguage, value: NotebookSessionRuntimeBinding) {
+        this.bindings[language] = value
+      },
+      kernelStatus(key: string) {
+        return this.statuses.get(key)
+      },
+      markForceStopped: vi.fn(),
+      drainExecution: vi.fn().mockResolvedValue(undefined),
+      terminateExecutor: vi.fn().mockResolvedValue(undefined),
+      clearProcessState: vi.fn(),
+      shutdownExecutor: vi.fn().mockResolvedValue({ reaped: true }),
+      releaseMcpRpcConnection: vi.fn()
+    })
+    const lanes = [
+      createRootNotebookLane('project', 'shared-session', 'root-frame-shared-session'),
+      createFrameNotebookLane('project', 'shared-session', 'child-a', 'attempt-1'),
+      createFrameNotebookLane('project', 'shared-session', 'child-a', 'attempt-2'),
+      createFrameNotebookLane('project', 'shared-session', 'child-b'),
+      createRootNotebookLane('other-project', 'shared-session', 'root-frame-shared-session')
+    ]
+    const registry = new NotebookSessionRegistry<ReturnType<typeof makeSession>>()
+    const current = await Promise.all(
+      lanes.map((lane) => registry.getOrCreate(lane, async () => makeSession(lane)))
+    )
+    const staleLane = createFrameNotebookLane('project', 'shared-session', 'replaced-child')
+    const stale = await registry.getOrCreate(staleLane, async () => makeSession(staleLane))
+    let replacement: ReturnType<typeof makeSession> | undefined
+    const writes = vi.fn(async () => {
+      await registry.remove(staleLane)
+      replacement = await registry.getOrCreate(staleLane, async () => makeSession(staleLane))
+    })
+    const { owner } = await createOwner(() => registry.values(), writes)
+
+    await owner.revokeRuntime('python', '/env/python', { force })
+    await owner.waitForRevocationDrains()
+
+    for (const candidate of current) {
+      expect
+        .soft(candidate.runtimeBinding('python'))
+        .toMatchObject({ status: 'unavailable', reason: 'disabled' })
+      expect.soft(candidate.terminateExecutor).toHaveBeenCalledWith('python', 'default-python')
+      expect.soft(candidate.markForceStopped).toHaveBeenCalledTimes(force ? 1 : 0)
+      expect.soft(candidate.drainExecution).toHaveBeenCalledTimes(force ? 0 : 1)
+    }
+    expect(stale.runtimeBinding('python')?.status).toBe('active')
+    expect(stale.terminateExecutor).not.toHaveBeenCalled()
+    expect(replacement?.runtimeBinding('python')?.status).toBe('active')
+    expect(writes).toHaveBeenCalledWith([...lanes, staleLane].map(notebookLaneKey))
+  })
+
   it('owns operation admission and releases a failed mutation before the next waiter', async () => {
     const { owner } = await createOwner()
     let releaseFirst!: () => void

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -862,7 +862,7 @@ describe('installPackages', () => {
     expect(result.attempts).toEqual([
       expect.objectContaining({
         installer: 'conda',
-        mutationRisk: 'unknown',
+        mutationRisk: 'none',
         reason: 'unknown'
       })
     ])

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -1756,7 +1756,11 @@ export async function installPackages(
   ])
   if (preflight.code !== 0) {
     const classification = classifyCondaFailure(preflight)
-    const condaAttempt = installerAttempt(0, 'conda', condaPkgs, preflight, classification)
+    // A dry-run cannot mutate the prefix. Keep its diagnostic classification for fallback admission.
+    const condaAttempt = installerAttempt(0, 'conda', condaPkgs, preflight, {
+      ...classification,
+      mutationRisk: 'none'
+    })
     if (condaFallbackIsAuthorized(classification)) {
       return cranFallback(preflight, condaAttempt)
     }
@@ -2076,7 +2080,11 @@ async function uninstallPackages(
   ])
   if (preflight.code !== 0) {
     const classification = classifyCondaFailure(preflight)
-    const condaAttempt = installerAttempt(0, 'conda', condaPkgs, preflight, classification)
+    // A dry-run cannot mutate the prefix. Keep its diagnostic classification for fallback admission.
+    const condaAttempt = installerAttempt(0, 'conda', condaPkgs, preflight, {
+      ...classification,
+      mutationRisk: 'none'
+    })
     if (classification.reason === 'package-not-found' && classification.mutationRisk === 'none') {
       return cranRemoveFallback(preflight, condaAttempt)
     }

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -221,9 +221,11 @@ class NotebookPackageMutationOwner {
               )
             }
           }
-          if (installResult && request.language === 'r') {
+          if (installResult && request.language === 'r' && !installResult.repairRequired) {
             // Batch satisfaction and a live R namespace's freshness are independent. A failed
             // installer may already have changed packages even when inventory cannot prove a delta.
+            // Protected-identity failures require repair and terminate the kernel; retain the
+            // installer's repair-only guidance rather than inferring advice for that dead kernel.
             installResult = {
               ...installResult,
               needsRestart:

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -221,6 +221,23 @@ class NotebookPackageMutationOwner {
               )
             }
           }
+          if (installResult && request.language === 'r') {
+            // Batch satisfaction and a live R namespace's freshness are independent. A failed
+            // installer may already have changed packages even when inventory cannot prove a delta.
+            installResult = {
+              ...installResult,
+              needsRestart:
+                installResult.needsRestart ||
+                Boolean(
+                  installResult.packageChanges?.some((change) =>
+                    ['installed', 'updated', 'removed'].includes(change.change)
+                  ) ||
+                  installResult.attempts?.some(
+                    (attempt) => attempt.status !== 'skipped' && attempt.mutationRisk !== 'none'
+                  )
+                )
+            }
+          }
           if (installResult?.ok && verification?.result === 'failure') {
             const packages =
               verification.unsatisfiedPackages?.join(', ') || request.packages.join(', ')
@@ -229,7 +246,6 @@ class NotebookPackageMutationOwner {
             installResult = {
               ...installResult,
               ok: false,
-              needsRestart: false,
               error: inventoryFailure
                 ? `Package installation could not be verified in the target runtime: ${packages}. ` +
                   'The installer exited successfully, but the environment inventory refresh failed.'

--- a/src/main/notebook/package-operations.test.ts
+++ b/src/main/notebook/package-operations.test.ts
@@ -149,6 +149,128 @@ const harness = (
 }
 
 describe('NotebookPackageOperations', () => {
+  it.each([
+    {
+      label: 'partially verified batch',
+      ok: true,
+      needsRestart: true,
+      changes: true,
+      risk: 'confirmed'
+    },
+    {
+      label: 'verified changes without installer restart flag',
+      ok: true,
+      needsRestart: false,
+      changes: true,
+      risk: 'none'
+    },
+    {
+      label: 'installer failure after partial changes',
+      ok: false,
+      needsRestart: false,
+      changes: true,
+      risk: 'possible'
+    },
+    {
+      label: 'installer failure with mutation risk and no readable delta',
+      ok: false,
+      needsRestart: false,
+      changes: false,
+      risk: 'possible'
+    }
+  ] as const)(
+    'E06 recommends R restart after $label',
+    async ({ ok, needsRestart, changes, risk }) => {
+      const activeSession = session('session-1')
+      const { owner, options } = harness(activeSession)
+      const packageChanges = changes
+        ? [
+            {
+              name: 'dplyr',
+              ecosystem: 'r' as const,
+              relationship: 'requested' as const,
+              change: 'updated' as const,
+              beforeVersion: '1.0',
+              afterVersion: '1.1'
+            }
+          ]
+        : []
+      vi.mocked(options.installPackages).mockResolvedValue({
+        ok,
+        needsRestart,
+        log: 'dplyr changed; missing unavailable',
+        method: 'cran',
+        attempts: [
+          {
+            groupOrdinal: 0,
+            installer: 'r-install-packages',
+            packages: ['dplyr', 'missing'],
+            status: ok ? 'succeeded' : 'failed',
+            mutationRisk: risk
+          }
+        ]
+      })
+      vi.mocked(options.environmentStateTracker.refreshAfterPackageMutation).mockResolvedValue({
+        result: 'failure',
+        unsatisfiedPackages: ['missing'],
+        packageChanges
+      })
+
+      const result = await owner.manage({ language: 'r', packages: ['dplyr', 'missing'] })
+
+      expect(result.ok).toBe(false)
+      expect(result.packageChanges).toEqual(packageChanges)
+      expect.soft(result.needsRestart).toBe(true)
+      expect
+        .soft(options.environmentOperations.recommendRestart)
+        .toHaveBeenCalledWith('r', 'default-r')
+      expect.soft(options.notifyChanged).toHaveBeenCalledWith(activeSession)
+    }
+  )
+
+  it('E06 does not recommend restart when admission prevents the installer from starting', async () => {
+    const { owner, options } = harness(session('session-1'), {
+      isDefaultEnvironmentDisabled: vi.fn().mockResolvedValue(true)
+    })
+    const result = await owner.manage({ language: 'r', packages: ['dplyr'] })
+    expect(result).toMatchObject({ ok: false, needsRestart: false })
+    expect(options.installPackages).not.toHaveBeenCalled()
+    expect(options.environmentOperations.recommendRestart).not.toHaveBeenCalled()
+  })
+
+  it.each(['failed', 'skipped'] as const)(
+    'E06 does not infer mutation from observations or an attempt that is %s without mutation',
+    async (status) => {
+      const { owner, options } = harness(session('session-1'))
+      vi.mocked(options.installPackages).mockResolvedValue({
+        ok: false,
+        needsRestart: false,
+        log: '',
+        attempts: [
+          {
+            groupOrdinal: 0,
+            installer: 'r-install-packages',
+            packages: ['missing'],
+            status,
+            mutationRisk: 'none'
+          }
+        ]
+      })
+      vi.mocked(options.environmentStateTracker.refreshAfterPackageMutation).mockResolvedValue({
+        result: 'failure',
+        packageChanges: [
+          { name: 'dplyr', ecosystem: 'r', relationship: 'dependency', change: 'observed' },
+          { name: 'tibble', ecosystem: 'r', relationship: 'dependency', change: 'unchanged' }
+        ]
+      })
+      await expect(owner.manage({ language: 'r', packages: ['missing'] })).resolves.toMatchObject({
+        ok: false,
+        needsRestart: false
+      })
+      expect(options.environmentOperations.recommendRestart).not.toHaveBeenCalled()
+    }
+  )
+
   it('inspects the Session-bound managed environment through the shared read slot', async () => {
     const managed = binding('python', '/runtime/analysis/python', 'managed', 'analysis')
     const activeSession = session('session-1', managed)

--- a/src/main/notebook/package-operations.test.ts
+++ b/src/main/notebook/package-operations.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { NotebookLanguage } from '../../shared/notebook'
 import { createRootNotebookLane } from './lane-identity'
 import { NotebookPackageOperations } from './package-operations'
+import { installPackages } from './package-manager'
 import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import { NotebookSessionAggregate, type NotebookSessionRuntimeBinding } from './session-aggregate'
@@ -149,6 +150,55 @@ const harness = (
 }
 
 describe('NotebookPackageOperations', () => {
+  it.each(['install', 'uninstall'] as const)(
+    'E06 does not recommend restart after an unstructured R %s preflight failure',
+    async (operation) => {
+      const commands: string[][] = []
+      const { owner, options } = harness(
+        session('session-1', binding('r', 'analysis', 'managed', 'analysis')),
+        {
+          installPackages: (request, deps) =>
+            installPackages(request, {
+              ...deps,
+              micromamba: '/test/micromamba',
+              pathExists: () => true,
+              readCondaPackageIdentity: () => ({
+                name: 'r-base',
+                version: '4.4.3',
+                build: 'test_0',
+                buildNumber: 0
+              }),
+              spawn: async (_command, args) => {
+                if (args[0] === '--no-rc' && args[1] === 'clean') {
+                  return { code: 0, stdout: '', stderr: '' }
+                }
+                commands.push(args)
+                return { code: 1, stdout: '', stderr: 'unstructured preflight failure' }
+              }
+            })
+        }
+      )
+
+      const result = await owner.manage({
+        sessionId: 'session-1',
+        language: 'r',
+        environment: 'analysis',
+        packages: ['dplyr'],
+        operation
+      })
+
+      expect(commands, result.error).toHaveLength(1)
+      expect(commands[0]).toContain('--dry-run')
+      expect(result.ok).toBe(false)
+      expect(result.fallbackUsed).toBe(false)
+      expect(result.attempts).toEqual([
+        expect.objectContaining({ mutationRisk: 'none', reason: 'unknown' })
+      ])
+      expect.soft(result.needsRestart).toBe(false)
+      expect.soft(options.environmentOperations.recommendRestart).not.toHaveBeenCalled()
+    }
+  )
+
   it.each([
     {
       label: 'partially verified batch',
@@ -177,6 +227,13 @@ describe('NotebookPackageOperations', () => {
       needsRestart: false,
       changes: false,
       risk: 'possible'
+    },
+    {
+      label: 'installer failure with unknown mutation risk and no readable delta',
+      ok: false,
+      needsRestart: false,
+      changes: false,
+      risk: 'unknown'
     }
   ] as const)(
     'E06 recommends R restart after $label',

--- a/src/main/notebook/package-operations.ts
+++ b/src/main/notebook/package-operations.ts
@@ -248,7 +248,7 @@ class NotebookPackageOperations {
       const admission = await this.admission.admit(request, resolution)
       if (admission.status === 'refused') return admission.result
       const result = await this.mutation.mutate({ target: admission.target, mirror })
-      if (result.ok && result.needsRestart && request.language === 'r') {
+      if (result.needsRestart && request.language === 'r') {
         this.options.environmentOperations.recommendRestart('r', admission.target.environmentName)
         for (const session of this.options.sessions()) this.options.notifyChanged(session)
       }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
@@ -37,6 +37,7 @@ import {
 import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
 import { serializeProvisioner } from './environment-operation-foundation'
+import { EnvironmentLeaseManager } from './environment-lease-manager'
 import { withExclusiveCacheLock, withSharedCacheLock } from './pkgs-cache-lock'
 import { validateAndSeedPack } from './pack-content'
 import { micromambaCacheLockKey } from './micromamba-cache'
@@ -2343,6 +2344,72 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     expect(order[0]).toBe(`lock:${DEFAULT_PY_ENV}`)
     expect(order.slice(-2)).toEqual(['repair:completed', 'unlock'])
     expect(runArgv).toHaveBeenCalled()
+  })
+
+  it('E05 stops active execution before taking the repair lease and ignores later cancellation', async () => {
+    const root = makeRoot()
+    const leases = new EnvironmentLeaseManager()
+    const execution = await leases.acquire(DEFAULT_PY_ENV, 'shared').granted
+    const onStarting = vi.fn(async () => {
+      execution.release()
+      provisioner.cancel('python')
+    })
+    const onVerified = vi.fn(() => {
+      expect(leases.snapshot().environments[0].holders).toEqual({ shared: 0, exclusive: 1 })
+    })
+    const provisioner = new DefaultRuntimeProvisioner(
+      makeDeps(root, {
+        withPrefixLock: async (environment, operation) => {
+          // Assert before waiting, so an inverted order fails rather than hanging on the live lease.
+          expect(onStarting).toHaveBeenCalledOnce()
+          const lease = await leases.acquire(environment, 'exclusive').granted
+          try {
+            return await operation()
+          } finally {
+            lease.release()
+          }
+        }
+      })
+    )
+    try {
+      await provisioner.repair('python', () => undefined, { onStarting, onVerified })
+      expect(onVerified).toHaveBeenCalledOnce()
+      expect(provisioner.status()).toMatchObject({ pythonReady: true, provisioning: false })
+      expect(leases.snapshot().environments).toEqual([])
+    } finally {
+      leases.dispose()
+    }
+  })
+
+  it('E05 preserves the original prefix and isolation when preparation fails', async () => {
+    const root = makeRoot()
+    const interpreter = pythonBin(envPrefix(root, DEFAULT_PY_ENV))
+    mkdirSync(dirname(interpreter), { recursive: true })
+    writeFileSync(interpreter, 'original')
+    const rebuild = vi.fn()
+    const onVerified = vi.fn()
+    const provisioner = new DefaultRuntimeProvisioner(makeDeps(root, { runArgv: rebuild }))
+
+    await expect(
+      provisioner.repair('python', () => undefined, {
+        force: true,
+        onStarting: () => {
+          addRepairRequired(root, DEFAULT_PY_ENV, 'protected-identity-change')
+          throw new Error('binding persist denied')
+        },
+        onVerified
+      })
+    ).rejects.toThrow('binding persist denied')
+
+    expect(readFileSync(interpreter, 'utf8')).toBe('original')
+    expect(rebuild).not.toHaveBeenCalled()
+    expect(onVerified).not.toHaveBeenCalled()
+    expect(provisioner.status()).toMatchObject({ pythonRecoveryBlocked: true, provisioning: false })
+    // A failed preparation must release the uninterruptible language guard.
+    provisioner.cancel('python')
+    await expect(provisioner.repair('python', () => undefined)).rejects.toThrow(
+      'Runtime setup cancelled.'
+    )
   })
 
   it.each([

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -38,6 +38,7 @@ import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
 import { serializeProvisioner } from './environment-operation-foundation'
 import { EnvironmentLeaseManager } from './environment-lease-manager'
+import { createNotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
 import { withExclusiveCacheLock, withSharedCacheLock } from './pkgs-cache-lock'
 import { validateAndSeedPack } from './pack-content'
 import { micromambaCacheLockKey } from './micromamba-cache'
@@ -2345,6 +2346,67 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     expect(order.slice(-2)).toEqual(['repair:completed', 'unlock'])
     expect(runArgv).toHaveBeenCalled()
   })
+
+  it.each(['provisioner', 'lifecycle'] as const)(
+    'E05 cancels an unprepared repair waiting for a package mutation lease through %s',
+    async (entry) => {
+      const root = makeRoot()
+      const interpreter = pythonBin(envPrefix(root, DEFAULT_PY_ENV))
+      mkdirSync(dirname(interpreter), { recursive: true })
+      writeFileSync(interpreter, 'original')
+      const leases = new EnvironmentLeaseManager()
+      const mutation = await leases.acquire(DEFAULT_PY_ENV, 'exclusive').granted
+      let waiting!: () => void
+      const queued = new Promise<void>((resolve) => {
+        waiting = resolve
+      })
+      const deps = makeDeps(root)
+      const rebuild = vi.fn(deps.runArgv)
+      const onVerified = vi.fn()
+      const provisioner = serializeProvisioner(
+        new DefaultRuntimeProvisioner({
+          ...deps,
+          runArgv: rebuild,
+          withPrefixLock: async (environment, operation) => {
+            const acquisition = leases.acquire(environment, 'exclusive')
+            waiting()
+            const lease = await acquisition.granted
+            try {
+              return await operation()
+            } finally {
+              lease.release()
+            }
+          }
+        })
+      )
+      const lifecycle = createNotebookEnvironmentLifecycle({
+        provisioner,
+        root,
+        projectProgress: () => undefined,
+        onRepairCompleted: onVerified
+      })
+      const result = (
+        entry === 'lifecycle'
+          ? lifecycle.repair('python', DEFAULT_PY_ENV)
+          : provisioner.repair('python', () => undefined, { onVerified })
+      ).catch((error) => error)
+      try {
+        await queued
+        expect(leases.snapshot().environments[0].waiters.exclusive).toBe(1)
+        provisioner.cancel('python')
+        mutation.release()
+
+        expect.soft(await result).toEqual(new Error('Runtime setup cancelled.'))
+        expect.soft(readFileSync(interpreter, 'utf8')).toBe('original')
+        expect.soft(rebuild).not.toHaveBeenCalled()
+        expect.soft(onVerified).not.toHaveBeenCalled()
+      } finally {
+        mutation.release()
+        leases.dispose()
+        await result
+      }
+    }
+  )
 
   it('E05 stops active execution before taking the repair lease and ignores later cancellation', async () => {
     const root = makeRoot()

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -112,6 +112,9 @@ export type FetchedBundle = {
 
 export type RuntimeRepairOptions = {
   force?: boolean
+  // Runs after queued cancellation is consumed, before acquiring the environment lock so active
+  // kernels can release their execution leases. Per-language cancellation is ignored afterward.
+  onStarting?: () => Promise<void> | void
   // Runs only after the rebuilt interpreter verifies, while the per-environment lock is still held.
   onVerified?: () => Promise<void> | void
 }
@@ -1042,16 +1045,14 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // rebuild), so a package install into this env can't slip in between the rm and the rebuild and
     // write into a half-deleted prefix. The rebuild calls the LOCK-FREE do* variants (not the public
     // provision*), which would otherwise re-acquire this same exclusive lock and deadlock.
-    return this.withEnvPrefixLock(spec.name, async () => {
-      // runLanguage consumes a QUEUED cancel (beginLanguageRun throws) BEFORE the rm below, so
-      // cancelling a queued Reset never leaves a deleted-but-not-rebuilt env.
-      await this.runLanguage(lang, async () => {
-        // Mark this repair UNINTERRUPTIBLE before any destructive step: once we clear the quarantine
-        // and rm the prefix there is no safe stopping point — a per-language Cancel arriving mid-repair
-        // would abort the rebuild and leave a missing/half-built env with the block already cleared.
-        // (Global/quit cancel still works to handle app shutdown.)
-        this.uninterruptible.add(lang)
-        try {
+    // Consume queued cancellation before preparation can invalidate bindings or persist isolation.
+    return this.runLanguage(lang, async () => {
+      // Preparation itself has side effects; per-language cancellation is no longer safe from here.
+      // Global/quit cancellation remains available for app shutdown.
+      this.uninterruptible.add(lang)
+      try {
+        await opts?.onStarting?.()
+        await this.withEnvPrefixLock(spec.name, async () => {
           if (opts?.force) {
             // EXPLICIT user recovery: clear the quarantine (in-memory block + retained journal record +
             // sidecar) so the rebuild below — and its inner materialize — aren't refused by the block
@@ -1089,10 +1090,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
             )
             throw error
           }
-        } finally {
-          this.uninterruptible.delete(lang)
-        }
-      })
+        })
+      } finally {
+        this.uninterruptible.delete(lang)
+      }
     })
   }
 

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1047,12 +1047,18 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // provision*), which would otherwise re-acquire this same exclusive lock and deadlock.
     // Consume queued cancellation before preparation can invalidate bindings or persist isolation.
     return this.runLanguage(lang, async () => {
-      // Preparation itself has side effects; per-language cancellation is no longer safe from here.
-      // Global/quit cancellation remains available for app shutdown.
-      this.uninterruptible.add(lang)
       try {
-        await opts?.onStarting?.()
+        if (opts?.onStarting) {
+          // Preparation invalidates bindings and stops kernels that may hold shared leases.
+          // It must precede the exclusive lease, and per-language cancellation is unsafe from here.
+          this.uninterruptible.add(lang)
+          await opts.onStarting()
+        }
         await this.withEnvPrefixLock(spec.name, async () => {
+          // An unprepared repair can still be cancelled while waiting for another prefix writer.
+          // Check before any destructive work; global/quit cancellation also remains effective.
+          this.abort?.signal.throwIfAborted()
+          this.uninterruptible.add(lang)
           if (opts?.force) {
             // EXPLICIT user recovery: clear the quarantine (in-memory block + retained journal record +
             // sidecar) so the rebuild below — and its inner materialize — aren't refused by the block

--- a/src/main/notebook/runtime-paths.ts
+++ b/src/main/notebook/runtime-paths.ts
@@ -107,8 +107,9 @@ export const RESERVED_ENV_NAMES: ReadonlySet<string> = new Set([
 // Validates a user-supplied environment name for manage_environments create/remove BEFORE it is
 // used to compose runtime/envs/<name> (design D8). Unlike resolveEnvName it never aliases — a
 // managed op must name a real, non-reserved env. Throws on missing/empty, path traversal or an
-// unsafe segment, or a reserved/default name. This is the single choke point that stops a hostile
-// name (e.g. "../../…") from escaping the runtime root into a recursive create/delete.
+// unsafe segment, or a reserved/default name (including versioned-default prefixes). This is the
+// single choke point that stops a hostile name (e.g. "../../…") from escaping the runtime root into
+// a recursive create/delete.
 export const assertSafeEnvName = (name: string | undefined): string => {
   const trimmed = name?.trim()
   if (!trimmed) throw new Error('An environment name is required.')
@@ -118,7 +119,11 @@ export const assertSafeEnvName = (name: string | undefined): string => {
         'starting with a letter or digit.'
     )
   }
-  if (RESERVED_ENV_NAMES.has(trimmed)) {
+  if (
+    RESERVED_ENV_NAMES.has(trimmed) ||
+    trimmed.startsWith(`${DEFAULT_PY_ENV}-`) ||
+    trimmed.startsWith(`${DEFAULT_R_ENV}-`)
+  ) {
     throw new Error(
       `"${trimmed}" is a reserved environment name (managed by the app); choose another name.`
     )

--- a/src/main/notebook/runtime-repair.test.ts
+++ b/src/main/notebook/runtime-repair.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -15,6 +15,10 @@ import {
 } from './runtime-paths'
 import { NotebookRuntimeRepairOwner } from './runtime-repair'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
+import { createNotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
+import { serializeProvisioner } from './environment-operation-foundation'
+import { DefaultRuntimeProvisioner } from './provisioner'
+import { envPrefix, pythonBin } from './runtime-paths'
 import { NotebookSessionAggregate, type NotebookSessionRuntimeBinding } from './session-aggregate'
 
 type RepairOptions = ConstructorParameters<typeof NotebookRuntimeRepairOwner>[0]
@@ -160,6 +164,75 @@ const harness = (
 }
 
 describe('NotebookRuntimeRepairOwner', () => {
+  it.each([false, true])(
+    'E05 preserves queued repair input when cancelled (previously quarantined: %s)',
+    async (quarantined) => {
+      const current = session('session-1')
+      const { owner, options, runtimeRoot } = harness([current.value])
+      const interpreter = pythonBin(envPrefix(runtimeRoot, 'default-python'))
+      mkdirSync(dirname(interpreter), { recursive: true })
+      writeFileSync(interpreter, 'original interpreter')
+      const originalBinding = binding(
+        'python',
+        interpreter,
+        'managed',
+        'default-python',
+        quarantined
+      )
+      current.value.setRuntimeBinding('python', originalBinding)
+      if (quarantined) addRepairRequired(runtimeRoot, interpreter, 'interrupted-install')
+      const registryBefore = existsSync(repairRegistryPath(runtimeRoot))
+        ? readFileSync(repairRegistryPath(runtimeRoot), 'utf8')
+        : undefined
+      const rebuild = vi.fn().mockResolvedValue(undefined)
+      const raw = new DefaultRuntimeProvisioner({
+        root: runtimeRoot,
+        mm: '/unused-mm',
+        channel: 'conda-forge',
+        fetchBundle: vi.fn().mockRejectedValue(new Error('cancelled repair must not fetch')),
+        runArgv: rebuild,
+        verify: vi.fn().mockResolvedValue(undefined)
+      })
+      let releaseR!: () => void
+      const rGate = new Promise<void>((resolve) => {
+        releaseR = resolve
+      })
+      // Only the unrelated queue occupant is replaced. Python cancellation and repair are real.
+      const rStarted = vi.spyOn(raw, 'provisionR').mockImplementation(() => rGate)
+      const serialized = serializeProvisioner(raw)
+      const repairQueued = vi.spyOn(serialized, 'repair')
+      const lifecycle = createNotebookEnvironmentLifecycle({
+        provisioner: serialized,
+        root: runtimeRoot,
+        projectProgress: () => undefined,
+        onRepairStarting: () => owner.prepareExplicitRepair('python', originalBinding)
+      })
+      const r = lifecycle.provision('r')
+      await vi.waitFor(() => expect(rStarted).toHaveBeenCalledOnce())
+      const repair = lifecycle.repair('python', interpreter).catch((error: unknown) => error)
+      try {
+        await vi.waitFor(() => expect(repairQueued).toHaveBeenCalledOnce())
+        lifecycle.cancel('python')
+      } finally {
+        releaseR()
+      }
+      await r
+      expect(await repair).toMatchObject({ message: 'Runtime setup cancelled.' })
+      expect(rebuild).not.toHaveBeenCalled()
+      expect(readFileSync(interpreter, 'utf8')).toBe('original interpreter')
+      const registryAfter = existsSync(repairRegistryPath(runtimeRoot))
+        ? readFileSync(repairRegistryPath(runtimeRoot), 'utf8')
+        : undefined
+      expect.soft(registryAfter).toBe(registryBefore)
+      expect.soft(current.value.runtimeBinding('python')).toEqual(originalBinding)
+      expect.soft(options.environmentOperations.blockRepair).not.toHaveBeenCalled()
+      expect.soft(current.terminate).not.toHaveBeenCalled()
+      if (quarantined) {
+        expect.soft(readRepairRequiredReason(runtimeRoot, interpreter)).toBe('interrupted-install')
+      }
+    }
+  )
+
   it('quarantines and stops running and idle default-runtime kernels before repair', async () => {
     const managed = binding(
       'python',

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -11039,6 +11039,48 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(rAfterRepair.status).toBe('completed')
   })
 
+  it('E06 does not leave restart advice after repairing a protected R identity', async () => {
+    const root = await createStorageRoot()
+    const service = bindingService(root, {
+      discovered: [managedR],
+      installPackagesImpl: async () => ({
+        ok: false,
+        needsRestart: false,
+        repairRequired: true,
+        log: 'r-base changed',
+        attempts: [
+          {
+            groupOrdinal: 0,
+            installer: 'conda',
+            packages: ['dplyr'],
+            status: 'succeeded',
+            mutationRisk: 'confirmed'
+          }
+        ]
+      })
+    })
+    const target = { sessionId: 's', workspaceCwd: root, language: 'r' as const }
+    await service.bindRuntime({ ...target, runtimeId: managedR.envId })
+    const result = await service.managePackages({ ...target, packages: ['dplyr'] })
+    expect(result.repairRequired).toBe(true)
+    expect(isProtectedIdentityRepairRequired(getRuntimeRoot(root), DEFAULT_R_ENV)).toBe(true)
+    expect.soft(result.needsRestart).toBe(false)
+
+    // Use the same service: an app restart would discard the process-local recommendation.
+    // The completion callback represents a verified rebuild, as in the other repair tests.
+    await service.completeRuntimeRepair('r')
+    expect((await service.execute({ ...target, code: 'R.version.string' })).status).toBe(
+      'completed'
+    )
+    const state = await service.state(target)
+    expect(state.runtimeBindings.r?.status).toBe('active')
+    expect
+      .soft(
+        state.environments.find((entry) => entry.processKey === 'r:default-r')?.restartRecommended
+      )
+      .toBe(false)
+  })
+
   it('does not let an ordinary package install clear a protected R identity quarantine', async () => {
     const root = await createStorageRoot()
     const runtimeRoot = getRuntimeRoot(root)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -7375,7 +7375,7 @@ describe('notebook runtime service', () => {
 
       expect(result).toMatchObject({
         ok: false,
-        needsRestart: false,
+        needsRestart: true,
         method: 'conda'
       })
       expect(result.error).toContain('dplyr')
@@ -7415,7 +7415,7 @@ describe('notebook runtime service', () => {
 
       const result = await service.managePackages({ language: 'python', packages: ['numpy'] })
 
-      expect(result).toMatchObject({ ok: false, needsRestart: false, method: 'conda' })
+      expect(result).toMatchObject({ ok: false, needsRestart: true, method: 'conda' })
       expect(result.error).toMatch(/inventory refresh failed/i)
       expect(info).not.toHaveBeenCalledWith('package installer completed', expect.anything())
       expect(warn).toHaveBeenCalledWith(
@@ -8287,55 +8287,58 @@ describe('notebook runtime service', () => {
       })
     })
 
-    it('flags restartRecommended on the R env after an R install and clears it on restart', async () => {
-      const root = await createStorageRoot()
-      const service = new NotebookRuntimeService({
-        configRoot: root,
-        dataRoot: root,
-        projectId: 'default-project',
-        repository: new NotebookRunRepository(root),
-        environmentStateTracker: {
-          prepareRun: vi.fn(),
-          captureCompletedRun: vi.fn(),
-          inspectPackages: vi.fn(),
-          markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
-          refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
-        },
-        executorFactory: () => ({
-          execute: async (request): Promise<NotebookExecutionResult> => ({
-            status: 'completed',
-            stdout: '',
-            stderr: '',
-            traceback: '',
-            cwdAfter: request.cwd,
-            outputs: []
+    it.each([true, false])(
+      'flags restartRecommended on the R env after an install (ok: %s) and clears it on restart',
+      async (ok) => {
+        const root = await createStorageRoot()
+        const service = new NotebookRuntimeService({
+          configRoot: root,
+          dataRoot: root,
+          projectId: 'default-project',
+          repository: new NotebookRunRepository(root),
+          environmentStateTracker: {
+            prepareRun: vi.fn(),
+            captureCompletedRun: vi.fn(),
+            inspectPackages: vi.fn(),
+            markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
+            refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
+          },
+          executorFactory: () => ({
+            execute: async (request): Promise<NotebookExecutionResult> => ({
+              status: 'completed',
+              stdout: '',
+              stderr: '',
+              traceback: '',
+              cwdAfter: request.cwd,
+              outputs: []
+            }),
+            shutdown: async () => ({ reaped: true })
           }),
-          shutdown: async () => ({ reaped: true })
-        }),
-        // An R install reports needsRestart; a Python install would not (asserted below).
-        installPackagesImpl: async (request) => ({
-          ok: true,
-          needsRestart: request.language === 'r',
-          log: 'done'
+          // An R install reports needsRestart; a Python install would not (asserted below).
+          installPackagesImpl: async (request) => ({
+            ok,
+            needsRestart: request.language === 'r',
+            log: 'done'
+          })
         })
-      })
 
-      // Spawn the R kernel status entry so the env view has something to flag.
-      await service.execute({ sessionId: 's', workspaceCwd: root, code: '1', language: 'r' })
+        // Spawn the R kernel status entry so the env view has something to flag.
+        await service.execute({ sessionId: 's', workspaceCwd: root, code: '1', language: 'r' })
 
-      const rEntry = (
-        s: Awaited<ReturnType<typeof service.state>>
-      ): NotebookEnvironmentStatus | undefined =>
-        s.environments.find((entry) => entry.processKey === 'r:default-r')
+        const rEntry = (
+          s: Awaited<ReturnType<typeof service.state>>
+        ): NotebookEnvironmentStatus | undefined =>
+          s.environments.find((entry) => entry.processKey === 'r:default-r')
 
-      await service.managePackages({ language: 'r', packages: ['ggplot2'] })
-      const afterInstall = await service.state({ sessionId: 's', workspaceCwd: root })
-      expect(rEntry(afterInstall)?.restartRecommended).toBe(true)
+        await service.managePackages({ language: 'r', packages: ['ggplot2'] })
+        const afterInstall = await service.state({ sessionId: 's', workspaceCwd: root })
+        expect(rEntry(afterInstall)?.restartRecommended).toBe(true)
 
-      await service.restart({ sessionId: 's', workspaceCwd: root })
-      const afterRestart = await service.state({ sessionId: 's', workspaceCwd: root })
-      expect(rEntry(afterRestart)?.restartRecommended).toBe(false)
-    })
+        await service.restart({ sessionId: 's', workspaceCwd: root })
+        const afterRestart = await service.state({ sessionId: 's', workspaceCwd: root })
+        expect(rEntry(afterRestart)?.restartRecommended).toBe(false)
+      }
+    )
 
     it('does not flag restartRecommended for a Python install', async () => {
       const root = await createStorageRoot()
@@ -12594,10 +12597,10 @@ describe('v4 runtime bindings & agent tools', () => {
       }
     })
 
-    // A versioned app-managed env slips past assertSafeEnvName but is refused by the provenance guard.
+    // Versioned defaults share the same reserved-name guard on creation and removal.
     await expect(
       service.manageEnvironments({ action: 'remove', name: 'default-python-3.13' })
-    ).rejects.toThrow(/app-managed and cannot be removed/)
+    ).rejects.toThrow(/reserved environment name/)
     expect(removed).toEqual([])
 
     // An agent-created env is removable.


### PR DESCRIPTION
## Problem

Queued Python repair could quarantine a healthy runtime before its serialized operation started,
so cancellation stopped rebuilding but left bindings unavailable and a durable repair marker.
R package batches could change installed packages, fail verification, and discard restart advice.
Named-environment creation also accepted reserved default prefixes that removal then refused.

## Proposed change

- Consume queued repair cancellation before preparation. Pass preparation through the existing
  Provisioner repair options, stop active kernels before acquiring the exclusive environment lease,
  and retain the lease through rebuild, verification and binding finalization. Without preparation,
  lease-wait cancellation is checked before deletion. Preparation failure
  prevents deletion; finalization failure retains the existing fail-closed readiness behavior.
- Preserve restart advice independently of batch success. For R, confirmed package deltas and
  non-skipped installer attempts with mutation risk can recommend restart even when `ok=false`.
  Admission refusal and observations without mutation do not recommend restart. Protected-identity
  quarantine results retain their repair-only guidance instead of inferring a stale restart hint.
  Failed read-only R install/remove preflights record no mutation risk, while their original failure
  classification continues to govern fallback admission. Real unknown-risk failures retain restart advice.
- Use one reserved-name guard for creation and removal, including `default-python-` and `default-r-`.
- Add root/child/attempt/Project/stale-owner revocation regressions for E04. Its production fix
  already landed in #2204; this PR does not duplicate that implementation.

## Scope and non-goals

No new state enumeration, database schema, persisted field, file format, dependency, or renderer
interaction. `RuntimeRepairOptions.onStarting` is an optional in-process callback. E05 changes the
timing of existing repair-marker and binding writes. Existing quarantine, journal and directory
ownership protections remain in effect. R kernels are not restarted automatically.

Historical compatibility is deliberately bounded: existing repair markers are not automatically
cleared because false preparation cannot safely be distinguished from a real integrity failure.
Existing reserved-name conflicts remain protected; historical environment recovery requires a
separate ownership decision. This prevents new conflicts without claiming to repair old ones.
The current Settings reinstall flow already hides Cancel; no queue-only cancellation UI is added.

## Acceptance criteria and validation

Before production changes, the eight E05–E07 behavioral regression cases failed twice for the
reported symptoms. The final tests were also rerun twice against original production: ten failures
(the original eight plus two repair callback/lease contracts), ten passing controls. E04's two
regressions fail twice against the pre-#2204 implementation and pass with main's existing fix.

Additional review regressions reproduce lease-wait cancellation through the real serialized Provisioner
and Lifecycle, and a stale restart hint after protected-R repair through the same RuntimeService.
The unprepared Provisioner cancellation and post-repair hint tests each failed twice before their fixes;
the cancellation control passed against main. Both entry paths and the post-repair hint now pass. R install/remove preflight regressions through
the real package manager also failed twice: only dry-run ran, but restart advice was published.
They now pass, and a real-installer unknown-risk control still requires restart advice.

Final local results, run after the last material edit:

| Behavior | Check | Result |
| --- | --- | --- |
| Revocation identities, repair queue/leases/failures, package outcomes, naming, binding/inventory and runtime consumers | Main owner/contract command below | 894 passed across module runs; see process-permission retry below |
| Authenticated local RPC dispatch | `npm test -- src/main/notebook/local-rpc-server.test.ts --maxWorkers=1` | 69 passed |
| Existing reinstall UI/store and package activity consumers | Renderer consumer command below | 148 passed |
| Main and sandbox type contracts | `npm run typecheck:node` | Passed |
| Source lint and patch integrity | `npm run lint`; `git diff --check` | Passed |

```sh
npm test -- src/main/notebook/{environment-operations,runtime-repair,package-operations,environment-management,environment-lifecycle-workflows,environment-operation-foundation,provisioner,provisioner.startup,provisioner.upgrade,package-manager,package-mutation,package-admission,runtime-paths,session-registry,lane-identity,runtime-repair-policy,environment-state-tracker,environment-lease-manager,runtime-service,runtime-service.architecture,mcp-server,env-ipc}.test.ts --maxWorkers=1
npm test -- src/main/notebook/package-manager.test.ts --maxWorkers=1
npm test -- src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx src/renderer/src/stores/notebook-env-store.test.ts src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts src/renderer/src/pages/workspace/WorkspaceActivityGroup.i18n.render.test.tsx --maxWorkers=1
```

The combined main run passed 893 tests; one existing child-reaping test could not inspect processes
inside the local sandbox. All 95 package-manager tests passed when rerun with process inspection
permission, leaving 894 unique passing main tests. Including the RPC and renderer consumers,
1,111 unique tests passed after the final material edit.

The initial RPC run hit sandbox `listen EPERM`; all 69 tests passed when run with local socket
permission. Older runtime-service assertions that erased restart advice were updated to preserve it.
The dependency classifier reports an unknown Notebook module owner and selects full CI. Per maintainer
instruction, local checks use the explicit owner/interface/consumer set above rather than the complete
portable suite; CI ownership metadata was not changed. Real binding behavior is covered by
runtime-service and repair tests.

Real interpreter downloads, R namespace/DLL behavior and full cross-platform Electron flows are not
established by these substitute-based regressions. Existing path helpers and Windows provisioning
cases remain covered; exact-head PR CI and independent review are the final validation authority.
Framework protocol adapters, branch replay and subscription payloads are unchanged.

## Review focus

Queued cancellation must precede every repair side effect. Preparation must stop active execution
before waiting for its environment lease. Once preparation starts, per-language cancellation remains
unsafe; before preparation, waiting for a writer must remain cancellable. Failed package batches must preserve actionable restart
advice, while unchanged metadata and never-started installers must not create it. Existing reserved
prefixes must remain protected from deletion without proven ownership.
