### PR TITLE
fix(specialist): preserve package recovery and approved capabilities

### DIFF
--- a/src/main/skills/specialist-package-adapter.test.ts
+++ b/src/main/skills/specialist-package-adapter.test.ts
@@ -293,7 +293,17 @@ describe('UserSkillSpecialistPackageAdapter', () => {
       'analysis-tools'
     ])
 
-    expect(snapshot).toMatchObject({ localId: 'analysis-tools', name: 'analysis-tools' })
+    expect(snapshot).toMatchObject({
+      localId: 'analysis-tools',
+      name: 'analysis-tools',
+      version: '1.2.3'
+    })
+
+    await rm(join(directory, SPECIALIST_PACKAGE_SKILL_METADATA))
+    const [withoutMetadata] = await new UserSkillSpecialistPackageAdapter(root).exportSnapshot([
+      'personal-analysis-tools'
+    ])
+    expect(withoutMetadata.version).toBe('0.1.0')
   })
 
   it('does not reinterpret a legacy directory whose name starts with personal-', async () => {

--- a/src/main/skills/specialist-package-adapter.test.ts
+++ b/src/main/skills/specialist-package-adapter.test.ts
@@ -26,7 +26,7 @@ const plan = (id = 'analysis-tools'): SpecialistPackageSkillPlan => ({
   versionRange: '^1.2.0',
   disposition: 'install',
   files: ['SKILL.md', 'scripts/run.sh'],
-  contentHash: 'a'.repeat(64),
+  contentHash: '72541991850adc0678ab5319bc5d205fdde34af8065c913b92cae0bad4cab342',
   filesToInstall: [
     {
       path: 'SKILL.md',
@@ -81,7 +81,7 @@ describe('UserSkillSpecialistPackageAdapter', () => {
       JSON.stringify({
         id: 'analysis-tools',
         version: '1.2.3',
-        contentHash: 'a'.repeat(64),
+        contentHash: '72541991850adc0678ab5319bc5d205fdde34af8065c913b92cae0bad4cab342',
         standalone: true,
         ownerIds: ['research-synth']
       })
@@ -159,7 +159,7 @@ describe('UserSkillSpecialistPackageAdapter', () => {
       {
         id: 'personal-analysis-tools',
         version: '1.2.3',
-        contentHash: 'a'.repeat(64),
+        contentHash: '72541991850adc0678ab5319bc5d205fdde34af8065c913b92cae0bad4cab342',
         standalone: false,
         ownerIds: ['research-synth']
       }
@@ -182,7 +182,7 @@ describe('UserSkillSpecialistPackageAdapter', () => {
       JSON.stringify({
         id: 'imported-analysis-tools',
         version: '1.2.3',
-        contentHash: 'a'.repeat(64),
+        contentHash: '72541991850adc0678ab5319bc5d205fdde34af8065c913b92cae0bad4cab342',
         standalone: false,
         ownerIds: ['first-specialist']
       })

--- a/src/main/skills/specialist-package-adapter.ts
+++ b/src/main/skills/specialist-package-adapter.ts
@@ -197,7 +197,11 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
         const localId = skill.localId ?? skill.id
         const current = live.find((candidate) => candidate.id === localId)
         if (skill.disposition === 'install') {
-          if (current || (await exists(join(this.personalRoot, skill.id)))) {
+          if (
+            current ||
+            (await this.findSkillDirectory(localId)) ||
+            (await exists(join(this.personalRoot, skill.id)))
+          ) {
             throw new Error(`Skill ${skill.id} changed after preview.`)
           }
           continue

--- a/src/main/skills/specialist-package-adapter.ts
+++ b/src/main/skills/specialist-package-adapter.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { cp, lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, join, resolve, sep } from 'node:path'
 
+import { validateSpecialistPackageVersion } from '../../shared/specialist'
 import type { SpecialistPackageSkillPlan } from '../../shared/specialist-package'
 import type { SpecialistPackageSkillPort } from '../specialist/package/skill-port'
 import { writeDurableJsonFile } from '../storage/durable-json-file'
@@ -359,6 +360,11 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
               new TextDecoder().decode(skillDocument.bytes)
             ).metadata.version?.trim()
           : undefined
+        if (version !== undefined && validateSpecialistPackageVersion(version)) {
+          throw new Error(
+            `Skill ${localId} has an invalid version. Correct SKILL.md before exporting.`
+          )
+        }
         result.push({
           localId,
           name,

--- a/src/main/skills/specialist-package-adapter.ts
+++ b/src/main/skills/specialist-package-adapter.ts
@@ -259,17 +259,17 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
         if (!SAFE_DIRECTORY_NAME.test(entry)) continue
         const directory = join(root, entry)
         const metadata = await readMetadata(directory)
-        if (metadata) {
-          const document = parseSkillDocument(await readFile(join(directory, 'SKILL.md'), 'utf8'))
-          result.push({
-            id: metadata.id,
-            version: document.metadata.version?.trim() ?? metadata.version,
-            contentHash: await directoryHash(directory),
-            standalone: metadata.standalone,
-            ownerIds: metadata.ownerIds
-          })
-        } else {
-          try {
+        try {
+          if (metadata) {
+            const document = parseSkillDocument(await readFile(join(directory, 'SKILL.md'), 'utf8'))
+            result.push({
+              id: metadata.id,
+              version: document.metadata.version?.trim() ?? metadata.version,
+              contentHash: await directoryHash(directory),
+              standalone: metadata.standalone,
+              ownerIds: metadata.ownerIds
+            })
+          } else {
             result.push({
               id: `${source}-${entry}`,
               version: '0.1.0',
@@ -277,9 +277,9 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
               standalone: true,
               ownerIds: []
             })
-          } catch {
-            // Invalid existing Skills remain visible through the ordinary catalog but cannot be reused.
           }
+        } catch {
+          // An unreadable Skill cannot be reused, but must not block unrelated packages.
         }
       }
     }

--- a/src/main/skills/specialist-package-adapter.ts
+++ b/src/main/skills/specialist-package-adapter.ts
@@ -349,10 +349,16 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
         ) {
           throw new Error('Skill changed during export. Preview again and retry.')
         }
+        const skillDocument = files.find((file) => file.path === 'SKILL.md')
+        const version = skillDocument
+          ? parseSkillDocument(
+              new TextDecoder().decode(skillDocument.bytes)
+            ).metadata.version?.trim()
+          : undefined
         result.push({
           localId,
           name,
-          version: beforeMetadata?.version ?? '0.1.0',
+          version: version ?? beforeMetadata?.version ?? '0.1.0',
           contentHash: afterHash,
           files
         })

--- a/src/main/skills/specialist-package-adapter.ts
+++ b/src/main/skills/specialist-package-adapter.ts
@@ -4,6 +4,8 @@ import { basename, dirname, join, resolve, sep } from 'node:path'
 
 import type { SpecialistPackageSkillPlan } from '../../shared/specialist-package'
 import type { SpecialistPackageSkillPort } from '../specialist/package/skill-port'
+import { writeDurableJsonFile } from '../storage/durable-json-file'
+import { parseSkillDocument } from './frontmatter'
 import { type SkillMutationOwner, skillMutationOwnerFor } from './skill-mutation-owner'
 
 const SAFE_DIRECTORY_NAME = /^[a-z0-9-]+$/
@@ -16,19 +18,32 @@ type PackageSkillMetadata = {
   contentHash: string
   standalone: boolean
   ownerIds: string[]
+  transactionId?: string
 }
 
 type SkillStorageSource = 'imported' | 'personal'
 
+type SkillTransactionLocation = {
+  directoryName: string
+  source: SkillStorageSource
+  // Written under the mutation lock before any rename, never inferred during recovery.
+  hadLive?: boolean
+  contentHash?: string
+}
+
 type PackageSkillTransaction = {
+  version?: 2
   mode: 'install' | 'delete'
-  locations: Map<string, { directoryName: string; source: SkillStorageSource }>
+  locations: Map<string, SkillTransactionLocation>
 }
 
 const exists = (path: string): Promise<boolean> =>
   stat(path).then(
     () => true,
-    () => false
+    (error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return false
+      throw error
+    }
   )
 
 const readMetadata = async (directory: string): Promise<PackageSkillMetadata | undefined> => {
@@ -53,11 +68,34 @@ const readMetadata = async (directory: string): Promise<PackageSkillMetadata | u
 
 const readTransaction = async (root: string): Promise<PackageSkillTransaction> => {
   const value = JSON.parse(await readFile(join(root, 'transaction.json'), 'utf8')) as {
+    version?: unknown
     mode?: unknown
     skills?: unknown
     skillIds?: unknown
   }
-  const locations = new Map<string, { directoryName: string; source: SkillStorageSource }>()
+  if (value.version !== undefined && value.version !== 2)
+    throw new Error('Unknown Skill transaction version.')
+  if (
+    value.version === 2 &&
+    (!Array.isArray(value.skills) ||
+      !['install', 'delete'].includes(String(value.mode)) ||
+      value.skills.some(
+        (skill) =>
+          !skill ||
+          typeof skill !== 'object' ||
+          typeof skill.localId !== 'string' ||
+          !SAFE_DIRECTORY_NAME.test(skill.localId) ||
+          typeof skill.directoryName !== 'string' ||
+          !SAFE_DIRECTORY_NAME.test(skill.directoryName) ||
+          !['personal', 'imported'].includes(skill.source) ||
+          (skill.hadLive !== undefined && typeof skill.hadLive !== 'boolean') ||
+          (skill.contentHash !== undefined &&
+            (typeof skill.contentHash !== 'string' || !/^[a-f0-9]{64}$/.test(skill.contentHash)))
+      ) ||
+      new Set(value.skills.map((skill) => skill.localId)).size !== value.skills.length)
+  )
+    throw new Error('Invalid Skill transaction journal; preserve it for repair.')
+  const locations = new Map<string, SkillTransactionLocation>()
   if (Array.isArray(value.skills)) {
     for (const skill of value.skills) {
       if (
@@ -72,7 +110,13 @@ const readTransaction = async (root: string): Promise<PackageSkillTransaction> =
       ) {
         locations.set(skill.localId, {
           directoryName: skill.directoryName,
-          source: 'source' in skill && skill.source === 'imported' ? 'imported' : 'personal'
+          source: 'source' in skill && skill.source === 'imported' ? 'imported' : 'personal',
+          ...('hadLive' in skill && typeof skill.hadLive === 'boolean'
+            ? { hadLive: skill.hadLive }
+            : {}),
+          ...('contentHash' in skill && typeof skill.contentHash === 'string'
+            ? { contentHash: skill.contentHash }
+            : {})
         })
       }
     }
@@ -85,7 +129,11 @@ const readTransaction = async (root: string): Promise<PackageSkillTransaction> =
       }
     }
   }
-  return { mode: value.mode === 'delete' ? 'delete' : 'install', locations }
+  return {
+    ...(value.version === 2 ? { version: 2 as const } : {}),
+    mode: value.mode === 'delete' ? 'delete' : 'install',
+    locations
+  }
 }
 
 const directoryHash = async (directory: string): Promise<string> => {
@@ -211,8 +259,16 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
         if (!SAFE_DIRECTORY_NAME.test(entry)) continue
         const directory = join(root, entry)
         const metadata = await readMetadata(directory)
-        if (metadata) result.push(metadata)
-        else {
+        if (metadata) {
+          const document = parseSkillDocument(await readFile(join(directory, 'SKILL.md'), 'utf8'))
+          result.push({
+            id: metadata.id,
+            version: document.metadata.version?.trim() ?? metadata.version,
+            contentHash: await directoryHash(directory),
+            standalone: metadata.standalone,
+            ownerIds: metadata.ownerIds
+          })
+        } else {
           try {
             result.push({
               id: `${source}-${entry}`,
@@ -339,6 +395,7 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
       await writeFile(
         join(root, 'transaction.json'),
         `${JSON.stringify({
+          version: 2,
           mode: 'install',
           skills: skills
             .map((skill) => {
@@ -360,8 +417,17 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
         if (!SAFE_DIRECTORY_NAME.test(localId)) throw new Error('Invalid local Skill ID.')
         const staging = join(root, 'staging', localId)
         const stagingRoot = resolve(staging)
-        await mkdir(staging, { recursive: true })
-        for (const file of skill.filesToInstall) {
+        const existingDirectory =
+          locations.get(localId)?.existingDirectory ?? join(this.personalRoot, skill.id)
+        if (skill.disposition === 'reuse-owned') {
+          // Reuse preserves the current tree; only ownership metadata changes.
+          await mkdir(dirname(staging), { recursive: true })
+          await cp(existingDirectory, staging, { recursive: true, errorOnExist: true })
+          if ((await directoryHash(staging)) !== skill.contentHash) {
+            throw new Error(`Skill ${skill.id} changed after preview.`)
+          }
+        } else await mkdir(staging, { recursive: true })
+        for (const file of skill.disposition === 'reuse-owned' ? [] : skill.filesToInstall) {
           const target = resolve(staging, file.path)
           if (
             target === stagingRoot ||
@@ -373,12 +439,11 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
           await mkdir(dirname(target), { recursive: true })
           await writeFile(target, file.bytes, { flag: 'wx' })
         }
-        const existingDirectory =
-          locations.get(localId)?.existingDirectory ?? join(this.personalRoot, skill.id)
         const existing = await readMetadata(existingDirectory)
         const ownerIds = [...new Set([...(existing?.ownerIds ?? []), specialistId])].sort()
         const metadata: PackageSkillMetadata = {
           id: localId,
+          transactionId,
           version: skill.version,
           contentHash: skill.contentHash,
           standalone:
@@ -388,7 +453,7 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
         await writeFile(
           join(staging, SPECIALIST_PACKAGE_SKILL_METADATA),
           `${JSON.stringify(metadata)}\n`,
-          { flag: 'wx' }
+          { flag: skill.disposition === 'reuse-owned' ? 'w' : 'wx' }
         )
       }
     } catch (error) {
@@ -440,6 +505,7 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
       await writeFile(
         join(root, 'transaction.json'),
         `${JSON.stringify({
+          version: 2,
           mode: 'delete',
           skills: affectedTransactionSkills.map(({ localId, directoryName, source }) => ({
             localId,
@@ -460,6 +526,7 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
           join(staging, SPECIALIST_PACKAGE_SKILL_METADATA),
           `${JSON.stringify({
             ...metadata,
+            transactionId,
             ownerIds,
             standalone: metadata.standalone || ownerIds.length === 0
           })}\n`,
@@ -475,23 +542,26 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
   async commit(transactionId: string): Promise<void> {
     const root = this.transactionDir(transactionId)
     const stagingRoot = join(root, 'staging')
-    const locations = new Map<string, { directoryName: string; source: SkillStorageSource }>()
-    try {
-      for (const [id, location] of (await readTransaction(root)).locations) {
-        locations.set(id, location)
-      }
-    } catch {
-      // Staging evidence below remains authoritative for legacy transactions.
+    const transaction = await readTransaction(root)
+    const locations = transaction.locations
+    for (const [id, location] of locations) {
+      if (location.hadLive !== undefined)
+        throw new Error('Skill commit already started; recover it first.')
+      const staging = join(stagingRoot, id)
+      location.hadLive = await exists(
+        join(dirname(this.personalRoot), location.source, location.directoryName)
+      )
+      if (await exists(staging)) location.contentHash = await directoryHash(staging)
+      else if (transaction.mode === 'install') throw new Error('Skill preparation is incomplete.')
     }
-    try {
-      for (const id of await readdir(stagingRoot)) {
-        if (SAFE_DIRECTORY_NAME.test(id) && !locations.has(id)) {
-          locations.set(id, { directoryName: id, source: 'personal' })
-        }
-      }
-    } catch {
-      // A delete-only transaction intentionally has no staging directory.
-    }
+    await writeDurableJsonFile(
+      join(root, 'transaction.json'),
+      JSON.stringify({
+        version: 2,
+        mode: transaction.mode,
+        skills: [...locations].map(([localId, location]) => ({ localId, ...location }))
+      })
+    )
     await mkdir(this.personalRoot, { recursive: true })
     await mkdir(join(root, 'backup'), { recursive: true })
     for (const [id, { directoryName, source }] of [...locations].sort(([left], [right]) =>
@@ -525,16 +595,17 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
     const root = this.transactionDir(transactionId)
     const stagingRoot = join(root, 'staging')
     const backupRoot = join(root, 'backup')
-    const locations = new Map<string, { directoryName: string; source: SkillStorageSource }>()
+    const locations = new Map<string, SkillTransactionLocation>()
     let mode: 'install' | 'delete' = 'install'
+    let version: 2 | undefined
     try {
       const transaction = await readTransaction(root)
       mode = transaction.mode
-      for (const [id, location] of transaction.locations) {
-        locations.set(id, location)
-      }
-    } catch {
-      // Legacy or partially prepared transaction; directory evidence below remains authoritative.
+      version = transaction.version
+      for (const [id, location] of transaction.locations) locations.set(id, location)
+    } catch (error) {
+      // A damaged journal is not an empty transaction. Preserve all evidence for repair.
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
     }
     for (const directory of [stagingRoot, backupRoot]) {
       try {
@@ -548,18 +619,41 @@ export class UserSkillSpecialistPackageAdapter implements SpecialistPackageSkill
       }
     }
     if (outcome === 'rollback') {
-      for (const [id, { directoryName, source }] of [...locations].sort(([left], [right]) =>
-        left.localeCompare(right)
+      for (const [id, { directoryName, source, hadLive, contentHash }] of [...locations].sort(
+        ([left], [right]) => left.localeCompare(right)
       )) {
         const live = join(dirname(this.personalRoot), source, directoryName)
         const staging = join(stagingRoot, id)
         const backup = join(backupRoot, id)
+        const hasLive = await exists(live)
+        const assertPromotedByThisTransaction = async (): Promise<void> => {
+          if (
+            (await readMetadata(live))?.transactionId !== transactionId ||
+            !contentHash ||
+            (await directoryHash(live)) !== contentHash
+          ) {
+            throw new Error(
+              `Skill ${id} cannot be safely rolled back; preserve the transaction for repair.`
+            )
+          }
+        }
         if (await exists(backup)) {
+          if (version === 2 && hasLive) await assertPromotedByThisTransaction()
           await rm(live, { recursive: true, force: true })
           await mkdir(dirname(live), { recursive: true })
           await rename(backup, live)
-        } else if (mode !== 'delete' && !(await exists(staging))) {
-          await rm(live, { recursive: true, force: true })
+        } else if (mode !== 'delete' && !(await exists(staging)) && hasLive) {
+          if (version !== 2) {
+            throw new Error(
+              `Legacy Skill transaction ${transactionId} is ambiguous; preserve it for repair.`
+            )
+          }
+          if (hadLive === false) {
+            await assertPromotedByThisTransaction()
+            await rm(live, { recursive: true, force: true })
+          }
+          // No commit intent means preparation never reached the first swap. hadLive=true
+          // without a backup also covers an original already restored by a previous recovery.
         }
       }
     } else {

--- a/src/main/specialist/ipc.test.ts
+++ b/src/main/specialist/ipc.test.ts
@@ -673,6 +673,17 @@ describe('specialist session IPC', () => {
         specialistId: 'research-synth'
       })
     ).resolves.toMatchObject({ specialistId: 'research-synth', canExport: true })
+    await handlers.get(SPECIALIST_IPC.PREVIEW_EXPORT)?.(undefined, {
+      specialistId: 'research-synth',
+      includedSkillIds: []
+    })
+    expect(previewExport).toHaveBeenLastCalledWith('research-synth', [])
+    await expect(
+      handlers.get(SPECIALIST_IPC.PREVIEW_EXPORT)?.(undefined, {
+        specialistId: 'research-synth',
+        includedSkillIds: 'invalid'
+      })
+    ).rejects.toThrow('Invalid Specialist export preview.')
     const result = await handlers.get(SPECIALIST_IPC.EXPORT)?.(undefined, {
       specialistId: 'research-synth',
       expectedRevision: 3,

--- a/src/main/specialist/ipc.ts
+++ b/src/main/specialist/ipc.ts
@@ -155,12 +155,19 @@ const isInstallCandidateRequest = (
   )
 }
 
-const isExportPreviewRequest = (request: unknown): request is { specialistId: string } =>
+const isExportPreviewRequest = (
+  request: unknown
+): request is { specialistId: string; includedSkillIds?: readonly string[] } =>
   typeof request === 'object' &&
   request !== null &&
-  Object.keys(request).length === 1 &&
+  Object.keys(request).every((key) => ['specialistId', 'includedSkillIds'].includes(key)) &&
   typeof (request as { specialistId?: unknown }).specialistId === 'string' &&
-  Boolean((request as { specialistId: string }).specialistId)
+  Boolean((request as { specialistId: string }).specialistId) &&
+  ((request as { includedSkillIds?: unknown }).includedSkillIds === undefined ||
+    (Array.isArray((request as { includedSkillIds?: unknown }).includedSkillIds) &&
+      (request as { includedSkillIds: unknown[] }).includedSkillIds.every(
+        (id) => typeof id === 'string'
+      )))
 
 const isExportRequest = (request: unknown): request is SpecialistExportRequest =>
   typeof request === 'object' &&
@@ -311,7 +318,7 @@ export const registerSpecialistIpcHandlers = (
       SPECIALIST_IPC.PREVIEW_EXPORT,
       async (_event, request: unknown): Promise<SpecialistExportPreview> => {
         if (!isExportPreviewRequest(request)) throw new Error('Invalid Specialist export preview.')
-        return packageImport.service.previewExport(request.specialistId)
+        return packageImport.service.previewExport(request.specialistId, request.includedSkillIds)
       }
     )
 

--- a/src/main/specialist/marketplace/repository.test.ts
+++ b/src/main/specialist/marketplace/repository.test.ts
@@ -355,7 +355,7 @@ describe('MarketplaceRepository', () => {
     )
   })
 
-  it('reconstructs persisted records from known, validated fields', async () => {
+  it('protects unreadable authoritative records while sanitizing disposable caches after repair', async () => {
     const root = await mkdtemp(join(tmpdir(), 'marketplace-sanitize-'))
     await writeFile(
       join(root, 'specialist-marketplace.json'),
@@ -476,7 +476,28 @@ describe('MarketplaceRepository', () => {
       'utf8'
     )
 
-    const document = await new MarketplaceRepository(root).getAll()
+    const file = join(root, 'specialist-marketplace.json')
+    const original = await readFile(file, 'utf8')
+    const repository = new MarketplaceRepository(root)
+    await expect(repository.getAll()).rejects.toThrow(/Repair specialist-marketplace.json/)
+    await expect(
+      repository.cacheRoot(
+        'other',
+        new Uint8Array([1]),
+        new Uint8Array([2]),
+        '2026-08-18T00:00:00.000Z'
+      )
+    ).rejects.toThrow(/Repair specialist-marketplace.json/)
+    expect(await readFile(file, 'utf8')).toBe(original)
+    // Explicitly repair authoritative records, leaving the original disposable cache fixture.
+    const repaired = JSON.parse(original)
+    repaired.sources = [repaired.sources[0]]
+    repaired.installations = [repaired.installations[0]]
+    delete repaired.sources[0].injected
+    delete repaired.installations[0].injected
+    repaired.pendingInstallations = []
+    await writeFile(file, JSON.stringify(repaired))
+    const document = await repository.getAll()
 
     expect(document.sources).toEqual([
       {

--- a/src/main/specialist/marketplace/repository.ts
+++ b/src/main/specialist/marketplace/repository.ts
@@ -1,6 +1,11 @@
 import { join } from 'node:path'
+import { MARKETPLACE_DOCUMENT_INTEGRITY_CODE } from '../../../shared/specialist-marketplace'
 
-import { readDurableJsonFile, writeDurableJsonFile } from '../../storage/durable-json-file'
+import {
+  DurableJsonRecoveryBarrierError,
+  readDurableJsonFile,
+  writeDurableJsonFile
+} from '../../storage/durable-json-file'
 
 export type StoredMarketplaceSource = {
   id: string
@@ -189,6 +194,7 @@ const sanitizePendingInstallation = (
   if (!provenance?.installedArchiveDigest || !isStringArray(item.newlyDisabledSkillIds)) {
     return undefined
   }
+  if (Object.keys(item.provenance!).some((key) => !Object.hasOwn(provenance, key))) return undefined
   return { provenance, newlyDisabledSkillIds: item.newlyDisabledSkillIds }
 }
 
@@ -270,8 +276,34 @@ const boundReleaseCaches = (caches: MarketplaceReleaseCache[]): MarketplaceRelea
   return kept.sort((left, right) => left.index - right.index).map((entry) => entry.item)
 }
 
+export class MarketplaceDocumentIntegrityError extends DurableJsonRecoveryBarrierError {
+  constructor(readonly section: string) {
+    super(
+      `${MARKETPLACE_DOCUMENT_INTEGRITY_CODE}: Marketplace data contains unreadable ${section}. Repair specialist-marketplace.json before retrying; the original file has been preserved.`
+    )
+    this.name = 'MarketplaceDocumentIntegrityError'
+  }
+}
+
+const authoritativeRecords = <T extends object>(
+  value: unknown,
+  sanitize: (item: unknown) => T | undefined,
+  section: string
+): T[] => {
+  // Earlier version-1 documents may omit an entire optional collection.
+  if (value === undefined) return []
+  if (!Array.isArray(value)) throw new MarketplaceDocumentIntegrityError(section)
+  return value.map((item) => {
+    const record = sanitize(item)
+    if (!record || Object.keys(item).some((key) => !Object.hasOwn(record, key))) {
+      throw new MarketplaceDocumentIntegrityError(section)
+    }
+    return record
+  })
+}
+
 const sanitizeDocument = (value: unknown): MarketplaceDocument => {
-  if (!value || typeof value !== 'object') return emptyDocument()
+  if (!value || typeof value !== 'object') throw new MarketplaceDocumentIntegrityError('document')
   const document = value as {
     version?: unknown
     sources?: unknown
@@ -280,18 +312,20 @@ const sanitizeDocument = (value: unknown): MarketplaceDocument => {
     rootCaches?: unknown
     releaseCaches?: unknown
   }
-  if (document.version !== 1) return emptyDocument()
+  if (document.version !== 1) throw new MarketplaceDocumentIntegrityError('document version')
   return {
     version: 1,
-    sources: Array.isArray(document.sources)
-      ? document.sources.flatMap((source) => sanitizeSource(source) ?? [])
-      : [],
-    installations: Array.isArray(document.installations)
-      ? document.installations.flatMap((item) => sanitizeInstallation(item) ?? [])
-      : [],
-    pendingInstallations: Array.isArray(document.pendingInstallations)
-      ? document.pendingInstallations.flatMap((item) => sanitizePendingInstallation(item) ?? [])
-      : [],
+    sources: authoritativeRecords(document.sources, sanitizeSource, 'sources'),
+    installations: authoritativeRecords(
+      document.installations,
+      sanitizeInstallation,
+      'installations'
+    ),
+    pendingInstallations: authoritativeRecords(
+      document.pendingInstallations,
+      sanitizePendingInstallation,
+      'pending installations'
+    ),
     rootCaches: Array.isArray(document.rootCaches)
       ? document.rootCaches.flatMap((item) => sanitizeRootCache(item) ?? [])
       : [],
@@ -312,9 +346,15 @@ export class MarketplaceRepository {
   }
 
   async getAll(): Promise<MarketplaceDocument> {
-    const result = await readDurableJsonFile(this.filePath, (contents) =>
-      sanitizeDocument(JSON.parse(contents))
-    )
+    const result = await readDurableJsonFile(this.filePath, (contents) => {
+      let document: unknown
+      try {
+        document = JSON.parse(contents)
+      } catch {
+        throw new MarketplaceDocumentIntegrityError('JSON')
+      }
+      return sanitizeDocument(document)
+    })
     return result.status === 'found' ? result.value : emptyDocument()
   }
 

--- a/src/main/specialist/marketplace/service.test.ts
+++ b/src/main/specialist/marketplace/service.test.ts
@@ -485,7 +485,20 @@ describe('MarketplaceService', () => {
             sourceId: 'source',
             packageCandidateToken: 'candidate',
             newSkillIds: ['personal-example-skill'],
-            provenance: {}
+            provenance: {
+              sourceId: 'source',
+              specialistId: 'example-specialist',
+              publisher: 'Example',
+              version: '1.0.0',
+              releasePath: 'releases/example-specialist/1.0.0.json',
+              releaseDigest: 'a'.repeat(64),
+              artifactDigest: 'b'.repeat(64),
+              installedArchiveDigest: 'c'.repeat(64),
+              upstreamCommit: 'd'.repeat(40),
+              selectedSkillIds: ['example-skill'],
+              selectedConnectorIds: [],
+              installedAt: '2026-09-05T00:00:00.000Z'
+            }
           }
         ]
       ])

--- a/src/main/specialist/marketplace/service.ts
+++ b/src/main/specialist/marketplace/service.ts
@@ -680,11 +680,16 @@ export class MarketplaceService {
         origin: 'marketplace'
       })
     } catch (error) {
-      await this.rollbackPendingInstallation(candidate.provenance, newlyDisabled)
+      // A rejected call does not prove rollback. Recovery must settle the package first.
+      this.packageRecovery = undefined
+      await this.recoverUnlocked().catch(() => undefined)
       throw error
     }
     if (result.status !== 'installed') {
-      await this.rollbackPendingInstallation(candidate.provenance, newlyDisabled)
+      if (result.code === 'recovery-failed' || result.code === 'rollback-failed') {
+        this.packageRecovery = undefined
+        await this.recoverUnlocked().catch(() => undefined)
+      } else await this.rollbackPendingInstallation(candidate.provenance, newlyDisabled)
       return result
     }
     this.installCandidates.delete(request.candidateToken)

--- a/src/main/specialist/package/reported-regressions.test.ts
+++ b/src/main/specialist/package/reported-regressions.test.ts
@@ -98,6 +98,29 @@ const provenance = (digest = 'c'.repeat(64)): MarketplaceInstallProvenance => ({
 })
 
 describe('reported Specialist package regressions', () => {
+  it('exports the edited Skill version shown by the current preview', async () => {
+    const { packages, userSkills } = await fixture()
+    const first = await packages.preview(archive('first-specialist'))
+    expect(await packages.install({ candidateToken: first.candidateToken })).toMatchObject({
+      status: 'installed'
+    })
+    await userSkills.updatePersonal('personal-analysis-tools', {
+      name: 'analysis-tools',
+      description: 'Analyze data',
+      body: 'UPDATED SKILL',
+      metadata: { version: '2.0.0' }
+    })
+    const preview = await packages.previewExport('first-specialist')
+    expect(preview.skills[0].version).toBe('2.0.0')
+    const exported = await packages.export({
+      specialistId: preview.specialistId,
+      expectedRevision: preview.expectedRevision,
+      includedSkillIds: ['personal-analysis-tools']
+    })
+    const imported = validateSpecialistZip(exported.archiveBytes, emptyCatalog)
+    expect(imported.plan?.skills[0].version).toBe('2.0.0')
+  })
+
   it('keeps unrelated package preview and export available when an owned Skill document is missing', async () => {
     const { packages, storageDir, skillPort } = await fixture()
     const first = await packages.preview(archive('first-specialist'))

--- a/src/main/specialist/package/reported-regressions.test.ts
+++ b/src/main/specialist/package/reported-regressions.test.ts
@@ -152,6 +152,49 @@ describe('reported Specialist package regressions', () => {
     expect(imported.plan?.skills[0].version).toBe('2.0.0')
   })
 
+  it.each(['2', '', 'next'])(
+    'blocks exporting an explicitly invalid Skill version %j until the Skill is excluded',
+    async (version) => {
+      const { packages, userSkills } = await fixture()
+      const first = await packages.preview(archive('first-specialist'))
+      expect(await packages.install({ candidateToken: first.candidateToken })).toMatchObject({
+        status: 'installed'
+      })
+      await userSkills.updatePersonal('personal-analysis-tools', {
+        name: 'analysis-tools',
+        description: 'Analyze data',
+        body: 'LOCAL SKILL CONTENT',
+        metadata: { version }
+      })
+
+      const preview = await packages.previewExport('first-specialist')
+      expect.soft(preview.canExport).toBe(false)
+      expect.soft(preview.diagnostics).toContainEqual(
+        expect.objectContaining({
+          severity: 'error',
+          code: 'specialist.export-validation-failed'
+        })
+      )
+      await expect
+        .soft(
+          packages.export({
+            specialistId: preview.specialistId,
+            expectedRevision: preview.expectedRevision,
+            includedSkillIds: ['personal-analysis-tools']
+          })
+        )
+        .rejects.toThrow(/invalid version/i)
+
+      expect((await packages.previewExport('first-specialist', [])).canExport).toBe(true)
+      const exported = await packages.export({
+        specialistId: preview.specialistId,
+        expectedRevision: preview.expectedRevision,
+        includedSkillIds: []
+      })
+      expect(validateSpecialistZip(exported.archiveBytes, emptyCatalog).plan?.skills).toEqual([])
+    }
+  )
+
   it('keeps unrelated package preview and export available when an owned Skill document is missing', async () => {
     const { packages, storageDir, skillPort } = await fixture()
     const first = await packages.preview(archive('first-specialist'))

--- a/src/main/specialist/package/reported-regressions.test.ts
+++ b/src/main/specialist/package/reported-regressions.test.ts
@@ -1,0 +1,566 @@
+import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { buildSync } from 'esbuild'
+import { strToU8, zipSync } from 'fflate'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SpecialistPackageCatalogSnapshot } from '../../../shared/specialist-package'
+import { UserSkillSpecialistPackageAdapter } from '../../skills/specialist-package-adapter'
+import { UserSkillRepository } from '../../skills/user-skill-repository'
+import { SpecialistRepository } from '../repository'
+import { MarketplaceRepository, type MarketplaceInstallProvenance } from '../marketplace/repository'
+import { MarketplaceService } from '../marketplace/service'
+import { SpecialistPackageService } from './service'
+import { validateSpecialistZip } from './zip-adapter'
+
+const roots: string[] = []
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+const emptyCatalog: SpecialistPackageCatalogSnapshot = {
+  appVersion: '0.9.2',
+  builtinSkills: [],
+  skills: [],
+  connectorIds: [],
+  protectedSpecialistIds: []
+}
+const archive = (id: string, bundled = true, connectorIds: string[] = []): Uint8Array =>
+  zipSync({
+    'manifest.json': strToU8(
+      JSON.stringify({
+        schema_version: 1,
+        id,
+        version: '1.0.0',
+        exported_with_app_version: '0.9.2'
+      })
+    ),
+    'specialist.json': strToU8(
+      JSON.stringify({
+        name: id.toUpperCase().replaceAll('-', '_'),
+        description: 'Research helper.',
+        system_prompt: 'Help with research.',
+        skill_ids: [],
+        connector_ids: connectorIds
+      })
+    ),
+    ...(bundled
+      ? {
+          'skills/analysis-tools/SKILL.md': strToU8(
+            '---\nname: analysis-tools\ndescription: Analyze data\nversion: 1.0.0\n---\nORIGINAL SKILL CONTENT'
+          )
+        }
+      : {})
+  })
+async function fixture(): Promise<{
+  storageDir: string
+  repository: SpecialistRepository
+  skillPort: UserSkillSpecialistPackageAdapter
+  userSkills: UserSkillRepository
+  liveCatalog: SpecialistPackageCatalogSnapshot
+  catalog: () => Promise<SpecialistPackageCatalogSnapshot>
+  packages: SpecialistPackageService
+}> {
+  const storageDir = await mkdtemp(join(tmpdir(), 'specialist-reported-'))
+  roots.push(storageDir)
+  const repository = new SpecialistRepository(storageDir)
+  const skillPort = new UserSkillSpecialistPackageAdapter(storageDir)
+  const userSkills = new UserSkillRepository(storageDir)
+  const liveCatalog = { ...emptyCatalog }
+  const catalog = async (): Promise<SpecialistPackageCatalogSnapshot> => ({
+    ...liveCatalog,
+    skills: (await skillPort.snapshot()).map((skill) => ({
+      ...skill,
+      name: skill.id.replace(/^personal-/, ''),
+      builtin: false,
+      mainEnabled: false
+    }))
+  })
+  const packages = new SpecialistPackageService({ storageDir, repository, skillPort, catalog })
+  return { storageDir, repository, skillPort, userSkills, liveCatalog, catalog, packages }
+}
+const provenance = (digest = 'c'.repeat(64)): MarketplaceInstallProvenance => ({
+  sourceId: 'official',
+  specialistId: 'first-specialist',
+  publisher: 'Example',
+  version: '1.0.0',
+  releasePath: 'releases/first-specialist/1.0.0.json',
+  releaseDigest: 'a'.repeat(64),
+  artifactDigest: 'b'.repeat(64),
+  installedArchiveDigest: digest,
+  upstreamCommit: 'd'.repeat(40),
+  selectedSkillIds: ['analysis-tools'],
+  selectedConnectorIds: [],
+  installedAt: '2026-09-05T00:00:00.000Z'
+})
+
+describe('reported Specialist package regressions', () => {
+  it.each([
+    ['journal', true],
+    ['staging-created', true],
+    ['staging-complete', true],
+    ['before-backup', true],
+    ['after-backup', true],
+    ['after-promotion', true],
+    ['after-restore', true],
+    ['after-promotion', false]
+  ] as const)(
+    'K01 rolls back process exit at %s (existing=%s) without deleting original content',
+    async (phase, existing) => {
+      const { storageDir, skillPort, repository, catalog } = await fixture()
+      const plan = validateSpecialistZip(archive('first-specialist'), emptyCatalog).plan!.skills[0]
+      if (existing) {
+        await skillPort.prepare('seed', 'first-specialist', [plan])
+        await skillPort.commit('seed')
+        await skillPort.recover('seed', 'commit')
+      }
+      const live = join(storageDir, 'skills', 'personal', 'analysis-tools', 'SKILL.md')
+      const original = existing ? await readFile(live, 'utf8') : undefined
+      const bundle = join(storageDir, 'adapter.cjs')
+      buildSync({
+        entryPoints: [resolve('src/main/skills/specialist-package-adapter.ts')],
+        outfile: bundle,
+        bundle: true,
+        platform: 'node',
+        format: 'cjs'
+      })
+      const input = join(storageDir, 'input.json')
+      await writeFile(
+        input,
+        JSON.stringify({
+          ...plan,
+          disposition: existing ? 'replace-existing' : 'install',
+          filesToInstall: plan.filesToInstall.map((file) => ({
+            path: file.path,
+            bytes: [
+              ...strToU8(
+                new TextDecoder()
+                  .decode(file.bytes)
+                  .replace('ORIGINAL SKILL CONTENT', 'INCOMING CONTENT')
+              )
+            ]
+          }))
+        })
+      )
+      const child = spawnSync(
+        process.execPath,
+        [
+          '-e',
+          `
+      const fs = require('node:fs/promises');
+      const path = require('node:path');
+      const [root, bundle, phase, input] = process.argv.slice(1);
+      const originalWrite = fs.writeFile, originalMkdir = fs.mkdir, originalRename = fs.rename;
+      const live = path.join(root, 'skills', 'personal', 'analysis-tools');
+      const staging = path.join(root, 'specialist-package-skill-transactions', 'interrupted', 'staging', 'personal-analysis-tools');
+      fs.writeFile = async (...args) => {
+        await originalWrite(...args);
+        if (phase === 'journal' && path.basename(String(args[0])) === 'transaction.json') process.exit(23);
+        if (phase === 'staging-complete' && String(args[0]) === path.join(staging, '.specialist-package.json')) process.exit(23);
+      };
+      fs.mkdir = async (...args) => {
+        const result = await originalMkdir(...args);
+        if (phase === 'staging-created' && String(args[0]) === staging) process.exit(23);
+        return result;
+      };
+      fs.rename = async (from, to) => {
+        if (phase === 'before-backup' && from === live) process.exit(23);
+        await originalRename(from, to);
+        if (phase === 'after-backup' && from === live) process.exit(23);
+        if (phase === 'after-promotion' && from === staging && to === live) process.exit(23);
+        if (phase === 'after-restore' && path.basename(path.dirname(from)) === 'backup' && to === live) process.exit(23);
+      };
+      const { UserSkillSpecialistPackageAdapter } = require(bundle);
+      (async () => {
+        const plan = JSON.parse(await fs.readFile(input, 'utf8'));
+        plan.filesToInstall = plan.filesToInstall.map(file => ({...file, bytes: Uint8Array.from(file.bytes)}));
+        const adapter = new UserSkillSpecialistPackageAdapter(root);
+        await adapter.prepare('interrupted', 'second-specialist', [plan]);
+        await adapter.commit('interrupted');
+        if (phase === 'after-restore') await adapter.rollback('interrupted');
+      })().then(() => process.exit(24)).catch(error => { console.error(error); process.exit(25); });
+    `,
+          storageDir,
+          bundle,
+          phase,
+          input
+        ],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+      expect(child.stderr).toBe('')
+      expect(child.status).toBe(23)
+      if (phase === 'journal') expect(await readFile(live, 'utf8')).toBe(original)
+      const restarted = new SpecialistPackageService({
+        storageDir,
+        repository,
+        catalog,
+        skillPort: new UserSkillSpecialistPackageAdapter(storageDir)
+      })
+      for (let attempt = 0; attempt < 2; attempt++) {
+        await restarted.recover()
+        if (existing) await expect.soft(readFile(live, 'utf8')).resolves.toBe(original)
+        else await expect.soft(readFile(live, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+      }
+    }
+  )
+
+  it('K05 requires conflict approval and retains an owned Skill edited through the personal editor', async () => {
+    const { packages, userSkills } = await fixture()
+    const first = await packages.preview(archive('first-specialist'))
+    expect(await packages.install({ candidateToken: first.candidateToken })).toMatchObject({
+      status: 'installed'
+    })
+    await userSkills.updatePersonal('personal-analysis-tools', {
+      name: 'analysis-tools',
+      description: 'Analyze data',
+      body: 'USER LOCAL EDIT MUST SURVIVE'
+    })
+    expect(await userSkills.body('personal-analysis-tools')).toContain(
+      'USER LOCAL EDIT MUST SURVIVE'
+    )
+    const second = await packages.preview(archive('second-specialist'))
+    expect.soft(second.summary?.skills[0].disposition).toBe('conflict')
+    expect.soft(second.installable).toBe(false)
+    const result = await packages.install({ candidateToken: second.candidateToken })
+    expect
+      .soft(result)
+      .toMatchObject({ status: 'failed', code: 'skill-conflict-resolution-required' })
+    expect
+      .soft(await userSkills.body('personal-analysis-tools'))
+      .toContain('USER LOCAL EDIT MUST SURVIVE')
+  })
+
+  it.each([1, 2])(
+    'K02 preserves Main isolation and provenance across %s committed cleanup failures',
+    async (failures) => {
+      const { packages, repository, skillPort, storageDir, userSkills } = await fixture()
+      const marketRepository = new MarketplaceRepository(storageDir)
+      const disabled = new Set<string>()
+      const market = new MarketplaceService({
+        repository: marketRepository,
+        packages,
+        fetch: vi.fn() as never,
+        getDisabledSkillIds: async () => [...disabled],
+        setSkillsMainEnabled: async (ids, enabled) => {
+          for (const id of ids) {
+            if (enabled) disabled.delete(id)
+            else disabled.add(id)
+          }
+        },
+        getInstalledSpecialists: async () =>
+          (await repository.getAll()).specialists.map((item) => ({
+            id: item.id,
+            origin: item.origin,
+            archiveDigest: item.importBaseline?.archiveDigest
+          }))
+      })
+      const bytes = archive('first-specialist')
+      const preview = await packages.preview(bytes, undefined, { origin: 'marketplace' })
+      expect(preview.installable).toBe(true)
+      // Match existing market tests: seed the already-reviewed candidate, bypassing only network/trust setup.
+      Reflect.set(
+        market,
+        'installCandidates',
+        new Map([
+          [
+            preview.candidateToken,
+            {
+              expiresAt: Date.now() + 60_000,
+              sourceId: 'official',
+              packageCandidateToken: preview.candidateToken,
+              newSkillIds: packages.candidateNewSkillIds(preview.candidateToken),
+              provenance: provenance(createHash('sha256').update(bytes).digest('hex'))
+            }
+          ]
+        ])
+      )
+      const recover = skillPort.recover.bind(skillPort)
+      let injected = 0
+      vi.spyOn(skillPort, 'recover').mockImplementation(async (id, outcome) => {
+        if (id && outcome === 'commit' && injected < failures) {
+          injected += 1
+          throw new Error('Transient committed cleanup failure')
+        }
+        return recover(id, outcome)
+      })
+      const result = await market.install({ candidateToken: preview.candidateToken })
+      expect(injected).toBeGreaterThan(0)
+      expect((await repository.getAll()).specialists).toHaveLength(1)
+      expect(await userSkills.list()).toHaveLength(1)
+      // Either an installed result or the existing recovery-failed result can preserve the obligation.
+      if (result.status === 'failed') expect(result.code).toBe('recovery-failed')
+      expect.soft([...disabled]).toEqual(['personal-analysis-tools'])
+      const pending = await marketRepository.getAll()
+      expect.soft(pending.pendingInstallations.length + pending.installations.length).toBe(1)
+      // Retry through the market public boundary, including after a previous recovery attempt failed.
+      await market.recover()
+      await expect(
+        readFile(join(storageDir, 'specialist-package-transaction.json'))
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+      await market.recover()
+      await market.recover()
+      expect.soft((await marketRepository.getAll()).installations).toHaveLength(1)
+      expect.soft([...disabled]).toEqual(['personal-analysis-tools'])
+    }
+  )
+
+  it('K03 refuses installation when an approved connector disappears after preview', async () => {
+    const { packages, liveCatalog, repository } = await fixture()
+    liveCatalog.connectorIds = ['demo']
+    const preview = await packages.preview(archive('first-specialist', false, ['demo']))
+    expect(preview.installable).toBe(true)
+    expect(preview.summary?.connectorIds).toEqual(['demo'])
+    liveCatalog.connectorIds = []
+    const result = await packages.install({ candidateToken: preview.candidateToken })
+    expect.soft(result).toMatchObject({ status: 'failed', code: 'stale-candidate' })
+    expect.soft((await repository.getAll()).specialists).toEqual([])
+  })
+
+  it('K04 confirms exporting without a missing owned Skill is valid at the service boundary', async () => {
+    const { packages, storageDir } = await fixture()
+    const preview = await packages.preview(archive('first-specialist'))
+    expect(await packages.install({ candidateToken: preview.candidateToken })).toMatchObject({
+      status: 'installed'
+    })
+    await rm(join(storageDir, 'skills/personal/analysis-tools'), { recursive: true })
+    const exportPreview = await packages.previewExport('first-specialist')
+    expect(exportPreview.canExport).toBe(false)
+    expect(exportPreview.skills).toContainEqual(
+      expect.objectContaining({ selected: true, kind: 'owned' })
+    )
+    const result = await packages.export({
+      specialistId: exportPreview.specialistId,
+      expectedRevision: exportPreview.expectedRevision,
+      includedSkillIds: []
+    })
+    expect(result.archiveBytes.byteLength).toBeGreaterThan(0)
+    expect((await packages.previewExport('first-specialist', [])).canExport).toBe(true)
+    expect(
+      (await packages.previewExport('first-specialist', ['personal-analysis-tools'])).canExport
+    ).toBe(false)
+  })
+
+  it('K06 preserves corrupt recovery obligations during an unrelated cache write', async () => {
+    const { storageDir } = await fixture()
+    const repository = new MarketplaceRepository(storageDir)
+    await repository.beginInstallation({
+      provenance: provenance(),
+      newlyDisabledSkillIds: ['personal-analysis-tools']
+    })
+    const file = join(storageDir, 'specialist-marketplace.json')
+    const document = JSON.parse(await readFile(file, 'utf8'))
+    expect(document.pendingInstallations).toHaveLength(1)
+    document.pendingInstallations[0].newlyDisabledSkillIds = 'corrupted-array'
+    await writeFile(file, JSON.stringify(document))
+    const restarted = new MarketplaceRepository(storageDir)
+    // A fail-closed repository may reject; either way no cache update may erase the obligation.
+    await restarted.getAll().catch(() => undefined)
+    await restarted
+      .cacheRoot('unrelated-source', strToU8('{}'), strToU8('{}'), '2026-09-05T00:00:00.000Z')
+      .catch(() => undefined)
+    const after = JSON.parse(await readFile(file, 'utf8'))
+    expect(after.pendingInstallations).toEqual(document.pendingInstallations)
+  })
+  it.each(['version', 'reference', 'unchanged'] as const)(
+    'K05 compares actual %s content and checks edits inside the commit lock',
+    async (change) => {
+      const { packages, userSkills, skillPort } = await fixture()
+      const first = await packages.preview(archive('first-specialist'))
+      expect(await packages.install({ candidateToken: first.candidateToken })).toMatchObject({
+        status: 'installed'
+      })
+      if (change !== 'unchanged')
+        await userSkills.updatePersonal('personal-analysis-tools', {
+          name: 'analysis-tools',
+          description: 'Analyze data',
+          body: 'ORIGINAL SKILL CONTENT',
+          metadata: { version: change === 'version' ? '2.0.0' : '1.0.0' },
+          ...(change === 'reference'
+            ? {
+                references: [
+                  {
+                    path: 'evidence.txt',
+                    dataBase64: Buffer.from('LOCAL REFERENCE').toString('base64')
+                  }
+                ]
+              }
+            : {})
+        })
+      const second = await packages.preview(archive('second-specialist'))
+      expect(second.summary?.skills[0].disposition).toBe(
+        change === 'unchanged' ? 'reuse-owned' : 'conflict'
+      )
+      if (change !== 'unchanged') {
+        expect(await packages.install({ candidateToken: second.candidateToken })).toMatchObject({
+          status: 'failed',
+          code: 'skill-conflict-resolution-required'
+        })
+        return
+      }
+      const prepare = skillPort.prepare.bind(skillPort)
+      vi.spyOn(skillPort, 'prepare').mockImplementation(async (...args) => {
+        await prepare(...args)
+        await userSkills.updatePersonal('personal-analysis-tools', {
+          name: 'analysis-tools',
+          description: 'Analyze data',
+          body: 'EDIT AFTER PREPARE'
+        })
+      })
+      expect(await packages.install({ candidateToken: second.candidateToken })).toMatchObject({
+        status: 'failed'
+      })
+      expect(await userSkills.body('personal-analysis-tools')).toContain('EDIT AFTER PREPARE')
+    }
+  )
+
+  it('K05 still reuses identical content without a conflict', async () => {
+    const { packages, userSkills, skillPort } = await fixture()
+    for (const id of ['first-specialist', 'second-specialist']) {
+      const preview = await packages.preview(archive(id))
+      expect(preview.installable).toBe(true)
+      expect(await packages.install({ candidateToken: preview.candidateToken })).toMatchObject({
+        status: 'installed'
+      })
+    }
+    expect(await userSkills.body('personal-analysis-tools')).toContain('ORIGINAL SKILL CONTENT')
+    expect((await skillPort.snapshot())[0].ownerIds).toEqual([
+      'first-specialist',
+      'second-specialist'
+    ])
+  })
+
+  it.each(['alias', 'unrelated', 'initially-missing'] as const)(
+    'K03 only invalidates relevant capability changes: %s',
+    async (change) => {
+      const { packages, liveCatalog } = await fixture()
+      liveCatalog.connectorIds = change === 'initially-missing' ? [] : ['first', 'second']
+      liveCatalog.connectorAliases = { first: 'demo' }
+      const preview = await packages.preview(archive('first-specialist', false, ['demo']))
+      expect(preview.installable).toBe(true)
+      if (change === 'alias') liveCatalog.connectorAliases = { second: 'demo' }
+      else liveCatalog.connectorIds = [...liveCatalog.connectorIds, 'unrelated']
+      const result = await packages.install({ candidateToken: preview.candidateToken })
+      expect(result).toMatchObject(
+        change === 'alias' ? { status: 'failed', code: 'stale-candidate' } : { status: 'installed' }
+      )
+    }
+  )
+
+  it('K03 rejects removal of a referenced unbundled Skill', async () => {
+    const { packages, userSkills } = await fixture()
+    const skillId = await userSkills.createPersonal({
+      name: 'analysis-tools',
+      description: 'Analyze data',
+      body: 'Local'
+    })
+    const bytes = zipSync({
+      'manifest.json': strToU8(
+        JSON.stringify({
+          schema_version: 1,
+          id: 'first-specialist',
+          version: '1.0.0',
+          exported_with_app_version: '0.9.2'
+        })
+      ),
+      'specialist.json': strToU8(
+        JSON.stringify({
+          name: 'FIRST_SPECIALIST',
+          description: 'Research helper.',
+          system_prompt: 'Help.',
+          skill_ids: ['analysis-tools'],
+          connector_ids: []
+        })
+      )
+    })
+    const preview = await packages.preview(bytes)
+    expect(preview.installable).toBe(true)
+    await userSkills.delete(skillId)
+    expect(await packages.install({ candidateToken: preview.candidateToken })).toMatchObject({
+      status: 'failed',
+      code: 'stale-candidate'
+    })
+  })
+
+  it.each(['unknown-version', 'pending', 'nested-provenance', 'invalid-json'] as const)(
+    'K06 write-protects %s and resumes after explicit repair',
+    async (damage) => {
+      const { storageDir } = await fixture()
+      const repository = new MarketplaceRepository(storageDir)
+      await repository.beginInstallation({
+        provenance: provenance(),
+        newlyDisabledSkillIds: ['personal-analysis-tools']
+      })
+      const file = join(storageDir, 'specialist-marketplace.json')
+      const healthy = await readFile(file, 'utf8')
+      const document = JSON.parse(healthy)
+      if (damage === 'unknown-version') document.version = 99
+      if (damage === 'pending') document.pendingInstallations[0].newlyDisabledSkillIds = 'broken'
+      if (damage === 'nested-provenance')
+        document.pendingInstallations[0].provenance.futureField = 'must survive'
+      const corrupt = damage === 'invalid-json' ? '{incomplete' : JSON.stringify(document)
+      await writeFile(file, corrupt)
+      await expect.soft(repository.getAll()).rejects.toThrow()
+      await expect
+        .soft(
+          repository.cacheRoot(
+            'unrelated',
+            strToU8('{}'),
+            strToU8('{}'),
+            '2026-09-05T00:00:00.000Z'
+          )
+        )
+        .rejects.toThrow()
+      expect.soft(await readFile(file, 'utf8')).toBe(corrupt)
+      await writeFile(file, healthy)
+      await repository.completeInstallation(provenance())
+      const recovered = await repository.getAll()
+      expect(recovered.pendingInstallations).toEqual([])
+      expect(recovered.installations).toHaveLength(1)
+    }
+  )
+  it.each(['legacy', 'foreign-owner'] as const)(
+    'K01 preserves ambiguous %s promotion evidence',
+    async (kind) => {
+      const { skillPort, storageDir } = await fixture()
+      const plan = validateSpecialistZip(archive('first-specialist'), emptyCatalog).plan!.skills[0]
+      await skillPort.prepare('uncertain', 'first-specialist', [plan])
+      await skillPort.commit('uncertain')
+      const journalPath = join(
+        storageDir,
+        'specialist-package-skill-transactions',
+        'uncertain',
+        'transaction.json'
+      )
+      const directory = join(storageDir, 'skills', 'personal', 'analysis-tools')
+      if (kind === 'legacy') {
+        const journal = JSON.parse(await readFile(journalPath, 'utf8'))
+        delete journal.version
+        for (const skill of journal.skills) {
+          delete skill.hadLive
+          delete skill.contentHash
+        }
+        await writeFile(journalPath, JSON.stringify(journal))
+      } else {
+        const metadataPath = join(directory, '.specialist-package.json')
+        const metadata = JSON.parse(await readFile(metadataPath, 'utf8'))
+        await writeFile(
+          metadataPath,
+          JSON.stringify({ ...metadata, transactionId: 'another-transaction' })
+        )
+      }
+      const journal = await readFile(journalPath, 'utf8')
+      for (let attempt = 0; attempt < 2; attempt++) {
+        await expect
+          .soft(new UserSkillSpecialistPackageAdapter(storageDir).rollback('uncertain'))
+          .rejects.toThrow()
+        await expect
+          .soft(readFile(join(directory, 'SKILL.md'), 'utf8'))
+          .resolves.toContain('ORIGINAL SKILL CONTENT')
+        await expect.soft(readFile(journalPath, 'utf8')).resolves.toBe(journal)
+      }
+    }
+  )
+})

--- a/src/main/specialist/package/reported-regressions.test.ts
+++ b/src/main/specialist/package/reported-regressions.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { spawnSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { buildSync } from 'esbuild'
@@ -98,6 +98,37 @@ const provenance = (digest = 'c'.repeat(64)): MarketplaceInstallProvenance => ({
 })
 
 describe('reported Specialist package regressions', () => {
+  it.each(['analysis-tools', 'relocated-tools'])(
+    'preserves an unreadable owned Skill in %s when another package requests its identity',
+    async (directoryName) => {
+      const { packages, storageDir, skillPort } = await fixture()
+      const first = await packages.preview(archive('first-specialist'))
+      expect(await packages.install({ candidateToken: first.candidateToken })).toMatchObject({
+        status: 'installed'
+      })
+      const original = join(storageDir, 'skills', 'personal', 'analysis-tools')
+      const directory = join(storageDir, 'skills', 'personal', directoryName)
+      if (directory !== original) await rename(original, directory)
+      await rm(join(directory, 'SKILL.md'))
+      await writeFile(join(directory, 'local-notes.txt'), 'KEEP LOCAL EVIDENCE')
+      const sidecar = join(directory, '.specialist-package.json')
+      const metadata = await readFile(sidecar, 'utf8')
+      expect(await skillPort.snapshot()).toEqual([])
+
+      const preview = await packages.preview(archive('second-specialist'))
+      expect(preview.summary?.skills[0].disposition).toBe('install')
+      const result = await packages.install({ candidateToken: preview.candidateToken })
+      expect.soft(result.status).toBe('failed')
+      await expect
+        .soft(readFile(join(directory, 'local-notes.txt'), 'utf8'))
+        .resolves.toBe('KEEP LOCAL EVIDENCE')
+      await expect.soft(readFile(sidecar, 'utf8')).resolves.toBe(metadata)
+      await expect
+        .soft(readFile(join(directory, 'SKILL.md'), 'utf8'))
+        .rejects.toMatchObject({ code: 'ENOENT' })
+    }
+  )
+
   it('exports the edited Skill version shown by the current preview', async () => {
     const { packages, userSkills } = await fixture()
     const first = await packages.preview(archive('first-specialist'))

--- a/src/main/specialist/package/reported-regressions.test.ts
+++ b/src/main/specialist/package/reported-regressions.test.ts
@@ -98,6 +98,27 @@ const provenance = (digest = 'c'.repeat(64)): MarketplaceInstallProvenance => ({
 })
 
 describe('reported Specialist package regressions', () => {
+  it('keeps unrelated package preview and export available when an owned Skill document is missing', async () => {
+    const { packages, storageDir, skillPort } = await fixture()
+    const first = await packages.preview(archive('first-specialist'))
+    expect(await packages.install({ candidateToken: first.candidateToken })).toMatchObject({
+      status: 'installed'
+    })
+    const directory = join(storageDir, 'skills', 'personal', 'analysis-tools')
+    const sidecar = join(directory, '.specialist-package.json')
+    const metadata = await readFile(sidecar, 'utf8')
+    await rm(join(directory, 'SKILL.md'))
+
+    await expect
+      .soft(packages.preview(archive('unrelated-specialist', false)))
+      .resolves.toMatchObject({ installable: true })
+    await expect
+      .soft(packages.previewExport('first-specialist', []))
+      .resolves.toMatchObject({ canExport: true })
+    await expect.soft(skillPort.snapshot()).resolves.toEqual([])
+    expect(await readFile(sidecar, 'utf8')).toBe(metadata)
+  })
+
   it.each([
     ['journal', true],
     ['staging-created', true],

--- a/src/main/specialist/package/service.test.ts
+++ b/src/main/specialist/package/service.test.ts
@@ -558,7 +558,7 @@ describe('SpecialistPackageService', () => {
       catalog: async () => catalog
     })
 
-    await expect(service.previewExport('draft-specialist')).resolves.toMatchObject({
+    await expect(service.previewExport('draft-specialist', [])).resolves.toMatchObject({
       canExport: false,
       diagnostics: [
         {

--- a/src/main/specialist/package/service.ts
+++ b/src/main/specialist/package/service.ts
@@ -585,7 +585,10 @@ export class SpecialistPackageService {
     }
   }
 
-  async previewExport(specialistId: string): Promise<SpecialistExportPreview> {
+  async previewExport(
+    specialistId: string,
+    includedSkillIds?: readonly string[]
+  ): Promise<SpecialistExportPreview> {
     const [document, catalog] = await Promise.all([
       this.options.repository.getAll(),
       this.options.catalog()
@@ -621,7 +624,11 @@ export class SpecialistPackageService {
         }
       })
       .sort((left, right) => left.id.localeCompare(right.id))
-    const selectedSkills = skills
+    const selectedSkills = skills.map((skill) => ({
+      ...skill,
+      selected:
+        includedSkillIds === undefined ? skill.selected : includedSkillIds.includes(skill.id)
+    }))
     const connectorIds = effectiveSpecialistConnectorIds(specialist, catalog)
     const diagnostics: PackageDiagnostic[] = []
     if (selectedSkills.some((skill) => skill.kind === 'referenced')) {
@@ -648,15 +655,14 @@ export class SpecialistPackageService {
       })
     }
     diagnostics.push(...specialistExportProfileDiagnostics(specialist))
-    const includedSkillIds = selectedSkills
-      .filter((skill) => skill.selected)
-      .map((skill) => skill.id)
+    const selection =
+      includedSkillIds ?? selectedSkills.filter((skill) => skill.selected).map((skill) => skill.id)
     if (!diagnostics.some((item) => item.severity === 'error')) {
       try {
         await this.export({
           specialistId: specialist.id,
           expectedRevision: specialist.revision,
-          includedSkillIds
+          includedSkillIds: selection
         })
       } catch {
         diagnostics.push({
@@ -921,6 +927,13 @@ export class SpecialistPackageService {
         return { status: 'failed', code: 'protected-target' }
       }
       if (!liveValidation.plan) return { status: 'failed', code: 'candidate-not-installable' }
+      const sameIds = (left: readonly string[], right: readonly string[]): boolean =>
+        [...left].sort().join('\0') === [...right].sort().join('\0')
+      if (
+        !sameIds(candidate.plan.skillIds, liveValidation.plan.skillIds) ||
+        !sameIds(candidate.plan.connectorIds, liveValidation.plan.connectorIds)
+      )
+        return { status: 'failed', code: 'stale-candidate' }
       const liveConflicts = liveValidation.plan.skills.filter(
         (skill) => skill.disposition === 'conflict'
       )

--- a/src/main/specialist/package/transaction.ts
+++ b/src/main/specialist/package/transaction.ts
@@ -113,7 +113,7 @@ export class SpecialistPackageTransaction {
       throw new SpecialistPackageRecoveryError()
     }
 
-    let retryableCommittedDeletion = false
+    let retryableCommitted = false
     try {
       const journal = JSON.parse(raw) as TransactionJournal
       if (
@@ -126,7 +126,7 @@ export class SpecialistPackageTransaction {
         throw new Error('Invalid Specialist package transaction journal.')
       }
       if (journal.phase === 'committed') {
-        retryableCommittedDeletion = journal.deleteSkillIds !== undefined
+        retryableCommitted = true
         const current = await this.repository.getAll()
         const currentDigest = documentDigest(current)
         const committedDeletionStillAbsent =
@@ -167,7 +167,7 @@ export class SpecialistPackageTransaction {
         specialistId: journal.specialistId
       })
     } catch (error) {
-      if (!retryableCommittedDeletion) this.recoveryFailure = error
+      if (!retryableCommitted) this.recoveryFailure = error
       throw new SpecialistPackageRecoveryError()
     }
   }

--- a/src/renderer/src/pages/settings/SpecialistMarketplace.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistMarketplace.render.test.tsx
@@ -996,4 +996,15 @@ describe('Specialist Marketplace settings', () => {
       )?.disabled
     ).toBe(true)
   })
+  it('shows the integrity repair notice instead of treating corrupt data as an empty Marketplace', async () => {
+    window.api.specialist.listMarketplace = vi
+      .fn()
+      .mockRejectedValue(new Error('MARKETPLACE_DOCUMENT_INTEGRITY: pending installations'))
+    await act(async () => {
+      root.render(<SpecialistMarketplace view={{ kind: 'marketplace' }} onNavigate={vi.fn()} />)
+    })
+    expect(document.body.textContent).toContain(
+      'Marketplace data needs repair. The original specialist-marketplace.json file has been preserved.'
+    )
+  })
 })

--- a/src/renderer/src/pages/settings/SpecialistMarketplace.tsx
+++ b/src/renderer/src/pages/settings/SpecialistMarketplace.tsx
@@ -191,6 +191,7 @@ const SpecialistMarketplace = ({ view, onNavigate }: Props): React.JSX.Element =
   const snapshot = useMarketplaceStore((state) => state.snapshot)
   const isRefreshing = useMarketplaceStore((state) => state.isRefreshing)
   const lastRefreshFailed = useMarketplaceStore((state) => state.lastRefreshFailed)
+  const integrityFailed = useMarketplaceStore((state) => state.integrityFailed)
   const refreshMarketplace = useMarketplaceStore((state) => state.refresh)
   // No snapshot and no failure verdict yet is a genuine first load, true from the very first render
   // before any effect has fired. Once a snapshot exists the content renders immediately whatever
@@ -651,7 +652,14 @@ const SpecialistMarketplace = ({ view, onNavigate }: Props): React.JSX.Element =
             // Without this arm a failed load reads as "no sources configured".
             <div className="mt-2">
               <MarketplaceError
-                message={t('Marketplace unavailable')}
+                message={
+                  integrityFailed
+                    ? t(
+                        'Marketplace data needs repair. The original {{fileName}} file has been preserved.',
+                        { fileName: 'specialist-marketplace.json' }
+                      )
+                    : t('Marketplace unavailable')
+                }
                 retry={() => void refreshMarketplace()}
               />
             </div>
@@ -1254,7 +1262,14 @@ const SpecialistMarketplace = ({ view, onNavigate }: Props): React.JSX.Element =
       {loading ? <MarketplaceLoading label={t('Loading Marketplace…')} /> : null}
       {!loading && !snapshot && lastRefreshFailed ? (
         <MarketplaceError
-          message={t('Marketplace unavailable')}
+          message={
+            integrityFailed
+              ? t(
+                  'Marketplace data needs repair. The original {{fileName}} file has been preserved.',
+                  { fileName: 'specialist-marketplace.json' }
+                )
+              : t('Marketplace unavailable')
+          }
           retry={() => void refreshMarketplace()}
         />
       ) : null}
@@ -1263,7 +1278,12 @@ const SpecialistMarketplace = ({ view, onNavigate }: Props): React.JSX.Element =
           role="status"
           className="mb-3 rounded-lg border border-warning-100/40 bg-warning-100/10 p-3 text-sm text-foreground"
         >
-          {t('Could not refresh Marketplace. Showing the last available data.')}
+          {integrityFailed
+            ? t(
+                'Marketplace data needs repair. The original {{fileName}} file has been preserved.',
+                { fileName: 'specialist-marketplace.json' }
+              )
+            : t('Could not refresh Marketplace. Showing the last available data.')}
         </div>
       ) : null}
       {!loading

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -533,6 +533,105 @@ describe('SpecialistsPanel', () => {
     expect(document.body.querySelector('[role="status"]')).toBeNull()
   })
 
+  it('K04 allows export after unchecking the missing owned Skill that blocked the initial preview', async () => {
+    const preview = exportPreviewFixture({
+      canExport: false,
+      diagnostics: [
+        {
+          severity: 'error',
+          code: 'specialist.export-validation-failed',
+          message: 'The current Specialist or selected Skills contain blocking validation errors.'
+        }
+      ]
+    })
+    preview.skills = [
+      { id: 'analysis-tools', version: '1.0.0', kind: 'owned', selected: true, selectable: true }
+    ]
+    const exportSpecialist = vi.fn().mockResolvedValue({ saved: false })
+    useSpecialistStore.setState({
+      exportPreview: preview,
+      previewExport: vi.fn().mockImplementation(async (_id, includedSkillIds) => {
+        const current =
+          includedSkillIds?.length === 0
+            ? {
+                ...preview,
+                canExport: true,
+                diagnostics: [],
+                skills: preview.skills.map((skill) => ({ ...skill, selected: false }))
+              }
+            : preview
+        useSpecialistStore.setState({ exportPreview: current })
+        return current
+      }),
+      exportSpecialist
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistsPanel view={{ kind: 'export', id: 'rna-reviewer' }} onNavigate={vi.fn()} />
+      )
+    })
+    const checkbox = Array.from(document.body.querySelectorAll('label'))
+      .find((node) => node.textContent?.includes('analysis-tools'))
+      ?.querySelector('input')
+    expect(checkbox).toBeDefined()
+    expect(checkbox!.checked).toBe(true)
+    await act(async () => fireEvent.click(checkbox!))
+    expect(checkbox!.checked).toBe(false)
+    const button = Array.from(document.body.querySelectorAll('button')).find(
+      (node) => node.textContent === 'Export ZIP'
+    )
+    expect(button).toBeDefined()
+    expect.soft(button!.disabled).toBe(false)
+    await act(async () => button!.click())
+    expect
+      .soft(exportSpecialist)
+      .toHaveBeenCalledWith(expect.objectContaining({ canExport: true }), [])
+  })
+
+  it('keeps export blocked when an older successful selection check finishes last', async () => {
+    const preview = exportPreviewFixture({ canExport: false })
+    preview.skills = [
+      { id: 'analysis-tools', version: '1.0.0', kind: 'owned', selected: true, selectable: true }
+    ]
+    let resolveOlder!: (preview: SpecialistExportPreview) => void
+    const older = new Promise<SpecialistExportPreview>((resolve) => {
+      resolveOlder = resolve
+    })
+    window.api.specialist.previewExport = vi
+      .fn()
+      .mockResolvedValueOnce(preview)
+      .mockReturnValueOnce(older)
+      .mockResolvedValueOnce(preview)
+    useSpecialistStore.setState({ previewExport: initialStore.previewExport })
+    await act(async () => {
+      root.render(
+        <SpecialistsPanel view={{ kind: 'export', id: 'rna-reviewer' }} onNavigate={vi.fn()} />
+      )
+    })
+    const checkbox = document.body.querySelector<HTMLInputElement>('input[type="checkbox"]')!
+    const button = Array.from(document.body.querySelectorAll('button')).find(
+      (node) => node.textContent === 'Export ZIP'
+    )!
+    await act(async () => fireEvent.click(checkbox))
+    expect(button.disabled).toBe(true)
+    expect(document.body.textContent).toContain('Checking…')
+    await act(async () => fireEvent.click(checkbox))
+    await act(async () =>
+      resolveOlder({
+        ...preview,
+        canExport: true,
+        skills: preview.skills.map((skill) => ({ ...skill, selected: false }))
+      })
+    )
+    expect(checkbox.checked).toBe(true)
+    expect(button.disabled).toBe(true)
+    expect(useSpecialistStore.getState().exportPreview?.canExport).toBe(false)
+    expect(window.api.specialist.previewExport).toHaveBeenNthCalledWith(2, {
+      specialistId: 'rna-reviewer',
+      includedSkillIds: []
+    })
+  })
+
   it('matches approved export defaults, portability warning, and native-cancel state', async () => {
     const preview = {
       specialistId: 'rna-reviewer',

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import {
   AlertTriangle,
@@ -234,6 +234,9 @@ const InstalledSpecialistsPanel = ({
   const [reportStatus, setReportStatus] = useState<string | undefined>()
   const [includedExportSkillIds, setIncludedExportSkillIds] = useState<string[]>([])
   const [exportBusy, setExportBusy] = useState(false)
+  const [exportChecking, setExportChecking] = useState(false)
+  const [exportValidationFailed, setExportValidationFailed] = useState(false)
+  const exportPreviewRequest = useRef(0)
   const [exportSaved, setExportSaved] = useState(false)
   const [exportError, setExportError] = useState<string | undefined>()
   // Specialist currently exporting from the list row (direct export bypasses the chooser).
@@ -284,21 +287,50 @@ const InstalledSpecialistsPanel = ({
 
   useEffect(() => {
     if (view.kind !== 'export') return
-    let active = true
-    void previewExport(view.id)
+    const requestId = ++exportPreviewRequest.current
+    void Promise.resolve()
+      .then(() => {
+        if (requestId !== exportPreviewRequest.current) return
+        setExportChecking(true)
+        setExportValidationFailed(false)
+        return previewExport(view.id)
+      })
       .then((preview) => {
-        if (!active) return
+        if (!preview || requestId !== exportPreviewRequest.current) return
         setIncludedExportSkillIds(
           preview.skills.filter((skill) => skill.selected).map((skill) => skill.id)
         )
       })
       .catch(() => {
-        if (active) setExportError('Could not preview this Specialist export. Try again.')
+        if (requestId !== exportPreviewRequest.current) return
+        setExportValidationFailed(true)
+        setExportError('Could not preview this Specialist export. Try again.')
+      })
+      .finally(() => {
+        if (requestId === exportPreviewRequest.current) setExportChecking(false)
       })
     return () => {
-      active = false
+      exportPreviewRequest.current += 1
     }
   }, [previewExport, view])
+
+  const recheckExportSelection = (includedSkillIds: string[]): void => {
+    if (view.kind !== 'export') return
+    setIncludedExportSkillIds(includedSkillIds)
+    setExportChecking(true)
+    setExportValidationFailed(false)
+    setExportError(undefined)
+    const requestId = ++exportPreviewRequest.current
+    void previewExport(view.id, includedSkillIds)
+      .catch(() => {
+        if (requestId !== exportPreviewRequest.current) return
+        setExportValidationFailed(true)
+        setExportError('Could not preview this Specialist export. Try again.')
+      })
+      .finally(() => {
+        if (requestId === exportPreviewRequest.current) setExportChecking(false)
+      })
+  }
 
   // Direct export from the list action menu: silently preview with the approved default selection
   // (builtin + owned Skills), then open the native save dialog. The chooser page is skipped unless
@@ -582,18 +614,20 @@ const InstalledSpecialistsPanel = ({
           <span
             role="status"
             className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold ${
-              exportPreview?.canExport
+              !exportChecking && !exportValidationFailed && exportPreview?.canExport
                 ? 'bg-success-000/10 text-success-000'
                 : exportPreview
                   ? 'bg-danger-000/10 text-danger-000'
                   : 'bg-muted text-muted-foreground'
             }`}
           >
-            {exportPreview?.canExport
-              ? t('✓ Ready')
-              : exportPreview
-                ? t('× Blocked')
-                : t('Checking…')}
+            {exportChecking
+              ? t('Checking…')
+              : !exportValidationFailed && exportPreview?.canExport
+                ? t('✓ Ready')
+                : exportPreview
+                  ? t('× Blocked')
+                  : t('Checking…')}
           </span>
         </div>
         {exportError ? (
@@ -627,12 +661,12 @@ const InstalledSpecialistsPanel = ({
                     <input
                       type="checkbox"
                       checked={checked}
-                      disabled={!skill.selectable}
+                      disabled={!skill.selectable || exportBusy}
                       onChange={(event) =>
-                        setIncludedExportSkillIds((current) =>
+                        recheckExportSelection(
                           event.target.checked
-                            ? [...new Set([...current, skill.id])]
-                            : current.filter((id) => id !== skill.id)
+                            ? [...new Set([...includedExportSkillIds, skill.id])]
+                            : includedExportSkillIds.filter((id) => id !== skill.id)
                         )
                       }
                     />
@@ -690,7 +724,9 @@ const InstalledSpecialistsPanel = ({
               </Button>
               <Button
                 type="button"
-                disabled={!exportPreview.canExport || exportBusy}
+                disabled={
+                  !exportPreview.canExport || exportBusy || exportChecking || exportValidationFailed
+                }
                 onClick={() => {
                   setExportBusy(true)
                   setExportError(undefined)

--- a/src/renderer/src/stores/marketplace-store.test.ts
+++ b/src/renderer/src/stores/marketplace-store.test.ts
@@ -116,4 +116,14 @@ describe('marketplace store', () => {
     expect(state().snapshot).toEqual(snapshot('github-fresh'))
     expect(state().isRefreshing).toBe(false)
   })
+  it('reports preserved corrupt data separately from a network failure and clears it after repair', async () => {
+    setListMarketplaceApi(
+      vi.fn().mockRejectedValue(new Error('MARKETPLACE_DOCUMENT_INTEGRITY: pending installations'))
+    )
+    await state().refresh()
+    expect(state()).toMatchObject({ lastRefreshFailed: true, integrityFailed: true })
+    setListMarketplaceApi(vi.fn().mockResolvedValue(snapshot('repaired')))
+    await state().refresh()
+    expect(state()).toMatchObject({ lastRefreshFailed: false, integrityFailed: false })
+  })
 })

--- a/src/renderer/src/stores/marketplace-store.ts
+++ b/src/renderer/src/stores/marketplace-store.ts
@@ -1,5 +1,8 @@
 import { create } from 'zustand'
-import type { MarketplaceSnapshot } from '../../../shared/specialist-marketplace'
+import {
+  MARKETPLACE_DOCUMENT_INTEGRITY_CODE,
+  type MarketplaceSnapshot
+} from '../../../shared/specialist-marketplace'
 
 // Marketplace snapshot outlives the settings view that loaded it: re-entering the Marketplace tab
 // renders the last snapshot immediately and refreshes in the background, instead of showing a
@@ -12,6 +15,7 @@ type MarketplaceStoreData = {
   // A flag, not a translated string: the view renders the message with i18next so it follows the
   // interface language at render time instead of freezing the locale that was active on failure.
   lastRefreshFailed: boolean
+  integrityFailed: boolean
 }
 
 type MarketplaceStoreActions = {
@@ -26,12 +30,13 @@ export const useMarketplaceStore = create<MarketplaceStore>((set) => ({
   snapshot: undefined,
   isRefreshing: false,
   lastRefreshFailed: false,
+  integrityFailed: false,
 
   refresh: async (options) => {
     // Guard: specialist.listMarketplace is Electron-only and unavailable in the web gateway.
     if (typeof window.api?.specialist?.listMarketplace !== 'function') {
       latestRefreshRequest += 1
-      set({ isRefreshing: false, lastRefreshFailed: true })
+      set({ isRefreshing: false, lastRefreshFailed: true, integrityFailed: false })
       return
     }
     const requestId = ++latestRefreshRequest
@@ -41,12 +46,17 @@ export const useMarketplaceStore = create<MarketplaceStore>((set) => ({
         options?.forceRefresh ? { forceRefresh: true } : undefined
       )
       if (requestId !== latestRefreshRequest) return
-      set({ snapshot, isRefreshing: false, lastRefreshFailed: false })
-    } catch {
+      set({ snapshot, isRefreshing: false, lastRefreshFailed: false, integrityFailed: false })
+    } catch (error) {
       if (requestId !== latestRefreshRequest) return
       // Keep any existing snapshot: stale content stays on screen and the view shows a
       // could-not-refresh notice instead of dropping the user back to an empty loader.
-      set({ isRefreshing: false, lastRefreshFailed: true })
+      set({
+        isRefreshing: false,
+        lastRefreshFailed: true,
+        integrityFailed:
+          error instanceof Error && error.message.includes(MARKETPLACE_DOCUMENT_INTEGRITY_CODE)
+      })
     }
   }
 }))
@@ -57,6 +67,7 @@ export const resetMarketplaceStoreForTests = (): void => {
   useMarketplaceStore.setState({
     snapshot: undefined,
     isRefreshing: false,
-    lastRefreshFailed: false
+    lastRefreshFailed: false,
+    integrityFailed: false
   })
 }

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -74,7 +74,10 @@ type SpecialistStoreActions = {
     options?: Omit<SpecialistPackageInstallRequest, 'candidateToken'>
   ) => Promise<SpecialistPackageInstallResult>
   cancelPackage: () => Promise<void>
-  previewExport: (specialistId: string) => Promise<SpecialistExportPreview>
+  previewExport: (
+    specialistId: string,
+    includedSkillIds?: readonly string[]
+  ) => Promise<SpecialistExportPreview>
   exportSpecialist: (
     preview: SpecialistExportPreview,
     includedSkillIds: readonly string[]
@@ -253,9 +256,12 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
     set({ packagePreview: undefined })
   },
 
-  previewExport: async (specialistId: string) => {
+  previewExport: async (specialistId: string, includedSkillIds?: readonly string[]) => {
     const requestId = ++latestExportPreviewRequest
-    const preview = await window.api.specialist.previewExport({ specialistId })
+    const preview = await window.api.specialist.previewExport({
+      specialistId,
+      ...(includedSkillIds === undefined ? {} : { includedSkillIds })
+    })
     if (requestId === latestExportPreviewRequest) set({ exportPreview: preview })
     return preview
   },

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -104,6 +104,7 @@
     "Discard unavailable Plan": "Nicht verfügbaren Plan verwerfen",
     "Discard unavailable Plan?": "Nicht verfügbaren Plan verwerfen?",
     "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "Dadurch werden der aktive Plan sowie seine Freigabe und sein Fortschritt aus dieser Konversation entfernt. Nachrichten und Artefakte bleiben erhalten. Dies kann nicht rückgängig gemacht werden.",
+    "Marketplace data needs repair. The original {{fileName}} file has been preserved.": "Die Marktplatzdaten müssen repariert werden. Die ursprüngliche Datei {{fileName}} wurde beibehalten.",
     "Receiving code. Cancelling discards the unfinished code.": "Code wird empfangen. Beim Abbrechen wird der unvollständige Code verworfen.",
     "Cancel code reception": "Codeempfang abbrechen",
     "Checking version…": "Version wird geprüft…",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -105,6 +105,7 @@
     "Discard unavailable Plan": "Descartar el plan no disponible",
     "Discard unavailable Plan?": "¿Descartar el plan no disponible?",
     "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "Se eliminarán de esta conversación el plan activo, su aprobación y su progreso. Se conservarán los mensajes y los artefactos. Esta acción no se puede deshacer.",
+    "Marketplace data needs repair. The original {{fileName}} file has been preserved.": "Es necesario reparar los datos del Mercado. Se ha conservado el archivo original {{fileName}}.",
     "Receiving code. Cancelling discards the unfinished code.": "Se está recibiendo código. Al cancelar, se descarta el código incompleto.",
     "Cancel code reception": "Cancelar recepción de código",
     "Checking version…": "Comprobando la versión…",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -105,6 +105,7 @@
     "Discard unavailable Plan": "Abandonner le plan indisponible",
     "Discard unavailable Plan?": "Abandonner le plan indisponible ?",
     "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "Le plan actif, son approbation et sa progression seront supprimés de cette conversation. Les messages et les artefacts seront conservés. Cette action est irréversible.",
+    "Marketplace data needs repair. The original {{fileName}} file has been preserved.": "Les données de la Place de marché doivent être réparées. Le fichier {{fileName}} d’origine a été conservé.",
     "Receiving code. Cancelling discards the unfinished code.": "Réception du code en cours. L’annulation supprime le code incomplet.",
     "Cancel code reception": "Annuler la réception du code",
     "Checking version…": "Vérification de la version…",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -103,6 +103,7 @@
     "Discard unavailable Plan": "利用できないプランを破棄",
     "Discard unavailable Plan?": "利用できないプランを破棄しますか？",
     "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "この会話から現在のプランとその承認および進捗を削除します。メッセージと成果物は保持されます。この操作は取り消せません。",
+    "Marketplace data needs repair. The original {{fileName}} file has been preserved.": "マーケットプレイスのデータを修復する必要があります。元の {{fileName}} ファイルは保持されています。",
     "Receiving code. Cancelling discards the unfinished code.": "コードを受信しています。キャンセルすると未完成のコードは破棄されます。",
     "Cancel code reception": "コードの受信をキャンセル",
     "Checking version…": "バージョンを確認中…",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -103,6 +103,7 @@
     "Discard unavailable Plan": "사용할 수 없는 계획 삭제",
     "Discard unavailable Plan?": "사용할 수 없는 계획을 삭제하시겠습니까?",
     "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "이 대화에서 현재 계획과 해당 승인 및 진행 상황을 제거합니다. 메시지와 아티팩트는 유지됩니다. 이 작업은 되돌릴 수 없습니다.",
+    "Marketplace data needs repair. The original {{fileName}} file has been preserved.": "마켓플레이스 데이터를 복구해야 합니다. 원본 {{fileName}} 파일은 보존되어 있습니다.",
     "Receiving code. Cancelling discards the unfinished code.": "코드를 수신 중입니다. 취소하면 미완성 코드가 삭제됩니다.",
     "Cancel code reception": "코드 수신 취소",
     "Checking version…": "버전 확인 중…",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -106,6 +106,7 @@
     "Discard unavailable Plan": "Удалить недоступный план",
     "Discard unavailable Plan?": "Удалить недоступный план?",
     "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "Активный план, его утверждение и прогресс будут удалены из этого диалога. Сообщения и артефакты сохранятся. Это действие нельзя отменить.",
+    "Marketplace data needs repair. The original {{fileName}} file has been preserved.": "Данные Маркетплейса требуют исправления. Исходный файл {{fileName}} сохранён.",
     "Receiving code. Cancelling discards the unfinished code.": "Получение кода. При отмене незавершённый код будет удалён.",
     "Cancel code reception": "Отменить получение кода",
     "Checking version…": "Проверка версии…",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -103,6 +103,7 @@
     "Discard unavailable Plan": "丢弃不可用计划",
     "Discard unavailable Plan?": "要丢弃不可用计划吗？",
     "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "这将从此对话中移除当前计划及其审批和进度。消息和产物会保留。此操作无法撤销。",
+    "Marketplace data needs repair. The original {{fileName}} file has been preserved.": "市场数据需要修复。原始 {{fileName}} 文件已保留。",
     "Receiving code. Cancelling discards the unfinished code.": "正在接收代码。取消将丢弃未完成的代码。",
     "Cancel code reception": "取消代码接收",
     "Checking version…": "正在检查版本…",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -103,6 +103,7 @@
     "Discard unavailable Plan": "捨棄無法使用的計畫",
     "Discard unavailable Plan?": "要捨棄無法使用的計畫嗎？",
     "This removes the active Plan and its approval and progress from this conversation. Messages and Artifacts are kept. This cannot be undone.": "這會從此對話中移除目前的計畫及其核准和進度。訊息和產物會保留。此操作無法復原。",
+    "Marketplace data needs repair. The original {{fileName}} file has been preserved.": "市集資料需要修復。原始 {{fileName}} 檔案已保留。",
     "Receiving code. Cancelling discards the unfinished code.": "正在接收程式碼。取消將捨棄未完成的程式碼。",
     "Cancel code reception": "取消程式碼接收",
     "Checking version…": "正在檢查版本…",

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -2133,7 +2133,10 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     (request: { id: string }) => Promise<SpecialistDeletePreview>
   >()('specialist', ['specialist:delete-preview', ELECTRON]),
   'specialist.previewExport': callable<
-    (request: { specialistId: string }) => Promise<SpecialistExportPreview>
+    (request: {
+      specialistId: string
+      includedSkillIds?: readonly string[]
+    }) => Promise<SpecialistExportPreview>
   >()('specialist', ['specialist:export-preview', ELECTRON]),
   'specialist.removeMarketplaceSource': callable<
     (request: RemoveMarketplaceSourceRequest) => Promise<void>

--- a/src/shared/specialist-marketplace.ts
+++ b/src/shared/specialist-marketplace.ts
@@ -1,3 +1,6 @@
+// Stable error marker retained by Electron's serialized Error message.
+export const MARKETPLACE_DOCUMENT_INTEGRITY_CODE = 'MARKETPLACE_DOCUMENT_INTEGRITY'
+
 import type {
   SpecialistPackageCandidatePreview,
   SpecialistPackageInstallRequest,


### PR DESCRIPTION
## Problem

Six reproduced package defects can delete an untouched existing Skill after interrupted preparation (K01), overwrite local edits during reuse (K05), remove Main isolation and provenance after a committed install encounters cleanup failure (K02), silently change preview-approved capabilities (K03), keep a valid export selection blocked (K04), or erase damaged Marketplace recovery obligations during unrelated writes (K06).

## Proposed change

- Record commit intent before Skill swaps and prove ownership/content before removing a promoted directory; preserve ambiguous legacy recovery evidence.
- Compare current Skill contents/version, preserve content during ownership-only reuse, and retain the existing mutation-lock check. Skip unreadable catalog entries while preserving metadata-located occupancy so another install cannot overwrite their files.
- Reconcile uncertain Marketplace install outcomes through real package recovery and exact archive identity. Keep committed cleanup retryable and compensate preferences only for confirmed rollback.
- Reject changed resolved capability selections through the existing `stale-candidate` result.
- Revalidate export previews for the current checkbox selection and ignore stale responses. Export the version captured from SKILL.md; block an invalid declared version instead of producing a ZIP whose bundled Skill is silently skipped on import. Exclusion remains available; absent versions keep the existing metadata/default fallback.
- Reject lossy reads/writes of authoritative Marketplace records, preserve original bytes, and display a translated repair message.

## Scope and non-goals

No new service architecture, database/schema migration, lifecycle enum, repair wizard, dependency, or background worker.

**Persistence:** Skill transaction journals now write version 2 with per-location `hadLive`/`contentHash`; the existing Skill sidecar gains an optional `transactionId` ownership stamp. Existing Marketplace pending/provenance fields and preferences remain the source of truth. The export request's optional `includedSkillIds` and UI checking/integrity flags are transient.

**Historical compatibility:** Healthy existing Skill metadata and Marketplace v1 documents remain readable. Legacy transactions with provable backups can recover; ambiguous live directories/journals are preserved with an error. Invalid pending records (including those lacking exact archive identity), unknown versions, and unknown authoritative record fields block writes instead of being discarded. No automatic historical reconstruction or downgrade repair.

## Acceptance criteria and validation

The six original reports were reproduced through real temporary repositories and public package/repository/UI boundaries before fixing them. K01 interrupts a child process at filesystem boundaries; K02 uses the existing SkillPort boundary. No production test seam was added. Additional public regressions cover unreadable metadata-located Skills, current edited export versions, and invalid-version exports.

For the final invalid-version guard, three permanent regressions failed twice against unchanged production code (`2`, empty, `next`): preview incorrectly allowed export and direct export succeeded. They pass after the fix, together with exclusion and absent-version compatibility checks.

Checks after the final source edit:

| Behavior / impact | Command | Result |
| --- | --- | --- |
| Skill owner and representative consumers, including export adapter and legacy fallback | `npm run test:module -- user_skills_repository` | 23 files / 917 passed |
| Package recovery/approval/export, IPC, Settings export UI and store | `npm test -- src/main/specialist/package src/main/specialist/ipc.test.ts src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx src/renderer/src/stores/specialist-store.test.ts` | 14 files / 267 passed |
| Main-process types and source lint | `npm run typecheck:node`; `npm run lint`; `git diff --check` | passed |
| Real export interaction | `npm run build:e2e`; local Playwright test using the repository ElectronAppHarness | passed: version 2 blocks, exclusion enables, correction to 2.0.0 enables; screenshots inspected |

Rebased onto main `5cdde8fa`, preserving both sides of adjacent locale additions. Before the final guard, broader owner/contract/consumer/i18n validation passed on `b87327b5` (23 files / 1,152 tests), with full typecheck and lint; PR Gate, portable shards, Windows core/E2E and macOS build/E2E also passed on that head. Those broader Marketplace/renderer/contract implementations are unchanged by the final guard. The new guard changes only the existing adapter and its two existing test files.

The impact map is package export -> SkillPort snapshot -> shared SemVer validator, with preview/export IPC -> store -> Settings as consumers. Earlier changes also cover Marketplace -> package recovery/repository/preferences. No agent execution, session subscription or database behavior changes. Full local `npm test` was intentionally not run per maintainer instruction. Final-head PR Gate remains authoritative for complete/platform checks; local process-interruption tests do not prove power-loss durability or Windows/Linux behavior. Local plans, screenshot fixtures and evidence are excluded from the PR.

## Review focus

Review rollback ownership and repeated recovery, healthy historical-format support versus fail-closed ambiguity, committed-cleanup provenance retention, and export selection/version consistency. Confirm that the behavior-to-check mapping covers the final diff. AI review of final head `d4fe7441` completed with **mergeable / no actionable findings**: https://github.com/aipoch/open-science/pull/2226#issuecomment-5556494407. Final-head PR Gate passed on `d4fe7441` after the isolated Windows E2E shard rerun; the original startup timeout and flaky-test gate were preserved. The initial failure occurred during fresh database startup before the test body; three local repetitions passed, and the Windows rerun passed all 11 functional and 16 workspace tests. No code or workflow changes were required.
