### PR TITLE
feat(notebook): show tool summaries in messages and approvals

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -553,6 +553,18 @@ colors communicate a successful or failed probe/migration result.
 
 ### Activity Stream
 
+- Notebook tool details use compact summary cards for runtime discovery, runtime binding, restart,
+  and state inspection; Artifact writes show file name, type and size without loading file bytes.
+  Keep the existing tool-row disclosure and put raw Notebook input/output behind collapsed detail
+  disclosures. Runtime paths in Message summaries are expandable; approval cards show exact targets.
+  Show failures directly with bounded diagnostic previews and an explicit truncation notice. A
+  failed activity must not confirm a successful restart. State summaries show recent runs and mark
+  compacted history; full history remains in the Notebook preview.
+- Permission cards for these operations summarize the requested action and its impact before
+  execution. Restart approvals explain variable loss and retained history. Artifact approvals retain
+  source paths and inspectable request metadata while omitting inline content bytes. Keep existing
+  Allow/Deny options, scopes, correlation, and submission behavior unchanged.
+
 - Outer shell: `ScrollArea className="min-w-0 flex-1"`.
 - Message scroller surface uses `bg-bg-10` with a top fade `bg-gradient-to-b from-bg-10 to-bg-10/0`.
 - Message content is centered in `mx-auto w-full max-w-4xl pb-[56px]`.

--- a/docs/design.md
+++ b/docs/design.md
@@ -553,7 +553,7 @@ colors communicate a successful or failed probe/migration result.
 
 ### Activity Stream
 
-- Notebook tool details use compact summary cards for runtime discovery, runtime binding, restart,
+- Notebook tool details use compact summary cards for runtime discovery, runtime binding/switching, restart,
   and state inspection; Artifact writes show file name, type and size without loading file bytes.
   Keep the existing tool-row disclosure and put raw Notebook input/output behind collapsed detail
   disclosures. Runtime paths in Message summaries are expandable; approval cards show exact targets.
@@ -561,7 +561,8 @@ colors communicate a successful or failed probe/migration result.
   failed activity must not confirm a successful restart. State summaries show recent runs and mark
   compacted history; full history remains in the Notebook preview.
 - Permission cards for these operations summarize the requested action and its impact before
-  execution. Restart approvals explain variable loss and retained history. Artifact approvals retain
+  execution. Restart approvals explain variable loss and retained history. Runtime switch approvals
+  explain that the selected language kernel loses its memory while other kernels are unaffected. Artifact approvals retain
   source paths and inspectable request metadata while omitting inline content bytes. Keep existing
   Allow/Deny options, scopes, correlation, and submission behavior unchanged.
 

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -10,6 +10,12 @@ import type { NotebookSessionRequest } from '../../../../shared/notebook'
 import { resolveProjectId } from '../../../../shared/project-scope'
 import { isEnvEnabled } from '../../../../shared/notebook-runtime'
 import { Badge } from '@/components/ui/badge'
+import {
+  buildNotebookToolSummary,
+  notebookInput,
+  type ToolSummary
+} from './notebook-tool-presentation'
+import { WorkspaceToolSummaryCard } from './WorkspaceToolSummaryCard'
 import { Button } from '@/components/ui/button'
 import { dialogTitleClassName } from '@/components/ui/dialog-chrome'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
@@ -760,6 +766,43 @@ const PermissionApprovalCard = ({
   const literatureSummary = isLiteratureReadRequest(request)
     ? buildLiteratureToolSummary(request.rawInput)
     : undefined
+  const notebookSummary = isMcpPermissionRequest(request)
+    ? buildNotebookToolSummary(request.mcpIdentity, request.rawInput, undefined, t, true)
+    : undefined
+  const fileInput = notebookInput(request.rawInput)
+  let fileSource = fileInput.source
+  if (typeof fileSource === 'string') {
+    try {
+      fileSource = JSON.parse(fileSource)
+    } catch {
+      /* Keep invalid input reviewable. */
+    }
+  }
+  const fileSourceRecord =
+    fileSource && typeof fileSource === 'object' && !Array.isArray(fileSource)
+      ? (fileSource as Record<string, unknown>)
+      : undefined
+  const filePath = fileSourceRecord?.path ?? fileInput.path
+  const fileSummary: ToolSummary | undefined = isArtifactWriteRequest(request)
+    ? {
+        title: t('Write file'),
+        subtitle: typeof fileInput.filename === 'string' ? fileInput.filename : undefined,
+        fields: [
+          ...(typeof fileInput.mimeType === 'string'
+            ? [{ label: t('Type'), value: fileInput.mimeType }]
+            : []),
+          ...(typeof filePath === 'string' ? [{ label: t('Path'), value: filePath }] : [])
+        ]
+      }
+    : undefined
+  // Preserve all request metadata for consent, without mounting inline file bytes in the DOM.
+  const fileDetails = fileSummary
+    ? JSON.stringify(
+        { ...fileInput, ...(fileSource !== undefined ? { source: fileSource } : {}) },
+        (key, value) => (key === 'content' ? `[${t('File content omitted')}]` : value),
+        2
+      )
+    : undefined
   const sourcePresentation = describePermissionRequest(request)
   const presentation: PermissionPresentation = {
     ...sourcePresentation,
@@ -968,7 +1011,23 @@ const PermissionApprovalCard = ({
       {/* Specialist switch/delete requests show a friendly detail block instead of the raw
           redacted payload; all other requests keep the activity-style code preview. Skill loads
           show the SKILL.md document itself — it is the payload being approved. */}
-      {literatureSummary ? (
+      {notebookSummary || fileSummary ? (
+        <div key={requestId} className="space-y-2">
+          <WorkspaceToolSummaryCard
+            summary={(notebookSummary ?? fileSummary)!}
+            file={Boolean(fileSummary)}
+          />
+          {fileDetails || (notebookSummary && permCode) ? (
+            <details className="text-xs text-text-300">
+              <summary className="cursor-pointer">{t('Input')}</summary>
+              <WorkspaceToolCodeBlock
+                code={fileDetails ?? permCode!.code}
+                language={fileDetails ? 'json' : permCode!.language}
+              />
+            </details>
+          ) : null}
+        </div>
+      ) : literatureSummary ? (
         <WorkspaceLiteratureToolCard summary={literatureSummary} />
       ) : isNotebookNetworkApprovalRequest(request) ? (
         <NotebookNetworkApprovalDetail request={request} />

--- a/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx
@@ -184,7 +184,7 @@ describe('WorkspaceToolDetailsRow', () => {
     })
     const details = buildToolActivityDetails(activity)
 
-    expect(details?.sections[0]?.kind).toBe('code')
+    expect(details?.sections[0]?.kind).toBe('summary')
 
     root = createRoot(container)
     await act(async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.tsx
@@ -20,6 +20,7 @@ import { WorkspaceToolActivityRowButton } from './WorkspaceToolActivityRowButton
 import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
 import { WorkspaceToolDiffBlock } from './WorkspaceToolDiffBlock'
 import { WorkspaceLiteratureToolCard } from './WorkspaceLiteratureToolCard'
+import { WorkspaceToolSummaryCard } from './WorkspaceToolSummaryCard'
 import type { ToolExecutionPhase } from './tool-execution-phase'
 import type { SessionTextAnnotationItemType } from '../../../../shared/annotations'
 import type { AnnotationPort } from './annotations/annotation-port'
@@ -173,6 +174,8 @@ const WorkspaceToolDetailsRow = ({
   }, [isNearViewport, notebookRunId, onNotebookRunNearViewport])
 
   const renderSection = (section: ToolDetailSection, index: number): React.JSX.Element => {
+    if (section.kind === 'summary')
+      return <WorkspaceToolSummaryCard key={index} summary={section.summary} file={section.file} />
     if (section.kind === 'literature') {
       return <WorkspaceLiteratureToolCard key={index} summary={section.summary} />
     }

--- a/src/renderer/src/pages/workspace/WorkspaceToolSummaryCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolSummaryCard.tsx
@@ -1,0 +1,95 @@
+import { FileText, FlaskConical, Info } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { ToolSummary } from './notebook-tool-presentation'
+
+const WorkspaceToolSummaryCard = ({
+  summary,
+  file = false
+}: {
+  summary: ToolSummary
+  file?: boolean
+}): React.JSX.Element => {
+  const Icon = file ? FileText : FlaskConical
+  const { t } = useTranslation()
+  const renderError = (error: string): React.JSX.Element => (
+    <div
+      role="status"
+      className="mt-2 rounded-md bg-status-failure-surface p-3 text-xs text-status-failure-foreground"
+    >
+      <p className="max-h-32 overflow-auto whitespace-pre-wrap break-words">
+        {error.slice(0, 2000)}
+      </p>
+      {error.length > 2000 ? <p className="mt-2">{t('Output truncated')}</p> : null}
+    </div>
+  )
+  return (
+    <section
+      data-testid="tool-summary-card"
+      aria-label={summary.title}
+      className="min-w-0 overflow-hidden rounded-xl border border-border-200 bg-bg-000"
+    >
+      <div className="flex items-center gap-3 border-b border-border-200/70 px-4 py-3">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Icon className="size-4" aria-hidden="true" />
+        </span>
+        <div className="min-w-0">
+          <h4 className="text-[13px] font-medium text-text-000">{summary.title}</h4>
+          {summary.subtitle ? (
+            <p className="break-words text-xs text-text-200">{summary.subtitle}</p>
+          ) : null}
+        </div>
+      </div>
+      {summary.fields.length ? (
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-5 gap-y-2 px-4 py-3 text-xs">
+          {summary.fields.map((field, index) => (
+            <div key={index} className="contents">
+              <dt className="text-text-300">{field.label}</dt>
+              <dd className="min-w-0 break-all text-text-100">
+                {field.expandable ? (
+                  <details>
+                    <summary className="cursor-pointer">
+                      {field.value.split(/[\\/]/u).filter(Boolean).slice(-2).join('/')}
+                    </summary>
+                    <p className="mt-2 text-text-300">{field.value}</p>
+                  </details>
+                ) : (
+                  field.value
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+      {summary.rows?.length ? (
+        <div className="divide-y divide-border-200/70 border-t border-border-200/70">
+          {summary.rows.map((row, index) => (
+            <div key={index} className="px-4 py-2.5">
+              <div className="flex items-start justify-between gap-3">
+                <span className="min-w-0 break-all text-xs font-medium text-text-100">
+                  {row.title}
+                </span>
+                {row.status ? (
+                  <span className="shrink-0 rounded bg-bg-200 px-1.5 py-0.5 text-[10px] text-text-200">
+                    {row.status}
+                  </span>
+                ) : null}
+              </div>
+              {row.detail ? (
+                <p className="mt-1 break-words text-[11px] text-text-300">{row.detail}</p>
+              ) : null}
+              {row.error ? renderError(row.error) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {summary.error ? <div className="m-3">{renderError(summary.error)}</div> : null}
+      {summary.note ? (
+        <div className="flex items-start gap-2 border-t border-border-200/70 bg-bg-100 px-4 py-3 text-[11px] leading-5 text-text-200">
+          <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+          <p>{summary.note}</p>
+        </div>
+      ) : null}
+    </section>
+  )
+}
+export { WorkspaceToolSummaryCard }

--- a/src/renderer/src/pages/workspace/notebook-tool-presentation.test.tsx
+++ b/src/renderer/src/pages/workspace/notebook-tool-presentation.test.tsx
@@ -41,14 +41,20 @@ it('does not confirm a restart when the final activity failed', () => {
     activity({
       title: 'open-science-notebook/notebook_restart',
       status: 'failed',
-      rawOutput: restart
+      rawOutput: {
+        ...restart,
+        note: 'Kernel restarted; in-memory variables cleared. Run history is preserved.'
+      }
     })
   )!
   const section = details.sections[0]
   if (section.kind !== 'summary') throw new Error('Expected a summary')
   expect(section.summary.note).toBeUndefined()
   expect(section.summary.fields).not.toContainEqual({ label: 'Status', value: 'Restarted' })
-  expect(section.summary.error).toBeTruthy()
+  expect(section.summary.error).toBe('Failed')
+  const html = renderToStaticMarkup(<WorkspaceToolSummaryCard summary={section.summary} />)
+  expect(html).not.toContain('Kernel restarted')
+  expect(html).not.toContain('variables cleared')
 })
 
 it('bounds visible error previews and marks truncation', () => {

--- a/src/renderer/src/pages/workspace/notebook-tool-presentation.test.tsx
+++ b/src/renderer/src/pages/workspace/notebook-tool-presentation.test.tsx
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ToolActivity } from '@/stores/session-store'
+import type { AcpPermissionRequest } from '../../../../shared/acp'
+import { buildToolActivityDetails } from './workspace-tool-activity-details'
+import { buildNotebookToolSummary, readNotebookToolResult } from './notebook-tool-presentation'
+import { WorkspaceToolDetailsRow } from './WorkspaceToolDetailsRow'
+import { PermissionApprovalControls } from './PermissionApprovalControls'
+import { WorkspaceToolSummaryCard } from './WorkspaceToolSummaryCard'
+
+const activity = (overrides: Partial<ToolActivity>): ToolActivity => ({
+  id: 'tool-1',
+  kind: 'tool',
+  title: '',
+  status: 'completed',
+  eventIds: [],
+  sortIndex: 1,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+const permission = (tool: string, rawInput: unknown = {}): AcpPermissionRequest => ({
+  requestId: 'request-1',
+  sessionId: 'session-1',
+  toolCallId: 'tool-1',
+  title: tool,
+  mcpIdentity: `open-science-notebook/${tool}`,
+  isMcp: true,
+  providerToolName: tool,
+  rawInput,
+  options: [
+    { optionId: 'allow', name: 'Allow once', kind: 'allow_once' },
+    { optionId: 'deny', name: 'Reject once', kind: 'reject_once' }
+  ]
+})
+
+const restart = { kernelStatus: 'idle', status: 'restarted', cells: 3 }
+it('does not confirm a restart when the final activity failed', () => {
+  const details = buildToolActivityDetails(
+    activity({
+      title: 'open-science-notebook/notebook_restart',
+      status: 'failed',
+      rawOutput: restart
+    })
+  )!
+  const section = details.sections[0]
+  if (section.kind !== 'summary') throw new Error('Expected a summary')
+  expect(section.summary.note).toBeUndefined()
+  expect(section.summary.fields).not.toContainEqual({ label: 'Status', value: 'Restarted' })
+  expect(section.summary.error).toBeTruthy()
+})
+
+it('bounds visible error previews and marks truncation', () => {
+  const html = renderToStaticMarkup(
+    <WorkspaceToolSummaryCard
+      summary={{
+        title: 'Notebook state',
+        fields: [],
+        error: 'x'.repeat(2100) + 'hidden-tail',
+        rows: [{ title: 'failed-cell', error: 'y'.repeat(2100) + 'hidden-tail' }]
+      }}
+    />
+  )
+  expect(html).toContain('Output truncated')
+  expect(html).not.toContain('hidden-tail')
+  expect(html).not.toContain('x'.repeat(2001))
+  expect(html).not.toContain('y'.repeat(2001))
+})
+it.each([
+  'mcp__open-science-notebook__notebook_restart',
+  'mcp__open_science_notebook__notebook_restart',
+  'open-science-notebook_notebook_restart',
+  'open_science_notebook_notebook_restart',
+  'mcp.open-science-notebook.notebook_restart',
+  'open-science-notebook/notebook_restart'
+])('renders a restart receipt for provider identity %s', (identity) => {
+  const item = activity({
+    title: identity,
+    rawOutput: {
+      result: { content: [{ type: 'text', text: JSON.stringify(restart) }] },
+      error: null
+    }
+  })
+  const details = buildToolActivityDetails(item)!
+  const html = renderToStaticMarkup(
+    <WorkspaceToolDetailsRow activity={item} details={details} isExpanded onToggle={vi.fn()} />
+  )
+  expect(html).toContain('tool-summary-card')
+  expect(html).toContain('Run history preserved')
+  expect(html).toContain('Idle')
+  expect(html).toContain('<details')
+  expect(html).not.toContain('<details open')
+})
+
+it('keeps lookalike servers on generic details', () => {
+  const details = buildToolActivityDetails(
+    activity({ title: 'mcp__open-science-notebook-staging__notebook_state', rawOutput: restart })
+  )
+  expect(details?.sections.some((section) => section.kind === 'summary')).toBe(false)
+})
+
+it('does not invent a successful restart from malformed or failed output', () => {
+  expect(readNotebookToolResult('not JSON')).toBeUndefined()
+  const details = buildToolActivityDetails(
+    activity({
+      title: 'open-science-notebook/notebook_restart',
+      status: 'failed',
+      rawOutput: 'Kernel unavailable'
+    })
+  )!
+  expect(details.sections[0]).toMatchObject({
+    kind: 'summary',
+    summary: { error: 'Kernel unavailable' }
+  })
+  expect(JSON.stringify(details)).not.toContain('Run history preserved')
+})
+
+it('shows runtime pagination, bindings and availability without fetching more results', () => {
+  const summary = buildNotebookToolSummary(
+    'open-science-notebook/list_notebook_runtimes',
+    { limit: 40 },
+    {
+      runtimeCount: 42,
+      nextOffset: 40,
+      runtimes: [
+        {
+          language: 'python',
+          label: 'default-python',
+          version: '3.12',
+          source: 'managed',
+          bound: true,
+          runnable: true
+        },
+        { language: 'r', label: 'default-r', runnable: false, reason: 'Runtime recovering' }
+      ]
+    }
+  )!
+  expect(summary.rows?.[0]).toMatchObject({ title: 'default-python', status: 'Bound' })
+  expect(summary.rows?.[1].error).toBe('Runtime recovering')
+  expect(summary.note).toContain('More runtimes')
+  expect(summary.fields).toContainEqual({ label: 'Limit', value: '40' })
+})
+
+it('keeps binding errors and partial mutation receipts visible', () => {
+  const summary = buildNotebookToolSummary(
+    'open-science-notebook/notebook_bind_runtime',
+    { arguments: { language: 'r', runtimeId: '/envs/R' } },
+    { ok: false, bindingChanged: true, error: 'Could not confirm storage' }
+  )!
+  expect(summary.error).toBe('Could not confirm storage')
+  expect(summary.note).toContain('binding changed')
+  expect(summary.fields).toContainEqual({ label: 'Runtime', value: '/envs/R', expandable: true })
+})
+
+it('summarizes compacted state and retains the latest failed run diagnostic', () => {
+  const summary = buildNotebookToolSummary(
+    'open-science-notebook/notebook_state',
+    {},
+    {
+      kernelStatus: 'idle',
+      cellCount: 3,
+      runCount: 4,
+      environmentCount: 1,
+      historyCompacted: true,
+      recentRuns: [
+        {
+          cellId: 'pie-plot-r',
+          kernelKind: 'r',
+          status: 'failed',
+          executionCount: 4,
+          outputPreview: 'RUNTIME_RECOVERY_BLOCKED: restart the app'
+        }
+      ]
+    }
+  )!
+  expect(summary.fields).toContainEqual({ label: 'Runs', value: '4' })
+  expect(summary.rows?.[0]).toMatchObject({
+    title: 'pie-plot-r',
+    status: 'Failed',
+    error: 'RUNTIME_RECOVERY_BLOCKED: restart the app'
+  })
+  expect(summary.note).toContain('Full history')
+})
+
+describe('permission summaries', () => {
+  it.each([false, true])(
+    'shows the actual file source and redacts inline bytes (encoded source: %s)',
+    (encoded) => {
+      const source = { kind: 'localPath', path: '/research/data/sin_curve.png' }
+      const request = {
+        ...permission('write_artifact_file'),
+        mcpIdentity: 'open-science-artifacts/write_artifact_file',
+        rawInput: {
+          filename: 'sin_curve.png',
+          mimeType: 'image/png',
+          source: encoded ? JSON.stringify(source) : source,
+          content: 'private-base64-bytes',
+          producerRunId: 'run-123'
+        }
+      }
+      const html = renderToStaticMarkup(
+        <PermissionApprovalControls requests={[request]} onRespond={vi.fn()} />
+      )
+      expect(html).toContain('tool-summary-card')
+      expect(html).toContain('/research/data/sin_curve.png')
+      expect(html).toContain('run-123')
+      expect(html).toContain('File content omitted')
+      expect(html).not.toContain('private-base64-bytes')
+    }
+  )
+  it.each([
+    'notebook_restart',
+    'notebook_state',
+    'notebook_bind_runtime',
+    'list_notebook_runtimes'
+  ])('shows %s before execution with existing approval choices', (tool) => {
+    const html = renderToStaticMarkup(
+      <PermissionApprovalControls
+        requests={[
+          permission(tool, { language: 'r', runtimeId: '/long/runtime/bin/R', limit: 40 })
+        ]}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(html).toContain('tool-summary-card')
+    expect(html).toContain('permission-actions')
+    expect(html).not.toContain('Run history preserved.')
+    if (tool === 'notebook_restart') expect(html).toContain('Clears in-memory variables')
+    if (tool === 'notebook_bind_runtime') expect(html).toContain('/long/runtime/bin/R')
+  })
+})

--- a/src/renderer/src/pages/workspace/notebook-tool-presentation.test.tsx
+++ b/src/renderer/src/pages/workspace/notebook-tool-presentation.test.tsx
@@ -230,3 +230,68 @@ describe('permission summaries', () => {
     if (tool === 'notebook_bind_runtime') expect(html).toContain('/long/runtime/bin/R')
   })
 })
+
+it.each([false, true])('renders runtime switch receipts (partial failure: %s)', (failed) => {
+  const result = failed
+    ? {
+        ok: false,
+        bindingChanged: true,
+        error: 'Could not confirm storage',
+        target: { runtimeId: '/envs/analysis-r/bin/R' }
+      }
+    : {
+        bound: {
+          language: 'r',
+          runtimeId: '/envs/analysis-r/bin/R',
+          label: 'analysis-r',
+          version: '4.4.3',
+          source: 'managed',
+          status: 'active'
+        }
+      }
+  const item = activity({
+    title: 'mcp__open_science_notebook__notebook_switch_runtime',
+    status: failed ? 'failed' : 'completed',
+    rawInput: { language: 'r', runtimeId: '/envs/analysis-r/bin/R' },
+    rawOutput: {
+      result: { content: [{ type: 'text', text: JSON.stringify(result) }] },
+      error: null
+    }
+  })
+  const details = buildToolActivityDetails(item)!
+  const html = renderToStaticMarkup(
+    <WorkspaceToolDetailsRow activity={item} details={details} isExpanded onToggle={vi.fn()} />
+  )
+  expect(html).toContain('tool-summary-card')
+  expect(html).toContain('Switch notebook runtime')
+  expect(html).toContain('/envs/analysis-r/bin/R')
+  if (failed) {
+    expect(html).toContain('Could not confirm storage')
+    expect(html).toContain('The runtime binding changed despite the error.')
+  } else {
+    expect(html).toContain('analysis-r')
+    expect(html).toContain('4.4.3')
+    expect(html).toContain('Active')
+  }
+})
+
+it('shows the switch target and memory impact before approval', () => {
+  const html = renderToStaticMarkup(
+    <PermissionApprovalControls
+      requests={[
+        permission('notebook_switch_runtime', {
+          language: 'r',
+          runtimeId: 'C:\\runtimes\\analysis-r\\R.exe'
+        })
+      ]}
+      onRespond={vi.fn()}
+    />
+  )
+  expect(html).toContain('tool-summary-card')
+  expect(html).toContain('Switch notebook runtime')
+  expect(html).toContain('C:\\runtimes\\analysis-r\\R.exe')
+  expect(html).toContain(
+    'Clears memory in the selected language kernel. Other kernels are unaffected.'
+  )
+  expect(html).toContain('permission-actions')
+})

--- a/src/renderer/src/pages/workspace/notebook-tool-presentation.ts
+++ b/src/renderer/src/pages/workspace/notebook-tool-presentation.ts
@@ -82,6 +82,7 @@ export const isNotebookSummaryTool = (identity: string | undefined): boolean =>
     'notebook_state',
     'list_notebook_runtimes',
     'notebook_bind_runtime',
+    'notebook_switch_runtime',
     'notebook_restart'
   ].includes(matchNotebookControlTool(identity) ?? '')
 
@@ -112,10 +113,15 @@ export const buildNotebookToolSummary = (
     if (approval) summary.note = t('Clears in-memory variables. Run history is preserved.')
     else if (result?.status === 'restarted' && !summary.error)
       summary.note = t('In-memory variables cleared. Run history preserved.')
-  } else if (tool === 'notebook_bind_runtime') {
+  } else if (tool === 'notebook_bind_runtime' || tool === 'notebook_switch_runtime') {
     const bound = record(result?.bound)
     const target = record(result?.target)
-    summary.title = t('Bind notebook runtime')
+    summary.title =
+      tool === 'notebook_switch_runtime' ? t('Switch notebook runtime') : t('Bind notebook runtime')
+    if (approval && tool === 'notebook_switch_runtime')
+      summary.note = t(
+        'Clears memory in the selected language kernel. Other kernels are unaffected.'
+      )
     summary.subtitle = text(bound?.label)
     field(t('Language'), language(bound?.language ?? input.language))
     field(t('Version'), bound?.version)

--- a/src/renderer/src/pages/workspace/notebook-tool-presentation.ts
+++ b/src/renderer/src/pages/workspace/notebook-tool-presentation.ts
@@ -1,0 +1,218 @@
+import { matchNotebookControlTool } from './notebook-tool-names'
+import { identityTranslate, type TranslateClause } from './workspace-translate-clause'
+
+export type ToolSummary = {
+  title: string
+  subtitle?: string
+  fields: Array<{ label: string; value: string; expandable?: boolean }>
+  rows?: Array<{ title: string; detail?: string; status?: string; error?: string }>
+  note?: string
+  error?: string
+}
+
+const record = (value: unknown): Record<string, unknown> | undefined =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+
+const text = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() ? value : undefined
+const scalar = (value: unknown): string | undefined =>
+  text(value) ?? (typeof value === 'number' && Number.isFinite(value) ? String(value) : undefined)
+
+// Providers wrap the same MCP result in JSON text, content blocks or a bridge envelope.
+export const readNotebookToolResult = (
+  value: unknown,
+  depth = 0
+): Record<string, unknown> | undefined => {
+  if (depth > 5) return undefined
+  if (typeof value === 'string') {
+    try {
+      return readNotebookToolResult(JSON.parse(value), depth + 1)
+    } catch {
+      return undefined
+    }
+  }
+  const item = record(value)
+  if (!item) return undefined
+  if (
+    ['kernelStatus', 'runtimes', 'bound', 'bindingChanged'].some((key) => key in item) ||
+    text(item.error)
+  )
+    return item
+  for (const nested of [item.structuredContent, item.result]) {
+    const found = readNotebookToolResult(nested, depth + 1)
+    if (found) return found
+  }
+  if (Array.isArray(item.content)) {
+    for (const block of item.content) {
+      const found = readNotebookToolResult(record(block)?.text, depth + 1)
+      if (found) return found
+    }
+  }
+  return undefined
+}
+
+export const notebookInput = (value: unknown): Record<string, unknown> => {
+  const input = record(value) ?? {}
+  return record(input.arguments) ?? input
+}
+
+const statusLabel = (value: unknown, t: TranslateClause): string | undefined => {
+  switch (value) {
+    case 'idle':
+      return t('Idle')
+    case 'active':
+      return t('Active')
+    case 'completed':
+      return t('Completed')
+    case 'failed':
+      return t('Failed')
+    case 'running':
+      return t('Running')
+    case 'restarted':
+      return t('Restarted')
+    default:
+      return text(value)
+  }
+}
+
+export const isNotebookSummaryTool = (identity: string | undefined): boolean =>
+  [
+    'notebook_state',
+    'list_notebook_runtimes',
+    'notebook_bind_runtime',
+    'notebook_restart'
+  ].includes(matchNotebookControlTool(identity) ?? '')
+
+export const buildNotebookToolSummary = (
+  identity: string | undefined,
+  rawInput: unknown,
+  result?: Record<string, unknown>,
+  t: TranslateClause = identityTranslate,
+  approval = false
+): ToolSummary | undefined => {
+  const tool = matchNotebookControlTool(identity)
+  if (!isNotebookSummaryTool(identity)) return undefined
+  const input = notebookInput(rawInput)
+  const fields: ToolSummary['fields'] = []
+  const field = (label: string, value: unknown, expandable = false): void => {
+    const formatted = scalar(value)
+    if (formatted !== undefined)
+      fields.push({ label, value: formatted, ...(expandable ? { expandable: true } : {}) })
+  }
+  const summary: ToolSummary = { title: '', fields, error: text(result?.error) }
+  const language = (value: unknown): string | undefined =>
+    value === 'r' ? 'R' : value === 'python' ? 'Python' : text(value)
+  if (tool === 'notebook_restart') {
+    summary.title = t('Restart notebook')
+    field(t('Status'), statusLabel(result?.status, t))
+    field(t('Kernel'), statusLabel(result?.kernelStatus, t))
+    field(t('Cells'), result?.cells)
+    if (approval) summary.note = t('Clears in-memory variables. Run history is preserved.')
+    else if (result?.status === 'restarted' && !summary.error)
+      summary.note = t('In-memory variables cleared. Run history preserved.')
+  } else if (tool === 'notebook_bind_runtime') {
+    const bound = record(result?.bound)
+    const target = record(result?.target)
+    summary.title = t('Bind notebook runtime')
+    summary.subtitle = text(bound?.label)
+    field(t('Language'), language(bound?.language ?? input.language))
+    field(t('Version'), bound?.version)
+    field(
+      t('Runtime source'),
+      bound?.source === 'managed'
+        ? t('Managed')
+        : bound?.source === 'external'
+          ? t('External')
+          : bound?.source
+    )
+    field(t('Status'), statusLabel(bound?.status, t))
+    field(t('Runtime'), bound?.runtimeId ?? target?.runtimeId ?? input.runtimeId, !approval)
+    if (result?.bindingChanged === true)
+      summary.note = t('The runtime binding changed despite the error.')
+  } else if (tool === 'list_notebook_runtimes') {
+    summary.title = t('Notebook runtimes')
+    if (approval) summary.note = t('Lists the notebook runtimes available to this conversation.')
+    field(t('Language'), language(input.language))
+    field(t('Limit'), input.limit)
+    field(t('Offset'), input.offset)
+    field(t('Total'), result?.runtimeCount)
+    if (Array.isArray(result?.runtimes)) {
+      summary.rows = result.runtimes.slice(0, 40).flatMap((entry) => {
+        const runtime = record(entry)
+        if (!runtime) return []
+        return [
+          {
+            title: text(runtime.label) ?? text(runtime.runtimeId) ?? t('Runtime'),
+            detail: [
+              language(runtime.language),
+              text(runtime.version),
+              runtime.source === 'managed'
+                ? t('Managed')
+                : runtime.source === 'external'
+                  ? t('External')
+                  : text(runtime.source)
+            ]
+              .filter(Boolean)
+              .join(' · '),
+            status: runtime.bound === true ? t('Bound') : statusLabel(runtime.status, t),
+            error:
+              runtime.runnable === false
+                ? (text(runtime.reason) ?? text(runtime.detail) ?? t('Unavailable'))
+                : undefined
+          }
+        ]
+      })
+      if (!result.runtimes.length) summary.note = t('No runtimes returned.')
+      else if (result.nextOffset !== undefined || result.runtimes.length > 40)
+        summary.note = t('More runtimes are available. See details for pagination.')
+    }
+  } else {
+    summary.title = t('Notebook state')
+    if (approval) summary.note = t('Reads the current notebook environment and runtime state.')
+    field(t('Kernel'), statusLabel(result?.kernelStatus, t))
+    field(t('Cells'), result?.cellCount)
+    field(t('Runs'), result?.runCount)
+    field(t('Environments'), result?.environmentCount)
+    if (Array.isArray(result?.environments)) {
+      for (const environment of result.environments.slice(0, 4)) {
+        const env = record(environment)
+        if (env)
+          field(
+            language(env.kind) ?? t('Environment'),
+            [text(env.environment), statusLabel(env.status, t)].filter(Boolean).join(' · ')
+          )
+      }
+    }
+    if (Array.isArray(result?.recentRuns)) {
+      summary.rows = result.recentRuns
+        .slice(-5)
+        .reverse()
+        .flatMap((entry) => {
+          const run = record(entry)
+          if (!run) return []
+          return [
+            {
+              title: text(run.cellId) ?? text(run.runId) ?? t('Notebook run'),
+              detail: [
+                language(run.kernelKind),
+                text(run.environment),
+                scalar(run.executionCount) ? `#${scalar(run.executionCount)}` : undefined
+              ]
+                .filter(Boolean)
+                .join(' · '),
+              status: statusLabel(run.status, t),
+              error: run.status === 'failed' ? text(run.outputPreview) : undefined
+            }
+          ]
+        })
+    }
+    if (
+      result?.historyCompacted === true ||
+      (Array.isArray(result?.recentRuns) && result.recentRuns.length > 5)
+    )
+      summary.note = t('Recent runs only. Full history is available in the Notebook preview.')
+  }
+  return summary
+}

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -1099,16 +1099,16 @@ describe('workspace tool activity details', () => {
     const section = details?.sections[0]
 
     expect(section).toMatchObject({
-      kind: 'code',
-      label: 'Tool output image',
-      language: 'json'
-    })
-    if (section?.kind !== 'code') throw new Error('Expected an artifact summary.')
-    expect(JSON.parse(section.text)).toEqual({
-      file: 'report.png',
-      type: 'image/png',
-      size: '2 KB',
-      path: '/files/report.png'
+      kind: 'summary',
+      summary: {
+        title: 'Tool output image',
+        subtitle: 'report.png',
+        fields: [
+          { label: 'Type', value: 'image/png' },
+          { label: 'Size', value: '2 KB' },
+          { label: 'Path', value: '/files/report.png', expandable: true }
+        ]
+      }
     })
   })
 
@@ -1149,11 +1149,10 @@ describe('workspace tool activity details', () => {
 
     const section = details?.sections[0]
 
-    expect(section?.kind).toBe('code')
-    expect(section?.kind === 'code' && section.text).toContain('report.csv')
-    expect(section?.kind === 'code' && section.text).toContain('/files/report.csv')
-    // The raw file content must never be dumped into the transcript.
-    expect(section?.kind === 'code' && section.text).not.toContain('a,b')
+    expect(section?.kind).toBe('summary')
+    expect(JSON.stringify(section)).toContain('report.csv')
+    expect(JSON.stringify(section)).toContain('/files/report.csv')
+    expect(JSON.stringify(section)).not.toContain('a,b')
   })
 
   it('matches the artifact-write tool by name even when MCP-namespaced', () => {
@@ -1166,7 +1165,7 @@ describe('workspace tool activity details', () => {
 
     expect(details?.displayName).toBe('Write file')
     expect(details?.subtitle).toBe('data.csv')
-    expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).not.toContain('a,b')
+    expect(JSON.stringify(details?.sections)).not.toContain('a,b')
   })
 
   it('does not classify artifact-file lookalikes as managed writes', () => {
@@ -1219,16 +1218,12 @@ describe('workspace tool activity details', () => {
     expect(details?.displayName).toBe('Write file')
     expect(details?.subtitle).toBe('sin.png')
     expect(details?.metaLabel).toBe('41 KB')
-    expect(details?.sections.map((section) => 'label' in section && section.label)).toEqual([
-      'Tool output image'
-    ])
-    expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).toContain('sin.png')
-    expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).not.toContain(
-      'artifact_id'
-    )
-    expect(details?.sections[0]?.kind === 'code' && details.sections[0].text).not.toContain(
-      'structuredContent'
-    )
+    expect(details?.sections[0]).toMatchObject({
+      kind: 'summary',
+      summary: { title: 'Tool output image', subtitle: 'sin.png' }
+    })
+    expect(JSON.stringify(details?.sections)).not.toContain('artifact_id')
+    expect(JSON.stringify(details?.sections)).not.toContain('structuredContent')
   })
 
   it('renders a WebFetch with its URL, prompt, and fetched result', () => {

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -1235,7 +1235,9 @@ const buildToolActivityDetails = (
   )
   if (notebookSummary) {
     if (activity.status === 'failed' && !notebookSummary.error)
-      notebookSummary.error = getOutputText(activity)?.code ?? t('Failed')
+      notebookSummary.error = notebookResult
+        ? t('Failed')
+        : (getOutputText(activity)?.code ?? t('Failed'))
     const fallback = buildGenericDetails(activity)
     return {
       displayName: notebookSummary.title,

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -1,6 +1,12 @@
 import type { ContentBlock, ToolCallContent, ToolKind } from '@agentclientprotocol/sdk'
 
 import { formatByteSize } from '@/lib/utils'
+import {
+  buildNotebookToolSummary,
+  isNotebookSummaryTool,
+  readNotebookToolResult,
+  type ToolSummary
+} from './notebook-tool-presentation'
 import type { ToolActivity } from '@/stores/session-store'
 import { memoryAgentRememberResultSchema, memoryAgentResultSchema } from '../../../../shared/memory'
 import type { NotebookRunStatus } from '../../../../shared/notebook'
@@ -49,7 +55,9 @@ type ToolLiteratureSection = {
   summary: LiteratureToolSummary
 }
 
-type ToolDetailSection = ToolCodeSection | ToolDiffSection | ToolLiteratureSection
+type ToolSummarySection = { kind: 'summary'; summary: ToolSummary; file?: boolean }
+type ToolDetailSection =
+  ToolCodeSection | ToolDiffSection | ToolLiteratureSection | ToolSummarySection
 
 type ToolActivityDetails = {
   displayName: string
@@ -532,7 +540,10 @@ const getRecordNumber = (
 }
 
 // Summarizes a saved artifact file (name/type/size/path) without reading or echoing its raw bytes.
-const buildArtifactDetails = (activity: ToolActivity): ToolActivityDetails | undefined => {
+const buildArtifactDetails = (
+  activity: ToolActivity,
+  t: TranslateClause
+): ToolActivityDetails | undefined => {
   const rawInput = isRecord(activity.rawInput) ? activity.rawInput : undefined
   const output = extractArtifactOutput(activity)
   const filename =
@@ -549,24 +560,22 @@ const buildArtifactDetails = (activity: ToolActivity): ToolActivityDetails | und
 
   if (!filename && !path) return undefined
 
-  const summary: Record<string, string> = {}
-
-  if (filename) summary.file = filename
-  if (mimeType) summary.type = mimeType
-  if (sizeLabel) summary.size = sizeLabel
-  if (path) summary.path = path
-
-  const summarySection = createCodeSection(
-    mimeType?.startsWith('image/') ? 'Tool output image' : 'File',
-    JSON.stringify(summary, null, 2),
-    'json'
-  )
+  const fields: ToolSummary['fields'] = []
+  if (mimeType) fields.push({ label: t('Type'), value: mimeType })
+  if (sizeLabel) fields.push({ label: t('Size'), value: sizeLabel })
+  if (path) fields.push({ label: t('Path'), value: path, expandable: true })
+  const summary: ToolSummary = {
+    title: mimeType?.startsWith('image/') ? t('Tool output image') : t('File'),
+    subtitle: filename ?? path,
+    fields,
+    ...(activity.status === 'failed' ? { error: getOutputText(activity)?.code ?? t('Failed') } : {})
+  }
 
   return {
     displayName: 'Write file',
     subtitle: filename ?? path,
     metaLabel: sizeLabel,
-    sections: summarySection ? [summarySection] : []
+    sections: [{ kind: 'summary', summary, file: true }]
   }
 }
 
@@ -1207,7 +1216,37 @@ const buildToolActivityDetails = (
   const literatureDetails = buildLiteratureDetails(activity)
   if (literatureDetails) return literatureDetails
   // Saved files show a metadata summary instead of dumping their (possibly base64) content.
-  if (isArtifactWriteActivity(activity)) return buildArtifactDetails(activity)
+  if (isArtifactWriteActivity(activity)) return buildArtifactDetails(activity, t)
+  const notebookIdentity = [activity.providerToolName, activity.title].find(isNotebookSummaryTool)
+  const notebookResult = notebookIdentity
+    ? [activity.rawOutput, ...collectToolTexts(activity)]
+        .map((value) => readNotebookToolResult(value))
+        .find(Boolean)
+    : undefined
+  const confirmedNotebookResult =
+    activity.status === 'failed' && notebookResult?.status === 'restarted'
+      ? { ...notebookResult, status: undefined }
+      : notebookResult
+  const notebookSummary = buildNotebookToolSummary(
+    notebookIdentity,
+    activity.rawInput,
+    confirmedNotebookResult,
+    t
+  )
+  if (notebookSummary) {
+    if (activity.status === 'failed' && !notebookSummary.error)
+      notebookSummary.error = getOutputText(activity)?.code ?? t('Failed')
+    const fallback = buildGenericDetails(activity)
+    return {
+      displayName: notebookSummary.title,
+      sections: [
+        { kind: 'summary', summary: notebookSummary },
+        ...(fallback?.sections ?? []).map((section) =>
+          section.kind === 'code' ? { ...section, collapsible: true } : section
+        )
+      ]
+    }
+  }
   // File edits prefer a diff view, falling back to raw input/output when no diff is provided.
   if (isEditActivity(activity))
     return buildDiffDetails(activity, t) ?? buildGenericDetails(activity)

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4226,6 +4226,26 @@
     "Exit queued editing": "Warteschlangenbearbeitung beenden",
     "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "Die Nachricht in der Warteschlange passt nicht mehr zu dieser Sitzung. Beenden Sie die Warteschlangenbearbeitung, um sie als neue Nachricht zu senden.",
     "Remove attachments before submitting a historical revision.": "Entfernen Sie die Anhänge, bevor Sie die Überarbeitung einer früheren Nachricht senden.",
-    "Exit queued editing before choosing another send mode.": "Beenden Sie die Warteschlangenbearbeitung, bevor Sie einen anderen Sendemodus wählen."
+    "Exit queued editing before choosing another send mode.": "Beenden Sie die Warteschlangenbearbeitung, bevor Sie einen anderen Sendemodus wählen.",
+    "Bind notebook runtime": "Notebook-Laufzeit zuordnen",
+    "Bound": "Zugeordnet",
+    "Cells": "Zellen",
+    "Clears in-memory variables. Run history is preserved.": "Löscht Variablen im Arbeitsspeicher. Der Ausführungsverlauf bleibt erhalten.",
+    "Environments": "Umgebungen",
+    "External": "Extern",
+    "In-memory variables cleared. Run history preserved.": "Variablen im Arbeitsspeicher gelöscht. Ausführungsverlauf beibehalten.",
+    "Kernel": "Kernel",
+    "Limit": "Limit",
+    "Managed": "Verwaltet",
+    "More runtimes are available. See details for pagination.": "Weitere Laufzeiten sind verfügbar. Informationen zur Seiteneinteilung stehen in den Details.",
+    "No runtimes returned.": "Keine Laufzeiten zurückgegeben.",
+    "Offset": "Startposition",
+    "Path": "Pfad",
+    "Recent runs only. Full history is available in the Notebook preview.": "Nur letzte Ausführungen. Der vollständige Verlauf ist in der Notebook-Vorschau verfügbar.",
+    "Restart notebook": "Notebook neu starten",
+    "Restarted": "Neu gestartet",
+    "The runtime binding changed despite the error.": "Die Laufzeitzuordnung wurde trotz des Fehlers geändert.",
+    "Runtime source": "Laufzeitquelle",
+    "File content omitted": "Dateiinhalt ausgelassen"
   }
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4246,6 +4246,8 @@
     "Restarted": "Neu gestartet",
     "The runtime binding changed despite the error.": "Die Laufzeitzuordnung wurde trotz des Fehlers geändert.",
     "Runtime source": "Laufzeitquelle",
-    "File content omitted": "Dateiinhalt ausgelassen"
+    "File content omitted": "Dateiinhalt ausgelassen",
+    "Switch notebook runtime": "Notebook-Laufzeit wechseln",
+    "Clears memory in the selected language kernel. Other kernels are unaffected.": "Löscht den Speicher des Kernels der ausgewählten Sprache. Andere Kernel bleiben unverändert."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4381,6 +4381,26 @@
     "Exit queued editing": "Salir de la edición de la cola",
     "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "El mensaje en cola ya no corresponde a esta sesión. Salga de la edición de la cola para enviarlo como un mensaje nuevo.",
     "Remove attachments before submitting a historical revision.": "Quite los archivos adjuntos antes de enviar una revisión de un mensaje anterior.",
-    "Exit queued editing before choosing another send mode.": "Salga de la edición de la cola antes de elegir otro modo de envío."
+    "Exit queued editing before choosing another send mode.": "Salga de la edición de la cola antes de elegir otro modo de envío.",
+    "Bind notebook runtime": "Vincular entorno de ejecución de Notebook",
+    "Bound": "Vinculado",
+    "Cells": "Celdas",
+    "Clears in-memory variables. Run history is preserved.": "Borra las variables en memoria. Se conserva el historial de ejecuciones.",
+    "Environments": "Entornos",
+    "External": "Externo",
+    "In-memory variables cleared. Run history preserved.": "Variables en memoria borradas. Historial de ejecuciones conservado.",
+    "Kernel": "Kernel",
+    "Limit": "Límite",
+    "Managed": "Administrado",
+    "More runtimes are available. See details for pagination.": "Hay más entornos disponibles. Consulte los detalles de paginación.",
+    "No runtimes returned.": "No se devolvieron entornos de ejecución.",
+    "Offset": "Posición inicial",
+    "Path": "Ruta",
+    "Recent runs only. Full history is available in the Notebook preview.": "Solo ejecuciones recientes. El historial completo está disponible en la vista previa de Notebook.",
+    "Restart notebook": "Reiniciar Notebook",
+    "Restarted": "Reiniciado",
+    "The runtime binding changed despite the error.": "La vinculación del entorno cambió a pesar del error.",
+    "Runtime source": "Origen del entorno",
+    "File content omitted": "Contenido del archivo omitido"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4401,6 +4401,8 @@
     "Restarted": "Reiniciado",
     "The runtime binding changed despite the error.": "La vinculación del entorno cambió a pesar del error.",
     "Runtime source": "Origen del entorno",
-    "File content omitted": "Contenido del archivo omitido"
+    "File content omitted": "Contenido del archivo omitido",
+    "Switch notebook runtime": "Cambiar entorno de ejecución de Notebook",
+    "Clears memory in the selected language kernel. Other kernels are unaffected.": "Borra la memoria del kernel del lenguaje seleccionado. Los demás kernels no se ven afectados."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4401,6 +4401,8 @@
     "Restarted": "Redémarré",
     "The runtime binding changed despite the error.": "L’association de l’environnement a été modifiée malgré l’erreur.",
     "Runtime source": "Origine de l’environnement",
-    "File content omitted": "Contenu du fichier omis"
+    "File content omitted": "Contenu du fichier omis",
+    "Switch notebook runtime": "Changer l’environnement Notebook",
+    "Clears memory in the selected language kernel. Other kernels are unaffected.": "Efface la mémoire du noyau du langage sélectionné. Les autres noyaux ne sont pas affectés."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4381,6 +4381,26 @@
     "Exit queued editing": "Quitter la modification de la file",
     "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "Le message en attente ne correspond plus à cette session. Quittez la modification de la file pour l’envoyer comme nouveau message.",
     "Remove attachments before submitting a historical revision.": "Retirez les pièces jointes avant d’envoyer la modification d’un ancien message.",
-    "Exit queued editing before choosing another send mode.": "Quittez la modification de la file avant de choisir un autre mode d’envoi."
+    "Exit queued editing before choosing another send mode.": "Quittez la modification de la file avant de choisir un autre mode d’envoi.",
+    "Bind notebook runtime": "Associer un environnement Notebook",
+    "Bound": "Associé",
+    "Cells": "Cellules",
+    "Clears in-memory variables. Run history is preserved.": "Efface les variables en mémoire. L’historique des exécutions est conservé.",
+    "Environments": "Environnements",
+    "External": "Externe",
+    "In-memory variables cleared. Run history preserved.": "Variables en mémoire effacées. Historique des exécutions conservé.",
+    "Kernel": "Noyau",
+    "Limit": "Limite",
+    "Managed": "Géré",
+    "More runtimes are available. See details for pagination.": "D’autres environnements sont disponibles. Consultez les détails pour la pagination.",
+    "No runtimes returned.": "Aucun environnement renvoyé.",
+    "Offset": "Position de départ",
+    "Path": "Chemin",
+    "Recent runs only. Full history is available in the Notebook preview.": "Exécutions récentes uniquement. L’historique complet est disponible dans l’aperçu Notebook.",
+    "Restart notebook": "Redémarrer le Notebook",
+    "Restarted": "Redémarré",
+    "The runtime binding changed despite the error.": "L’association de l’environnement a été modifiée malgré l’erreur.",
+    "Runtime source": "Origine de l’environnement",
+    "File content omitted": "Contenu du fichier omis"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4071,6 +4071,26 @@
     "Exit queued editing": "キューの編集を終了",
     "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "キュー内のメッセージは、このセッションと一致しなくなりました。キューの編集を終了して、新しいメッセージとして送信してください。",
     "Remove attachments before submitting a historical revision.": "過去のメッセージの修正を送信する前に、添付ファイルを削除してください。",
-    "Exit queued editing before choosing another send mode.": "別の送信モードを選択する前に、キューの編集を終了してください。"
+    "Exit queued editing before choosing another send mode.": "別の送信モードを選択する前に、キューの編集を終了してください。",
+    "Bind notebook runtime": "Notebook ランタイムを関連付け",
+    "Bound": "関連付け済み",
+    "Cells": "セル",
+    "Clears in-memory variables. Run history is preserved.": "メモリ内の変数を消去します。実行履歴は保持されます。",
+    "Environments": "環境",
+    "External": "外部",
+    "In-memory variables cleared. Run history preserved.": "メモリ内の変数を消去しました。実行履歴は保持されています。",
+    "Kernel": "カーネル",
+    "Limit": "上限",
+    "Managed": "アプリ管理",
+    "More runtimes are available. See details for pagination.": "ほかにもランタイムがあります。ページ情報は詳細をご覧ください。",
+    "No runtimes returned.": "ランタイムは返されませんでした。",
+    "Offset": "開始位置",
+    "Path": "パス",
+    "Recent runs only. Full history is available in the Notebook preview.": "最近の実行のみ表示しています。全履歴は Notebook プレビューで確認できます。",
+    "Restart notebook": "Notebook を再起動",
+    "Restarted": "再起動済み",
+    "The runtime binding changed despite the error.": "エラーが発生しましたが、ランタイムの関連付けは変更されました。",
+    "Runtime source": "ランタイムの提供元",
+    "File content omitted": "ファイル内容は省略されています"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4091,6 +4091,8 @@
     "Restarted": "再起動済み",
     "The runtime binding changed despite the error.": "エラーが発生しましたが、ランタイムの関連付けは変更されました。",
     "Runtime source": "ランタイムの提供元",
-    "File content omitted": "ファイル内容は省略されています"
+    "File content omitted": "ファイル内容は省略されています",
+    "Switch notebook runtime": "Notebook ランタイムを切り替え",
+    "Clears memory in the selected language kernel. Other kernels are unaffected.": "選択した言語のカーネルのメモリを消去します。他のカーネルには影響しません。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4069,6 +4069,26 @@
     "Exit queued editing": "대기열 편집 종료",
     "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "대기 중인 메시지가 더 이상 이 세션과 일치하지 않습니다. 대기열 편집을 종료하여 새 메시지로 보내세요.",
     "Remove attachments before submitting a historical revision.": "이전 메시지 수정 내용을 제출하기 전에 첨부 파일을 제거하세요.",
-    "Exit queued editing before choosing another send mode.": "다른 전송 모드를 선택하기 전에 대기열 편집을 종료하세요."
+    "Exit queued editing before choosing another send mode.": "다른 전송 모드를 선택하기 전에 대기열 편집을 종료하세요.",
+    "Bind notebook runtime": "Notebook 런타임 연결",
+    "Bound": "연결됨",
+    "Cells": "셀",
+    "Clears in-memory variables. Run history is preserved.": "메모리의 변수를 지웁니다. 실행 기록은 유지됩니다.",
+    "Environments": "환경",
+    "External": "외부",
+    "In-memory variables cleared. Run history preserved.": "메모리의 변수를 지웠습니다. 실행 기록은 유지됩니다.",
+    "Kernel": "커널",
+    "Limit": "최대 개수",
+    "Managed": "앱 관리",
+    "More runtimes are available. See details for pagination.": "런타임이 더 있습니다. 페이지 정보는 세부 내용을 확인하세요.",
+    "No runtimes returned.": "반환된 런타임이 없습니다.",
+    "Offset": "시작 위치",
+    "Path": "경로",
+    "Recent runs only. Full history is available in the Notebook preview.": "최근 실행만 표시합니다. 전체 기록은 Notebook 미리보기에서 확인할 수 있습니다.",
+    "Restart notebook": "Notebook 다시 시작",
+    "Restarted": "다시 시작됨",
+    "The runtime binding changed despite the error.": "오류가 발생했지만 런타임 연결은 변경되었습니다.",
+    "Runtime source": "런타임 출처",
+    "File content omitted": "파일 내용 생략됨"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4089,6 +4089,8 @@
     "Restarted": "다시 시작됨",
     "The runtime binding changed despite the error.": "오류가 발생했지만 런타임 연결은 변경되었습니다.",
     "Runtime source": "런타임 출처",
-    "File content omitted": "파일 내용 생략됨"
+    "File content omitted": "파일 내용 생략됨",
+    "Switch notebook runtime": "Notebook 런타임 전환",
+    "Clears memory in the selected language kernel. Other kernels are unaffected.": "선택한 언어 커널의 메모리를 지웁니다. 다른 커널에는 영향을 주지 않습니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4531,6 +4531,8 @@
     "Restarted": "Перезапущено",
     "The runtime binding changed despite the error.": "Привязка среды выполнения изменилась, несмотря на ошибку.",
     "Runtime source": "Источник среды выполнения",
-    "File content omitted": "Содержимое файла опущено"
+    "File content omitted": "Содержимое файла опущено",
+    "Switch notebook runtime": "Переключить среду выполнения Notebook",
+    "Clears memory in the selected language kernel. Other kernels are unaffected.": "Очищает память ядра выбранного языка. Другие ядра не затрагиваются."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4511,6 +4511,26 @@
     "Exit queued editing": "Завершить редактирование очереди",
     "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "Сообщение в очереди больше не соответствует этому сеансу. Завершите редактирование очереди, чтобы отправить его как новое сообщение.",
     "Remove attachments before submitting a historical revision.": "Удалите вложения перед отправкой исправления предыдущего сообщения.",
-    "Exit queued editing before choosing another send mode.": "Завершите редактирование очереди, прежде чем выбрать другой режим отправки."
+    "Exit queued editing before choosing another send mode.": "Завершите редактирование очереди, прежде чем выбрать другой режим отправки.",
+    "Bind notebook runtime": "Привязать среду выполнения Notebook",
+    "Bound": "Привязана",
+    "Cells": "Ячейки",
+    "Clears in-memory variables. Run history is preserved.": "Удаляет переменные из памяти. История запусков сохраняется.",
+    "Environments": "Среды",
+    "External": "Внешняя",
+    "In-memory variables cleared. Run history preserved.": "Переменные из памяти удалены. История запусков сохранена.",
+    "Kernel": "Ядро",
+    "Limit": "Лимит",
+    "Managed": "Управляемая",
+    "More runtimes are available. See details for pagination.": "Доступны другие среды выполнения. Параметры страниц указаны в подробностях.",
+    "No runtimes returned.": "Среды выполнения не возвращены.",
+    "Offset": "Начальная позиция",
+    "Path": "Путь",
+    "Recent runs only. Full history is available in the Notebook preview.": "Показаны только последние запуски. Полная история доступна в предпросмотре Notebook.",
+    "Restart notebook": "Перезапустить Notebook",
+    "Restarted": "Перезапущено",
+    "The runtime binding changed despite the error.": "Привязка среды выполнения изменилась, несмотря на ошибку.",
+    "Runtime source": "Источник среды выполнения",
+    "File content omitted": "Содержимое файла опущено"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4091,6 +4091,8 @@
     "Restarted": "已重启",
     "The runtime binding changed despite the error.": "虽然发生错误，但运行环境绑定已更改。",
     "Runtime source": "运行环境来源",
-    "File content omitted": "文件内容已省略"
+    "File content omitted": "文件内容已省略",
+    "Switch notebook runtime": "切换 Notebook 运行环境",
+    "Clears memory in the selected language kernel. Other kernels are unaffected.": "清空所选语言内核的内存，不影响其他内核。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4071,6 +4071,26 @@
     "Exit queued editing": "退出队列编辑",
     "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "排队消息已不再与此会话匹配。请退出队列编辑，将其作为新消息发送。",
     "Remove attachments before submitting a historical revision.": "提交历史消息修订前，请移除附件。",
-    "Exit queued editing before choosing another send mode.": "选择其他发送模式前，请退出队列编辑。"
+    "Exit queued editing before choosing another send mode.": "选择其他发送模式前，请退出队列编辑。",
+    "Bind notebook runtime": "绑定 Notebook 运行环境",
+    "Bound": "已绑定",
+    "Cells": "单元格",
+    "Clears in-memory variables. Run history is preserved.": "将清空内存中的变量，保留运行历史。",
+    "Environments": "运行环境",
+    "External": "外部",
+    "In-memory variables cleared. Run history preserved.": "已清空内存中的变量，运行历史已保留。",
+    "Kernel": "内核",
+    "Limit": "数量上限",
+    "Managed": "应用管理",
+    "More runtimes are available. See details for pagination.": "还有更多运行环境，分页信息见详情。",
+    "No runtimes returned.": "未返回运行环境。",
+    "Offset": "起始位置",
+    "Path": "路径",
+    "Recent runs only. Full history is available in the Notebook preview.": "仅显示最近运行，完整历史可在 Notebook 预览中查看。",
+    "Restart notebook": "重启 Notebook",
+    "Restarted": "已重启",
+    "The runtime binding changed despite the error.": "虽然发生错误，但运行环境绑定已更改。",
+    "Runtime source": "运行环境来源",
+    "File content omitted": "文件内容已省略"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4091,6 +4091,8 @@
     "Restarted": "已重新啟動",
     "The runtime binding changed despite the error.": "雖然發生錯誤，但執行環境綁定已變更。",
     "Runtime source": "執行環境來源",
-    "File content omitted": "已省略檔案內容"
+    "File content omitted": "已省略檔案內容",
+    "Switch notebook runtime": "切換 Notebook 執行環境",
+    "Clears memory in the selected language kernel. Other kernels are unaffected.": "清空所選語言核心的記憶體，不影響其他核心。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4071,6 +4071,26 @@
     "Exit queued editing": "結束佇列編輯",
     "The queued message no longer matches this Session. Exit queued editing to send it as a new message.": "排隊訊息已不再與此工作階段相符。請結束佇列編輯，將其作為新訊息傳送。",
     "Remove attachments before submitting a historical revision.": "提交歷史訊息修訂前，請移除附件。",
-    "Exit queued editing before choosing another send mode.": "選擇其他傳送模式前，請結束佇列編輯。"
+    "Exit queued editing before choosing another send mode.": "選擇其他傳送模式前，請結束佇列編輯。",
+    "Bind notebook runtime": "綁定 Notebook 執行環境",
+    "Bound": "已綁定",
+    "Cells": "儲存格",
+    "Clears in-memory variables. Run history is preserved.": "將清空記憶體中的變數，保留執行歷程。",
+    "Environments": "執行環境",
+    "External": "外部",
+    "In-memory variables cleared. Run history preserved.": "已清空記憶體中的變數，執行歷程已保留。",
+    "Kernel": "核心",
+    "Limit": "數量上限",
+    "Managed": "應用程式管理",
+    "More runtimes are available. See details for pagination.": "還有更多執行環境，分頁資訊請見詳細資料。",
+    "No runtimes returned.": "未傳回執行環境。",
+    "Offset": "起始位置",
+    "Path": "路徑",
+    "Recent runs only. Full history is available in the Notebook preview.": "僅顯示最近執行，完整歷程可在 Notebook 預覽中檢視。",
+    "Restart notebook": "重新啟動 Notebook",
+    "Restarted": "已重新啟動",
+    "The runtime binding changed despite the error.": "雖然發生錯誤，但執行環境綁定已變更。",
+    "Runtime source": "執行環境來源",
+    "File content omitted": "已省略檔案內容"
   }
 }


### PR DESCRIPTION
## Problem

Artifact write receipts and common Notebook control tools display JSON or text in Messages and permission approvals, making filenames, runtime choices, restart effects and failed runs difficult to scan.

## Proposed change

Show compact summaries for `write_artifact_file`, `list_notebook_runtimes`, `notebook_restart`, `notebook_bind_runtime`, `notebook_switch_runtime` and `notebook_state`. Reuse the existing tool identity matching and approval detail slot, with one shared renderer card and presentation helper.

Cards surface file metadata, runtime availability/binding, kernel state, counts and recent failed runs. Errors, partial binding changes and compacted history remain visible. Restart success copy requires a confirmed successful receipt. Switch approvals explain that the selected language kernel loses its memory while other kernels remain unaffected. Raw control details stay collapsed and inspectable; artifact approval details retain metadata while omitting inline file bytes. All new copy is translated in eight locales.

## Scope and non-goals

- Renderer presentation only; allow/deny choices, grant scopes and submission behavior are unchanged. No new dependencies, preview fetches, backend/API changes or ACP protocol changes.
- **Persistence/data model:** no stored fields, schema changes, migrations or data relationships change.
- **States:** no business or durable enum values added. A derived `summary` section selects the renderer card.
- **Historical compatibility:** existing recognized saved payloads render at read time; no migration or backfill. Unknown payloads retain inspectable fallback details.
- Independent specification and standards reviews completed. Visual examples were reviewed locally before publishing this PR.

## Acceptance criteria and validation

The listed checks completed after the latest fix (7fe6db05). The nine-file run passed 1,073 tests; one locale source-scan test timed out under heavy concurrent local load and then passed when retried alone with no configuration changes. Web typecheck and lint passed. Nine affected test files passed, **1,074 tests**; no full local test suite was run.

| Behavior / affected consumer | Command / evidence | Result |
| --- | --- | --- |
| Tool projection, receipts, failures, identity variants and actual row rendering | `npm test -- src/renderer/src/pages/workspace/notebook-tool-presentation.test.tsx src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx src/renderer/src/pages/workspace/notebook-tool-names.test.ts` | Passed |
| Permission presentation, existing approval interactions/scopes and workspace consumers | `npm test -- src/renderer/src/pages/workspace/permission-request-presentation.test.ts src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx` | Passed |
| Eight-locale coverage and translation contracts | `npm test -- src/renderer/src/i18n/resources.test.ts` | Passed |
| Affected renderer types and source standards | `npm run typecheck:web`; `npm run lint`; `git diff --check` | Passed |
| Actual Message and Approval component layouts | Isolated localhost sample data in installed Chromium; five cards per surface, keyboard disclosures, 390 px viewport | Passed; no browser errors or horizontal overflow |

The nine test files above were executed together with `--maxWorkers=2`. The independent review confirmed this impact mapping. The public projection tests exercise supported names/envelopes used by Claude Code, OpenCode, Codex Responses and Codex bridge; canonical MCP identity remains the approval boundary. Live framework launchers, models, protocol replay, subscriptions and main-process Notebook execution are excluded because this change does not alter those paths. Screenshots use actual components with isolated fixtures, not an authenticated backend end-to-end run. Electron-specific and other-OS execution were not run locally; required PR CI remains authoritative.

## Review focus

Check exact tool matching, honest success/error summaries, inspectable approval targets, payload omission and preservation of existing permission interactions.
