### PR TITLE
fix(composer): preserve queued intent and cancelled uploads

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -633,9 +633,13 @@ colors communicate a successful or failed probe/migration result.
   hairline separators rather than nested cards. Dragging over another row moves neighboring rows
   aside to preview whether the item will land before or after it. Each row also supports Arrow
   Up/Arrow Down keyboard reordering, Edit, Remove, and Send now. Edit moves an item back into an
-  unchanged empty composer. Send now promotes the item and first tries to inject it into the current
+  empty composer, including its annotations, attachments and unfinished transfers. Restored queue
+  edits retain their branch, authorization, model configuration and historical revision target in
+  renderer memory. The composer identifies queued editing; Exit queued editing keeps the content
+  as an ordinary draft. Submitting a restored edit reuses queue admission and dispatch. Send now promotes the item and first tries to inject it into the current
   run through the agent framework's native follow-up, without cancelling that run. While inject is in
-  flight, the row shows a sending state. If inject is unavailable or refused, Send now keeps the live
+  flight, the row shows a sending state. Native follow-up validates the captured target against the
+  bound runtime generation and rechecks the turn after asynchronous preparation. If inject is unavailable or refused, Send now keeps the live
   turn and sends the promoted item after that run finishes; the row returns to queued. Stop remains
   the explicit control for cancelling a live turn without sending a queued message. Branch, admission,
   cancellation, or edit failures keep

--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -630,11 +630,31 @@ describe('ACP application commands', () => {
 
     const outcome = await router.dispatcher.invoke(
       acpCommands.steerFollowUp,
-      invocation([{ sessionId: 'session-1', text: 'focus on tests' }])
+      invocation([
+        {
+          sessionId: 'session-1',
+          text: 'focus on tests',
+          agentTarget: {
+            frameworkId: 'claude-code',
+            providerId: 'provider',
+            model: 'queued-model',
+            reasoningEffort: 'high'
+          }
+        }
+      ])
     )
 
     expect(outcome).toEqual({ injected: false, reason: 'prompt-required' })
-    expect(dependencies.runtime.steerFollowUp).toHaveBeenCalledOnce()
+    expect(dependencies.runtime.steerFollowUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentTarget: {
+          frameworkId: 'claude-code',
+          providerId: 'provider',
+          model: 'queued-model',
+          reasoningEffort: 'high'
+        }
+      })
+    )
   })
 
   it('holds Session admission through ACP response mutations', async () => {

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -1143,7 +1143,16 @@ describe('installAcpIpcHandlers — reset-session-context bridge', () => {
       }))
     )
     installAcpIpcHandlers({ steerFollowUp } as never, {} as never, archiveAvailability)
-    const request: AcpSteerFollowUpRequest = { sessionId: 's-1', text: 'focus on tests' }
+    const request: AcpSteerFollowUpRequest = {
+      sessionId: 's-1',
+      text: 'focus on tests',
+      agentTarget: {
+        frameworkId: 'claude-code',
+        providerId: 'provider',
+        model: 'queued-model',
+        reasoningEffort: 'high'
+      }
+    }
 
     const outcome = await handlers.get('acp:steer-follow-up')?.({}, request)
 

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -118,6 +118,7 @@ const registerAcpIpcHandlerSet = (
     runtime.steerFollowUp({
       sessionId: request.sessionId,
       text: typeof request.text === 'string' ? request.text : '',
+      ...(request.agentTarget ? { agentTarget: request.agentTarget } : {}),
       ...(Array.isArray(request.attachments) ? { attachments: request.attachments } : {}),
       ...(Array.isArray(request.referencedArtifacts)
         ? { referencedArtifacts: request.referencedArtifacts }

--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -105,6 +105,41 @@ const createWorkflow = (
 }
 
 describe('AcpNativeFollowUpWorkflow', () => {
+  it('Q03 rechecks the bound generation after preparing a follow-up', async () => {
+    let current = true
+    const close = vi.fn()
+    const { workflow, request } = createWorkflow({
+      prepareFollowUp: async () => {
+        current = false
+        return { prompt: [{ type: 'text', text: 'Queued' }], close }
+      }
+    })
+    expect(
+      await workflow.steerFollowUp({ sessionId: 'session-1', text: 'Queued' }, () => current)
+    ).toMatchObject({ injected: false })
+    expect(request).not.toHaveBeenCalled()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('Q03 refuses a different live turn after asynchronous follow-up preparation', async () => {
+    let finish!: (value: { prompt: readonly { type: 'text'; text: string }[] }) => void
+    const pending = new Promise<{ prompt: readonly { type: 'text'; text: string }[] }>(
+      (resolve) => {
+        finish = resolve
+      }
+    )
+    let token = 'turn-a'
+    const { workflow, request } = createWorkflow({
+      livePromptTurn: () => ({ turnToken: token, signal: new AbortController().signal }),
+      prepareFollowUp: () => pending
+    })
+    const sending = workflow.steerFollowUp({ sessionId: 'session-1', text: 'queued intent' })
+    token = 'turn-b'
+    finish({ prompt: [{ type: 'text', text: 'queued intent' }] })
+    expect(await sending).toMatchObject({ injected: false })
+    expect(request).not.toHaveBeenCalled()
+  })
+
   it('injects advertised ACP steering without opening a second prompt', async () => {
     const { request, workflow } = createWorkflow()
     await expect(

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -235,15 +235,21 @@ class AcpNativeFollowUpWorkflow {
       : Object.freeze({ injected: false })
   }
 
-  async steerFollowUp(request: AcpSteerFollowUpRequest): Promise<AcpSteerFollowUpResult> {
-    return this.dispatch(request, true)
+  async steerFollowUp(
+    request: AcpSteerFollowUpRequest,
+    isCurrent?: () => boolean
+  ): Promise<AcpSteerFollowUpResult> {
+    return this.dispatch(request, true, undefined, isCurrent)
   }
 
   private async dispatch(
     request: AcpSteerFollowUpRequest,
     publishUserMessage: boolean,
-    expectedTurnToken?: string
+    expectedTurnToken?: string,
+    isCurrent: () => boolean = () => true
   ): Promise<AcpSteerFollowUpResult> {
+    const initialLive = this.options.livePrompt?.(request.sessionId)
+    if (!isCurrent()) return refused('prompt-required')
     const text = typeof request.text === 'string' ? request.text : ''
     const attachments = request.attachments ?? []
     const forcedSkillIds = request.forcedSkillIds ?? []
@@ -326,7 +332,9 @@ class AcpNativeFollowUpWorkflow {
       return refusePrepared('empty-text')
     }
 
-    const live = this.options.livePrompt?.(request.sessionId)
+    const live = initialLive
+    if (!isCurrent() || !this.sameLivePrompt(request.sessionId, live))
+      return refusePrepared('no-live-turn')
     if (!this.options.hasLivePrompt(request.sessionId) || (this.options.livePrompt && !live)) {
       log.info('native follow-up refused', {
         sessionId: request.sessionId,
@@ -388,6 +396,8 @@ class AcpNativeFollowUpWorkflow {
       }
     }
 
+    if (!isCurrent() || !this.sameLivePrompt(request.sessionId, live))
+      return refusePrepared('no-live-turn')
     const transportSignal = this.transportTimeout(route.transport)
     if (route.transport === 'acp-steering') {
       let result: unknown

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -434,6 +434,45 @@ describe('AcpRuntimeCoordinator', () => {
     expect(onCodexWebSocketFallback).toHaveBeenCalledOnce()
   })
 
+  it.each(['providerId', 'model', 'reasoningEffort', 'frameworkId'] as const)(
+    'Q03 refuses native follow-up when the captured %s differs from the bound runtime',
+    async (field) => {
+      const created: ReturnType<typeof createFakeRuntime>[] = []
+      const coordinator = new AcpRuntimeCoordinator((callbacks, _grants, target) => {
+        const fake = createFakeRuntime({
+          frameworkId: target?.frameworkId ?? 'claude-code',
+          sessionIds: [`session-${created.length}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      })
+      const target: AcpSessionAgentTarget = {
+        frameworkId: 'claude-code',
+        providerId: 'provider-a',
+        model: 'model-a',
+        reasoningEffort: 'high'
+      }
+      const session = await coordinator.createSession({ agentTarget: target })
+      const different = {
+        ...target,
+        [field]:
+          field === 'frameworkId' ? 'opencode' : field === 'reasoningEffort' ? 'low' : 'different'
+      } as AcpSessionAgentTarget
+      const request = {
+        sessionId: session.sessionId,
+        text: 'queued intent',
+        agentTarget: different
+      }
+      expect(await coordinator.steerFollowUp(request)).toMatchObject({ injected: false })
+      expect(created[1].steerFollowUp).not.toHaveBeenCalled()
+      expect(await coordinator.steerFollowUp({ ...request, agentTarget: target })).toMatchObject({
+        injected: true
+      })
+      expect(created[1].steerFollowUp).toHaveBeenCalledOnce()
+    }
+  )
+
   it('routes Sessions through runtimes keyed by their explicit agent target', async () => {
     const targets: Array<AcpSessionAgentTarget | undefined> = []
     const created: ReturnType<typeof createFakeRuntime>[] = []
@@ -2685,10 +2724,13 @@ describe('AcpRuntimeCoordinator', () => {
       messageId: 'message-steer-1'
     })
     expect(admittedSessionIds).toEqual([session.sessionId])
-    expect(createdRuntime.steerFollowUp).toHaveBeenCalledWith({
-      sessionId: session.sessionId,
-      text: 'focus on tests'
-    })
+    expect(createdRuntime.steerFollowUp).toHaveBeenCalledWith(
+      {
+        sessionId: session.sessionId,
+        text: 'focus on tests'
+      },
+      expect.any(Function)
+    )
   })
 
   it('refuses native follow-up when prompt admission rejects', async () => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1174,8 +1174,24 @@ class AcpRuntimeCoordinator {
     this.assertPromptAdmissionOpen()
     await this.promptAdmissionGuard?.(request.sessionId)
     this.assertPromptAdmissionOpen()
-    const dispatch = (): Promise<AcpSteerFollowUpResult> =>
-      this.runtimeForSession(request.sessionId).steerFollowUp(request)
+    const dispatch = (): Promise<AcpSteerFollowUpResult> => {
+      const runtime = this.runtimeForSession(request.sessionId)
+      const isCurrent = (): boolean => {
+        if (this.findRuntimeForSession(request.sessionId) !== runtime) return false
+        const expected = request.agentTarget
+        if (!expected) return true
+        const actual = this.runtimeTargets.get(runtime)
+        return (
+          actual !== undefined &&
+          actual.frameworkId === expected.frameworkId &&
+          actual.providerId === expected.providerId &&
+          actual.model === expected.model &&
+          actual.reasoningEffort === expected.reasoningEffort
+        )
+      }
+      if (!isCurrent()) return Promise.resolve({ injected: false, reason: 'prompt-required' })
+      return runtime.steerFollowUp(request, isCurrent)
+    }
     return this.promptDispatchAdmissionGuard
       ? this.promptDispatchAdmissionGuard(request.sessionId, dispatch)
       : dispatch()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1349,9 +1349,12 @@ class AcpRuntime {
   }
 
   // Side-band follow-up into the live prompt. Does not open a second prompt interaction.
-  async steerFollowUp(request: AcpSteerFollowUpRequest): Promise<AcpSteerFollowUpResult> {
+  async steerFollowUp(
+    request: AcpSteerFollowUpRequest,
+    isCurrent: () => boolean = () => true
+  ): Promise<AcpSteerFollowUpResult> {
     return this.withOperationLease(() =>
-      withDataRootWrite(() => this.nativeFollowUp.steerFollowUp(request))
+      withDataRootWrite(() => this.nativeFollowUp.steerFollowUp(request, isCurrent))
     )
   }
 

--- a/src/main/uploads/command-owner.test.ts
+++ b/src/main/uploads/command-owner.test.ts
@@ -131,6 +131,33 @@ describe('upload command owner', () => {
     owner.claimLocalFile(invocationFor(caller, [{ transferId: 'native-transfer' }] as const))
   })
 
+  it('Q02 deletes the exact claimed pending file after a late renderer cancellation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upload-claim-'))
+    temporaryRoots.push(root)
+    const sourcePath = join(root, 'notes.txt')
+    await writeFile(sourcePath, 'keep the original')
+    const repository = new UploadRepository(root)
+    const owner = createUploadCommandOwner(repository)
+    const caller = createCaller(new ApplicationCallerLeaseRegistry(), 17)
+    const attachment = await owner.stageLocalFile(
+      invocationFor(caller, [
+        {
+          transferId: 'late-claim',
+          sourcePath,
+          name: 'notes.txt',
+          size: 17
+        }
+      ] as const),
+      { report: () => undefined }
+    )
+    owner.claimLocalFile(invocationFor(caller, [{ transferId: 'late-claim' }] as const))
+    await owner.abortTransfer(invocationFor(caller, [{ transferId: 'late-claim' }] as const))
+    await expect(readFile(attachment.path, 'utf8')).resolves.toBe('keep the original')
+    await owner.deleteUpload(invocationFor(caller, [{ path: attachment.path }] as const))
+    await expect(stat(attachment.path)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(sourcePath, 'utf8')).resolves.toBe('keep the original')
+  })
+
   it('rejects an invalid standalone native path before staging', async () => {
     const repository = { stageLocalFile: vi.fn() } as unknown as UploadRepository
     const owner = createUploadCommandOwner(repository)

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -499,6 +499,7 @@ const hookKeys = [
   'resolveSessionRuntimeSelection'
 ] as const
 const sendIntentKeys = [
+  'expectedFrameworkId',
   'sessionId',
   'messageId',
   'branchSourceSessionId',
@@ -611,7 +612,8 @@ describe('workspace runtime architecture', () => {
       setPermissionProfile: 1,
       resumeSession: 1,
       respondToPermission: 1,
-      revokePermissionGrant: 1
+      revokePermissionGrant: 1,
+      steerFollowUp: 2
     })
     const effects = effectBodies(facadeFile)
     for (const responsibility of [

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -292,6 +292,123 @@ describe('workspace Agent Runtime hook contract', () => {
     })
   })
 
+  it('Q03 validates captured configurations and forwards their target through the real runtime hook', async () => {
+    useSettingsStore.setState({
+      activeProviderId: 'provider',
+      activeModel: 'model-a',
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: [
+        {
+          id: 'claude-code',
+          displayName: 'Claude Code',
+          supportsSkills: true,
+          supportedApiTypes: ['anthropic']
+        }
+      ],
+      providers: [
+        {
+          id: 'provider',
+          type: 'custom',
+          name: 'Provider',
+          apiEndpoints: ['anthropic'],
+          baseUrl: 'https://example.test/v1',
+          model: 'model-a',
+          models: ['model-a', 'model-b'],
+          supportsImageInput: false,
+          hasKey: true,
+          needsKey: false
+        }
+      ]
+    })
+    const pending = useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Original',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code',
+      agentConfiguration: { providerId: 'provider', model: 'model-a', reasoningEffort: 'default' }
+    })
+    if (!pending) throw new Error('Expected the original message fixture')
+    useSessionStore.getState().finishRun('session-1')
+    const runtime = createRuntime(createSnapshot({ sessionIds: ['session-1'] }))
+    runtimeMock.current = runtime
+    await render()
+    const captured = {
+      providerId: 'provider',
+      model: 'model-b',
+      reasoningEffort: 'default' as const
+    }
+    await act(async () => {
+      await latest.steerFollowUp({
+        sessionId: 'session-1',
+        text: 'Queued',
+        agentConfiguration: captured
+      })
+    })
+    expect(runtime.steerFollowUp).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      text: 'Queued',
+      agentTarget: { frameworkId: 'claude-code', ...captured }
+    })
+    runtime.steerFollowUp.mockClear()
+    await act(async () => {
+      expect(
+        await latest.steerFollowUp({
+          sessionId: 'session-1',
+          text: 'Queued',
+          agentConfiguration: { ...captured, model: 'removed' }
+        })
+      ).toMatchObject({ injected: false })
+      expect(
+        await latest.resendEditedMessage('session-1', pending.messageId, {
+          text: 'Revision',
+          agentConfiguration: { ...captured, model: 'removed' }
+        })
+      ).toBe(false)
+    })
+    expect(runtime.steerFollowUp).not.toHaveBeenCalled()
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    await act(async () => {
+      expect(
+        await latest.sendMessage({
+          sessionId: 'session-1',
+          text: 'Queued',
+          agentConfiguration: captured,
+          expectedFrameworkId: 'opencode'
+        })
+      ).toBeUndefined()
+      expect(
+        await latest.resendEditedMessage('session-1', pending.messageId, {
+          text: 'Revision',
+          agentConfiguration: captured,
+          expectedFrameworkId: 'opencode'
+        })
+      ).toBe(false)
+      expect(
+        await latest.steerFollowUp({
+          sessionId: 'session-1',
+          text: 'Queued',
+          agentConfiguration: captured,
+          expectedFrameworkId: 'opencode'
+        })
+      ).toMatchObject({ injected: false })
+    })
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(runtime.steerFollowUp).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0].messages[0].content).toBe('Original')
+    await act(async () => {
+      await latest.resendEditedMessage('session-1', pending.messageId, {
+        text: 'Revision',
+        agentConfiguration: captured
+      })
+    })
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(runtime.resumeSession.mock.calls[0]?.[10]).toEqual({
+      frameworkId: 'claude-code',
+      ...captured
+    })
+  })
+
   it('resolves image input support from the Session-selected official model', async () => {
     useSettingsStore.setState({
       activeProviderId: 'deepseek',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1,3 +1,4 @@
+import type { AgentFrameworkId, SessionAgentConfiguration } from '../../../../shared/settings'
 import {
   createContext,
   createElement,
@@ -18,6 +19,8 @@ import {
   type AcpPermissionRequest,
   type AcpPermissionResponse,
   type AcpSaveAsSkillRequest,
+  type AcpSteerFollowUpRequest,
+  type AcpSteerFollowUpResult,
   type DelegatedWorkUnavailableReason
 } from '../../../../shared/acp'
 import {
@@ -149,7 +152,12 @@ type WorkspaceAgentRuntime = {
     input: ResendEditedMessageInput
   ) => Promise<boolean>
   cancelRun: (sessionId: string) => Promise<void>
-  steerFollowUp: ReturnType<typeof useAcpRuntime>['steerFollowUp']
+  steerFollowUp: (
+    request: AcpSteerFollowUpRequest & {
+      agentConfiguration?: SessionAgentConfiguration
+      expectedFrameworkId?: AgentFrameworkId
+    }
+  ) => Promise<AcpSteerFollowUpResult>
   resumeInterruptedSession: (sessionId: string) => Promise<void>
   respondToPermission: (requestId: string, optionId?: string) => Promise<void>
   setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => Promise<boolean>
@@ -404,7 +412,11 @@ const useOwnedWorkspaceAgentRuntime = (
 
   const resendEditedMessage = useCallback(
     (sessionId: string, messageId: string, input: ResendEditedMessageInput): Promise<boolean> => {
-      const configuration = admitSendConfiguration({ sessionId })
+      const configuration = admitSendConfiguration({
+        sessionId,
+        agentConfiguration: input.agentConfiguration,
+        expectedFrameworkId: input.expectedFrameworkId
+      })
       if (!configuration) return Promise.resolve(false)
       const selected = resolveRuntimeSelection(configuration)
       return resendEditedWorkspaceMessage(
@@ -433,6 +445,23 @@ const useOwnedWorkspaceAgentRuntime = (
       runtime,
       visionRelayAvailable
     ]
+  )
+
+  const steerFollowUp = useCallback<WorkspaceAgentRuntime['steerFollowUp']>(
+    ({ agentConfiguration, expectedFrameworkId, ...request }) => {
+      if (!agentConfiguration) return runtime.steerFollowUp(request)
+      const configuration = admitSendConfiguration({
+        sessionId: request.sessionId,
+        agentConfiguration,
+        expectedFrameworkId
+      })
+      if (!configuration) return Promise.resolve({ injected: false, reason: 'prompt-required' })
+      const selected = resolveRuntimeSelection(configuration)
+      if (!selected.agentTarget)
+        return Promise.resolve({ injected: false, reason: 'prompt-required' })
+      return runtime.steerFollowUp({ ...request, agentTarget: selected.agentTarget })
+    },
+    [admitSendConfiguration, resolveRuntimeSelection, runtime]
   )
 
   const compactContext = useCallback(
@@ -632,7 +661,7 @@ const useOwnedWorkspaceAgentRuntime = (
     sendMessage,
     resendEditedMessage,
     cancelRun,
-    steerFollowUp: runtime.steerFollowUp,
+    steerFollowUp,
     resumeInterruptedSession,
     respondToPermission,
     setPermissionProfile,

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -54,6 +54,7 @@ import type { useAcpRuntime } from './useAcpRuntime'
 import { validateImageAnnotationSourcesBeforeSend } from '../../pages/workspace/annotations/image-annotation-source-validation'
 import { VISION_MODEL_NOT_CONFIGURED_MESSAGE } from '../../../../shared/run-error-classification'
 type SendWorkspaceMessageIntent = {
+  expectedFrameworkId?: AgentFrameworkId
   sessionId?: string
   // Optional durable caller identity for restart-safe application-owned prompts.
   messageId?: string
@@ -104,6 +105,8 @@ type WorkspaceCommandLifecycle = {
   onSessionSizeLimit?: (sessionId: string) => void
 }
 type ResendEditedMessageInput = {
+  expectedFrameworkId?: AgentFrameworkId
+  agentConfiguration?: SessionAgentConfiguration
   text: string
   annotations?: annotationProtocol.Annotation[]
   parts?: MessagePart[]

--- a/src/renderer/src/lib/acp/workspace-runtime-selection-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-selection-owner.ts
@@ -32,6 +32,7 @@ type WorkspaceSessionRuntimeSelection = Readonly<{
 }>
 
 type AdmitSendConfigurationInput = Readonly<{
+  expectedFrameworkId?: AcpSessionAgentTarget['frameworkId']
   sessionId?: string
   agentConfiguration?: SessionAgentConfiguration
 }>
@@ -166,6 +167,8 @@ const useWorkspaceRuntimeSelectionOwner = (): {
   )
   const admitSendConfiguration = useCallback(
     (input: AdmitSendConfigurationInput): SessionAgentConfiguration | undefined => {
+      if (input.expectedFrameworkId && input.expectedFrameworkId !== agentFrameworkId)
+        return undefined
       const storedResolution = input.agentConfiguration
         ? undefined
         : resolveStoredSessionResolution(input.sessionId)
@@ -182,7 +185,7 @@ const useWorkspaceRuntimeSelectionOwner = (): {
       }
       return agentConfiguration
     },
-    [configuredModelCatalog, resolveStoredSessionResolution]
+    [agentFrameworkId, configuredModelCatalog, resolveStoredSessionResolution]
   )
 
   return {

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -356,6 +356,36 @@ const delegatedQuestionSession = (): ChatSession => ({
 })
 
 describe('ConversationPanel annotation composer integration', () => {
+  it('Q01 identifies a restored historical revision and exposes the exit action', () => {
+    const cancelQueuedEdit = vi.fn()
+    renderPanel({
+      composer: {
+        view: {
+          queuedEdit: {
+            kind: 'user',
+            revisionMessageId: 'message-1',
+            sessionId: 'session-1',
+            projectId: 'project-1',
+            cwd: undefined,
+            agentFrameId: 'frame-1',
+            messageBranchId: 'branch-1',
+            permissionProfile: 'full',
+            agentConfiguration: { providerId: 'provider', model: 'model', reasoningEffort: 'high' },
+            specialistId: undefined
+          }
+        },
+        actions: { cancelQueuedEdit }
+      }
+    })
+    expect(container.textContent).toContain('Editing a historical revision')
+    const exit = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Exit queued editing'
+    )
+    expect(exit).toBeDefined()
+    act(() => exit!.click())
+    expect(cancelQueuedEdit).toHaveBeenCalledOnce()
+  })
+
   it('renders a compact annotation chip, reveals its source, returns focus on Esc, and removes it', async () => {
     const removeAnnotation = vi.fn()
     renderPanel({

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1721,6 +1721,23 @@ const ConversationPanel = ({
                       {...messageQueue}
                       expanded={messageQueueExpanded}
                     />
+                    {composer.view.queuedEdit ? (
+                      <div className="flex items-center justify-between gap-2 text-xs text-text-300">
+                        <span>
+                          {composer.view.queuedEdit.revisionMessageId
+                            ? t('Editing a historical revision')
+                            : t('Editing a queued message')}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={composer.actions.cancelQueuedEdit}
+                          className="rounded px-2 py-1 hover:bg-bg-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          disabled={!canEditDraft}
+                        >
+                          {t('Exit queued editing')}
+                        </button>
+                      </div>
+                    ) : null}
                     <AnnotationDraftCards
                       annotations={annotations}
                       disabled={!canEditDraft}

--- a/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx
@@ -25,6 +25,8 @@ import {
   setDefaultWorkspaceAgentSettings
 } from './workspace-page-test-fixtures'
 
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
 // Capture the ConversationPanel props the page computes, notably canEditMessage and the resend handler.
 let conversationProps: Parameters<(typeof import('./ConversationPanel'))['ConversationPanel']>[0]
 
@@ -194,7 +196,9 @@ describe('WorkspacePage inline edit resend', () => {
       },
       preview: {
         load: vi.fn(() => Promise.resolve(undefined)),
-        save: vi.fn(() => Promise.resolve())
+        save: vi.fn(({ expectedRevision }: { expectedRevision: number }) =>
+          Promise.resolve({ status: 'saved', revision: expectedRevision + 1 })
+        )
       },
       uploads: { deleteUpload: vi.fn() },
       reviewer: {
@@ -248,6 +252,90 @@ describe('WorkspacePage inline edit resend', () => {
       forcedSkillIds: ['skill-forecast'],
       referencedArtifacts: []
     })
+  })
+
+  it('Q01 preserves an independent draft when editing a queued historical revision', async () => {
+    await renderPage()
+    const draft: ComposerDoc = { nodes: [{ type: 'text', text: 'Unsent independent draft' }] }
+    await act(async () => {
+      conversationProps.composer.actions.changeDoc(draft)
+      setSession({ status: 'running', messages: [promptMessage] })
+    })
+    await act(async () => {
+      await conversationProps.conversation.actions.revise('message-1', editedDoc, [])
+    })
+    expect(conversationProps.composer.view.doc).toEqual(draft)
+    const queued = conversationProps.conversation.queue.items[0]
+    expect(queued).toMatchObject({ text: 'Run /forecast tomorrow', phase: 'queued' })
+
+    await act(async () => conversationProps.conversation.queue.actions.edit(queued.id))
+
+    expect.soft(conversationProps.composer.view.doc).toEqual(draft)
+    expect
+      .soft(conversationProps.conversation.queue.items)
+      .toEqual([expect.objectContaining({ id: queued.id, error: { kind: 'edit' } })])
+    expect(runtime.resendEditedMessage).not.toHaveBeenCalled()
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('Q01 retains the historical revision target after queue editing and submitting', async () => {
+    runtime.sendMessage.mockResolvedValue({ sessionId: 'sess-a', messageId: 'new-message' })
+    runtime.resendEditedMessage.mockResolvedValue(true)
+    await renderPage()
+    await act(async () => setSession({ status: 'running', messages: [promptMessage] }))
+    await act(async () => {
+      await conversationProps.conversation.actions.revise('message-1', editedDoc, [])
+    })
+    const queued = conversationProps.conversation.queue.items[0]
+    await act(async () => conversationProps.conversation.queue.actions.edit(queued.id))
+    expect(conversationProps.composer.view.doc).toEqual(editedDoc)
+    expect(conversationProps.conversation.queue.items).toEqual([])
+    await act(async () => setSession({ messages: [promptMessage] }))
+    await act(async () => {
+      await conversationProps.conversation.actions.submit.draft({
+        forcedSkillIds: ['skill-forecast']
+      })
+    })
+
+    expect
+      .soft(runtime.resendEditedMessage)
+      .toHaveBeenCalledWith(
+        'sess-a',
+        'message-1',
+        expect.objectContaining({ text: 'Run /forecast tomorrow' })
+      )
+    expect.soft(runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('Q01 retains a restored revision when its original branch is no longer active', async () => {
+    await renderPage()
+    await act(async () => setSession({ status: 'running', messages: [promptMessage] }))
+    await act(async () => {
+      await conversationProps.conversation.actions.revise('message-1', editedDoc, [])
+    })
+    await act(async () =>
+      conversationProps.conversation.queue.actions.edit(
+        conversationProps.conversation.queue.items[0].id
+      )
+    )
+    const graph = createSession().conversationGraph!
+    await act(async () =>
+      setSession({
+        messages: [promptMessage],
+        conversationGraph: {
+          ...graph,
+          frames: graph.frames.map((frame) => ({ ...frame, activeBranchId: 'branch-b' }))
+        }
+      })
+    )
+    await act(async () =>
+      conversationProps.conversation.actions.submit.draft({ forcedSkillIds: [] })
+    )
+    expect(conversationProps.composer.view.doc).toEqual(editedDoc)
+    expect(conversationProps.composer.view.queuedEdit?.revisionMessageId).toBe('message-1')
+    expect(conversationProps.composer.view.error).toContain('no longer matches')
+    expect(runtime.sendMessage).not.toHaveBeenCalled()
+    expect(runtime.resendEditedMessage).not.toHaveBeenCalled()
   })
 
   it('queues a revision while a run is active and still rejects an empty edit', async () => {

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -582,6 +582,101 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.transfers).toEqual([])
   })
 
+  it.each(['cancel', 'delete', 'unmount'] as const)(
+    'Q02 does not attach a file after %s while its claim response is pending',
+    async (action) => {
+      const claimed = deferred<void>()
+      const attachment: UploadedAttachment = {
+        id: 'upload-notes-1',
+        sessionId: '.pending',
+        name: 'research-notes.md',
+        originalName: 'research-notes.md',
+        path: '/uploads/.pending/research-notes.md',
+        mimeType: 'text/markdown',
+        size: 5
+      }
+      const uploadApi = uploads(vi.fn().mockResolvedValue(attachment))
+      uploadApi.claimLocalFile = vi.fn(() => claimed.promise)
+      const hook = renderController(uploadApi)
+      mounted.push(hook)
+      act(() =>
+        hook.result.current.actions.stageFiles([
+          new File(['notes'], 'research-notes.md', { type: 'text/markdown' })
+        ])
+      )
+      await flushAsyncWork()
+      expect(uploadApi.claimLocalFile).toHaveBeenCalledOnce()
+      const transfer = hook.result.current.view.transfers[0]
+      expect(transfer).toBeDefined()
+      if (action === 'cancel') act(() => hook.result.current.actions.cancelTransfer(transfer))
+      if (action === 'delete') {
+        act(() => {
+          hook.result.current.lifecycle.beginSessionDeletion('session-a')
+          hook.result.current.lifecycle.settleSessionDeletion('session-a', true)
+        })
+      }
+      if (action === 'unmount') {
+        mounted.splice(mounted.indexOf(hook), 1)
+        hook.unmount()
+      }
+      await flushAsyncWork()
+      if (action !== 'unmount') expect(hook.result.current.view.transfers).toEqual([])
+      expect(uploadApi.abortTransfer).toHaveBeenCalledWith({ transferId: transfer.transferId })
+
+      await act(async () => claimed.resolve())
+      await flushAsyncWork()
+
+      expect.soft(hook.result.current.view.attachments).toEqual([])
+      expect.soft(uploadApi.deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+      if (action !== 'unmount') expect(hook.result.current.view.transfers).toEqual([])
+    }
+  )
+
+  it.each(['switch', 'deletion-rollback'] as const)(
+    'Q02 retains a claimed attachment in its owning draft after %s',
+    async (action) => {
+      const claimed = deferred<void>()
+      const attachment: UploadedAttachment = {
+        id: 'notes',
+        sessionId: '.pending',
+        name: 'notes.txt',
+        originalName: 'notes.txt',
+        path: '/uploads/.pending/notes.txt',
+        mimeType: 'text/plain',
+        size: 5
+      }
+      const uploadApi = uploads(vi.fn().mockResolvedValue(attachment))
+      uploadApi.claimLocalFile = vi.fn(() => claimed.promise)
+      const hook = renderController(uploadApi)
+      mounted.push(hook)
+      act(() => hook.result.current.actions.stageFiles([new File(['notes'], 'notes.txt')]))
+      await flushAsyncWork()
+      expect(uploadApi.claimLocalFile).toHaveBeenCalledOnce()
+      if (action === 'switch') hook.selectDraft('session-b')
+      else
+        act(() => {
+          hook.result.current.lifecycle.beginSessionDeletion('session-a')
+        })
+      await act(async () => claimed.resolve())
+      await flushAsyncWork()
+      if (action === 'switch') {
+        expect(hook.result.current.view.attachments).toEqual([])
+        hook.selectDraft('session-a')
+      } else act(() => hook.result.current.lifecycle.settleSessionDeletion('session-a', false))
+      expect(hook.result.current.view.attachments).toEqual([attachment])
+      expect(uploadApi.deleteUpload).not.toHaveBeenCalled()
+      // Queue editing must retain the same attachment and annotations, without deleting its bytes.
+      act(() => hook.result.current.actions.addAnnotation(annotation()))
+      const snapshot = hook.result.current.lifecycle.captureSend()
+      expect(hook.result.current.lifecycle.restoreFailedSend(snapshot, true)).toBe(false)
+      act(() => hook.result.current.lifecycle.clearDraft(snapshot.draftKey, snapshot.version))
+      act(() => expect(hook.result.current.lifecycle.restoreFailedSend(snapshot, true)).toBe(true))
+      expect(hook.result.current.view.attachments).toEqual([attachment])
+      expect(hook.result.current.view.annotations).toEqual([annotation()])
+      expect(uploadApi.deleteUpload).not.toHaveBeenCalled()
+    }
+  )
+
   it('keeps a staged attachment unavailable when claiming its local writer fails', async () => {
     const uploadApi = uploads(
       vi.fn().mockResolvedValue({
@@ -2182,6 +2277,77 @@ describe('workspace composer controller', () => {
     act(() => hook.result.current.lifecycle.restoreFailedSend(superseded))
     expect(hook.result.current.view.doc).toEqual(textDoc('new intent'))
   })
+
+  it.each(['ordinary', 'revision'] as const)(
+    'Q01 preserves %s queue intent through editing, undo and draft switching',
+    (kind) => {
+      const hook = renderController()
+      mounted.push(hook)
+      const queued = hook.result.current.lifecycle.captureRevision(textDoc('Queued'), [
+        annotation()
+      ])
+      queued.queuedEdit = {
+        kind: 'user',
+        sessionId: 'session-a',
+        agentFrameId: 'root',
+        messageBranchId: 'branch-a',
+        permissionProfile: 'full',
+        specialistId: undefined,
+        projectId: 'project',
+        cwd: undefined,
+        agentConfiguration: { providerId: 'provider', model: 'model-b', reasoningEffort: 'high' },
+        ...(kind === 'revision' ? { revisionMessageId: 'historical-message' } : {})
+      }
+      act(() => expect(hook.result.current.lifecycle.restoreFailedSend(queued, true)).toBe(true))
+      act(() => hook.result.current.actions.changeDoc(textDoc('Changed')))
+      act(() => expect(hook.result.current.actions.undo()).toBe(true))
+      expect(hook.result.current.view.doc).toEqual(queued.doc)
+      act(() => expect(hook.result.current.actions.redo()).toBe(true))
+      hook.selectDraft('session-b')
+      expect(hook.result.current.view.queuedEdit).toBeUndefined()
+      hook.selectDraft('session-a')
+      const restored = hook.result.current.lifecycle.captureSend()
+      expect(restored).toMatchObject({
+        doc: textDoc('Changed'),
+        annotations: [annotation()],
+        attachments: [],
+        queuedEdit: queued.queuedEdit
+      })
+      act(() => hook.result.current.actions.cancelQueuedEdit?.())
+      expect(hook.result.current.view.queuedEdit).toBeUndefined()
+      expect(hook.result.current.view.doc).toEqual(textDoc('Changed'))
+      expect(hook.result.current.actions.undo()).toBe(false)
+    }
+  )
+
+  it.each(['text', 'annotation', 'mention'] as const)(
+    'Q01 rejects an occupied %s draft at equal and different versions',
+    (content) => {
+      const hook = renderController()
+      mounted.push(hook)
+      if (content === 'text')
+        act(() => hook.result.current.actions.changeDoc(textDoc('Independent')))
+      if (content === 'annotation')
+        act(() => hook.result.current.actions.addAnnotation(annotation()))
+      if (content === 'mention')
+        act(() =>
+          hook.result.current.actions.changeDoc({
+            nodes: [{ type: 'skill', id: 'skill', name: 'skill' }]
+          })
+        )
+      const before = hook.result.current.lifecycle.captureSend()
+      const revision = hook.result.current.lifecycle.captureRevision(textDoc('Revision'), [])
+      expect(revision.version).toBe(before.version)
+      expect(hook.result.current.lifecycle.restoreFailedSend(revision, true)).toBe(false)
+      expect(
+        hook.result.current.lifecycle.restoreFailedSend(
+          { ...revision, version: revision.version - 1 },
+          true
+        )
+      ).toBe(false)
+      expect(hook.result.current.lifecycle.captureSend()).toEqual(before)
+    }
+  )
 
   it('reports a queued-edit conflict without replacing the newer composer draft', () => {
     const hook = renderController()

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -75,6 +75,7 @@ const samePdfContextSources = (
   left.every((source, index) => pdfContextSourceKey(source) === pdfContextSourceKey(right[index]))
 
 export type ComposerSendSnapshot = {
+  queuedEdit?: ComposerDraft['queuedEdit']
   draftKey: string
   version: number
   doc: ComposerDoc
@@ -117,6 +118,7 @@ type WorkspaceComposerControllerInput = {
 
 type WorkspaceComposerController = {
   view: {
+    queuedEdit?: ComposerDraft['queuedEdit']
     doc: ComposerDoc
     annotations: Annotation[]
     attachments: UploadedAttachment[]
@@ -135,6 +137,7 @@ type WorkspaceComposerController = {
     }
   }
   actions: {
+    cancelQueuedEdit?: () => void
     changeDoc: (doc: ComposerDoc, caret?: ComposerCaretPosition) => void
     addAnnotation: (annotation: Annotation) => AnnotationValidationError | undefined
     updateAnnotationNote: (id: string, note: string) => AnnotationValidationError | undefined
@@ -191,6 +194,12 @@ const useWorkspaceComposerController = ({
   uploads,
   onSessionSizeLimit
 }: WorkspaceComposerControllerInput): WorkspaceComposerController => {
+  const [queuedEdit, setQueuedEdit] = useState<ComposerDraft['queuedEdit']>()
+  const queuedEditRef = useRef<ComposerDraft['queuedEdit']>(undefined)
+  const setActiveQueuedEdit = useCallback((intent: ComposerDraft['queuedEdit']): void => {
+    queuedEditRef.current = intent
+    setQueuedEdit(intent)
+  }, [])
   const [doc, setDoc] = useState<ComposerDoc>(emptyDoc)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
   const [historyBrowsingKey, setHistoryBrowsingKey] = useState<string>()
@@ -727,6 +736,7 @@ const useWorkspaceComposerController = ({
         annotations,
         attachments,
         attachmentTransfers: transfers,
+        queuedEdit: queuedEditRef.current,
         automaticReadingEnabled: automaticReadingEnabledRef.current
       }
     }
@@ -744,6 +754,7 @@ const useWorkspaceComposerController = ({
     setActiveAnnotations(nextDraft.annotations)
     activateDraftAttachments(nextDraft)
     setActiveAutomaticReadingEnabled(nextDraft.automaticReadingEnabled)
+    setActiveQueuedEdit(nextDraft.queuedEdit)
     activeDraftKeyRef.current = currentDraftKey
   }, [
     activeProjectId,
@@ -754,6 +765,7 @@ const useWorkspaceComposerController = ({
     newConversationDraftKey,
     pendingCustomizePrefill,
     setActiveAutomaticReadingEnabled,
+    setActiveQueuedEdit,
     activateDraftAttachments,
     setActiveAnnotations,
     setActiveDoc,
@@ -762,7 +774,7 @@ const useWorkspaceComposerController = ({
 
   const navigateHistory = useCallback(
     (direction: 'previous' | 'next'): boolean => {
-      if (attachments.length > 0 || transfers.length > 0) return false
+      if (queuedEditRef.current || attachments.length > 0 || transfers.length > 0) return false
 
       let navigation = historyRef.current[currentDraftKey]
       if (!navigation) {
@@ -959,6 +971,7 @@ const useWorkspaceComposerController = ({
         doc: docRef.current,
         annotations: [...annotationsRef.current],
         attachments,
+        queuedEdit: queuedEditRef.current,
         automaticReadingEnabled: automaticReadingEnabledRef.current,
         ...(includeReadingContext && durableReadingContext
           ? {
@@ -1001,6 +1014,7 @@ const useWorkspaceComposerController = ({
       delete draftsRef.current[draftKey]
       if (activeDraftKeyRef.current !== draftKey) return true
       setActiveDoc(emptyDoc)
+      setActiveQueuedEdit(undefined)
       setActiveAnnotations([])
       clearActiveAttachments()
       setActiveAutomaticReadingEnabled(true)
@@ -1015,6 +1029,7 @@ const useWorkspaceComposerController = ({
       setActiveAnnotations,
       setActiveDoc,
       setActiveAutomaticReadingEnabled,
+      setActiveQueuedEdit,
       setError
     ]
   )
@@ -1025,20 +1040,28 @@ const useWorkspaceComposerController = ({
         return false
       }
       if (
-        (versionsRef.current[snapshot.draftKey] ?? 0) !== snapshot.version &&
-        !(
-          preserveOnConflict &&
-          activeDraftKeyRef.current === snapshot.draftKey &&
-          docIsEmpty(doc) &&
-          annotations.length === 0 &&
-          attachments.length === 0 &&
-          transfers.length === 0
-        )
+        preserveOnConflict &&
+        (activeDraftKeyRef.current !== snapshot.draftKey ||
+          !docIsEmpty(docRef.current) ||
+          annotationsRef.current.length > 0 ||
+          attachments.length > 0 ||
+          transfers.length > 0 ||
+          queuedEditRef.current)
+      )
+        return false
+      if (
+        !preserveOnConflict &&
+        (versionsRef.current[snapshot.draftKey] ?? 0) !== snapshot.version
       ) {
-        if (!preserveOnConflict) deleteAttachmentFiles(snapshot.attachments)
+        deleteAttachmentFiles(snapshot.attachments)
         return false
       }
+      if (preserveOnConflict) markChanged(snapshot.draftKey)
+      clearUndo(snapshot.draftKey)
+      clearPastedTextUndo(snapshot.draftKey)
+      clearHistory(snapshot.draftKey)
       if (activeDraftKeyRef.current === snapshot.draftKey) {
+        setActiveQueuedEdit(snapshot.queuedEdit)
         setActiveDoc(snapshot.doc)
         setActiveAnnotations([...snapshot.annotations])
         setActiveAttachments(snapshot.attachments)
@@ -1046,6 +1069,7 @@ const useWorkspaceComposerController = ({
         return true
       }
       draftsRef.current[snapshot.draftKey] = {
+        queuedEdit: snapshot.queuedEdit,
         doc: snapshot.doc,
         annotations: [...snapshot.annotations],
         attachments: snapshot.attachments,
@@ -1056,9 +1080,12 @@ const useWorkspaceComposerController = ({
     },
     [
       attachments.length,
-      annotations.length,
+      clearUndo,
+      clearPastedTextUndo,
+      clearHistory,
+      markChanged,
+      setActiveQueuedEdit,
       deleteAttachmentFiles,
-      doc,
       setActiveAttachments,
       setActiveAnnotations,
       setActiveDoc,
@@ -1097,6 +1124,7 @@ const useWorkspaceComposerController = ({
 
   return {
     view: {
+      queuedEdit,
       doc,
       annotations,
       attachments,
@@ -1119,6 +1147,12 @@ const useWorkspaceComposerController = ({
       }
     },
     actions: {
+      cancelQueuedEdit: (): void => {
+        clearUndo()
+        clearHistory(activeDraftKeyRef.current)
+        markChanged()
+        setActiveQueuedEdit(undefined)
+      },
       changeDoc,
       addAnnotation,
       updateAnnotationNote: (id, note): AnnotationValidationError | undefined => {
@@ -1178,6 +1212,7 @@ const useWorkspaceComposerController = ({
         if (activeDraftKeyRef.current !== draftKey) return
         clearHistory(draftKey)
         setActiveDoc(emptyDoc)
+        setActiveQueuedEdit(undefined)
         setActiveAnnotations([])
         clearActiveAttachments()
         setError(null)

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -24,7 +24,10 @@ import {
   type ComposerPastedTextStage
 } from './composer/composer-doc'
 
+import type { MessageQueueEditIntent } from './workspace-message-queue-owner'
+
 export type ComposerDraft = {
+  queuedEdit?: MessageQueueEditIntent
   doc: ComposerDoc
   annotations: Annotation[]
   attachments: UploadedAttachment[]
@@ -622,6 +625,10 @@ export const useWorkspaceComposerUploadController = ({
                 .abortTransfer({ transferId: transfer.transferId })
                 .catch(() => undefined)
               throw claimError
+            }
+            if (controller.signal.aborted) {
+              await uploads.deleteUpload({ path: attachment.path }).catch(() => undefined)
+              continue
             }
             commitDraftAttachment(draftKey, transfer.transferId, attachment, transfer.pastedTextId)
           } catch (uploadError) {

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -1,3 +1,4 @@
+import { i18next } from '@/i18n'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import type { PermissionProfileId } from '../../../../shared/permission-profiles'
@@ -67,7 +68,7 @@ type PlanProjectionRecoveryPorts = {
 type ConversationComposer = {
   view: Pick<
     WorkspaceComposerController['view'],
-    'doc' | 'annotations' | 'attachments' | 'transfers' | 'readingContext'
+    'doc' | 'annotations' | 'attachments' | 'transfers' | 'readingContext' | 'queuedEdit'
   >
   actions: Pick<WorkspaceComposerController['actions'], 'setError'>
   lifecycle: Pick<
@@ -436,7 +437,20 @@ const useWorkspaceConversationController = (
         composer.actions.setError(VISION_MODEL_NOT_CONFIGURED_MESSAGE)
         return
       }
-      if (queueDraft && activeSession) {
+      const restored = composer.view.queuedEdit
+      if (restored?.revisionMessageId && composer.view.attachments.length > 0) {
+        composer.actions.setError(
+          i18next.t('Remove attachments before submitting a historical revision.')
+        )
+        return
+      }
+      if (restored && mode !== 'continue') {
+        composer.actions.setError(
+          i18next.t('Exit queued editing before choosing another send mode.')
+        )
+        return
+      }
+      if ((queueDraft || restored) && activeSession) {
         const { hasPendingSwitch } = session.lifecycle.captureSendIntent(false)
         if (hasPendingSwitch) return
         const snapshot = composer.lifecycle.captureSend()

--- a/src/renderer/src/pages/workspace/workspace-message-queue-admission.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-admission.ts
@@ -1,3 +1,4 @@
+import { i18next } from '@/i18n'
 import { DEFAULT_PERMISSION_PROFILE } from '../../../../shared/permission-profiles'
 import type { ChatSession } from '@/stores/session-store'
 
@@ -9,6 +10,7 @@ import {
   type MessageQueueAdmission,
   type MessageQueueError,
   type MessageQueueItem,
+  type MessageQueueEditIntent,
   type WorkspaceMessageQueueControllerOptions
 } from './workspace-message-queue-owner'
 
@@ -23,7 +25,7 @@ const activeBranchIdentity = (
   return frame ? { agentFrameId: frame.id, messageBranchId: frame.activeBranchId } : undefined
 }
 
-const queueBranchMatches = (session: ChatSession, item: MessageQueueItem): boolean => {
+const queueBranchMatches = (session: ChatSession, item: MessageQueueEditIntent): boolean => {
   const identity = activeBranchIdentity(session)
   return (
     identity?.agentFrameId === item.agentFrameId &&
@@ -33,7 +35,7 @@ const queueBranchMatches = (session: ChatSession, item: MessageQueueItem): boole
 
 const queueItemContextError = (
   session: ChatSession,
-  item: MessageQueueItem
+  item: MessageQueueEditIntent
 ): MessageQueueError | undefined => {
   if (!queueBranchMatches(session, item)) return { kind: 'branch' }
   if ((session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE) !== item.permissionProfile) {
@@ -138,8 +140,18 @@ const enqueueQueuedMessage = (
     setComposerError('Wait for the active message branch to finish loading, then try again.')
     return false
   }
+  const restored = snapshot.queuedEdit
+  if (restored && (restored.sessionId !== session.id || queueItemContextError(session, restored))) {
+    setComposerError(
+      i18next.t(
+        'The queued message no longer matches this Session. Exit queued editing to send it as a new message.'
+      )
+    )
+    return false
+  }
   const item: MessageQueueItem = {
     kind: 'user',
+    agentFrameworkId: session.agentFrameworkId,
     id: owner.createQueueItemId(),
     sessionId: session.id,
     ...identity,
@@ -148,7 +160,8 @@ const enqueueQueuedMessage = (
     projectId: session.projectId,
     cwd: session.cwd,
     phase: 'queued',
-    ...intent
+    ...intent,
+    ...restored
   }
   owner.queues.set(session.id, [...owner.itemsFor(session.id), item])
   owner.emit(MESSAGE_QUEUE_ANNOUNCEMENTS.added)

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -428,6 +428,66 @@ describe('workspace message queue controller', () => {
     )
   })
 
+  it('Q03 forwards the captured configuration when a queued revision drains', async () => {
+    let currentSession = session()
+    const resendEditedMessage = vi.fn(async () => true)
+    const input = options(currentSession, {
+      promptInFlightSessionIds: [],
+      runtime: { sendMessage: vi.fn(), resendEditedMessage, cancelRun: vi.fn() },
+      getSession: () => currentSession
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+    const queued = { ...admission('revised prompt'), revisionMessageId: 'message-user-a' }
+    act(() => hook.result.current.lifecycle.enqueue(queued))
+    currentSession = {
+      ...session('idle'),
+      agentConfiguration: { providerId: 'openai', model: 'gpt-5', reasoningEffort: 'high' }
+    }
+    await act(async () => hook.rerender({ ...input, activeSession: currentSession }))
+    expect(resendEditedMessage).toHaveBeenCalledOnce()
+    expect(resendEditedMessage).toHaveBeenCalledWith(
+      'session-a',
+      'message-user-a',
+      expect.objectContaining({ agentConfiguration: queued.agentConfiguration })
+    )
+  })
+
+  it('Q03 preserves the captured target when Send now attempts native follow-up', async () => {
+    const currentSession = {
+      ...session(),
+      agentConfiguration: { providerId: 'openai', model: 'gpt-5', reasoningEffort: 'high' as const }
+    }
+    const queued = admission('use the queued model')
+    const steerFollowUp = vi.fn(async () => ({
+      injected: true as const,
+      transport: 'acp-steering' as const,
+      messageId: 'steered'
+    }))
+    const input = options(currentSession, {
+      runtime: { sendMessage: vi.fn(), cancelRun: vi.fn(), steerFollowUp }
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+    act(() => hook.result.current.lifecycle.enqueue(queued))
+    await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
+
+    // The runtime can verify its real live binding only if it receives the intended target.
+    // Deferring before attempting injection is also safe; silently injecting without it is not.
+    if (steerFollowUp.mock.calls.length > 0) {
+      expect(steerFollowUp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentConfiguration: queued.agentConfiguration
+        })
+      )
+    } else {
+      expect(hook.result.current.items).toEqual([
+        expect.objectContaining({ text: queued.text, phase: 'queued', deferredUntilIdle: true })
+      ])
+    }
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+  })
+
   it('dispatches a queued revision through the unified edited-message runtime seam', async () => {
     let currentSession = session()
     const resendEditedMessage = vi.fn(async () => true)
@@ -451,6 +511,7 @@ describe('workspace message queue controller', () => {
 
     await vi.waitFor(() => expect(resendEditedMessage).toHaveBeenCalledOnce())
     expect(resendEditedMessage).toHaveBeenCalledWith('session-a', 'message-user-a', {
+      agentConfiguration: admission('').agentConfiguration,
       text: 'revised prompt',
       annotations: [],
       referencedArtifacts: [],
@@ -817,6 +878,7 @@ describe('workspace message queue controller', () => {
     })
     await vi.waitFor(() => expect(steerFollowUp).toHaveBeenCalledOnce())
     expect(steerFollowUp).toHaveBeenCalledWith({
+      agentConfiguration: admission('').agentConfiguration,
       sessionId: 'session-a',
       text: 'Draw a pie chart',
       attachments: [attachment],
@@ -1482,6 +1544,7 @@ describe('workspace message queue controller', () => {
     await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
 
     expect(steerFollowUp).toHaveBeenCalledWith({
+      agentConfiguration: admission('').agentConfiguration,
       sessionId: 'session-a',
       text: 'steer me',
       parts: textDoc('steer me').nodes
@@ -1777,6 +1840,7 @@ describe('workspace message queue controller', () => {
 
     await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
     expect(steerFollowUp).toHaveBeenCalledWith({
+      agentConfiguration: admission('').agentConfiguration,
       sessionId: 'session-a',
       text: 'with file',
       attachments: [attachment],
@@ -1811,6 +1875,7 @@ describe('workspace message queue controller', () => {
 
     await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
     expect(steerFollowUp).toHaveBeenCalledWith({
+      agentConfiguration: admission('').agentConfiguration,
       sessionId: 'session-a',
       text: 'use research',
       forcedSkillIds: ['research'],

--- a/src/renderer/src/pages/workspace/workspace-message-queue-drain.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-drain.ts
@@ -95,6 +95,8 @@ const dispatchQueuedSession = (
       const result = item.revisionMessageId
         ? await current.runtime.resendEditedMessage!(sessionId, item.revisionMessageId, {
             text: item.text,
+            ...(item.agentFrameworkId ? { expectedFrameworkId: item.agentFrameworkId } : {}),
+            agentConfiguration: item.agentConfiguration,
             annotations: item.snapshot?.annotations,
             referencedArtifacts: item.snapshot ? docToArtifactRefs(item.snapshot.doc) : undefined,
             parts: item.snapshot ? docToMessageParts(item.snapshot.doc) : undefined,
@@ -114,6 +116,7 @@ const dispatchQueuedSession = (
             cwd: item.cwd,
             projectId: item.projectId,
             permissionProfile: item.permissionProfile,
+            ...(item.agentFrameworkId ? { expectedFrameworkId: item.agentFrameworkId } : {}),
             agentConfiguration: item.agentConfiguration,
             forcedSkillIds: item.forcedSkillIds,
             specialistId: item.specialistId,
@@ -279,6 +282,8 @@ const sendQueuedItemNow = async (
       try {
         const steered = await current.runtime.steerFollowUp({
           sessionId,
+          ...(item.agentFrameworkId ? { expectedFrameworkId: item.agentFrameworkId } : {}),
+          agentConfiguration: item.agentConfiguration,
           text: item.text,
           ...(item.snapshot.attachments.length > 0
             ? { attachments: item.snapshot.attachments }

--- a/src/renderer/src/pages/workspace/workspace-message-queue-owner.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-owner.ts
@@ -41,6 +41,22 @@ type MessageQueueItem = {
   revisionMessageId?: string
 }
 
+type MessageQueueEditIntent = Pick<
+  MessageQueueItem,
+  | 'kind'
+  | 'sessionId'
+  | 'agentFrameId'
+  | 'messageBranchId'
+  | 'permissionProfile'
+  | 'agentConfiguration'
+  | 'specialistId'
+  | 'agentFrameworkId'
+  | 'agentBackendId'
+  | 'projectId'
+  | 'cwd'
+  | 'revisionMessageId'
+>
+
 type MessageQueueAdmission = {
   session: ChatSession
   snapshot: ComposerSendSnapshot
@@ -252,3 +268,5 @@ export type {
   WorkspaceMessageQueueControllerOptions,
   WorkspaceMessageQueueRuntimeOptions
 }
+
+export type { MessageQueueEditIntent }

--- a/src/renderer/src/pages/workspace/workspace-message-queue-projection.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-projection.ts
@@ -102,7 +102,39 @@ const editQueuedItem = (
   if (!queue) return
   const item = queue.items.find((candidate) => candidate.id === itemId)
   if (!item?.snapshot || queueItemIsBusy(item)) return
-  if (!optionsRef.current.composer.restoreQueuedDraft(item.snapshot)) {
+  const {
+    kind,
+    sessionId,
+    agentFrameId,
+    messageBranchId,
+    permissionProfile,
+    agentConfiguration,
+    specialistId,
+    agentFrameworkId,
+    agentBackendId,
+    projectId,
+    cwd,
+    revisionMessageId
+  } = item
+  if (
+    !optionsRef.current.composer.restoreQueuedDraft({
+      ...item.snapshot,
+      queuedEdit: {
+        kind,
+        sessionId,
+        agentFrameId,
+        messageBranchId,
+        permissionProfile,
+        agentConfiguration,
+        specialistId,
+        agentFrameworkId,
+        agentBackendId,
+        projectId,
+        cwd,
+        revisionMessageId
+      }
+    })
+  ) {
     owner.replaceItem(queue.sessionId, itemId, {
       phase: 'error',
       error: { kind: 'edit' },

--- a/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
@@ -167,6 +167,7 @@ describe('workspace page architecture', () => {
       'pages/workspace/workspace-conversation-controller.ts'
     ])
     expect(importersOf(ownerPaths.messageQueueOwner)).toEqual([
+      'pages/workspace/workspace-composer-upload-controller.ts',
       'pages/workspace/workspace-message-queue-admission.ts',
       'pages/workspace/workspace-message-queue-controller.ts',
       'pages/workspace/workspace-message-queue-drain.ts',

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -953,6 +953,7 @@ export type AcpPromptRequest = {
 }
 
 export type AcpSteerFollowUpRequest = {
+  agentTarget?: AcpSessionAgentTarget
   sessionId: string
   text: string
   attachments?: UploadedAttachment[]

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4218,6 +4218,12 @@
     "{{percent}}% of {{size}}": "{{percent}} % von {{size}}",
     "Could not save project. Please try again.": "Das Projekt konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
     "Could not attach the file. Check available storage and try again.": "Die Datei konnte nicht angehängt werden. Prüfen Sie den verfügbaren Speicherplatz und versuchen Sie es erneut.",
-    "Close the file browser and open it again to retry.": "Schließen Sie den Dateibrowser und öffnen Sie ihn erneut, um es noch einmal zu versuchen."
+    "Close the file browser and open it again to retry.": "Schließen Sie den Dateibrowser und öffnen Sie ihn erneut, um es noch einmal zu versuchen.",
+    "Editing a historical revision": "Überarbeitung einer früheren Nachricht bearbeiten",
+    "Editing a queued message": "Nachricht in der Warteschlange bearbeiten",
+    "Exit queued editing": "Warteschlangenbearbeitung beenden",
+    "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "Die Nachricht in der Warteschlange passt nicht mehr zu dieser Sitzung. Beenden Sie die Warteschlangenbearbeitung, um sie als neue Nachricht zu senden.",
+    "Remove attachments before submitting a historical revision.": "Entfernen Sie die Anhänge, bevor Sie die Überarbeitung einer früheren Nachricht senden.",
+    "Exit queued editing before choosing another send mode.": "Beenden Sie die Warteschlangenbearbeitung, bevor Sie einen anderen Sendemodus wählen."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4373,6 +4373,12 @@
     "{{percent}}% of {{size}}": "{{percent}} % de {{size}}",
     "Could not save project. Please try again.": "No se pudo guardar el proyecto. Vuelva a intentarlo.",
     "Could not attach the file. Check available storage and try again.": "No se pudo adjuntar el archivo. Compruebe el espacio de almacenamiento disponible y vuelva a intentarlo.",
-    "Close the file browser and open it again to retry.": "Cierre el explorador de archivos y vuelva a abrirlo para intentarlo de nuevo."
+    "Close the file browser and open it again to retry.": "Cierre el explorador de archivos y vuelva a abrirlo para intentarlo de nuevo.",
+    "Editing a historical revision": "Editando una revisión de un mensaje anterior",
+    "Editing a queued message": "Editando un mensaje en cola",
+    "Exit queued editing": "Salir de la edición de la cola",
+    "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "El mensaje en cola ya no corresponde a esta sesión. Salga de la edición de la cola para enviarlo como un mensaje nuevo.",
+    "Remove attachments before submitting a historical revision.": "Quite los archivos adjuntos antes de enviar una revisión de un mensaje anterior.",
+    "Exit queued editing before choosing another send mode.": "Salga de la edición de la cola antes de elegir otro modo de envío."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4373,6 +4373,12 @@
     "{{percent}}% of {{size}}": "{{percent}} % de {{size}}",
     "Could not save project. Please try again.": "Impossible d’enregistrer le projet. Veuillez réessayer.",
     "Could not attach the file. Check available storage and try again.": "Impossible de joindre le fichier. Vérifiez l’espace de stockage disponible et réessayez.",
-    "Close the file browser and open it again to retry.": "Fermez le navigateur de fichiers et rouvrez-le pour réessayer."
+    "Close the file browser and open it again to retry.": "Fermez le navigateur de fichiers et rouvrez-le pour réessayer.",
+    "Editing a historical revision": "Modification d’un ancien message",
+    "Editing a queued message": "Modification d’un message en attente",
+    "Exit queued editing": "Quitter la modification de la file",
+    "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "Le message en attente ne correspond plus à cette session. Quittez la modification de la file pour l’envoyer comme nouveau message.",
+    "Remove attachments before submitting a historical revision.": "Retirez les pièces jointes avant d’envoyer la modification d’un ancien message.",
+    "Exit queued editing before choosing another send mode.": "Quittez la modification de la file avant de choisir un autre mode d’envoi."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4063,6 +4063,12 @@
     "{{percent}}% of {{size}}": "{{size}} の {{percent}}%",
     "Could not save project. Please try again.": "プロジェクトを保存できませんでした。もう一度お試しください。",
     "Could not attach the file. Check available storage and try again.": "ファイルを添付できませんでした。ストレージの空き容量を確認して、もう一度お試しください。",
-    "Close the file browser and open it again to retry.": "ファイルブラウザーを閉じて再度開き、もう一度お試しください。"
+    "Close the file browser and open it again to retry.": "ファイルブラウザーを閉じて再度開き、もう一度お試しください。",
+    "Editing a historical revision": "過去のメッセージの修正を編集中",
+    "Editing a queued message": "キュー内のメッセージを編集中",
+    "Exit queued editing": "キューの編集を終了",
+    "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "キュー内のメッセージは、このセッションと一致しなくなりました。キューの編集を終了して、新しいメッセージとして送信してください。",
+    "Remove attachments before submitting a historical revision.": "過去のメッセージの修正を送信する前に、添付ファイルを削除してください。",
+    "Exit queued editing before choosing another send mode.": "別の送信モードを選択する前に、キューの編集を終了してください。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4061,6 +4061,12 @@
     "{{percent}}% of {{size}}": "{{size}} 중 {{percent}}%",
     "Could not save project. Please try again.": "프로젝트를 저장하지 못했습니다. 다시 시도해 주세요.",
     "Could not attach the file. Check available storage and try again.": "파일을 첨부하지 못했습니다. 저장 공간을 확인한 후 다시 시도해 주세요.",
-    "Close the file browser and open it again to retry.": "파일 브라우저를 닫았다가 다시 열어 재시도해 주세요."
+    "Close the file browser and open it again to retry.": "파일 브라우저를 닫았다가 다시 열어 재시도해 주세요.",
+    "Editing a historical revision": "이전 메시지 수정 내용 편집 중",
+    "Editing a queued message": "대기 중인 메시지 편집 중",
+    "Exit queued editing": "대기열 편집 종료",
+    "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "대기 중인 메시지가 더 이상 이 세션과 일치하지 않습니다. 대기열 편집을 종료하여 새 메시지로 보내세요.",
+    "Remove attachments before submitting a historical revision.": "이전 메시지 수정 내용을 제출하기 전에 첨부 파일을 제거하세요.",
+    "Exit queued editing before choosing another send mode.": "다른 전송 모드를 선택하기 전에 대기열 편집을 종료하세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4503,6 +4503,12 @@
     "{{percent}}% of {{size}}": "{{percent}}% из {{size}}",
     "Could not save project. Please try again.": "Не удалось сохранить проект. Повторите попытку.",
     "Could not attach the file. Check available storage and try again.": "Не удалось прикрепить файл. Проверьте свободное место и повторите попытку.",
-    "Close the file browser and open it again to retry.": "Закройте файловый браузер и откройте его снова, чтобы повторить попытку."
+    "Close the file browser and open it again to retry.": "Закройте файловый браузер и откройте его снова, чтобы повторить попытку.",
+    "Editing a historical revision": "Редактирование предыдущего сообщения",
+    "Editing a queued message": "Редактирование сообщения в очереди",
+    "Exit queued editing": "Завершить редактирование очереди",
+    "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "Сообщение в очереди больше не соответствует этому сеансу. Завершите редактирование очереди, чтобы отправить его как новое сообщение.",
+    "Remove attachments before submitting a historical revision.": "Удалите вложения перед отправкой исправления предыдущего сообщения.",
+    "Exit queued editing before choosing another send mode.": "Завершите редактирование очереди, прежде чем выбрать другой режим отправки."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4063,6 +4063,12 @@
     "{{percent}}% of {{size}}": "{{size}} 的 {{percent}}%",
     "Could not save project. Please try again.": "无法保存项目。请重试。",
     "Could not attach the file. Check available storage and try again.": "无法添加附件。请检查可用存储空间后重试。",
-    "Close the file browser and open it again to retry.": "请关闭文件浏览器后重新打开以重试。"
+    "Close the file browser and open it again to retry.": "请关闭文件浏览器后重新打开以重试。",
+    "Editing a historical revision": "正在编辑历史消息修订",
+    "Editing a queued message": "正在编辑排队消息",
+    "Exit queued editing": "退出队列编辑",
+    "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "排队消息已不再与此会话匹配。请退出队列编辑，将其作为新消息发送。",
+    "Remove attachments before submitting a historical revision.": "提交历史消息修订前，请移除附件。",
+    "Exit queued editing before choosing another send mode.": "选择其他发送模式前，请退出队列编辑。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4063,6 +4063,12 @@
     "{{percent}}% of {{size}}": "{{size}} 的 {{percent}}%",
     "Could not save project. Please try again.": "無法儲存專案。請重試。",
     "Could not attach the file. Check available storage and try again.": "無法附加檔案。請檢查可用儲存空間後重試。",
-    "Close the file browser and open it again to retry.": "請關閉檔案瀏覽器後重新開啟以重試。"
+    "Close the file browser and open it again to retry.": "請關閉檔案瀏覽器後重新開啟以重試。",
+    "Editing a historical revision": "正在編輯歷史訊息修訂",
+    "Editing a queued message": "正在編輯排隊訊息",
+    "Exit queued editing": "結束佇列編輯",
+    "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "排隊訊息已不再與此工作階段相符。請結束佇列編輯，將其作為新訊息傳送。",
+    "Remove attachments before submitting a historical revision.": "提交歷史訊息修訂前，請移除附件。",
+    "Exit queued editing before choosing another send mode.": "選擇其他傳送模式前，請結束佇列編輯。"
   }
 }


### PR DESCRIPTION
## Problem

Editing a queued historical revision can overwrite a separate unsent draft and subsequently send the revision as a new message. An upload claim that resolves after cancellation can reattach the cancelled file. Queued revisions and native follow-ups can lose their captured execution target.

## Proposed change

- Reject queue editing while the composer contains another draft; carry the accepted queue edit's original message, branch and configuration through the existing composer. Show an editing indicator and an explicit exit action.
- Recheck the existing cancellation signal after upload claim and remove the exact claimed pending file through its existing owner before any attachment is published.
- Preserve the queued configuration/framework across revision and follow-up boundaries, including Electron IPC. Check the actual bound runtime target and recheck its generation/live turn after asynchronous preparation. Defer incompatible native follow-ups through the existing idle path.

## Scope and non-goals

No schema, migration, persisted field, enum value, new service or subscription. One optional in-memory composer edit context and optional internal command target fields reuse existing queue/runtime ownership. The interaction adds an edit indicator/exit action and rejects incompatible send modes or newly staged revision attachments; original historical message uploads retain their existing replay behavior.

Persistence impact: cancelled claimed files are deleted by exact pending-upload path; source files and historical uploads are retained. Ordinary revision/message persistence remains unchanged. No historical migration or bulk repair of previously lost drafts, sent messages or orphan files.

## Acceptance criteria and validation

The original five report regressions failed twice before production edits. Expanded regression tests then ran twice against the original production source: 23 identical failures, with identical failure messages, plus one passing positive control. The Electron forwarding contract also failed twice before its fix. Tests use existing page/hooks, upload and command boundaries without adding a production test seam.

Final local Test Impact Set: **3,765 tests passed across 69 test files**, after the final production edit. The final UI fixture was additionally rerun after its type-only completion.

| Behavior / contract | Project-owned command / selection | Result |
| --- | --- | --- |
| Queue edit, draft protection, branch/undo/switch behavior | `npm test -- <workspace_page module test files>` plus `ConversationPanel.interaction.test.tsx` | Passed |
| Captured target, runtime generation and live-turn lifecycle | `npm test -- <workspace_runtime module test files>` plus `runtime-coordinator.test.ts`, `native-follow-up-workflow.test.ts`, `native-follow-up.test.ts` | Passed |
| Electron/Web/renderer command propagation | `npm test -- src/main/acp/ipc.test.ts src/main/acp/application-commands.test.ts src/renderer/src/lib/acp/useAcpRuntime.test.ts` | Passed |
| Cancel/claim cleanup and retained history | `npm test -- <upload_repository and session_persistence module test files>` | Passed |
| Translated editing surface | `npm test -- <i18n_renderer_adapter module test files> src/renderer/src/i18n/resources.test.ts` | Passed |
| Main, renderer and sandbox types | `npm run typecheck` | Passed |
| Source style | `npm run lint`; changed-file Prettier check; `git diff --check` | Passed |

The union uses the existing module manifest's curated test lists plus the named interface consumers. Renderer-state, i18n and Windows-sensitive file ownership risks are included. Runtime compatibility tests exercise claude-code, opencode, codex-response and codex-bridge; native follow-up tests retain CodeBuddy coverage. No complete local `npm test` run, as requested by the maintainer. Required PR CI is the final authority for the final commit and platform lanes.

CI evidence for `bc36e88`: Ubuntu full-suite shards, module coverage, Windows core/E2E, macOS builds/native/E2E, static checks and CodeQL passed. The first macOS job failed in an unchanged network-sandbox test because the denial-response body was empty; the exact focused test passed locally, and one retry of only that job passed without source/test changes. Independent AI review returned **mergeable**, with no actionable findings (static review, no reviewer test execution). Final PR Gate aggregation passed.

Uncovered locally: real provider execution/billing and real desktop UI timing; tests control those external adapters. Filesystem cleanup uses real temporary files and platform-aware paths. No dependency, build configuration or persisted-format changes require additional migration/package validation locally.

## Review focus

Check that retained queue intent cannot silently change branch/model, that cancellation wins after ownership transfer without removing source/history files, and that the target guard remains effective across Electron/Web and asynchronous native preparation. Please independently assess the final impact mapping and lifecycle coverage before marking this change verified.
