### PR TITLE
fix(specialists): preserve permissions and recover catalog operations

### DIFF
--- a/src/main/specialist/repository.ts
+++ b/src/main/specialist/repository.ts
@@ -10,13 +10,15 @@ import {
   type StoredSpecialist,
   type StoredSpecialists
 } from './types'
-import type {
-  SpecialistCapabilityMode,
-  SpecialistDocumentIntegrity,
-  SpecialistDocumentIntegrityIssue,
-  SpecialistFullAccessConfig,
-  SpecialistSelectedConfig,
-  ConnectorToolRule
+import {
+  CONNECTOR_TOOL_PATTERN_MAX_LENGTH,
+  CONNECTOR_TOOL_RULE_MAX_COUNT,
+  type SpecialistCapabilityMode,
+  type SpecialistDocumentIntegrity,
+  type SpecialistDocumentIntegrityIssue,
+  type SpecialistFullAccessConfig,
+  type SpecialistSelectedConfig,
+  type ConnectorToolRule
 } from '../../shared/specialist'
 
 const SPECIALISTS_FILE = 'specialists.json'
@@ -77,10 +79,13 @@ const connectorToolRuleWouldLoseData = (value: unknown): boolean => {
   if (typeof value.connectorId !== 'string' || !value.connectorId) return true
   if (value.includedMethods !== undefined && !isExactStringArray(value.includedMethods)) return true
   if (value.excludedMethods !== undefined && !isExactStringArray(value.excludedMethods)) return true
-  if (value.includeToolsPattern !== undefined && typeof value.includeToolsPattern !== 'string') {
-    return true
-  }
-  return value.excludeToolsPattern !== undefined && typeof value.excludeToolsPattern !== 'string'
+  return ['includeToolsPattern', 'excludeToolsPattern'].some(
+    (key) =>
+      value[key] !== undefined &&
+      (typeof value[key] !== 'string' ||
+        value[key].length === 0 ||
+        value[key].length > CONNECTOR_TOOL_PATTERN_MAX_LENGTH)
+  )
 }
 
 const FULL_ACCESS_KEYS = new Set(['excludedSkillIds', 'excludedConnectorIds', 'connectorTools'])
@@ -99,9 +104,20 @@ const capabilityConfigWouldLoseData = (
   return (
     value.connectorTools !== undefined &&
     (!Array.isArray(value.connectorTools) ||
+      value.connectorTools.length > CONNECTOR_TOOL_RULE_MAX_COUNT ||
       value.connectorTools.some(connectorToolRuleWouldLoseData))
   )
 }
+
+const capabilitiesWouldLoseData = (value: Record<string, unknown>): boolean =>
+  capabilityConfigWouldLoseData(value.fullAccess, FULL_ACCESS_KEYS, [
+    'excludedSkillIds',
+    'excludedConnectorIds'
+  ]) ||
+  capabilityConfigWouldLoseData(value.selectedCapabilities, SELECTED_KEYS, [
+    'skillIds',
+    'connectorIds'
+  ])
 
 const IMPORT_BASELINE_KEYS = new Set([
   'importedAt',
@@ -146,18 +162,7 @@ const storedSpecialistWouldLoseData = (value: Record<string, unknown>): boolean 
     return true
   }
   if (value.ownedSkillIds !== undefined && !isExactStringArray(value.ownedSkillIds)) return true
-  if (
-    capabilityConfigWouldLoseData(value.fullAccess, FULL_ACCESS_KEYS, [
-      'excludedSkillIds',
-      'excludedConnectorIds'
-    ]) ||
-    capabilityConfigWouldLoseData(value.selectedCapabilities, SELECTED_KEYS, [
-      'skillIds',
-      'connectorIds'
-    ])
-  ) {
-    return true
-  }
+  if (capabilitiesWouldLoseData(value)) return true
   if (value.importBaseline !== undefined) {
     if (!isRecord(value.importBaseline)) return true
     if (
@@ -295,16 +300,20 @@ export const sanitizeStoredSpecialist = (v: unknown): StoredSpecialist | undefin
   return specialist
 }
 
-const sanitizeSpecialistsWithIntegrity = (
-  v: unknown
-): {
+type SpecialistReadSnapshot = {
   document: StoredSpecialists
   integrity: SpecialistDocumentIntegrity
-} => {
+  // Read-time metadata only: never serialize sanitized permissions as runnable.
+  invalidCapabilityIds: ReadonlySet<string>
+}
+
+const sanitizeSpecialistsWithIntegrity = (v: unknown): SpecialistReadSnapshot => {
+  const invalidCapabilityIds = new Set<string>()
   const issues: SpecialistDocumentIntegrityIssue[] = []
   if (!isRecord(v)) {
     return {
       document: createEmptySpecialists(),
+      invalidCapabilityIds,
       integrity: { status: 'degraded', issues: [{ code: 'document-invalid' }] }
     }
   }
@@ -321,6 +330,7 @@ const sanitizeSpecialistsWithIntegrity = (
       log.warn('ignoring old experimental specialist schema (kebab-case agentId detected)')
       return {
         document: createEmptySpecialists(),
+        invalidCapabilityIds,
         integrity: { status: 'degraded', issues: [{ code: 'legacy-schema-unsupported' }] }
       }
     }
@@ -333,6 +343,9 @@ const sanitizeSpecialistsWithIntegrity = (
         issues.push({ code: 'record-invalid', recordIndex })
         return
       }
+      if (isRecord(candidate) && capabilitiesWouldLoseData(candidate)) {
+        invalidCapabilityIds.add(sanitized.id)
+      }
       specialists.push(sanitized)
       if (isRecord(candidate) && storedSpecialistWouldLoseData(candidate)) {
         issues.push({ code: 'record-sanitized', recordIndex })
@@ -341,6 +354,7 @@ const sanitizeSpecialistsWithIntegrity = (
   }
   return {
     document: { version: SPECIALISTS_FILE_VERSION, specialists },
+    invalidCapabilityIds,
     integrity: issues.length > 0 ? { status: 'degraded', issues } : { status: 'ok' }
   }
 }
@@ -367,17 +381,18 @@ export class SpecialistRepository {
     return (await this.getAllWithIntegrity()).document
   }
 
-  async getAllWithIntegrity(): Promise<{
-    document: StoredSpecialists
-    integrity: SpecialistDocumentIntegrity
-  }> {
+  async getAllWithIntegrity(): Promise<SpecialistReadSnapshot> {
     try {
       const result = await readDurableJsonFile(this.filePath, (contents) =>
         sanitizeSpecialistsWithIntegrity(JSON.parse(contents) as unknown)
       )
       return result.status === 'found'
         ? result.value
-        : { document: createEmptySpecialists(), integrity: { status: 'ok' } }
+        : {
+            document: createEmptySpecialists(),
+            integrity: { status: 'ok' },
+            invalidCapabilityIds: new Set()
+          }
     } catch (err) {
       const parseFailure = err instanceof SyntaxError
       log.error(

--- a/src/main/specialist/service.test.ts
+++ b/src/main/specialist/service.test.ts
@@ -1,10 +1,12 @@
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdir, rm } from 'node:fs/promises'
+import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 import { SpecialistService } from './service'
+import { ConnectorService } from '../connectors/service'
+import { SessionBindingService } from './session-binding'
 import { SpecialistRepository } from './repository'
 import type { BuiltinSpecialistRegistryEntry } from '../../shared/specialist-package'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
@@ -941,4 +943,90 @@ describe('SpecialistService stable Skill/Connector references', () => {
     expect(detached.selectedCapabilities.skillIds).not.toContain('skill-v1')
     expect(detached.selectedCapabilities.skillIds).toContain('skill-v2')
   })
+})
+
+describe('S03 damaged capability records', () => {
+  it.each([
+    ['method array', { connectorTools: [{ connectorId: 'demo', includedMethods: 'read' }] }],
+    ['rule object', { connectorTools: [null] }],
+    ['pattern type', { connectorTools: [{ connectorId: 'demo', includeToolsPattern: 42 }] }],
+    ['empty pattern', { connectorTools: [{ connectorId: 'demo', includeToolsPattern: '' }] }],
+    ['mode configuration', null]
+  ])(
+    'blocks a record with damaged %s while keeping its healthy neighbor',
+    async (_label, damaged) => {
+      const source = await service.create({
+        name: 'Restricted',
+        capabilityMode: 'full',
+        fullAccess: {
+          excludedSkillIds: [],
+          excludedConnectorIds: [],
+          connectorTools: [{ connectorId: 'demo', includedMethods: ['read'] }]
+        }
+      })
+      const healthy = await service.create({ name: 'Healthy neighbor' })
+      const path = join(tmpDir, 'specialists.json')
+      const original = await readFile(path, 'utf8')
+      const document = JSON.parse(original)
+      document.specialists[0].fullAccess =
+        damaged === null ? null : { ...document.specialists[0].fullAccess, ...damaged }
+      document.specialists.unshift(null) // Dropped records must not shift the validity association.
+      const corrupted = JSON.stringify(document)
+      await writeFile(path, corrupted)
+
+      expect.soft((await service.listForSettingsSnapshot()).integrity.status).toBe('degraded')
+      const dispatch = vi.fn().mockResolvedValue({ ok: true })
+      const gate = new ConnectorService({
+        mcpClientManager: {
+          call: dispatch,
+          listTools: vi.fn().mockResolvedValue([{ name: 'danger' }])
+        },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'demo',
+              name: 'demo',
+              displayName: 'Demo',
+              transport: 'stdio',
+              command: 'unused-test-command',
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined,
+        resolveSpecialistProfile: (id) => service.resolveRunnableById(id)
+      })
+      await expect
+        .soft(
+          gate.call(
+            'demo',
+            'danger',
+            {},
+            { origin: 'agent', sessionId: 'damaged-session', specialistId: source.id }
+          )
+        )
+        .rejects.toThrow()
+      expect.soft(dispatch).not.toHaveBeenCalled()
+      await expect.soft(service.resolveRunnableByName(source.name)).rejects.toThrow()
+      await expect.soft(service.resolveRunnableByReference(source.id)).rejects.toThrow()
+      await expect.soft(service.resolveRunnableByReference(source.name)).rejects.toThrow()
+      const bindings = new SessionBindingService(service)
+      bindings.setBinding('damaged-session', source.id)
+      bindings.setBinding('healthy-session', healthy.id)
+      expect.soft(await bindings.resolve('damaged-session')).toMatchObject({ kind: 'unavailable' })
+      expect(await bindings.resolve('healthy-session')).toMatchObject({
+        kind: 'bound',
+        profile: { id: healthy.id }
+      })
+      expect(await readFile(path, 'utf8')).toBe(corrupted)
+
+      await writeFile(path, original)
+      expect(await bindings.resolve('damaged-session')).toMatchObject({
+        kind: 'bound',
+        profile: { id: source.id }
+      })
+    }
+  )
 })

--- a/src/main/specialist/service.test.ts
+++ b/src/main/specialist/service.test.ts
@@ -945,88 +945,137 @@ describe('SpecialistService stable Skill/Connector references', () => {
   })
 })
 
-describe('S03 damaged capability records', () => {
-  it.each([
-    ['method array', { connectorTools: [{ connectorId: 'demo', includedMethods: 'read' }] }],
-    ['rule object', { connectorTools: [null] }],
-    ['pattern type', { connectorTools: [{ connectorId: 'demo', includeToolsPattern: 42 }] }],
-    ['empty pattern', { connectorTools: [{ connectorId: 'demo', includeToolsPattern: '' }] }],
-    ['mode configuration', null]
-  ])(
-    'blocks a record with damaged %s while keeping its healthy neighbor',
-    async (_label, damaged) => {
-      const source = await service.create({
-        name: 'Restricted',
-        capabilityMode: 'full',
-        fullAccess: {
-          excludedSkillIds: [],
-          excludedConnectorIds: [],
-          connectorTools: [{ connectorId: 'demo', includedMethods: ['read'] }]
-        }
-      })
-      const healthy = await service.create({ name: 'Healthy neighbor' })
-      const path = join(tmpDir, 'specialists.json')
-      const original = await readFile(path, 'utf8')
-      const document = JSON.parse(original)
-      document.specialists[0].fullAccess =
-        damaged === null ? null : { ...document.specialists[0].fullAccess, ...damaged }
-      document.specialists.unshift(null) // Dropped records must not shift the validity association.
-      const corrupted = JSON.stringify(document)
-      await writeFile(path, corrupted)
+describe.each(['full', 'selected'] as const)(
+  'S03 damaged capability records in %s mode',
+  (capabilityMode) => {
+    it.each([
+      ['method array', { connectorTools: [{ connectorId: 'demo', includedMethods: 'read' }] }],
+      ['rule object', { connectorTools: [null] }],
+      ['pattern type', { connectorTools: [{ connectorId: 'demo', includeToolsPattern: 42 }] }],
+      ['empty pattern', { connectorTools: [{ connectorId: 'demo', includeToolsPattern: '' }] }],
+      ['mode configuration', null]
+    ])(
+      'blocks a record with damaged %s while keeping its healthy neighbor',
+      async (_label, damaged) => {
+        const source = await service.create({
+          name: 'Restricted',
+          capabilityMode,
+          selectedCapabilities: {
+            skillIds: [],
+            connectorIds: ['demo'],
+            connectorTools: [{ connectorId: 'demo', includedMethods: ['read'] }]
+          },
+          fullAccess: {
+            excludedSkillIds: [],
+            excludedConnectorIds: [],
+            connectorTools: [{ connectorId: 'demo', includedMethods: ['read'] }]
+          }
+        })
+        const healthy = await service.create({ name: 'Healthy neighbor' })
+        const path = join(tmpDir, 'specialists.json')
+        const original = await readFile(path, 'utf8')
+        const document = JSON.parse(original)
+        document.specialists[0].fullAccess =
+          damaged === null ? null : { ...document.specialists[0].fullAccess, ...damaged }
+        document.specialists.unshift(null) // Dropped records must not shift the validity association.
+        const corrupted = JSON.stringify(document)
+        await writeFile(path, corrupted)
 
-      expect.soft((await service.listForSettingsSnapshot()).integrity.status).toBe('degraded')
-      const dispatch = vi.fn().mockResolvedValue({ ok: true })
-      const gate = new ConnectorService({
-        mcpClientManager: {
-          call: dispatch,
-          listTools: vi.fn().mockResolvedValue([{ name: 'danger' }])
-        },
-        getConnectors: () => ({
-          enabledIds: [],
-          autoAllowIds: [],
-          customMcpServers: [
-            {
-              id: 'demo',
-              name: 'demo',
-              displayName: 'Demo',
-              transport: 'stdio',
-              command: 'unused-test-command',
-              enabled: true
-            }
-          ]
-        }),
-        resolveApiKey: () => undefined,
-        resolveSpecialistProfile: (id) => service.resolveRunnableById(id)
-      })
-      await expect
-        .soft(
-          gate.call(
-            'demo',
-            'danger',
-            {},
-            { origin: 'agent', sessionId: 'damaged-session', specialistId: source.id }
+        expect.soft((await service.listForSettingsSnapshot()).integrity.status).toBe('degraded')
+        const dispatch = vi.fn().mockResolvedValue({ ok: true })
+        const gate = new ConnectorService({
+          mcpClientManager: {
+            call: dispatch,
+            listTools: vi.fn().mockResolvedValue([{ name: 'danger' }])
+          },
+          getConnectors: () => ({
+            enabledIds: [],
+            autoAllowIds: [],
+            customMcpServers: [
+              {
+                id: 'demo',
+                name: 'demo',
+                displayName: 'Demo',
+                transport: 'stdio',
+                command: 'unused-test-command',
+                enabled: true
+              }
+            ]
+          }),
+          resolveApiKey: () => undefined,
+          resolveSpecialistProfile: (id) => service.resolveRunnableById(id)
+        })
+        await expect
+          .soft(
+            gate.call(
+              'demo',
+              'danger',
+              {},
+              { origin: 'agent', sessionId: 'damaged-session', specialistId: source.id }
+            )
           )
-        )
-        .rejects.toThrow()
-      expect.soft(dispatch).not.toHaveBeenCalled()
-      await expect.soft(service.resolveRunnableByName(source.name)).rejects.toThrow()
-      await expect.soft(service.resolveRunnableByReference(source.id)).rejects.toThrow()
-      await expect.soft(service.resolveRunnableByReference(source.name)).rejects.toThrow()
-      const bindings = new SessionBindingService(service)
-      bindings.setBinding('damaged-session', source.id)
-      bindings.setBinding('healthy-session', healthy.id)
-      expect.soft(await bindings.resolve('damaged-session')).toMatchObject({ kind: 'unavailable' })
-      expect(await bindings.resolve('healthy-session')).toMatchObject({
-        kind: 'bound',
-        profile: { id: healthy.id }
-      })
-      expect(await readFile(path, 'utf8')).toBe(corrupted)
+          .rejects.toThrow()
+        expect.soft(dispatch).not.toHaveBeenCalled()
+        await expect.soft(service.resolveRunnableByName(source.name)).rejects.toThrow()
+        await expect.soft(service.resolveRunnableByReference(source.id)).rejects.toThrow()
+        await expect.soft(service.resolveRunnableByReference(source.name)).rejects.toThrow()
+        const bindings = new SessionBindingService(service)
+        bindings.setBinding('damaged-session', source.id)
+        bindings.setBinding('healthy-session', healthy.id)
+        expect
+          .soft(await bindings.resolve('damaged-session'))
+          .toMatchObject({ kind: 'unavailable' })
+        expect(await bindings.resolve('healthy-session')).toMatchObject({
+          kind: 'bound',
+          profile: { id: healthy.id }
+        })
+        expect(await readFile(path, 'utf8')).toBe(corrupted)
 
-      await writeFile(path, original)
-      expect(await bindings.resolve('damaged-session')).toMatchObject({
-        kind: 'bound',
-        profile: { id: source.id }
-      })
-    }
-  )
+        await writeFile(path, original)
+        expect(await bindings.resolve('damaged-session')).toMatchObject({
+          kind: 'bound',
+          profile: { id: source.id }
+        })
+      }
+    )
+  }
+)
+
+it.each([1, 2])(
+  'keeps legitimate version %i defaults runnable without rewriting history',
+  async (version) => {
+    const source = await service.create({ name: 'Legacy defaults' })
+    const path = join(tmpDir, 'specialists.json')
+    const document = JSON.parse(await readFile(path, 'utf8'))
+    document.version = version
+    for (const key of [
+      'fullAccess',
+      'selectedCapabilities',
+      'revision',
+      'packageVersion',
+      'origin',
+      'ownedSkillIds'
+    ])
+      delete document.specialists[0][key]
+    const original = JSON.stringify(document)
+    await writeFile(path, original)
+    expect(await service.resolveRunnableById(source.id)).toMatchObject({
+      id: source.id,
+      fullAccess: emptyFullAccessConfig(),
+      selectedCapabilities: emptySelectedConfig()
+    })
+    expect(await service.resolveRunnableByName(source.name)).toMatchObject({ id: source.id })
+    expect(await service.resolveRunnableByReference(source.id)).toMatchObject({ id: source.id })
+    expect(await readFile(path, 'utf8')).toBe(original)
+  }
+)
+
+it('does not disable a record for an unrelated appearance diagnostic', async () => {
+  const source = await service.create({ name: 'Healthy capabilities' })
+  const path = join(tmpDir, 'specialists.json')
+  const document = JSON.parse(await readFile(path, 'utf8'))
+  document.specialists[0].iconKey = 42
+  await writeFile(path, JSON.stringify(document))
+  expect((await service.listForSettingsSnapshot()).integrity.status).toBe('degraded')
+  expect(await service.resolveRunnableById(source.id)).toMatchObject({ id: source.id })
 })

--- a/src/main/specialist/service.ts
+++ b/src/main/specialist/service.ts
@@ -309,8 +309,15 @@ export class SpecialistService {
     return { items, integrity: snapshot.integrity }
   }
 
+  private async listRunnableCustom(): Promise<SpecialistView[]> {
+    const snapshot = await this.repo.getAllWithIntegrity()
+    return snapshot.document.specialists
+      .filter((profile) => !snapshot.invalidCapabilityIds.has(profile.id))
+      .map(toView)
+  }
+
   async resolveRunnableById(id: string): Promise<SpecialistView> {
-    const custom = await this.list()
+    const custom = await this.listRunnableCustom()
     const customMatch = custom.find((profile) => profile.id === id)
     if (customMatch) return customMatch
     const builtin = (await this.builtinEntries()).find((entry) => entry.id === id)
@@ -319,7 +326,7 @@ export class SpecialistService {
   }
 
   async resolveRunnableByName(name: string): Promise<SpecialistView> {
-    const custom = await this.list()
+    const custom = await this.listRunnableCustom()
     const customMatch = custom.find((profile) => profile.name === name)
     if (customMatch) return customMatch
     const builtin = (await this.builtinEntries()).find((entry) => entry.name === name)
@@ -329,7 +336,7 @@ export class SpecialistService {
 
   async resolveRunnableByReference(reference: string): Promise<SpecialistView> {
     const profiles = [
-      ...(await this.list()),
+      ...(await this.listRunnableCustom()),
       ...(await this.builtinEntries()).map((entry) => this.toBuiltinView(entry))
     ]
     const byId = profiles.find((profile) => profile.id === reference)

--- a/src/renderer/src/pages/settings/SpecialistEditor.persistence.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.persistence.render.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpecialistEditor } from './SpecialistEditor'
+import { useSettingsStore } from '@/stores/settings-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
+import { ConnectorService } from '../../../../main/connectors/service'
+import { SpecialistRepository } from '../../../../main/specialist/repository'
+import { SpecialistService } from '../../../../main/specialist/service'
+import type { CreateSpecialistInput, UpdateSpecialistInput } from '../../../../shared/specialist'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let directory: string
+let service: SpecialistService
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'specialist-editor-regression-'))
+  service = new SpecialistService(new SpecialistRepository(directory))
+  useSpecialistStore.setState({ editorDrafts: {} })
+  useSettingsStore.setState({
+    skills: [
+      {
+        id: 'example',
+        name: 'Example',
+        displayName: 'Example',
+        description: '',
+        source: 'featured',
+        enabled: true,
+        updatedAt: ''
+      }
+    ],
+    connectors: [],
+    loadSkills: vi.fn().mockResolvedValue(undefined),
+    loadConnectors: vi.fn().mockResolvedValue(undefined)
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  await rm(directory, { recursive: true, force: true })
+})
+
+const clickButton = async (label: string): Promise<void> => {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent === label
+  )
+  expect(button).toBeDefined()
+  await act(async () => fireEvent.click(button!))
+}
+
+const readStored = async (): Promise<{ specialists: Array<Record<string, unknown>> }> =>
+  JSON.parse(await readFile(join(directory, 'specialists.json'), 'utf8'))
+
+describe('Specialist editor durable behavior regressions', () => {
+  it.each([
+    ['description', ''],
+    ['systemPrompt', ''],
+    ['both', ''],
+    ['both', '   ']
+  ])('S01 clears %s using %j and persists the cleared value', async (field, value) => {
+    const profile = await service.create({
+      name: 'Editor example',
+      description: 'Old description',
+      systemPrompt: 'Old system instruction'
+    })
+    const save = vi.fn(async (input: UpdateSpecialistInput) => {
+      await service.update(input)
+    })
+    await act(async () =>
+      root.render(
+        <SpecialistEditor
+          editSpecialist={profile}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={save}
+        />
+      )
+    )
+    await act(async () => {
+      if (field !== 'systemPrompt')
+        fireEvent.change(container.querySelector('#sp-description')!, { target: { value } })
+      if (field !== 'description')
+        fireEvent.change(container.querySelector('#sp-system-prompt')!, { target: { value } })
+    })
+    await clickButton('Save changes')
+    expect(save).toHaveBeenCalledOnce()
+    await act(async () => {
+      await save.mock.results[0].value
+    })
+    expect((await readStored()).specialists[0]).toMatchObject({
+      revision: 2,
+      description: field === 'systemPrompt' ? 'Old description' : '',
+      systemPrompt: field === 'description' ? 'Old system instruction' : ''
+    })
+  })
+
+  it('S01 control: omitted programmatic edits preserve existing text', async () => {
+    const profile = await service.create({
+      name: 'Omitted edit',
+      description: 'Keep description',
+      systemPrompt: 'Keep instruction'
+    })
+    await service.update({ id: profile.id, revision: profile.revision, displayName: 'New label' })
+    expect((await readStored()).specialists[0]).toMatchObject({
+      description: 'Keep description',
+      systemPrompt: 'Keep instruction'
+    })
+  })
+
+  it.each(['direct', 'mode toggle', 'detail round trip', 'prefilled detail round trip'])(
+    'S02 preserves copied method restrictions after %s',
+    async (journey) => {
+      const connectorTools = [
+        {
+          connectorId: 'demo',
+          includedMethods: ['read'],
+          excludedMethods: ['danger'],
+          includeToolsPattern: 'read_*',
+          excludeToolsPattern: 'delete_*'
+        }
+      ]
+      const source = await service.create({
+        name: 'Restricted example',
+        capabilityMode: 'selected',
+        fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools },
+        selectedCapabilities: { skillIds: ['example'], connectorIds: ['demo'], connectorTools }
+      })
+      const initialInput = await service.duplicate(source.id)
+      const save = vi.fn(async (input: CreateSpecialistInput) => {
+        await service.create(input)
+      })
+      const render = async (input?: CreateSpecialistInput): Promise<void> => {
+        await act(async () =>
+          root.render(
+            <SpecialistEditor
+              initialInput={input}
+              onCancel={vi.fn()}
+              onSave={save}
+              onOpenSkillDetail={() => root.render(<div>Skill details</div>)}
+            />
+          )
+        )
+      }
+      await render(initialInput)
+      if (journey === 'mode toggle') {
+        await act(async () =>
+          fireEvent.click(container.querySelector('[aria-label="Full access"]')!)
+        )
+        await act(async () =>
+          fireEvent.click(container.querySelector('[aria-label="Full access"]')!)
+        )
+      }
+      if (journey.includes('detail round trip')) {
+        await act(async () =>
+          fireEvent.change(container.querySelector('#sp-description')!, {
+            target: { value: 'Unsaved copied description' }
+          })
+        )
+        await act(async () =>
+          fireEvent.click(container.querySelector('[aria-label="View Example details"]')!)
+        )
+        expect(container.textContent).toBe('Skill details')
+        await render(journey.startsWith('prefilled') ? initialInput : undefined)
+        expect
+          .soft(container.querySelector<HTMLInputElement>('#sp-description')!.value)
+          .toBe('Unsaved copied description')
+      }
+      await clickButton('Create specialist')
+      expect(save).toHaveBeenCalledOnce()
+      await act(async () => {
+        await save.mock.results[0].value
+      })
+      const document = await readStored()
+      expect(document.specialists).toHaveLength(2)
+      const dispatch = vi.fn().mockResolvedValue({ ok: true })
+      const gate = new ConnectorService({
+        mcpClientManager: {
+          call: dispatch,
+          listTools: vi.fn().mockResolvedValue([{ name: 'read' }, { name: 'danger' }])
+        },
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'demo',
+              name: 'demo',
+              displayName: 'Demo',
+              transport: 'stdio',
+              command: 'unused-test-command',
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined,
+        resolveSpecialistProfile: (id) => service.resolveRunnableById(id)
+      })
+      const call = (id: string, method: string): Promise<unknown> =>
+        gate.call(
+          'demo',
+          method,
+          {},
+          { origin: 'agent', sessionId: 'copy-session', specialistId: id }
+        )
+      await expect(call(source.id, 'read')).resolves.toEqual({ ok: true })
+      await expect(call(source.id, 'danger')).rejects.toThrow('specialist_capability_denied')
+      dispatch.mockClear()
+      await expect
+        .soft(call(String(document.specialists[1].id), 'danger'))
+        .rejects.toThrow('specialist_capability_denied')
+      expect.soft(dispatch).not.toHaveBeenCalled()
+      expect(document.specialists[1]).toMatchObject({
+        fullAccess: source.fullAccess,
+        selectedCapabilities: source.selectedCapabilities
+      })
+    }
+  )
+})

--- a/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
@@ -1663,6 +1663,8 @@ describe('SpecialistEditor', () => {
             selectedSkillIds: [],
             excludedConnectorIds: [],
             connectorIds: [],
+            fullConnectorTools: [],
+            selectedConnectorTools: [],
             baseRevision: 0
           },
           idTouched: false,

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -168,28 +168,20 @@ const SpecialistEditor = ({
     try {
       const trimmed = {
         displayName: form.name.trim(),
-        description: form.description.trim() || undefined,
-        systemPrompt: form.systemPrompt.trim() || undefined,
+        description: isEdit ? form.description.trim() : form.description.trim() || undefined,
+        systemPrompt: isEdit ? form.systemPrompt.trim() : form.systemPrompt.trim() || undefined,
         iconKey: form.iconKey,
         colorKey: form.colorKey,
         capabilityMode: form.capabilityMode,
         fullAccess: {
-          ...(editSpecialist?.fullAccess ?? {
-            excludedSkillIds: [],
-            excludedConnectorIds: [],
-            connectorTools: []
-          }),
           excludedSkillIds: form.excludedSkillIds,
-          excludedConnectorIds: form.excludedConnectorIds
+          excludedConnectorIds: form.excludedConnectorIds,
+          connectorTools: form.fullConnectorTools
         },
         selectedCapabilities: {
-          ...(editSpecialist?.selectedCapabilities ?? {
-            skillIds: [],
-            connectorIds: [],
-            connectorTools: []
-          }),
           skillIds: form.selectedSkillIds,
-          connectorIds: form.connectorIds
+          connectorIds: form.connectorIds,
+          connectorTools: form.selectedConnectorTools
         }
       }
       if (editSpecialist) {

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -2227,3 +2227,71 @@ describe('SpecialistsPanel Chat with agent', () => {
     expect(onNavigate).not.toHaveBeenCalled()
   })
 })
+
+describe('S04 explicit Specialist refresh controls', () => {
+  it.each(['read failure', 'repaired file'])(
+    'Retry reads an already loaded catalog after %s',
+    async (scenario) => {
+      useSpecialistStore.setState(
+        scenario === 'read failure'
+          ? {
+              loadError: 'Open Science could not load Specialists. Retry to continue.'
+            }
+          : {
+              integrity: {
+                status: 'degraded',
+                issues: [{ code: 'record-sanitized', recordIndex: 0 }]
+              }
+            }
+      )
+      await act(async () =>
+        root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+      )
+      expect(window.api.specialist.list).not.toHaveBeenCalled()
+      const retry = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Retry'
+      )!
+      expect(retry).toBeDefined()
+      await act(async () => fireEvent.click(retry))
+      expect(window.api.specialist.list).toHaveBeenCalledOnce()
+      expect(useSpecialistStore.getState()).toMatchObject({
+        loadError: undefined,
+        integrity: { status: 'ok' }
+      })
+    }
+  )
+
+  it('Reload fetches and adopts the latest revision after a conflict', async () => {
+    vi.mocked(window.api.specialist.update).mockRejectedValueOnce(
+      new Error('Revision conflict: expected 1, found 2.')
+    )
+    const fresh = { ...specialistItems[0], revision: 2, description: 'Fresh server description' }
+    vi.mocked(window.api.specialist.list).mockResolvedValue({
+      items: [fresh],
+      integrity: { status: 'ok' }
+    })
+    await act(async () =>
+      root.render(
+        <SpecialistsPanel view={{ kind: 'edit', id: 'rna-reviewer' }} onNavigate={vi.fn()} />
+      )
+    )
+    const click = async (text: string): Promise<void> => {
+      const button = Array.from(container.querySelectorAll('button')).find(
+        (candidate) => candidate.textContent === text
+      )!
+      expect(button).toBeDefined()
+      await act(async () => fireEvent.click(button))
+    }
+    await click('Save changes')
+    await click('Reload')
+    expect(window.api.specialist.list).toHaveBeenCalledOnce()
+    expect(container.querySelector<HTMLInputElement>('#sp-description')!.value).toBe(
+      'Fresh server description'
+    )
+    vi.mocked(window.api.specialist.update).mockResolvedValue(fresh as never)
+    await click('Save changes')
+    expect(window.api.specialist.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({ revision: 2 })
+    )
+  })
+})

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -795,7 +795,7 @@ const InstalledSpecialistsPanel = ({
             onReload={async () => {
               // Load the fresh list and read the result from the store directly —
               // not from the render closure, which captured the pre-load items.
-              await load()
+              await load({ force: true })
               const refreshed = useSpecialistStore
                 .getState()
                 .items.find((item) => item.kind === 'custom' && item.id === view.id)
@@ -1548,7 +1548,7 @@ const InstalledSpecialistsPanel = ({
             variant="outline"
             size="sm"
             className="mt-3"
-            onClick={() => void load()}
+            onClick={() => void load({ force: true })}
           >
             {t('Retry')}
           </Button>
@@ -1570,7 +1570,12 @@ const InstalledSpecialistsPanel = ({
             </div>
           </div>
           <div className="mt-3 flex gap-2">
-            <Button type="button" variant="outline" size="sm" onClick={() => void load()}>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void load({ force: true })}
+            >
               {t('Retry')}
             </Button>
             <Button
@@ -2432,7 +2437,7 @@ const InstalledSpecialistsPanel = ({
                       }
                     } catch (err) {
                       // Reload the list so a retry picks up the current revision.
-                      void load()
+                      void load({ force: true })
                       setDeleteError(
                         err instanceof Error
                           ? err.message

--- a/src/renderer/src/pages/settings/useSpecialistEditorForm.ts
+++ b/src/renderer/src/pages/settings/useSpecialistEditorForm.ts
@@ -21,6 +21,8 @@ export const formFromProfile = (profile: SpecialistView): SpecialistEditorFormDr
   selectedSkillIds: profile.selectedCapabilities.skillIds,
   excludedConnectorIds: profile.fullAccess.excludedConnectorIds,
   connectorIds: profile.selectedCapabilities.connectorIds,
+  fullConnectorTools: profile.fullAccess.connectorTools,
+  selectedConnectorTools: profile.selectedCapabilities.connectorTools,
   // Pin base revision so concurrent remote writes do not silently refresh it.
   // Only a successful save or an explicit Reload may update it.
   baseRevision: profile.revision
@@ -41,6 +43,8 @@ export const formFromCreateInput = (
   selectedSkillIds: input?.selectedCapabilities?.skillIds ?? [],
   excludedConnectorIds: input?.fullAccess?.excludedConnectorIds ?? [],
   connectorIds: input?.selectedCapabilities?.connectorIds ?? [],
+  fullConnectorTools: input?.fullAccess?.connectorTools ?? [],
+  selectedConnectorTools: input?.selectedCapabilities?.connectorTools ?? [],
   baseRevision: 0
 })
 
@@ -77,7 +81,7 @@ export const useSpecialistEditorForm = ({
   // Editor drafts survive unmounts — opening a capability's detail page navigates Settings away —
   // so a returning editor re-seeds from the draft instead of the stored profile. A draft restores
   // only while the profile revision it was taken from still matches; the create form additionally
-  // yields to a provided initialInput (e.g. a marketplace import's prefill) so an abandoned
+  // yields to a new initialInput (e.g. a marketplace import's prefill) so an abandoned
   // earlier draft cannot swallow the new prefill.
   const draftKey = editSpecialist ? editSpecialist.id : CREATE_SPECIALIST_DRAFT_KEY
   const storedDraft = useSpecialistStore.getState().editorDrafts[draftKey]
@@ -85,7 +89,7 @@ export const useSpecialistEditorForm = ({
     storedDraft !== undefined &&
     (editSpecialist !== undefined
       ? storedDraft.form.baseRevision === editSpecialist.revision
-      : initialInput === undefined)
+      : initialInput === undefined || storedDraft.initialInput === initialInput)
       ? storedDraft
       : undefined
   const [form, setForm] = useState<SpecialistEditorFormDraft>(() =>
@@ -112,8 +116,8 @@ export const useSpecialistEditorForm = ({
       suppressDraftWriteRef.current = false
       return
     }
-    saveEditorDraft(draftKey, { form, idTouched, activeCapTab })
-  }, [saveEditorDraft, draftKey, form, idTouched, activeCapTab])
+    saveEditorDraft(draftKey, { form, idTouched, activeCapTab, initialInput })
+  }, [saveEditorDraft, draftKey, form, idTouched, activeCapTab, initialInput])
 
   const clearDraft = useCallback(() => clearEditorDraft(draftKey), [clearEditorDraft, draftKey])
   const suppressNextDraftWrite = useCallback(() => {

--- a/src/renderer/src/stores/specialist-store.test.ts
+++ b/src/renderer/src/stores/specialist-store.test.ts
@@ -113,7 +113,7 @@ describe('specialist store catalog', () => {
             }>((resolve) => (resolveInitial = resolve))
         )
         .mockResolvedValueOnce({ items: refreshedItems, integrity: { status: 'ok' } }),
-      setEnabled: vi.fn().mockResolvedValue(undefined)
+      setEnabled: vi.fn().mockResolvedValue({ id: 'researcher' })
     })
 
     const initialLoad = useSpecialistStore.getState().load()
@@ -380,8 +380,8 @@ describe('S04 and S05 catalog recovery regressions', () => {
       .getState()
       .update({ id: profile.id, revision: 1, description: 'Updated' })
     await vi.waitFor(() => expect(useSpecialistStore.getState().loadError).toBeDefined())
-    // This is the public action currently invoked by the Retry button.
-    await useSpecialistStore.getState().load()
+    // The explicit action wired to Retry bypasses the cached mount load.
+    await useSpecialistStore.getState().load({ force: true })
     expect(list).toHaveBeenCalledTimes(3)
     expect(useSpecialistStore.getState().loadError).toBeUndefined()
     expect(useSpecialistStore.getState().items).toEqual([{ kind: 'custom', ...profile }])
@@ -415,6 +415,12 @@ describe('S04 and S05 catalog recovery regressions', () => {
           installable: true
         }
       })
+      useSpecialistStore.setState({
+        items: [
+          { ...profile, enabled: false, kind: 'custom' },
+          { kind: 'reviewer', id: 'reviewer' }
+        ]
+      })
       const store = useSpecialistStore.getState()
       const result =
         operation === 'create'
@@ -438,6 +444,16 @@ describe('S04 and S05 catalog recovery regressions', () => {
       expect(
         { create, setEnabled, delete: remove, installPackage }[operation]
       ).toHaveBeenCalledOnce()
+      expect(useSpecialistStore.getState().items).toEqual(
+        operation === 'delete'
+          ? [{ kind: 'reviewer', id: 'reviewer' }]
+          : [
+              { ...profile, kind: 'custom' },
+              { kind: 'reviewer', id: 'reviewer' }
+            ]
+      )
+      if (operation === 'installPackage')
+        expect(useSpecialistStore.getState().packagePreview).toBeUndefined()
     }
   )
 })
@@ -468,4 +484,27 @@ it('S05 a committed create remains successful even when catalog enrichment fails
   } finally {
     await rm(directory, { recursive: true, force: true })
   }
+})
+
+it('keeps the forced snapshot when an older initial load finishes last', async () => {
+  let finishInitial!: (value: unknown) => void
+  const fresh = { items: [{ kind: 'reviewer', id: 'reviewer' }], integrity: { status: 'ok' } }
+  const list = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishInitial = resolve
+        })
+    )
+    .mockResolvedValueOnce(fresh)
+  setSpecialistApi({ list })
+  const initial = useSpecialistStore.getState().load()
+  await useSpecialistStore.getState().load({ force: true })
+  finishInitial({ items: [], integrity: { status: 'ok' } })
+  await initial
+  expect(list).toHaveBeenCalledTimes(2)
+  expect(useSpecialistStore.getState().items).toEqual(fresh.items)
+  await useSpecialistStore.getState().load()
+  expect(list).toHaveBeenCalledTimes(2)
 })

--- a/src/renderer/src/stores/specialist-store.test.ts
+++ b/src/renderer/src/stores/specialist-store.test.ts
@@ -1,3 +1,8 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { SpecialistService } from '../../../main/specialist/service'
+import { SpecialistRepository } from '../../../main/specialist/repository'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SpecialistExportPreview } from '../../../shared/specialist-package'
@@ -348,4 +353,119 @@ describe('specialist store package import', () => {
       setupPending: true
     })
   })
+})
+
+describe('S04 and S05 catalog recovery regressions', () => {
+  const profile = {
+    id: 'confirmed',
+    name: 'Confirmed',
+    description: '',
+    systemPrompt: '',
+    enabled: true,
+    capabilityMode: 'full' as const,
+    fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+    selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+    revision: 1
+  }
+
+  it('S04 Retry reads again after an already-loaded catalog refresh fails', async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [], integrity: { status: 'ok' } })
+      .mockRejectedValueOnce(new Error('catalog enrichment unavailable'))
+      .mockResolvedValue({ items: [{ kind: 'custom', ...profile }], integrity: { status: 'ok' } })
+    setSpecialistApi({ list, update: vi.fn().mockResolvedValue(profile) })
+    await useSpecialistStore.getState().load()
+    await useSpecialistStore
+      .getState()
+      .update({ id: profile.id, revision: 1, description: 'Updated' })
+    await vi.waitFor(() => expect(useSpecialistStore.getState().loadError).toBeDefined())
+    // This is the public action currently invoked by the Retry button.
+    await useSpecialistStore.getState().load()
+    expect(list).toHaveBeenCalledTimes(3)
+    expect(useSpecialistStore.getState().loadError).toBeUndefined()
+    expect(useSpecialistStore.getState().items).toEqual([{ kind: 'custom', ...profile }])
+  })
+
+  it.each(['create', 'setEnabled', 'delete', 'installPackage'] as const)(
+    'S05 %s retains its successful write receipt when the subsequent list fails',
+    async (operation) => {
+      const list = vi.fn().mockRejectedValue(new Error('catalog enrichment unavailable'))
+      const create = vi.fn().mockResolvedValue(profile)
+      const setEnabled = vi.fn().mockResolvedValue(profile)
+      const remove = vi.fn().mockResolvedValue({ status: 'deleted' })
+      const installPackage = vi.fn().mockResolvedValue({ status: 'installed', specialist: profile })
+      setSpecialistApi({ list, create, setEnabled, delete: remove, installPackage })
+      useSpecialistStore.setState({
+        packagePreview: {
+          candidateToken: 'candidate',
+          summary: {
+            id: profile.id,
+            name: profile.name,
+            version: '0.1.0',
+            description: '',
+            source: 'zip',
+            skills: [],
+            bundledSkillIds: [],
+            requiredSkillIds: [],
+            builtinSkillIds: [],
+            connectorIds: []
+          },
+          diagnostics: [],
+          installable: true
+        }
+      })
+      const store = useSpecialistStore.getState()
+      const result =
+        operation === 'create'
+          ? store.create({ name: profile.name })
+          : operation === 'setEnabled'
+            ? store.setEnabled(profile.id, true)
+            : operation === 'delete'
+              ? store.delete(profile.id, 1, [])
+              : store.installPackage()
+      await expect(result).resolves.toEqual(
+        operation === 'create'
+          ? profile
+          : operation === 'setEnabled'
+            ? undefined
+            : operation === 'delete'
+              ? { status: 'deleted' }
+              : { status: 'installed', specialist: profile }
+      )
+      await vi.waitFor(() => expect(useSpecialistStore.getState().loadError).toBeDefined())
+      expect(list).toHaveBeenCalledOnce()
+      expect(
+        { create, setEnabled, delete: remove, installPackage }[operation]
+      ).toHaveBeenCalledOnce()
+    }
+  )
+})
+
+it('S05 a committed create remains successful even when catalog enrichment fails', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'specialist-create-receipt-'))
+  try {
+    const service = new SpecialistService(new SpecialistRepository(directory))
+    setSpecialistApi({
+      create: (input) => service.create(input),
+      list: vi.fn().mockRejectedValue(new Error('catalog enrichment unavailable'))
+    })
+    const result = await useSpecialistStore
+      .getState()
+      .create({ name: 'Durable example' })
+      .then(
+        (value) => ({ value, error: undefined }),
+        (error) => ({ value: undefined, error })
+      )
+    const document = JSON.parse(await readFile(join(directory, 'specialists.json'), 'utf8'))
+    expect(document.specialists).toHaveLength(1)
+    expect(document.specialists[0].name).toBe('Durable example')
+    await expect(service.create({ name: 'Durable example' })).rejects.toThrow(
+      'Name is already in use'
+    )
+    expect(result.error).toBeUndefined()
+    expect(result.value).toMatchObject({ id: document.specialists[0].id })
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 })

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -4,7 +4,8 @@ import type {
   SpecialistDocumentIntegrity,
   SpecialistView,
   CreateSpecialistInput,
-  UpdateSpecialistInput
+  UpdateSpecialistInput,
+  ConnectorToolRule
 } from '../../../shared/specialist'
 import type {
   SpecialistPackageCandidatePreview,
@@ -34,11 +35,14 @@ export type SpecialistEditorFormDraft = {
   selectedSkillIds: string[]
   excludedConnectorIds: string[]
   connectorIds: string[]
+  fullConnectorTools: ConnectorToolRule[]
+  selectedConnectorTools: ConnectorToolRule[]
   baseRevision: number
 }
 
 export type SpecialistEditorDraft = {
   form: SpecialistEditorFormDraft
+  initialInput?: CreateSpecialistInput
   idTouched: boolean
   activeCapTab: 'skills' | 'connectors'
 }
@@ -54,7 +58,7 @@ type SpecialistStoreData = {
 }
 
 type SpecialistStoreActions = {
-  load: () => Promise<void>
+  load: (options?: { force?: boolean }) => Promise<void>
   create: (input: CreateSpecialistInput) => Promise<SpecialistView>
   update: (input: UpdateSpecialistInput) => Promise<SpecialistView>
   setEnabled: (id: string, enabled: boolean) => Promise<void>
@@ -113,6 +117,25 @@ const refreshCatalog = async (set: StoreApi<SpecialistStore>['setState']): Promi
   }
 }
 
+// Mutation receipts are authoritative even if the broader catalog cannot be enriched.
+const applySpecialistReceipt = (
+  set: StoreApi<SpecialistStore>['setState'],
+  view: SpecialistView
+): void => {
+  set((state) => {
+    const exists = state.items.some((item) => item.kind === 'custom' && item.id === view.id)
+    return {
+      items: exists
+        ? state.items.map((item) =>
+            item.kind === 'custom' && item.id === view.id
+              ? { ...item, ...view, kind: 'custom' as const }
+              : item
+          )
+        : [{ ...view, kind: 'custom' as const }, ...state.items]
+    }
+  })
+}
+
 const useSpecialistStore = create<SpecialistStore>((set) => ({
   items: [],
   isLoaded: false,
@@ -122,7 +145,7 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
   exportPreview: undefined,
   editorDrafts: {},
 
-  load: () => {
+  load: (options) => {
     // Guard: specialist.list is Electron-only and unavailable in the web gateway.
     if (typeof window.api?.specialist?.list !== 'function') {
       latestCatalogRequest += 1
@@ -132,8 +155,10 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
     removeCatalogChangedListener ??= window.api.specialist.onCatalogChanged?.(() => {
       void refreshCatalog(set).catch(() => undefined)
     })
-    if (useSpecialistStore.getState().isLoaded) return Promise.resolve()
-    if (catalogLoadRequest) return catalogLoadRequest
+    if (!options?.force) {
+      if (useSpecialistStore.getState().isLoaded) return Promise.resolve()
+      if (catalogLoadRequest) return catalogLoadRequest
+    }
     const request = refreshCatalog(set)
     const trackedRequest = request.finally(() => {
       if (catalogLoadRequest === trackedRequest) catalogLoadRequest = undefined
@@ -150,8 +175,8 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
       throw new Error(SPECIALIST_DOCUMENT_READ_ONLY_ERROR)
     }
     const view = await window.api.specialist.create(input)
-    // Reload the full list so Reviewer and ordering stay consistent.
-    await refreshCatalog(set)
+    applySpecialistReceipt(set, view)
+    void refreshCatalog(set).catch(() => undefined)
     return view
   },
 
@@ -160,13 +185,7 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
       throw new Error(SPECIALIST_DOCUMENT_READ_ONLY_ERROR)
     }
     const view = await window.api.specialist.update(input)
-    // The mutation result is authoritative for this custom Specialist. Apply it immediately so a
-    // slow catalog enrichment cannot leave an already-saved appearance stuck in its loading state.
-    set((state) => ({
-      items: state.items.map((item) =>
-        item.kind === 'custom' && item.id === view.id ? { ...item, ...view, kind: 'custom' } : item
-      )
-    }))
+    applySpecialistReceipt(set, view)
     // Keep derived catalog fields and ordering synchronized without making mutation completion depend
     // on the broader catalog read. Catalog-change events may race this refresh; request IDs ensure
     // only the newest response is applied.
@@ -178,8 +197,9 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
     if (useSpecialistStore.getState().integrity.status === 'degraded') {
       throw new Error(SPECIALIST_DOCUMENT_READ_ONLY_ERROR)
     }
-    await window.api.specialist.setEnabled({ id, enabled })
-    await refreshCatalog(set)
+    const view = await window.api.specialist.setEnabled({ id, enabled })
+    applySpecialistReceipt(set, view)
+    void refreshCatalog(set).catch(() => undefined)
   },
 
   previewDelete: async (id: string) => window.api.specialist.previewDelete({ id }),
@@ -190,7 +210,8 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
     }
     const result = await window.api.specialist.delete({ id, expectedRevision, deleteSkillIds })
     if (result.status === 'deleted') {
-      await refreshCatalog(set)
+      set((state) => ({ items: state.items.filter((item) => item.id !== id) }))
+      void refreshCatalog(set).catch(() => undefined)
     }
     return result
   },
@@ -217,8 +238,9 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
       ...options
     })
     if (result.status === 'installed') {
-      await refreshCatalog(set)
+      applySpecialistReceipt(set, result.specialist)
       set({ packagePreview: undefined })
+      void refreshCatalog(set).catch(() => undefined)
     }
     return result
   },


### PR DESCRIPTION
## Problem

Specialist copies lose method restrictions, malformed persisted capability rules can become runnable, and editor/catalog operations can report results that disagree with saved state. Clearing a description or system prompt retains its previous value; Retry/Reload can reuse stale data; a failed list after a successful mutation incorrectly rejects the operation.

## Proposed change

- Preserve both capability rule collections through editor prefills, drafts, mode changes, and detail navigation. Send explicit empty strings when clearing existing text.
- Track invalid capability record IDs only in repository read snapshots. All three runnable resolvers exclude those records while Settings retains diagnostics and healthy neighbors remain available. Reuse existing method-rule bounds.
- Force actual reads for explicit Retry/Reload, retaining ordinary mount caching and request-order protection.
- Apply authoritative create/update/enable/install receipts (and confirmed deletions) locally before independent catalog enrichment. Reuse the existing catalog error and Retry UI.

## Scope and non-goals

No persisted fields, schema/version changes, migrations, or new state enum values. Valid v1/v2 omitted optional fields retain existing defaults; reads never rewrite damaged files. Previously widened copies cannot be reconstructed automatically. New data is transient: two draft rule arrays, prefill provenance, and repository validity metadata. No full method editor, stale-draft merge/history, provider protocol changes, or new dependencies.

## Acceptance criteria and validation

Production-unmodified commit `49c5d83` contains reproductions: two runs each produced 136 passing tests and 22 failures with causes matching the reports. Tests cross the real editor/service/repository and ConnectorService gate; the existing MCP dispatch dependency is stubbed, so no external tools run. The fix makes these tests pass and adds historical-default, healthy-neighbor, both-mode, confirmed-local-state, and stale-response controls.

The final combined Test Impact Set passed 1,664 tests with 47 RUN_KERNEL-gated cases skipped. A follow-up with `RUN_KERNEL=1` passed all 73 tests in those two suites (including the 47 previously skipped cases): **1,711 distinct selected tests passed, 0 failures, none left skipped**. Both runs occurred after the last source/test edit. The following project-owned files constitute that run:

| Behavior | Root command selecting the checks | Final result |
| --- | --- | --- |
| Text clearing, copied permissions, draft restoration | `npm test -- src/renderer/src/pages/settings/SpecialistEditor{,.persistence}.render.test.tsx` | Pass |
| Explicit Retry/Reload and successful mutation receipts | `npm test -- src/renderer/src/stores/specialist-store.test.ts src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx` | Pass |
| Corrupt-record rejection, history/defaults, binding, identity, package/IPC contracts, actual tool gate | `npm test -- src/main/specialist src/main/connectors/service.test.ts` | Pass |
| Agent, delegation, ACP and authenticated REPL consumers | `npm test -- src/main/agents/{specialist-approval-gateway.test.ts,specialist-privileged-ops.test.ts,agents-repl.privileged.integration.test.ts} src/main/delegation/{specialist-runtime-consumption.test.ts,session-record-adapter.test.ts,durable-delegated-work.test.ts} src/main/acp/runtime-coordinator.test.ts src/main/notebook/repl-loop.integration.test.ts` | Pass |
| Renderer translation contracts | `npm test -- src/renderer/src/i18n/resources.test.ts` | Pass |
| Affected process types and lint | `npm run typecheck`; `npm run lint` | Pass |

Additional consumer command: `RUN_KERNEL=1 npm test -- src/main/agents/agents-repl.privileged.integration.test.ts src/main/notebook/repl-loop.integration.test.ts` → 73 passed, 0 skipped.

Local RPC consumers require permission to create local sockets; their initial sandbox EPERM failures passed in the final run with that permission. No complete local npm test was run, as requested by the maintainer. Specialist ownership is not yet declared in the Module manifest, so the explain plan selects full CI rather than pretending a curated module plan covers it.

An isolated Electron/Playwright preview of the real components and styles verified clear/save/reopen, duplicate/create with injected list failure, preserved rules, and Retry recovery; three screenshots were inspected. Its API uses fixture data, so this is UI interaction evidence, not a full packaged-application E2E claim. Persistence is independently covered by the tests above. Screenshot/plan artifacts remain local.

## Review focus

- Every runtime capability consumer continues through the existing runnable resolver facade; management reads retain recoverable data.
- Valid missing historical fields must remain distinct from malformed present fields. Diagnostic metadata must never enter specialists.json.
- Explicit refresh races must not restore older snapshots, and enrichment errors must not reverse successful operation receipts.
- Final selected CI/platform lanes and independent automated review remain authoritative. Live external-provider execution and cross-platform desktop screenshots were not exercised locally.
