### PR TITLE
fix(notebook): isolate managed runtime state

### DIFF
--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -1,4 +1,4 @@
-import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -352,6 +352,116 @@ afterEach(async () => {
     await rm(cwdDir, { recursive: true, force: true })
     cwdDir = undefined
   }
+})
+
+describe.skipIf(process.platform === 'win32')('managed R kernel isolation', () => {
+  it('ignores user startup files and uses only the managed environment library', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-managed-r-kernel-home-'))
+    const request = baseRequest(cwdDir)
+    const prefix = envPrefix(request.runtimeRoot, DEFAULT_R_ENV)
+    const managedHome = join(request.runtimeRoot, 'home')
+    const managedLibrary = join(prefix, 'lib', 'R', 'library')
+    const hostHome = join(cwdDir, 'host-home')
+    const hostLibrary = join(hostHome, 'R', 'library')
+    const rscript = rScriptBin(prefix)
+    const inheritedKeys = ['HOME', 'R_USER', 'R_LIBS_USER'] as const
+    const inherited = Object.fromEntries(inheritedKeys.map((key) => [key, process.env[key]]))
+    await mkdir(dirname(rscript), { recursive: true })
+    await mkdir(hostLibrary, { recursive: true })
+    await writeFile(rBin(prefix), '')
+    await writeFile(join(hostHome, '.Rprofile'), 'stop("host .Rprofile loaded")\n')
+    await writeFile(join(hostHome, '.Renviron'), 'OPEN_SCIENCE_HOST_RENVIRON=loaded\n')
+    await writeFile(join(hostLibrary, 'host-package'), 'private\n')
+    await writeFile(
+      rscript,
+      [
+        `#!${process.execPath}`,
+        "const fs = require('node:fs')",
+        `const hostHome = ${JSON.stringify(hostHome)}`,
+        `const expectedHome = ${JSON.stringify(managedHome)}`,
+        `const expectedLibrary = ${JSON.stringify(managedLibrary)}`,
+        "if (!process.argv.includes('--vanilla') && (fs.existsSync(hostHome + '/.Rprofile') || fs.existsSync(hostHome + '/.Renviron'))) process.exit(41)",
+        'if (process.env.HOME !== expectedHome || process.env.R_USER !== expectedHome) process.exit(42)',
+        'if (process.env.R_LIBS_USER !== expectedLibrary) process.exit(43)',
+        'let input = Buffer.alloc(0)',
+        "process.stdin.on('data', (chunk) => {",
+        '  input = Buffer.concat([input, chunk])',
+        '  for (;;) {',
+        '    const newline = input.indexOf(10)',
+        '    if (newline < 0) return',
+        "    const [reqId, rawLength] = input.subarray(0, newline).toString('utf8').split(' ')",
+        '    const length = Number(rawLength)',
+        '    if (input.length < newline + 1 + length) return',
+        '    input = input.subarray(newline + 1 + length)',
+        '    process.stdout.write(JSON.stringify({',
+        '      req_id: reqId, stdout: "isolated managed R kernel", stderr: "",',
+        '      error: null, error_line: null, result: null, cwd: process.cwd(), figures: []',
+        '    }) + "\\n")',
+        '  }',
+        '})'
+      ].join('\n') + '\n'
+    )
+    await chmod(rscript, 0o755)
+    process.env.HOME = hostHome
+    process.env.R_USER = hostHome
+    process.env.R_LIBS_USER = hostLibrary
+    const executor = new NotebookKernelExecutor({
+      rLoopPath: join(cwdDir, 'ignored-r-loop.R'),
+      platform: 'linux'
+    })
+    try {
+      await expect(
+        executor.execute({ ...request, code: '1 + 1', language: 'r' })
+      ).resolves.toMatchObject({
+        status: 'completed',
+        stdout: 'isolated managed R kernel'
+      })
+    } finally {
+      await executor.shutdown()
+      for (const key of inheritedKeys) {
+        const value = inherited[key]
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+    }
+  })
+})
+
+describe.skipIf(process.platform === 'win32' || !python3)('managed Python kernel isolation', () => {
+  it('cannot import a package that exists only in the host user site through public execute', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-managed-python-kernel-home-'))
+    const request = baseRequest(cwdDir)
+    const hostHome = join(cwdDir, 'host-home')
+    await mkdir(hostHome, { recursive: true })
+    const discovered = spawnSync(
+      python3 as string,
+      ['-c', 'import site; print(site.getusersitepackages())'],
+      { encoding: 'utf8', env: { PATH: process.env.PATH, HOME: hostHome } }
+    )
+    expect(discovered.status, discovered.stderr).toBe(0)
+    const userSite = discovered.stdout.trim()
+    await mkdir(userSite, { recursive: true })
+    await writeFile(join(userSite, 'open_science_managed_sentinel.py'), 'VALUE = "private"\n')
+    await stubEnvPython(request.runtimeRoot, DEFAULT_PY_ENV)
+    const previousHome = process.env.HOME
+    process.env.HOME = hostHome
+    const executor = new NotebookKernelExecutor({
+      pythonLoopPath: join(__dirname, '../../../resources/notebook/python_loop.py'),
+      platform: 'linux'
+    })
+    try {
+      const result = await executor.execute({
+        ...request,
+        code: 'import open_science_managed_sentinel'
+      })
+      expect(result.status).toBe('failed')
+      expect(JSON.stringify(result)).toMatch(/open_science_managed_sentinel/u)
+    } finally {
+      await executor.shutdown()
+      if (previousHome === undefined) delete process.env.HOME
+      else process.env.HOME = previousHome
+    }
+  })
 })
 
 gate('NotebookKernelExecutor (fake loop)', () => {
@@ -877,6 +987,43 @@ gate('NotebookKernelExecutor (fake loop)', () => {
       await executor.shutdown()
     }
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps the external Python user site available through the public execute path',
+    async () => {
+      cwdDir = await mkdtemp(join(tmpdir(), 'os-kernel-external-user-site-'))
+      const hostHome = join(cwdDir, 'host-home')
+      await mkdir(hostHome, { recursive: true })
+      const discovered = spawnSync(
+        python3 as string,
+        ['-c', 'import site; print(site.getusersitepackages())'],
+        { encoding: 'utf8', env: { PATH: process.env.PATH, HOME: hostHome } }
+      )
+      expect(discovered.status, discovered.stderr).toBe(0)
+      const userSite = discovered.stdout.trim()
+      await mkdir(userSite, { recursive: true })
+      await writeFile(join(userSite, 'open_science_external_sentinel.py'), 'VALUE = "available"\n')
+      const previousHome = process.env.HOME
+      process.env.HOME = hostHome
+      const executor = new NotebookKernelExecutor({
+        pythonLoopPath: join(__dirname, '../../../resources/notebook/python_loop.py'),
+        platform: 'linux'
+      })
+      try {
+        await expect(
+          executor.execute({
+            ...baseRequest(cwdDir),
+            code: 'import open_science_external_sentinel; print(open_science_external_sentinel.VALUE)',
+            resolvedInterpreter: { command: python3 as string }
+          })
+        ).resolves.toMatchObject({ status: 'completed', stdout: 'available\n' })
+      } finally {
+        await executor.shutdown()
+        if (previousHome === undefined) delete process.env.HOME
+        else process.env.HOME = previousHome
+      }
+    }
+  )
 
   it('reuses the same loop process across executes of the same language', async () => {
     cwdDir = await makeDefaultEnvCwd('os-kernel-reuse-')

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -20,7 +20,11 @@ import {
 } from './kernel-protocol'
 import { mapLoopOutputs, type MappedFigure } from './loop-output-mapper'
 import { protectManagedRuntimeWrites } from './managed-runtime-guard'
-import { buildNotebookKernelEnvironment, environmentPathRoots } from './process-environment'
+import {
+  buildManagedRuntimeProcessEnvironment,
+  buildNotebookKernelEnvironment,
+  environmentPathRoots
+} from './process-environment'
 import type { NotebookProcessSandbox } from './process-sandbox'
 import {
   notebookWorkloadCacheEnv,
@@ -837,7 +841,11 @@ class NotebookKernelExecutor implements NotebookExecutor {
       const managedBin =
         kind === 'r' ? rScriptBin(prefix, this.platform) : pythonBin(prefix, this.platform)
       command = request.resolvedInterpreter?.command ?? managedBin
-      args = [...(request.resolvedInterpreter?.args ?? []), loopPath]
+      args = [
+        ...(request.resolvedInterpreter?.args ?? []),
+        ...(kind === 'r' && !request.resolvedInterpreter ? ['--vanilla'] : []),
+        loopPath
+      ]
     }
 
     // The semantic guard rejects known installers before dispatch. This native layer makes the
@@ -998,6 +1006,17 @@ class NotebookKernelExecutor implements NotebookExecutor {
     // requires Library\bin (BLAS/LAPACK and compiler runtimes), not just <prefix>\bin.
     if (rEnvPrefix) {
       env.PATH = condaActivatedPath(rEnvPrefix, process.env.PATH, this.platform)
+    }
+    if (kind !== 'repl' && !request.resolvedInterpreter) {
+      Object.assign(
+        env,
+        buildManagedRuntimeProcessEnvironment(request.runtimeRoot, {
+          language: kind,
+          prefix: rEnvPrefix,
+          platform: this.platform,
+          sourceEnv: env
+        })
+      )
     }
     return env
   }

--- a/src/main/notebook/micromamba-archive-store.test.ts
+++ b/src/main/notebook/micromamba-archive-store.test.ts
@@ -1,4 +1,7 @@
-import { createHash } from 'node:crypto'
+import crypto, { createHash } from 'node:crypto'
+import { renameSync, symlinkSync } from 'node:fs'
+import filesystem from 'node:fs/promises'
+import { syncBuiltinESMExports } from 'node:module'
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -24,10 +27,80 @@ const authorization = (
 })
 
 afterEach(async () => {
+  vi.restoreAllMocks()
+  syncBuiltinESMExports()
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
 describe('publishMicromambaArchives', () => {
+  it.skipIf(process.platform === 'win32')(
+    'rejects an archive replaced by a symlink after enumeration',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'os-archive-enumeration-race-'))
+      roots.push(root)
+      const working = join(root, 'working')
+      await mkdir(working)
+      const source = join(working, 'a.conda')
+      const outside = join(root, 'outside.conda')
+      await writeFile(source, 'trusted')
+      await writeFile(outside, 'trusted')
+      const expected = authorization('a.conda', 'trusted')
+      const original = filesystem.realpath
+      let replaced = false
+      vi.spyOn(filesystem, 'realpath').mockImplementation(async (path, ...args) => {
+        const result = await original(path, ...args)
+        if (path === source && !replaced) {
+          replaced = true
+          renameSync(source, `${source}.old`)
+          symlinkSync(outside, source)
+        }
+        return result
+      })
+      syncBuiltinESMExports()
+      await expect(
+        publishMicromambaArchives(join(root, 'runtime'), working, [expected])
+      ).rejects.toThrow()
+      expect(replaced).toBe(true)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'publishes the verified snapshot if the source is replaced when its digest completes',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'os-archive-copy-race-'))
+      roots.push(root)
+      const working = join(root, 'working')
+      await mkdir(working)
+      const source = join(working, 'a.conda')
+      const outside = join(root, 'outside.conda')
+      await writeFile(source, 'trusted')
+      await writeFile(outside, 'outside bytes must not be copied')
+      const expected = authorization('a.conda', 'trusted')
+      const original = crypto.createHash
+      let replaced = false
+      vi.spyOn(crypto, 'createHash').mockImplementation((...args) => {
+        const hash = original(...args)
+        const digest = hash.digest.bind(hash)
+        vi.spyOn(hash, 'digest').mockImplementation((encoding) => {
+          const result = digest(encoding)
+          if (!replaced) {
+            replaced = true
+            renameSync(source, `${source}.old`)
+            symlinkSync(outside, source)
+          }
+          return result
+        })
+        return hash
+      })
+      syncBuiltinESMExports()
+      await expect(
+        publishMicromambaArchives(join(root, 'runtime'), working, [expected])
+      ).resolves.toBe(1)
+      expect(replaced).toBe(true)
+      expect(await readFile(join(root, 'runtime', 'pkgs', 'a.conda'), 'utf8')).toBe('trusted')
+    }
+  )
+
   it.skipIf(process.platform === 'win32').each(['archive', 'directory'])(
     'does not publish an authorized archive reached through a %s symlink',
     async (linkType) => {

--- a/src/main/notebook/micromamba-archive-store.test.ts
+++ b/src/main/notebook/micromamba-archive-store.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -28,6 +28,58 @@ afterEach(async () => {
 })
 
 describe('publishMicromambaArchives', () => {
+  it.skipIf(process.platform === 'win32').each(['archive', 'directory'])(
+    'does not publish an authorized archive reached through a %s symlink',
+    async (linkType) => {
+      const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-untrusted-link-'))
+      roots.push(root)
+      const runtimeRoot = join(root, 'runtime')
+      const workingRoot = join(root, 'working')
+      const outside = join(root, 'outside')
+      const file = 'python-3.12-0.conda'
+      await mkdir(workingRoot)
+      await mkdir(outside)
+      await writeFile(join(outside, file), 'trusted archive')
+      if (linkType === 'archive') await symlink(join(outside, file), join(workingRoot, file))
+      else await symlink(outside, join(workingRoot, 'extracted-directory'))
+
+      await expect(
+        publishMicromambaArchives(runtimeRoot, workingRoot, [
+          authorization(file, 'trusted archive')
+        ])
+      ).rejects.toThrow(/authorized package archive is unavailable/)
+      await expect(readFile(join(runtimeRoot, 'pkgs', file))).rejects.toMatchObject({
+        code: 'ENOENT'
+      })
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'publishes verified archives alongside extracted Python and dylib symlinks',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-extracted-links-'))
+      roots.push(root)
+      const runtimeRoot = join(root, 'runtime')
+      const workingRoot = join(root, 'working')
+      const extracted = join(workingRoot, 'python-3.12-0')
+      await mkdir(join(extracted, 'bin'), { recursive: true })
+      await mkdir(join(extracted, 'lib'))
+      await writeFile(join(extracted, 'bin', 'python3.12'), 'extracted executable')
+      await symlink('python3.12', join(extracted, 'bin', 'python'))
+      await symlink('libpython3.12.dylib', join(extracted, 'lib', 'libpython.dylib'))
+      await writeFile(join(workingRoot, 'python-3.12-0.conda'), 'trusted archive')
+
+      await expect(
+        publishMicromambaArchives(runtimeRoot, workingRoot, [
+          authorization('python-3.12-0.conda', 'trusted archive')
+        ])
+      ).resolves.toBe(1)
+      expect(await readFile(join(runtimeRoot, 'pkgs', 'python-3.12-0.conda'), 'utf8')).toBe(
+        'trusted archive'
+      )
+    }
+  )
+
   it('derives archive authority from explicit locks and structured transaction results', () => {
     const md5 = createHash('md5').update('a').digest('hex')
     const sha256 = createHash('sha256').update('b').digest('hex')

--- a/src/main/notebook/micromamba-archive-store.ts
+++ b/src/main/notebook/micromamba-archive-store.ts
@@ -182,7 +182,10 @@ const archiveFiles = async (root: string, validateRoot?: () => boolean): Promise
       const path = join(dir, entry.name)
       const state = await lstat(path)
       if (state.isSymbolicLink()) {
-        throw new Error('Micromamba working cache contains an untrusted reparse entry.')
+        // Extracted Conda packages legitimately contain executable/library links.
+        // Never follow them or consider them archive sources, even if their names
+        // match an authorization; missing authorized archives still fail publication.
+        continue
       }
       const physical = await realpath(path)
       if (!isInsideOrEqual(physicalRoot, physical)) {

--- a/src/main/notebook/micromamba-archive-store.ts
+++ b/src/main/notebook/micromamba-archive-store.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { createReadStream } from 'node:fs'
-import { copyFile, lstat, mkdir, readdir, realpath, rename, rm, stat } from 'node:fs/promises'
+import { constants, createReadStream } from 'node:fs'
+import { lstat, mkdir, open, readdir, realpath, rename, rm, stat } from 'node:fs/promises'
 import { basename, isAbsolute, join, relative, sep } from 'node:path'
 
 import { withExclusiveCacheLock } from './pkgs-cache-lock'
@@ -150,8 +150,13 @@ const isInsideOrEqual = (root: string, candidate: string): boolean => {
   return nested === '' || (!isAbsolute(nested) && nested !== '..' && !nested.startsWith(`..${sep}`))
 }
 
-const archiveFiles = async (root: string, validateRoot?: () => boolean): Promise<string[]> => {
-  const files: string[] = []
+type ArchiveCandidate = { path: string; physical: string; dev: number; ino: number }
+
+const archiveFiles = async (
+  root: string,
+  validateRoot?: () => boolean
+): Promise<ArchiveCandidate[]> => {
+  const files: ArchiveCandidate[] = []
   if (validateRoot && !validateRoot()) {
     throw new Error('Micromamba working cache changed before archive traversal.')
   }
@@ -192,7 +197,9 @@ const archiveFiles = async (root: string, validateRoot?: () => boolean): Promise
         throw new Error('Micromamba working cache entry escaped its validated root.')
       }
       if (state.isDirectory()) await visit(path)
-      else if (state.isFile() && isPackageArchive(entry.name)) files.push(path)
+      else if (state.isFile() && isPackageArchive(entry.name)) {
+        files.push({ path, physical, dev: state.dev, ino: state.ino })
+      }
     }
   }
   await visit(root)
@@ -236,30 +243,73 @@ export const publishMicromambaArchives = async (
       throw new Error('Micromamba working cache failed recovery trust validation.')
     }
 
-    const sourcesByFile = new Map<string, string[]>()
+    const sourcesByFile = new Map<string, ArchiveCandidate[]>()
     for (const source of await archiveFiles(workingRoot, validateWorkingRoot)) {
-      const file = basename(source)
+      const file = basename(source.path)
       sourcesByFile.set(file, [...(sourcesByFile.get(file) ?? []), source])
     }
     let published = 0
     for (const [file, expected] of missing) {
       const destination = join(durableRoot, file)
-      let source: string | undefined
-      for (const candidate of sourcesByFile.get(file) ?? []) {
-        if (await matchesAuthorizations(candidate, expected)) {
-          source = candidate
-          break
-        }
-      }
-      if (!source) {
-        throw new Error(`authorized package archive is unavailable or failed verification: ${file}`)
-      }
-
+      let verified = false
       const temp = `${destination}.${process.pid}-${randomUUID()}.tmp`
       try {
-        await copyFile(source, temp)
-        if (!(await matchesAuthorizations(temp, expected))) {
-          throw new Error(`copied package archive failed verification: ${file}`)
+        for (const candidate of sourcesByFile.get(file) ?? []) {
+          const source = await open(
+            candidate.path,
+            constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+          )
+          try {
+            const identity = await source.stat()
+            const current = await lstat(candidate.path)
+            if (
+              !identity.isFile() ||
+              current.isSymbolicLink() ||
+              identity.dev !== candidate.dev ||
+              identity.ino !== candidate.ino ||
+              current.dev !== identity.dev ||
+              current.ino !== identity.ino ||
+              (await realpath(candidate.path)) !== candidate.physical ||
+              (validateWorkingRoot && !validateWorkingRoot())
+            ) {
+              throw new Error('Micromamba archive identity changed before publication.')
+            }
+            // Snapshot and hash the same descriptor: a later path replacement cannot
+            // redirect either the bytes we verify or the bytes we publish.
+            const snapshot = await open(temp, 'wx', 0o600)
+            try {
+              const hashes = expected.map(({ algorithm }) => createHash(algorithm))
+              for await (const chunk of source.createReadStream({ autoClose: false })) {
+                const bytes = chunk as Buffer
+                hashes.forEach((hash) => hash.update(bytes))
+                let offset = 0
+                while (offset < bytes.length) {
+                  const { bytesWritten } = await snapshot.write(
+                    bytes,
+                    offset,
+                    bytes.length - offset
+                  )
+                  if (bytesWritten === 0)
+                    throw new Error('Micromamba archive snapshot write made no progress.')
+                  offset += bytesWritten
+                }
+              }
+              verified = hashes.every(
+                (hash, index) => hash.digest('hex') === expected[index].digest
+              )
+            } finally {
+              await snapshot.close()
+            }
+          } finally {
+            await source.close()
+          }
+          if (verified) break
+          await rm(temp, { force: true })
+        }
+        if (!verified) {
+          throw new Error(
+            `authorized package archive is unavailable or failed verification: ${file}`
+          )
         }
         await rename(temp, destination)
         published += 1

--- a/src/main/notebook/micromamba.test.ts
+++ b/src/main/notebook/micromamba.test.ts
@@ -316,17 +316,42 @@ describe('micromambaSpawnEnv', () => {
       CURL_CA_BUNDLE: '/ca.pem'
     })
     expect(env.conda_prefix).toBeUndefined()
-    expect(env.MAMBA_ROOT_PREFIX).toBeUndefined()
+    expect(env.MAMBA_ROOT_PREFIX).toBe('D:\\OpenScience\\runtime')
   })
 
-  it.each(['darwin', 'linux'] as const)('pins the managed package cache on %s', (platform) => {
-    const env = micromambaSpawnEnv('/runtime', '/ca.pem', {
-      platform,
-      env: { CONDA_PKGS_DIRS: '/existing', MAMBA_ROOT_PREFIX: '/existing-root' }
-    })
+  it.each(['darwin', 'linux', 'win32'] as const)(
+    'confines all managed Micromamba state to the runtime on %s',
+    (platform) => {
+      const root = platform === 'win32' ? 'D:\\OpenScience\\runtime' : '/runtime'
+      const runtimePath = platform === 'win32' ? win32 : { join }
+      const cache = runtimePath.join(root, 'pkgs')
+      const home = runtimePath.join(root, 'home')
+      const env = micromambaSpawnEnv(root, '/ca.pem', {
+        platform,
+        env: {
+          HOME: '/host-home',
+          USERPROFILE: 'C:\\Users\\host-user',
+          CONDA_PKGS_DIRS: '/existing',
+          CONDA_ENVS_PATH: '/existing-envs',
+          MAMBA_ROOT_PREFIX: '/existing-root',
+          R_USER: '/host-r-user',
+          R_LIBS: '/host-r-libs',
+          R_LIBS_USER: '/host-r-user-library',
+          R_LIBS_SITE: '/host-r-site-library'
+        },
+        selectCache: () => ({ path: cache, lockKey: cache.toLowerCase() })
+      })
 
-    expect(env.CONDA_PKGS_DIRS).toBe('/runtime/pkgs')
-    expect(env.MAMBA_ROOT_PREFIX).toBe('/existing-root')
-    expect(env.CONDA_SSL_VERIFY).toBe('/ca.pem')
-  })
+      expect(env.HOME).toBe(home)
+      expect(env.USERPROFILE).toBe(home)
+      expect(env.MAMBA_ROOT_PREFIX).toBe(root)
+      expect(env.CONDA_PKGS_DIRS).toBe(cache)
+      expect(env.CONDA_ENVS_PATH).toBe(runtimePath.join(root, 'envs'))
+      expect(env.CONDA_SSL_VERIFY).toBe('/ca.pem')
+      expect(env.R_USER).toBeUndefined()
+      expect(env.R_LIBS).toBeUndefined()
+      expect(env.R_LIBS_USER).toBeUndefined()
+      expect(env.R_LIBS_SITE).toBeUndefined()
+    }
+  )
 })

--- a/src/main/notebook/micromamba.ts
+++ b/src/main/notebook/micromamba.ts
@@ -171,7 +171,7 @@ export const micromambaSpawnEnv = (
   // package cache or registering the managed prefix in ~/.conda/environments.txt.
   const cleaned = sanitizeManagedRuntimeHostState(
     Object.fromEntries(Object.entries(inherited).filter(([key]) => !/^(CONDA|MAMBA)_/i.test(key))),
-    true
+    'all'
   )
   return {
     ...cleaned,

--- a/src/main/notebook/micromamba.ts
+++ b/src/main/notebook/micromamba.ts
@@ -1,7 +1,11 @@
 import { statSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, posix, win32 } from 'node:path'
 
 import { PROD_SESSION_DIR_NAME } from '../session-persistence/paths'
+import {
+  buildManagedRuntimeProcessEnvironment,
+  sanitizeManagedRuntimeHostState
+} from './process-environment'
 import {
   DEFAULT_MAX_CACHE_RELATIVE_PATH,
   selectMicromambaCache,
@@ -157,19 +161,25 @@ export const micromambaSpawnEnv = (
   const selected = deps.selectCache
     ? deps.selectCache(root, maxCacheRelativePath)
     : selectMicromambaCache(root, maxCacheRelativePath, deps)
-  // Pin every platform to the cache covered by our locks and filesystem grant. Otherwise libmamba
-  // also probes its user-home cache, which is deliberately inaccessible inside the Notebook sandbox.
-  if (platform !== 'win32') {
-    return { ...inherited, ...caBundleEnv(caBundle), CONDA_PKGS_DIRS: selected.path }
-  }
-
-  const cleaned = Object.fromEntries(
-    Object.entries(inherited).filter(([key]) => !/^(CONDA|MAMBA)_/i.test(key))
+  const platformPath = platform === 'win32' ? win32 : posix
+  const managedUserEnv = buildManagedRuntimeProcessEnvironment(root, {
+    platform,
+    sourceEnv: {}
+  })
+  // Keep every Micromamba discovery and state path beneath the app runtime. `--no-rc` prevents rc
+  // configuration, while these variables also prevent libmamba from probing the host's ~/.mamba
+  // package cache or registering the managed prefix in ~/.conda/environments.txt.
+  const cleaned = sanitizeManagedRuntimeHostState(
+    Object.fromEntries(Object.entries(inherited).filter(([key]) => !/^(CONDA|MAMBA)_/i.test(key))),
+    true
   )
   return {
     ...cleaned,
     ...caBundleEnv(caBundle),
-    CONDA_PKGS_DIRS: selected.path
+    ...managedUserEnv,
+    MAMBA_ROOT_PREFIX: root,
+    CONDA_PKGS_DIRS: selected.path,
+    CONDA_ENVS_PATH: platformPath.join(root, 'envs')
   }
 }
 

--- a/src/main/notebook/mirror-probe.test.ts
+++ b/src/main/notebook/mirror-probe.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { netFetchStandard } from '../skills/net-fetch'
+
 import {
   DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
   buildNotebookNetworkPolicy,
@@ -13,24 +15,29 @@ import {
   resetAutoMirrorCache
 } from './mirror-probe'
 
+vi.mock('../skills/net-fetch', () => ({ netFetchStandard: vi.fn() }))
+
 const candidates: MirrorCandidate[] = [
   {
     name: 'public',
     mirror: {},
     probeUrl: 'https://public/conda-forge/repodata.json',
-    biocondaProbeUrl: 'https://public/bioconda/repodata.json'
+    biocondaProbeUrl: 'https://public/bioconda/repodata.json',
+    trustedDomains: ['public']
   },
   {
     name: 'tuna',
     mirror: { condaChannel: 'https://tuna/conda-forge/', pypiIndex: 'https://tuna/pypi' },
     probeUrl: 'https://tuna/conda-forge/repodata.json',
-    biocondaProbeUrl: 'https://tuna/bioconda/repodata.json'
+    biocondaProbeUrl: 'https://tuna/bioconda/repodata.json',
+    trustedDomains: ['tuna']
   },
   {
     name: 'aliyun',
     mirror: { condaChannel: 'https://aliyun/conda-forge/' },
     probeUrl: 'https://aliyun/conda-forge/repodata.json',
-    biocondaProbeUrl: 'https://aliyun/bioconda/repodata.json'
+    biocondaProbeUrl: 'https://aliyun/bioconda/repodata.json',
+    trustedDomains: ['aliyun']
   }
 ]
 
@@ -59,6 +66,7 @@ describe('pickFastestMirror', () => {
     const policy = buildNotebookNetworkPolicy(DEFAULT_NOTEBOOK_NETWORK_SETTINGS)
     const automaticMirrorHosts = MIRROR_CANDIDATES.flatMap((candidate) =>
       [
+        ...candidate.trustedDomains,
         candidate.probeUrl,
         candidate.biocondaProbeUrl,
         candidate.mirror.condaChannel,
@@ -66,7 +74,7 @@ describe('pickFastestMirror', () => {
         candidate.mirror.cranMirror
       ]
         .filter((url): url is string => Boolean(url))
-        .map((url) => new URL(url).hostname)
+        .map((url) => (url.includes('://') ? new URL(url).hostname : url))
     )
 
     expect(
@@ -75,6 +83,20 @@ describe('pickFastestMirror', () => {
           !policy.allowedDomains.some((pattern) => domainPatternMatches(pattern, hostname))
       )
     ).toEqual([])
+    expect(
+      MIRROR_CANDIDATES.every((candidate) => candidate.probeUrl.endsWith('current_repodata.json'))
+    ).toBe(true)
+    expect(
+      MIRROR_CANDIDATES.every((candidate) =>
+        candidate.biocondaProbeUrl.endsWith('current_repodata.json')
+      )
+    ).toBe(true)
+    expect(
+      MIRROR_CANDIDATES.find((candidate) => candidate.name === 'ustc')?.trustedDomains
+    ).toContain('mirrors.nju.edu.cn')
+    expect(
+      policy.allowedDomains.some((pattern) => domainPatternMatches(pattern, 'redirect.invalid'))
+    ).toBe(false)
   })
 
   it('returns the fastest candidate whose conda-forge and bioconda channels respond', async () => {
@@ -86,6 +108,50 @@ describe('pickFastestMirror', () => {
       condaChannel: 'https://tuna/conda-forge/',
       pypiIndex: 'https://tuna/pypi'
     })
+  })
+
+  it('accepts the USTC to NJU redirect only when NJU is explicitly trusted', async () => {
+    const ustc = {
+      name: 'ustc',
+      mirror: { condaChannel: 'https://mirrors.ustc.edu.cn/anaconda/cloud/conda-forge/' },
+      probeUrl:
+        'https://mirrors.ustc.edu.cn/anaconda/cloud/conda-forge/noarch/current_repodata.json',
+      biocondaProbeUrl:
+        'https://mirrors.ustc.edu.cn/anaconda/cloud/bioconda/noarch/current_repodata.json',
+      trustedDomains: ['mirrors.ustc.edu.cn']
+    }
+    const official = {
+      name: 'public',
+      mirror: { condaChannel: 'https://conda.anaconda.org/conda-forge/' },
+      probeUrl: 'https://conda.anaconda.org/conda-forge/noarch/current_repodata.json',
+      biocondaProbeUrl: 'https://conda.anaconda.org/bioconda/noarch/current_repodata.json',
+      trustedDomains: ['conda.anaconda.org']
+    }
+    vi.mocked(netFetchStandard).mockImplementation(async (url) => {
+      const requested = String(url)
+      const finalUrl = requested.includes('mirrors.ustc.edu.cn')
+        ? requested.replace('mirrors.ustc.edu.cn', 'mirrors.nju.edu.cn')
+        : requested
+      return { ok: true, status: 200, url: finalUrl } as Response
+    })
+
+    await expect(pickFastestMirror({ candidates: [ustc, official] })).resolves.toEqual(
+      official.mirror
+    )
+    await expect(
+      pickFastestMirror({
+        candidates: [
+          { ...ustc, trustedDomains: [...ustc.trustedDomains, 'mirrors.nju.edu.cn'] },
+          official
+        ]
+      })
+    ).resolves.toEqual(ustc.mirror)
+    expect(vi.mocked(netFetchStandard).mock.calls.map(([url]) => String(url))).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('/conda-forge/noarch/current_repodata.json'),
+        expect.stringContaining('/bioconda/noarch/current_repodata.json')
+      ])
+    )
   })
 
   it('skips a candidate when its bioconda channel is unreachable', async () => {

--- a/src/main/notebook/mirror-probe.test.ts
+++ b/src/main/notebook/mirror-probe.test.ts
@@ -226,7 +226,7 @@ describe('effectiveMirrorAsync', () => {
     expect(result.condaChannel).toBe('https://tuna/conda-forge/')
   })
 
-  it('falls back to the locale default when no complete channel pair responds', async () => {
+  it('falls back to public indexes instead of reviving a rejected locale mirror', async () => {
     const result = await effectiveMirrorAsync(undefined, 'zh-CN', {
       candidates,
       probe: probeFrom({
@@ -235,8 +235,26 @@ describe('effectiveMirrorAsync', () => {
         'https://aliyun/conda-forge/repodata.json': 120
       })
     })
-    // No candidate has a reachable bioconda channel -> zh-CN locale default (TUNA).
-    expect(result.condaChannel).toContain('tuna')
+    expect(result).toEqual({})
+  })
+
+  it('retries automatic selection after a transient probe failure', async () => {
+    await expect(
+      effectiveMirrorAsync(undefined, 'zh-CN', {
+        candidates,
+        probe: probeFrom({})
+      })
+    ).resolves.toEqual({})
+
+    await expect(
+      effectiveMirrorAsync(undefined, 'zh-CN', {
+        candidates,
+        probe: probeFrom(reachableLatencies)
+      })
+    ).resolves.toEqual({
+      condaChannel: 'https://tuna/conda-forge/',
+      pypiIndex: 'https://tuna/pypi'
+    })
   })
 
   it('preserves a caBundle-only config while still using the fastest-probed channel', async () => {

--- a/src/main/notebook/mirror-probe.ts
+++ b/src/main/notebook/mirror-probe.ts
@@ -13,15 +13,23 @@ export const MIRROR_CANDIDATES = AUTOMATIC_PACKAGE_MIRROR_CANDIDATES
 
 // Measures one URL's latency (ms), rejecting on error/timeout. Injectable so the selection logic is
 // testable without network.
-export type LatencyProbe = (url: string, timeoutMs: number) => Promise<number>
+export type LatencyProbe = (
+  url: string,
+  timeoutMs: number,
+  trustedDomains: readonly string[]
+) => Promise<number>
 
-const defaultProbe: LatencyProbe = async (url, timeoutMs) => {
+const defaultProbe: LatencyProbe = async (url, timeoutMs, trustedDomains) => {
   const started = Date.now()
   const res = await netFetchStandard(url, {
     method: 'HEAD',
     signal: AbortSignal.timeout(timeoutMs)
   })
   if (!res.ok) throw new Error(`probe failed ${res.status}`)
+  const finalHostname = new URL(res.url || url).hostname.toLowerCase()
+  if (!trustedDomains.some((domain) => domain.toLowerCase() === finalHostname)) {
+    throw new Error(`probe redirected to untrusted host ${finalHostname}`)
+  }
   return Date.now() - started
 }
 
@@ -45,8 +53,8 @@ export const pickFastestMirror = async (
     candidates.map(async (candidate) => {
       try {
         const [condaMs, biocondaMs] = await Promise.all([
-          probe(candidate.probeUrl, timeoutMs),
-          probe(candidate.biocondaProbeUrl, timeoutMs)
+          probe(candidate.probeUrl, timeoutMs, candidate.trustedDomains),
+          probe(candidate.biocondaProbeUrl, timeoutMs, candidate.trustedDomains)
         ])
         return { candidate, ms: Math.max(condaMs, biocondaMs) }
       } catch {

--- a/src/main/notebook/mirror-probe.ts
+++ b/src/main/notebook/mirror-probe.ts
@@ -4,7 +4,6 @@ import {
   type PackageMirror
 } from '../../shared/mirror'
 import { netFetchStandard } from '../skills/net-fetch'
-import { effectiveMirror } from './mirror'
 
 // A candidate mirror bundle + cheap URLs to measure both required conda channels. Public endpoints
 // only (no secrets). The repodata URLs are HEAD-ed so no body is downloaded.
@@ -41,7 +40,7 @@ export type ProbeDeps = {
 
 // Probes every candidate's conda-forge and bioconda channels in parallel. A candidate is reachable only
 // when both respond; its score is the slower response because both channels are required for installs.
-// Returns undefined when no complete candidate responds (caller then falls back to the locale default).
+// Returns undefined when no complete candidate responds (caller then uses the public indexes).
 export const pickFastestMirror = async (
   deps: ProbeDeps = {}
 ): Promise<PackageMirror | undefined> => {
@@ -70,33 +69,44 @@ export const pickFastestMirror = async (
   return { ...reachable[0].candidate.mirror }
 }
 
-// Memoized once-per-process probe: the winning mirror is measured on first need and reused, so an
-// install/provision never re-probes. Reset between tests via resetAutoMirrorCache.
+// Memoize a successful once-per-process probe while still coalescing concurrent attempts. A failed
+// attempt is not sticky: startup can race network readiness, so the next install must be able to
+// probe again after connectivity recovers. Reset between tests via resetAutoMirrorCache.
 let cached: Promise<PackageMirror | undefined> | undefined
 export const resetAutoMirrorCache = (): void => {
   cached = undefined
 }
 const resolveAutoMirror = (deps?: ProbeDeps): Promise<PackageMirror | undefined> => {
-  if (!cached) cached = pickFastestMirror(deps)
+  if (!cached) {
+    const attempt = pickFastestMirror(deps)
+    cached = attempt
+    void attempt.then(
+      (result) => {
+        if (result === undefined && cached === attempt) cached = undefined
+      },
+      () => {
+        if (cached === attempt) cached = undefined
+      }
+    )
+  }
   return cached
 }
 
 // Effective mirror WITH the speed probe: a user-configured override always wins (no probe); otherwise
-// use the fastest-probed mirror; if the probe finds nothing reachable, fall back to the sync locale
-// default (effectiveMirror). Kept separate from the sync effectiveMirror so non-probing callers and
-// existing tests are unaffected.
+// use the fastest-probed mirror; if the probe finds nothing reachable, use the public indexes rather
+// than reviving a locale mirror that the probe just rejected.
 export const effectiveMirrorAsync = async (
   configured: PackageMirror | undefined,
-  locale: string,
+  _locale: string,
   deps?: ProbeDeps
 ): Promise<PackageMirror> => {
   const hasAny =
     configured && (configured.condaChannel || configured.pypiIndex || configured.cranMirror)
   // Configured channel override already carries any caBundle it was given.
   if (hasAny) return configured!
-  // Otherwise use the probed/locale mirror, but always preserve a configured caBundle (e.g. a
+  // Otherwise use the probed/public mirror, but always preserve a configured caBundle (e.g. a
   // caBundle-only config behind an enterprise TLS proxy still gets the fastest-probed channel).
   const probed = await resolveAutoMirror(deps)
-  const base = probed ?? effectiveMirror(undefined, locale)
+  const base = probed ?? {}
   return configured?.caBundle ? { ...base, caBundle: configured.caBundle } : base
 }

--- a/src/main/notebook/mirror.ts
+++ b/src/main/notebook/mirror.ts
@@ -2,8 +2,8 @@ import { CURATED_MIRRORS, type PackageMirror } from '../../shared/mirror'
 
 export { CURATED_MIRRORS, MIRROR_HELP_URL } from '../../shared/mirror'
 
-// Cheap locale heuristic: a Chinese locale gets the CN mirror default; everyone else uses public
-// hosts (empty overrides). A more precise speed-based pick is future work (spec §9, §16).
+// Cheap synchronous locale fallback for call sites that cannot use the asynchronous speed probe: a
+// Chinese locale gets the CN mirror default; everyone else uses public hosts (empty overrides).
 const isCnLocale = (locale: string): boolean => /^zh\b/i.test(locale) || /-CN$/i.test(locale)
 
 export function resolveMirror(locale: string): PackageMirror {

--- a/src/main/notebook/package-cache-sandbox.integration.test.ts
+++ b/src/main/notebook/package-cache-sandbox.integration.test.ts
@@ -1,17 +1,519 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import filesystem from 'node:fs'
+import { syncBuiltinESMExports } from 'node:module'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-import { expect, it } from 'vitest'
+import { expect, it, vi } from 'vitest'
 
-import { installPackages } from './package-manager'
+import { DEFAULT_NOTEBOOK_NETWORK_SETTINGS } from '../../shared/notebook-network'
+import { defaultSpawn, installPackages, type InstallSpawn } from './package-manager'
+import { micromambaSpawnEnv, resolveMicromamba } from './micromamba'
+import { NotebookNetworkSandboxOwner } from './network-sandbox-owner'
 import { sandboxedPackageSpawn } from './package-process-sandbox'
+import { createProductionProvisioner } from './provisioner'
+import { envPrefix, rLibraryDir, rScriptBin, runtimeRoot } from './runtime-paths'
 
 // Use an already staged binary; this check never downloads tools or packages.
-const micromamba = resolve(
-  process.env.OPEN_SCIENCE_TEST_MICROMAMBA ?? `resources/bin/mac/${process.arch}/micromamba`
+const micromamba = resolveMicromamba() ?? ''
+
+it.skipIf(process.platform !== 'darwin')(
+  'supports a configured storage root reached through a symlink',
+  async () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), 'os-cache-storage-link-')))
+    const physicalStorage = join(directory, 'physical-storage')
+    const storageRoot = join(directory, 'storage-link')
+    mkdirSync(physicalStorage)
+    symlinkSync(physicalStorage, storageRoot)
+    const managedRoot = runtimeRoot(storageRoot)
+    const spawn = sandboxedPackageSpawn({
+      request: { language: 'python', packages: ['example'] },
+      runtimeRoot: managedRoot,
+      storageRoot,
+      processSandbox: {
+        wrap: async (invocation) => ({
+          executable: invocation.executable,
+          args: invocation.args,
+          env: invocation.env,
+          annotateStderr: (stderr) => stderr,
+          cleanup: () => {}
+        })
+      }
+    })
+    try {
+      const result = await spawn('/usr/bin/true', [], {
+        CONDA_PKGS_DIRS: join(managedRoot, 'pkgs')
+      })
+      expect(result.code).toBe(0)
+      expect(statSync(join(runtimeRoot(physicalStorage), 'pkgs', 'cache')).mode & 0o2000).toBe(0)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  }
+)
+
+it.skipIf(process.platform !== 'darwin').each(['opened', 'validated'])(
+  'fails closed if the repodata cache is replaced after its descriptor is %s',
+  async (replacementPoint) => {
+    const storageRoot = realpathSync(mkdtempSync(join(tmpdir(), 'os-cache-replaced-')))
+    const managedRoot = runtimeRoot(storageRoot)
+    const packageRoot = join(managedRoot, 'pkgs')
+    const cache = join(packageRoot, 'cache')
+    const outside = join(storageRoot, 'outside')
+    mkdirSync(cache, { recursive: true })
+    mkdirSync(outside)
+    chmodSync(cache, 0o2775)
+    chmodSync(outside, 0o2775)
+    const originalFstat = filesystem.fstatSync
+    const originalFchmod = filesystem.fchmodSync
+    const replaceCache = (): void => {
+      renameSync(cache, join(packageRoot, 'previous-cache'))
+      symlinkSync(outside, cache)
+    }
+    const observed =
+      replacementPoint === 'opened'
+        ? vi.spyOn(filesystem, 'fstatSync').mockImplementationOnce((fd) => {
+            const state = originalFstat(fd)
+            replaceCache()
+            return state
+          })
+        : vi.spyOn(filesystem, 'fchmodSync').mockImplementationOnce((fd, mode) => {
+            replaceCache()
+            originalFchmod(fd, mode)
+          })
+    syncBuiltinESMExports()
+    const spawn = sandboxedPackageSpawn({
+      request: { language: 'python', packages: ['example'] },
+      runtimeRoot: managedRoot,
+      storageRoot,
+      processSandbox: {
+        wrap: async () => {
+          throw new Error('must reject before sandbox launch')
+        }
+      }
+    })
+    try {
+      await expect(spawn('/usr/bin/true', [], { CONDA_PKGS_DIRS: packageRoot })).rejects.toThrow(
+        /not a trusted directory|changed during preparation/
+      )
+      expect(statSync(outside).mode & 0o2000).toBe(0o2000)
+    } finally {
+      observed.mockRestore()
+      syncBuiltinESMExports()
+      rmSync(storageRoot, { recursive: true, force: true })
+    }
+  }
+)
+
+it.skipIf(process.platform !== 'darwin').each(['parent', 'cache'])(
+  'rejects a %s symlink before changing any external Micromamba cache',
+  async (linkLocation) => {
+    const storageRoot = realpathSync(mkdtempSync(join(tmpdir(), 'os-cache-symlink-')))
+    const managedRoot = runtimeRoot(storageRoot)
+    const packageRoot = join(managedRoot, 'pkgs')
+    const outside = join(storageRoot, 'outside')
+    mkdirSync(managedRoot, { recursive: true })
+    mkdirSync(outside)
+    chmodSync(outside, 0o2775)
+    if (linkLocation === 'parent') symlinkSync(outside, packageRoot)
+    else {
+      mkdirSync(packageRoot)
+      symlinkSync(outside, join(packageRoot, 'cache'))
+    }
+    const spawn = sandboxedPackageSpawn({
+      request: { language: 'python', packages: ['example'] },
+      runtimeRoot: managedRoot,
+      storageRoot,
+      processSandbox: {
+        wrap: async () => {
+          throw new Error('must reject before sandbox launch')
+        }
+      }
+    })
+    try {
+      await expect(spawn('/usr/bin/true', [], { CONDA_PKGS_DIRS: packageRoot })).rejects.toThrow()
+      expect(statSync(outside).mode & 0o2000).toBe(0o2000)
+      expect(existsSync(join(outside, 'cache'))).toBe(false)
+    } finally {
+      rmSync(storageRoot, { recursive: true, force: true })
+    }
+  }
+)
+
+it.skipIf(process.platform !== 'darwin' || !existsSync(micromamba)).each(['fresh', 'setgid'])(
+  'lets real Micromamba write its %s managed repodata cache through the production sandbox owner',
+  async (cacheState) => {
+    const storageRoot = realpathSync(mkdtempSync(join(tmpdir(), 'os-real-package-sandbox-')))
+    const managedRoot = runtimeRoot(storageRoot)
+    const prefix = envPrefix(managedRoot, 'analysis')
+    const channel = join(storageRoot, 'channel')
+    const repodataCache = join(managedRoot, 'pkgs', 'cache')
+    if (cacheState === 'setgid') {
+      mkdirSync(repodataCache, { recursive: true })
+      chmodSync(repodataCache, 0o2775)
+    }
+    writeOfflineChannel(channel, ['python', 'pip'])
+    const owner = new NotebookNetworkSandboxOwner({
+      resourceRoot: join(process.cwd(), 'packages', 'notebook-network-sandbox', 'vendor'),
+      getSettings: async () => DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+      persistAlwaysAllow: async () => DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+      requestDecision: async () => 'deny'
+    })
+    const spawn = sandboxedPackageSpawn({
+      request: {
+        language: 'python',
+        packages: ['python'],
+        projectId: 'project',
+        sessionId: 'session',
+        workspaceCwd: storageRoot
+      },
+      runtimeRoot: managedRoot,
+      storageRoot,
+      processSandbox: {
+        wrap: (invocation) => {
+          expect(existsSync(repodataCache)).toBe(true)
+          expect(statSync(repodataCache).mode & 0o2000).toBe(0)
+          return owner.wrap(invocation)
+        }
+      }
+    })
+
+    try {
+      const result = await spawn(
+        micromamba,
+        [
+          '--no-rc',
+          'create',
+          '--root-prefix',
+          managedRoot,
+          '--prefix',
+          prefix,
+          '-y',
+          '-c',
+          pathToFileURL(channel).href,
+          'python',
+          '--offline',
+          '--dry-run'
+        ],
+        micromambaSpawnEnv(managedRoot)
+      )
+
+      expect(result.code, result.stderr).toBe(0)
+      expect(statSync(repodataCache).mode & 0o2000).toBe(0)
+    } finally {
+      await owner.dispose()
+      rmSync(storageRoot, { recursive: true, force: true })
+    }
+  }
+)
+
+const writeOfflineChannel = (root: string, packageNames: readonly string[]): void => {
+  for (const subdir of ['noarch', process.arch === 'arm64' ? 'osx-arm64' : 'osx-64']) {
+    const channel = join(root, subdir)
+    mkdirSync(channel, { recursive: true })
+    writeFileSync(
+      join(channel, 'repodata.json'),
+      JSON.stringify({
+        info: { subdir },
+        packages:
+          subdir === 'noarch'
+            ? Object.fromEntries(
+                packageNames.map((name) => [
+                  `${name}-1.0-0.tar.bz2`,
+                  {
+                    name,
+                    version: name === 'python' ? '3.12' : '1.0',
+                    build: '0',
+                    build_number: 0,
+                    depends: [],
+                    subdir,
+                    noarch: 'generic',
+                    size: 1,
+                    sha256: '0'.repeat(64)
+                  }
+                ])
+              )
+            : {},
+        'packages.conda': {},
+        repodata_version: 1
+      })
+    )
+  }
+}
+
+it.skipIf(process.platform !== 'darwin' || !existsSync(micromamba))(
+  'installs a real package into a managed environment through the production sandbox owner',
+  async () => {
+    const storageRoot = realpathSync(mkdtempSync(join(tmpdir(), 'os-real-conda-install-')))
+    const managedRoot = runtimeRoot(storageRoot)
+    const prefix = envPrefix(managedRoot, 'default-python')
+    const channel = join(storageRoot, 'channel')
+    const source = join(storageRoot, 'package-source')
+    const owner = new NotebookNetworkSandboxOwner({
+      resourceRoot: join(process.cwd(), 'packages', 'notebook-network-sandbox', 'vendor'),
+      getSettings: async () => DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+      persistAlwaysAllow: async () => DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+      requestDecision: async () => 'deny'
+    })
+    try {
+      mkdirSync(join(prefix, 'conda-meta'), { recursive: true })
+      writeFileSync(join(prefix, 'conda-meta', 'history'), '')
+      mkdirSync(join(source, 'info'), { recursive: true })
+      mkdirSync(join(source, 'share'))
+      writeFileSync(join(source, 'share', 'sandbox-proof.txt'), 'installed by real Micromamba\n')
+      const metadata = {
+        name: 'sandbox-proof',
+        version: '1.0',
+        build: '0',
+        build_number: 0,
+        depends: [],
+        subdir: 'noarch',
+        noarch: 'generic'
+      }
+      writeFileSync(join(source, 'info', 'index.json'), JSON.stringify(metadata))
+      writeFileSync(join(source, 'info', 'files'), 'share/sandbox-proof.txt\n')
+      writeOfflineChannel(channel, [])
+      const filename = 'sandbox-proof-1.0-0.tar.bz2'
+      const archive = join(channel, 'noarch', filename)
+      const packed = spawnSync('/usr/bin/tar', ['-cjf', archive, '-C', source, 'info', 'share'], {
+        encoding: 'utf8'
+      })
+      expect(packed.status, packed.stderr).toBe(0)
+      const bytes = readFileSync(archive)
+      writeFileSync(
+        join(channel, 'noarch', 'repodata.json'),
+        JSON.stringify({
+          info: { subdir: 'noarch' },
+          packages: {
+            [filename]: {
+              ...metadata,
+              size: bytes.length,
+              sha256: createHash('sha256').update(bytes).digest('hex')
+            }
+          },
+          'packages.conda': {},
+          repodata_version: 1
+        })
+      )
+      const request = {
+        language: 'python' as const,
+        packages: ['sandbox-proof'],
+        workspaceCwd: storageRoot
+      }
+      const result = await installPackages(request, {
+        storageRoot,
+        micromamba,
+        condaChannel: pathToFileURL(channel).href,
+        spawn: sandboxedPackageSpawn({
+          request,
+          runtimeRoot: managedRoot,
+          storageRoot,
+          processSandbox: owner
+        })
+      })
+      expect(result.ok, result.log).toBe(true)
+      expect(result.method).toBe('conda')
+      expect(readFileSync(join(prefix, 'share', 'sandbox-proof.txt'), 'utf8')).toBe(
+        'installed by real Micromamba\n'
+      )
+    } finally {
+      await owner.dispose()
+      rmSync(storageRoot, { recursive: true, force: true })
+    }
+  },
+  60_000
+)
+
+it.skipIf(process.platform === 'win32')(
+  'keeps a managed pip process isolated from packages in the real user site directory',
+  async () => {
+    const storageRoot = realpathSync(mkdtempSync(join(tmpdir(), 'os-pip-user-site-')))
+    const home = join(storageRoot, 'user-home')
+    const prefix = envPrefix(runtimeRoot(storageRoot), 'default-python')
+    const pip = join(prefix, 'bin', 'pip')
+    try {
+      mkdirSync(home, { recursive: true })
+      const discovered = spawnSync(
+        '/usr/bin/python3',
+        ['-c', 'import site; print(site.getusersitepackages())'],
+        { encoding: 'utf8', env: { PATH: '/usr/bin:/bin', HOME: home } }
+      )
+      expect(discovered.status, discovered.stderr).toBe(0)
+      const userSite = discovered.stdout.trim()
+      mkdirSync(userSite, { recursive: true })
+      writeFileSync(join(userSite, 'open_science_user_site_sentinel.py'), 'VALUE = "private"\n')
+      mkdirSync(join(prefix, 'bin'), { recursive: true })
+      writeFileSync(
+        pip,
+        [
+          '#!/bin/sh',
+          `/usr/bin/python3 -c 'import open_science_user_site_sentinel' >/dev/null 2>&1`,
+          'test $? -ne 0'
+        ].join('\n') + '\n'
+      )
+      chmodSync(pip, 0o755)
+
+      const spawn = sandboxedPackageSpawn({
+        request: { language: 'python', packages: ['example'], usePip: true },
+        runtimeRoot: runtimeRoot(storageRoot),
+        storageRoot,
+        processSandbox: {
+          wrap: async (invocation) => ({
+            executable: invocation.executable,
+            args: invocation.args,
+            env: invocation.env,
+            annotateStderr: (stderr) => stderr,
+            cleanup: () => {}
+          })
+        }
+      })
+      const result = await installPackages(
+        { language: 'python', packages: ['example'], usePip: true },
+        {
+          storageRoot,
+          spawn: (command, args, env, ...rest) =>
+            spawn(command, args, { ...env, HOME: home }, ...rest)
+        }
+      )
+
+      expect(result.ok, result.log).toBe(true)
+    } finally {
+      rmSync(storageRoot, { recursive: true, force: true })
+    }
+  }
+)
+
+it.skipIf(process.platform === 'win32')(
+  'isolates every managed R installer from user startup files and libraries',
+  async () => {
+    const storageRoot = realpathSync(mkdtempSync(join(tmpdir(), 'os-r-user-config-')))
+    const managedRoot = runtimeRoot(storageRoot)
+    const environment = 'analysis'
+    const prefix = envPrefix(managedRoot, environment)
+    const managedHome = join(managedRoot, 'home')
+    const managedLibrary = rLibraryDir(prefix)
+    const hostHome = join(storageRoot, 'host-home')
+    const hostLibrary = join(hostHome, 'R', 'library')
+    const executable = rScriptBin(prefix)
+    const fakeMicromamba = '/managed/micromamba'
+    const inheritedKeys = ['HOME', 'R_USER', 'R_LIBS_USER'] as const
+    const inherited = Object.fromEntries(inheritedKeys.map((key) => [key, process.env[key]]))
+    try {
+      mkdirSync(join(prefix, 'bin'), { recursive: true })
+      mkdirSync(hostLibrary, { recursive: true })
+      writeFileSync(join(hostHome, '.Rprofile'), 'stop("host .Rprofile loaded")\n')
+      writeFileSync(join(hostHome, '.Renviron'), 'OPEN_SCIENCE_HOST_RENVIRON=loaded\n')
+      writeFileSync(join(hostLibrary, 'host-package'), 'private\n')
+      writeFileSync(
+        executable,
+        [
+          `#!${process.execPath}`,
+          "const fs = require('node:fs')",
+          `const hostHome = ${JSON.stringify(hostHome)}`,
+          `const expectedHome = ${JSON.stringify(managedHome)}`,
+          `const expectedLibrary = ${JSON.stringify(managedLibrary)}`,
+          "const vanilla = process.argv.includes('--vanilla')",
+          "if (!vanilla && (fs.existsSync(hostHome + '/.Rprofile') || fs.existsSync(hostHome + '/.Renviron'))) process.exit(41)",
+          'if (process.env.HOME !== expectedHome || process.env.R_USER !== expectedHome) process.exit(42)',
+          'if (process.env.R_LIBS_USER !== expectedLibrary) process.exit(43)',
+          "process.stdout.write('isolated managed R')"
+        ].join('\n') + '\n'
+      )
+      chmodSync(executable, 0o755)
+      process.env.HOME = hostHome
+      process.env.R_USER = hostHome
+      process.env.R_LIBS_USER = hostLibrary
+
+      const condaPackageUnavailable = {
+        code: 1,
+        stdout: JSON.stringify({
+          success: false,
+          solver_problems: ['r-example does not exist'],
+          actions: { LINK: [], UNLINK: [], FETCH: [] }
+        }),
+        stderr: 'package not found'
+      }
+      const condaPackageNotManaged = {
+        code: 1,
+        stdout: JSON.stringify({
+          success: false,
+          error: 'packages to remove not found in the environment: r-example',
+          actions: {}
+        }),
+        stderr: 'package not installed'
+      }
+      const spawn: InstallSpawn = (command, args, env) => {
+        if (command === fakeMicromamba) {
+          if (args[1] === 'clean') {
+            return Promise.resolve({ code: 0, stdout: '', stderr: '' })
+          }
+          return Promise.resolve(
+            args.includes('remove') ? condaPackageNotManaged : condaPackageUnavailable
+          )
+        }
+        return defaultSpawn(command, args, env)
+      }
+      const deps = {
+        storageRoot,
+        micromamba: fakeMicromamba,
+        spawn,
+        pathExists: () => true,
+        readCondaPackageIdentity: () => ({
+          name: 'r-base',
+          version: '4.4.3',
+          build: 'h123_0',
+          buildNumber: 0
+        })
+      }
+      const results = []
+      results.push(
+        await installPackages({ language: 'r', packages: ['example'], environment }, deps)
+      )
+      results.push(
+        await installPackages(
+          { language: 'r', packages: ['example'], environment, operation: 'uninstall' },
+          deps
+        )
+      )
+      results.push(
+        await installPackages(
+          { language: 'r', packages: ['Example'], environment, installer: 'biocmanager' },
+          deps
+        )
+      )
+      results.push(
+        await installPackages(
+          { language: 'r', packages: ['owner/repository'], environment, installer: 'github' },
+          deps
+        )
+      )
+
+      expect(results.map(({ ok }) => ok)).toEqual([true, true, true, true])
+      expect(results.every(({ log }) => log.includes('isolated managed R'))).toBe(true)
+    } finally {
+      for (const key of inheritedKeys) {
+        const value = inherited[key]
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+      rmSync(storageRoot, { recursive: true, force: true })
+    }
+  }
 )
 
 it.skipIf(process.platform !== 'darwin' || !existsSync(micromamba))(
@@ -30,34 +532,7 @@ it.skipIf(process.platform !== 'darwin' || !existsSync(micromamba))(
       mkdirSync(join(runtimeRoot, 'envs', 'default-python', 'conda-meta'), { recursive: true })
       writeFileSync(join(runtimeRoot, 'envs', 'default-python', 'conda-meta', 'history'), '')
       // An offline solver-only package: no archive is downloaded or installed.
-      for (const subdir of ['noarch', process.arch === 'arm64' ? 'osx-arm64' : 'osx-64']) {
-        const channel = join(storageRoot, 'channel', subdir)
-        mkdirSync(channel, { recursive: true })
-        writeFileSync(
-          join(channel, 'repodata.json'),
-          JSON.stringify({
-            info: { subdir },
-            packages:
-              subdir === 'noarch'
-                ? {
-                    'pandas-1.0-0.tar.bz2': {
-                      name: 'pandas',
-                      version: '1.0',
-                      build: '0',
-                      build_number: 0,
-                      depends: [],
-                      subdir,
-                      noarch: 'generic',
-                      size: 1,
-                      sha256: '0'.repeat(64)
-                    }
-                  }
-                : {},
-            'packages.conda': {},
-            repodata_version: 1
-          })
-        )
-      }
+      writeOfflineChannel(join(storageRoot, 'channel'), ['pandas'])
       writeFileSync(
         profile,
         `(version 1)\n(allow default)\n(deny file-read* file-write* (subpath ${JSON.stringify(userCache)}))\n`
@@ -101,6 +576,105 @@ it.skipIf(process.platform !== 'darwin' || !existsSync(micromamba))(
       expect(result.fallbackUsed).toBe(false)
       checkDenied()
     } finally {
+      rmSync(storageRoot, { recursive: true, force: true })
+    }
+  }
+)
+
+it.skipIf(process.platform !== 'darwin' || !existsSync(micromamba))(
+  'plans managed Python and R environment creates while host Micromamba and Conda state remain denied',
+  async () => {
+    const storageRoot = realpathSync(mkdtempSync(join(tmpdir(), 'os-env-state-sandbox-')))
+    const managedRoot = runtimeRoot(storageRoot)
+    const hostHome = join(storageRoot, 'host-home')
+    const hostMambaState = join(hostHome, '.mamba')
+    const hostCondaState = join(hostHome, '.conda')
+    const profile = join(storageRoot, 'sandbox.sb')
+    const previousHome = process.env.HOME
+    try {
+      mkdirSync(hostMambaState, { recursive: true })
+      mkdirSync(hostCondaState, { recursive: true })
+      writeFileSync(join(hostMambaState, 'private-state'), 'private')
+      writeFileSync(join(hostCondaState, 'environments.txt'), '/private/environment\n')
+      writeOfflineChannel(join(storageRoot, 'channel'), [
+        'python',
+        'pip',
+        'matplotlib-base',
+        'nomkl',
+        'r-base',
+        'r-jsonlite'
+      ])
+      writeFileSync(
+        profile,
+        [
+          '(version 1)',
+          '(allow default)',
+          `(deny file-read* file-write* (subpath ${JSON.stringify(hostMambaState)}))`,
+          `(deny file-read* file-write* (subpath ${JSON.stringify(hostCondaState)}))`
+        ].join('\n') + '\n'
+      )
+      process.env.HOME = hostHome
+      const processSandbox = {
+        wrap: async (invocation: {
+          executable: string
+          args: readonly string[]
+          env: NodeJS.ProcessEnv
+        }) => ({
+          executable: '/usr/bin/sandbox-exec',
+          args: [
+            '-f',
+            profile,
+            invocation.executable,
+            ...invocation.args,
+            '--offline',
+            '--dry-run'
+          ],
+          env: invocation.env,
+          annotateStderr: (stderr: string) => stderr,
+          cleanup: () => {}
+        })
+      }
+      const provisioner = createProductionProvisioner(
+        {
+          root: managedRoot,
+          channel: pathToFileURL(join(storageRoot, 'channel')).href,
+          processSandbox
+        },
+        {
+          runner: { initialPath: micromamba, resolve: async () => micromamba },
+          maintainCache: async () => undefined,
+          verify: async () => undefined,
+          captureExplicitLock: async () => '@EXPLICIT\n'
+        }
+      )
+
+      await expect(
+        provisioner.createNamedEnvironment('analysis', 'python', [], {
+          projectId: 'project',
+          sessionId: 'session',
+          workspaceCwd: storageRoot
+        })
+      ).resolves.toMatchObject({ name: 'analysis', language: 'python', ready: false })
+      await expect(
+        provisioner.createNamedEnvironment('r-stats', 'r', [], {
+          projectId: 'project',
+          sessionId: 'session',
+          workspaceCwd: storageRoot
+        })
+      ).resolves.toMatchObject({ name: 'r-stats', language: 'r', ready: false })
+      for (const deniedPath of [
+        join(hostMambaState, 'private-state'),
+        join(hostCondaState, 'environments.txt')
+      ]) {
+        const denied = spawnSync('/usr/bin/sandbox-exec', ['-f', profile, '/bin/cat', deniedPath], {
+          encoding: 'utf8'
+        })
+        expect(denied.stderr).toContain('Operation not permitted')
+        expect(denied.status).toBe(1)
+      }
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME
+      else process.env.HOME = previousHome
       rmSync(storageRoot, { recursive: true, force: true })
     }
   }

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -419,6 +419,7 @@ describe('installPackages', () => {
     const prefix = envPrefix(runtimeRoot('/root'), DEFAULT_PY_ENV)
     expect(calls[0][0]).toBe(pipBin(prefix))
     expect(calls[0][1]).toEqual(['install', '-i', 'https://mirror.test/simple', 'seaborn'])
+    expect(calls[0][2]?.PYTHONNOUSERSITE).toBe('1')
   })
 
   it('installs into an EXTERNAL interpreter via its own pip, never the app-managed prefix', async () => {
@@ -442,6 +443,7 @@ describe('installPackages', () => {
       'https://mirror.test/simple',
       'rich'
     ])
+    expect(calls[0][2]?.PYTHONNOUSERSITE).toBeUndefined()
     expect(result).toMatchObject({ ok: true, method: 'pip' })
   })
 
@@ -800,15 +802,16 @@ describe('installPackages', () => {
     const prefix = envPrefix(runtimeRoot('/root'), DEFAULT_R_ENV)
     const rLib = rLibraryDir(prefix)
     expect(calls[1][0]).toBe(rScriptBin(prefix))
-    expect(calls[1][1][0]).toBe('-e')
+    expect(calls[1][1].slice(0, 3)).toEqual(['--vanilla', '--slave', '-e'])
+    const rScript = calls[1][1][3]
     // The env R library is created and install is pinned to it via an explicit lib=, so a fronted
     // user library can never receive the package.
     // The code JSON-stringifies the lib path into the R script (so a Windows backslash path is escaped
     // correctly); mirror that here so the assertion holds on both POSIX and Windows.
-    expect(calls[1][1][1]).toContain(
+    expect(rScript).toContain(
       `dir.create(${JSON.stringify(rLib)}, recursive=TRUE, showWarnings=FALSE)`
     )
-    expect(calls[1][1][1]).toContain(
+    expect(rScript).toContain(
       `install.packages(c("someCranOnlyPkg"), lib=${JSON.stringify(rLib)}, repos="https://cran.mirror.test")`
     )
     expect(result).toMatchObject({
@@ -1049,7 +1052,8 @@ describe('installPackages', () => {
 
     const env = calls[0][2] ?? {}
     expect(env.CONDA_PKGS_DIRS).toBe('C:\\osp1234567890')
-    expect(env.MAMBA_ROOT_PREFIX).toBeUndefined()
+    expect(env.MAMBA_ROOT_PREFIX).toBe('/root/runtime')
+    expect(env.CONDA_ENVS_PATH).toBe('\\root\\runtime\\envs')
   })
 
   it('does not inject the package cache into a pip subprocess', async () => {
@@ -1588,9 +1592,9 @@ describe('installPackages uninstall', () => {
     // First a conda remove is attempted, then the CRAN remove.packages fallback.
     expect(calls[0][0]).toBe('/mm/bin/micromamba')
     expect(calls[1][0]).toBe(rScriptBin(prefix))
-    expect(calls[1][1][0]).toBe('-e')
+    expect(calls[1][1].slice(0, 3)).toEqual(['--vanilla', '--slave', '-e'])
     // Removal is pinned to the env's own R library via an explicit lib=, never .libPaths()[1].
-    expect(calls[1][1][1]).toContain(
+    expect(calls[1][1][3]).toContain(
       `remove.packages(c("someCranOnlyPkg"), lib=${JSON.stringify(rLib)})`
     )
     expect(result).toMatchObject({

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -61,6 +61,7 @@ import {
   runtimeRoot
 } from './runtime-paths'
 import { toErrorMessage } from '../error-message'
+import { buildManagedRuntimeProcessEnvironment } from './process-environment'
 
 export type InstallRequest = OptionalProjectIdScope & {
   language: NotebookLanguage
@@ -1172,7 +1173,10 @@ export async function installPackages(
   // Every install subprocess inherits the parent env plus the CA-bundle vars (no-op when unset), so a
   // custom corporate CA is trusted by conda/pip/R. Wrapping here keeps every run() call site 2-arg.
   const baseSpawn = deps.spawn ?? defaultSpawn
-  const spawnEnv: NodeJS.ProcessEnv = { ...process.env, ...caBundleEnv(deps.caBundle) }
+  let spawnEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...caBundleEnv(deps.caBundle)
+  }
   const run: InstallSpawn = (command, args) =>
     baseSpawn(command, args, spawnEnv, deps.onChild, deps.onBeforeSpawn)
 
@@ -1225,6 +1229,15 @@ export async function installPackages(
   Object.assign(spawnEnv, notebookWorkloadCacheEnv(root))
   const channels = condaInstallChannels(deps.condaChannel ?? DEFAULT_CONDA_CHANNEL, req.channels)
   const prefix = envPrefix(root, envName)
+  if (!deps.interpreter) {
+    const platform = deps.micromambaEnv?.platform ?? process.platform
+    spawnEnv = buildManagedRuntimeProcessEnvironment(root, {
+      language: req.language,
+      prefix,
+      platform,
+      sourceEnv: spawnEnv
+    })
+  }
   // micromamba install/remove extract into and mutate the SHARED pkgs cache (<root>/runtime/pkgs), so
   // they must hold the shared cache lock — otherwise a concurrent corrupt-cache repair (which takes the
   // cache EXCLUSIVE and removes incomplete extractions) could delete a package dir mid-install. pip and
@@ -1236,15 +1249,20 @@ export async function installPackages(
     const cache = deps.micromambaEnv?.selectCache
       ? deps.micromambaEnv.selectCache(root, DEFAULT_MAX_CACHE_RELATIVE_PATH)
       : selectMicromambaCache(root, DEFAULT_MAX_CACHE_RELATIVE_PATH, deps.micromambaEnv)
-    const env = {
-      ...micromambaSpawnEnv(
-        root,
-        deps.caBundle,
-        { ...deps.micromambaEnv, selectCache: () => cache },
-        DEFAULT_MAX_CACHE_RELATIVE_PATH
-      ),
-      ...notebookWorkloadCacheEnv(root)
-    }
+    const env = buildManagedRuntimeProcessEnvironment(root, {
+      language: req.language,
+      prefix,
+      platform: deps.micromambaEnv?.platform,
+      sourceEnv: {
+        ...micromambaSpawnEnv(
+          root,
+          deps.caBundle,
+          { ...deps.micromambaEnv, selectCache: () => cache },
+          DEFAULT_MAX_CACHE_RELATIVE_PATH
+        ),
+        ...notebookWorkloadCacheEnv(root)
+      }
+    })
     condaContext = { cache, env }
     return condaContext
   }
@@ -1720,7 +1738,7 @@ export async function installPackages(
     const script =
       `dir.create(${JSON.stringify(rLib)}, recursive=TRUE, showWarnings=FALSE); ` +
       `install.packages(c(${vector}), lib=${JSON.stringify(rLib)}, repos=${JSON.stringify(cran)})`
-    const fallback = await run(rScriptBin(prefix), ['-e', script])
+    const fallback = await run(rScriptBin(prefix), ['--vanilla', '--slave', '-e', script])
     const ok = fallback.code === 0
     return {
       ok,
@@ -2058,7 +2076,7 @@ async function uninstallPackages(
     const vector = req.packages.map((pkg) => JSON.stringify(pkg)).join(', ')
     const rLib = envRLibrary(prefix)
     const script = `remove.packages(c(${vector}), lib=${JSON.stringify(rLib)})`
-    const fallback = await run(rScriptBin(prefix), ['-e', script])
+    const fallback = await run(rScriptBin(prefix), ['--vanilla', '--slave', '-e', script])
     const ok = fallback.code === 0
     return {
       ok,

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -1226,17 +1226,22 @@ export async function installPackages(
     process.env.OPEN_SCIENCE_STORAGE_ROOT ??
     join(homedir(), PROD_SESSION_DIR_NAME)
   const root = runtimeRoot(storageRoot)
-  Object.assign(spawnEnv, notebookWorkloadCacheEnv(root))
+  const workloadCacheEnv = notebookWorkloadCacheEnv(root)
+  Object.assign(spawnEnv, workloadCacheEnv)
   const channels = condaInstallChannels(deps.condaChannel ?? DEFAULT_CONDA_CHANNEL, req.channels)
   const prefix = envPrefix(root, envName)
   if (!deps.interpreter) {
     const platform = deps.micromambaEnv?.platform ?? process.platform
-    spawnEnv = buildManagedRuntimeProcessEnvironment(root, {
-      language: req.language,
-      prefix,
-      platform,
-      sourceEnv: spawnEnv
-    })
+    spawnEnv = {
+      ...buildManagedRuntimeProcessEnvironment(root, {
+        language: req.language,
+        prefix,
+        platform,
+        sourceEnv: spawnEnv
+      }),
+      ...workloadCacheEnv,
+      ...caBundleEnv(deps.caBundle)
+    }
   }
   // micromamba install/remove extract into and mutate the SHARED pkgs cache (<root>/runtime/pkgs), so
   // they must hold the shared cache lock — otherwise a concurrent corrupt-cache repair (which takes the
@@ -1249,20 +1254,24 @@ export async function installPackages(
     const cache = deps.micromambaEnv?.selectCache
       ? deps.micromambaEnv.selectCache(root, DEFAULT_MAX_CACHE_RELATIVE_PATH)
       : selectMicromambaCache(root, DEFAULT_MAX_CACHE_RELATIVE_PATH, deps.micromambaEnv)
-    const env = buildManagedRuntimeProcessEnvironment(root, {
-      language: req.language,
-      prefix,
-      platform: deps.micromambaEnv?.platform,
-      sourceEnv: {
-        ...micromambaSpawnEnv(
-          root,
-          deps.caBundle,
-          { ...deps.micromambaEnv, selectCache: () => cache },
-          DEFAULT_MAX_CACHE_RELATIVE_PATH
-        ),
-        ...notebookWorkloadCacheEnv(root)
-      }
-    })
+    const env = {
+      ...buildManagedRuntimeProcessEnvironment(root, {
+        language: req.language,
+        prefix,
+        platform: deps.micromambaEnv?.platform,
+        sourceEnv: {
+          ...micromambaSpawnEnv(
+            root,
+            deps.caBundle,
+            { ...deps.micromambaEnv, selectCache: () => cache },
+            DEFAULT_MAX_CACHE_RELATIVE_PATH
+          ),
+          ...workloadCacheEnv
+        }
+      }),
+      ...workloadCacheEnv,
+      ...caBundleEnv(deps.caBundle)
+    }
     condaContext = { cache, env }
     return condaContext
   }

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -1170,8 +1170,9 @@ export async function installPackages(
   req: InstallRequest,
   deps: Partial<InstallDeps> = {}
 ): Promise<InstallResult> {
-  // Every install subprocess inherits the parent env plus the CA-bundle vars (no-op when unset), so a
-  // custom corporate CA is trusted by conda/pip/R. Wrapping here keeps every run() call site 2-arg.
+  // Start from the parent env plus the CA-bundle vars; managed runtimes sanitize host Python/R/user
+  // state below while external runtimes keep the caller environment. Wrapping here keeps every run()
+  // call site 2-arg.
   const baseSpawn = deps.spawn ?? defaultSpawn
   let spawnEnv: NodeJS.ProcessEnv = {
     ...process.env,

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -254,6 +254,21 @@ describe('NotebookPackageMutationOwner', () => {
     expect(options.runtimeRepair.quarantineProtectedIdentity).not.toHaveBeenCalled()
   })
 
+  it('completes a managed conda install without retaining archive publication when no cache retainer exists', async () => {
+    const { owner, target, runtimeRoot } = ownerHarness({
+      installPackages: vi.fn(async (_request, deps) => {
+        deps?.onCondaArchiveAuthorizations?.(
+          [{ file: 'numpy-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }],
+          '/managed-working-cache'
+        )
+        return { ok: true, needsRestart: false, log: 'installed', method: 'conda' as const }
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).resolves.toMatchObject({ ok: true })
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
   it('publishes a successful conda transaction before releasing its working cache', async () => {
     let finishPublication!: (published: boolean) => void
     const publication = new Promise<boolean>((resolve) => {

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -173,6 +173,7 @@ class NotebookPackageMutationOwner {
                 removeOperationChildSync(runtimeRoot, operationId)
               },
               onCondaArchiveAuthorizations: (authorizations, workingRoot, evidenceComplete) => {
+                if (!archiveCacheTransaction) return
                 if (evidenceComplete === false) archiveEvidenceIncomplete = true
                 if (authorizations.length === 0) return
                 const previous = archivePublications.get(workingRoot)

--- a/src/main/notebook/package-process-sandbox.test.ts
+++ b/src/main/notebook/package-process-sandbox.test.ts
@@ -50,6 +50,7 @@ describe('sandboxedPackageSpawn', () => {
     const result = await spawn(process.execPath, ['-e', 'process.stderr.write("installer")'], {
       PATH: process.env.PATH,
       PIP_CERT: '/trusted/bundle.pem',
+      PYTHONNOUSERSITE: '1',
       CONDA_PKGS_DIRS: packageCache,
       MPLCONFIGDIR: matplotlibCache,
       OPENAI_API_KEY: 'must-not-cross'
@@ -68,7 +69,8 @@ describe('sandboxedPackageSpawn', () => {
     expect(vi.mocked(processSandbox.wrap).mock.calls[0]?.[0].env).toMatchObject({
       PATH: process.env.PATH,
       PIP_CERT: '/trusted/bundle.pem',
-      MPLCONFIGDIR: matplotlibCache
+      MPLCONFIGDIR: matplotlibCache,
+      PYTHONNOUSERSITE: '1'
     })
     expect(vi.mocked(processSandbox.wrap).mock.calls[0]?.[0].env).not.toHaveProperty(
       'OPENAI_API_KEY'

--- a/src/main/notebook/package-process-sandbox.ts
+++ b/src/main/notebook/package-process-sandbox.ts
@@ -1,5 +1,15 @@
-import { existsSync } from 'node:fs'
-import { delimiter, dirname, isAbsolute, win32 } from 'node:path'
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fchmodSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  realpathSync
+} from 'node:fs'
+import { delimiter, dirname, isAbsolute, join, relative, resolve, win32 } from 'node:path'
 
 import { defaultSpawn, type InstallRequest, type InstallSpawn } from './package-manager'
 import { buildNotebookKernelEnvironment } from './process-environment'
@@ -16,7 +26,17 @@ type PackageProcessSandboxOptions = Readonly<{
 
 const PACKAGE_ENV_KEYS = [
   'CONDA_PKGS_DIRS',
+  'CONDA_ENVS_PATH',
   'MAMBA_ROOT_PREFIX',
+  'HOME',
+  'USERPROFILE',
+  'XDG_CACHE_HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_STATE_HOME',
+  'R_USER',
+  'R_LIBS_USER',
+  'PYTHONNOUSERSITE',
   'CONDA_SSL_VERIFY',
   'SSL_CERT_FILE',
   'REQUESTS_CA_BUNDLE',
@@ -79,6 +99,64 @@ const packageWriteRoots = (env: NodeJS.ProcessEnv, platform: NodeJS.Platform): s
   )
 }
 
+const normalizeDarwinRepodataCachePermissions = (
+  env: NodeJS.ProcessEnv,
+  runtimeRoot: string,
+  platform: NodeJS.Platform
+): void => {
+  if (platform !== 'darwin') return
+  const managedRoot = resolve(runtimeRoot)
+  for (const packageRoot of (env.CONDA_PKGS_DIRS ?? '').split(delimiter)) {
+    if (!isAbsolute(packageRoot)) continue
+    const fromManagedRoot = relative(managedRoot, resolve(packageRoot))
+    if (fromManagedRoot.startsWith('..') || isAbsolute(fromManagedRoot)) continue
+    // The configured storage path may itself contain a symlink. Resolve that trusted
+    // anchor once; links beneath it must never redirect this unsandboxed preparation.
+    mkdirSync(managedRoot, { recursive: true })
+    const physicalRoot = join(realpathSync(managedRoot), fromManagedRoot)
+    const cache = join(physicalRoot, 'cache')
+    // Node has no mkdirat: validate each parent before creation and recheck the
+    // resulting physical path. Permission changes below are descriptor-bound.
+    const ensureDirectory = (path: string): void => {
+      try {
+        const state = lstatSync(path)
+        if (!state.isDirectory() || state.isSymbolicLink() || realpathSync(path) !== path) {
+          throw new Error(`Managed Micromamba repodata cache is not a trusted directory: ${path}`)
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+        ensureDirectory(dirname(path))
+        mkdirSync(path, { mode: 0o755 })
+        ensureDirectory(path)
+      }
+    }
+    ensureDirectory(cache)
+    const fd = openSync(cache, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW)
+    try {
+      const state = fstatSync(fd)
+      const current = lstatSync(cache)
+      if (
+        !state.isDirectory() ||
+        state.dev !== current.dev ||
+        state.ino !== current.ino ||
+        realpathSync(cache) !== cache
+      ) {
+        throw new Error(`Managed Micromamba repodata cache is not a trusted directory: ${cache}`)
+      }
+      // Micromamba can leave cache/ setgid. Seatbelt denies clearing that bit even
+      // with file-write-mode, so repair it before entering the production sandbox.
+      // Operate on the validated descriptor, never on a path that can be replaced.
+      if ((state.mode & 0o2000) !== 0) fchmodSync(fd, state.mode & 0o5777)
+      const after = lstatSync(cache)
+      if (after.dev !== state.dev || after.ino !== state.ino || realpathSync(cache) !== cache) {
+        throw new Error(`Managed Micromamba repodata cache changed during preparation: ${cache}`)
+      }
+    } finally {
+      closeSync(fd)
+    }
+  }
+}
+
 /** Routes manage_packages workers through the same network/filesystem boundary as Notebook code. */
 export const sandboxedPackageSpawn =
   (options: PackageProcessSandboxOptions): InstallSpawn =>
@@ -86,6 +164,7 @@ export const sandboxedPackageSpawn =
     const { processSandbox, request, runtimeRoot, storageRoot } = options
     const platform = options.platform ?? process.platform
     const projectedEnv = packageEnvironment(env ?? {}, platform)
+    normalizeDarwinRepodataCachePermissions(projectedEnv, runtimeRoot, platform)
     const cwd =
       request.workspaceCwd && isAbsolute(request.workspaceCwd) ? request.workspaceCwd : storageRoot
     const sandboxed = await processSandbox.wrap({

--- a/src/main/notebook/process-environment.test.ts
+++ b/src/main/notebook/process-environment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildManagedRuntimeProcessEnvironment,
   buildNotebookKernelEnvironment,
   buildNotebookShellEnvironment,
   environmentPathRoots,
@@ -36,6 +37,39 @@ describe('Notebook process environment', () => {
     expect(env.API_TOKEN).toBeUndefined()
     expect(env.AWS_SECRET_ACCESS_KEY).toBeUndefined()
     expect(env.JAVA_TOOL_OPTIONS).toBeUndefined()
+    expect(env.PYTHONNOUSERSITE).toBeUndefined()
+  })
+
+  it('adds Python user-site isolation only for an app-managed runtime', () => {
+    expect(
+      buildManagedRuntimeProcessEnvironment('/runtime', {
+        language: 'python',
+        platform: 'linux',
+        sourceEnv: { PATH: '/usr/bin', HOME: '/host' }
+      })
+    ).toMatchObject({ HOME: '/runtime/home', PYTHONNOUSERSITE: '1' })
+  })
+
+  it('removes inherited R library injection and selects the managed prefix library', () => {
+    const env = buildManagedRuntimeProcessEnvironment('/runtime', {
+      language: 'r',
+      prefix: '/runtime/envs/analysis',
+      platform: 'linux',
+      sourceEnv: {
+        R_USER: '/host',
+        R_LIBS: '/host/libs',
+        R_LIBS_USER: '/host/user-lib',
+        R_LIBS_SITE: '/host/site-lib'
+      }
+    })
+
+    expect(env).toMatchObject({
+      HOME: '/runtime/home',
+      R_USER: '/runtime/home',
+      R_LIBS_USER: '/runtime/envs/analysis/lib/R/library'
+    })
+    expect(env.R_LIBS).toBeUndefined()
+    expect(env.R_LIBS_SITE).toBeUndefined()
   })
 
   it('keeps the dedicated Windows account identity instead of overlaying the host profile', () => {

--- a/src/main/notebook/process-environment.test.ts
+++ b/src/main/notebook/process-environment.test.ts
@@ -41,13 +41,40 @@ describe('Notebook process environment', () => {
   })
 
   it('adds Python user-site isolation only for an app-managed runtime', () => {
+    const env = buildManagedRuntimeProcessEnvironment('/runtime', {
+      language: 'python',
+      platform: 'linux',
+      sourceEnv: {
+        PATH: '/usr/bin',
+        HOME: '/host',
+        PYTHONHOME: '/host/python',
+        PYTHONPATH: '/host/python/modules',
+        PYTHONSTARTUP: '/host/python/startup.py',
+        PYTHONUSERBASE: '/host/python/user-base',
+        PYTHONEXECUTABLE: '/host/python/bin/python',
+        PYTHONNOUSERSITE: '0',
+        PIP_CONFIG_FILE: '/host/pip.conf',
+        PIP_USER: '1',
+        PIP_TARGET: '/host/pip-target',
+        PIP_PREFIX: '/host/pip-prefix',
+        PIP_INDEX_URL: 'https://host.invalid/simple',
+        PIP_EXTRA_INDEX_URL: 'https://extra.invalid/simple',
+        PIP_NO_INDEX: '1',
+        PIP_FIND_LINKS: '/host/wheels',
+        PIP_TRUSTED_HOST: 'host.invalid',
+        PIP_REQUIRE_VIRTUALENV: '1',
+        PIP_CERT: '/host/cert.pem',
+        PIP_CLIENT_CERT: '/host/client.pem',
+        PIP_CACHE_DIR: '/host/pip-cache'
+      }
+    })
+
+    expect(env).toMatchObject({ HOME: '/runtime/home', PYTHONNOUSERSITE: '1' })
     expect(
-      buildManagedRuntimeProcessEnvironment('/runtime', {
-        language: 'python',
-        platform: 'linux',
-        sourceEnv: { PATH: '/usr/bin', HOME: '/host' }
-      })
-    ).toMatchObject({ HOME: '/runtime/home', PYTHONNOUSERSITE: '1' })
+      Object.keys(env).filter(
+        (key) => key !== 'PYTHONNOUSERSITE' && (/^PYTHON/u.test(key) || /^PIP_/u.test(key))
+      )
+    ).toEqual([])
   })
 
   it('removes inherited R library injection and selects the managed prefix library', () => {
@@ -57,9 +84,14 @@ describe('Notebook process environment', () => {
       platform: 'linux',
       sourceEnv: {
         R_USER: '/host',
+        R_HOME: '/host/r-home',
         R_LIBS: '/host/libs',
         R_LIBS_USER: '/host/user-lib',
-        R_LIBS_SITE: '/host/site-lib'
+        R_LIBS_SITE: '/host/site-lib',
+        R_ENVIRON: '/host/Renviron',
+        R_ENVIRON_USER: '/host/user.Renviron',
+        R_PROFILE: '/host/Rprofile',
+        R_PROFILE_USER: '/host/user.Rprofile'
       }
     })
 
@@ -70,6 +102,11 @@ describe('Notebook process environment', () => {
     })
     expect(env.R_LIBS).toBeUndefined()
     expect(env.R_LIBS_SITE).toBeUndefined()
+    expect(env.R_HOME).toBeUndefined()
+    expect(env.R_ENVIRON).toBeUndefined()
+    expect(env.R_ENVIRON_USER).toBeUndefined()
+    expect(env.R_PROFILE).toBeUndefined()
+    expect(env.R_PROFILE_USER).toBeUndefined()
   })
 
   it('keeps the dedicated Windows account identity instead of overlaying the host profile', () => {

--- a/src/main/notebook/process-environment.ts
+++ b/src/main/notebook/process-environment.ts
@@ -1,6 +1,9 @@
 import { statSync } from 'node:fs'
 import { posix, win32 } from 'node:path'
 
+import type { NotebookLanguage } from '../../shared/notebook'
+import { rLibraryDir } from './runtime-paths'
+
 const COMMON_ENV_ALLOWLIST = ['PATH', 'LANG', 'LC_ALL', 'LC_CTYPE', 'TERM', 'TZ'] as const
 
 const POSIX_ENV_ALLOWLIST = ['HOME', 'USER', 'LOGNAME', 'SHELL'] as const
@@ -66,6 +69,66 @@ export const buildNotebookKernelEnvironment = (
   platform: NodeJS.Platform = process.platform,
   sourceEnv: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv => projectEnvironment(sourceEnv, platform)
+
+type ManagedRuntimeProcessEnvironmentOptions = {
+  language?: NotebookLanguage
+  prefix?: string
+  platform?: NodeJS.Platform
+  sourceEnv?: NodeJS.ProcessEnv
+}
+
+const MANAGED_USER_STATE_KEYS = [
+  'HOME',
+  'USERPROFILE',
+  'XDG_CACHE_HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_STATE_HOME'
+] as const
+
+const R_USER_STATE_KEYS = ['R_USER', 'R_LIBS', 'R_LIBS_USER', 'R_LIBS_SITE'] as const
+
+export const sanitizeManagedRuntimeHostState = (
+  sourceEnv: NodeJS.ProcessEnv,
+  includeRState = false
+): NodeJS.ProcessEnv => {
+  const removed = new Set<string>([
+    ...MANAGED_USER_STATE_KEYS,
+    ...(includeRState ? R_USER_STATE_KEYS : [])
+  ])
+  return Object.fromEntries(
+    Object.entries(sourceEnv).filter(([key]) => !removed.has(key.toUpperCase()))
+  )
+}
+
+export const buildManagedRuntimeProcessEnvironment = (
+  root: string,
+  options: ManagedRuntimeProcessEnvironmentOptions = {}
+): NodeJS.ProcessEnv => {
+  const platform = options.platform ?? process.platform
+  const platformPath = platform === 'win32' ? win32 : posix
+  const home = platformPath.join(root, 'home')
+  const env = sanitizeManagedRuntimeHostState(
+    options.sourceEnv ?? process.env,
+    options.language === 'r'
+  )
+  return {
+    ...env,
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CACHE_HOME: platformPath.join(home, '.cache'),
+    XDG_CONFIG_HOME: platformPath.join(home, '.config'),
+    XDG_DATA_HOME: platformPath.join(home, '.local', 'share'),
+    XDG_STATE_HOME: platformPath.join(home, '.local', 'state'),
+    ...(options.language === 'python' ? { PYTHONNOUSERSITE: '1' } : {}),
+    ...(options.language === 'r'
+      ? {
+          R_USER: home,
+          ...(options.prefix ? { R_LIBS_USER: rLibraryDir(options.prefix, platform) } : {})
+        }
+      : {})
+  }
+}
 
 export const notebookTrustBundleEnvironment = (path?: string): NodeJS.ProcessEnv =>
   path

--- a/src/main/notebook/process-environment.ts
+++ b/src/main/notebook/process-environment.ts
@@ -86,18 +86,37 @@ const MANAGED_USER_STATE_KEYS = [
   'XDG_STATE_HOME'
 ] as const
 
-const R_USER_STATE_KEYS = ['R_USER', 'R_LIBS', 'R_LIBS_USER', 'R_LIBS_SITE'] as const
+const R_USER_STATE_KEYS = [
+  'R_USER',
+  'R_HOME',
+  'R_LIBS',
+  'R_LIBS_USER',
+  'R_LIBS_SITE',
+  'R_ENVIRON',
+  'R_ENVIRON_USER',
+  'R_PROFILE',
+  'R_PROFILE_USER'
+] as const
+
+type ManagedRuntimeHostStateScope = NotebookLanguage | 'all'
 
 export const sanitizeManagedRuntimeHostState = (
   sourceEnv: NodeJS.ProcessEnv,
-  includeRState = false
+  scope?: ManagedRuntimeHostStateScope
 ): NodeJS.ProcessEnv => {
   const removed = new Set<string>([
     ...MANAGED_USER_STATE_KEYS,
-    ...(includeRState ? R_USER_STATE_KEYS : [])
+    ...(scope === 'r' || scope === 'all' ? R_USER_STATE_KEYS : [])
   ])
   return Object.fromEntries(
-    Object.entries(sourceEnv).filter(([key]) => !removed.has(key.toUpperCase()))
+    Object.entries(sourceEnv).filter(([key]) => {
+      const normalized = key.toUpperCase()
+      if (removed.has(normalized)) return false
+      return !(
+        (scope === 'python' || scope === 'all') &&
+        (normalized.startsWith('PYTHON') || normalized.startsWith('PIP_'))
+      )
+    })
   )
 }
 
@@ -108,10 +127,7 @@ export const buildManagedRuntimeProcessEnvironment = (
   const platform = options.platform ?? process.platform
   const platformPath = platform === 'win32' ? win32 : posix
   const home = platformPath.join(root, 'home')
-  const env = sanitizeManagedRuntimeHostState(
-    options.sourceEnv ?? process.env,
-    options.language === 'r'
-  )
+  const env = sanitizeManagedRuntimeHostState(options.sourceEnv ?? process.env, options.language)
   return {
     ...env,
     HOME: home,

--- a/src/main/notebook/provisioner-runtime.test.ts
+++ b/src/main/notebook/provisioner-runtime.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  captureMicromamba,
   killAndConfirmExit,
   md5File,
   micromambaDiagnosticText,
@@ -43,6 +44,30 @@ describe('verifyExecutable', () => {
     await expect(verifyExecutable(bin, { prefix })).rejects.toThrow(/outside.*prefix|relocat/i)
   })
 
+  it('rejects an R runtime that mixes a managed library with an injected host library', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'os-mixed-r-libraries-'))
+    const prefix = join(dir, 'runtime', 'envs', 'default-r')
+    const library = join(prefix, 'lib', 'R', 'library')
+    const hostLibrary = join(dir, 'host-library')
+    const bin = join(prefix, 'bin', 'R')
+    mkdirSync(library, { recursive: true })
+    mkdirSync(hostLibrary, { recursive: true })
+    mkdirSync(join(prefix, 'bin'), { recursive: true })
+    writeFileSync(
+      bin,
+      `#!${process.execPath}\n` +
+        `process.stdout.write([` +
+        `'OPEN_SCIENCE_R_HOME=${join(prefix, 'lib', 'R')}',` +
+        `'OPEN_SCIENCE_R_BASE_LIBRARY=${library}',` +
+        `'OPEN_SCIENCE_R_LIBRARY=${library}',` +
+        `'OPEN_SCIENCE_R_LIBRARY=${hostLibrary}'` +
+        `].join('\\n') + '\\n')\n`
+    )
+    chmodSync(bin, 0o755)
+
+    await expect(verifyExecutable(bin, { prefix })).rejects.toThrow(/outside.*prefix|relocat/i)
+  })
+
   it.skipIf(process.platform === 'win32')(
     'passes the activated Windows conda PATH to the interpreter process',
     async () => {
@@ -71,6 +96,25 @@ describe('verifyExecutable', () => {
       ).resolves.toBeUndefined()
     }
   )
+})
+
+describe('captureMicromamba', () => {
+  it('uses the complete managed environment without merging host state back in', async () => {
+    const key = 'OPEN_SCIENCE_CAPTURE_HOST_SENTINEL'
+    const previous = process.env[key]
+    process.env[key] = 'host-state'
+    try {
+      await expect(
+        captureMicromamba(
+          [process.execPath, '-e', `process.stdout.write(process.env.${key} ?? 'isolated')`],
+          { PATH: process.env.PATH }
+        )
+      ).resolves.toBe('isolated')
+    } finally {
+      if (previous === undefined) delete process.env[key]
+      else process.env[key] = previous
+    }
+  })
 })
 
 describe('md5File', () => {

--- a/src/main/notebook/provisioner-runtime.ts
+++ b/src/main/notebook/provisioner-runtime.ts
@@ -70,13 +70,21 @@ type VerifyExecutableOptions = {
   prefix?: string
   env?: NodeJS.ProcessEnv
   platform?: NodeJS.Platform
+  completeEnv?: boolean
 }
 
 const executableEnv = ({
   prefix,
   env,
-  platform = process.platform
+  platform = process.platform,
+  completeEnv = false
 }: VerifyExecutableOptions): NodeJS.ProcessEnv | undefined => {
+  if (completeEnv) {
+    const complete = { ...env }
+    return platform === 'win32' && prefix
+      ? { ...complete, PATH: condaActivatedPath(prefix, complete.PATH, platform) }
+      : complete
+  }
   if (platform !== 'win32' || !prefix) {
     return env && Object.keys(env).length > 0 ? { ...process.env, ...env } : undefined
   }
@@ -136,7 +144,8 @@ const assertRRuntimePaths = (
     baseLibraries.length !== 1 ||
     !pathIsWithin(homes[0], prefix, platform) ||
     !pathIsWithin(baseLibraries[0], prefix, platform) ||
-    !libraries.some((library) => pathIsWithin(library, prefix, platform))
+    libraries.length === 0 ||
+    !libraries.every((library) => pathIsWithin(library, prefix, platform))
   ) {
     throw new Error(
       `R runtime paths resolve outside the expected prefix ${prefix}; the environment may have been ` +
@@ -376,7 +385,9 @@ export const captureMicromamba = async (
       timeout: 600_000,
       windowsHide: true,
       maxBuffer: 32 * 1024 * 1024,
-      env: env && Object.keys(env).length > 0 ? { ...process.env, ...env } : undefined
+      // Callers pass a complete managed environment. Merging process.env here would reintroduce
+      // host CONDA_*/MAMBA_* state after micromambaSpawnEnv deliberately removed it.
+      env
     })
     return stdout
   } catch (error) {

--- a/src/main/notebook/provisioner-runtime.ts
+++ b/src/main/notebook/provisioner-runtime.ts
@@ -64,8 +64,8 @@ export const killAndConfirmExit = (
   return terminateTree(child).then(({ reaped }) => reaped)
 }
 
-// Merges extra vars over the current process env for a subprocess (used to inject the CA-bundle vars
-// so an online provision behind an enterprise TLS proxy verifies HTTPS). Undefined → inherit as-is.
+// Builds the subprocess environment. By default extra vars merge over the current process env; callers
+// that already built a sanitized managed-runtime environment set completeEnv to prevent re-inheritance.
 type VerifyExecutableOptions = {
   prefix?: string
   env?: NodeJS.ProcessEnv

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
@@ -17,6 +17,7 @@ import {
   pkgsCache,
   pythonBin,
   rBin,
+  rLibraryDir,
   readRReadyMarker,
   readReadyMarker,
   readyMarkerPath,
@@ -30,6 +31,7 @@ import {
   DEFAULT_PYTHON_SPEC,
   DEFAULT_R_SPEC,
   DefaultRuntimeProvisioner,
+  createProductionProvisioner,
   type FetchedBundle,
   type ProvisionProgress,
   type ProvisionerDeps
@@ -1381,6 +1383,63 @@ const makeNamedEnvDeps = (
 }
 
 describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
+  it.skipIf(process.platform === 'win32')(
+    'verifies a managed R environment with app-owned user state and only its prefix library',
+    async () => {
+      const root = makeRoot()
+      const prefix = envPrefix(root, 'r-stats')
+      const bin = rBin(prefix)
+      const expectedHome = join(root, 'home')
+      const expectedLibrary = rLibraryDir(prefix)
+      const inheritedKeys = ['HOME', 'R_USER', 'R_LIBS', 'R_LIBS_USER', 'R_LIBS_SITE'] as const
+      const inherited = Object.fromEntries(inheritedKeys.map((key) => [key, process.env[key]]))
+      process.env.HOME = join(root, 'host-home')
+      process.env.R_USER = join(root, 'host-r-user')
+      process.env.R_LIBS = join(root, 'host-r-libs')
+      process.env.R_LIBS_USER = join(root, 'host-r-user-library')
+      process.env.R_LIBS_SITE = join(root, 'host-r-site-library')
+      const provisioner = createProductionProvisioner(
+        { root, channel: 'https://conda.example/conda-forge' },
+        {
+          runner: { initialPath: '/fake/micromamba', resolve: async () => '/fake/micromamba' },
+          maintainCache: async () => undefined,
+          captureExplicitLock: async () => '@EXPLICIT\n',
+          runArgv: async () => {
+            mkdirSync(expectedLibrary, { recursive: true })
+            mkdirSync(dirname(bin), { recursive: true })
+            writeFileSync(
+              bin,
+              [
+                `#!${process.execPath}`,
+                `if (process.env.HOME !== ${JSON.stringify(expectedHome)}) process.exit(41)`,
+                `if (process.env.R_USER !== ${JSON.stringify(expectedHome)}) process.exit(42)`,
+                `if (process.env.R_LIBS_USER !== ${JSON.stringify(expectedLibrary)}) process.exit(43)`,
+                'if (process.env.R_LIBS || process.env.R_LIBS_SITE) process.exit(44)',
+                `const prefix = ${JSON.stringify(prefix)}`,
+                "process.stdout.write(['OPEN_SCIENCE_R_HOME=' + prefix + '/lib/R', 'OPEN_SCIENCE_R_BASE_LIBRARY=' + prefix + '/lib/R/library', 'OPEN_SCIENCE_R_LIBRARY=' + process.env.R_LIBS_USER].join('\\n') + '\\n')"
+              ].join('\n') + '\n'
+            )
+            chmodSync(bin, 0o755)
+          }
+        }
+      )
+
+      try {
+        await expect(provisioner.createNamedEnvironment('r-stats', 'r')).resolves.toMatchObject({
+          name: 'r-stats',
+          language: 'r',
+          ready: true
+        })
+      } finally {
+        for (const key of inheritedKeys) {
+          const value = inherited[key]
+          if (value === undefined) delete process.env[key]
+          else process.env[key] = value
+        }
+      }
+    }
+  )
+
   it('uses the injected platform for the interpreter it verifies', async () => {
     const root = makeRoot()
     const platform: NodeJS.Platform = process.platform === 'win32' ? 'linux' : 'win32'

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1455,6 +1455,19 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
     )
   })
 
+  it('completes a named create without capturing archive publications when no cache retainer exists', async () => {
+    const root = makeRoot()
+    const captureExplicitLock = vi.fn(
+      async () => `@EXPLICIT\nhttps://conda.example/osx-arm64/python-1.tar.bz2#${'a'.repeat(32)}\n`
+    )
+    const { deps } = makeNamedEnvDeps(root, { captureExplicitLock })
+
+    await new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
+
+    expect(await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).toEqual([])
+    expect(captureExplicitLock).not.toHaveBeenCalled()
+  })
+
   it('publishes and releases the Windows working cache after a successful create', async () => {
     const root = makeRoot()
     const release = vi.fn().mockResolvedValue(true)

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -67,6 +67,7 @@ import { defaultOperationChildLiveness, readProcessStartToken } from './operatio
 import { sandboxedPackageSpawn } from './package-process-sandbox'
 import type { InstallRequest } from './package-manager'
 import type { NotebookProcessSandbox } from './process-sandbox'
+import { buildManagedRuntimeProcessEnvironment } from './process-environment'
 import {
   isChildUnconfirmedError,
   captureMicromamba,
@@ -2007,10 +2008,27 @@ export const createProductionProvisioner = (
             const selected = await runner.resolve()
             return captureMicromamba(
               [selected, '--no-rc', 'list', '--prefix', prefix, '--explicit', '--md5'],
-              caEnv
+              micromambaSpawnEnv(opts.root, opts.caBundle)
             )
           }),
-    verify: deps.verify ?? ((bin, prefix) => verifyExecutable(bin, { prefix, env: caEnv })),
+    verify:
+      deps.verify ??
+      ((bin, prefix) => {
+        const language: NotebookLanguage = ['r', 'r.exe'].includes(basename(bin).toLowerCase())
+          ? 'r'
+          : 'python'
+        return verifyExecutable(bin, {
+          prefix,
+          env: buildManagedRuntimeProcessEnvironment(opts.root, {
+            language,
+            prefix,
+            platform: opts.micromamba?.platform,
+            sourceEnv: { ...process.env, ...caEnv }
+          }),
+          platform: opts.micromamba?.platform,
+          completeEnv: true
+        })
+      }),
     isPrefixBlocked: opts.isPrefixBlocked,
     clearPrefixBlock: opts.clearPrefixBlock,
     clearRuntimeBlock: opts.clearRuntimeBlock,

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1346,6 +1346,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           })
         )
         await this.deps.verify(bin, prefix)
+        if (!this.deps.retainWorkingCache) return []
         const explicitLock = await this.deps.captureExplicitLock?.(prefix)
         return explicitLock
           ? [

--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -376,6 +376,48 @@ describe('NotebookRecoveryCoordinator', () => {
     })
   })
 
+  it.skipIf(process.platform === 'win32')(
+    'keeps a valid managed Python prefix when host Python and pip state is hostile',
+    async () => {
+      const inherited = {
+        HOME: process.env.HOME,
+        PYTHONHOME: process.env.PYTHONHOME,
+        PIP_CONFIG_FILE: process.env.PIP_CONFIG_FILE
+      }
+      const runtimeRoot = await createRuntimeRoot()
+      const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+      const bin = pythonBin(prefix)
+      await mkdir(join(prefix, 'conda-meta'), { recursive: true })
+      await mkdir(dirname(bin), { recursive: true })
+      await writeFile(
+        bin,
+        `#!${process.execPath}\n` +
+          `if (process.env.HOME !== ${JSON.stringify(join(runtimeRoot, 'home'))}) process.exit(41)\n` +
+          `if (process.env.PYTHONHOME || process.env.PIP_CONFIG_FILE) process.exit(42)\n` +
+          `if (process.env.PYTHONNOUSERSITE !== '1') process.exit(43)\n`
+      )
+      await chmod(bin, 0o755)
+      const journal = await beginInterruptedMaterialize(runtimeRoot, 'valid-python', prefix)
+      try {
+        process.env.HOME = '/host/home'
+        process.env.PYTHONHOME = '/host/python'
+        process.env.PIP_CONFIG_FILE = '/host/pip.conf'
+
+        await new NotebookRecoveryCoordinator(runtimeRoot).recover()
+
+        expect({ prefixExists: existsSync(prefix), pending: await journal.pending() }).toEqual({
+          prefixExists: true,
+          pending: []
+        })
+      } finally {
+        for (const [key, value] of Object.entries(inherited)) {
+          if (value === undefined) delete process.env[key]
+          else process.env[key] = value
+        }
+      }
+    }
+  )
+
   describe.skipIf(process.platform === 'win32')('language-specific interpreter recovery', () => {
     it.each(['create-r', 'restore'])(
       'verifies the R interpreter for an interrupted %s operation',

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -18,6 +18,7 @@ import {
   type WorkingCacheFinalizationTarget
 } from './windows-micromamba-working-cache'
 import { defaultOperationChildLiveness, reconcileInterruptedOperations } from './operation-recovery'
+import { buildManagedRuntimeProcessEnvironment } from './process-environment'
 import { verifyExecutable } from './provisioner-runtime'
 import { addRepairRequired, DEFAULT_PY_ENV, DEFAULT_R_ENV, pythonBin, rBin } from './runtime-paths'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
@@ -277,7 +278,15 @@ export class NotebookRecoveryCoordinator {
             rejectUnsafe('Interrupted environment executable escapes the managed runtime root.')
           }
           try {
-            await verifyExecutable(canonicalBin, { prefix: canonicalPrefix })
+            const executableLanguage = language ?? (bin === pythonBin(targetPath) ? 'python' : 'r')
+            await verifyExecutable(canonicalBin, {
+              prefix: canonicalPrefix,
+              env: buildManagedRuntimeProcessEnvironment(this.runtimeRoot, {
+                language: executableLanguage,
+                prefix: canonicalPrefix
+              }),
+              completeEnv: true
+            })
             return
           } catch {
             // An interrupted mutation can leave an interpreter file before the prefix is runnable.

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -987,6 +987,9 @@ describe('notebook runtime service', () => {
       projectId: 'default-project',
       repository: new NotebookRunRepository(root),
       environmentStateTracker: verifiedPackageMutationTracker(),
+      getPackageMirror: () => ({
+        condaChannel: 'https://mirror.invalid/conda-forge/'
+      }),
       installPackagesImpl
     })
 
@@ -7692,7 +7695,7 @@ describe('notebook runtime service', () => {
       expect(result.target).toEqual({ language: 'python', selection: 'unresolved' })
     })
 
-    it('falls back to the region default mirror when nothing is configured', async () => {
+    it('falls back to public indexes when no configured or probed mirror is reachable', async () => {
       const root = await createStorageRoot()
       const calls: Array<Partial<InstallDepsForTest> | undefined> = []
       const service = new NotebookRuntimeService({
@@ -7709,9 +7712,8 @@ describe('notebook runtime service', () => {
         }),
         getPackageMirror: () => undefined,
         locale: 'zh-CN',
-        // Force the latency probe to find nothing reachable so the resolver takes the deterministic
-        // locale fallback (zh-CN -> CN mirror) instead of racing real network from the CI runner,
-        // where the public mirror wins and leaves condaChannel unset.
+        // Force the latency probe to find nothing reachable. The resolver must use public indexes
+        // rather than reviving an unverified locale mirror that the probe just rejected.
         mirrorProbe: {
           probe: async () => {
             throw new Error('probe unreachable (test)')
@@ -7727,8 +7729,9 @@ describe('notebook runtime service', () => {
       resetAutoMirrorCache()
       await service.managePackages({ language: 'r', packages: ['ggplot2'] })
 
-      expect(calls[0]?.condaChannel).toMatch(/tuna|ustc|aliyun/i)
-      expect(calls[0]?.cranMirror).toMatch(/tuna|ustc/i)
+      expect(calls[0]?.condaChannel).toBeUndefined()
+      expect(calls[0]?.pypiIndex).toBeUndefined()
+      expect(calls[0]?.cranMirror).toBeUndefined()
     })
 
     it('never spawns real installs when installPackagesImpl is injected (no getPackageMirror wired)', async () => {

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -24,10 +24,11 @@ import {
   resolveDataRoot,
   samePath
 } from '../storage-root'
-import { resolveMicromamba } from '../notebook/micromamba'
+import { micromambaSpawnEnv, resolveMicromamba } from '../notebook/micromamba'
 import type { MicromambaRunner } from '../notebook/windows-micromamba-runner'
 import { captureMicromamba } from '../notebook/provisioner-runtime'
 import { exportRuntimeLocks } from '../notebook/runtime-relocation'
+import { runtimeRoot } from '../notebook/runtime-paths'
 import { removeMicromambaCacheForRoot } from '../notebook/micromamba-cache'
 import { removeNotebookWorkloadCache } from '../notebook/notebook-workload-cache-paths'
 import { detectActiveSessions } from './detect-active'
@@ -504,7 +505,8 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
               mm: deps.micromambaRunner
                 ? await deps.micromambaRunner.resolve()
                 : resolveMicromamba({ resourcesPath: process.resourcesPath }),
-              capture: captureMicromamba
+              capture: (argv) =>
+                captureMicromamba(argv, micromambaSpawnEnv(runtimeRoot(fromDataRoot)))
             })
         },
         request.parent,

--- a/src/shared/mirror.ts
+++ b/src/shared/mirror.ts
@@ -14,12 +14,13 @@ export type AutomaticPackageMirrorCandidate = Readonly<{
   mirror: PackageMirror
   probeUrl: string
   biocondaProbeUrl: string
+  trustedDomains: readonly string[]
 }>
 
 const condaRepodata = (base: string): string =>
-  `${base}anaconda/cloud/conda-forge/noarch/repodata.json`
+  `${base}anaconda/cloud/conda-forge/noarch/current_repodata.json`
 const biocondaRepodata = (base: string): string =>
-  `${base}anaconda/cloud/bioconda/noarch/repodata.json`
+  `${base}anaconda/cloud/bioconda/noarch/current_repodata.json`
 
 export const CURATED_MIRRORS = {
   cn: {
@@ -35,14 +36,16 @@ export const AUTOMATIC_PACKAGE_MIRROR_CANDIDATES: readonly AutomaticPackageMirro
   {
     name: 'public',
     mirror: {},
-    probeUrl: 'https://conda.anaconda.org/conda-forge/noarch/repodata.json',
-    biocondaProbeUrl: 'https://conda.anaconda.org/bioconda/noarch/repodata.json'
+    probeUrl: 'https://conda.anaconda.org/conda-forge/noarch/current_repodata.json',
+    biocondaProbeUrl: 'https://conda.anaconda.org/bioconda/noarch/current_repodata.json',
+    trustedDomains: ['conda.anaconda.org']
   },
   {
     name: 'tuna',
     mirror: { ...CURATED_MIRRORS.cn },
     probeUrl: condaRepodata('https://mirrors.tuna.tsinghua.edu.cn/'),
-    biocondaProbeUrl: biocondaRepodata('https://mirrors.tuna.tsinghua.edu.cn/')
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.tuna.tsinghua.edu.cn/'),
+    trustedDomains: ['mirrors.tuna.tsinghua.edu.cn', 'pypi.tuna.tsinghua.edu.cn']
   },
   {
     name: 'ustc',
@@ -52,7 +55,8 @@ export const AUTOMATIC_PACKAGE_MIRROR_CANDIDATES: readonly AutomaticPackageMirro
       cranMirror: 'https://mirrors.ustc.edu.cn/CRAN/'
     },
     probeUrl: condaRepodata('https://mirrors.ustc.edu.cn/'),
-    biocondaProbeUrl: biocondaRepodata('https://mirrors.ustc.edu.cn/')
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.ustc.edu.cn/'),
+    trustedDomains: ['mirrors.ustc.edu.cn', 'mirrors.nju.edu.cn']
   },
   {
     name: 'aliyun',
@@ -62,24 +66,13 @@ export const AUTOMATIC_PACKAGE_MIRROR_CANDIDATES: readonly AutomaticPackageMirro
       cranMirror: 'https://mirrors.aliyun.com/CRAN/'
     },
     probeUrl: condaRepodata('https://mirrors.aliyun.com/'),
-    biocondaProbeUrl: biocondaRepodata('https://mirrors.aliyun.com/')
+    biocondaProbeUrl: biocondaRepodata('https://mirrors.aliyun.com/'),
+    trustedDomains: ['mirrors.aliyun.com']
   }
 ]
 
 export const AUTOMATIC_PACKAGE_MIRROR_DOMAINS = [
-  ...new Set(
-    AUTOMATIC_PACKAGE_MIRROR_CANDIDATES.flatMap((candidate) =>
-      [
-        candidate.probeUrl,
-        candidate.biocondaProbeUrl,
-        candidate.mirror.condaChannel,
-        candidate.mirror.pypiIndex,
-        candidate.mirror.cranMirror
-      ]
-        .filter((url): url is string => Boolean(url))
-        .map((url) => new URL(url).hostname)
-    )
-  )
+  ...new Set(AUTOMATIC_PACKAGE_MIRROR_CANDIDATES.flatMap((candidate) => candidate.trustedDomains))
 ]
 
 // "View available mirrors" help link target: the TUNA Anaconda mirror help page, which lists the


### PR DESCRIPTION
## Problem

Managed notebook provisioning and package operations could inherit the host user Python, Conda/Micromamba, and R state. On the reported macOS network, the selected TUNA Conda mirror returned HTTP 403; the application then reused the rejected locale mirror instead of falling back and cached the failed probe indefinitely. Recovery also treated legitimate Conda package symlinks as corruption and could leave completed non-Windows operations in the recovery journal. The production sandbox additionally conflicted with Micromamba setgid repodata-cache preparation.

## Proposed change

- Give managed Python and R processes app-owned HOME/XDG, package caches, runtime registries, rc state, and language-specific isolation while preserving external/BYO runtime behavior.
- Probe mirrors with redirect-domain validation, fall back to public/default sources after all probes fail, and allow failed selections to retry.
- Prepare and validate the macOS Micromamba repodata cache before entering Seatbelt, with descriptor-bound identity and permission checks.
- Skip legitimate extracted-package symlinks during archive discovery while preventing symlinks or replacement races from becoming trusted archive sources.
- Bind archive verification and publication to one validated source descriptor, copy to an exclusive snapshot while hashing, then atomically publish only authorized bytes.
- Do not create archive-publication journal work on platforms without a managed working-cache retainer; sanitize recovery subprocess environments.

## Scope and non-goals

- Managed runtimes only; external/BYO Python and R behavior is preserved.
- No expansion of sandbox filesystem grants.
- No deletion or adoption of user-managed Conda, Micromamba, Python, or R state.
- No UI, schema, or package-manager selection changes.

## Acceptance criteria and validation

Current head is `0daca88c`, rebased onto `origin/main` at `f9cc7963`.

- Rebased-head regression set for the conflict and final security/recovery changes -> focused Vitest run for provisioner, archive store, and package mutation -> 3 files / 143 tests passed.
- Archive source replacement defenses -> deterministic tests cover replacement with a symlink after enumeration and path replacement when digesting completes; publication either rejects the changed identity or publishes only the already verified descriptor snapshot.
- Real macOS development flow -> `npm run dev` started the application; the app created fresh managed environment `mirror-fix-final3-test`, provisioned Python 3.12.14 and pandas 3.0.5, switched the Notebook runtime, imported pandas, and produced `3.0.5`.
- Recovery durability after the real create/install -> direct runtime verification returned Python 3.12.14 / pandas 3.0.5 and `operation-journal.json` was absent.
- Patch hygiene -> `git diff --check origin/main...HEAD` passed; worktree is clean.
- Independent final review after the rebase -> Spec review: 0 findings; Standards review: 0 hard findings. `range-diff` confirmed the five-commit patch semantics were preserved, with the sole manual conflict correctly retaining both upstream `readFileSync` and branch `chmodSync` imports.

The PR Gate supplies the repository-wide portable, platform, type, lint, and E2E validation for this final head.

## Review focus

- Managed versus external/BYO runtime boundary.
- Mirror failure fallback and retry behavior after HTTP 403 or other probe failures.
- Micromamba state/cache confinement and macOS pre-sandbox setgid preparation.
- Descriptor-bound symlink/TOCTOU defenses during archive publication.
- Recovery-journal completion on platforms without a working-cache publisher.
- Managed R startup, installation, and library isolation.

## Risks

- Archive publication is enabled for the Windows managed working-cache path. The implementation does not rely only on `O_NOFOLLOW`: it also validates `fstat` against the enumerated `dev/ino`, rejects a current-path symlink via `lstat`, checks the physical path, and reads only the fixed descriptor. A dedicated Windows junction/reparse integration case would still be a useful follow-up; current Windows behavior remains covered by PR CI.