### PR TITLE
test(resource-bounds): characterize leak cache and polling paths

### DIFF
--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -13,7 +13,7 @@ import {
   type ComputeConnectionBrokerAcquirer,
   type ComputeConnectionLease
 } from './connection-broker'
-import { JobPoller } from './job-poller'
+import { JobPoller, POLL_INTERVAL_MS } from './job-poller'
 import { DispatchTracker } from './dispatch-tracker'
 import type { HarvestFn } from './job-poller'
 
@@ -1558,6 +1558,32 @@ describe('JobPoller', () => {
 
     // runner.run should not be called when there are no jobs.
     expect((runner.run as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0)
+  })
+
+  it('starts a 15s interval even when the job list is empty', () => {
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([]))
+    } as unknown as ComputeJobRepository
+    const hostRepo = { get: vi.fn() } as unknown as ComputeHostRepository
+    const runner = makeSshRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const setIntervalMock = vi.fn(() => 1 as unknown as ReturnType<typeof setInterval>)
+
+    const poller = new JobPoller({
+      connectionBroker: brokerFromRunner(runner),
+      hostRepository: hostRepo,
+      jobRepository: jobRepo,
+      setInterval: setIntervalMock,
+      clearInterval: vi.fn()
+    })
+    poller.start()
+
+    expect(setIntervalMock).toHaveBeenCalledWith(expect.any(Function), POLL_INTERVAL_MS)
   })
 
   it('start/stop manage the interval', () => {

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -1733,4 +1733,32 @@ describe('ComputeJob repository (SQLite integration)', () => {
       remote_cleanup_disposition: 'abandoned'
     })
   })
+
+  it('returns every Session job without a list limit', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-job-session-list-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const repo = makeJobRepository(client)
+    const jobCount = 20
+
+    for (let index = 0; index < jobCount; index += 1) {
+      await repo.create({
+        id: `session-list-job-${index}`,
+        providerId: 'ssh:list-host',
+        shape: 'direct_ssh',
+        sessionId: 'session-list',
+        projectId: 'project-list',
+        intent: `job ${index}`,
+        command: `echo ${index}`,
+        commandHash: `session-list-hash-${index}`
+      })
+    }
+
+    const jobs = await repo.findBySession('session-list')
+    expect(jobs).toHaveLength(jobCount)
+    expect(new Set(jobs.map((job) => job.job_id))).toEqual(
+      new Set(Array.from({ length: jobCount }, (_, index) => `session-list-job-${index}`))
+    )
+  })
 })

--- a/src/main/crash-diagnostics.test.ts
+++ b/src/main/crash-diagnostics.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { installChildProcessGoneLogging, startLocalCrashReporting } from './crash-diagnostics'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
 describe('startLocalCrashReporting', () => {
   it.each<NodeJS.Platform>(['win32', 'darwin', 'linux'])(
@@ -40,6 +45,25 @@ describe('startLocalCrashReporting', () => {
 
     expect(status).toEqual({ enabled: false })
     expect(start).not.toHaveBeenCalled()
+  })
+
+  it('does not schedule crash-dump cleanup when Crashpad starts', () => {
+    vi.useFakeTimers()
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const start = vi.fn()
+
+    startLocalCrashReporting({
+      platform: 'darwin',
+      productName: 'Open Science',
+      companyName: 'aipoch',
+      appVersion: '0.25.1',
+      start
+    })
+
+    expect(start).toHaveBeenCalledOnce()
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/memory/service.test.ts
+++ b/src/main/memory/service.test.ts
@@ -90,6 +90,20 @@ describe('MemoryService', () => {
     expect((await service.snapshot()).categories[0]?.entries).toHaveLength(1)
   })
 
+  it('loads every Memory entry into the settings snapshot', async () => {
+    const service = createService()
+    const entryCount = 25
+    for (let index = 0; index < entryCount; index += 1) {
+      await service.createEntry({
+        categoryId: ABOUT_YOU_MEMORY_CATEGORY_ID,
+        content: `Durable note ${index}.`
+      })
+    }
+
+    const snapshot = await service.snapshot()
+    expect(snapshot.categories[0]?.entries).toHaveLength(entryCount)
+  })
+
   it('rejects duplicate global Memory content within the same scope', async () => {
     const service = createService()
     const request = {

--- a/src/main/notebook/repository.test.ts
+++ b/src/main/notebook/repository.test.ts
@@ -1314,4 +1314,93 @@ describe('notebook run repository', () => {
     const again = await repository.reconcileInterruptedRuns('default-project', 'session-1', lane)
     expect(again.runs[0].status).toBe('interrupted')
   })
+
+  it('rewrites the complete lane document and materializes every run before applying a window', async () => {
+    const root = await createStorageRoot()
+    const writer = new NotebookRunRepository(root)
+    const lane = createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1')
+    await writer.loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      lane
+    })
+    const runCount = 8
+    for (let index = 0; index < runCount; index += 1) {
+      await writer.appendRun({
+        projectId: 'default-project',
+        sessionId: 'session-1',
+        lane,
+        run: {
+          runId: `run-${index}`,
+          cellId: `cell-${index}`,
+          source: 'agent',
+          kernelKind: 'python',
+          script: `print(${index})`,
+          status: 'completed',
+          startedAt: index + 1,
+          text: { stdout: `out-${index}`, stderr: '', traceback: '', plain: [] },
+          outputs: [],
+          artifacts: [],
+          workingFiles: []
+        }
+      })
+    }
+
+    const runJsonPath = join(
+      getNotebookSessionRoot(root, 'default-project', 'session-1'),
+      'run.json'
+    )
+    const persisted = JSON.parse(await readFile(runJsonPath, 'utf8')) as {
+      runs: Array<{ runId: string }>
+    }
+    expect(persisted.runs.map((run) => run.runId)).toEqual(
+      Array.from({ length: runCount }, (_, index) => `run-${index}`)
+    )
+
+    const reader = new NotebookRunRepository(root)
+    const window = await reader.readSessionRunWindow('default-project', 'session-1', 2)
+    expect(window.runs.map((run) => run.runId)).toEqual(['run-6', 'run-7'])
+    expect(window.total).toBe(runCount)
+
+    const cache = reader as unknown as {
+      documentCache: Map<string, { document: { runs: Array<{ runId: string }> } }>
+    }
+    expect([...cache.documentCache.values()][0]?.document.runs).toHaveLength(runCount)
+  })
+
+  it('leaves Session workspace output files in place when another run is appended', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const lane = createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1')
+    const document = await repository.loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      lane
+    })
+    const leftoverPath = join(document.notebookSessionRoot, 'outputs', 'keep.bin')
+    await writeFile(leftoverPath, Buffer.alloc(4096, 7))
+
+    await repository.appendRun({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane,
+      run: {
+        runId: 'run-keep-outputs',
+        cellId: 'cell-keep-outputs',
+        source: 'agent',
+        kernelKind: 'python',
+        script: '1',
+        status: 'completed',
+        startedAt: 1,
+        text: { stdout: '', stderr: '', traceback: '', plain: [] },
+        outputs: [],
+        artifacts: [],
+        workingFiles: []
+      }
+    })
+
+    await expect(stat(leftoverPath)).resolves.toMatchObject({ size: 4096 })
+  })
 })

--- a/src/main/office-preview/office-preview-oopif-supervisor.test.ts
+++ b/src/main/office-preview/office-preview-oopif-supervisor.test.ts
@@ -44,6 +44,7 @@ const createDependencies = (
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.restoreAllMocks()
 })
 
 describe('OfficePreviewSupervisor OOPIF sessions', () => {
@@ -281,6 +282,21 @@ describe('OfficePreviewSupervisor OOPIF sessions', () => {
       error: 'PREVIEW_PROCESS_CRASHED'
     })
     expect(dependencies.releaseResource).toHaveBeenCalledWith(7, 'resource-1')
+  })
+
+  it('clears the process-memory poll when the preview session closes', async () => {
+    vi.useFakeTimers()
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const dependencies = createDependencies({
+      getProcessMemoryUsageBytes: vi.fn().mockResolvedValue(1)
+    })
+    const supervisor = new OfficePreviewSupervisor(dependencies)
+
+    await supervisor.open(7, request)
+    await supervisor.attachFrame(7, 'session-1')
+    await supervisor.close(7, 'session-1')
+
+    expect(clearIntervalSpy).toHaveBeenCalled()
   })
 
   it('releases only the owning session and makes repeated closes idempotent', async () => {

--- a/src/main/uploads/attachment-media.test.ts
+++ b/src/main/uploads/attachment-media.test.ts
@@ -167,7 +167,9 @@ const getDocument = vi.fn(() => ({
   })
 }))
 
-vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({ getDocument: () => getDocument() }))
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+  getDocument: (options?: unknown) => getDocument(options)
+}))
 
 let root: string
 
@@ -653,6 +655,22 @@ describe('extractPdfText', () => {
     await writeFile(filePath, Buffer.from('%PDF-1.4 fake'))
 
     await expect(inspectPdfPageCount(filePath)).resolves.toBe(2)
+  })
+
+  it('loads an admitted PDF into pdfjs as a complete in-memory buffer', async () => {
+    const filePath = join(root, 'admitted.pdf')
+    const bytes = Buffer.alloc(32 * 1024, 0x25)
+    await writeFile(filePath, bytes)
+
+    await extractPdfText(filePath)
+
+    expect(getDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.any(Uint8Array)
+      })
+    )
+    const options = getDocument.mock.calls[0]?.[0] as { data: Uint8Array }
+    expect(options.data.byteLength).toBe(bytes.byteLength)
   })
 
   it('does not inspect or read PDF sources above the automatic extraction limit', async () => {

--- a/src/main/uploads/attachment-media.test.ts
+++ b/src/main/uploads/attachment-media.test.ts
@@ -149,7 +149,17 @@ type FakePdfTextItem =
       dir?: string
     }>
 let fakePdf: { numPages: number; pages: FakePdfTextItem[][] }
-const getDocument = vi.fn(() => ({
+type FakePdfDocument = {
+  promise: Promise<{
+    numPages: number
+    getPage: (pageNumber: number) => Promise<{
+      getTextContent: () => Promise<{ items: unknown[] }>
+      cleanup: () => void
+    }>
+    destroy: () => Promise<void>
+  }>
+}
+const getDocument = vi.fn<(options?: { data?: Uint8Array }) => FakePdfDocument>(() => ({
   promise: Promise.resolve({
     numPages: fakePdf.numPages,
     getPage: async (pageNumber: number) => ({
@@ -168,7 +178,7 @@ const getDocument = vi.fn(() => ({
 }))
 
 vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
-  getDocument: (options?: unknown) => getDocument(options)
+  getDocument: (options?: unknown) => getDocument(options as { data?: Uint8Array } | undefined)
 }))
 
 let root: string
@@ -669,8 +679,7 @@ describe('extractPdfText', () => {
         data: expect.any(Uint8Array)
       })
     )
-    const options = getDocument.mock.calls[0]?.[0] as { data: Uint8Array }
-    expect(options.data.byteLength).toBe(bytes.byteLength)
+    expect(getDocument.mock.calls[0]?.[0]?.data?.byteLength).toBe(bytes.byteLength)
   })
 
   it('does not inspect or read PDF sources above the automatic extraction limit', async () => {

--- a/src/renderer/src/stores/session-job-store.test.ts
+++ b/src/renderer/src/stores/session-job-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { JobSummary } from '../../../shared/compute'
+import type { ComputeJobsListFilter, JobSummary } from '../../../shared/compute'
 import { createInitialSessionJobState, useSessionJobStore } from './session-job-store'
 import { makeJob as makeComputeJob } from '@/test-utils/compute-job'
 
@@ -54,6 +54,26 @@ describe('session job store — hydrate', () => {
     expect(state.jobsById.has('old')).toBe(true)
     expect(state.jobsById.has('new')).toBe(true)
     expect(state.hydratedSessionId).toBe('sess-2')
+  })
+
+  it('accumulates job rows from every visited Session', async () => {
+    setJobsApi({
+      jobsList: vi.fn(async (filter: ComputeJobsListFilter) => {
+        if (!('sessionId' in filter)) return []
+        return Array.from({ length: 3 }, (_, index) =>
+          makeJob({
+            job_id: `${filter.sessionId}-job-${index}`,
+            session_id: filter.sessionId
+          })
+        )
+      })
+    })
+
+    for (let index = 0; index < 6; index += 1) {
+      await useSessionJobStore.getState().hydrate(`sess-${index}`)
+    }
+
+    expect(useSessionJobStore.getState().jobsById.size).toBe(18)
   })
 
   it('does not let an older Session hydrate completion switch the active Session back', async () => {

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1658,6 +1658,79 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0]?.contentLoaded).not.toBe(false)
   })
 
+  it('keeps a loaded Session body after selecting a different Session', () => {
+    const loadedMessages = Array.from({ length: 12 }, (_, index) => ({
+      id: `message-${index + 1}`,
+      role: 'user' as const,
+      content: `Turn ${index + 1}`,
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: index + 1,
+      updatedAt: index + 1
+    }))
+    useSessionStore.getState().hydrateSessionSummaries(
+      [
+        {
+          number: 1,
+          id: 'session-loaded',
+          projectId: 'project-1',
+          title: 'Loaded session',
+          status: 'idle',
+          presentedStatus: 'idle',
+          pinned: false,
+          revision: 1,
+          activeMessageCount: loadedMessages.length,
+          artifactCount: 0,
+          filesRevision: 0,
+          createdAt: 1,
+          updatedAt: 4,
+          needsStartupRecovery: false
+        },
+        {
+          number: 2,
+          id: 'session-summary',
+          projectId: 'project-1',
+          title: 'Summary session',
+          status: 'idle',
+          presentedStatus: 'idle',
+          pinned: false,
+          revision: 1,
+          activeMessageCount: 0,
+          artifactCount: 0,
+          filesRevision: 0,
+          createdAt: 2,
+          updatedAt: 3,
+          needsStartupRecovery: false
+        }
+      ],
+      {
+        id: 'session-loaded',
+        projectId: 'project-1',
+        title: 'Loaded session',
+        cwd: '/workspace',
+        status: 'idle',
+        messages: loadedMessages,
+        createdAt: 1,
+        updatedAt: 4,
+        revision: 1
+      }
+    )
+
+    useSessionStore.getState().selectSession('session-summary')
+
+    const loaded = useSessionStore
+      .getState()
+      .sessions.find((session) => session.id === 'session-loaded')
+    const summary = useSessionStore
+      .getState()
+      .sessions.find((session) => session.id === 'session-summary')
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-summary')
+    expect(loaded?.contentLoaded).not.toBe(false)
+    expect(loaded?.messages).toHaveLength(12)
+    expect(summary?.contentLoaded).toBe(false)
+    expect(summary?.messages).toEqual([])
+  })
+
   it('applies archive state from an older durable Session update without losing newer local state', () => {
     useSessionStore.getState().hydrateSessions([
       {


### PR DESCRIPTION
## Problem

Resource-leak and growth risks (memory/handle leaks, unbounded caches, bulk list loads, whole-file reads, disk fill, background polling) were previously inferred from source. That is not enough to know which paths are actually bounded at runtime.

## Proposed change

Add characterization tests that **run the owners** and record current behavior:

| Finding | Runtime observation |
| --- | --- |
| Notebook history is unbounded on disk | `run.json` still contains every appended run after a windowed read of 2 |
| Windowed Notebook reads still load the full document | A fresh repository cache holds all 8 runs after `readSessionRunWindow(..., 2)` |
| Notebook workspace files are not pruned | A 4 KiB file in `outputs/` survives a later append |
| Loaded Sessions stay in renderer memory | Selecting another Session leaves the previous body (`12` messages) loaded |
| Compute job UI cache grows across Sessions | Visiting 6 Sessions with 3 jobs each leaves `jobsById.size === 18` |
| Compute job lists have no page limit | `findBySession` returns all 20 jobs |
| Compute poller still ticks when idle | Empty job list starts a 15s interval and does not SSH |
| Memory settings snapshot is complete | `snapshot()` returns all 25 entries |
| Crashpad dumps have no cleanup timer | Starting Crashpad schedules neither `setInterval` nor `setTimeout` |
| Office preview poll is session-scoped | Memory poll is cleared on close |
| Admitted PDFs are read whole | pdfjs receives a buffer whose length equals the file size |

Existing coverage already proves logger rotation, kernel idle-off by default, ACP event cap, transcript window of 80, PDF >50 MiB rejected, and Office >40 MiB rejected.

This PR does **not** change production behavior.

## Scope and non-goals

- Tests only, next to the existing owners.
- No production bound, retention, pagination, or cleanup changes.
- No Crashpad dump rotation.
- No `run.json` or Session JSON format change.

## Historical compatibility

None in this PR. Later fixes that bound Notebook history, Session JSON, Memory snapshots, or Compute job lists will need a separate compatibility decision for existing on-disk data.

## New state / enum values

None.

## Data persistence

None changed. The tests only **observe** current persistence:

- Notebook `run.json` keeps the full run list.
- Notebook `outputs/` is not garbage-collected on append.
- Memory and Compute Job SQLite rows are returned in full by their list/snapshot APIs.

## Acceptance criteria and validation

- New tests fail closed if the current unbounded or bounded behavior changes without an intentional update.
- Listed Test Impact Set passed after the last material edit.

## Review focus

Whether these tests observe the real owners (not source-grep architecture checks), and whether documenting current unbounded behavior is the right landing before any fix.

## Test Impact Set

Ran after the last material edit from `.worktree/resource-bounds-characterization`:

| Behavior | Command | Result |
| --- | --- | --- |
| Notebook history rewrite / windowed full-document load / outputs retention | `npx vitest run src/main/notebook/repository.test.ts` | pass (included in 422) |
| Loaded Session body retained after selection | `npx vitest run src/renderer/src/stores/session-store.test.ts` | pass |
| Job cache accumulation across Sessions | `npx vitest run src/renderer/src/stores/session-job-store.test.ts` | pass |
| Compute job list has no limit; poller 15s idle interval | `npx vitest run src/main/compute/job-repository.test.ts src/main/compute/job-poller.test.ts` | pass |
| Memory snapshot returns every entry | `npx vitest run src/main/memory/service.test.ts` | pass |
| Crashpad starts without dump-cleanup timers | `npx vitest run src/main/crash-diagnostics.test.ts` | pass |
| Office preview memory poll cleared on close | `npx vitest run src/main/office-preview/office-preview-oopif-supervisor.test.ts` | pass |
| Admitted PDF loaded as a complete buffer | `npx vitest run src/main/uploads/attachment-media.test.ts` | pass |
| Lint of changed test files | `npx eslint <changed test files>` | pass |

Combined affected-file run: `npx vitest run` on the nine files above → **422 passed, 0 failed**.

Excluded: full `npm test`, typecheck, E2E. PR Gate CI is authoritative for the complete portable suite. No ACP protocol, renderer contract, or migration files changed.

### Uncovered risks

- Crash dump **directory** growth cannot be exercised without Electron Crashpad writing real dumps; the test only proves this process does not schedule cleanup.
- Micromamba package-cache disk growth is not covered here (would need a provisioned env).
- Kernel idle-off is already covered by `kernel-executor.test.ts` and was not duplicated.