### PR TITLE
fix(session-plan): preserve response and delivery correctness

### DIFF
--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -62,6 +62,7 @@ const createDependencies = (): AcpApplicationCommandDependencies => ({
     respondToElicitation: vi.fn(async () => snapshot),
     getSessionPlanProjection: vi.fn(async () => null),
     respondSessionPlan: vi.fn(async () => ({ projection: {} as never, changed: true })),
+    discardUnavailableSessionPlan: vi.fn(async () => ({ revision: 2 })),
     setPermissionProfile: vi.fn(async () => snapshot),
     revokePermissionGrant: vi.fn(async () => snapshot)
   },
@@ -140,6 +141,7 @@ describe('ACP application commands', () => {
       'acp:continue-interrupted-turn',
       'acp:create-session',
       'acp:delete-session',
+      'acp:discard-unavailable-plan',
       'acp:disconnect',
       'acp:get-plan-projection',
       'acp:get-state',
@@ -404,6 +406,55 @@ describe('ACP application commands', () => {
     ).rejects.toThrow('Caller authorization is no longer current.')
 
     expect(dependencies.runtime.respondToPermission).toHaveBeenCalledTimes(humanCallers.length)
+  })
+
+  it('admits explicit unavailable Plan discard only for a current human and an available Session', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    const available = vi.fn(
+      async (_project: string, _session: string, operation: () => Promise<unknown>) => operation()
+    )
+    const archiveAvailability = {
+      ...ownerResolvingArchiveAvailability('project-1'),
+      withSessionAvailable: available
+    } as NonNullable<AcpApplicationCommandDependencies['archiveAvailability']>
+    registerAcpCommands(router.registrar, { ...dependencies, archiveAvailability })
+    const request = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      expectedRevision: 1
+    }
+    await expect(
+      router.dispatcher.invoke(acpCommands.discardUnavailablePlan, invocation([request]))
+    ).resolves.toEqual({ revision: 2 })
+    expect(available).toHaveBeenCalledWith('project-1', 'session-1', expect.any(Function))
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.discardUnavailablePlan,
+        invocation([request], createTaskCallerContext())
+      )
+    ).rejects.toThrow('Only a current human')
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.discardUnavailablePlan,
+        invocation(
+          [request],
+          createWebCallerContext('stale', { isAuthorizationCurrent: () => false })
+        )
+      )
+    ).rejects.toThrow('Caller authorization')
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.discardUnavailablePlan,
+        invocation([{ ...request, expectedRevision: -1 }])
+      )
+    ).rejects.toBeInstanceOf(Error)
+    available.mockRejectedValueOnce(new Error('Session archived'))
+    await expect(
+      router.dispatcher.invoke(acpCommands.discardUnavailablePlan, invocation([request]))
+    ).rejects.toThrow('Session archived')
+    expect(dependencies.runtime.discardUnavailableSessionPlan).toHaveBeenCalledTimes(1)
   })
 
   it('routes Plan decisions and revision feedback from current humans and Task automation', async () => {

--- a/src/main/acp/application-commands.ts
+++ b/src/main/acp/application-commands.ts
@@ -110,6 +110,21 @@ const acpResponseCommandContracts = Object.freeze({
     ),
     acpStateCommandResponseCodec
   ),
+  discardUnavailablePlan: defineApplicationCommandContract(
+    validationCodec(
+      z.tuple([
+        z
+          .object({
+            projectId: z.string().min(1),
+            sessionId: z.string().min(1),
+            artifactVersionId: z.string().min(1),
+            expectedRevision: z.number().int().nonnegative()
+          })
+          .strict()
+      ])
+    ),
+    validationCodec(z.object({ revision: z.number().int().nonnegative() }).strict())
+  ),
   plan: defineApplicationCommandContract(
     validationCodec(
       z.tuple([
@@ -224,6 +239,11 @@ const acpCommands = Object.freeze({
     readonly [projectId: string, sessionId: string],
     ActivePlanProjection | null
   >('acp:get-plan-projection'),
+  discardUnavailablePlan: defineApplicationCommand<
+    'acp:discard-unavailable-plan',
+    readonly [request: Parameters<AcpRuntimeCoordinator['discardUnavailableSessionPlan']>[0]],
+    { revision: number }
+  >('acp:discard-unavailable-plan', acpResponseCommandContracts.discardUnavailablePlan),
   respondPlan: defineApplicationCommand<
     'acp:respond-plan',
     readonly [request: Parameters<AcpRuntimeCoordinator['respondSessionPlan']>[0]],
@@ -250,7 +270,8 @@ const acpApplicationCommands = defineApplicationCommandGroup('acp', [
   acpCommands.setPermissionProfile,
   acpCommands.revokePermissionGrant,
   acpCommands.getPlanProjection,
-  acpCommands.respondPlan
+  acpCommands.respondPlan,
+  acpCommands.discardUnavailablePlan
 ] as const)
 
 type AcpApplicationCommandRuntime = Pick<
@@ -270,6 +291,7 @@ type AcpApplicationCommandRuntime = Pick<
   | 'revokePermissionGrant'
   | 'getSessionPlanProjection'
   | 'respondSessionPlan'
+  | 'discardUnavailableSessionPlan'
 >
 
 type AcpApplicationCommandDependencies = Readonly<{
@@ -432,6 +454,20 @@ const registerAcpCommands = (
           )
         }
         return dependencies.runtime.getSessionPlanProjection(invocation.args[0], invocation.args[1])
+      },
+      'acp:discard-unavailable-plan': (invocation) => {
+        if (!canSatisfyHumanApproval(invocation.callerContext)) {
+          throw new Error('Only a current human caller can discard an unavailable Session Plan.')
+        }
+        return preserveSessionSizeLimitCode(() =>
+          dependencies.archiveAvailability
+            ? dependencies.archiveAvailability.withSessionAvailable(
+                invocation.args[0].projectId,
+                invocation.args[0].sessionId,
+                () => dependencies.runtime.discardUnavailableSessionPlan(invocation.args[0])
+              )
+            : dependencies.runtime.discardUnavailableSessionPlan(invocation.args[0])
+        )
       },
       'acp:respond-plan': (invocation) => {
         if (!canAccessSessionPlan(invocation.callerContext)) {

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -444,6 +444,7 @@ describe('ACP module transport seam', () => {
       .sort()
 
     const runtimeValidatedChannels = [
+      'acp:discard-unavailable-plan',
       'acp:respond-elicitation',
       'acp:respond-permission',
       'acp:respond-plan'

--- a/src/main/acp/provider-prompt-executor.test.ts
+++ b/src/main/acp/provider-prompt-executor.test.ts
@@ -18,6 +18,15 @@ import {
   type ProviderPromptExecutionInput
 } from './provider-prompt-executor'
 import type { AcpProviderTurnAdapter, AcpProviderTurnProbe } from './provider-turn-adapter'
+import {
+  sanitizeSessionRuntimeContext,
+  type SessionRuntimeContext
+} from '../../shared/session-persistence'
+import {
+  SessionPlanDeliveryOwner,
+  type SessionPlanDeliverySessions
+} from './session-plan-delivery-owner'
+import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
 
 type NextUpdate = Awaited<ReturnType<ActiveSession['nextUpdate']>>
 
@@ -129,6 +138,86 @@ const setup = (
 }
 
 describe('AcpProviderPromptExecutor', () => {
+  it.each(['claude-code', 'opencode', 'codex', 'codebuddy'] as const)(
+    'P03 does not requeue accepted output after a receipt revision conflict on %s',
+    async (frameworkId) => {
+      const fixture = setup()
+      let context: SessionRuntimeContext = {
+        version: 1,
+        revision: 0,
+        plan: {
+          artifactId: 'artifact-1',
+          artifactVersionId: 'version-1',
+          artifactChecksum: 'a'.repeat(64),
+          originatingPromptMessageId: 'prompt-1',
+          approval: 'approved',
+          stepStatuses: {},
+          delivery: {
+            commandId: 'command-1',
+            kind: 'approved-plan',
+            state: 'delivering',
+            originatingPromptMessageId: 'prompt-1',
+            createdAt: 1
+          }
+        }
+      }
+      let concurrentWritePending = true
+      const sessions: SessionPlanDeliverySessions = {
+        readSessionRuntimeContext: vi.fn(async () => structuredClone(context)),
+        patchSessionRuntimeContext: vi.fn(async (command) => {
+          if (concurrentWritePending) {
+            concurrentWritePending = false
+            // An unrelated owner wins the same runtime-context revision; the receipt is unchanged.
+            context = { ...context, revision: context.revision + 1 }
+          }
+          if (command.expectedRevision !== context.revision) {
+            throw Object.assign(new Error('revision conflict'), { code: 'revision-conflict' })
+          }
+          const next = sanitizeSessionRuntimeContext({
+            ...context,
+            ...command.patch,
+            revision: context.revision + 1
+          })
+          if (!next) throw new Error('Session runtime context patch is not JSON-safe.')
+          context = next
+          return structuredClone(context)
+        })
+      }
+      const deliveries = new SessionPlanDeliveryOwner(sessions)
+      const workflow = composeAcpRuntimePlanWorkflow(
+        {} as Parameters<typeof composeAcpRuntimePlanWorkflow>[0],
+        {} as Parameters<typeof composeAcpRuntimePlanWorkflow>[1],
+        { publication: { pushEvent: vi.fn() } } as unknown as Parameters<
+          typeof composeAcpRuntimePlanWorkflow
+        >[2],
+        { deliveries }
+      )
+      const disconnected = new Error('provider disconnected after first output')
+      vi.mocked(fixture.session.nextUpdate)
+        .mockResolvedValueOnce(update())
+        .mockRejectedValueOnce(disconnected)
+      await expect(
+        fixture.executor.execute({
+          ...fixture.input,
+          frameworkId,
+          onAccepted: () =>
+            workflow.prompt.providerAccepted('session-1', {
+              kind: 'app-continuation',
+              planDelivery: { projectId: 'project-1', commandId: 'command-1' }
+            })
+        })
+      ).rejects.toBe(disconnected)
+      expect(fixture.routeNotification).toHaveBeenCalledWith(notification)
+      // A fresh owner sees only persisted state, as after a restart. Recovery uses this public operation.
+      const restartedOwner = new SessionPlanDeliveryOwner(sessions)
+      const requeued = await restartedOwner.rearmUnaccepted('project-1', 'session-1', 'command-1')
+      expect({ requeued, state: context.plan?.delivery?.state }).toEqual({
+        requeued: false,
+        state: 'accepted'
+      })
+    }
+  )
+
   it('gives the Claude adapter a transcript reader for the active config root', async () => {
     const executor = new AcpProviderPromptExecutor({
       backendGeneration: {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -356,6 +356,12 @@ class AcpRuntimeCoordinator {
     return this.runtimeForSession(sessionId).getSessionPlanProjection(projectId, sessionId)
   }
 
+  discardUnavailableSessionPlan(
+    input: Parameters<AcpRuntime['discardUnavailableSessionPlan']>[0]
+  ): Promise<{ revision: number }> {
+    return this.runtimeForSession(input.sessionId).discardUnavailableSessionPlan(input)
+  }
+
   respondSessionPlan(
     input: Parameters<AcpRuntime['respondSessionPlan']>[0]
   ): ReturnType<AcpRuntime['respondSessionPlan']> {

--- a/src/main/acp/runtime-plan-composition.test.ts
+++ b/src/main/acp/runtime-plan-composition.test.ts
@@ -263,6 +263,88 @@ beforeEach(() => {
 })
 
 describe('ACP Session Plan approval causality', () => {
+  it.each(
+    ['approved', 'rejected', 'feedback'].flatMap((responseKind) =>
+      [false, true].map((reusePrompt) => ({
+        responseKind: responseKind as 'approved' | 'rejected' | 'feedback',
+        reusePrompt
+      }))
+    )
+  )(
+    'P02 preserves the replacement waiter for $responseKind (reuse prompt: $reusePrompt)',
+    async ({ responseKind, reusePrompt }) => {
+      const harness = createHarness()
+      const replacementPrompt = reusePrompt ? 'prompt-1' : 'prompt-2'
+      const controller = new AbortController()
+      const generation = harness.workflow
+        .call({
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          operation: 'generate',
+          input: {},
+          signal: controller.signal
+        })
+        .catch((error: unknown) => error)
+      await vi.waitFor(() =>
+        expect(harness.interactions.approvalInteractionIdFor('session-1')).toBe('prompt-1')
+      )
+      let releaseBegin!: () => void
+      const barrier = new Promise<void>((resolve) => {
+        releaseBegin = resolve
+      })
+      const originalBegin =
+        harness.deliveries.begin.getMockImplementation() as () => Promise<boolean>
+      harness.deliveries.begin.mockImplementationOnce(async () => {
+        await barrier
+        return originalBegin()
+      })
+      const response = harness.workflow.respond(
+        responseKind === 'feedback'
+          ? { projectId: 'project-1', sessionId: 'session-1', feedback: 'Revise the analysis.' }
+          : {
+              projectId: 'project-1',
+              sessionId: 'session-1',
+              artifactVersionId: 'version-1',
+              expectedRevision: 1,
+              decision: responseKind
+            }
+      )
+      await vi.waitFor(() => expect(harness.deliveries.begin).toHaveBeenCalledOnce())
+      controller.abort()
+      await expect(generation).resolves.toBeInstanceOf(Error)
+      harness.sessionInteractions.release(harness.interaction)
+      harness.sessionInteractions.claim({
+        sessionId: 'session-1',
+        kind: 'prompt',
+        promptMessageId: replacementPrompt
+      })
+      harness.interactions.register({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-2',
+        interactionId: replacementPrompt
+      })
+      const received = vi.fn()
+      const replacement = harness.interactions
+        .parkApproval('session-1', replacementPrompt)
+        .then(received, () => undefined)
+      try {
+        releaseBegin()
+        await response
+        expect.soft(received).not.toHaveBeenCalled()
+        expect(harness.interactions.approvalInteractionIdFor('session-1')).toBe(replacementPrompt)
+        expect(harness.deliveries.clear).not.toHaveBeenCalled()
+        expect(harness.deliveries.rearmUnaccepted).toHaveBeenCalledWith(
+          'project-1',
+          'session-1',
+          'receipt-1'
+        )
+      } finally {
+        harness.interactions.clearSession('session-1', 'test cleanup')
+        await replacement
+      }
+    }
+  )
+
   it('aborts generate by clearing the real approval waiter while retaining the pending Plan', async () => {
     const harness = createHarness()
     const controller = new AbortController()

--- a/src/main/acp/runtime-plan-composition.test.ts
+++ b/src/main/acp/runtime-plan-composition.test.ts
@@ -90,6 +90,7 @@ const createHarness = (
   queueReviewFeedbackDelivery: ReturnType<typeof vi.fn>
   getProjection: ReturnType<typeof vi.fn>
   getDeliveryContext: ReturnType<typeof vi.fn>
+  discardUnavailable: ReturnType<typeof vi.fn>
   containsMessageOnActiveBranch: ReturnType<typeof vi.fn>
   deliveryState: () => 'queued' | 'delivering' | 'accepted' | undefined
   deliveries: Readonly<{
@@ -181,6 +182,16 @@ const createHarness = (
     if (!options.deliveryContext) throw new Error('No delivery context configured.')
     return options.deliveryContext
   })
+  const discardUnavailable = vi.fn(
+    async (input: {
+      authorizeDiscard?: (plan: { originatingPromptMessageId: string }) => Promise<void>
+      beforePersist?: () => void
+    }) => {
+      await input.authorizeDiscard?.({ originatingPromptMessageId: 'prompt-1' })
+      input.beforePersist?.()
+      return { revision: current.revision + 1 }
+    }
+  )
   const service = {
     generate,
     respond,
@@ -188,7 +199,8 @@ const createHarness = (
     queueSettledDecisionDelivery,
     queueReviewFeedbackDelivery,
     getProjection,
-    getDeliveryContext
+    getDeliveryContext,
+    discardUnavailable
   }
   const deliveries = {
     accept: vi.fn(async () => {
@@ -252,6 +264,7 @@ const createHarness = (
     queueReviewFeedbackDelivery,
     getProjection,
     getDeliveryContext,
+    discardUnavailable,
     containsMessageOnActiveBranch,
     deliveryState: () => deliveryState,
     deliveries
@@ -1230,5 +1243,66 @@ describe('ACP Runtime Session Plan composition', () => {
     expect(prompt).toContain('plan: host.plan')
     expect(plan).toContain('const prompt: AcpPromptTurnPlanWorkflow = Object.freeze({')
     expect(plan).not.toMatch(/from ['"]electron['"]|application-commands|ipc|runtime-coordinator/)
+  })
+})
+
+describe('explicit unavailable Plan recovery ownership', () => {
+  const identity = {
+    projectId: 'project-1',
+    sessionId: 'session-1',
+    artifactVersionId: 'version-1',
+    expectedRevision: 1
+  }
+  it('allows restored recovery on the active branch without a live prompt', async () => {
+    const harness = createHarness()
+    harness.sessionInteractions.release(harness.interaction)
+    await expect(harness.workflow.discardUnavailable(identity)).resolves.toMatchObject({
+      revision: expect.any(Number)
+    })
+    expect(harness.containsMessageOnActiveBranch).toHaveBeenCalledWith(
+      'project-1',
+      'session-1',
+      'prompt-1'
+    )
+  })
+  it('rejects cross-branch recovery without releasing the waiter', async () => {
+    const harness = createHarness({ containsOriginatingMessage: false })
+    const approval = harness.interactions
+      .parkApproval('session-1', 'prompt-1')
+      .catch(() => undefined)
+    const token = harness.interactions.approvalTokenFor('session-1')
+    await expect(harness.workflow.discardUnavailable(identity)).rejects.toMatchObject({
+      code: 'interaction-mismatch'
+    })
+    expect(harness.interactions.approvalTokenFor('session-1')).toBe(token)
+    harness.interactions.rejectApproval('session-1', 'test cleanup')
+    await approval
+  })
+  it('releases only the parked approval after successful persistence', async () => {
+    const harness = createHarness()
+    const approval = harness.interactions
+      .parkApproval('session-1', 'prompt-1')
+      .catch((error: unknown) => error)
+    await harness.workflow.discardUnavailable(identity)
+    expect(await approval).toMatchObject({ message: 'The unavailable Session Plan was discarded.' })
+  })
+  it('does not discard during an executing prompt or after a replacement claims the Session', async () => {
+    const harness = createHarness()
+    await expect(harness.workflow.discardUnavailable(identity)).rejects.toMatchObject({
+      code: 'interaction-mismatch'
+    })
+    expect(harness.discardUnavailable).not.toHaveBeenCalled()
+    harness.sessionInteractions.release(harness.interaction)
+    harness.containsMessageOnActiveBranch.mockImplementation(async () => {
+      harness.sessionInteractions.claim({
+        sessionId: 'session-1',
+        kind: 'prompt',
+        promptMessageId: 'replacement'
+      })
+      return true
+    })
+    await expect(harness.workflow.discardUnavailable(identity)).rejects.toMatchObject({
+      code: 'interaction-mismatch'
+    })
   })
 })

--- a/src/main/acp/runtime-plan-composition.test.ts
+++ b/src/main/acp/runtime-plan-composition.test.ts
@@ -276,6 +276,62 @@ beforeEach(() => {
 })
 
 describe('ACP Session Plan approval causality', () => {
+  it('preserves a replacement waiter when stale feedback cleanup reuses the prompt ID', async () => {
+    const harness = createHarness()
+    harness.interactions.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionId: 'prompt-1'
+    })
+    const oldApproval = harness.interactions
+      .parkApproval('session-1', 'prompt-1')
+      .catch(() => undefined)
+    const entered = Promise.withResolvers<void>()
+    const resume = Promise.withResolvers<void>()
+    const originalRespond = harness.respond.getMockImplementation() as (
+      input: unknown
+    ) => Promise<unknown>
+    harness.respond.mockImplementationOnce(async (input) => {
+      entered.resolve()
+      await resume.promise
+      return originalRespond(input)
+    })
+    const response = harness.workflow
+      .respond({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        feedback: 'Revise the analysis.'
+      })
+      .catch((error: unknown) => error)
+    await entered.promise
+    harness.interactions.rejectApproval('session-1', 'old prompt detached')
+    await oldApproval
+    harness.sessionInteractions.release(harness.interaction)
+    harness.sessionInteractions.claim({
+      sessionId: 'session-1',
+      kind: 'prompt',
+      promptMessageId: 'prompt-1'
+    })
+    harness.interactions.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-2',
+      interactionId: 'prompt-1'
+    })
+    const rejected = vi.fn()
+    const replacement = harness.interactions.parkApproval('session-1', 'prompt-1').catch(rejected)
+    const token = harness.interactions.approvalTokenFor('session-1')
+    try {
+      resume.resolve()
+      expect(await response).toMatchObject({ code: 'interaction-mismatch' })
+      expect.soft(rejected).not.toHaveBeenCalled()
+      expect.soft(harness.interactions.approvalTokenFor('session-1')).toBe(token)
+      expect(harness.interactions.interactionIdFor('session-1', 'version-2')).toBe('prompt-1')
+    } finally {
+      harness.interactions.clearSession('session-1', 'test cleanup')
+      await replacement
+    }
+  })
+
   it.each(
     ['approved', 'rejected', 'feedback'].flatMap((responseKind) =>
       [false, true].map((reusePrompt) => ({

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -172,6 +172,7 @@ const composeAcpRuntimePlanWorkflow = (
     interactions.rejectApproval(sessionId, reason)
   }
   const call = async (input: AcpSessionPlanCall): Promise<unknown> => {
+    const approvalToken = interactions.approvalTokenFor(input.sessionId)
     if (!service) throw new Error('Session Plan capability is not configured.')
     if (input.operation === 'generate') {
       const execution = sessionInteractions.current(input.sessionId)
@@ -296,7 +297,7 @@ const composeAcpRuntimePlanWorkflow = (
           authorization.interactionSequence
         )
       }
-      interactions.resolveApproval(input.sessionId, result)
+      interactions.resolveApproval(input.sessionId, result, approvalToken)
       if (result.deliveryCommandId) {
         await clearDeliveryReceipt(input.projectId, input.sessionId, result.deliveryCommandId)
       }
@@ -374,6 +375,7 @@ const composeAcpRuntimePlanWorkflow = (
   const respond = async (input: PlanResponseCommand): Promise<PlanResponseResult> => {
     if (!service) throw new Error('Session Plan capability is not configured.')
     const approvalInteractionId = interactions.approvalInteractionIdFor(input.sessionId)
+    const approvalToken = interactions.approvalTokenFor(input.sessionId)
     const feedbackInteraction =
       input.decision === undefined ? sessionInteractions.current(input.sessionId) : undefined
     const detachedFeedback = input.decision === undefined && approvalInteractionId === undefined
@@ -418,7 +420,7 @@ const composeAcpRuntimePlanWorkflow = (
         ? (): void => {
             const activeInteraction = sessionInteractions.current(input.sessionId)
             if (
-              interactions.approvalInteractionIdFor(input.sessionId) === approvalInteractionId &&
+              interactions.approvalTokenFor(input.sessionId) === approvalToken &&
               interactions.interactionIdFor(input.sessionId, current.artifactVersionId) ===
                 approvalInteractionId &&
               activeInteraction?.kind === 'prompt' &&
@@ -441,7 +443,7 @@ const composeAcpRuntimePlanWorkflow = (
     const beforeDecisionCommit =
       input.decision !== undefined && approvalInteractionId
         ? (): boolean =>
-            interactions.approvalInteractionIdFor(input.sessionId) === approvalInteractionId &&
+            interactions.approvalTokenFor(input.sessionId) === approvalToken &&
             interactions.interactionIdFor(input.sessionId, current.artifactVersionId) ===
               approvalInteractionId
         : undefined
@@ -461,7 +463,7 @@ const composeAcpRuntimePlanWorkflow = (
       const waiterDetached =
         input.decision !== undefined &&
         approvalInteractionId !== undefined &&
-        interactions.approvalInteractionIdFor(input.sessionId) !== approvalInteractionId
+        interactions.approvalTokenFor(input.sessionId) !== approvalToken
       if (!waiterDetached) throw error
       retriedAfterDecisionDetach = true
       result = await service.respond({
@@ -478,7 +480,7 @@ const composeAcpRuntimePlanWorkflow = (
         interactionIsLive &&
         !retriedAfterDecisionDetach &&
         approvalInteractionId !== undefined &&
-        interactions.approvalInteractionIdFor(input.sessionId) === approvalInteractionId
+        interactions.approvalTokenFor(input.sessionId) === approvalToken
       if (result.deliveryCommandId && !sameWaiterIsLive) {
         publishProjection(input.sessionId, result.projection)
         return result
@@ -492,7 +494,8 @@ const composeAcpRuntimePlanWorkflow = (
       }
       const handedOffResult = { ...result }
       const resolved =
-        interactionIsLive && interactions.resolveApproval(input.sessionId, handedOffResult)
+        interactionIsLive &&
+        interactions.resolveApproval(input.sessionId, handedOffResult, approvalToken)
       if (result.deliveryCommandId && !resolved) {
         await rearmDeliveryReceipt(input.projectId, input.sessionId, result.deliveryCommandId)
         const queuedProjection =
@@ -565,25 +568,26 @@ const composeAcpRuntimePlanWorkflow = (
       currentInteraction.sequence === feedbackInteraction.sequence &&
       currentInteraction.promptMessageId === feedbackInteraction.promptMessageId
     const sameFeedbackWaiterIsLive =
-      interactionIsCurrent &&
-      interactions.approvalInteractionIdFor(input.sessionId) === approvalInteractionId
+      interactionIsCurrent && interactions.approvalTokenFor(input.sessionId) === approvalToken
     if (!sameFeedbackWaiterIsLive) {
       return result
     }
     if (!(await beginDeliveryReceipt(input.projectId, input.sessionId, result.deliveryCommandId))) {
       return result
     }
-    if (interactionIsCurrent) {
+    const afterBegin = sessionInteractions.current(input.sessionId)
+    const handedOffFeedback = { ...result }
+    const feedbackResolved =
+      afterBegin?.kind === 'prompt' &&
+      afterBegin.sequence === feedbackInteraction.sequence &&
+      afterBegin.promptMessageId === feedbackInteraction.promptMessageId &&
+      interactions.resolveApproval(input.sessionId, handedOffFeedback, approvalToken)
+    if (feedbackResolved) {
       interactions.authorizeAgentDecision({
         sessionId: input.sessionId,
         artifactVersionId: result.artifactVersionId,
         interactionSequence: feedbackInteraction.sequence
       })
-    }
-    const handedOffFeedback = { ...result }
-    const feedbackResolved = interactions.resolveApproval(input.sessionId, handedOffFeedback)
-    if (!feedbackResolved && interactionIsCurrent) {
-      interactions.releaseAgentDecisionAuthorization(input.sessionId, feedbackInteraction.sequence)
     }
     if (!feedbackResolved) {
       await rearmDeliveryReceipt(input.projectId, input.sessionId, result.deliveryCommandId)
@@ -707,14 +711,26 @@ const composeAcpRuntimePlanWorkflow = (
   }
   const providerAccepted = async (sessionId: string, mode: AcpPromptTurnMode): Promise<void> => {
     if (mode.kind !== 'app-continuation' || !mode.planDelivery || !deliveryOwner) return
-    if (
-      !(await deliveryOwner.accept(
-        mode.planDelivery.projectId,
-        sessionId,
-        mode.planDelivery.commandId
-      ))
-    ) {
+    try {
+      if (
+        await deliveryOwner.accept(
+          mode.planDelivery.projectId,
+          sessionId,
+          mode.planDelivery.commandId
+        )
+      )
+        return
       throw new Error('The Plan delivery could not record provider acceptance.')
+    } catch (error) {
+      // Acceptance is delivery evidence, not disposable usage telemetry. Keep the receipt uncertain.
+      pushEvent({
+        kind: 'error',
+        level: 'error',
+        sessionId,
+        title: 'Could not record Plan delivery acceptance',
+        text: 'The Agent has responded, but its Plan delivery receipt could not be saved. Check the conversation before sending another execution request.'
+      })
+      throw error
     }
   }
   const prompt: AcpPromptTurnPlanWorkflow = Object.freeze({

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -2,7 +2,8 @@ import type { AcpPromptRequest, AcpRuntimeEventInput } from '../../shared/acp'
 import type {
   ActivePlanProjection,
   GeneratePlanContent,
-  PlanResponseCommand
+  PlanResponseCommand,
+  PlanResponseIdentity
 } from '../../shared/session-plan/contract'
 import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { SessionPlanStepStatus } from '../../shared/session-persistence'
@@ -371,6 +372,46 @@ const composeAcpRuntimePlanWorkflow = (
   ): Promise<ActivePlanProjection | null> => {
     if (!service) return Promise.resolve(null)
     return service.getProjection(projectId, sessionId)
+  }
+  const discardUnavailable = async (input: PlanResponseIdentity): Promise<{ revision: number }> => {
+    if (!service) throw new Error('Session Plan capability is not configured.')
+    const interaction = sessionInteractions.current(input.sessionId)
+    const approvalToken = interactions.approvalTokenFor(input.sessionId)
+    const assertCurrent = (): void => {
+      if (
+        sessionInteractions.current(input.sessionId) !== interaction ||
+        interactions.approvalTokenFor(input.sessionId) !== approvalToken ||
+        (interaction && !approvalToken)
+      ) {
+        throw new PlanCommandError(
+          'interaction-mismatch',
+          'Stop the active turn before discarding the unavailable Plan.'
+        )
+      }
+    }
+    assertCurrent()
+    const result = await service.discardUnavailable({
+      ...input,
+      authorizeDiscard: async (plan) => {
+        if (
+          !(await containsDurableBranchMessage(
+            input.projectId,
+            input.sessionId,
+            plan.originatingPromptMessageId
+          ))
+        ) {
+          throw new PlanCommandError(
+            'interaction-mismatch',
+            'The Plan does not belong to the active Message Branch.'
+          )
+        }
+      },
+      beforePersist: assertCurrent
+    })
+    if (approvalToken && interactions.approvalTokenFor(input.sessionId) === approvalToken) {
+      interactions.rejectApproval(input.sessionId, 'The unavailable Session Plan was discarded.')
+    }
+    return result
   }
   const respond = async (input: PlanResponseCommand): Promise<PlanResponseResult> => {
     if (!service) throw new Error('Session Plan capability is not configured.')
@@ -767,6 +808,7 @@ const composeAcpRuntimePlanWorkflow = (
     call,
     projection,
     respond,
+    discardUnavailable,
     prompt,
     capturePromptCancellation,
     sessionDeleted

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -393,7 +393,10 @@ const composeAcpRuntimePlanWorkflow = (
     const result = await service.discardUnavailable({
       ...input,
       authorizeDiscard: async (plan) => {
+        // Legacy Plans may predate origin provenance. Explicit cleanup remains bound to
+        // the exact Session/version/revision and the current interaction below.
         if (
+          plan.originatingPromptMessageId !== undefined &&
           !(await containsDurableBranchMessage(
             input.projectId,
             input.sessionId,

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -166,8 +166,10 @@ const composeAcpRuntimePlanWorkflow = (
   const rejectApprovalForInteraction = (
     sessionId: string,
     interactionId: string,
-    reason: string
+    reason: string,
+    expectedApprovalToken = interactions.approvalTokenFor(sessionId)
   ): void => {
+    if (interactions.approvalTokenFor(sessionId) !== expectedApprovalToken) return
     interactions.releaseApprovalReservation(sessionId, interactionId)
     if (interactions.approvalInteractionIdFor(sessionId) !== interactionId) return
     interactions.rejectApproval(sessionId, reason)
@@ -433,7 +435,8 @@ const composeAcpRuntimePlanWorkflow = (
           rejectApprovalForInteraction(
             input.sessionId,
             approvalInteractionId,
-            'The paused Session Plan interaction was superseded before feedback was routed.'
+            'The paused Session Plan interaction was superseded before feedback was routed.',
+            approvalToken
           )
         }
         throw new Error('The paused Session Plan interaction is no longer available.')
@@ -476,7 +479,8 @@ const composeAcpRuntimePlanWorkflow = (
             rejectApprovalForInteraction(
               input.sessionId,
               approvalInteractionId,
-              'The paused Session Plan interaction was superseded before feedback was persisted.'
+              'The paused Session Plan interaction was superseded before feedback was persisted.',
+              approvalToken
             )
             throw new PlanCommandError(
               'interaction-mismatch',
@@ -579,7 +583,8 @@ const composeAcpRuntimePlanWorkflow = (
           rejectApprovalForInteraction(
             input.sessionId,
             approvalInteractionId,
-            'The paused Session Plan interaction was superseded while feedback was routed.'
+            'The paused Session Plan interaction was superseded while feedback was routed.',
+            approvalToken
           )
         }
         throw new Error('The paused Session Plan interaction is no longer available.')

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -402,7 +402,11 @@ describe('AcpRuntime Session Plan seam', () => {
     await cancellation
 
     expect(interactions.approvalInteractionIdFor('session-1')).toBe('interaction-2')
-    interactions.resolveApproval('session-1', { decision: 'approved' })
+    interactions.resolveApproval(
+      'session-1',
+      { decision: 'approved' },
+      interactions.approvalTokenFor('session-1')
+    )
     await expect(successorApproval).resolves.toEqual({ decision: 'approved' })
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4733,37 +4733,31 @@ describe('ACP runtime session management', () => {
     await vi.waitFor(() => expect(fixture.runtimeContext().plan?.delivery).toBeUndefined())
   })
 
-  it('recovers a claimed Plan delivery without durable provider acceptance', async () => {
-    const fixture = createDurablePlanDeliveryResumeHarness('delivering')
-
-    await fixture.runtime.resumeSession({
-      sessionId: 'restored-plan-session',
-      providerSessionId: 'restored-plan-session',
-      cwd: '/workspace',
-      projectId: 'project-1',
-      previousFrameworkId: opencodeFramework.id
-    })
-    await vi.waitFor(() => expect(fixture.fakeAgent.prompts).toHaveLength(1))
-    await vi.waitFor(() => expect(fixture.runtimeContext().plan?.delivery).toBeUndefined())
-    expect(fixture.promptAttempts).toEqual(['plan-delivery-resume-1'])
-  })
-
-  it('recovers claimed review feedback without durable provider acceptance', async () => {
-    const fixture = createDurablePlanDeliveryResumeHarness('delivering', {
-      kind: 'review-feedback'
-    })
-
-    await fixture.runtime.resumeSession({
-      sessionId: 'restored-plan-session',
-      providerSessionId: 'restored-plan-session',
-      cwd: '/workspace',
-      projectId: 'project-1',
-      previousFrameworkId: opencodeFramework.id
-    })
-
-    await vi.waitFor(() => expect(fixture.fakeAgent.prompts).toHaveLength(1))
-    await vi.waitFor(() => expect(fixture.runtimeContext().plan?.delivery).toBeUndefined())
-  })
+  it.each(['approved-plan', 'rejected-plan', 'review-feedback'] as const)(
+    'P03 preserves an uncertain %s receipt after restart without automatically replaying it',
+    async (kind) => {
+      const fixture = createDurablePlanDeliveryResumeHarness('delivering', { kind })
+      await fixture.runtime.resumeSession({
+        sessionId: 'restored-plan-session',
+        providerSessionId: 'restored-plan-session',
+        cwd: '/workspace',
+        projectId: 'project-1',
+        previousFrameworkId: opencodeFramework.id
+      })
+      // Wait for the public resume scheduler to finish inspecting the persisted receipt.
+      await vi.waitFor(() => expect(fixture.readSessionRuntimeContext).toHaveBeenCalled())
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      expect(fixture.fakeAgent.prompts).toHaveLength(0)
+      expect(fixture.patchSessionRuntimeContext).not.toHaveBeenCalled()
+      expect(fixture.runtimeContext().plan?.delivery?.state).toBe('delivering')
+      expect(fixture.events).toContainEqual(
+        expect.objectContaining({
+          kind: 'error',
+          text: expect.stringMatching(/may already have been accepted/i)
+        })
+      )
+    }
+  )
 
   it('clears an accepted Plan delivery after restart without replaying it', async () => {
     const fixture = createDurablePlanDeliveryResumeHarness('accepted')

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -146,7 +146,11 @@ import {
 import type { PlanResponseResult, PlanServiceDependencies } from '../session-plan/plan-service'
 import { matchPlanDelivery } from '../session-plan/plan-delivery'
 import { SessionPlanDeliveryOwner } from './session-plan-delivery-owner'
-import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
+import type {
+  ActivePlanProjection,
+  PlanResponseCommand,
+  PlanResponseIdentity
+} from '../../shared/session-plan/contract'
 import type {
   SessionCatalog,
   SessionMutation,
@@ -784,6 +788,10 @@ class AcpRuntime {
     sessionId: string
   ): Promise<ActivePlanProjection | null> {
     return this.sessionPlanWorkflow.projection(projectId, sessionId)
+  }
+
+  discardUnavailableSessionPlan(input: PlanResponseIdentity): Promise<{ revision: number }> {
+    return this.sessionPlanWorkflow.discardUnavailable(input)
   }
 
   async respondSessionPlan(input: PlanResponseCommand): Promise<PlanResponseResult> {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2216,14 +2216,16 @@ class AcpRuntime {
       return
     }
     if (command.state === 'delivering') {
-      if (await owner.rearmUnaccepted(projectId, sessionId, command.commandId)) {
-        this.clearPlanDeliveryClaimRetry(sessionId, command.commandId)
-        setTimeout(() => {
-          this.scheduleQueuedPlanDelivery(projectId, sessionId, command.commandId)
-        }, 0)
-      } else {
-        this.retryPlanDeliveryClaim(projectId, sessionId, command.commandId)
-      }
+      this.clearPlanDeliveryClaimRetry(sessionId, command.commandId)
+      // Persisted delivering alone cannot prove that the provider never received this command.
+      this.pushEvent({
+        kind: 'error',
+        level: 'error',
+        sessionId,
+        title: 'Plan delivery outcome is uncertain',
+        text: 'This Plan delivery may already have been accepted by the Agent. It was not sent again. Check the conversation before sending another execution request.'
+      })
+      this.emitState()
       return
     }
     if (command.state !== 'queued') {

--- a/src/main/acp/session-plan-delivery-owner.test.ts
+++ b/src/main/acp/session-plan-delivery-owner.test.ts
@@ -64,6 +64,83 @@ const createSessions = (
 }
 
 describe('Session Plan delivery owner', () => {
+  it.each(['command', 'version', 'accepted'] as const)(
+    'does not overwrite a concurrent %s replacement while retrying acceptance',
+    async (replacement) => {
+      const fixture = createSessions({
+        commandId: 'delivery-1',
+        kind: 'approved-plan',
+        state: 'delivering',
+        originatingPromptMessageId: 'prompt-1',
+        createdAt: 42
+      })
+      const originalPatch =
+        fixture.patch.getMockImplementation() as SessionPlanDeliverySessions['patchSessionRuntimeContext']
+      fixture.patch.mockImplementationOnce(async (command) => {
+        const plan = fixture.context().plan!
+        await originalPatch({
+          ...command,
+          patch: {
+            plan: {
+              ...plan,
+              ...(replacement === 'version' ? { artifactVersionId: 'replacement-version' } : {}),
+              delivery: {
+                ...plan.delivery!,
+                ...(replacement === 'command' ? { commandId: 'replacement-command' } : {}),
+                state: replacement === 'accepted' ? 'accepted' : 'delivering'
+              }
+            }
+          }
+        })
+        throw Object.assign(new Error('revision conflict'), { code: 'revision-conflict' })
+      })
+      const owner = new SessionPlanDeliveryOwner(fixture.sessions)
+      await expect(owner.accept('project-1', 'session-1', 'delivery-1')).resolves.toBe(
+        replacement === 'accepted'
+      )
+      expect(fixture.patch).toHaveBeenCalledOnce()
+      if (replacement === 'command')
+        expect(fixture.context().plan?.delivery?.commandId).toBe('replacement-command')
+      if (replacement === 'version')
+        expect(fixture.context().plan?.artifactVersionId).toBe('replacement-version')
+    }
+  )
+
+  it('bounds persistent acceptance conflicts without marking the receipt unaccepted', async () => {
+    const fixture = createSessions({
+      commandId: 'delivery-1',
+      kind: 'approved-plan',
+      state: 'delivering',
+      originatingPromptMessageId: 'prompt-1',
+      createdAt: 42
+    })
+    fixture.patch.mockRejectedValue(
+      Object.assign(new Error('revision conflict'), { code: 'revision-conflict' })
+    )
+    await expect(
+      new SessionPlanDeliveryOwner(fixture.sessions).accept('project-1', 'session-1', 'delivery-1')
+    ).resolves.toBe(false)
+    expect(fixture.patch).toHaveBeenCalledTimes(3)
+    expect(fixture.context().plan?.delivery?.state).toBe('delivering')
+  })
+
+  it('preserves uncertain delivery evidence when acceptance storage fails', async () => {
+    const fixture = createSessions({
+      commandId: 'delivery-1',
+      kind: 'approved-plan',
+      state: 'delivering',
+      originatingPromptMessageId: 'prompt-1',
+      createdAt: 42
+    })
+    const failure = Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+    fixture.patch.mockRejectedValue(failure)
+    await expect(
+      new SessionPlanDeliveryOwner(fixture.sessions).accept('project-1', 'session-1', 'delivery-1')
+    ).rejects.toBe(failure)
+    expect(fixture.patch).toHaveBeenCalledOnce()
+    expect(fixture.context().plan?.delivery?.state).toBe('delivering')
+  })
+
   it('claims one queued delivery before dispatch without changing Session status', async () => {
     const fixture = createSessions()
     const owner = new SessionPlanDeliveryOwner(fixture.sessions)

--- a/src/main/acp/session-plan-delivery-owner.ts
+++ b/src/main/acp/session-plan-delivery-owner.ts
@@ -20,6 +20,7 @@ class SessionPlanDeliveryOwner {
     }))
   }
 
+  // Call only with live proof that dispatch/handoff never happened; persisted state alone is insufficient.
   async rearmUnaccepted(projectId: string, sessionId: string, commandId: string): Promise<boolean> {
     return this.transitionTo(projectId, sessionId, commandId, 'delivering', (delivery) => ({
       ...delivery,
@@ -28,10 +29,41 @@ class SessionPlanDeliveryOwner {
   }
 
   async accept(projectId: string, sessionId: string, commandId: string): Promise<boolean> {
-    return this.transitionTo(projectId, sessionId, commandId, 'delivering', (delivery) => ({
-      ...delivery,
-      state: 'accepted'
-    }))
+    const initial = await this.sessions.readSessionRuntimeContext(projectId, sessionId)
+    const original = matchPlanDelivery(initial.plan, { commandId })
+    if (!initial.plan || !original) return false
+    // Keep dispatch claims single-attempt; only acceptance retries unrelated context writes.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const context =
+        attempt === 0
+          ? initial
+          : await this.sessions.readSessionRuntimeContext(projectId, sessionId)
+      const plan = context.plan
+      const delivery = matchPlanDelivery(plan, {
+        commandId,
+        artifactVersionId: initial.plan.artifactVersionId,
+        kind: original.kind,
+        originatingPromptMessageId: original.originatingPromptMessageId
+      })
+      if (
+        !plan ||
+        !delivery ||
+        plan.artifactId !== initial.plan.artifactId ||
+        plan.artifactChecksum !== initial.plan.artifactChecksum ||
+        delivery.createdAt !== original.createdAt
+      )
+        return false
+      if (delivery.state === 'accepted') return true
+      if (delivery.state !== 'delivering') return false
+      if (
+        await this.patch(projectId, sessionId, context.revision, plan, {
+          ...delivery,
+          state: 'accepted'
+        })
+      )
+        return true
+    }
+    return false
   }
 
   async clear(projectId: string, sessionId: string, commandId: string): Promise<boolean> {

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -191,6 +191,7 @@ describe('application command composition', () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.electron.commandNames()).toEqual([
+      'acp:discard-unavailable-plan',
       'acp:respond-elicitation',
       'acp:respond-permission',
       'acp:respond-plan',

--- a/src/main/application-command-electron-adapter.test.ts
+++ b/src/main/application-command-electron-adapter.test.ts
@@ -19,6 +19,7 @@ vi.mock('./ipc-handler-registry', () => ({
 import { registerApplicationCommandElectronAdapter } from './application-command-electron-adapter'
 
 const validatedChannels = [
+  'acp:discard-unavailable-plan',
   'acp:respond-elicitation',
   'acp:respond-permission',
   'acp:respond-plan',

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -7917,6 +7917,7 @@ describe('notebook runtime service', () => {
       const root = await createStorageRoot()
       const events: string[] = []
       let releaseInstall: (() => void) | undefined
+      const installStarted = Promise.withResolvers<void>()
       // v4: a session runs ONE env per language, so "different envs" now means different SESSIONS —
       // an installer session bound to a named env vs a runner session on the app-managed default.
       const namedPy = pythonBin(envPrefix(getRuntimeRoot(root), 'my-analysis'))
@@ -7960,6 +7961,7 @@ describe('notebook runtime service', () => {
           events.push('install:my-analysis:start')
           await new Promise<void>((resolve) => {
             releaseInstall = resolve
+            installStarted.resolve()
           })
           return { ok: true, needsRestart: false, log: '' }
         }
@@ -7977,7 +7979,7 @@ describe('notebook runtime service', () => {
         language: 'python',
         packages: ['numpy']
       })
-      await vi.waitFor(() => expect(releaseInstall).toBeDefined())
+      await installStarted.promise
 
       // A run in a DIFFERENT session on the DEFAULT python env proceeds while the my-analysis install
       // holds only its own env lock — the lock is keyed by resolved env name, not language.

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -2011,6 +2011,114 @@ describe('PlanService', () => {
     )
   })
 
+  describe('explicit unavailable Plan recovery', () => {
+    const unavailable = async () => {
+      const fixture = setup()
+      const generated = await fixture.service.generate({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        executionId: 'execution-1',
+        interactionId: 'interaction-1',
+        content
+      })
+      const legacy = { ...fixture.context().plan! }
+      delete legacy.document
+      fixture.setContext({ ...fixture.context(), plan: legacy })
+      const read = vi.mocked(fixture.dependencies.readArtifactVersion)
+      const originalRead = read.getMockImplementation()!
+      read.mockRejectedValue(
+        Object.assign(new Error('artifact file does not exist'), { code: 'ENOENT' })
+      )
+      return {
+        ...fixture,
+        read,
+        originalRead,
+        identity: {
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          artifactVersionId: generated.projection.artifactVersionId,
+          expectedRevision: fixture.context().revision
+        }
+      }
+    }
+
+    it('preserves failed rejection evidence, then permits explicit discard', async () => {
+      const fixture = await unavailable()
+      const before = fixture.context()
+      await expect(
+        fixture.service.respond({ ...fixture.identity, decision: 'rejected' })
+      ).rejects.toMatchObject({ code: 'artifact-unavailable' })
+      expect(fixture.context()).toEqual(before)
+      await expect(fixture.service.discardUnavailable(fixture.identity)).resolves.toEqual({
+        revision: before.revision + 1
+      })
+      expect(fixture.context().plan).toBeUndefined()
+      expect(fixture.status()).toBe('idle')
+      expect(
+        fixture.interactions.interactionIdFor('session-1', fixture.identity.artifactVersionId)
+      ).toBeUndefined()
+      await expect(fixture.service.getProjection('project-1', 'session-1')).resolves.toBeNull()
+      expect(fixture.dependencies.persistUserMessage).not.toHaveBeenCalled()
+      expect(fixture.dependencies.writeArtifactForExecution).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses to discard a Plan whose read has recovered', async () => {
+      const fixture = await unavailable()
+      fixture.read.mockImplementation(fixture.originalRead)
+      const before = fixture.context()
+      await expect(fixture.service.discardUnavailable(fixture.identity)).rejects.toMatchObject({
+        code: 'invalid-plan'
+      })
+      expect(fixture.context()).toEqual(before)
+      await expect(fixture.service.getProjection('project-1', 'session-1')).resolves.toMatchObject({
+        approval: 'pending'
+      })
+    })
+
+    it.each([
+      'stale-version',
+      'stale-revision',
+      'read-race',
+      'storage-failure',
+      'revoked'
+    ] as const)('preserves Plan authority on %s during explicit discard', async (mode) => {
+      const fixture = await unavailable()
+      const identity = { ...fixture.identity }
+      if (mode === 'stale-version') identity.artifactVersionId = 'old-version'
+      if (mode === 'stale-revision') identity.expectedRevision -= 1
+      if (mode === 'read-race')
+        fixture.read.mockImplementation(async () => {
+          fixture.setContext({
+            ...fixture.context(),
+            revision: fixture.context().revision + 1,
+            plan: { ...fixture.context().plan!, artifactVersionId: 'replacement' }
+          })
+          throw new Error('old artifact disappeared')
+        })
+      if (mode === 'storage-failure')
+        vi.mocked(fixture.dependencies.patchRuntimeContext).mockRejectedValue(new Error('ENOSPC'))
+      const before = fixture.context()
+      await expect(
+        fixture.service.discardUnavailable({
+          ...identity,
+          beforePersist: () => {
+            if (mode === 'revoked') throw new Error('authorization revoked')
+          }
+        })
+      ).rejects.toBeInstanceOf(Error)
+      expect(fixture.context()).toEqual(
+        mode === 'read-race'
+          ? {
+              ...before,
+              revision: before.revision + 1,
+              plan: { ...before.plan, artifactVersionId: 'replacement' }
+            }
+          : before
+      )
+      expect(fixture.dependencies.onApprovalSettled).not.toHaveBeenCalled()
+    })
+  })
+
   it('P05 preserves an unreadable embedded Plan document as recovery evidence', async () => {
     const { service, context, setContext, status } = setup()
     await service.generate({

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { SessionRuntimeContext } from '../../shared/session-persistence'
+import {
+  sanitizeSessionRuntimeContext,
+  type SessionRuntimeContext
+} from '../../shared/session-persistence'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 import { PlanService, type PlanServiceDependencies } from './plan-service'
 import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
@@ -202,6 +205,163 @@ const approveExecutionPlan = async (): Promise<
 }
 
 describe('PlanService', () => {
+  it.each(['EBUSY', 'EACCES'])(
+    'P05 retains the legacy plan after a temporary %s read failure and recovers on the next read',
+    async (code) => {
+      const fixture = setup()
+      const generated = await fixture.service.generate({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        executionId: 'execution-1',
+        interactionId: 'interaction-1',
+        content
+      })
+      const legacyPlan = { ...fixture.context().plan! }
+      delete legacyPlan.document
+      fixture.setContext({ ...fixture.context(), plan: legacyPlan })
+      const before = structuredClone(fixture.context())
+      vi.mocked(fixture.dependencies.patchRuntimeContext).mockClear()
+      vi.mocked(fixture.dependencies.readArtifactVersion)
+        .mockClear()
+        .mockRejectedValueOnce(Object.assign(new Error('temporary read failure'), { code }))
+
+      await fixture.service.getProjection('project-1', 'session-1').catch(() => undefined)
+      expect.soft(fixture.context()).toEqual(before)
+      expect.soft(fixture.dependencies.patchRuntimeContext).not.toHaveBeenCalled()
+      expect.soft(fixture.status()).toBe('waiting-plan-approval')
+      await expect(fixture.service.getProjection('project-1', 'session-1')).resolves.toEqual(
+        generated.projection
+      )
+      expect(fixture.dependencies.readArtifactVersion).toHaveBeenCalledTimes(2)
+    }
+  )
+
+  it.each([400, 661])(
+    'P06 completes an admitted %s-step plan through the persistence sanitizer',
+    async (stepCount) => {
+      const fixture = setup()
+      if (stepCount === 661) {
+        fixture.setContext({
+          version: 1,
+          revision: 0,
+          delegatedWork: { records: [], messageCommands: [] },
+          permission: {
+            state: 'pending',
+            request: {
+              requestId: 'permission-1',
+              sessionId: 'session-1',
+              toolCallId: 'tool-1',
+              title: 'Run tests',
+              options: [{ optionId: 'deny', name: 'Deny', kind: 'reject_once' }]
+            },
+            originatingPromptMessageId: 'interaction-1',
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        })
+      }
+      vi.mocked(fixture.dependencies.patchRuntimeContext).mockImplementation(
+        async ({ expectedRevision, plan, beforePersist }) => {
+          if (expectedRevision !== fixture.context().revision) throw new Error('revision conflict')
+          beforePersist?.()
+          const next = sanitizeSessionRuntimeContext({
+            ...fixture.context(),
+            revision: expectedRevision + 1,
+            plan
+          })
+          if (!next) throw new Error('Session runtime context patch is not JSON-safe.')
+          fixture.setContext(next)
+          return next
+        }
+      )
+      const steps = Array.from({ length: stepCount }, (_, index) => ({
+        title: `Step ${index + 1}`,
+        description: 'Produce the result.'
+      }))
+      const generated = await fixture.service.generate({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        executionId: 'execution-1',
+        interactionId: 'interaction-1',
+        content: {
+          ...content,
+          phases: [{ name: 'Analysis', delegations: [{ name: 'Primary agent', steps }] }]
+        }
+      })
+      const identity = {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        artifactVersionId: generated.projection.artifactVersionId
+      }
+      await fixture.service.respond({
+        ...identity,
+        expectedRevision: fixture.context().revision,
+        decision: 'approved'
+      })
+      let failure: unknown
+      let completed = 0
+      try {
+        for (const step of steps) {
+          await fixture.service.updateStepStatus({
+            ...identity,
+            expectedRevision: fixture.context().revision,
+            title: step.title,
+            status: 'in_progress'
+          })
+          await fixture.service.updateStepStatus({
+            ...identity,
+            expectedRevision: fixture.context().revision,
+            title: step.title,
+            status: 'completed',
+            ...(stepCount === 661 ? { notes: 'Verified result.' } : {})
+          })
+          completed += 1
+        }
+      } catch (error) {
+        failure = error
+      }
+      expect({ completed, failure }).toEqual({ completed: steps.length, failure: undefined })
+      await expect(fixture.service.getProjection('project-1', 'session-1')).resolves.toMatchObject({
+        lifecycle: 'completed'
+      })
+    }
+  )
+
+  it('P06 rejects an oversized plan before creating its Artifact', async () => {
+    const fixture = setup()
+    const oversized = {
+      ...content,
+      phases: [
+        {
+          name: 'Analysis',
+          delegations: [
+            {
+              name: 'Primary agent',
+              steps: Array.from({ length: 662 }, (_, index) => ({
+                title: `Step ${index}`,
+                description: 'Work.'
+              }))
+            }
+          ]
+        }
+      ]
+    }
+    await expect(
+      fixture.service.generate({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        executionId: 'execution-1',
+        interactionId: 'interaction-1',
+        content: oversized
+      })
+    ).rejects.toMatchObject({
+      code: 'invalid-plan',
+      message: expect.stringMatching(/too large.*split/i)
+    })
+    expect(fixture.dependencies.writeArtifactForExecution).not.toHaveBeenCalled()
+    expect(fixture.context()).not.toHaveProperty('plan')
+  })
+
   it('durably verifies a generated Plan before atomically activating it for the Session', async () => {
     const { service, dependencies, context, status } = setup()
 
@@ -1851,7 +2011,7 @@ describe('PlanService', () => {
     )
   })
 
-  it('drops an unreadable embedded Plan document instead of exposing corrupt state', async () => {
+  it('P05 preserves an unreadable embedded Plan document as recovery evidence', async () => {
     const { service, context, setContext, status } = setup()
     await service.generate({
       projectId: 'project-1',
@@ -1868,12 +2028,14 @@ describe('PlanService', () => {
       }
     })
 
-    await expect(service.getProjection('project-1', 'session-1')).resolves.toBeNull()
-    expect(context().plan).toBeUndefined()
-    expect(status()).toBe('idle')
+    await expect(service.getProjection('project-1', 'session-1')).rejects.toMatchObject({
+      code: 'artifact-unavailable'
+    })
+    expect(context().plan).toBeDefined()
+    expect(status()).toBe('waiting-plan-approval')
   })
 
-  it('drops a checksum-valid restored Plan when the embedded document structure is corrupt', async () => {
+  it('P05 preserves a checksum-valid restored Plan with a corrupt document', async () => {
     const { service, context, setContext, status } = setup()
     await service.generate({
       projectId: 'project-1',
@@ -1899,9 +2061,11 @@ describe('PlanService', () => {
       }
     })
 
-    await expect(service.getProjection('project-1', 'session-1')).resolves.toBeNull()
-    expect(context().plan).toBeUndefined()
-    expect(status()).toBe('idle')
+    await expect(service.getProjection('project-1', 'session-1')).rejects.toMatchObject({
+      code: 'artifact-unavailable'
+    })
+    expect(context().plan).toBeDefined()
+    expect(status()).toBe('waiting-plan-approval')
   })
 
   it('retains a verified restored Plan when unpublished provenance content is unavailable', async () => {

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -364,6 +364,63 @@ describe('PlanService', () => {
     expect(fixture.context()).not.toHaveProperty('plan')
   })
 
+  it('keeps oversized artifact-only legacy Plans readable and rejectable', async () => {
+    const fixture = setup()
+    await fixture.service.generate({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      executionId: 'execution-1',
+      interactionId: 'interaction-1',
+      content
+    })
+    const document = {
+      schema_version: 1,
+      ...content,
+      phases: [
+        {
+          name: 'Analysis',
+          delegations: [
+            {
+              name: 'Primary agent',
+              steps: Array.from({ length: 662 }, (_, index) => ({
+                title: `Step ${index}`,
+                description: 'Work.'
+              }))
+            }
+          ]
+        }
+      ]
+    }
+    const bytes = JSON.stringify(document)
+    const checksum = createHash('sha256').update(bytes).digest('hex')
+    const legacy = { ...fixture.context().plan!, artifactChecksum: checksum }
+    delete legacy.document
+    fixture.setContext({ ...fixture.context(), plan: legacy })
+    vi.mocked(fixture.dependencies.readArtifactVersion).mockResolvedValue({
+      content: bytes,
+      checksum
+    })
+    const identity = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactVersionId: legacy.artifactVersionId,
+      expectedRevision: fixture.context().revision
+    }
+    await expect(fixture.service.getProjection('project-1', 'session-1')).resolves.toMatchObject({
+      counts: { steps: 662 }
+    })
+    await expect(
+      fixture.service.respond({ ...identity, decision: 'approved' })
+    ).rejects.toMatchObject({
+      code: 'invalid-plan',
+      message: expect.stringMatching(/too large.*split/i)
+    })
+    await expect(
+      fixture.service.respond({ ...identity, decision: 'rejected' })
+    ).resolves.toMatchObject({ projection: { approval: 'rejected' } })
+    expect(fixture.status()).toBe('idle')
+  })
+
   it('durably verifies a generated Plan before atomically activating it for the Session', async () => {
     const { service, dependencies, context, status } = setup()
 

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -8,6 +8,8 @@ import {
 import type { ActivePlanProjection, PlanResponseIdentity } from '../../shared/session-plan/contract'
 import { PlanService, type PlanServiceDependencies } from './plan-service'
 import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
+import { composeAcpRuntimePlanWorkflow } from '../acp/runtime-plan-composition'
+import { AcpSessionInteractionOwner } from '../acp/session-interaction-owner'
 
 const content = {
   task_summary: 'Analyze one dataset',
@@ -2047,6 +2049,29 @@ describe('PlanService', () => {
         }
       }
     }
+
+    it('permits confirmed discard for a legacy Plan without origin provenance', async () => {
+      const fixture = await unavailable()
+      const legacy = { ...fixture.context().plan! }
+      delete legacy.originatingPromptMessageId
+      fixture.setContext({ ...fixture.context(), plan: legacy })
+      const containsMessageOnActiveBranch = vi.fn(async () => false)
+      const workflow = composeAcpRuntimePlanWorkflow(
+        { plan: { sessions: { containsMessageOnActiveBranch } } } as never,
+        {
+          planService: fixture.service,
+          planInteractions: fixture.interactions,
+          sessionInteractions: new AcpSessionInteractionOwner()
+        } as never,
+        { publication: { pushEvent: vi.fn() } } as never
+      )
+      const result = await workflow
+        .discardUnavailable(fixture.identity)
+        .catch((error: unknown) => error)
+      expect(result).toEqual({ revision: fixture.identity.expectedRevision + 1 })
+      expect(fixture.context().plan).toBeUndefined()
+      expect(containsMessageOnActiveBranch).not.toHaveBeenCalled()
+    })
 
     it('preserves failed rejection evidence, then permits explicit discard', async () => {
       const fixture = await unavailable()

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -1,11 +1,11 @@
 import { createHash } from 'node:crypto'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type MockedFunction } from 'vitest'
 
 import {
   sanitizeSessionRuntimeContext,
   type SessionRuntimeContext
 } from '../../shared/session-persistence'
-import type { ActivePlanProjection } from '../../shared/session-plan/contract'
+import type { ActivePlanProjection, PlanResponseIdentity } from '../../shared/session-plan/contract'
 import { PlanService, type PlanServiceDependencies } from './plan-service'
 import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
 
@@ -2012,7 +2012,13 @@ describe('PlanService', () => {
   })
 
   describe('explicit unavailable Plan recovery', () => {
-    const unavailable = async () => {
+    const unavailable = async (): Promise<
+      PlanServiceHarness & {
+        read: MockedFunction<PlanServiceDependencies['readArtifactVersion']>
+        originalRead: PlanServiceDependencies['readArtifactVersion']
+        identity: PlanResponseIdentity
+      }
+    > => {
       const fixture = setup()
       const generated = await fixture.service.generate({
         projectId: 'project-1',

--- a/src/main/session-plan/plan-service.ts
+++ b/src/main/session-plan/plan-service.ts
@@ -642,6 +642,42 @@ class PlanService {
     return { projection: this.project(document, settled, next.revision), changed: true }
   }
 
+  // Explicit recovery only: queries never discard approval, progress or delivery authority.
+  async discardUnavailable(
+    input: PlanIdentityCommand & {
+      authorizeDiscard?: (plan: SessionPlanRuntimeContext) => Promise<void>
+      beforePersist?: () => void
+    }
+  ): Promise<{ revision: number }> {
+    const context = await this.dependencies.readRuntimeContext(input.projectId, input.sessionId)
+    const plan = context.plan
+    if (!plan || plan.artifactVersionId !== input.artifactVersionId) {
+      throw new PlanCommandError('stale-plan', 'A newer Plan is active.')
+    }
+    if (context.revision !== input.expectedRevision) {
+      throw new PlanCommandError('revision-conflict', 'The Plan revision changed concurrently.')
+    }
+    await input.authorizeDiscard?.(plan)
+    try {
+      await this.readDocument(input.projectId, input.sessionId, plan)
+    } catch (error) {
+      if (!(error instanceof PlanCommandError) || error.code !== 'artifact-unavailable') throw error
+      const next = await this.patch(input, undefined, 'idle', input.beforePersist)
+      this.dependencies.interactions.release(input.sessionId, plan.artifactVersionId)
+      this.dependencies.onApprovalSettled?.({
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        artifactVersionId: plan.artifactVersionId,
+        state: 'cancelled'
+      })
+      return { revision: next.revision }
+    }
+    throw new PlanCommandError(
+      'invalid-plan',
+      'The Plan is readable again. Review it before continuing.'
+    )
+  }
+
   async getProjection(projectId: string, sessionId: string): Promise<ActivePlanProjection | null> {
     const current = await this.loadCurrent(projectId, sessionId)
     if (!current) return null
@@ -768,7 +804,7 @@ class PlanService {
 
   private async patch(
     input: PlanIdentityCommand,
-    plan: SessionPlanRuntimeContext,
+    plan: SessionPlanRuntimeContext | undefined,
     sessionStatus: 'waiting-plan-approval' | 'running' | 'idle',
     beforePersist?: () => void
   ): Promise<SessionRuntimeContext> {

--- a/src/main/session-plan/plan-service.ts
+++ b/src/main/session-plan/plan-service.ts
@@ -8,6 +8,7 @@ import type {
   SessionRuntimeContext
 } from '../../shared/session-persistence'
 import {
+  assertPlanDocumentCapacity,
   createPlanDocumentV1,
   derivePlanLifecycle,
   isPlanTerminalOutcome,
@@ -183,6 +184,7 @@ class PlanService {
     content: GeneratePlanContent
   }): Promise<{ projection: ActivePlanProjection; pauseInteraction: true }> {
     const document = createPlanDocumentV1(input.content)
+    assertPlanDocumentCapacity(document)
     const serialized = JSON.stringify(document, null, 2)
     const checksum = sha256(serialized)
     const current = await this.dependencies.readRuntimeContext(input.projectId, input.sessionId)
@@ -368,6 +370,7 @@ class PlanService {
       }
     }
     const { context, plan, document } = await this.loadActive(input, input.decision)
+    if (input.decision === 'approved') assertPlanDocumentCapacity(document)
     if (plan.approval === input.decision) {
       this.dependencies.interactions.release(input.sessionId, plan.artifactVersionId)
       this.dependencies.onApprovalSettled?.({
@@ -581,6 +584,7 @@ class PlanService {
       })
     }
     const { plan, document } = loaded
+    assertPlanDocumentCapacity(document)
     if (plan.approval !== 'approved') {
       throw new PlanCommandError(
         'plan-not-approved',
@@ -709,56 +713,10 @@ class PlanService {
   } | null> {
     const context = await this.dependencies.readRuntimeContext(projectId, sessionId)
     if (!context.plan) return null
-    try {
-      return {
-        context,
-        plan: context.plan,
-        document: await this.readDocument(projectId, sessionId, context.plan)
-      }
-    } catch (error) {
-      if (!(error instanceof PlanCommandError) || error.code !== 'artifact-unavailable') throw error
-      await this.dropUnavailablePlan(projectId, sessionId, context)
-      return null
-    }
-  }
-
-  private async dropUnavailablePlan(
-    projectId: string,
-    sessionId: string,
-    observed: SessionRuntimeContext
-  ): Promise<void> {
-    let current = observed
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      try {
-        await this.dependencies.patchRuntimeContext({
-          projectId,
-          sessionId,
-          expectedRevision: current.revision,
-          plan: undefined,
-          sessionStatus: 'idle'
-        })
-        if (observed.plan?.approval === 'pending') {
-          this.dependencies.onApprovalSettled?.({
-            projectId,
-            sessionId,
-            artifactVersionId: observed.plan.artifactVersionId,
-            state: 'expired'
-          })
-        }
-        return
-      } catch (error) {
-        if (!this.dependencies.isRevisionConflict(error)) throw error
-        const latest = await this.dependencies.readRuntimeContext(projectId, sessionId)
-        if (!latest.plan || !observed.plan) return
-        if (
-          latest.plan.artifactId !== observed.plan.artifactId ||
-          latest.plan.artifactVersionId !== observed.plan.artifactVersionId ||
-          latest.plan.artifactChecksum !== observed.plan.artifactChecksum
-        ) {
-          return
-        }
-        current = latest
-      }
+    return {
+      context,
+      plan: context.plan,
+      document: await this.readDocument(projectId, sessionId, context.plan)
     }
   }
 

--- a/src/main/session-plan/production-plan-service.test.ts
+++ b/src/main/session-plan/production-plan-service.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { readManagedArtifactVersion } from './production-plan-service'
+import { createHash } from 'node:crypto'
+import {
+  sanitizeSessionRuntimeContext,
+  type SessionRuntimeContext,
+  type PersistedChatMessage
+} from '../../shared/session-persistence'
+import { createPlanDocumentV1 } from '../../shared/session-plan/contract'
+import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
+import {
+  createProductionPlanService,
+  readManagedArtifactVersion,
+  type ProductionPlanServiceDependencies
+} from './production-plan-service'
 
 describe('readManagedArtifactVersion', () => {
   it('reads an exact Artifact Version, including an unpublished one, through a lease and closes it', async () => {
@@ -54,4 +66,112 @@ describe('readManagedArtifactVersion', () => {
     ).rejects.toThrow(/different Session/i)
     expect(close).toHaveBeenCalledOnce()
   })
+})
+
+describe('production Plan feedback persistence', () => {
+  it.each([undefined, 'queued', 'delivering', 'accepted', 'interrupted'] as const)(
+    'P01 persists the returned feedback command when the previous receipt is %s',
+    async (previousState) => {
+      const document = createPlanDocumentV1({
+        task_summary: 'Analyze one dataset',
+        phases: [
+          {
+            name: 'Analysis',
+            delegations: [
+              {
+                name: 'Primary agent',
+                steps: [{ title: 'Analyze', description: 'Produce results.' }]
+              }
+            ]
+          }
+        ],
+        desired_outputs: ['Result'],
+        feasibility: { confidence: 'high', rationale: 'Ready.' }
+      })
+      let context: SessionRuntimeContext = {
+        version: 1,
+        revision: 1,
+        plan: {
+          artifactId: 'artifact-1',
+          artifactVersionId: 'version-1',
+          artifactChecksum: createHash('sha256')
+            .update(JSON.stringify(document, null, 2))
+            .digest('hex'),
+          document,
+          originatingPromptMessageId: 'prompt-1',
+          approval: 'pending',
+          stepStatuses: {},
+          ...(previousState
+            ? {
+                reviewFeedbackMessageId: 'old-feedback',
+                delivery: {
+                  commandId: 'old-command',
+                  kind: 'review-feedback',
+                  state: previousState,
+                  originatingPromptMessageId: 'old-feedback',
+                  createdAt: 1
+                }
+              }
+            : {})
+        }
+      }
+      const messages: PersistedChatMessage[] = []
+      const append = vi.fn<
+        ProductionPlanServiceDependencies['sessions']['appendUserMessageToInteraction']
+      >(async (input) => {
+        const message: PersistedChatMessage = {
+          id: 'new-feedback',
+          role: 'user',
+          content: input.content,
+          status: 'complete',
+          responseToMessageId: input.interactionId,
+          eventIds: [],
+          createdAt: 42,
+          updatedAt: 42
+        }
+        const patch = input.runtimeContextPatch!
+        expect(patch.expectedRevision).toBe(context.revision)
+        const next = sanitizeSessionRuntimeContext({
+          ...context,
+          ...(typeof patch.patch === 'function' ? patch.patch(message) : patch.patch),
+          revision: context.revision + 1
+        })
+        if (!next) throw new Error('Session runtime context patch is not JSON-safe.')
+        context = next
+        messages.push(message)
+        return message
+      })
+      const interactions = new SessionPlanInteractionOwner()
+      interactions.register({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-1',
+        interactionId: 'prompt-1'
+      })
+      const service = createProductionPlanService({
+        interactions,
+        artifactTurns: { handleForExecution: vi.fn(), write: vi.fn() },
+        managedFileVersions: { openUnpublishedVersion: vi.fn() },
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(context)),
+          appendUserMessageToInteraction: append
+        } as unknown as ProductionPlanServiceDependencies['sessions']
+      })
+      const result = await service.respond({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        feedback: 'Split the analysis by cohort.'
+      })
+      if (!('kind' in result)) throw new Error('Expected feedback result')
+      expect(messages).toHaveLength(1)
+      expect(context.plan?.reviewFeedbackMessageId).toBe(result.message.id)
+      expect(context.plan?.delivery).toEqual({
+        commandId: result.deliveryCommandId,
+        kind: 'review-feedback',
+        state: 'queued',
+        originatingPromptMessageId: result.message.id,
+        createdAt: expect.any(Number)
+      })
+      expect(context.plan).not.toHaveProperty('continuation')
+    }
+  )
 })

--- a/src/main/session-plan/production-plan-service.test.ts
+++ b/src/main/session-plan/production-plan-service.test.ts
@@ -8,6 +8,8 @@ import {
 } from '../../shared/session-persistence'
 import { createPlanDocumentV1 } from '../../shared/session-plan/contract'
 import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
+import { AcpSessionInteractionOwner } from '../acp/session-interaction-owner'
+import { composeAcpRuntimePlanWorkflow } from '../acp/runtime-plan-composition'
 import {
   createProductionPlanService,
   readManagedArtifactVersion,
@@ -69,9 +71,14 @@ describe('readManagedArtifactVersion', () => {
 })
 
 describe('production Plan feedback persistence', () => {
-  it.each([undefined, 'queued', 'delivering', 'accepted', 'interrupted'] as const)(
-    'P01 persists the returned feedback command when the previous receipt is %s',
-    async (previousState) => {
+  it.each([
+    ...([undefined, 'queued', 'delivering', 'accepted', 'interrupted'] as const).map(
+      (previousState) => ({ previousState, detached: false })
+    ),
+    { previousState: 'delivering' as const, detached: true }
+  ])(
+    'P01 persists feedback with previous receipt $previousState (detached: $detached)',
+    async ({ previousState, detached }) => {
       const document = createPlanDocumentV1({
         task_summary: 'Analyze one dataset',
         phases: [
@@ -142,11 +149,12 @@ describe('production Plan feedback persistence', () => {
         return message
       })
       const interactions = new SessionPlanInteractionOwner()
-      interactions.register({
-        sessionId: 'session-1',
-        artifactVersionId: 'version-1',
-        interactionId: 'prompt-1'
-      })
+      if (!detached)
+        interactions.register({
+          sessionId: 'session-1',
+          artifactVersionId: 'version-1',
+          interactionId: 'prompt-1'
+        })
       const service = createProductionPlanService({
         interactions,
         artifactTurns: { handleForExecution: vi.fn(), write: vi.fn() },
@@ -156,11 +164,27 @@ describe('production Plan feedback persistence', () => {
           appendUserMessageToInteraction: append
         } as unknown as ProductionPlanServiceDependencies['sessions']
       })
-      const result = await service.respond({
+      const response = {
         projectId: 'project-1',
         sessionId: 'session-1',
         feedback: 'Split the analysis by cohort.'
-      })
+      }
+      const result = detached
+        ? await composeAcpRuntimePlanWorkflow(
+            {
+              plan: { sessions: { containsMessageOnActiveBranch: vi.fn(async () => true) } }
+            } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[0],
+            {
+              planService: service,
+              planInteractions: interactions,
+              sessionInteractions: new AcpSessionInteractionOwner()
+            } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[1],
+            {
+              publication: { pushEvent: vi.fn() },
+              sessionEnvironment: { projectId: () => 'project-1' }
+            } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[2]
+          ).respond(response)
+        : await service.respond(response)
       if (!('kind' in result)) throw new Error('Expected feedback result')
       expect(messages).toHaveLength(1)
       expect(context.plan?.reviewFeedbackMessageId).toBe(result.message.id)

--- a/src/main/session-plan/production-plan-service.ts
+++ b/src/main/session-plan/production-plan-service.ts
@@ -98,7 +98,7 @@ const createProductionPlanService = ({
                   plan: {
                     ...input.markPlanReview!.plan,
                     reviewFeedbackMessageId: message.id,
-                    continuation: {
+                    delivery: {
                       commandId: input.markPlanReview!.commandId,
                       kind: 'review-feedback' as const,
                       state: 'queued' as const,

--- a/src/main/session-plan/session-plan-interaction-owner.test.ts
+++ b/src/main/session-plan/session-plan-interaction-owner.test.ts
@@ -117,8 +117,20 @@ describe('SessionPlanInteractionOwner', () => {
         code: 'approval-already-pending'
       })
     )
-    expect(owner.resolveApproval('session-1', { decision: 'approved' })).toBe(true)
-    expect(owner.resolveApproval('session-1', { decision: 'rejected' })).toBe(false)
+    expect(
+      owner.resolveApproval(
+        'session-1',
+        { decision: 'approved' },
+        owner.approvalTokenFor('session-1')
+      )
+    ).toBe(true)
+    expect(
+      owner.resolveApproval(
+        'session-1',
+        { decision: 'rejected' },
+        owner.approvalTokenFor('session-1')
+      )
+    ).toBe(false)
     await expect(approval).resolves.toEqual({ decision: 'approved' })
   })
 
@@ -142,7 +154,11 @@ describe('SessionPlanInteractionOwner', () => {
     )
     const approval = owner.parkReservedApproval('session-1', 'interaction-1')
     expect(owner.approvalInteractionIdFor('session-1')).toBe('interaction-1')
-    owner.resolveApproval('session-1', { decision: 'approved' })
+    owner.resolveApproval(
+      'session-1',
+      { decision: 'approved' },
+      owner.approvalTokenFor('session-1')
+    )
     await expect(approval).resolves.toEqual({ decision: 'approved' })
   })
 

--- a/src/main/session-plan/session-plan-interaction-owner.ts
+++ b/src/main/session-plan/session-plan-interaction-owner.ts
@@ -97,10 +97,15 @@ class SessionPlanInteractionOwner {
     return this.rows.get(sessionId)?.approval?.interactionId
   }
 
-  resolveApproval(sessionId: string, result: unknown): boolean {
+  // The parking object is an opaque, non-reusable identity, including when a prompt ID is reused.
+  approvalTokenFor(sessionId: string): object | undefined {
+    return this.rows.get(sessionId)?.approval
+  }
+
+  resolveApproval(sessionId: string, result: unknown, expectedToken: object | undefined): boolean {
     const row = this.rows.get(sessionId)
     const approval = row?.approval
-    if (!row || !approval) return false
+    if (!row || !approval || approval !== expectedToken) return false
     delete row.approval
     this.prune(sessionId, row)
     approval.resolve(result)

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -3058,7 +3058,7 @@ describe('startWebHttpServer', () => {
       .filter(([path]) => path.startsWith('acp.'))
       .map(([, channel]) => channel)
       .sort()
-    expect(acpChannels).toHaveLength(19)
+    expect(acpChannels).toHaveLength(20)
     const permissionChannels = [
       'permissions:extend-undo',
       'permissions:list',

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -262,6 +262,7 @@ describe('preload bridge — public surface inventory', () => {
       'acp.continueInterruptedTurn',
       'acp.createSession',
       'acp.deleteSession',
+      'acp.discardUnavailablePlan',
       'acp.disconnect',
       'acp.getPlanProjection',
       'acp.getState',

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -4032,7 +4032,7 @@ describe('ConversationPanel + menu', () => {
     )
   })
 
-  it('reopens an actionable Plan card after restart without reviving the expired interaction', async () => {
+  it('reopens an actionable Plan card for explicit feedback retry after an uncertain delivery', async () => {
     const onRespondToRestoredPlan = vi.fn().mockResolvedValue(undefined)
     const session: ChatSession = {
       id: 'session-orphaned-plan',
@@ -4040,6 +4040,26 @@ describe('ConversationPanel + menu', () => {
       title: 'Orphaned pending Plan',
       cwd: '/workspace',
       status: 'waiting-plan-approval',
+      runtimeContext: {
+        version: 1,
+        revision: 3,
+        plan: {
+          artifactId: completedPlanProjection.artifactId,
+          artifactVersionId: completedPlanProjection.artifactVersionId,
+          artifactChecksum: completedPlanProjection.artifactChecksum,
+          originatingPromptMessageId: 'interaction-1',
+          approval: 'pending',
+          stepStatuses: {},
+          reviewFeedbackMessageId: 'previous-feedback',
+          delivery: {
+            commandId: 'previous-delivery',
+            kind: 'review-feedback',
+            state: 'delivering',
+            originatingPromptMessageId: 'previous-feedback',
+            createdAt: 1
+          }
+        }
+      },
       messages: planOriginMessages(),
       createdAt: 1,
       updatedAt: 2,

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1,3 +1,4 @@
+import { UnavailablePlanNotice } from './session-plan/UnavailablePlanNotice'
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
@@ -1106,6 +1107,12 @@ const ConversationPanel = ({
             {/* Runtime and session errors stay near the composer so recovery is visible. */}
             <div className={composerContentClassName}>
               <div className="px-1 md:px-3">
+                {!sideChat && conversation.planProjectionRecoveryError && activeSession ? (
+                  <UnavailablePlanNotice
+                    key={`${activeSession.id}:${String(activeSession.runtimeContext?.revision)}`}
+                    session={activeSession}
+                  />
+                ) : null}
                 {composerError ? (
                   <div
                     role="alert"

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -488,7 +488,7 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(conversationProps.agentControls.canChange).toBe(false)
   })
 
-  it('unlocks a waiting Session after main drops unreadable Plan authority', async () => {
+  it('unlocks a waiting Session after main confirms there is no active Plan', async () => {
     useSessionStore.setState({
       sessions: [createSession({ status: 'waiting-plan-approval' })],
       selectedSessionId: 'sess-a'
@@ -519,7 +519,7 @@ describe('WorkspacePage send gate while compacting', () => {
       await firstProjection.catch(() => undefined)
     })
 
-    expect(conversationProps.view.actionError).toBe('Unable to restore plan state. Retrying…')
+    expect(conversationProps.conversation.planProjectionRecoveryError).toBe(true)
     expect(conversationProps.view.canEditDraft).toBe(false)
 
     await act(async () => {
@@ -527,6 +527,7 @@ describe('WorkspacePage send gate while compacting', () => {
     })
 
     expect(window.api.acp.getPlanProjection).toHaveBeenCalledTimes(2)
+    expect(conversationProps.conversation.planProjectionRecoveryError).toBe(false)
     expect(useSessionStore.getState().sessions[0]?.status).toBe('idle')
     expect(conversationProps.view.actionError).toBeNull()
     expect(conversationProps.view.canEditDraft).toBe(true)

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -533,6 +533,73 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(conversationProps.view.canEditDraft).toBe(true)
   })
 
+  it('retries a failed feedback refresh while an old projection was cached', async () => {
+    vi.useFakeTimers()
+    const pending = {
+      ...planProjection('pending'),
+      originatingPromptMessageId: planOriginMessage.id
+    }
+    useSessionStore.setState({
+      sessions: [
+        createSession({
+          status: 'waiting-plan-approval',
+          messages: [planOriginMessage],
+          activePlanProjection: pending,
+          runtimeContext: {
+            version: 1,
+            revision: pending.revision,
+            plan: {
+              artifactId: pending.artifactId,
+              artifactVersionId: pending.artifactVersionId,
+              artifactChecksum: pending.artifactChecksum,
+              approval: 'pending',
+              stepStatuses: {},
+              originatingPromptMessageId: planOriginMessage.id,
+              document: pending.document
+            }
+          }
+        })
+      ],
+      selectedSessionId: 'sess-a'
+    })
+    vi.mocked(window.api.acp.respondPlan).mockResolvedValue({
+      kind: 'feedback',
+      message: {
+        id: 'committed-feedback',
+        content: 'Split by cohort.',
+        createdAt: 2,
+        responseToMessageId: planOriginMessage.id
+      },
+      planRevision: pending.revision + 1
+    })
+    vi.mocked(window.api.acp.getPlanProjection).mockRejectedValue(
+      new Error('temporary refresh failure')
+    )
+    await renderPage()
+    await act(async () => {
+      await conversationProps.conversation.actions.submit.restoredPlan({
+        feedback: 'Split by cohort.'
+      })
+    })
+    expect(
+      useSessionStore
+        .getState()
+        .sessions[0].messages.some((message) => message.id === 'committed-feedback')
+    ).toBe(true)
+    const callsAfterSubmission = vi.mocked(window.api.acp.getPlanProjection).mock.calls.length
+    const latest = { ...pending, revision: pending.revision + 1 }
+    vi.mocked(window.api.acp.getPlanProjection).mockResolvedValue(latest)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000)
+    })
+    expect(vi.mocked(window.api.acp.getPlanProjection).mock.calls.length).toBeGreaterThan(
+      callsAfterSubmission
+    )
+    expect(useSessionStore.getState().sessions[0].activePlanProjection?.revision).toBe(
+      latest.revision
+    )
+  })
+
   it('submits restored Plan-card feedback through the atomic human-gated Plan command', async () => {
     const pending = {
       ...planProjection('pending'),

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -756,11 +756,7 @@ const WorkspacePage = ({
     activeSession.runtimeContext?.permission?.state === 'pending'
       ? (activeSession.error ?? actionError)
       : null
-  const planProjectionRecoveryError = conversation.planProjectionRecoveryError
-    ? t('Unable to restore plan state. Retrying…')
-    : null
   const visibleActionError =
-    planProjectionRecoveryError ??
     activeManualReviewRequest?.error ??
     attachmentError ??
     sessionController.view.exportError ??

--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ActivePlanProjection } from '../../../../../shared/session-plan/contract'
 import { PlanPreviewSurface, PlanProgressChip, WorkspacePlanCard } from './SessionPlanSurfaces'
 import { isPlanProgressVisible } from './plan-progress'
+import { respondToSessionPlan } from './respond-to-session-plan'
+import { useSessionStore } from '@/stores/session-store'
 
 afterEach(cleanup)
 
@@ -145,6 +147,64 @@ describe('Session Plan renderer surfaces', () => {
     expect(screen.getByRole('button', { name: 'Open' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull()
     expect(screen.queryByLabelText('Respond to Plan')).toBeNull()
+  })
+
+  it('P04 clears the submitted feedback card even when projection hydration fails', async () => {
+    const originalApi = window.api
+    const feedback = 'Split the analysis by cohort.'
+    const respondPlan = vi.fn().mockResolvedValue({
+      kind: 'feedback',
+      message: { id: 'feedback-1', role: 'user', content: feedback, createdAt: 10 }
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        acp: {
+          respondPlan,
+          getPlanProjection: vi.fn().mockRejectedValue(new Error('refresh connection lost'))
+        }
+      }
+    })
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-1',
+          status: 'waiting-plan-approval',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 1,
+          activePlanProjection: projection
+        } as never
+      ]
+    })
+    try {
+      const view = render(
+        <WorkspacePlanCard
+          projection={projection}
+          onOpen={vi.fn()}
+          onRespond={vi.fn()}
+          onSubmitResponse={(text) =>
+            respondToSessionPlan(
+              { projectId: 'project-1', sessionId: 'session-1', projection },
+              { feedback: text }
+            )
+          }
+        />
+      )
+      const input = view.container.querySelector('textarea')!
+      fireEvent.change(input, { target: { value: feedback } })
+      await act(async () => {
+        fireEvent.submit(input.closest('form')!)
+      })
+      expect(respondPlan).toHaveBeenCalledOnce()
+      expect(useSessionStore.getState().sessions[0].messages).toHaveLength(1)
+      expect(view.container.querySelector('article')).toBeNull()
+      expect(view.container.querySelector('textarea')).toBeNull()
+      expect(screen.queryByText('refresh connection lost')).toBeNull()
+    } finally {
+      Object.defineProperty(window, 'api', { configurable: true, value: originalApi })
+    }
   })
 
   it('submits inline revision feedback as a user Message', async () => {

--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
@@ -225,7 +225,7 @@ describe('Session Plan renderer surfaces', () => {
     await waitFor(() =>
       expect(onSubmitResponse).toHaveBeenCalledWith('Split the analysis by cohort.')
     )
-    expect(view.container.querySelector('article')).toBeNull()
+    await waitFor(() => expect(view.container.querySelector('article')).toBeNull())
     expect(onRespond).not.toHaveBeenCalled()
     expect(screen.queryByRole('button', { name: /request changes/i })).toBeNull()
   })

--- a/src/renderer/src/pages/workspace/session-plan/UnavailablePlanNotice.test.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/UnavailablePlanNotice.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChatSession } from '@/stores/session-store'
+import { UnavailablePlanNotice } from './UnavailablePlanNotice'
+
+const originalApi = window.api
+const discardUnavailablePlan = vi.fn()
+const session = {
+  id: 'session-1',
+  projectId: 'project-1',
+  status: 'waiting-plan-approval',
+  messages: [],
+  runtimeContext: {
+    version: 1,
+    revision: 4,
+    plan: {
+      artifactId: 'artifact-1',
+      artifactVersionId: 'version-1',
+      artifactChecksum: 'a'.repeat(64),
+      approval: 'pending',
+      stepStatuses: {}
+    }
+  }
+} as unknown as ChatSession
+beforeEach(() => {
+  discardUnavailablePlan.mockReset().mockResolvedValue({ revision: 5 })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { acp: { discardUnavailablePlan } }
+  })
+})
+afterEach(() => {
+  cleanup()
+  Object.defineProperty(window, 'api', { configurable: true, value: originalApi })
+})
+
+describe('unavailable Plan recovery confirmation', () => {
+  it('requires confirmation, retains the reviewed identity, and prevents duplicate submission', async () => {
+    const view = render(<UnavailablePlanNotice session={session} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Discard unavailable Plan' }))
+    expect(discardUnavailablePlan).not.toHaveBeenCalled()
+    expect(screen.getByRole('alertdialog').textContent).toContain(
+      'Messages and Artifacts are kept.'
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(discardUnavailablePlan).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Discard unavailable Plan' }))
+    // A stale confirmation must not silently switch to a newer Plan.
+    view.rerender(
+      <UnavailablePlanNotice
+        session={{
+          ...session,
+          runtimeContext: {
+            ...session.runtimeContext!,
+            revision: 8,
+            plan: { ...session.runtimeContext!.plan!, artifactVersionId: 'version-2' }
+          }
+        }}
+      />
+    )
+    let resolve!: (value: { revision: number }) => void
+    discardUnavailablePlan.mockReturnValue(
+      new Promise((done) => {
+        resolve = done
+      })
+    )
+    const confirm = within(screen.getByRole('alertdialog')).getByRole('button', {
+      name: 'Discard unavailable Plan'
+    })
+    fireEvent.click(confirm)
+    fireEvent.click(confirm)
+    expect(discardUnavailablePlan).toHaveBeenCalledTimes(1)
+    expect(discardUnavailablePlan).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      expectedRevision: 4
+    })
+    await act(async () => {
+      resolve({ revision: 5 })
+    })
+    expect(screen.queryByRole('alertdialog')).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Discard unavailable Plan' }).hasAttribute('disabled')
+    ).toBe(true)
+  })
+
+  it('keeps a failed discard visible and allows a new explicit confirmation', async () => {
+    discardUnavailablePlan.mockRejectedValueOnce(
+      new Error('The Plan revision changed concurrently.')
+    )
+    render(<UnavailablePlanNotice session={session} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Discard unavailable Plan' }))
+    await act(async () => {
+      fireEvent.click(
+        within(screen.getByRole('alertdialog')).getByRole('button', {
+          name: 'Discard unavailable Plan'
+        })
+      )
+    })
+    expect(screen.getByText('The Plan revision changed concurrently.')).toBeTruthy()
+    expect(screen.queryByRole('alertdialog')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Discard unavailable Plan' }))
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+    expect(discardUnavailablePlan).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/pages/workspace/session-plan/UnavailablePlanNotice.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/UnavailablePlanNotice.tsx
@@ -1,0 +1,85 @@
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle } from 'lucide-react'
+import type { PlanResponseIdentity } from '../../../../../shared/session-plan/contract'
+import { ErrorNotice } from '@/components/error-notice'
+import { ConfirmActionDialog } from '@/components/ui/confirm-action-dialog'
+import type { ChatSession } from '@/stores/session-store'
+
+const UnavailablePlanNotice = ({ session }: { session: ChatSession }): React.JSX.Element => {
+  const { t } = useTranslation()
+  const [confirmation, setConfirmation] = useState<PlanResponseIdentity>()
+  const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState<string>()
+  const inFlight = useRef(false)
+  const context = session.runtimeContext
+  const artifactVersionId = context?.plan?.artifactVersionId
+  const revision = context?.revision
+  const canDiscard =
+    typeof artifactVersionId === 'string' &&
+    typeof revision === 'number' &&
+    typeof window.api.acp.discardUnavailablePlan === 'function'
+  const discard = async (): Promise<void> => {
+    if (!confirmation || inFlight.current) return
+    inFlight.current = true
+    setLoading(true)
+    setError(undefined)
+    try {
+      await window.api.acp.discardUnavailablePlan(confirmation)
+      setConfirmation(undefined)
+      setSubmitted(true)
+      // The existing durable Session subscription and projection retry own the refresh.
+    } catch (cause) {
+      setConfirmation(undefined)
+      setError(cause instanceof Error ? cause.message : t('Unable to discard the Plan.'))
+    } finally {
+      inFlight.current = false
+      setLoading(false)
+    }
+  }
+  return (
+    <div
+      role="alert"
+      className="mb-2 [&>section]:max-w-none [&>section]:items-start [&>section]:gap-2 [&>section>svg]:hidden [&_h1]:text-xs"
+    >
+      <ErrorNotice
+        icon={AlertTriangle}
+        tone="amber"
+        title={t('Unable to restore plan state. Retrying…')}
+        description={error}
+        primaryButton={
+          canDiscard
+            ? {
+                label: t('Discard unavailable Plan'),
+                disabled: submitted,
+                loading,
+                onClick: () =>
+                  setConfirmation({
+                    projectId: session.projectId,
+                    sessionId: session.id,
+                    artifactVersionId,
+                    expectedRevision: revision
+                  })
+              }
+            : undefined
+        }
+      />
+      <ConfirmActionDialog
+        open={confirmation !== undefined}
+        title={t('Discard unavailable Plan?')}
+        description={t(
+          'This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.'
+        )}
+        cancelLabel={t('Cancel')}
+        confirmLabel={t('Discard unavailable Plan')}
+        loading={loading}
+        destructive
+        onCancel={() => setConfirmation(undefined)}
+        onConfirm={() => void discard()}
+      />
+    </div>
+  )
+}
+
+export { UnavailablePlanNotice }

--- a/src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.test.ts
+++ b/src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.test.ts
@@ -85,6 +85,51 @@ beforeEach(() => {
 })
 
 describe('respondToSessionPlan', () => {
+  it.each([false, true])(
+    'P04 preserves submit failure when refresh failure is %s',
+    async (refreshFails) => {
+      const failure = new Error('feedback commit failed')
+      respondPlan.mockRejectedValue(failure)
+      if (refreshFails) getPlanProjection.mockRejectedValue(new Error('refresh connection lost'))
+      await expect(
+        respondToSessionPlan(
+          { projectId: 'project-1', sessionId: 'session-1', projection },
+          { feedback: feedbackMessage.content }
+        )
+      ).rejects.toBe(failure)
+      expect(useSessionStore.getState().sessions[0].messages).toEqual([])
+      expect(getPlanProjection).toHaveBeenCalledOnce()
+    }
+  )
+
+  it.each(['approved', 'rejected', 'feedback'] as const)(
+    'P04 keeps committed %s successful when projection refresh fails',
+    async (kind) => {
+      respondPlan.mockResolvedValue(
+        kind === 'feedback'
+          ? { kind: 'feedback', message: feedbackMessage }
+          : { changed: true, projection: { ...approvedProjection, approval: kind } }
+      )
+      getPlanProjection.mockRejectedValue(new Error('refresh connection lost'))
+      const outcome = await respondToSessionPlan(
+        { projectId: 'project-1', sessionId: 'session-1', projection },
+        kind === 'feedback' ? { feedback: feedbackMessage.content } : kind
+      ).then(
+        () => ({ committed: true }),
+        (error: unknown) => ({ error })
+      )
+
+      expect(respondPlan).toHaveBeenCalledOnce()
+      expect(getPlanProjection).toHaveBeenCalledOnce()
+      if (kind === 'feedback') {
+        expect(useSessionStore.getState().sessions[0].messages).toEqual([
+          expect.objectContaining({ id: feedbackMessage.id, content: feedbackMessage.content })
+        ])
+      }
+      expect(outcome).toEqual({ committed: true })
+    }
+  )
+
   it('shares the version-bound response and projection refresh across renderer surfaces', async () => {
     await respondToSessionPlan(
       { projectId: 'project-1', sessionId: 'session-1', projection },

--- a/src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.test.ts
+++ b/src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.test.ts
@@ -209,6 +209,31 @@ describe('respondToSessionPlan', () => {
     expect(getPlanProjection).toHaveBeenCalledWith('project-1', 'session-1')
   })
 
+  it.each(['revision', 'version'] as const)(
+    'preserves a newer %s projection received while feedback hydration fails',
+    async (replacement) => {
+      const newer = {
+        ...projection,
+        ...(replacement === 'revision'
+          ? { revision: projection.revision + 1 }
+          : { artifactVersionId: 'version-2' })
+      }
+      respondPlan.mockResolvedValue({ kind: 'feedback', message: feedbackMessage })
+      getPlanProjection.mockImplementation(async () => {
+        useSessionStore.getState().setActivePlanProjection('session-1', newer)
+        throw new Error('refresh connection lost')
+      })
+      await respondToSessionPlan(
+        { projectId: 'project-1', sessionId: 'session-1', projection },
+        { feedback: feedbackMessage.content }
+      )
+      expect(useSessionStore.getState().sessions[0].activePlanProjection).toBe(newer)
+      expect(useSessionStore.getState().sessions[0].messages).toEqual([
+        expect.objectContaining({ id: feedbackMessage.id })
+      ])
+    }
+  )
+
   it('projects feedback optimistically when the adapter omits its Message payload', async () => {
     respondPlan.mockResolvedValue(undefined)
     getPlanProjection.mockResolvedValue(projection)

--- a/src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.ts
+++ b/src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.ts
@@ -204,5 +204,10 @@ export const respondToSessionPlan = async (
     }
     throw error
   }
-  await refreshSessionPlanProjection({ ...target, authoritativeProjection })
+  try {
+    await refreshSessionPlanProjection({ ...target, authoritativeProjection })
+  } catch (error) {
+    // The command committed. Existing Plan events and later reads can refresh its projection.
+    console.warn('Plan response committed, but projection refresh failed.', error)
+  }
 }

--- a/src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.ts
+++ b/src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.ts
@@ -207,7 +207,11 @@ export const respondToSessionPlan = async (
   try {
     await refreshSessionPlanProjection({ ...target, authoritativeProjection })
   } catch (error) {
-    // The command committed. Existing Plan events and later reads can refresh its projection.
+    // A stale cached projection suppresses the existing recovery hook. Invalidate only
+    // the submitted version/revision, preserving a newer projection delivered meanwhile.
+    if ('feedback' in payload) {
+      useSessionStore.getState().invalidateActivePlanProjection(target.sessionId, target.projection)
+    }
     console.warn('Plan response committed, but projection refresh failed.', error)
   }
 }

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -139,6 +139,10 @@ export type SessionRunProjectionActions = {
     answers: ElicitationAnswer[]
   ) => void
   setActivePlanProjection: (sessionId: string, projection: ActivePlanProjection) => void
+  invalidateActivePlanProjection: (
+    sessionId: string,
+    expected: Pick<ActivePlanProjection, 'artifactVersionId' | 'revision'>
+  ) => void
   beginActivityGroup: (
     sessionId: string,
     groupId: string,
@@ -344,6 +348,26 @@ export const createSessionRunProjectionOwner = <
           projectActivePlan(session, projection)
         )
       }))
+    },
+
+    invalidateActivePlanProjection: (sessionId, expected) => {
+      setSessionState((state) => {
+        const session = state.sessions.find((candidate) => candidate.id === sessionId)
+        const projection = session?.activePlanProjection
+        if (
+          !projection ||
+          projection.artifactVersionId !== expected.artifactVersionId ||
+          projection.revision !== expected.revision
+        ) {
+          return state
+        }
+        return {
+          sessions: projectSession(state.sessions, sessionId, (current) => ({
+            ...current,
+            activePlanProjection: undefined
+          }))
+        }
+      })
     },
 
     upsertToolActivity: (input) => {

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -974,6 +974,7 @@ describe('Session Store architecture', () => {
       'finishCompaction',
       'finishRun',
       'interruptRun',
+      'invalidateActivePlanProjection',
       'markResumed',
       'prepareInterruptedTurnContinuation',
       'recordArtifactError',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -6150,6 +6150,7 @@ describe('session store public contract', () => {
       'src/renderer/src/pages/workspace/session-action-menu.ts',
       'src/renderer/src/pages/workspace/session-message-artifact-reference.ts',
       'src/renderer/src/pages/workspace/session-notebook-projection.ts',
+      'src/renderer/src/pages/workspace/session-plan/UnavailablePlanNotice.tsx',
       'src/renderer/src/pages/workspace/session-plan/active-branch-plan.ts',
       'src/renderer/src/pages/workspace/session-plan/plan-file-projection.ts',
       'src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.ts',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2696,6 +2696,47 @@ describe('session store', () => {
     ).toBe(current.messages.at(-1)?.id)
   })
 
+  it('invalidates only the matching transient Plan cache without changing durable Session data', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Plan cache recovery',
+        cwd: '/workspace',
+        status: 'idle',
+        messages: [],
+        createdAt: 1,
+        updatedAt: 2
+      }
+    ])
+    const projection = createPlanProjection('version-1')
+    useSessionStore.getState().setActivePlanProjection('session-1', projection)
+    const before = useSessionStore.getState().sessions[0]
+    const durable = toPersistedSession(before)
+    const listener = vi.fn()
+    const unsubscribe = useSessionStore.subscribe(listener)
+    for (const expected of [
+      { ...projection, artifactVersionId: 'old-version' },
+      { ...projection, revision: projection.revision - 1 }
+    ]) {
+      useSessionStore.getState().invalidateActivePlanProjection('session-1', expected)
+      expect(useSessionStore.getState().sessions[0]).toBe(before)
+    }
+    expect(listener).not.toHaveBeenCalled()
+
+    useSessionStore.getState().invalidateActivePlanProjection('session-1', projection)
+    const after = useSessionStore.getState().sessions[0]
+    expect(after.activePlanProjection).toBeUndefined()
+    expect(after.runtimeContext).toBe(before.runtimeContext)
+    expect(after.messages).toBe(before.messages)
+    expect(after.status).toBe(before.status)
+    expect(toPersistedSession(after)).toEqual(durable)
+    expect(listener).toHaveBeenCalledTimes(1)
+    useSessionStore.getState().invalidateActivePlanProjection('session-1', projection)
+    expect(listener).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
   it('restores branch-bound Plan history after saving and hydrating a Session', () => {
     useSessionStore.getState().hydrateSessions(
       [
@@ -6034,6 +6075,7 @@ describe('session store public contract', () => {
         'hydrateSessionSummaries',
         'hydrateSessions',
         'interruptRun',
+        'invalidateActivePlanProjection',
         'markDisconnected',
         'markResumed',
         'markSpecialistSwitchResetRequired',

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -100,6 +100,10 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "Unable to discard the Plan.": "Der Plan kann nicht verworfen werden.",
+    "Discard unavailable Plan": "Nicht verfügbaren Plan verwerfen",
+    "Discard unavailable Plan?": "Nicht verfügbaren Plan verwerfen?",
+    "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "Dadurch werden der aktive Plan sowie seine Freigabe und sein Fortschritt aus dieser Konversation entfernt. Nachrichten und Artefakte bleiben erhalten. Dies kann nicht rückgängig gemacht werden.",
     "Receiving code. Cancelling discards the unfinished code.": "Code wird empfangen. Beim Abbrechen wird der unvollständige Code verworfen.",
     "Cancel code reception": "Codeempfang abbrechen",
     "Checking version…": "Version wird geprüft…",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -101,6 +101,10 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "Unable to discard the Plan.": "No se puede descartar el plan.",
+    "Discard unavailable Plan": "Descartar el plan no disponible",
+    "Discard unavailable Plan?": "¿Descartar el plan no disponible?",
+    "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "Se eliminarán de esta conversación el plan activo, su aprobación y su progreso. Se conservarán los mensajes y los artefactos. Esta acción no se puede deshacer.",
     "Receiving code. Cancelling discards the unfinished code.": "Se está recibiendo código. Al cancelar, se descarta el código incompleto.",
     "Cancel code reception": "Cancelar recepción de código",
     "Checking version…": "Comprobando la versión…",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -101,6 +101,10 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "Unable to discard the Plan.": "Impossible d’abandonner le plan.",
+    "Discard unavailable Plan": "Abandonner le plan indisponible",
+    "Discard unavailable Plan?": "Abandonner le plan indisponible ?",
+    "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "Le plan actif, son approbation et sa progression seront supprimés de cette conversation. Les messages et les artefacts seront conservés. Cette action est irréversible.",
     "Receiving code. Cancelling discards the unfinished code.": "Réception du code en cours. L’annulation supprime le code incomplet.",
     "Cancel code reception": "Annuler la réception du code",
     "Checking version…": "Vérification de la version…",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -99,6 +99,10 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "Unable to discard the Plan.": "プランを破棄できません。",
+    "Discard unavailable Plan": "利用できないプランを破棄",
+    "Discard unavailable Plan?": "利用できないプランを破棄しますか？",
+    "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "この会話から現在のプランとその承認および進捗を削除します。メッセージと成果物は保持されます。この操作は取り消せません。",
     "Receiving code. Cancelling discards the unfinished code.": "コードを受信しています。キャンセルすると未完成のコードは破棄されます。",
     "Cancel code reception": "コードの受信をキャンセル",
     "Checking version…": "バージョンを確認中…",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -99,6 +99,10 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "Unable to discard the Plan.": "계획을 삭제할 수 없습니다.",
+    "Discard unavailable Plan": "사용할 수 없는 계획 삭제",
+    "Discard unavailable Plan?": "사용할 수 없는 계획을 삭제하시겠습니까?",
+    "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "이 대화에서 현재 계획과 해당 승인 및 진행 상황을 제거합니다. 메시지와 아티팩트는 유지됩니다. 이 작업은 되돌릴 수 없습니다.",
     "Receiving code. Cancelling discards the unfinished code.": "코드를 수신 중입니다. 취소하면 미완성 코드가 삭제됩니다.",
     "Cancel code reception": "코드 수신 취소",
     "Checking version…": "버전 확인 중…",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -102,6 +102,10 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "Unable to discard the Plan.": "Не удалось удалить план.",
+    "Discard unavailable Plan": "Удалить недоступный план",
+    "Discard unavailable Plan?": "Удалить недоступный план?",
+    "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "Активный план, его утверждение и прогресс будут удалены из этого диалога. Сообщения и артефакты сохранятся. Это действие нельзя отменить.",
     "Receiving code. Cancelling discards the unfinished code.": "Получение кода. При отмене незавершённый код будет удалён.",
     "Cancel code reception": "Отменить получение кода",
     "Checking version…": "Проверка версии…",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -99,6 +99,10 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "Unable to discard the Plan.": "无法丢弃计划。",
+    "Discard unavailable Plan": "丢弃不可用计划",
+    "Discard unavailable Plan?": "要丢弃不可用计划吗？",
+    "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "这将从此对话中移除当前计划及其审批和进度。消息和产物会保留。此操作无法撤销。",
     "Receiving code. Cancelling discards the unfinished code.": "正在接收代码。取消将丢弃未完成的代码。",
     "Cancel code reception": "取消代码接收",
     "Checking version…": "正在检查版本…",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -99,6 +99,10 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "Unable to discard the Plan.": "無法捨棄計畫。",
+    "Discard unavailable Plan": "捨棄無法使用的計畫",
+    "Discard unavailable Plan?": "要捨棄無法使用的計畫嗎？",
+    "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "這會從此對話中移除目前的計畫及其核准和進度。訊息和產物會保留。此操作無法復原。",
     "Receiving code. Cancelling discards the unfinished code.": "正在接收程式碼。取消將捨棄未完成的程式碼。",
     "Cancel code reception": "取消程式碼接收",
     "Checking version…": "正在檢查版本…",

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -421,6 +421,7 @@ describe('renderer contract catalog', () => {
 
   it('marks the runtime-validated command slice', () => {
     expect(paths(({ applicationCommand }) => applicationCommand === 'runtime-validated')).toEqual([
+      'acp.discardUnavailablePlan',
       'acp.respondPlan',
       'acp.respondToElicitation',
       'acp.respondToPermission',
@@ -457,6 +458,7 @@ describe('renderer contract catalog', () => {
       'uploads.finalizeSession'
     ])
     expect(ELECTRON_APPLICATION_COMMAND_CHANNELS).toEqual([
+      'acp:discard-unavailable-plan',
       'acp:respond-elicitation',
       'acp:respond-permission',
       'acp:respond-plan',

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -23,7 +23,11 @@ import type {
   AcpStateSnapshot,
   AcpStateUpdate
 } from './acp'
-import type { ActivePlanProjection, PlanResponseCommand } from './session-plan/contract'
+import type {
+  ActivePlanProjection,
+  PlanResponseCommand,
+  PlanResponseIdentity
+} from './session-plan/contract'
 import type {
   SideChatCloseRequest,
   SideChatPromptRequest,
@@ -761,6 +765,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'acp.resetSessionContext': callable<
     (request: AcpResumeSessionRequest) => Promise<AcpCreateSessionResponse>
   >()('acp', ['acp:reset-session-context']),
+  'acp.discardUnavailablePlan': callable<
+    (request: PlanResponseIdentity) => Promise<{ revision: number }>
+  >()('acp', ['acp:discard-unavailable-plan', WEB, undefined, undefined, RUNTIME_VALIDATED]),
   'acp.respondPlan': callable<(request: PlanResponseCommand) => Promise<unknown>>()('acp', [
     'acp:respond-plan',
     WEB,

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -41,6 +41,7 @@ import { sanitizeActivityGroupTitle } from './activity-groups'
 import { sanitizeElicitationProjection, type ElicitationProjection } from './elicitation'
 import {
   derivePlanLifecycle,
+  MAX_PLAN_RUNTIME_CONTEXT_NODES,
   parsePlanDocumentV1,
   planStepTitles,
   projectPlanStepStates,
@@ -2679,7 +2680,10 @@ export const sanitizeSessionRuntimeContext = (
       owner === 'permission' ||
       owner === 'pdfContext'
     ) {
-      const sanitizedJson = sanitizeRuntimeContextValue(ownerValue, budget)
+      const sanitizedJson = sanitizeRuntimeContextValue(
+        ownerValue,
+        owner === 'plan' ? { remaining: MAX_PLAN_RUNTIME_CONTEXT_NODES } : budget
+      )
       if (sanitizedJson === undefined) return undefined
       if (owner === 'pdfContext') {
         const pdfContext = sanitizeSessionPdfContext(sanitizedJson)

--- a/src/shared/session-plan/contract.ts
+++ b/src/shared/session-plan/contract.ts
@@ -313,6 +313,30 @@ export const parsePlanDocumentV1 = (input: unknown): PlanDocumentV1 => {
   return createPlanDocumentV1(input)
 }
 
+// Keep the former document-size envelope; reserve independent space for every step's status/notes.
+const MAX_PLAN_DOCUMENT_NODES = 2_000
+export const MAX_PLAN_RUNTIME_CONTEXT_NODES = MAX_PLAN_DOCUMENT_NODES * 3
+
+export const assertPlanDocumentCapacity = (document: PlanDocumentV1): void => {
+  // V1 has eight fixed JSON values, three per phase/delegation/step, and one per desired output.
+  const nodes = document.phases.reduce(
+    (total, phase) =>
+      total +
+      3 +
+      phase.delegations.reduce(
+        (subtotal, delegation) => subtotal + 3 + 3 * delegation.steps.length,
+        0
+      ),
+    8 + document.desired_outputs.length
+  )
+  if (nodes > MAX_PLAN_DOCUMENT_NODES) {
+    throw new PlanCommandError(
+      'invalid-plan',
+      'The Plan is too large to track all of its steps. Split it into smaller Plans.'
+    )
+  }
+}
+
 export const planStepTitles = (document: PlanDocumentV1): string[] =>
   document.phases.flatMap((phase) =>
     phase.delegations.flatMap((delegation) => delegation.steps.map((step) => step.title))

--- a/src/shared/session-plan/contract.ts
+++ b/src/shared/session-plan/contract.ts
@@ -188,7 +188,7 @@ export type PlanCommandErrorCode = (typeof PLAN_COMMAND_ERROR_CODES)[number]
 export const isPlanCommandErrorCode = (value: unknown): value is PlanCommandErrorCode =>
   typeof value === 'string' && PLAN_COMMAND_ERROR_CODES.includes(value as PlanCommandErrorCode)
 
-type PlanResponseIdentity = Readonly<{
+export type PlanResponseIdentity = Readonly<{
   projectId: string
   sessionId: string
   artifactVersionId: string

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -6,6 +6,7 @@ export const WEB_INVOKE_CHANNELS = {
   'acp.continueInterruptedTurn': 'acp:continue-interrupted-turn',
   'acp.createSession': 'acp:create-session',
   'acp.deleteSession': 'acp:delete-session',
+  'acp.discardUnavailablePlan': 'acp:discard-unavailable-plan',
   'acp.disconnect': 'acp:disconnect',
   'acp.getPlanProjection': 'acp:get-plan-projection',
   'acp.getState': 'acp:get-state',


### PR DESCRIPTION
## Problem

Session Plan responses can lose a feedback delivery receipt, settle a replacement approval waiter, or become replayable after the Agent has already responded. A successful renderer submission can also be reported as failed when its follow-up refresh fails. Separately, projection reads can erase legacy plans after temporary I/O errors, and admitted plans can exhaust the shared context-node budget before recording all their steps.

## Proposed change

- Write new feedback receipts to canonical `delivery` in the existing atomic message/context patch.
- Bind approval resolution and stale feedback cleanup to the exact parked waiter, including reused prompt IDs; grant feedback decision authorization only after that handoff succeeds.
- Retry acceptance CAS conflicts at most three times, matching the original plan and receipt. Preserve uncertain `delivering` receipts across restart and report the uncertainty instead of automatically replaying them.
- Preserve committed renderer response success when projection hydration fails. Invalidate only the matching stale feedback projection cache so the existing recovery hook retries; preserve any newer version/revision received meanwhile.
- Keep authoritative Plan state on projection read/verification errors. Add a confirmed, human-only discard action for an unavailable Plan: recheck readability, exact revision/version and live waiter, plus active-branch membership when origin provenance exists before clearing Plan authority through the existing CAS patch. Preserve messages and Artifacts.
- Validate a 2,000-node document allowance before generation/approval/execution and give Plan an independent 6,000-node runtime allowance for progress and notes. Other context owners keep their shared 2,000-node limit.

## Scope and non-goals

No new tables, persisted fields, enum values, dependencies, or migrations. The waiter token is transient object identity. Existing `continuation` and artifact-only document readers remain supported; no historical backfill or recovery scan is performed. Historical `delivering` receipts use the conservative restart policy. Oversized artifact-only plans remain readable but require splitting before approval/execution. Existing Session byte/resource limits still apply.

The new discard command is exposed through the validated Electron/Web application-command contract, with the existing Session facade and error/confirmation components. It adds no Task automation command. Historical Plans without source Message provenance support explicit human cleanup bound to the exact project, Session, version and revision. No branch provenance is inferred or backfilled.

A feedback refresh failure is logged and invalidates only the matching transient projection cache. The existing recovery/loading surface and backoff recover it without feedback resubmission. This adds no durable synchronization flag, toast, or background poller. Delivery uncertainty is reported through the existing runtime error-event surface. This does not guarantee exactly-once external model effects or repair previously lost receipts/plans.

## Acceptance criteria and validation

The original regression selection was run twice against unchanged b5077745 production sources: both runs produced 28 expected failures and 3 passing controls. Restoring the fix made the same 31 cases pass. Subsequent review findings were also reproduced before production changes: ordinary rejection cannot clear an unavailable legacy Artifact; confirmed cleanup fails when legacy origin provenance is absent; committed feedback with failed hydration leaves a stale projection that suppresses retry. The latter two tests each failed twice at the real workflow and WorkspacePage/store boundaries, then passed after their fixes. Controls cover exact identity, branch mismatch, active interactions, read recovery, persistence failure, newer projection races and unchanged durable serialization. No production test seam was added.

After the latest production edit (captured-token feedback cleanup), the 100 Plan/workflow tests and 641 runtime/provider/interaction consumer tests passed, along with node/sandbox types and lint. The unchanged renderer, persistence, and transport checks retain the earlier evidence below. The Notebook CI test readiness correction runs only in its existing install double and leaves production behavior and assertions unchanged.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Feedback cleanup, reused prompt IDs and legacy capacity recovery | `npm test -- src/main/acp/runtime-plan-composition.test.ts src/main/session-plan/plan-service.test.ts` | 100 passed after latest production edit |
| Feedback card dismissal after asynchronous submission | `npm test -- src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx` | 25 passed after the final test edit; delayed callback fails twice with the old assertion and passes with `waitFor` |
| Notebook install/run concurrency readiness | `npm test -- src/main/notebook/runtime-service.test.ts` | 312 passed; delayed-start probe fails twice with old polling and passes with explicit signal |
| Runtime, provider executor and interaction-owner consumers | `npm test -- src/main/acp/runtime-session-plan.test.ts src/main/acp/runtime.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/session-plan/session-plan-interaction-owner.test.ts` | 641 passed after latest production edit |
| Earlier broad framework/Plan validation | Focused main command below | 1,272 passed; four opt-in live bridge checks skipped |
| Atomic context/message storage and restoration | `npm run test:module -- session_persistence` | 587 passed |
| Session projection/store consumers | `npm run test:module -- session_renderer` | 642 passed |
| ACP subscriptions, branch and event consumers | `npm run test:module -- workspace_runtime` | 441 passed |
| Plan card/recovery UI, preview/controller, i18n and application-command inventories | Focused renderer command below | 1,125 passed |
| Preload, IPC, remote Web capability inventories and Plan test types | `npm test -- src/preload/index.test.ts src/main/acp/ipc.test.ts src/main/web-service/http-server.test.ts src/main/session-plan/plan-service.test.ts` | 258 passed |
| Main/sandbox and renderer contracts | `npm run typecheck:node`; `npm run typecheck:web` | Passed |
| Prior CI failures: Memory/restart and uploaded Markdown/diff navigation | Focused Electron E2E command below, macOS | 2 passed |
| Lint/format and patch hygiene | `npm run lint`; `git diff --check` | Passed |

Counts are per invocation and include overlapping consumer coverage. The full local suite was explicitly waived by the maintainer. The impact planner selects full CI because several Plan/runtime files have no curated module assignment; its routing is unchanged. Exact-head PR CI remains authoritative for portable and platform lanes. On final head `f75f8d11a7e4c01a51107ce364578a34cb017189`, [PR Gate](https://github.com/aipoch/open-science/actions/runs/34002220852) passed all three portable test shards, module/coverage aggregation, static checks, Windows core, both Windows E2E shards, macOS build/E2E and Linux Notebook isolation. CodeQL also passed. The [latest AI review](https://github.com/aipoch/open-science/pull/2218#issuecomment-5555955692) requests changes on post-commit hydration, malformed persisted-plan recovery and already-approved oversized legacy plans. Those new claims have not yet been reproduced; review iteration is paused at the maintainer’s limit, and compatibility/design decisions require confirmation. The PR is not declared fully verified or ready to merge. Superseded feedback cleanup was reproduced twice before correction. The legacy-capacity recommendation was evaluated with a passing control: a 662-step artifact-only Plan with origin provenance remains readable and rejectable to idle; approval still requires splitting under the maintainer-approved policy.

<details>
<summary>Reproducible focused commands</summary>

```sh
npm test -- src/main/session-plan src/main/acp/runtime-plan-composition.test.ts src/main/acp/runtime-session-plan.test.ts src/main/acp/session-plan-delivery-owner.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/acp/prompt-turn-workflow.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/application-commands.test.ts src/shared/session-plan/contract.test.ts src/main/agent-framework/claude-code.test.ts src/main/agent-framework/opencode.test.ts src/main/agent-framework/codex.test.ts src/main/agent-framework/registry.test.ts src/main/settings/backend-route-planner.test.ts src/main/settings/native-responses-compatibility.test.ts src/main/settings/responses-bridge.test.ts src/main/settings/responses-bridge.integration.test.ts
npm test -- src/renderer/src/pages/workspace/session-plan src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx src/renderer/src/pages/workspace/previews/PreviewToolContent.plan.test.tsx src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts src/renderer/src/i18n/resources.test.ts src/shared/renderer-contract-catalog.test.ts src/main/application-command-composition.test.ts src/main/application-command-electron-adapter.test.ts
npm run build:e2e
npm run test:e2e -- e2e/workspace-files.spec.ts e2e/workspace-conversation.spec.ts --grep 'edits uploaded Markdown versions|keeps Memory reversible' --workers=1
```

Loopback MCP/runtime tests need permission to bind temporary local ports. Initial sandbox EPERM failures were rerun with scoped permission and passed. Claude/OpenCode/Codex use their framework contracts; Codex response and bridge paths have separate protocol contracts. No real model, credentials, remote execution, or external side effects were used. The two first-head E2E failures were graceful Electron close on Windows and resource ERR_FAILED/404 in the macOS Markdown editing journey. Both workflows pass locally on macOS; this is not proof of Windows behavior. Both Windows E2E shards and the macOS build/E2E lane passed on ddbdbb0. On 1891644, portable/static/module checks pass but platform E2E fails: Windows remains in initial database migration with a timed-out storage probe, and macOS records a renderer resource error. The exact macOS case passed three local repeats. A focused Windows E2E dry-run uses the existing workflow; these observations do not establish a root cause or waive current-head CI. The focused Windows repeat passed both shards. At 537956bb, macOS and Windows shard 2 pass; Windows shard 1 has a paced-tool layout overshoot that passes retry, while the portable suite has one Notebook install-start polling timeout. The exact layout case passes three local repeats on a rebuilt 537956bb. The Notebook test now awaits the install double’s explicit readiness signal. No startup thresholds or renderer error guards were relaxed; current-head CI remains required.

</details>

## Review focus

Exact waiter identity across awaits; receipt identity and finite conflict retries; distinguishing known-undelivered live handoffs from uncertain restart state; non-destructive legacy reads and explicit human recovery; admission capacity versus worst-case step state growth. Verify that the test mapping covers the final diff and that uncertainty notices do not imply an unobserved rollback.
