### PR TITLE
feat(permissions): expand notebook, memory, and plan defaults

### DIFF
--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -1074,69 +1074,71 @@ describe('ACP permission broker with durable grants', () => {
     expect(emitted).toEqual([])
   })
 
-  it.each(['list_notebook_runtimes', 'notebook_state'])(
-    'uses the default %s Global grant across frameworks and respects revocation',
-    async (tool) => {
-      storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-notebook-default-'))
-      client = createProjectDbClient(storageRoot)
-      await migrateApplicationDatabase(client)
-      const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
-      await seedDefaultPermissionGrants(registry, client)
-      const emit = vi.fn()
-      const broker = new AcpPermissionBroker(emit, undefined, registry)
-      const context = {
-        profile: 'ask' as const,
-        mcpServerNames: ['open-science-notebook']
-      }
-      const requests = [
-        mcpRequest('claude', `mcp__open-science-notebook__${tool}`),
-        mcpRequest('codebuddy', `mcp__open_science_notebook__${tool}`),
-        mcpRequest('opencode', `open_science_notebook_${tool}`),
-        mcpRequest('codex-response', `mcp.open-science-notebook.${tool}`),
-        withTrustedMcpToolIdentity(
-          {
-            ...titleOnlyRequest('Execute MCP tool'),
-            sessionId: 'codex-bridge',
-            _meta: { is_mcp_tool_approval: true }
-          },
-          `open-science-notebook/${tool}`
-        )
-      ]
-
-      for (const request of requests) {
-        await expect(
-          broker.requestPermission(request, { ...context, projectId: request.sessionId })
-        ).resolves.toEqual({
-          outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
-        })
-      }
-      expect(emit).not.toHaveBeenCalled()
-
-      const withoutOneShot = {
-        ...requests[0]!,
-        options: [{ optionId: 'always', name: 'Always', kind: 'allow_always' as const }]
-      }
-      await expect(broker.requestPermission(withoutOneShot, context)).resolves.toEqual({
-        outcome: { outcome: 'cancelled' }
-      })
-      expect(emit).not.toHaveBeenCalled()
-
-      const granted = (await registry.list()).find(
-        (grant) => grant.capability.key === `mcp:open-science-notebook/${tool}`
-      )!
-      await registry.revoke({ grants: [{ id: granted.id, revision: granted.revision }] })
-      for (const request of requests) {
-        const pending = broker.requestPermission(request, context)
-        await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce())
-        const [approval] = emit.mock.calls[0]!
-        broker.respond({ requestId: approval.requestId, optionId: 'provider-reject-once' })
-        await expect(pending).resolves.toEqual({
-          outcome: { outcome: 'selected', optionId: 'provider-reject-once' }
-        })
-        emit.mockClear()
-      }
+  it.each([
+    'list_notebook_runtimes',
+    'notebook_state',
+    'list_memory_categories',
+    'search_memories'
+  ])('uses the default %s Global grant across frameworks and respects revocation', async (tool) => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-notebook-default-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
+    await seedDefaultPermissionGrants(registry, client)
+    const emit = vi.fn()
+    const broker = new AcpPermissionBroker(emit, undefined, registry)
+    const context = {
+      profile: 'ask' as const,
+      mcpServerNames: ['open-science-notebook']
     }
-  )
+    const requests = [
+      mcpRequest('claude', `mcp__open-science-notebook__${tool}`),
+      mcpRequest('codebuddy', `mcp__open_science_notebook__${tool}`),
+      mcpRequest('opencode', `open_science_notebook_${tool}`),
+      mcpRequest('codex-response', `mcp.open-science-notebook.${tool}`),
+      withTrustedMcpToolIdentity(
+        {
+          ...titleOnlyRequest('Execute MCP tool'),
+          sessionId: 'codex-bridge',
+          _meta: { is_mcp_tool_approval: true }
+        },
+        `open-science-notebook/${tool}`
+      )
+    ]
+
+    for (const request of requests) {
+      await expect(
+        broker.requestPermission(request, { ...context, projectId: request.sessionId })
+      ).resolves.toEqual({
+        outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
+      })
+    }
+    expect(emit).not.toHaveBeenCalled()
+
+    const withoutOneShot = {
+      ...requests[0]!,
+      options: [{ optionId: 'always', name: 'Always', kind: 'allow_always' as const }]
+    }
+    await expect(broker.requestPermission(withoutOneShot, context)).resolves.toEqual({
+      outcome: { outcome: 'cancelled' }
+    })
+    expect(emit).not.toHaveBeenCalled()
+
+    const granted = (await registry.list()).find(
+      (grant) => grant.capability.key === `mcp:open-science-notebook/${tool}`
+    )!
+    await registry.revoke({ grants: [{ id: granted.id, revision: granted.revision }] })
+    for (const request of requests) {
+      const pending = broker.requestPermission(request, context)
+      await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce())
+      const [approval] = emit.mock.calls[0]!
+      broker.respond({ requestId: approval.requestId, optionId: 'provider-reject-once' })
+      await expect(pending).resolves.toEqual({
+        outcome: { outcome: 'selected', optionId: 'provider-reject-once' }
+      })
+      emit.mockClear()
+    }
+  })
 
   it('does not use Notebook defaults for presentation text, unknown servers, or execution', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-notebook-default-boundary-'))
@@ -1150,9 +1152,13 @@ describe('ACP permission broker with durable grants', () => {
     for (const request of [
       titleOnlyRequest('mcp__open-science-notebook__notebook_state'),
       titleOnlyRequest('mcp__open-science-notebook__list_notebook_runtimes'),
+      titleOnlyRequest('mcp__open-science-notebook__list_memory_categories'),
+      titleOnlyRequest('mcp__open-science-notebook__search_memories'),
       mcpRequest('other-server', 'mcp__other_notebook__notebook_state'),
       mcpRequest('execution', 'mcp__open_science_notebook__notebook_execute'),
-      mcpRequest('packages', 'mcp__open_science_notebook__manage_packages')
+      mcpRequest('packages', 'mcp__open_science_notebook__manage_packages'),
+      mcpRequest('memory-write', 'mcp__open_science_notebook__remember_memory'),
+      mcpRequest('other-memory-server', 'mcp__other_notebook__search_memories')
     ]) {
       const pending = broker.requestPermission(request, {
         profile: 'ask',

--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -1075,72 +1075,77 @@ describe('ACP permission broker with durable grants', () => {
   })
 
   it.each([
-    'list_notebook_runtimes',
-    'notebook_state',
-    'list_memory_categories',
-    'search_memories'
-  ])('uses the default %s Global grant across frameworks and respects revocation', async (tool) => {
-    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-notebook-default-'))
-    client = createProjectDbClient(storageRoot)
-    await migrateApplicationDatabase(client)
-    const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
-    await seedDefaultPermissionGrants(registry, client)
-    const emit = vi.fn()
-    const broker = new AcpPermissionBroker(emit, undefined, registry)
-    const context = {
-      profile: 'ask' as const,
-      mcpServerNames: ['open-science-notebook']
-    }
-    const requests = [
-      mcpRequest('claude', `mcp__open-science-notebook__${tool}`),
-      mcpRequest('codebuddy', `mcp__open_science_notebook__${tool}`),
-      mcpRequest('opencode', `open_science_notebook_${tool}`),
-      mcpRequest('codex-response', `mcp.open-science-notebook.${tool}`),
-      withTrustedMcpToolIdentity(
-        {
-          ...titleOnlyRequest('Execute MCP tool'),
-          sessionId: 'codex-bridge',
-          _meta: { is_mcp_tool_approval: true }
-        },
-        `open-science-notebook/${tool}`
-      )
-    ]
+    ['open-science-notebook', 'list_notebook_runtimes'],
+    ['open-science-notebook', 'notebook_state'],
+    ['open-science-notebook', 'list_memory_categories'],
+    ['open-science-notebook', 'search_memories'],
+    ['open-science-notebook', 'inspect_packages'],
+    ['open-science-plan', 'update_step_status']
+  ])(
+    'uses the default %s/%s Global grant across frameworks and respects revocation',
+    async (server, tool) => {
+      storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-notebook-default-'))
+      client = createProjectDbClient(storageRoot)
+      await migrateApplicationDatabase(client)
+      const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
+      await seedDefaultPermissionGrants(registry, client)
+      const emit = vi.fn()
+      const broker = new AcpPermissionBroker(emit, undefined, registry)
+      const context = {
+        profile: 'ask' as const,
+        mcpServerNames: [server]
+      }
+      const requests = [
+        mcpRequest('claude', `mcp__${server}__${tool}`),
+        mcpRequest('codebuddy', `mcp__${server.replaceAll('-', '_')}__${tool}`),
+        mcpRequest('opencode', `${server.replaceAll('-', '_')}_${tool}`),
+        mcpRequest('codex-response', `mcp.${server}.${tool}`),
+        withTrustedMcpToolIdentity(
+          {
+            ...titleOnlyRequest('Execute MCP tool'),
+            sessionId: 'codex-bridge',
+            _meta: { is_mcp_tool_approval: true }
+          },
+          `${server}/${tool}`
+        )
+      ]
 
-    for (const request of requests) {
-      await expect(
-        broker.requestPermission(request, { ...context, projectId: request.sessionId })
-      ).resolves.toEqual({
-        outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
+      for (const request of requests) {
+        await expect(
+          broker.requestPermission(request, { ...context, projectId: request.sessionId })
+        ).resolves.toEqual({
+          outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
+        })
+      }
+      expect(emit).not.toHaveBeenCalled()
+
+      const withoutOneShot = {
+        ...requests[0]!,
+        options: [{ optionId: 'always', name: 'Always', kind: 'allow_always' as const }]
+      }
+      await expect(broker.requestPermission(withoutOneShot, context)).resolves.toEqual({
+        outcome: { outcome: 'cancelled' }
       })
-    }
-    expect(emit).not.toHaveBeenCalled()
+      expect(emit).not.toHaveBeenCalled()
 
-    const withoutOneShot = {
-      ...requests[0]!,
-      options: [{ optionId: 'always', name: 'Always', kind: 'allow_always' as const }]
+      const granted = (await registry.list()).find(
+        (grant) => grant.capability.key === `mcp:${server}/${tool}`
+      )!
+      await registry.revoke({ grants: [{ id: granted.id, revision: granted.revision }] })
+      for (const request of requests) {
+        const pending = broker.requestPermission(request, context)
+        await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce())
+        const [approval] = emit.mock.calls[0]!
+        broker.respond({ requestId: approval.requestId, optionId: 'provider-reject-once' })
+        await expect(pending).resolves.toEqual({
+          outcome: { outcome: 'selected', optionId: 'provider-reject-once' }
+        })
+        emit.mockClear()
+      }
     }
-    await expect(broker.requestPermission(withoutOneShot, context)).resolves.toEqual({
-      outcome: { outcome: 'cancelled' }
-    })
-    expect(emit).not.toHaveBeenCalled()
+  )
 
-    const granted = (await registry.list()).find(
-      (grant) => grant.capability.key === `mcp:open-science-notebook/${tool}`
-    )!
-    await registry.revoke({ grants: [{ id: granted.id, revision: granted.revision }] })
-    for (const request of requests) {
-      const pending = broker.requestPermission(request, context)
-      await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce())
-      const [approval] = emit.mock.calls[0]!
-      broker.respond({ requestId: approval.requestId, optionId: 'provider-reject-once' })
-      await expect(pending).resolves.toEqual({
-        outcome: { outcome: 'selected', optionId: 'provider-reject-once' }
-      })
-      emit.mockClear()
-    }
-  })
-
-  it('does not use Notebook defaults for presentation text, unknown servers, or execution', async () => {
+  it('does not use default grants for presentation text, unknown servers, or unapproved tools', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-notebook-default-boundary-'))
     client = createProjectDbClient(storageRoot)
     await migrateApplicationDatabase(client)
@@ -1154,6 +1159,12 @@ describe('ACP permission broker with durable grants', () => {
       titleOnlyRequest('mcp__open-science-notebook__list_notebook_runtimes'),
       titleOnlyRequest('mcp__open-science-notebook__list_memory_categories'),
       titleOnlyRequest('mcp__open-science-notebook__search_memories'),
+      titleOnlyRequest('mcp__open-science-notebook__inspect_packages'),
+      titleOnlyRequest('mcp__open-science-plan__update_step_status'),
+      mcpRequest('other-package-server', 'mcp__other_notebook__inspect_packages'),
+      mcpRequest('other-plan-server', 'mcp__other_plan__update_step_status'),
+      mcpRequest('plan-decision', 'mcp__open_science_plan__generate_plan'),
+      mcpRequest('environment-mutation', 'mcp__open_science_notebook__manage_environments'),
       mcpRequest('other-server', 'mcp__other_notebook__notebook_state'),
       mcpRequest('execution', 'mcp__open_science_notebook__notebook_execute'),
       mcpRequest('packages', 'mcp__open_science_notebook__manage_packages'),
@@ -1162,7 +1173,7 @@ describe('ACP permission broker with durable grants', () => {
     ]) {
       const pending = broker.requestPermission(request, {
         profile: 'ask',
-        mcpServerNames: ['open-science-notebook']
+        mcpServerNames: ['open-science-notebook', 'open-science-plan']
       })
       await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce())
       const [approval] = emit.mock.calls[0]!

--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -1074,6 +1074,100 @@ describe('ACP permission broker with durable grants', () => {
     expect(emitted).toEqual([])
   })
 
+  it.each(['list_notebook_runtimes', 'notebook_state'])(
+    'uses the default %s Global grant across frameworks and respects revocation',
+    async (tool) => {
+      storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-notebook-default-'))
+      client = createProjectDbClient(storageRoot)
+      await migrateApplicationDatabase(client)
+      const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
+      await seedDefaultPermissionGrants(registry, client)
+      const emit = vi.fn()
+      const broker = new AcpPermissionBroker(emit, undefined, registry)
+      const context = {
+        profile: 'ask' as const,
+        mcpServerNames: ['open-science-notebook']
+      }
+      const requests = [
+        mcpRequest('claude', `mcp__open-science-notebook__${tool}`),
+        mcpRequest('codebuddy', `mcp__open_science_notebook__${tool}`),
+        mcpRequest('opencode', `open_science_notebook_${tool}`),
+        mcpRequest('codex-response', `mcp.open-science-notebook.${tool}`),
+        withTrustedMcpToolIdentity(
+          {
+            ...titleOnlyRequest('Execute MCP tool'),
+            sessionId: 'codex-bridge',
+            _meta: { is_mcp_tool_approval: true }
+          },
+          `open-science-notebook/${tool}`
+        )
+      ]
+
+      for (const request of requests) {
+        await expect(
+          broker.requestPermission(request, { ...context, projectId: request.sessionId })
+        ).resolves.toEqual({
+          outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
+        })
+      }
+      expect(emit).not.toHaveBeenCalled()
+
+      const withoutOneShot = {
+        ...requests[0]!,
+        options: [{ optionId: 'always', name: 'Always', kind: 'allow_always' as const }]
+      }
+      await expect(broker.requestPermission(withoutOneShot, context)).resolves.toEqual({
+        outcome: { outcome: 'cancelled' }
+      })
+      expect(emit).not.toHaveBeenCalled()
+
+      const granted = (await registry.list()).find(
+        (grant) => grant.capability.key === `mcp:open-science-notebook/${tool}`
+      )!
+      await registry.revoke({ grants: [{ id: granted.id, revision: granted.revision }] })
+      for (const request of requests) {
+        const pending = broker.requestPermission(request, context)
+        await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce())
+        const [approval] = emit.mock.calls[0]!
+        broker.respond({ requestId: approval.requestId, optionId: 'provider-reject-once' })
+        await expect(pending).resolves.toEqual({
+          outcome: { outcome: 'selected', optionId: 'provider-reject-once' }
+        })
+        emit.mockClear()
+      }
+    }
+  )
+
+  it('does not use Notebook defaults for presentation text, unknown servers, or execution', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-notebook-default-boundary-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
+    await seedDefaultPermissionGrants(registry, client)
+    const emit = vi.fn()
+    const broker = new AcpPermissionBroker(emit, undefined, registry)
+
+    for (const request of [
+      titleOnlyRequest('mcp__open-science-notebook__notebook_state'),
+      titleOnlyRequest('mcp__open-science-notebook__list_notebook_runtimes'),
+      mcpRequest('other-server', 'mcp__other_notebook__notebook_state'),
+      mcpRequest('execution', 'mcp__open_science_notebook__notebook_execute'),
+      mcpRequest('packages', 'mcp__open_science_notebook__manage_packages')
+    ]) {
+      const pending = broker.requestPermission(request, {
+        profile: 'ask',
+        mcpServerNames: ['open-science-notebook']
+      })
+      await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce())
+      const [approval] = emit.mock.calls[0]!
+      broker.respond({ requestId: approval.requestId, optionId: 'provider-reject-once' })
+      await expect(pending).resolves.toEqual({
+        outcome: { outcome: 'selected', optionId: 'provider-reject-once' }
+      })
+      emit.mockClear()
+    }
+  })
+
   it('reuses one app MCP grant across Claude Code, Codex, OpenCode, and runtime-trusted sparse requests', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-acp-mcp-aliases-'))
     client = createProjectDbClient(storageRoot)

--- a/src/main/agent-framework/app-mcp-names.test.ts
+++ b/src/main/agent-framework/app-mcp-names.test.ts
@@ -25,6 +25,17 @@ const APP_MCP_CODEC_CASES = appMcpToolIdentities().flatMap((identity) => {
 })
 
 describe('resolveCanonicalMcpToolIdentity', () => {
+  it.each([
+    ['claude-code', 'mcp__open-science-notebook__'],
+    ['codebuddy', 'mcp__open_science_notebook__'],
+    ['opencode', 'open_science_notebook_'],
+    ['codex', '']
+  ] as const)('renders the memory query references for %s', (frameworkId, prefix) => {
+    expect(
+      renderAppMcpToolReferences(frameworkId, 'Use list_memory_categories then search_memories.')
+    ).toBe(`Use ${prefix}list_memory_categories then ${prefix}search_memories.`)
+  })
+
   it('keeps the app MCP inventory aligned with the remembered-permission catalog', () => {
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool.toSorted()).toEqual(
       appMcpToolIdentities()

--- a/src/main/agent-framework/app-mcp-names.ts
+++ b/src/main/agent-framework/app-mcp-names.ts
@@ -37,7 +37,9 @@ const APP_MCP_SERVERS: readonly AppMcpServerDefinition[] = [
       'notebook_shutdown',
       'inspect_packages',
       'manage_packages',
-      'manage_environments'
+      'manage_environments',
+      'list_memory_categories',
+      'search_memories'
     ]
   },
   {

--- a/src/main/permission-grants/defaults.test.ts
+++ b/src/main/permission-grants/defaults.test.ts
@@ -49,7 +49,9 @@ describe('default permission grants', () => {
         key
       })),
       { kind: 'skill_operation', key: 'skill:invoke' },
-      { kind: 'mcp_tool', key: 'mcp:open-science-literature/read_document' }
+      { kind: 'mcp_tool', key: 'mcp:open-science-literature/read_document' },
+      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_notebook_runtimes' },
+      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/notebook_state' }
     ])
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.skill_operation).toContain('skill:invoke')
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toContain(

--- a/src/main/permission-grants/defaults.test.ts
+++ b/src/main/permission-grants/defaults.test.ts
@@ -51,7 +51,9 @@ describe('default permission grants', () => {
       { kind: 'skill_operation', key: 'skill:invoke' },
       { kind: 'mcp_tool', key: 'mcp:open-science-literature/read_document' },
       { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_notebook_runtimes' },
-      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/notebook_state' }
+      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/notebook_state' },
+      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_memory_categories' },
+      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/search_memories' }
     ])
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.skill_operation).toContain('skill:invoke')
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toContain(
@@ -86,6 +88,8 @@ describe('default permission grants', () => {
     await seedDefaultPermissionGrants(fixture.registry, fixture.client)
 
     await expect(fixture.registry.list()).resolves.toEqual([])
+    await expect(restoreDefaultPermissionGrants(fixture.registry)).resolves.toBe(14)
+    await expect(restoreDefaultPermissionGrants(fixture.registry)).resolves.toBe(0)
   })
 
   it('does not recreate a revoked default on a later startup', async () => {

--- a/src/main/permission-grants/defaults.test.ts
+++ b/src/main/permission-grants/defaults.test.ts
@@ -53,7 +53,9 @@ describe('default permission grants', () => {
       { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_notebook_runtimes' },
       { kind: 'mcp_tool', key: 'mcp:open-science-notebook/notebook_state' },
       { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_memory_categories' },
-      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/search_memories' }
+      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/search_memories' },
+      { kind: 'mcp_tool', key: 'mcp:open-science-notebook/inspect_packages' },
+      { kind: 'mcp_tool', key: 'mcp:open-science-plan/update_step_status' }
     ])
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.skill_operation).toContain('skill:invoke')
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toContain(
@@ -88,7 +90,7 @@ describe('default permission grants', () => {
     await seedDefaultPermissionGrants(fixture.registry, fixture.client)
 
     await expect(fixture.registry.list()).resolves.toEqual([])
-    await expect(restoreDefaultPermissionGrants(fixture.registry)).resolves.toBe(14)
+    await expect(restoreDefaultPermissionGrants(fixture.registry)).resolves.toBe(16)
     await expect(restoreDefaultPermissionGrants(fixture.registry)).resolves.toBe(0)
   })
 

--- a/src/main/permission-grants/defaults.ts
+++ b/src/main/permission-grants/defaults.ts
@@ -27,7 +27,9 @@ const DEFAULT_GLOBAL_PERMISSION_CAPABILITIES: readonly PermissionCapability[] = 
   { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_notebook_runtimes' },
   { kind: 'mcp_tool', key: 'mcp:open-science-notebook/notebook_state' },
   { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_memory_categories' },
-  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/search_memories' }
+  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/search_memories' },
+  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/inspect_packages' },
+  { kind: 'mcp_tool', key: 'mcp:open-science-plan/update_step_status' }
 ]
 
 const missingDefaultGlobalPermissionCapabilities = (

--- a/src/main/permission-grants/defaults.ts
+++ b/src/main/permission-grants/defaults.ts
@@ -25,7 +25,9 @@ const DEFAULT_GLOBAL_PERMISSION_CAPABILITIES: readonly PermissionCapability[] = 
   { kind: 'skill_operation', key: 'skill:invoke' },
   { kind: 'mcp_tool', key: 'mcp:open-science-literature/read_document' },
   { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_notebook_runtimes' },
-  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/notebook_state' }
+  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/notebook_state' },
+  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_memory_categories' },
+  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/search_memories' }
 ]
 
 const missingDefaultGlobalPermissionCapabilities = (

--- a/src/main/permission-grants/defaults.ts
+++ b/src/main/permission-grants/defaults.ts
@@ -23,7 +23,9 @@ const DEFAULT_GLOBAL_PERMISSION_CAPABILITIES: readonly PermissionCapability[] = 
     key
   })),
   { kind: 'skill_operation', key: 'skill:invoke' },
-  { kind: 'mcp_tool', key: 'mcp:open-science-literature/read_document' }
+  { kind: 'mcp_tool', key: 'mcp:open-science-literature/read_document' },
+  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/list_notebook_runtimes' },
+  { kind: 'mcp_tool', key: 'mcp:open-science-notebook/notebook_state' }
 ]
 
 const missingDefaultGlobalPermissionCapabilities = (

--- a/src/main/permission-grants/identity-catalog.test.ts
+++ b/src/main/permission-grants/identity-catalog.test.ts
@@ -6,17 +6,29 @@ import {
 } from './identity-catalog'
 
 describe('permission identity catalog', () => {
-  it('contains the closed 37-identity v1 bootstrap inventory', () => {
-    expect(PRE_REGISTERED_PERMISSION_IDENTITY_COUNT).toBe(37)
+  it('contains the closed 39-identity bootstrap inventory', () => {
+    expect(PRE_REGISTERED_PERMISSION_IDENTITY_COUNT).toBe(39)
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.builtin_tool).toEqual([])
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.customize_mutation).toHaveLength(8)
-    expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toHaveLength(20)
+    expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toHaveLength(22)
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toContain(
       'mcp:open-science-notebook/request_network_access'
     )
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.execution).toHaveLength(2)
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.file_operation).toHaveLength(6)
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.skill_operation).toHaveLength(1)
+  })
+
+  it('admits memory queries without granting the memory write tool', () => {
+    expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toEqual(
+      expect.arrayContaining([
+        'mcp:open-science-notebook/list_memory_categories',
+        'mcp:open-science-notebook/search_memories'
+      ])
+    )
+    expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).not.toContain(
+      'mcp:open-science-notebook/remember_memory'
+    )
   })
 
   it('admits both Session Plan capabilities to remembered permission scopes', () => {

--- a/src/main/permission-grants/identity-catalog.ts
+++ b/src/main/permission-grants/identity-catalog.ts
@@ -22,6 +22,8 @@ const PRE_REGISTERED_PERMISSION_IDENTITIES: Readonly<
     'mcp:open-science-notebook/bash_execute',
     'mcp:open-science-notebook/notebook_state',
     'mcp:open-science-notebook/list_notebook_runtimes',
+    'mcp:open-science-notebook/list_memory_categories',
+    'mcp:open-science-notebook/search_memories',
     'mcp:open-science-notebook/notebook_bind_runtime',
     'mcp:open-science-notebook/notebook_switch_runtime',
     'mcp:open-science-notebook/notebook_restart',

--- a/src/main/permission-grants/projection-controller.test.ts
+++ b/src/main/permission-grants/projection-controller.test.ts
@@ -232,10 +232,10 @@ describe('Permission Grant projection controller', () => {
     })
 
     await expect(controller.restoreDefaults()).resolves.toMatchObject({
-      restoredCount: 10,
-      version: 10,
-      counts: { global: 10 }
+      restoredCount: 12,
+      version: 12,
+      counts: { global: 12 }
     })
-    expect(remember).toHaveBeenCalledTimes(10)
+    expect(remember).toHaveBeenCalledTimes(12)
   })
 })

--- a/src/main/permission-grants/projection-controller.test.ts
+++ b/src/main/permission-grants/projection-controller.test.ts
@@ -232,10 +232,10 @@ describe('Permission Grant projection controller', () => {
     })
 
     await expect(controller.restoreDefaults()).resolves.toMatchObject({
-      restoredCount: 12,
-      version: 12,
-      counts: { global: 12 }
+      restoredCount: 14,
+      version: 14,
+      counts: { global: 14 }
     })
-    expect(remember).toHaveBeenCalledTimes(12)
+    expect(remember).toHaveBeenCalledTimes(14)
   })
 })

--- a/src/main/permission-grants/projection-controller.test.ts
+++ b/src/main/permission-grants/projection-controller.test.ts
@@ -232,10 +232,10 @@ describe('Permission Grant projection controller', () => {
     })
 
     await expect(controller.restoreDefaults()).resolves.toMatchObject({
-      restoredCount: 14,
-      version: 14,
-      counts: { global: 14 }
+      restoredCount: 16,
+      version: 16,
+      counts: { global: 16 }
     })
-    expect(remember).toHaveBeenCalledTimes(14)
+    expect(remember).toHaveBeenCalledTimes(16)
   })
 })


### PR DESCRIPTION
## Problem

Routine Notebook/package inspection, memory queries and approved Plan progress updates repeatedly interrupt research conversations with approval requests.

## Proposed change

Add six existing tools to default Global permissions, increasing the default set from 10 to 16:

- `open-science-notebook/list_notebook_runtimes`
- `open-science-notebook/notebook_state`
- `open-science-notebook/list_memory_categories`
- `open-science-notebook/search_memories`
- `open-science-notebook/inspect_packages`
- `open-science-plan/update_step_status`

Register the two memory query identities in the shared permission and framework catalogs. Grants remain visible and revocable in Settings; the broker answers each provider request with a native one-shot approval. Memory must remain enabled, and queries retain authenticated global/current-project scope.

## Scope and non-goals

- **Historical compatibility:** preserve `global-customize-v1`. Existing installations receive no automatic backfill, including previously revoked grants. Users can explicitly choose Settings → Permissions → Restore defaults; repeated restore is idempotent.
- **Persistence:** reuse existing PermissionGrant rows and PermissionGrantSeed. Fresh installs and explicit restore persist missing grants; no database migration or persisted-format change.
- **States/enums:** no new permission mode, enum value, or lifecycle state. The two catalog entries identify existing tools.
- **Existing Notebook side effects:** runtime discovery launches interpreter version/dependency probes, including external candidates. Session initialization can create Notebook directories/run.json; state recovery may persist existing binding/history reconciliation. These existing effects become reachable without repeated approval; no execution or recovery implementation changes.
- **Package/Plan persistence:** `inspect_packages` runs fixed interpreter inventory/fingerprint probes and persists existing inventory caches/recovery records; it refuses external interpreters and cannot provision a missing default runtime. `update_step_status` persists progress/notes only for approved active Plan steps, preserving step identity, dependencies, transition and revision checks. It cannot approve a Plan or execute a step.
- Memory writes (`remember_memory`), Notebook execution, package/environment changes, arbitrary file access, and network/connector policies retain their existing approval rules.

The broader assessment found question/network tools already omit redundant outer approvals while preserving actual user consent. Artifact/activity tools also have existing narrow automatic rules. `generate_plan` includes approval/rejection decisions and remains gated. `manage_environments` combines listing with create/remove, so the whole tool remains gated; a future action-scoped listing permission would require a separate design.

## Acceptance criteria and validation

After the final material edit, default seed/restore/no-backfill and six-tool framework/revocation regressions passed: `npm test -- src/main/permission-grants/defaults.test.ts src/main/permission-grants/projection-controller.test.ts src/main/acp/permission-broker-registry.test.ts -t 'default|restore' --maxWorkers=1` → 19 passed, 99 unselected. Independent Standards and Spec reviews found no implementation defects. `npm run typecheck:node`, `npm run lint`, changed-file Prettier and `git diff --check` passed after the final material edit. The broader selected run completed 35 of 38 files successfully (1,165 tests passed, 19 failed with test/SQLite transaction timeouts); the host had load above 300 and approximately 59 MB unused memory. The focused Notebook/ACP runtime boundary command `npm test -- src/main/notebook/runtime-service.test.ts src/main/acp/runtime.test.ts -t 'inspectPackages|ACP Notebook permission presentation contract|elicitation|ask_user_question' --maxWorkers=1` passed 37 tests (876 unselected), including missing-default and external-interpreter refusal. A real isolated Web preview retained 14 existing grants at startup; explicit Restore defaults added exactly two grants to Global (16), and all six tools are visible in the captured screenshot. The main/preload build passed using the repository configuration with the unchanged renderer omitted to reduce resource use. Do not interpret the previous four-tool CI result as validation of this HEAD. The selected set includes permissions, framework/IPC/Web/Settings consumers, memory, package operations/tracker, Session Plan owner/MCP/interaction contracts, and focused Notebook/ACP runtime boundaries. The maintainer explicitly excludes a complete local suite; the module-impact classifier falls back to full because the broker-registry test has no module owner. Required PR CI remains authoritative.

The broader 38-file command (resource-limited result above) was:

```sh
npm test -- src/main/permission-grants src/main/acp/permission-broker-registry.test.ts src/main/acp/permission-broker.test.ts src/main/acp/permission-policy.test.ts src/main/acp/permission-context.test.ts src/main/acp/client-interaction-owner.test.ts src/main/acp/elicitation-owner.test.ts src/main/acp/permission-wait-owner.test.ts src/main/runtime-electron-wiring.test.ts src/main/web-service/controller.test.ts src/renderer/src/pages/settings/PermissionsPanel.render.test.tsx src/renderer/src/stores/permission-grants-store.test.ts src/main/agent-framework/app-mcp-names.test.ts src/main/agent-framework/claude-code.test.ts src/main/agent-framework/opencode.test.ts src/main/agent-framework/codex.test.ts src/main/agent-framework/codebuddy.test.ts src/main/agent-framework/claude-code-memory.integration.test.ts src/main/memory/service.test.ts src/main/notebook/local-rpc-server.test.ts src/main/notebook/mcp-server.test.ts src/main/notebook/package-operations.test.ts src/main/notebook/environment-state-tracker.test.ts src/main/session-plan --maxWorkers=1
```

No live model/provider or complete OS matrix was run locally. MCP approval fixtures cover `session/request_permission`; shared runtime fixtures cover Codex `elicitation/create` translation, trusted correlation, and real user elicitation. Broker alias fixtures are not live provider tests. No launcher/transport, protocol schema, history replay, subscription lifecycle, or OS path implementation changes. The existing renderer build was reused because renderer sources did not change; the headless backend was rebuilt for the final defaults.

## Review focus

The exact six-tool scope, existing-user choices, memory scope, trusted identity matching, revocation and provider-native one-shot responses.
