### PR TITLE
fix(acp): preserve ownership across recovery and permission waits

### DIFF
--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -399,6 +399,108 @@ describe('ACP permission broker with durable grants', () => {
     await expect(providerResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
   })
 
+  describe.each([
+    { blockedOperation: 'settleLive', fails: false },
+    { blockedOperation: 'remember', fails: false },
+    { blockedOperation: 'settleLive', fails: true },
+    { blockedOperation: 'remember', fails: true }
+  ] as const)('A01: blocked $blockedOperation (fails=$fails)', ({ blockedOperation, fails }) => {
+    it.each(['cancelForSession', 'cancelAllPending', 'abandonAllPending'] as const)(
+      '%s cancels a remembered response before provider release',
+      async (cancelMethod) => {
+        let enterPersistence!: () => void
+        const persistenceEntered = new Promise<void>((resolve) => {
+          enterPersistence = resolve
+        })
+        let finishPersistence!: () => void
+        const persistence = new Promise<void>((resolve) => {
+          finishPersistence = resolve
+        })
+        const waitForPersistence = async (operation: typeof blockedOperation): Promise<void> => {
+          if (operation !== blockedOperation) return
+          enterPersistence()
+          await persistence
+          if (fails) throw new Error('storage unavailable')
+        }
+        let grantSaved = false
+        const registry = {
+          resolve: vi.fn().mockResolvedValue(undefined),
+          remember: vi.fn(async () => {
+            await waitForPersistence('remember')
+            grantSaved = true
+            return undefined as never
+          }),
+          list: vi.fn().mockResolvedValue([]),
+          listCached: vi.fn().mockReturnValue([]),
+          revoke: vi.fn(),
+          extendUndo: vi.fn(),
+          restore: vi.fn(),
+          prune: vi.fn(),
+          finalizeOwnerDeletion: vi.fn(),
+          subscribe: vi.fn().mockReturnValue(() => undefined)
+        } satisfies PermissionGrantRegistry
+        type EmittedRequest = Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]
+        let publish!: (request: EmittedRequest) => void
+        const published = new Promise<EmittedRequest>((resolve) => {
+          publish = resolve
+        })
+        const settleLive = vi.fn(() => waitForPersistence('settleLive'))
+        const onSettled = vi.fn()
+        const broker = new AcpPermissionBroker(publish, undefined, registry, onSettled, {
+          persist: vi.fn(async () => true),
+          settleLive
+        })
+        const released = vi.fn()
+        const providerResponse = broker.requestPermission(shellRequest('session-1'), {
+          profile: 'ask',
+          projectId: 'project-1',
+          promptMessageId: 'prompt-1'
+        })
+        void providerResponse.then(released)
+        const request = await published
+        expect(request.durable).toBe(true)
+        const projectOption = request.options.find((option) => option.scope === 'project')
+        expect(projectOption).toBeDefined()
+        const response = broker.respond({
+          requestId: request.requestId,
+          optionId: projectOption!.optionId
+        })
+        const responseCompleted = fails
+          ? expect(response).rejects.toThrow('Permission approval could not be saved')
+          : expect(response).resolves.toBe(true)
+        await persistenceEntered
+        expect(released).not.toHaveBeenCalled()
+
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          if (cancelMethod === 'cancelForSession') broker.cancelForSession('session-1')
+          else broker[cancelMethod]()
+        }
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        expect.soft(released).toHaveBeenCalledWith({ outcome: { outcome: 'cancelled' } })
+        finishPersistence()
+        await responseCompleted
+        const result = await providerResponse
+
+        expect(settleLive).toHaveBeenCalledOnce()
+        expect
+          .soft(registry.remember)
+          .toHaveBeenCalledTimes(blockedOperation === 'remember' ? 1 : 0)
+        expect.soft(grantSaved).toBe(blockedOperation === 'remember' && !fails)
+        expect(registry.revoke).not.toHaveBeenCalled()
+        expect(released).toHaveBeenCalledOnce()
+        expect(onSettled.mock.calls.length).toBeLessThanOrEqual(1)
+        expect(broker.getPendingRequests()).toEqual([])
+        await expect(
+          broker.respond({ requestId: request.requestId, optionId: projectOption!.optionId })
+        ).resolves.toBe(false)
+        expect.soft(result).toEqual({ outcome: { outcome: 'cancelled' } })
+        expect
+          .soft(onSettled.mock.calls.map(([, state]) => state))
+          .toEqual(cancelMethod === 'abandonAllPending' ? [] : ['cancelled'])
+      }
+    )
+  })
+
   it('settles durable Session authority before committing a persistent grant', async () => {
     const journal: string[] = []
     const registry = {

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -195,6 +195,154 @@ describe('ACP permission broker', () => {
     })
   })
 
+  it.each(['cancelForSession', 'cancelAllPending', 'abandonAllPending'] as const)(
+    'A01: %s cancels an allow-once response waiting for settleLive',
+    async (cancelMethod) => {
+      let publish!: (request: EmittedPermissionRequest) => void
+      const published = new Promise<EmittedPermissionRequest>((resolve) => {
+        publish = resolve
+      })
+      let enterSettlement!: () => void
+      const settlementEntered = new Promise<void>((resolve) => {
+        enterSettlement = resolve
+      })
+      let finishSettlement!: () => void
+      const settlement = new Promise<void>((resolve) => {
+        finishSettlement = resolve
+      })
+      const settleLive = vi.fn(() => {
+        enterSettlement()
+        return settlement
+      })
+      const onSettled = vi.fn()
+      const broker = new AcpPermissionBroker(publish, undefined, undefined, onSettled, {
+        persist: vi.fn(async () => true),
+        settleLive
+      })
+      const released = vi.fn()
+      const providerResponse = broker.requestPermission(createPermissionRequest(), {
+        profile: 'ask',
+        projectId: 'project-1',
+        promptMessageId: 'prompt-1'
+      })
+      void providerResponse.then(released)
+      const request = await published
+      expect(request.durable).toBe(true)
+      const queuedResponse = broker.requestPermission(createPermissionRequest(), {
+        profile: 'ask',
+        projectId: 'project-1',
+        promptMessageId: 'prompt-1'
+      })
+      const response = broker.respond({ requestId: request.requestId, optionId: 'allow-once' })
+      await settlementEntered
+      expect(released).not.toHaveBeenCalled()
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        if (cancelMethod === 'cancelForSession') broker.cancelForSession('session-1')
+        else broker[cancelMethod]()
+      }
+      await Promise.resolve()
+      expect.soft(released).toHaveBeenCalledWith({ outcome: { outcome: 'cancelled' } })
+      finishSettlement()
+      await response
+      await expect(queuedResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+      const result = await providerResponse
+
+      expect(settleLive).toHaveBeenCalledOnce()
+      expect(released).toHaveBeenCalledOnce()
+      const requestSettlements = onSettled.mock.calls.filter(([id]) => id === request.requestId)
+      expect(requestSettlements.length).toBeLessThanOrEqual(1)
+      expect(broker.getPendingRequests()).toEqual([])
+      await expect(
+        broker.respond({ requestId: request.requestId, optionId: 'allow-once' })
+      ).resolves.toBe(false)
+      expect.soft(result).toEqual({ outcome: { outcome: 'cancelled' } })
+      expect
+        .soft(requestSettlements.map(([, state]) => state))
+        .toEqual(cancelMethod === 'abandonAllPending' ? [] : ['cancelled'])
+    }
+  )
+
+  it.each(['cancelForSession', 'cancelAllPending', 'abandonAllPending'] as const)(
+    'A01: a settlement failure after %s preserves a replacement session queue',
+    async (cancelMethod) => {
+      const emitted: EmittedPermissionRequest[] = []
+      let enterSettlement!: () => void
+      const settlementEntered = new Promise<void>((resolve) => {
+        enterSettlement = resolve
+      })
+      let failSettlement!: (error: Error) => void
+      const settlement = new Promise<void>((_, reject) => {
+        failSettlement = reject
+      })
+      const settleLive = vi
+        .fn(async (): Promise<void> => undefined)
+        .mockImplementationOnce(() => {
+          enterSettlement()
+          return settlement
+        })
+      const onSettled = vi.fn()
+      const persist = vi.fn(async () => true)
+      const broker = new AcpPermissionBroker(
+        (request) => emitted.push(request),
+        undefined,
+        undefined,
+        onSettled,
+        { persist, settleLive }
+      )
+      const policy = {
+        profile: 'ask' as const,
+        projectId: 'project-1',
+        promptMessageId: 'prompt-1'
+      }
+      const oldProvider = broker.requestPermission(createPermissionRequest(), policy)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      const oldRequest = emitted[0]
+      const oldResponse = broker.respond({
+        requestId: oldRequest.requestId,
+        optionId: 'allow-once'
+      })
+      const oldFailure = expect(oldResponse).rejects.toThrow(
+        'Permission decision could not be persisted'
+      )
+      await settlementEntered
+      if (cancelMethod === 'cancelForSession') broker.cancelForSession('session-1')
+      else broker[cancelMethod]()
+
+      const replacement = broker.requestPermission(createPermissionRequest(), policy)
+      const queued = broker.requestPermission(createPermissionRequest(), policy)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      expect(emitted).toHaveLength(cancelMethod === 'abandonAllPending' ? 2 : 1)
+      failSettlement(new Error('old disk write failed'))
+      await oldFailure
+      await expect(oldProvider).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+      expect
+        .soft(onSettled.mock.calls.map(([, state]) => state))
+        .toEqual(cancelMethod === 'abandonAllPending' ? [] : ['cancelled'])
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      expect.soft(emitted).toHaveLength(2)
+
+      if (emitted[1])
+        await broker.respond({ requestId: emitted[1].requestId, optionId: 'allow-once' })
+      await expect
+        .soft(replacement)
+        .resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } })
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      expect.soft(emitted).toHaveLength(3)
+      if (emitted[2])
+        await broker.respond({ requestId: emitted[2].requestId, optionId: 'allow-once' })
+      await expect(queued).resolves.toEqual({
+        outcome: { outcome: 'selected', optionId: 'allow-once' }
+      })
+      expect(persist).toHaveBeenCalledTimes(3)
+      expect(settleLive).toHaveBeenCalledTimes(3)
+      expect(broker.getPendingRequests()).toEqual([])
+      await expect(
+        broker.respond({ requestId: oldRequest.requestId, optionId: 'allow-once' })
+      ).resolves.toBe(false)
+    }
+  )
+
   it('serializes durable permission requests for the same session', async () => {
     const emitted: EmittedPermissionRequest[] = []
     let activeRequestId: string | undefined

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -736,6 +736,7 @@ const projectRegistrySessionGrants = (
 // Tracks permission requests until the renderer chooses an outcome.
 class AcpPermissionBroker {
   private pendingRequests = new Map<string, PendingPermission>()
+  private readonly respondingRequests = new Map<string, PendingPermission>()
   private readonly restoredAllowOnceBySession = new Map<string, string>()
   private readonly durableRequestQueues = new Map<string, string[]>()
   private readonly activeDurableRequestBySession = new Map<string, string>()
@@ -1261,99 +1262,113 @@ class AcpPermissionBroker {
 
     this.pendingRequests.delete(response.requestId)
 
-    if (response.cancelled || !response.optionId) {
-      const persistence = this.persistLiveSettlement(pending)
-      if (persistence) await persistence
-      this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
-      return true
-    }
-
-    // Only options projected to the renderer are valid responses. This keeps provider-specific
-    // persistent policy actions hidden at the protocol boundary as well as in the UI.
-    if (!pending.request.options.some((option) => option.optionId === response.optionId)) {
-      const persistence = this.persistLiveSettlement(pending)
-      if (persistence) await persistence
-      this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
-      return true
-    }
-
-    const selected = pending.request.options.find((option) => option.optionId === response.optionId)
-    const settlementState: AcpPermissionSettlementState = selected?.kind
-      .toLowerCase()
-      .startsWith('reject')
-      ? 'rejected'
-      : 'resolved'
-    const rememberedScope =
-      selected?.scope === 'session' || selected?.scope === 'project' || selected?.scope === 'global'
-    // App-owned requests use the shared scope UI but keep their decision semantics in the caller;
-    // only provider requests translate remembered scopes back to a provider-native one-shot option.
-    const providerOptionId =
-      rememberedScope && !pending.appOwned ? pending.providerAllowOnceOptionId : response.optionId
-
-    if (!providerOptionId) {
-      const persistence = this.persistLiveSettlement(pending)
-      if (persistence) await persistence
-      this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
-      return true
-    }
-
-    if (
-      rememberedScope &&
-      !pending.appOwned &&
-      selected?.scope &&
-      pending.capability &&
-      pending.projectId &&
-      this.permissionGrantRegistry
-    ) {
-      const scope: PermissionGrantScope =
-        selected.scope === 'global'
-          ? { kind: 'global' }
-          : selected.scope === 'project'
-            ? { kind: 'project', projectId: pending.projectId }
-            : {
-                kind: 'session',
-                projectId: pending.projectId,
-                sessionId:
-                  pending.policyContext?.permissionGrantSessionId ?? pending.request.sessionId
-              }
-      try {
+    // Keep the claimed request cancellable until its provider decision is released.
+    this.respondingRequests.set(response.requestId, pending)
+    try {
+      if (response.cancelled || !response.optionId) {
         const persistence = this.persistLiveSettlement(pending)
         if (persistence) await persistence
-        await this.permissionGrantRegistry.remember({ capability: pending.capability, scope })
-        this.settlePending(
-          pending,
-          { outcome: { outcome: 'selected', optionId: providerOptionId } },
-          settlementState
-        )
-      } catch (error) {
         this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
-        throw new Error('Permission approval could not be saved; the tool call was cancelled.', {
-          cause: error
-        })
+        return true
       }
-      return true
-    }
 
-    // Legacy Session grants are owned by Open Science. The Agent receives only its one-shot option.
-    if (pending.categoryKey) {
-      this.rememberSessionGrant(pending.request, pending.categoryKey, response.optionId)
-    }
+      // Only options projected to the renderer are valid responses. This keeps provider-specific
+      // persistent policy actions hidden at the protocol boundary as well as in the UI.
+      if (!pending.request.options.some((option) => option.optionId === response.optionId)) {
+        const persistence = this.persistLiveSettlement(pending)
+        if (persistence) await persistence
+        this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+        return true
+      }
 
-    const persistence = this.persistLiveSettlement(pending)
-    if (persistence) await persistence
+      const selected = pending.request.options.find(
+        (option) => option.optionId === response.optionId
+      )
+      const settlementState: AcpPermissionSettlementState = selected?.kind
+        .toLowerCase()
+        .startsWith('reject')
+        ? 'rejected'
+        : 'resolved'
+      const rememberedScope =
+        selected?.scope === 'session' ||
+        selected?.scope === 'project' ||
+        selected?.scope === 'global'
+      // App-owned requests use the shared scope UI but keep their decision semantics in the caller;
+      // only provider requests translate remembered scopes back to a provider-native one-shot option.
+      const providerOptionId =
+        rememberedScope && !pending.appOwned ? pending.providerAllowOnceOptionId : response.optionId
 
-    this.settlePending(
-      pending,
-      {
-        outcome: {
-          outcome: 'selected',
-          optionId: providerOptionId
+      if (!providerOptionId) {
+        const persistence = this.persistLiveSettlement(pending)
+        if (persistence) await persistence
+        this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+        return true
+      }
+
+      if (
+        rememberedScope &&
+        !pending.appOwned &&
+        selected?.scope &&
+        pending.capability &&
+        pending.projectId &&
+        this.permissionGrantRegistry
+      ) {
+        const scope: PermissionGrantScope =
+          selected.scope === 'global'
+            ? { kind: 'global' }
+            : selected.scope === 'project'
+              ? { kind: 'project', projectId: pending.projectId }
+              : {
+                  kind: 'session',
+                  projectId: pending.projectId,
+                  sessionId:
+                    pending.policyContext?.permissionGrantSessionId ?? pending.request.sessionId
+                }
+        try {
+          const persistence = this.persistLiveSettlement(pending)
+          if (persistence) await persistence
+          if (pending.settled) return true
+          await this.permissionGrantRegistry.remember({ capability: pending.capability, scope })
+          if (pending.settled) return true
+          this.settlePending(
+            pending,
+            { outcome: { outcome: 'selected', optionId: providerOptionId } },
+            settlementState
+          )
+        } catch (error) {
+          this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+          throw new Error('Permission approval could not be saved; the tool call was cancelled.', {
+            cause: error
+          })
         }
-      },
-      settlementState
-    )
+        return true
+      }
 
-    return true
+      // Legacy Session grants are owned by Open Science. The Agent receives only its one-shot option.
+      if (pending.categoryKey) {
+        this.rememberSessionGrant(pending.request, pending.categoryKey, response.optionId)
+      }
+
+      const persistence = this.persistLiveSettlement(pending)
+      if (persistence) await persistence
+
+      this.settlePending(
+        pending,
+        {
+          outcome: {
+            outcome: 'selected',
+            optionId: providerOptionId
+          }
+        },
+        settlementState
+      )
+
+      return true
+    } finally {
+      if (this.respondingRequests.get(response.requestId) === pending) {
+        this.respondingRequests.delete(response.requestId)
+      }
+    }
   }
 
   private persistLiveSettlement(pending: PendingPermission): Promise<void> | undefined {
@@ -1372,8 +1387,16 @@ class AcpPermissionBroker {
         await hooks.settleLive(candidate)
         this.releaseDurablePermissionSlot(pending)
       } catch (error) {
-        this.cancelQueuedDurablePermissions(pending.request.sessionId)
-        this.activeDurableRequestBySession.delete(pending.request.sessionId)
+        const sessionId = pending.request.sessionId
+        if (pending.settled) {
+          // Cancellation already removed the old queue; later requests belong to new work.
+          this.releaseDurablePermissionSlot(pending)
+        } else if (
+          this.activeDurableRequestBySession.get(sessionId) === pending.request.requestId
+        ) {
+          this.cancelQueuedDurablePermissions(sessionId)
+          this.activeDurableRequestBySession.delete(sessionId)
+        }
         this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
         throw new Error(
           'Permission decision could not be persisted; the tool call was cancelled.',
@@ -1489,8 +1512,9 @@ class AcpPermissionBroker {
     this.restoredAllowOnceBySession.clear()
     this.durableRequestQueues.clear()
     this.activeDurableRequestBySession.clear()
-    const pending = Array.from(this.pendingRequests.values())
+    const pending = [...this.pendingRequests.values(), ...this.respondingRequests.values()]
     this.pendingRequests.clear()
+    this.respondingRequests.clear()
     for (const request of pending) {
       if (request.settled) continue
       if (
@@ -1512,6 +1536,9 @@ class AcpPermissionBroker {
     this.livePermissionProfiles.clear()
     this.restoredAllowOnceBySession.clear()
     const pendingRequests = Array.from(this.pendingRequests.keys())
+    for (const pending of Array.from(this.respondingRequests.values())) {
+      this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+    }
 
     for (const requestId of pendingRequests) {
       void this.respond({ requestId, cancelled: true }).catch(() => undefined)
@@ -1525,6 +1552,11 @@ class AcpPermissionBroker {
     for (const token of cancellationTokens ?? []) token.cancelled = true
     this.restoredAllowOnceBySession.delete(sessionId)
     const pendingRequests = Array.from(this.pendingRequests.values())
+    for (const pending of Array.from(this.respondingRequests.values())) {
+      if (pending.request.sessionId === sessionId) {
+        this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+      }
+    }
 
     for (const { request } of pendingRequests) {
       if (request.sessionId === sessionId) {

--- a/src/main/acp/permission-profile-controller.test.ts
+++ b/src/main/acp/permission-profile-controller.test.ts
@@ -16,6 +16,103 @@ const createModes = (
 })
 
 describe('permission profile controller', () => {
+  describe('A03: native permission downgrade', () => {
+    it.each(['ask', 'auto'] as const)(
+      'rejects %s when the current native bypass has no advertised exit',
+      (profile) => {
+        expect(() =>
+          resolvePermissionProfileApplication(profile, createModes(['bypassPermissions']))
+        ).toThrow(PermissionProfileUnavailableError)
+      }
+    )
+
+    it.each(['ask', 'auto'] as const)(
+      'rejects %s from CodeBuddy fullAccess even with broker fallback enabled',
+      (profile) => {
+        expect(() =>
+          resolvePermissionProfileApplication(profile, createModes(['fullAccess']), {
+            fullAccessModeId: 'fullAccess',
+            brokerEnforcesFullAccess: true
+          })
+        ).toThrow(PermissionProfileUnavailableError)
+      }
+    )
+
+    it('rejects Ask from bypass when Auto is advertised but default is missing', () => {
+      const modes = createModes(['auto', 'bypassPermissions'], 'bypassPermissions')
+      expect(() => resolvePermissionProfileApplication('ask', modes)).toThrow(
+        PermissionProfileUnavailableError
+      )
+    })
+
+    it('can leave bypass through an advertised native Auto mode without default', () => {
+      const modes = createModes(['auto', 'bypassPermissions'], 'bypassPermissions')
+      expect(resolvePermissionProfileApplication('auto', modes)).toMatchObject({
+        modeId: 'auto',
+        state: { effectiveProfile: 'auto', currentModeId: 'auto', autoReviewStrategy: 'native' }
+      })
+    })
+
+    // Preserve the existing fallback outside the confirmed native-bypass defect. These mapping
+    // checks do not prove that an unknown provider delegates every permission to the broker.
+    it.each([
+      { label: 'null mode state', modes: null },
+      { label: 'undefined mode state', modes: undefined },
+      { label: 'unknown current mode', modes: createModes(['custom'], 'custom') }
+    ])('preserves the existing fallback for $label', ({ modes }) => {
+      for (const profile of ['ask', 'auto'] as const) {
+        expect(resolvePermissionProfileApplication(profile, modes)).toMatchObject({
+          modeId: undefined,
+          state: {
+            selectedProfile: profile,
+            effectiveProfile: profile,
+            currentModeId: modes?.currentModeId
+          }
+        })
+      }
+    })
+
+    it('retains a known default posture even when it is absent from the mode catalog', () => {
+      for (const profile of ['ask', 'auto'] as const) {
+        expect(
+          resolvePermissionProfileApplication(profile, createModes([], 'default'))
+        ).toMatchObject({
+          modeId: undefined,
+          state: { selectedProfile: profile, effectiveProfile: profile, currentModeId: 'default' }
+        })
+      }
+    })
+
+    it('can leave an unknown mode using an advertised default', () => {
+      for (const profile of ['ask', 'auto'] as const) {
+        expect(
+          resolvePermissionProfileApplication(profile, createModes(['default'], 'custom'))
+        ).toMatchObject({
+          modeId: 'default',
+          state: { selectedProfile: profile, effectiveProfile: profile, currentModeId: 'default' }
+        })
+      }
+    })
+
+    it.each([null, undefined, createModes(['build', 'plan'])])(
+      'retains app-enforced profiles when the framework guarantees broker enforcement (%j)',
+      (modes) => {
+        for (const profile of ['ask', 'auto', 'full'] as const) {
+          expect(
+            resolvePermissionProfileApplication(profile, modes, { brokerEnforcesFullAccess: true })
+          ).toMatchObject({
+            modeId: undefined,
+            state: {
+              selectedProfile: profile,
+              effectiveProfile: profile,
+              fullAccessAvailable: true
+            }
+          })
+        }
+      }
+    )
+  })
+
   it('maps Ask and native Auto to advertised ACP modes', () => {
     const modes = createModes(['default', 'auto', 'bypassPermissions'])
 

--- a/src/main/acp/permission-profile-controller.ts
+++ b/src/main/acp/permission-profile-controller.ts
@@ -54,6 +54,16 @@ const resolvePermissionProfileApplication = (
     throw new PermissionProfileUnavailableError(profile)
   }
 
+  // Broker fallback cannot downgrade a provider that remains in native bypass.
+  if (
+    profile !== 'full' &&
+    modes?.currentModeId === fullAccessModeId &&
+    !hasMode(DEFAULT_MODE_ID) &&
+    !(profile === 'auto' && hasMode(AUTO_MODE_ID))
+  ) {
+    throw new PermissionProfileUnavailableError(profile)
+  }
+
   if (profile === 'auto') {
     const nativeAuto = hasMode(AUTO_MODE_ID)
     const modeId = nativeAuto

--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -15,6 +15,7 @@ import type { ContextWindowTurnHandle } from './context-usage-tracker'
 import { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
 import type { ReadyPreparedPromptHandle } from './prompt-preparation-owner'
 import { AcpPromptTurnWorkflow, type AcpPromptTurnWorkflowOptions } from './prompt-turn-workflow'
+import { AcpProviderPromptExecutor } from './provider-prompt-executor'
 import { AcpProviderPromptSerializationOwner } from './provider-prompt-serialization-owner'
 import { AcpSessionAggregate } from './session-aggregate'
 import { AcpSessionInteractionOwner } from './session-interaction-owner'
@@ -225,6 +226,7 @@ const createHarness = (
   )
   const context = {
     complete: vi.fn(() => true),
+    captureTerminal: vi.fn(() => undefined),
     fail: vi.fn(),
     supersede: vi.fn()
   } as unknown as ContextWindowTurnHandle
@@ -985,6 +987,135 @@ describe('AcpPromptTurnWorkflow', () => {
       harness.onProviderPromptAccepted.mock.invocationCallOrder[0]
     )
   })
+
+  it.each([
+    ['Plan', 'disconnect', 'text', false],
+    ['Plan', 'interaction', 'tool', false],
+    ['Plan', 'session', 'stop', false],
+    ['relay', 'disconnect', 'text', false],
+    ['relay', 'interaction', 'tool', false],
+    ['relay', 'session', 'stop', false],
+    ['Plan', 'disconnect', 'text', true],
+    ['relay', 'disconnect', 'text', true]
+  ] as const)(
+    'drops stale live acceptance after %s wait (%s, first %s, rejection=%s)',
+    async (waitAt, invalidation, firstKind, rejects) => {
+      const entered = deferred<void>()
+      const release = deferred<void>()
+      const persistedReceipt = vi.fn()
+      const durableNotification = vi.fn()
+      const failure = new Error('acceptance persistence failed')
+      const settleReceipt = async (identity: unknown): Promise<void> => {
+        entered.resolve()
+        await release.promise
+        if (rejects) throw failure
+        persistedReceipt(identity)
+        durableNotification(identity)
+      }
+      const commit = vi.fn(settleReceipt)
+      const restore = vi.fn()
+      const executor = new AcpProviderPromptExecutor({
+        backendGeneration: { current: backend, openCodeUsageApi: () => undefined }
+      })
+      const harness = createHarness({
+        execute: (input) => executor.execute(input),
+        finalize: (handles, outcome) => new AcpPromptOutcomeFinalizer().finalize(handles, outcome),
+        ...(waitAt === 'relay'
+          ? { sideChatClaim: () => ({ historyPreamble: 'Side note.', commit, restore }) }
+          : {})
+      })
+      if (waitAt === 'Plan') {
+        harness.planLifecycle.providerAccepted.mockImplementationOnce((_sessionId, mode) =>
+          settleReceipt(mode)
+        )
+      }
+      const response: PromptResponse = { stopReason: 'end_turn' }
+      type NextUpdate = Awaited<ReturnType<ActiveSession['nextUpdate']>>
+      const terminal = { kind: 'stop', response } as NextUpdate
+      const update =
+        firstKind === 'tool'
+          ? {
+              sessionUpdate: 'tool_call_update' as const,
+              toolCallId: 'old-tool',
+              status: 'in_progress' as const
+            }
+          : {
+              sessionUpdate: 'agent_message_chunk' as const,
+              content: { type: 'text' as const, text: 'Old answer' }
+            }
+      const messages: NextUpdate[] =
+        firstKind === 'stop'
+          ? [terminal]
+          : [
+              { kind: 'session_update', notification: { sessionId: 'provider-1', update }, update },
+              terminal
+            ]
+      const nextUpdate = vi.fn(async () => messages.shift()!)
+      harness.setSession({
+        sessionId: 'provider-1',
+        prompt: vi.fn(async () => undefined),
+        nextUpdate
+      } as unknown as ActiveSession)
+      const mode =
+        waitAt === 'Plan'
+          ? {
+              kind: 'app-continuation' as const,
+              promptAttemptId: 'old-attempt',
+              planDelivery: { projectId: 'project-1', commandId: 'delivery-1' }
+            }
+          : { kind: 'user' as const, promptAttemptId: 'old-attempt' }
+      const pending = harness.workflow.run(request(), mode)
+      await entered.promise
+      const oldInteraction = harness.owner.current('s1')!
+      let replacement: typeof oldInteraction | undefined
+      if (invalidation === 'disconnect') {
+        harness.owner.supersedeAll()
+      } else if (invalidation === 'interaction') {
+        harness.owner.supersede(oldInteraction)
+        replacement = harness.owner.activatePrompt(
+          harness.owner.reservePrompt({
+            sessionId: 's1',
+            kind: 'prompt',
+            promptMessageId: 'new-message'
+          })
+        )
+      } else {
+        // Keep the same interaction and provider id: only attachment object identity changes.
+        harness.setSession({ sessionId: 'provider-1' } as ActiveSession)
+        expect(harness.owner.current('s1')).toBe(oldInteraction)
+      }
+      expect(harness.onProviderPromptAccepted).not.toHaveBeenCalled()
+      release.resolve()
+      await expect(pending).resolves.toEqual(response)
+
+      expect.soft(harness.onProviderPromptAccepted).not.toHaveBeenCalled()
+      expect
+        .soft(harness.emitSkillActivities.mock.calls.map((call) => call[3]))
+        .toEqual(['in_progress'])
+      expect.soft(harness.routeNotification).not.toHaveBeenCalled()
+      expect.soft(harness.finalizer.mock.calls[0][1]).toEqual({ kind: 'superseded', response })
+      expect.soft(harness.finalization.pushEvent).not.toHaveBeenCalled()
+      expect(nextUpdate).toHaveBeenCalledTimes(firstKind === 'stop' ? 1 : 2)
+      expect(harness.owner.current('s1')).toBe(replacement)
+      expect(harness.prepared.close).toHaveBeenCalledOnce()
+      expect(harness.artifacts.dispose).toHaveBeenCalledOnce()
+      if (replacement) {
+        expect(harness.finalization.onPromptEnded).not.toHaveBeenCalled()
+        expect(harness.permission.clearCorrelationsForSession).not.toHaveBeenCalled()
+        expect(harness.planLifecycle.beforeRelease).not.toHaveBeenCalled()
+        expect(harness.planLifecycle.afterRelease).not.toHaveBeenCalled()
+        harness.owner.release(replacement)
+      }
+      expect(restore).not.toHaveBeenCalled()
+      expect(commit).toHaveBeenCalledTimes(waitAt === 'relay' ? 1 : 0)
+      expect(persistedReceipt).toHaveBeenCalledTimes(rejects ? 0 : 1)
+      expect(durableNotification).toHaveBeenCalledTimes(rejects ? 0 : 1)
+      if (!rejects) {
+        expect(persistedReceipt).toHaveBeenCalledWith(waitAt === 'Plan' ? mode : 'message-1')
+        expect(durableNotification).toHaveBeenCalledWith(waitAt === 'Plan' ? mode : 'message-1')
+      }
+    }
+  )
 
   it('restores claimed side-chat advisories when the provider never accepts the prompt', async () => {
     const commit = vi.fn()

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -469,6 +469,9 @@ class AcpPromptTurnWorkflow {
                 })
               }
             }
+            // Receipts describe provider acceptance and keep their durable notifications. Only
+            // the current turn may publish live acceptance and Skill completion after those waits.
+            if (!this.isCurrent(turn)) return
             this.safeCallback('provider-prompt-accepted callback failed', () =>
               env.onProviderPromptAccepted?.(sessionId, turn.mode.promptAttemptId)
             )

--- a/src/main/acp/provider-prompt-executor.test.ts
+++ b/src/main/acp/provider-prompt-executor.test.ts
@@ -474,6 +474,96 @@ describe('AcpProviderPromptExecutor', () => {
     expect(acceptedThenStale.probe.cancel).toHaveBeenCalledOnce()
   })
 
+  it.each(['text', 'tool', 'stop'] as const)(
+    'drops a first %s superseded during acceptance without disturbing the new interaction',
+    async (firstKind) => {
+      const response: PromptResponse = { stopReason: 'cancelled' }
+      const toolNotification: SessionNotification = {
+        sessionId: 'provider-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'old-tool',
+          status: 'in_progress'
+        }
+      }
+      const first: NextUpdate =
+        firstKind === 'stop'
+          ? stop(response)
+          : firstKind === 'text'
+            ? update()
+            : {
+                kind: 'session_update',
+                notification: toolNotification,
+                update: toolNotification.update
+              }
+      const old = setup(firstKind === 'stop' ? [first] : [first, update(), stop(response)])
+      const oldOwner = Symbol('old interaction')
+      const newOwner = Symbol('new interaction')
+      let owner = oldOwner
+      const acceptedEntered = deferred<void>()
+      const acceptedGate = deferred<void>()
+      old.accepted.mockImplementationOnce(() => {
+        acceptedEntered.resolve()
+        return acceptedGate.promise
+      })
+      old.captureStop.mockImplementation(() => owner === oldOwner)
+      const pendingOld = old.executor.execute({
+        ...old.input,
+        isCurrent: () => owner === oldOwner
+      })
+      await acceptedEntered.promise
+      expect(old.routeNotification).not.toHaveBeenCalled()
+      expect(old.captureStop).not.toHaveBeenCalled()
+
+      // Replace ownership while acceptance is suspended, not before dispatch or after routing.
+      owner = newOwner
+      const nextResponse: PromptResponse = { stopReason: 'end_turn' }
+      const next = setup([update(), stop(nextResponse)])
+      const nextAcceptedEntered = deferred<void>()
+      const nextAcceptedGate = deferred<void>()
+      next.accepted.mockImplementationOnce(() => {
+        nextAcceptedEntered.resolve()
+        return nextAcceptedGate.promise
+      })
+      next.captureStop.mockImplementation(() => owner === newOwner)
+      // Same executor and provider id exercise token-scoped cleanup, with a new session queue.
+      const pendingNext = old.executor.execute({
+        ...next.input,
+        isCurrent: () => owner === newOwner
+      })
+      await nextAcceptedEntered.promise
+
+      acceptedGate.resolve()
+      const oldOutcome = await pendingOld
+      const providerMessage = { sessionId: 'provider-1', message: { type: 'result' } }
+      old.executor.observeProviderMessage(providerMessage)
+      nextAcceptedGate.resolve()
+      const nextOutcome = await pendingNext
+
+      expect(oldOutcome).toEqual({ kind: 'superseded', response })
+      expect(old.accepted).toHaveBeenCalledOnce()
+      expect.soft(old.routeNotification).not.toHaveBeenCalled()
+      expect.soft(old.probe.observe).not.toHaveBeenCalled()
+      // Stop already has a second ownership boundary in captureStop; retain it as a control.
+      if (firstKind !== 'stop') expect(old.captureStop).not.toHaveBeenCalled()
+      expect(old.probe.finalize).not.toHaveBeenCalled()
+      expect(old.probe.cancel).toHaveBeenCalledOnce()
+      expect(old.report).not.toHaveBeenCalled()
+      expect(old.session.nextUpdate).toHaveBeenCalledTimes(firstKind === 'stop' ? 1 : 3)
+
+      expect(nextOutcome).toMatchObject({ kind: 'stopped', response: nextResponse })
+      expect(next.accepted).toHaveBeenCalledOnce()
+      expect(next.probe.observe.mock.calls).toEqual([[providerMessage], [notification]])
+      expect(next.routeNotification.mock.calls).toEqual([[notification]])
+      expect(next.captureStop).toHaveBeenCalledOnce()
+      expect(next.probe.finalize).toHaveBeenCalledWith({ response: nextResponse })
+      expect(next.probe.cancel).not.toHaveBeenCalled()
+      expect(next.report).not.toHaveBeenCalled()
+      old.executor.observeProviderMessage(providerMessage)
+      expect(next.probe.observe).toHaveBeenCalledTimes(2)
+    }
+  )
+
   it('treats a lost terminal capture race as superseded', async () => {
     const response: PromptResponse = { stopReason: 'end_turn' }
     const fixture = setup([stop(response)])

--- a/src/main/acp/provider-prompt-executor.ts
+++ b/src/main/acp/provider-prompt-executor.ts
@@ -271,13 +271,7 @@ class AcpProviderPromptExecutor {
         const message = await Promise.race([input.session.nextUpdate(), promptFailure])
         if (message.kind === 'provider-rejection') throw message.error
 
-        if (!input.isCurrent()) {
-          if (message.kind !== 'stop') continue
-          await cancelProbe()
-          return Object.freeze({ kind: 'superseded', response: message.response })
-        }
-
-        if (!accepted) {
+        if (!accepted && input.isCurrent()) {
           accepted = true
           try {
             await input.onAccepted()
@@ -285,6 +279,13 @@ class AcpProviderPromptExecutor {
             reportBestEffort(input.reportBestEffortFailure, 'accepted', error)
           }
         }
+        // Acceptance can await durable delivery; the same owner must still hold the message.
+        if (!input.isCurrent()) {
+          if (message.kind !== 'stop') continue
+          await cancelProbe()
+          return Object.freeze({ kind: 'superseded', response: message.response })
+        }
+
         if (message.kind !== 'stop') {
           try {
             probe.observe?.(message.notification)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -25,6 +25,7 @@ import { SessionPlanInteractionOwner } from '../session-plan/session-plan-intera
 import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
 import type { RuntimeEventInput } from './runtime-snapshot-owner'
 import { AcpPermissionContext } from './permission-context'
+import { PermissionProfileUnavailableError } from './permission-profile-controller'
 import { permissionRequestFingerprint } from './permission-broker'
 import { ACP_STEERING_METHOD } from './native-follow-up'
 import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
@@ -11954,6 +11955,55 @@ describe('ACP runtime session management', () => {
     runtime.respondToPermission({ requestId: permission.requestId, cancelled: true })
     await expect(prompting).resolves.toMatchObject({ stopReason: 'end_turn' })
   })
+
+  it.each([
+    { framework: claudeCodeFramework, bypass: 'bypassPermissions', profile: 'ask' as const },
+    { framework: claudeCodeFramework, bypass: 'bypassPermissions', profile: 'auto' as const },
+    { framework: codeBuddyFramework, bypass: 'fullAccess', profile: 'ask' as const },
+    { framework: codeBuddyFramework, bypass: 'fullAccess', profile: 'auto' as const }
+  ])(
+    'A03: preserves $framework.id Full state without publishing an unavailable $profile downgrade',
+    async ({ framework, bypass, profile }) => {
+      const process = new FakeAgentProcess()
+      const onSetMode = vi.fn()
+      const onStateChanged = vi.fn()
+      startPermissionProbeAgent(process, {
+        newSessionId: 'native-bypass-session',
+        toolCallId: 'tool-1',
+        toolTitle: 'Run command',
+        modes: createModes([bypass]),
+        onSetMode
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework,
+        callbacks: { onStateChanged }
+      })
+      const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'full' })
+      const previousProfile = structuredClone(
+        runtime.getSnapshot().permissionProfiles[session.sessionId]
+      )
+      expect(previousProfile).toMatchObject({
+        selectedProfile: 'full',
+        effectiveProfile: 'full',
+        currentModeId: bypass
+      })
+      onSetMode.mockClear()
+      onStateChanged.mockClear()
+
+      await expect
+        .soft(runtime.setPermissionProfile({ sessionId: session.sessionId, profile }))
+        .rejects.toThrow(PermissionProfileUnavailableError)
+
+      expect
+        .soft(runtime.getSnapshot().permissionProfiles[session.sessionId])
+        .toEqual(previousProfile)
+      expect.soft(onStateChanged).not.toHaveBeenCalled()
+      expect(onSetMode).not.toHaveBeenCalled()
+    }
+  )
 
   it('restores the committed profile when the provider mode change fails', async () => {
     const process = new FakeAgentProcess()

--- a/src/main/acp/session-configurator.test.ts
+++ b/src/main/acp/session-configurator.test.ts
@@ -2,8 +2,14 @@ import * as acp from '@agentclientprotocol/sdk'
 import type { ActiveSession, ClientConnection, SessionConfigOption } from '@agentclientprotocol/sdk'
 import { describe, expect, it, vi } from 'vitest'
 
-import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
+import {
+  claudeCodeFramework,
+  codeBuddyFramework,
+  codexFramework,
+  opencodeFramework
+} from '../agent-framework'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
+import { PermissionProfileUnavailableError } from './permission-profile-controller'
 import { AcpSessionConfigurator } from './session-configurator'
 
 const backendView = (
@@ -34,6 +40,79 @@ const selectOption = (
   }) as SessionConfigOption
 
 describe('AcpSessionConfigurator', () => {
+  describe('A03: permission enforcement at the RPC boundary', () => {
+    it.each([
+      { framework: claudeCodeFramework, bypass: 'bypassPermissions' },
+      { framework: codeBuddyFramework, bypass: 'fullAccess' },
+      { framework: codexFramework, bypass: 'agent-full-access' }
+    ])(
+      'rejects an unavailable downgrade for $framework.id before reporting success',
+      async ({ framework, bypass }) => {
+        for (const profile of ['ask', 'auto'] as const) {
+          const request = vi.fn(async () => ({}))
+          const input = {
+            backend: backendView({ modelRequired: false }, framework),
+            connection: { agent: { request } } as unknown as ClientConnection,
+            session: {
+              sessionId: 'session-1',
+              modes: { currentModeId: bypass, availableModes: [{ id: bypass, name: bypass }] }
+            } as unknown as ActiveSession,
+            permissionProfile: profile
+          }
+          const configurator = new AcpSessionConfigurator({
+            assertCurrentConnection: vi.fn(),
+            diagnosticContext: () => ({ framework: framework.id })
+          })
+
+          // Both initial attachment and a forced live change use the real framework mapper.
+          // Soft assertions preserve the resolved false-success state and RPC evidence in red logs.
+          await expect
+            .soft(configurator.configure(input))
+            .rejects.toThrow(PermissionProfileUnavailableError)
+          await expect
+            .soft(configurator.configurePermissionProfile(input, true))
+            .rejects.toThrow(PermissionProfileUnavailableError)
+          expect(request).not.toHaveBeenCalled()
+        }
+      }
+    )
+
+    it('keeps OpenCode broker-enforced profiles available without a mode RPC', async () => {
+      const request = vi.fn(async () => ({}))
+      const configurator = new AcpSessionConfigurator({
+        assertCurrentConnection: vi.fn(),
+        diagnosticContext: () => ({ framework: 'opencode' })
+      })
+      for (const profile of ['ask', 'auto', 'full'] as const) {
+        await expect(
+          configurator.configurePermissionProfile(
+            {
+              backend: backendView({ modelRequired: false }, opencodeFramework),
+              connection: { agent: { request } } as unknown as ClientConnection,
+              session: {
+                sessionId: 'session-1',
+                modes: {
+                  currentModeId: 'build',
+                  availableModes: [
+                    { id: 'build', name: 'Build' },
+                    { id: 'plan', name: 'Plan' }
+                  ]
+                }
+              } as unknown as ActiveSession,
+              permissionProfile: profile
+            },
+            true
+          )
+        ).resolves.toMatchObject({
+          selectedProfile: profile,
+          effectiveProfile: profile,
+          currentModeId: 'build'
+        })
+      }
+      expect(request).not.toHaveBeenCalled()
+    })
+  })
+
   it('applies mode, model, and post-model effort in protocol order and returns immutable facts', async () => {
     const initialOptions = [
       selectOption('model', 'model', 'model-a', ['model-a', 'model-b']),

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -10,6 +10,8 @@ import type {
   SessionPdfContext
 } from '../../../../shared/session-persistence'
 import { SessionSizeLimitError } from '../../../../shared/session-persistence'
+import { VISION_MODEL_NOT_CONFIGURED_MESSAGE } from '../../../../shared/run-error-classification'
+import { IMAGE_ANNOTATION_SOURCE_UNAVAILABLE_MESSAGE } from '../../pages/workspace/annotations/image-annotation-source-validation'
 import type { AgentFrameworkId } from '../../../../shared/settings'
 import {
   MAX_COMPOSER_ATTACHMENTS,
@@ -142,6 +144,46 @@ const flushRuntimeTasks = async (): Promise<void> => {
 
 beforeEach(() => {
   resetSessionPersistenceWriteFailuresForTests()
+})
+
+describe('A03 unavailable permission downgrade projection', () => {
+  it.each(['empty snapshot', 'rejection'] as const)(
+    'preserves the stored profile without notifying the saver after %s',
+    async (failure) => {
+      useSessionStore.setState(createInitialSessionState())
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'Original question',
+        permissionProfile: 'full'
+      })
+      useSessionStore.getState().finishRun('session-1')
+      const original = useSessionStore.getState().sessions[0]
+      const durable = toPersistedSession(original)
+      const changed = vi.fn()
+      const unsubscribe = useSessionStore.subscribe(changed)
+      const runtime = {
+        state: createSnapshot(['session-1']),
+        setPermissionProfile:
+          failure === 'rejection'
+            ? vi.fn().mockRejectedValue(new Error('Permission profile is not available: ask'))
+            : vi.fn().mockResolvedValue(undefined)
+      }
+      try {
+        if (failure === 'rejection') {
+          await expect(setWorkspacePermissionProfile(runtime, 'session-1', 'ask')).rejects.toThrow(
+            'not available'
+          )
+        } else {
+          expect(await setWorkspacePermissionProfile(runtime, 'session-1', 'ask')).toBe(false)
+        }
+        expect(useSessionStore.getState().sessions[0]).toBe(original)
+        expect(toPersistedSession(useSessionStore.getState().sessions[0])).toEqual(durable)
+        expect(changed).not.toHaveBeenCalled()
+      } finally {
+        unsubscribe()
+      }
+    }
+  )
 })
 
 describe('workspace permission wait recovery', () => {
@@ -8431,6 +8473,680 @@ describe('recovering from a request-size overflow', () => {
     })
     useSessionStore.getState().failRun('session-1', 'Request too large (max 32MB)')
   }
+
+  describe('A04 retry admission failures', () => {
+    const imageAnnotation: NonNullable<ChatMessage['annotations']>[number] = {
+      id: 'point-unavailable',
+      kind: 'image-point',
+      target: 'agent',
+      note: 'Inspect this point.',
+      source: {
+        kind: 'artifact-version',
+        projectId: 'default-project',
+        sessionId: 'session-1',
+        versionId: 'fixed-version',
+        name: 'figure.png',
+        path: 'artifact-version:default-project/session-1/artifact-1/fixed-version',
+        mimeType: 'image/png'
+      },
+      point: { x: 0.5, y: 0.5 },
+      naturalSize: { width: 800, height: 600 }
+    }
+    const regionAnnotation: NonNullable<ChatMessage['annotations']>[number] = {
+      id: 'pdf-region-1',
+      kind: 'pdf',
+      target: 'agent',
+      source: {
+        kind: 'upload-version',
+        projectId: 'default-project',
+        sessionId: 'session-1',
+        versionId: 'version-1',
+        name: 'paper.pdf',
+        path: 'upload-version:default-project/session-1/version-1',
+        checksum: 'a'.repeat(64)
+      },
+      selector: {
+        kind: 'region',
+        pageNumber: 2,
+        rect: { x: 0.1, y: 0.2, width: 0.4, height: 0.3 },
+        pageRotation: 0,
+        image: { mimeType: 'image/png', data: 'AQID', byteLength: 3 }
+      }
+    }
+    const retryRuntime = (
+      native: boolean
+    ): Parameters<typeof recoverContextOverflowWorkspaceSession>[0] => ({
+      state: {
+        ...createSnapshot(['session-1']),
+        nativeContextCompactionSessionIds: native ? ['session-1'] : []
+      },
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        providerSessionId: 'replacement-provider',
+        contextReset: true
+      }),
+      compactSession: vi.fn().mockResolvedValue(createSnapshot(['session-1'])),
+      sendPrompt: vi.fn()
+    })
+
+    it.each([
+      { native: false, failure: 'source' },
+      { native: true, failure: 'source' },
+      { native: false, failure: 'vision' },
+      { native: true, failure: 'vision' },
+      { native: false, failure: 'empty admission' },
+      { native: true, failure: 'empty admission' }
+    ])(
+      'retains the same question and unlocks after $failure (native=$native)',
+      async ({ native, failure }) => {
+        const acquire = vi.fn().mockRejectedValue(new Error('Fixed version is inaccessible'))
+        vi.stubGlobal('window', {
+          api: { previewResources: { acquire, release: vi.fn() } }
+        })
+        seedOverflowedConversation(false, undefined, [
+          failure === 'vision' ? regionAnnotation : imageAnnotation
+        ])
+        const messageId = useSessionStore.getState().sessions[0].messages.at(-1)!.id
+        useSessionStore.getState().replaceMessageUploads({
+          sessionId: 'session-1',
+          messageId,
+          uploads: [
+            {
+              id: 'upload-1',
+              versionId: 'upload-version-1',
+              sessionId: 'session-1',
+              name: 'notes.txt',
+              originalName: 'notes.txt',
+              mimeType: 'text/plain',
+              size: 12
+            }
+          ]
+        })
+        // Inject invalid input into the visible projection to exercise admission returning undefined.
+        // This does not claim to exercise historical file hydration.
+        if (failure === 'empty admission') {
+          useSessionStore.setState((state) => ({
+            sessions: state.sessions.map((session) => ({
+              ...session,
+              messages: session.messages.map((message) =>
+                message.id === messageId
+                  ? { ...message, annotations: [{ ...imageAnnotation, note: 'x'.repeat(100_000) }] }
+                  : message
+              )
+            }))
+          }))
+        }
+        const original = useSessionStore.getState().sessions[0].messages.at(-1)!
+        const runtime = retryRuntime(native)
+        const result = await recoverContextOverflowWorkspaceSession(
+          runtime,
+          'session-1',
+          false
+        ).then(
+          (value) => ({ value, error: undefined }),
+          (error: unknown) => ({ value: undefined, error })
+        )
+        const session = useSessionStore.getState().sessions[0]
+        if (failure === 'empty admission') {
+          expect(result.error).toBeUndefined()
+          expect(result.value).toBe(false)
+          expect(acquire).not.toHaveBeenCalled()
+        } else {
+          const errorText = result.error instanceof Error ? result.error.message : session.error
+          expect(errorText).toContain(
+            failure === 'source'
+              ? IMAGE_ANNOTATION_SOURCE_UNAVAILABLE_MESSAGE
+              : VISION_MODEL_NOT_CONFIGURED_MESSAGE
+          )
+          if (failure === 'source') expect(acquire).toHaveBeenCalledOnce()
+          else expect(acquire).not.toHaveBeenCalled()
+        }
+
+        expect
+          .soft(session.messages.find((message) => message.id === original.id))
+          .toEqual(original)
+        expect.soft(session.compacting).not.toBe(true)
+        expect.soft(session.status).toBe('error')
+        expect.soft(session.error).toEqual(expect.any(String))
+        expect.soft(result.error).toBeUndefined()
+        expect.soft(result.value).toBe(false)
+        expect(runtime.sendPrompt).not.toHaveBeenCalled()
+        if (failure === 'source') expect(acquire).toHaveBeenCalledOnce()
+      }
+    )
+
+    it('allows removing an unavailable annotation and resending the preserved question', async () => {
+      seedOverflowedConversation(false, undefined, [imageAnnotation])
+      const original = useSessionStore.getState().sessions[0].messages.at(-1)!
+      vi.stubGlobal('window', {
+        api: {
+          previewResources: {
+            acquire: vi.fn().mockRejectedValue(new Error('Unavailable')),
+            release: vi.fn()
+          }
+        }
+      })
+      const runtime = {
+        ...retryRuntime(false),
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+      }
+      expect(await recoverContextOverflowWorkspaceSession(runtime, 'session-1', true)).toBe(false)
+      expect(
+        await resendEditedWorkspaceMessage(runtime, {
+          sessionId: 'session-1',
+          messageId: original.id,
+          text: original.content,
+          annotations: []
+        })
+      ).toBe(true)
+      const session = useSessionStore.getState().sessions[0]
+      expect(session.compacting).not.toBe(true)
+      expect(session.status).toBe('running')
+      expect(session.messages.at(-1)?.annotations ?? []).toEqual([])
+      expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    })
+
+    it('does not replace newer messages or their run when preparation returns empty', async () => {
+      seedOverflowedConversation()
+      const preparation = createDeferred<void>()
+      const runtime = {
+        ...retryRuntime(false),
+        state: createSnapshot([]),
+        resumeSession: vi.fn(async () => {
+          await preparation.promise
+          throw new Error('Old recovery admission failed')
+        })
+      }
+      const recovery = recoverContextOverflowWorkspaceSession(runtime, 'session-1')
+      await vi.waitFor(() => expect(runtime.resumeSession).toHaveBeenCalledOnce())
+      useSessionStore.getState().finishCompaction('session-1')
+      const newer = useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'A newer valid question'
+      })!
+      const newerRun = useSessionStore.getState().sessions[0].activeRun
+      preparation.resolve(undefined)
+      expect(await recovery).toBe(false)
+      const session = useSessionStore.getState().sessions[0]
+
+      expect
+        .soft(session.messages)
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: newer.messageId, content: 'A newer valid question' })
+          ])
+        )
+      expect.soft(session.activeRun).toEqual(newerRun)
+      expect.soft(session.status).toBe('running')
+      expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    })
+
+    it.each(['cancel', 'disconnect'] as const)(
+      'keeps the question and respects %s while source admission is pending',
+      async (terminal) => {
+        const admission = createDeferred<void>()
+        const acquire = vi.fn(async () => {
+          await admission.promise
+          throw new Error('Fixed version disappeared')
+        })
+        vi.stubGlobal('window', {
+          api: { previewResources: { acquire, release: vi.fn() } }
+        })
+        seedOverflowedConversation(false, undefined, [imageAnnotation])
+        const original = useSessionStore.getState().sessions[0].messages.at(-1)!
+        const cancelled = new Set<string>()
+        const runtime = retryRuntime(false)
+        const recovery = recoverContextOverflowWorkspaceSession(
+          runtime,
+          'session-1',
+          true,
+          cancelled
+        ).then(
+          (value) => ({ value, error: undefined }),
+          (error: unknown) => ({ value: undefined, error })
+        )
+        await vi.waitFor(() => expect(acquire).toHaveBeenCalledOnce())
+        if (terminal === 'cancel') {
+          await cancelWorkspaceRun(
+            { cancel: vi.fn().mockResolvedValue(runtime.state) },
+            'session-1',
+            cancelled
+          )
+        } else {
+          useSessionStore.getState().markDisconnected('session-1', 'Connection closed')
+        }
+        admission.resolve(undefined)
+        const result = await recovery
+        const session = useSessionStore.getState().sessions[0]
+
+        expect
+          .soft(session.messages.find((message) => message.id === original.id))
+          .toEqual(original)
+        expect.soft(session.compacting).not.toBe(true)
+        expect.soft(result.error).toBeUndefined()
+        expect.soft(result.value).toBe(false)
+        if (terminal === 'disconnect') expect(session.error).toContain('Connection closed')
+        else expect.soft(session.status).toBe('idle')
+        expect(runtime.sendPrompt).not.toHaveBeenCalled()
+      }
+    )
+  })
+
+  describe('A04 recovery ownership', () => {
+    it.each(['cancel', 'disconnect', 'replace'] as const)(
+      'does not dispatch after %s during successful source admission',
+      async (terminal) => {
+        const admission = createDeferred<{ id: string }>()
+        const acquire = vi.fn(() => admission.promise)
+        const release = vi.fn().mockResolvedValue(undefined)
+        vi.stubGlobal('window', { api: { previewResources: { acquire, release } } })
+        seedOverflowedConversation(false, undefined, [
+          {
+            id: 'point-1',
+            kind: 'image-point',
+            target: 'agent',
+            note: 'Inspect.',
+            source: {
+              kind: 'artifact-version',
+              projectId: 'default-project',
+              sessionId: 'session-1',
+              versionId: 'v1',
+              name: 'image.png',
+              mimeType: 'image/png',
+              path: 'artifact-version:default-project/session-1/a1/v1'
+            },
+            point: { x: 0.5, y: 0.5 },
+            naturalSize: { width: 10, height: 10 }
+          }
+        ])
+        const original = useSessionStore.getState().sessions[0].messages.at(-1)!
+        const runtime = {
+          state: createSnapshot(['session-1']),
+          createSession: vi.fn(),
+          resumeSession: vi.fn(),
+          resetSessionContext: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+          sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+        }
+        const cancelled = new Set<string>()
+        const pending = recoverContextOverflowWorkspaceSession(
+          runtime,
+          'session-1',
+          true,
+          cancelled
+        )
+        await vi.waitFor(() => expect(acquire).toHaveBeenCalledOnce())
+        if (terminal === 'cancel') {
+          await cancelWorkspaceRun(
+            { cancel: vi.fn().mockResolvedValue(runtime.state) },
+            'session-1',
+            cancelled
+          )
+        } else if (terminal === 'disconnect') {
+          useSessionStore.getState().markDisconnected('session-1', 'Connection closed')
+        } else {
+          useSessionStore.setState(createInitialSessionState())
+          useSessionStore
+            .getState()
+            .appendUserMessage({ sessionId: 'session-1', content: 'Replacement question' })
+          useSessionStore.getState().beginCompaction('session-1', { supersedeActiveRun: true })
+        }
+        const terminalSession = useSessionStore.getState().sessions[0]
+        admission.resolve({ id: 'preview-1' })
+        expect(await pending).toBe(false)
+        expect(runtime.sendPrompt).not.toHaveBeenCalled()
+        expect(release).toHaveBeenCalledWith({ resourceId: 'preview-1' })
+        const session = useSessionStore.getState().sessions[0]
+        if (terminal === 'replace') expect(session).toBe(terminalSession)
+        else {
+          expect(session.messages).toContainEqual(original)
+          expect(session.compacting).not.toBe(true)
+        }
+      }
+    )
+
+    it('retries the same unanswered message and branch even with a failed reply', async () => {
+      seedOverflowedConversation()
+      const original = useSessionStore.getState().sessions[0]
+      const question = original.messages.at(-1)!
+      const runtime = {
+        state: createSnapshot(['session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+      }
+      // An error response still belongs to the unanswered turn and must not suppress its retry.
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'session-1',
+        streamId: 'failed-reply',
+        eventId: 'failed-event',
+        content: 'Partial reply'
+      })
+      useSessionStore.getState().failRun('session-1', 'Context window exceeded')
+      const graphBeforeRetry = useSessionStore.getState().sessions[0].conversationGraph
+      expect(await recoverContextOverflowWorkspaceSession(runtime, 'session-1')).toBe(true)
+      await flushRuntimeTasks()
+      const session = useSessionStore.getState().sessions[0]
+      expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+      expect(session.messages.filter((message) => message.role === 'user').at(-1)?.id).toBe(
+        question.id
+      )
+      expect(session.conversationGraph?.activeFrameId).toBe(
+        original.conversationGraph?.activeFrameId
+      )
+      expect(session.conversationGraph?.branches).toEqual(graphBeforeRetry?.branches)
+      expect(session.activeRun?.promptMessageId).toBe(question.id)
+      expect(session.compacting).not.toBe(true)
+    })
+
+    it.each(['replay', 'dispatch'] as const)(
+      'settles a synchronous %s failure while retaining the same question',
+      async (failure) => {
+        seedOverflowedConversation()
+        const original = useSessionStore.getState().sessions[0].messages.at(-1)!
+        if (failure === 'replay') {
+          useSessionStore.getState().replaceMessageUploads({
+            sessionId: 'session-1',
+            messageId: useSessionStore.getState().sessions[0].messages[0].id,
+            uploads: [
+              {
+                id: 'broken-history',
+                sessionId: 'session-1',
+                name: 'image.png',
+                originalName: 'image.png',
+                mimeType: 'image/png',
+                size: 1
+              }
+            ]
+          })
+        }
+        const runtime = {
+          state: createSnapshot(['session-1']),
+          createSession: vi.fn(),
+          resumeSession: vi.fn(),
+          resetSessionContext: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+          sendPrompt: vi.fn(() => {
+            throw new Error('Synchronous dispatch failed')
+          })
+        }
+        expect(await recoverContextOverflowWorkspaceSession(runtime, 'session-1')).toBe(false)
+        const session = useSessionStore.getState().sessions[0]
+        expect.soft(session.status).toBe('error')
+        expect.soft(session.activeRun).toBeUndefined()
+        expect.soft(session.compacting).not.toBe(true)
+        expect
+          .soft(session.error)
+          .toContain(
+            failure === 'replay' ? 'immutable Version identity' : 'Synchronous dispatch failed'
+          )
+        expect(session.messages).toContainEqual(original)
+        if (failure === 'replay') expect(runtime.sendPrompt).not.toHaveBeenCalled()
+        else expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+      }
+    )
+
+    it('does not fail a newer run when the old dispatch throws synchronously', async () => {
+      seedOverflowedConversation()
+      let replacement: ChatSession | undefined
+      const runtime = {
+        state: createSnapshot(['session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+        sendPrompt: vi.fn(() => {
+          useSessionStore.getState().finishRun('session-1')
+          useSessionStore
+            .getState()
+            .appendUserMessage({ sessionId: 'session-1', content: 'Newer question' })
+          replacement = useSessionStore.getState().sessions[0]
+          throw new Error('Obsolete dispatch failed')
+        })
+      }
+      expect(await recoverContextOverflowWorkspaceSession(runtime, 'session-1')).toBe(false)
+      expect(useSessionStore.getState().sessions[0]).toBe(replacement)
+      expect(replacement?.status).toBe('running')
+    })
+
+    it('ignores an old asynchronous overlapping rejection after recovery rearms the question', async () => {
+      seedOverflowedConversation()
+      const rejection = createDeferred<void>()
+      const runtime = {
+        state: createSnapshot(['session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+        sendPrompt: vi
+          .fn()
+          .mockImplementationOnce(async () => {
+            await rejection.promise
+            throw new Error('An ACP prompt is already running for this session')
+          })
+          .mockResolvedValue(createSnapshot(['session-1']))
+      }
+      vi.stubGlobal('window', {
+        api: { acp: { getState: vi.fn().mockResolvedValue(runtime.state) } }
+      })
+      expect(
+        await sendWorkspaceMessage(runtime, {
+          sessionId: 'session-1',
+          text: 'Question whose original dispatch is still settling'
+        })
+      ).toBeDefined()
+      const originalRun = useSessionStore.getState().sessions[0].activeRun
+      useSessionStore.getState().failRun('session-1', 'Context window exceeded')
+      expect(await recoverContextOverflowWorkspaceSession(runtime, 'session-1')).toBe(true)
+      expect(runtime.sendPrompt).toHaveBeenCalledTimes(2)
+      const recoveredRun = useSessionStore.getState().sessions[0].activeRun
+      expect(recoveredRun).toBeDefined()
+      expect(recoveredRun).not.toBe(originalRun)
+
+      rejection.resolve(undefined)
+      await flushRuntimeTasks()
+      await flushRuntimeTasks()
+
+      const session = useSessionStore.getState().sessions[0]
+      expect.soft(session.status).toBe('running')
+      expect.soft(session.activeRun).toBe(recoveredRun)
+      expect.soft(session.error).toBeUndefined()
+    })
+
+    it.each(['connected', 'closed'] as const)(
+      'preserves a newer run while asynchronous recovery failure awaits a %s snapshot',
+      async (status) => {
+        seedOverflowedConversation()
+        const rejection = createDeferred<void>()
+        const snapshot = createDeferred<AcpStateSnapshot>()
+        const getState = vi.fn(() => snapshot.promise)
+        vi.stubGlobal('window', { api: { acp: { getState } } })
+        const runtime = {
+          state: createSnapshot(['session-1']),
+          createSession: vi.fn(),
+          resumeSession: vi.fn(),
+          resetSessionContext: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+          sendPrompt: vi
+            .fn()
+            .mockImplementationOnce(async () => {
+              await rejection.promise
+              throw new Error('An ACP prompt is already running for this session')
+            })
+            .mockResolvedValue(createSnapshot(['session-1']))
+        }
+        expect(await recoverContextOverflowWorkspaceSession(runtime, 'session-1')).toBe(true)
+        rejection.resolve(undefined)
+        await vi.waitFor(() => expect(getState).toHaveBeenCalledOnce())
+
+        // The failure still owns its run when getState starts. Another public send takes over
+        // during that await; neither a connected nor closed old snapshot may settle the new run.
+        useSessionStore.getState().finishRun('session-1')
+        expect(
+          await sendWorkspaceMessage(runtime, {
+            sessionId: 'session-1',
+            text: 'New question while the old failure snapshot is pending'
+          })
+        ).toBeDefined()
+        await flushRuntimeTasks()
+        const newerSession = useSessionStore.getState().sessions[0]
+        expect(newerSession.status).toBe('running')
+        expect(runtime.sendPrompt).toHaveBeenCalledTimes(2)
+
+        snapshot.resolve({ ...runtime.state, status })
+        await flushRuntimeTasks()
+
+        const session = useSessionStore.getState().sessions[0]
+        expect.soft(session.status).toBe('running')
+        expect.soft(session.activeRun).toBe(newerSession.activeRun)
+        expect.soft(session.error).toBeUndefined()
+        expect(session.messages).toEqual(newerSession.messages)
+      }
+    )
+
+    it.each(['save acknowledgement', 'text stream'] as const)(
+      'projects the current dispatch failure after a %s for the same run',
+      async (projection) => {
+        seedOverflowedConversation()
+        const rejection = createDeferred<void>()
+        const runtime = {
+          state: createSnapshot(['session-1']),
+          createSession: vi.fn(),
+          resumeSession: vi.fn(),
+          resetSessionContext: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+          sendPrompt: vi.fn(async () => {
+            await rejection.promise
+            throw new Error('Current dispatch failed')
+          })
+        }
+        vi.stubGlobal('window', {
+          api: { acp: { getState: vi.fn().mockResolvedValue(runtime.state) } }
+        })
+        expect(await recoverContextOverflowWorkspaceSession(runtime, 'session-1')).toBe(true)
+        const source = useSessionStore.getState().sessions[0]
+        expect(source.activeRun).toBeDefined()
+        if (projection === 'save acknowledgement') {
+          // IPC returns a distinct object for the same durable run. A save acknowledgement is
+          // not a new dispatch, and must not revoke the current dispatch's failure ownership.
+          const durable = structuredClone(toPersistedSession(source))
+          durable.revision = (durable.revision ?? 0) + 1
+          useSessionStore.getState().applyDurableSessionProjection({
+            source,
+            session: durable,
+            mode: 'replace-persisted-if-current'
+          })
+          expect(useSessionStore.getState().sessions[0].activeRun).toEqual(source.activeRun)
+        } else {
+          useSessionStore.getState().appendAgentMessageChunk({
+            sessionId: 'session-1',
+            streamId: 'current-recovery-stream',
+            eventId: 'current-recovery-output',
+            content: 'Partial live output'
+          })
+          expect(useSessionStore.getState().sessions[0].activeRun).toBe(source.activeRun)
+        }
+
+        rejection.resolve(undefined)
+        await flushRuntimeTasks()
+        await flushRuntimeTasks()
+
+        const session = useSessionStore.getState().sessions[0]
+        expect.soft(session.status).toBe('error')
+        expect.soft(session.error).toBe('Current dispatch failed')
+        expect.soft(session.activeRun).toBeUndefined()
+        expect(session.messages).toContainEqual(source.messages.at(-1))
+        expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+      }
+    )
+
+    it('does not revive recovery after switching away from its message Branch and back', async () => {
+      seedOverflowedConversation()
+      const original = useSessionStore.getState().sessions[0]
+      const question = original.messages.at(-1)!
+      useSessionStore.getState().removeMessage('session-1', question.id)
+      const otherBranch = useSessionStore.getState().sessions[0]
+      useSessionStore.setState({ sessions: [original] })
+      const reset = createDeferred<{ sessionId: string; providerSessionId: string }>()
+      const runtime = {
+        state: createSnapshot(['session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn(() => reset.promise),
+        sendPrompt: vi.fn()
+      }
+      const pending = recoverContextOverflowWorkspaceSession(runtime, 'session-1')
+      const owned = useSessionStore.getState().sessions[0]
+      // Model an authoritative branch projection while the provider operation is pending.
+      useSessionStore.setState({ sessions: [{ ...otherBranch, compacting: true }] })
+      useSessionStore.setState({ sessions: [owned] })
+      reset.resolve({ sessionId: 'session-1', providerSessionId: 'obsolete-provider' })
+      expect(await pending).toBe(false)
+      expect(runtime.sendPrompt).not.toHaveBeenCalled()
+      expect(useSessionStore.getState().sessions[0]).toBe(owned)
+    })
+
+    it('contains unexpected scheduler failures and releases recovery dedup', async () => {
+      seedOverflowedConversation()
+      const runtime = {
+        state: createSnapshot(['session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn(),
+        sendPrompt: vi.fn()
+      }
+      const active = new Set<string>()
+      const cooldown = new Set<string>()
+      const recover = vi.fn(async () => {
+        useSessionStore.getState().beginCompaction('session-1', { supersedeActiveRun: true })
+        throw new Error('Recovery setup failed')
+      })
+      processContextOverflowRecovery(
+        runtime,
+        [
+          createEvent({
+            kind: 'error',
+            sessionId: 'session-1',
+            recoverable: 'context-overflow'
+          })
+        ],
+        new Set(),
+        cooldown,
+        active,
+        recover
+      )
+      await vi.waitFor(() => expect(active.size).toBe(0))
+      const session = useSessionStore.getState().sessions[0]
+      expect(session.compacting).not.toBe(true)
+      expect(session.error).toBe('Recovery setup failed')
+      expect(cooldown.has('session-1')).toBe(true)
+    })
+
+    it('keeps the replacement recovery when an older reset finishes last', async () => {
+      seedOverflowedConversation()
+      const firstReset = createDeferred<{ sessionId: string; providerSessionId: string }>()
+      const secondReset = createDeferred<{ sessionId: string; providerSessionId: string }>()
+      const resetSessionContext = vi
+        .fn()
+        .mockReturnValueOnce(firstReset.promise)
+        .mockReturnValueOnce(secondReset.promise)
+      const runtime = {
+        state: createSnapshot(['session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext,
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+      }
+      const first = recoverContextOverflowWorkspaceSession(runtime, 'session-1')
+      const second = recoverContextOverflowWorkspaceSession(runtime, 'session-1')
+      firstReset.resolve({ sessionId: 'session-1', providerSessionId: 'obsolete-provider' })
+      expect(await first).toBe(false)
+      expect(runtime.sendPrompt).not.toHaveBeenCalled()
+      expect(useSessionStore.getState().sessions[0].providerSessionId).not.toBe('obsolete-provider')
+      expect(useSessionStore.getState().sessions[0].compacting).toBe(true)
+      secondReset.resolve({ sessionId: 'session-1', providerSessionId: 'current-provider' })
+      expect(await second).toBe(true)
+      expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+      expect(useSessionStore.getState().sessions[0].providerSessionId).toBe('current-provider')
+    })
+  })
 
   it('keeps overflow dedup without retaining durable Plan admission in renderer memory', async () => {
     seedOverflowedConversation()

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -96,6 +96,8 @@ type SendWorkspaceMessageCommand = SendWorkspaceMessageIntent & {
 }
 type SendWorkspaceMessageResult = { sessionId: string; messageId: string }
 type WorkspaceCommandLifecycle = {
+  // Ownership of asynchronous admission, before the command establishes its own prompt run.
+  isCurrent?: () => boolean
   awaitPendingPreparation?: boolean
   onSendPreparationStateChange?: (sessionId: string, inFlight: boolean) => void
   drainRuntimeEvents?: (sessionId?: string) => Promise<void>
@@ -169,13 +171,16 @@ const latestFailureId = (events: AcpRuntimeEvent[], sessionId: string): string |
 const failPrompt = async (
   sessionId: string,
   message: string,
+  isCurrent: () => boolean,
   priorErrorEventId?: string
 ): Promise<void> => {
+  if (!isCurrent()) return
   if (useSessionStore.getState().sessions.find((item) => item.id === sessionId)?.compacting) return
 
   let reportable: boolean | undefined
   try {
     const snapshot = await window.api.acp.getState()
+    if (!isCurrent()) return
     const status = snapshot.sessionConnectionStatuses?.[sessionId] ?? snapshot.status
     if (status === 'closed' || status === 'error') {
       useSessionStore.getState().markDisconnected(sessionId, message)
@@ -188,6 +193,7 @@ const failPrompt = async (
   } catch {
     reportable = undefined
   }
+  if (!isCurrent()) return
   useSessionStore.getState().failRun(sessionId, message, { reportable })
 }
 const replayHistory = (
@@ -219,9 +225,6 @@ const ownsPrompt = (sessionId: string, messageId: string): boolean => {
   return session?.status === 'running' && session.activeRun?.promptMessageId === messageId
 }
 
-const isOverlappingPromptRejection = (error: unknown): boolean =>
-  /An ACP (?:prompt|interaction) is already running/i.test(errorMessage(error))
-
 type PromptDispatch = {
   sessionId: string
   messageId: string
@@ -240,6 +243,14 @@ type PromptDispatch = {
 }
 
 const dispatchPrompt = (runtime: WorkspaceCommandRuntime, request: PromptDispatch): void => {
+  // Recovery can rearm the same Message, so its ID cannot identify a dispatch attempt.
+  const admittedRun = useSessionStore
+    .getState()
+    .sessions.find((session) => session.id === request.sessionId)?.activeRun
+  const isCurrent = (): boolean =>
+    admittedRun !== undefined &&
+    useSessionStore.getState().sessions.find((session) => session.id === request.sessionId)
+      ?.activeRun === admittedRun
   const priorErrorEventId = latestFailureId(
     [...(runtime.currentRuntimeEvents?.() ?? runtime.state.events)],
     request.sessionId
@@ -277,10 +288,9 @@ const dispatchPrompt = (runtime: WorkspaceCommandRuntime, request: PromptDispatc
   void result
     .then(() => request.accepted?.())
     .catch((error) => {
-      if (isOverlappingPromptRejection(error) && !ownsPrompt(request.sessionId, request.messageId))
-        return
+      if (!isCurrent()) return
       const message = errorMessage(error).trim() || 'Agent run failed'
-      void failPrompt(request.sessionId, message, priorErrorEventId)
+      void failPrompt(request.sessionId, message, isCurrent, priorErrorEventId)
     })
 }
 
@@ -649,6 +659,7 @@ const sendWorkspaceMessage = async (
       lifecycle.onSessionSizeLimit
     )
   }
+  if (lifecycle.isCurrent?.() === false) return undefined
   const content = input.text.trim()
   const replaySession = input.sessionId
     ? useSessionStore.getState().sessions.find((item) => item.id === input.sessionId)
@@ -679,6 +690,7 @@ const sendWorkspaceMessage = async (
     throw new Error(VISION_MODEL_NOT_CONFIGURED_MESSAGE)
   }
   await validateImageAnnotationSourcesBeforeSend(annotations)
+  if (lifecycle.isCurrent?.() === false) return undefined
   const effectiveAttachments =
     attachments.length > 0 || !replayPrompt?.uploads?.length
       ? attachments
@@ -802,7 +814,9 @@ const sendWorkspaceMessage = async (
       }
       const hasResponse = session?.messages.some(
         (message) =>
-          message.role === 'agent' && message.responseToMessageId === existingStableMessage.id
+          message.role === 'agent' &&
+          message.responseToMessageId === existingStableMessage.id &&
+          !(input.allowCompactionRecovery && message.status === 'error')
       )
       if (hasResponse || session?.activeRun?.promptMessageId === existingStableMessage.id) {
         return { sessionId, messageId: existingStableMessage.id }
@@ -814,8 +828,10 @@ const sendWorkspaceMessage = async (
     if (session?.delegationPolicyAuthorityPending) {
       try {
         await confirmPendingDelegationPolicyAuthority(session)
+        if (lifecycle.isCurrent?.() === false) return undefined
         session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
       } catch (error) {
+        if (lifecycle.isCurrent?.() === false) return undefined
         useSessionStore.getState().failRun(sessionId, errorMessage(error))
         return undefined
       }
@@ -903,8 +919,10 @@ const sendWorkspaceMessage = async (
         includeResumeFallback: Boolean(input.forcedSkillIds?.length)
       },
       onPreparationStateChange: lifecycle.onSendPreparationStateChange,
-      drainRuntimeEvents: lifecycle.drainRuntimeEvents
+      drainRuntimeEvents: lifecycle.drainRuntimeEvents,
+      isCurrent: lifecycle.isCurrent
     })
+    if (lifecycle.isCurrent?.() === false) return undefined
     if (!prepared) return undefined
     let promptAttachments
     try {
@@ -914,12 +932,14 @@ const sendWorkspaceMessage = async (
         pendingPdfContextVersions: input.pendingPdfContextVersions,
         projectId
       })
+      if (lifecycle.isCurrent?.() === false) return undefined
       promptAttachments = await finalizeWorkspaceAttachments({
         sessionId,
         attachments: effectiveAttachments,
         projectId,
         preserveSourceOwnership: Boolean(input.truncateFromMessageId)
       })
+      if (lifecycle.isCurrent?.() === false) return undefined
       const pdfContextSources = [
         ...finalizedPdfContextSources({
           attachmentIds: eligiblePendingPdfContext.attachmentIds,
@@ -944,11 +964,15 @@ const sendWorkspaceMessage = async (
         lifecycle.onPdfContextLinked?.(sessionId, pdfContext)
       }
     } catch (error) {
+      if (lifecycle.isCurrent?.() === false) return undefined
       if (isSessionSizeLimitError(error)) lifecycle.onSessionSizeLimit?.(sessionId)
       useSessionStore.getState().failRun(sessionId, errorMessage(error))
       return undefined
     }
+    if (lifecycle.isCurrent?.() === false) return undefined
     if (!canAdmitExistingWorkspacePrompt(runtime.state, input)) return undefined
+    // Replay conversion may reject malformed media; complete it before establishing a run.
+    const replay = prepared.replay()
     if (input.truncateFromMessageId) {
       if (promptAttachments.length > 0) {
         useSessionStore.getState().replaceMessageUploads({
@@ -984,7 +1008,9 @@ const sendWorkspaceMessage = async (
       preserveSelection: input.preserveSelection
     })
     if (!appended) return undefined
-    if (stableMessageId) {
+    // Recovery rearms an existing Message; its normal store saver already owns persistence.
+    // Keep the explicit durability barrier for new application-authored stable identities.
+    if (stableMessageId && !(input.allowCompactionRecovery && rearmExistingStableMessage)) {
       const durableSession = useSessionStore
         .getState()
         .sessions.find((candidate) => candidate.id === sessionId)
@@ -998,7 +1024,6 @@ const sendWorkspaceMessage = async (
       }
       if (!ownsPrompt(sessionId, appended.messageId)) return undefined
     }
-    const replay = prepared.replay()
     const promptMedia =
       input.truncateFromMessageId && promptAttachments.length > 0
         ? partitionWorkspacePromptAttachments({
@@ -1008,21 +1033,34 @@ const sendWorkspaceMessage = async (
             supportsImageRelay: input.supportsImageRelay
           })
         : undefined
-    dispatchPrompt(runtime, {
-      sessionId,
-      messageId: appended.messageId,
-      content,
-      annotations,
-      attachments: promptMedia?.currentAttachments ?? promptAttachments,
-      forcedSkillIds: input.forcedSkillIds,
-      referencedArtifacts: withPdf(projectId, input.referencedArtifacts, pdfContext),
-      referencedSessions: collectSessionReferences(input.parts),
-      replay: promptMedia
-        ? { ...replay, historyAttachments: promptMedia.historyAttachments }
-        : replay,
-      turnIntent: input.turnIntent,
-      accepted: () => prepared.acceptPrompt(appended.messageId)
-    })
+    const admittedRun = useSessionStore
+      .getState()
+      .sessions.find((item) => item.id === sessionId)?.activeRun
+    try {
+      dispatchPrompt(runtime, {
+        sessionId,
+        messageId: appended.messageId,
+        content,
+        annotations,
+        attachments: promptMedia?.currentAttachments ?? promptAttachments,
+        forcedSkillIds: input.forcedSkillIds,
+        referencedArtifacts: withPdf(projectId, input.referencedArtifacts, pdfContext),
+        referencedSessions: collectSessionReferences(input.parts),
+        replay: promptMedia
+          ? { ...replay, historyAttachments: promptMedia.historyAttachments }
+          : replay,
+        turnIntent: input.turnIntent,
+        accepted: () => prepared.acceptPrompt(appended.messageId)
+      })
+    } catch (error) {
+      if (
+        useSessionStore.getState().sessions.find((item) => item.id === sessionId)?.activeRun ===
+        admittedRun
+      ) {
+        useSessionStore.getState().failRun(sessionId, errorMessage(error))
+      }
+      return undefined
+    }
     return appended
   }
 

--- a/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
@@ -39,6 +39,7 @@ type HistoryReplayContext = {
 }
 
 type PrepareExistingWorkspacePromptRequest = {
+  isCurrent?: () => boolean
   sessionId: string
   requireExistingSession?: boolean
   cwd?: string
@@ -220,6 +221,7 @@ const prepareExistingWorkspacePrompt = async (
   request: PrepareExistingWorkspacePromptRequest
 ): Promise<PreparedExistingWorkspacePrompt | undefined> => {
   const { sessionId } = request
+  if (request.isCurrent?.() === false) return undefined
   const currentSession = useSessionStore
     .getState()
     .sessions.find((session) => session.id === sessionId)
@@ -281,6 +283,7 @@ const prepareExistingWorkspacePrompt = async (
       }
 
       await shutdownNotebookForBranchChange(sessionId, resetCwd, request.projectId)
+      if (request.isCurrent?.() === false) return undefined
       if (!runtimeMustAdoptSession) {
         const reset = await runtime.resetSessionContext(
           sessionId,
@@ -289,6 +292,7 @@ const prepareExistingWorkspacePrompt = async (
           currentSession?.permissionProfile ?? request.permissionProfile,
           currentSession?.memoryEnabled !== false
         )
+        if (request.isCurrent?.() === false) return undefined
         useSessionStore.getState().markResumed(
           sessionId,
           reset
@@ -298,7 +302,8 @@ const prepareExistingWorkspacePrompt = async (
                 providerSessionId: reset.providerSessionId,
                 providerContinuityToken: reset.providerContinuityToken
               }
-            : undefined
+            : undefined,
+          { preserveCompaction: Boolean(request.isCurrent && currentSession?.compacting) }
         )
         agentContextResetPerformed = true
       }
@@ -337,6 +342,7 @@ const prepareExistingWorkspacePrompt = async (
         target,
         currentSession?.memoryEnabled !== false
       )
+      if (request.isCurrent?.() === false) return undefined
       contextResetFromResume = Boolean(resumeResult?.contextReset)
       useSessionStore.getState().markResumed(
         sessionId,
@@ -347,7 +353,8 @@ const prepareExistingWorkspacePrompt = async (
               providerSessionId: resumeResult.providerSessionId,
               providerContinuityToken: resumeResult.providerContinuityToken
             }
-          : undefined
+          : undefined,
+        { preserveCompaction: Boolean(request.isCurrent && currentSession?.compacting) }
       )
 
       if ((branchContextResetPerformed || resumeNeedsImageFiltering) && !contextResetFromResume) {
@@ -358,6 +365,7 @@ const prepareExistingWorkspacePrompt = async (
           currentSession?.permissionProfile ?? request.permissionProfile,
           currentSession?.memoryEnabled !== false
         )
+        if (request.isCurrent?.() === false) return undefined
         useSessionStore.getState().markResumed(
           sessionId,
           reset
@@ -367,7 +375,8 @@ const prepareExistingWorkspacePrompt = async (
                 providerSessionId: reset.providerSessionId,
                 providerContinuityToken: reset.providerContinuityToken
               }
-            : undefined
+            : undefined,
+          { preserveCompaction: Boolean(request.isCurrent && currentSession?.compacting) }
         )
         contextResetFromResume = true
       }
@@ -376,12 +385,14 @@ const prepareExistingWorkspacePrompt = async (
       await request.drainRuntimeEvents?.(sessionId)
     }
   } catch (error) {
+    if (request.isCurrent?.() === false) return undefined
     useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
     return undefined
   } finally {
     releasePreparation?.()
   }
 
+  if (request.isCurrent?.() === false) return undefined
   const preparedSession = useSessionStore
     .getState()
     .sessions.find((session) => session.id === sessionId)

--- a/src/renderer/src/lib/acp/workspace-runtime-session-lifecycle-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-lifecycle-owner.ts
@@ -57,22 +57,6 @@ const findUnansweredUserTurn = (messages: ChatMessage[]): ChatMessage | undefine
   return undefined
 }
 
-const restoreRemovedTurnProjection = (sessionBeforeRemoval: ChatSession): void => {
-  useSessionStore.setState((state) => ({
-    sessions: state.sessions.map((session) => {
-      if (session.id !== sessionBeforeRemoval.id) return session
-
-      return {
-        ...session,
-        messages: sessionBeforeRemoval.messages,
-        conversationGraph: sessionBeforeRemoval.conversationGraph,
-        filesRevision: sessionBeforeRemoval.filesRevision,
-        updatedAt: Date.now()
-      }
-    })
-  }))
-}
-
 const ensureWorkspaceSessionReady = async (
   runtime: WorkspaceMessageRuntime,
   sessionId: string,
@@ -332,6 +316,9 @@ const compactWorkspaceSession = async (
   }
 }
 
+// One live recovery may own a Session's compaction projection. Entries never leave renderer memory.
+const contextOverflowRecoveryAttempts = new Map<string, object>()
+
 const recoverContextOverflowWorkspaceSession = async (
   runtime: WorkspaceMessageRuntime,
   sessionId: string,
@@ -342,129 +329,152 @@ const recoverContextOverflowWorkspaceSession = async (
   supportsImageRelay?: boolean
 ): Promise<boolean> => {
   const session = workspaceSession(sessionId)
-
   if (!session) return false
-
   const resumeCwd = session.cwd || runtime.state.cwd
-
   if (!resumeCwd) return false
-
   const interruptedTurn = findUnansweredUserTurn(session.messages)
-
   if (!interruptedTurn) return false
 
-  // Flip to the neutral compacting state up front so the UI never shows the raw overflow error while the
-  // reset round-trip is in flight (idempotent with the event-path beginCompaction).
+  const attempt = {}
+  contextOverflowRecoveryAttempts.set(sessionId, attempt)
   useSessionStore.getState().beginCompaction(sessionId, { supersedeActiveRun: true })
-  const isCompactionStillActive = (): boolean => workspaceSession(sessionId)?.compacting === true
+  const frameId = session.conversationGraph?.activeFrameId
+  const branchId = session.conversationGraph?.frames.find(
+    (frame) => frame.id === frameId
+  )?.activeBranchId
+  let current = true
+  const ownsCompaction = (): boolean => {
+    const live = workspaceSession(sessionId)
+    return (
+      current &&
+      contextOverflowRecoveryAttempts.get(sessionId) === attempt &&
+      live?.compacting === true &&
+      !live.activeRun &&
+      live.createdAt === session.createdAt &&
+      live.projectId === session.projectId &&
+      live.conversationGraph?.activeFrameId === frameId &&
+      live.conversationGraph?.frames.find((frame) => frame.id === frameId)?.activeBranchId ===
+        branchId &&
+      findUnansweredUserTurn(live.messages)?.id === interruptedTurn.id
+    )
+  }
+  // Latch invalidation so switching away and back cannot revive a stale async continuation.
+  const unsubscribe = useSessionStore.subscribe(() => {
+    current = ownsCompaction()
+  })
+  const isCurrent = (): boolean => ownsCompaction() && !cancelledSessionIds?.has(sessionId)
   const finishCancelledRecovery = (): boolean => {
-    if (cancelledSessionIds?.delete(sessionId) !== true) return false
+    if (!ownsCompaction() || cancelledSessionIds?.delete(sessionId) !== true) return false
     useSessionStore.getState().finishCompaction(sessionId)
     return true
   }
 
-  const supportsNativeCompaction =
-    runtime.state.nativeContextCompactionSessionIds?.includes(sessionId) === true &&
-    runtime.compactSession !== undefined
-  let nativeCompacted = false
-  let postRecoveryState: WorkspaceMessageRuntime['state'] | undefined
-
-  if (supportsNativeCompaction) {
-    try {
-      const compactedState = await runtime.compactSession?.(sessionId, 'overflow-recovery')
-      postRecoveryState = compactedState ? { ...runtime.state, ...compactedState } : undefined
-      nativeCompacted = Boolean(compactedState)
-    } catch {
-      // Fall through to the replacement+replay safety net below.
+  try {
+    const supportsNativeCompaction =
+      runtime.state.nativeContextCompactionSessionIds?.includes(sessionId) === true &&
+      runtime.compactSession !== undefined
+    let nativeCompacted = false
+    let postRecoveryState: WorkspaceMessageRuntime['state'] | undefined
+    if (supportsNativeCompaction) {
+      try {
+        const compactedState = await runtime.compactSession?.(sessionId, 'overflow-recovery')
+        postRecoveryState = compactedState ? { ...runtime.state, ...compactedState } : undefined
+        nativeCompacted = Boolean(compactedState)
+      } catch {
+        // A current failed native control turn can still use replacement and history replay.
+      }
+      if (finishCancelledRecovery() || !isCurrent()) return false
     }
-
-    // Cancellation intent is consumed only after the native control turn actually stops, keeping the
-    // composer locked between the cancel acknowledgement and the terminal response.
-    if (finishCancelledRecovery()) return false
-    // Disconnect handling clears the local compacting state. Respect that terminal transition instead
-    // of turning a dropped native control turn into reset-and-replay.
-    if (!isCompactionStillActive()) return false
-  }
-
-  if (!nativeCompacted) {
-    try {
-      const replacement = await runtime.resetSessionContext(
-        sessionId,
-        resumeCwd,
-        session.projectId,
-        session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-        session.memoryEnabled !== false
-      )
+    if (!nativeCompacted) {
+      let replacement
+      try {
+        replacement = await runtime.resetSessionContext(
+          sessionId,
+          resumeCwd,
+          session.projectId,
+          session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+          session.memoryEnabled !== false
+        )
+      } catch (error) {
+        if (!finishCancelledRecovery() && isCurrent()) {
+          useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
+        }
+        return false
+      }
+      if (finishCancelledRecovery() || !isCurrent()) return false
       replaceWorkspaceProviderIdentity(sessionId, replacement)
       const remainingPromptInFlightSessionIds = runtime.state.promptInFlightSessionIds.filter(
         (id) => id !== sessionId
       )
-      // resetSessionContext returns session metadata rather than a runtime snapshot. Its terminal
-      // response nevertheless releases this session's operation lease, so project that fact into the
-      // stale event snapshot retained by this recovery task before applying the authoritative guard.
       postRecoveryState = {
         ...runtime.state,
         promptInFlight: remainingPromptInFlightSessionIds.length > 0,
         promptInFlightSessionIds: remainingPromptInFlightSessionIds
       }
-    } catch (error) {
-      if (finishCancelledRecovery()) return false
-      if (!isCompactionStillActive()) return false
-      useSessionStore.getState().failRun(sessionId, getResumeFailureMessage(error))
-      return false
+    }
+    if (finishCancelledRecovery() || !isCurrent()) return false
+    const retryRuntime = { ...runtime, state: postRecoveryState ?? runtime.state }
+    // A premature adapter response cannot release runtime ownership of a control turn.
+    if (retryRuntime.state.promptInFlightSessionIds.includes(sessionId)) return false
+
+    // Rearm the same unanswered Message. Admission failures must never fork or truncate its Branch.
+    const retried = await sendWorkspaceMessage(
+      retryRuntime,
+      {
+        sessionId,
+        messageId: interruptedTurn.id,
+        requireExistingSession: true,
+        preserveSelection: true,
+        text: interruptedTurn.content,
+        annotations: interruptedTurn.annotations,
+        attachments: (interruptedTurn.uploads ?? []).map((upload) =>
+          toRuntimeUploadedAttachment(upload, session.projectId)
+        ),
+        parts: interruptedTurn.parts,
+        pdfContext: interruptedTurn.pdfContext,
+        cwd: resumeCwd,
+        projectId: session.projectId,
+        permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+        // Native compaction retained its own framework-authored summary. Only a replacement session needs
+        // OpenScience to replay the prior transcript into its first prompt.
+        forceHistoryReplay: !nativeCompacted,
+        allowCompactionRecovery: true,
+        supportsImageInput,
+        supportsImageRelay,
+        agentFrameworkId: agentTarget?.frameworkId,
+        agentBackendId: agentTarget
+          ? `${agentTarget.frameworkId}:${agentTarget.providerId}`
+          : session.agentBackendId,
+        agentModel: agentTarget?.model ?? session.agentModel,
+        agentConfiguration: agentTarget
+          ? {
+              providerId: agentTarget.providerId,
+              ...(agentTarget.model ? { model: agentTarget.model } : {}),
+              reasoningEffort: agentTarget.reasoningEffort
+            }
+          : session.agentConfiguration,
+        historyReplayDescriptor
+      },
+      { isCurrent }
+    )
+    if (finishCancelledRecovery()) return false
+    if (!retried && isCurrent()) {
+      useSessionStore.getState().failCompaction(sessionId, 'Agent run failed')
+    }
+    return Boolean(retried)
+  } catch (error) {
+    if (!finishCancelledRecovery() && isCurrent()) {
+      useSessionStore
+        .getState()
+        .failCompaction(sessionId, getErrorMessage(error).trim() || 'Agent run failed')
+    }
+    return false
+  } finally {
+    unsubscribe()
+    if (contextOverflowRecoveryAttempts.get(sessionId) === attempt) {
+      contextOverflowRecoveryAttempts.delete(sessionId)
     }
   }
-
-  // A user can cancel while the reset request is in flight. The fresh context may already exist, but
-  // cancellation still owns the UI decision: leave the unanswered turn intact and do not resend it.
-  if (finishCancelledRecovery()) return false
-  if (!isCompactionStillActive()) return false
-
-  const retryRuntime = { ...runtime, state: postRecoveryState ?? runtime.state }
-  // Do not mutate the transcript unless the terminal compaction/reset response confirms that the
-  // runtime released this session. This protects against an adapter returning a premature snapshot.
-  if (retryRuntime.state.promptInFlightSessionIds.includes(sessionId)) return false
-
-  // Drop the unanswered turn so the re-send does not duplicate the bubble; the remaining prior turns are
-  // replayed as a text preamble via forceHistoryReplay (session.messages was captured before removal).
-  useSessionStore.getState().removeMessage(sessionId, interruptedTurn.id)
-
-  const retried = await sendWorkspaceMessage(retryRuntime, {
-    sessionId,
-    text: interruptedTurn.content,
-    annotations: interruptedTurn.annotations,
-    attachments: (interruptedTurn.uploads ?? []).map((upload) =>
-      toRuntimeUploadedAttachment(upload, session.projectId)
-    ),
-    parts: interruptedTurn.parts,
-    pdfContext: interruptedTurn.pdfContext,
-    cwd: resumeCwd,
-    projectId: session.projectId,
-    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-    // Native compaction retained its own framework-authored summary. Only a replacement session needs
-    // OpenScience to replay the prior transcript into its first prompt.
-    forceHistoryReplay: !nativeCompacted,
-    allowCompactionRecovery: true,
-    supportsImageInput,
-    supportsImageRelay,
-    agentFrameworkId: agentTarget?.frameworkId,
-    agentBackendId: agentTarget
-      ? `${agentTarget.frameworkId}:${agentTarget.providerId}`
-      : session.agentBackendId,
-    agentModel: agentTarget?.model ?? session.agentModel,
-    agentConfiguration: agentTarget
-      ? {
-          providerId: agentTarget.providerId,
-          ...(agentTarget.model ? { model: agentTarget.model } : {}),
-          reasoningEffort: agentTarget.reasoningEffort
-        }
-      : session.agentConfiguration,
-    historyReplayDescriptor
-  })
-
-  if (!retried) restoreRemovedTurnProjection(session)
-
-  return Boolean(retried)
 }
 
 const cancelWorkspaceRun = async (
@@ -523,13 +533,26 @@ const processContextOverflowRecovery = (
 
     recoveryCooldownSessionIds.add(sessionId)
     activeRecoverySessionIds.add(sessionId)
-    void recover(runtime, sessionId).finally(() => {
-      activeRecoverySessionIds.delete(sessionId)
-      setTimeout(
-        () => recoveryCooldownSessionIds.delete(sessionId),
-        CONTEXT_OVERFLOW_RECOVERY_COOLDOWN_MS
-      )
-    })
+    void (async () => {
+      let recoverySession = workspaceSession(sessionId)
+      try {
+        const pending = recover(runtime, sessionId)
+        recoverySession = workspaceSession(sessionId)
+        await pending
+      } catch (error) {
+        // The recovery owner handles expected failures. Contain unexpected setup/recovery errors
+        // without allowing this scheduler fallback to alter a newer Session projection.
+        if (workspaceSession(sessionId) === recoverySession) {
+          useSessionStore.getState().failCompaction(sessionId, getErrorMessage(error))
+        }
+      } finally {
+        activeRecoverySessionIds.delete(sessionId)
+        setTimeout(
+          () => recoveryCooldownSessionIds.delete(sessionId),
+          CONTEXT_OVERFLOW_RECOVERY_COOLDOWN_MS
+        )
+      }
+    })()
   }
 
   // Forget ids that fell out of the bounded runtime event window so the set cannot grow unbounded.

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -1002,6 +1002,18 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
         }
       }
 
+      // A current save acknowledgement must not replace the dispatch's in-memory run owner.
+      // Source identity prevents an old receipt from reclaiming a rearmed Message, even when
+      // two attempts have the same timestamp. Changed durable run fields still take effect.
+      if (
+        current === source &&
+        current.activeRun &&
+        projected.activeRun?.promptMessageId === current.activeRun.promptMessageId &&
+        projected.activeRun.startedAt === current.activeRun.startedAt
+      ) {
+        projected = { ...projected, activeRun: current.activeRun }
+      }
+
       projected = sessionDetails.withAcknowledgedUnsavedTitle(
         {
           ...projected,

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -104,7 +104,8 @@ export type SessionRunProjectionActions = {
       | 'providerSessionId'
       | 'providerContinuityToken'
       | 'pendingHistoryReplay'
-    >
+    >,
+    options?: { preserveCompaction?: boolean }
   ) => void
   prepareInterruptedTurnContinuation: (
     sessionId: string,
@@ -426,7 +427,7 @@ export const createSessionRunProjectionOwner = <
     },
 
     // Clears the interrupted/error state after a successful resume so the composer is usable again.
-    markResumed: (sessionId, update) => {
+    markResumed: (sessionId, update, options) => {
       setSessionState((state) => ({
         sessions: projectSession(state.sessions, sessionId, (session) => ({
           ...session,
@@ -442,7 +443,7 @@ export const createSessionRunProjectionOwner = <
           providerContinuityToken:
             update === undefined ? session.providerContinuityToken : update.providerContinuityToken,
           pendingHistoryReplay: update?.pendingHistoryReplay ?? session.pendingHistoryReplay,
-          compacting: undefined,
+          compacting: options?.preserveCompaction ? session.compacting : undefined,
           updatedAt: Date.now()
         }))
       }))

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1931,6 +1931,74 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].title).toBe('Remote later')
   })
 
+  it('keeps the new run reference when an old source acknowledges the same message and millisecond', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1710000000000)
+    try {
+      const input = {
+        sessionId: 'session-1',
+        messageId: 'retry-prompt',
+        content: 'Retry the same question'
+      }
+      useSessionStore.getState().appendUserMessage(input)
+      const source = useSessionStore.getState().sessions[0]
+      const durable = structuredClone(toPersistedSession(source))
+      durable.revision = (durable.revision ?? 0) + 1
+      useSessionStore.getState().finishRun('session-1')
+      useSessionStore.getState().appendUserMessage({ ...input, rearmExisting: true })
+      const current = useSessionStore.getState().sessions[0]
+      expect(current).not.toBe(source)
+      expect(current.activeRun).toBeDefined()
+      expect(current.activeRun).toEqual(source.activeRun)
+      expect(current.activeRun).not.toBe(source.activeRun)
+
+      useSessionStore.getState().applyDurableSessionProjection({
+        source,
+        session: durable,
+        mode: 'replace-persisted-if-current'
+      })
+
+      const projected = useSessionStore.getState().sessions[0]
+      expect(projected.activeRun).toBe(current.activeRun)
+      expect(projected.activeRun).not.toBe(source.activeRun)
+      expect(projected.status).toBe('running')
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it.each(['promptMessageId', 'startedAt'] as const)(
+    'does not reuse the old run reference when the current save acknowledgement changes %s',
+    (field) => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        messageId: 'earlier-prompt',
+        content: 'Earlier question'
+      })
+      useSessionStore.getState().finishRun('session-1')
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        messageId: 'current-prompt',
+        content: 'Current question'
+      })
+      const source = useSessionStore.getState().sessions[0]
+      const durable = structuredClone(toPersistedSession(source))
+      durable.revision = (durable.revision ?? 0) + 1
+      expect(durable.activeRun).toBeDefined()
+      if (field === 'promptMessageId') durable.activeRun!.promptMessageId = 'earlier-prompt'
+      else durable.activeRun!.startedAt += 1
+
+      useSessionStore.getState().applyDurableSessionProjection({
+        source,
+        session: durable,
+        mode: 'replace-persisted-if-current'
+      })
+
+      const projected = useSessionStore.getState().sessions[0]
+      expect(projected.activeRun).toEqual(durable.activeRun)
+      expect(projected.activeRun).not.toBe(source.activeRun)
+    }
+  )
+
   it('keeps a newer unsaved title when a durable save acknowledgement is for the previous title', () => {
     useSessionStore.getState().hydrateSessions([
       {


### PR DESCRIPTION
## Problem

Four ACP ownership gaps can surface across asynchronous waits: context-overflow retry admission can lose the unanswered question and leave compaction running (A04); cancellation can miss a permission response awaiting persistence and still release allow (A01); the first provider update can escape after its interaction becomes stale during acceptance (A02); and an unavailable downgrade from known native bypass can falsely report Ask/Auto (A03).

## Proposed change

- Rearm the same unanswered message and preserve its attachments, annotations and branch. Guard recovery/preparation continuations by the current attempt, and project admission/replay/dispatch failures through existing terminal errors. Release recovery subscriptions and scheduler bookkeeping on completion.
- Keep responding permissions addressable until the provider decision is released. Cancellation settles them once and prevents an old persistence failure from clearing a newer request queue.
- Recheck interaction/session ownership after asynchronous acceptance, before routing updates or applying live acceptance effects. Preserve committed Plan/relay receipts.
- Reject Ask/Auto when the provider is demonstrably in native bypass and advertises no supported exit. Reuse the existing unavailable-profile error and preserve the prior profile projection.

## Scope and non-goals

No new persisted fields, enum values, schema, migration, IPC protocol or UI controls. New ownership bookkeeping and preparation options are transient.

Persistence: A04 retains the existing message identity and store save bridge; new application-authored stable messages retain their save-before-dispatch barrier. A save acknowledgement preserves the in-memory run identity only when its source still owns the current session and its run fields are unchanged; stale acknowledgements do not reclaim a newer run. A01 skips a remembered grant that has not started when cancellation wins; an already-started successful grant write remains saved, but the cancelled invocation receives no allow. Committed Plan/relay receipts are not rolled back.

Historical compatibility: no data migration or format fallback. An old session still in a known native bypass may now fail attachment/profile application instead of falsely reporting a safer mode. Unknown/missing modes and stricter native Auto-to-Ask policy remain outside this bounded fix. Preserve OpenCode's explicit broker fallback and Codex's existing independent permission mapping.

## Acceptance criteria and validation

Regression tests exercise the real recovery, broker, executor/workflow, configurator and runtime owners with controlled async dependencies. Before fixes, A04's 17 admission/ownership cases failed twice; two additional replay/dispatch cases failed with the same stuck-running symptom. Three async-dispatch/replacement cases then failed twice; the overlapping-rejection control passes on the original baseline and detects the same-message retry regression before its final fix. A01's 18 cases failed twice; A02's two executor and eight workflow cases failed twice; A03's seven mapper/configurator and four runtime cases failed twice. A save-acknowledgement/current-rejection regression also failed twice before preserving the current in-memory run reference; a text-stream control and stale/changed receipt controls pass. Final owner/module selections pass, including cancellation, disconnect, replacement-run and no-false-projection controls. Passing controls are not counted as reproductions.

Final evidence mapping (each selection ran after the last material edit to its covered behavior):

| Behavior | Project-owned command/selection | Result |
| --- | --- | --- |
| Recovery admission, retry identity, branch/replacement ownership, subscriptions and renderer consumers | `npm run test:module -- workspace_runtime` | 11 files, 467 passed |
| Session projections, store architecture, branches and serialization consumers | `npm run test:module -- session_renderer` | 6 files, 671 passed |
| Permission cancellation/persistence, acceptance, permission mapping and runtime consumers | `npm test --` the nine ACP owner/consumer files below | 9 files, 915 passed |
| Normalized framework updates, interaction/projector/finalizer, Plan and relay consumers | `npm test --` the nine boundary files below | 9 files, 118 passed |
| Profile resolver/configurator, Claude/OpenCode/CodeBuddy and create/adopt/resume consumers | `npm test --` the eight permission framework files below | 8 files, 206 passed |
| Codex framework (shared by Responses and Bridge) | `npm test -- src/main/agent-framework/codex.test.ts` | 64 passed |
| Store save acknowledgement, delayed upload projection and save conflict consumers | `npm test -- src/renderer/src/lib/session-persistence/session-persistence.test.ts` | 73 passed |
| Main, sandbox and renderer typing; source quality | `npm run typecheck`; `npm run lint`; changed-file Prettier check; `git diff --check` | Passed |

<details>
<summary>Exact targeted file selections</summary>

ACP owner/consumer files:

```text
src/main/acp/permission-broker.test.ts
src/main/acp/permission-broker-registry.test.ts
src/main/acp/permission-profile-controller.test.ts
src/main/acp/session-configurator.test.ts
src/main/acp/provider-prompt-executor.test.ts
src/main/acp/prompt-turn-workflow.test.ts
src/main/acp/runtime.test.ts
src/main/acp/permission-context.test.ts
src/main/acp/runtime-lifecycle-composition.test.ts
```

Boundary files:

```text
src/main/acp/session-update-projector.test.ts
src/main/acp/prompt-outcome-finalizer.test.ts
src/main/acp/claude-turn-adapter.test.ts
src/main/acp/codex-turn-adapter.test.ts
src/main/acp/opencode-turn-adapter.test.ts
src/main/acp/codebuddy-turn-adapter.test.ts
src/main/side-chat/main-prompt-relay.test.ts
src/main/acp/session-plan-delivery-owner.test.ts
src/main/acp/session-interaction-owner.test.ts
```

Permission framework files:

```text
src/main/acp/permission-profile-controller.test.ts
src/main/acp/session-configurator.test.ts
src/main/agent-framework/claude-code.test.ts
src/main/agent-framework/codebuddy.test.ts
src/main/agent-framework/opencode.test.ts
src/main/acp/provider-session-creator.test.ts
src/main/acp/provider-session-adopter.test.ts
src/main/acp/provider-session-resumer.test.ts
```

</details>

Claude Code, OpenCode, Codex Responses and Codex Bridge were assessed separately; shared normalized executor/adapter checks do not certify live provider timing. Recovery additionally covers native compaction and replacement replay. No platform-dependent production logic changed; selected Codex process and runtime socket controls passed with scoped sandbox exceptions. `test:affected --explain` selects the full fallback because the manifest has no owner for these main ACP files. Full local `npm test` was intentionally not run at the maintainer's request; PR CI remains authoritative for the full and platform suites.

Uncovered risks: no live-provider/UI race test, crash-recovery durability test, or evidence of permanent disk deletion. A03 proves the function/RPC contract defect, not that all production agents advertise this mode combination.

Independent review confirmed the final behavior-to-check mapping. Its additional memory probes are excluded from the repository test counts.

## Review focus

Recovery invalidation across awaits and branch ABA; preservation of later valid state; exactly-once permission settlement and the documented grant-write boundary; durable acceptance facts versus stale live effects; known native bypass rejection without broadening framework fallback policy.
