### PR TITLE
fix(ci): apply Windows test budgets to every Vitest project

### DIFF
--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -16,6 +16,7 @@ on:
         options:
           - full
           - notebook-sandbox
+          - regressions
 
 permissions:
   actions: read
@@ -58,13 +59,15 @@ jobs:
   windows_full_test:
     name: Windows full test (${{ matrix.shard }}/3)
     needs: plan
-    if: ${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode == 'full') }}
+    if: ${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode != 'notebook-sandbox') }}
     runs-on: windows-latest
     timeout-minutes: 35
+    env:
+      VITEST_WINDOWS_FULL_TEST: '1'
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: ${{ fromJSON(inputs.mode == 'regressions' && '[1]' || '[1,2,3]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -80,6 +83,7 @@ jobs:
         run: node scripts/ci/npm-ci.mjs
 
       - name: Test complete suite shard
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'full' }}
         # SQLite-heavy integration suites contend heavily for Windows disk I/O when Vitest uses
         # every available core, and hosted-runner disk latency occasionally exceeds the default
         # per-test/hook budgets. Keep files serial and use bounded 60-second budgets; individual
@@ -87,10 +91,26 @@ jobs:
         # slow serial suite without treating a still-progressing shard as a hang.
         run: npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
 
+      - name: Test recent Windows regressions
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'regressions' }}
+        # Reuse the full job's runner, install and effective project budgets without running the
+        # unrelated shards or native sandbox. These are the suites from the recent failed batches.
+        run: >-
+          npm test --
+          vitest.config.test.ts
+          scripts/ci/release-workflows.test.ts
+          src/main/database/database-null-and-version-bounds.test.ts
+          src/main/database/migration-service.test.ts
+          src/main/notebook/runtime-service.test.ts
+          src/main/artifacts/provenance-repository.test.ts
+          src/main/artifacts/provenance-write-contract.test.ts
+          src/main/delegation/production-composition.test.ts
+          --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
+
   notebook_sandbox:
     name: Windows Notebook sandbox lifecycle
     needs: plan
-    if: needs.plan.outputs.should_test == 'true'
+    if: ${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode != 'regressions') }}
     runs-on: windows-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -99,6 +99,7 @@ jobs:
           npm test --
           vitest.config.test.ts
           scripts/ci/release-workflows.test.ts
+          scripts/windows-release-workflows.test.ts
           src/main/database/database-null-and-version-bounds.test.ts
           src/main/database/migration-service.test.ts
           src/main/notebook/runtime-service.test.ts

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -57,14 +57,17 @@ describe('release and scheduled workflow topology', () => {
     const test = step(job, 'Test complete suite shard')
     const sandboxSmoke = step(sandbox, 'Test AppContainer ownership and removal lifecycle')
 
-    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])
+    expect(job.strategy?.matrix?.shard).toBe(
+      "${{ fromJSON(inputs.mode == 'regressions' && '[1]' || '[1,2,3]') }}"
+    )
+    expect(job.env).toMatchObject({ VITEST_WINDOWS_FULL_TEST: '1' })
     expect(test.run).toContain('--shard=${{ matrix.shard }}/3')
     expect(test.run).toContain('--maxWorkers=1')
     expect(windows.on).not.toHaveProperty('push')
     expect(schedule).toEqual([{ cron: '47 * * * *' }])
     expect(dispatch.inputs?.mode).toMatchObject({
       default: 'full',
-      options: ['full', 'notebook-sandbox']
+      options: ['full', 'notebook-sandbox', 'regressions']
     })
     expect(windows.permissions).toEqual({ actions: 'read', contents: 'read' })
     expect(plan).toMatchObject({
@@ -76,18 +79,37 @@ describe('release and scheduled workflow topology', () => {
     )
     expect(job).toMatchObject({
       needs: 'plan',
-      if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode == 'full') }}",
+      if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode != 'notebook-sandbox') }}",
       'timeout-minutes': 35
     })
     expect(sandbox).toMatchObject({
       needs: 'plan',
-      if: "needs.plan.outputs.should_test == 'true'",
+      if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode != 'regressions') }}",
       'runs-on': 'windows-latest',
       'timeout-minutes': 20
     })
     expect(sandboxSmoke.run).toContain('vendor/windows-src/ci/smoke.ps1')
     expect(sandboxSmoke.run).toContain('vendor/windows/x64/notebook-appcontainer-host.exe')
     expect(sandboxSmoke.run).toContain('-Mode Full')
+    expect(test.if).toBe("${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'full' }}")
+    const regressions = step(job, 'Test recent Windows regressions')
+    expect(regressions.if).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'regressions' }}"
+    )
+    expect(regressions.run).not.toContain('--shard')
+    expect(regressions.run).toContain('--maxWorkers=1 --testTimeout=60000 --hookTimeout=60000')
+    for (const file of [
+      'vitest.config.test.ts',
+      'scripts/ci/release-workflows.test.ts',
+      'src/main/database/database-null-and-version-bounds.test.ts',
+      'src/main/database/migration-service.test.ts',
+      'src/main/notebook/runtime-service.test.ts',
+      'src/main/artifacts/provenance-repository.test.ts',
+      'src/main/artifacts/provenance-write-contract.test.ts',
+      'src/main/delegation/production-composition.test.ts'
+    ]) {
+      expect(regressions.run).toContain(file)
+    }
   })
 
   it('runs a separate daily Windows resource soak with a focused manual smoke path', () => {

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -101,6 +101,7 @@ describe('release and scheduled workflow topology', () => {
     for (const file of [
       'vitest.config.test.ts',
       'scripts/ci/release-workflows.test.ts',
+      'scripts/windows-release-workflows.test.ts',
       'src/main/database/database-null-and-version-bounds.test.ts',
       'src/main/database/migration-service.test.ts',
       'src/main/notebook/runtime-service.test.ts',

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -100,7 +100,7 @@ describe('post-merge Windows validation', () => {
     expect(workflow.on?.schedule).toEqual([{ cron: '47 * * * *' }])
     expect(dispatch?.inputs?.mode).toMatchObject({
       default: 'full',
-      options: ['full', 'notebook-sandbox']
+      options: ['full', 'notebook-sandbox', 'regressions']
     })
     expect(workflow.on).not.toHaveProperty('workflow_call')
     expect(findStep(plan, 'Check for untested main changes').run).toContain(
@@ -108,18 +108,30 @@ describe('post-merge Windows validation', () => {
     )
     expect(job).toMatchObject({
       needs: 'plan',
-      if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode == 'full') }}",
+      if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode != 'notebook-sandbox') }}",
+      env: { VITEST_WINDOWS_FULL_TEST: '1' },
       'runs-on': 'windows-latest',
       'timeout-minutes': 35
     })
     expect(job['continue-on-error']).toBeUndefined()
-    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])
+    expect(job.strategy?.matrix).toEqual({
+      shard: "${{ fromJSON(inputs.mode == 'regressions' && '[1]' || '[1,2,3]') }}"
+    })
     expect(findStep(job, 'Test complete suite shard').run).toBe(
       'npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000'
     )
+    expect(findStep(job, 'Test complete suite shard').if).toBe(
+      "${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'full' }}"
+    )
+    const regressions = findStep(job, 'Test recent Windows regressions')
+    expect(regressions.if).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'regressions' }}"
+    )
+    expect(regressions.run).toContain('scripts/windows-release-workflows.test.ts')
+    expect(regressions.run).not.toContain('--shard')
     expect(sandbox).toMatchObject({
       needs: 'plan',
-      if: "needs.plan.outputs.should_test == 'true'",
+      if: "${{ needs.plan.outputs.should_test == 'true' && (github.event_name != 'workflow_dispatch' || inputs.mode != 'regressions') }}",
       'runs-on': 'windows-latest',
       'timeout-minutes': 20
     })

--- a/src/main/database/database-null-and-version-bounds.test.ts
+++ b/src/main/database/database-null-and-version-bounds.test.ts
@@ -229,7 +229,8 @@ describe('D02/D04 persisted database boundaries', () => {
 
   afterEach(async () => {
     await client?.$disconnect()
-    if (root) await rm(root, { recursive: true, force: true })
+    // Windows may briefly retain the SQLite file handle after Prisma disconnects.
+    if (root) await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   })
 
   describe('current schema', () => {

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -1,4 +1,5 @@
 import { availableParallelism, cpus } from 'node:os'
+import { spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
@@ -90,7 +91,45 @@ it('ratchets full coverage without raising selective changed-source thresholds',
 })
 
 it('keeps a safe default timeout for schema-backed hooks', () => {
-  expect(vitestConfig.test?.hookTimeout).toBe(30_000)
+  expect(vitestConfig.test?.hookTimeout).toBe(
+    process.env.VITEST_WINDOWS_FULL_TEST === '1' ? 60_000 : 30_000
+  )
+})
+
+it.each(['0', '1'])('resolves real Vitest project budgets with Windows profile %s', (profile) => {
+  const probe = spawnSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `import { createVitest } from 'vitest/node'
+       const ctx = await createVitest('test', {
+         watch: false, hookTimeout: 60000, testTimeout: 60000, maxWorkers: 1
+       })
+       try {
+         console.log(JSON.stringify(ctx.projects.map(({ name, config }) => ({
+           name, hookTimeout: config.hookTimeout, maxWorkers: config.maxWorkers,
+           testTimeout: config.testTimeout
+         }))))
+       } finally { await ctx.close() }`
+    ],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, VITEST_WINDOWS_FULL_TEST: profile },
+      encoding: 'utf8',
+      timeout: 30_000
+    }
+  )
+  expect(probe.error).toBeUndefined()
+  expect(probe.status, probe.stderr).toBe(0)
+  expect(JSON.parse(probe.stdout)).toEqual(
+    ['default', 'architecture', 'process', 'database'].map((name) => ({
+      name,
+      hookTimeout: profile === '1' ? 60_000 : 30_000,
+      maxWorkers: profile === '1' || name !== 'default' ? 1 : resolveVitestMaxWorkers(),
+      testTimeout: 60_000
+    }))
+  )
 })
 
 it('prints captured console output only for failed tests', () => {
@@ -103,8 +142,9 @@ it('pins the full-suite worker cap to the machine rather than leaving it unbound
   expect(resolveVitestMaxWorkers(8)).toBe(7)
   expect(resolveVitestMaxWorkers(1)).toBe(1)
   expect(resolveVitestMaxWorkers(0)).toBe(1)
-  expect(vitestConfig.test?.maxWorkers).toBe(resolveVitestMaxWorkers())
-  expect(vitestConfig.test?.maxWorkers).toBe(Math.max(available - 1, 1))
+  expect(vitestConfig.test?.maxWorkers).toBe(
+    process.env.VITEST_WINDOWS_FULL_TEST === '1' ? 1 : Math.max(available - 1, 1)
+  )
 })
 
 type VitestProjectTest = {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, configDefaults } from 'vitest/config'
 
 const testRoot = resolve('.')
 const sharedInstallRoot = basename(dirname(testRoot)) === '.worktree' ? resolve('../..') : testRoot
+const windowsFullTest = process.env.VITEST_WINDOWS_FULL_TEST === '1'
 
 export function resolveVitestMaxWorkers(
   available = typeof availableParallelism === 'function' ? availableParallelism() : cpus().length
@@ -170,12 +171,12 @@ export default defineConfig({
     // shared CI runner, so a fast fully-mocked test can still be CPU-starved past 5s and time out
     // spuriously. 15s absorbs that contention without masking a genuine hang (real work is far slower).
     testTimeout: 15000,
-    // Schema-backed hooks can exceed Vitest's 10s default on loaded runners. Keep a safe repository
-    // default while allowing slower platform workflows to raise it explicitly from the CLI.
-    hookTimeout: 30000,
+    // Inline projects inherit these values before root CLI overrides are applied. Set the Windows
+    // budget here so every project's hooks actually receive the workflow's intended 60 seconds.
+    hookTimeout: windowsFullTest ? 60000 : 30000,
     // Pin the pool to Vitest's own CPU-minus-one bound so full-suite runs cannot spawn an unbounded
     // set of short-lived workers. Heavy files below run in later groups and do not share that pool.
-    maxWorkers: resolveVitestMaxWorkers(),
+    maxWorkers: windowsFullTest ? 1 : resolveVitestMaxWorkers(),
     projects: [
       {
         extends: true,


### PR DESCRIPTION
## Problem

Windows Full Test passed `--hookTimeout=60000 --maxWorkers=1`, but Vitest's inline projects
inherited the root configuration before those CLI overrides. The effective hook budget stayed at
30 seconds and the default project retained CPU-minus-one workers. Recent scheduled batches
show database fixture timeouts and timing-sensitive Notebook/artifact/delegation failures under
this unintended contention.
The latest batch also hit a transient Windows EBUSY while removing a disconnected test database.

## Proposed change

Set the Windows job's inherited Vitest budgets through an explicit workflow environment profile,
and check the effective settings by initializing real Vitest projects in a regression test. Keep
ordinary local and portable defaults. Retry temporary database removal at most five times after
disconnect. Add a `regressions` dispatch mode that runs the recently failing suites through the
same Windows job, installation, Node version and environment while skipping other shards and the
native sandbox lifecycle. Both existing Windows workflow contract suites cover the new topology,
and the focused invocation includes the previously omitted release-workflow contract.

## Scope and non-goals

- No runtime application logic, schema, migration, historical compatibility, persisted format,
  application state/enum, or UI/interaction changes. Historical database assertions are retained.
- `regressions` is a workflow scope choice only. The dry-run has read-only repository permissions
  and no publish, deploy, release or tag-mutation steps.
- One older batch also had an Electron download ECONNRESET. That separate transient transport
  failure is recorded; this patch does not introduce blanket dependency-install retries.

## Acceptance criteria and validation

After the final material edit (`756d940`), all **87 tests in six files** passed:
`vitest.config.test.ts`, `scripts/windows-release-workflows.test.ts`,
`scripts/ci/release-workflows.test.ts`, `scripts/ci/check-ci-integrity.test.ts`,
`scripts/ci/ci-integrity-workflow.test.ts`, and `scripts/ci/npm-ci.test.ts`.
The command used `VITEST_WINDOWS_FULL_TEST=1 npm test -- <those files>
--maxWorkers=1 --testTimeout=60000 --hookTimeout=60000`.
`npm run typecheck`, `npm run lint`, changed-file Prettier and `git diff --check` also passed
after that edit. This covers the changed contract assertions and their workflow consumer.

The following initial implementation evidence was recorded on `76c1841`. The subsequent change
only synchronizes the remaining test contract and adds it to the focused invocation; it does not
change the previously validated Vitest budgets, runtime code, or database cleanup:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Effective worker/hook budgets and full/focused workflow routing | `npm test -- vitest.config.test.ts scripts/ci/release-workflows.test.ts` with the Windows profile and workflow CLI budgets | 28 passed |
| Recent database, Notebook, artifact and delegation regressions | The eight explicit test files in `Test recent Windows regressions`, using the Windows profile and workflow CLI budgets | 624 tests passed across the initial run and a delegation-only rerun; initial delegation failures were sandbox `listen EPERM` and the unsandboxed rerun passed all 62 |
| Database temporary cleanup and historical migration contracts | `npm test -- src/main/database --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000` with `VITEST_WINDOWS_FULL_TEST=1` | 18 files / 282 tests passed |
| CI integrity and install helper contracts | `npm test -- scripts/ci/check-ci-integrity.test.ts scripts/ci/ci-integrity-workflow.test.ts scripts/ci/npm-ci.test.ts` | 45 passed |
| Main, sandbox and renderer types | `npm run typecheck` | Passed |
| Linted source/configuration | `npm run lint` | Passed |
| Changed-file formatting and patch whitespace | Prettier check of the five changed files; `git diff --check` | Passed |
| Actual Windows runner and SQLite cleanup | [Focused Windows dispatch](https://github.com/aipoch/open-science/actions/runs/33975970874) on `76c1841` | Success: 8 files, 618 passed / 5 existing platform skips; 765.46 seconds |

The final impact explain plan selects **full CI** because Vitest configuration and CI contract
tests are global gate inputs. Per maintainer instruction, local runs remain scoped by module and
explicit test files; the full local suite was not run. Relevant consumer suites are included in
the focused dispatch. Native sandbox work is unchanged and excluded from this dry-run; PR Gate
remains authoritative for the complete portable and platform plan. Full three-shard Windows wall
time and independent PR review remain CI evidence to assess, not claims from the focused run.

## Review focus

Confirm effective project settings (not merely CLI text), unchanged ordinary defaults, retained
database corruption/rollback assertions, and focused/full/native workflow selection.
